### PR TITLE
feat: Add rpgerr package for game-oriented error handling

### DIFF
--- a/rpgerr/context.go
+++ b/rpgerr/context.go
@@ -1,0 +1,254 @@
+package rpgerr
+
+import (
+	"context"
+)
+
+// contextKey is a private type to avoid collisions
+type contextKey string
+
+const metadataKey contextKey = "rpgerr-metadata"
+
+// MetadataScope holds accumulated metadata for errors
+type MetadataScope struct {
+	fields map[string]any
+}
+
+// MetaField represents a single metadata field
+type MetaField struct {
+	Key   string
+	Value any
+}
+
+// Meta creates a metadata field for use with WithMetadata
+func Meta(key string, value any) MetaField {
+	return MetaField{Key: key, Value: value}
+}
+
+// WithMetadata adds metadata to context that will be automatically included
+// in any errors created with Ctx functions. Metadata is inherited and can
+// be overwritten by child contexts.
+//
+// Example:
+//
+//	ctx = rpgerr.WithMetadata(ctx,
+//	    rpgerr.Meta("pipeline", "AttackPipeline"),
+//	    rpgerr.Meta("attacker_id", "barbarian-1"),
+//	    rpgerr.Meta("weapon", "greataxe"),
+//	)
+//	// Any errors created with WrapCtx will include this metadata
+func WithMetadata(ctx context.Context, fields ...MetaField) context.Context {
+	scope := &MetadataScope{
+		fields: make(map[string]any),
+	}
+
+	// Inherit parent metadata if exists
+	if parent, ok := ctx.Value(metadataKey).(*MetadataScope); ok && parent != nil {
+		for k, v := range parent.fields {
+			scope.fields[k] = v
+		}
+	}
+
+	// Add new metadata (overwrites on conflict)
+	for _, field := range fields {
+		scope.fields[field.Key] = field.Value
+	}
+
+	return context.WithValue(ctx, metadataKey, scope)
+}
+
+// getMetadata extracts metadata from context
+func getMetadata(ctx context.Context) map[string]any {
+	if ctx == nil {
+		return nil
+	}
+
+	if scope, ok := ctx.Value(metadataKey).(*MetadataScope); ok && scope != nil {
+		return scope.fields
+	}
+
+	return nil
+}
+
+// applyContextMetadata applies metadata from context to an error
+func applyContextMetadata(ctx context.Context, err *Error) *Error {
+	if metadata := getMetadata(ctx); metadata != nil {
+		for k, v := range metadata {
+			if err.Meta == nil {
+				err.Meta = make(map[string]any)
+			}
+			err.Meta[k] = v
+		}
+	}
+	return err
+}
+
+// WrapCtx wraps an error with message and metadata from context
+//
+// Example:
+//
+//	if err != nil {
+//	    return rpgerr.WrapCtx(ctx, err, "attack failed")
+//	}
+func WrapCtx(ctx context.Context, err error, message string) *Error {
+	wrapped := Wrap(err, message)
+	return applyContextMetadata(ctx, wrapped)
+}
+
+// WrapfCtx wraps an error with formatted message and metadata from context
+func WrapfCtx(ctx context.Context, err error, format string, args ...any) *Error {
+	wrapped := Wrapf(err, format, args...)
+	return applyContextMetadata(ctx, wrapped)
+}
+
+// WrapWithCodeCtx wraps an error with specific code and metadata from context
+func WrapWithCodeCtx(ctx context.Context, err error, code Code, message string) *Error {
+	wrapped := WrapWithCode(err, code, message)
+	return applyContextMetadata(ctx, wrapped)
+}
+
+// NewCtx creates a new error with code, message and metadata from context
+func NewCtx(ctx context.Context, code Code, message string) *Error {
+	err := New(code, message)
+	return applyContextMetadata(ctx, err)
+}
+
+// NewfCtx creates a new error with formatted message and metadata from context
+func NewfCtx(ctx context.Context, code Code, format string, args ...any) *Error {
+	err := Newf(code, format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// Context-aware game rule error constructors
+
+// NotAllowedCtx creates a not allowed error with metadata from context
+func NotAllowedCtx(ctx context.Context, action string) *Error {
+	err := NotAllowed(action)
+	return applyContextMetadata(ctx, err)
+}
+
+// NotAllowedfCtx creates a formatted not allowed error with metadata from context
+func NotAllowedfCtx(ctx context.Context, format string, args ...any) *Error {
+	err := NotAllowedf(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// PrerequisiteNotMetCtx creates a prerequisite error with metadata from context
+func PrerequisiteNotMetCtx(ctx context.Context, requirement string) *Error {
+	err := PrerequisiteNotMet(requirement)
+	return applyContextMetadata(ctx, err)
+}
+
+// PrerequisiteNotMetfCtx creates a formatted prerequisite error with metadata from context
+func PrerequisiteNotMetfCtx(ctx context.Context, format string, args ...any) *Error {
+	err := PrerequisiteNotMetf(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// ResourceExhaustedCtx creates a resource error with metadata from context
+func ResourceExhaustedCtx(ctx context.Context, resource string) *Error {
+	err := ResourceExhausted(resource)
+	return applyContextMetadata(ctx, err)
+}
+
+// ResourceExhaustedfCtx creates a formatted resource error with metadata from context
+func ResourceExhaustedfCtx(ctx context.Context, format string, args ...any) *Error {
+	err := ResourceExhaustedf(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// OutOfRangeCtx creates a range error with metadata from context
+func OutOfRangeCtx(ctx context.Context, action string) *Error {
+	err := OutOfRange(action)
+	return applyContextMetadata(ctx, err)
+}
+
+// OutOfRangefCtx creates a formatted range error with metadata from context
+func OutOfRangefCtx(ctx context.Context, format string, args ...any) *Error {
+	err := OutOfRangef(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// InvalidTargetCtx creates a target error with metadata from context
+func InvalidTargetCtx(ctx context.Context, reason string) *Error {
+	err := InvalidTarget(reason)
+	return applyContextMetadata(ctx, err)
+}
+
+// InvalidTargetfCtx creates a formatted target error with metadata from context
+func InvalidTargetfCtx(ctx context.Context, format string, args ...any) *Error {
+	err := InvalidTargetf(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// ConflictingStateCtx creates a state error with metadata from context
+func ConflictingStateCtx(ctx context.Context, conflict string) *Error {
+	err := ConflictingState(conflict)
+	return applyContextMetadata(ctx, err)
+}
+
+// ConflictingStatefCtx creates a formatted state error with metadata from context
+func ConflictingStatefCtx(ctx context.Context, format string, args ...any) *Error {
+	err := ConflictingStatef(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// TimingRestrictionCtx creates a timing error with metadata from context
+func TimingRestrictionCtx(ctx context.Context, reason string) *Error {
+	err := TimingRestriction(reason)
+	return applyContextMetadata(ctx, err)
+}
+
+// TimingRestrictionfCtx creates a formatted timing error with metadata from context
+func TimingRestrictionfCtx(ctx context.Context, format string, args ...any) *Error {
+	err := TimingRestrictionf(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// CooldownActiveCtx creates a cooldown error with metadata from context
+func CooldownActiveCtx(ctx context.Context, ability string) *Error {
+	err := CooldownActive(ability)
+	return applyContextMetadata(ctx, err)
+}
+
+// CooldownActivefCtx creates a formatted cooldown error with metadata from context
+func CooldownActivefCtx(ctx context.Context, format string, args ...any) *Error {
+	err := CooldownActivef(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// ImmuneCtx creates an immunity error with metadata from context
+func ImmuneCtx(ctx context.Context, immunity string) *Error {
+	err := Immune(immunity)
+	return applyContextMetadata(ctx, err)
+}
+
+// ImmunefCtx creates a formatted immunity error with metadata from context
+func ImmunefCtx(ctx context.Context, format string, args ...any) *Error {
+	err := Immunef(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// BlockedCtx creates a blocked error with metadata from context
+func BlockedCtx(ctx context.Context, blocker string) *Error {
+	err := Blocked(blocker)
+	return applyContextMetadata(ctx, err)
+}
+
+// BlockedfCtx creates a formatted blocked error with metadata from context
+func BlockedfCtx(ctx context.Context, format string, args ...any) *Error {
+	err := Blockedf(format, args...)
+	return applyContextMetadata(ctx, err)
+}
+
+// InterruptedCtx creates an interrupted error with metadata from context
+func InterruptedCtx(ctx context.Context, interruptor string) *Error {
+	err := Interrupted(interruptor)
+	return applyContextMetadata(ctx, err)
+}
+
+// InterruptedfCtx creates a formatted interrupted error with metadata from context
+func InterruptedfCtx(ctx context.Context, format string, args ...any) *Error {
+	err := Interruptedf(format, args...)
+	return applyContextMetadata(ctx, err)
+}

--- a/rpgerr/context_test.go
+++ b/rpgerr/context_test.go
@@ -1,0 +1,242 @@
+package rpgerr_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/stretchr/testify/suite"
+)
+
+type ContextTestSuite struct {
+	suite.Suite
+}
+
+func TestContextSuite(t *testing.T) {
+	suite.Run(t, new(ContextTestSuite))
+}
+
+func (s *ContextTestSuite) TestContextMetadataAccumulation() {
+	// Start with base context
+	ctx := context.Background()
+
+	// Add game-level metadata
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("game_id", "game-123"),
+		rpgerr.Meta("turn", 5),
+	)
+
+	// Add player-level metadata
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("player_id", "player-456"),
+		rpgerr.Meta("character", "wizard"),
+	)
+
+	// Add action-level metadata
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("action", "cast_spell"),
+		rpgerr.Meta("spell", "fireball"),
+	)
+
+	// Create error with all accumulated context
+	err := rpgerr.ResourceExhaustedCtx(ctx, "spell slots")
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal("game-123", meta["game_id"])
+	s.Equal(5, meta["turn"])
+	s.Equal("player-456", meta["player_id"])
+	s.Equal("wizard", meta["character"])
+	s.Equal("cast_spell", meta["action"])
+	s.Equal("fireball", meta["spell"])
+}
+
+func (s *ContextTestSuite) TestContextMetadataOverwrite() {
+	ctx := context.Background()
+
+	// Set initial value
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("phase", "main"),
+		rpgerr.Meta("priority", "normal"),
+	)
+
+	// Overwrite with new value
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("phase", "combat"),
+		rpgerr.Meta("priority", "urgent"),
+	)
+
+	err := rpgerr.NewCtx(ctx, rpgerr.CodeTimingRestriction, "wrong phase")
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal("combat", meta["phase"]) // Should be overwritten
+	s.Equal("urgent", meta["priority"])
+}
+
+func (s *ContextTestSuite) TestWrapCtx() {
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("pipeline", "AttackPipeline"),
+		rpgerr.Meta("attacker", "fighter"),
+	)
+
+	// Create a base error
+	baseErr := rpgerr.OutOfRange("melee attack",
+		rpgerr.WithMeta("distance", 30),
+		rpgerr.WithMeta("weapon_range", 5),
+	)
+
+	// Wrap with context
+	wrapped := rpgerr.WrapCtx(ctx, baseErr, "attack failed")
+
+	meta := rpgerr.GetMeta(wrapped)
+	// Should have both original and context metadata
+	s.Equal("AttackPipeline", meta["pipeline"])
+	s.Equal("fighter", meta["attacker"])
+	s.Equal(30, meta["distance"])
+	s.Equal(5, meta["weapon_range"])
+}
+
+func (s *ContextTestSuite) TestNestedPipelineContext() {
+	// Simulate nested pipeline execution with context accumulation
+
+	// Outer pipeline
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("pipeline", "SpellCastPipeline"),
+		rpgerr.Meta("spell", "fireball"),
+		rpgerr.Meta("caster", "wizard"),
+	)
+
+	// Inner pipeline (damage calculation)
+	innerCtx := rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("pipeline", "DamagePipeline"),
+		rpgerr.Meta("damage_type", "fire"),
+		rpgerr.Meta("base_damage", 8*6), // 8d6
+	)
+
+	// Resistance check
+	resistCtx := rpgerr.WithMetadata(innerCtx,
+		rpgerr.Meta("stage", "ResistanceCheck"),
+		rpgerr.Meta("target", "fire_elemental"),
+		rpgerr.Meta("immunity", "fire"),
+	)
+
+	// Create error at deepest level
+	err := rpgerr.ImmuneCtx(resistCtx, "fire damage")
+
+	meta := rpgerr.GetMeta(err)
+	// Should have metadata from all levels
+	s.Equal("fireball", meta["spell"])
+	s.Equal("wizard", meta["caster"])
+	s.Equal("ResistanceCheck", meta["stage"])
+	s.Equal("fire_elemental", meta["target"])
+	s.Equal("fire", meta["immunity"])
+}
+
+func (s *ContextTestSuite) TestAllContextConstructors() {
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("test_id", "test-123"),
+	)
+
+	tests := []struct {
+		name        string
+		constructor func() *rpgerr.Error
+		code        rpgerr.Code
+	}{
+		{
+			name:        "NotAllowedCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.NotAllowedCtx(ctx, "action") },
+			code:        rpgerr.CodeNotAllowed,
+		},
+		{
+			name:        "PrerequisiteNotMetCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.PrerequisiteNotMetCtx(ctx, "level 5") },
+			code:        rpgerr.CodePrerequisiteNotMet,
+		},
+		{
+			name:        "ResourceExhaustedCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.ResourceExhaustedCtx(ctx, "energy") },
+			code:        rpgerr.CodeResourceExhausted,
+		},
+		{
+			name:        "OutOfRangeCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.OutOfRangeCtx(ctx, "attack") },
+			code:        rpgerr.CodeOutOfRange,
+		},
+		{
+			name:        "InvalidTargetCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.InvalidTargetCtx(ctx, "self") },
+			code:        rpgerr.CodeInvalidTarget,
+		},
+		{
+			name:        "ConflictingStateCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.ConflictingStateCtx(ctx, "rage") },
+			code:        rpgerr.CodeConflictingState,
+		},
+		{
+			name:        "TimingRestrictionCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.TimingRestrictionCtx(ctx, "not your turn") },
+			code:        rpgerr.CodeTimingRestriction,
+		},
+		{
+			name:        "CooldownActiveCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.CooldownActiveCtx(ctx, "ability") },
+			code:        rpgerr.CodeCooldownActive,
+		},
+		{
+			name:        "ImmuneCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.ImmuneCtx(ctx, "poison") },
+			code:        rpgerr.CodeImmune,
+		},
+		{
+			name:        "BlockedCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.BlockedCtx(ctx, "shield") },
+			code:        rpgerr.CodeBlocked,
+		},
+		{
+			name:        "InterruptedCtx",
+			constructor: func() *rpgerr.Error { return rpgerr.InterruptedCtx(ctx, "counterspell") },
+			code:        rpgerr.CodeInterrupted,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := tt.constructor()
+			s.Equal(tt.code, rpgerr.GetCode(err))
+
+			meta := rpgerr.GetMeta(err)
+			s.Equal("test-123", meta["test_id"], "Context metadata should be preserved")
+		})
+	}
+}
+
+func (s *ContextTestSuite) TestFormattedContextErrors() {
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("character", "rogue"),
+		rpgerr.Meta("weapon", "dagger"),
+	)
+
+	err := rpgerr.NotAllowedfCtx(ctx, "cannot use %s without proficiency", "longbow")
+	s.Contains(err.Error(), "cannot use longbow without proficiency")
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal("rogue", meta["character"])
+	s.Equal("dagger", meta["weapon"])
+}
+
+func (s *ContextTestSuite) TestWrapWithCodeCtx() {
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("session", "session-789"),
+	)
+
+	baseErr := rpgerr.New(rpgerr.CodeUnknown, "something failed")
+	wrapped := rpgerr.WrapWithCodeCtx(ctx, baseErr, rpgerr.CodeInternal, "system error")
+
+	s.Equal(rpgerr.CodeInternal, rpgerr.GetCode(wrapped))
+	meta := rpgerr.GetMeta(wrapped)
+	s.Equal("session-789", meta["session"])
+}

--- a/rpgerr/errors.go
+++ b/rpgerr/errors.go
@@ -19,6 +19,8 @@ const (
 	CodeInternal Code = "internal"
 	// CodeCanceled indicates the operation was canceled
 	CodeCanceled Code = "canceled"
+	// CodeNil indicates an attempt to wrap a nil error (programming error)
+	CodeNil Code = "nil"
 
 	// CodeNotAllowed indicates action not permitted by game rules
 	CodeNotAllowed Code = "not_allowed"
@@ -159,7 +161,7 @@ func NewfWithOpts(code Code, opts []Option, format string, args ...any) *Error {
 // Wrap wraps an error with additional context
 func Wrap(err error, message string, opts ...Option) *Error {
 	if err == nil {
-		return New(CodeInternal, fmt.Sprintf("rpgerr.Wrap called with nil: %s", message))
+		return New(CodeNil, fmt.Sprintf("rpgerr.Wrap called with nil: %s", message))
 	}
 
 	var wrapped *Error
@@ -197,7 +199,7 @@ func Wrapf(err error, format string, args ...any) *Error {
 // WrapWithCode wraps an error with a specific code
 func WrapWithCode(err error, code Code, message string, opts ...Option) *Error {
 	if err == nil {
-		return New(CodeInternal, fmt.Sprintf("rpgerr.WrapWithCode called with nil: %s", message))
+		return New(CodeNil, fmt.Sprintf("rpgerr.WrapWithCode called with nil: %s", message))
 	}
 
 	var meta map[string]any
@@ -461,4 +463,9 @@ func IsBlocked(err error) bool {
 // IsInterrupted checks if error is CodeInterrupted
 func IsInterrupted(err error) bool {
 	return GetCode(err) == CodeInterrupted
+}
+
+// IsNil checks if error is CodeNil (indicates nil error was wrapped)
+func IsNil(err error) bool {
+	return GetCode(err) == CodeNil
 }

--- a/rpgerr/errors.go
+++ b/rpgerr/errors.go
@@ -1,0 +1,464 @@
+// Package rpgerr provides structured error handling for RPG game mechanics.
+// It enables clear communication of why game actions cannot proceed, with full
+// context about the game state when rules are evaluated.
+package rpgerr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Code represents a game rule or system error code that explains why an action failed
+type Code string
+
+const (
+	// CodeUnknown indicates an unknown error occurred
+	CodeUnknown Code = "unknown"
+	// CodeInternal indicates an internal system error
+	CodeInternal Code = "internal"
+	// CodeCanceled indicates the operation was canceled
+	CodeCanceled Code = "canceled"
+
+	// CodeNotAllowed indicates action not permitted by game rules
+	CodeNotAllowed Code = "not_allowed"
+	// CodePrerequisiteNotMet indicates missing requirements (level, class, feat)
+	CodePrerequisiteNotMet Code = "prerequisite_not_met"
+	// CodeResourceExhausted indicates out of resources (HP, spell slots, energy, actions)
+	CodeResourceExhausted Code = "resource_exhausted"
+	// CodeOutOfRange indicates target too far away
+	CodeOutOfRange Code = "out_of_range"
+	// CodeInvalidTarget indicates cannot target that entity
+	CodeInvalidTarget Code = "invalid_target"
+	// CodeConflictingState indicates states conflict (rage + concentration)
+	CodeConflictingState Code = "conflicting_state"
+	// CodeTimingRestriction indicates wrong phase/turn for this action
+	CodeTimingRestriction Code = "timing_restriction"
+	// CodeCapacityExceeded indicates too many items, effects, etc.
+	CodeCapacityExceeded Code = "capacity_exceeded"
+	// CodeCooldownActive indicates ability still on cooldown
+	CodeCooldownActive Code = "cooldown_active"
+	// CodeImmune indicates target immune to this effect
+	CodeImmune Code = "immune"
+	// CodeBlocked indicates action blocked by another effect
+	CodeBlocked Code = "blocked"
+	// CodeInterrupted indicates action interrupted by reaction/trigger
+	CodeInterrupted Code = "interrupted"
+	// CodeInvalidState indicates entity in wrong state for action
+	CodeInvalidState Code = "invalid_state"
+	// CodeNotFound indicates requested entity/resource not found
+	CodeNotFound Code = "not_found"
+	// CodeAlreadyExists indicates entity/resource already exists
+	CodeAlreadyExists Code = "already_exists"
+	// CodeInvalidArgument indicates invalid input provided
+	CodeInvalidArgument Code = "invalid_argument"
+)
+
+// Error represents a game error with code, message, and metadata
+type Error struct {
+	// Code categorizes the error type
+	Code Code
+
+	// Message describes what happened
+	Message string
+
+	// Cause is the wrapped error if any
+	Cause error
+
+	// Meta contains game state context
+	Meta map[string]any
+
+	// CallStack tracks execution path through nested systems
+	CallStack []string
+}
+
+// Error returns the error message
+func (e *Error) Error() string {
+	if e == nil {
+		return "rpgerr: nil error"
+	}
+
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Cause)
+	}
+
+	return e.Message
+}
+
+// Unwrap returns the wrapped error
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// Option is a functional option for configuring errors
+type Option func(*Error)
+
+// WithMeta adds metadata to the error
+func WithMeta(key string, value any) Option {
+	return func(e *Error) {
+		if e.Meta == nil {
+			e.Meta = make(map[string]any)
+		}
+		e.Meta[key] = value
+	}
+}
+
+// WithCallStack sets the call stack for the error
+func WithCallStack(stack []string) Option {
+	return func(e *Error) {
+		e.CallStack = stack
+	}
+}
+
+// AddToCallStack appends to the call stack
+func AddToCallStack(frame string) Option {
+	return func(e *Error) {
+		e.CallStack = append(e.CallStack, frame)
+	}
+}
+
+// New creates a new error with the given code and message
+func New(code Code, message string, opts ...Option) *Error {
+	err := &Error{
+		Code:    code,
+		Message: message,
+	}
+
+	for _, opt := range opts {
+		opt(err)
+	}
+
+	return err
+}
+
+// Newf creates a new error with formatted message
+func Newf(code Code, format string, args ...any) *Error {
+	return &Error{
+		Code:    code,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// NewfWithOpts creates a new error with formatted message and options
+func NewfWithOpts(code Code, opts []Option, format string, args ...any) *Error {
+	err := &Error{
+		Code:    code,
+		Message: fmt.Sprintf(format, args...),
+	}
+
+	for _, opt := range opts {
+		opt(err)
+	}
+
+	return err
+}
+
+// Wrap wraps an error with additional context
+func Wrap(err error, message string, opts ...Option) *Error {
+	if err == nil {
+		return New(CodeInternal, fmt.Sprintf("rpgerr.Wrap called with nil: %s", message))
+	}
+
+	var wrapped *Error
+
+	// Preserve code if it's already our error type
+	var rpgErr *Error
+	if errors.As(err, &rpgErr) {
+		wrapped = &Error{
+			Code:      rpgErr.Code,
+			Message:   message,
+			Cause:     err,
+			Meta:      copyMeta(rpgErr.Meta),
+			CallStack: copyCallStack(rpgErr.CallStack),
+		}
+	} else {
+		wrapped = &Error{
+			Code:    CodeUnknown,
+			Message: message,
+			Cause:   err,
+		}
+	}
+
+	for _, opt := range opts {
+		opt(wrapped)
+	}
+
+	return wrapped
+}
+
+// Wrapf wraps an error with formatted message
+func Wrapf(err error, format string, args ...any) *Error {
+	return Wrap(err, fmt.Sprintf(format, args...))
+}
+
+// WrapWithCode wraps an error with a specific code
+func WrapWithCode(err error, code Code, message string, opts ...Option) *Error {
+	if err == nil {
+		return New(CodeInternal, fmt.Sprintf("rpgerr.WrapWithCode called with nil: %s", message))
+	}
+
+	var meta map[string]any
+	var stack []string
+
+	// Preserve metadata and stack if it's our error
+	var rpgErr *Error
+	if errors.As(err, &rpgErr) {
+		meta = copyMeta(rpgErr.Meta)
+		stack = copyCallStack(rpgErr.CallStack)
+	}
+
+	wrapped := &Error{
+		Code:      code,
+		Message:   message,
+		Cause:     err,
+		Meta:      meta,
+		CallStack: stack,
+	}
+
+	for _, opt := range opts {
+		opt(wrapped)
+	}
+
+	return wrapped
+}
+
+// copyMeta creates a shallow copy of metadata
+func copyMeta(meta map[string]any) map[string]any {
+	if meta == nil {
+		return nil
+	}
+
+	copied := make(map[string]any, len(meta))
+	for k, v := range meta {
+		copied[k] = v
+	}
+	return copied
+}
+
+// copyCallStack creates a copy of the call stack
+func copyCallStack(stack []string) []string {
+	if stack == nil {
+		return nil
+	}
+
+	copied := make([]string, len(stack))
+	copy(copied, stack)
+	return copied
+}
+
+// GetCode extracts the error code from any error
+func GetCode(err error) Code {
+	var rpgErr *Error
+	if errors.As(err, &rpgErr) {
+		if rpgErr == nil {
+			return CodeUnknown
+		}
+
+		// Check standard context errors
+		if rpgErr.Code == CodeUnknown {
+			if errors.Is(err, context.Canceled) {
+				return CodeCanceled
+			}
+		}
+
+		return rpgErr.Code
+	}
+
+	// Check standard errors
+	switch {
+	case errors.Is(err, context.Canceled):
+		return CodeCanceled
+	default:
+		return CodeUnknown
+	}
+}
+
+// GetMeta extracts metadata from an error
+func GetMeta(err error) map[string]any {
+	var rpgErr *Error
+	if errors.As(err, &rpgErr) && rpgErr != nil {
+		return rpgErr.Meta
+	}
+	return nil
+}
+
+// GetCallStack extracts the call stack from an error
+func GetCallStack(err error) []string {
+	var rpgErr *Error
+	if errors.As(err, &rpgErr) && rpgErr != nil {
+		return rpgErr.CallStack
+	}
+	return nil
+}
+
+// Common game rule error constructors
+
+// NotAllowed creates an error for actions not permitted by game rules
+func NotAllowed(action string, opts ...Option) *Error {
+	return New(CodeNotAllowed, fmt.Sprintf("%s not allowed", action), opts...)
+}
+
+// NotAllowedf creates a formatted not allowed error
+func NotAllowedf(format string, args ...any) *Error {
+	return Newf(CodeNotAllowed, format, args...)
+}
+
+// PrerequisiteNotMet creates an error for missing requirements
+func PrerequisiteNotMet(requirement string, opts ...Option) *Error {
+	return New(CodePrerequisiteNotMet, fmt.Sprintf("prerequisite not met: %s", requirement), opts...)
+}
+
+// PrerequisiteNotMetf creates a formatted prerequisite error
+func PrerequisiteNotMetf(format string, args ...any) *Error {
+	return Newf(CodePrerequisiteNotMet, format, args...)
+}
+
+// ResourceExhausted creates an error for depleted resources
+func ResourceExhausted(resource string, opts ...Option) *Error {
+	return New(CodeResourceExhausted, fmt.Sprintf("insufficient %s", resource), opts...)
+}
+
+// ResourceExhaustedf creates a formatted resource exhausted error
+func ResourceExhaustedf(format string, args ...any) *Error {
+	return Newf(CodeResourceExhausted, format, args...)
+}
+
+// OutOfRange creates an error for range restrictions
+func OutOfRange(action string, opts ...Option) *Error {
+	return New(CodeOutOfRange, fmt.Sprintf("%s out of range", action), opts...)
+}
+
+// OutOfRangef creates a formatted out of range error
+func OutOfRangef(format string, args ...any) *Error {
+	return Newf(CodeOutOfRange, format, args...)
+}
+
+// InvalidTarget creates an error for invalid targeting
+func InvalidTarget(reason string, opts ...Option) *Error {
+	return New(CodeInvalidTarget, fmt.Sprintf("invalid target: %s", reason), opts...)
+}
+
+// InvalidTargetf creates a formatted invalid target error
+func InvalidTargetf(format string, args ...any) *Error {
+	return Newf(CodeInvalidTarget, format, args...)
+}
+
+// ConflictingState creates an error for conflicting game states
+func ConflictingState(conflict string, opts ...Option) *Error {
+	return New(CodeConflictingState, fmt.Sprintf("conflicting state: %s", conflict), opts...)
+}
+
+// ConflictingStatef creates a formatted conflicting state error
+func ConflictingStatef(format string, args ...any) *Error {
+	return Newf(CodeConflictingState, format, args...)
+}
+
+// TimingRestriction creates an error for timing violations
+func TimingRestriction(reason string, opts ...Option) *Error {
+	return New(CodeTimingRestriction, fmt.Sprintf("timing restriction: %s", reason), opts...)
+}
+
+// TimingRestrictionf creates a formatted timing restriction error
+func TimingRestrictionf(format string, args ...any) *Error {
+	return Newf(CodeTimingRestriction, format, args...)
+}
+
+// CooldownActive creates an error for abilities on cooldown
+func CooldownActive(ability string, opts ...Option) *Error {
+	return New(CodeCooldownActive, fmt.Sprintf("%s on cooldown", ability), opts...)
+}
+
+// CooldownActivef creates a formatted cooldown error
+func CooldownActivef(format string, args ...any) *Error {
+	return Newf(CodeCooldownActive, format, args...)
+}
+
+// Immune creates an error for immunity
+func Immune(immunity string, opts ...Option) *Error {
+	return New(CodeImmune, fmt.Sprintf("immune to %s", immunity), opts...)
+}
+
+// Immunef creates a formatted immunity error
+func Immunef(format string, args ...any) *Error {
+	return Newf(CodeImmune, format, args...)
+}
+
+// Blocked creates an error for blocked actions
+func Blocked(blocker string, opts ...Option) *Error {
+	return New(CodeBlocked, fmt.Sprintf("blocked by %s", blocker), opts...)
+}
+
+// Blockedf creates a formatted blocked error
+func Blockedf(format string, args ...any) *Error {
+	return Newf(CodeBlocked, format, args...)
+}
+
+// Interrupted creates an error for interrupted actions
+func Interrupted(interruptor string, opts ...Option) *Error {
+	return New(CodeInterrupted, fmt.Sprintf("interrupted by %s", interruptor), opts...)
+}
+
+// Interruptedf creates a formatted interrupted error
+func Interruptedf(format string, args ...any) *Error {
+	return Newf(CodeInterrupted, format, args...)
+}
+
+// Helper functions for checking error codes
+
+// IsNotAllowed checks if error is CodeNotAllowed
+func IsNotAllowed(err error) bool {
+	return GetCode(err) == CodeNotAllowed
+}
+
+// IsPrerequisiteNotMet checks if error is CodePrerequisiteNotMet
+func IsPrerequisiteNotMet(err error) bool {
+	return GetCode(err) == CodePrerequisiteNotMet
+}
+
+// IsResourceExhausted checks if error is CodeResourceExhausted
+func IsResourceExhausted(err error) bool {
+	return GetCode(err) == CodeResourceExhausted
+}
+
+// IsOutOfRange checks if error is CodeOutOfRange
+func IsOutOfRange(err error) bool {
+	return GetCode(err) == CodeOutOfRange
+}
+
+// IsInvalidTarget checks if error is CodeInvalidTarget
+func IsInvalidTarget(err error) bool {
+	return GetCode(err) == CodeInvalidTarget
+}
+
+// IsConflictingState checks if error is CodeConflictingState
+func IsConflictingState(err error) bool {
+	return GetCode(err) == CodeConflictingState
+}
+
+// IsTimingRestriction checks if error is CodeTimingRestriction
+func IsTimingRestriction(err error) bool {
+	return GetCode(err) == CodeTimingRestriction
+}
+
+// IsCooldownActive checks if error is CodeCooldownActive
+func IsCooldownActive(err error) bool {
+	return GetCode(err) == CodeCooldownActive
+}
+
+// IsImmune checks if error is CodeImmune
+func IsImmune(err error) bool {
+	return GetCode(err) == CodeImmune
+}
+
+// IsBlocked checks if error is CodeBlocked
+func IsBlocked(err error) bool {
+	return GetCode(err) == CodeBlocked
+}
+
+// IsInterrupted checks if error is CodeInterrupted
+func IsInterrupted(err error) bool {
+	return GetCode(err) == CodeInterrupted
+}

--- a/rpgerr/errors_test.go
+++ b/rpgerr/errors_test.go
@@ -1,0 +1,200 @@
+package rpgerr_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/stretchr/testify/suite"
+)
+
+type ErrorsTestSuite struct {
+	suite.Suite
+}
+
+func TestErrorsSuite(t *testing.T) {
+	suite.Run(t, new(ErrorsTestSuite))
+}
+
+func (s *ErrorsTestSuite) TestBasicError() {
+	err := rpgerr.ResourceExhausted("energy",
+		rpgerr.WithMeta("current", 2),
+		rpgerr.WithMeta("required", 5),
+	)
+
+	s.Equal(rpgerr.CodeResourceExhausted, rpgerr.GetCode(err))
+	s.Equal("insufficient energy", err.Error())
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal(2, meta["current"])
+	s.Equal(5, meta["required"])
+}
+
+func (s *ErrorsTestSuite) TestErrorWrapping() {
+	original := errors.New("database connection failed")
+	wrapped := rpgerr.Wrap(original, "failed to load character",
+		rpgerr.WithMeta("character_id", "char-123"),
+	)
+
+	s.Equal(rpgerr.CodeUnknown, rpgerr.GetCode(wrapped))
+	s.Contains(wrapped.Error(), "failed to load character")
+	s.Contains(wrapped.Error(), "database connection failed")
+	s.Equal("char-123", rpgerr.GetMeta(wrapped)["character_id"])
+	s.Equal(original, wrapped.Unwrap())
+}
+
+func (s *ErrorsTestSuite) TestWrapWithCode() {
+	original := errors.New("file not found")
+	wrapped := rpgerr.WrapWithCode(original, rpgerr.CodeNotFound, "character not found",
+		rpgerr.WithMeta("character_id", "char-456"),
+	)
+
+	s.Equal(rpgerr.CodeNotFound, rpgerr.GetCode(wrapped))
+	s.Contains(wrapped.Error(), "character not found")
+}
+
+func (s *ErrorsTestSuite) TestCallStack() {
+	err := rpgerr.New(rpgerr.CodeInvalidTarget, "cannot target ally",
+		rpgerr.WithCallStack([]string{"AttackPipeline", "TargetValidation"}),
+	)
+
+	stack := rpgerr.GetCallStack(err)
+	s.Len(stack, 2)
+	s.Equal("AttackPipeline", stack[0])
+	s.Equal("TargetValidation", stack[1])
+
+	// Test adding to call stack
+	err2 := rpgerr.Wrap(err, "attack failed",
+		rpgerr.AddToCallStack("CombatSystem"),
+	)
+
+	stack2 := rpgerr.GetCallStack(err2)
+	s.Len(stack2, 3)
+	s.Equal("CombatSystem", stack2[2])
+}
+
+func (s *ErrorsTestSuite) TestErrorCodeHelpers() {
+	tests := []struct {
+		name     string
+		err      *rpgerr.Error
+		checkFn  func(error) bool
+		expected bool
+	}{
+		{
+			name:     "IsResourceExhausted true",
+			err:      rpgerr.ResourceExhausted("energy"),
+			checkFn:  rpgerr.IsResourceExhausted,
+			expected: true,
+		},
+		{
+			name:     "IsResourceExhausted false",
+			err:      rpgerr.OutOfRange("attack"),
+			checkFn:  rpgerr.IsResourceExhausted,
+			expected: false,
+		},
+		{
+			name:     "IsNotAllowed",
+			err:      rpgerr.NotAllowed("cast spell while silenced"),
+			checkFn:  rpgerr.IsNotAllowed,
+			expected: true,
+		},
+		{
+			name:     "IsPrerequisiteNotMet",
+			err:      rpgerr.PrerequisiteNotMet("level 5 required"),
+			checkFn:  rpgerr.IsPrerequisiteNotMet,
+			expected: true,
+		},
+		{
+			name:     "IsOutOfRange",
+			err:      rpgerr.OutOfRange("movement"),
+			checkFn:  rpgerr.IsOutOfRange,
+			expected: true,
+		},
+		{
+			name:     "IsInvalidTarget",
+			err:      rpgerr.InvalidTarget("cannot target self"),
+			checkFn:  rpgerr.IsInvalidTarget,
+			expected: true,
+		},
+		{
+			name:     "IsConflictingState",
+			err:      rpgerr.ConflictingState("rage and concentration"),
+			checkFn:  rpgerr.IsConflictingState,
+			expected: true,
+		},
+		{
+			name:     "IsTimingRestriction",
+			err:      rpgerr.TimingRestriction("not your turn"),
+			checkFn:  rpgerr.IsTimingRestriction,
+			expected: true,
+		},
+		{
+			name:     "IsCooldownActive",
+			err:      rpgerr.CooldownActive("second wind"),
+			checkFn:  rpgerr.IsCooldownActive,
+			expected: true,
+		},
+		{
+			name:     "IsImmune",
+			err:      rpgerr.Immune("fire damage"),
+			checkFn:  rpgerr.IsImmune,
+			expected: true,
+		},
+		{
+			name:     "IsBlocked",
+			err:      rpgerr.Blocked("shield spell"),
+			checkFn:  rpgerr.IsBlocked,
+			expected: true,
+		},
+		{
+			name:     "IsInterrupted",
+			err:      rpgerr.Interrupted("counterspell"),
+			checkFn:  rpgerr.IsInterrupted,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expected, tt.checkFn(tt.err))
+		})
+	}
+}
+
+func (s *ErrorsTestSuite) TestMetadataPreservation() {
+	// Create an error with metadata
+	err1 := rpgerr.ResourceExhausted("spell slots",
+		rpgerr.WithMeta("spell_level", 3),
+		rpgerr.WithMeta("caster", "wizard"),
+	)
+
+	// Wrap it and add more metadata
+	err2 := rpgerr.Wrap(err1, "cannot cast fireball",
+		rpgerr.WithMeta("target_count", 5),
+	)
+
+	// Original metadata should be preserved
+	meta := rpgerr.GetMeta(err2)
+	s.Equal(3, meta["spell_level"])
+	s.Equal("wizard", meta["caster"])
+	s.Equal(5, meta["target_count"])
+}
+
+func (s *ErrorsTestSuite) TestNilErrorHandling() {
+	// Wrapping nil should create an internal error
+	err := rpgerr.Wrap(nil, "something went wrong")
+	s.Equal(rpgerr.CodeInternal, rpgerr.GetCode(err))
+	s.Contains(err.Error(), "nil")
+
+	// WrapWithCode with nil
+	err2 := rpgerr.WrapWithCode(nil, rpgerr.CodeNotFound, "not found")
+	s.Equal(rpgerr.CodeInternal, rpgerr.GetCode(err2))
+}
+
+func (s *ErrorsTestSuite) TestFormattedErrors() {
+	err := rpgerr.ResourceExhaustedf("insufficient %s: need %d, have %d", "energy", 5, 2)
+	s.Equal("insufficient energy: need 5, have 2", err.Error())
+
+	err2 := rpgerr.NotAllowedf("cannot %s while %s", "attack", "stunned")
+	s.Equal("cannot attack while stunned", err2.Error())
+}

--- a/rpgerr/errors_test.go
+++ b/rpgerr/errors_test.go
@@ -181,14 +181,16 @@ func (s *ErrorsTestSuite) TestMetadataPreservation() {
 }
 
 func (s *ErrorsTestSuite) TestNilErrorHandling() {
-	// Wrapping nil should create an internal error
+	// Wrapping nil should create a CodeNil error
 	err := rpgerr.Wrap(nil, "something went wrong")
-	s.Equal(rpgerr.CodeInternal, rpgerr.GetCode(err))
+	s.Equal(rpgerr.CodeNil, rpgerr.GetCode(err))
 	s.Contains(err.Error(), "nil")
+	s.True(rpgerr.IsNil(err))
 
 	// WrapWithCode with nil
 	err2 := rpgerr.WrapWithCode(nil, rpgerr.CodeNotFound, "not found")
-	s.Equal(rpgerr.CodeInternal, rpgerr.GetCode(err2))
+	s.Equal(rpgerr.CodeNil, rpgerr.GetCode(err2))
+	s.True(rpgerr.IsNil(err2))
 }
 
 func (s *ErrorsTestSuite) TestFormattedErrors() {

--- a/rpgerr/go.mod
+++ b/rpgerr/go.mod
@@ -1,0 +1,11 @@
+module github.com/KirkDiggler/rpg-toolkit/rpgerr
+
+go 1.23.0
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/rpgerr/go.sum
+++ b/rpgerr/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rpgerr/rpg_scenarios_test.go
+++ b/rpgerr/rpg_scenarios_test.go
@@ -1,0 +1,330 @@
+package rpgerr_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/stretchr/testify/suite"
+)
+
+type RPGScenariosTestSuite struct {
+	suite.Suite
+}
+
+func TestRPGScenariosSuite(t *testing.T) {
+	suite.Run(t, new(RPGScenariosTestSuite))
+}
+
+// TestMeleeAttackOutOfRange shows how context accumulates through an attack attempt
+func (s *RPGScenariosTestSuite) TestMeleeAttackOutOfRange() {
+	// Combat system level
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("encounter_id", "enc-001"),
+		rpgerr.Meta("round", 3),
+		rpgerr.Meta("turn", "fighter"),
+	)
+
+	// Attack action level
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("action_type", "attack"),
+		rpgerr.Meta("attacker_id", "fighter-001"),
+		rpgerr.Meta("target_id", "goblin-002"),
+	)
+
+	// Range validation level
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("attacker_position", "5,5"),
+		rpgerr.Meta("target_position", "15,15"),
+		rpgerr.Meta("weapon", "shortsword"),
+		rpgerr.Meta("weapon_reach", 5),
+		rpgerr.Meta("calculated_distance", 14.14),
+	)
+
+	// Create the error with full context
+	err := rpgerr.OutOfRangeCtx(ctx, "melee attack")
+
+	// Verify the error tells the complete story
+	meta := rpgerr.GetMeta(err)
+	s.Equal("enc-001", meta["encounter_id"])
+	s.Equal(3, meta["round"])
+	s.Equal("fighter", meta["turn"])
+	s.Equal("shortsword", meta["weapon"])
+	s.Equal(14.14, meta["calculated_distance"])
+	s.Equal(5, meta["weapon_reach"])
+
+	// The error message plus metadata tells us exactly why the attack failed
+	s.Contains(err.Error(), "melee attack out of range")
+}
+
+// TestSpellcastingWithoutSlots shows resource exhaustion with full context
+func (s *RPGScenariosTestSuite) TestSpellcastingWithoutSlots() {
+	// Game session level
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("session_id", "session-456"),
+		rpgerr.Meta("campaign", "lost_mines"),
+	)
+
+	// Character state level
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("character_id", "wizard-001"),
+		rpgerr.Meta("character_level", 5),
+		rpgerr.Meta("character_class", "wizard"),
+	)
+
+	// Spellcasting attempt level
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("spell", "fireball"),
+		rpgerr.Meta("spell_level", 3),
+		rpgerr.Meta("attempted_slot_level", 3),
+		rpgerr.Meta("slots_remaining", map[string]int{
+			"1st": 4,
+			"2nd": 3,
+			"3rd": 0, // No 3rd level slots
+			"4th": 0,
+		}),
+	)
+
+	err := rpgerr.ResourceExhaustedCtx(ctx, "spell slots")
+
+	meta := rpgerr.GetMeta(err)
+	slots := meta["slots_remaining"].(map[string]int)
+	s.Equal(0, slots["3rd"])
+	s.Equal("fireball", meta["spell"])
+	s.Equal(3, meta["spell_level"])
+}
+
+// TestConcentrationConflict shows conflicting game states
+func (s *RPGScenariosTestSuite) TestConcentrationConflict() {
+	ctx := context.Background()
+
+	// Current state
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("character_id", "cleric-001"),
+		rpgerr.Meta("current_concentration", "bless"),
+		rpgerr.Meta("concentration_duration", "3 rounds"),
+		rpgerr.Meta("concentration_targets", []string{"fighter-001", "rogue-001"}),
+	)
+
+	// Attempted action
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("attempted_spell", "hold_person"),
+		rpgerr.Meta("requires_concentration", true),
+		rpgerr.Meta("target", "orc-001"),
+	)
+
+	err := rpgerr.ConflictingStateCtx(ctx, "already concentrating on bless")
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal("bless", meta["current_concentration"])
+	s.Equal("hold_person", meta["attempted_spell"])
+	s.True(meta["requires_concentration"].(bool))
+}
+
+// TestNestedPipelineAttackFlow shows deep nesting with context accumulation
+func (s *RPGScenariosTestSuite) TestNestedPipelineAttackFlow() {
+	// Level 1: Attack Pipeline
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("pipeline", "AttackPipeline"),
+		rpgerr.Meta("attacker", "barbarian-001"),
+		rpgerr.Meta("target", "dragon-001"),
+		rpgerr.Meta("weapon", "greataxe"),
+	)
+
+	// Level 2: Hit Calculation
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("pipeline", "HitCalculation"),
+		rpgerr.Meta("attack_roll", 18),
+		rpgerr.Meta("attack_bonus", 7),
+		rpgerr.Meta("total_attack", 25),
+		rpgerr.Meta("target_ac", 19),
+		rpgerr.Meta("hit", true),
+	)
+
+	// Level 3: Damage Pipeline
+	damageCtx := rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("pipeline", "DamagePipeline"),
+		rpgerr.Meta("base_damage", "1d12"),
+		rpgerr.Meta("damage_roll", 8),
+		rpgerr.Meta("strength_bonus", 4),
+		rpgerr.Meta("rage_bonus", 2),
+	)
+
+	// Level 4: Damage Reduction
+	reductionCtx := rpgerr.WithMetadata(damageCtx,
+		rpgerr.Meta("pipeline", "DamageReduction"),
+		rpgerr.Meta("damage_type", "slashing"),
+		rpgerr.Meta("target_immunities", []string{"poison", "psychic"}),
+		rpgerr.Meta("target_resistances", []string{"slashing", "piercing", "bludgeoning"}),
+	)
+
+	// Dragon has resistance to non-magical weapons
+	err := rpgerr.NewCtx(reductionCtx, rpgerr.CodeBlocked,
+		"damage reduced by resistance to non-magical slashing")
+
+	// Add call stack to show the execution path
+	err.CallStack = []string{
+		"AttackPipeline",
+		"HitCalculation",
+		"DamagePipeline",
+		"DamageReduction",
+	}
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal("barbarian-001", meta["attacker"])
+	s.Equal("dragon-001", meta["target"])
+	s.Equal("greataxe", meta["weapon"])
+	s.Equal(true, meta["hit"])
+	s.Equal("slashing", meta["damage_type"])
+
+	resistances := meta["target_resistances"].([]string)
+	s.Contains(resistances, "slashing")
+
+	stack := rpgerr.GetCallStack(err)
+	s.Len(stack, 4)
+	s.Equal("DamageReduction", stack[3])
+}
+
+// TestActionEconomyViolation shows timing restrictions with context
+func (s *RPGScenariosTestSuite) TestActionEconomyViolation() {
+	ctx := context.Background()
+
+	// Turn tracking
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("round", 2),
+		rpgerr.Meta("current_turn", "rogue-001"),
+		rpgerr.Meta("phase", "action"),
+	)
+
+	// Character's action economy state
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("character_id", "rogue-001"),
+		rpgerr.Meta("action_used", true),
+		rpgerr.Meta("bonus_action_used", false),
+		rpgerr.Meta("movement_used", 15),
+		rpgerr.Meta("movement_total", 30),
+		rpgerr.Meta("reaction_used", false),
+	)
+
+	// Attempted action
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("attempted_action", "attack"),
+		rpgerr.Meta("action_type", "action"),
+		rpgerr.Meta("previous_action", "dash"),
+	)
+
+	err := rpgerr.TimingRestrictionCtx(ctx, "action already used this turn")
+
+	meta := rpgerr.GetMeta(err)
+	s.True(meta["action_used"].(bool))
+	s.Equal("attack", meta["attempted_action"])
+	s.Equal("dash", meta["previous_action"])
+}
+
+// TestPrerequisiteChain shows multiple prerequisite failures
+func (s *RPGScenariosTestSuite) TestPrerequisiteChain() {
+	ctx := context.Background()
+
+	// Character attempting the action
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("character_id", "fighter-001"),
+		rpgerr.Meta("character_level", 3),
+		rpgerr.Meta("character_class", "fighter"),
+		rpgerr.Meta("subclass", "none"), // Haven't chosen archetype yet
+	)
+
+	// Ability being attempted
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("ability", "action_surge"),
+		rpgerr.Meta("ability_level_required", 2),
+		rpgerr.Meta("ability_uses_remaining", 0),
+		rpgerr.Meta("ability_recharge", "short_rest"),
+		rpgerr.Meta("last_rest", "long_rest_2_encounters_ago"),
+	)
+
+	err := rpgerr.ResourceExhaustedCtx(ctx, "action surge uses")
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal(0, meta["ability_uses_remaining"])
+	s.Equal("short_rest", meta["ability_recharge"])
+	s.Equal(3, meta["character_level"]) // Has the level requirement
+}
+
+// TestImmunityContext shows immunity with full context
+func (s *RPGScenariosTestSuite) TestImmunityContext() {
+	ctx := context.Background()
+
+	// Spell being cast
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("spell", "charm_person"),
+		rpgerr.Meta("spell_school", "enchantment"),
+		rpgerr.Meta("save_dc", 15),
+		rpgerr.Meta("caster", "bard-001"),
+	)
+
+	// Target information
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("target", "undead-skeleton-001"),
+		rpgerr.Meta("target_type", "undead"),
+		rpgerr.Meta("target_immunities", []string{
+			"poison",
+			"exhaustion",
+			"charm",
+			"frightened",
+		}),
+	)
+
+	err := rpgerr.ImmuneCtx(ctx, "charm effects (undead immunity)")
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal("charm_person", meta["spell"])
+	s.Equal("undead", meta["target_type"])
+
+	immunities := meta["target_immunities"].([]string)
+	s.Contains(immunities, "charm")
+}
+
+// TestInterruptionChain shows how counterspell interrupts a spell
+func (s *RPGScenariosTestSuite) TestInterruptionChain() {
+	// Original spell cast
+	ctx := context.Background()
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("pipeline", "SpellCastPipeline"),
+		rpgerr.Meta("caster", "wizard-001"),
+		rpgerr.Meta("spell", "disintegrate"),
+		rpgerr.Meta("spell_level", 6),
+		rpgerr.Meta("target", "fighter-001"),
+		rpgerr.Meta("phase", "casting"),
+	)
+
+	// Reaction triggered
+	ctx = rpgerr.WithMetadata(ctx,
+		rpgerr.Meta("interrupt_pipeline", "CounterspellPipeline"),
+		rpgerr.Meta("interruptor", "wizard-002"),
+		rpgerr.Meta("counterspell_level", 6),
+		rpgerr.Meta("automatic_success", true), // Same level = auto success
+		rpgerr.Meta("reaction_used", true),
+	)
+
+	err := rpgerr.InterruptedCtx(ctx, "counterspell")
+	err.CallStack = []string{
+		"SpellCastPipeline.Begin",
+		"SpellCastPipeline.DeclareTarget",
+		"ReactionWindow.Open",
+		"CounterspellPipeline.Trigger",
+		"CounterspellPipeline.Resolve",
+		"SpellCastPipeline.Cancelled",
+	}
+
+	meta := rpgerr.GetMeta(err)
+	s.Equal("disintegrate", meta["spell"])
+	s.Equal("wizard-002", meta["interruptor"])
+	s.True(meta["automatic_success"].(bool))
+
+	stack := rpgerr.GetCallStack(err)
+	s.Contains(stack, "ReactionWindow.Open")
+	s.Contains(stack, "SpellCastPipeline.Cancelled")
+}


