### PR TITLE
Add TargetAC field to combat.AttackResult

### DIFF
--- a/rulebooks/dnd5e/combat/attack.go
+++ b/rulebooks/dnd5e/combat/attack.go
@@ -87,6 +87,7 @@ type AttackResult struct {
 	AttackRoll      int  // The d20 roll
 	AttackBonus     int  // Total bonus applied
 	TotalAttack     int  // Roll + bonus
+	TargetAC        int  // Target's armor class
 	Hit             bool // Did the attack hit?
 	Critical        bool // Was it a critical hit?
 	IsNaturalTwenty bool // Natural 20
@@ -115,6 +116,7 @@ func ResolveAttack(ctx context.Context, input *AttackInput) (*AttackResult, erro
 
 	result := &AttackResult{
 		DamageType: string(input.Weapon.DamageType),
+		TargetAC:   input.DefenderAC,
 	}
 
 	// Step 1: Publish AttackEvent (before any rolls)


### PR DESCRIPTION
Expose the target's AC in attack results so API layers can display it. Previously DefenderAC was only used internally for hit/miss calculation.

Changes:
- Add TargetAC field to AttackResult struct
- Populate from input.DefenderAC in ResolveAttack
- All existing tests pass

Related: rpg-api#239

🤖 Generated with [Claude Code](https://claude.com/claude-code)