### PR TITLE
fix: Add subclass-aware validation for Knowledge Domain and other sub…

### DIFF
--- a/rulebooks/dnd5e/character/choices/nature_domain_test.go
+++ b/rulebooks/dnd5e/character/choices/nature_domain_test.go
@@ -1,0 +1,110 @@
+package choices_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"github.com/stretchr/testify/suite"
+)
+
+type NatureDomainTestSuite struct {
+	suite.Suite
+}
+
+func TestNatureDomainTestSuite(t *testing.T) {
+	suite.Run(t, new(NatureDomainTestSuite))
+}
+
+func (s *NatureDomainTestSuite) TestNatureDomainRequirements() {
+	// Nature Domain should get:
+	// - 2 base Cleric skills
+	// - 1 additional skill from Animal Handling, Nature, or Survival
+	// - 1 additional druid cantrip (4 total cantrips)
+	
+	reqs := choices.GetSubclassRequirements(classes.NatureDomain)
+	
+	s.NotNil(reqs)
+	s.NotNil(reqs.Skills)
+	s.NotNil(reqs.Cantrips)
+	
+	// Should require 3 skills total (2 base + 1 nature domain)
+	s.Equal(3, reqs.Skills.Count, "Nature Domain should require 3 skills")
+	
+	// Should have the Nature Domain specific skills in options
+	hasAnimalHandling := false
+	hasNature := false
+	hasSurvival := false
+	for _, skill := range reqs.Skills.Options {
+		switch skill {
+		case skills.AnimalHandling:
+			hasAnimalHandling = true
+		case skills.Nature:
+			hasNature = true
+		case skills.Survival:
+			hasSurvival = true
+		}
+	}
+	s.True(hasAnimalHandling, "Should have Animal Handling as option")
+	s.True(hasNature, "Should have Nature as option")
+	s.True(hasSurvival, "Should have Survival as option")
+	
+	// Should require 4 cantrips (3 base + 1 druid)
+	s.Equal(4, reqs.Cantrips.Count, "Nature Domain should require 4 cantrips")
+	s.Contains(reqs.Cantrips.Label, "Druid", "Label should mention Druid cantrip")
+}
+
+func (s *NatureDomainTestSuite) TestNatureDomainValidation() {
+	context := choices.NewValidationContext()
+	submissions := choices.NewTypedSubmissions()
+	
+	// Add 3 skills - 2 from base Cleric list + 1 from Nature Domain list
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldSkills,
+		ChoiceID: "cleric_skills",
+		Values: []string{
+			string(skills.Insight),
+			string(skills.Medicine),
+			string(skills.Nature), // Nature Domain bonus
+		},
+	})
+	
+	// Add 4 cantrips
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldCantrips,
+		ChoiceID: "cleric_cantrips",
+		Values:   []string{"sacred_flame", "guidance", "thaumaturgy", "druidcraft"},
+	})
+	
+	// Add equipment choices
+	for i := 0; i < 4; i++ {
+		submissions.AddChoice(choices.ChoiceSubmission{
+			Source:   choices.SourceClass,
+			Field:    choices.Field("equipment_choice_" + string(rune('0'+i))),
+			ChoiceID: "equipment_" + string(rune('0'+i)),
+			Values:   []string{"mace", "scale-mail", "light-crossbow-set", "priests-pack"}[i:i+1],
+		})
+	}
+	
+	// Validate with Nature Domain subclass
+	result := choices.ValidateClassChoicesWithSubclass(
+		classes.Cleric,
+		classes.NatureDomain,
+		1,
+		submissions,
+		context,
+	)
+	
+	// Should be valid
+	s.True(result.CanFinalize, "Nature Domain with 3 skills and 4 cantrips should be valid")
+	
+	// Check for errors
+	for _, issue := range result.AllIssues {
+		if issue.Severity == choices.SeverityError {
+			s.Fail("Should not have errors: Field=%v, Message=%s", issue.Field, issue.Message)
+		}
+	}
+}

