### PR TITLE
feat: Declarative validation and warning system

### DIFF
--- a/rulebooks/dnd5e/validation/validator_v3.go
+++ b/rulebooks/dnd5e/validation/validator_v3.go
@@ -1,0 +1,214 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// ValidateClassChoicesV3 validates choices and returns both errors and warnings
+func ValidateClassChoicesV3(classID classes.Class, choices []character.Choice) (*Result, error) {
+	result := &Result{
+		Errors:   []Error{},
+		Warnings: []Warning{},
+	}
+
+	// Filter for class-sourced choices for error checking
+	classChoices := filterChoicesBySource(choices, shared.SourceClass)
+
+	// Get class-specific errors using existing V2 validation
+	errors, err := ValidateClassChoicesV2(classID, classChoices)
+	if err != nil {
+		return nil, err
+	}
+	result.Errors = errors
+
+	// Now check for cross-source warnings using ALL choices
+	result.Warnings = append(result.Warnings, DetectCrossSourceDuplicates(choices)...)
+
+	// Check expertise prerequisites (especially important for Rogue)
+	if classID == classes.Rogue {
+		result.Warnings = append(result.Warnings, ValidateExpertisePrerequisites(choices)...)
+	}
+
+	// Add class-specific warnings
+	switch classID {
+	case classes.Fighter:
+		result.Warnings = append(result.Warnings, validateFighterWarnings(choices)...)
+	case classes.Bard:
+		result.Warnings = append(result.Warnings, validateBardWarnings(choices)...)
+	case classes.Rogue:
+		result.Warnings = append(result.Warnings, validateRogueWarnings(choices)...)
+	}
+
+	return result, nil
+}
+
+// validateFighterWarnings checks for Fighter-specific warnings
+func validateFighterWarnings(choices []character.Choice) []Warning {
+	var warnings []Warning
+
+	// Check if Fighter picked Intimidation and race is Half-Orc
+	hasClassIntimidation := false
+	hasRaceIntimidation := false
+
+	for _, choice := range choices {
+		if sc, ok := choice.(character.SkillChoice); ok {
+			for _, skill := range sc.Skills {
+				if skill == "intimidation" {
+					if choice.GetSource() == shared.SourceClass {
+						hasClassIntimidation = true
+					} else if choice.GetSource() == shared.SourceRace {
+						hasRaceIntimidation = true
+					}
+				}
+			}
+		}
+	}
+
+	if hasClassIntimidation && hasRaceIntimidation {
+		msg := "Intimidation skill selected from both Fighter class and Half-Orc race. " +
+			"Consider choosing a different Fighter skill."
+		warnings = append(warnings, Warning{
+			Field:   "skills",
+			Message: msg,
+			Code:    WarningDuplicateSkill,
+		})
+	}
+
+	return warnings
+}
+
+// validateBardWarnings checks for Bard-specific warnings
+func validateBardWarnings(choices []character.Choice) []Warning {
+	var warnings []Warning
+
+	// Check if Bard has any overlapping skills from background
+	backgroundSkills := make(map[string]bool)
+	classSkills := make(map[string]bool)
+
+	for _, choice := range choices {
+		if sc, ok := choice.(character.SkillChoice); ok {
+			for _, skill := range sc.Skills {
+				skillStr := string(skill)
+				if choice.GetSource() == shared.SourceBackground {
+					backgroundSkills[skillStr] = true
+				} else if choice.GetSource() == shared.SourceClass {
+					classSkills[skillStr] = true
+				}
+			}
+		}
+	}
+
+	// Check for overlaps
+	for skill := range classSkills {
+		if backgroundSkills[skill] {
+			warnings = append(warnings, Warning{
+				Field:   "skills",
+				Message: fmt.Sprintf("Bard can choose any skill, but '%s' is already provided by background", skill),
+				Code:    WarningDuplicateSkill,
+			})
+		}
+	}
+
+	return warnings
+}
+
+// validateRogueWarnings checks for Rogue-specific warnings
+func validateRogueWarnings(choices []character.Choice) []Warning {
+	var warnings []Warning
+
+	// Check if Rogue has expertise in thieves' tools without proficiency
+	hasThievesToolsProficiency := false
+	hasThievesToolsExpertise := false
+
+	for _, choice := range choices {
+		// Rogues automatically get thieves' tools proficiency, but let's check anyway
+		if tc, ok := choice.(character.ToolProficiencyChoice); ok {
+			for _, tool := range tc.Tools {
+				if tool == "thieves-tools" {
+					hasThievesToolsProficiency = true
+				}
+			}
+		}
+
+		if ec, ok := choice.(character.ExpertiseChoice); ok {
+			for _, expertise := range ec.Expertise {
+				if expertise == "thieves-tools" {
+					hasThievesToolsExpertise = true
+				}
+			}
+		}
+	}
+
+	// Note: Rogues automatically get thieves' tools, so this is more of a data validation
+	if hasThievesToolsExpertise && !hasThievesToolsProficiency {
+		warnings = append(warnings, Warning{
+			Field:   "expertise",
+			Message: "Expertise in thieves' tools selected, but proficiency not found (Rogues get this automatically)",
+			Code:    WarningExpertiseWithoutProficiency,
+		})
+	}
+
+	return warnings
+}
+
+// ValidateDraftWithWarnings validates an entire character draft including cross-source warnings
+func ValidateDraftWithWarnings(draft *character.Draft) (*Result, error) {
+	if draft == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "draft cannot be nil")
+	}
+
+	result := &Result{
+		Errors:   []Error{},
+		Warnings: []Warning{},
+	}
+
+	// Convert ChoiceData to Choice interface types
+	allChoices := []character.Choice{}
+	for _, choiceData := range draft.Choices {
+		choice, err := character.ConvertFromChoiceData(choiceData)
+		if err != nil {
+			// Log conversion error but continue
+			continue
+		}
+		allChoices = append(allChoices, choice)
+	}
+
+	// Run class validation if class is selected
+	if draft.ClassChoice.ClassID != "" {
+		classID := draft.ClassChoice.ClassID
+		classResult, err := ValidateClassChoicesV3(classID, allChoices)
+		if err != nil {
+			return nil, err
+		}
+		result.Errors = append(result.Errors, classResult.Errors...)
+		result.Warnings = append(result.Warnings, classResult.Warnings...)
+	}
+
+	// Run race validation if implemented
+	// TODO: Add race validation when available
+
+	// Check for general cross-source issues
+	crossSourceWarnings := DetectCrossSourceDuplicates(allChoices)
+
+	// De-duplicate warnings (in case class validation already added some)
+	warningMap := make(map[string]bool)
+	for _, w := range result.Warnings {
+		key := fmt.Sprintf("%s:%s:%s", w.Field, w.Code, w.Message)
+		warningMap[key] = true
+	}
+
+	for _, w := range crossSourceWarnings {
+		key := fmt.Sprintf("%s:%s:%s", w.Field, w.Code, w.Message)
+		if !warningMap[key] {
+			result.Warnings = append(result.Warnings, w)
+			warningMap[key] = true
+		}
+	}
+
+	return result, nil
+}

