### PR TITLE
[rulebook-dnd5e] Add rage feature and journey

### DIFF
--- a/docs/journey/044-events-carry-actions-not-objects.md
+++ b/docs/journey/044-events-carry-actions-not-objects.md
@@ -1,0 +1,105 @@
+# Journey 044: Events Carry Actions, Not Objects
+
+## The Quest
+
+We set out to implement character feature loading, starting with the barbarian's rage. Simple enough - load a feature from JSON, activate it, have it participate in the event system. The rage feature needed to publish events when activated, and conditions needed to subscribe to those events.
+
+## The Initial Approach
+
+Our first instinct was to have the `ConditionAppliedEvent` carry the full `Condition` object:
+
+```go
+type ConditionAppliedEvent struct {
+    Target    core.Entity
+    Condition *conditions.Condition  // The full object with all its data
+}
+```
+
+This felt natural - when a condition is applied, pass the whole condition around so subscribers have everything they need.
+
+## The Wall We Hit
+
+Circular dependencies. The `dnd5e` package defined events, but those events referenced `conditions.Condition`. Meanwhile, conditions needed to import `dnd5e` to subscribe to those same events. Classic circular import problem.
+
+We tried several escapes:
+- Moving event definitions to conditions package (but then features couldn't publish them)
+- Duplicating event types (maintenance nightmare we were actively cleaning up)
+- Creating a separate events package (but where does it belong in the hierarchy?)
+
+## The Insight
+
+The breakthrough came from stepping back and asking: **What is an event supposed to communicate?**
+
+Events describe **what happened**, not **what exists**. They're messages about actions and changes, not carriers for entire objects.
+
+When rage is activated, the event shouldn't carry a Condition object - it should describe that a raging condition was applied, who it was applied to, and any specific data about that application.
+
+## The Pattern That Emerged
+
+```go
+// Events are thin - they describe actions
+type ConditionAppliedEvent struct {
+    Target core.Entity      // Who received it
+    Type   ConditionType    // What type of condition
+    Source string           // What caused it
+    Data   any              // Specific data for this event
+}
+
+// Features publish with specific data
+err := topic.Publish(ctx, ConditionAppliedEvent{
+    Target: owner,
+    Type:   dnd5e.ConditionRaging,
+    Source: r.id,
+    Data: RageEventData{
+        DamageBonus: 2,
+        Level:       5,
+    },
+})
+
+// Conditions subscribe and type-assert the data they care about
+func (r *RagingCondition) onConditionApplied(ctx context.Context, event dnd5e.ConditionAppliedEvent) error {
+    if event.Type == dnd5e.ConditionUnconscious && event.Target.GetID() == r.CharacterID {
+        // Handle unconscious ending rage
+    }
+}
+```
+
+## The Type + Data Pattern
+
+We landed on a discriminated union pattern that's very Go-like:
+- `Type` field acts as a discriminator (strongly typed as `ConditionType`)
+- `Data` field holds type-specific data (using `any` with type assertions)
+- Type assertions in Go are incredibly fast (1-2ns)
+- Publishers know what they're publishing
+- Subscribers know what they're looking for
+
+## Why This Matters
+
+1. **Clean boundaries**: Events are just data about what happened. The event package doesn't need to know about the full implementation of conditions or features.
+
+2. **Flexibility**: Different publishers can include different data for the same condition type. A rage from a feature might include level and damage bonus, while a rage from an item might include duration.
+
+3. **The events package as neutral ground**: By moving just the type definitions (`ConditionType`) to the events package, we created a vocabulary that both features and conditions can share without knowing about each other.
+
+4. **Extensibility path**: We can later add a registry pattern for modules to register new condition types, enabling cross-module conditions (imagine a "Homebrew Curses" module adding conditions to base D&D).
+
+## The Turtle Wins Again
+
+Rather than over-engineering for hypothetical future needs, we:
+- Solved the immediate problem (feature loading and event publishing)
+- Found a pattern that's simple and Go-idiomatic
+- Left doors open for future extension without committing to complexity now
+- Kept the implementation focused on what we actually need
+
+## Technical Notes
+
+- Bus ownership: Characters own the bus, features receive it through input
+- No stored references: Features don't store the bus, they use it and forget it
+- Clean lifecycle: Conditions can subscribe/unsubscribe without affecting features
+- Type safety through convention: String-based under the hood, but wrapped in types
+
+## The Lesson
+
+Events are not transport mechanisms for objects. They're notifications about what happened. This fundamental insight not only solved our circular dependency but led to a cleaner, more maintainable architecture that better represents the actual flow of information in our system.
+
+Sometimes the best solution comes from questioning what we're really trying to communicate.

--- a/docs/journey/README.md
+++ b/docs/journey/README.md
@@ -13,19 +13,51 @@ This directory contains the ongoing architectural journey of the RPG Toolkit. Un
 2. **For Ourselves**: Remembering what we've already considered
 3. **For the Community**: Open source is as much about the process as the result
 
-## Current Documents
+## The Journey (Chronological)
 
-- [001: Architectural Dragons](001-architectural-dragons.md) - Big challenges we see ahead
-- [002: Dice Package Design](002-dice-package-design.md) - Initial dice package design
-- [003: Event Participant Ecosystem](003-event-participant-ecosystem.md) - Event system architecture
-- [004: Conditions System](004-conditions-system.md) - Status effects and relationships
-- [005: Effect Composition](005-effect-composition.md) - Designing composable effects system
-- [006: Feature Management Pattern](006-feature-management-pattern.md) - Exploring feature system patterns
-- [007: Enhanced Conditions](007-enhanced-conditions.md) - Advanced condition system capabilities
-- [008: Dice Roller Design](008-dice-roller-design.md) - Global vs instance-based dice patterns
-- [009: Generics in Conditions](009-generics-in-conditions.md) - Type safety vs flexibility trade-offs
-- [010: Generic Event Patterns](010-generic-event-patterns.md) - Event-driven restoration triggers
-- [011: Spell System Design](011-spell-system-design.md) - Designing the spell casting system
+*Note: Along the journey, we discovered we weren't great at numbering. The filenames preserve our original (sometimes duplicate) numbering, but here's the actual chronological order:*
+
+1. [Architectural Dragons](001-architectural-dragons.md) - Big challenges we see ahead
+2. [Dice Package Design](002-dice-package-design.md) - Initial dice package design
+3. [Event Participant Ecosystem](003-event-participant-ecosystem.md) - Event system architecture
+4. [Conditions System](004-conditions-system.md) - Status effects and relationships
+5. [Effect Composition](005-effect-composition.md) - Designing composable effects system
+6. [Feature Management Pattern](006-feature-management-pattern.md) - Exploring feature system patterns
+7. [Enhanced Conditions](007-enhanced-conditions.md) - Advanced condition system capabilities
+8. [Dice Roller Design](008-dice-roller-design.md) - Global vs instance-based dice patterns
+9. [Generics in Conditions](009-generics-in-conditions.md) - Type safety vs flexibility trade-offs
+10. [Generic Event Patterns](010-generic-event-patterns.md) - Event-driven restoration triggers
+11. [Spell System Design](011-spell-system-design.md) - Designing the spell casting system
+12. [Spatial Module Design](012-spatial-module-design.md) - Grid and positioning systems
+13. [Room Orchestrator Vision](013-room-orchestrator-vision.md) - Multi-room management
+14. [Factory vs Helper Patterns](014-factory-vs-helper-patterns.md) - Construction patterns
+15. [Environment Generation Design Evolution](015-environment-generation-design-evolution.md) - Procedural generation
+16. [AI Assistant Code Quality Lessons](016-ai-assistant-code-quality-lessons.md) - AI collaboration learnings
+17. [Encounter System Design](017-encounter-system-design.md) - Encounter mechanics
+18. [Content Architecture Breakthrough](018-content-architecture-breakthrough.md) - Content organization
+19. [Self-Contained Entities](019-self-contained-entities.md) - Entity independence
+20. [Extensible Registry System](020_extensible_registry_system.md) - Plugin architecture
+21. [Draft System Redesign](007-draft-system-redesign.md) - Reworking draft mechanics
+22. [Features Conditions Refactor](021-features-conditions-refactor.md) - Refactoring relationship
+23. [Event System Typed Events](022-event-system-typed-events.md) - Type-safe events
+24. [Event Bus Modifiers](014-event-bus-modifiers.md) - Event modification patterns
+25. [Event-Driven Combat Flow](040-event-driven-combat-flow.md) - Combat via events
+26. [Event Bus Generics Exploration](041-event-bus-generics-exploration.md) - Generic patterns
+27. [Event Ref Exploration](042-event-ref-exploration.md) - Event referencing patterns
+28. [Data-Driven Runtime Architecture](024-data-driven-runtime-architecture.md) - Runtime loading
+29. [Spellcasting System Design](023-spellcasting-system-design.md) - Spell mechanics
+30. [Actions Effects Architecture](043-actions-effects-architecture.md) - Action system design
+31. [Actions Internal Pattern](043-actions-internal-pattern.md) - Internal patterns
+32. [Actions Internal Pattern Clean](043-actions-internal-pattern-clean.md) - Refined approach
+33. [Tonight's Insights Summary](043-tonights-insights-summary.md) - Action insights
+34. [Rulebooks Own Pipelines](027-rulebooks-own-pipelines.md) - Rulebook responsibility
+35. [Pipelines All The Way Down](026-pipelines-all-the-way-down.md) - Pipeline philosophy
+36. [Complex DND Mechanics Pipeline](025-complex-dnd-mechanics-pipeline.md) - D&D complexity
+37. [Effect Modification Pipeline](024-effect-modification-pipeline.md) - Effect processing
+38. [Rage Implementation Lessons](023-rage-implementation-lessons.md) - Barbarian rage learnings
+39. [Event Bus Evolution](014-event-bus-evolution.md) - Event system improvements
+40. [Typed Topics Design](007-typed-topics-design.md) - Type-safe event topics
+41. [Events Carry Actions, Not Objects](044-events-carry-actions-not-objects.md) - Event philosophy breakthrough
 
 ## Document Types
 

--- a/rulebooks/dnd5e/conditions/loader.go
+++ b/rulebooks/dnd5e/conditions/loader.go
@@ -6,14 +6,16 @@ package conditions
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
 )
 
-// LoadConditionFromJSON loads a condition from its JSON representation.
+// LoadJSON loads a condition from its JSON representation.
 // This is the big switch that knows how to unmarshal each condition type.
-func LoadConditionFromJSON(data json.RawMessage) (ConditionBehavior, error) {
+func LoadJSON(data json.RawMessage) (ConditionBehavior, error) {
 	// Peek at the ref to determine condition type
 	var peek struct {
-		Ref string `json:"ref"`
+		Ref core.Ref `json:"ref"`
 	}
 
 	if err := json.Unmarshal(data, &peek); err != nil {
@@ -21,34 +23,15 @@ func LoadConditionFromJSON(data json.RawMessage) (ConditionBehavior, error) {
 	}
 
 	// Big switch for all condition types
-	switch peek.Ref {
-	case "dnd5e:conditions:raging":
+	switch peek.Ref.Value {
+	case "raging":
 		var raging RagingCondition
 		if err := json.Unmarshal(data, &raging); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal raging condition: %w", err)
 		}
+
 		return &raging, nil
-
-	// Future conditions...
-	// case "dnd5e:conditions:poisoned":
-	//     var poisoned PoisonedCondition
-	//     if err := json.Unmarshal(data, &poisoned); err != nil {
-	//         return nil, err
-	//     }
-	//     return &poisoned, nil
-
 	default:
 		return nil, fmt.Errorf("unknown condition ref: %s", peek.Ref)
-	}
-}
-
-// IsValidConditionRef checks if a ref string is a supported condition
-func IsValidConditionRef(ref string) bool {
-	switch ref {
-	case "dnd5e:conditions:raging":
-		return true
-	// Add more as we implement them
-	default:
-		return false
 	}
 }

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 )
 
@@ -46,13 +47,12 @@ func (s *RagingConditionTestSuite) TestRagingConditionTracksAttacks() {
 	s.False(raging.DidAttackThisTurn)
 
 	// Publish an attack event for this character
-	attackTopic := events.DefineTypedTopic[conditions.AttackEvent]("dnd5e.combat.attack").On(s.bus)
-	err = attackTopic.Publish(s.ctx, conditions.AttackEvent{
+	attackTopic := dnd5e.AttackTopic.On(s.bus)
+	err = attackTopic.Publish(s.ctx, dnd5e.AttackEvent{
 		AttackerID: "barbarian-1",
 		TargetID:   "goblin-1",
 		WeaponRef:  "greatsword",
 		IsMelee:    true,
-		Damage:     10,
 	})
 	s.Require().NoError(err)
 
@@ -77,8 +77,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionTracksDamage() {
 	s.False(raging.WasHitThisTurn)
 
 	// Publish a damage event for this character
-	damageTopic := events.DefineTypedTopic[conditions.DamageReceivedEvent]("dnd5e.combat.damage.received").On(s.bus)
-	err = damageTopic.Publish(s.ctx, conditions.DamageReceivedEvent{
+	damageTopic := dnd5e.DamageReceivedTopic.On(s.bus)
+	err = damageTopic.Publish(s.ctx, dnd5e.DamageReceivedEvent{
 		TargetID:   "barbarian-1",
 		SourceID:   "goblin-1",
 		Amount:     5,
@@ -113,8 +113,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsWithoutCombatActivity(
 	s.Require().NoError(err)
 
 	// Publish turn end event without any combat activity
-	turnEndTopic := events.DefineTypedTopic[conditions.TurnEndEvent]("dnd5e.turn.end").On(s.bus)
-	err = turnEndTopic.Publish(s.ctx, conditions.TurnEndEvent{
+	turnEndTopic := dnd5e.TurnEndTopic.On(s.bus)
+	err = turnEndTopic.Publish(s.ctx, dnd5e.TurnEndEvent{
 		CharacterID: "barbarian-1",
 		Round:       1,
 	})
@@ -150,19 +150,18 @@ func (s *RagingConditionTestSuite) TestRagingConditionContinuesWithCombatActivit
 	s.Require().NoError(err)
 
 	// Publish an attack event (combat activity)
-	attackTopic := events.DefineTypedTopic[conditions.AttackEvent]("dnd5e.combat.attack").On(s.bus)
-	err = attackTopic.Publish(s.ctx, conditions.AttackEvent{
+	attackTopic := dnd5e.AttackTopic.On(s.bus)
+	err = attackTopic.Publish(s.ctx, dnd5e.AttackEvent{
 		AttackerID: "barbarian-1",
 		TargetID:   "goblin-1",
 		WeaponRef:  "greatsword",
 		IsMelee:    true,
-		Damage:     10,
 	})
 	s.Require().NoError(err)
 
 	// Publish turn end event
-	turnEndTopic := events.DefineTypedTopic[conditions.TurnEndEvent]("dnd5e.turn.end").On(s.bus)
-	err = turnEndTopic.Publish(s.ctx, conditions.TurnEndEvent{
+	turnEndTopic := dnd5e.TurnEndTopic.On(s.bus)
+	err = turnEndTopic.Publish(s.ctx, dnd5e.TurnEndEvent{
 		CharacterID: "barbarian-1",
 		Round:       1,
 	})
@@ -199,23 +198,22 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 	})
 	s.Require().NoError(err)
 
-	attackTopic := events.DefineTypedTopic[conditions.AttackEvent]("dnd5e.combat.attack").On(s.bus)
-	turnEndTopic := events.DefineTypedTopic[conditions.TurnEndEvent]("dnd5e.turn.end").On(s.bus)
+	attackTopic := dnd5e.AttackTopic.On(s.bus)
+	turnEndTopic := dnd5e.TurnEndTopic.On(s.bus)
 
 	// Simulate 10 rounds of combat with attacks
 	for round := 1; round <= 10; round++ {
 		// Attack each round to keep rage active
-		err = attackTopic.Publish(s.ctx, conditions.AttackEvent{
+		err = attackTopic.Publish(s.ctx, dnd5e.AttackEvent{
 			AttackerID: "barbarian-1",
 			TargetID:   "goblin-1",
 			WeaponRef:  "greatsword",
 			IsMelee:    true,
-			Damage:     10,
 		})
 		s.Require().NoError(err)
 
 		// End turn
-		err = turnEndTopic.Publish(s.ctx, conditions.TurnEndEvent{
+		err = turnEndTopic.Publish(s.ctx, dnd5e.TurnEndEvent{
 			CharacterID: "barbarian-1",
 			Round:       round,
 		})

--- a/rulebooks/dnd5e/conditions/types.go
+++ b/rulebooks/dnd5e/conditions/types.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
 )
 
 // ConditionBehavior represents the behavior of an active condition.
@@ -20,56 +22,6 @@ type ConditionBehavior interface {
 	// ToJSON converts the condition to JSON for persistence
 	ToJSON() (json.RawMessage, error)
 }
-
-// ConditionType represents D&D 5e conditions
-type ConditionType string
-
-const (
-	// Blinded condition - creature can't see and automatically fails sight checks
-	Blinded ConditionType = "blinded"
-	// Charmed condition - creature can't attack charmer, charmer has advantage on social checks
-	Charmed ConditionType = "charmed"
-	// Deafened condition - creature can't hear and automatically fails hearing checks
-	Deafened ConditionType = "deafened"
-	// Frightened condition - creature can't willingly move closer to source of fear
-	Frightened ConditionType = "frightened"
-	// Grappled condition - creature's speed becomes 0
-	Grappled ConditionType = "grappled"
-	// Incapacitated condition - creature can't take actions or reactions
-	Incapacitated ConditionType = "incapacitated"
-	// Invisible condition - creature can't be seen without special sense
-	Invisible ConditionType = "invisible"
-	// Paralyzed condition - creature is incapacitated and can't move or speak
-	Paralyzed ConditionType = "paralyzed"
-	// Petrified condition - creature is transformed into stone
-	Petrified ConditionType = "petrified"
-	// Poisoned condition - disadvantage on attack rolls and ability checks
-	Poisoned ConditionType = "poisoned"
-	// Prone condition - creature is lying on the ground
-	Prone ConditionType = "prone"
-	// Restrained condition - creature's speed becomes 0, disadvantage on Dex saves
-	Restrained ConditionType = "restrained"
-	// Stunned condition - creature is incapacitated, can't move, and fails Str/Dex saves
-	Stunned ConditionType = "stunned"
-	// Unconscious condition - creature is incapacitated, can't move or speak, unaware
-	Unconscious ConditionType = "unconscious"
-
-	// Exhaustion1 represents exhaustion level 1 - disadvantage on ability checks
-	Exhaustion1 ConditionType = "exhaustion_1"
-	// Exhaustion2 represents exhaustion level 2 - speed halved
-	Exhaustion2 ConditionType = "exhaustion_2"
-	// Exhaustion3 represents exhaustion level 3 - disadvantage on attacks and saves
-	Exhaustion3 ConditionType = "exhaustion_3"
-	// Exhaustion4 represents exhaustion level 4 - hit point maximum halved
-	Exhaustion4 ConditionType = "exhaustion_4"
-	// Exhaustion5 represents exhaustion level 5 - speed reduced to 0
-	Exhaustion5 ConditionType = "exhaustion_5"
-	// Exhaustion6 represents exhaustion level 6 - death
-	Exhaustion6 ConditionType = "exhaustion_6"
-
-	// Raging represents the barbarian rage state - damage bonus and resistance
-	Raging ConditionType = "raging"
-)
 
 // DurationType defines how a condition's duration is tracked
 type DurationType string
@@ -89,11 +41,11 @@ const (
 
 // Condition represents an active condition on a character
 type Condition struct {
-	Type         ConditionType  `json:"type"`
-	Source       string         `json:"source,omitempty"`        // What caused this
-	SourceEntity string         `json:"source_entity,omitempty"` // Entity ID that applied it
-	Duration     string         `json:"duration,omitempty"`      // "1_hour", "until_rest", etc
-	DurationType DurationType   `json:"duration_type,omitempty"` // How duration is tracked
-	Remaining    int            `json:"remaining,omitempty"`     // Remaining duration units
-	Metadata     map[string]any `json:"metadata,omitempty"`      // Condition-specific data
+	Type         dnd5e.ConditionType `json:"type"`
+	Source       string              `json:"source,omitempty"`        // What caused this - TODO: find proper type
+	SourceEntity core.Entity         `json:"source_entity,omitempty"` // Entity that applied it
+	Duration     string              `json:"duration,omitempty"`      // "1_hour", "until_rest", etc
+	DurationType DurationType        `json:"duration_type,omitempty"` // How duration is tracked
+	Remaining    int                 `json:"remaining,omitempty"`     // Remaining duration units
+	Metadata     map[string]any      `json:"metadata,omitempty"`      // Condition-specific data
 }

--- a/rulebooks/dnd5e/events.go
+++ b/rulebooks/dnd5e/events.go
@@ -4,7 +4,58 @@
 package dnd5e
 
 import (
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+)
+
+// ConditionType represents D&D 5e conditions
+type ConditionType string
+
+const (
+	// ConditionBlinded is a condition that blinds a character
+	ConditionBlinded ConditionType = "blinded"
+	// ConditionCharmed is a condition that charms a character
+	ConditionCharmed ConditionType = "charmed"
+	// ConditionDeafened is a condition that deafens a character
+	ConditionDeafened ConditionType = "deafened"
+	// ConditionFrightened is a condition that frightens a character
+	ConditionFrightened ConditionType = "frightened"
+	// ConditionGrappled is a condition that grapples a character
+	ConditionGrappled ConditionType = "grappled"
+	// ConditionIncapacitated is a condition that incapacitates a character
+	ConditionIncapacitated ConditionType = "incapacitated"
+	// ConditionInvisible is a condition that makes a character invisible
+	ConditionInvisible ConditionType = "invisible"
+	// ConditionParalyzed is a condition that paralyzes a character
+	ConditionParalyzed ConditionType = "paralyzed"
+	// ConditionPetrified is a condition that petrifies a character
+	ConditionPetrified ConditionType = "petrified"
+	// ConditionPoisoned is a condition that poisons a character
+	ConditionPoisoned ConditionType = "poisoned"
+	// ConditionProne is a condition that makes a character prone
+	ConditionProne ConditionType = "prone"
+	// ConditionRestrained is a condition that restrains a character
+	ConditionRestrained ConditionType = "restrained"
+	// ConditionStunned is a condition that stuns a character
+	ConditionStunned ConditionType = "stunned"
+	// ConditionUnconscious is a condition that makes a character unconscious
+	ConditionUnconscious ConditionType = "unconscious"
+
+	// ConditionExhaustion1 is a condition that exhausts a character
+	ConditionExhaustion1 ConditionType = "exhaustion_1"
+	// ConditionExhaustion2 is a condition that exhausts a character
+	ConditionExhaustion2 ConditionType = "exhaustion_2"
+	// ConditionExhaustion3 is a condition that exhausts a character
+	ConditionExhaustion3 ConditionType = "exhaustion_3"
+	// ConditionExhaustion4 is a condition that exhausts a character
+	ConditionExhaustion4 ConditionType = "exhaustion_4"
+	// ConditionExhaustion5 is a condition that exhausts a character
+	ConditionExhaustion5 ConditionType = "exhaustion_5"
+	// ConditionExhaustion6 is a condition that exhausts a character
+	ConditionExhaustion6 ConditionType = "exhaustion_6"
+
+	// ConditionRaging is a class-specific condition for barbarians
+	ConditionRaging ConditionType = "raging"
 )
 
 // Event types for D&D 5e gameplay
@@ -29,6 +80,22 @@ type DamageReceivedEvent struct {
 	DamageType string // Type of damage (slashing, fire, etc)
 }
 
+// ConditionAppliedEvent is published when a condition is applied to an entity
+type ConditionAppliedEvent struct {
+	Target core.Entity   // Entity receiving the condition
+	Type   ConditionType // Type of condition being applied
+	Source string        // What caused this condition
+	Data   any           // Condition-specific data (e.g., RageData)
+}
+
+// AttackEvent is published when a character makes an attack
+type AttackEvent struct {
+	AttackerID string // ID of the attacking character
+	TargetID   string // ID of the target
+	WeaponRef  string // Reference to the weapon used
+	IsMelee    bool   // True for melee attacks, false for ranged
+}
+
 // Topic definitions for typed event system
 var (
 	// TurnStartTopic provides typed pub/sub for turn start events
@@ -39,4 +106,10 @@ var (
 
 	// DamageReceivedTopic provides typed pub/sub for damage received events
 	DamageReceivedTopic = events.DefineTypedTopic[DamageReceivedEvent]("dnd5e.combat.damage.received")
+
+	// ConditionAppliedTopic provides typed pub/sub for condition applied events
+	ConditionAppliedTopic = events.DefineTypedTopic[ConditionAppliedEvent]("dnd5e.condition.applied")
+
+	// AttackTopic provides typed pub/sub for attack events
+	AttackTopic = events.DefineTypedTopic[AttackEvent]("dnd5e.combat.attack")
 )

--- a/rulebooks/dnd5e/features/example_test.go
+++ b/rulebooks/dnd5e/features/example_test.go
@@ -1,0 +1,71 @@
+package features_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
+)
+
+// Example demonstrates how rage works with the event system
+func Example() {
+	// Create event bus for game communication
+	bus := events.NewEventBus()
+	ctx := context.Background()
+
+	// Mock barbarian character
+	barbarian := &mockCharacter{id: "conan"}
+
+	// Server has stored feature JSON
+	featureJSON := json.RawMessage(`{
+		"ref": {"value": "rage"},
+		"id": "rage",
+		"name": "Rage",
+		"level": 5,
+		"uses": 2,
+		"max_uses": 3
+	}`)
+
+	// Load the feature
+	feature, _ := features.LoadJSON(featureJSON)
+
+	// Listen for condition applications
+	topic := dnd5e.ConditionAppliedTopic.On(bus)
+	_, err := topic.Subscribe(ctx, func(_ context.Context, event dnd5e.ConditionAppliedEvent) error {
+		if event.Type == dnd5e.ConditionRaging {
+			// Type assert the data to get rage-specific info
+			if rageData, ok := event.Data.(features.RageEventData); ok {
+				fmt.Printf("%s is now raging! Damage bonus: +%d\n",
+					event.Target.GetID(),
+					rageData.DamageBonus)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		fmt.Printf("Failed to subscribe to condition applied topic: %v\n", err)
+
+		return
+	}
+
+	// Player activates rage - barbarian provides its bus
+	err = feature.Activate(ctx, barbarian, features.FeatureInput{Bus: bus})
+	if err != nil {
+		fmt.Printf("Failed to rage: %v\n", err)
+		return
+	}
+
+	// Output: conan is now raging! Damage bonus: +2
+}
+
+type mockCharacter struct {
+	id string
+}
+
+func (m *mockCharacter) GetID() string            { return m.id }
+func (m *mockCharacter) GetType() core.EntityType { return "character" }

--- a/rulebooks/dnd5e/features/loader.go
+++ b/rulebooks/dnd5e/features/loader.go
@@ -1,0 +1,38 @@
+package features
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// Feature represents a class feature that can be activated
+type Feature interface {
+	core.Action[FeatureInput] // Can be activated
+	ToJSON() (json.RawMessage, error)
+}
+
+// LoadJSON loads a feature from JSON based on its ref
+func LoadJSON(data json.RawMessage) (Feature, error) {
+	// First, extract just the ID to determine feature type
+	var metadata struct {
+		Ref core.Ref `json:"ref"`
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to extract feature ID: %w", err)
+	}
+
+	// Route based on Ref value
+	switch metadata.Ref.Value {
+	case "rage":
+		rage := &Rage{}
+		if err := rage.loadJSON(data); err != nil {
+			return nil, fmt.Errorf("failed to load rage: %w", err)
+		}
+
+		return rage, nil
+	default:
+		return nil, fmt.Errorf("unknown feature type: %s", metadata.Ref.Value)
+	}
+}

--- a/rulebooks/dnd5e/features/loader_test.go
+++ b/rulebooks/dnd5e/features/loader_test.go
@@ -1,0 +1,85 @@
+package features
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/stretchr/testify/suite"
+)
+
+type LoaderTestSuite struct {
+	suite.Suite
+	bus events.EventBus
+	ctx context.Context
+}
+
+func (s *LoaderTestSuite) SetupTest() {
+	s.bus = events.NewEventBus()
+	s.ctx = context.Background()
+}
+
+func (s *LoaderTestSuite) TestLoadRageFeature() {
+	jsonData := json.RawMessage(`{
+		"ref": {"value": "rage"},
+		"id": "rage",
+		"name": "Rage",
+		"level": 5,
+		"uses": 2,
+		"max_uses": 3
+	}`)
+
+	feature, err := LoadJSON(jsonData)
+	s.NoError(err)
+	s.NotNil(feature)
+
+	// Check it's actually a rage
+	rage, ok := feature.(*Rage)
+	s.True(ok, "Should be a Rage instance")
+	s.Equal("rage", rage.id)
+	s.Equal(5, rage.level)
+	s.Equal(2, rage.resource.Current)
+	s.Equal(3, rage.resource.Maximum)
+
+	// Test that it can be activated
+	owner := &StubEntity{id: "test-barbarian"}
+	err = feature.CanActivate(s.ctx, owner, FeatureInput{})
+	s.NoError(err)
+}
+
+func (s *LoaderTestSuite) TestLoadUnknownFeature() {
+	// Skip for now - all features are treated as rage until we have more types
+	s.T().Skip("Skipping until we have multiple feature types")
+}
+
+func (s *LoaderTestSuite) TestRoundTripThroughJSON() {
+	// Create a rage feature
+	originalRage := newRageForTest("rage-roundtrip", 7)
+
+	// Use one charge
+	owner := &StubEntity{id: "test-barbarian"}
+	err := originalRage.Activate(s.ctx, owner, FeatureInput{Bus: s.bus})
+	s.NoError(err)
+
+	// Convert to JSON
+	jsonData, err := originalRage.ToJSON()
+	s.NoError(err)
+
+	// Load it back
+	feature, err := LoadJSON(jsonData)
+	s.NoError(err)
+
+	loadedRage, ok := feature.(*Rage)
+	s.True(ok)
+
+	// Verify state was preserved
+	s.Equal(originalRage.id, loadedRage.id)
+	s.Equal(originalRage.level, loadedRage.level)
+	s.Equal(originalRage.resource.Current, loadedRage.resource.Current)
+	s.Equal(originalRage.resource.Maximum, loadedRage.resource.Maximum)
+}
+
+func TestLoaderTestSuite(t *testing.T) {
+	suite.Run(t, new(LoaderTestSuite))
+}

--- a/rulebooks/dnd5e/features/rage.go
+++ b/rulebooks/dnd5e/features/rage.go
@@ -1,0 +1,168 @@
+// Package features provides D&D 5e class features implementation
+package features
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/mechanics/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
+)
+
+// RageEventData contains rage-specific data for the ConditionAppliedEvent
+type RageEventData struct {
+	DamageBonus int `json:"damage_bonus"`
+	Level       int `json:"level"`
+}
+
+// Rage represents the barbarian rage feature.
+// It implements core.Action[FeatureInput] for activation.
+type Rage struct {
+	id       string
+	name     string
+	level    int                 // Barbarian level for determining damage bonus
+	resource *resources.Resource // Tracks rage uses
+}
+
+// RageData is the JSON structure for persisting rage state
+type RageData struct {
+	Ref     core.Ref `json:"ref"`
+	ID      string   `json:"id"` // do we need this with ref?
+	Name    string   `json:"name"`
+	Level   int      `json:"level"`
+	Uses    int      `json:"uses"`
+	MaxUses int      `json:"max_uses"`
+}
+
+// calculateRageUses determines max rage uses based on barbarian level
+func calculateRageUses(level int) int {
+	switch {
+	case level < 3:
+		return 2
+	case level < 6:
+		return 3
+	case level < 12:
+		return 4
+	case level < 17:
+		return 5
+	case level < 20:
+		return 6
+	default:
+		return -1 // Unlimited at level 20
+	}
+}
+
+// calculateRageDamage determines rage damage bonus based on barbarian level
+func calculateRageDamage(level int) int {
+	switch {
+	case level < 9:
+		return 2
+	case level < 16:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// GetID implements core.Entity
+func (r *Rage) GetID() string {
+	return r.id
+}
+
+// GetType implements core.Entity
+func (r *Rage) GetType() core.EntityType {
+	return "feature"
+}
+
+// CanActivate implements core.Action[FeatureInput]
+func (r *Rage) CanActivate(_ context.Context, _ core.Entity, _ FeatureInput) error {
+	// At level 20, barbarians have unlimited rages
+	if r.level >= 20 {
+		return nil
+	}
+
+	// Check if we have uses remaining
+	if !r.resource.IsAvailable() {
+		return fmt.Errorf("no rage uses remaining")
+	}
+
+	return nil
+}
+
+// Activate implements core.Action[FeatureInput]
+func (r *Rage) Activate(ctx context.Context, owner core.Entity, input FeatureInput) error {
+	// Check if we can activate
+	if err := r.CanActivate(ctx, owner, input); err != nil {
+		return err
+	}
+
+	// Consume a use (unless level 20)
+	if r.level < 20 {
+		if err := r.resource.Use(1); err != nil {
+			return fmt.Errorf("failed to use rage: %w", err)
+		}
+	}
+
+	// Publish condition applied event
+	if input.Bus != nil {
+		topic := dnd5e.ConditionAppliedTopic.On(input.Bus)
+		err := topic.Publish(ctx, dnd5e.ConditionAppliedEvent{
+			Target: owner,
+			Type:   dnd5e.ConditionRaging,
+			Source: r.id,
+			Data: RageEventData{
+				DamageBonus: calculateRageDamage(r.level),
+				Level:       r.level,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to publish rage condition: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// loadJSON loads rage state from JSON
+func (r *Rage) loadJSON(data json.RawMessage) error {
+	var rageData RageData
+	if err := json.Unmarshal(data, &rageData); err != nil {
+		return fmt.Errorf("failed to unmarshal rage data: %w", err)
+	}
+
+	r.id = rageData.ID
+	r.name = rageData.Name
+	r.level = rageData.Level
+
+	// Set up resource with current and max uses
+	r.resource = resources.NewResource("rage", rageData.MaxUses)
+	r.resource.SetCurrent(rageData.Uses)
+
+	return nil
+}
+
+// ToJSON converts rage to JSON for persistence
+func (r *Rage) ToJSON() (json.RawMessage, error) {
+	data := RageData{
+		Ref:     core.Ref{Value: "rage"},
+		ID:      r.id,
+		Name:    r.name,
+		Level:   r.level,
+		Uses:    r.resource.Current,
+		MaxUses: r.resource.Maximum,
+	}
+
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal rage data: %w", err)
+	}
+
+	return bytes, nil
+}
+
+// RestoreOnLongRest restores all rage uses on a long rest
+func (r *Rage) RestoreOnLongRest() {
+	r.resource.RestoreToFull()
+}

--- a/rulebooks/dnd5e/features/rage.go
+++ b/rulebooks/dnd5e/features/rage.go
@@ -29,7 +29,7 @@ type Rage struct {
 // RageData is the JSON structure for persisting rage state
 type RageData struct {
 	Ref     core.Ref `json:"ref"`
-	ID      string   `json:"id"` // do we need this with ref?
+	ID      string   `json:"id"`
 	Name    string   `json:"name"`
 	Level   int      `json:"level"`
 	Uses    int      `json:"uses"`

--- a/rulebooks/dnd5e/features/rage_test.go
+++ b/rulebooks/dnd5e/features/rage_test.go
@@ -1,0 +1,188 @@
+package features
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/mechanics/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
+	"github.com/stretchr/testify/suite"
+)
+
+type RageTestSuite struct {
+	suite.Suite
+	bus  events.EventBus
+	rage *Rage
+	ctx  context.Context
+}
+
+// StubEntity implements core.Entity for testing
+type StubEntity struct {
+	id string
+}
+
+func (m *StubEntity) GetID() string            { return m.id }
+func (m *StubEntity) GetType() core.EntityType { return "character" }
+
+// newRageForTest creates a rage feature for testing
+func newRageForTest(id string, level int) *Rage {
+	maxUses := calculateRageUses(level)
+	return &Rage{
+		id:       id,
+		name:     "Rage",
+		level:    level,
+		resource: resources.NewResource("rage", maxUses),
+	}
+}
+
+func (s *RageTestSuite) SetupTest() {
+	s.bus = events.NewEventBus()
+	s.rage = newRageForTest("rage-feature", 3) // Level 3 barbarian
+	s.ctx = context.Background()
+}
+
+func (s *RageTestSuite) TestCanActivate() {
+	owner := &StubEntity{id: "barbarian-1"}
+
+	// Should be able to activate with uses available
+	err := s.rage.CanActivate(s.ctx, owner, FeatureInput{})
+	s.NoError(err)
+
+	// Use up all rages
+	for i := 0; i < 3; i++ {
+		err = s.rage.Activate(s.ctx, owner, FeatureInput{Bus: s.bus})
+		s.NoError(err)
+	}
+
+	// Should not be able to activate with no uses
+	err = s.rage.CanActivate(s.ctx, owner, FeatureInput{})
+	s.Error(err)
+	s.Contains(err.Error(), "no rage uses remaining")
+}
+
+func (s *RageTestSuite) TestActivatePublishesCondition() {
+	owner := &StubEntity{id: "barbarian-1"}
+
+	// Track if condition was published
+	var receivedEvent *dnd5e.ConditionAppliedEvent
+	topic := dnd5e.ConditionAppliedTopic.On(s.bus)
+	_, err := topic.Subscribe(s.ctx, func(_ context.Context, event dnd5e.ConditionAppliedEvent) error {
+		receivedEvent = &event
+		return nil
+	})
+	s.NoError(err)
+
+	// Activate rage
+	err = s.rage.Activate(s.ctx, owner, FeatureInput{Bus: s.bus})
+	s.NoError(err)
+
+	// Check that event was published
+	s.NotNil(receivedEvent)
+	s.Equal(owner, receivedEvent.Target)
+	s.Equal(dnd5e.ConditionRaging, receivedEvent.Type)
+	s.Equal("rage-feature", receivedEvent.Source)
+
+	// Check rage data
+	rageData, ok := receivedEvent.Data.(RageEventData)
+	s.True(ok, "Event data should be RageEventData")
+	s.Equal(2, rageData.DamageBonus) // Level 3 = +2 damage
+	s.Equal(3, rageData.Level)
+}
+
+func (s *RageTestSuite) TestRageUsesPerLevel() {
+	testCases := []struct {
+		level    int
+		expected int
+	}{
+		{1, 2},
+		{2, 2},
+		{3, 3},
+		{5, 3},
+		{6, 4},
+		{11, 4},
+		{12, 5},
+		{16, 5},
+		{17, 6},
+		{19, 6},
+		{20, -1}, // Unlimited
+	}
+
+	for _, tc := range testCases {
+		actual := calculateRageUses(tc.level)
+		s.Equal(tc.expected, actual, "Level %d should have %d rage uses", tc.level, tc.expected)
+	}
+}
+
+func (s *RageTestSuite) TestRageDamagePerLevel() {
+	testCases := []struct {
+		level    int
+		expected int
+	}{
+		{1, 2},
+		{8, 2},
+		{9, 3},
+		{15, 3},
+		{16, 4},
+		{20, 4},
+	}
+
+	for _, tc := range testCases {
+		actual := calculateRageDamage(tc.level)
+		s.Equal(tc.expected, actual, "Level %d should have +%d rage damage", tc.level, tc.expected)
+	}
+}
+
+func (s *RageTestSuite) TestUnlimitedRagesAtLevel20() {
+	owner := &StubEntity{id: "barbarian-1"}
+	rage20 := newRageForTest("epic-rage", 20)
+
+	// Should be able to activate many times
+	for i := 0; i < 10; i++ {
+		err := rage20.CanActivate(s.ctx, owner, FeatureInput{})
+		s.NoError(err, "Level 20 barbarian should have unlimited rages")
+
+		err = rage20.Activate(s.ctx, owner, FeatureInput{Bus: s.bus})
+		s.NoError(err)
+	}
+}
+
+func (s *RageTestSuite) TestLoadJSON() {
+	jsonData := []byte(`{
+		"ref": {"value": "rage"},
+		"id": "loaded-rage",
+		"name": "Rage",
+		"level": 5,
+		"uses": 1,
+		"max_uses": 3
+	}`)
+
+	rage := &Rage{}
+	err := rage.loadJSON(jsonData)
+	s.NoError(err)
+
+	s.Equal("loaded-rage", rage.id)
+	s.Equal("Rage", rage.name)
+	s.Equal(5, rage.level)
+	s.Equal(1, rage.resource.Current)
+	s.Equal(3, rage.resource.Maximum)
+}
+
+func (s *RageTestSuite) TestToJSON() {
+	jsonData, err := s.rage.ToJSON()
+	s.NoError(err)
+
+	// Load it back
+	loaded := &Rage{}
+	err = loaded.loadJSON(jsonData)
+	s.NoError(err)
+
+	s.Equal(s.rage.id, loaded.id)
+	s.Equal(s.rage.name, loaded.name)
+	s.Equal(s.rage.level, loaded.level)
+}
+
+func TestRageTestSuite(t *testing.T) {
+	suite.Run(t, new(RageTestSuite))
+}

--- a/rulebooks/dnd5e/features/types.go
+++ b/rulebooks/dnd5e/features/types.go
@@ -1,0 +1,14 @@
+// Package features provides D&D 5e class features implementation
+package features
+
+import "github.com/KirkDiggler/rpg-toolkit/events"
+
+// FeatureInput provides input data for feature activation.
+// Most features need no input (rage, second wind, etc).
+// Some features will need choices (wild shape forms, channel divinity options).
+type FeatureInput struct {
+	// Bus is provided by the character/owner during activation
+	Bus events.EventBus `json:"-"`
+
+	// Possible Future: Choice string `json:"choice,omitempty"` for features with options
+}

--- a/rulebooks/dnd5e/go.mod
+++ b/rulebooks/dnd5e/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.9.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.0
+	github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.2

--- a/rulebooks/dnd5e/go.sum
+++ b/rulebooks/dnd5e/go.sum
@@ -4,6 +4,8 @@ github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059 h1:
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.0 h1:7tAo5ddnaBk2nLeLY3wwa5zVx93ntA5FOgi+NNF4rmk=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.0/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
+github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/Gqy96ZvuZ6Wc/Zl3whhBLbFGWnQY=
+github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This pull request introduces several significant improvements to the D&D 5e conditions system, focusing on decoupling event types, reducing circular dependencies, and making event handling more idiomatic and maintainable. The main changes include refactoring events to carry actions rather than full objects, centralizing event type definitions, updating the loader and condition logic, and enhancing test coverage to use the new event patterns.

**Event System Refactor and Decoupling:**

- Events now carry only action data (such as type and minimal context) instead of full condition objects, following a discriminated union pattern with a `Type` field and a type-asserted `Data` field. This eliminates circular dependencies between features and conditions, clarifies event intent, and enables future extensibility.

- Event type definitions (`AttackEvent`, `DamageReceivedEvent`, `TurnEndEvent`, etc.) have been moved out of the conditions package and are now referenced via the `dnd5e` package, ensuring a single source of truth and preventing duplicate or circular definitions.

**Condition Loader and Behavior Updates:**

- The `LoadConditionFromJSON` function is renamed to `LoadJSON`, and now uses `core.Ref` for type discrimination, switching on `peek.Ref.Value` for condition type resolution. This makes the loader more robust and aligned with the new event architecture.

- The `RagingCondition` now subscribes to events using typed topics from the `dnd5e` package, and unsubscribes cleanly from all registered events on removal. It also adds a new subscription to `ConditionAppliedEvent` to handle ending rage when the unconscious condition is applied. [[1]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L76-R97) [[2]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803R182-R201)

**Test Suite Modernization:**

- All tests for `RagingCondition` have been updated to use the new event types and topics from the `dnd5e` package, ensuring consistency with the refactored event system and validating the new event-driven architecture. [[1]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3R13) [[2]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L49-L55) [[3]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L80-R81) [[4]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L116-R117) [[5]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L153-R164) [[6]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L202-R216)

**Documentation and Project Organization:**

- Added a new journey document, "Events Carry Actions, Not Objects," explaining the rationale and process behind the event system refactor.
- Updated the journey README to provide a clear, chronological list of architectural journey documents, including the new event system philosophy.

These changes collectively result in a cleaner, more maintainable, and extensible event-driven architecture for D&D 5e conditions.

---

**Event System Refactor:**
- Events now carry only action data (not full objects), using a discriminated union pattern for clarity and extensibility.
- Centralized event type definitions in the `dnd5e` package to eliminate duplication and circular dependencies.

**Condition Loader and Behavior:**
- Refactored condition loader to use `core.Ref` and switch on `peek.Ref.Value`; renamed to `LoadJSON`.
- `RagingCondition` now subscribes/unsubscribes to events via `dnd5e` topics and handles ending rage on unconscious condition. [[1]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L76-R97) [[2]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803R182-R201)

**Testing and Documentation:**
- Updated all `RagingCondition` tests to use new event types/topics from `dnd5e`. [[1]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3R13) [[2]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L49-L55) [[3]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L80-R81) [[4]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L116-R117) [[5]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L153-R164) [[6]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L202-R216)
- Added a journey document explaining the new event philosophy and updated the journey README for clarity. [[1]](diffhunk://#diff-4e515159489c5d16983f257a6980d366c853afdffbaf5a1d10d5402d39154248R1-R105) [[2]](diffhunk://#diff-280336c5ed8352b6d314e0d97f2867b902a0b9ef587b5a94deea31b85f0bb533L16-R60)