### PR TITLE
feat: Implement D&D 5e combat initiative system

### DIFF
--- a/rulebooks/dnd5e/combat/README.md
+++ b/rulebooks/dnd5e/combat/README.md
@@ -1,0 +1,222 @@
+# D&D 5e Combat Initiative System
+
+This package implements the D&D 5e initiative system following the RPG Toolkit's established patterns for rich domain objects, event-driven architecture, and persistence.
+
+## Overview
+
+The combat system provides:
+
+- **Initiative Rolling**: Roll 1d20 + DEX modifier for each combatant
+- **Turn Order Management**: Sort combatants by initiative (highest first)
+- **Tie Breaking**: Handle ties using DEX scores, DM decisions, or re-rolls
+- **Round Tracking**: Manage combat rounds and turn progression
+- **Event Integration**: Emit events for all combat state changes
+- **Persistence**: Save/load combat state using the GameContext pattern
+
+## Architecture
+
+The implementation follows the toolkit's domain-rich pattern:
+
+```
+CombatState (Rich Domain Object)
+├── Initiative Rolling & Management
+├── Turn Progression Logic
+├── Event Emission
+└── ToData() for Persistence
+
+CombatStateData (Data Object)
+├── All state for persistence
+├── JSON serializable
+└── LoadCombatStateFromContext()
+
+Event System Integration
+├── Combat lifecycle events
+├── Initiative events
+└── Turn/round events
+```
+
+## Core Components
+
+### CombatState
+
+Rich domain object that manages combat state with methods for:
+- Adding/removing combatants
+- Rolling initiative with multiple modes
+- Resolving ties
+- Starting combat and managing turns
+- Converting to/from persistent data
+
+### CombatStateData
+
+Data structure containing all information needed to persist and reconstruct combat:
+- Combat metadata (ID, name, status)
+- Round and turn tracking
+- Initiative order with full details
+- Combatant data and statistics
+- Combat settings
+
+### Initiative System
+
+Comprehensive initiative handling with:
+- **Roll Mode**: Standard 1d20 + DEX modifier
+- **Static Mode**: Use 10 + DEX modifier (no randomness)
+- **Manual Mode**: DM sets initiative values directly
+
+### Tie Breaking
+
+Multiple tie resolution methods:
+- **Dexterity**: Higher DEX score wins (D&D 5e default)
+- **DM Decision**: Manual ordering by the DM
+- **Re-roll**: Roll another d20 to break ties
+
+## Usage Example
+
+```go
+// Create combat encounter
+combat := combat.NewCombatState(combat.CombatStateConfig{
+    ID:       "encounter-001",
+    Name:     "Goblin Ambush",
+    EventBus: eventBus,
+    Settings: combat.CombatSettings{
+        InitiativeRollMode: combat.InitiativeRollModeRoll,
+        TieBreakingMode:   combat.TieBreakingModeDexterity,
+    },
+})
+
+// Add combatants (must implement combat.Combatant interface)
+for _, combatant := range combatants {
+    err := combat.AddCombatant(combatant)
+    // handle error
+}
+
+// Roll initiative
+rollOutput, err := combat.RollInitiative(&combat.RollInitiativeInput{
+    Combatants: combatants,
+    RollMode:   combat.InitiativeRollModeRoll,
+})
+
+// Resolve any ties
+if len(rollOutput.UnresolvedTies) > 0 {
+    _, err = combat.ResolveTies(&combat.ResolveTiesInput{
+        TiedGroups:        rollOutput.UnresolvedTies,
+        InitiativeEntries: rollOutput.InitiativeEntries,
+        TieBreakingMode:   combat.TieBreakingModeDexterity,
+    })
+}
+
+// Start combat
+err = combat.StartCombat()
+
+// Progress through turns
+err = combat.NextTurn()
+```
+
+## Persistence
+
+The system supports full persistence using the GameContext pattern:
+
+```go
+// Save combat state
+data := combat.ToData()
+// ... save data to database/file
+
+// Load combat state
+gameCtx, err := game.NewContext(eventBus, data)
+loadedCombat, err := combat.LoadCombatStateFromContext(ctx, gameCtx)
+```
+
+## Events
+
+The system emits detailed events for all state changes:
+
+### Combat Lifecycle
+- `dnd5e.combat.started` - Combat begins
+- `dnd5e.combat.ended` - Combat concludes
+- `dnd5e.combat.paused/resumed` - Combat state changes
+
+### Initiative Events
+- `dnd5e.combat.initiative.rolled` - Individual initiative roll
+- `dnd5e.combat.initiative.order_set` - Initiative order established
+
+### Turn Events
+- `dnd5e.combat.turn.started` - Combatant's turn begins
+- `dnd5e.combat.turn.ended` - Combatant's turn ends
+- `dnd5e.combat.round.started` - New round begins
+- `dnd5e.combat.round.ended` - Round concludes
+
+### Combatant Events
+- `dnd5e.combat.combatant.added` - Combatant joins
+- `dnd5e.combat.combatant.removed` - Combatant leaves
+- `dnd5e.combat.combatant.updated` - Combatant state changes
+
+## Interfaces
+
+### Combatant Interface
+
+Entities participating in combat must implement:
+
+```go
+type Combatant interface {
+    core.Entity
+    
+    // Initiative calculation
+    GetDexterityModifier() int
+    GetDexterityScore() int
+    
+    // Combat stats
+    GetArmorClass() int
+    GetHitPoints() int
+    GetMaxHitPoints() int
+    
+    // Status checks
+    IsConscious() bool
+    IsDefeated() bool
+}
+```
+
+## Testing
+
+The package includes comprehensive tests using the testify suite pattern:
+
+- Initiative rolling with all modes
+- Tie resolution with all methods
+- Turn progression and round tracking
+- Event emission verification
+- Persistence round-trip testing
+- Edge case handling
+
+Run tests with:
+```bash
+go test -v
+```
+
+## Integration with RPG Toolkit
+
+This implementation follows all toolkit patterns:
+
+- **Rich Domain Objects**: CombatState has methods and behavior
+- **Data Separation**: CombatStateData for persistence only
+- **Event-Driven**: Full event bus integration
+- **GameContext Pattern**: Standard loading mechanism
+- **Input/Output Types**: All methods use structured parameters
+- **Thread Safety**: Proper mutex usage throughout
+
+## D&D 5e Compliance
+
+The implementation follows official D&D 5e rules:
+
+- Initiative: 1d20 + DEX modifier
+- Turn order: Highest initiative first
+- Tie breaking: DEX score comparison (PHB p. 189)
+- Round structure: All combatants act once per round
+- Combat phases: Roll initiative → Start combat → Turn progression
+
+## Future Extensions
+
+The architecture supports future enhancements:
+
+- Action economy tracking (action, bonus action, reaction)
+- Condition and effect management
+- Damage and healing integration
+- Advanced combat options (ready actions, delays)
+- Integration with spatial positioning system

