### PR TITLE
feat: implement Monk Level 1 features

### DIFF
--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -851,7 +851,7 @@ func (d *Draft) compileFeatures() ([]features.Feature, error) {
 func (d *Draft) compileConditions(characterID string) ([]dnd5eEvents.ConditionBehavior, error) {
 	conditionList := make([]dnd5eEvents.ConditionBehavior, 0)
 
-	// Check for fighting style
+	// Check for fighting style (Fighter, Paladin, Ranger)
 	if style := d.GetFightingStyleSelection(); style != nil {
 		if !fightingstyles.IsImplemented(*style) {
 			return nil, rpgerr.Newf(rpgerr.CodeNotAllowed,
@@ -863,6 +863,24 @@ func (d *Draft) compileConditions(characterID string) ([]dnd5eEvents.ConditionBe
 			Style:       *style,
 		})
 		conditionList = append(conditionList, fsCondition)
+	}
+
+	// Monk gets Unarmored Defense (WIS-based) and Martial Arts at level 1
+	if d.class == classes.Monk {
+		// Add Unarmored Defense (Monk uses WIS modifier)
+		udCondition := conditions.NewUnarmoredDefenseCondition(conditions.UnarmoredDefenseInput{
+			CharacterID: characterID,
+			Type:        conditions.UnarmoredDefenseMonk,
+			Source:      "monk:unarmored_defense",
+		})
+		conditionList = append(conditionList, udCondition)
+
+		// Add Martial Arts
+		maCondition := conditions.NewMartialArtsCondition(conditions.MartialArtsConditionConfig{
+			CharacterID: characterID,
+			Level:       1, // Character level at creation
+		})
+		conditionList = append(conditionList, maCondition)
 	}
 
 	return conditionList, nil

--- a/rulebooks/dnd5e/character/monk_finalize_test.go
+++ b/rulebooks/dnd5e/character/monk_finalize_test.go
@@ -1,0 +1,253 @@
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/backgrounds"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/languages"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// MonkFinalizeSuite tests Monk-specific finalization
+type MonkFinalizeSuite struct {
+	suite.Suite
+	eventBus events.EventBus
+}
+
+// SetupTest runs before each test
+func (s *MonkFinalizeSuite) SetupTest() {
+	s.eventBus = events.NewEventBus()
+}
+
+// TestMonkWithUnarmoredDefenseAndMartialArts tests that a Monk gets both
+// Unarmored Defense and Martial Arts conditions when finalized
+func (s *MonkFinalizeSuite) TestMonkWithUnarmoredDefenseAndMartialArts() {
+	// Create a new draft
+	draft, err := NewDraft(&DraftConfig{
+		ID:       "test-monk-draft",
+		PlayerID: "player-1",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(draft)
+
+	// Set name
+	err = draft.SetName(&SetNameInput{
+		Name: "Chen Wei the Swift",
+	})
+	s.Require().NoError(err)
+
+	// Set race (Human)
+	err = draft.SetRace(&SetRaceInput{
+		RaceID: races.Human,
+		Choices: RaceChoices{
+			Languages: []languages.Language{languages.Elvish},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Set class (Monk)
+	err = draft.SetClass(&SetClassInput{
+		ClassID: classes.Monk,
+		Choices: ClassChoices{
+			Skills: []skills.Skill{
+				skills.Acrobatics,
+				skills.Stealth,
+			},
+			Equipment: []EquipmentChoiceSelection{
+				{ChoiceID: choices.MonkWeaponsPrimary, OptionID: choices.MonkWeaponShortsword},
+				{ChoiceID: choices.MonkPack, OptionID: choices.MonkPackDungeoneer},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Set background
+	err = draft.SetBackground(&SetBackgroundInput{
+		BackgroundID: backgrounds.Hermit,
+	})
+	s.Require().NoError(err)
+
+	// Set ability scores (DEX and WIS focused for Monk)
+	err = draft.SetAbilityScores(&SetAbilityScoresInput{
+		Scores: shared.AbilityScores{
+			abilities.STR: 10,
+			abilities.DEX: 16,
+			abilities.CON: 14,
+			abilities.INT: 8,
+			abilities.WIS: 15,
+			abilities.CHA: 12,
+		},
+		Method: "standard-array",
+	})
+	s.Require().NoError(err)
+
+	// Finalize to character
+	char, err := draft.ToCharacter(context.Background(), "monk-1", s.eventBus)
+	s.Require().NoError(err, "Failed to convert draft to character")
+	s.Require().NotNil(char)
+
+	// Verify character was created correctly
+	s.Equal("Chen Wei the Swift", char.GetName())
+	data := char.ToData()
+	s.Equal(classes.Monk, data.ClassID)
+
+	// Verify both conditions were applied (Unarmored Defense and Martial Arts)
+	charConditions := char.GetConditions()
+	s.Require().Len(charConditions, 2, "Character should have exactly 2 conditions (Unarmored Defense and Martial Arts)")
+
+	// Find and verify UnarmoredDefenseCondition
+	var udCondition *conditions.UnarmoredDefenseCondition
+	var maCondition *conditions.MartialArtsCondition
+
+	for _, cond := range charConditions {
+		switch c := cond.(type) {
+		case *conditions.UnarmoredDefenseCondition:
+			udCondition = c
+		case *conditions.MartialArtsCondition:
+			maCondition = c
+		}
+	}
+
+	// Verify Unarmored Defense
+	s.Require().NotNil(udCondition, "Character should have UnarmoredDefenseCondition")
+	s.Equal(conditions.UnarmoredDefenseMonk, udCondition.Type, "Unarmored Defense should be Monk type (WIS-based)")
+	s.Equal("monk-1", udCondition.CharacterID)
+	s.Equal("monk:unarmored_defense", udCondition.Source)
+
+	// Verify Martial Arts
+	s.Require().NotNil(maCondition, "Character should have MartialArtsCondition")
+	s.Equal("monk-1", maCondition.CharacterID)
+	s.Equal("1d4", maCondition.GetUnarmedDamage(), "Level 1 Monk should have 1d4 unarmed strike")
+}
+
+// TestMonkUnarmoredDefenseACCalculation tests that the Monk's Unarmored Defense
+// correctly calculates AC using DEX + WIS
+func (s *MonkFinalizeSuite) TestMonkUnarmoredDefenseACCalculation() {
+	// Create a draft with specific ability scores to test AC calculation
+	draft, err := NewDraft(&DraftConfig{
+		ID:       "test-monk-ac",
+		PlayerID: "player-2",
+	})
+	s.Require().NoError(err)
+
+	// Set name
+	err = draft.SetName(&SetNameInput{Name: "Test AC Monk"})
+	s.Require().NoError(err)
+
+	// Set race
+	err = draft.SetRace(&SetRaceInput{
+		RaceID: races.Human,
+		Choices: RaceChoices{
+			Languages: []languages.Language{languages.Common},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Set class
+	err = draft.SetClass(&SetClassInput{
+		ClassID: classes.Monk,
+		Choices: ClassChoices{
+			Skills: []skills.Skill{
+				skills.Acrobatics,
+				skills.Insight,
+			},
+			Equipment: []EquipmentChoiceSelection{
+				{
+					ChoiceID:           choices.MonkWeaponsPrimary,
+					OptionID:           choices.MonkWeaponSimple,
+					CategorySelections: []shared.EquipmentID{weapons.Quarterstaff},
+				},
+				{ChoiceID: choices.MonkPack, OptionID: choices.MonkPackExplorer},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Set background
+	err = draft.SetBackground(&SetBackgroundInput{
+		BackgroundID: backgrounds.Acolyte,
+	})
+	s.Require().NoError(err)
+
+	// Set ability scores: DEX 16 (+3), WIS 14 (+2) = AC 15
+	err = draft.SetAbilityScores(&SetAbilityScoresInput{
+		Scores: shared.AbilityScores{
+			abilities.STR: 10,
+			abilities.DEX: 16, // +3 modifier
+			abilities.CON: 12,
+			abilities.INT: 8,
+			abilities.WIS: 14, // +2 modifier
+			abilities.CHA: 10,
+		},
+		Method: "standard-array",
+	})
+	s.Require().NoError(err)
+
+	// Finalize to character
+	char, err := draft.ToCharacter(context.Background(), "monk-ac-test", s.eventBus)
+	s.Require().NoError(err)
+	s.Require().NotNil(char)
+
+	// Get the UnarmoredDefenseCondition
+	charConditions := char.GetConditions()
+	var udCondition *conditions.UnarmoredDefenseCondition
+	for _, cond := range charConditions {
+		if ud, ok := cond.(*conditions.UnarmoredDefenseCondition); ok {
+			udCondition = ud
+			break
+		}
+	}
+	s.Require().NotNil(udCondition)
+
+	// Calculate expected AC: 10 + DEX(3) + WIS(2) = 15
+	// Note: We need to use the character's final ability scores (with racial bonuses)
+	charData := char.ToData()
+	calculatedAC := udCondition.CalculateAC(charData.AbilityScores)
+	s.Equal(15, calculatedAC, "Unarmored Defense AC should be 10 + DEX(+3) + WIS(+2) = 15")
+}
+
+// TestMonkMartialArtsDieLevels tests that the Martial Arts damage die
+// scales correctly with monk level
+func (s *MonkFinalizeSuite) TestMonkMartialArtsDieLevels() {
+	testCases := []struct {
+		level       int
+		expectedDie string
+	}{
+		{1, "1d4"},
+		{4, "1d4"},
+		{5, "1d6"},
+		{10, "1d6"},
+		{11, "1d8"},
+		{16, "1d8"},
+		{17, "1d10"},
+		{20, "1d10"},
+	}
+
+	for _, tc := range testCases {
+		s.Run("Level "+string(rune('0'+tc.level/10))+string(rune('0'+tc.level%10)), func() {
+			// Create martial arts condition at the specified level
+			maCondition := conditions.NewMartialArtsCondition(conditions.MartialArtsConditionConfig{
+				CharacterID: "test-monk",
+				Level:       tc.level,
+			})
+
+			s.Equal(tc.expectedDie, maCondition.GetUnarmedDamage(),
+				"Level %d monk should have %s unarmed damage", tc.level, tc.expectedDie)
+		})
+	}
+}
+
+func TestMonkFinalizeSuite(t *testing.T) {
+	suite.Run(t, new(MonkFinalizeSuite))
+}

--- a/rulebooks/dnd5e/conditions/loader.go
+++ b/rulebooks/dnd5e/conditions/loader.go
@@ -54,6 +54,13 @@ func LoadJSON(data json.RawMessage) (dnd5eEvents.ConditionBehavior, error) {
 		}
 		return fs, nil
 
+	case "martial_arts":
+		ma := &MartialArtsCondition{}
+		if err := ma.loadJSON(data); err != nil {
+			return nil, rpgerr.Wrap(err, "failed to load martial arts condition")
+		}
+		return ma, nil
+
 	default:
 		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition ref: %s", peek.Ref.Value)
 	}

--- a/rulebooks/dnd5e/conditions/martial_arts.go
+++ b/rulebooks/dnd5e/conditions/martial_arts.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// MartialArtsData is the JSON structure for persisting martial arts condition state.
+// The Name field provides a human-readable display name for API consumers.
+type MartialArtsData struct {
+	Ref           core.Ref `json:"ref"`
+	Name          string   `json:"name"`
+	CharacterID   string   `json:"character_id"`
+	UnarmedDamage string   `json:"unarmed_damage"` // e.g., "1d4", "1d6", etc.
+	Level         int      `json:"level"`
+}
+
+// MartialArtsCondition represents the monk's Martial Arts feature.
+// At Level 1:
+// - Unarmed strikes deal 1d4 damage (increases with level)
+// - Can use DEX instead of STR for unarmed strikes and monk weapons
+// - Bonus action unarmed strike after Attack action (not yet implemented)
+type MartialArtsCondition struct {
+	CharacterID   string
+	UnarmedDamage string // Dice notation for unarmed strike damage
+	Level         int    // Monk level (affects damage die)
+	bus           events.EventBus
+}
+
+// Ensure MartialArtsCondition implements dnd5eEvents.ConditionBehavior
+var _ dnd5eEvents.ConditionBehavior = (*MartialArtsCondition)(nil)
+
+// MartialArtsConditionConfig configures a martial arts condition
+type MartialArtsConditionConfig struct {
+	CharacterID string
+	Level       int
+}
+
+// NewMartialArtsCondition creates a martial arts condition from config
+func NewMartialArtsCondition(cfg MartialArtsConditionConfig) *MartialArtsCondition {
+	return &MartialArtsCondition{
+		CharacterID:   cfg.CharacterID,
+		Level:         cfg.Level,
+		UnarmedDamage: getMartialArtsDie(cfg.Level),
+	}
+}
+
+// getMartialArtsDie returns the martial arts damage die for a given monk level
+func getMartialArtsDie(level int) string {
+	switch {
+	case level >= 17:
+		return "1d10"
+	case level >= 11:
+		return "1d8"
+	case level >= 5:
+		return "1d6"
+	default:
+		return "1d4"
+	}
+}
+
+// IsApplied returns true if this condition is currently applied
+func (m *MartialArtsCondition) IsApplied() bool {
+	return m.bus != nil
+}
+
+// Apply registers this condition with the event bus.
+// For Level 1 MVP, Martial Arts is a passive feature that modifies unarmed strike damage.
+// Future implementation will subscribe to combat chains for DEX-for-attacks logic.
+func (m *MartialArtsCondition) Apply(_ context.Context, bus events.EventBus) error {
+	if m.IsApplied() {
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "martial arts condition already applied")
+	}
+	m.bus = bus
+	return nil
+}
+
+// Remove unregisters this condition from the event bus
+func (m *MartialArtsCondition) Remove(_ context.Context, _ events.EventBus) error {
+	m.bus = nil
+	return nil
+}
+
+// ToJSON converts the condition to JSON for persistence
+func (m *MartialArtsCondition) ToJSON() (json.RawMessage, error) {
+	data := MartialArtsData{
+		Ref: core.Ref{
+			Module: "dnd5e",
+			Type:   "conditions",
+			Value:  "martial_arts",
+		},
+		Name:          "Martial Arts",
+		CharacterID:   m.CharacterID,
+		UnarmedDamage: m.UnarmedDamage,
+		Level:         m.Level,
+	}
+	return json.Marshal(data)
+}
+
+// loadJSON loads martial arts condition state from JSON
+func (m *MartialArtsCondition) loadJSON(data json.RawMessage) error {
+	var maData MartialArtsData
+	if err := json.Unmarshal(data, &maData); err != nil {
+		return rpgerr.Wrap(err, "failed to unmarshal martial arts data")
+	}
+
+	m.CharacterID = maData.CharacterID
+	m.UnarmedDamage = maData.UnarmedDamage
+	m.Level = maData.Level
+
+	return nil
+}
+
+// GetUnarmedDamage returns the current unarmed strike damage die
+func (m *MartialArtsCondition) GetUnarmedDamage() string {
+	return m.UnarmedDamage
+}


### PR DESCRIPTION
## Summary
- Add `MartialArtsCondition` with level-based damage die scaling (1d4→1d6→1d8→1d10)
- Apply `UnarmoredDefenseCondition` (Monk type, WIS-based AC) on character finalize
- Apply `MartialArtsCondition` on character finalize
- Register `martial_arts` in conditions loader

## Files Changed
- `conditions/martial_arts.go` - New MartialArtsCondition implementation
- `conditions/loader.go` - Register martial_arts ref
- `character/draft.go` - Add Monk class detection in compileConditions()
- `character/monk_finalize_test.go` - Full test coverage

## Test plan
- [x] TestMonkWithUnarmoredDefenseAndMartialArts - verifies both conditions applied
- [x] TestMonkUnarmoredDefenseACCalculation - verifies AC = 10 + DEX + WIS
- [x] TestMonkMartialArtsDieLevels - verifies damage die at all level breakpoints
- [x] All existing tests pass
- [x] Linter passes

## Future Work
Level 1 MVP tracks damage die only. Future enhancements:
- Combat chain integration for DEX-for-attacks on monk weapons
- Bonus action unarmed strike tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)