### PR TITLE
[rulebook-dnd5e] Move condition events to events

### DIFF
--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -739,10 +739,6 @@ func (d *Draft) compileInventory() []InventoryItem {
 		}
 	}
 
-	// Add starting equipment from background grants
-	// TODO: Backgrounds don't currently have starting equipment in grants
-	// This would be added when background equipment is implemented
-
 	// Add equipment from choices (user selections)
 	for _, choice := range d.choices {
 		if choice.Category == shared.ChoiceEquipment {
@@ -760,9 +756,6 @@ func (d *Draft) compileInventory() []InventoryItem {
 			}
 		}
 	}
-
-	// Note: Packs are automatically expanded by equipment.GetByID
-	// It returns the pack as an Equipment item, which can be expanded later if needed
 
 	return inventory
 }

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2024 Kirk Diggler
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package conditions_test
+package conditions
 
 import (
 	"context"
@@ -11,8 +11,25 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 )
+
+// ragingConditionInput provides configuration for creating a raging condition
+type ragingConditionInput struct {
+	CharacterID string // ID of the raging character
+	DamageBonus int    // Bonus damage for rage
+	Level       int    // Barbarian level
+	Source      string // What triggered this (feature ID)
+}
+
+// newRagingCondition creates a raging condition from input
+func newRagingCondition(input ragingConditionInput) *RagingCondition {
+	return &RagingCondition{
+		CharacterID: input.CharacterID,
+		DamageBonus: input.DamageBonus,
+		Level:       input.Level,
+		Source:      input.Source,
+	}
+}
 
 // RagingConditionTestSuite tests the RagingCondition behavior
 type RagingConditionTestSuite struct {
@@ -32,7 +49,7 @@ func TestRagingConditionTestSuite(t *testing.T) {
 
 func (s *RagingConditionTestSuite) TestRagingConditionTracksAttacks() {
 	// Create a raging condition
-	raging := conditions.NewRagingCondition(conditions.RagingConditionInput{
+	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
 		Level:       5,
@@ -62,7 +79,7 @@ func (s *RagingConditionTestSuite) TestRagingConditionTracksAttacks() {
 
 func (s *RagingConditionTestSuite) TestRagingConditionTracksDamage() {
 	// Create a raging condition
-	raging := conditions.NewRagingCondition(conditions.RagingConditionInput{
+	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
 		Level:       5,
@@ -92,7 +109,7 @@ func (s *RagingConditionTestSuite) TestRagingConditionTracksDamage() {
 
 func (s *RagingConditionTestSuite) TestRagingConditionEndsWithoutCombatActivity() {
 	// Create a raging condition
-	raging := conditions.NewRagingCondition(conditions.RagingConditionInput{
+	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
 		Level:       5,
@@ -104,9 +121,9 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsWithoutCombatActivity(
 	s.Require().NoError(err)
 
 	// Track if condition removed event is published
-	var removedEvent *conditions.ConditionRemovedEvent
-	removalTopic := events.DefineTypedTopic[conditions.ConditionRemovedEvent]("dnd5e.condition.removed").On(s.bus)
-	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event conditions.ConditionRemovedEvent) error {
+	var removedEvent *dnd5e.ConditionRemovedEvent
+	removalTopic := dnd5e.ConditionRemovedTopic.On(s.bus)
+	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event dnd5e.ConditionRemovedEvent) error {
 		removedEvent = &event
 		return nil
 	})
@@ -129,7 +146,7 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsWithoutCombatActivity(
 
 func (s *RagingConditionTestSuite) TestRagingConditionContinuesWithCombatActivity() {
 	// Create a raging condition
-	raging := conditions.NewRagingCondition(conditions.RagingConditionInput{
+	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
 		Level:       5,
@@ -141,9 +158,9 @@ func (s *RagingConditionTestSuite) TestRagingConditionContinuesWithCombatActivit
 	s.Require().NoError(err)
 
 	// Track if condition removed event is published
-	var removedEvent *conditions.ConditionRemovedEvent
-	removalTopic := events.DefineTypedTopic[conditions.ConditionRemovedEvent]("dnd5e.condition.removed").On(s.bus)
-	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event conditions.ConditionRemovedEvent) error {
+	var removedEvent *dnd5e.ConditionRemovedEvent
+	removalTopic := dnd5e.ConditionRemovedTopic.On(s.bus)
+	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event dnd5e.ConditionRemovedEvent) error {
 		removedEvent = &event
 		return nil
 	})
@@ -178,7 +195,7 @@ func (s *RagingConditionTestSuite) TestRagingConditionContinuesWithCombatActivit
 
 func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 	// Create a raging condition
-	raging := conditions.NewRagingCondition(conditions.RagingConditionInput{
+	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
 		Level:       5,
@@ -190,9 +207,9 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 	s.Require().NoError(err)
 
 	// Track if condition removed event is published
-	var removedEvent *conditions.ConditionRemovedEvent
-	removalTopic := events.DefineTypedTopic[conditions.ConditionRemovedEvent]("dnd5e.condition.removed").On(s.bus)
-	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event conditions.ConditionRemovedEvent) error {
+	var removedEvent *dnd5e.ConditionRemovedEvent
+	removalTopic := dnd5e.ConditionRemovedTopic.On(s.bus)
+	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event dnd5e.ConditionRemovedEvent) error {
 		removedEvent = &event
 		return nil
 	})

--- a/rulebooks/dnd5e/events.go
+++ b/rulebooks/dnd5e/events.go
@@ -88,6 +88,13 @@ type ConditionAppliedEvent struct {
 	Data   any           // Condition-specific data (e.g., RageData)
 }
 
+// ConditionRemovedEvent is published when a condition ends
+type ConditionRemovedEvent struct {
+	CharacterID  string
+	ConditionRef string
+	Reason       string
+}
+
 // AttackEvent is published when a character makes an attack
 type AttackEvent struct {
 	AttackerID string // ID of the attacking character
@@ -109,6 +116,9 @@ var (
 
 	// ConditionAppliedTopic provides typed pub/sub for condition applied events
 	ConditionAppliedTopic = events.DefineTypedTopic[ConditionAppliedEvent]("dnd5e.condition.applied")
+
+	// ConditionRemovedTopic provides typed pub/sub for condition removed events
+	ConditionRemovedTopic = events.DefineTypedTopic[ConditionRemovedEvent]("dnd5e.condition.removed")
 
 	// AttackTopic provides typed pub/sub for attack events
 	AttackTopic = events.DefineTypedTopic[AttackEvent]("dnd5e.combat.attack")


### PR DESCRIPTION
This pull request refactors how the "Raging" condition and its related events are handled in the D&D 5e rulebook implementation. The main focus is on consolidating event types and topics for condition removal, cleaning up the code, and improving test organization. It also removes outdated comments and unused code.

**Event handling and code organization improvements:**

* Moved the `ConditionRemovedEvent` type and its associated event topic (`ConditionRemovedTopic`) from `raging.go` to `events.go`, centralizing event definitions for better maintainability. All references to condition removal events in `raging.go` now use the shared definition from `events.go`. [[1]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L14-L28) [[2]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L148-R134) [[3]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L163-R149) [[4]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L188-R174) [[5]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L201-L210) [[6]](diffhunk://#diff-353bafad50fe82e1b20c1f88b0f0b633ffb721edccb7822d5621926b81532dc3R91-R97) [[7]](diffhunk://#diff-353bafad50fe82e1b20c1f88b0f0b633ffb721edccb7822d5621926b81532dc3R120-R122)

* Removed the local `ConditionRemovedEvent`, `RagingConditionInput`, and `NewRagingCondition` definitions from `raging.go`, and replaced them with test-local equivalents in `raging_test.go` to keep production code clean. [[1]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L14-L28) [[2]](diffhunk://#diff-7cced6631ce0d01613e10e656d5ae6574024c6dabea65afaf5d791dc021ae803L201-L210) [[3]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L14-R33)

**Test improvements and refactoring:**

* Changed the test package for `raging_test.go` from `conditions_test` to `conditions` to allow direct access to unexported identifiers, and replaced usage of the removed constructor with a test-local version. Updated tests to use the centralized event type and topic. [[1]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L4-R4) [[2]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L14-R33) [[3]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L35-R52) [[4]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L65-R82) [[5]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L95-R112) [[6]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L107-R126) [[7]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L132-R149) [[8]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L144-R163) [[9]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L181-R198) [[10]](diffhunk://#diff-899fae6d5de5cad88f438db1ccd16c087d42f14a795cb48b3b5653f0aef6edc3L193-R212)

**Minor code cleanup:**

* Removed outdated or now-irrelevant comments from `draft.go` related to background equipment and equipment packs, streamlining the inventory compilation logic. [[1]](diffhunk://#diff-bd0a5ba07658e14f984fc2605b800001554a537954c76e9104b0780d4bc39e38L742-L745) [[2]](diffhunk://#diff-bd0a5ba07658e14f984fc2605b800001554a537954c76e9104b0780d4bc39e38L764-L766)