--- a/rulebooks/dnd5e/combat/data.go
+++ b/rulebooks/dnd5e/combat/data.go
@@ -1,0 +1,337 @@
+package combat
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/game"
+)
+
+// CombatStateData contains all information needed to persist and reconstruct combat state.
+// This follows the established data pattern for serialization and loading.
+type CombatStateData struct {
+	// ID is the unique identifier for this combat encounter
+	ID string `json:"id"`
+
+	// Name is a human-readable name for this combat
+	Name string `json:"name,omitempty"`
+
+	// Status indicates the current state of combat
+	Status CombatStatus `json:"status"`
+
+	// Round tracks the current round number (1-based)
+	Round int `json:"round"`
+
+	// TurnIndex tracks whose turn it is (0-based index into InitiativeOrder)
+	TurnIndex int `json:"turn_index"`
+
+	// InitiativeOrder contains combatants ordered by initiative (highest first)
+	InitiativeOrder []InitiativeEntry `json:"initiative_order"`
+
+	// Combatants maps entity IDs to their combat data
+	Combatants map[string]CombatantData `json:"combatants"`
+
+	// Settings contains combat configuration
+	Settings CombatSettings `json:"settings"`
+
+	// CreatedAt timestamp when combat was created
+	CreatedAt int64 `json:"created_at"`
+
+	// StartedAt timestamp when combat actually began
+	StartedAt int64 `json:"started_at,omitempty"`
+
+	// EndedAt timestamp when combat ended
+	EndedAt int64 `json:"ended_at,omitempty"`
+}
+
+// CombatStatus represents the current state of combat
+type CombatStatus string
+
+const (
+	CombatStatusPending   CombatStatus = "pending"   // Created but not started
+	CombatStatusActive    CombatStatus = "active"    // Combat in progress
+	CombatStatusPaused    CombatStatus = "paused"    // Temporarily suspended
+	CombatStatusCompleted CombatStatus = "completed" // Finished normally
+	CombatStatusAbandoned CombatStatus = "abandoned" // Ended abnormally
+)
+
+// InitiativeEntry represents a single combatant's initiative data
+type InitiativeEntry struct {
+	// EntityID is the unique identifier of the combatant
+	EntityID string `json:"entity_id"`
+
+	// Roll is the d20 result (1-20)
+	Roll int `json:"roll"`
+
+	// Modifier is the initiative modifier (typically DEX modifier)
+	Modifier int `json:"modifier"`
+
+	// Total is the final initiative value (Roll + Modifier)
+	Total int `json:"total"`
+
+	// DexterityScore is used for tie-breaking
+	DexterityScore int `json:"dexterity_score"`
+
+	// TieBreaker is an additional value for resolving ties (DM input)
+	TieBreaker int `json:"tie_breaker,omitempty"`
+
+	// Active indicates if this combatant is still participating
+	Active bool `json:"active"`
+}
+
+// CombatantData contains combat-relevant data for a single combatant
+type CombatantData struct {
+	// EntityID references the combatant entity
+	EntityID string `json:"entity_id"`
+
+	// EntityType for quick identification
+	EntityType string `json:"entity_type"`
+
+	// Initiative information
+	Initiative InitiativeEntry `json:"initiative"`
+
+	// Combat stats (cached for performance)
+	HitPoints    int `json:"hit_points"`
+	MaxHitPoints int `json:"max_hit_points"`
+	ArmorClass   int `json:"armor_class"`
+
+	// Conditions and effects
+	Conditions []string `json:"conditions,omitempty"`
+	Effects    []string `json:"effects,omitempty"`
+
+	// Turn tracking
+	TurnsTaken     int          `json:"turns_taken"`
+	LastActionTurn int          `json:"last_action_turn,omitempty"`
+	ActionsUsed    []ActionType `json:"actions_used,omitempty"`
+
+	// Status flags
+	IsActive      bool `json:"is_active"`
+	IsUnconscious bool `json:"is_unconscious"`
+	IsDefeated    bool `json:"is_defeated"`
+	HasActed      bool `json:"has_acted"` // This round
+}
+
+// ActionType represents types of actions that can be taken
+type ActionType string
+
+const (
+	ActionTypeAction      ActionType = "action"
+	ActionTypeBonusAction ActionType = "bonus_action"
+	ActionTypeReaction    ActionType = "reaction"
+	ActionTypeMovement    ActionType = "movement"
+	ActionTypeFreeAction  ActionType = "free_action"
+)
+
+// CombatSettings contains configuration for combat behavior
+type CombatSettings struct {
+	// AutoAdvanceTurns automatically moves to next turn
+	AutoAdvanceTurns bool `json:"auto_advance_turns"`
+
+	// MaxRounds limits combat duration (0 = unlimited)
+	MaxRounds int `json:"max_rounds"`
+
+	// InitiativeRollMode controls how initiative is rolled
+	InitiativeRollMode InitiativeRollMode `json:"initiative_roll_mode"`
+
+	// TieBreakingMode controls how ties are resolved
+	TieBreakingMode TieBreakingMode `json:"tie_breaking_mode"`
+
+	// AllowDelayedEntry permits joining combat after it starts
+	AllowDelayedEntry bool `json:"allow_delayed_entry"`
+}
+
+// InitiativeRollMode controls how initiative is determined
+type InitiativeRollMode string
+
+const (
+	InitiativeRollModeRoll   InitiativeRollMode = "roll"   // Roll d20 + modifier
+	InitiativeRollModeStatic InitiativeRollMode = "static" // Use 10 + modifier
+	InitiativeRollModeManual InitiativeRollMode = "manual" // DM sets values
+)
+
+// TieBreakingMode controls how initiative ties are resolved
+type TieBreakingMode string
+
+const (
+	TieBreakingModeDexterity TieBreakingMode = "dexterity" // Higher DEX wins
+	TieBreakingModeDM        TieBreakingMode = "dm"        // DM decides
+	TieBreakingModeRoll      TieBreakingMode = "roll"      // Re-roll d20
+)
+
+// Combatant interface defines what entities need to participate in combat
+type Combatant interface {
+	core.Entity
+
+	// GetDexterityModifier returns the entity's DEX modifier for initiative
+	GetDexterityModifier() int
+
+	// GetDexterityScore returns the entity's DEX score for tie-breaking
+	GetDexterityScore() int
+
+	// GetArmorClass returns the entity's AC
+	GetArmorClass() int
+
+	// GetHitPoints returns current hit points
+	GetHitPoints() int
+
+	// GetMaxHitPoints returns maximum hit points
+	GetMaxHitPoints() int
+
+	// IsConscious returns true if the entity can act
+	IsConscious() bool
+
+	// IsDefeated returns true if the entity is out of combat
+	IsDefeated() bool
+}
+
+// RollInitiativeInput contains parameters for rolling initiative
+type RollInitiativeInput struct {
+	// Combatants to roll initiative for
+	Combatants []Combatant `json:"combatants"`
+
+	// Roller for random number generation
+	Roller dice.Roller `json:"-"`
+
+	// Settings for how to handle the roll
+	RollMode InitiativeRollMode `json:"roll_mode"`
+
+	// Manual values if using manual mode (EntityID -> InitiativeValue)
+	ManualValues map[string]int `json:"manual_values,omitempty"`
+}
+
+// RollInitiativeOutput contains the results of rolling initiative
+type RollInitiativeOutput struct {
+	// InitiativeEntries ordered by total (highest first)
+	InitiativeEntries []InitiativeEntry `json:"initiative_entries"`
+
+	// UnresolvedTies contains groups of tied combatants (if any)
+	UnresolvedTies [][]string `json:"unresolved_ties,omitempty"`
+
+	// RollResults contains individual roll details for transparency
+	RollResults map[string]InitiativeRollResult `json:"roll_results"`
+}
+
+// InitiativeRollResult contains detailed information about a single initiative roll
+type InitiativeRollResult struct {
+	EntityID       string `json:"entity_id"`
+	Roll           int    `json:"roll"`
+	Modifier       int    `json:"modifier"`
+	Total          int    `json:"total"`
+	DexterityScore int    `json:"dexterity_score"`
+	WasManual      bool   `json:"was_manual"`
+}
+
+// ResolveTiesInput contains parameters for resolving initiative ties
+type ResolveTiesInput struct {
+	// TiedGroups contains groups of tied combatants
+	TiedGroups [][]string `json:"tied_groups"`
+
+	// InitiativeEntries to modify
+	InitiativeEntries []InitiativeEntry `json:"initiative_entries"`
+
+	// TieBreakingMode determines resolution method
+	TieBreakingMode TieBreakingMode `json:"tie_breaking_mode"`
+
+	// ManualOrder if using DM resolution (EntityID -> Priority)
+	ManualOrder map[string]int `json:"manual_order,omitempty"`
+
+	// Roller for re-rolling if needed
+	Roller dice.Roller `json:"-"`
+}
+
+// ResolveTiesOutput contains the results of tie resolution
+type ResolveTiesOutput struct {
+	// ResolvedEntries with ties broken
+	ResolvedEntries []InitiativeEntry `json:"resolved_entries"`
+
+	// RemainingTies if some could not be resolved
+	RemainingTies [][]string `json:"remaining_ties,omitempty"`
+}
+
+// SortInitiativeEntries sorts initiative entries by total, then by DEX score, then by tie breaker
+func SortInitiativeEntries(entries []InitiativeEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		// Higher total initiative wins
+		if entries[i].Total != entries[j].Total {
+			return entries[i].Total > entries[j].Total
+		}
+
+		// If tied, higher DEX score wins
+		if entries[i].DexterityScore != entries[j].DexterityScore {
+			return entries[i].DexterityScore > entries[j].DexterityScore
+		}
+
+		// If still tied, higher tie breaker wins
+		return entries[i].TieBreaker > entries[j].TieBreaker
+	})
+}
+
+// FindTiedGroups identifies groups of combatants with identical initiative totals
+func FindTiedGroups(entries []InitiativeEntry) [][]string {
+	tiedGroups := make([][]string, 0)
+
+	i := 0
+	for i < len(entries) {
+		currentTotal := entries[i].Total
+		group := []string{entries[i].EntityID}
+
+		// Look for others with same total
+		j := i + 1
+		for j < len(entries) && entries[j].Total == currentTotal {
+			group = append(group, entries[j].EntityID)
+			j++
+		}
+
+		// Only add if there's actually a tie
+		if len(group) > 1 {
+			tiedGroups = append(tiedGroups, group)
+		}
+
+		i = j
+	}
+
+	return tiedGroups
+}
+
+// LoadCombatStateFromContext creates a CombatState from data using the GameContext pattern.
+// This allows combat to integrate with the event system and other game infrastructure.
+func LoadCombatStateFromContext(ctx context.Context, gameCtx game.Context[CombatStateData]) (*CombatState, error) {
+	data := gameCtx.Data()
+	eventBus := gameCtx.EventBus()
+
+	// Validate required data
+	if data.ID == "" {
+		return nil, fmt.Errorf("combat ID is required")
+	}
+
+	// Create the combat state
+	combat := NewCombatState(CombatStateConfig{
+		ID:       data.ID,
+		Name:     data.Name,
+		EventBus: eventBus,
+		Settings: data.Settings,
+	})
+
+	// Restore state
+	combat.status = data.Status
+	combat.round = data.Round
+	combat.turnIndex = data.TurnIndex
+	combat.initiativeOrder = make([]InitiativeEntry, len(data.InitiativeOrder))
+	copy(combat.initiativeOrder, data.InitiativeOrder)
+
+	// Restore combatants
+	for entityID, combatantData := range data.Combatants {
+		combat.combatants[entityID] = combatantData
+	}
+
+	// Restore timestamps
+	combat.createdAt = time.Unix(data.CreatedAt, 0)
+	combat.startedAt = time.Unix(data.StartedAt, 0)
+	combat.endedAt = time.Unix(data.EndedAt, 0)
+
+	return combat, nil
+}

