### PR TITLE
feat: add speed and size to character.Data struct

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -199,6 +199,10 @@ type Data struct {
 	HitPoints     int                  `json:"hit_points"`
 	MaxHitPoints  int                  `json:"max_hit_points"`
 
+	// Physical characteristics (denormalized from race)
+	Speed int    `json:"speed"`
+	Size  string `json:"size"`
+
 	// Proficiencies and skills
 	Skills        map[string]int       `json:"skills"`        // skill name -> proficiency level
 	SavingThrows  map[string]int       `json:"saving_throws"` // ability -> proficiency level
@@ -269,6 +273,8 @@ func (c *Character) ToData() Data {
 		AbilityScores:  c.abilityScores,
 		HitPoints:      c.hitPoints,
 		MaxHitPoints:   c.maxHitPoints,
+		Speed:          c.speed,
+		Size:           c.size,
 		Skills:         skillsData,
 		SavingThrows:   savesData,
 		Languages:      c.languages,
@@ -336,8 +342,8 @@ func LoadCharacterFromData(data Data, raceData *race.Data, classData *class.Data
 		classID:          data.ClassID,
 		backgroundID:     data.BackgroundID,
 		abilityScores:    data.AbilityScores,
-		size:             raceData.Size,
-		speed:            raceData.Speed,
+		size:             data.Size,
+		speed:            data.Speed,
 		hitPoints:        data.HitPoints,
 		maxHitPoints:     data.MaxHitPoints,
 		tempHitPoints:    0,                                              // Reset on load

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -100,6 +100,10 @@ func (d *Draft) compileCharacter(raceData *race.Data, classData *class.Data,
 	charData.MaxHitPoints = classData.HitPointsAt1st + ((charData.AbilityScores.Constitution - 10) / 2)
 	charData.HitPoints = charData.MaxHitPoints
 
+	// Physical characteristics from race
+	charData.Speed = raceData.Speed
+	charData.Size = raceData.Size
+
 	// Skills
 	charData.Skills = make(map[string]int)
 	if skills, ok := d.Choices[shared.ChoiceSkills].([]string); ok {

--- a/rulebooks/dnd5e/character/draft_test.go
+++ b/rulebooks/dnd5e/character/draft_test.go
@@ -115,6 +115,10 @@ func (s *DraftTestSuite) TestToCharacter_Success() {
 	s.Assert().Equal(12, character.maxHitPoints)
 	s.Assert().Equal(12, character.hitPoints)
 
+	// Verify physical characteristics from race
+	s.Assert().Equal(30, character.speed)
+	s.Assert().Equal("Medium", character.size)
+
 	// Verify skills
 	s.Assert().Equal(shared.Proficient, character.skills["Perception"])
 	s.Assert().Equal(shared.Proficient, character.skills["Survival"])
@@ -195,6 +199,10 @@ func (s *DraftTestSuite) TestToCharacter_WithSubrace() {
 	// Verify ability scores include racial bonuses
 	s.Assert().Equal(17, character.abilityScores.Dexterity)    // 15 + 2 (elf)
 	s.Assert().Equal(13, character.abilityScores.Intelligence) // 12 + 1 (high elf)
+
+	// Verify physical characteristics from elf race
+	s.Assert().Equal(30, character.speed)
+	s.Assert().Equal("Medium", character.size)
 }
 
 func (s *DraftTestSuite) TestToCharacter_IncompleteDraft() {


### PR DESCRIPTION
## Summary
- Added `Speed` and `Size` fields to `character.Data` struct for denormalization
- Updated character creation and loading to populate these fields
- Added test coverage to verify fields are populated correctly

## Why this change?
When rpg-api creates/loads characters, it needs race-derived stats like speed and size, but shouldn't have to load the full race object every time. These values are now denormalized and stored in character.Data.

## Changes made
1. Added `Speed int` and `Size string` fields to `character.Data` struct
2. Updated `NewFromCreationData` to populate from race data
3. Updated `draft.compileCharacter` to populate from race data
4. Updated `LoadCharacterFromData` to use denormalized data instead of race data
5. Updated `ToData` to include new fields in serialization
6. Added test assertions to verify fields are populated correctly

## Test plan
- [x] All tests pass
- [x] Pre-commit checks pass
- [x] Speed and size are correctly populated from race data
- [x] Tests verify both normal races and subraces work correctly

Fixes #119

🤖 Generated with [Claude Code](https://claude.ai/code)