### PR TITLE
feat(core): Add chain, effect, and topic types

### DIFF
--- a/core/chain/types.go
+++ b/core/chain/types.go
@@ -16,10 +16,12 @@ type Stage string
 // Each modification transforms the data and passes it to the next.
 type Chain[T any] interface {
 	// Add registers a modifier at the specified stage with a unique ID.
-	Add(stage Stage, id string, modifier func(context.Context, T) (T, error))
+	// Returns an error if the ID already exists.
+	Add(stage Stage, id string, modifier func(context.Context, T) (T, error)) error
 
 	// Remove unregisters a modifier by its ID.
-	Remove(id string)
+	// Returns an error if the ID does not exist.
+	Remove(id string) error
 
 	// Execute runs all modifiers in stage order, transforming the data.
 	Execute(ctx context.Context, data T) (T, error)

--- a/core/chain/types.go
+++ b/core/chain/types.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package chain provides interfaces for ordered processing of data through stages.
+// Chains allow modifications to be applied in a predictable order, making complex
+// game mechanics composable and testable.
+package chain
+
+import "context"
+
+// Stage represents a processing stage in a chain.
+// Stages determine the order of execution for modifications.
+type Stage string
+
+// Chain processes data through ordered stages of modifications.
+// Each modification transforms the data and passes it to the next.
+type Chain[T any] interface {
+	// Add registers a modifier at the specified stage with a unique ID.
+	Add(stage Stage, id string, modifier func(context.Context, T) (T, error))
+
+	// Remove unregisters a modifier by its ID.
+	Remove(id string)
+
+	// Execute runs all modifiers in stage order, transforming the data.
+	Execute(ctx context.Context, data T) (T, error)
+}

--- a/core/effect/types.go
+++ b/core/effect/types.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package effect provides interfaces for modifying chains with typed effects.
+// Effects encapsulate modifications that can be applied to and removed from chains,
+// enabling composition of complex game mechanics.
+package effect
+
+import "github.com/KirkDiggler/rpg-toolkit/core/chain"
+
+// Effect modifies a chain of a specific type.
+// Effects can be composed to create complex modifications.
+type Effect[T any] interface {
+	// Apply adds this effect's modifications to the chain.
+	Apply(chain chain.Chain[T]) error
+
+	// Remove removes this effect's modifications from the chain.
+	Remove(chain chain.Chain[T]) error
+}

--- a/core/topic.go
+++ b/core/topic.go
@@ -1,0 +1,8 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+// Topic represents a typed event routing key for pub/sub systems.
+// Topics provide compile-time safety and avoid magic strings.
+type Topic string


### PR DESCRIPTION
## Summary
- Add foundational types for event-driven architecture
- Topic type for typed event routing
- Chain[T] interface for ordered processing
- Effect[T] interface for typed modifications

## Changes
- `core/topic.go` - Topic type to replace magic strings in event routing
- `core/chain/types.go` - Chain[T] interface for ordered data transformation
- `core/effect/types.go` - Effect[T] interface for composable modifications

## Context
Based on prototype work, these minimal core types provide the foundation for:
- Type-safe event pub/sub (Topic)
- Ordered modifier processing (Chain)
- Composable effects (Effect)

The events package will implement these interfaces, and rulebooks will use them to build game mechanics.

## Testing
These are just type definitions - implementation and tests will come in the events package.

Relates to #228, #242, #243

🤖 Generated with [Claude Code](https://claude.ai/code)