### PR TITLE
feat(proficiency): update to use core.Ref and core.Source

### DIFF
--- a/mechanics/proficiency/go.mod
+++ b/mechanics/proficiency/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.1.2
+	github.com/KirkDiggler/rpg-toolkit/core v0.2.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/mechanics/effects v0.0.0
 	go.uber.org/mock v0.5.2

--- a/mechanics/proficiency/go.sum
+++ b/mechanics/proficiency/go.sum
@@ -1,6 +1,8 @@
 github.com/KirkDiggler/rpg-toolkit/core v0.1.0 h1:BUJ877kikqcQ0aOt2qUhLSUOVtCaCHLOSyw6nd18B7w=
 github.com/KirkDiggler/rpg-toolkit/core v0.1.0/go.mod h1:N7xIvJGjmrHHNjfWQ3O1LlkalzImcMav3O0fNOg+8No=
 github.com/KirkDiggler/rpg-toolkit/core v0.1.2/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.2.0 h1:yU/6c/jxRXB0Q7RP/uFK7kCXWanY08wUU+C5m3wSBRM=
+github.com/KirkDiggler/rpg-toolkit/core v0.2.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.1.0 h1:/tpfvSeV2NeaerItinsd1cc1I680cq3lkBL3EsV5Wz4=
 github.com/KirkDiggler/rpg-toolkit/dice v0.1.0/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.0 h1:ec8t66jaZkuir+FfqNZvK6m2PfLOwmtOY2vjZ64+Bpg=

--- a/mechanics/proficiency/proficiency.go
+++ b/mechanics/proficiency/proficiency.go
@@ -23,10 +23,10 @@ type Proficiency interface {
 	Owner() core.Entity
 
 	// Subject returns what the entity is proficient with (e.g., "longsword", "athletics").
-	Subject() string
+	Subject() *core.Ref
 
 	// Source returns what granted this proficiency (e.g., "fighter-class", "elf-race").
-	Source() string
+	Source() *core.Source
 
 	// IsActive returns whether the proficiency is currently active.
 	IsActive() bool

--- a/mechanics/proficiency/simple.go
+++ b/mechanics/proficiency/simple.go
@@ -14,8 +14,8 @@ type SimpleProficiencyConfig struct {
 	ID      string
 	Type    string // e.g., "proficiency.weapon", "proficiency.skill"
 	Owner   core.Entity
-	Subject string // What they're proficient with
-	Source  string // What granted this proficiency
+	Subject *core.Ref    // What they're proficient with
+	Source  *core.Source // What granted this proficiency
 
 	// Optional handlers - receive the proficiency itself for self-reference
 	ApplyFunc  func(p *SimpleProficiency, bus events.EventBus) error
@@ -29,7 +29,7 @@ type SimpleProficiency struct {
 	core *effects.Core
 
 	owner   core.Entity
-	subject string
+	subject *core.Ref
 
 	// Handler functions
 	applyFunc  func(p *SimpleProficiency, bus events.EventBus) error
@@ -81,10 +81,10 @@ func (p *SimpleProficiency) GetType() string { return p.core.GetType() }
 func (p *SimpleProficiency) Owner() core.Entity { return p.owner }
 
 // Subject returns what the entity is proficient with
-func (p *SimpleProficiency) Subject() string { return p.subject }
+func (p *SimpleProficiency) Subject() *core.Ref { return p.subject }
 
 // Source returns what granted this proficiency
-func (p *SimpleProficiency) Source() string { return p.core.Source() }
+func (p *SimpleProficiency) Source() *core.Source { return p.core.Source() }
 
 // IsActive returns whether the proficiency is active
 func (p *SimpleProficiency) IsActive() bool { return p.core.IsActive() }

--- a/mechanics/proficiency/simple_test.go
+++ b/mechanics/proficiency/simple_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/mechanics/proficiency"
 )
@@ -35,8 +36,15 @@ func TestSimpleProficiency(t *testing.T) {
 		ID:      "prof-longsword",
 		Type:    "proficiency.weapon",
 		Owner:   character,
-		Subject: "longsword",
-		Source:  "fighter-class",
+		Subject: core.MustNewRef(core.RefInput{
+			Module: "core",
+			Type:   "weapon",
+			Value:  "longsword",
+		}),
+		Source:  &core.Source{
+			Category: core.SourceClass,
+			Name:     "fighter",
+		},
 		ApplyFunc: func(p *proficiency.SimpleProficiency, bus events.EventBus) error {
 			// Subscribe to attack roll events
 			p.Subscribe(bus, events.EventBeforeAttack, 100, func(_ context.Context, e events.Event) error {
@@ -94,8 +102,15 @@ func TestProficiencyMetadata(t *testing.T) {
 		ID:      "prof-athletics",
 		Type:    "proficiency.skill",
 		Owner:   character,
-		Subject: "athletics",
-		Source:  "barbarian-class",
+		Subject: core.MustNewRef(core.RefInput{
+			Module: "core",
+			Type:   "skill",
+			Value:  "athletics",
+		}),
+		Source:  &core.Source{
+			Category: core.SourceClass,
+			Name:     "barbarian",
+		},
 	})
 
 	// Test metadata
@@ -111,11 +126,16 @@ func TestProficiencyMetadata(t *testing.T) {
 		t.Errorf("Expected owner ID %s, got %s", character.GetID(), prof.Owner().GetID())
 	}
 
-	if prof.Subject() != "athletics" {
-		t.Errorf("Expected subject 'athletics', got %s", prof.Subject())
+	athleticsRef := core.MustNewRef(core.RefInput{
+		Module: "core",
+		Type:   "skill",
+		Value:  "athletics",
+	})
+	if !prof.Subject().Equals(athleticsRef) {
+		t.Errorf("Expected subject 'athletics', got %s", prof.Subject().String())
 	}
 
-	if prof.Source() != "barbarian-class" {
-		t.Errorf("Expected source 'barbarian-class', got %s", prof.Source())
+	if prof.Source().Category != core.SourceClass || prof.Source().Name != "barbarian" {
+		t.Errorf("Expected source class:barbarian, got %s", prof.Source().String())
 	}
 }


### PR DESCRIPTION
## Summary
- Updated proficiency module to use structured types for Subject and Source
- Leverages effects.Core v0.2.0 which already supports *core.Source

## Changes
- **Proficiency interface**: 
  - `Subject()` now returns `*core.Ref` instead of string
  - `Source()` now returns `*core.Source` instead of string
- **SimpleProficiencyConfig**: Uses structured types
- **SimpleProficiency**: Delegates Source() to effects.Core
- **Tests**: Updated to use RefInput and Source structs

## Example Usage
```go
// Before
prof := proficiency.NewSimpleProficiency(proficiency.SimpleProficiencyConfig{
    Subject: "longsword",
    Source:  "fighter-class",
})

// After  
prof := proficiency.NewSimpleProficiency(proficiency.SimpleProficiencyConfig{
    Subject: core.MustNewRef(core.RefInput{
        Module: "core",
        Type:   "weapon",
        Value:  "longsword",
    }),
    Source: &core.Source{
        Category: core.SourceClass,
        Name:     "fighter",
    },
})
```

## Benefits
- Type safety for proficiency subjects
- Clear source categorization (class, race, feat, etc.)
- Consistency with other mechanics modules
- No more string parsing or guessing formats

## Test Plan
- [x] All existing tests pass
- [x] Proficiency metadata correctly uses new types

🤖 Generated with [Claude Code](https://claude.ai/code)