### PR TITLE
feat: Phase 1 - Add generic Action[T] interface

### DIFF
--- a/core/action.go
+++ b/core/action.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import "context"
+
+// Action represents something that can be activated in the game.
+// The generic type T defines what input the action requires.
+//
+// Actions are the fundamental unit of "doing things" in RPGs - casting spells,
+// using abilities, activating items, or any other triggered behavior.
+// The toolkit provides this interface, but all implementations live in rulebooks.
+//
+// Example usage in a rulebook:
+//
+//	type RageInput struct{}  // No input needed for rage
+//	
+//	type Rage struct {
+//	    id   string
+//	    uses int
+//	}
+//	
+//	func (r *Rage) GetID() string { return r.id }
+//	func (r *Rage) GetType() string { return "feature" }
+//	
+//	func (r *Rage) CanActivate(ctx context.Context, owner Entity, input RageInput) error {
+//	    if r.uses <= 0 {
+//	        return errors.New("no rage uses remaining")
+//	    }
+//	    return nil
+//	}
+//	
+//	func (r *Rage) Activate(ctx context.Context, owner Entity, input RageInput) error {
+//	    r.uses--
+//	    // Apply rage effects via event bus
+//	    return nil
+//	}
+type Action[T any] interface {
+	Entity // Has GetID() and GetType()
+
+	// CanActivate checks if this action can currently be activated.
+	// Should return an error if the action cannot be used (no resources,
+	// conditions not met, on cooldown, etc.)
+	CanActivate(ctx context.Context, owner Entity, input T) error
+
+	// Activate performs the action.
+	// Should consume resources, apply effects, and trigger events as needed.
+	// The owner is the entity performing the action.
+	Activate(ctx context.Context, owner Entity, input T) error
+}

