### PR TITLE
refactor(spatial): Rename HexOrientation to HexFlatTop for clarity

### DIFF
--- a/tools/spatial/data_test.go
+++ b/tools/spatial/data_test.go
@@ -407,8 +407,8 @@ func (s *RoomDataTestSuite) TestSpatialPropertiesPreserved() {
 	s.True(blocked, "Dragon should block line of sight")
 }
 
-// TestHexOrientationPersistence tests that hex orientation is properly persisted and loaded
-func (s *RoomDataTestSuite) TestHexOrientationPersistence() {
+// TestHexFlatTopPersistence tests that hex orientation is properly persisted and loaded
+func (s *RoomDataTestSuite) TestHexFlatTopPersistence() {
 	// Helper function to test hex orientation persistence
 	testHexOrientation := func(roomID, roomType string, width, height int, pointyTop bool, label string) {
 		// Create hex room with specified orientation
@@ -428,8 +428,8 @@ func (s *RoomDataTestSuite) TestHexOrientationPersistence() {
 
 		// Verify hex orientation is captured
 		s.Equal("hex", data.GridType)
-		s.Require().NotNil(data.HexOrientation)
-		s.Equal(pointyTop, *data.HexOrientation)
+		// HexFlatTop is opposite of pointyTop
+		s.Equal(!pointyTop, data.HexFlatTop)
 
 		// Load from data
 		gameCtx, err := game.NewContext(s.eventBus, data)
@@ -453,15 +453,15 @@ func (s *RoomDataTestSuite) TestHexOrientationPersistence() {
 		testHexOrientation("flat-hex", "campaign", 6, 6, false, "Loaded grid should be flat-top")
 	})
 
-	s.Run("legacy hex grid defaults to pointy-top", func() {
-		// Create room data without hex orientation (legacy format)
+	s.Run("hex grid defaults to pointy-top", func() {
+		// Create room data without HexFlatTop set (defaults to false = pointy-top)
 		roomData := RoomData{
-			ID:       "legacy-hex",
+			ID:       "default-hex",
 			Type:     "dungeon",
 			Width:    10,
 			Height:   10,
 			GridType: "hex",
-			// HexOrientation is nil (legacy)
+			// HexFlatTop omitted, defaults to false (pointy-top)
 		}
 
 		// Load from data
@@ -475,10 +475,10 @@ func (s *RoomDataTestSuite) TestHexOrientationPersistence() {
 		s.Equal(GridShapeHex, grid.GetShape())
 		hexGrid, ok := grid.(*HexGrid)
 		s.Require().True(ok)
-		s.True(hexGrid.GetOrientation(), "Legacy hex grid should default to pointy-top for D&D 5e")
+		s.True(hexGrid.GetOrientation(), "Hex grid should default to pointy-top")
 	})
 
-	s.Run("non-hex grids don't have orientation", func() {
+	s.Run("non-hex grids don't have HexFlatTop set", func() {
 		// Create square room
 		room := NewBasicRoom(BasicRoomConfig{
 			ID:   "square-room",
@@ -493,8 +493,8 @@ func (s *RoomDataTestSuite) TestHexOrientationPersistence() {
 		// Convert to data
 		data := room.ToData()
 
-		// Verify no hex orientation for square grid
+		// Verify HexFlatTop is false (default) for non-hex grids
 		s.Equal("square", data.GridType)
-		s.Nil(data.HexOrientation)
+		s.False(data.HexFlatTop)
 	})
 }


### PR DESCRIPTION
## Summary

Refactors the hex orientation field to use clearer naming and simpler semantics, removing the confusing pointer and misleading D&D 5e references.

## Problem

The current `HexOrientation *bool` field has several issues:
1. **Confusing semantics**: What does `true` mean? Pointy? Flat?
2. **Pointer complexity**: Requires nil checks and has panic risk from blind dereferencing  
3. **Misleading comments**: References "D&D 5e compatibility" but D&D 5e uses square grids, not hex!

## Solution

Rename to `HexFlatTop bool` with clear semantics:
- `false` (zero value) = pointy-top (default)
- `true` = flat-top
- No pointer, no nil checks, no confusion

## Changes

### Field Rename
- `HexOrientation *bool` → `HexFlatTop bool`
- JSON field: `hex_orientation` → `hex_flat_top`

### Logic Updates
- `ToData()`: Inverts `HexGrid.GetOrientation()` to store as HexFlatTop
- `LoadRoomFromContext()`: Inverts HexFlatTop when creating HexGrid
- Removed all misleading "D&D 5e compatibility" comments about hex orientation

### Test Updates
- Renamed `TestHexOrientationPersistence` → `TestHexFlatTopPersistence`
- Updated all assertions to use `data.HexFlatTop` instead of `*data.HexOrientation`
- Simplified "legacy" test to just verify default behavior

## Breaking Change

**JSON field renamed**: `hex_orientation` → `hex_flat_top`

**Migration**: Invert the boolean value
```
Before: { "hex_orientation": true }  // pointy-top
After:  { "hex_flat_top": false }    // pointy-top

Before: { "hex_orientation": false }  // flat-top  
After:  { "hex_flat_top": true }      // flat-top
```

## Benefits

✅ Crystal clear what the field means  
✅ Simpler code (no pointers, no nil checks)  
✅ Safer (no panic risk from dereferencing)  
✅ Removed misleading D&D 5e comments  

🤖 Generated with [Claude Code](https://claude.com/claude-code)