### PR TITLE
add ammunition to validation

### DIFF
--- a/rulebooks/dnd5e/weapons/weapons.go
+++ b/rulebooks/dnd5e/weapons/weapons.go
@@ -348,6 +348,18 @@ var SimpleRangedWeapons = map[WeaponID]Weapon{
 		Properties: []WeaponProperty{PropertyAmmunition},
 		Range:      &Range{Normal: 30, Long: 120},
 	},
+	// Ammunition items (treated as equipment in D&D 5e)
+	Bolts20: {
+		ID:         Bolts20,
+		Name:       "Crossbow Bolts (20)",
+		Category:   CategorySimpleRanged, // Ammunition is categorized as simple ranged
+		Cost:       "1 gp",
+		Damage:     "", // No damage on their own
+		DamageType: damage.Piercing,
+		Weight:     1.5,                // 20 bolts weigh about 1.5 lbs
+		Properties: []WeaponProperty{}, // No special properties
+		Range:      nil,                // No range on their own
+	},
 }
 
 // MartialRangedWeapons - fighter-accessible martial ranged weapons (for testing)


### PR DESCRIPTION
This pull request strengthens equipment validation for D&D 5e character creation, ensuring that only valid equipment IDs can be selected, stored, or compiled into a character's inventory. It adds comprehensive validation checks at every step, improves error reporting, and expands test coverage, particularly for ammunition items like "bolts-20". This prevents invalid data from being silently accepted or causing runtime panics.

**Validation and Error Handling Improvements**
- Added validation in `SetClass`, `ValidateChoices`, and inventory compilation to ensure all equipment IDs are checked for existence, returning clear errors or panicking if invalid IDs are found. This prevents invalid equipment from being accepted or causing subtle bugs. [[1]](diffhunk://#diff-bd0a5ba07658e14f984fc2605b800001554a537954c76e9104b0780d4bc39e38L336-R345) [[2]](diffhunk://#diff-bd0a5ba07658e14f984fc2605b800001554a537954c76e9104b0780d4bc39e38R367-R372) [[3]](diffhunk://#diff-bd0a5ba07658e14f984fc2605b800001554a537954c76e9104b0780d4bc39e38R568-R576) [[4]](diffhunk://#diff-bd0a5ba07658e14f984fc2605b800001554a537954c76e9104b0780d4bc39e38L710) [[5]](diffhunk://#diff-bd0a5ba07658e14f984fc2605b800001554a537954c76e9104b0780d4bc39e38L732-R754)

**Test Suite Enhancements**
- Replaced and expanded tests to ensure invalid equipment IDs are caught early, and that valid ammunition items (like "bolts-20") are handled correctly. Added tests to verify that validation errors are raised as expected and that valid items do not trigger false positives. [[1]](diffhunk://#diff-162d430c28044c35b8d2d2a4eb260e08d6a872f64c081cb3c4b6aa9e67be7ffeL419-R471) [[2]](diffhunk://#diff-162d430c28044c35b8d2d2a4eb260e08d6a872f64c081cb3c4b6aa9e67be7ffeL462-R631)

**Equipment Data Update**
- Explicitly added "bolts-20" as a valid ammunition item in the equipment data, ensuring it is recognized as valid equipment and preventing previous issues where it caused panics.