### PR TITLE
fix: remove redundant HitPointsAt1st field from class.Data

### DIFF
--- a/rulebooks/dnd5e/builder_test.go
+++ b/rulebooks/dnd5e/builder_test.go
@@ -33,7 +33,6 @@ func createTestClassData() dnd5e.ClassData {
 		ID:                    "fighter",
 		Name:                  "Fighter",
 		HitDice:               10,
-		HitPointsAt1st:        10,
 		HitPointsPerLevel:     6,
 		SkillProficiencyCount: 2,
 		SkillOptions: []string{

--- a/rulebooks/dnd5e/character/creation.go
+++ b/rulebooks/dnd5e/character/creation.go
@@ -59,7 +59,7 @@ func NewFromCreationData(data CreationData) (*Character, error) {
 
 	// Calculate HP
 	conMod := (abilityScores.Constitution - 10) / 2
-	maxHP := data.ClassData.HitPointsAt1st + conMod
+	maxHP := data.ClassData.HitDice + conMod
 
 	// Build skills map
 	skills := make(map[string]shared.ProficiencyLevel)

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -97,7 +97,7 @@ func (d *Draft) compileCharacter(raceData *race.Data, classData *class.Data,
 	}
 
 	// Calculate HP
-	charData.MaxHitPoints = classData.HitPointsAt1st + ((charData.AbilityScores.Constitution - 10) / 2)
+	charData.MaxHitPoints = classData.HitDice + ((charData.AbilityScores.Constitution - 10) / 2)
 	charData.HitPoints = charData.MaxHitPoints
 
 	// Skills

--- a/rulebooks/dnd5e/character/draft_test.go
+++ b/rulebooks/dnd5e/character/draft_test.go
@@ -41,7 +41,6 @@ func (s *DraftTestSuite) SetupTest() {
 		ID:                    "fighter",
 		Name:                  "Fighter",
 		HitDice:               10,
-		HitPointsAt1st:        10,
 		SavingThrows:          []string{shared.AbilityStrength, shared.AbilityConstitution},
 		SkillProficiencyCount: 2,
 		SkillOptions: []string{

--- a/rulebooks/dnd5e/class/types.go
+++ b/rulebooks/dnd5e/class/types.go
@@ -9,7 +9,6 @@ type Data struct {
 
 	// Core mechanics
 	HitDice           int `json:"hit_dice"`             // d6, d8, d10, d12
-	HitPointsAt1st    int `json:"hit_points_at_1st"`    // Base HP at level 1
 	HitPointsPerLevel int `json:"hit_points_per_level"` // Average HP per level
 
 	// Proficiencies

--- a/rulebooks/dnd5e/example/cli.go
+++ b/rulebooks/dnd5e/example/cli.go
@@ -493,7 +493,6 @@ func getWizardClassData() *class.Data {
 		Name:                  "Wizard",
 		Description:           "Scholars of the arcane",
 		HitDice:               6,
-		HitPointsAt1st:        6,
 		HitPointsPerLevel:     4,
 		SkillProficiencyCount: 2,
 		SkillOptions: []string{
@@ -521,7 +520,6 @@ func getRogueClassData() *class.Data {
 		Name:                  "Rogue",
 		Description:           "Skilled in stealth and subterfuge",
 		HitDice:               8,
-		HitPointsAt1st:        8,
 		HitPointsPerLevel:     5,
 		SkillProficiencyCount: 4,
 		SkillOptions: []string{

--- a/rulebooks/dnd5e/example/main.go
+++ b/rulebooks/dnd5e/example/main.go
@@ -341,7 +341,6 @@ func getFighterClassData() *class.Data {
 		Name:                  "Fighter",
 		Description:           "Masters of martial combat",
 		HitDice:               10,
-		HitPointsAt1st:        10,
 		HitPointsPerLevel:     6,
 		SkillProficiencyCount: 2,
 		SkillOptions: []string{


### PR DESCRIPTION
## Summary
- Removed redundant `HitPointsAt1st` field from `class.Data` struct
- Updated HP calculations to use `HitDice` directly (they're always the same in D&D 5e)
- Updated all test data and examples

## Why this change?
In D&D 5e, hit points at first level are always the maximum value of the hit die:
- Fighter (d10) → 10 HP at level 1
- Wizard (d6) → 6 HP at level 1
- Barbarian (d12) → 12 HP at level 1

There's never a case where `HitPointsAt1st` differs from `HitDice`, making the field redundant.

## Changes made
1. Removed `HitPointsAt1st` field from `class.Data` struct
2. Updated `character/creation.go` HP calculation (line 62)
3. Updated `character/draft.go` HP calculation (line 100)
4. Updated all test data and examples

## Test plan
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] HP calculations still work correctly

Fixes #118

🤖 Generated with [Claude Code](https://claude.ai/code)