--- a/rulebooks/dnd5e/validation/warnings.go
+++ b/rulebooks/dnd5e/validation/warnings.go
@@ -1,0 +1,168 @@
+package validation
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+)
+
+// Warning represents a non-blocking validation issue
+type Warning struct {
+	Field   string
+	Message string
+	Code    string // e.g., "duplicate_skill", "expertise_without_proficiency"
+}
+
+// Common warning codes
+const (
+	WarningDuplicateSkill              = "duplicate_skill"
+	WarningDuplicateLanguage           = "duplicate_language"
+	WarningExpertiseWithoutProficiency = "expertise_without_proficiency"
+	WarningDuplicateTool               = "duplicate_tool"
+	WarningDuplicateInstrument         = "duplicate_instrument"
+)
+
+// Result contains both errors and warnings from validation
+type Result struct {
+	Errors   []Error
+	Warnings []Warning
+}
+
+// DetectCrossSourceDuplicates checks for duplicate proficiencies across all sources
+func DetectCrossSourceDuplicates(choices []character.Choice) []Warning {
+	var warnings []Warning
+
+	// Collect skills from all sources
+	skillsBySource := make(map[skills.Skill][]shared.ChoiceSource)
+	languagesBySource := make(map[string][]shared.ChoiceSource)
+	toolsBySource := make(map[string][]shared.ChoiceSource)
+	instrumentsBySource := make(map[string][]shared.ChoiceSource)
+
+	for _, choice := range choices {
+		source := choice.GetSource()
+
+		switch c := choice.(type) {
+		case character.SkillChoice:
+			for _, skill := range c.Skills {
+				skillsBySource[skill] = append(skillsBySource[skill], source)
+			}
+		case character.LanguageChoice:
+			for _, lang := range c.Languages {
+				langStr := string(lang)
+				languagesBySource[langStr] = append(languagesBySource[langStr], source)
+			}
+		case character.ToolProficiencyChoice:
+			for _, tool := range c.Tools {
+				toolsBySource[tool] = append(toolsBySource[tool], source)
+			}
+		case character.InstrumentProficiencyChoice:
+			for _, instrument := range c.Instruments {
+				instrumentsBySource[instrument] = append(instrumentsBySource[instrument], source)
+			}
+		}
+	}
+
+	// Check for duplicates
+	for skill, sources := range skillsBySource {
+		if len(sources) > 1 {
+			warnings = append(warnings, Warning{
+				Field:   "skills",
+				Message: fmt.Sprintf("Skill '%s' granted by multiple sources: %v", skill, sources),
+				Code:    WarningDuplicateSkill,
+			})
+		}
+	}
+
+	for lang, sources := range languagesBySource {
+		if len(sources) > 1 {
+			warnings = append(warnings, Warning{
+				Field:   "languages",
+				Message: fmt.Sprintf("Language '%s' granted by multiple sources: %v", lang, sources),
+				Code:    WarningDuplicateLanguage,
+			})
+		}
+	}
+
+	for tool, sources := range toolsBySource {
+		if len(sources) > 1 {
+			warnings = append(warnings, Warning{
+				Field:   "tools",
+				Message: fmt.Sprintf("Tool proficiency '%s' granted by multiple sources: %v", tool, sources),
+				Code:    WarningDuplicateTool,
+			})
+		}
+	}
+
+	for instrument, sources := range instrumentsBySource {
+		if len(sources) > 1 {
+			warnings = append(warnings, Warning{
+				Field:   "instruments",
+				Message: fmt.Sprintf("Instrument proficiency '%s' granted by multiple sources: %v", instrument, sources),
+				Code:    WarningDuplicateInstrument,
+			})
+		}
+	}
+
+	return warnings
+}
+
+// ValidateExpertisePrerequisites checks that expertise choices are for skills the character is proficient in
+func ValidateExpertisePrerequisites(choices []character.Choice) []Warning {
+	var warnings []Warning
+
+	// First, collect all skill proficiencies
+	proficientSkills := make(map[string]bool)
+	for _, choice := range choices {
+		if sc, ok := choice.(character.SkillChoice); ok {
+			for _, skill := range sc.Skills {
+				proficientSkills[string(skill)] = true
+			}
+		}
+	}
+
+	// Also collect tool proficiencies (for Rogue expertise in thieves' tools)
+	proficientTools := make(map[string]bool)
+	for _, choice := range choices {
+		if tc, ok := choice.(character.ToolProficiencyChoice); ok {
+			for _, tool := range tc.Tools {
+				proficientTools[tool] = true
+			}
+		}
+	}
+
+	// Now check expertise choices
+	for _, choice := range choices {
+		if ec, ok := choice.(character.ExpertiseChoice); ok {
+			for _, expertise := range ec.Expertise {
+				// Check if it's a skill or tool
+				if !proficientSkills[expertise] && !proficientTools[expertise] {
+					warnings = append(warnings, Warning{
+						Field:   "expertise",
+						Message: fmt.Sprintf("Expertise in '%s' requires proficiency from class, race, or background", expertise),
+						Code:    WarningExpertiseWithoutProficiency,
+					})
+				}
+			}
+		}
+	}
+
+	return warnings
+}
+
+// ValidateWithWarnings performs full validation including warnings
+func ValidateWithWarnings(choices []character.Choice) Result {
+	result := Result{
+		Errors:   []Error{},
+		Warnings: []Warning{},
+	}
+
+	// Detect cross-source duplicates
+	result.Warnings = append(result.Warnings, DetectCrossSourceDuplicates(choices)...)
+
+	// Validate expertise prerequisites
+	result.Warnings = append(result.Warnings, ValidateExpertisePrerequisites(choices)...)
+
+	return result
+}

