### PR TITLE
feat(barbarian): implement Brutal Critical condition (#349)

### DIFF
--- a/docs/journey/046-feature-implementation-workflows.md
+++ b/docs/journey/046-feature-implementation-workflows.md
@@ -1,0 +1,383 @@
+# Journey 046: Feature Implementation Workflows
+
+## The Context
+
+We've proven the event bus architecture works with the Rage feature. A barbarian can rage, the raging condition subscribes to the damage chain, and we see the +2 damage bonus appearing in the combat breakdown. The pattern is validated.
+
+Now we need to systematically implement class features. This document establishes workflows for adding features to the toolkit, using Rage as the proven template.
+
+## The Architecture (What We Proved Works)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        EVENT BUS                                     │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  TypedTopics (notifications)      ChainedTopics (modifiers)         │
+│  ├── AttackTopic                  ├── AttackChain                   │
+│  ├── DamageReceivedTopic          └── DamageChain                   │
+│  ├── TurnStartTopic                                                 │
+│  ├── TurnEndTopic                                                   │
+│  ├── ConditionAppliedTopic                                          │
+│  └── ConditionRemovedTopic                                          │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+
+Feature.Activate()
+    └── Publishes ConditionAppliedEvent
+        └── Condition.Apply(bus) subscribes to:
+            ├── TypedTopics (track state, end conditions)
+            └── ChainedTopics (add modifiers at appropriate stage)
+                    │
+                    ▼
+            ┌──────────────────────────────────────┐
+            │       ModifierStages (order)         │
+            │  1. StageBase       - dice, ability  │
+            │  2. StageFeatures   - rage, sneak    │
+            │  3. StageConditions - bless, bane    │
+            │  4. StageEquipment  - magic items    │
+            │  5. StageFinal      - resistance     │
+            └──────────────────────────────────────┘
+```
+
+## The Decision Tree
+
+When adding a new game mechanic, ask:
+
+```
+Does it MODIFY a roll or damage?
+├── YES → Use a ChainedTopic (AttackChain or DamageChain)
+│         └── Subscribe with SubscribeWithChain()
+│             └── Add modifier at appropriate stage
+│
+└── NO → Does it need to TRACK state or TRIGGER on events?
+         ├── YES → Use TypedTopics (Subscribe())
+         │         └── Track turns, hits, etc.
+         │
+         └── NO → Is it a ONE-SHOT effect?
+                  └── Just publish event, don't subscribe
+```
+
+## Workflow 1: Adding a Damage Modifier
+
+**Examples:** Rage (+2 damage), Sneak Attack (+Xd6), Divine Smite (+2d8)
+
+### Step 1: Add DamageSourceType constant
+File: `rulebooks/dnd5e/combat/attack.go`
+
+```go
+const (
+    DamageSourceWeapon      DamageSourceType = "weapon"
+    DamageSourceAbility     DamageSourceType = "ability"
+    DamageSourceRage        DamageSourceType = "rage"
+    DamageSourceSneakAttack DamageSourceType = "sneak_attack"  // ADD NEW
+)
+```
+
+### Step 2: Create the Condition
+File: `rulebooks/dnd5e/conditions/<name>.go`
+
+```go
+type SneakAttackCondition struct {
+    CharacterID     string
+    DamageDice      string  // e.g., "3d6"
+    subscriptionIDs []string
+    bus             events.EventBus
+}
+
+// Implement ConditionBehavior interface
+func (s *SneakAttackCondition) Apply(ctx context.Context, bus events.EventBus) error {
+    s.bus = bus
+
+    // Subscribe to damage chain
+    damageChain := combat.DamageChain.On(bus)
+    subID, err := damageChain.SubscribeWithChain(ctx, s.onDamageChain)
+    if err != nil {
+        return err
+    }
+    s.subscriptionIDs = append(s.subscriptionIDs, subID)
+
+    return nil
+}
+
+func (s *SneakAttackCondition) onDamageChain(
+    ctx context.Context,
+    event *combat.DamageChainEvent,
+    c chain.Chain[*combat.DamageChainEvent],
+) (chain.Chain[*combat.DamageChainEvent], error) {
+    // Only add if we're the attacker
+    if event.AttackerID != s.CharacterID {
+        return c, nil
+    }
+
+    // Add modifier at StageFeatures
+    modifyDamage := func(_ context.Context, e *combat.DamageChainEvent) (*combat.DamageChainEvent, error) {
+        // Roll sneak attack dice...
+        e.Components = append(e.Components, combat.DamageComponent{
+            Source:     combat.DamageSourceSneakAttack,
+            FlatBonus:  0,
+            FinalDiceRolls: diceRolls,
+            DamageType: e.DamageType,
+        })
+        return e, nil
+    }
+
+    return c.Add(dnd5e.StageFeatures, "sneak_attack", modifyDamage)
+}
+```
+
+### Step 3: Create the Feature (if activatable)
+File: `rulebooks/dnd5e/features/<name>.go`
+
+```go
+type SneakAttack struct {
+    level int  // Determines dice count
+}
+
+func (s *SneakAttack) Activate(ctx context.Context, owner core.Entity, input FeatureInput) error {
+    condition := &conditions.SneakAttackCondition{
+        CharacterID: owner.GetID(),
+        DamageDice:  s.calculateDice(),
+    }
+
+    // Publish condition
+    topic := dnd5eEvents.ConditionAppliedTopic.On(input.Bus)
+    return topic.Publish(ctx, dnd5eEvents.ConditionAppliedEvent{
+        Target:    owner,
+        Type:      dnd5eEvents.ConditionSneakAttack,
+        Condition: condition,
+    })
+}
+```
+
+## Workflow 2: Adding an Attack Roll Modifier
+
+**Examples:** Bless (+1d4), Bane (-1d4), Prone (disadvantage on ranged)
+
+### The Pattern
+
+Subscribe to `AttackChain` instead of `DamageChain`:
+
+```go
+func (b *BlessedCondition) Apply(ctx context.Context, bus events.EventBus) error {
+    attackChain := combat.AttackChain.On(bus)
+    subID, err := attackChain.SubscribeWithChain(ctx, b.onAttackChain)
+    // ...
+}
+
+func (b *BlessedCondition) onAttackChain(
+    ctx context.Context,
+    event AttackChainEvent,
+    c chain.Chain[AttackChainEvent],
+) (chain.Chain[AttackChainEvent], error) {
+    if event.AttackerID != b.CharacterID {
+        return c, nil
+    }
+
+    // Add at StageConditions (spell effects go here)
+    modifyAttack := func(_ context.Context, e AttackChainEvent) (AttackChainEvent, error) {
+        // Roll 1d4, add to attack bonus
+        e.AttackBonus += blessBonus
+        return e, nil
+    }
+
+    return c.Add(dnd5e.StageConditions, "bless", modifyAttack)
+}
+```
+
+## Workflow 3: Adding a Passive Tracker
+
+**Examples:** Rage's "did I attack this turn?", Concentration tracking
+
+### The Pattern
+
+Subscribe to TypedTopics (not chains) to track state:
+
+```go
+func (r *RagingCondition) Apply(ctx context.Context, bus events.EventBus) error {
+    // Track attacks
+    attacks := dnd5eEvents.AttackTopic.On(bus)
+    subID1, err := attacks.Subscribe(ctx, r.onAttack)
+
+    // Track being hit
+    damages := dnd5eEvents.DamageReceivedTopic.On(bus)
+    subID2, err := damages.Subscribe(ctx, r.onDamageReceived)
+
+    // Check at turn end
+    turnEnds := dnd5eEvents.TurnEndTopic.On(bus)
+    subID3, err := turnEnds.Subscribe(ctx, r.onTurnEnd)
+}
+
+func (r *RagingCondition) onAttack(_ context.Context, event dnd5eEvents.AttackEvent) error {
+    if event.AttackerID == r.CharacterID {
+        r.DidAttackThisTurn = true
+    }
+    return nil
+}
+
+func (r *RagingCondition) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnEndEvent) error {
+    if !r.DidAttackThisTurn && !r.WasHitThisTurn {
+        // End the condition
+        removals := dnd5eEvents.ConditionRemovedTopic.On(r.bus)
+        return removals.Publish(ctx, dnd5eEvents.ConditionRemovedEvent{...})
+    }
+    r.DidAttackThisTurn = false
+    r.WasHitThisTurn = false
+    return nil
+}
+```
+
+## Workflow 4: Adding a New Event Topic
+
+**Examples:** Rest events, spell casting events, movement events
+
+### Step 1: Define the Event
+File: `rulebooks/dnd5e/events/events.go`
+
+```go
+type RestCompleteEvent struct {
+    CharacterID string
+    RestType    string // "short" or "long"
+}
+
+var RestCompleteTopic = events.DefineTypedTopic[RestCompleteEvent]("dnd5e.rest.complete")
+```
+
+### Step 2: Publish where appropriate
+```go
+// In rest resolution code
+topic := dnd5eEvents.RestCompleteTopic.On(bus)
+topic.Publish(ctx, dnd5eEvents.RestCompleteEvent{
+    CharacterID: char.GetID(),
+    RestType:    "long",
+})
+```
+
+### Step 3: Subscribe in conditions that care
+```go
+func (r *RageFeature) Apply(ctx context.Context, bus events.EventBus) error {
+    rests := dnd5eEvents.RestCompleteTopic.On(bus)
+    return rests.Subscribe(ctx, r.onRestComplete)
+}
+
+func (r *RageFeature) onRestComplete(ctx context.Context, e dnd5eEvents.RestCompleteEvent) error {
+    if e.RestType == "long" {
+        r.resource.RestoreToFull()
+    }
+    return nil
+}
+```
+
+## Workflow 5: Adding a New Chain Topic
+
+**Examples:** Saving throw modifiers, healing modifiers, AC calculation
+
+### Step 1: Define the chain event and topic
+File: `rulebooks/dnd5e/combat/<topic>.go`
+
+```go
+type SavingThrowChainEvent struct {
+    CharacterID string
+    Ability     abilities.Ability
+    DC          int
+    Bonus       int
+    HasAdvantage bool
+    HasDisadvantage bool
+}
+
+var SavingThrowChain = events.DefineChainedTopic[*SavingThrowChainEvent]("dnd5e.combat.save.chain")
+```
+
+### Step 2: Use in resolution code
+```go
+func ResolveSavingThrow(ctx context.Context, input *SaveInput) (*SaveResult, error) {
+    event := &SavingThrowChainEvent{
+        CharacterID: input.Character.GetID(),
+        Ability:     input.Ability,
+        DC:          input.DC,
+        Bonus:       baseBonus,
+    }
+
+    chain := events.NewStagedChain[*SavingThrowChainEvent](dnd5e.ModifierStages)
+    saves := SavingThrowChain.On(input.EventBus)
+
+    modifiedChain, err := saves.PublishWithChain(ctx, event, chain)
+    finalEvent, err := modifiedChain.Execute(ctx, event)
+
+    // Use finalEvent.Bonus, finalEvent.HasAdvantage, etc.
+}
+```
+
+## The Stage Selection Guide
+
+| Stage | Use For | Examples |
+|-------|---------|----------|
+| `StageBase` | Initial values, proficiency | Base attack bonus, ability modifier |
+| `StageFeatures` | Class/race features | Rage damage, Sneak Attack, Brutal Critical |
+| `StageConditions` | Spell effects, status effects | Bless, Bane, Frightened, Poisoned |
+| `StageEquipment` | Magic items, gear | +1 weapon, Ring of Protection |
+| `StageFinal` | Resistance, vulnerability, caps | Damage resistance, minimum damage |
+
+## Barbarian: Current State & What's Missing
+
+### Implemented
+- **Rage** (Level 1) - Full implementation with damage bonus, duration, auto-end
+
+### Not Yet Implemented
+
+| Feature | Level | Type | Infrastructure Needed |
+|---------|-------|------|----------------------|
+| **Unarmored Defense** | 1 | Passive | AC calculation chain |
+| **Reckless Attack** | 2 | Action | Advantage/disadvantage system |
+| **Danger Sense** | 2 | Passive | Saving throw chain |
+| **Extra Attack** | 5 | Passive | Action economy system |
+| **Fast Movement** | 5 | Passive | Movement calculation |
+| **Feral Instinct** | 7 | Passive | Initiative chain |
+| **Brutal Critical** | 9 | Passive | Critical damage chain (have DamageChain) |
+| **Relentless Rage** | 11 | Reaction | Death save intervention |
+| **Persistent Rage** | 15 | Passive | Modify RagingCondition |
+
+### Recommended Implementation Order
+
+1. **Brutal Critical** - Already have DamageChain, just need to check `IsCritical`
+2. **Persistent Rage** - Modify existing RagingCondition
+3. **Unarmored Defense** - Need AC calculation chain (useful for many classes)
+4. **Reckless Attack** - Need advantage/disadvantage (useful everywhere)
+5. **Danger Sense** - Need saving throw chain (useful everywhere)
+
+## Implementation Checklist Template
+
+When adding a new feature:
+
+- [ ] Identify feature type (damage mod, attack mod, passive tracker, etc.)
+- [ ] Choose appropriate workflow from above
+- [ ] Add any needed constants (DamageSourceType, ConditionType, etc.)
+- [ ] Create condition file if needed (`conditions/<name>.go`)
+- [ ] Implement `ConditionBehavior` interface (Apply, Remove, ToJSON)
+- [ ] Create feature file if activatable (`features/<name>.go`)
+- [ ] Subscribe to correct topics at correct stages
+- [ ] Add tests for condition behavior
+- [ ] Add integration test showing full flow
+- [ ] Update loader if using JSON persistence
+
+## The Philosophy
+
+**Features activate, Conditions modify.**
+
+Keep this separation clean:
+- Features manage resources (uses per rest, action economy)
+- Features publish events when activated
+- Conditions subscribe to events and modify game mechanics
+- The event bus is the glue - everything flows through it
+
+This architecture means we can add new features without modifying existing code. New conditions just subscribe to existing events. New events can be subscribed to by existing conditions. Loose coupling, high cohesion.
+
+## Next Steps
+
+1. Pick the next barbarian feature (recommend Brutal Critical)
+2. Follow the appropriate workflow
+3. Add tests
+4. Document any new patterns discovered
+5. Update this journey doc if workflows evolve
+
+The goal: Make adding a new feature a ~30-minute task, not a multi-day adventure.

--- a/docs/journey/README.md
+++ b/docs/journey/README.md
@@ -58,6 +58,8 @@ This directory contains the ongoing architectural journey of the RPG Toolkit. Un
 39. [Event Bus Evolution](014-event-bus-evolution.md) - Event system improvements
 40. [Typed Topics Design](007-typed-topics-design.md) - Type-safe event topics
 41. [Events Carry Actions, Not Objects](044-events-carry-actions-not-objects.md) - Event philosophy breakthrough
+42. [Circular Dependencies Events Subpackage](045-circular-dependencies-events-subpackage.md) - Solving import cycles
+43. [Feature Implementation Workflows](046-feature-implementation-workflows.md) - Patterns for adding class features
 
 ## Document Types
 

--- a/rulebooks/dnd5e/combat/attack.go
+++ b/rulebooks/dnd5e/combat/attack.go
@@ -27,6 +27,7 @@ const (
 	DamageSourceSneakAttack     DamageSourceType = "sneak_attack"
 	DamageSourceDivineSmite     DamageSourceType = "divine_smite"
 	DamageSourceElementalWeapon DamageSourceType = "elemental_weapon"
+	DamageSourceBrutalCritical  DamageSourceType = "brutal_critical"
 	// Add more as needed
 )
 

--- a/rulebooks/dnd5e/conditions/brutal_critical.go
+++ b/rulebooks/dnd5e/conditions/brutal_critical.go
@@ -1,0 +1,186 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strconv"
+
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// diceNotationRegex matches simple dice notation like "1d8", "2d6", etc.
+var diceNotationRegex = regexp.MustCompile(`^(\d*)[dD](\d+)`)
+
+// BrutalCriticalCondition represents the barbarian's brutal critical feature.
+// It adds extra weapon damage dice on critical hits based on barbarian level.
+// It implements the ConditionBehavior interface.
+type BrutalCriticalCondition struct {
+	CharacterID     string          `json:"character_id"`
+	Level           int             `json:"level"`
+	ExtraDice       int             `json:"extra_dice"`
+	subscriptionIDs []string        `json:"-"` // Don't persist subscription IDs
+	bus             events.EventBus `json:"-"` // Don't persist bus reference
+	roller          dice.Roller     `json:"-"` // Don't persist roller reference
+}
+
+// Ensure BrutalCriticalCondition implements dnd5eEvents.ConditionBehavior
+var _ dnd5eEvents.ConditionBehavior = (*BrutalCriticalCondition)(nil)
+
+// BrutalCriticalInput provides configuration for creating a brutal critical condition
+type BrutalCriticalInput struct {
+	CharacterID string      // ID of the barbarian
+	Level       int         // Barbarian level (determines extra dice)
+	Roller      dice.Roller // Dice roller for rolling extra damage
+}
+
+// NewBrutalCriticalCondition creates a brutal critical condition from input
+func NewBrutalCriticalCondition(input BrutalCriticalInput) *BrutalCriticalCondition {
+	return &BrutalCriticalCondition{
+		CharacterID: input.CharacterID,
+		Level:       input.Level,
+		ExtraDice:   calculateExtraDice(input.Level),
+		roller:      input.Roller,
+	}
+}
+
+// calculateExtraDice determines extra weapon dice based on barbarian level
+func calculateExtraDice(level int) int {
+	switch {
+	case level >= 17:
+		return 3
+	case level >= 13:
+		return 2
+	case level >= 9:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// Apply subscribes this condition to relevant combat events
+func (b *BrutalCriticalCondition) Apply(ctx context.Context, bus events.EventBus) error {
+	b.bus = bus
+
+	// Subscribe to damage chain to add extra dice on crits
+	damageChain := combat.DamageChain.On(bus)
+	subID, err := damageChain.SubscribeWithChain(ctx, b.onDamageChain)
+	if err != nil {
+		return rpgerr.Wrap(err, "failed to subscribe to damage chain")
+	}
+	b.subscriptionIDs = append(b.subscriptionIDs, subID)
+
+	return nil
+}
+
+// Remove unsubscribes this condition from events
+func (b *BrutalCriticalCondition) Remove(ctx context.Context, bus events.EventBus) error {
+	if b.bus == nil {
+		return nil // Not applied, nothing to remove
+	}
+
+	for _, subID := range b.subscriptionIDs {
+		err := bus.Unsubscribe(ctx, subID)
+		if err != nil {
+			return rpgerr.Wrap(err, "failed to unsubscribe from damage chain")
+		}
+	}
+
+	b.subscriptionIDs = nil
+	b.bus = nil
+	return nil
+}
+
+// ToJSON converts the condition to JSON for persistence
+func (b *BrutalCriticalCondition) ToJSON() (json.RawMessage, error) {
+	data := map[string]interface{}{
+		"ref":          "dnd5e:conditions:brutal_critical",
+		"type":         "brutal_critical",
+		"character_id": b.CharacterID,
+		"level":        b.Level,
+		"extra_dice":   b.ExtraDice,
+	}
+	return json.Marshal(data)
+}
+
+// onDamageChain adds extra weapon damage dice on critical hits
+func (b *BrutalCriticalCondition) onDamageChain(
+	_ context.Context,
+	event *combat.DamageChainEvent,
+	c chain.Chain[*combat.DamageChainEvent],
+) (chain.Chain[*combat.DamageChainEvent], error) {
+	// Only add extra dice if:
+	// 1. We're the attacker
+	// 2. This is a critical hit
+	// 3. We have extra dice to add (level 9+)
+	if event.AttackerID != b.CharacterID || !event.IsCritical || b.ExtraDice == 0 {
+		return c, nil
+	}
+
+	// Parse weapon damage notation to get die size (e.g., "1d8" -> 8)
+	dieSize, err := parseDieSize(event.WeaponDamage)
+	if err != nil {
+		return c, rpgerr.Wrapf(err, "failed to parse weapon damage notation: %s", event.WeaponDamage)
+	}
+
+	if dieSize == 0 {
+		return c, nil // No dice to roll (shouldn't happen with valid weapons)
+	}
+
+	// Add brutal critical modifier at StageFeatures
+	modifyDamage := func(modCtx context.Context, e *combat.DamageChainEvent) (*combat.DamageChainEvent, error) {
+		// Roll extra dice
+		roller := b.roller
+		if roller == nil {
+			roller = dice.NewRoller()
+		}
+
+		extraRolls, rollErr := roller.RollN(modCtx, b.ExtraDice, dieSize)
+		if rollErr != nil {
+			return e, rpgerr.Wrap(rollErr, "failed to roll brutal critical dice")
+		}
+
+		// Append brutal critical damage component
+		e.Components = append(e.Components, combat.DamageComponent{
+			Source:            combat.DamageSourceBrutalCritical,
+			OriginalDiceRolls: extraRolls,
+			FinalDiceRolls:    extraRolls,
+			Rerolls:           nil,
+			FlatBonus:         0,
+			DamageType:        e.DamageType,
+			IsCritical:        true,
+		})
+		return e, nil
+	}
+
+	err = c.Add(dnd5e.StageFeatures, "brutal_critical", modifyDamage)
+	if err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add brutal critical modifier for character %s", b.CharacterID)
+	}
+
+	return c, nil
+}
+
+// parseDieSize extracts the die size from a dice notation string (e.g., "1d8" -> 8)
+func parseDieSize(notation string) (int, error) {
+	matches := diceNotationRegex.FindStringSubmatch(notation)
+	if len(matches) < 3 {
+		return 0, rpgerr.Newf(rpgerr.CodeInvalidArgument, "invalid dice notation: %s", notation)
+	}
+
+	dieSize, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return 0, rpgerr.Wrapf(err, "invalid die size in notation: %s", notation)
+	}
+
+	return dieSize, nil
+}

--- a/rulebooks/dnd5e/conditions/brutal_critical_test.go
+++ b/rulebooks/dnd5e/conditions/brutal_critical_test.go
@@ -1,0 +1,360 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// BrutalCriticalTestSuite tests the BrutalCriticalCondition behavior
+type BrutalCriticalTestSuite struct {
+	suite.Suite
+	ctrl   *gomock.Controller
+	ctx    context.Context
+	bus    events.EventBus
+	roller *mock_dice.MockRoller
+}
+
+func (s *BrutalCriticalTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.roller = mock_dice.NewMockRoller(s.ctrl)
+}
+
+func (s *BrutalCriticalTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func TestBrutalCriticalTestSuite(t *testing.T) {
+	suite.Run(t, new(BrutalCriticalTestSuite))
+}
+
+// executeCriticalDamageChain creates a critical damage chain event and executes it.
+// Returns the final event after all chain modifications have been applied.
+//
+//nolint:unparam // Parameters kept for consistency with other test helpers in this package
+func (s *BrutalCriticalTestSuite) executeCriticalDamageChain(
+	attackerID string,
+	weaponDamage string,
+	isCritical bool,
+) (*combat.DamageChainEvent, error) {
+	// Create weapon component with base damage (already doubled for crit in real flow)
+	weaponComp := combat.DamageComponent{
+		Source:            combat.DamageSourceWeapon,
+		OriginalDiceRolls: []int{6, 4}, // 2d8 rolled (crit doubles dice)
+		FinalDiceRolls:    []int{6, 4},
+		FlatBonus:         0,
+		DamageType:        "slashing",
+		IsCritical:        isCritical,
+	}
+
+	// Create ability component
+	abilityComp := combat.DamageComponent{
+		Source:            combat.DamageSourceAbility,
+		OriginalDiceRolls: nil,
+		FinalDiceRolls:    nil,
+		FlatBonus:         4, // STR modifier
+		DamageType:        "slashing",
+		IsCritical:        isCritical,
+	}
+
+	damageEvent := &combat.DamageChainEvent{
+		AttackerID:   attackerID,
+		TargetID:     "goblin-1",
+		Components:   []combat.DamageComponent{weaponComp, abilityComp},
+		DamageType:   "slashing",
+		IsCritical:   isCritical,
+		WeaponDamage: weaponDamage,
+		AbilityUsed:  "str",
+	}
+
+	chain := events.NewStagedChain[*combat.DamageChainEvent](dnd5e.ModifierStages)
+	damageTopic := combat.DamageChain.On(s.bus)
+
+	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
+	if err != nil {
+		return nil, err
+	}
+
+	return modifiedChain.Execute(s.ctx, damageEvent)
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalAddsExtraDieLevel9() {
+	// Level 9 barbarian gets 1 extra weapon damage die on crits
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       9,
+		Roller:      s.roller,
+	})
+
+	// Apply condition to subscribe to damage chain
+	err := brutal.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// Mock the extra die roll: RollN(ctx, 1, 8) returns [5]
+	s.roller.EXPECT().
+		RollN(gomock.Any(), 1, 8).
+		Return([]int{5}, nil)
+
+	// Execute critical damage chain
+	finalEvent, err := s.executeCriticalDamageChain("barbarian-1", "1d8", true)
+	s.Require().NoError(err)
+
+	// Should have weapon, ability, and brutal critical components
+	s.Require().Len(finalEvent.Components, 3, "Should have weapon, ability, and brutal critical components")
+
+	// Verify brutal critical component
+	brutalComp := finalEvent.Components[2]
+	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal([]int{5}, brutalComp.FinalDiceRolls, "Should have rolled 1 extra d8")
+	s.Equal(5, brutalComp.Total(), "Brutal critical should add 5 damage")
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalAddsExtraDiceLevel13() {
+	// Level 13 barbarian gets 2 extra weapon damage dice on crits
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       13,
+		Roller:      s.roller,
+	})
+
+	err := brutal.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// Mock the extra dice rolls: RollN(ctx, 2, 8) returns [5, 7]
+	s.roller.EXPECT().
+		RollN(gomock.Any(), 2, 8).
+		Return([]int{5, 7}, nil)
+
+	finalEvent, err := s.executeCriticalDamageChain("barbarian-1", "1d8", true)
+	s.Require().NoError(err)
+
+	s.Require().Len(finalEvent.Components, 3)
+
+	brutalComp := finalEvent.Components[2]
+	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal([]int{5, 7}, brutalComp.FinalDiceRolls, "Should have rolled 2 extra d8s")
+	s.Equal(12, brutalComp.Total(), "Brutal critical should add 12 damage (5+7)")
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalAddsExtraDiceLevel17() {
+	// Level 17 barbarian gets 3 extra weapon damage dice on crits
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       17,
+		Roller:      s.roller,
+	})
+
+	err := brutal.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// Mock the extra dice rolls: RollN(ctx, 3, 8) returns [3, 6, 8]
+	s.roller.EXPECT().
+		RollN(gomock.Any(), 3, 8).
+		Return([]int{3, 6, 8}, nil)
+
+	finalEvent, err := s.executeCriticalDamageChain("barbarian-1", "1d8", true)
+	s.Require().NoError(err)
+
+	s.Require().Len(finalEvent.Components, 3)
+
+	brutalComp := finalEvent.Components[2]
+	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal([]int{3, 6, 8}, brutalComp.FinalDiceRolls, "Should have rolled 3 extra d8s")
+	s.Equal(17, brutalComp.Total(), "Brutal critical should add 17 damage (3+6+8)")
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalIgnoresNonCriticalHits() {
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       9,
+		Roller:      s.roller,
+	})
+
+	err := brutal.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// No mock expectation - RollN should NOT be called for non-crits
+
+	// Execute NON-critical damage chain
+	finalEvent, err := s.executeCriticalDamageChain("barbarian-1", "1d8", false)
+	s.Require().NoError(err)
+
+	// Should only have weapon and ability components (no brutal critical)
+	s.Require().Len(finalEvent.Components, 2, "Should NOT have brutal critical on non-crit")
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalOnlyAffectsOwnAttacks() {
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       9,
+		Roller:      s.roller,
+	})
+
+	err := brutal.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// No mock expectation - RollN should NOT be called for other characters
+
+	// Create critical damage chain for a DIFFERENT attacker
+	weaponComp := combat.DamageComponent{
+		Source:            combat.DamageSourceWeapon,
+		OriginalDiceRolls: []int{6, 4},
+		FinalDiceRolls:    []int{6, 4},
+		DamageType:        "slashing",
+		IsCritical:        true,
+	}
+
+	damageEvent := &combat.DamageChainEvent{
+		AttackerID:   "barbarian-2", // Different character
+		TargetID:     "goblin-1",
+		Components:   []combat.DamageComponent{weaponComp},
+		DamageType:   "slashing",
+		IsCritical:   true,
+		WeaponDamage: "1d8",
+		AbilityUsed:  "str",
+	}
+
+	chain := events.NewStagedChain[*combat.DamageChainEvent](dnd5e.ModifierStages)
+	damageTopic := combat.DamageChain.On(s.bus)
+
+	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
+	s.Require().NoError(err)
+
+	// Should NOT have brutal critical component (different character)
+	s.Require().Len(finalEvent.Components, 1, "Should NOT have brutal critical for other character's crit")
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalWorksWithDifferentWeaponDice() {
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       9,
+		Roller:      s.roller,
+	})
+
+	err := brutal.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// Mock roll for d12 (greataxe): RollN(ctx, 1, 12) returns [10]
+	s.roller.EXPECT().
+		RollN(gomock.Any(), 1, 12).
+		Return([]int{10}, nil)
+
+	// Use a greataxe (1d12)
+	weaponComp := combat.DamageComponent{
+		Source:            combat.DamageSourceWeapon,
+		OriginalDiceRolls: []int{8, 11}, // 2d12 for crit
+		FinalDiceRolls:    []int{8, 11},
+		DamageType:        "slashing",
+		IsCritical:        true,
+	}
+
+	damageEvent := &combat.DamageChainEvent{
+		AttackerID:   "barbarian-1",
+		TargetID:     "goblin-1",
+		Components:   []combat.DamageComponent{weaponComp},
+		DamageType:   "slashing",
+		IsCritical:   true,
+		WeaponDamage: "1d12", // Greataxe
+		AbilityUsed:  "str",
+	}
+
+	chain := events.NewStagedChain[*combat.DamageChainEvent](dnd5e.ModifierStages)
+	damageTopic := combat.DamageChain.On(s.bus)
+
+	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
+	s.Require().NoError(err)
+
+	s.Require().Len(finalEvent.Components, 2)
+
+	brutalComp := finalEvent.Components[1]
+	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal([]int{10}, brutalComp.FinalDiceRolls, "Should roll extra d12 for greataxe")
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalRemoveUnsubscribes() {
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       9,
+		Roller:      s.roller,
+	})
+
+	err := brutal.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// Remove the condition
+	err = brutal.Remove(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// No mock expectation - RollN should NOT be called after Remove
+
+	// Now critical hits should not get brutal critical bonus
+	finalEvent, err := s.executeCriticalDamageChain("barbarian-1", "1d8", true)
+	s.Require().NoError(err)
+
+	// Should only have weapon and ability (brutal critical unsubscribed)
+	s.Require().Len(finalEvent.Components, 2, "Brutal critical should not apply after Remove()")
+}
+
+func (s *BrutalCriticalTestSuite) TestBrutalCriticalToJSON() {
+	brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+		CharacterID: "barbarian-1",
+		Level:       13,
+		Roller:      s.roller,
+	})
+
+	jsonData, err := brutal.ToJSON()
+	s.Require().NoError(err)
+
+	// Verify JSON contains expected fields
+	s.Contains(string(jsonData), `"character_id":"barbarian-1"`)
+	s.Contains(string(jsonData), `"level":13`)
+	s.Contains(string(jsonData), `"extra_dice":2`)
+	s.Contains(string(jsonData), `"ref":"dnd5e:conditions:brutal_critical"`)
+}
+
+func (s *BrutalCriticalTestSuite) TestCalculateExtraDice() {
+	testCases := []struct {
+		level     int
+		extraDice int
+	}{
+		{level: 1, extraDice: 0},  // Below level 9
+		{level: 8, extraDice: 0},  // Just below level 9
+		{level: 9, extraDice: 1},  // Level 9
+		{level: 12, extraDice: 1}, // Between 9 and 13
+		{level: 13, extraDice: 2}, // Level 13
+		{level: 16, extraDice: 2}, // Between 13 and 17
+		{level: 17, extraDice: 3}, // Level 17
+		{level: 20, extraDice: 3}, // Max level
+	}
+
+	for _, tc := range testCases {
+		brutal := NewBrutalCriticalCondition(BrutalCriticalInput{
+			CharacterID: "barbarian-1",
+			Level:       tc.level,
+			Roller:      s.roller,
+		})
+		s.Equal(tc.extraDice, brutal.ExtraDice, "Level %d should have %d extra dice", tc.level, tc.extraDice)
+	}
+}
+
+// Ensure we have the unused import warning suppressed
+var _ dice.Roller = (*mock_dice.MockRoller)(nil)


### PR DESCRIPTION
## Summary
- Implement Brutal Critical feature for barbarians (Level 9+)
- Add DamageSourceBrutalCritical constant to damage source types
- Document feature implementation workflows in Journey 046

## D&D 5e Rules Implemented
- **Level 9**: +1 extra weapon damage die on critical hits
- **Level 13**: +2 extra weapon damage dice on critical hits
- **Level 17**: +3 extra weapon damage dice on critical hits

## Implementation Details
The `BrutalCriticalCondition` follows the established pattern from Rage:
1. Implements `ConditionBehavior` interface (Apply, Remove, ToJSON)
2. Subscribes to `DamageChain` at `StageFeatures`
3. Checks if attack is critical and from the right character
4. Parses weapon damage notation to get die size
5. Rolls extra dice and adds component to damage breakdown

## Test Plan
- [x] Extra die added at level 9 (1 die)
- [x] Extra dice scale at level 13 (2 dice) and 17 (3 dice)
- [x] Non-critical hits ignored
- [x] Only affects own attacks
- [x] Works with different weapon dice (d8, d12)
- [x] Remove unsubscribes from events
- [x] JSON serialization works
- [x] Level breakpoints calculated correctly

## Files Changed
- `rulebooks/dnd5e/combat/attack.go` - Add `DamageSourceBrutalCritical`
- `rulebooks/dnd5e/conditions/brutal_critical.go` - New condition
- `rulebooks/dnd5e/conditions/brutal_critical_test.go` - Tests
- `docs/journey/046-feature-implementation-workflows.md` - New journey doc
- `docs/journey/README.md` - Update index

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)