--- a/rulebooks/dnd5e/combat/events.go
+++ b/rulebooks/dnd5e/combat/events.go
@@ -1,0 +1,118 @@
+// Package combat provides D&D 5e combat mechanics following the toolkit's domain patterns
+package combat
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// Combat event constants following the toolkit's dot notation pattern
+const (
+	// Combat lifecycle events
+	EventCombatStarted = "dnd5e.combat.started"
+	EventCombatEnded   = "dnd5e.combat.ended"
+	EventCombatPaused  = "dnd5e.combat.paused"
+	EventCombatResumed = "dnd5e.combat.resumed"
+
+	// Initiative events
+	EventInitiativeRolled = "dnd5e.combat.initiative.rolled"
+	EventInitiativeOrder  = "dnd5e.combat.initiative.order_set"
+
+	// Turn events
+	EventTurnStarted  = "dnd5e.combat.turn.started"
+	EventTurnEnded    = "dnd5e.combat.turn.ended"
+	EventRoundStarted = "dnd5e.combat.round.started"
+	EventRoundEnded   = "dnd5e.combat.round.ended"
+
+	// Combatant events
+	EventCombatantAdded   = "dnd5e.combat.combatant.added"
+	EventCombatantRemoved = "dnd5e.combat.combatant.removed"
+	EventCombatantUpdated = "dnd5e.combat.combatant.updated"
+)
+
+// CombatStartedData contains data for combat start events
+type CombatStartedData struct {
+	CombatID        string   `json:"combat_id"`
+	Combatants      []string `json:"combatants"`       // Entity IDs
+	InitiativeOrder []string `json:"initiative_order"` // Ordered by initiative
+}
+
+// CombatEndedData contains data for combat end events
+type CombatEndedData struct {
+	CombatID string `json:"combat_id"`
+	Winner   string `json:"winner,omitempty"` // Entity ID or faction
+	Duration int    `json:"duration"`         // Total rounds
+	Reason   string `json:"reason,omitempty"` // Why combat ended
+}
+
+// InitiativeRolledData contains data for initiative roll events
+type InitiativeRolledData struct {
+	CombatID string      `json:"combat_id"`
+	Entity   core.Entity `json:"entity"`
+	Roll     int         `json:"roll"`      // d20 roll
+	Modifier int         `json:"modifier"`  // DEX modifier
+	Total    int         `json:"total"`     // Roll + modifier
+	DexScore int         `json:"dex_score"` // For tie-breaking
+}
+
+// InitiativeOrderData contains data for initiative order events
+type InitiativeOrderData struct {
+	CombatID        string   `json:"combat_id"`
+	InitiativeOrder []string `json:"initiative_order"` // Entity IDs in turn order
+	TiesResolved    bool     `json:"ties_resolved"`
+}
+
+// TurnStartedData contains data for turn start events
+type TurnStartedData struct {
+	CombatID   string      `json:"combat_id"`
+	Entity     core.Entity `json:"entity"`
+	Round      int         `json:"round"`
+	TurnNumber int         `json:"turn_number"` // Turn within this round
+	Initiative int         `json:"initiative"`
+}
+
+// TurnEndedData contains data for turn end events
+type TurnEndedData struct {
+	CombatID    string      `json:"combat_id"`
+	Entity      core.Entity `json:"entity"`
+	Round       int         `json:"round"`
+	TurnNumber  int         `json:"turn_number"`
+	ActionsUsed []string    `json:"actions_used,omitempty"` // Action types used
+}
+
+// RoundStartedData contains data for round start events
+type RoundStartedData struct {
+	CombatID     string `json:"combat_id"`
+	Round        int    `json:"round"`
+	Participants int    `json:"participants"` // Number of active combatants
+}
+
+// RoundEndedData contains data for round end events
+type RoundEndedData struct {
+	CombatID     string `json:"combat_id"`
+	Round        int    `json:"round"`
+	ActionsTotal int    `json:"actions_total"` // Total actions taken this round
+}
+
+// CombatantAddedData contains data for combatant addition events
+type CombatantAddedData struct {
+	CombatID      string      `json:"combat_id"`
+	Entity        core.Entity `json:"entity"`
+	Initiative    int         `json:"initiative,omitempty"` // If joining mid-combat
+	JoinedAtRound int         `json:"joined_at_round"`
+}
+
+// CombatantRemovedData contains data for combatant removal events
+type CombatantRemovedData struct {
+	CombatID       string      `json:"combat_id"`
+	Entity         core.Entity `json:"entity"`
+	Reason         string      `json:"reason"` // "defeated", "fled", "dismissed"
+	RemovedAtRound int         `json:"removed_at_round"`
+}
+
+// CombatantUpdatedData contains data for combatant update events
+type CombatantUpdatedData struct {
+	CombatID   string      `json:"combat_id"`
+	Entity     core.Entity `json:"entity"`
+	Changes    []string    `json:"changes"`     // What was updated
+	UpdateType string      `json:"update_type"` // "stats", "conditions", "position"
+}

--- a/rulebooks/dnd5e/combat/example_test.go
+++ b/rulebooks/dnd5e/combat/example_test.go
@@ -1,0 +1,214 @@
+package combat_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/game"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// ExampleCharacter represents a D&D 5e character for combat
+type ExampleCharacter struct {
+	id       string
+	name     string
+	dexMod   int
+	dexScore int
+	ac       int
+	hp       int
+	maxHP    int
+}
+
+func (c *ExampleCharacter) GetID() string             { return c.id }
+func (c *ExampleCharacter) GetType() string           { return "character" }
+func (c *ExampleCharacter) GetDexterityModifier() int { return c.dexMod }
+func (c *ExampleCharacter) GetDexterityScore() int    { return c.dexScore }
+func (c *ExampleCharacter) GetArmorClass() int        { return c.ac }
+func (c *ExampleCharacter) GetHitPoints() int         { return c.hp }
+func (c *ExampleCharacter) GetMaxHitPoints() int      { return c.maxHP }
+func (c *ExampleCharacter) IsConscious() bool         { return c.hp > 0 }
+func (c *ExampleCharacter) IsDefeated() bool          { return c.hp <= 0 }
+
+// Example demonstrates the complete D&D 5e initiative system
+func ExampleCombatState() {
+	// Create event bus for combat events
+	eventBus := events.NewBus()
+
+	// Subscribe to combat events for logging
+	eventBus.SubscribeFunc(combat.EventCombatStarted, 100, func(_ context.Context, e events.Event) error {
+		fmt.Println("⚔️  Combat has begun!")
+		return nil
+	})
+
+	eventBus.SubscribeFunc(combat.EventInitiativeRolled, 100, func(_ context.Context, e events.Event) error {
+		if data, ok := e.Context().Get("data"); ok {
+			if initData, ok := data.(combat.InitiativeRolledData); ok {
+				fmt.Printf("🎲 %s rolled initiative: %d (d20: %d + mod: %d)\n",
+					initData.Entity.GetID(), initData.Total, initData.Roll, initData.Modifier)
+			}
+		}
+		return nil
+	})
+
+	eventBus.SubscribeFunc(combat.EventTurnStarted, 100, func(_ context.Context, e events.Event) error {
+		if data, ok := e.Context().Get("data"); ok {
+			if turnData, ok := data.(combat.TurnStartedData); ok {
+				fmt.Printf("👤 %s's turn (Round %d, Initiative: %d)\n",
+					turnData.Entity.GetID(), turnData.Round, turnData.Initiative)
+			}
+		}
+		return nil
+	})
+
+	// Create combat encounter
+	combatState := combat.NewCombatState(combat.CombatStateConfig{
+		ID:       "tavern-brawl-001",
+		Name:     "Tavern Brawl",
+		EventBus: eventBus,
+		Settings: combat.CombatSettings{
+			InitiativeRollMode: combat.InitiativeRollModeRoll,
+			TieBreakingMode:    combat.TieBreakingModeDexterity,
+		},
+		Roller: dice.DefaultRoller,
+	})
+
+	// Create party members
+	fighter := &ExampleCharacter{
+		id:       "korrath-fighter",
+		name:     "Korrath the Bold",
+		dexMod:   1,
+		dexScore: 13,
+		ac:       18,
+		hp:       58,
+		maxHP:    58,
+	}
+
+	rogue := &ExampleCharacter{
+		id:       "silara-rogue",
+		name:     "Silara Shadowstep",
+		dexMod:   4,
+		dexScore: 18,
+		ac:       15,
+		hp:       42,
+		maxHP:    42,
+	}
+
+	wizard := &ExampleCharacter{
+		id:       "eldrin-wizard",
+		name:     "Eldrin Starweaver",
+		dexMod:   2,
+		dexScore: 14,
+		ac:       12,
+		hp:       28,
+		maxHP:    28,
+	}
+
+	// Add combatants to the encounter
+	combatants := []combat.Combatant{fighter, rogue, wizard}
+	for _, combatant := range combatants {
+		if err := combatState.AddCombatant(combatant); err != nil {
+			log.Fatalf("Failed to add combatant: %v", err)
+		}
+	}
+
+	fmt.Println("🏰 Setting up Tavern Brawl encounter...")
+	fmt.Printf("   Combatants: %s, %s, %s\n\n",
+		fighter.name, rogue.name, wizard.name)
+
+	// Roll initiative
+	fmt.Println("🎲 Rolling initiative...")
+	rollInput := &combat.RollInitiativeInput{
+		Combatants: combatants,
+		RollMode:   combat.InitiativeRollModeRoll,
+	}
+
+	rollOutput, err := combatState.RollInitiative(rollInput)
+	if err != nil {
+		log.Fatalf("Failed to roll initiative: %v", err)
+	}
+
+	// Show initiative order
+	fmt.Println("\n📋 Initiative Order:")
+	for i, entry := range rollOutput.InitiativeEntries {
+		fmt.Printf("   %d. %s - %d (DEX: %d)\n",
+			i+1, entry.EntityID, entry.Total, entry.DexterityScore)
+	}
+
+	// Handle any ties
+	if len(rollOutput.UnresolvedTies) > 0 {
+		fmt.Printf("\n⚖️  Resolving %d tie(s)...\n", len(rollOutput.UnresolvedTies))
+
+		tieInput := &combat.ResolveTiesInput{
+			TiedGroups:        rollOutput.UnresolvedTies,
+			InitiativeEntries: rollOutput.InitiativeEntries,
+			TieBreakingMode:   combat.TieBreakingModeDexterity,
+		}
+
+		tieOutput, err := combatState.ResolveTies(tieInput)
+		if err != nil {
+			log.Fatalf("Failed to resolve ties: %v", err)
+		}
+
+		if len(tieOutput.RemainingTies) == 0 {
+			fmt.Println("   ✅ All ties resolved!")
+		}
+	}
+
+	// Start combat
+	fmt.Println("\n⚔️  Starting combat...")
+	if err := combatState.StartCombat(); err != nil {
+		log.Fatalf("Failed to start combat: %v", err)
+	}
+
+	// Demonstrate turn progression
+	fmt.Println("\n🔄 Turn progression:")
+	for i := 0; i < 6; i++ { // Show first few turns
+		_, err := combatState.GetCurrentTurn()
+		if err != nil {
+			log.Fatalf("Failed to get current turn: %v", err)
+		}
+
+		if i > 0 { // Don't advance before first turn
+			if err := combatState.NextTurn(); err != nil {
+				log.Fatalf("Failed to advance turn: %v", err)
+			}
+		}
+
+		if i == 3 {
+			fmt.Println("   ... (combat continues)")
+			break
+		}
+	}
+
+	// Demonstrate persistence
+	fmt.Println("\n💾 Demonstrating persistence...")
+
+	// Convert to data for saving
+	combatData := combatState.ToData()
+	fmt.Printf("   Combat state serialized (ID: %s, Status: %s, Round: %d)\n",
+		combatData.ID, combatData.Status, combatData.Round)
+
+	// Load from context (simulate loading from database)
+	newEventBus := events.NewBus()
+	gameCtx, err := game.NewContext(newEventBus, combatData)
+	if err != nil {
+		log.Fatalf("Failed to create game context: %v", err)
+	}
+
+	loadedCombat, err := combat.LoadCombatStateFromContext(context.Background(), gameCtx)
+	if err != nil {
+		log.Fatalf("Failed to load combat from context: %v", err)
+	}
+
+	fmt.Printf("   Combat state loaded successfully (Round: %d)\n", loadedCombat.GetRound())
+
+	// Output will vary due to dice rolls, but demonstrates:
+	// - Combat setup with multiple combatants
+	// - Initiative rolling with modifiers
+	// - Turn order based on initiative
+	// - Combat progression through rounds
+	// - State persistence and loading
+}