--- a/rulebooks/dnd5e/validation/warnings_test.go
+++ b/rulebooks/dnd5e/validation/warnings_test.go
@@ -1,0 +1,298 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/languages"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"github.com/stretchr/testify/suite"
+)
+
+type WarningsTestSuite struct {
+	suite.Suite
+}
+
+func TestWarningsTestSuite(t *testing.T) {
+	suite.Run(t, new(WarningsTestSuite))
+}
+
+// Test duplicate skill detection across sources
+func (s *WarningsTestSuite) TestDetectCrossSourceDuplicates_Skills() {
+	choices := []character.Choice{
+		// Fighter chooses Intimidation
+		character.SkillChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "fighter-skills",
+			Skills:   []skills.Skill{skills.Intimidation, skills.Athletics},
+		},
+		// Half-Orc grants Intimidation
+		character.SkillChoice{
+			Source:   shared.SourceRace,
+			ChoiceID: "half-orc-skills",
+			Skills:   []skills.Skill{skills.Intimidation},
+		},
+	}
+
+	warnings := DetectCrossSourceDuplicates(choices)
+
+	s.Require().Len(warnings, 1, "Should have one warning for duplicate Intimidation")
+	s.Assert().Equal(WarningDuplicateSkill, warnings[0].Code)
+	s.Assert().Contains(warnings[0].Message, "intimidation")
+	s.Assert().Contains(warnings[0].Message, "multiple sources")
+}
+
+// Test duplicate language detection
+func (s *WarningsTestSuite) TestDetectCrossSourceDuplicates_Languages() {
+	choices := []character.Choice{
+		// Race grants Elvish
+		character.LanguageChoice{
+			Source:    shared.SourceRace,
+			ChoiceID:  "elf-languages",
+			Languages: []languages.Language{languages.Common, languages.Elvish},
+		},
+		// Background also grants Elvish
+		character.LanguageChoice{
+			Source:    shared.SourceBackground,
+			ChoiceID:  "sage-languages",
+			Languages: []languages.Language{languages.Elvish, languages.Draconic},
+		},
+	}
+
+	warnings := DetectCrossSourceDuplicates(choices)
+
+	s.Require().Len(warnings, 1, "Should have one warning for duplicate Elvish")
+	s.Assert().Equal(WarningDuplicateLanguage, warnings[0].Code)
+	s.Assert().Contains(warnings[0].Message, "elvish") // Language string is lowercase
+}
+
+// Test expertise without proficiency warning
+func (s *WarningsTestSuite) TestValidateExpertisePrerequisites_MissingProficiency() {
+	choices := []character.Choice{
+		// Rogue chooses skills
+		character.SkillChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "rogue-skills",
+			Skills:   []skills.Skill{skills.Stealth, skills.Deception, skills.Investigation, skills.Perception},
+		},
+		// Rogue chooses expertise in skills they don't have
+		character.ExpertiseChoice{
+			Source:    shared.SourceClass,
+			ChoiceID:  "rogue-expertise",
+			Expertise: []string{"stealth", "persuasion"}, // persuasion not in skills!
+		},
+	}
+
+	warnings := ValidateExpertisePrerequisites(choices)
+
+	s.Require().Len(warnings, 1, "Should have warning for expertise without proficiency")
+	s.Assert().Equal(WarningExpertiseWithoutProficiency, warnings[0].Code)
+	s.Assert().Contains(warnings[0].Message, "persuasion")
+	s.Assert().Contains(warnings[0].Message, "requires proficiency")
+}
+
+// Test expertise with proficiency (no warning)
+func (s *WarningsTestSuite) TestValidateExpertisePrerequisites_ValidExpertise() {
+	choices := []character.Choice{
+		// Rogue chooses skills
+		character.SkillChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "rogue-skills",
+			Skills:   []skills.Skill{skills.Stealth, skills.Deception, skills.Investigation, skills.Perception},
+		},
+		// Rogue chooses expertise in skills they have
+		character.ExpertiseChoice{
+			Source:    shared.SourceClass,
+			ChoiceID:  "rogue-expertise",
+			Expertise: []string{"stealth", "deception"},
+		},
+	}
+
+	warnings := ValidateExpertisePrerequisites(choices)
+
+	s.Assert().Empty(warnings, "Should have no warnings for valid expertise choices")
+}
+
+// Test expertise in thieves' tools
+func (s *WarningsTestSuite) TestValidateExpertisePrerequisites_ThievesTools() {
+	choices := []character.Choice{
+		// Rogue gets thieves' tools proficiency
+		character.ToolProficiencyChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "rogue-tools",
+			Tools:    []string{"thieves-tools"},
+		},
+		// Rogue chooses expertise in thieves' tools
+		character.ExpertiseChoice{
+			Source:    shared.SourceClass,
+			ChoiceID:  "rogue-expertise",
+			Expertise: []string{"thieves-tools", "stealth"},
+		},
+		// But no stealth proficiency!
+		character.SkillChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "rogue-skills",
+			Skills:   []skills.Skill{skills.Deception, skills.Investigation, skills.Perception, skills.Acrobatics},
+		},
+	}
+
+	warnings := ValidateExpertisePrerequisites(choices)
+
+	s.Require().Len(warnings, 1, "Should warn about stealth expertise without proficiency")
+	s.Assert().Contains(warnings[0].Message, "stealth")
+	s.Assert().NotContains(warnings[0].Message, "thieves-tools", "Should not warn about thieves' tools")
+}
+
+// Test full validation with Fighter + Half-Orc
+func (s *WarningsTestSuite) TestValidateClassChoicesV3_FighterHalfOrc() {
+	choices := []character.Choice{
+		// Fighter chooses Intimidation and Athletics
+		character.SkillChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "fighter-skills",
+			Skills:   []skills.Skill{skills.Intimidation, skills.Athletics},
+		},
+		// Half-Orc grants Intimidation
+		character.SkillChoice{
+			Source:   shared.SourceRace,
+			ChoiceID: "half-orc-skills",
+			Skills:   []skills.Skill{skills.Intimidation},
+		},
+		// Fighter equipment and fighting style
+		character.EquipmentChoice{
+			Source:    shared.SourceClass,
+			ChoiceID:  "fighter-equipment",
+			Equipment: []string{"chain-mail", "longsword", "shield"},
+		},
+		character.FightingStyleChoice{
+			Source:        shared.SourceClass,
+			ChoiceID:      "fighter-style",
+			FightingStyle: "defense",
+		},
+	}
+
+	result, err := ValidateClassChoicesV3(classes.Fighter, choices)
+	s.Require().NoError(err)
+
+	// Should have no errors (valid Fighter choices)
+	s.Assert().Empty(result.Errors, "Valid Fighter choices should have no errors")
+
+	// Should have warning about duplicate Intimidation
+	s.Require().NotEmpty(result.Warnings, "Should have warnings")
+
+	hasIntimidationWarning := false
+	for _, w := range result.Warnings {
+		if w.Code == WarningDuplicateSkill {
+			// Check for either case since different sources may format differently
+			if containsString(w.Message, "intimidation") || containsString(w.Message, "Intimidation") {
+				hasIntimidationWarning = true
+			}
+		}
+	}
+	s.Assert().True(hasIntimidationWarning, "Should have warning about duplicate Intimidation")
+}
+
+// Test Bard with overlapping background skills
+func (s *WarningsTestSuite) TestValidateClassChoicesV3_BardBackgroundOverlap() {
+	choices := []character.Choice{
+		// Bard chooses Performance (which background also provides)
+		character.SkillChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "bard-skills",
+			Skills:   []skills.Skill{skills.Performance, skills.Persuasion, skills.Deception},
+		},
+		// Entertainer background grants Performance
+		character.SkillChoice{
+			Source:   shared.SourceBackground,
+			ChoiceID: "entertainer-skills",
+			Skills:   []skills.Skill{skills.Performance, skills.Acrobatics},
+		},
+		// Other required Bard choices
+		character.CantripChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "bard-cantrips",
+			Cantrips: []string{"vicious-mockery", "minor-illusion"},
+		},
+		character.SpellChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "bard-spells",
+			Spells:   []string{"charm-person", "cure-wounds", "disguise-self", "healing-word"},
+		},
+		character.EquipmentChoice{
+			Source:    shared.SourceClass,
+			ChoiceID:  "bard-equipment",
+			Equipment: []string{"rapier", "diplomats-pack", "lute"},
+		},
+		character.InstrumentProficiencyChoice{
+			Source:      shared.SourceClass,
+			ChoiceID:    "bard-instruments",
+			Instruments: []string{"lute", "flute", "drum"},
+		},
+	}
+
+	result, err := ValidateClassChoicesV3(classes.Bard, choices)
+	s.Require().NoError(err)
+
+	// Should have no errors
+	s.Assert().Empty(result.Errors, "Valid Bard choices should have no errors")
+
+	// Should have warning about Performance overlap
+	hasPerformanceWarning := false
+	for _, w := range result.Warnings {
+		if w.Code == WarningDuplicateSkill && containsString(w.Message, "performance") {
+			hasPerformanceWarning = true
+		}
+	}
+	s.Assert().True(hasPerformanceWarning, "Should warn about Performance from both sources")
+}
+
+// Test Rogue with invalid expertise
+func (s *WarningsTestSuite) TestValidateClassChoicesV3_RogueInvalidExpertise() {
+	choices := []character.Choice{
+		// Rogue chooses 4 skills
+		character.SkillChoice{
+			Source:   shared.SourceClass,
+			ChoiceID: "rogue-skills",
+			Skills:   []skills.Skill{skills.Stealth, skills.Deception, skills.Investigation, skills.Perception},
+		},
+		// Rogue chooses expertise in skill they don't have
+		character.ExpertiseChoice{
+			Source:    shared.SourceClass,
+			ChoiceID:  "rogue-expertise",
+			Expertise: []string{"stealth", "persuasion"}, // persuasion not chosen!
+		},
+		character.EquipmentChoice{
+			Source:    shared.SourceClass,
+			ChoiceID:  "rogue-equipment",
+			Equipment: []string{"shortsword", "shortbow", "burglars-pack"},
+		},
+	}
+
+	result, err := ValidateClassChoicesV3(classes.Rogue, choices)
+	s.Require().NoError(err)
+
+	// Should have no errors (structurally valid)
+	s.Assert().Empty(result.Errors)
+
+	// Should have warning about expertise without proficiency
+	hasExpertiseWarning := false
+	for _, w := range result.Warnings {
+		if w.Code == WarningExpertiseWithoutProficiency {
+			s.Assert().Contains(w.Message, "persuasion")
+			hasExpertiseWarning = true
+		}
+	}
+	s.Assert().True(hasExpertiseWarning, "Should warn about expertise in non-proficient skill")
+}
+
+// Helper function
+func containsString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
Builds on #291 to complete the validation system refactor with declarative rules and a comprehensive warning system.

