### PR TITLE
feat(dice): Add context.Context to Roller interface

### DIFF
--- a/dice/example_test.go
+++ b/dice/example_test.go
@@ -4,6 +4,7 @@
 package dice_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -60,9 +61,10 @@ func TestWithMockRoller(t *testing.T) {
 	defer ctrl.Finish()
 
 	// Create mock roller with predictable results
+	ctx := context.Background()
 	mockRoller := mock_dice.NewMockRoller(ctrl)
-	mockRoller.EXPECT().RollN(1, 20).Return([]int{20}, nil) // Natural 20!
-	mockRoller.EXPECT().RollN(2, 6).Return([]int{6, 5}, nil)
+	mockRoller.EXPECT().RollN(ctx, 1, 20).Return([]int{20}, nil) // Natural 20!
+	mockRoller.EXPECT().RollN(ctx, 2, 6).Return([]int{6, 5}, nil)
 
 	// Set the mock as the default
 	dice.SetDefaultRoller(mockRoller)
@@ -88,8 +90,9 @@ func TestParallelSafety(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
+		ctx := context.Background()
 		mockRoller := mock_dice.NewMockRoller(ctrl)
-		mockRoller.EXPECT().RollN(1, 6).Return([]int{4}, nil)
+		mockRoller.EXPECT().RollN(ctx, 1, 6).Return([]int{4}, nil)
 
 		roll, err := dice.NewRollWithRoller(1, 6, mockRoller)
 		if err != nil {
@@ -107,8 +110,9 @@ func TestParallelSafety(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
+		ctx := context.Background()
 		mockRoller := mock_dice.NewMockRoller(ctrl)
-		mockRoller.EXPECT().RollN(1, 6).Return([]int{2}, nil)
+		mockRoller.EXPECT().RollN(ctx, 1, 6).Return([]int{2}, nil)
 
 		roll, err := dice.NewRollWithRoller(1, 6, mockRoller)
 		if err != nil {

--- a/dice/mock/mock_roller.go
+++ b/dice/mock/mock_roller.go
@@ -10,6 +10,7 @@
 package mock_dice
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -40,31 +41,31 @@ func (m *MockRoller) EXPECT() *MockRollerMockRecorder {
 }
 
 // Roll mocks base method.
-func (m *MockRoller) Roll(size int) (int, error) {
+func (m *MockRoller) Roll(ctx context.Context, size int) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Roll", size)
+	ret := m.ctrl.Call(m, "Roll", ctx, size)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Roll indicates an expected call of Roll.
-func (mr *MockRollerMockRecorder) Roll(size any) *gomock.Call {
+func (mr *MockRollerMockRecorder) Roll(ctx, size any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Roll", reflect.TypeOf((*MockRoller)(nil).Roll), size)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Roll", reflect.TypeOf((*MockRoller)(nil).Roll), ctx, size)
 }
 
 // RollN mocks base method.
-func (m *MockRoller) RollN(count, size int) ([]int, error) {
+func (m *MockRoller) RollN(ctx context.Context, count, size int) ([]int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RollN", count, size)
+	ret := m.ctrl.Call(m, "RollN", ctx, count, size)
 	ret0, _ := ret[0].([]int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RollN indicates an expected call of RollN.
-func (mr *MockRollerMockRecorder) RollN(count, size any) *gomock.Call {
+func (mr *MockRollerMockRecorder) RollN(ctx, count, size any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollN", reflect.TypeOf((*MockRoller)(nil).RollN), count, size)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollN", reflect.TypeOf((*MockRoller)(nil).RollN), ctx, count, size)
 }

--- a/dice/modifier.go
+++ b/dice/modifier.go
@@ -6,6 +6,7 @@
 package dice
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -127,7 +128,10 @@ func (r *Roll) roll() {
 		absCount = -absCount
 	}
 
-	rolls, err := r.roller.RollN(absCount, r.size)
+	// TODO: This should receive context from the caller
+	// For now using Background context to maintain compatibility
+	ctx := context.Background()
+	rolls, err := r.roller.RollN(ctx, absCount, r.size)
 	if err != nil {
 		r.err = err
 		r.rolled = true

--- a/dice/modifier_test.go
+++ b/dice/modifier_test.go
@@ -163,9 +163,9 @@ func TestRoll_GetValue(t *testing.T) {
 			mockRoller := mock_dice.NewMockRoller(ctrl)
 
 			if tt.rollError != nil {
-				mockRoller.EXPECT().RollN(gomock.Any(), tt.size).Return(nil, tt.rollError)
+				mockRoller.EXPECT().RollN(gomock.Any(), gomock.Any(), tt.size).Return(nil, tt.rollError)
 			} else if len(tt.rolls) > 0 {
-				mockRoller.EXPECT().RollN(gomock.Any(), tt.size).Return(tt.rolls, nil)
+				mockRoller.EXPECT().RollN(gomock.Any(), gomock.Any(), tt.size).Return(tt.rolls, nil)
 			}
 
 			roll, err := NewRollWithRoller(tt.count, tt.size, mockRoller)
@@ -254,9 +254,9 @@ func TestRoll_GetDescription(t *testing.T) {
 			mockRoller := mock_dice.NewMockRoller(ctrl)
 
 			if tt.rollError != nil {
-				mockRoller.EXPECT().RollN(gomock.Any(), tt.size).Return(nil, tt.rollError)
+				mockRoller.EXPECT().RollN(gomock.Any(), gomock.Any(), tt.size).Return(nil, tt.rollError)
 			} else if len(tt.rolls) > 0 {
-				mockRoller.EXPECT().RollN(gomock.Any(), tt.size).Return(tt.rolls, nil)
+				mockRoller.EXPECT().RollN(gomock.Any(), gomock.Any(), tt.size).Return(tt.rolls, nil)
 			}
 
 			roll, err := NewRollWithRoller(tt.count, tt.size, mockRoller)
@@ -278,7 +278,7 @@ func TestRoll_CachedBehavior(t *testing.T) {
 
 	mockRoller := mock_dice.NewMockRoller(ctrl)
 	// Expect only one call to RollN, proving caching works
-	mockRoller.EXPECT().RollN(2, 6).Return([]int{1, 2}, nil).Times(1)
+	mockRoller.EXPECT().RollN(gomock.Any(), 2, 6).Return([]int{1, 2}, nil).Times(1)
 
 	roll, err := NewRollWithRoller(2, 6, mockRoller)
 	if err != nil {
@@ -368,7 +368,7 @@ func TestRoll_ErrorPropagation(t *testing.T) {
 
 	mockRoller := mock_dice.NewMockRoller(ctrl)
 	expectedErr := errors.New("crypto/rand: test error")
-	mockRoller.EXPECT().RollN(1, 20).Return(nil, expectedErr)
+	mockRoller.EXPECT().RollN(gomock.Any(), 1, 20).Return(nil, expectedErr)
 
 	roll, err := NewRollWithRoller(1, 20, mockRoller)
 	if err != nil {
@@ -399,7 +399,7 @@ func TestRoll_Err_BeforeRoll(t *testing.T) {
 
 	mockRoller := mock_dice.NewMockRoller(ctrl)
 	// Expect RollN to be called when Err() is called before any roll
-	mockRoller.EXPECT().RollN(1, 6).Return([]int{4}, nil)
+	mockRoller.EXPECT().RollN(gomock.Any(), 1, 6).Return([]int{4}, nil)
 
 	roll, err := NewRollWithRoller(1, 6, mockRoller)
 	if err != nil {

--- a/dice/roller_test.go
+++ b/dice/roller_test.go
@@ -4,6 +4,7 @@
 package dice
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 
 func TestCryptoRoller_Roll(t *testing.T) {
 	roller := &CryptoRoller{}
+	ctx := context.Background()
 
 	// Test various die sizes
 	sizes := []int{4, 6, 8, 10, 12, 20, 100}
@@ -25,7 +27,7 @@ func TestCryptoRoller_Roll(t *testing.T) {
 			iterations := size * 100
 
 			for i := 0; i < iterations; i++ {
-				result, err := roller.Roll(size)
+				result, err := roller.Roll(ctx, size)
 				if err != nil {
 					t.Fatalf("Roll(%d) error = %v", size, err)
 				}
@@ -54,6 +56,7 @@ func TestCryptoRoller_Roll(t *testing.T) {
 
 func TestCryptoRoller_RollN(t *testing.T) {
 	roller := &CryptoRoller{}
+	ctx := context.Background()
 
 	tests := []struct {
 		name  string
@@ -68,7 +71,7 @@ func TestCryptoRoller_RollN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results, err := roller.RollN(tt.count, tt.size)
+			results, err := roller.RollN(ctx, tt.count, tt.size)
 			if err != nil {
 				t.Fatalf("RollN(%d, %d) error = %v", tt.count, tt.size, err)
 			}
@@ -90,6 +93,7 @@ func TestCryptoRoller_RollN(t *testing.T) {
 
 func TestCryptoRoller_Errors(t *testing.T) {
 	roller := &CryptoRoller{}
+	ctx := context.Background()
 
 	tests := []struct {
 		name    string
@@ -99,7 +103,7 @@ func TestCryptoRoller_Errors(t *testing.T) {
 		{
 			name: "Roll with zero size",
 			fn: func() error {
-				_, err := roller.Roll(0)
+				_, err := roller.Roll(ctx, 0)
 				return err
 			},
 			wantErr: "dice: invalid die size 0",
@@ -107,7 +111,7 @@ func TestCryptoRoller_Errors(t *testing.T) {
 		{
 			name: "Roll with negative size",
 			fn: func() error {
-				_, err := roller.Roll(-1)
+				_, err := roller.Roll(ctx, -1)
 				return err
 			},
 			wantErr: "dice: invalid die size -1",
@@ -115,7 +119,7 @@ func TestCryptoRoller_Errors(t *testing.T) {
 		{
 			name: "RollN with zero size",
 			fn: func() error {
-				_, err := roller.RollN(1, 0)
+				_, err := roller.RollN(ctx, 1, 0)
 				return err
 			},
 			wantErr: "dice: invalid die size 0",
@@ -123,7 +127,7 @@ func TestCryptoRoller_Errors(t *testing.T) {
 		{
 			name: "RollN with negative count",
 			fn: func() error {
-				_, err := roller.RollN(-1, 6)
+				_, err := roller.RollN(ctx, -1, 6)
 				return err
 			},
 			wantErr: "dice: invalid die count -1",
@@ -143,13 +147,14 @@ func TestCryptoRoller_Errors(t *testing.T) {
 }
 
 func TestDefaultRoller(t *testing.T) {
+	ctx := context.Background()
 	// Ensure DefaultRoller is set
 	if DefaultRoller == nil {
 		t.Fatal("DefaultRoller is nil")
 	}
 
 	// Test it works
-	result, err := DefaultRoller.Roll(6)
+	result, err := DefaultRoller.Roll(ctx, 6)
 	if err != nil {
 		t.Fatalf("DefaultRoller.Roll(6) error = %v", err)
 	}
@@ -159,6 +164,7 @@ func TestDefaultRoller(t *testing.T) {
 }
 
 func TestSetDefaultRoller(t *testing.T) {
+	ctx := context.Background()
 	// Save original
 	original := DefaultRoller
 	defer func() { DefaultRoller = original }()
@@ -168,12 +174,12 @@ func TestSetDefaultRoller(t *testing.T) {
 
 	// Set mock roller
 	mockRoller := mock_dice.NewMockRoller(ctrl)
-	mockRoller.EXPECT().Roll(6).Return(4, nil)
+	mockRoller.EXPECT().Roll(ctx, 6).Return(4, nil)
 
 	SetDefaultRoller(mockRoller)
 
 	// Verify it was set
-	result, err := DefaultRoller.Roll(6)
+	result, err := DefaultRoller.Roll(ctx, 6)
 	if err != nil {
 		t.Fatalf("DefaultRoller.Roll(6) error = %v", err)
 	}


### PR DESCRIPTION
## Summary
Adds `context.Context` as the first parameter to all methods in the `Roller` interface, following Go best practices and enabling cancellation, timeouts, and request tracing.

## Motivation
Part of #236 - adding context to all public APIs in the toolkit. The dice module is foundational (used everywhere), so updating it first establishes the pattern for other modules.

## Changes
- Updated `Roller` interface:
  - `Roll(ctx context.Context, size int) (int, error)`  
  - `RollN(ctx context.Context, count, size int) ([]int, error)`
- Updated `CryptoRoller` implementation with cancellation check in `RollN`
- Updated all tests to pass context
- Regenerated mocks with new signatures
- Added TODO in `modifier.go` for future context propagation

## Implementation Notes
- Using `context.Background()` in `Roll` struct's internal `roll()` method for now
- This maintains compatibility while we work on updating the modifier interface
- Added cancellation check in `RollN` loop for long operations
- Context parameter marked as unused (`_`) in `CryptoRoller.Roll` since crypto/rand operations are fast

## Testing
- All existing tests updated and passing
- Mocks regenerated and working
- Linting passes

## Next Steps
After this PR:
1. Update other foundational modules (core, events)
2. Design pipeline interfaces with context from the start
3. Eventually update the modifier interface to properly propagate context

## Related Issues
- Implements part of #236 (Add context.Context to all public APIs)
- Foundation for #232 (Pipeline architecture)