### PR TITLE
refactor(dice): remove global state and add Pool/Lazy patterns

### DIFF
--- a/dice/errors.go
+++ b/dice/errors.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import "errors"
+
+// Common errors returned by the dice package
+var (
+	// ErrInvalidNotation indicates the dice notation string is invalid
+	ErrInvalidNotation = errors.New("dice: invalid notation")
+
+	// ErrNotationNotImplemented indicates notation parsing is not yet implemented
+	ErrNotationNotImplemented = errors.New("dice: notation parser not implemented")
+
+	// ErrInvalidDieSize indicates an invalid die size (must be > 0)
+	ErrInvalidDieSize = errors.New("dice: invalid die size")
+
+	// ErrInvalidDieCount indicates an invalid die count
+	ErrInvalidDieCount = errors.New("dice: invalid die count")
+
+	// ErrNilRoller indicates a nil roller was provided
+	ErrNilRoller = errors.New("dice: roller cannot be nil")
+)

--- a/dice/example_test.go
+++ b/dice/example_test.go
@@ -143,10 +143,6 @@ func Example_roguesSneakAttack() {
 
 // TestWithMockRoller demonstrates how to test code that uses dice
 func TestWithMockRoller(t *testing.T) {
-	// Save the original roller and restore it after the test
-	original := dice.DefaultRoller
-	defer dice.SetDefaultRoller(original)
-
 	// Create a mock controller
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -157,18 +153,15 @@ func TestWithMockRoller(t *testing.T) {
 	mockRoller.EXPECT().RollN(ctx, 1, 20).Return([]int{20}, nil) // Natural 20!
 	mockRoller.EXPECT().RollN(ctx, 2, 6).Return([]int{6, 5}, nil)
 
-	// Set the mock as the default
-	dice.SetDefaultRoller(mockRoller)
-
-	// Now test your game logic with predictable dice
-	attackRoll := dice.D20(1).GetValue()
-	if attackRoll != 20 {
-		t.Errorf("Expected critical hit (20), got %d", attackRoll)
+	// Now test your game logic with predictable dice using the mock roller
+	attackRoll, _ := dice.NewRollWithRoller(1, 20, mockRoller)
+	if attackRoll.GetValue() != 20 {
+		t.Errorf("Expected critical hit (20), got %d", attackRoll.GetValue())
 	}
 
-	damage := dice.D6(2).GetValue()
-	if damage != 11 {
-		t.Errorf("Expected damage of 11, got %d", damage)
+	damageRoll, _ := dice.NewRollWithRoller(2, 6, mockRoller)
+	if damageRoll.GetValue() != 11 {
+		t.Errorf("Expected damage of 11, got %d", damageRoll.GetValue())
 	}
 }
 

--- a/dice/lazy.go
+++ b/dice/lazy.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import (
+	"context"
+)
+
+// Lazy represents a dice roll that is evaluated fresh each time.
+// Unlike Roll which caches its result, Lazy rolls fresh dice every time GetValue() is called.
+// This is essential for effects like Bless that add dice to each attack.
+type Lazy struct {
+	pool   *Pool
+	roller Roller
+}
+
+// NewLazy creates a new lazy dice roll from a Pool.
+func NewLazy(pool *Pool) *Lazy {
+	return &Lazy{
+		pool:   pool,
+		roller: NewRoller(),
+	}
+}
+
+// NewLazyWithRoller creates a new lazy dice roll with a specific roller.
+func NewLazyWithRoller(pool *Pool, roller Roller) *Lazy {
+	if roller == nil {
+		roller = NewRoller()
+	}
+	return &Lazy{
+		pool:   pool,
+		roller: roller,
+	}
+}
+
+// LazyFromNotation creates a lazy roll from a dice notation string.
+func LazyFromNotation(notation string) (*Lazy, error) {
+	pool, err := ParseNotation(notation)
+	if err != nil {
+		return nil, err
+	}
+	return NewLazy(pool), nil
+}
+
+// GetValue rolls the dice fresh and returns the total.
+// Each call produces a new random result.
+func (l *Lazy) GetValue() int {
+	return l.GetValueWithContext(context.Background())
+}
+
+// GetValueWithContext rolls the dice fresh with context support.
+func (l *Lazy) GetValueWithContext(ctx context.Context) int {
+	result := l.pool.RollContext(ctx, l.roller)
+	if result.Error() != nil {
+		return 0
+	}
+	return result.Total()
+}
+
+// GetDescription returns a description of the most recent roll.
+func (l *Lazy) GetDescription() string {
+	return l.GetDescriptionWithContext(context.Background())
+}
+
+// GetDescriptionWithContext returns a description with context support.
+func (l *Lazy) GetDescriptionWithContext(ctx context.Context) string {
+	result := l.pool.RollContext(ctx, l.roller)
+	if result.Error() != nil {
+		return "ERROR: " + result.Error().Error()
+	}
+	// Add + prefix for positive values to match modifier format
+	if result.Total() >= 0 {
+		return "+" + result.Description()
+	}
+	return result.Description()
+}
+
+// Pool returns the underlying dice pool configuration.
+func (l *Lazy) Pool() *Pool {
+	return l.pool
+}

--- a/dice/lazy_test.go
+++ b/dice/lazy_test.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
+)
+
+func TestNewLazy(t *testing.T) {
+	pool := SimplePool(2, 6, 3)
+	lazy := NewLazy(pool)
+
+	if lazy.Pool() != pool {
+		t.Error("NewLazy() did not store pool correctly")
+	}
+
+	// Test that it has a roller
+	if lazy.roller == nil {
+		t.Error("NewLazy() did not create roller")
+	}
+}
+
+func TestNewLazyWithRoller(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pool := SimplePool(1, 20, 0)
+	mockRoller := mock_dice.NewMockRoller(ctrl)
+
+	// Test with mock roller
+	lazy := NewLazyWithRoller(pool, mockRoller)
+	if lazy.roller != mockRoller {
+		t.Error("NewLazyWithRoller() did not use provided roller")
+	}
+
+	// Test with nil roller (should create default)
+	lazy2 := NewLazyWithRoller(pool, nil)
+	if lazy2.roller == nil {
+		t.Error("NewLazyWithRoller(nil) did not create default roller")
+	}
+}
+
+func TestLazy_GetValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockRoller := mock_dice.NewMockRoller(ctrl)
+
+	// Set up expectations for multiple calls
+	mockRoller.EXPECT().RollN(ctx, 1, 6).Return([]int{4}, nil).Times(1)
+	mockRoller.EXPECT().RollN(ctx, 1, 6).Return([]int{2}, nil).Times(1)
+	mockRoller.EXPECT().RollN(ctx, 1, 6).Return([]int{6}, nil).Times(1)
+
+	pool := SimplePool(1, 6, 0)
+	lazy := NewLazyWithRoller(pool, mockRoller)
+
+	// Test that each call produces fresh results
+	results := []int{
+		lazy.GetValue(),
+		lazy.GetValue(),
+		lazy.GetValue(),
+	}
+
+	expected := []int{4, 2, 6}
+	for i, result := range results {
+		if result != expected[i] {
+			t.Errorf("Call %d: GetValue() = %d, want %d", i+1, result, expected[i])
+		}
+	}
+}
+
+func TestLazy_GetDescription(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockRoller := mock_dice.NewMockRoller(ctrl)
+
+	// Set up expectation for description
+	mockRoller.EXPECT().RollN(ctx, 2, 6).Return([]int{4, 5}, nil)
+
+	pool := SimplePool(2, 6, 3)
+	lazy := NewLazyWithRoller(pool, mockRoller)
+
+	desc := lazy.GetDescription()
+
+	// Should have a + prefix and show the roll details
+	if !strings.HasPrefix(desc, "+") {
+		t.Errorf("GetDescription() = %q, expected to start with +", desc)
+	}
+
+	if !strings.Contains(desc, "2d6") {
+		t.Errorf("GetDescription() = %q, expected to contain '2d6'", desc)
+	}
+
+	if !strings.Contains(desc, "12") { // 4+5+3=12
+		t.Errorf("GetDescription() = %q, expected to contain total '12'", desc)
+	}
+}
+
+func TestLazy_ErrorHandling(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockRoller := mock_dice.NewMockRoller(ctrl)
+
+	// Set up roller to return error
+	mockRoller.EXPECT().RollN(ctx, 1, 20).Return(nil, ErrInvalidDieSize).AnyTimes()
+
+	pool := SimplePool(1, 20, 0)
+	lazy := NewLazyWithRoller(pool, mockRoller)
+
+	// GetValue should return 0 on error
+	if value := lazy.GetValue(); value != 0 {
+		t.Errorf("GetValue() with error = %d, want 0", value)
+	}
+
+	// GetDescription should show error
+	desc := lazy.GetDescription()
+	if !strings.Contains(desc, "ERROR") {
+		t.Errorf("GetDescription() with error = %q, expected to contain 'ERROR'", desc)
+	}
+}
+
+func TestLazy_FreshRolls(t *testing.T) {
+	// Test with real roller to ensure fresh rolls
+	pool := SimplePool(1, 6, 0)
+	lazy := NewLazy(pool)
+
+	// Roll many times and track results
+	results := make(map[int]int)
+	for i := 0; i < 60; i++ {
+		value := lazy.GetValue()
+		if value < 1 || value > 6 {
+			t.Errorf("GetValue() = %d, want between 1 and 6", value)
+		}
+		results[value]++
+	}
+
+	// Should see multiple different values
+	if len(results) < 3 {
+		t.Errorf("After 60 rolls, only saw %d different values, expected more variety", len(results))
+	}
+}
+
+func TestLazyFromNotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		notation string
+		wantErr  bool
+	}{
+		{
+			name:     "valid notation",
+			notation: "2d6+3",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid notation",
+			notation: "invalid",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lazy, err := LazyFromNotation(tt.notation)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LazyFromNotation(%q) error = %v, wantErr %v", tt.notation, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && lazy == nil {
+				t.Error("LazyFromNotation() returned nil without error")
+			}
+		})
+	}
+}