## Part 1: Declarative Validation System

### Problem
- Hardcoded magic numbers (e.g., "3 instruments for Bard")
- Procedural validation logic scattered throughout code
- Difficult to maintain and extend

### Solution
- Created `classes/requirements.go` with data-driven validation rules
- Implemented `ValidateWithRequirements()` for generic validation
- Moved validation logic from code to data structures

### Benefits
- ✅ No more hardcoded magic numbers
- ✅ Validation rules are now data, not code
- ✅ Easy to add/modify class requirements
- ✅ Single source of truth for validation rules

## Part 2: Warning System (#284)

### Problem
Players need non-blocking feedback about character choices:
- Duplicate skill proficiencies from different sources
- Expertise in non-proficient skills
- Overlapping proficiencies

### Solution
- New `Result` type with both `Errors` (blocking) and `Warnings` (non-blocking)
- `DetectCrossSourceDuplicates()` finds duplicate proficiencies
- `ValidateExpertisePrerequisites()` validates expertise choices
- `ValidateClassChoicesV3()` provides comprehensive validation

### Features
- **Cross-Source Detection**: Identifies duplicate skills, languages, tools, instruments
- **Expertise Validation**: Warns when expertise selected for non-proficient skills
- **Class-Specific Warnings**: Fighter+Half-Orc intimidation overlap, etc.

## Testing
- Comprehensive test coverage for declarative validation
- Full test suite for warning scenarios
- All existing tests still pass ✅

## Example Usage
```go
// Validation now returns both errors and warnings
result, err := ValidateClassChoicesV3(classes.Fighter, choices)
if err != nil {
    return err
}

// Display errors (must fix)
for _, e := range result.Errors {
    showError(e.Message)
}

// Display warnings (optional to fix)
for _, w := range result.Warnings {
    showWarning(w.Message)
}
```

Addresses #284, completes validation refactor from #290

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>