--- a/rulebooks/dnd5e/combat/initiative.go
+++ b/rulebooks/dnd5e/combat/initiative.go
@@ -1,0 +1,743 @@
+package combat
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+)
+
+// CombatState implements rich domain logic for D&D 5e combat encounters.
+// It follows the toolkit pattern of rich domain objects with methods and behavior.
+type CombatState struct {
+	// Core identity
+	id       string
+	name     string
+	eventBus events.EventBus
+
+	// Combat state tracking
+	status          CombatStatus
+	round           int
+	turnIndex       int
+	initiativeOrder []InitiativeEntry
+	combatants      map[string]CombatantData
+	settings        CombatSettings
+
+	// Timing
+	createdAt time.Time
+	startedAt time.Time
+	endedAt   time.Time
+
+	// Services
+	roller dice.Roller
+
+	// Mutex for thread-safe access
+	mutex sync.RWMutex
+}
+
+// CombatStateConfig holds configuration for creating combat state
+type CombatStateConfig struct {
+	ID       string
+	Name     string
+	EventBus events.EventBus
+	Settings CombatSettings
+	Roller   dice.Roller
+}
+
+// NewCombatState creates a new combat state with event integration
+func NewCombatState(config CombatStateConfig) *CombatState {
+	// Use default roller if none provided
+	roller := config.Roller
+	if roller == nil {
+		roller = dice.DefaultRoller
+	}
+
+	// Default settings if none provided
+	settings := config.Settings
+	if settings.InitiativeRollMode == "" {
+		settings.InitiativeRollMode = InitiativeRollModeRoll
+	}
+	if settings.TieBreakingMode == "" {
+		settings.TieBreakingMode = TieBreakingModeDexterity
+	}
+
+	combat := &CombatState{
+		id:              config.ID,
+		name:            config.Name,
+		eventBus:        config.EventBus,
+		status:          CombatStatusPending,
+		round:           0,
+		turnIndex:       0,
+		initiativeOrder: make([]InitiativeEntry, 0),
+		combatants:      make(map[string]CombatantData),
+		settings:        settings,
+		createdAt:       time.Now(),
+		roller:          roller,
+	}
+
+	return combat
+}
+
+// GetID returns the combat's unique identifier (implements core.Entity)
+func (c *CombatState) GetID() string {
+	return c.id
+}
+
+// GetType returns the combat's type (implements core.Entity)
+func (c *CombatState) GetType() string {
+	return "combat_encounter"
+}
+
+// GetName returns the combat's name
+func (c *CombatState) GetName() string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.name
+}
+
+// GetStatus returns the current combat status
+func (c *CombatState) GetStatus() CombatStatus {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.status
+}
+
+// GetRound returns the current round number
+func (c *CombatState) GetRound() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.round
+}
+
+// GetCurrentTurn returns information about whose turn it is
+func (c *CombatState) GetCurrentTurn() (*InitiativeEntry, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if c.status != CombatStatusActive {
+		return nil, fmt.Errorf("combat is not active")
+	}
+
+	if len(c.initiativeOrder) == 0 {
+		return nil, fmt.Errorf("no combatants in initiative order")
+	}
+
+	if c.turnIndex < 0 || c.turnIndex >= len(c.initiativeOrder) {
+		return nil, fmt.Errorf("invalid turn index: %d", c.turnIndex)
+	}
+
+	entry := c.initiativeOrder[c.turnIndex]
+	return &entry, nil
+}
+
+// AddCombatant adds a combatant to the encounter
+func (c *CombatState) AddCombatant(combatant Combatant) error {
+	if combatant == nil {
+		return fmt.Errorf("combatant cannot be nil")
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	entityID := combatant.GetID()
+
+	// Check if already added
+	if _, exists := c.combatants[entityID]; exists {
+		return fmt.Errorf("combatant %s already in combat", entityID)
+	}
+
+	// Create combatant data
+	combatantData := CombatantData{
+		EntityID:      entityID,
+		EntityType:    combatant.GetType(),
+		HitPoints:     combatant.GetHitPoints(),
+		MaxHitPoints:  combatant.GetMaxHitPoints(),
+		ArmorClass:    combatant.GetArmorClass(),
+		Conditions:    make([]string, 0),
+		Effects:       make([]string, 0),
+		ActionsUsed:   make([]ActionType, 0),
+		IsActive:      true,
+		IsUnconscious: !combatant.IsConscious(),
+		IsDefeated:    combatant.IsDefeated(),
+		HasActed:      false,
+	}
+
+	c.combatants[entityID] = combatantData
+
+	// Emit event
+	if c.eventBus != nil {
+		event := events.NewGameEvent(EventCombatantAdded, combatant, nil)
+		eventData := CombatantAddedData{
+			CombatID:      c.id,
+			Entity:        combatant,
+			JoinedAtRound: c.round,
+		}
+		event.Context().Set("data", eventData)
+		_ = c.eventBus.Publish(context.Background(), event)
+	}
+
+	return nil
+}
+
+// RemoveCombatant removes a combatant from the encounter
+func (c *CombatState) RemoveCombatant(entityID string, reason string) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// Check if combatant exists
+	combatantData, exists := c.combatants[entityID]
+	if !exists {
+		return fmt.Errorf("combatant %s not found", entityID)
+	}
+
+	// Mark as inactive
+	combatantData.IsActive = false
+	c.combatants[entityID] = combatantData
+
+	// Remove from initiative order
+	newOrder := make([]InitiativeEntry, 0)
+	wasInOrder := false
+	removedIndex := -1
+
+	for i, entry := range c.initiativeOrder {
+		if entry.EntityID == entityID {
+			wasInOrder = true
+			removedIndex = i
+			entry.Active = false
+			// Keep in order but mark inactive for history
+			newOrder = append(newOrder, entry)
+		} else {
+			newOrder = append(newOrder, entry)
+		}
+	}
+
+	c.initiativeOrder = newOrder
+
+	// Adjust turn index if necessary
+	if wasInOrder && removedIndex <= c.turnIndex && c.turnIndex > 0 {
+		c.turnIndex--
+	}
+
+	// Emit event
+	if c.eventBus != nil {
+		// Create a minimal entity for the event
+		entity := &simpleEntity{id: entityID, entityType: combatantData.EntityType}
+		event := events.NewGameEvent(EventCombatantRemoved, entity, nil)
+		eventData := CombatantRemovedData{
+			CombatID:       c.id,
+			Entity:         entity,
+			Reason:         reason,
+			RemovedAtRound: c.round,
+		}
+		event.Context().Set("data", eventData)
+		_ = c.eventBus.Publish(context.Background(), event)
+	}
+
+	return nil
+}
+
+// RollInitiative rolls initiative for all combatants
+func (c *CombatState) RollInitiative(input *RollInitiativeInput) (*RollInitiativeOutput, error) {
+	if input == nil {
+		return nil, fmt.Errorf("input cannot be nil")
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if len(input.Combatants) == 0 {
+		return nil, fmt.Errorf("no combatants to roll initiative for")
+	}
+
+	roller := input.Roller
+	if roller == nil {
+		roller = c.roller
+	}
+
+	rollMode := input.RollMode
+	if rollMode == "" {
+		rollMode = c.settings.InitiativeRollMode
+	}
+
+	// Roll for each combatant
+	initiativeEntries := make([]InitiativeEntry, 0, len(input.Combatants))
+	rollResults := make(map[string]InitiativeRollResult)
+
+	for _, combatant := range input.Combatants {
+		entityID := combatant.GetID()
+		modifier := combatant.GetDexterityModifier()
+		dexScore := combatant.GetDexterityScore()
+
+		var roll, total int
+		wasManual := false
+
+		switch rollMode {
+		case InitiativeRollModeRoll:
+			diceRoll, err := roller.Roll(20)
+			if err != nil {
+				return nil, fmt.Errorf("failed to roll initiative for %s: %w", entityID, err)
+			}
+			roll = diceRoll
+			total = roll + modifier
+
+		case InitiativeRollModeStatic:
+			roll = 10
+			total = roll + modifier
+
+		case InitiativeRollModeManual:
+			manualValue, exists := input.ManualValues[entityID]
+			if !exists {
+				return nil, fmt.Errorf("manual value not provided for %s", entityID)
+			}
+			roll = 0 // Not applicable for manual
+			total = manualValue
+			wasManual = true
+
+		default:
+			return nil, fmt.Errorf("unknown initiative roll mode: %s", rollMode)
+		}
+
+		entry := InitiativeEntry{
+			EntityID:       entityID,
+			Roll:           roll,
+			Modifier:       modifier,
+			Total:          total,
+			DexterityScore: dexScore,
+			Active:         true,
+		}
+
+		initiativeEntries = append(initiativeEntries, entry)
+
+		rollResult := InitiativeRollResult{
+			EntityID:       entityID,
+			Roll:           roll,
+			Modifier:       modifier,
+			Total:          total,
+			DexterityScore: dexScore,
+			WasManual:      wasManual,
+		}
+		rollResults[entityID] = rollResult
+
+		// Emit individual roll event
+		if c.eventBus != nil {
+			event := events.NewGameEvent(EventInitiativeRolled, combatant, nil)
+			eventData := InitiativeRolledData{
+				CombatID: c.id,
+				Entity:   combatant,
+				Roll:     roll,
+				Modifier: modifier,
+				Total:    total,
+				DexScore: dexScore,
+			}
+			event.Context().Set("data", eventData)
+			_ = c.eventBus.Publish(context.Background(), event)
+		}
+	}
+
+	// Sort by initiative
+	SortInitiativeEntries(initiativeEntries)
+
+	// Find tied groups
+	tiedGroups := FindTiedGroups(initiativeEntries)
+
+	output := &RollInitiativeOutput{
+		InitiativeEntries: initiativeEntries,
+		UnresolvedTies:    tiedGroups,
+		RollResults:       rollResults,
+	}
+
+	// Store the order (even if there are ties)
+	c.initiativeOrder = initiativeEntries
+
+	// Emit initiative order event
+	if c.eventBus != nil {
+		entityIDs := make([]string, len(initiativeEntries))
+		for i, entry := range initiativeEntries {
+			entityIDs[i] = entry.EntityID
+		}
+
+		event := events.NewGameEvent(EventInitiativeOrder, nil, nil)
+		eventData := InitiativeOrderData{
+			CombatID:        c.id,
+			InitiativeOrder: entityIDs,
+			TiesResolved:    len(tiedGroups) == 0,
+		}
+		event.Context().Set("data", eventData)
+		_ = c.eventBus.Publish(context.Background(), event)
+	}
+
+	return output, nil
+}
+
+// ResolveTies resolves initiative ties using the specified method
+func (c *CombatState) ResolveTies(input *ResolveTiesInput) (*ResolveTiesOutput, error) {
+	if input == nil {
+		return nil, fmt.Errorf("input cannot be nil")
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	tieBreakingMode := input.TieBreakingMode
+	if tieBreakingMode == "" {
+		tieBreakingMode = c.settings.TieBreakingMode
+	}
+
+	resolvedEntries := make([]InitiativeEntry, len(input.InitiativeEntries))
+	copy(resolvedEntries, input.InitiativeEntries)
+
+	remainingTies := make([][]string, 0)
+
+	for _, group := range input.TiedGroups {
+		switch tieBreakingMode {
+		case TieBreakingModeDexterity:
+			// Already handled by SortInitiativeEntries - no additional work needed
+			// Ties that remain after DEX comparison are truly tied
+			if c.stillTied(resolvedEntries, group) {
+				remainingTies = append(remainingTies, group)
+			}
+
+		case TieBreakingModeDM:
+			if input.ManualOrder == nil {
+				remainingTies = append(remainingTies, group)
+				continue
+			}
+
+			// Apply manual tie breaker values
+			for i := range resolvedEntries {
+				for _, entityID := range group {
+					if resolvedEntries[i].EntityID == entityID {
+						if tieBreaker, exists := input.ManualOrder[entityID]; exists {
+							resolvedEntries[i].TieBreaker = tieBreaker
+						}
+					}
+				}
+			}
+
+		case TieBreakingModeRoll:
+			roller := input.Roller
+			if roller == nil {
+				roller = c.roller
+			}
+
+			// Re-roll for tied combatants
+			for i := range resolvedEntries {
+				for _, entityID := range group {
+					if resolvedEntries[i].EntityID == entityID {
+						reroll, err := roller.Roll(20)
+						if err != nil {
+							return nil, fmt.Errorf("failed to re-roll for %s: %w", entityID, err)
+						}
+						resolvedEntries[i].TieBreaker = reroll
+					}
+				}
+			}
+
+		default:
+			return nil, fmt.Errorf("unknown tie breaking mode: %s", tieBreakingMode)
+		}
+	}
+
+	// Re-sort with tie breakers applied
+	SortInitiativeEntries(resolvedEntries)
+
+	// Update our initiative order
+	c.initiativeOrder = resolvedEntries
+
+	output := &ResolveTiesOutput{
+		ResolvedEntries: resolvedEntries,
+		RemainingTies:   remainingTies,
+	}
+
+	// Emit updated initiative order event
+	if c.eventBus != nil {
+		entityIDs := make([]string, len(resolvedEntries))
+		for i, entry := range resolvedEntries {
+			entityIDs[i] = entry.EntityID
+		}
+
+		event := events.NewGameEvent(EventInitiativeOrder, nil, nil)
+		eventData := InitiativeOrderData{
+			CombatID:        c.id,
+			InitiativeOrder: entityIDs,
+			TiesResolved:    len(remainingTies) == 0,
+		}
+		event.Context().Set("data", eventData)
+		_ = c.eventBus.Publish(context.Background(), event)
+	}
+
+	return output, nil
+}
+
+// stillTied checks if a group of combatants are still tied after sorting
+func (c *CombatState) stillTied(entries []InitiativeEntry, group []string) bool {
+	if len(group) <= 1 {
+		return false
+	}
+
+	// Find the entries for this group
+	var groupEntries []InitiativeEntry
+	for _, entry := range entries {
+		for _, entityID := range group {
+			if entry.EntityID == entityID {
+				groupEntries = append(groupEntries, entry)
+				break
+			}
+		}
+	}
+
+	if len(groupEntries) <= 1 {
+		return false
+	}
+
+	// Check if they all have the same total and DEX score
+	firstEntry := groupEntries[0]
+	for i := 1; i < len(groupEntries); i++ {
+		if groupEntries[i].Total != firstEntry.Total ||
+			groupEntries[i].DexterityScore != firstEntry.DexterityScore {
+			return false
+		}
+	}
+
+	return true
+}
+
+// StartCombat begins the combat encounter
+func (c *CombatState) StartCombat() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.status != CombatStatusPending {
+		return fmt.Errorf("combat cannot be started from status: %s", c.status)
+	}
+
+	if len(c.initiativeOrder) == 0 {
+		return fmt.Errorf("cannot start combat without initiative order")
+	}
+
+	c.status = CombatStatusActive
+	c.round = 1
+	c.turnIndex = 0
+	c.startedAt = time.Now()
+
+	// Emit combat started event
+	if c.eventBus != nil {
+		combatantIDs := make([]string, 0, len(c.combatants))
+		initiativeOrder := make([]string, len(c.initiativeOrder))
+
+		for entityID := range c.combatants {
+			combatantIDs = append(combatantIDs, entityID)
+		}
+
+		for i, entry := range c.initiativeOrder {
+			initiativeOrder[i] = entry.EntityID
+		}
+
+		event := events.NewGameEvent(EventCombatStarted, nil, nil)
+		eventData := CombatStartedData{
+			CombatID:        c.id,
+			Combatants:      combatantIDs,
+			InitiativeOrder: initiativeOrder,
+		}
+		event.Context().Set("data", eventData)
+		_ = c.eventBus.Publish(context.Background(), event)
+	}
+
+	// Start the first turn
+	return c.startCurrentTurn()
+}
+
+// NextTurn advances to the next combatant's turn
+func (c *CombatState) NextTurn() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.status != CombatStatusActive {
+		return fmt.Errorf("combat is not active")
+	}
+
+	// End current turn
+	if err := c.endCurrentTurn(); err != nil {
+		return fmt.Errorf("failed to end current turn: %w", err)
+	}
+
+	// Advance turn index
+	c.turnIndex++
+
+	// Check if we need to start a new round
+	if c.turnIndex >= len(c.initiativeOrder) {
+		c.turnIndex = 0
+		c.round++
+
+		// Emit round events
+		if c.eventBus != nil {
+			// End previous round
+			prevRound := c.round - 1
+			if prevRound > 0 {
+				event := events.NewGameEvent(EventRoundEnded, nil, nil)
+				eventData := RoundEndedData{
+					CombatID: c.id,
+					Round:    prevRound,
+				}
+				event.Context().Set("data", eventData)
+				_ = c.eventBus.Publish(context.Background(), event)
+			}
+
+			// Start new round
+			activeCount := 0
+			for _, combatant := range c.combatants {
+				if combatant.IsActive {
+					activeCount++
+				}
+			}
+
+			event := events.NewGameEvent(EventRoundStarted, nil, nil)
+			eventData := RoundStartedData{
+				CombatID:     c.id,
+				Round:        c.round,
+				Participants: activeCount,
+			}
+			event.Context().Set("data", eventData)
+			_ = c.eventBus.Publish(context.Background(), event)
+		}
+
+		// Reset has acted flags
+		for entityID, combatant := range c.combatants {
+			combatant.HasActed = false
+			c.combatants[entityID] = combatant
+		}
+	}
+
+	// Start the next turn
+	return c.startCurrentTurn()
+}
+
+// startCurrentTurn begins the current combatant's turn
+func (c *CombatState) startCurrentTurn() error {
+	if len(c.initiativeOrder) == 0 {
+		return fmt.Errorf("no combatants in initiative order")
+	}
+
+	currentEntry := c.initiativeOrder[c.turnIndex]
+
+	// Skip inactive combatants
+	if !currentEntry.Active {
+		if c.turnIndex < len(c.initiativeOrder)-1 {
+			c.turnIndex++
+			return c.startCurrentTurn() // Recursively try next
+		} else {
+			// End of round with no active combatants
+			return fmt.Errorf("no active combatants remaining")
+		}
+	}
+
+	// Mark combatant as having started their turn
+	if combatantData, exists := c.combatants[currentEntry.EntityID]; exists {
+		combatantData.HasActed = true
+		combatantData.TurnsTaken++
+		combatantData.ActionsUsed = make([]ActionType, 0) // Reset actions for new turn
+		c.combatants[currentEntry.EntityID] = combatantData
+	}
+
+	// Emit turn started event
+	if c.eventBus != nil {
+		// Create a minimal entity for the event
+		combatantData := c.combatants[currentEntry.EntityID]
+		entity := &simpleEntity{id: currentEntry.EntityID, entityType: combatantData.EntityType}
+
+		event := events.NewGameEvent(EventTurnStarted, entity, nil)
+		eventData := TurnStartedData{
+			CombatID:   c.id,
+			Entity:     entity,
+			Round:      c.round,
+			TurnNumber: c.turnIndex + 1,
+			Initiative: currentEntry.Total,
+		}
+		event.Context().Set("data", eventData)
+		_ = c.eventBus.Publish(context.Background(), event)
+	}
+
+	return nil
+}
+
+// endCurrentTurn ends the current combatant's turn
+func (c *CombatState) endCurrentTurn() error {
+	if len(c.initiativeOrder) == 0 {
+		return fmt.Errorf("no combatants in initiative order")
+	}
+
+	currentEntry := c.initiativeOrder[c.turnIndex]
+
+	// Update turn tracking
+	if combatantData, exists := c.combatants[currentEntry.EntityID]; exists {
+		combatantData.LastActionTurn = c.round
+		c.combatants[currentEntry.EntityID] = combatantData
+	}
+
+	// Emit turn ended event
+	if c.eventBus != nil {
+		combatantData := c.combatants[currentEntry.EntityID]
+		entity := &simpleEntity{id: currentEntry.EntityID, entityType: combatantData.EntityType}
+
+		// Convert ActionType slice to string slice for event
+		actionsUsed := make([]string, len(combatantData.ActionsUsed))
+		for i, action := range combatantData.ActionsUsed {
+			actionsUsed[i] = string(action)
+		}
+
+		event := events.NewGameEvent(EventTurnEnded, entity, nil)
+		eventData := TurnEndedData{
+			CombatID:    c.id,
+			Entity:      entity,
+			Round:       c.round,
+			TurnNumber:  c.turnIndex + 1,
+			ActionsUsed: actionsUsed,
+		}
+		event.Context().Set("data", eventData)
+		_ = c.eventBus.Publish(context.Background(), event)
+	}
+
+	return nil
+}
+
+// ToData converts the CombatState to CombatStateData for persistence
+func (c *CombatState) ToData() CombatStateData {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	// Copy combatants map
+	combatants := make(map[string]CombatantData)
+	for k, v := range c.combatants {
+		combatants[k] = v
+	}
+
+	// Copy initiative order
+	initiativeOrder := make([]InitiativeEntry, len(c.initiativeOrder))
+	copy(initiativeOrder, c.initiativeOrder)
+
+	return CombatStateData{
+		ID:              c.id,
+		Name:            c.name,
+		Status:          c.status,
+		Round:           c.round,
+		TurnIndex:       c.turnIndex,
+		InitiativeOrder: initiativeOrder,
+		Combatants:      combatants,
+		Settings:        c.settings,
+		CreatedAt:       c.createdAt.Unix(),
+		StartedAt:       c.startedAt.Unix(),
+		EndedAt:         c.endedAt.Unix(),
+	}
+}
+
+// simpleEntity is a minimal implementation of core.Entity for events
+type simpleEntity struct {
+	id         string
+	entityType string
+}
+
+func (e *simpleEntity) GetID() string   { return e.id }
+func (e *simpleEntity) GetType() string { return e.entityType }

