### PR TITLE
feat(core): improve Ref API with RefInput struct

### DIFF
--- a/core/doc.go
+++ b/core/doc.go
@@ -46,7 +46,11 @@
 // Ref Example:
 //
 //	// Define compile-time constants for core features
-//	var Rage = core.MustNewRef("rage", "core", "feature")
+//	var Rage = core.MustNewRef(core.RefInput{
+//		Module: "core",
+//		Type:   "feature",
+//		Value:  "rage",
+//	})
 //
 //	// Track where features come from
 //	feature := core.NewSourcedRef(Rage, "class:barbarian")

--- a/core/ref.go
+++ b/core/ref.go
@@ -195,12 +195,30 @@ func (id *Ref) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// NewRef creates a new identifier with validation
-func NewRef(value, module, idType string) (*Ref, error) {
+// RefInput provides a structured way to create a Ref with clear field names
+type RefInput struct {
+	Module string // e.g., "dnd5e", "core"
+	Type   string // e.g., "spell", "feature", "skill"
+	Value  string // e.g., "charm_person", "rage", "acrobatics"
+}
+
+// NewRef creates a new identifier with validation using RefInput
+func NewRef(input RefInput) (*Ref, error) {
+	// Validate all fields are provided
+	if input.Module == "" {
+		return nil, fmt.Errorf("module cannot be empty")
+	}
+	if input.Type == "" {
+		return nil, fmt.Errorf("type cannot be empty")
+	}
+	if input.Value == "" {
+		return nil, fmt.Errorf("value cannot be empty")
+	}
+
 	id := &Ref{
-		Value:  value,
-		Module: module,
-		Type:   idType,
+		Module: input.Module,
+		Type:   input.Type,
+		Value:  input.Value,
 	}
 
 	if err := id.IsValid(); err != nil {
@@ -212,8 +230,8 @@ func NewRef(value, module, idType string) (*Ref, error) {
 
 // MustNewRef creates a new identifier, panicking on validation error.
 // Use this for compile-time constants where you know the values are valid.
-func MustNewRef(value, module, idType string) *Ref {
-	id, err := NewRef(value, module, idType)
+func MustNewRef(input RefInput) *Ref {
+	id, err := NewRef(input)
 	if err != nil {
 		panic(fmt.Sprintf("invalid identifier: %v", err))
 	}

--- a/core/ref_test.go
+++ b/core/ref_test.go
@@ -51,7 +51,11 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			id, err := core.NewRef(tt.value, tt.module, tt.idType)
+			id, err := core.NewRef(core.RefInput{
+				Module: tt.module,
+				Type:   tt.idType,
+				Value:  tt.value,
+			})
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -65,15 +69,15 @@ func TestNew(t *testing.T) {
 }
 
 func TestID_String(t *testing.T) {
-	id := core.MustNewRef("darkvision", "core", "feature")
+	id := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: "darkvision"})
 	assert.Equal(t, "core:feature:darkvision", id.String())
 }
 
 func TestID_Equals(t *testing.T) {
-	id1 := core.MustNewRef("darkvision", "core", "feature")
-	id2 := core.MustNewRef("darkvision", "core", "feature")
-	id3 := core.MustNewRef("darkvision", "core", "proficiency")
-	id4 := core.MustNewRef("keen_senses", "core", "feature")
+	id1 := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: "darkvision"})
+	id2 := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: "darkvision"})
+	id3 := core.MustNewRef(core.RefInput{Module: "core", Type: "proficiency", Value: "darkvision"})
+	id4 := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: "keen_senses"})
 
 	assert.True(t, id1.Equals(id2), "identical IDs should be equal")
 	assert.False(t, id1.Equals(id3), "different types should not be equal")
