### PR TITLE
feat: add ModifierTarget type to core/events

### DIFF
--- a/core/events/types.go
+++ b/core/events/types.go
@@ -20,6 +20,10 @@ type ModifierType string
 // Example: const SourceRage ModifierSource = "rage"
 type ModifierSource string
 
+// ModifierTarget identifies what aspect of the game is being modified.
+// Example: const TargetDamage ModifierTarget = "damage"
+type ModifierTarget string
+
 // Priority represents the order in which handlers or modifiers are applied.
 // Lower values are processed first.
 type Priority int

--- a/events/go.mod
+++ b/events/go.mod
@@ -5,7 +5,7 @@ go 1.24
 // Copyright (C) 2024 Kirk Diggler
 // Licensed under GPL-3.0-or-later
 
-require github.com/KirkDiggler/rpg-toolkit/core v0.3.0
+require github.com/KirkDiggler/rpg-toolkit/core v0.6.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/events/go.sum
+++ b/events/go.sum
@@ -1,5 +1,7 @@
 github.com/KirkDiggler/rpg-toolkit/core v0.3.0 h1:D1TS6TKC1+NLLFmMuEM4UStkluDs2Kwj6TV0/0i7304=
 github.com/KirkDiggler/rpg-toolkit/core v0.3.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.6.0 h1:PfY2fMoIcG5O7qANL8wj6Y9nsgX6SkQQHqfr7326gO0=
+github.com/KirkDiggler/rpg-toolkit/core v0.6.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/events/modifier.go
+++ b/events/modifier.go
@@ -3,17 +3,19 @@
 
 package events
 
+import "github.com/KirkDiggler/rpg-toolkit/core/events"
+
 // Modifier represents a modification to be applied to an event's outcome.
 // Modifiers are added by event handlers and interpreted by the event resolver.
 type Modifier interface {
 	// Source identifies what added this modifier (e.g., "rage", "bless")
-	Source() string
+	Source() events.ModifierSource
 
 	// Type describes how this modifier should be applied (e.g., "additive", "multiplicative")
-	Type() string
+	Type() events.ModifierType
 
 	// Target identifies what is being modified (e.g., "damage", "ac", "attack_roll")
-	Target() string
+	Target() events.ModifierTarget
 
 	// Priority determines the order of application (lower = earlier)
 	Priority() int
@@ -25,15 +27,15 @@ type Modifier interface {
 // SimpleModifier is a basic implementation of the Modifier interface.
 // This is all you need for most modifiers.
 type SimpleModifier struct {
-	source   string
-	modType  string
-	target   string
+	source   events.ModifierSource
+	modType  events.ModifierType
+	target   events.ModifierTarget
 	priority int
 	value    any
 }
 
 // NewSimpleModifier creates a new modifier
-func NewSimpleModifier(source, modType, target string, priority int, value any) *SimpleModifier {
+func NewSimpleModifier(source events.ModifierSource, modType events.ModifierType, target events.ModifierTarget, priority int, value any) *SimpleModifier {
 	return &SimpleModifier{
 		source:   source,
 		modType:  modType,
@@ -44,17 +46,17 @@ func NewSimpleModifier(source, modType, target string, priority int, value any) 
 }
 
 // Source implements Modifier
-func (m *SimpleModifier) Source() string {
+func (m *SimpleModifier) Source() events.ModifierSource {
 	return m.source
 }
 
 // Type implements Modifier
-func (m *SimpleModifier) Type() string {
+func (m *SimpleModifier) Type() events.ModifierType {
 	return m.modType
 }
 
 // Target implements Modifier
-func (m *SimpleModifier) Target() string {
+func (m *SimpleModifier) Target() events.ModifierTarget {
 	return m.target
 }
 


### PR DESCRIPTION
## Summary
- Adds `ModifierTarget` type to `core/events/types.go` for type-safe modifier targeting
- Updates `events` package to use the new typed approach for modifiers
- Eliminates string literals in favor of typed constants

## Changes
- Added `ModifierTarget` type to core/events package
- Updated `Modifier` interface to use typed Source, Type, and Target
- Updated `SimpleModifier` implementation to use typed fields
- Updated `NewSimpleModifier` constructor signature

## Why
This change enables rulebooks to define typed constants for modifier targets (e.g., damage, AC, attack rolls) instead of using error-prone string literals. This provides compile-time safety and better IDE support.

Fixes #216

## Test plan
- [ ] Core module tests pass
- [ ] Events module tests pass
- [ ] Dependent modules compile and test successfully