### PR TITLE
refactor: update proficiency module to core v0.9.3

### DIFF
--- a/mechanics/proficiency/go.mod
+++ b/mechanics/proficiency/go.mod
@@ -5,9 +5,9 @@ go 1.24
 toolchain go1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.2.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.9.3
 	github.com/KirkDiggler/rpg-toolkit/events v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/mechanics/effects v0.0.0
+	github.com/KirkDiggler/rpg-toolkit/mechanics/effects v0.2.1
 	go.uber.org/mock v0.5.2
 )
 

--- a/mechanics/proficiency/go.sum
+++ b/mechanics/proficiency/go.sum
@@ -1,5 +1,5 @@
-github.com/KirkDiggler/rpg-toolkit/core v0.2.0 h1:yU/6c/jxRXB0Q7RP/uFK7kCXWanY08wUU+C5m3wSBRM=
-github.com/KirkDiggler/rpg-toolkit/core v0.2.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.3 h1:u85NwPaikKCrdfzDD4BS8GRXl+W13zfwsR4LuE8oocI=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.3/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.1.0 h1:/tpfvSeV2NeaerItinsd1cc1I680cq3lkBL3EsV5Wz4=
 github.com/KirkDiggler/rpg-toolkit/dice v0.1.0/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.0 h1:ec8t66jaZkuir+FfqNZvK6m2PfLOwmtOY2vjZ64+Bpg=

--- a/mechanics/proficiency/simple.go
+++ b/mechanics/proficiency/simple.go
@@ -75,7 +75,7 @@ func NewSimpleProficiency(cfg SimpleProficiencyConfig) *SimpleProficiency {
 func (p *SimpleProficiency) GetID() string { return p.core.GetID() }
 
 // GetType implements core.Entity
-func (p *SimpleProficiency) GetType() string { return p.core.GetType() }
+func (p *SimpleProficiency) GetType() string { return string(p.core.GetType()) }
 
 // Owner returns the entity that has this proficiency
 func (p *SimpleProficiency) Owner() core.Entity { return p.owner }
@@ -107,8 +107,9 @@ func (p *SimpleProficiency) Remove(bus events.EventBus) error {
 	return p.core.Remove(bus)
 }
 
-// AddSubscription tracks an event subscription for cleanup
-// Deprecated: This is now handled internally by Core
+// AddSubscription tracks an event subscription for cleanup.
+//
+// Deprecated: This is now handled internally by Core.
 func (p *SimpleProficiency) AddSubscription(_ string) {
 	// No-op for backward compatibility
 	// Core handles subscription tracking internally

--- a/mechanics/proficiency/simple_test.go
+++ b/mechanics/proficiency/simple_test.go
@@ -15,11 +15,11 @@ import (
 // MockEntity for testing
 type MockEntity struct {
 	id  string
-	typ string
+	typ core.EntityType
 }
 
-func (e *MockEntity) GetID() string   { return e.id }
-func (e *MockEntity) GetType() string { return e.typ }
+func (e *MockEntity) GetID() string            { return e.id }
+func (e *MockEntity) GetType() core.EntityType { return e.typ }
 
 func TestSimpleProficiency(t *testing.T) {
 	// Create event bus
@@ -39,7 +39,7 @@ func TestSimpleProficiency(t *testing.T) {
 		Subject: core.MustNewRef(core.RefInput{
 			Module: "core",
 			Type:   "weapon",
-			Value:  "longsword",
+			ID:     "longsword",
 		}),
 		Source: &core.Source{
 			Category: core.SourceClass,
@@ -105,7 +105,7 @@ func TestProficiencyMetadata(t *testing.T) {
 		Subject: core.MustNewRef(core.RefInput{
 			Module: "core",
 			Type:   "skill",
-			Value:  "athletics",
+			ID:     "athletics",
 		}),
 		Source: &core.Source{
 			Category: core.SourceClass,
@@ -129,7 +129,7 @@ func TestProficiencyMetadata(t *testing.T) {
 	athleticsRef := core.MustNewRef(core.RefInput{
 		Module: "core",
 		Type:   "skill",
-		Value:  "athletics",
+		ID:     "athletics",
 	})
 	if !prof.Subject().Equals(athleticsRef) {
 		t.Errorf("Expected subject 'athletics', got %s", prof.Subject().String())


### PR DESCRIPTION
## Summary

Update the proficiency module to use the latest core and effects versions.

## Changes

- Update core dependency to v0.9.3
- Update effects dependency to v0.2.1  
- Change `RefInput.Value` to `RefInput.ID`
- Fix `MockEntity.GetType()` to return `core.EntityType`
- Fix deprecated comment format (lint)

## Test plan
- [x] All proficiency tests pass
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)