--- a/rulebooks/dnd5e/character/choices/nature_domain_test.go
+++ b/rulebooks/dnd5e/character/choices/nature_domain_test.go
@@ -22,16 +22,16 @@ func (s *NatureDomainTestSuite) TestNatureDomainRequirements() {
 	// - 2 base Cleric skills
 	// - 1 additional skill from Animal Handling, Nature, or Survival
 	// - 1 additional druid cantrip (4 total cantrips)
-	
+
 	reqs := choices.GetSubclassRequirements(classes.NatureDomain)
-	
+
 	s.NotNil(reqs)
 	s.NotNil(reqs.Skills)
 	s.NotNil(reqs.Cantrips)
-	
+
 	// Should require 3 skills total (2 base + 1 nature domain)
 	s.Equal(3, reqs.Skills.Count, "Nature Domain should require 3 skills")
-	
+
 	// Should have the Nature Domain specific skills in options
 	hasAnimalHandling := false
 	hasNature := false
@@ -49,7 +49,7 @@ func (s *NatureDomainTestSuite) TestNatureDomainRequirements() {
 	s.True(hasAnimalHandling, "Should have Animal Handling as option")
 	s.True(hasNature, "Should have Nature as option")
 	s.True(hasSurvival, "Should have Survival as option")
-	
+
 	// Should require 4 cantrips (3 base + 1 druid)
 	s.Equal(4, reqs.Cantrips.Count, "Nature Domain should require 4 cantrips")
 	s.Contains(reqs.Cantrips.Label, "Druid", "Label should mention Druid cantrip")
@@ -58,7 +58,7 @@ func (s *NatureDomainTestSuite) TestNatureDomainRequirements() {
 func (s *NatureDomainTestSuite) TestNatureDomainValidation() {
 	context := choices.NewValidationContext()
 	submissions := choices.NewTypedSubmissions()
-	
+
 	// Add 3 skills - 2 from base Cleric list + 1 from Nature Domain list
 	submissions.AddChoice(choices.ChoiceSubmission{
 		Source:   choices.SourceClass,
@@ -70,7 +70,7 @@ func (s *NatureDomainTestSuite) TestNatureDomainValidation() {
 			string(skills.Nature), // Nature Domain bonus
 		},
 	})
-	
+
 	// Add 4 cantrips
 	submissions.AddChoice(choices.ChoiceSubmission{
 		Source:   choices.SourceClass,
@@ -78,17 +78,17 @@ func (s *NatureDomainTestSuite) TestNatureDomainValidation() {
 		ChoiceID: "cleric_cantrips",
 		Values:   []string{"sacred_flame", "guidance", "thaumaturgy", "druidcraft"},
 	})
-	
+
 	// Add equipment choices
 	for i := 0; i < 4; i++ {
 		submissions.AddChoice(choices.ChoiceSubmission{
 			Source:   choices.SourceClass,
 			Field:    choices.Field("equipment_choice_" + string(rune('0'+i))),
 			ChoiceID: "equipment_" + string(rune('0'+i)),
-			Values:   []string{"mace", "scale-mail", "light-crossbow-set", "priests-pack"}[i:i+1],
+			Values:   []string{"mace", "scale-mail", "light-crossbow-set", "priests-pack"}[i : i+1],
 		})
 	}
-	
+
 	// Validate with Nature Domain subclass
 	result := choices.ValidateClassChoicesWithSubclass(
 		classes.Cleric,
@@ -97,10 +97,10 @@ func (s *NatureDomainTestSuite) TestNatureDomainValidation() {
 		submissions,
 		context,
 	)
-	
+
 	// Should be valid
 	s.True(result.CanFinalize, "Nature Domain with 3 skills and 4 cantrips should be valid")
-	
+
 	// Check for errors
 	for _, issue := range result.AllIssues {
 		if issue.Severity == choices.SeverityError {

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -733,6 +733,13 @@ func GetSubclassRequirements(subclassID classes.Subclass) *Requirements {
 			}
 		}
 		baseReqs.Skills.Label = "Choose 2 skills (base) + 2: Arcana/History/Nature/Religion (Knowledge Domain)"
+		
+		// Knowledge Domain also gets expertise in 2 INT skills
+		baseReqs.Expertise = &ExpertiseRequirement{
+			Count: 2,
+			Label: "Choose 2 from Arcana, History, Nature, or Religion for expertise (Knowledge Domain)",
+			// Note: The actual skill options are validated against what the character has proficiency in
+		}
 
 	case classes.NatureDomain:
 		// Nature Domain gets one druid cantrip and proficiency in one of: Animal Handling, Nature, or Survival

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -718,22 +718,19 @@ func GetSubclassRequirements(subclassID classes.Subclass) *Requirements {
 			skills.Nature,
 			skills.Religion,
 		}
-		// Merge the knowledge domain skills with existing options
+		// Use map for O(1) lookups to avoid nested loops
+		existingSkills := make(map[skills.Skill]bool)
+		for _, skill := range baseReqs.Skills.Options {
+			existingSkills[skill] = true
+		}
+		// Add only skills that don't already exist
 		for _, skill := range knowledgeSkills {
-			// Check if skill is not already in the list
-			found := false
-			for _, existing := range baseReqs.Skills.Options {
-				if existing == skill {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !existingSkills[skill] {
 				baseReqs.Skills.Options = append(baseReqs.Skills.Options, skill)
 			}
 		}
 		baseReqs.Skills.Label = "Choose 2 skills (base) + 2: Arcana/History/Nature/Religion (Knowledge Domain)"
-		
+
 		// Knowledge Domain also gets expertise in 2 INT skills
 		baseReqs.Expertise = &ExpertiseRequirement{
 			Count: 2,
@@ -751,23 +748,21 @@ func GetSubclassRequirements(subclassID classes.Subclass) *Requirements {
 		if baseReqs.Skills == nil {
 			baseReqs.Skills = &SkillRequirement{}
 		}
-		baseReqs.Skills.Count += 1
+		baseReqs.Skills.Count++
 		// Add Nature Domain specific skill options
 		natureDomainSkills := []skills.Skill{
 			skills.AnimalHandling,
 			skills.Nature,
 			skills.Survival,
 		}
-		// Merge with existing options
+		// Use map for O(1) lookups to avoid nested loops
+		existingSkills := make(map[skills.Skill]bool)
+		for _, skill := range baseReqs.Skills.Options {
+			existingSkills[skill] = true
+		}
+		// Add only skills that don't already exist
 		for _, skill := range natureDomainSkills {
-			found := false
-			for _, existing := range baseReqs.Skills.Options {
-				if existing == skill {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !existingSkills[skill] {
 				baseReqs.Skills.Options = append(baseReqs.Skills.Options, skill)
 			}
 		}

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -740,6 +740,31 @@ func GetSubclassRequirements(subclassID classes.Subclass) *Requirements {
 			baseReqs.Cantrips.Count++
 			baseReqs.Cantrips.Label = "Choose 3 Cleric cantrips + 1 Druid cantrip (Nature Domain)"
 		}
+		// Add skill proficiency choice
+		if baseReqs.Skills == nil {
+			baseReqs.Skills = &SkillRequirement{}
+		}
+		baseReqs.Skills.Count += 1
+		// Add Nature Domain specific skill options
+		natureDomainSkills := []skills.Skill{
+			skills.AnimalHandling,
+			skills.Nature,
+			skills.Survival,
+		}
+		// Merge with existing options
+		for _, skill := range natureDomainSkills {
+			found := false
+			for _, existing := range baseReqs.Skills.Options {
+				if existing == skill {
+					found = true
+					break
+				}
+			}
+			if !found {
+				baseReqs.Skills.Options = append(baseReqs.Skills.Options, skill)
+			}
+		}
+		baseReqs.Skills.Label = "Choose 2 skills (base) + 1: Animal Handling/Nature/Survival (Nature Domain)"
 
 	case classes.TrickeryDomain:
 		// No additional requirements, but gets specific domain spells (handled elsewhere)

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -711,6 +711,27 @@ func GetSubclassRequirements(subclassID classes.Subclass) *Requirements {
 		}
 		// Knowledge Domain adds 2 skills from: Arcana, History, Nature, or Religion
 		baseReqs.Skills.Count += 2
+		// Add the Knowledge Domain specific skills to the allowed options
+		knowledgeSkills := []skills.Skill{
+			skills.Arcana,
+			skills.History,
+			skills.Nature,
+			skills.Religion,
+		}
+		// Merge the knowledge domain skills with existing options
+		for _, skill := range knowledgeSkills {
+			// Check if skill is not already in the list
+			found := false
+			for _, existing := range baseReqs.Skills.Options {
+				if existing == skill {
+					found = true
+					break
+				}
+			}
+			if !found {
+				baseReqs.Skills.Options = append(baseReqs.Skills.Options, skill)
+			}
+		}
 		baseReqs.Skills.Label = "Choose 2 skills (base) + 2: Arcana/History/Nature/Religion (Knowledge Domain)"
 
 	case classes.NatureDomain:

--- a/rulebooks/dnd5e/character/choices/types.go
+++ b/rulebooks/dnd5e/character/choices/types.go
@@ -176,6 +176,20 @@ func Validate(
 	return validator.ValidateAll(classID, raceID, backgroundID, level, submissions)
 }
 
+// ValidateWithSubclass provides validation with subclass-specific requirements
+func ValidateWithSubclass(
+	classID classes.Class,
+	subclassID classes.Subclass,
+	raceID races.Race,
+	backgroundID backgrounds.Background,
+	level int,
+	submissions *TypedSubmissions,
+	context *ValidationContext,
+) *ValidationResult {
+	validator := NewValidator(context)
+	return validator.ValidateAllWithSubclass(classID, subclassID, raceID, backgroundID, level, submissions)
+}
+
 // ValidateClassChoices validates choices for a specific class
 func ValidateClassChoices(
 	classID classes.Class,
@@ -185,6 +199,18 @@ func ValidateClassChoices(
 ) *ValidationResult {
 	validator := NewValidator(context)
 	return validator.ValidateClassChoices(classID, level, submissions)
+}
+
+// ValidateClassChoicesWithSubclass validates choices for a specific class and subclass
+func ValidateClassChoicesWithSubclass(
+	classID classes.Class,
+	subclassID classes.Subclass,
+	level int,
+	submissions *TypedSubmissions,
+	context *ValidationContext,
+) *ValidationResult {
+	validator := NewValidator(context)
+	return validator.ValidateClassChoicesWithSubclass(classID, subclassID, level, submissions)
 }
 
 // ValidateRaceChoices validates choices for a specific race

--- a/rulebooks/dnd5e/character/choices/validator.go
+++ b/rulebooks/dnd5e/character/choices/validator.go
@@ -86,7 +86,7 @@ func (v *Validator) ValidateClassChoicesWithSubclass(
 	submissions *TypedSubmissions,
 ) *ValidationResult {
 	result := NewValidationResult()
-	
+
 	// Get requirements that include subclass modifications
 	var reqs *Requirements
 	if subclassID != "" {
@@ -96,7 +96,7 @@ func (v *Validator) ValidateClassChoicesWithSubclass(
 		// Fall back to base class requirements
 		reqs = getClassRequirementsInternal(classID)
 	}
-	
+
 	if reqs == nil {
 		return result
 	}

--- a/rulebooks/dnd5e/character/choices/validator_knowledge_test.go
+++ b/rulebooks/dnd5e/character/choices/validator_knowledge_test.go
@@ -107,7 +107,7 @@ func (s *KnowledgeDomainTestSuite) TestValidateClassChoicesWithSubclass_Knowledg
 
 	// Should be valid - Knowledge Domain allows 4 skills
 	s.True(result.CanFinalize, "Knowledge Domain Cleric with 4 skills should be valid")
-	
+
 	// Check for skill errors and debug
 	for _, issue := range result.AllIssues {
 		s.T().Logf("Issue: Field=%v, Severity=%v, Message=%s", issue.Field, issue.Severity, issue.Message)
@@ -146,7 +146,7 @@ func (s *KnowledgeDomainTestSuite) TestValidateClassChoicesWithSubclass_RegularC
 
 	// Should have an error - regular Cleric only allows 2 skills
 	s.False(result.CanFinalize, "Regular Cleric with 4 skills should be invalid")
-	
+
 	// Check for skill errors
 	hasSkillError := false
 	for _, issue := range result.AllIssues {
@@ -161,7 +161,7 @@ func (s *KnowledgeDomainTestSuite) TestValidateClassChoicesWithSubclass_RegularC
 
 func (s *KnowledgeDomainTestSuite) TestValidateAllWithSubclass_CompleteKnowledgeDomainCharacter() {
 	// Test complete validation with Knowledge Domain subclass
-	
+
 	context := choices.NewValidationContext()
 	// Add proficiencies for expertise validation
 	context.AddProficiency(string(skills.Arcana))
@@ -247,7 +247,7 @@ func (s *KnowledgeDomainTestSuite) TestValidateAllWithSubclass_CompleteKnowledge
 
 	// Should be valid
 	s.True(result.CanFinalize, "Complete Knowledge Domain character should be valid")
-	
+
 	// No skill errors
 	for _, issue := range result.AllIssues {
 		if issue.Field == choices.FieldSkills && issue.Severity == choices.SeverityError {

--- a/rulebooks/dnd5e/character/choices/validator_knowledge_test.go
+++ b/rulebooks/dnd5e/character/choices/validator_knowledge_test.go
@@ -24,6 +24,9 @@ func (s *KnowledgeDomainTestSuite) TestValidateClassChoicesWithSubclass_Knowledg
 	// - 2 additional from: Arcana, History, Nature, or Religion
 
 	context := choices.NewValidationContext()
+	// Add proficiencies for expertise validation
+	context.AddProficiency(string(skills.Arcana))
+	context.AddProficiency(string(skills.History))
 	submissions := choices.NewTypedSubmissions()
 
 	// Add 4 skills as a Knowledge Domain Cleric would
@@ -83,6 +86,14 @@ func (s *KnowledgeDomainTestSuite) TestValidateClassChoicesWithSubclass_Knowledg
 		Field:    choices.FieldLanguages,
 		ChoiceID: "knowledge_languages",
 		Values:   []string{"elvish", "dwarvish"},
+	})
+
+	// Add required expertise (2 INT skills for Knowledge Domain)
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldExpertise,
+		ChoiceID: "knowledge_expertise",
+		Values:   []string{string(skills.Arcana), string(skills.History)},
 	})
 
 	// Validate with subclass
@@ -152,6 +163,9 @@ func (s *KnowledgeDomainTestSuite) TestValidateAllWithSubclass_CompleteKnowledge
 	// Test complete validation with Knowledge Domain subclass
 	
 	context := choices.NewValidationContext()
+	// Add proficiencies for expertise validation
+	context.AddProficiency(string(skills.Arcana))
+	context.AddProficiency(string(skills.History))
 	submissions := choices.NewTypedSubmissions()
 
 	// Class choices - Knowledge Domain gets 4 skills
@@ -207,6 +221,14 @@ func (s *KnowledgeDomainTestSuite) TestValidateAllWithSubclass_CompleteKnowledge
 		Field:    choices.FieldLanguages,
 		ChoiceID: "knowledge_languages",
 		Values:   []string{"elvish", "dwarvish"},
+	})
+
+	// Expertise for Knowledge Domain
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldExpertise,
+		ChoiceID: "knowledge_expertise",
+		Values:   []string{string(skills.Arcana), string(skills.History)},
 	})
 
 	// Race choices (Human for simplicity - no choices needed)

--- a/rulebooks/dnd5e/character/choices/validator_knowledge_test.go
+++ b/rulebooks/dnd5e/character/choices/validator_knowledge_test.go
@@ -1,0 +1,235 @@
+package choices_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"github.com/stretchr/testify/suite"
+)
+
+type KnowledgeDomainTestSuite struct {
+	suite.Suite
+}
+
+func TestKnowledgeDomainTestSuite(t *testing.T) {
+	suite.Run(t, new(KnowledgeDomainTestSuite))
+}
+
+func (s *KnowledgeDomainTestSuite) TestValidateClassChoicesWithSubclass_KnowledgeDomain() {
+	// Knowledge Domain Clerics should be able to choose 4 skills total:
+	// - 2 from base Cleric list
+	// - 2 additional from: Arcana, History, Nature, or Religion
+
+	context := choices.NewValidationContext()
+	submissions := choices.NewTypedSubmissions()
+
+	// Add 4 skills as a Knowledge Domain Cleric would
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldSkills,
+		ChoiceID: "cleric_skills",
+		Values: []string{
+			string(skills.Insight),
+			string(skills.Medicine),
+			string(skills.Arcana),  // Knowledge Domain bonus
+			string(skills.History), // Knowledge Domain bonus
+		},
+	})
+
+	// Add required equipment choices for Cleric
+	// Choice 0: weapon (mace or warhammer)
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_0"),
+		ChoiceID: "equipment_0",
+		Values:   []string{"mace"},
+	})
+	// Choice 1: armor (scale-mail, leather-armor, or chain-mail)
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_1"),
+		ChoiceID: "equipment_1",
+		Values:   []string{"scale-mail"},
+	})
+	// Choice 2: secondary weapon (light-crossbow-set or any-simple)
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_2"),
+		ChoiceID: "equipment_2",
+		Values:   []string{"light-crossbow-set"},
+	})
+	// Choice 3: pack (priests-pack or explorers-pack)
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_3"),
+		ChoiceID: "equipment_3",
+		Values:   []string{"priests-pack"},
+	})
+
+	// Add required cantrips (3 for Cleric)
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldCantrips,
+		ChoiceID: "cleric_cantrips",
+		Values:   []string{"sacred_flame", "guidance", "thaumaturgy"},
+	})
+
+	// Add required languages (2 for Knowledge Domain)
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldLanguages,
+		ChoiceID: "knowledge_languages",
+		Values:   []string{"elvish", "dwarvish"},
+	})
+
+	// Validate with subclass
+	result := choices.ValidateClassChoicesWithSubclass(
+		classes.Cleric,
+		classes.KnowledgeDomain,
+		1, // level
+		submissions,
+		context,
+	)
+
+	// Should be valid - Knowledge Domain allows 4 skills
+	s.True(result.CanFinalize, "Knowledge Domain Cleric with 4 skills should be valid")
+	
+	// Check for skill errors and debug
+	for _, issue := range result.AllIssues {
+		s.T().Logf("Issue: Field=%v, Severity=%v, Message=%s", issue.Field, issue.Severity, issue.Message)
+		if issue.Field == choices.FieldSkills && issue.Severity == choices.SeverityError {
+			s.Fail("Should not have skill errors for Knowledge Domain with 4 skills: %s", issue.Message)
+		}
+	}
+}
+
+func (s *KnowledgeDomainTestSuite) TestValidateClassChoicesWithSubclass_RegularCleric() {
+	// Regular Cleric (no subclass yet) should only be able to choose 2 skills
+
+	context := choices.NewValidationContext()
+	submissions := choices.NewTypedSubmissions()
+
+	// Try to add 4 skills as a regular Cleric
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldSkills,
+		ChoiceID: "cleric_skills",
+		Values: []string{
+			string(skills.Insight),
+			string(skills.Medicine),
+			string(skills.History),
+			string(skills.Religion),
+		},
+	})
+
+	// Validate without subclass
+	result := choices.ValidateClassChoices(
+		classes.Cleric,
+		1, // level
+		submissions,
+		context,
+	)
+
+	// Should have an error - regular Cleric only allows 2 skills
+	s.False(result.CanFinalize, "Regular Cleric with 4 skills should be invalid")
+	
+	// Check for skill errors
+	hasSkillError := false
+	for _, issue := range result.AllIssues {
+		if issue.Field == choices.FieldSkills && issue.Severity == choices.SeverityError {
+			hasSkillError = true
+			s.Contains(issue.Message, "2 skills")
+			s.Contains(issue.Message, "4")
+		}
+	}
+	s.True(hasSkillError, "Should have skill error for regular Cleric with 4 skills")
+}
+
+func (s *KnowledgeDomainTestSuite) TestValidateAllWithSubclass_CompleteKnowledgeDomainCharacter() {
+	// Test complete validation with Knowledge Domain subclass
+	
+	context := choices.NewValidationContext()
+	submissions := choices.NewTypedSubmissions()
+
+	// Class choices - Knowledge Domain gets 4 skills
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldSkills,
+		ChoiceID: "cleric_skills",
+		Values: []string{
+			string(skills.Insight),
+			string(skills.Medicine),
+			string(skills.Arcana),
+			string(skills.History),
+		},
+	})
+
+	// Equipment choices
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_0"),
+		ChoiceID: "equipment_0",
+		Values:   []string{"mace"},
+	})
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_1"),
+		ChoiceID: "equipment_1",
+		Values:   []string{"scale-mail"},
+	})
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_2"),
+		ChoiceID: "equipment_2",
+		Values:   []string{"light-crossbow-set"},
+	})
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.Field("equipment_choice_3"),
+		ChoiceID: "equipment_3",
+		Values:   []string{"priests-pack"},
+	})
+
+	// Cantrips
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldCantrips,
+		ChoiceID: "cleric_cantrips",
+		Values:   []string{"sacred_flame", "guidance", "thaumaturgy"},
+	})
+
+	// Languages for Knowledge Domain
+	submissions.AddChoice(choices.ChoiceSubmission{
+		Source:   choices.SourceClass,
+		Field:    choices.FieldLanguages,
+		ChoiceID: "knowledge_languages",
+		Values:   []string{"elvish", "dwarvish"},
+	})
+
+	// Race choices (Human for simplicity - no choices needed)
+	// Background skills would be separate
+
+	// Validate the complete character
+	result := choices.ValidateWithSubclass(
+		classes.Cleric,
+		classes.KnowledgeDomain,
+		races.Human,
+		"", // background not relevant for this test
+		1,  // level
+		submissions,
+		context,
+	)
+
+	// Should be valid
+	s.True(result.CanFinalize, "Complete Knowledge Domain character should be valid")
+	
+	// No skill errors
+	for _, issue := range result.AllIssues {
+		if issue.Field == choices.FieldSkills && issue.Severity == choices.SeverityError {
+			s.Fail("Should not have skill errors: %s", issue.Message)
+		}
+	}
+}

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -280,7 +280,7 @@ func (d *Draft) ValidateChoices() (*choices.ValidationResult, error) {
 
 	// Create validator and validate with typed constants from the Draft
 	validator := choices.NewValidator(context)
-	
+
 	// Use subclass-aware validation if subclass is selected
 	var result *choices.ValidationResult
 	if d.ClassChoice.SubclassID != "" {

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -280,13 +280,27 @@ func (d *Draft) ValidateChoices() (*choices.ValidationResult, error) {
 
 	// Create validator and validate with typed constants from the Draft
 	validator := choices.NewValidator(context)
-	result := validator.ValidateAll(
-		d.ClassChoice.ClassID,
-		d.RaceChoice.RaceID,
-		d.BackgroundChoice,
-		1, // Level 1 for now
-		submissions,
-	)
+	
+	// Use subclass-aware validation if subclass is selected
+	var result *choices.ValidationResult
+	if d.ClassChoice.SubclassID != "" {
+		result = validator.ValidateAllWithSubclass(
+			d.ClassChoice.ClassID,
+			d.ClassChoice.SubclassID,
+			d.RaceChoice.RaceID,
+			d.BackgroundChoice,
+			1, // Level 1 for now
+			submissions,
+		)
+	} else {
+		result = validator.ValidateAll(
+			d.ClassChoice.ClassID,
+			d.RaceChoice.RaceID,
+			d.BackgroundChoice,
+			1, // Level 1 for now
+			submissions,
+		)
+	}
 
 	// Update draft's validation state from result
 	d.updateValidationState(result)

--- a/rulebooks/dnd5e/classes/grants.go
+++ b/rulebooks/dnd5e/classes/grants.go
@@ -247,6 +247,11 @@ func GetSubclassGrants(subclassID Subclass) *AutomaticGrants {
 		// Life Domain gets heavy armor
 		grants.ArmorProficiencies = append(grants.ArmorProficiencies, proficiencies.ArmorHeavy)
 
+	case KnowledgeDomain:
+		// Knowledge Domain gets expertise in 2 INT skills (handled through features)
+		// Languages are handled through requirements/choices
+		// No additional proficiencies
+
 	case NatureDomain:
 		// Nature Domain gets heavy armor
 		grants.ArmorProficiencies = append(grants.ArmorProficiencies, proficiencies.ArmorHeavy)


### PR DESCRIPTION
…classes

- Add ValidateClassChoicesWithSubclass and ValidateAllWithSubclass methods
- Fix Knowledge Domain to properly add Arcana/History/Nature/Religion to skill options
- Update Draft to use subclass-aware validation when subclass is selected
- Add comprehensive tests for Knowledge Domain validation
- Knowledge Domain Clerics can now correctly choose 4 skills (2 base + 2 domain)

Fixes validation issues where subclass-specific requirements weren't being considered