--- a/dice/modifier.go
+++ b/dice/modifier.go
@@ -25,7 +25,7 @@ type Roll struct {
 	err    error // Store any error that occurred during rolling
 }
 
-// NewRoll creates a new dice roll modifier using the DefaultRoller.
+// NewRoll creates a new dice roll modifier using a new CryptoRoller.
 // Returns an error if size <= 0.
 func NewRoll(count, size int) (*Roll, error) {
 	if size <= 0 {
@@ -34,7 +34,7 @@ func NewRoll(count, size int) (*Roll, error) {
 	return &Roll{
 		count:  count,
 		size:   size,
-		roller: DefaultRoller,
+		roller: NewRoller(),
 	}, nil
 }
 

--- a/dice/modifier_test.go
+++ b/dice/modifier_test.go
@@ -332,9 +332,9 @@ func TestRoll_HelperFunctions(t *testing.T) {
 				t.Errorf("%s(%d).size = %d, want %d", tt.name, tt.count, roll.size, tt.wantSize)
 			}
 
-			// Verify it uses DefaultRoller
-			if roll.roller != DefaultRoller {
-				t.Errorf("%s(%d) not using DefaultRoller", tt.name, tt.count)
+			// Verify roller is not nil
+			if roll.roller == nil {
+				t.Errorf("%s(%d) has nil roller", tt.name, tt.count)
 			}
 		})
 	}

