### PR TITLE
refactor: Migrate to new dice package with dependency injection

### DIFF
--- a/rulebooks/dnd5e/go.mod
+++ b/rulebooks/dnd5e/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.9.0
-	github.com/KirkDiggler/rpg-toolkit/dice v0.1.1-0.20250807211656-0f8ebffb7bf0
+	github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.0
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1
 	github.com/stretchr/testify v1.10.0

--- a/rulebooks/dnd5e/go.sum
+++ b/rulebooks/dnd5e/go.sum
@@ -1,7 +1,7 @@
 github.com/KirkDiggler/rpg-toolkit/core v0.9.0 h1:kXj1i2Wa9gGb76aznk1GB9ogsDSTkSjENPuMVJEAjK8=
 github.com/KirkDiggler/rpg-toolkit/core v0.9.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
-github.com/KirkDiggler/rpg-toolkit/dice v0.1.1-0.20250807211656-0f8ebffb7bf0 h1:j9ljVJXFnIl9dUs+nNjc08iPuH9wgw5LgrBb2GgyhR4=
-github.com/KirkDiggler/rpg-toolkit/dice v0.1.1-0.20250807211656-0f8ebffb7bf0/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
+github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059 h1:74OW0fnq459g28p2JpyrB20tjno4FlF18+cHJ2xiTes=
+github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.0 h1:7tAo5ddnaBk2nLeLY3wwa5zVx93ntA5FOgi+NNF4rmk=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.0/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=

--- a/rulebooks/dnd5e/initiative/roller.go
+++ b/rulebooks/dnd5e/initiative/roller.go
@@ -1,6 +1,7 @@
 package initiative
 
 import (
+	"context"
 	"sort"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -17,9 +18,9 @@ type Roll struct {
 
 // RollForOrder rolls initiative and returns InitiativeRolls in turn order
 func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []Roll {
-	// Use default roller if none provided
+	// Use new roller if none provided
 	if roller == nil {
-		roller = dice.DefaultRoller
+		roller = dice.NewRoller()
 	}
 
 	// TODO(#285): Make iteration deterministic to ensure consistent ordering
@@ -27,8 +28,9 @@ func RollForOrder(entities map[core.Entity]int, roller dice.Roller) []Roll {
 	// Currently, map iteration is non-deterministic in Go.
 	// Roll for each entity
 	entries := make([]Roll, 0, len(entities))
+	ctx := context.Background()
 	for entity, modifier := range entities {
-		roll, _ := roller.Roll(20)
+		roll, _ := roller.Roll(ctx, 20)
 		entries = append(entries, Roll{
 			Entity:   entity,
 			Roll:     roll,

--- a/rulebooks/dnd5e/initiative/roller_test.go
+++ b/rulebooks/dnd5e/initiative/roller_test.go
@@ -21,7 +21,7 @@ func TestRollForOrder(t *testing.T) {
 	// Since map iteration is non-deterministic, we need to set up expectations
 	// that work regardless of iteration order. All entities get the same roll (10)
 	// so the order will be determined by modifiers alone
-	mockRoller.EXPECT().Roll(20).Return(10, nil).Times(3)
+	mockRoller.EXPECT().Roll(gomock.Any(), 20).Return(10, nil).Times(3)
 
 	participants := map[core.Entity]int{
 		initiative.NewParticipant("ranger", dnd5e.EntityTypeCharacter): +3, // Total: 13


### PR DESCRIPTION
Migrated from the deprecated global dice.DefaultRoller to the new dependency injection pattern using dice.NewRoller().

Changes:
- Updated dice module to v0.3.3 with context-aware Roll methods
- Replaced dice.DefaultRoller with dice.NewRoller() in initiative/roller.go
- Added context.Background() for dice roll calls
- Updated tests to expect context parameter in mock Roll calls

This improves testability and removes global state dependency, following Go best practices for concurrent-safe code.