--- a/rulebooks/dnd5e/combat/initiative_test.go
+++ b/rulebooks/dnd5e/combat/initiative_test.go
@@ -1,0 +1,694 @@
+package combat_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/game"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// CombatTestSuite contains tests for the combat system
+type CombatTestSuite struct {
+	suite.Suite
+	ctrl       *gomock.Controller
+	mockRoller *mock_dice.MockRoller
+	eventBus   events.EventBus
+	combat     *combat.CombatState
+}
+
+func (s *CombatTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockRoller = mock_dice.NewMockRoller(s.ctrl)
+	s.eventBus = events.NewBus()
+
+	s.combat = combat.NewCombatState(combat.CombatStateConfig{
+		ID:       "test-combat-001",
+		Name:     "Test Combat",
+		EventBus: s.eventBus,
+		Roller:   s.mockRoller,
+		Settings: combat.CombatSettings{
+			InitiativeRollMode: combat.InitiativeRollModeRoll,
+			TieBreakingMode:    combat.TieBreakingModeDexterity,
+		},
+	})
+}
+
+func (s *CombatTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func TestCombatSuite(t *testing.T) {
+	suite.Run(t, new(CombatTestSuite))
+}
+
+// Test helper: mock combatant
+type mockCombatant struct {
+	id         string
+	entityType string
+	dexMod     int
+	dexScore   int
+	ac         int
+	hp         int
+	maxHP      int
+	conscious  bool
+	defeated   bool
+}
+
+func (m *mockCombatant) GetID() string             { return m.id }
+func (m *mockCombatant) GetType() string           { return m.entityType }
+func (m *mockCombatant) GetDexterityModifier() int { return m.dexMod }
+func (m *mockCombatant) GetDexterityScore() int    { return m.dexScore }
+func (m *mockCombatant) GetArmorClass() int        { return m.ac }
+func (m *mockCombatant) GetHitPoints() int         { return m.hp }
+func (m *mockCombatant) GetMaxHitPoints() int      { return m.maxHP }
+func (m *mockCombatant) IsConscious() bool         { return m.conscious }
+func (m *mockCombatant) IsDefeated() bool          { return m.defeated }
+
+func (s *CombatTestSuite) TestCombatStateCreation() {
+	assert.Equal(s.T(), "test-combat-001", s.combat.GetID())
+	assert.Equal(s.T(), "Test Combat", s.combat.GetName())
+	assert.Equal(s.T(), "combat_encounter", s.combat.GetType())
+	assert.Equal(s.T(), combat.CombatStatusPending, s.combat.GetStatus())
+	assert.Equal(s.T(), 0, s.combat.GetRound())
+}
+
+func (s *CombatTestSuite) TestAddCombatant() {
+	combatant := &mockCombatant{
+		id:         "fighter-001",
+		entityType: "character",
+		dexMod:     2,
+		dexScore:   14,
+		ac:         18,
+		hp:         45,
+		maxHP:      45,
+		conscious:  true,
+		defeated:   false,
+	}
+
+	err := s.combat.AddCombatant(combatant)
+	require.NoError(s.T(), err)
+
+	// Test duplicate addition
+	err = s.combat.AddCombatant(combatant)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "already in combat")
+}
+
+func (s *CombatTestSuite) TestRollInitiativeBasic() {
+	// Create test combatants
+	combatants := []combat.Combatant{
+		&mockCombatant{
+			id:         "fighter-001",
+			entityType: "character",
+			dexMod:     2,
+			dexScore:   14,
+		},
+		&mockCombatant{
+			id:         "rogue-001",
+			entityType: "character",
+			dexMod:     4,
+			dexScore:   18,
+		},
+		&mockCombatant{
+			id:         "orc-001",
+			entityType: "monster",
+			dexMod:     1,
+			dexScore:   12,
+		},
+	}
+
+	// Add combatants
+	for _, combatant := range combatants {
+		err := s.combat.AddCombatant(combatant)
+		require.NoError(s.T(), err)
+	}
+
+	// Set up dice rolls
+	s.mockRoller.EXPECT().Roll(20).Return(15, nil) // Fighter
+	s.mockRoller.EXPECT().Roll(20).Return(12, nil) // Rogue
+	s.mockRoller.EXPECT().Roll(20).Return(18, nil) // Orc
+
+	// Roll initiative
+	input := &combat.RollInitiativeInput{
+		Combatants: combatants,
+		Roller:     s.mockRoller,
+		RollMode:   combat.InitiativeRollModeRoll,
+	}
+
+	output, err := s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+	assert.NotNil(s.T(), output)
+
+	// Check results
+	assert.Len(s.T(), output.InitiativeEntries, 3)
+	assert.Len(s.T(), output.RollResults, 3)
+	assert.Len(s.T(), output.UnresolvedTies, 0) // No ties in this case
+
+	// Verify initiative order (highest first)
+	entries := output.InitiativeEntries
+
+	// Orc should be first (18 + 1 = 19)
+	assert.Equal(s.T(), "orc-001", entries[0].EntityID)
+	assert.Equal(s.T(), 18, entries[0].Roll)
+	assert.Equal(s.T(), 1, entries[0].Modifier)
+	assert.Equal(s.T(), 19, entries[0].Total)
+
+	// Fighter should be second (15 + 2 = 17)
+	assert.Equal(s.T(), "fighter-001", entries[1].EntityID)
+	assert.Equal(s.T(), 15, entries[1].Roll)
+	assert.Equal(s.T(), 2, entries[1].Modifier)
+	assert.Equal(s.T(), 17, entries[1].Total)
+
+	// Rogue should be third (12 + 4 = 16)
+	assert.Equal(s.T(), "rogue-001", entries[2].EntityID)
+	assert.Equal(s.T(), 12, entries[2].Roll)
+	assert.Equal(s.T(), 4, entries[2].Modifier)
+	assert.Equal(s.T(), 16, entries[2].Total)
+}
+
+func (s *CombatTestSuite) TestRollInitiativeWithTies() {
+	// Create combatants with potential for ties
+	combatants := []combat.Combatant{
+		&mockCombatant{
+			id:         "fighter-001",
+			entityType: "character",
+			dexMod:     2,
+			dexScore:   14,
+		},
+		&mockCombatant{
+			id:         "wizard-001",
+			entityType: "character",
+			dexMod:     1,
+			dexScore:   12,
+		},
+	}
+
+	// Add combatants
+	for _, combatant := range combatants {
+		err := s.combat.AddCombatant(combatant)
+		require.NoError(s.T(), err)
+	}
+
+	// Set up dice rolls to create a tie
+	s.mockRoller.EXPECT().Roll(20).Return(15, nil) // Fighter: 15 + 2 = 17
+	s.mockRoller.EXPECT().Roll(20).Return(16, nil) // Wizard: 16 + 1 = 17
+
+	input := &combat.RollInitiativeInput{
+		Combatants: combatants,
+		Roller:     s.mockRoller,
+		RollMode:   combat.InitiativeRollModeRoll,
+	}
+
+	output, err := s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+
+	// Should detect the tie
+	assert.Len(s.T(), output.UnresolvedTies, 1)
+	assert.Len(s.T(), output.UnresolvedTies[0], 2)
+
+	// Fighter should win tie due to higher DEX score
+	entries := output.InitiativeEntries
+	assert.Equal(s.T(), "fighter-001", entries[0].EntityID)
+	assert.Equal(s.T(), "wizard-001", entries[1].EntityID)
+}
+
+func (s *CombatTestSuite) TestResolveTiesWithDexterity() {
+	// Create initiative entries with a tie
+	entries := []combat.InitiativeEntry{
+		{
+			EntityID:       "fighter-001",
+			Roll:           15,
+			Modifier:       2,
+			Total:          17,
+			DexterityScore: 14,
+			Active:         true,
+		},
+		{
+			EntityID:       "wizard-001",
+			Roll:           16,
+			Modifier:       1,
+			Total:          17,
+			DexterityScore: 12,
+			Active:         true,
+		},
+	}
+
+	tiedGroups := [][]string{{"fighter-001", "wizard-001"}}
+
+	input := &combat.ResolveTiesInput{
+		TiedGroups:        tiedGroups,
+		InitiativeEntries: entries,
+		TieBreakingMode:   combat.TieBreakingModeDexterity,
+	}
+
+	output, err := s.combat.ResolveTies(input)
+	require.NoError(s.T(), err)
+
+	// Fighter should win due to higher DEX
+	resolvedEntries := output.ResolvedEntries
+	assert.Equal(s.T(), "fighter-001", resolvedEntries[0].EntityID)
+	assert.Equal(s.T(), "wizard-001", resolvedEntries[1].EntityID)
+
+	// No remaining ties since DEX scores are different
+	assert.Len(s.T(), output.RemainingTies, 0)
+}
+
+func (s *CombatTestSuite) TestResolveTiesWithReroll() {
+	// Create initiative entries with identical totals and DEX
+	entries := []combat.InitiativeEntry{
+		{
+			EntityID:       "fighter-001",
+			Roll:           15,
+			Modifier:       2,
+			Total:          17,
+			DexterityScore: 14,
+			Active:         true,
+		},
+		{
+			EntityID:       "ranger-001",
+			Roll:           17,
+			Modifier:       0,
+			Total:          17,
+			DexterityScore: 14, // Same DEX - true tie
+			Active:         true,
+		},
+	}
+
+	tiedGroups := [][]string{{"fighter-001", "ranger-001"}}
+
+	// Mock the re-rolls
+	s.mockRoller.EXPECT().Roll(20).Return(12, nil) // Fighter tie-breaker
+	s.mockRoller.EXPECT().Roll(20).Return(18, nil) // Ranger tie-breaker
+
+	input := &combat.ResolveTiesInput{
+		TiedGroups:        tiedGroups,
+		InitiativeEntries: entries,
+		TieBreakingMode:   combat.TieBreakingModeRoll,
+		Roller:            s.mockRoller,
+	}
+
+	output, err := s.combat.ResolveTies(input)
+	require.NoError(s.T(), err)
+
+	// Ranger should win due to higher re-roll
+	resolvedEntries := output.ResolvedEntries
+	assert.Equal(s.T(), "ranger-001", resolvedEntries[0].EntityID)
+	assert.Equal(s.T(), 18, resolvedEntries[0].TieBreaker)
+
+	assert.Equal(s.T(), "fighter-001", resolvedEntries[1].EntityID)
+	assert.Equal(s.T(), 12, resolvedEntries[1].TieBreaker)
+
+	assert.Len(s.T(), output.RemainingTies, 0)
+}
+
+func (s *CombatTestSuite) TestResolveTiesWithDMDecision() {
+	entries := []combat.InitiativeEntry{
+		{
+			EntityID:       "fighter-001",
+			Roll:           15,
+			Modifier:       2,
+			Total:          17,
+			DexterityScore: 14,
+			Active:         true,
+		},
+		{
+			EntityID:       "ranger-001",
+			Roll:           17,
+			Modifier:       0,
+			Total:          17,
+			DexterityScore: 14,
+			Active:         true,
+		},
+	}
+
+	tiedGroups := [][]string{{"fighter-001", "ranger-001"}}
+
+	// DM decides ranger goes first
+	manualOrder := map[string]int{
+		"ranger-001":  100,
+		"fighter-001": 50,
+	}
+
+	input := &combat.ResolveTiesInput{
+		TiedGroups:        tiedGroups,
+		InitiativeEntries: entries,
+		TieBreakingMode:   combat.TieBreakingModeDM,
+		ManualOrder:       manualOrder,
+	}
+
+	output, err := s.combat.ResolveTies(input)
+	require.NoError(s.T(), err)
+
+	// Ranger should be first due to DM decision
+	resolvedEntries := output.ResolvedEntries
+	assert.Equal(s.T(), "ranger-001", resolvedEntries[0].EntityID)
+	assert.Equal(s.T(), 100, resolvedEntries[0].TieBreaker)
+
+	assert.Equal(s.T(), "fighter-001", resolvedEntries[1].EntityID)
+	assert.Equal(s.T(), 50, resolvedEntries[1].TieBreaker)
+
+	assert.Len(s.T(), output.RemainingTies, 0)
+}
+
+func (s *CombatTestSuite) TestStartCombat() {
+	// Add combatants and roll initiative first
+	combatants := []combat.Combatant{
+		&mockCombatant{
+			id:         "fighter-001",
+			entityType: "character",
+			dexMod:     2,
+			dexScore:   14,
+		},
+		&mockCombatant{
+			id:         "orc-001",
+			entityType: "monster",
+			dexMod:     1,
+			dexScore:   12,
+		},
+	}
+
+	for _, combatant := range combatants {
+		err := s.combat.AddCombatant(combatant)
+		require.NoError(s.T(), err)
+	}
+
+	// Roll initiative
+	s.mockRoller.EXPECT().Roll(20).Return(15, nil) // Fighter
+	s.mockRoller.EXPECT().Roll(20).Return(12, nil) // Orc
+
+	input := &combat.RollInitiativeInput{
+		Combatants: combatants,
+		Roller:     s.mockRoller,
+		RollMode:   combat.InitiativeRollModeRoll,
+	}
+
+	_, err := s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+
+	// Start combat
+	err = s.combat.StartCombat()
+	require.NoError(s.T(), err)
+
+	assert.Equal(s.T(), combat.CombatStatusActive, s.combat.GetStatus())
+	assert.Equal(s.T(), 1, s.combat.GetRound())
+
+	// Should be fighter's turn (17 > 13)
+	currentTurn, err := s.combat.GetCurrentTurn()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "fighter-001", currentTurn.EntityID)
+}
+
+func (s *CombatTestSuite) TestTurnProgression() {
+	// Setup combat with two combatants
+	combatants := []combat.Combatant{
+		&mockCombatant{
+			id:         "fighter-001",
+			entityType: "character",
+			dexMod:     2,
+			dexScore:   14,
+		},
+		&mockCombatant{
+			id:         "orc-001",
+			entityType: "monster",
+			dexMod:     1,
+			dexScore:   12,
+		},
+	}
+
+	for _, combatant := range combatants {
+		err := s.combat.AddCombatant(combatant)
+		require.NoError(s.T(), err)
+	}
+
+	// Roll initiative
+	s.mockRoller.EXPECT().Roll(20).Return(15, nil) // Fighter: 17
+	s.mockRoller.EXPECT().Roll(20).Return(12, nil) // Orc: 13
+
+	input := &combat.RollInitiativeInput{
+		Combatants: combatants,
+		Roller:     s.mockRoller,
+		RollMode:   combat.InitiativeRollModeRoll,
+	}
+
+	_, err := s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+
+	// Start combat
+	err = s.combat.StartCombat()
+	require.NoError(s.T(), err)
+
+	// Round 1, Turn 1 - Fighter
+	assert.Equal(s.T(), 1, s.combat.GetRound())
+	currentTurn, err := s.combat.GetCurrentTurn()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "fighter-001", currentTurn.EntityID)
+
+	// Next turn
+	err = s.combat.NextTurn()
+	require.NoError(s.T(), err)
+
+	// Round 1, Turn 2 - Orc
+	assert.Equal(s.T(), 1, s.combat.GetRound())
+	currentTurn, err = s.combat.GetCurrentTurn()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "orc-001", currentTurn.EntityID)
+
+	// Next turn should start Round 2
+	err = s.combat.NextTurn()
+	require.NoError(s.T(), err)
+
+	// Round 2, Turn 1 - Fighter again
+	assert.Equal(s.T(), 2, s.combat.GetRound())
+	currentTurn, err = s.combat.GetCurrentTurn()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "fighter-001", currentTurn.EntityID)
+}
+
+func (s *CombatTestSuite) TestStaticInitiative() {
+	combatants := []combat.Combatant{
+		&mockCombatant{
+			id:         "fighter-001",
+			entityType: "character",
+			dexMod:     2,
+			dexScore:   14,
+		},
+		&mockCombatant{
+			id:         "wizard-001",
+			entityType: "character",
+			dexMod:     3,
+			dexScore:   16,
+		},
+	}
+
+	for _, combatant := range combatants {
+		err := s.combat.AddCombatant(combatant)
+		require.NoError(s.T(), err)
+	}
+
+	// Use static mode (no dice rolls expected)
+	input := &combat.RollInitiativeInput{
+		Combatants: combatants,
+		RollMode:   combat.InitiativeRollModeStatic,
+	}
+
+	output, err := s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+
+	// Verify static calculation (10 + modifier)
+	entries := output.InitiativeEntries
+
+	// Wizard should be first (10 + 3 = 13)
+	assert.Equal(s.T(), "wizard-001", entries[0].EntityID)
+	assert.Equal(s.T(), 10, entries[0].Roll)
+	assert.Equal(s.T(), 3, entries[0].Modifier)
+	assert.Equal(s.T(), 13, entries[0].Total)
+
+	// Fighter should be second (10 + 2 = 12)
+	assert.Equal(s.T(), "fighter-001", entries[1].EntityID)
+	assert.Equal(s.T(), 10, entries[1].Roll)
+	assert.Equal(s.T(), 2, entries[1].Modifier)
+	assert.Equal(s.T(), 12, entries[1].Total)
+}
+
+func (s *CombatTestSuite) TestManualInitiative() {
+	combatants := []combat.Combatant{
+		&mockCombatant{
+			id:         "fighter-001",
+			entityType: "character",
+		},
+		&mockCombatant{
+			id:         "wizard-001",
+			entityType: "character",
+		},
+	}
+
+	for _, combatant := range combatants {
+		err := s.combat.AddCombatant(combatant)
+		require.NoError(s.T(), err)
+	}
+
+	// Use manual values
+	manualValues := map[string]int{
+		"fighter-001": 18,
+		"wizard-001":  15,
+	}
+
+	input := &combat.RollInitiativeInput{
+		Combatants:   combatants,
+		RollMode:     combat.InitiativeRollModeManual,
+		ManualValues: manualValues,
+	}
+
+	output, err := s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+
+	entries := output.InitiativeEntries
+
+	// Fighter should be first (18 > 15)
+	assert.Equal(s.T(), "fighter-001", entries[0].EntityID)
+	assert.Equal(s.T(), 0, entries[0].Roll) // Roll not applicable for manual
+	assert.Equal(s.T(), 18, entries[0].Total)
+
+	// Wizard should be second
+	assert.Equal(s.T(), "wizard-001", entries[1].EntityID)
+	assert.Equal(s.T(), 15, entries[1].Total)
+
+	// Check roll results indicate manual mode
+	assert.True(s.T(), output.RollResults["fighter-001"].WasManual)
+	assert.True(s.T(), output.RollResults["wizard-001"].WasManual)
+}
+
+func (s *CombatTestSuite) TestToDataAndLoadFromContext() {
+	// Add combatants and set up combat
+	combatants := []combat.Combatant{
+		&mockCombatant{
+			id:         "fighter-001",
+			entityType: "character",
+			dexMod:     2,
+			dexScore:   14,
+		},
+	}
+
+	for _, combatant := range combatants {
+		err := s.combat.AddCombatant(combatant)
+		require.NoError(s.T(), err)
+	}
+
+	// Roll initiative and start
+	s.mockRoller.EXPECT().Roll(20).Return(15, nil)
+
+	input := &combat.RollInitiativeInput{
+		Combatants: combatants,
+		Roller:     s.mockRoller,
+		RollMode:   combat.InitiativeRollModeRoll,
+	}
+
+	_, err := s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+
+	err = s.combat.StartCombat()
+	require.NoError(s.T(), err)
+
+	// Convert to data
+	data := s.combat.ToData()
+
+	// Verify data
+	assert.Equal(s.T(), "test-combat-001", data.ID)
+	assert.Equal(s.T(), "Test Combat", data.Name)
+	assert.Equal(s.T(), combat.CombatStatusActive, data.Status)
+	assert.Equal(s.T(), 1, data.Round)
+	assert.Equal(s.T(), 0, data.TurnIndex)
+	assert.Len(s.T(), data.InitiativeOrder, 1)
+	assert.Len(s.T(), data.Combatants, 1)
+
+	// Load from context
+	newEventBus := events.NewBus()
+	gameCtx, err := game.NewContext(newEventBus, data)
+	require.NoError(s.T(), err)
+
+	loadedCombat, err := combat.LoadCombatStateFromContext(context.Background(), gameCtx)
+	require.NoError(s.T(), err)
+
+	// Verify loaded combat
+	assert.Equal(s.T(), s.combat.GetID(), loadedCombat.GetID())
+	assert.Equal(s.T(), s.combat.GetName(), loadedCombat.GetName())
+	assert.Equal(s.T(), s.combat.GetStatus(), loadedCombat.GetStatus())
+	assert.Equal(s.T(), s.combat.GetRound(), loadedCombat.GetRound())
+
+	// Current turn should be the same
+	originalTurn, err := s.combat.GetCurrentTurn()
+	require.NoError(s.T(), err)
+
+	loadedTurn, err := loadedCombat.GetCurrentTurn()
+	require.NoError(s.T(), err)
+
+	assert.Equal(s.T(), originalTurn.EntityID, loadedTurn.EntityID)
+	assert.Equal(s.T(), originalTurn.Total, loadedTurn.Total)
+}
+
+func (s *CombatTestSuite) TestEventEmission() {
+	// Track events
+	var capturedEvents []events.Event
+	s.eventBus.SubscribeFunc(combat.EventCombatantAdded, 100, func(_ context.Context, e events.Event) error {
+		capturedEvents = append(capturedEvents, e)
+		return nil
+	})
+
+	s.eventBus.SubscribeFunc(combat.EventInitiativeRolled, 100, func(_ context.Context, e events.Event) error {
+		capturedEvents = append(capturedEvents, e)
+		return nil
+	})
+
+	s.eventBus.SubscribeFunc(combat.EventCombatStarted, 100, func(_ context.Context, e events.Event) error {
+		capturedEvents = append(capturedEvents, e)
+		return nil
+	})
+
+	// Add combatant
+	combatant := &mockCombatant{
+		id:         "fighter-001",
+		entityType: "character",
+		dexMod:     2,
+		dexScore:   14,
+	}
+
+	err := s.combat.AddCombatant(combatant)
+	require.NoError(s.T(), err)
+
+	// Roll initiative
+	s.mockRoller.EXPECT().Roll(20).Return(15, nil)
+
+	input := &combat.RollInitiativeInput{
+		Combatants: []combat.Combatant{combatant},
+		Roller:     s.mockRoller,
+		RollMode:   combat.InitiativeRollModeRoll,
+	}
+
+	_, err = s.combat.RollInitiative(input)
+	require.NoError(s.T(), err)
+
+	// Start combat
+	err = s.combat.StartCombat()
+	require.NoError(s.T(), err)
+
+	// Verify events were emitted
+	assert.GreaterOrEqual(s.T(), len(capturedEvents), 3)
+
+	// Check event types
+	eventTypes := make([]string, len(capturedEvents))
+	for i, event := range capturedEvents {
+		eventTypes[i] = event.Type()
+	}
+
+	assert.Contains(s.T(), eventTypes, combat.EventCombatantAdded)
+	assert.Contains(s.T(), eventTypes, combat.EventInitiativeRolled)
+	assert.Contains(s.T(), eventTypes, combat.EventCombatStarted)
+}