--- a/dice/notation.go
+++ b/dice/notation.go
@@ -1,0 +1,145 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// notationRegex matches dice notation like "2d6+3", "d20", "3d8-2", etc.
+var notationRegex = regexp.MustCompile(`^([+-]?\d*)[dD](\d+)([+-]\d+)?$`)
+
+// ParseNotation parses a dice notation string into a Pool.
+// Supports formats like:
+//   - "2d6" - roll 2 six-sided dice
+//   - "d20" - roll 1 twenty-sided die
+//   - "3d8+5" - roll 3 eight-sided dice and add 5
+//   - "2d10-3" - roll 2 ten-sided dice and subtract 3
+func ParseNotation(notation string) (*Pool, error) {
+	notation = strings.TrimSpace(notation)
+	if notation == "" {
+		return nil, fmt.Errorf("%w: empty notation", ErrInvalidNotation)
+	}
+
+	// Handle multiple dice types with + separator
+	if strings.Contains(notation, "+") && strings.Contains(notation, "d") {
+		return parseComplexNotation(notation)
+	}
+
+	// Simple notation with single dice type
+	matches := notationRegex.FindStringSubmatch(notation)
+	if matches == nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidNotation, notation)
+	}
+
+	// Parse count (default to 1 if not specified)
+	count := 1
+	if matches[1] != "" && matches[1] != "+" && matches[1] != "-" {
+		var err error
+		count, err = strconv.Atoi(matches[1])
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid count in %s", ErrInvalidNotation, notation)
+		}
+	}
+
+	// Parse die size
+	size, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid die size in %s", ErrInvalidNotation, notation)
+	}
+	if size <= 0 {
+		return nil, fmt.Errorf("%w: die size must be positive in %s", ErrInvalidDieSize, notation)
+	}
+
+	// Parse modifier
+	modifier := 0
+	if matches[3] != "" {
+		modifier, err = strconv.Atoi(matches[3])
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid modifier in %s", ErrInvalidNotation, notation)
+		}
+	}
+
+	return SimplePool(count, size, modifier), nil
+}
+
+// parseComplexNotation handles notation with multiple dice types like "2d6+1d4+3"
+func parseComplexNotation(notation string) (*Pool, error) {
+	parts := strings.Split(notation, "+")
+	var dice []Spec
+	modifier := 0
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+
+		// Check if this part is a dice notation or just a number
+		if strings.Contains(part, "d") {
+			// Handle negative dice like "-2d6" that might appear after split
+			if strings.HasPrefix(part, "-") {
+				// This shouldn't happen with + split, but handle it anyway
+				continue
+			}
+
+			// Parse this dice part
+			matches := notationRegex.FindStringSubmatch(part)
+			if matches == nil {
+				return nil, fmt.Errorf("%w: invalid dice part %s", ErrInvalidNotation, part)
+			}
+
+			count := 1
+			if matches[1] != "" {
+				var err error
+				count, err = strconv.Atoi(matches[1])
+				if err != nil {
+					return nil, fmt.Errorf("%w: invalid count in %s", ErrInvalidNotation, part)
+				}
+			}
+
+			size, err := strconv.Atoi(matches[2])
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid die size in %s", ErrInvalidNotation, part)
+			}
+			if size <= 0 {
+				return nil, fmt.Errorf("%w: die size must be positive in %s", ErrInvalidDieSize, part)
+			}
+
+			dice = append(dice, Spec{Count: count, Size: size})
+
+			// Handle any modifier attached to this dice
+			if matches[3] != "" {
+				mod, err := strconv.Atoi(matches[3])
+				if err != nil {
+					return nil, fmt.Errorf("%w: invalid modifier in %s", ErrInvalidNotation, part)
+				}
+				modifier += mod
+			}
+		} else {
+			// It's just a number modifier
+			mod, err := strconv.Atoi(part)
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid modifier %s", ErrInvalidNotation, part)
+			}
+			modifier += mod
+		}
+	}
+
+	if len(dice) == 0 {
+		return nil, fmt.Errorf("%w: no dice found in %s", ErrInvalidNotation, notation)
+	}
+
+	return NewPool(dice, modifier), nil
+}
+
+// MustParseNotation parses notation and panics on error.
+// Useful for tests and compile-time known notation.
+func MustParseNotation(notation string) *Pool {
+	pool, err := ParseNotation(notation)
+	if err != nil {
+		panic(fmt.Sprintf("dice: failed to parse notation %q: %v", notation, err))
+	}
+	return pool
+}

