### PR TITLE
add Inititive roll as the output for roll for order

### DIFF
--- a/rulebooks/dnd5e/initiative/roller.go
+++ b/rulebooks/dnd5e/initiative/roller.go
@@ -15,7 +15,7 @@ type InitiativeRoll struct {
 	Total    int // Roll + Modifier
 }
 
-// RollForOrder rolls initiative and returns entities in turn order
+// RollForOrder rolls initiative and returns InitiativeRolls in turn order
 func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []InitiativeRoll {
 	// Use default roller if none provided
 	if roller == nil {

--- a/rulebooks/dnd5e/initiative/roller.go
+++ b/rulebooks/dnd5e/initiative/roller.go
@@ -7,8 +7,8 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 )
 
-// InitiativeRoll represents a single initiative roll
-type InitiativeRoll struct {
+// Roll represents a single initiative roll
+type Roll struct {
 	Entity   core.Entity
 	Roll     int // d20 result
 	Modifier int // DEX modifier
@@ -16,17 +16,17 @@ type InitiativeRoll struct {
 }
 
 // RollForOrder rolls initiative and returns InitiativeRolls in turn order
-func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []InitiativeRoll {
+func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []Roll {
 	// Use default roller if none provided
 	if roller == nil {
 		roller = dice.DefaultRoller
 	}
 
 	// Roll for each entity
-	entries := make([]InitiativeRoll, 0, len(entities))
+	entries := make([]Roll, 0, len(entities))
 	for entity, modifier := range entities {
 		roll, _ := roller.Roll(20)
-		entries = append(entries, InitiativeRoll{
+		entries = append(entries, Roll{
 			Entity:   entity,
 			Roll:     roll,
 			Modifier: modifier,

--- a/rulebooks/dnd5e/initiative/roller.go
+++ b/rulebooks/dnd5e/initiative/roller.go
@@ -7,26 +7,26 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 )
 
-// Entry represents someone's initiative with their entity
-type Entry struct {
+// InitiativeRoll represents a single initiative roll
+type InitiativeRoll struct {
 	Entity   core.Entity
-	Roll     int
-	Modifier int
-	Total    int
+	Roll     int // d20 result
+	Modifier int // DEX modifier
+	Total    int // Roll + Modifier
 }
 
 // RollForOrder rolls initiative and returns entities in turn order
-func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []core.Entity {
+func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []InitiativeRoll {
 	// Use default roller if none provided
 	if roller == nil {
 		roller = dice.DefaultRoller
 	}
 
 	// Roll for each entity
-	entries := make([]Entry, 0, len(entities))
+	entries := make([]InitiativeRoll, 0, len(entities))
 	for entity, modifier := range entities {
 		roll, _ := roller.Roll(20)
-		entries = append(entries, Entry{
+		entries = append(entries, InitiativeRoll{
 			Entity:   entity,
 			Roll:     roll,
 			Modifier: modifier,
@@ -39,11 +39,5 @@ func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []core.Entit
 		return entries[i].Total > entries[j].Total
 	})
 
-	// Extract just the entities in order
-	order := make([]core.Entity, len(entries))
-	for i, entry := range entries {
-		order[i] = entry.Entity
-	}
-
-	return order
+	return entries
 }

--- a/rulebooks/dnd5e/initiative/roller_test.go
+++ b/rulebooks/dnd5e/initiative/roller_test.go
@@ -34,7 +34,7 @@ func TestRollForOrder(t *testing.T) {
 
 	// Should be sorted by total: ranger (18), goblin (12), wizard (9)
 	assert.Equal(t, 3, len(order))
-	assert.Equal(t, "ranger", order[0].GetID())
-	assert.Equal(t, "goblin", order[1].GetID())
-	assert.Equal(t, "wizard", order[2].GetID())
+	assert.Equal(t, "ranger", order[0].Entity.GetID())
+	assert.Equal(t, "goblin", order[1].Entity.GetID())
+	assert.Equal(t, "wizard", order[2].Entity.GetID())
 }


### PR DESCRIPTION
This pull request refactors how initiative rolls are represented and returned in the D&D 5e initiative roller. Instead of returning an ordered list of entities, the core function now returns detailed roll results for each entity, including their roll, modifier, and total. This change improves transparency and flexibility for downstream consumers of the initiative logic.

Refactor initiative roll representation:

* Renamed the `Entry` struct to `InitiativeRoll` and made its purpose clearer by documenting its fields (`Roll`, `Modifier`, `Total`).

Change to function return type and logic:

* Updated the `RollForOrder` function to return a slice of `InitiativeRoll` structs instead of just entity order, preserving all roll details for each entity. [[1]](diffhunk://#diff-847fcea1d25b495a5b9c29c9441371c8f52fdcb2973bd1edbf1eb5828b3a538dL10-R29) [[2]](diffhunk://#diff-847fcea1d25b495a5b9c29c9441371c8f52fdcb2973bd1edbf1eb5828b3a538dL42-R42)

Test updates for new structure:

* Modified the test assertions in `roller_test.go` to access entity IDs through the new `InitiativeRoll` struct, ensuring tests validate the updated function output.