### PR TITLE
refactor: update dnd5e to use Ref.ID instead of Ref.Value

### DIFF
--- a/core/doc.go
+++ b/core/doc.go
@@ -49,7 +49,7 @@
 //	var Rage = core.MustNewRef(core.RefInput{
 //		Module: "core",
 //		Type:   "feature",
-//		Value:  "rage",
+//		ID:     "rage",
 //	})
 //
 //	// Track where features come from

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -820,7 +820,7 @@ func (d *Draft) compileFeatures() ([]features.Feature, error) {
 			"ref": core.Ref{
 				Module: "dnd5e",
 				Type:   "features",
-				Value:  "rage",
+				ID:     "rage",
 			},
 			"id":       "rage",
 			"name":     "Rage",

--- a/rulebooks/dnd5e/combat/integration_test.go
+++ b/rulebooks/dnd5e/combat/integration_test.go
@@ -107,7 +107,7 @@ func (s *CombatIntegrationSuite) createBarbarian() *character.Character {
 				"ref": {
 					"module": "dnd5e",
 					"type":   "features",
-					"value":  "rage"
+					"id":     "rage"
 				},
 				"id":       "rage",
 				"name":     "Rage",
@@ -395,7 +395,7 @@ func (s *CombatIntegrationSuite) TestSecondWindIntegration() {
 					"ref": {
 						"module": "dnd5e",
 						"type":   "features",
-						"value":  "second_wind"
+						"id":     "second_wind"
 					},
 					"id":       "second_wind",
 					"name":     "Second Wind",

--- a/rulebooks/dnd5e/conditions/brutal_critical.go
+++ b/rulebooks/dnd5e/conditions/brutal_critical.go
@@ -120,7 +120,7 @@ func (b *BrutalCriticalCondition) ToJSON() (json.RawMessage, error) {
 		Ref: core.Ref{
 			Module: "dnd5e",
 			Type:   "conditions",
-			Value:  "brutal_critical",
+			ID:     "brutal_critical",
 		},
 		CharacterID: b.CharacterID,
 		Level:       b.Level,

--- a/rulebooks/dnd5e/conditions/brutal_critical_test.go
+++ b/rulebooks/dnd5e/conditions/brutal_critical_test.go
@@ -328,7 +328,7 @@ func (s *BrutalCriticalTestSuite) TestBrutalCriticalToJSON() {
 	s.Contains(string(jsonData), `"character_id":"barbarian-1"`)
 	s.Contains(string(jsonData), `"level":13`)
 	s.Contains(string(jsonData), `"extra_dice":2`)
-	s.Contains(string(jsonData), `"value":"brutal_critical"`)
+	s.Contains(string(jsonData), `"id":"brutal_critical"`)
 	s.Contains(string(jsonData), `"module":"dnd5e"`)
 	s.Contains(string(jsonData), `"type":"conditions"`)
 }

--- a/rulebooks/dnd5e/conditions/fighting_style.go
+++ b/rulebooks/dnd5e/conditions/fighting_style.go
@@ -120,7 +120,7 @@ func (f *FightingStyleCondition) ToJSON() (json.RawMessage, error) {
 		Ref: core.Ref{
 			Module: "dnd5e",
 			Type:   "conditions",
-			Value:  "fighting_style",
+			ID:     "fighting_style",
 		},
 		Name:        fightingstyles.Name(f.Style),
 		CharacterID: f.CharacterID,

--- a/rulebooks/dnd5e/conditions/loader.go
+++ b/rulebooks/dnd5e/conditions/loader.go
@@ -24,8 +24,8 @@ func LoadJSON(data json.RawMessage) (dnd5eEvents.ConditionBehavior, error) {
 		return nil, rpgerr.Wrap(err, "failed to peek at condition ref")
 	}
 
-	// Route based on ref value
-	switch peek.Ref.Value {
+	// Route based on ref ID
+	switch peek.Ref.ID {
 	case "raging":
 		raging := &RagingCondition{}
 		if err := raging.loadJSON(data); err != nil {
@@ -55,6 +55,6 @@ func LoadJSON(data json.RawMessage) (dnd5eEvents.ConditionBehavior, error) {
 		return fs, nil
 
 	default:
-		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition ref: %s", peek.Ref.Value)
+		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition ref: %s", peek.Ref.ID)
 	}
 }

--- a/rulebooks/dnd5e/conditions/loader_test.go
+++ b/rulebooks/dnd5e/conditions/loader_test.go
@@ -124,7 +124,7 @@ func (s *LoaderTestSuite) TestLoadMonkUnarmoredDefense() {
 
 func (s *LoaderTestSuite) TestLoadUnknownCondition() {
 	// Test loading unknown condition ref
-	jsonData := []byte(`{"ref":{"module":"dnd5e","type":"conditions","value":"unknown"}}`)
+	jsonData := []byte(`{"ref":{"module":"dnd5e","type":"conditions","id":"unknown"}}`)
 
 	_, err := LoadJSON(jsonData)
 	s.Error(err)

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -123,7 +123,7 @@ func (r *RagingCondition) ToJSON() (json.RawMessage, error) {
 		Ref: core.Ref{
 			Module: "dnd5e",
 			Type:   "conditions",
-			Value:  "raging",
+			ID:     "raging",
 		},
 		CharacterID:       r.CharacterID,
 		DamageBonus:       r.DamageBonus,

--- a/rulebooks/dnd5e/conditions/unarmored_defense.go
+++ b/rulebooks/dnd5e/conditions/unarmored_defense.go
@@ -88,7 +88,7 @@ func (u *UnarmoredDefenseCondition) ToJSON() (json.RawMessage, error) {
 		Ref: core.Ref{
 			Module: "dnd5e",
 			Type:   "conditions",
-			Value:  "unarmored_defense",
+			ID:     "unarmored_defense",
 		},
 		Type:        string(u.Type),
 		CharacterID: u.CharacterID,

--- a/rulebooks/dnd5e/conditions/unarmored_defense_test.go
+++ b/rulebooks/dnd5e/conditions/unarmored_defense_test.go
@@ -164,7 +164,7 @@ func (s *UnarmoredDefenseTestSuite) TestUnarmoredDefenseToJSON() {
 	s.Contains(string(jsonData), `"character_id":"barbarian-1"`)
 	s.Contains(string(jsonData), `"type":"barbarian"`)
 	s.Contains(string(jsonData), `"source":"barbarian:unarmored_defense"`)
-	s.Contains(string(jsonData), `"value":"unarmored_defense"`)
+	s.Contains(string(jsonData), `"id":"unarmored_defense"`)
 	s.Contains(string(jsonData), `"module":"dnd5e"`)
 }
 

--- a/rulebooks/dnd5e/features/example_test.go
+++ b/rulebooks/dnd5e/features/example_test.go
@@ -23,7 +23,7 @@ func Example() {
 
 	// Server has stored feature JSON
 	featureJSON := json.RawMessage(`{
-		"ref": {"value": "rage"},
+		"ref": {"module": "dnd5e", "type": "features", "id": "rage"},
 		"id": "rage",
 		"name": "Rage",
 		"level": 5,

--- a/rulebooks/dnd5e/features/loader.go
+++ b/rulebooks/dnd5e/features/loader.go
@@ -23,8 +23,8 @@ func LoadJSON(data json.RawMessage) (Feature, error) {
 		return nil, fmt.Errorf("failed to extract feature ID: %w", err)
 	}
 
-	// Route based on Ref value
-	switch metadata.Ref.Value {
+	// Route based on Ref ID
+	switch metadata.Ref.ID {
 	case "rage":
 		rage := &Rage{}
 		if err := rage.loadJSON(data); err != nil {
@@ -40,6 +40,6 @@ func LoadJSON(data json.RawMessage) (Feature, error) {
 
 		return secondWind, nil
 	default:
-		return nil, fmt.Errorf("unknown feature type: %s", metadata.Ref.Value)
+		return nil, fmt.Errorf("unknown feature type: %s", metadata.Ref.ID)
 	}
 }

--- a/rulebooks/dnd5e/features/loader_test.go
+++ b/rulebooks/dnd5e/features/loader_test.go
@@ -23,7 +23,7 @@ func (s *LoaderTestSuite) SetupTest() {
 
 func (s *LoaderTestSuite) TestLoadRageFeature() {
 	jsonData := json.RawMessage(`{
-		"ref": {"value": "rage"},
+		"ref": {"module": "dnd5e", "type": "features", "id": "rage"},
 		"id": "rage",
 		"name": "Rage",
 		"level": 5,

--- a/rulebooks/dnd5e/features/rage.go
+++ b/rulebooks/dnd5e/features/rage.go
@@ -150,7 +150,7 @@ func (r *Rage) ToJSON() (json.RawMessage, error) {
 		Ref: core.Ref{
 			Module: "dnd5e",
 			Type:   "features",
-			Value:  "rage",
+			ID:     "rage",
 		},
 		ID:      r.id,
 		Name:    r.name,

--- a/rulebooks/dnd5e/features/second_wind.go
+++ b/rulebooks/dnd5e/features/second_wind.go
@@ -121,7 +121,7 @@ func (s *SecondWind) ToJSON() (json.RawMessage, error) {
 		Ref: core.Ref{
 			Module: "dnd5e",
 			Type:   "features",
-			Value:  "second_wind",
+			ID:     "second_wind",
 		},
 		ID:      s.id,
 		Name:    s.name,

--- a/rulebooks/dnd5e/go.mod
+++ b/rulebooks/dnd5e/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.9.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.9.3
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.0
 	github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1

--- a/rulebooks/dnd5e/go.sum
+++ b/rulebooks/dnd5e/go.sum
@@ -1,5 +1,5 @@
-github.com/KirkDiggler/rpg-toolkit/core v0.9.0 h1:kXj1i2Wa9gGb76aznk1GB9ogsDSTkSjENPuMVJEAjK8=
-github.com/KirkDiggler/rpg-toolkit/core v0.9.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.3 h1:u85NwPaikKCrdfzDD4BS8GRXl+W13zfwsR4LuE8oocI=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.3/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059 h1:74OW0fnq459g28p2JpyrB20tjno4FlF18+cHJ2xiTes=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.3-0.20250914062452-e2c6a0f32059/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.0 h1:7tAo5ddnaBk2nLeLY3wwa5zVx93ntA5FOgi+NNF4rmk=


### PR DESCRIPTION
## Summary

Update the dnd5e module to use `Ref.ID` instead of `Ref.Value`, matching the core v0.9.3 change.

## Changes

- Update core dependency to v0.9.3
- Change all `Ref.Value` usages to `Ref.ID`
- Change all `RefInput{Value:}` to `RefInput{ID:}`
- Update JSON test data to use "id" field
- Update core/doc.go example

## Files Changed

- `rulebooks/dnd5e/features/` - loader.go, rage.go, second_wind.go, tests
- `rulebooks/dnd5e/conditions/` - loader.go, all condition files, tests
- `rulebooks/dnd5e/character/draft.go`
- `rulebooks/dnd5e/combat/integration_test.go`
- `core/doc.go`

## Test plan
- [x] All dnd5e tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)