--- a/dice/notation_test.go
+++ b/dice/notation_test.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import (
+	"testing"
+)
+
+func TestParseNotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		notation     string
+		wantNotation string // Expected normalized notation
+		wantErr      bool
+	}{
+		{
+			name:         "simple d20",
+			notation:     "d20",
+			wantNotation: "d20",
+		},
+		{
+			name:         "2d6",
+			notation:     "2d6",
+			wantNotation: "2d6",
+		},
+		{
+			name:         "2d6+3",
+			notation:     "2d6+3",
+			wantNotation: "2d6+3",
+		},
+		{
+			name:         "3d8-2",
+			notation:     "3d8-2",
+			wantNotation: "3d8-2",
+		},
+		{
+			name:         "capital D",
+			notation:     "2D6+3",
+			wantNotation: "2d6+3",
+		},
+		{
+			name:         "with spaces",
+			notation:     "  2d6 + 3  ",
+			wantNotation: "2d6+3",
+		},
+		{
+			name:         "complex notation",
+			notation:     "2d6+1d4+3",
+			wantNotation: "2d6+d4+3",
+		},
+		{
+			name:     "empty string",
+			notation: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid notation",
+			notation: "invalid",
+			wantErr:  true,
+		},
+		{
+			name:     "zero die size",
+			notation: "2d0",
+			wantErr:  true,
+		},
+		{
+			name:     "negative die size",
+			notation: "2d-6",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, err := ParseNotation(tt.notation)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseNotation(%q) error = %v, wantErr %v", tt.notation, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && pool.Notation() != tt.wantNotation {
+				t.Errorf("ParseNotation(%q).Notation() = %q, want %q", tt.notation, pool.Notation(), tt.wantNotation)
+			}
+		})
+	}
+}
+
+func TestParseComplexNotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		notation string
+		wantAvg  float64
+		wantMin  int
+		wantMax  int
+	}{
+		{
+			name:     "2d6+1d4+3",
+			notation: "2d6+1d4+3",
+			wantAvg:  12.5, // 7 + 2.5 + 3
+			wantMin:  6,    // 2 + 1 + 3
+			wantMax:  19,   // 12 + 4 + 3
+		},
+		{
+			name:     "d20+d12+5",
+			notation: "d20+d12+5",
+			wantAvg:  22, // 10.5 + 6.5 + 5
+			wantMin:  7,  // 1 + 1 + 5
+			wantMax:  37, // 20 + 12 + 5
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, err := ParseNotation(tt.notation)
+			if err != nil {
+				t.Fatalf("ParseNotation(%q) error = %v", tt.notation, err)
+			}
+
+			if avg := pool.Average(); avg != tt.wantAvg {
+				t.Errorf("Average() = %v, want %v", avg, tt.wantAvg)
+			}
+			if minValue := pool.Min(); minValue != tt.wantMin {
+				t.Errorf("Min() = %v, want %v", minValue, tt.wantMin)
+			}
+			if maxValue := pool.Max(); maxValue != tt.wantMax {
+				t.Errorf("Max() = %v, want %v", maxValue, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestMustParseNotation(t *testing.T) {
+	// Test valid notation
+	pool := MustParseNotation("2d6+3")
+	if pool.Notation() != "2d6+3" {
+		t.Errorf("MustParseNotation(\"2d6+3\").Notation() = %q, want \"2d6+3\"", pool.Notation())
+	}
+
+	// Test panic on invalid notation
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("MustParseNotation with invalid notation did not panic")
+		}
+	}()
+	MustParseNotation("invalid")
+}

--- a/dice/pool.go
+++ b/dice/pool.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Pool represents a reusable dice configuration that can be rolled multiple times.
+// Unlike Roll, Pool doesn't cache results - each Roll() call produces fresh results.
+type Pool struct {
+	notation string // Original notation for display (e.g., "2d6+3")
+	dice     []Spec // Individual dice groups
+	modifier int    // Static modifier to add
+}
+
+// Spec represents a group of dice of the same size
+type Spec struct {
+	Count int // Number of dice
+	Size  int // Die size (d6 = 6, d20 = 20)
+}
+
+// NewPool creates a new dice pool from components
+func NewPool(dice []Spec, modifier int) *Pool {
+	// Build notation string
+	parts := make([]string, 0, len(dice)+1)
+	for _, d := range dice {
+		if d.Count == 1 {
+			parts = append(parts, fmt.Sprintf("d%d", d.Size))
+		} else if d.Count > 1 {
+			parts = append(parts, fmt.Sprintf("%dd%d", d.Count, d.Size))
+		}
+	}
+
+	notation := strings.Join(parts, "+")
+	if modifier > 0 {
+		notation = fmt.Sprintf("%s+%d", notation, modifier)
+	} else if modifier < 0 {
+		notation = fmt.Sprintf("%s%d", notation, modifier)
+	}
+
+	return &Pool{
+		notation: notation,
+		dice:     dice,
+		modifier: modifier,
+	}
+}
+
+// SimplePool creates a pool for a single dice type (e.g., 2d6+3)
+func SimplePool(count, size, modifier int) *Pool {
+	return NewPool([]Spec{{Count: count, Size: size}}, modifier)
+}
+
+// Notation returns the dice notation string (e.g., "2d6+3")
+func (p *Pool) Notation() string {
+	return p.notation
+}
+
+// Roll performs a fresh roll of the pool using the provided roller
+func (p *Pool) Roll(roller Roller) *Result {
+	return p.RollContext(context.Background(), roller)
+}
+
+// RollContext performs a fresh roll with context support
+func (p *Pool) RollContext(ctx context.Context, roller Roller) *Result {
+	if roller == nil {
+		roller = NewRoller()
+	}
+
+	result := &Result{
+		pool:     p,
+		rolls:    make([][]int, len(p.dice)),
+		modifier: p.modifier,
+	}
+
+	// Roll each dice group
+	for i, spec := range p.dice {
+		groupRolls, err := roller.RollN(ctx, spec.Count, spec.Size)
+		if err != nil {
+			result.err = err
+			return result
+		}
+		result.rolls[i] = groupRolls
+	}
+
+	// Calculate total
+	result.total = p.modifier
+	for _, group := range result.rolls {
+		for _, roll := range group {
+			result.total += roll
+		}
+	}
+
+	return result
+}
+
+// Average returns the average expected value of the pool
+func (p *Pool) Average() float64 {
+	avg := float64(p.modifier)
+	for _, spec := range p.dice {
+		// Average of a die is (1 + size) / 2 * count
+		avg += float64(spec.Count) * (float64(spec.Size) + 1) / 2
+	}
+	return avg
+}
+
+// Min returns the minimum possible roll
+func (p *Pool) Min() int {
+	minValue := p.modifier
+	for _, spec := range p.dice {
+		minValue += spec.Count // Each die minimum is 1
+	}
+	return minValue
+}
+
+// Max returns the maximum possible roll
+func (p *Pool) Max() int {
+	maxValue := p.modifier
+	for _, spec := range p.dice {
+		maxValue += spec.Count * spec.Size
+	}
+	return maxValue
+}

--- a/dice/pool_test.go
+++ b/dice/pool_test.go
@@ -1,0 +1,160 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
+)
+
+func TestNewPool(t *testing.T) {
+	tests := []struct {
+		name         string
+		dice         []Spec
+		modifier     int
+		wantNotation string
+	}{
+		{
+			name:         "single dice type with modifier",
+			dice:         []Spec{{Count: 2, Size: 6}},
+			modifier:     3,
+			wantNotation: "2d6+3",
+		},
+		{
+			name:         "single die no modifier",
+			dice:         []Spec{{Count: 1, Size: 20}},
+			modifier:     0,
+			wantNotation: "d20",
+		},
+		{
+			name:         "multiple dice types",
+			dice:         []Spec{{Count: 2, Size: 6}, {Count: 1, Size: 4}},
+			modifier:     2,
+			wantNotation: "2d6+d4+2",
+		},
+		{
+			name:         "negative modifier",
+			dice:         []Spec{{Count: 3, Size: 8}},
+			modifier:     -2,
+			wantNotation: "3d8-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := NewPool(tt.dice, tt.modifier)
+			if pool.Notation() != tt.wantNotation {
+				t.Errorf("Pool.Notation() = %q, want %q", pool.Notation(), tt.wantNotation)
+			}
+		})
+	}
+}
+
+func TestSimplePool(t *testing.T) {
+	pool := SimplePool(2, 6, 3)
+	if pool.Notation() != "2d6+3" {
+		t.Errorf("SimplePool(2, 6, 3).Notation() = %q, want %q", pool.Notation(), "2d6+3")
+	}
+}
+
+func TestPool_Roll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRoller := mock_dice.NewMockRoller(ctrl)
+	ctx := context.Background()
+
+	// Expect rolls for 2d6+3
+	mockRoller.EXPECT().RollN(ctx, 2, 6).Return([]int{4, 5}, nil)
+
+	pool := SimplePool(2, 6, 3)
+	result := pool.RollContext(ctx, mockRoller)
+
+	if result.Error() != nil {
+		t.Fatalf("Pool.Roll() error = %v", result.Error())
+	}
+
+	if result.Total() != 12 { // 4 + 5 + 3
+		t.Errorf("Pool.Roll() total = %d, want 12", result.Total())
+	}
+
+	if result.Modifier() != 3 {
+		t.Errorf("Result.Modifier() = %d, want 3", result.Modifier())
+	}
+
+	rolls := result.Rolls()
+	if len(rolls) != 1 || len(rolls[0]) != 2 {
+		t.Errorf("Result.Rolls() = %v, want [[4, 5]]", rolls)
+	}
+}
+
+func TestPool_Statistics(t *testing.T) {
+	tests := []struct {
+		name        string
+		pool        *Pool
+		wantAverage float64
+		wantMin     int
+		wantMax     int
+	}{
+		{
+			name:        "2d6+3",
+			pool:        SimplePool(2, 6, 3),
+			wantAverage: 10, // (3.5 * 2) + 3
+			wantMin:     5,  // 2 + 3
+			wantMax:     15, // 12 + 3
+		},
+		{
+			name:        "d20",
+			pool:        SimplePool(1, 20, 0),
+			wantAverage: 10.5, // (20 + 1) / 2
+			wantMin:     1,
+			wantMax:     20,
+		},
+		{
+			name:        "3d4-2",
+			pool:        SimplePool(3, 4, -2),
+			wantAverage: 5.5, // (2.5 * 3) - 2
+			wantMin:     1,   // 3 - 2
+			wantMax:     10,  // 12 - 2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if avg := tt.pool.Average(); avg != tt.wantAverage {
+				t.Errorf("Pool.Average() = %v, want %v", avg, tt.wantAverage)
+			}
+			if minValue := tt.pool.Min(); minValue != tt.wantMin {
+				t.Errorf("Pool.Min() = %v, want %v", minValue, tt.wantMin)
+			}
+			if maxValue := tt.pool.Max(); maxValue != tt.wantMax {
+				t.Errorf("Pool.Max() = %v, want %v", maxValue, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestPool_MultipleRolls(t *testing.T) {
+	// Test that Pool produces fresh results each time
+	pool := SimplePool(1, 6, 0)
+	roller := NewRoller()
+
+	results := make(map[int]bool)
+	for i := 0; i < 20; i++ {
+		result := pool.Roll(roller)
+		if result.Error() != nil {
+			t.Fatalf("Roll %d failed: %v", i, result.Error())
+		}
+		results[result.Total()] = true
+	}
+
+	// With 20 rolls of a d6, we should see at least 2 different results
+	if len(results) < 2 {
+		t.Errorf("After 20 rolls, only saw %d different results, expected variety", len(results))
+	}
+}

--- a/dice/result.go
+++ b/dice/result.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Result represents the outcome of rolling a dice pool
+type Result struct {
+	pool     *Pool   // The pool that was rolled
+	rolls    [][]int // Actual rolls grouped by dice spec
+	modifier int     // Static modifier
+	total    int     // Total result
+	err      error   // Any error that occurred
+}
+
+// Total returns the total value of the roll
+func (r *Result) Total() int {
+	return r.total
+}
+
+// Rolls returns the individual dice rolls
+func (r *Result) Rolls() [][]int {
+	return r.rolls
+}
+
+// Modifier returns the static modifier
+func (r *Result) Modifier() int {
+	return r.modifier
+}
+
+// Error returns any error that occurred during rolling
+func (r *Result) Error() error {
+	return r.err
+}
+
+// Description returns a formatted description of the roll
+// Format: "2d6+3: [4,2]+3 = 9" or "3d8: [7,2,5] = 14"
+func (r *Result) Description() string {
+	if r.err != nil {
+		return fmt.Sprintf("ERROR: %v", r.err)
+	}
+
+	var parts []string
+
+	// Build the roll details
+	for i, group := range r.rolls {
+		if len(group) == 0 {
+			continue
+		}
+
+		// Convert rolls to strings
+		rollStrs := make([]string, len(group))
+		for j, roll := range group {
+			rollStrs[j] = fmt.Sprintf("%d", roll)
+		}
+
+		// Format based on count
+		spec := r.pool.dice[i]
+		if spec.Count == 1 {
+			parts = append(parts, fmt.Sprintf("d%d:[%s]", spec.Size, strings.Join(rollStrs, ",")))
+		} else {
+			parts = append(parts, fmt.Sprintf("%dd%d:[%s]", spec.Count, spec.Size, strings.Join(rollStrs, ",")))
+		}
+	}
+
+	// Add modifier if present
+	result := strings.Join(parts, " + ")
+	if r.modifier > 0 {
+		result = fmt.Sprintf("%s + %d", result, r.modifier)
+	} else if r.modifier < 0 {
+		result = fmt.Sprintf("%s - %d", result, -r.modifier)
+	}
+
+	// Add total
+	return fmt.Sprintf("%s = %d", result, r.total)
+}
+
+// String implements Stringer interface
+func (r *Result) String() string {
+	return r.Description()
+}

--- a/dice/roller.go
+++ b/dice/roller.go
@@ -68,12 +68,3 @@ func (c *CryptoRoller) RollN(ctx context.Context, count, size int) ([]int, error
 	}
 	return results, nil
 }
-
-// DefaultRoller is the default roller using crypto/rand.
-var DefaultRoller Roller = &CryptoRoller{}
-
-// SetDefaultRoller allows changing the default roller (primarily for testing).
-// This function is not safe for concurrent use with other dice operations.
-func SetDefaultRoller(r Roller) {
-	DefaultRoller = r
-}

--- a/dice/roller_new.go
+++ b/dice/roller_new.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dice
+
+// NewRoller creates a new instance of a dice roller.
+// This replaces the global DefaultRoller pattern with dependency injection.
+func NewRoller() Roller {
+	return &CryptoRoller{}
+}
+
+// NewMockableRoller creates a roller that can be easily mocked for testing.
+// In tests, you can pass a mock that implements the Roller interface.
+func NewMockableRoller(r Roller) Roller {
+	if r == nil {
+		return NewRoller()
+	}
+	return r
+}

--- a/dice/roller_test.go
+++ b/dice/roller_test.go
@@ -146,44 +146,48 @@ func TestCryptoRoller_Errors(t *testing.T) {
 	}
 }
 
-func TestDefaultRoller(t *testing.T) {
+func TestNewRoller(t *testing.T) {
 	ctx := context.Background()
-	// Ensure DefaultRoller is set
-	if DefaultRoller == nil {
-		t.Fatal("DefaultRoller is nil")
+	// Create a new roller
+	roller := NewRoller()
+	if roller == nil {
+		t.Fatal("NewRoller() returned nil")
 	}
 
 	// Test it works
-	result, err := DefaultRoller.Roll(ctx, 6)
+	result, err := roller.Roll(ctx, 6)
 	if err != nil {
-		t.Fatalf("DefaultRoller.Roll(6) error = %v", err)
+		t.Fatalf("roller.Roll(6) error = %v", err)
 	}
 	if result < 1 || result > 6 {
-		t.Errorf("DefaultRoller.Roll(6) = %d, want between 1 and 6", result)
+		t.Errorf("roller.Roll(6) = %d, want between 1 and 6", result)
 	}
 }
 
-func TestSetDefaultRoller(t *testing.T) {
+func TestNewMockableRoller(t *testing.T) {
 	ctx := context.Background()
-	// Save original
-	original := DefaultRoller
-	defer func() { DefaultRoller = original }()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	// Set mock roller
+	// Test with mock roller
 	mockRoller := mock_dice.NewMockRoller(ctrl)
 	mockRoller.EXPECT().Roll(ctx, 6).Return(4, nil)
 
-	SetDefaultRoller(mockRoller)
+	roller := NewMockableRoller(mockRoller)
 
-	// Verify it was set
-	result, err := DefaultRoller.Roll(ctx, 6)
+	// Verify mock is used
+	result, err := roller.Roll(ctx, 6)
 	if err != nil {
-		t.Fatalf("DefaultRoller.Roll(6) error = %v", err)
+		t.Fatalf("roller.Roll(6) error = %v", err)
 	}
 	if result != 4 {
-		t.Errorf("DefaultRoller.Roll(6) = %d, want 4", result)
+		t.Errorf("roller.Roll(6) = %d, want 4", result)
+	}
+
+	// Test with nil returns default
+	defaultRoller := NewMockableRoller(nil)
+	if defaultRoller == nil {
+		t.Fatal("NewMockableRoller(nil) returned nil")
 	}
 }


### PR DESCRIPTION
## Summary
- Removes global `DefaultRoller` state in favor of dependency injection with `NewRoller()`
- Adds `Pool` type for reusable dice configurations that roll fresh each time
- Adds `Lazy` type for deferred rolling (essential for effects like Bless that add dice to each attack)
- Adds notation parser to create pools from strings like "2d6+3" or "d20+1d4+5"
- Adds `Result` type to encapsulate roll outcomes with detailed information

## Motivation
The dice package had several issues that made it difficult to use in the rulebooks:
1. Global state made testing hard and created potential race conditions
2. Storing damage as strings like "2d6" was inefficient and hard to work with
3. No way to reuse dice configurations efficiently
4. No distinction between cached rolls and fresh rolls (needed for modifiers)

## Changes
- **Breaking**: Removed `DefaultRoller` global variable and `SetDefaultRoller()` function
- **New**: `NewRoller()` creates a new roller instance
- **New**: `Pool` type for reusable dice configurations
- **New**: `Lazy` type for fresh rolls on each call
- **New**: `ParseNotation()` and `MustParseNotation()` for parsing dice strings
- **New**: `Result` type with methods for `Total()`, `Rolls()`, `Modifier()`, `Description()`
- **Updated**: All tests to use new patterns instead of global state

## Testing
- Comprehensive tests for all new types
- All existing tests updated and passing
- No linter warnings

## Next Steps
After merge and tagging, other modules can update to use the new patterns.

🤖 Generated with [Claude Code](https://claude.ai/code)