### PR TITLE
feat: Remove deprecated Group field and improve item consistency

### DIFF
--- a/rulebooks/dnd5e/armor/armor.go
+++ b/rulebooks/dnd5e/armor/armor.go
@@ -68,6 +68,11 @@ type Armor struct {
 	Cost                string // e.g., "5 gp"
 }
 
+// GetName returns the name of the armor
+func (a Armor) GetName() string {
+	return a.Name
+}
+
 // All armor definitions
 var All = map[ArmorID]Armor{
 	// Light armor

--- a/rulebooks/dnd5e/character/choices/requirements_test.go
+++ b/rulebooks/dnd5e/character/choices/requirements_test.go
@@ -15,13 +15,11 @@ func TestGetClassRequirements(t *testing.T) {
 	tests := []struct {
 		name     string
 		classID  classes.Class
-		level    int
 		validate func(t *testing.T, reqs *Requirements)
 	}{
 		{
 			name:    "Fighter Level 1",
 			classID: classes.Fighter,
-			level:   1,
 			validate: func(t *testing.T, reqs *Requirements) {
 				require.NotNil(t, reqs)
 
@@ -44,7 +42,6 @@ func TestGetClassRequirements(t *testing.T) {
 		{
 			name:    "Rogue Level 1",
 			classID: classes.Rogue,
-			level:   1,
 			validate: func(t *testing.T, reqs *Requirements) {
 				require.NotNil(t, reqs)
 
@@ -65,7 +62,6 @@ func TestGetClassRequirements(t *testing.T) {
 		{
 			name:    "Wizard Level 1",
 			classID: classes.Wizard,
-			level:   1,
 			validate: func(t *testing.T, reqs *Requirements) {
 				require.NotNil(t, reqs)
 
@@ -89,7 +85,6 @@ func TestGetClassRequirements(t *testing.T) {
 		{
 			name:    "Bard Level 1",
 			classID: classes.Bard,
-			level:   1,
 			validate: func(t *testing.T, reqs *Requirements) {
 				require.NotNil(t, reqs)
 
@@ -104,31 +99,11 @@ func TestGetClassRequirements(t *testing.T) {
 				assert.Nil(t, reqs.Instruments.Options) // can choose any
 			},
 		},
-		{
-			name:    "Level 4 ASI",
-			classID: classes.Fighter,
-			level:   4,
-			validate: func(t *testing.T, reqs *Requirements) {
-				require.NotNil(t, reqs)
-
-				// Level 4 gets ability score improvement
-				require.NotNil(t, reqs.AbilityScoreImprovement)
-				assert.Equal(t, 2, reqs.AbilityScoreImprovement.Points)
-			},
-		},
-		{
-			name:    "Unknown Level Returns Empty",
-			classID: classes.Fighter,
-			level:   7,
-			validate: func(t *testing.T, reqs *Requirements) {
-				assert.Nil(t, reqs)
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reqs := GetClassRequirements(tt.classID, tt.level)
+			reqs := GetClassRequirements(tt.classID)
 			tt.validate(t, reqs)
 		})
 	}
@@ -189,7 +164,7 @@ func TestGetRaceRequirements(t *testing.T) {
 
 func TestGetRequirements_Combined(t *testing.T) {
 	// Test combining class and race requirements
-	reqs := GetRequirements(classes.Fighter, races.HalfElf, 1)
+	reqs := GetRequirements(classes.Fighter, races.HalfElf)
 	require.NotNil(t, reqs)
 
 	// Should have Fighter's skills requirement
@@ -206,7 +181,7 @@ func TestGetRequirements_Combined(t *testing.T) {
 }
 
 func TestEquipmentRequirements(t *testing.T) {
-	reqs := GetClassRequirements(classes.Fighter, 1)
+	reqs := GetClassRequirements(classes.Fighter)
 	require.NotNil(t, reqs)
 	require.Len(t, reqs.Equipment, 4)
 
@@ -246,7 +221,7 @@ func TestAllClassesHaveLevel1Requirements(t *testing.T) {
 
 	for _, classID := range allClasses {
 		t.Run(string(classID), func(t *testing.T) {
-			reqs := GetClassRequirements(classID, 1)
+			reqs := GetClassRequirements(classID)
 			require.NotNil(t, reqs, "Every class should have level 1 requirements")
 
 			// Every class should have skill choices

--- a/rulebooks/dnd5e/character/choices/types.go
+++ b/rulebooks/dnd5e/character/choices/types.go
@@ -36,6 +36,9 @@ type Requirements struct {
 	// Level-up choices
 	AbilityScoreImprovement *ASIRequirement  `json:"ability_score_improvement,omitempty"`
 	Feat                    *FeatRequirement `json:"feat,omitempty"`
+
+	// Subclass choice (required at specific levels)
+	Subclass *SubclassRequirement `json:"subclass,omitempty"`
 }
 
 // SkillRequirement defines skill choice requirements
@@ -123,12 +126,18 @@ type FeatRequirement struct {
 	Label string `json:"label"`
 }
 
+// SubclassRequirement defines subclass choice requirements
+type SubclassRequirement struct {
+	Options []classes.Subclass `json:"options"` // Available subclasses
+	Label   string             `json:"label"`   // e.g., "Choose your Martial Archetype"
+}
+
 // API Functions - These are the main entry points
 
-// GetClassRequirements returns the requirements for a specific class at a given level
-func GetClassRequirements(classID classes.Class, level int) *Requirements {
+// GetClassRequirements returns the requirements for a specific class at level 1
+func GetClassRequirements(classID classes.Class) *Requirements {
 	// Implementation in requirements.go
-	return getClassRequirementsInternal(classID, level)
+	return getClassRequirementsInternal(classID)
 }
 
 // GetRaceRequirements returns the requirements for a specific race
@@ -144,10 +153,10 @@ func GetBackgroundRequirements(backgroundID backgrounds.Background) *Requirement
 	return getBackgroundRequirementsInternal(backgroundID)
 }
 
-// GetRequirements returns combined requirements for a character at a specific level
-func GetRequirements(classID classes.Class, raceID races.Race, level int) *Requirements {
-	// This combines class and race requirements for level-up scenarios
-	classReqs := GetClassRequirements(classID, level)
+// GetRequirements returns combined requirements for character creation
+func GetRequirements(classID classes.Class, raceID races.Race) *Requirements {
+	// This combines class and race requirements for character creation
+	classReqs := GetClassRequirements(classID)
 	raceReqs := GetRaceRequirements(raceID)
 
 	// Merge requirements (implementation will be in requirements.go)

--- a/rulebooks/dnd5e/character/choices/validation_constants.go
+++ b/rulebooks/dnd5e/character/choices/validation_constants.go
@@ -7,6 +7,7 @@ type Source string
 
 // Source constants - where choices come from
 const (
+	SourceInvalid    Source = "invalid" // Invalid or unknown source
 	SourceClass      Source = "class"
 	SourceRace       Source = "race"
 	SourceSubrace    Source = "subrace"
@@ -22,6 +23,11 @@ type Field string
 
 // Field constants - what's being validated
 const (
+	FieldInvalid             Field = "invalid"    // Invalid or unknown field
+	FieldClass               Field = "class"      // Class selection
+	FieldRace                Field = "race"       // Race selection
+	FieldBackground          Field = "background" // Background selection
+	FieldName                Field = "name"       // Character name
 	FieldSkills              Field = "skills"
 	FieldRaceSkills          Field = "race_skills"
 	FieldBackgroundSkills    Field = "background_skills"

--- a/rulebooks/dnd5e/character/choices/validator.go
+++ b/rulebooks/dnd5e/character/choices/validator.go
@@ -25,14 +25,17 @@ func NewValidator(context *ValidationContext) *Validator {
 	}
 }
 
-// ValidateClassChoices validates choices for a specific class
+// ValidateClassChoices validates choices for a specific class at level 1
+// Note: This only handles level 1 character creation validation.
+// Level-up validation should be handled by the Character struct.
+// TODO: Remove level parameter since it's always 1
 func (v *Validator) ValidateClassChoices(
 	classID classes.Class,
-	level int,
+	_ int, // Deprecated: always 1 for character creation
 	submissions *TypedSubmissions,
 ) *ValidationResult {
 	result := NewValidationResult()
-	reqs := getClassRequirementsInternal(classID, level)
+	reqs := getClassRequirementsInternal(classID)
 	if reqs == nil {
 		return result
 	}

--- a/rulebooks/dnd5e/character/starting_class.go
+++ b/rulebooks/dnd5e/character/starting_class.go
@@ -1,0 +1,185 @@
+package character
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+)
+
+// StartingClass represents a valid starting class option for character creation
+type StartingClass struct {
+	ID           string                   // "fighter" or "life-domain"
+	Name         string                   // "Fighter" or "Life Domain"
+	Description  string                   // Brief description
+	Group        classes.Class            // For UI grouping (Fighter, Cleric, etc.)
+	Grants       *classes.AutomaticGrants // What you automatically get
+	Requirements *choices.Requirements    // What choices you must make
+}
+
+// ListStartingClasses returns all valid starting class options
+// For classes with level 1 subclasses (Cleric, Sorcerer, Warlock), only subclasses are returned
+// For other classes, the base class is returned
+func ListStartingClasses() []StartingClass {
+	// Pre-allocate with estimated capacity (12 base classes + ~15 subclasses)
+	startingClasses := make([]StartingClass, 0, 27)
+
+	// Fighter - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Fighter),
+		Name:         classes.Fighter.String(),
+		Description:  classes.Fighter.Description(),
+		Group:        classes.Fighter,
+		Grants:       classes.GetAutomaticGrants(classes.Fighter),
+		Requirements: choices.GetClassRequirements(classes.Fighter),
+	})
+
+	// Barbarian - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Barbarian),
+		Name:         classes.Barbarian.String(),
+		Description:  classes.Barbarian.Description(),
+		Group:        classes.Barbarian,
+		Grants:       classes.GetAutomaticGrants(classes.Barbarian),
+		Requirements: choices.GetClassRequirements(classes.Barbarian),
+	})
+
+	// Bard - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Bard),
+		Name:         classes.Bard.String(),
+		Description:  classes.Bard.Description(),
+		Group:        classes.Bard,
+		Grants:       classes.GetAutomaticGrants(classes.Bard),
+		Requirements: choices.GetClassRequirements(classes.Bard),
+	})
+
+	// Cleric - subclass at level 1, so add all subclasses
+	clericSubclasses := []classes.Subclass{
+		classes.LifeDomain,
+		classes.LightDomain,
+		classes.NatureDomain,
+		classes.TempestDomain,
+		classes.TrickeryDomain,
+		classes.WarDomain,
+		classes.KnowledgeDomain,
+		classes.DeathDomain,
+	}
+	for _, subclass := range clericSubclasses {
+		startingClasses = append(startingClasses, StartingClass{
+			ID:           string(subclass),
+			Name:         subclass.String(),
+			Description:  subclass.Description(),
+			Group:        classes.Cleric,
+			Grants:       getSubclassGrants(subclass),
+			Requirements: getSubclassRequirements(subclass),
+		})
+	}
+
+	// Druid - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Druid),
+		Name:         classes.Druid.String(),
+		Description:  classes.Druid.Description(),
+		Group:        classes.Druid,
+		Grants:       classes.GetAutomaticGrants(classes.Druid),
+		Requirements: choices.GetClassRequirements(classes.Druid),
+	})
+
+	// Monk - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Monk),
+		Name:         classes.Monk.String(),
+		Description:  classes.Monk.Description(),
+		Group:        classes.Monk,
+		Grants:       classes.GetAutomaticGrants(classes.Monk),
+		Requirements: choices.GetClassRequirements(classes.Monk),
+	})
+
+	// Paladin - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Paladin),
+		Name:         classes.Paladin.String(),
+		Description:  classes.Paladin.Description(),
+		Group:        classes.Paladin,
+		Grants:       classes.GetAutomaticGrants(classes.Paladin),
+		Requirements: choices.GetClassRequirements(classes.Paladin),
+	})
+
+	// Ranger - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Ranger),
+		Name:         classes.Ranger.String(),
+		Description:  classes.Ranger.Description(),
+		Group:        classes.Ranger,
+		Grants:       classes.GetAutomaticGrants(classes.Ranger),
+		Requirements: choices.GetClassRequirements(classes.Ranger),
+	})
+
+	// Rogue - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Rogue),
+		Name:         classes.Rogue.String(),
+		Description:  classes.Rogue.Description(),
+		Group:        classes.Rogue,
+		Grants:       classes.GetAutomaticGrants(classes.Rogue),
+		Requirements: choices.GetClassRequirements(classes.Rogue),
+	})
+
+	// Sorcerer - subclass at level 1
+	sorcererSubclasses := []classes.Subclass{
+		classes.DraconicBloodline,
+		classes.WildMagic,
+		classes.DivineSoul,
+	}
+	for _, subclass := range sorcererSubclasses {
+		startingClasses = append(startingClasses, StartingClass{
+			ID:           string(subclass),
+			Name:         subclass.String(),
+			Description:  subclass.Description(),
+			Group:        classes.Sorcerer,
+			Grants:       getSubclassGrants(subclass),
+			Requirements: getSubclassRequirements(subclass),
+		})
+	}
+
+	// Warlock - subclass at level 1
+	warlockSubclasses := []classes.Subclass{
+		classes.Archfey,
+		classes.Fiend,
+		classes.GreatOldOne,
+		classes.Hexblade,
+	}
+	for _, subclass := range warlockSubclasses {
+		startingClasses = append(startingClasses, StartingClass{
+			ID:           string(subclass),
+			Name:         subclass.String(),
+			Description:  subclass.Description(),
+			Group:        classes.Warlock,
+			Grants:       getSubclassGrants(subclass),
+			Requirements: getSubclassRequirements(subclass),
+		})
+	}
+
+	// Wizard - no subclass at level 1
+	startingClasses = append(startingClasses, StartingClass{
+		ID:           string(classes.Wizard),
+		Name:         classes.Wizard.String(),
+		Description:  classes.Wizard.Description(),
+		Group:        classes.Wizard,
+		Grants:       classes.GetAutomaticGrants(classes.Wizard),
+		Requirements: choices.GetClassRequirements(classes.Wizard),
+	})
+
+	return startingClasses
+}
+
+// getSubclassGrants returns the complete grants for a subclass (base + subclass specific)
+func getSubclassGrants(subclass classes.Subclass) *classes.AutomaticGrants {
+	// Use the new GetSubclassGrants function from the classes package
+	return classes.GetSubclassGrants(subclass)
+}
+
+// getSubclassRequirements returns the complete requirements for a subclass
+func getSubclassRequirements(subclass classes.Subclass) *choices.Requirements {
+	// Use the new GetSubclassRequirements function from the choices package
+	return choices.GetSubclassRequirements(subclass)
+}

--- a/rulebooks/dnd5e/character/starting_class.go
+++ b/rulebooks/dnd5e/character/starting_class.go
@@ -7,47 +7,44 @@ import (
 
 // StartingClass represents a valid starting class option for character creation
 type StartingClass struct {
-	ID           string                   // "fighter" or "life-domain"
-	Name         string                   // "Fighter" or "Life Domain"
-	Description  string                   // Brief description
-	Group        classes.Class            // For UI grouping (Fighter, Cleric, etc.)
+	ID           classes.Class            // "fighter" or "life-domain"
 	Grants       *classes.AutomaticGrants // What you automatically get
 	Requirements *choices.Requirements    // What choices you must make
+	Subclass     []*SubclassOption        // Level 1 subclasses if applicable
+}
+
+// SubclassOption represents a subclass choice available at character creation
+type SubclassOption struct {
+	ID           classes.Subclass
+	Level        int // When you get this subclass
+	Grants       *classes.AutomaticGrants
+	Requirements *choices.Requirements
 }
 
 // ListStartingClasses returns all valid starting class options
 // For classes with level 1 subclasses (Cleric, Sorcerer, Warlock), only subclasses are returned
 // For other classes, the base class is returned
-func ListStartingClasses() []StartingClass {
+func ListStartingClasses() []*StartingClass {
 	// Pre-allocate with estimated capacity (12 base classes + ~15 subclasses)
-	startingClasses := make([]StartingClass, 0, 27)
+	startingClasses := make([]*StartingClass, 0, 27)
 
 	// Fighter - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Fighter),
-		Name:         classes.Fighter.String(),
-		Description:  classes.Fighter.Description(),
-		Group:        classes.Fighter,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Fighter,
 		Grants:       classes.GetAutomaticGrants(classes.Fighter),
 		Requirements: choices.GetClassRequirements(classes.Fighter),
 	})
 
 	// Barbarian - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Barbarian),
-		Name:         classes.Barbarian.String(),
-		Description:  classes.Barbarian.Description(),
-		Group:        classes.Barbarian,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Barbarian,
 		Grants:       classes.GetAutomaticGrants(classes.Barbarian),
 		Requirements: choices.GetClassRequirements(classes.Barbarian),
 	})
 
 	// Bard - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Bard),
-		Name:         classes.Bard.String(),
-		Description:  classes.Bard.Description(),
-		Group:        classes.Bard,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Bard,
 		Grants:       classes.GetAutomaticGrants(classes.Bard),
 		Requirements: choices.GetClassRequirements(classes.Bard),
 	})
@@ -63,83 +60,82 @@ func ListStartingClasses() []StartingClass {
 		classes.KnowledgeDomain,
 		classes.DeathDomain,
 	}
+
+	cleric := &StartingClass{
+		ID:           classes.Cleric,
+		Grants:       classes.GetAutomaticGrants(classes.Cleric),
+		Requirements: choices.GetClassRequirements(classes.Cleric),
+		Subclass:     make([]*SubclassOption, 0, len(clericSubclasses)),
+	}
+
 	for _, subclass := range clericSubclasses {
-		startingClasses = append(startingClasses, StartingClass{
-			ID:           string(subclass),
-			Name:         subclass.String(),
-			Description:  subclass.Description(),
-			Group:        classes.Cleric,
+		cleric.Subclass = append(cleric.Subclass, &SubclassOption{
+			ID:           subclass,
+			Level:        1,
 			Grants:       getSubclassGrants(subclass),
 			Requirements: getSubclassRequirements(subclass),
 		})
 	}
 
+	startingClasses = append(startingClasses, cleric)
+
 	// Druid - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Druid),
-		Name:         classes.Druid.String(),
-		Description:  classes.Druid.Description(),
-		Group:        classes.Druid,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Druid,
 		Grants:       classes.GetAutomaticGrants(classes.Druid),
 		Requirements: choices.GetClassRequirements(classes.Druid),
 	})
 
 	// Monk - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Monk),
-		Name:         classes.Monk.String(),
-		Description:  classes.Monk.Description(),
-		Group:        classes.Monk,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Monk,
 		Grants:       classes.GetAutomaticGrants(classes.Monk),
 		Requirements: choices.GetClassRequirements(classes.Monk),
 	})
 
 	// Paladin - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Paladin),
-		Name:         classes.Paladin.String(),
-		Description:  classes.Paladin.Description(),
-		Group:        classes.Paladin,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Paladin,
 		Grants:       classes.GetAutomaticGrants(classes.Paladin),
 		Requirements: choices.GetClassRequirements(classes.Paladin),
 	})
 
 	// Ranger - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Ranger),
