### PR TITLE
Add player ID to character

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -15,6 +15,7 @@ import (
 // Character represents a D&D 5e character with full game mechanics
 type Character struct {
 	id               string
+	playerID         string
 	name             string
 	level            int
 	proficiencyBonus int
@@ -180,6 +181,7 @@ func (c *Character) GetEffects() []effects.Effect {
 // Data represents the persistent state of a character
 type Data struct {
 	ID         string `json:"id"`
+	PlayerID   string `json:"player_id"`
 	Name       string `json:"name"`
 	Level      int    `json:"level"`
 	Experience int    `json:"experience"`
@@ -255,6 +257,7 @@ func (c *Character) ToData() Data {
 	}
 
 	data := Data{
+		PlayerID:       c.playerID,
 		ID:             c.id,
 		Name:           c.name,
 		Level:          c.level,
@@ -322,6 +325,7 @@ func LoadCharacterFromData(data Data, raceData *race.Data, classData *class.Data
 	}
 
 	return &Character{
+		playerID:         data.PlayerID,
 		id:               data.ID,
 		name:             data.Name,
 		level:            data.Level,


### PR DESCRIPTION
This pull request introduces a new `playerID` field to the `Character` struct in the `rulebooks/dnd5e/character/character.go` file, ensuring that a character can be associated with a specific player. The changes include updates to the struct, its serialization, deserialization, and data transformation methods.

### Addition of `playerID` field:

* `rulebooks/dnd5e/character/character.go`:
  - Added `playerID` to the `Character` struct to associate a character with a player.
  - Updated the `Data` struct to include a `PlayerID` field for JSON serialization.

### Serialization and deserialization updates:

* `rulebooks/dnd5e/character/character.go`:
  - Modified the `ToData` method to populate the `PlayerID` field in the serialized `Data` object.
  - Updated the `LoadCharacterFromData` function to initialize the `playerID` field when deserializing a `Character` from `Data`.