@@ -87,7 +91,7 @@ func TestID_Equals(t *testing.T) {
 }
 
 func TestID_JSONMarshaling(t *testing.T) {
-	original := core.MustNewRef("athletics", "core", "skill")
+	original := core.MustNewRef(core.RefInput{Module: "core", Type: "skill", Value: "athletics"})
 
 	// Marshal to JSON
 	data, err := json.Marshal(original)
@@ -115,7 +119,7 @@ func TestID_JSONUnmarshal_BackwardCompatibility(t *testing.T) {
 }
 
 func TestWithSource(t *testing.T) {
-	id := core.MustNewRef("second_wind", "core", "feature")
+	id := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: "second_wind"})
 	withSource := core.NewWithSourcedRef(id, &core.Source{
 		Category: core.SourceClass,
 		Name:     "fighter",
@@ -138,7 +142,7 @@ func TestWithSource(t *testing.T) {
 
 func TestMustNew_Panics(t *testing.T) {
 	assert.Panics(t, func() {
-		core.MustNewRef("", "core", "feature")
+		core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: ""})
 	}, "MustNewRef should panic with invalid input")
 }
 
@@ -154,17 +158,17 @@ func TestParseString(t *testing.T) {
 		{
 			name:  "valid identifier",
 			input: "core:feature:rage",
-			want:  core.MustNewRef("rage", "core", "feature"),
+			want:  core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: "rage"}),
 		},
 		{
 			name:  "valid with underscores",
 			input: "core:feature:sneak_attack",
-			want:  core.MustNewRef("sneak_attack", "core", "feature"),
+			want:  core.MustNewRef(core.RefInput{Module: "core", Type: "feature", Value: "sneak_attack"}),
 		},
 		{
 			name:  "valid with dashes",
 			input: "third-party:feature:custom-ability",
-			want:  core.MustNewRef("custom-ability", "third-party", "feature"),
+			want:  core.MustNewRef(core.RefInput{Module: "third-party", Type: "feature", Value: "custom-ability"}),
 		},
 		{
 			name:         "empty string",

--- a/mechanics/conditions/go.mod
+++ b/mechanics/conditions/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-toolkit/mechanics/conditions
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.1.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/mechanics/effects v0.0.0
 	github.com/stretchr/testify v1.10.0

--- a/mechanics/proficiency/go.mod
+++ b/mechanics/proficiency/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.1.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.1.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/mechanics/effects v0.0.0
 	go.uber.org/mock v0.5.2

--- a/mechanics/proficiency/go.sum
+++ b/mechanics/proficiency/go.sum
@@ -1,5 +1,6 @@
 github.com/KirkDiggler/rpg-toolkit/core v0.1.0 h1:BUJ877kikqcQ0aOt2qUhLSUOVtCaCHLOSyw6nd18B7w=
 github.com/KirkDiggler/rpg-toolkit/core v0.1.0/go.mod h1:N7xIvJGjmrHHNjfWQ3O1LlkalzImcMav3O0fNOg+8No=
+github.com/KirkDiggler/rpg-toolkit/core v0.1.2/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.1.0 h1:/tpfvSeV2NeaerItinsd1cc1I680cq3lkBL3EsV5Wz4=
 github.com/KirkDiggler/rpg-toolkit/dice v0.1.0/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.0 h1:ec8t66jaZkuir+FfqNZvK6m2PfLOwmtOY2vjZ64+Bpg=


### PR DESCRIPTION
## Summary
- Replaced confusing 3-string parameters with clear RefInput struct
- Fields now match logical order: Module, Type, Value (like "dnd5e:spell:charm_person")
- Added validation to prevent empty RefInput{} bugs

## Why This Change?
The old API had parameters in the wrong order:
```go
// Old - confusing order
MustNewRef("charm_person", "dnd5e", "spell") // value, module, type??

// New - clear and self-documenting  
MustNewRef(RefInput{
    Module: "dnd5e",
    Type:   "spell",
    Value:  "charm_person",
})
```

## Benefits
- Self-documenting at call sites
- Can't mix up parameter order
- Validation prevents empty struct bugs
- Matches how we think about refs: module:type:value

## Test Plan
- [x] All existing tests pass
- [x] Updated documentation examples

🤖 Generated with [Claude Code](https://claude.ai/code)