### PR TITLE
feat: Add comprehensive constants package for D&D 5e

### DIFF
--- a/rulebooks/dnd5e/builder_test.go
+++ b/rulebooks/dnd5e/builder_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
 // Test data helpers
@@ -17,12 +19,12 @@ func createTestRaceData() dnd5e.RaceData {
 		Size:  "medium",
 		Speed: 30,
 		AbilityScoreIncreases: map[string]int{
-			"strength":     1,
-			"dexterity":    1,
-			"constitution": 1,
-			"intelligence": 1,
-			"wisdom":       1,
-			"charisma":     1,
+			"str": 1,
+			"dex": 1,
+			"con": 1,
+			"int": 1,
+			"wis": 1,
+			"cha": 1,
 		},
 		Languages: []string{"common"},
 	}
@@ -39,7 +41,7 @@ func createTestClassData() dnd5e.ClassData {
 			"acrobatics", "athletics", "history", "insight",
 			"intimidation", "perception", "survival",
 		},
-		SavingThrows:        []string{"strength", "constitution"},
+		SavingThrows:        []string{"str", "con"},
 		ArmorProficiencies:  []string{"light", "medium", "heavy", "shields"},
 		WeaponProficiencies: []string{"simple", "martial"},
 	}
@@ -115,14 +117,15 @@ func TestCharacterCreationFlow(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set ability scores
-	scores := dnd5e.AbilityScores{
-		Strength:     15,
-		Dexterity:    14,
-		Constitution: 13,
-		Intelligence: 12,
-		Wisdom:       10,
-		Charisma:     8,
-	}
+	scores, err := shared.NewAbilityScores(&shared.AbilityScoreConfig{
+		STR: 15,
+		DEX: 14,
+		CON: 13,
+		INT: 12,
+		WIS: 10,
+		CHA: 8,
+	})
+	require.NoError(t, err)
 	err = builder.SetAbilityScores(scores)
 	require.NoError(t, err)
 
@@ -149,8 +152,8 @@ func TestCharacterCreationFlow(t *testing.T) {
 	assert.Equal(t, "soldier", charData.BackgroundID)
 
 	// Check ability scores include racial bonuses
-	assert.Equal(t, 16, charData.AbilityScores.Strength)  // 15 + 1 racial
-	assert.Equal(t, 15, charData.AbilityScores.Dexterity) // 14 + 1 racial
+	assert.Equal(t, 16, charData.AbilityScores[constants.STR]) // 15 + 1 racial
+	assert.Equal(t, 15, charData.AbilityScores[constants.DEX]) // 14 + 1 racial
 
 	// Check HP calculation
 	// Base 10 + CON modifier ((14 - 10) / 2 = 2)

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/game"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/effects"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
@@ -390,9 +391,9 @@ func LoadCharacterFromData(data Data, raceData *race.Data, classData *class.Data
 		speed:            data.Speed,
 		hitPoints:        data.HitPoints,
 		maxHitPoints:     data.MaxHitPoints,
-		tempHitPoints:    0,                                              // Reset on load
-		armorClass:       10 + ((data.AbilityScores.Dexterity - 10) / 2), // Base AC, equipment will modify
-		initiative:       (data.AbilityScores.Dexterity - 10) / 2,
+		tempHitPoints:    0,                                               // Reset on load
+		armorClass:       10 + data.AbilityScores.Modifier(constants.DEX), // Base AC, equipment will modify
+		initiative:       data.AbilityScores.Modifier(constants.DEX),
 		hitDice:          classData.HitDice,
 		skills:           skills,
 		savingThrows:     saves,

--- a/rulebooks/dnd5e/character/character_test.go
+++ b/rulebooks/dnd5e/character/character_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
@@ -40,12 +41,12 @@ func (s *CharacterTestSuite) TestLoadCharacterFromData_WithChoices() {
 		ClassID:      "fighter",
 		BackgroundID: "soldier",
 		AbilityScores: shared.AbilityScores{
-			Strength:     16,
-			Dexterity:    15,
-			Constitution: 14,
-			Intelligence: 13,
-			Wisdom:       11,
-			Charisma:     9,
+			constants.STR: 16,
+			constants.DEX: 15,
+			constants.CON: 14,
+			constants.INT: 13,
+			constants.WIS: 11,
+			constants.CHA: 9,
 		},
 		Speed:        30,
 		Size:         "Medium",
@@ -152,12 +153,12 @@ func (s *CharacterTestSuite) TestLoadCharacterFromData_BackwardsCompatibility() 
 		ClassID:      "fighter",
 		BackgroundID: "soldier",
 		AbilityScores: shared.AbilityScores{
-			Strength:     16,
-			Dexterity:    15,
-			Constitution: 14,
-			Intelligence: 13,
-			Wisdom:       11,
-			Charisma:     9,
+			constants.STR: 16,
+			constants.DEX: 15,
+			constants.CON: 14,
+			constants.INT: 13,
+			constants.WIS: 11,
+			constants.CHA: 9,
 		},
 		Speed:        30,
 		Size:         "Medium",
@@ -214,12 +215,12 @@ func (s *CharacterTestSuite) TestLoadCharacterFromData_MixedSelectionTypes() {
 		ClassID:      "fighter",
 		BackgroundID: "soldier",
 		AbilityScores: shared.AbilityScores{
-			Strength:     16,
-			Dexterity:    15,
-			Constitution: 14,
-			Intelligence: 13,
-			Wisdom:       11,
-			Charisma:     9,
+			constants.STR: 16,
+			constants.DEX: 15,
+			constants.CON: 14,
+			constants.INT: 13,
+			constants.WIS: 11,
+			constants.CHA: 9,
 		},
 		Speed:        30,
 		Size:         "Medium",

--- a/rulebooks/dnd5e/character/creation_test.go
+++ b/rulebooks/dnd5e/character/creation_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
@@ -33,12 +34,12 @@ func (s *CreationTestSuite) TestNewFromCreationData_ProcessesChoices() {
 		ClassData:      s.testClass,
 		BackgroundData: s.testBackground,
 		AbilityScores: shared.AbilityScores{
-			Strength:     15,
-			Dexterity:    14,
-			Constitution: 13,
-			Intelligence: 12,
-			Wisdom:       10,
-			Charisma:     8,
+			constants.STR: 15,
+			constants.DEX: 14,
+			constants.CON: 13,
+			constants.INT: 12,
+			constants.WIS: 10,
+			constants.CHA: 8,
 		},
 		Choices: map[string]any{
 			"skills":    []string{"Acrobatics", "Animal Handling"},
@@ -93,12 +94,12 @@ func (s *CreationTestSuite) TestNewFromCreationData_EmptyChoices() {
 		ClassData:      s.testClass,
 		BackgroundData: s.testBackground,
 		AbilityScores: shared.AbilityScores{
-			Strength:     15,
-			Dexterity:    14,
-			Constitution: 13,
-			Intelligence: 12,
-			Wisdom:       10,
-			Charisma:     8,
+			constants.STR: 15,
+			constants.DEX: 14,
+			constants.CON: 13,
+			constants.INT: 12,
+			constants.WIS: 10,
+			constants.CHA: 8,
 		},
 		Choices: map[string]any{}, // Empty choices
 	}
@@ -147,12 +148,12 @@ func (s *CreationTestSuite) TestNewFromCreationData_CommonAlwaysIncluded() {
 		ClassData:      s.testClass,
 		BackgroundData: exoticBackground,
 		AbilityScores: shared.AbilityScores{
-			Strength:     15,
-			Dexterity:    14,
-			Constitution: 13,
-			Intelligence: 12,
-			Wisdom:       10,
-			Charisma:     8,
+			constants.STR: 15,
+			constants.DEX: 14,
+			constants.CON: 13,
+			constants.INT: 12,
+			constants.WIS: 10,
+			constants.CHA: 8,
 		},
 		Choices: map[string]any{
 			"languages": []string{"Infernal"}, // Also no Common

--- a/rulebooks/dnd5e/character/draft_test.go
+++ b/rulebooks/dnd5e/character/draft_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
@@ -75,12 +76,12 @@ func (s *DraftTestSuite) TestToCharacter_Success() {
 			shared.ChoiceClass:      "fighter",
 			shared.ChoiceBackground: "soldier",
 			shared.ChoiceAbilityScores: shared.AbilityScores{
-				Strength:     15,
-				Dexterity:    14,
-				Constitution: 13,
-				Intelligence: 12,
-				Wisdom:       10,
-				Charisma:     8,
+				constants.STR: 15,
+				constants.DEX: 14,
+				constants.CON: 13,
+				constants.INT: 12,
+				constants.WIS: 10,
+				constants.CHA: 8,
 			},
 			shared.ChoiceSkills: []string{"Perception", "Survival"},
 		},
@@ -103,12 +104,12 @@ func (s *DraftTestSuite) TestToCharacter_Success() {
 	s.Assert().Equal(1, character.level)
 
 	// Verify ability scores (with racial bonuses)
-	s.Assert().Equal(16, character.abilityScores.Strength)     // 15 + 1
-	s.Assert().Equal(15, character.abilityScores.Dexterity)    // 14 + 1
-	s.Assert().Equal(14, character.abilityScores.Constitution) // 13 + 1
-	s.Assert().Equal(13, character.abilityScores.Intelligence) // 12 + 1
-	s.Assert().Equal(11, character.abilityScores.Wisdom)       // 10 + 1
-	s.Assert().Equal(9, character.abilityScores.Charisma)      // 8 + 1
+	s.Assert().Equal(16, character.abilityScores[constants.STR]) // 15 + 1
+	s.Assert().Equal(15, character.abilityScores[constants.DEX]) // 14 + 1
+	s.Assert().Equal(14, character.abilityScores[constants.CON]) // 13 + 1
+	s.Assert().Equal(13, character.abilityScores[constants.INT]) // 12 + 1
+	s.Assert().Equal(11, character.abilityScores[constants.WIS]) // 10 + 1
+	s.Assert().Equal(9, character.abilityScores[constants.CHA])  // 8 + 1
 
 	// Verify HP (10 base + 2 from Con modifier)
 	s.Assert().Equal(12, character.maxHitPoints)
@@ -174,12 +175,12 @@ func (s *DraftTestSuite) TestToCharacter_WithSubrace() {
 			shared.ChoiceClass:      "fighter",
 			shared.ChoiceBackground: "soldier",
 			shared.ChoiceAbilityScores: shared.AbilityScores{
-				Strength:     14,
-				Dexterity:    15,
-				Constitution: 13,
-				Intelligence: 12,
-				Wisdom:       10,
-				Charisma:     8,
+				constants.STR: 14,
+				constants.DEX: 15,
+				constants.CON: 13,
+				constants.INT: 12,
+				constants.WIS: 10,
+				constants.CHA: 8,
 			},
 		},
 		Progress: DraftProgress{
@@ -196,8 +197,8 @@ func (s *DraftTestSuite) TestToCharacter_WithSubrace() {
 	s.Assert().Equal("test-draft-2", character.id)
 
 	// Verify ability scores include racial bonuses
-	s.Assert().Equal(17, character.abilityScores.Dexterity)    // 15 + 2 (elf)
-	s.Assert().Equal(13, character.abilityScores.Intelligence) // 12 + 1 (high elf)
+	s.Assert().Equal(17, character.abilityScores[constants.DEX]) // 15 + 2 (elf)
+	s.Assert().Equal(13, character.abilityScores[constants.INT]) // 12 + 1 (high elf)
 
 	// Verify physical characteristics from elf race
 	s.Assert().Equal(30, character.speed)
@@ -365,12 +366,12 @@ func (s *DraftTestSuite) TestToCharacter_WithLanguageChoices() {
 			shared.ChoiceClass:      "fighter",
 			shared.ChoiceBackground: "soldier",
 			shared.ChoiceAbilityScores: shared.AbilityScores{
-				Strength:     15,
-				Dexterity:    14,
-				Constitution: 13,
-				Intelligence: 12,
-				Wisdom:       10,
-				Charisma:     8,
+				constants.STR: 15,
+				constants.DEX: 14,
+				constants.CON: 13,
+				constants.INT: 12,
+				constants.WIS: 10,
+				constants.CHA: 8,
 			},
 			shared.ChoiceLanguages: []string{"Elvish", "Goblin", "Draconic"},
 		},
@@ -427,12 +428,12 @@ func (s *DraftTestSuite) TestToCharacter_CommonAlwaysIncluded() {
 			shared.ChoiceClass:      "fighter",
 			shared.ChoiceBackground: "soldier",
 			shared.ChoiceAbilityScores: shared.AbilityScores{
-				Strength:     15,
-				Dexterity:    14,
-				Constitution: 13,
-				Intelligence: 12,
-				Wisdom:       10,
-				Charisma:     8,
+				constants.STR: 15,
+				constants.DEX: 14,
+				constants.CON: 13,
+				constants.INT: 12,
+				constants.WIS: 10,
+				constants.CHA: 8,
 			},
 		},
 		Progress: DraftProgress{

--- a/rulebooks/dnd5e/character/feature_test.go
+++ b/rulebooks/dnd5e/character/feature_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
@@ -101,12 +102,12 @@ func (s *FeatureTestSuite) TestFighterFeatures() {
 				shared.ChoiceClass:      "fighter",
 				shared.ChoiceBackground: "soldier",
 				shared.ChoiceAbilityScores: shared.AbilityScores{
-					Strength:     16,
-					Dexterity:    14,
-					Constitution: 15,
-					Intelligence: 10,
-					Wisdom:       12,
-					Charisma:     8,
+					constants.STR: 16,
+					constants.DEX: 14,
+					constants.CON: 15,
+					constants.INT: 10,
+					constants.WIS: 12,
+					constants.CHA: 8,
 				},
 				shared.ChoiceSkills:        []string{"Perception", "Survival"},
 				shared.ChoiceFightingStyle: "defense", // Fighter-specific choice
@@ -154,12 +155,12 @@ func (s *FeatureTestSuite) TestFighterFeatures() {
 			ClassID:      "fighter",
 			BackgroundID: "soldier",
 			AbilityScores: shared.AbilityScores{
-				Strength:     17, // With racial bonus
-				Dexterity:    15,
-				Constitution: 16,
-				Intelligence: 11,
-				Wisdom:       13,
-				Charisma:     9,
+				constants.STR: 17, // With racial bonus
+				constants.DEX: 15,
+				constants.CON: 16,
+				constants.INT: 11,
+				constants.WIS: 13,
+				constants.CHA: 9,
 			},
 			MaxHitPoints: 20, // 10 + 3 (con) at level 1, +6 +3 at level 2
 			HitPoints:    20,
@@ -290,12 +291,12 @@ func (s *FeatureTestSuite) TestFighterFeatures() {
 				shared.ChoiceClass:      "wizard",
 				shared.ChoiceBackground: "sage",
 				shared.ChoiceAbilityScores: shared.AbilityScores{
-					Strength:     8,
-					Dexterity:    14,
-					Constitution: 13,
-					Intelligence: 15,
-					Wisdom:       12,
-					Charisma:     10,
+					constants.STR: 8,
+					constants.DEX: 14,
+					constants.CON: 13,
+					constants.INT: 15,
+					constants.WIS: 12,
+					constants.CHA: 10,
 				},
 				shared.ChoiceSkills:   []string{"Investigation", "Insight"},
 				shared.ChoiceCantrips: []string{"fire_bolt", "mage_hand", "prestidigitation"},
@@ -341,12 +342,12 @@ func (s *FeatureTestSuite) TestFighterFeatures() {
 		s.Assert().True(hasSpellChoice, "Spell choices should be stored")
 
 		// Check ability scores with racial bonuses
-		s.Assert().Equal(8, character.abilityScores.Strength)
-		s.Assert().Equal(16, character.abilityScores.Dexterity) // 14 + 2 (elf)
-		s.Assert().Equal(13, character.abilityScores.Constitution)
-		s.Assert().Equal(16, character.abilityScores.Intelligence) // 15 + 1 (high elf)
-		s.Assert().Equal(12, character.abilityScores.Wisdom)
-		s.Assert().Equal(10, character.abilityScores.Charisma)
+		s.Assert().Equal(8, character.abilityScores[constants.STR])
+		s.Assert().Equal(16, character.abilityScores[constants.DEX]) // 14 + 2 (elf)
+		s.Assert().Equal(13, character.abilityScores[constants.CON])
+		s.Assert().Equal(16, character.abilityScores[constants.INT]) // 15 + 1 (high elf)
+		s.Assert().Equal(12, character.abilityScores[constants.WIS])
+		s.Assert().Equal(10, character.abilityScores[constants.CHA])
 	})
 }
 

--- a/rulebooks/dnd5e/character/validator.go
+++ b/rulebooks/dnd5e/character/validator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
@@ -98,24 +99,15 @@ func (v *Validator) ValidateAbilityScores(scores shared.AbilityScores) error {
 	// Point buy: 27 points, scores 8-15 before racial modifiers
 	// Rolled: Each score 3-18
 
-	// Check minimum and maximum values
-	if scores.Strength < 3 || scores.Strength > 20 {
-		return fmt.Errorf("strength must be between 3 and 20")
-	}
-	if scores.Dexterity < 3 || scores.Dexterity > 20 {
-		return fmt.Errorf("dexterity must be between 3 and 20")
-	}
-	if scores.Constitution < 3 || scores.Constitution > 20 {
-		return fmt.Errorf("constitution must be between 3 and 20")
-	}
-	if scores.Intelligence < 3 || scores.Intelligence > 20 {
-		return fmt.Errorf("intelligence must be between 3 and 20")
-	}
-	if scores.Wisdom < 3 || scores.Wisdom > 20 {
-		return fmt.Errorf("wisdom must be between 3 and 20")
-	}
-	if scores.Charisma < 3 || scores.Charisma > 20 {
-		return fmt.Errorf("charisma must be between 3 and 20")
+	// Check that all abilities are present and within range
+	for _, ability := range constants.AllAbilities() {
+		score, ok := scores[ability]
+		if !ok {
+			return fmt.Errorf("missing ability score: %s", ability.Display())
+		}
+		if score < 3 || score > 20 {
+			return fmt.Errorf("%s must be between 3 and 20", ability.Display())
+		}
 	}
 
 	// TODO: Validate based on character creation method (point buy, standard array, rolled)

--- a/rulebooks/dnd5e/constants/abilities.go
+++ b/rulebooks/dnd5e/constants/abilities.go
@@ -1,0 +1,39 @@
+package constants
+
+// Ability represents a D&D 5e ability score
+type Ability string
+
+// Ability score constants
+const (
+	STR Ability = "str"
+	DEX Ability = "dex"
+	CON Ability = "con"
+	INT Ability = "int"
+	WIS Ability = "wis"
+	CHA Ability = "cha"
+)
+
+// Display returns the human-readable name of the ability
+func (a Ability) Display() string {
+	switch a {
+	case STR:
+		return "Strength"
+	case DEX:
+		return "Dexterity"
+	case CON:
+		return "Constitution"
+	case INT:
+		return "Intelligence"
+	case WIS:
+		return "Wisdom"
+	case CHA:
+		return "Charisma"
+	default:
+		return string(a)
+	}
+}
+
+// AllAbilities returns all ability scores in standard order
+func AllAbilities() []Ability {
+	return []Ability{STR, DEX, CON, INT, WIS, CHA}
+}

--- a/rulebooks/dnd5e/constants/abilities_test.go
+++ b/rulebooks/dnd5e/constants/abilities_test.go
@@ -1,0 +1,88 @@
+package constants_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
+)
+
+type AbilitiesTestSuite struct {
+	suite.Suite
+}
+
+func (s *AbilitiesTestSuite) TestAbilityConstants() {
+	tests := []struct {
+		name     string
+		ability  constants.Ability
+		expected string
+		display  string
+	}{
+		{
+			name:     "strength constant",
+			ability:  constants.STR,
+			expected: "str",
+			display:  "Strength",
+		},
+		{
+			name:     "dexterity constant",
+			ability:  constants.DEX,
+			expected: "dex",
+			display:  "Dexterity",
+		},
+		{
+			name:     "constitution constant",
+			ability:  constants.CON,
+			expected: "con",
+			display:  "Constitution",
+		},
+		{
+			name:     "intelligence constant",
+			ability:  constants.INT,
+			expected: "int",
+			display:  "Intelligence",
+		},
+		{
+			name:     "wisdom constant",
+			ability:  constants.WIS,
+			expected: "wis",
+			display:  "Wisdom",
+		},
+		{
+			name:     "charisma constant",
+			ability:  constants.CHA,
+			expected: "cha",
+			display:  "Charisma",
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.Equal(tc.expected, string(tc.ability))
+			s.Equal(tc.display, tc.ability.Display())
+		})
+	}
+}
+
+func (s *AbilitiesTestSuite) TestAbilityDisplay_UnknownAbility() {
+	unknown := constants.Ability("unknown")
+	s.Equal("unknown", unknown.Display())
+}
+
+func (s *AbilitiesTestSuite) TestAllAbilities() {
+	abilities := constants.AllAbilities()
+	s.Len(abilities, 6)
+
+	// Verify standard order
+	s.Equal(constants.STR, abilities[0])
+	s.Equal(constants.DEX, abilities[1])
+	s.Equal(constants.CON, abilities[2])
+	s.Equal(constants.INT, abilities[3])
+	s.Equal(constants.WIS, abilities[4])
+	s.Equal(constants.CHA, abilities[5])
+}
+
+func TestAbilitiesTestSuite(t *testing.T) {
+	suite.Run(t, new(AbilitiesTestSuite))
+}

--- a/rulebooks/dnd5e/constants/backgrounds.go
+++ b/rulebooks/dnd5e/constants/backgrounds.go
@@ -1,0 +1,55 @@
+package constants
+
+// Background represents a D&D 5e character background
+type Background string
+
+// Background constants
+const (
+	BackgroundAcolyte      Background = "acolyte"
+	BackgroundCharlatan    Background = "charlatan"
+	BackgroundCriminal     Background = "criminal"
+	BackgroundEntertainer  Background = "entertainer"
+	BackgroundFolkHero     Background = "folk-hero"
+	BackgroundGuildArtisan Background = "guild-artisan"
+	BackgroundHermit       Background = "hermit"
+	BackgroundNoble        Background = "noble"
+	BackgroundOutlander    Background = "outlander"
+	BackgroundSage         Background = "sage"
+	BackgroundSailor       Background = "sailor"
+	BackgroundSoldier      Background = "soldier"
+	BackgroundUrchin       Background = "urchin"
+)
+
+// Display returns the human-readable name of the background
+func (b Background) Display() string {
+	switch b {
+	case BackgroundAcolyte:
+		return "Acolyte"
+	case BackgroundCharlatan:
+		return "Charlatan"
+	case BackgroundCriminal:
+		return "Criminal"
+	case BackgroundEntertainer:
+		return "Entertainer"
+	case BackgroundFolkHero:
+		return "Folk Hero"
+	case BackgroundGuildArtisan:
+		return "Guild Artisan"
+	case BackgroundHermit:
+		return "Hermit"
+	case BackgroundNoble:
+		return "Noble"
+	case BackgroundOutlander:
+		return "Outlander"
+	case BackgroundSage:
+		return "Sage"
+	case BackgroundSailor:
+		return "Sailor"
+	case BackgroundSoldier:
+		return "Soldier"
+	case BackgroundUrchin:
+		return "Urchin"
+	default:
+		return string(b)
+	}
+}

--- a/rulebooks/dnd5e/constants/classes.go
+++ b/rulebooks/dnd5e/constants/classes.go
@@ -1,0 +1,86 @@
+package constants
+
+// Class represents a D&D 5e character class
+type Class string
+
+// Class constants
+const (
+	ClassBarbarian Class = "barbarian"
+	ClassBard      Class = "bard"
+	ClassCleric    Class = "cleric"
+	ClassDruid     Class = "druid"
+	ClassFighter   Class = "fighter"
+	ClassMonk      Class = "monk"
+	ClassPaladin   Class = "paladin"
+	ClassRanger    Class = "ranger"
+	ClassRogue     Class = "rogue"
+	ClassSorcerer  Class = "sorcerer"
+	ClassWarlock   Class = "warlock"
+	ClassWizard    Class = "wizard"
+)
+
+// Display returns the human-readable name of the class
+func (c Class) Display() string {
+	switch c {
+	case ClassBarbarian:
+		return "Barbarian"
+	case ClassBard:
+		return "Bard"
+	case ClassCleric:
+		return "Cleric"
+	case ClassDruid:
+		return "Druid"
+	case ClassFighter:
+		return "Fighter"
+	case ClassMonk:
+		return "Monk"
+	case ClassPaladin:
+		return "Paladin"
+	case ClassRanger:
+		return "Ranger"
+	case ClassRogue:
+		return "Rogue"
+	case ClassSorcerer:
+		return "Sorcerer"
+	case ClassWarlock:
+		return "Warlock"
+	case ClassWizard:
+		return "Wizard"
+	default:
+		return string(c)
+	}
+}
+
+// HitDice returns the hit dice size for the class
+func (c Class) HitDice() int {
+	switch c {
+	case ClassBarbarian:
+		return 12
+	case ClassFighter, ClassPaladin, ClassRanger:
+		return 10
+	case ClassBard, ClassCleric, ClassDruid, ClassMonk, ClassRogue, ClassWarlock:
+		return 8
+	case ClassSorcerer, ClassWizard:
+		return 6
+	default:
+		return 0
+	}
+}
+
+// PrimaryStat returns the primary ability score for the class
+func (c Class) PrimaryStat() Ability {
+	switch c {
+	case ClassBarbarian, ClassFighter:
+		return STR
+	case ClassRogue, ClassRanger, ClassMonk:
+		return DEX
+	case ClassWizard:
+		return INT
+	case ClassCleric, ClassDruid:
+		return WIS
+	case ClassBard, ClassPaladin, ClassSorcerer, ClassWarlock:
+		return CHA
+	default:
+		return ""
+	}
+}

--- a/rulebooks/dnd5e/constants/classes_test.go
+++ b/rulebooks/dnd5e/constants/classes_test.go
@@ -1,0 +1,94 @@
+package constants_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
+)
+
+type ClassesTestSuite struct {
+	suite.Suite
+}
+
+func (s *ClassesTestSuite) TestClassConstants() {
+	tests := []struct {
+		name        string
+		class       constants.Class
+		expected    string
+		display     string
+		hitDice     int
+		primaryStat constants.Ability
+	}{
+		{
+			name:        "barbarian class",
+			class:       constants.ClassBarbarian,
+			expected:    "barbarian",
+			display:     "Barbarian",
+			hitDice:     12,
+			primaryStat: constants.STR,
+		},
+		{
+			name:        "wizard class",
+			class:       constants.ClassWizard,
+			expected:    "wizard",
+			display:     "Wizard",
+			hitDice:     6,
+			primaryStat: constants.INT,
+		},
+		{
+			name:        "rogue class",
+			class:       constants.ClassRogue,
+			expected:    "rogue",
+			display:     "Rogue",
+			hitDice:     8,
+			primaryStat: constants.DEX,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.Equal(tc.expected, string(tc.class))
+			s.Equal(tc.display, tc.class.Display())
+			s.Equal(tc.hitDice, tc.class.HitDice())
+			s.Equal(tc.primaryStat, tc.class.PrimaryStat())
+		})
+	}
+}
+
+func (s *ClassesTestSuite) TestClassDisplay_UnknownClass() {
+	unknown := constants.Class("unknown")
+	s.Equal("unknown", unknown.Display())
+	s.Equal(0, unknown.HitDice())
+	s.Equal(constants.Ability(""), unknown.PrimaryStat())
+}
+
+func (s *ClassesTestSuite) TestAllClassHitDice() {
+	// Test all classes have valid hit dice
+	classes := []constants.Class{
+		constants.ClassBarbarian,
+		constants.ClassBard,
+		constants.ClassCleric,
+		constants.ClassDruid,
+		constants.ClassFighter,
+		constants.ClassMonk,
+		constants.ClassPaladin,
+		constants.ClassRanger,
+		constants.ClassRogue,
+		constants.ClassSorcerer,
+		constants.ClassWarlock,
+		constants.ClassWizard,
+	}
+
+	for _, class := range classes {
+		s.Run(string(class), func() {
+			hitDice := class.HitDice()
+			s.Contains([]int{6, 8, 10, 12}, hitDice, "Hit dice should be 6, 8, 10, or 12")
+		})
+	}
+}
+
+func TestClassesTestSuite(t *testing.T) {
+	suite.Run(t, new(ClassesTestSuite))
+}

--- a/rulebooks/dnd5e/constants/damage.go
+++ b/rulebooks/dnd5e/constants/damage.go
@@ -1,0 +1,113 @@
+package constants
+
+// DamageType represents types of damage in D&D 5e
+type DamageType string
+
+// Damage type constants
+const (
+	DamageAcid        DamageType = "acid"
+	DamageBludgeoning DamageType = "bludgeoning"
+	DamageCold        DamageType = "cold"
+	DamageFire        DamageType = "fire"
+	DamageForce       DamageType = "force"
+	DamageLightning   DamageType = "lightning"
+	DamageNecrotic    DamageType = "necrotic"
+	DamagePiercing    DamageType = "piercing"
+	DamagePoison      DamageType = "poison"
+	DamagePsychic     DamageType = "psychic"
+	DamageRadiant     DamageType = "radiant"
+	DamageSlashing    DamageType = "slashing"
+	DamageThunder     DamageType = "thunder"
+)
+
+// Display returns the human-readable name of the damage type
+func (d DamageType) Display() string {
+	switch d {
+	case DamageAcid:
+		return "Acid"
+	case DamageBludgeoning:
+		return "Bludgeoning"
+	case DamageCold:
+		return "Cold"
+	case DamageFire:
+		return "Fire"
+	case DamageForce:
+		return "Force"
+	case DamageLightning:
+		return "Lightning"
+	case DamageNecrotic:
+		return "Necrotic"
+	case DamagePiercing:
+		return "Piercing"
+	case DamagePoison:
+		return "Poison"
+	case DamagePsychic:
+		return "Psychic"
+	case DamageRadiant:
+		return "Radiant"
+	case DamageSlashing:
+		return "Slashing"
+	case DamageThunder:
+		return "Thunder"
+	default:
+		return string(d)
+	}
+}
+
+// IsPhysical returns true if this is physical damage (bludgeoning, piercing, slashing)
+func (d DamageType) IsPhysical() bool {
+	switch d {
+	case DamageBludgeoning, DamagePiercing, DamageSlashing:
+		return true
+	default:
+		return false
+	}
+}
+
+// WeaponProperty represents weapon properties in D&D 5e
+type WeaponProperty string
+
+// Weapon property constants
+const (
+	WeaponAmmunition WeaponProperty = "ammunition"
+	WeaponFinesse    WeaponProperty = "finesse"
+	WeaponHeavy      WeaponProperty = "heavy"
+	WeaponLight      WeaponProperty = "light"
+	WeaponLoading    WeaponProperty = "loading"
+	WeaponRange      WeaponProperty = "range"
+	WeaponReach      WeaponProperty = "reach"
+	WeaponSpecial    WeaponProperty = "special"
+	WeaponThrown     WeaponProperty = "thrown"
+	WeaponTwoHanded  WeaponProperty = "two-handed"
+	WeaponVersatile  WeaponProperty = "versatile"
+)
+
+// Display returns the human-readable name of the weapon property
+func (w WeaponProperty) Display() string {
+	switch w {
+	case WeaponAmmunition:
+		return "Ammunition"
+	case WeaponFinesse:
+		return "Finesse"
+	case WeaponHeavy:
+		return "Heavy"
+	case WeaponLight:
+		return "Light"
+	case WeaponLoading:
+		return "Loading"
+	case WeaponRange:
+		return "Range"
+	case WeaponReach:
+		return "Reach"
+	case WeaponSpecial:
+		return "Special"
+	case WeaponThrown:
+		return "Thrown"
+	case WeaponTwoHanded:
+		return "Two-Handed"
+	case WeaponVersatile:
+		return "Versatile"
+	default:
+		return string(w)
+	}
+}

--- a/rulebooks/dnd5e/constants/doc.go
+++ b/rulebooks/dnd5e/constants/doc.go
@@ -1,0 +1,25 @@
+// Package constants provides type-safe constants for D&D 5e game elements.
+//
+// Purpose:
+// This package serves as the single source of truth for all D&D 5e constants
+// used throughout the rpg-toolkit and any consuming applications like rpg-api.
+// It provides both programmatic values and human-readable display names.
+//
+// Design:
+// Each constant type is a string-based type with associated methods:
+//   - Display() returns the human-readable form
+//   - Additional helper methods provide game-specific relationships
+//
+// The constants use lowercase values for consistency and readability,
+// while Display() methods provide properly formatted names for UI display.
+//
+// Example:
+//
+//	ability := constants.STR
+//	fmt.Println(ability)          // "str"
+//	fmt.Println(ability.Display()) // "Strength"
+//
+//	language := constants.LanguageElvish
+//	fmt.Println(language)          // "elvish"
+//	fmt.Println(language.Display()) // "Elvish"
+package constants

--- a/rulebooks/dnd5e/constants/languages.go
+++ b/rulebooks/dnd5e/constants/languages.go
@@ -62,8 +62,10 @@ func (l Language) Display() string {
 		return "Undercommon"
 	default:
 		// Capitalize first letter as fallback
-		if len(l) > 0 {
+		if len(l) > 1 {
 			return strings.ToUpper(string(l[0])) + string(l[1:])
+		} else if len(l) == 1 {
+			return strings.ToUpper(string(l))
 		}
 		return string(l)
 	}

--- a/rulebooks/dnd5e/constants/languages.go
+++ b/rulebooks/dnd5e/constants/languages.go
@@ -1,0 +1,109 @@
+package constants
+
+import "strings"
+
+// Language represents a D&D 5e language
+type Language string
+
+// Standard language constants
+const (
+	LanguageCommon      Language = "common"
+	LanguageDwarvish    Language = "dwarvish"
+	LanguageElvish      Language = "elvish"
+	LanguageGiant       Language = "giant"
+	LanguageGnomish     Language = "gnomish"
+	LanguageGoblin      Language = "goblin"
+	LanguageHalfling    Language = "halfling"
+	LanguageOrc         Language = "orc"
+	LanguageAbyssal     Language = "abyssal"
+	LanguageCelestial   Language = "celestial"
+	LanguageDraconic    Language = "draconic"
+	LanguageDeepSpeech  Language = "deep speech"
+	LanguageInfernal    Language = "infernal"
+	LanguagePrimordial  Language = "primordial"
+	LanguageSylvan      Language = "sylvan"
+	LanguageUndercommon Language = "undercommon"
+)
+
+// Display returns the human-readable name of the language
+func (l Language) Display() string {
+	switch l {
+	case LanguageCommon:
+		return "Common"
+	case LanguageDwarvish:
+		return "Dwarvish"
+	case LanguageElvish:
+		return "Elvish"
+	case LanguageGiant:
+		return "Giant"
+	case LanguageGnomish:
+		return "Gnomish"
+	case LanguageGoblin:
+		return "Goblin"
+	case LanguageHalfling:
+		return "Halfling"
+	case LanguageOrc:
+		return "Orc"
+	case LanguageAbyssal:
+		return "Abyssal"
+	case LanguageCelestial:
+		return "Celestial"
+	case LanguageDraconic:
+		return "Draconic"
+	case LanguageDeepSpeech:
+		return "Deep Speech"
+	case LanguageInfernal:
+		return "Infernal"
+	case LanguagePrimordial:
+		return "Primordial"
+	case LanguageSylvan:
+		return "Sylvan"
+	case LanguageUndercommon:
+		return "Undercommon"
+	default:
+		// Capitalize first letter as fallback
+		if len(l) > 0 {
+			return strings.ToUpper(string(l[0])) + string(l[1:])
+		}
+		return string(l)
+	}
+}
+
+// IsStandard returns true if this is a standard language (vs exotic)
+func (l Language) IsStandard() bool {
+	switch l {
+	case LanguageCommon, LanguageDwarvish, LanguageElvish, LanguageGiant,
+		LanguageGnomish, LanguageGoblin, LanguageHalfling, LanguageOrc:
+		return true
+	default:
+		return false
+	}
+}
+
+// StandardLanguages returns all standard languages
+func StandardLanguages() []Language {
+	return []Language{
+		LanguageCommon,
+		LanguageDwarvish,
+		LanguageElvish,
+		LanguageGiant,
+		LanguageGnomish,
+		LanguageGoblin,
+		LanguageHalfling,
+		LanguageOrc,
+	}
+}
+
+// ExoticLanguages returns all exotic languages
+func ExoticLanguages() []Language {
+	return []Language{
+		LanguageAbyssal,
+		LanguageCelestial,
+		LanguageDraconic,
+		LanguageDeepSpeech,
+		LanguageInfernal,
+		LanguagePrimordial,
+		LanguageSylvan,
+		LanguageUndercommon,
+	}
+}

--- a/rulebooks/dnd5e/constants/languages_test.go
+++ b/rulebooks/dnd5e/constants/languages_test.go
@@ -1,0 +1,94 @@
+package constants_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
+)
+
+type LanguagesTestSuite struct {
+	suite.Suite
+}
+
+func (s *LanguagesTestSuite) TestLanguageConstants() {
+	tests := []struct {
+		name     string
+		language constants.Language
+		expected string
+		display  string
+		standard bool
+	}{
+		{
+			name:     "common language",
+			language: constants.LanguageCommon,
+			expected: "common",
+			display:  "Common",
+			standard: true,
+		},
+		{
+			name:     "elvish language",
+			language: constants.LanguageElvish,
+			expected: "elvish",
+			display:  "Elvish",
+			standard: true,
+		},
+		{
+			name:     "draconic language",
+			language: constants.LanguageDraconic,
+			expected: "draconic",
+			display:  "Draconic",
+			standard: false,
+		},
+		{
+			name:     "deep speech language",
+			language: constants.LanguageDeepSpeech,
+			expected: "deep speech",
+			display:  "Deep Speech",
+			standard: false,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.Equal(tc.expected, string(tc.language))
+			s.Equal(tc.display, tc.language.Display())
+			s.Equal(tc.standard, tc.language.IsStandard())
+		})
+	}
+}
+
+func (s *LanguagesTestSuite) TestLanguageDisplay_UnknownLanguage() {
+	unknown := constants.Language("unknown")
+	s.Equal("Unknown", unknown.Display()) // Should capitalize first letter
+}
+
+func (s *LanguagesTestSuite) TestLanguageDisplay_EmptyLanguage() {
+	empty := constants.Language("")
+	s.Equal("", empty.Display())
+}
+
+func (s *LanguagesTestSuite) TestStandardLanguages() {
+	languages := constants.StandardLanguages()
+	s.Len(languages, 8)
+
+	// Verify all are standard
+	for _, lang := range languages {
+		s.True(lang.IsStandard())
+	}
+}
+
+func (s *LanguagesTestSuite) TestExoticLanguages() {
+	languages := constants.ExoticLanguages()
+	s.Len(languages, 8)
+
+	// Verify none are standard
+	for _, lang := range languages {
+		s.False(lang.IsStandard())
+	}
+}
+
+func TestLanguagesTestSuite(t *testing.T) {
+	suite.Run(t, new(LanguagesTestSuite))
+}

--- a/rulebooks/dnd5e/constants/languages_test.go
+++ b/rulebooks/dnd5e/constants/languages_test.go
@@ -69,6 +69,16 @@ func (s *LanguagesTestSuite) TestLanguageDisplay_EmptyLanguage() {
 	s.Equal("", empty.Display())
 }
 
+func (s *LanguagesTestSuite) TestLanguageDisplay_SingleCharacterLanguage() {
+	// Test the edge case that Copilot identified
+	single := constants.Language("x")
+	s.Equal("X", single.Display()) // Should uppercase single character without panic
+
+	// Test another single character
+	single2 := constants.Language("a")
+	s.Equal("A", single2.Display())
+}
+
 func (s *LanguagesTestSuite) TestStandardLanguages() {
 	languages := constants.StandardLanguages()
 	s.Len(languages, 8)

--- a/rulebooks/dnd5e/constants/races.go
+++ b/rulebooks/dnd5e/constants/races.go
@@ -1,0 +1,118 @@
+package constants
+
+// Race represents a D&D 5e race
+type Race string
+
+// Race constants
+const (
+	RaceHuman      Race = "human"
+	RaceDwarf      Race = "dwarf"
+	RaceElf        Race = "elf"
+	RaceHalfling   Race = "halfling"
+	RaceDragonborn Race = "dragonborn"
+	RaceGnome      Race = "gnome"
+	RaceHalfElf    Race = "half-elf"
+	RaceHalfOrc    Race = "half-orc"
+	RaceTiefling   Race = "tiefling"
+)
+
+// Display returns the human-readable name of the race
+func (r Race) Display() string {
+	switch r {
+	case RaceHuman:
+		return "Human"
+	case RaceDwarf:
+		return "Dwarf"
+	case RaceElf:
+		return "Elf"
+	case RaceHalfling:
+		return "Halfling"
+	case RaceDragonborn:
+		return "Dragonborn"
+	case RaceGnome:
+		return "Gnome"
+	case RaceHalfElf:
+		return "Half-Elf"
+	case RaceHalfOrc:
+		return "Half-Orc"
+	case RaceTiefling:
+		return "Tiefling"
+	default:
+		return string(r)
+	}
+}
+
+// Subrace represents a D&D 5e subrace
+type Subrace string
+
+// Subrace constants
+const (
+	SubraceHighElf           Subrace = "high-elf"
+	SubraceWoodElf           Subrace = "wood-elf"
+	SubraceDarkElf           Subrace = "dark-elf"
+	SubraceHillDwarf         Subrace = "hill-dwarf"
+	SubraceMountainDwarf     Subrace = "mountain-dwarf"
+	SubraceLightfootHalfling Subrace = "lightfoot-halfling"
+	SubraceStoutHalfling     Subrace = "stout-halfling"
+	SubraceForestGnome       Subrace = "forest-gnome"
+	SubraceRockGnome         Subrace = "rock-gnome"
+)
+
+// Display returns the human-readable name of the subrace
+func (s Subrace) Display() string {
+	switch s {
+	case SubraceHighElf:
+		return "High Elf"
+	case SubraceWoodElf:
+		return "Wood Elf"
+	case SubraceDarkElf:
+		return "Dark Elf (Drow)"
+	case SubraceHillDwarf:
+		return "Hill Dwarf"
+	case SubraceMountainDwarf:
+		return "Mountain Dwarf"
+	case SubraceLightfootHalfling:
+		return "Lightfoot Halfling"
+	case SubraceStoutHalfling:
+		return "Stout Halfling"
+	case SubraceForestGnome:
+		return "Forest Gnome"
+	case SubraceRockGnome:
+		return "Rock Gnome"
+	default:
+		return string(s)
+	}
+}
+
+// Size represents creature size categories
+type Size string
+
+// Size constants
+const (
+	SizeTiny       Size = "tiny"
+	SizeSmall      Size = "small"
+	SizeMedium     Size = "medium"
+	SizeLarge      Size = "large"
+	SizeHuge       Size = "huge"
+	SizeGargantuan Size = "gargantuan"
+)
+
+// Display returns the human-readable name of the size
+func (s Size) Display() string {
+	switch s {
+	case SizeTiny:
+		return "Tiny"
+	case SizeSmall:
+		return "Small"
+	case SizeMedium:
+		return "Medium"
+	case SizeLarge:
+		return "Large"
+	case SizeHuge:
+		return "Huge"
+	case SizeGargantuan:
+		return "Gargantuan"
+	default:
+		return string(s)
+	}
+}

--- a/rulebooks/dnd5e/constants/skills.go
+++ b/rulebooks/dnd5e/constants/skills.go
@@ -1,0 +1,112 @@
+package constants
+
+// Skill represents a D&D 5e skill
+type Skill string
+
+// Skill constants
+const (
+	SkillAcrobatics     Skill = "acrobatics"
+	SkillAnimalHandling Skill = "animal-handling"
+	SkillArcana         Skill = "arcana"
+	SkillAthletics      Skill = "athletics"
+	SkillDeception      Skill = "deception"
+	SkillHistory        Skill = "history"
+	SkillInsight        Skill = "insight"
+	SkillIntimidation   Skill = "intimidation"
+	SkillInvestigation  Skill = "investigation"
+	SkillMedicine       Skill = "medicine"
+	SkillNature         Skill = "nature"
+	SkillPerception     Skill = "perception"
+	SkillPerformance    Skill = "performance"
+	SkillPersuasion     Skill = "persuasion"
+	SkillReligion       Skill = "religion"
+	SkillSleightOfHand  Skill = "sleight-of-hand"
+	SkillStealth        Skill = "stealth"
+	SkillSurvival       Skill = "survival"
+)
+
+// Display returns the human-readable name of the skill
+func (s Skill) Display() string {
+	switch s {
+	case SkillAcrobatics:
+		return "Acrobatics"
+	case SkillAnimalHandling:
+		return "Animal Handling"
+	case SkillArcana:
+		return "Arcana"
+	case SkillAthletics:
+		return "Athletics"
+	case SkillDeception:
+		return "Deception"
+	case SkillHistory:
+		return "History"
+	case SkillInsight:
+		return "Insight"
+	case SkillIntimidation:
+		return "Intimidation"
+	case SkillInvestigation:
+		return "Investigation"
+	case SkillMedicine:
+		return "Medicine"
+	case SkillNature:
+		return "Nature"
+	case SkillPerception:
+		return "Perception"
+	case SkillPerformance:
+		return "Performance"
+	case SkillPersuasion:
+		return "Persuasion"
+	case SkillReligion:
+		return "Religion"
+	case SkillSleightOfHand:
+		return "Sleight of Hand"
+	case SkillStealth:
+		return "Stealth"
+	case SkillSurvival:
+		return "Survival"
+	default:
+		return string(s)
+	}
+}
+
+// Ability returns the ability score this skill is based on
+func (s Skill) Ability() Ability {
+	switch s {
+	case SkillAthletics:
+		return STR
+	case SkillAcrobatics, SkillSleightOfHand, SkillStealth:
+		return DEX
+	case SkillArcana, SkillHistory, SkillInvestigation, SkillNature, SkillReligion:
+		return INT
+	case SkillAnimalHandling, SkillInsight, SkillMedicine, SkillPerception, SkillSurvival:
+		return WIS
+	case SkillDeception, SkillIntimidation, SkillPerformance, SkillPersuasion:
+		return CHA
+	default:
+		return ""
+	}
+}
+
+// AllSkills returns all skills in alphabetical order
+func AllSkills() []Skill {
+	return []Skill{
+		SkillAcrobatics,
+		SkillAnimalHandling,
+		SkillArcana,
+		SkillAthletics,
+		SkillDeception,
+		SkillHistory,
+		SkillInsight,
+		SkillIntimidation,
+		SkillInvestigation,
+		SkillMedicine,
+		SkillNature,
+		SkillPerception,
+		SkillPerformance,
+		SkillPersuasion,
+		SkillReligion,
+		SkillSleightOfHand,
+		SkillStealth,
+		SkillSurvival,
+	}
+}

--- a/rulebooks/dnd5e/constants/skills_test.go
+++ b/rulebooks/dnd5e/constants/skills_test.go
@@ -1,0 +1,114 @@
+package constants_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
+)
+
+type SkillsTestSuite struct {
+	suite.Suite
+}
+
+func (s *SkillsTestSuite) TestSkillConstants() {
+	tests := []struct {
+		name     string
+		skill    constants.Skill
+		expected string
+		display  string
+		ability  constants.Ability
+	}{
+		{
+			name:     "athletics skill",
+			skill:    constants.SkillAthletics,
+			expected: "athletics",
+			display:  "Athletics",
+			ability:  constants.STR,
+		},
+		{
+			name:     "acrobatics skill",
+			skill:    constants.SkillAcrobatics,
+			expected: "acrobatics",
+			display:  "Acrobatics",
+			ability:  constants.DEX,
+		},
+		{
+			name:     "arcana skill",
+			skill:    constants.SkillArcana,
+			expected: "arcana",
+			display:  "Arcana",
+			ability:  constants.INT,
+		},
+		{
+			name:     "insight skill",
+			skill:    constants.SkillInsight,
+			expected: "insight",
+			display:  "Insight",
+			ability:  constants.WIS,
+		},
+		{
+			name:     "persuasion skill",
+			skill:    constants.SkillPersuasion,
+			expected: "persuasion",
+			display:  "Persuasion",
+			ability:  constants.CHA,
+		},
+		{
+			name:     "sleight of hand skill",
+			skill:    constants.SkillSleightOfHand,
+			expected: "sleight-of-hand",
+			display:  "Sleight of Hand",
+			ability:  constants.DEX,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.Equal(tc.expected, string(tc.skill))
+			s.Equal(tc.display, tc.skill.Display())
+			s.Equal(tc.ability, tc.skill.Ability())
+		})
+	}
+}
+
+func (s *SkillsTestSuite) TestSkillDisplay_UnknownSkill() {
+	unknown := constants.Skill("unknown")
+	s.Equal("unknown", unknown.Display())
+	s.Equal(constants.Ability(""), unknown.Ability())
+}
+
+func (s *SkillsTestSuite) TestAllSkills() {
+	skills := constants.AllSkills()
+	s.Len(skills, 18) // D&D 5e has 18 skills
+
+	// Verify no duplicates
+	seen := make(map[constants.Skill]bool)
+	for _, skill := range skills {
+		s.False(seen[skill], "Duplicate skill found: %s", skill)
+		seen[skill] = true
+	}
+}
+
+func (s *SkillsTestSuite) TestSkillAbilityMapping() {
+	// Test that all skills map to valid abilities
+	skills := constants.AllSkills()
+	validAbilities := map[constants.Ability]bool{
+		constants.STR: true,
+		constants.DEX: true,
+		constants.CON: true,
+		constants.INT: true,
+		constants.WIS: true,
+		constants.CHA: true,
+	}
+
+	for _, skill := range skills {
+		ability := skill.Ability()
+		s.True(validAbilities[ability], "Skill %s maps to invalid ability %s", skill, ability)
+	}
+}
+
+func TestSkillsTestSuite(t *testing.T) {
+	suite.Run(t, new(SkillsTestSuite))
+}

--- a/rulebooks/dnd5e/example/cli.go
+++ b/rulebooks/dnd5e/example/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/effects"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
@@ -176,12 +177,12 @@ func (c *CLI) createCharacterWizard() {
 		ClassData:      classData,
 		BackgroundData: backgroundData,
 		AbilityScores: shared.AbilityScores{
-			Strength:     str,
-			Dexterity:    dex,
-			Constitution: con,
-			Intelligence: intl,
-			Wisdom:       wis,
-			Charisma:     cha,
+			constants.STR: str,
+			constants.DEX: dex,
+			constants.CON: con,
+			constants.INT: intl,
+			constants.WIS: wis,
+			constants.CHA: cha,
 		},
 		Choices: choices,
 	})
@@ -340,8 +341,8 @@ func (c *CLI) demonstrateBuilder() {
 
 	fmt.Println("\nStep 5: Setting ability scores...")
 	if err := builder.SetAbilityScores(shared.AbilityScores{
-		Strength: 16, Dexterity: 13, Constitution: 14,
-		Intelligence: 10, Wisdom: 12, Charisma: 11,
+		constants.STR: 16, constants.DEX: 13, constants.CON: 14,
+		constants.INT: 10, constants.WIS: 12, constants.CHA: 11,
 	}); err != nil {
 		fmt.Printf("Failed to set ability scores: %v\n", err)
 		return
@@ -441,8 +442,8 @@ func getElfRaceData() *race.Data {
 		Size:        "medium",
 		Speed:       30,
 		AbilityScoreIncreases: map[string]int{
-			shared.AbilityDexterity:    2,
-			shared.AbilityIntelligence: 1,
+			string(constants.DEX): 2,
+			string(constants.INT): 1,
 		},
 		Languages: []string{"common", "elvish"},
 		Traits: []race.TraitData{
@@ -468,7 +469,7 @@ func getDwarfRaceData() *race.Data {
 		Size:        "medium",
 		Speed:       25,
 		AbilityScoreIncreases: map[string]int{
-			shared.AbilityConstitution: 2,
+			string(constants.CON): 2,
 		},
 		Languages: []string{"common", "dwarvish"},
 		Traits: []race.TraitData{
@@ -499,11 +500,11 @@ func getWizardClassData() *class.Data {
 			"arcana", "history", "insight", "investigation",
 			"medicine", "religion",
 		},
-		SavingThrows:        []string{shared.AbilityIntelligence, shared.AbilityWisdom},
+		SavingThrows:        []string{string(constants.INT), string(constants.WIS)},
 		ArmorProficiencies:  []string{},
 		WeaponProficiencies: []string{"daggers", "darts", "slings", "quarterstaffs", "light_crossbows"},
 		Spellcasting: &class.SpellcastingData{
-			Ability: shared.AbilityIntelligence,
+			Ability: string(constants.INT),
 			CantripsKnown: map[int]int{
 				1: 3, 2: 3, 3: 3, 4: 4, 5: 4, 6: 4, 7: 4, 8: 4, 9: 4, 10: 5,
 				11: 5, 12: 5, 13: 5, 14: 5, 15: 5, 16: 5, 17: 5, 18: 5, 19: 5, 20: 5,
@@ -527,7 +528,7 @@ func getRogueClassData() *class.Data {
 			"investigation", "perception", "performance", "persuasion",
 			"sleight_of_hand", "stealth",
 		},
-		SavingThrows:        []string{shared.AbilityDexterity, shared.AbilityIntelligence},
+		SavingThrows:        []string{string(constants.DEX), string(constants.INT)},
 		ArmorProficiencies:  []string{"light"},
 		WeaponProficiencies: []string{"simple", "hand_crossbows", "longswords", "rapiers", "shortswords"},
 		Features: map[int][]class.FeatureData{

--- a/rulebooks/dnd5e/example/main.go
+++ b/rulebooks/dnd5e/example/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/class"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/effects"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/race"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
@@ -68,12 +69,12 @@ func createCharacter(raceData *race.Data, classData *class.Data,
 		ClassData:      classData,
 		BackgroundData: backgroundData,
 		AbilityScores: shared.AbilityScores{
-			Strength:     15,
-			Dexterity:    14,
-			Constitution: 13,
-			Intelligence: 12,
-			Wisdom:       10,
-			Charisma:     8,
+			constants.STR: 15,
+			constants.DEX: 14,
+			constants.CON: 13,
+			constants.INT: 12,
+			constants.WIS: 10,
+			constants.CHA: 8,
 		},
 		Choices: map[string]any{
 			"skills":   []string{"athletics", "intimidation"},
@@ -94,12 +95,12 @@ func displayCharacter(char *character.Character) {
 	fmt.Printf("HP: %d/%d\n", data.HitPoints, data.MaxHitPoints)
 	fmt.Printf("AC: %d\n", char.AC())
 	fmt.Printf("Ability Scores: STR %d, DEX %d, CON %d, INT %d, WIS %d, CHA %d\n",
-		data.AbilityScores.Strength,
-		data.AbilityScores.Dexterity,
-		data.AbilityScores.Constitution,
-		data.AbilityScores.Intelligence,
-		data.AbilityScores.Wisdom,
-		data.AbilityScores.Charisma)
+		data.AbilityScores[constants.STR],
+		data.AbilityScores[constants.DEX],
+		data.AbilityScores[constants.CON],
+		data.AbilityScores[constants.INT],
+		data.AbilityScores[constants.WIS],
+		data.AbilityScores[constants.CHA])
 
 	if len(data.Conditions) > 0 {
 		fmt.Print("Conditions: ")
@@ -274,8 +275,8 @@ func demonstrateBuilder(raceData *race.Data, classData *class.Data, backgroundDa
 
 	// Step 5: Ability Scores
 	if err := builder.SetAbilityScores(shared.AbilityScores{
-		Strength: 16, Dexterity: 13, Constitution: 14,
-		Intelligence: 10, Wisdom: 12, Charisma: 11,
+		constants.STR: 16, constants.DEX: 13, constants.CON: 14,
+		constants.INT: 10, constants.WIS: 12, constants.CHA: 11,
 	}); err != nil {
 		log.Fatal("Failed to set ability scores:", err)
 	}
@@ -317,12 +318,12 @@ func getHumanRaceData() *race.Data {
 		Size:        "medium",
 		Speed:       30,
 		AbilityScoreIncreases: map[string]int{
-			shared.AbilityStrength:     1,
-			shared.AbilityDexterity:    1,
-			shared.AbilityConstitution: 1,
-			shared.AbilityIntelligence: 1,
-			shared.AbilityWisdom:       1,
-			shared.AbilityCharisma:     1,
+			string(constants.STR): 1,
+			string(constants.DEX): 1,
+			string(constants.CON): 1,
+			string(constants.INT): 1,
+			string(constants.WIS): 1,
+			string(constants.CHA): 1,
 		},
 		Languages: []string{"common"},
 		LanguageChoice: &race.ChoiceData{
@@ -347,7 +348,7 @@ func getFighterClassData() *class.Data {
 			"acrobatics", "animal_handling", "athletics", "history",
 			"insight", "intimidation", "perception", "survival",
 		},
-		SavingThrows:        []string{shared.AbilityStrength, shared.AbilityConstitution},
+		SavingThrows:        []string{string(constants.STR), string(constants.CON)},
 		ArmorProficiencies:  []string{"light", "medium", "heavy", "shields"},
 		WeaponProficiencies: []string{"simple", "martial"},
 		Features: map[int][]class.FeatureData{

--- a/rulebooks/dnd5e/shared/constants.go
+++ b/rulebooks/dnd5e/shared/constants.go
@@ -1,6 +1,9 @@
 package shared
 
-// Ability score names as constants to avoid magic strings
+import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
+
+// Re-export ability constants for backward compatibility
+// These map to the lowercase values for compatibility with existing code
 const (
 	AbilityStrength     = "strength"
 	AbilityDexterity    = "dexterity"
@@ -9,3 +12,23 @@ const (
 	AbilityWisdom       = "wisdom"
 	AbilityCharisma     = "charisma"
 )
+
+// AbilityToConstant converts legacy ability strings to typed constants
+func AbilityToConstant(ability string) constants.Ability {
+	switch ability {
+	case AbilityStrength, "str":
+		return constants.STR
+	case AbilityDexterity, "dex":
+		return constants.DEX
+	case AbilityConstitution, "con":
+		return constants.CON
+	case AbilityIntelligence, "int":
+		return constants.INT
+	case AbilityWisdom, "wis":
+		return constants.WIS
+	case AbilityCharisma, "cha":
+		return constants.CHA
+	default:
+		return constants.Ability(ability)
+	}
+}

--- a/rulebooks/dnd5e/shared/constants.go
+++ b/rulebooks/dnd5e/shared/constants.go
@@ -2,33 +2,13 @@ package shared
 
 import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/constants"
 
-// Re-export ability constants for backward compatibility
-// These map to the lowercase values for compatibility with existing code
+// Re-export ability constants from the constants package
+// These now use the new short format (str, dex, etc.)
 const (
-	AbilityStrength     = "strength"
-	AbilityDexterity    = "dexterity"
-	AbilityConstitution = "constitution"
-	AbilityIntelligence = "intelligence"
-	AbilityWisdom       = "wisdom"
-	AbilityCharisma     = "charisma"
+	AbilityStrength     = string(constants.STR) // "str"
+	AbilityDexterity    = string(constants.DEX) // "dex"
+	AbilityConstitution = string(constants.CON) // "con"
+	AbilityIntelligence = string(constants.INT) // "int"
+	AbilityWisdom       = string(constants.WIS) // "wis"
+	AbilityCharisma     = string(constants.CHA) // "cha"
 )
-
-// AbilityToConstant converts legacy ability strings to typed constants
-func AbilityToConstant(ability string) constants.Ability {
-	switch ability {
-	case AbilityStrength, "str":
-		return constants.STR
-	case AbilityDexterity, "dex":
-		return constants.DEX
-	case AbilityConstitution, "con":
-		return constants.CON
-	case AbilityIntelligence, "int":
-		return constants.INT
-	case AbilityWisdom, "wis":
-		return constants.WIS
-	case AbilityCharisma, "cha":
-		return constants.CHA
-	default:
-		return constants.Ability(ability)
-	}
-}


### PR DESCRIPTION
## Summary
This PR addresses issue #131 by standardizing constants between rpg-toolkit and rpg-api, making rpg-toolkit the single source of truth for all D&D 5e constants.

## Breaking Changes ⚠️
This is a major refactoring that changes the public API:
- `AbilityScores` changed from struct to `map[constants.Ability]int`
- All ability score access must now use constants (e.g., `scores[constants.STR]` instead of `scores.Strength`)
- New constructor with validation required: `NewAbilityScores(&AbilityScoreConfig{...})`

## Changes
### Constants Package
- Created comprehensive constants package with all D&D 5e constants
- Added typed constants for abilities, languages, races, classes, skills, damage types, conditions, and more
- Each constant type has a `Display()` method for human-readable names

### AbilityScores Refactoring
- Changed from struct to `map[constants.Ability]int` for type safety
- Added constructor with validation (enforces 3-18 range)
- Added methods:
  - `Modifier(ability)` - Calculate ability modifier
  - `ApplyIncreases(increases)` - Apply racial/other bonuses
  - `Increase(ability, amount)` - Increase single ability (max 20)

### Migration Guide
```go
// Before
scores := shared.AbilityScores{
    Strength: 15,
    Dexterity: 14,
}
modifier := shared.CalculateModifier(scores.Strength)

// After
scores := shared.AbilityScores{
    constants.STR: 15,
    constants.DEX: 14,
}
modifier := scores.Modifier(constants.STR)
```

## Test Plan
- [x] All existing tests pass with new constants
- [x] New tests for AbilityScores validation
- [x] Linter passes
- [x] Example code updated and working

## Notes
- No backward compatibility maintained per user request (project is in alpha)
- This establishes rpg-toolkit as the canonical source for D&D 5e constants
- rpg-api should import and use these constants going forward

Resolves #131

🤖 Generated with [Claude Code](https://claude.ai/code)