### PR TITLE
Fix Dueling damage source to use 3-part ref format

### DIFF
--- a/rulebooks/dnd5e/combat/attack.go
+++ b/rulebooks/dnd5e/combat/attack.go
@@ -27,7 +27,7 @@ const (
 	DamageSourceDivineSmite     DamageSourceType = "divine_smite"
 	DamageSourceElementalWeapon DamageSourceType = "elemental_weapon"
 	DamageSourceBrutalCritical  DamageSourceType = "dnd5e:conditions:brutal_critical"
-	DamageSourceDueling         DamageSourceType = "dnd5e:conditions:fighting_style:dueling"
+	DamageSourceDueling         DamageSourceType = "dnd5e:conditions:fighting_style_dueling"
 	// Add more as needed
 )
 


### PR DESCRIPTION
## Summary
Changed Dueling damage source from 4-part to 3-part ref format:
- From: `dnd5e:conditions:fighting_style:dueling`  
- To: `dnd5e:conditions:fighting_style_dueling`

Fighting styles are conditions - the ID just describes which one. This keeps the 3-part ref contract (`module:type:id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)