### PR TITLE
feat(core): Add EventDataKey type for typed event data maps

### DIFF
--- a/core/events/types.go
+++ b/core/events/types.go
@@ -24,6 +24,12 @@ type ModifierSource string
 // Example: const TargetDamage ModifierTarget = "damage"
 type ModifierTarget string
 
+// EventDataKey is a typed key for event data maps.
+// Using typed keys instead of raw strings provides compile-time safety
+// and prevents typos in event data access.
+// Example: const DataKeyLevel EventDataKey = "level"
+type EventDataKey string
+
 // Priority represents the order in which handlers or modifiers are applied.
 // Lower values are processed first.
 type Priority int

--- a/core/events/types_test.go
+++ b/core/events/types_test.go
@@ -12,35 +12,35 @@ import (
 
 // Example event data keys that a rulebook might define
 const (
-	DataKeyLevel     events.EventDataKey = "level"
-	DataKeyDuration  events.EventDataKey = "duration"
-	DataKeyTarget    events.EventDataKey = "target"
-	DataKeyAmount    events.EventDataKey = "amount"
+	DataKeyLevel    events.EventDataKey = "level"
+	DataKeyDuration events.EventDataKey = "duration"
+	DataKeyTarget   events.EventDataKey = "target"
+	DataKeyAmount   events.EventDataKey = "amount"
 )
 
 func TestEventDataKey_TypeSafety(t *testing.T) {
 	// Create a typed event data map
 	data := make(map[events.EventDataKey]interface{})
-	
+
 	// Add data with typed keys
 	data[DataKeyLevel] = 5
 	data[DataKeyDuration] = 10
 	data[DataKeyTarget] = "player-123"
 	data[DataKeyAmount] = 25.5
-	
+
 	// Access data with typed keys
 	level, ok := data[DataKeyLevel].(int)
 	assert.True(t, ok)
 	assert.Equal(t, 5, level)
-	
+
 	duration, ok := data[DataKeyDuration].(int)
 	assert.True(t, ok)
 	assert.Equal(t, 10, duration)
-	
+
 	target, ok := data[DataKeyTarget].(string)
 	assert.True(t, ok)
 	assert.Equal(t, "player-123", target)
-	
+
 	amount, ok := data[DataKeyAmount].(float64)
 	assert.True(t, ok)
 	assert.Equal(t, 25.5, amount)
@@ -50,11 +50,11 @@ func TestEventDataKey_StringConversion(t *testing.T) {
 	// EventDataKey can be converted to string when needed
 	key := DataKeyLevel
 	assert.Equal(t, "level", string(key))
-	
+
 	// Can be used in string contexts if necessary
 	stringMap := make(map[string]interface{})
 	stringMap[string(DataKeyLevel)] = 5
-	
+
 	value := stringMap["level"]
 	assert.Equal(t, 5, value)
 }

--- a/core/events/types_test.go
+++ b/core/events/types_test.go
@@ -7,52 +7,54 @@ import (
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/core/events"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestTypedConstants(t *testing.T) {
-	// This test demonstrates how rulebooks will use these types
+// Example event data keys that a rulebook might define
+const (
+	DataKeyLevel     events.EventDataKey = "level"
+	DataKeyDuration  events.EventDataKey = "duration"
+	DataKeyTarget    events.EventDataKey = "target"
+	DataKeyAmount    events.EventDataKey = "amount"
+)
 
-	// Event types
-	const (
-		AttackRoll  events.EventType = "combat.attack.roll"
-		DamageRoll  events.EventType = "combat.damage.roll"
-		SavingThrow events.EventType = "save.throw"
-	)
+func TestEventDataKey_TypeSafety(t *testing.T) {
+	// Create a typed event data map
+	data := make(map[events.EventDataKey]interface{})
+	
+	// Add data with typed keys
+	data[DataKeyLevel] = 5
+	data[DataKeyDuration] = 10
+	data[DataKeyTarget] = "player-123"
+	data[DataKeyAmount] = 25.5
+	
+	// Access data with typed keys
+	level, ok := data[DataKeyLevel].(int)
+	assert.True(t, ok)
+	assert.Equal(t, 5, level)
+	
+	duration, ok := data[DataKeyDuration].(int)
+	assert.True(t, ok)
+	assert.Equal(t, 10, duration)
+	
+	target, ok := data[DataKeyTarget].(string)
+	assert.True(t, ok)
+	assert.Equal(t, "player-123", target)
+	
+	amount, ok := data[DataKeyAmount].(float64)
+	assert.True(t, ok)
+	assert.Equal(t, 25.5, amount)
+}
 
-	// Modifier types
-	const (
-		ModifierAttackBonus events.ModifierType = "attack_bonus"
-		ModifierDamageBonus events.ModifierType = "damage_bonus"
-		ModifierAdvantage   events.ModifierType = "advantage"
-	)
-
-	// Modifier sources
-	const (
-		SourceRage        events.ModifierSource = "rage"
-		SourceBless       events.ModifierSource = "bless"
-		SourceProficiency events.ModifierSource = "proficiency"
-	)
-
-	// Verify they work as expected
-	if AttackRoll != "combat.attack.roll" {
-		t.Error("EventType constant not working correctly")
-	}
-
-	if ModifierAttackBonus != "attack_bonus" {
-		t.Error("ModifierType constant not working correctly")
-	}
-
-	if SourceRage != "rage" {
-		t.Error("ModifierSource constant not working correctly")
-	}
-
-	// Verify type safety - these should be different types
-	eventType := AttackRoll
-	modType := ModifierAttackBonus
-	modSource := SourceRage
-
-	// These should work
-	_ = eventType
-	_ = modType
-	_ = modSource
+func TestEventDataKey_StringConversion(t *testing.T) {
+	// EventDataKey can be converted to string when needed
+	key := DataKeyLevel
+	assert.Equal(t, "level", string(key))
+	
+	// Can be used in string contexts if necessary
+	stringMap := make(map[string]interface{})
+	stringMap[string(DataKeyLevel)] = 5
+	
+	value := stringMap["level"]
+	assert.Equal(t, 5, value)
 }


### PR DESCRIPTION
## Summary
Adds `EventDataKey` type to core/events for type-safe event data keys.

## What's Included
- New `EventDataKey` type in core/events/types.go
- Test demonstrating usage pattern
- Documentation with examples

## Why This Matters
Instead of using raw strings as map keys:
```go
data := map[string]any{
    "level": 5,  // Could typo as "lvl" or "Level"
}
```

Rulebooks can now define typed constants:
```go
const DataKeyLevel events.EventDataKey = "level"

data := map[events.EventDataKey]any{
    DataKeyLevel: 5,  // Compile-time safety!
}
```

## Benefits
- **Type safety** - Can't accidentally use wrong type for keys
- **No typos** - Compiler catches misspelled constants
- **Discoverability** - IDE autocomplete shows available keys
- **Consistency** - All rulebooks use the same pattern

Part of the event-driven conditions architecture for D&D 5e features.

🤖 Generated with [Claude Code](https://claude.ai/code)