### PR TITLE
fix: add name field to FightingStyleData for API display

### DIFF
--- a/rulebooks/dnd5e/conditions/fighting_style.go
+++ b/rulebooks/dnd5e/conditions/fighting_style.go
@@ -23,6 +23,7 @@ import (
 // FightingStyleData is the JSON structure for persisting fighting style condition state
 type FightingStyleData struct {
 	Ref         core.Ref                     `json:"ref"`
+	Name        string                       `json:"name"`
 	CharacterID string                       `json:"character_id"`
 	Style       fightingstyles.FightingStyle `json:"style"`
 }
@@ -121,6 +122,7 @@ func (f *FightingStyleCondition) ToJSON() (json.RawMessage, error) {
 			Type:   "conditions",
 			Value:  "fighting_style",
 		},
+		Name:        fightingstyles.Name(f.Style),
 		CharacterID: f.CharacterID,
 		Style:       f.Style,
 	}


### PR DESCRIPTION
## Summary
- Added `Name` field to `FightingStyleData` so rpg-api can display fighting styles in active conditions
- Uses existing `fightingstyles.Name()` function to get human-readable names

## Test plan
- [x] Verify `TestJSONRoundTrip` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)