### PR TITLE
refactor: Move validation logic to domain methods

### DIFF
--- a/rulebooks/dnd5e/character/draft_conversion_test.go
+++ b/rulebooks/dnd5e/character/draft_conversion_test.go
@@ -502,7 +502,10 @@ func (s *DraftConversionTestSuite) TestDuplicateLanguageHandling() {
 		ID:         "test-duplicate-lang",
 		PlayerID:   "player-999",
 		Name:       "Linguist",
-		RaceChoice: RaceChoice{RaceID: races.Elf},
+		RaceChoice: RaceChoice{
+			RaceID:    races.Elf,
+			SubraceID: races.HighElf,
+		},
 		ClassChoice: ClassChoice{
 			ClassID: classes.Wizard,
 		},

--- a/rulebooks/dnd5e/character/draft_test.go
+++ b/rulebooks/dnd5e/character/draft_test.go
@@ -245,7 +245,7 @@ func (s *DraftTestSuite) TestToCharacter_IncompleteDraft() {
 	character, err := draft.ToCharacter(s.testRace, s.testClass, s.testBackground)
 	s.Assert().Error(err)
 	s.Assert().Nil(character)
-	s.Assert().Contains(err.Error(), "incomplete")
+	s.Assert().Contains(err.Error(), "ability scores must be set")
 }
 
 func (s *DraftTestSuite) TestToCharacter_MissingData() {


### PR DESCRIPTION
## Summary
Continues the cleanup effort by moving validation logic from the separate Validator class into domain methods on the Draft itself.

## Changes

### ✨ New Domain Method
- Added `ValidateBasicRequirements()` to Draft that checks:
  - Name is provided
  - Race is selected (with valid subrace if required)
  - Class is selected (with subclass if required at level 1) 
  - Background is selected
  - Ability scores are set and within valid ranges (3-20)

### 🔄 Refactored Validation Flow
- `ToCharacter()` now calls `ValidateBasicRequirements()` instead of `ValidateDraft`
- Removed redundant validation from `Builder.Build()` - now relies on `ToCharacter()`
- Deprecated `Builder.Validate()` but kept for backwards compatibility

### 🎯 Better Error Handling
- All validation errors now use rpgerr with rich context
- Errors include metadata (field names, values) for easier debugging
- Clear, specific error messages

## Why These Changes?

1. **Domain logic belongs with the data** - The Draft knows what makes itself valid
2. **Single source of truth** - No more duplicate validation logic
3. **Better errors** - rpgerr provides context that makes debugging easier
4. **Simpler code flow** - Build() just calls ToCharacter() which handles everything

## Testing
- Fixed test that had invalid Elf without subrace
- Updated test expectation for new error message format
- All tests passing ✅

## Next Steps
Could potentially deprecate the entire Validator struct since all its logic is now in domain methods, but keeping it for now for backwards compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)