--- a/core/action_test.go
+++ b/core/action_test.go
@@ -1,0 +1,172 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Example: An action with no input (like Rage)
+type EmptyInput struct{}
+
+type SimpleAction struct {
+	id        string
+	uses      int
+	activated bool
+}
+
+func (s *SimpleAction) GetID() string   { return s.id }
+func (s *SimpleAction) GetType() string { return "simple" }
+
+func (s *SimpleAction) CanActivate(ctx context.Context, owner core.Entity, input EmptyInput) error {
+	if s.uses <= 0 {
+		return errors.New("no uses remaining")
+	}
+	return nil
+}
+
+func (s *SimpleAction) Activate(ctx context.Context, owner core.Entity, input EmptyInput) error {
+	s.uses--
+	s.activated = true
+	return nil
+}
+
+// Example: An action with targeting input (like a spell)
+type TargetInput struct {
+	Target   core.Entity
+	Distance float64
+}
+
+type TargetedAction struct {
+	id       string
+	maxRange float64
+	lastTarget core.Entity
+}
+
+func (t *TargetedAction) GetID() string   { return t.id }
+func (t *TargetedAction) GetType() string { return "targeted" }
+
+func (t *TargetedAction) CanActivate(ctx context.Context, owner core.Entity, input TargetInput) error {
+	if input.Distance > t.maxRange {
+		return errors.New("target out of range")
+	}
+	if input.Target == nil {
+		return errors.New("no target specified")
+	}
+	return nil
+}
+
+func (t *TargetedAction) Activate(ctx context.Context, owner core.Entity, input TargetInput) error {
+	t.lastTarget = input.Target
+	// Would apply effects to target here
+	return nil
+}
+
+// MockEntity for testing
+type MockEntity struct {
+	id    string
+	eType string
+}
+
+func (m *MockEntity) GetID() string   { return m.id }
+func (m *MockEntity) GetType() string { return m.eType }
+
+func TestActionInterface(t *testing.T) {
+	t.Run("SimpleAction", func(t *testing.T) {
+		action := &SimpleAction{
+			id:   "rage",
+			uses: 3,
+		}
+		owner := &MockEntity{id: "barbarian", eType: "character"}
+		
+		// Verify it implements the interface
+		var _ core.Action[EmptyInput] = action
+		
+		// Can activate when has uses
+		err := action.CanActivate(context.Background(), owner, EmptyInput{})
+		require.NoError(t, err)
+		
+		// Activate consumes a use
+		err = action.Activate(context.Background(), owner, EmptyInput{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, action.uses)
+		assert.True(t, action.activated)
+		
+		// Use remaining uses
+		action.Activate(context.Background(), owner, EmptyInput{})
+		action.Activate(context.Background(), owner, EmptyInput{})
+		
+		// Cannot activate with no uses
+		err = action.CanActivate(context.Background(), owner, EmptyInput{})
+		assert.EqualError(t, err, "no uses remaining")
+	})
+	
+	t.Run("TargetedAction", func(t *testing.T) {
+		action := &TargetedAction{
+			id:       "fireball",
+			maxRange: 150.0,
+		}
+		owner := &MockEntity{id: "wizard", eType: "character"}
+		target := &MockEntity{id: "goblin", eType: "monster"}
+		
+		// Verify it implements the interface
+		var _ core.Action[TargetInput] = action
+		
+		// Can activate with valid target in range
+		input := TargetInput{
+			Target:   target,
+			Distance: 100.0,
+		}
+		err := action.CanActivate(context.Background(), owner, input)
+		require.NoError(t, err)
+		
+		// Activate tracks the target
+		err = action.Activate(context.Background(), owner, input)
+		require.NoError(t, err)
+		assert.Equal(t, target, action.lastTarget)
+		
+		// Cannot activate if target out of range
+		farInput := TargetInput{
+			Target:   target,
+			Distance: 200.0,
+		}
+		err = action.CanActivate(context.Background(), owner, farInput)
+		assert.EqualError(t, err, "target out of range")
+		
+		// Cannot activate without target
+		noTargetInput := TargetInput{
+			Distance: 50.0,
+		}
+		err = action.CanActivate(context.Background(), owner, noTargetInput)
+		assert.EqualError(t, err, "no target specified")
+	})
+	
+	t.Run("DifferentInputTypes", func(t *testing.T) {
+		// This demonstrates that different actions have different input types
+		// and they're type-safe at compile time
+		
+		simple := &SimpleAction{id: "rage", uses: 1}
+		targeted := &TargetedAction{id: "fireball", maxRange: 150}
+		
+		owner := &MockEntity{id: "player", eType: "character"}
+		
+		// Each action only accepts its specific input type
+		simple.Activate(context.Background(), owner, EmptyInput{})
+		
+		targeted.Activate(context.Background(), owner, TargetInput{
+			Target:   &MockEntity{id: "enemy", eType: "monster"},
+			Distance: 50.0,
+		})
+		
+		// These would not compile (commented out to keep test passing):
+		// simple.Activate(context.Background(), owner, TargetInput{})  // Wrong input type
+		// targeted.Activate(context.Background(), owner, EmptyInput{}) // Wrong input type
+	})
+}


### PR DESCRIPTION
## Summary
Implements Phase 1 of the Actions/Effects architecture (#202) by adding the generic Action interface to core.

## Changes
- Added `core.Action[T]` interface - the foundation for all activatable game elements
- Created comprehensive tests demonstrating different input patterns
- Kept it intentionally minimal - just the interface, no implementations

## Design Decisions
- **Generic over input type T**: Provides compile-time type safety, no runtime casting
- **Lives in core**: It's just an interface with no behavior, so belongs in core not mechanics
- **Extends Entity**: Actions have IDs and types like all game objects
- **Two methods**: `CanActivate` for validation, `Activate` for execution

## Test Coverage
Tests demonstrate two common patterns:
1. **SimpleAction** with `EmptyInput` (for actions like Rage with no parameters)
2. **TargetedAction** with `TargetInput` (for targeted spells/abilities)

## Next Steps
- Phase 2: Implement Rage feature in a rulebook as first concrete Action
- Phase 3: Implement Bless spell with concentration
- Phase 4: Loader pattern for creating Actions from data

Part of epic #202 - Actions/Effects Architecture
Closes #203

🤖 Generated with [Claude Code](https://claude.ai/code)