-		Name:         classes.Ranger.String(),
-		Description:  classes.Ranger.Description(),
-		Group:        classes.Ranger,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Ranger,
 		Grants:       classes.GetAutomaticGrants(classes.Ranger),
 		Requirements: choices.GetClassRequirements(classes.Ranger),
 	})
 
 	// Rogue - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Rogue),
-		Name:         classes.Rogue.String(),
-		Description:  classes.Rogue.Description(),
-		Group:        classes.Rogue,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Rogue,
 		Grants:       classes.GetAutomaticGrants(classes.Rogue),
 		Requirements: choices.GetClassRequirements(classes.Rogue),
 	})
-
 	// Sorcerer - subclass at level 1
 	sorcererSubclasses := []classes.Subclass{
 		classes.DraconicBloodline,
 		classes.WildMagic,
 		classes.DivineSoul,
 	}
+
+	sorcerer := &StartingClass{
+		ID:           classes.Sorcerer,
+		Grants:       classes.GetAutomaticGrants(classes.Sorcerer),
+		Requirements: choices.GetClassRequirements(classes.Sorcerer),
+		Subclass:     make([]*SubclassOption, 0, len(sorcererSubclasses)),
+	}
+
 	for _, subclass := range sorcererSubclasses {
-		startingClasses = append(startingClasses, StartingClass{
-			ID:           string(subclass),
-			Name:         subclass.String(),
-			Description:  subclass.Description(),
-			Group:        classes.Sorcerer,
+		sorcerer.Subclass = append(sorcerer.Subclass, &SubclassOption{
+			ID:           subclass,
+			Level:        1,
 			Grants:       getSubclassGrants(subclass),
 			Requirements: getSubclassRequirements(subclass),
 		})
 	}
+	startingClasses = append(startingClasses, sorcerer)
 
 	// Warlock - subclass at level 1
 	warlockSubclasses := []classes.Subclass{
@@ -148,23 +144,27 @@ func ListStartingClasses() []StartingClass {
 		classes.GreatOldOne,
 		classes.Hexblade,
 	}
+
+	warlock := &StartingClass{
+		ID:           classes.Warlock,
+		Grants:       classes.GetAutomaticGrants(classes.Warlock),
+		Requirements: choices.GetClassRequirements(classes.Warlock),
+		Subclass:     make([]*SubclassOption, 0, len(warlockSubclasses)),
+	}
+
 	for _, subclass := range warlockSubclasses {
-		startingClasses = append(startingClasses, StartingClass{
-			ID:           string(subclass),
-			Name:         subclass.String(),
-			Description:  subclass.Description(),
-			Group:        classes.Warlock,
+		warlock.Subclass = append(warlock.Subclass, &SubclassOption{
+			ID:           subclass,
+			Level:        1,
 			Grants:       getSubclassGrants(subclass),
 			Requirements: getSubclassRequirements(subclass),
 		})
 	}
+	startingClasses = append(startingClasses, warlock)
 
 	// Wizard - no subclass at level 1
-	startingClasses = append(startingClasses, StartingClass{
-		ID:           string(classes.Wizard),
-		Name:         classes.Wizard.String(),
-		Description:  classes.Wizard.Description(),
-		Group:        classes.Wizard,
+	startingClasses = append(startingClasses, &StartingClass{
+		ID:           classes.Wizard,
 		Grants:       classes.GetAutomaticGrants(classes.Wizard),
 		Requirements: choices.GetClassRequirements(classes.Wizard),
 	})

--- a/rulebooks/dnd5e/classes/classes.go
+++ b/rulebooks/dnd5e/classes/classes.go
@@ -385,6 +385,11 @@ func (c Class) String() string {
 	}
 }
 
+// Name returns the display name of the class
+func (c Class) Name() string {
+	return c.String()
+}
+
 // Description returns a brief description of the class
 func (c Class) Description() string {
 	switch c {
@@ -430,7 +435,13 @@ func (s Subclass) String() string {
 	if name, ok := subclassNames[s]; ok {
 		return name
 	}
+
 	return string(s)
+}
+
+// Name returns the display name of the subclass
+func (s Subclass) Name() string {
+	return s.String()
 }
 
 // Description returns a brief description of the subclass

--- a/rulebooks/dnd5e/classes/classes.go
+++ b/rulebooks/dnd5e/classes/classes.go
@@ -11,8 +11,105 @@ type Class string
 // Subclass represents a D&D 5e character subclass/archetype
 type Subclass string
 
+// Fighter subclasses
+const (
+	Champion       Subclass = "champion"
+	BattleMaster   Subclass = "battle-master"
+	EldritchKnight Subclass = "eldritch-knight"
+)
+
+// Barbarian subclasses
+const (
+	Berserker         Subclass = "berserker"
+	Totem             Subclass = "totem-warrior"
+	AncestralGuardian Subclass = "ancestral-guardian"
+)
+
+// Bard subclasses
+const (
+	Lore    Subclass = "lore"
+	Valor   Subclass = "valor"
+	Glamour Subclass = "glamour"
+)
+
+// Cleric subclasses
+const (
+	LifeDomain      Subclass = "life-domain"
+	LightDomain     Subclass = "light-domain"
+	NatureDomain    Subclass = "nature-domain"
+	TempestDomain   Subclass = "tempest-domain"
+	TrickeryDomain  Subclass = "trickery-domain"
+	WarDomain       Subclass = "war-domain"
+	KnowledgeDomain Subclass = "knowledge-domain"
+	DeathDomain     Subclass = "death-domain"
+)
+
+// Druid subclasses
+const (
+	CircleLand   Subclass = "circle-land"
+	CircleMoon   Subclass = "circle-moon"
+	CircleDreams Subclass = "circle-dreams"
+)
+
+// Monk subclasses
+const (
+	OpenHand     Subclass = "open-hand"
+	Shadow       Subclass = "shadow"
+	FourElements Subclass = "four-elements"
+)
+
+// Paladin subclasses
+const (
+	Devotion    Subclass = "devotion"
+	Ancients    Subclass = "ancients"
+	Vengeance   Subclass = "vengeance"
+	Oathbreaker Subclass = "oathbreaker"
+)
+
+// Ranger subclasses
+const (
+	Hunter       Subclass = "hunter"
+	BeastMaster  Subclass = "beast-master"
+	Gloomstalker Subclass = "gloom-stalker"
+)
+
+// Rogue subclasses
+const (
+	Thief           Subclass = "thief"
+	Assassin        Subclass = "assassin"
+	ArcaneTrickster Subclass = "arcane-trickster"
+)
+
+// Sorcerer subclasses
+const (
+	DraconicBloodline Subclass = "draconic-bloodline"
+	WildMagic         Subclass = "wild-magic"
+	DivineSoul        Subclass = "divine-soul"
+)
+
+// Warlock subclasses
+const (
+	Archfey     Subclass = "archfey"
+	Fiend       Subclass = "fiend"
+	GreatOldOne Subclass = "great-old-one"
+	Hexblade    Subclass = "hexblade"
+)
+
+// Wizard subclasses
+const (
+	Abjuration    Subclass = "abjuration"
+	Conjuration   Subclass = "conjuration"
+	Divination    Subclass = "divination"
+	Enchantment   Subclass = "enchantment"
+	Evocation     Subclass = "evocation"
+	Illusion      Subclass = "illusion"
+	Necromancy    Subclass = "necromancy"
+	Transmutation Subclass = "transmutation"
+)
+
 // Core classes from Player's Handbook
 const (
+	Invalid   Class = "invalid" // Invalid or unknown class
 	Barbarian Class = "barbarian"
 	Bard      Class = "bard"
 	Cleric    Class = "cleric"
@@ -56,4 +153,290 @@ func GetByID(id string) (Class, error) {
 			rpgerr.WithMeta("valid_options", validClasses))
 	}
 	return class, nil
+}
+
+// subclassNames maps subclass constants to their display names
+//
+//nolint:dupl // Intentionally separate from subclassDescriptions and subclassParents
+var subclassNames = map[Subclass]string{
+	// Fighter
+	Champion:       "Champion",
+	BattleMaster:   "Battle Master",
+	EldritchKnight: "Eldritch Knight",
+	// Barbarian
+	Berserker:         "Path of the Berserker",
+	Totem:             "Path of the Totem Warrior",
+	AncestralGuardian: "Path of the Ancestral Guardian",
+	// Bard
+	Lore:    "College of Lore",
+	Valor:   "College of Valor",
+	Glamour: "College of Glamour",
+	// Cleric
+	LifeDomain:      "Life Domain",
+	LightDomain:     "Light Domain",
+	NatureDomain:    "Nature Domain",
+	TempestDomain:   "Tempest Domain",
+	TrickeryDomain:  "Trickery Domain",
+	WarDomain:       "War Domain",
+	KnowledgeDomain: "Knowledge Domain",
+	DeathDomain:     "Death Domain",
+	// Druid
+	CircleLand:   "Circle of the Land",
+	CircleMoon:   "Circle of the Moon",
+	CircleDreams: "Circle of Dreams",
+	// Monk
+	OpenHand:     "Way of the Open Hand",
+	Shadow:       "Way of Shadow",
+	FourElements: "Way of the Four Elements",
+	// Paladin
+	Devotion:    "Oath of Devotion",
+	Ancients:    "Oath of the Ancients",
+	Vengeance:   "Oath of Vengeance",
+	Oathbreaker: "Oathbreaker",
+	// Ranger
+	Hunter:       "Hunter",
+	BeastMaster:  "Beast Master",
+	Gloomstalker: "Gloom Stalker",
+	// Rogue
+	Thief:           "Thief",
+	Assassin:        "Assassin",
+	ArcaneTrickster: "Arcane Trickster",
+	// Sorcerer
+	DraconicBloodline: "Draconic Bloodline",
+	WildMagic:         "Wild Magic",
+	DivineSoul:        "Divine Soul",
+	// Warlock
+	Archfey:     "The Archfey",
+	Fiend:       "The Fiend",
+	GreatOldOne: "The Great Old One",
+	Hexblade:    "Hexblade",
+	// Wizard
+	Abjuration:    "School of Abjuration",
+	Conjuration:   "School of Conjuration",
+	Divination:    "School of Divination",
+	Enchantment:   "School of Enchantment",
+	Evocation:     "School of Evocation",
+	Illusion:      "School of Illusion",
+	Necromancy:    "School of Necromancy",
+	Transmutation: "School of Transmutation",
+}
+
+// subclassDescriptions maps subclass constants to their descriptions
+//
+//nolint:dupl // Intentionally separate from subclassNames and subclassParents
+var subclassDescriptions = map[Subclass]string{
+	// Fighter
+	Champion:       "A master of raw physical prowess and athletic ability",
+	BattleMaster:   "A student of combat tactics and battlefield control",
+	EldritchKnight: "A warrior who combines martial might with arcane magic",
+	// Barbarian
+	Berserker:         "Fueled by fury to become an unstoppable force of destruction",
+	Totem:             "Draws power from spirit animals to gain supernatural abilities",
+	AncestralGuardian: "Calls upon ancestral spirits for protection and vengeance",
+	// Bard
+	Lore:    "Masters of song, speech, and the magic they contain",
+	Valor:   "Daring skalds whose tales keep alive the memory of great heroes",
+	Glamour: "Taught by satyrs and fey, weaving magic through captivating performance",
+	// Cleric
+	LifeDomain:      "Focuses on the vibrant positive energy that sustains all life",
+	LightDomain:     "Infused with radiance, wielding fire and light against darkness",
+	NatureDomain:    "Masters of nature granted power by nature deities",
+	TempestDomain:   "Commands the storm, delivering divine wrath through thunder and lightning",
+	TrickeryDomain:  "Channels divine mischief and subterfuge",
+	WarDomain:       "Champions of battle, inspiring others to fight",
+	KnowledgeDomain: "Values learning and understanding above all",
+	DeathDomain:     "Concerned with the forces that cause death and undeath",
+	// Druid
+	CircleLand:   "Mystics and sages who safeguard ancient knowledge and rites",
+	CircleMoon:   "Fierce guardians of the wilds who channel primal beast forms",
+	CircleDreams: "Has ties to the Feywild and its dreamlike realms",
+	// Monk
+	OpenHand:     "Masters of unarmed combat and martial arts techniques",
+	Shadow:       "Follows a tradition of stealth and subterfuge",
+	FourElements: "Harnesses the power of the four elements",
+	// Paladin
+	Devotion:    "Bound to the highest ideals of justice, virtue, and order",
+	Ancients:    "Fights for light and life in an eternal struggle against darkness",
+	Vengeance:   "A solemn commitment to punish those who have committed grievous sins",
+	Oathbreaker: "Has forsaken their sacred oath in pursuit of dark ambitions",
+	// Ranger
+	Hunter:       "Accepts the place as a bulwark between civilization and wilderness",
+	BeastMaster:  "Forms a powerful bond with a beast companion",
+	Gloomstalker: "At home in the darkest places, ambushing threats from the shadows",
+	// Rogue
+	Thief:           "Hones skills in larceny and agility",
+	Assassin:        "Focuses on the grim art of death",
+	ArcaneTrickster: "Enhances cunning with magic",
+	// Sorcerer
+	DraconicBloodline: "Magic inherited from draconic ancestry",
+	WildMagic:         "Power from the raw chaos of wild magic",
+	DivineSoul:        "Divine magic from a connection to the divine",
+	// Warlock
+	Archfey:     "Formed a pact with a lord or lady of the fey",
+	Fiend:       "Made a pact with a fiend from the lower planes",
+	GreatOldOne: "Bound to an alien entity from the Far Realm",
+	Hexblade:    "Forged a pact with a mysterious entity from the Shadowfell",
+	// Wizard
+	Abjuration:    "Masters of protective magic and banishment",
+	Conjuration:   "Savants of summoning and teleportation",
+	Divination:    "Masters of discernment, remote viewing, and foresight",
+	Enchantment:   "Masters of enchanting and beguiling others",
+	Evocation:     "Sculptors of spells, shaping energy into desired effects",
+	Illusion:      "Masters of deception and tricks of the mind",
+	Necromancy:    "Explorers of the cosmic forces of life, death, and undeath",
+	Transmutation: "Students of spells that modify energy and matter",
+}
+
+// subclassParents maps subclasses to their parent class
+//
+//nolint:dupl // Intentionally separate from subclassNames and subclassDescriptions
+var subclassParents = map[Subclass]Class{
+	// Fighter
+	Champion:       Fighter,
+	BattleMaster:   Fighter,
+	EldritchKnight: Fighter,
+	// Barbarian
+	Berserker:         Barbarian,
+	Totem:             Barbarian,
+	AncestralGuardian: Barbarian,
+	// Bard
+	Lore:    Bard,
+	Valor:   Bard,
+	Glamour: Bard,
+	// Cleric
+	LifeDomain:      Cleric,
+	LightDomain:     Cleric,
+	NatureDomain:    Cleric,
+	TempestDomain:   Cleric,
+	TrickeryDomain:  Cleric,
+	WarDomain:       Cleric,
+	KnowledgeDomain: Cleric,
+	DeathDomain:     Cleric,
+	// Druid
+	CircleLand:   Druid,
+	CircleMoon:   Druid,
+	CircleDreams: Druid,
+	// Monk
+	OpenHand:     Monk,
+	Shadow:       Monk,
+	FourElements: Monk,
+	// Paladin
+	Devotion:    Paladin,
+	Ancients:    Paladin,
+	Vengeance:   Paladin,
+	Oathbreaker: Paladin,
+	// Ranger
+	Hunter:       Ranger,
+	BeastMaster:  Ranger,
+	Gloomstalker: Ranger,
+	// Rogue
+	Thief:           Rogue,
+	Assassin:        Rogue,
+	ArcaneTrickster: Rogue,
+	// Sorcerer
+	DraconicBloodline: Sorcerer,
+	WildMagic:         Sorcerer,
+	DivineSoul:        Sorcerer,
+	// Warlock
+	Archfey:     Warlock,
+	Fiend:       Warlock,
+	GreatOldOne: Warlock,
+	Hexblade:    Warlock,
+	// Wizard
+	Abjuration:    Wizard,
+	Conjuration:   Wizard,
+	Divination:    Wizard,
+	Enchantment:   Wizard,
+	Evocation:     Wizard,
+	Illusion:      Wizard,
+	Necromancy:    Wizard,
+	Transmutation: Wizard,
+}
+
+// String returns the display name of the class
+func (c Class) String() string {
+	switch c {
+	case Barbarian:
+		return "Barbarian"
+	case Bard:
+		return "Bard"
+	case Cleric:
+		return "Cleric"
+	case Druid:
+		return "Druid"
+	case Fighter:
+		return "Fighter"
+	case Monk:
+		return "Monk"
+	case Paladin:
+		return "Paladin"
+	case Ranger:
+		return "Ranger"
+	case Rogue:
+		return "Rogue"
+	case Sorcerer:
+		return "Sorcerer"
+	case Warlock:
+		return "Warlock"
+	case Wizard:
+		return "Wizard"
+	default:
+		return string(c)
+	}
+}
+
+// Description returns a brief description of the class
+func (c Class) Description() string {
+	switch c {
+	case Barbarian:
+		return "A fierce warrior of primitive background who can enter a battle rage"
+	case Bard:
+		return "An inspiring magician whose power echoes the music of creation"
+	case Cleric:
+		return "A priestly champion who wields divine magic in service of a higher power"
+	case Druid:
+		return "A priest of nature, wielding elemental forces and transforming into beasts"
+	case Fighter:
+		return "A master of martial combat, skilled with a variety of weapons and armor"
+	case Monk:
+		return "A master of martial arts, harnessing inner power through discipline"
+	case Paladin:
+		return "A holy warrior bound to a sacred oath, smiting foes with divine might"
+	case Ranger:
+		return "A warrior of the wilderness, skilled in tracking, survival, and combat"
+	case Rogue:
+		return "A scoundrel who uses stealth and trickery to overcome obstacles"
+	case Sorcerer:
+		return "A spellcaster who draws on inherent magic from a gift or bloodline"
+	case Warlock:
+		return "A wielder of magic derived from a bargain with an extraplanar entity"
+	case Wizard:
+		return "A scholarly magic-user capable of manipulating the structures of reality"
+	default:
+		return ""
+	}
+}
+
+// Parent returns the base class for a subclass
+func (s Subclass) Parent() Class {
+	if parent, ok := subclassParents[s]; ok {
+		return parent
+	}
+	return Invalid
+}
+
+// String returns the display name of the subclass
+func (s Subclass) String() string {
+	if name, ok := subclassNames[s]; ok {
+		return name
+	}
+	return string(s)
+}
+
+// Description returns a brief description of the subclass
+func (s Subclass) Description() string {
+	if desc, ok := subclassDescriptions[s]; ok {
+		return desc
+	}
+	return ""
 }

--- a/rulebooks/dnd5e/classes/grants.go
+++ b/rulebooks/dnd5e/classes/grants.go
@@ -1,0 +1,275 @@
+package classes
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+)
+
+// AutomaticGrants represents what a class automatically provides (not player choices)
+type AutomaticGrants struct {
+	// Core mechanics
+	HitDice int // The die size (6, 8, 10, 12)
+
+	// Proficiencies that ALL members of this class get
+	SavingThrows        []abilities.Ability    // Two saving throw proficiencies
+	ArmorProficiencies  []proficiencies.Armor  // e.g., "light", "medium", "heavy", "shields"
+	WeaponProficiencies []proficiencies.Weapon // e.g., "simple", "martial"
+	ToolProficiencies   []proficiencies.Tool   // Some classes get tools (e.g., thieves' tools for rogue)
+
+	// Note: Skill proficiencies are NOT here because they're choices, not grants
+	// They belong in Requirements, not Grants
+}
+
+// GetAutomaticGrants returns what a class automatically grants at level 1
+// Returns nil if the classID is invalid
+func GetAutomaticGrants(classID Class) *AutomaticGrants {
+	switch classID {
+	case Barbarian:
+		return &AutomaticGrants{
+			HitDice:      12,
+			SavingThrows: []abilities.Ability{abilities.STR, abilities.CON},
+			ArmorProficiencies: []proficiencies.Armor{
+				proficiencies.ArmorLight,
+				proficiencies.ArmorMedium,
+				proficiencies.ArmorHeavy,
+				proficiencies.ArmorShields,
+			},
+			WeaponProficiencies: []proficiencies.Weapon{proficiencies.WeaponSimple, proficiencies.WeaponMartial},
+		}
+
+	case Bard:
+		return &AutomaticGrants{
+			HitDice:            8,
+			SavingThrows:       []abilities.Ability{abilities.DEX, abilities.CHA},
+			ArmorProficiencies: []proficiencies.Armor{proficiencies.ArmorLight},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponSimple,
+				proficiencies.WeaponHandCrossbow,
+				proficiencies.WeaponLongsword,
+				proficiencies.WeaponRapier,
+				proficiencies.WeaponShortsword,
+			},
+			// Bards get 3 musical instruments of choice - that's in Requirements, not here
+		}
+
+	case Cleric:
+		return &AutomaticGrants{
+			HitDice:      8,
+			SavingThrows: []abilities.Ability{abilities.WIS, abilities.CHA},
+			ArmorProficiencies: []proficiencies.Armor{
+				proficiencies.ArmorLight,
+				proficiencies.ArmorMedium,
+				proficiencies.ArmorShields,
+			},
+			WeaponProficiencies: []proficiencies.Weapon{proficiencies.WeaponSimple},
+		}
+
+	case Druid:
+		return &AutomaticGrants{
+			HitDice:      8,
+			SavingThrows: []abilities.Ability{abilities.INT, abilities.WIS},
+			ArmorProficiencies: []proficiencies.Armor{
+				proficiencies.ArmorLight,
+				proficiencies.ArmorMedium,
+				proficiencies.ArmorShields,
+			}, // Note: non-metal restriction is a rule, not a proficiency
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponClub,
+				proficiencies.WeaponDagger,
+				proficiencies.WeaponDart,
+				proficiencies.WeaponJavelin,
+				proficiencies.WeaponMace,
+				proficiencies.WeaponQuarterstaff,
+				proficiencies.WeaponScimitar,
+				proficiencies.WeaponSickle,
+				proficiencies.WeaponSling,
+				proficiencies.WeaponSpear,
+			},
+			ToolProficiencies: []proficiencies.Tool{proficiencies.ToolHerbalism},
+		}
+
+	case Fighter:
+		return &AutomaticGrants{
+			HitDice:      10,
+			SavingThrows: []abilities.Ability{abilities.STR, abilities.CON},
+			ArmorProficiencies: []proficiencies.Armor{
+				proficiencies.ArmorLight,
+				proficiencies.ArmorMedium,
+				proficiencies.ArmorHeavy,
+				proficiencies.ArmorShields,
+			},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponSimple,
+				proficiencies.WeaponMartial,
+			},
+		}
+
+	case Monk:
+		return &AutomaticGrants{
+			HitDice:      8,
+			SavingThrows: []abilities.Ability{abilities.STR, abilities.DEX},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponSimple,
+				proficiencies.WeaponShortsword,
+			},
+		}
+
+	case Paladin:
+		return &AutomaticGrants{
+			HitDice:      10,
+			SavingThrows: []abilities.Ability{abilities.WIS, abilities.CHA},
+			ArmorProficiencies: []proficiencies.Armor{
+				proficiencies.ArmorLight,
+				proficiencies.ArmorMedium,
+				proficiencies.ArmorHeavy,
+				proficiencies.ArmorShields,
+			},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponSimple,
+				proficiencies.WeaponMartial,
+			},
+		}
+
+	case Ranger:
+		return &AutomaticGrants{
+			HitDice:      10,
+			SavingThrows: []abilities.Ability{abilities.STR, abilities.DEX},
+			ArmorProficiencies: []proficiencies.Armor{
+				proficiencies.ArmorLight,
+				proficiencies.ArmorMedium,
+				proficiencies.ArmorShields,
+			},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponSimple,
+				proficiencies.WeaponMartial,
+			},
+		}
+
+	case Rogue:
+		return &AutomaticGrants{
+			HitDice:            8,
+			SavingThrows:       []abilities.Ability{abilities.DEX, abilities.INT},
+			ArmorProficiencies: []proficiencies.Armor{proficiencies.ArmorLight},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponSimple,
+				proficiencies.WeaponHandCrossbow,
+				proficiencies.WeaponLongsword,
+				proficiencies.WeaponRapier,
+				proficiencies.WeaponShortsword,
+			},
+			ToolProficiencies: []proficiencies.Tool{proficiencies.ToolThieves},
+		}
+
+	case Sorcerer:
+		return &AutomaticGrants{
+			HitDice:      6,
+			SavingThrows: []abilities.Ability{abilities.CON, abilities.CHA},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponDagger,
+				proficiencies.WeaponDart,
+				proficiencies.WeaponSling,
+				proficiencies.WeaponQuarterstaff,
+				proficiencies.WeaponLightCrossbow,
+			},
+		}
+
+	case Warlock:
+		return &AutomaticGrants{
+			HitDice:             8,
+			SavingThrows:        []abilities.Ability{abilities.WIS, abilities.CHA},
+			ArmorProficiencies:  []proficiencies.Armor{proficiencies.ArmorLight},
+			WeaponProficiencies: []proficiencies.Weapon{proficiencies.WeaponSimple},
+		}
+
+	case Wizard:
+		return &AutomaticGrants{
+			HitDice:      6,
+			SavingThrows: []abilities.Ability{abilities.INT, abilities.WIS},
+			WeaponProficiencies: []proficiencies.Weapon{
+				proficiencies.WeaponDagger,
+				proficiencies.WeaponDart,
+				proficiencies.WeaponSling,
+				proficiencies.WeaponQuarterstaff,
+				proficiencies.WeaponLightCrossbow,
+			},
+		}
+
+	default:
+		return nil
+	}
+}
+
+// GetHitDice is a convenience function to quickly get a class's hit die
+// Returns 0 if the classID is invalid
+func GetHitDice(classID Class) int {
+	grants := GetAutomaticGrants(classID)
+	if grants == nil {
+		return 0
+	}
+	return grants.HitDice
+}
+
+// GetSavingThrows is a convenience function to get saving throw proficiencies
+// Returns nil if the classID is invalid
+func GetSavingThrows(classID Class) []abilities.Ability {
+	grants := GetAutomaticGrants(classID)
+	if grants == nil {
+		return nil
+	}
+	return grants.SavingThrows
+}
+
+// GetSubclassGrants returns the complete grants for a subclass (base + subclass specific)
+// Returns nil if the subclassID is invalid
+func GetSubclassGrants(subclassID Subclass) *AutomaticGrants {
+	// Get base class grants
+	baseGrants := GetAutomaticGrants(subclassID.Parent())
+	if baseGrants == nil {
+		return nil
+	}
+
+	// Copy base grants to avoid modifying the original
+	grants := &AutomaticGrants{
+		HitDice:             baseGrants.HitDice,
+		SavingThrows:        baseGrants.SavingThrows,
+		ArmorProficiencies:  make([]proficiencies.Armor, len(baseGrants.ArmorProficiencies)),
+		WeaponProficiencies: make([]proficiencies.Weapon, len(baseGrants.WeaponProficiencies)),
+		ToolProficiencies:   make([]proficiencies.Tool, len(baseGrants.ToolProficiencies)),
+	}
+	copy(grants.ArmorProficiencies, baseGrants.ArmorProficiencies)
+	copy(grants.WeaponProficiencies, baseGrants.WeaponProficiencies)
+	copy(grants.ToolProficiencies, baseGrants.ToolProficiencies)
+
+	// Add subclass-specific grants
+	switch subclassID {
+	// Cleric subclasses
+	case LifeDomain:
+		// Life Domain gets heavy armor
+		grants.ArmorProficiencies = append(grants.ArmorProficiencies, proficiencies.ArmorHeavy)
+
+	case NatureDomain:
+		// Nature Domain gets heavy armor
+		grants.ArmorProficiencies = append(grants.ArmorProficiencies, proficiencies.ArmorHeavy)
+
+	case TempestDomain:
+		// Tempest Domain gets martial weapons and heavy armor
+		grants.WeaponProficiencies = append(grants.WeaponProficiencies, proficiencies.WeaponMartial)
+		grants.ArmorProficiencies = append(grants.ArmorProficiencies, proficiencies.ArmorHeavy)
+
+	case WarDomain:
+		// War Domain gets martial weapons and heavy armor
+		grants.WeaponProficiencies = append(grants.WeaponProficiencies, proficiencies.WeaponMartial)
+		grants.ArmorProficiencies = append(grants.ArmorProficiencies, proficiencies.ArmorHeavy)
+
+	// Sorcerer subclasses
+	case DraconicBloodline:
+		// Draconic Bloodline gets +1 HP per level (handled elsewhere)
+		// Base AC becomes 13 + Dex (handled as a feature, not a grant)
+
+	// Most subclasses don't add proficiencies
+	default:
+		// No additional grants
+	}
+
+	return grants
+}