--- a/rulebooks/dnd5e/go.mod
+++ b/rulebooks/dnd5e/go.mod
@@ -3,13 +3,15 @@ module github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e
 go 1.24.1
 
 require (
+	github.com/KirkDiggler/rpg-toolkit/core v0.1.0
+	github.com/KirkDiggler/rpg-toolkit/dice v0.1.0
+	github.com/KirkDiggler/rpg-toolkit/events v0.1.1
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/mock v0.5.2
 )
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.1.0 // indirect
-	github.com/KirkDiggler/rpg-toolkit/events v0.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/rulebooks/dnd5e/go.sum
+++ b/rulebooks/dnd5e/go.sum
@@ -1,5 +1,7 @@
 github.com/KirkDiggler/rpg-toolkit/core v0.1.0 h1:BUJ877kikqcQ0aOt2qUhLSUOVtCaCHLOSyw6nd18B7w=
 github.com/KirkDiggler/rpg-toolkit/core v0.1.0/go.mod h1:N7xIvJGjmrHHNjfWQ3O1LlkalzImcMav3O0fNOg+8No=
+github.com/KirkDiggler/rpg-toolkit/dice v0.1.0 h1:/tpfvSeV2NeaerItinsd1cc1I680cq3lkBL3EsV5Wz4=
+github.com/KirkDiggler/rpg-toolkit/dice v0.1.0/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.1 h1:6EFI8NsdPwoymE+ZEU0i2hBTCXBV7yXrFQ73RScdewE=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.1/go.mod h1:M+mF5gE04daLz73PX173IOn0CmVoAC6ff10Kx3BBCe8=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
@@ -10,6 +12,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
+go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary
- Implements Phase 1 of the turn-based combat system (issue #49)
- Adds complete D&D 5e initiative system to the toolkit's dnd5e rulebook
- Follows toolkit's rich domain object pattern with event-driven architecture

## Implementation Details
The combat system provides:
- **CombatState**: Rich domain object managing combat encounters
- **Initiative Rolling**: Multiple modes (roll d20, static 10+mod, manual)
- **Tie Resolution**: DEX comparison, DM decision, or re-rolls
- **Turn Management**: Round tracking with proper turn progression
- **Event System**: Full integration with toolkit's event bus
- **Persistence**: ToData/LoadFromContext pattern for save/load

## Architecture
Follows the toolkit patterns:
- Rich domain objects with behavior (CombatState)
- Data objects for persistence (CombatStateData)
- Input/Output types for all methods
- Event-driven communication
- Thread-safe with proper mutex usage

## Testing
- Comprehensive test suite using testify
- All initiative modes tested
- Tie resolution scenarios covered
- Turn progression validated
- Event emission verified
- Persistence round-trip tested

## Related Issues
- Implements Phase 1 of #49 (StartCombat RPC specification)
- Part of the movement system implementation tracked on project board

## Next Steps
- Phase 1: Define StartCombat and GetCombatState protos in rpg-api
- Phase 1: Add combat state management to rpg-api orchestrator
- Phase 1: Display initiative order in web UI

🤖 Generated with [Claude Code](https://claude.ai/code)