### PR DESCRIPTION
## Summary
Adds a comprehensive error package (`rpgerr`) designed specifically for RPG game development. This package enables clear communication of why game actions cannot proceed, with full context about the game state when rules are evaluated.

## Motivation
RPG games need to communicate rule violations clearly - not as system failures, but as game mechanics working correctly. This package provides the foundation for observable game mechanics where every error tells the complete story of what happened and why.

## Key Features
- **Game-specific error codes**: `NotAllowed`, `ResourceExhausted`, `OutOfRange`, `InvalidTarget`, etc.
- **Context accumulation**: Errors accumulate metadata as they bubble up through game systems
- **Full observability**: Every error contains the complete game state when the rule was evaluated
- **Call stack tracking**: Track execution path through nested game systems
- **73.4% test coverage**: Comprehensive tests demonstrating real RPG scenarios

## Implementation
The package provides two key patterns:
1. **Error context (outbound)**: Accumulates metadata as errors bubble UP and OUT
2. **Preparation for runtime context (inbound)**: Designed to work with context.Context flowing DOWN and IN

## Examples
```go
// Attack out of range - error contains full context
ctx = rpgerr.WithMetadata(ctx,
    rpgerr.Meta("attacker_position", "5,5"),
    rpgerr.Meta("target_position", "15,15"),
    rpgerr.Meta("weapon_reach", 5),
    rpgerr.Meta("calculated_distance", 14.14),
)
err := rpgerr.OutOfRangeCtx(ctx, "melee attack")
// Error contains complete story of why attack failed

// Resource exhaustion with full context
ctx = rpgerr.WithMetadata(ctx,
    rpgerr.Meta("spell", "fireball"),
    rpgerr.Meta("spell_level", 3),
    rpgerr.Meta("slots_remaining", map[string]int{"3rd": 0}),
)
err := rpgerr.ResourceExhaustedCtx(ctx, "spell slots")
```

## Testing
All tests pass with comprehensive coverage of RPG scenarios including:
- Melee attacks out of range
- Spell casting without slots
- Concentration conflicts
- Immunity handling
- Action economy violations
- Counterspell interruptions

## Related Issues
- Implements Phase 0 of #234 (Error package for RPG development)
- Foundation for #232 (Pipeline architecture)
- Works with #235 (Runtime context exploration) and #236 (Add context everywhere)

## Next Steps
After this is merged:
1. Add runtime context.Context to foundational modules
2. Build pipeline architecture on top of this error foundation