--- a/rulebooks/dnd5e/items/items.go
+++ b/rulebooks/dnd5e/items/items.go
@@ -1,0 +1,30 @@
+// Package items provides a unified interface for accessing D&D 5e items
+package items
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// Item represents any item in D&D 5e (weapons, armor, etc.)
+type Item interface {
+	GetName() string
+}
+
+// GetByID retrieves an item by its ID from any item category
+func GetByID(id string) (Item, error) {
+	// Check if the item is a weapon (convert string to WeaponID)
+	if weapon, ok := weapons.All[weapons.WeaponID(id)]; ok {
+		return weapon, nil
+	}
+
+	// Check if it is armor (convert string to ArmorID)
+	if armorItem, ok := armor.All[armor.ArmorID(id)]; ok {
+		return armorItem, nil
+	}
+
+	// Item not found
+	return nil, rpgerr.New(rpgerr.CodeNotFound, "item not found",
+		rpgerr.WithMeta("item_id", id))
+}

--- a/rulebooks/dnd5e/languages/languages.go
+++ b/rulebooks/dnd5e/languages/languages.go
@@ -10,6 +10,7 @@ type Language string
 
 // Standard languages that most characters can learn
 const (
+	Invalid  Language = "invalid" // Invalid or unknown language
 	Common   Language = "common"
 	Dwarvish Language = "dwarvish"
 	Elvish   Language = "elvish"

--- a/rulebooks/dnd5e/proficiencies/proficiency.go
+++ b/rulebooks/dnd5e/proficiencies/proficiency.go
@@ -1,0 +1,53 @@
+// Package proficiencies defines typed proficiency constants for D&D 5e
+package proficiencies
+
+// Armor represents an armor proficiency type
+type Armor string
+
+// Weapon represents a weapon proficiency type
+type Weapon string
+
+// Tool represents a tool proficiency type
+type Tool string
+
+// Armor proficiencies (all are categories)
+const (
+	ArmorLight   Armor = "light"
+	ArmorMedium  Armor = "medium"
+	ArmorHeavy   Armor = "heavy"
+	ArmorShields Armor = "shields"
+)
+
+// Weapon proficiencies - Categories
+const (
+	WeaponSimple  Weapon = "simple"  // All simple weapons
+	WeaponMartial Weapon = "martial" // All martial weapons
+)
+
+// Weapon proficiencies - Specific weapons
+const (
+	// Simple weapons that appear in class grants
+	WeaponClub          Weapon = "clubs"
+	WeaponDagger        Weapon = "daggers"
+	WeaponDart          Weapon = "darts"
+	WeaponJavelin       Weapon = "javelins"
+	WeaponLightCrossbow Weapon = "light-crossbows"
+	WeaponMace          Weapon = "maces"
+	WeaponQuarterstaff  Weapon = "quarterstaffs"
+	WeaponSickle        Weapon = "sickles"
+	WeaponSling         Weapon = "slings"
+	WeaponSpear         Weapon = "spears"
+
+	// Martial weapons that appear in class grants
+	WeaponHandCrossbow Weapon = "hand-crossbows"
+	WeaponLongsword    Weapon = "longswords"
+	WeaponRapier       Weapon = "rapiers"
+	WeaponScimitar     Weapon = "scimitars"
+	WeaponShortsword   Weapon = "shortswords"
+)
+
+// Tool proficiencies (all are specific)
+const (
+	ToolThieves   Tool = "thieves-tools"
+	ToolHerbalism Tool = "herbalism-kit"
+)

--- a/rulebooks/dnd5e/races/races.go
+++ b/rulebooks/dnd5e/races/races.go
@@ -13,6 +13,7 @@ type Subrace = Race
 
 // Core races from Player's Handbook
 const (
+	Invalid    Race = "invalid" // Invalid or unknown race
 	Human      Race = "human"
 	Elf        Race = "elf"
 	Dwarf      Race = "dwarf"

--- a/rulebooks/dnd5e/skills/skills.go
+++ b/rulebooks/dnd5e/skills/skills.go
@@ -11,6 +11,7 @@ type Skill string
 
 // All D&D 5e skills
 const (
+	Invalid        Skill = "invalid" // Invalid or unknown skill
 	Acrobatics     Skill = "acrobatics"
 	AnimalHandling Skill = "animal-handling"
 	Arcana         Skill = "arcana"

--- a/rulebooks/dnd5e/weapons/types.go
+++ b/rulebooks/dnd5e/weapons/types.go
@@ -45,7 +45,7 @@ const (
 
 // Weapon represents a D&D 5e weapon
 type Weapon struct {
-	ID         string
+	ID         WeaponID
 	Name       string
 	Category   WeaponCategory
 	Cost       string      // "5 gp"
@@ -54,6 +54,11 @@ type Weapon struct {
 	Weight     float64
 	Properties []WeaponProperty
 	Range      *Range // nil for melee-only weapons
+}
+
+// GetName returns the name of the weapon
+func (w Weapon) GetName() string {
+	return w.Name
 }
 
 // Range represents weapon range (for thrown/ranged weapons)

--- a/rulebooks/dnd5e/weapons/weapons.go
+++ b/rulebooks/dnd5e/weapons/weapons.go
@@ -9,9 +9,9 @@ import (
 // Note: Fighter gets all simple and martial weapons, but we'll add just a few for testing
 
 // SimpleMeleeWeapons - fighter-accessible simple melee weapons (for testing)
-var SimpleMeleeWeapons = map[string]Weapon{
-	"club": {
-		ID:         "club",
+var SimpleMeleeWeapons = map[WeaponID]Weapon{
+	Club: {
+		ID:         Club,
 		Name:       "Club",
 		Category:   CategorySimpleMelee,
 		Cost:       "1 sp",
@@ -20,8 +20,8 @@ var SimpleMeleeWeapons = map[string]Weapon{
 		Weight:     2,
 		Properties: []WeaponProperty{PropertyLight},
 	},
-	"dagger": {
-		ID:         "dagger",
+	Dagger: {
+		ID:         Dagger,
 		Name:       "Dagger",
 		Category:   CategorySimpleMelee,
 		Cost:       "2 gp",
@@ -31,8 +31,8 @@ var SimpleMeleeWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyFinesse, PropertyLight, PropertyThrown},
 		Range:      &Range{Normal: 20, Long: 60},
 	},
-	"handaxe": {
-		ID:         "handaxe",
+	Handaxe: {
+		ID:         Handaxe,
 		Name:       "Handaxe",
 		Category:   CategorySimpleMelee,
 		Cost:       "5 gp",
@@ -42,8 +42,8 @@ var SimpleMeleeWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyLight, PropertyThrown},
 		Range:      &Range{Normal: 20, Long: 60},
 	},
-	"javelin": {
-		ID:         "javelin",
+	Javelin: {
+		ID:         Javelin,
 		Name:       "Javelin",
 		Category:   CategorySimpleMelee,
 		Cost:       "5 sp",
@@ -53,12 +53,74 @@ var SimpleMeleeWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyThrown},
 		Range:      &Range{Normal: 30, Long: 120},
 	},
+	Greatclub: {
+		ID:         Greatclub,
+		Name:       "Greatclub",
+		Category:   CategorySimpleMelee,
+		Cost:       "2 sp",
+		Damage:     "1d8",
+		DamageType: damage.Bludgeoning,
+		Weight:     10,
+		Properties: []WeaponProperty{PropertyTwoHanded},
+	},
+	LightHammer: {
+		ID:         LightHammer,
+		Name:       "Light Hammer",
+		Category:   CategorySimpleMelee,
+		Cost:       "2 gp",
+		Damage:     "1d4",
+		DamageType: damage.Bludgeoning,
+		Weight:     2,
+		Properties: []WeaponProperty{PropertyLight, PropertyThrown},
+		Range:      &Range{Normal: 20, Long: 60},
+	},
+	Mace: {
+		ID:         Mace,
+		Name:       "Mace",
+		Category:   CategorySimpleMelee,
+		Cost:       "5 gp",
+		Damage:     "1d6",
+		DamageType: damage.Bludgeoning,
+		Weight:     4,
+		Properties: []WeaponProperty{},
+	},
+	Quarterstaff: {
+		ID:         Quarterstaff,
+		Name:       "Quarterstaff",
+		Category:   CategorySimpleMelee,
+		Cost:       "2 sp",
+		Damage:     "1d6",
+		DamageType: damage.Bludgeoning,
+		Weight:     4,
+		Properties: []WeaponProperty{PropertyVersatile},
+	},
+	Sickle: {
+		ID:         Sickle,
+		Name:       "Sickle",
+		Category:   CategorySimpleMelee,
+		Cost:       "1 gp",
+		Damage:     "1d4",
+		DamageType: damage.Slashing,
+		Weight:     2,
+		Properties: []WeaponProperty{PropertyLight},
+	},
+	Spear: {
+		ID:         Spear,
+		Name:       "Spear",
+		Category:   CategorySimpleMelee,
+		Cost:       "1 gp",
+		Damage:     "1d6",
+		DamageType: damage.Piercing,
+		Weight:     3,
+		Properties: []WeaponProperty{PropertyThrown, PropertyVersatile},
+		Range:      &Range{Normal: 20, Long: 60},
+	},
 }
 
 // MartialMeleeWeapons - fighter-accessible martial melee weapons (for testing)
-var MartialMeleeWeapons = map[string]Weapon{
-	"greatsword": {
-		ID:         "greatsword",
+var MartialMeleeWeapons = map[WeaponID]Weapon{
+	Greatsword: {
+		ID:         Greatsword,
 		Name:       "Greatsword",
 		Category:   CategoryMartialMelee,
 		Cost:       "50 gp",
@@ -67,8 +129,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     6,
 		Properties: []WeaponProperty{PropertyHeavy, PropertyTwoHanded},
 	},
-	"longsword": {
-		ID:         "longsword",
+	Longsword: {
+		ID:         Longsword,
 		Name:       "Longsword",
 		Category:   CategoryMartialMelee,
 		Cost:       "15 gp",
@@ -77,8 +139,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     3,
 		Properties: []WeaponProperty{PropertyVersatile},
 	},
-	"rapier": {
-		ID:         "rapier",
+	Rapier: {
+		ID:         Rapier,
 		Name:       "Rapier",
 		Category:   CategoryMartialMelee,
 		Cost:       "25 gp",
@@ -87,8 +149,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     2,
 		Properties: []WeaponProperty{PropertyFinesse},
 	},
-	"shortsword": {
-		ID:         "shortsword",
+	Shortsword: {
+		ID:         Shortsword,
 		Name:       "Shortsword",
 		Category:   CategoryMartialMelee,
 		Cost:       "10 gp",
@@ -97,8 +159,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     2,
 		Properties: []WeaponProperty{PropertyFinesse, PropertyLight},
 	},
-	"battleaxe": {
-		ID:         "battleaxe",
+	Battleaxe: {
+		ID:         Battleaxe,
 		Name:       "Battleaxe",
 		Category:   CategoryMartialMelee,
 		Cost:       "10 gp",
@@ -107,8 +169,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     4,
 		Properties: []WeaponProperty{PropertyVersatile},
 	},
-	"flail": {
-		ID:         "flail",
+	Flail: {
+		ID:         Flail,
 		Name:       "Flail",
 		Category:   CategoryMartialMelee,
 		Cost:       "10 gp",
@@ -117,8 +179,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     2,
 		Properties: []WeaponProperty{},
 	},
-	"glaive": {
-		ID:         "glaive",
+	Glaive: {
+		ID:         Glaive,
 		Name:       "Glaive",
 		Category:   CategoryMartialMelee,
 		Cost:       "20 gp",
@@ -127,8 +189,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     6,
 		Properties: []WeaponProperty{PropertyHeavy, PropertyReach, PropertyTwoHanded},
 	},
-	"greataxe": {
-		ID:         "greataxe",
+	Greataxe: {
+		ID:         Greataxe,
 		Name:       "Greataxe",
 		Category:   CategoryMartialMelee,
 		Cost:       "30 gp",
@@ -137,8 +199,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     7,
 		Properties: []WeaponProperty{PropertyHeavy, PropertyTwoHanded},
 	},
-	"halberd": {
-		ID:         "halberd",
+	Halberd: {
+		ID:         Halberd,
 		Name:       "Halberd",
 		Category:   CategoryMartialMelee,
 		Cost:       "20 gp",
@@ -147,8 +209,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     6,
 		Properties: []WeaponProperty{PropertyHeavy, PropertyReach, PropertyTwoHanded},
 	},
-	"lance": {
-		ID:         "lance",
+	Lance: {
+		ID:         Lance,
 		Name:       "Lance",
 		Category:   CategoryMartialMelee,
 		Cost:       "10 gp",
@@ -157,8 +219,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     6,
 		Properties: []WeaponProperty{PropertyReach}, // Special: disadvantage when within 5 feet
 	},
-	"maul": {
-		ID:         "maul",
+	Maul: {
+		ID:         Maul,
 		Name:       "Maul",
 		Category:   CategoryMartialMelee,
 		Cost:       "10 gp",
@@ -167,8 +229,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     10,
 		Properties: []WeaponProperty{PropertyHeavy, PropertyTwoHanded},
 	},
-	"morningstar": {
-		ID:         "morningstar",
+	Morningstar: {
+		ID:         Morningstar,
 		Name:       "Morningstar",
 		Category:   CategoryMartialMelee,
 		Cost:       "15 gp",
@@ -177,8 +239,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     4,
 		Properties: []WeaponProperty{},
 	},
-	"pike": {
-		ID:         "pike",
+	Pike: {
+		ID:         Pike,
 		Name:       "Pike",
 		Category:   CategoryMartialMelee,
 		Cost:       "5 gp",
@@ -187,8 +249,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     18,
 		Properties: []WeaponProperty{PropertyHeavy, PropertyReach, PropertyTwoHanded},
 	},
-	"scimitar": {
-		ID:         "scimitar",
+	Scimitar: {
+		ID:         Scimitar,
 		Name:       "Scimitar",
 		Category:   CategoryMartialMelee,
 		Cost:       "25 gp",
@@ -197,8 +259,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     3,
 		Properties: []WeaponProperty{PropertyFinesse, PropertyLight},
 	},
-	"trident": {
-		ID:         "trident",
+	Trident: {
+		ID:         Trident,
 		Name:       "Trident",
 		Category:   CategoryMartialMelee,
 		Cost:       "5 gp",
@@ -208,8 +270,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyThrown, PropertyVersatile},
 		Range:      &Range{Normal: 20, Long: 60},
 	},
-	"war-pick": {
-		ID:         "war-pick",
+	WarPick: {
+		ID:         WarPick,
 		Name:       "War Pick",
 		Category:   CategoryMartialMelee,
 		Cost:       "5 gp",
@@ -218,8 +280,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     2,
 		Properties: []WeaponProperty{},
 	},
-	"warhammer": {
-		ID:         "warhammer",
+	Warhammer: {
+		ID:         Warhammer,
 		Name:       "Warhammer",
 		Category:   CategoryMartialMelee,
 		Cost:       "15 gp",
@@ -228,8 +290,8 @@ var MartialMeleeWeapons = map[string]Weapon{
 		Weight:     2,
 		Properties: []WeaponProperty{PropertyVersatile},
 	},
-	"whip": {
-		ID:         "whip",
+	Whip: {
+		ID:         Whip,
 		Name:       "Whip",
 		Category:   CategoryMartialMelee,
 		Cost:       "2 gp",
@@ -241,9 +303,9 @@ var MartialMeleeWeapons = map[string]Weapon{
 }
 
 // SimpleRangedWeapons - fighter-accessible simple ranged weapons (for testing)
-var SimpleRangedWeapons = map[string]Weapon{
-	"light-crossbow": {
-		ID:         "light-crossbow",
+var SimpleRangedWeapons = map[WeaponID]Weapon{
+	LightCrossbow: {
+		ID:         LightCrossbow,
 		Name:       "Light Crossbow",
 		Category:   CategorySimpleRanged,
 		Cost:       "25 gp",
@@ -253,8 +315,8 @@ var SimpleRangedWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyAmmunition, PropertyLoading, PropertyTwoHanded},
 		Range:      &Range{Normal: 80, Long: 320},
 	},
-	"shortbow": {
-		ID:         "shortbow",
+	Shortbow: {
+		ID:         Shortbow,
 		Name:       "Shortbow",
 		Category:   CategorySimpleRanged,
 		Cost:       "25 gp",
@@ -264,12 +326,34 @@ var SimpleRangedWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyAmmunition, PropertyTwoHanded},
 		Range:      &Range{Normal: 80, Long: 320},
 	},
+	Dart: {
+		ID:         Dart,
+		Name:       "Dart",
+		Category:   CategorySimpleRanged,
+		Cost:       "5 cp",
+		Damage:     "1d4",
+		DamageType: damage.Piercing,
+		Weight:     0.25,
+		Properties: []WeaponProperty{PropertyFinesse, PropertyThrown},
+		Range:      &Range{Normal: 20, Long: 60},
+	},
+	Sling: {
+		ID:         Sling,
+		Name:       "Sling",
+		Category:   CategorySimpleRanged,
+		Cost:       "1 sp",
+		Damage:     "1d4",
+		DamageType: damage.Bludgeoning,
+		Weight:     0,
+		Properties: []WeaponProperty{PropertyAmmunition},
+		Range:      &Range{Normal: 30, Long: 120},
+	},
 }
 
 // MartialRangedWeapons - fighter-accessible martial ranged weapons (for testing)
-var MartialRangedWeapons = map[string]Weapon{
-	"heavy-crossbow": {
-		ID:         "heavy-crossbow",
+var MartialRangedWeapons = map[WeaponID]Weapon{
+	HeavyCrossbow: {
+		ID:         HeavyCrossbow,
 		Name:       "Heavy Crossbow",
 		Category:   CategoryMartialRanged,
 		Cost:       "50 gp",
@@ -279,8 +363,8 @@ var MartialRangedWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyAmmunition, PropertyHeavy, PropertyLoading, PropertyTwoHanded},
 		Range:      &Range{Normal: 100, Long: 400},
 	},
-	"longbow": {
-		ID:         "longbow",
+	Longbow: {
+		ID:         Longbow,
 		Name:       "Longbow",
 		Category:   CategoryMartialRanged,
 		Cost:       "50 gp",
@@ -290,8 +374,8 @@ var MartialRangedWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyAmmunition, PropertyHeavy, PropertyTwoHanded},
 		Range:      &Range{Normal: 150, Long: 600},
 	},
-	"blowgun": {
-		ID:         "blowgun",
+	Blowgun: {
+		ID:         Blowgun,
 		Name:       "Blowgun",
 		Category:   CategoryMartialRanged,
 		Cost:       "10 gp",
@@ -301,8 +385,8 @@ var MartialRangedWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyAmmunition, PropertyLoading},
 		Range:      &Range{Normal: 25, Long: 100},
 	},
-	"hand-crossbow": {
-		ID:         "hand-crossbow",
+	HandCrossbow: {
+		ID:         HandCrossbow,
 		Name:       "Hand Crossbow",
 		Category:   CategoryMartialRanged,
 		Cost:       "75 gp",
@@ -312,8 +396,8 @@ var MartialRangedWeapons = map[string]Weapon{
 		Properties: []WeaponProperty{PropertyAmmunition, PropertyLight, PropertyLoading},
 		Range:      &Range{Normal: 30, Long: 120},
 	},
-	"net": {
-		ID:         "net",
+	Net: {
+		ID:         Net,
 		Name:       "Net",
 		Category:   CategoryMartialRanged,
 		Cost:       "1 gp",
@@ -326,7 +410,7 @@ var MartialRangedWeapons = map[string]Weapon{
 }
 
 // All combines all weapon maps for easy lookup
-var All = make(map[string]Weapon)
+var All = make(map[WeaponID]Weapon)
 
 func init() {
 	// Populate the All map
@@ -345,15 +429,15 @@ func init() {
 }
 
 // GetByID returns a weapon by its ID
-func GetByID(id string) (Weapon, error) {
+func GetByID(id WeaponID) (Weapon, error) {
 	w, ok := All[id]
 	if !ok {
 		validWeapons := make([]string, 0, len(All))
 		for k := range All {
-			validWeapons = append(validWeapons, k)
+			validWeapons = append(validWeapons, string(k))
 		}
 		return Weapon{}, rpgerr.New(rpgerr.CodeInvalidArgument, "invalid weapon",
-			rpgerr.WithMeta("provided", id),
+			rpgerr.WithMeta("provided", string(id)),
 			rpgerr.WithMeta("valid_options", validWeapons))
 	}
 	return w, nil

--- a/rulebooks/dnd5e/weapons/weapons_test.go
+++ b/rulebooks/dnd5e/weapons/weapons_test.go
@@ -20,7 +20,7 @@ func TestWeaponLookup(t *testing.T) {
 			name:     "find longsword",
 			weaponID: "longsword",
 			want: weapons.Weapon{
-				ID:         "longsword",
+				ID:         weapons.Longsword,
 				Name:       "Longsword",
 				Category:   weapons.CategoryMartialMelee,
 				Cost:       "15 gp",
@@ -35,7 +35,7 @@ func TestWeaponLookup(t *testing.T) {
 			name:     "find dagger",
 			weaponID: "dagger",
 			want: weapons.Weapon{
-				ID:         "dagger",
+				ID:         weapons.Dagger,
 				Name:       "Dagger",
 				Category:   weapons.CategorySimpleMelee,
 				Cost:       "2 gp",
@@ -56,7 +56,7 @@ func TestWeaponLookup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := weapons.GetByID(tt.weaponID)
+			got, err := weapons.GetByID(weapons.WeaponID(tt.weaponID))
 			if tt.wantOK {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
@@ -75,7 +75,7 @@ func TestWeaponCategories(t *testing.T) {
 		// Check we have the expected weapons
 		ids := make(map[string]bool)
 		for _, w := range simple {
-			ids[w.ID] = true
+			ids[string(w.ID)] = true
 			assert.True(t, w.IsSimple())
 			assert.True(t, w.IsMelee())
 		}
@@ -92,7 +92,7 @@ func TestWeaponCategories(t *testing.T) {
 
 		ids := make(map[string]bool)
 		for _, w := range martial {
-			ids[w.ID] = true
+			ids[string(w.ID)] = true
 			assert.True(t, w.IsMartial())
 			assert.True(t, w.IsMelee())
 		}


### PR DESCRIPTION
## Summary
- Remove deprecated Group field from StartingClass that is no longer needed
- Convert weapon and armor IDs to strongly typed constants for better type safety
- Add GetName() method to weapons and armor to implement Item interface
- Create items package for unified item access across the toolkit

## Changes

### Remove Deprecated Group Field
The Group field was originally used for UI grouping when subclasses were separate entries in class lists. Now that subclasses are properly nested within parent classes (e.g., Life Domain within Cleric), this field serves no purpose and has been removed.

### Improve Type Safety
- Converted all weapon IDs from strings to `WeaponID` type constants
- Converted all armor IDs from strings to `ArmorID` type constants  
- This prevents typos and provides compile-time safety when referencing items

### Item Interface
- Added `GetName()` method to both Weapon and Armor types
- Created `items` package with unified `GetByID()` function
- This allows rpg-api to work with items generically

## Testing
- All existing tests pass
- Updated weapon tests to use typed constants
- Linting passes

## Related
This change supports the rpg-api character creation flow by providing better type safety and a cleaner interface for equipment choices.

🤖 Generated with [Claude Code](https://claude.ai/code)