### PR TITLE
fix: Remove local game module dependency

### DIFF
--- a/rulebooks/dnd5e/go.mod
+++ b/rulebooks/dnd5e/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/game v0.0.0-00010101000000-000000000000
+	github.com/KirkDiggler/rpg-toolkit/game v0.1.0
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -14,5 +14,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/KirkDiggler/rpg-toolkit/game => ../../game

--- a/rulebooks/dnd5e/go.sum
+++ b/rulebooks/dnd5e/go.sum
@@ -2,6 +2,8 @@ github.com/KirkDiggler/rpg-toolkit/core v0.1.0 h1:BUJ877kikqcQ0aOt2qUhLSUOVtCaCH
 github.com/KirkDiggler/rpg-toolkit/core v0.1.0/go.mod h1:N7xIvJGjmrHHNjfWQ3O1LlkalzImcMav3O0fNOg+8No=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.1 h1:6EFI8NsdPwoymE+ZEU0i2hBTCXBV7yXrFQ73RScdewE=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.1/go.mod h1:M+mF5gE04daLz73PX173IOn0CmVoAC6ff10Kx3BBCe8=
+github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
+github.com/KirkDiggler/rpg-toolkit/game v0.1.0/go.mod h1:6k+SKiGEAjeI4JRaQtVKOcsUsp3O/sDDee4GH9rl+WM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary
- Removed local replace directive for game module that was preventing toolkit usage
- Updated to use published game module v0.1.0

## Context
The toolkit had a local dependency on the game module via a replace directive:
```
replace github.com/KirkDiggler/rpg-toolkit/game => ../../game
```

This made the toolkit unusable for external users as the local path wouldn't exist in their environments.

## Changes
- Removed the replace directive from `rulebooks/dnd5e/go.mod`
- Updated to use the published version: `github.com/KirkDiggler/rpg-toolkit/game v0.1.0`
- All tests pass with the published dependency

## Impact
The toolkit can now be properly imported and used as a dependency in other projects.

Fixes the dependency issue that was blocking toolkit usage.