### PR TITLE
fix: Disable redundant CI workflows

### DIFF
--- a/.github/workflows/ci-enhanced.yml
+++ b/.github/workflows/ci-enhanced.yml
@@ -15,6 +15,8 @@ env:
 
 jobs:
   detect-modules:
+    # Skip this workflow - using optimized workflow instead
+    if: false
     runs-on: ubuntu-latest
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   test:
+    # Skip this workflow - using optimized workflow instead
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Disables redundant CI workflows to improve build times and reduce flaky test impact.

## Changes
- Add `if: false` condition to **ci.yml** workflow
- Add `if: false` condition to **ci-enhanced.yml** workflow  
- Keep **ci-optimized.yml** as the only active workflow

## Benefits
- ✅ Faster CI feedback - only changed modules tested on PRs
- ✅ Reduced flaky test impact - failures only affect changed modules
- ✅ Better resource utilization - no redundant builds
- ✅ Full tests still run on main branch merges
- ✅ Workflows can be manually triggered if needed by removing the condition

## Testing
After merging, PRs should only show one CI workflow running (CI Optimized) instead of three.

Fixes #112

🤖 Generated with [Claude Code](https://claude.ai/code)