### PR TITLE
add safe way to tag modules

### DIFF
--- a/.github/workflows/auto-tag-modules-safe.yml
+++ b/.github/workflows/auto-tag-modules-safe.yml
@@ -1,0 +1,237 @@
+name: Auto Tag Modules (Safe)
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Set up Git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+    
+    - name: Analyze commits and tag modules
+      run: |
+        # Function to determine version bump from commit messages
+        # Looks for conventional commit patterns:
+        # - feat: minor bump
+        # - fix: patch bump  
+        # - BREAKING CHANGE: major bump
+        # - chore/docs/style/refactor/test: patch bump
+        determine_bump() {
+          local module=$1
+          local last_tag=$2
+          
+          if [[ -z "$last_tag" ]]; then
+            compare_from="HEAD~10"  # Look at last 10 commits for new modules
+          else
+            compare_from="$last_tag"
+          fi
+          
+          # Check commit messages for this module
+          commits=$(git log --format="%s" "$compare_from..HEAD" -- "$module" 2>/dev/null || echo "")
+          
+          # Default to patch
+          bump="patch"
+          
+          # Check for breaking changes (major)
+          if echo "$commits" | grep -q "BREAKING CHANGE\|!:"; then
+            bump="major"
+          # Check for features (minor)
+          elif echo "$commits" | grep -q "^feat"; then
+            bump="minor"
+          fi
+          
+          echo "$bump"
+        }
+        
+        # Function to increment version
+        increment_version() {
+          local version=$1
+          local bump=$2
+          
+          # Remove 'v' prefix
+          version=${version#v}
+          
+          # Split into major.minor.patch
+          IFS='.' read -r major minor patch <<< "$version"
+          
+          case $bump in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+          esac
+          
+          echo "v${major}.${minor}.${patch}"
+        }
+        
+        # Track what we tag for the summary
+        TAGGED_MODULES=()
+        SKIPPED_MODULES=()
+        
+        # Process each module
+        for modfile in $(find . -name "go.mod" -type f -not -path "./vendor/*" -not -path "./examples/*"); do
+          module_path=$(dirname "$modfile" | sed 's|^\./||')
+          
+          # Skip root module
+          if [[ "$module_path" == "." ]]; then
+            continue
+          fi
+          
+          # Get last tag for this module
+          last_tag=$(git tag -l "${module_path}/v*" | sort -V | tail -1)
+          
+          # Check if module has changes since last tag
+          if [[ -z "$last_tag" ]]; then
+            has_changes=true  # New module
+          else
+            changes=$(git diff --name-only "$last_tag" HEAD -- "$module_path" | head -1)
+            has_changes=$([[ -n "$changes" ]] && echo true || echo false)
+          fi
+          
+          if [[ "$has_changes" == "true" ]]; then
+            echo "Module $module_path has changes"
+            
+            # Determine version bump type
+            bump=$(determine_bump "$module_path" "$last_tag")
+            echo "Detected bump type: $bump"
+            
+            # Calculate new version
+            if [[ -z "$last_tag" ]]; then
+              new_version="v0.1.0"
+            else
+              current_version=${last_tag#${module_path}/}
+              new_version=$(increment_version "$current_version" "$bump")
+            fi
+            
+            # Create tag
+            tag_name="${module_path}/${new_version}"
+            
+            # Check if tag already exists
+            if git tag -l "$tag_name" | grep -q "^${tag_name}$"; then
+              echo "Tag ${tag_name} already exists locally, skipping"
+              SKIPPED_MODULES+=("${module_path}:${new_version}:exists")
+              continue
+            fi
+            
+            # Check if tag exists on remote
+            if git ls-remote --tags origin | grep -q "refs/tags/${tag_name}$"; then
+              echo "Tag ${tag_name} already exists on remote, skipping"
+              SKIPPED_MODULES+=("${module_path}:${new_version}:remote_exists")
+              continue
+            fi
+            
+            # Generate release notes
+            release_notes="## ${module_path} ${new_version}\n\n"
+            
+            if [[ -n "$last_tag" ]]; then
+              # Include commit summary
+              release_notes="${release_notes}### Changes\n"
+              git log --format="- %s (%h)" "$last_tag..HEAD" -- "$module_path" | while read -r line; do
+                release_notes="${release_notes}${line}\n"
+              done
+            else
+              release_notes="${release_notes}Initial release\n"
+            fi
+            
+            # Create annotated tag
+            echo -e "$release_notes" | git tag -a "$tag_name" -F -
+            echo "Created tag: $tag_name"
+            
+            TAGGED_MODULES+=("${module_path}:${new_version}")
+          fi
+        done
+        
+        # Push only the new tags
+        if [[ ${#TAGGED_MODULES[@]} -gt 0 ]]; then
+          echo "Pushing ${#TAGGED_MODULES[@]} new tags..."
+          
+          # Push each tag individually to avoid failures
+          for item in "${TAGGED_MODULES[@]}"; do
+            IFS=':' read -r module version <<< "$item"
+            tag_name="${module}/${version}"
+            
+            if git push origin "$tag_name" 2>/dev/null; then
+              echo "✅ Pushed tag: $tag_name"
+            else
+              echo "⚠️  Failed to push tag: $tag_name (may already exist)"
+            fi
+          done
+          
+          # Save for summary
+          printf '%s\n' "${TAGGED_MODULES[@]}" > tagged_modules.txt
+        else
+          echo "No modules needed tagging"
+          touch tagged_modules.txt
+        fi
+        
+        # Save skipped modules for summary
+        if [[ ${#SKIPPED_MODULES[@]} -gt 0 ]]; then
+          printf '%s\n' "${SKIPPED_MODULES[@]}" > skipped_modules.txt
+        else
+          touch skipped_modules.txt
+        fi
+    
+    - name: Generate summary
+      run: |
+        echo "## 📦 Module Tagging Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        if [[ -s tagged_modules.txt ]]; then
+          echo "### ✅ Successfully Tagged" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The following modules were automatically versioned based on their commits:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          while IFS=: read -r module version; do
+            echo "- **${module}** → ${version}" >> $GITHUB_STEP_SUMMARY
+            echo "  - Install: \`go get github.com/KirkDiggler/rpg-toolkit/${module}@${module}/${version}\`" >> $GITHUB_STEP_SUMMARY
+          done < tagged_modules.txt
+          echo "" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        if [[ -s skipped_modules.txt ]]; then
+          echo "### ⚠️  Skipped (Already Exists)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The following tags were skipped because they already exist:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          while IFS=: read -r module version reason; do
+            echo "- **${module}** → ${version} (${reason})" >> $GITHUB_STEP_SUMMARY
+          done < skipped_modules.txt
+          echo "" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        if [[ ! -s tagged_modules.txt ]] && [[ ! -s skipped_modules.txt ]]; then
+          echo "### ℹ️ No Module Changes" >> $GITHUB_STEP_SUMMARY
+          echo "No modules had changes that required new version tags." >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "---" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Version Bump Rules:" >> $GITHUB_STEP_SUMMARY
+        echo "- \`feat:\` commits trigger **minor** version bump (0.X.0)" >> $GITHUB_STEP_SUMMARY
+        echo "- \`fix:\` commits trigger **patch** version bump (0.0.X)" >> $GITHUB_STEP_SUMMARY
+        echo "- \`BREAKING CHANGE\` triggers **major** version bump (X.0.0)" >> $GITHUB_STEP_SUMMARY

--- a/scripts/safe-tag-modules.sh
+++ b/scripts/safe-tag-modules.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+# Safe module tagging script that handles existing tags gracefully
+
+set -e
+
+echo "🔍 Analyzing modules for tagging..."
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to determine version bump from commit messages
+determine_bump() {
+  local module=$1
+  local last_tag=$2
+  
+  if [[ -z "$last_tag" ]]; then
+    compare_from="HEAD~10"  # Look at last 10 commits for new modules
+  else
+    compare_from="$last_tag"
+  fi
+  
+  # Check commit messages for this module
+  commits=$(git log --format="%s" "$compare_from..HEAD" -- "$module" 2>/dev/null || echo "")
+  
+  # Default to patch
+  bump="patch"
+  
+  # Check for breaking changes (major)
+  if echo "$commits" | grep -q "BREAKING CHANGE\|!:"; then
+    bump="major"
+  # Check for features (minor)
+  elif echo "$commits" | grep -q "^feat"; then
+    bump="minor"
+  fi
+  
+  echo "$bump"
+}
+
+# Function to increment version
+increment_version() {
+  local version=$1
+  local bump=$2
+  
+  # Remove 'v' prefix
+  version=${version#v}
+  
+  # Split into major.minor.patch
+  IFS='.' read -r major minor patch <<< "$version"
+  
+  case $bump in
+    major)
+      major=$((major + 1))
+      minor=0
+      patch=0
+      ;;
+    minor)
+      minor=$((minor + 1))
+      patch=0
+      ;;
+    patch)
+      patch=$((patch + 1))
+      ;;
+  esac
+  
+  echo "v${major}.${minor}.${patch}"
+}
+
+# Track what we tag for the summary
+TAGGED_MODULES=()
+SKIPPED_MODULES=()
+FAILED_MODULES=()
+
+# Process each module
+for modfile in $(find . -name "go.mod" -type f -not -path "./vendor/*" -not -path "./examples/*"); do
+  module_path=$(dirname "$modfile" | sed 's|^\./||')
+  
+  # Skip root module
+  if [[ "$module_path" == "." ]]; then
+    continue
+  fi
+  
+  echo -e "${BLUE}📦 Checking module: ${module_path}${NC}"
+  
+  # Get last tag for this module
+  last_tag=$(git tag -l "${module_path}/v*" 2>/dev/null | sort -V | tail -1)
+  
+  # Check if module has changes since last tag
+  if [[ -z "$last_tag" ]]; then
+    has_changes=true  # New module
+    echo "  → New module (no existing tags)"
+  else
+    changes=$(git diff --name-only "$last_tag" HEAD -- "$module_path" 2>/dev/null | head -1)
+    has_changes=$([[ -n "$changes" ]] && echo true || echo false)
+    if [[ "$has_changes" == "true" ]]; then
+      echo "  → Has changes since ${last_tag}"
+    else
+      echo "  → No changes since ${last_tag}"
+    fi
+  fi
+  
+  if [[ "$has_changes" == "true" ]]; then
+    # Determine version bump type
+    bump=$(determine_bump "$module_path" "$last_tag")
+    echo "  → Detected bump type: ${bump}"
+    
+    # Calculate new version
+    if [[ -z "$last_tag" ]]; then
+      new_version="v0.1.0"
+    else
+      current_version=${last_tag#${module_path}/}
+      new_version=$(increment_version "$current_version" "$bump")
+    fi
+    
+    # Create tag
+    tag_name="${module_path}/${new_version}"
+    
+    # Check if tag already exists (locally or remotely)
+    if git tag -l "$tag_name" | grep -q "^${tag_name}$"; then
+      echo -e "  ${YELLOW}⚠️  Tag ${tag_name} already exists locally, skipping${NC}"
+      SKIPPED_MODULES+=("${module_path}:${new_version}:exists_locally")
+      continue
+    fi
+    
+    # Check if tag exists on remote
+    if git ls-remote --tags origin | grep -q "refs/tags/${tag_name}$"; then
+      echo -e "  ${YELLOW}⚠️  Tag ${tag_name} already exists on remote, skipping${NC}"
+      SKIPPED_MODULES+=("${module_path}:${new_version}:exists_remotely")
+      continue
+    fi
+    
+    # Generate release notes
+    release_notes="## ${module_path} ${new_version}
+
+"
+    
+    if [[ -n "$last_tag" ]]; then
+      # Include commit summary
+      release_notes="${release_notes}### Changes
+"
+      while IFS= read -r line; do
+        release_notes="${release_notes}${line}
+"
+      done < <(git log --format="- %s (%h)" "$last_tag..HEAD" -- "$module_path" 2>/dev/null || echo "- No commit history available")
+    else
+      release_notes="${release_notes}Initial release
+"
+    fi
+    
+    # Create annotated tag
+    if echo -e "$release_notes" | git tag -a "$tag_name" -F - 2>/dev/null; then
+      echo -e "  ${GREEN}✓ Created tag: ${tag_name}${NC}"
+      TAGGED_MODULES+=("${module_path}:${new_version}")
+    else
+      echo -e "  ${RED}✗ Failed to create tag: ${tag_name}${NC}"
+      FAILED_MODULES+=("${module_path}:${new_version}")
+    fi
+  fi
+  echo ""
+done
+
+# Summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "📊 Summary:"
+echo ""
+
+if [[ ${#TAGGED_MODULES[@]} -gt 0 ]]; then
+  echo -e "${GREEN}✅ Successfully tagged ${#TAGGED_MODULES[@]} module(s):${NC}"
+  for item in "${TAGGED_MODULES[@]}"; do
+    IFS=':' read -r module version <<< "$item"
+    echo "   • ${module} → ${version}"
+  done
+  echo ""
+fi
+
+if [[ ${#SKIPPED_MODULES[@]} -gt 0 ]]; then
+  echo -e "${YELLOW}⚠️  Skipped ${#SKIPPED_MODULES[@]} module(s) (tags already exist):${NC}"
+  for item in "${SKIPPED_MODULES[@]}"; do
+    IFS=':' read -r module version reason <<< "$item"
+    echo "   • ${module} → ${version} (${reason})"
+  done
+  echo ""
+fi
+
+if [[ ${#FAILED_MODULES[@]} -gt 0 ]]; then
+  echo -e "${RED}✗ Failed to tag ${#FAILED_MODULES[@]} module(s):${NC}"
+  for item in "${FAILED_MODULES[@]}"; do
+    IFS=':' read -r module version <<< "$item"
+    echo "   • ${module} → ${version}"
+  done
+  echo ""
+fi
+
+# Push tags if any were created
+if [[ ${#TAGGED_MODULES[@]} -gt 0 ]]; then
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "📤 Ready to push tags to remote"
+  echo ""
+  echo "To push the new tags, run:"
+  echo -e "${BLUE}  git push origin --tags${NC}"
+  echo ""
+  echo "Or to push specific tags only:"
+  for item in "${TAGGED_MODULES[@]}"; do
+    IFS=':' read -r module version <<< "$item"
+    echo -e "${BLUE}  git push origin ${module}/${version}${NC}"
+  done
+else
+  if [[ ${#SKIPPED_MODULES[@]} -eq 0 ]]; then
+    echo "No modules needed tagging."
+  fi
+fi


### PR DESCRIPTION
This pull request introduces automated and safe tagging for Go modules based on commit history, both as a GitHub Actions workflow and as a standalone script. The main goal is to analyze changes in each module, determine the appropriate semantic version bump (major, minor, patch), and create annotated tags with release notes, while gracefully handling cases where tags already exist.

**Automated module tagging and versioning:**

* Added `.github/workflows/auto-tag-modules-safe.yml` to run on pushes to `main`, automatically analyzing each module for changes and tagging them according to semantic versioning rules based on commit messages.
* Introduced `scripts/safe-tag-modules.sh`, a bash script that performs similar tagging logic locally, including color-coded output, summary of tagged/skipped/failed modules, and instructions for pushing new tags.

**Tagging logic and safety improvements:**

* Both the workflow and script determine bump type (`major`, `minor`, `patch`) by parsing commit messages for conventional keywords (`feat`, `fix`, `BREAKING CHANGE`), and increment the version accordingly [[1]](diffhunk://#diff-2aa01f624d401ab76b29b6a774f22a5b23e191ee85738a8af6e117d30a09110aR1-R237) [[2]](diffhunk://#diff-a3cd8fff8f79fd6b9f99de9019e8dff52b796b800749a11e48b5332d1f305c70R1-R218).
* Skips tagging if the computed tag already exists locally or remotely, preventing accidental duplicate tags and reporting skipped modules in the summary [[1]](diffhunk://#diff-2aa01f624d401ab76b29b6a774f22a5b23e191ee85738a8af6e117d30a09110aR1-R237) [[2]](diffhunk://#diff-a3cd8fff8f79fd6b9f99de9019e8dff52b796b800749a11e48b5332d1f305c70R1-R218).

**Release notes and reporting:**

* Generates release notes for each tag, including a summary of commits since the last tag or an "Initial release" note for new modules [[1]](diffhunk://#diff-2aa01f624d401ab76b29b6a774f22a5b23e191ee85738a8af6e117d30a09110aR1-R237) [[2]](diffhunk://#diff-a3cd8fff8f79fd6b9f99de9019e8dff52b796b800749a11e48b5332d1f305c70R1-R218).
* Provides a summary of all actions taken (tagged, skipped, failed) at the end of the workflow and script, improving visibility for maintainers [[1]](diffhunk://#diff-2aa01f624d401ab76b29b6a774f22a5b23e191ee85738a8af6e117d30a09110aR1-R237) [[2]](diffhunk://#diff-a3cd8fff8f79fd6b9f99de9019e8dff52b796b800749a11e48b5332d1f305c70R1-R218).