### PR TITLE
docs: Add ideas directory structure for cross-repo feature planning

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -1,0 +1,44 @@
+# Ideas
+
+Self-contained directories for ideas progressing from brainstorm to implementation.
+
+## Structure
+
+Each idea gets its own directory:
+
+```
+docs/ideas/<idea-name>/
+├── progress.json    # Tracks phases, decisions, reasoning
+├── README.md        # Human-readable summary and status
+├── brainstorm.md    # Initial exploration
+├── use-cases.md     # Concrete scenarios
+├── design.md        # Implementation specification
+└── ...              # Additional docs as needed
+```
+
+## progress.json
+
+The spine of each idea. Tracks:
+
+- **status**: Current phase (brainstorming, designing, implementing, complete)
+- **phases**: Each phase with status, date, file, and notes
+- **decisions**: Key choices made with reasoning
+
+Phases can be marked as:
+- `pending` - Not started
+- `in_progress` - Currently working on
+- `completed` - Done
+- `skipped` - Intentionally skipped (must include reason)
+
+## Philosophy
+
+- Each directory tells the complete story
+- JSON tracks what happened and why
+- Decisions are captured so they survive context switches
+- Phases can be skipped but must explain why
+
+## Current Ideas
+
+| Idea | Status | Summary |
+|------|--------|---------|
+| [action-economy-history](./action-economy-history/) | Issues Created | Track what actions were taken, not just how many remain |

--- a/docs/ideas/action-economy-history/README.md
+++ b/docs/ideas/action-economy-history/README.md
@@ -1,0 +1,63 @@
+# Action Economy History
+
+Track what actions were taken during a turn, not just how many remain.
+
+## Status: Issues Created → Ready for Implementation
+
+## Summary
+
+When a Monk uses Step of the Wind, they choose Disengage or Dash. Later game logic (like Opportunity Attack checks, speed calculations) needs to know which was chosen. Currently `ActionEconomy` only tracks budget, not history.
+
+## Trigger
+
+Implementing Monk levels 1-3 revealed that Step of Wind's choice needs to be queryable later in the turn. The `Action string` field attempted on the branch doesn't scale - no type safety, no validation, and per-feature event topics don't work for homebrew.
+
+## Key Decisions
+
+| Question | Decision | Reason |
+|----------|----------|--------|
+| Where does history live? | On ActionEconomy | Budget and history go together |
+| ActionType location | Type in core, constants in dnd5e | Follows established pattern |
+| Source field type | core.Ref | Typed, validated, no typo risk |
+| Old API methods | Remove | Pre-release, no backwards compat needed |
+| Pointer vs value in FeatureInput | Pointer | Accurate error messages |
+| Feature choices | GetActivationChoices() method | Features self-describe |
+| Event topics | One FeatureActivatedTopic | Per-feature topics don't scale |
+| ActionType format | Enum | Type safety in protos and toolkit |
+| Downstream effects | Turn-scoped conditions | Fits event-driven architecture |
+
+## Documents
+
+| Phase | Document | Description |
+|-------|----------|-------------|
+| Brainstorm | [brainstorm.md](./brainstorm.md) | Initial exploration and core design |
+| Use Cases | [use-cases.md](./use-cases.md) | End-to-end flows, alternative approaches |
+| Design | [design-protos.md](./design-protos.md) | Proto changes (ActionType, ActivationChoice, TurnState) |
+| Design | [design-toolkit.md](./design-toolkit.md) | Toolkit changes (ActionEconomy, features, conditions) |
+| Design | [design-api.md](./design-api.md) | Game server integration |
+
+## Affected Projects
+
+| Project | Key Changes |
+|---------|-------------|
+| rpg-api-protos | ActionType enum, ActivationChoice messages, TurnState with history |
+| rpg-toolkit | ActionEconomy history, ActivationChoiceProvider, Disengaged condition |
+| rpg-api | Pass ActionType through, include choices in GetCharacter, AoO events |
+
+## Implementation Order
+
+1. **rpg-api-protos** - ActionType enum, messages (API contract first)
+2. **rpg-toolkit** - ActionEconomy, feature interface, conditions
+3. **rpg-api** - Integration, conversion helpers
+
+## GitHub Issues
+
+| Project | Issue | Status |
+|---------|-------|--------|
+| rpg-api-protos | [#81](https://github.com/KirkDiggler/rpg-api-protos/issues/81) | Open |
+| rpg-toolkit | [#399](https://github.com/KirkDiggler/rpg-toolkit/issues/399) | Open |
+| rpg-api | [#266](https://github.com/KirkDiggler/rpg-api/issues/266) | Open |
+
+## Progress
+
+See [progress.json](./progress.json) for detailed tracking.

--- a/docs/ideas/action-economy-history/brainstorm.md
+++ b/docs/ideas/action-economy-history/brainstorm.md
@@ -1,0 +1,164 @@
+# Action Economy History - Brainstorm
+
+## Problem
+
+Step of the Wind allows a Monk to spend 1 Ki and take Disengage **or** Dash as a bonus action. Later in the turn, game logic needs to know which one was chosen:
+
+- **AoO check**: Did they Disengage? If so, no opportunity attacks.
+- **Movement processing**: Did they Dash? If so, double speed.
+
+Currently `ActionEconomy` only tracks "how many actions remain" - it has no knowledge of what those actions were used for.
+
+## Current State (main branch)
+
+### ActionEconomy
+
+Budget tracking only:
+
+```go
+type ActionEconomy struct {
+    ActionsRemaining      int
+    BonusActionsRemaining int
+    ReactionsRemaining    int
+}
+
+func (ae *ActionEconomy) UseBonusAction() error  // Decrements, no record of what used it
+```
+
+### FeatureInput
+
+Provides optional ActionEconomy to features:
+
+```go
+type FeatureInput struct {
+    Bus           events.EventBus
+    ActionEconomy *combat.ActionEconomy
+}
+```
+
+No way to pass action choices (like Disengage vs Dash).
+
+### The Gaps
+
+1. **No action choices**: Features with options (Step of Wind: Disengage or Dash) have no way to receive the choice
+2. **No history**: After `UseBonusAction()`, no record of what consumed it
+3. **No queryability**: Later logic cannot ask "did they Disengage this turn?"
+
+## Solution
+
+### 1. Add ActionType
+
+Type in core, constants in rulebook:
+
+```go
+// core/combat/types.go
+type ActionType string
+
+// rulebooks/dnd5e/combat/action_types.go
+const (
+    ActionDodge     ActionType = "dodge"
+    ActionDisengage ActionType = "disengage"
+    ActionDash      ActionType = "dash"
+    ActionAttack    ActionType = "attack"
+    // ... more as needed
+)
+```
+
+### 2. Add ActionRecord
+
+```go
+// rulebooks/dnd5e/combat/action_economy.go
+type ActionRecord struct {
+    Source     core.Ref   // refs.Features.StepOfTheWind()
+    ActionType ActionType // ActionDisengage, ActionDash, etc.
+}
+```
+
+### 3. Extend ActionEconomy with History
+
+```go
+type ActionEconomy struct {
+    ActionsRemaining      int
+    BonusActionsRemaining int
+    ReactionsRemaining    int
+
+    ActionsTaken      []ActionRecord
+    BonusActionsTaken []ActionRecord
+    ReactionsTaken    []ActionRecord
+}
+```
+
+### 4. Replace API with Recording Versions
+
+Remove:
+```go
+func (ae *ActionEconomy) UseAction() error
+func (ae *ActionEconomy) UseBonusAction() error
+func (ae *ActionEconomy) UseReaction() error
+```
+
+Add:
+```go
+func (ae *ActionEconomy) UseActionFor(record ActionRecord) error
+func (ae *ActionEconomy) UseBonusActionFor(record ActionRecord) error
+func (ae *ActionEconomy) UseReactionFor(record ActionRecord) error
+
+func (ae *ActionEconomy) HasTakenAction(actionType ActionType) bool
+func (ae *ActionEconomy) HasTakenBonusAction(actionType ActionType) bool
+func (ae *ActionEconomy) HasTakenReaction(actionType ActionType) bool
+```
+
+### 5. Feature Integration
+
+Features that cost actions consume via the new API:
+
+```go
+func (s *StepOfTheWind) Activate(ctx context.Context, owner core.Entity, input FeatureInput) error {
+    // Consume Ki
+    ki := accessor.GetResource(resources.Ki)
+    if err := ki.Use(1); err != nil {
+        return err
+    }
+
+    // Consume bonus action with record
+    record := ActionRecord{
+        Source:     refs.Features.StepOfTheWind(),
+        ActionType: input.ActionType, // ActionDisengage or ActionDash
+    }
+    if err := input.ActionEconomy.UseBonusActionFor(record); err != nil {
+        return err
+    }
+
+    // Publish event
+    // ...
+}
+```
+
+Note: `FeatureInput` gains an `ActionType` field for features with choices, replacing the untyped `Action string` that was attempted on the branch.
+
+### 6. Query Example (Future AoO Check)
+
+```go
+func (c *OpportunityAttackCondition) shouldTrigger(economy *ActionEconomy) bool {
+    if economy.HasTakenBonusAction(ActionDisengage) {
+        return false // They disengaged, no AoO
+    }
+    if economy.HasTakenAction(ActionDisengage) {
+        return false // Normal Disengage action also works
+    }
+    return true
+}
+```
+
+## Open Questions
+
+1. Should `ActionRecord` include timestamp or sequence number for ordering?
+2. Should there be an `ActionRecord.Data` field for action-specific data?
+3. How does this interact with reactions taken outside your turn (e.g., AoO you take on enemy's turn)?
+
+## Next Steps
+
+- Define concrete use cases to validate the design
+- Implement ActionType in core/combat
+- Extend ActionEconomy with history tracking
+- Update features to use new API

--- a/docs/ideas/action-economy-history/design-api.md
+++ b/docs/ideas/action-economy-history/design-api.md
@@ -1,0 +1,368 @@
+# Design: Game Server (rpg-api) Changes
+
+## Overview
+
+Game server changes to support passing ActionType through, including feature choices in character responses, and tracking action history in TurnState.
+
+**Key principle:** rpg-api stores data and orchestrates. rpg-toolkit handles rules.
+
+## 1. Handler: ActivateFeature
+
+Handler validates request and calls orchestrator:
+
+```go
+// internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+
+// ActivateFeature handles feature activation requests
+func (h *Handler) ActivateFeature(
+    ctx context.Context,
+    req *dnd5ev1alpha1.ActivateFeatureRequest,
+) (*dnd5ev1alpha1.ActivateFeatureResponse, error) {
+    // 1. Validate request
+    if req.GetEncounterId() == "" {
+        return nil, status.Error(codes.InvalidArgument, "encounter_id is required")
+    }
+    if req.GetCharacterId() == "" {
+        return nil, status.Error(codes.InvalidArgument, "character_id is required")
+    }
+    if req.GetFeatureId() == "" {
+        return nil, status.Error(codes.InvalidArgument, "feature_id is required")
+    }
+
+    // 2. Create orchestrator input
+    input := &encounter.ActivateFeatureInput{
+        EncounterID: req.GetEncounterId(),
+        CharacterID: req.GetCharacterId(),
+        FeatureID:   req.GetFeatureId(),
+        ActionType:  req.GetActionType(),  // Pass through proto enum
+    }
+
+    // 3. Call orchestrator
+    output, err := h.encounterService.ActivateFeature(ctx, input)
+    if err != nil {
+        return nil, errors.ToGRPCError(err)  // Uses internal/errors package
+    }
+
+    // 4. Convert to proto response
+    return &dnd5ev1alpha1.ActivateFeatureResponse{
+        Success:            true,
+        Message:            output.Message,
+        UpdatedCharacter:   toProtoCharacter(output.Character),
+        UpdatedCombatState: toProtoCombatState(output.CombatState),
+    }, nil
+}
+```
+
+## 2. Orchestrator: ActivateFeature
+
+Orchestrator loads data, calls toolkit, saves results:
+
+```go
+// internal/orchestrators/encounter/orchestrator.go
+
+// ActivateFeatureInput is the input for feature activation
+type ActivateFeatureInput struct {
+    EncounterID string
+    CharacterID string
+    FeatureID   string
+    ActionType  dnd5ev1alpha1.ActionType  // Proto enum, passed through
+}
+
+// ActivateFeatureOutput is the output for feature activation
+type ActivateFeatureOutput struct {
+    Message     string
+    Character   *entities.Character
+    CombatState *entities.CombatState
+}
+
+func (o *Orchestrator) ActivateFeature(
+    ctx context.Context,
+    input *ActivateFeatureInput,
+) (*ActivateFeatureOutput, error) {
+    if input == nil {
+        return nil, errors.InvalidArgument("input is required")
+    }
+
+    // 1. Load encounter
+    encounter, err := o.encounterRepo.Get(ctx, input.EncounterID)
+    if err != nil {
+        return nil, errors.Wrapf(err, "failed to load encounter %s", input.EncounterID)
+    }
+
+    // 2. Load character
+    character, err := o.characterRepo.Get(ctx, input.CharacterID)
+    if err != nil {
+        return nil, errors.Wrapf(err, "failed to load character %s", input.CharacterID)
+    }
+
+    // 3. Get feature from character
+    feature := character.GetFeature(input.FeatureID)
+    if feature == nil {
+        return nil, errors.NotFound("feature %s not found", input.FeatureID)
+    }
+
+    // 4. Get turn state and convert to ActionEconomy
+    turnState := encounter.GetTurnState(input.CharacterID)
+    actionEconomy := o.toActionEconomy(turnState)
+
+    // 5. Build feature input - pass ActionType through without interpretation
+    featureInput := features.FeatureInput{
+        Bus:           o.eventBus,
+        ActionEconomy: actionEconomy,
+        ActionType:    fromProtoActionType(input.ActionType),
+    }
+
+    // 6. Activate feature (toolkit does validation)
+    if err := feature.Activate(ctx, character, featureInput); err != nil {
+        // Toolkit returns typed errors - preserve them
+        return nil, err
+    }
+
+    // 7. Update turn state from action economy
+    encounter.UpdateTurnState(input.CharacterID, o.toTurnState(actionEconomy, turnState))
+
+    // 8. Save encounter
+    if err := o.encounterRepo.Save(ctx, encounter); err != nil {
+        return nil, errors.Wrapf(err, "failed to save encounter")
+    }
+
+    // 9. Save character if modified
+    if character.IsDirty() {
+        if err := o.characterRepo.Save(ctx, character); err != nil {
+            return nil, errors.Wrapf(err, "failed to save character")
+        }
+    }
+
+    return &ActivateFeatureOutput{
+        Message:     fmt.Sprintf("%s activated", feature.Name()),
+        Character:   character,
+        CombatState: encounter.CombatState,
+    }, nil
+}
+```
+
+## 3. Conversion Helpers
+
+### ActionType Conversion
+
+```go
+// internal/handlers/dnd5e/v1alpha1/encounter/converters.go
+
+import (
+    dnd5ev1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+func fromProtoActionType(pt dnd5ev1alpha1.ActionType) combat.ActionType {
+    switch pt {
+    case dnd5ev1alpha1.ActionType_ACTION_TYPE_ATTACK:
+        return combat.ActionAttack
+    case dnd5ev1alpha1.ActionType_ACTION_TYPE_DASH:
+        return combat.ActionDash
+    case dnd5ev1alpha1.ActionType_ACTION_TYPE_DISENGAGE:
+        return combat.ActionDisengage
+    case dnd5ev1alpha1.ActionType_ACTION_TYPE_DODGE:
+        return combat.ActionDodge
+    default:
+        return ""
+    }
+}
+
+func toProtoActionType(at combat.ActionType) dnd5ev1alpha1.ActionType {
+    switch at {
+    case combat.ActionAttack:
+        return dnd5ev1alpha1.ActionType_ACTION_TYPE_ATTACK
+    case combat.ActionDash:
+        return dnd5ev1alpha1.ActionType_ACTION_TYPE_DASH
+    case combat.ActionDisengage:
+        return dnd5ev1alpha1.ActionType_ACTION_TYPE_DISENGAGE
+    case combat.ActionDodge:
+        return dnd5ev1alpha1.ActionType_ACTION_TYPE_DODGE
+    default:
+        return dnd5ev1alpha1.ActionType_ACTION_TYPE_UNSPECIFIED
+    }
+}
+```
+
+### ActionEconomy Conversion
+
+```go
+// internal/orchestrators/encounter/converters.go
+
+func (o *Orchestrator) toActionEconomy(ts *dnd5ev1alpha1.TurnState) *combat.ActionEconomy {
+    ae := combat.NewActionEconomy()
+    ae.ActionsRemaining = int(ts.GetActionsRemaining())
+    ae.BonusActionsRemaining = int(ts.GetBonusActionsRemaining())
+    ae.ReactionsRemaining = int(ts.GetReactionsRemaining())
+
+    // Convert history
+    for _, record := range ts.GetActionsTaken() {
+        ae.Taken.Actions = append(ae.Taken.Actions, combat.ActionRecord{
+            Source:     core.ParseRef(record.GetSourceRef()),
+            ActionType: fromProtoActionType(record.GetActionType()),
+        })
+    }
+    for _, record := range ts.GetBonusActionsTaken() {
+        ae.Taken.BonusActions = append(ae.Taken.BonusActions, combat.ActionRecord{
+            Source:     core.ParseRef(record.GetSourceRef()),
+            ActionType: fromProtoActionType(record.GetActionType()),
+        })
+    }
+    for _, record := range ts.GetReactionsTaken() {
+        ae.Taken.Reactions = append(ae.Taken.Reactions, combat.ActionRecord{
+            Source:     core.ParseRef(record.GetSourceRef()),
+            ActionType: fromProtoActionType(record.GetActionType()),
+        })
+    }
+
+    return ae
+}
+
+func (o *Orchestrator) toTurnState(ae *combat.ActionEconomy, existing *dnd5ev1alpha1.TurnState) *dnd5ev1alpha1.TurnState {
+    ts := &dnd5ev1alpha1.TurnState{
+        EntityId:              existing.GetEntityId(),
+        MovementUsed:          existing.GetMovementUsed(),
+        MovementMax:           existing.GetMovementMax(),
+        Position:              existing.GetPosition(),
+        ActionsRemaining:      int32(ae.ActionsRemaining),
+        BonusActionsRemaining: int32(ae.BonusActionsRemaining),
+        ReactionsRemaining:    int32(ae.ReactionsRemaining),
+    }
+
+    // Convert history
+    for _, record := range ae.Taken.Actions {
+        ts.ActionsTaken = append(ts.ActionsTaken, &dnd5ev1alpha1.ActionRecord{
+            SourceRef:  record.Source.String(),
+            ActionType: toProtoActionType(record.ActionType),
+        })
+    }
+    for _, record := range ae.Taken.BonusActions {
+        ts.BonusActionsTaken = append(ts.BonusActionsTaken, &dnd5ev1alpha1.ActionRecord{
+            SourceRef:  record.Source.String(),
+            ActionType: toProtoActionType(record.ActionType),
+        })
+    }
+    for _, record := range ae.Taken.Reactions {
+        ts.ReactionsTaken = append(ts.ReactionsTaken, &dnd5ev1alpha1.ActionRecord{
+            SourceRef:  record.Source.String(),
+            ActionType: toProtoActionType(record.ActionType),
+        })
+    }
+
+    return ts
+}
+```
+
+## 4. GetCharacter with Activation Choices
+
+Include feature choices in character response:
+
+```go
+// internal/handlers/dnd5e/v1alpha1/character/converters.go
+
+func toProtoFeature(f toolkitfeatures.Feature) *dnd5ev1alpha1.Feature {
+    protoFeature := &dnd5ev1alpha1.Feature{
+        Id:          f.GetID(),
+        Ref:         toProtoRef(f.Ref()),
+        Name:        f.Name(),
+        Description: f.Description(),
+    }
+
+    // Check if feature provides activation choices
+    if provider, ok := f.(toolkitfeatures.ActivationChoiceProvider); ok {
+        protoFeature.ActivationChoices = toProtoActivationChoices(provider.GetActivationChoices())
+    }
+
+    return protoFeature
+}
+
+func toProtoActivationChoices(choices []toolkitfeatures.ActivationChoice) []*dnd5ev1alpha1.ActivationChoice {
+    if len(choices) == 0 {
+        return nil
+    }
+
+    result := make([]*dnd5ev1alpha1.ActivationChoice, len(choices))
+    for i, choice := range choices {
+        options := make([]*dnd5ev1alpha1.ActivationOption, len(choice.Options))
+        for j, opt := range choice.Options {
+            options[j] = &dnd5ev1alpha1.ActivationOption{
+                ActionType:  toProtoActionType(opt.ActionType),
+                Label:       opt.Label,
+                Description: opt.Description,
+            }
+        }
+
+        result[i] = &dnd5ev1alpha1.ActivationChoice{
+            Id:          choice.ID,
+            Description: choice.Description,
+            Options:     options,
+        }
+    }
+    return result
+}
+```
+
+## 5. Movement with AoO Check
+
+When processing movement, publish AoO check events:
+
+```go
+// internal/orchestrators/encounter/movement.go
+
+func (o *Orchestrator) processMovement(ctx context.Context, mover *entities.Character, path []Position) error {
+    for i := 1; i < len(path); i++ {
+        previousPos := path[i-1]
+        currentPos := path[i]
+
+        // Check for opportunity attacks when leaving threatened squares
+        for _, enemy := range o.getAdjacentEnemies(previousPos) {
+            if o.isLeavingThreat(previousPos, currentPos, enemy) {
+                // Publish check event - conditions can cancel
+                checkEvent := &dnd5eEvents.OpportunityAttackCheckEvent{
+                    AttackerID: enemy.GetID(),
+                    TargetID:   mover.GetID(),
+                }
+
+                topic := dnd5eEvents.OpportunityAttackCheckTopic.On(o.eventBus)
+                if err := topic.Publish(ctx, checkEvent); err != nil {
+                    return errors.Wrapf(err, "failed to publish AoO check event")
+                }
+
+                // If not cancelled, trigger AoO
+                if !checkEvent.IsCancelled() {
+                    if err := o.triggerOpportunityAttack(ctx, enemy, mover); err != nil {
+                        return errors.Wrapf(err, "failed to trigger opportunity attack")
+                    }
+                }
+            }
+        }
+
+        // Move to new position
+        if err := o.moveEntity(mover, currentPos); err != nil {
+            return errors.Wrapf(err, "failed to move entity to %v", currentPos)
+        }
+    }
+
+    return nil
+}
+```
+
+## File Summary
+
+| Layer | File | Changes |
+|-------|------|---------|
+| Handler | handlers/dnd5e/v1alpha1/encounter/handler.go | ActivateFeature handler |
+| Handler | handlers/dnd5e/v1alpha1/encounter/converters.go | ActionType converters |
+| Handler | handlers/dnd5e/v1alpha1/character/converters.go | Feature with choices |
+| Orchestrator | orchestrators/encounter/orchestrator.go | ActivateFeature implementation |
+| Orchestrator | orchestrators/encounter/converters.go | ActionEconomy <-> TurnState |
+| Orchestrator | orchestrators/encounter/movement.go | AoO check events |
+
+## Key Principles
+
+1. **Handler validates request** - Required fields, format
+2. **Orchestrator orchestrates** - Load, call toolkit, save
+3. **Toolkit validates logic** - Features validate their own requirements
+4. **Game server doesn't interpret ActionType** - Just passes it through
+5. **Events decouple** - AoO checks go through event bus, conditions can cancel
+6. **Use internal/errors package** - Consistent error handling

--- a/docs/ideas/action-economy-history/design-protos.md
+++ b/docs/ideas/action-economy-history/design-protos.md
@@ -1,0 +1,165 @@
+# Design: Proto Changes for Action Economy History
+
+## Overview
+
+Proto changes to support ActionType enums, feature activation choices, and turn state with action history.
+
+## Changes to dnd5e/api/v1alpha1/enums.proto
+
+Add ActionType enum:
+
+```protobuf
+// ActionType represents standard D&D 5e actions
+enum ActionType {
+  ACTION_TYPE_UNSPECIFIED = 0;
+  ACTION_TYPE_ATTACK = 1;
+  ACTION_TYPE_DASH = 2;
+  ACTION_TYPE_DISENGAGE = 3;
+  ACTION_TYPE_DODGE = 4;
+  ACTION_TYPE_HELP = 5;
+  ACTION_TYPE_HIDE = 6;
+  ACTION_TYPE_READY = 7;
+  ACTION_TYPE_SEARCH = 8;
+  ACTION_TYPE_USE_OBJECT = 9;
+}
+```
+
+## New file: dnd5e/api/v1alpha1/activation.proto
+
+Feature activation choices:
+
+```protobuf
+syntax = "proto3";
+
+package dnd5e.api.v1alpha1;
+
+import "dnd5e/api/v1alpha1/enums.proto";
+
+option go_package = "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1;v1alpha1";
+
+// ActivationOption represents one selectable option for feature activation
+message ActivationOption {
+  // The action type this option grants
+  ActionType action_type = 1;
+
+  // Display label for UI (e.g., "Disengage")
+  string label = 2;
+
+  // Optional description (e.g., "Avoid opportunity attacks")
+  string description = 3;
+}
+
+// ActivationChoice represents a choice required to activate a feature
+message ActivationChoice {
+  // Identifier for this choice (e.g., "action_type")
+  string id = 1;
+
+  // Description of what the user is choosing
+  string description = 2;
+
+  // Available options
+  repeated ActivationOption options = 3;
+}
+```
+
+## Changes to dnd5e/api/v1alpha1/character.proto
+
+Add choices to Feature message:
+
+```protobuf
+// Feature represents a character feature (class ability, racial trait, etc.)
+message Feature {
+  string id = 1;
+  Ref ref = 2;
+  string name = 3;
+  string description = 4;
+
+  // Choices required for activation (empty if none needed)
+  repeated ActivationChoice activation_choices = 5;
+}
+```
+
+## Changes to dnd5e/api/v1alpha1/encounter.proto
+
+### Update ActivateFeatureRequest
+
+```protobuf
+message ActivateFeatureRequest {
+  string encounter_id = 1;
+  string character_id = 2;
+  string feature_id = 3;
+
+  // Action type choice (for features that grant actions)
+  ActionType action_type = 4;
+}
+```
+
+### Add ActionRecord message
+
+```protobuf
+// ActionRecord tracks what used an action slot
+message ActionRecord {
+  // Feature/ability that consumed this action
+  string source_ref = 1;
+
+  // What action was taken
+  ActionType action_type = 2;
+}
+```
+
+### Update TurnState
+
+Replace bools with counts and history:
+
+```protobuf
+message TurnState {
+  string entity_id = 1;
+  int32 movement_used = 2;
+  int32 movement_max = 3;
+
+  // Budget - how many remain
+  int32 actions_remaining = 4;
+  int32 bonus_actions_remaining = 5;
+  int32 reactions_remaining = 6;
+
+  // History - what was used
+  repeated ActionRecord actions_taken = 7;
+  repeated ActionRecord bonus_actions_taken = 8;
+  repeated ActionRecord reactions_taken = 9;
+
+  .api.v1alpha1.Position position = 10;
+}
+```
+
+**Note:** This replaces the current bool fields (`action_used`, `bonus_action_used`, `reaction_available`). Existing clients will need updates.
+
+### Update ActivateFeatureResponse
+
+```protobuf
+message ActivateFeatureResponse {
+  bool success = 1;
+  string message = 2;
+  Character updated_character = 3;
+  CombatState updated_combat_state = 4;  // Includes TurnState with history
+}
+```
+
+## Migration Notes
+
+### Breaking Changes
+
+- `TurnState.action_used` (bool) -> `actions_remaining` (int32) + `actions_taken` (repeated)
+- Same for bonus_action and reaction
+
+### Client Updates Required
+
+Clients checking `turn_state.action_used` need to check `turn_state.actions_remaining == 0` or look at `actions_taken`.
+
+## File Summary
+
+| File | Changes |
+|------|---------|
+| enums.proto | Add ActionType enum |
+| activation.proto | New file - ActivationChoice, ActivationOption |
+| character.proto | Add activation_choices to Feature |
+| encounter.proto | Update ActivateFeatureRequest, TurnState, add ActionRecord |

--- a/docs/ideas/action-economy-history/design-toolkit.md
+++ b/docs/ideas/action-economy-history/design-toolkit.md
@@ -1,0 +1,498 @@
+# Design: Toolkit Changes for Action Economy History
+
+## Overview
+
+Toolkit changes to support ActionType, ActionEconomy history, feature activation choices, turn-scoped conditions, and consolidated event topics.
+
+## 1. ActionType in core/combat
+
+Type definition only (constants in rulebook):
+
+```go
+// core/combat/types.go
+package combat
+
+// ActionType represents a type of action that can be taken
+type ActionType string
+```
+
+## 2. ActionType Constants in rulebooks/dnd5e/combat
+
+```go
+// rulebooks/dnd5e/combat/action_types.go
+package combat
+
+import corecombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+
+// Action type constants for D&D 5e
+// Only add constants when there's a concrete use case
+const (
+    ActionAttack    corecombat.ActionType = "attack"
+    ActionDash      corecombat.ActionType = "dash"
+    ActionDisengage corecombat.ActionType = "disengage"
+    ActionDodge     corecombat.ActionType = "dodge"
+
+    // Future action types - add when use cases arise:
+    // ActionHelp      corecombat.ActionType = "help"
+    // ActionHide      corecombat.ActionType = "hide"
+    // ActionReady     corecombat.ActionType = "ready"
+    // ActionSearch    corecombat.ActionType = "search"
+    // ActionUseObject corecombat.ActionType = "use_object"
+)
+```
+
+## 3. ActionRecord
+
+```go
+// rulebooks/dnd5e/combat/action_record.go
+package combat
+
+import (
+    "github.com/KirkDiggler/rpg-toolkit/core"
+    corecombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+)
+
+// ActionRecord tracks what consumed an action slot
+type ActionRecord struct {
+    // Source is the feature/ability that used this action
+    Source *core.Ref
+
+    // ActionType is what action was taken
+    ActionType corecombat.ActionType
+}
+```
+
+## 4. ActionHistory
+
+Group history slices together:
+
+```go
+// rulebooks/dnd5e/combat/action_history.go
+package combat
+
+import corecombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+
+// ActionHistory tracks what actions have been taken during a turn
+type ActionHistory struct {
+    Actions      []ActionRecord
+    BonusActions []ActionRecord
+    Reactions    []ActionRecord
+}
+
+// NewActionHistory creates an empty ActionHistory
+func NewActionHistory() *ActionHistory {
+    return &ActionHistory{
+        Actions:      make([]ActionRecord, 0),
+        BonusActions: make([]ActionRecord, 0),
+        Reactions:    make([]ActionRecord, 0),
+    }
+}
+
+// HasTakenAction returns true if an action of the given type was taken
+func (h *ActionHistory) HasTakenAction(actionType corecombat.ActionType) bool {
+    for _, record := range h.Actions {
+        if record.ActionType == actionType {
+            return true
+        }
+    }
+    return false
+}
+
+// HasTakenBonusAction returns true if a bonus action of the given type was taken
+func (h *ActionHistory) HasTakenBonusAction(actionType corecombat.ActionType) bool {
+    for _, record := range h.BonusActions {
+        if record.ActionType == actionType {
+            return true
+        }
+    }
+    return false
+}
+
+// HasTakenReaction returns true if a reaction of the given type was taken
+func (h *ActionHistory) HasTakenReaction(actionType corecombat.ActionType) bool {
+    for _, record := range h.Reactions {
+        if record.ActionType == actionType {
+            return true
+        }
+    }
+    return false
+}
+
+// Reset clears all history
+func (h *ActionHistory) Reset() {
+    h.Actions = make([]ActionRecord, 0)
+    h.BonusActions = make([]ActionRecord, 0)
+    h.Reactions = make([]ActionRecord, 0)
+}
+```
+
+## 5. ActionEconomy Updates
+
+```go
+// rulebooks/dnd5e/combat/action_economy.go
+package combat
+
+import "github.com/KirkDiggler/rpg-toolkit/rpgerr"
+
+// ActionEconomy tracks action budget and history for a combatant's turn
+type ActionEconomy struct {
+    ActionsRemaining      int
+    BonusActionsRemaining int
+    ReactionsRemaining    int
+
+    Taken *ActionHistory
+}
+
+// NewActionEconomy creates a new ActionEconomy with default values (1/1/1)
+func NewActionEconomy() *ActionEconomy {
+    return &ActionEconomy{
+        ActionsRemaining:      1,
+        BonusActionsRemaining: 1,
+        ReactionsRemaining:    1,
+        Taken:                 NewActionHistory(),
+    }
+}
+
+// UseActionFor consumes an action and records what used it
+func (ae *ActionEconomy) UseActionFor(record ActionRecord) error {
+    if ae.ActionsRemaining <= 0 {
+        return rpgerr.ResourceExhausted("action")
+    }
+    ae.ActionsRemaining--
+    ae.Taken.Actions = append(ae.Taken.Actions, record)
+    return nil
+}
+
+// UseBonusActionFor consumes a bonus action and records what used it
+func (ae *ActionEconomy) UseBonusActionFor(record ActionRecord) error {
+    if ae.BonusActionsRemaining <= 0 {
+        return rpgerr.ResourceExhausted("bonus action")
+    }
+    ae.BonusActionsRemaining--
+    ae.Taken.BonusActions = append(ae.Taken.BonusActions, record)
+    return nil
+}
+
+// UseReactionFor consumes a reaction and records what used it
+func (ae *ActionEconomy) UseReactionFor(record ActionRecord) error {
+    if ae.ReactionsRemaining <= 0 {
+        return rpgerr.ResourceExhausted("reaction")
+    }
+    ae.ReactionsRemaining--
+    ae.Taken.Reactions = append(ae.Taken.Reactions, record)
+    return nil
+}
+
+// CanUseAction returns whether an action is available
+func (ae *ActionEconomy) CanUseAction() bool {
+    return ae.ActionsRemaining > 0
+}
+
+// CanUseBonusAction returns whether a bonus action is available
+func (ae *ActionEconomy) CanUseBonusAction() bool {
+    return ae.BonusActionsRemaining > 0
+}
+
+// CanUseReaction returns whether a reaction is available
+func (ae *ActionEconomy) CanUseReaction() bool {
+    return ae.ReactionsRemaining > 0
+}
+
+// Reset restores budget to defaults and clears history
+func (ae *ActionEconomy) Reset() {
+    ae.ActionsRemaining = 1
+    ae.BonusActionsRemaining = 1
+    ae.ReactionsRemaining = 1
+    ae.Taken.Reset()
+}
+
+// GrantExtraAction grants an additional action
+func (ae *ActionEconomy) GrantExtraAction() {
+    ae.ActionsRemaining++
+}
+
+// GrantExtraBonusAction grants an additional bonus action
+func (ae *ActionEconomy) GrantExtraBonusAction() {
+    ae.BonusActionsRemaining++
+}
+```
+
+## 6. FeatureInput Updates
+
+```go
+// rulebooks/dnd5e/features/types.go
+package features
+
+import (
+    corecombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+    "github.com/KirkDiggler/rpg-toolkit/events"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// FeatureInput provides input data for feature activation.
+type FeatureInput struct {
+    // Bus is provided by the character/owner during activation
+    Bus events.EventBus `json:"-"`
+
+    // ActionEconomy is provided for features that consume actions
+    ActionEconomy *combat.ActionEconomy `json:"-"`
+
+    // ActionType is the chosen action for features with choices
+    ActionType corecombat.ActionType `json:"action_type,omitempty"`
+}
+```
+
+## 7. Activation Choices Interface
+
+```go
+// rulebooks/dnd5e/features/activation.go
+package features
+
+import corecombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+
+// ActivationOption represents one selectable option for feature activation
+type ActivationOption struct {
+    ActionType  corecombat.ActionType
+    Label       string
+    Description string
+}
+
+// ActivationChoice represents a choice required to activate a feature
+type ActivationChoice struct {
+    ID          string
+    Description string
+    Options     []ActivationOption
+}
+
+// ActivationChoiceProvider is implemented by features that require choices
+type ActivationChoiceProvider interface {
+    // GetActivationChoices returns choices needed for activation
+    // Returns nil or empty slice if no choices required
+    GetActivationChoices() []ActivationChoice
+}
+```
+
+## 8. Step of the Wind Implementation
+
+```go
+// rulebooks/dnd5e/features/step_of_the_wind.go
+
+import (
+    "context"
+
+    "github.com/KirkDiggler/rpg-toolkit/core"
+    "github.com/KirkDiggler/rpg-toolkit/rpgerr"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+    dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+)
+
+// GetActivationChoices implements ActivationChoiceProvider
+func (s *StepOfTheWind) GetActivationChoices() []ActivationChoice {
+    return []ActivationChoice{
+        {
+            ID:          "action_type",
+            Description: "Choose your action",
+            Options: []ActivationOption{
+                {ActionType: combat.ActionDisengage, Label: "Disengage", Description: "Avoid opportunity attacks"},
+                {ActionType: combat.ActionDash, Label: "Dash", Description: "Double your movement"},
+            },
+        },
+    }
+}
+
+func (s *StepOfTheWind) Activate(ctx context.Context, owner core.Entity, input FeatureInput) error {
+    // Validate ActionEconomy provided
+    if input.ActionEconomy == nil {
+        return rpgerr.New(rpgerr.CodeInvalidArgument, "ActionEconomy is required")
+    }
+
+    // Validate choice
+    if input.ActionType != combat.ActionDisengage && input.ActionType != combat.ActionDash {
+        return rpgerr.New(rpgerr.CodeInvalidArgument, "action_type must be disengage or dash")
+    }
+
+    // Consume Ki
+    accessor, ok := owner.(ResourceAccessor)
+    if !ok {
+        return rpgerr.New(rpgerr.CodeInvalidArgument, "owner must implement ResourceAccessor")
+    }
+    ki := accessor.GetResource(resources.Ki)
+    if err := ki.Use(1); err != nil {
+        return rpgerr.Wrapf(err, "failed to use ki for step of the wind")
+    }
+
+    // Consume bonus action with record
+    record := combat.ActionRecord{
+        Source:     refs.Features.StepOfTheWind(),
+        ActionType: input.ActionType,
+    }
+    if err := input.ActionEconomy.UseBonusActionFor(record); err != nil {
+        return rpgerr.Wrapf(err, "failed to use bonus action")
+    }
+
+    // Apply turn-scoped condition based on choice
+    if input.Bus != nil {
+        if input.ActionType == combat.ActionDisengage {
+            // Apply Disengaged condition - cancels AoO for this turn
+            condition := conditions.NewDisengaged(owner.GetID())
+            if err := condition.Apply(ctx, input.Bus); err != nil {
+                return rpgerr.Wrapf(err, "failed to apply disengaged condition")
+            }
+        }
+        // Note: Dash effect handled by querying ActionEconomy.Taken.HasTakenBonusAction(ActionDash)
+
+        // Publish generic feature activated event
+        topic := dnd5eEvents.FeatureActivatedTopic.On(input.Bus)
+        err := topic.Publish(ctx, dnd5eEvents.FeatureActivatedEvent{
+            CharacterID: owner.GetID(),
+            FeatureRef:  refs.Features.StepOfTheWind(),
+            ActionType:  input.ActionType,
+        })
+        if err != nil {
+            return rpgerr.Wrapf(err, "failed to publish feature activated event")
+        }
+    }
+
+    return nil
+}
+```
+
+## 9. Consolidated Event Topic
+
+Replace per-feature topics with single topic:
+
+```go
+// rulebooks/dnd5e/events/events.go
+
+import (
+    "github.com/KirkDiggler/rpg-toolkit/core"
+    corecombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+    "github.com/KirkDiggler/rpg-toolkit/events"
+)
+
+// FeatureActivatedEvent is published when any feature is activated
+type FeatureActivatedEvent struct {
+    CharacterID string
+    FeatureRef  *core.Ref
+    ActionType  corecombat.ActionType  // What action was taken (if applicable)
+}
+
+// FeatureActivatedTopic provides typed pub/sub for all feature activation events
+var FeatureActivatedTopic = events.DefineTypedTopic[FeatureActivatedEvent]("dnd5e.feature.activated")
+
+// DEPRECATED: Remove these per-feature topics
+// var FlurryOfBlowsActivatedTopic = ...
+// var PatientDefenseActivatedTopic = ...
+// var StepOfTheWindActivatedTopic = ...
+```
+
+## 10. Disengaged Condition (Turn-Scoped)
+
+```go
+// rulebooks/dnd5e/conditions/disengaged.go
+package conditions
+
+import (
+    "context"
+
+    "github.com/KirkDiggler/rpg-toolkit/events"
+    dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// Disengaged is a turn-scoped condition that prevents opportunity attacks
+type Disengaged struct {
+    characterID  string
+    subscription events.Subscription
+}
+
+// NewDisengaged creates a new Disengaged condition for the character
+func NewDisengaged(characterID string) *Disengaged {
+    return &Disengaged{
+        characterID: characterID,
+    }
+}
+
+// Apply subscribes to opportunity attack check events
+func (d *Disengaged) Apply(ctx context.Context, bus events.EventBus) error {
+    topic := dnd5eEvents.OpportunityAttackCheckTopic.On(bus)
+    sub, err := topic.Subscribe(ctx, d.onOpportunityAttackCheck)
+    if err != nil {
+        return err
+    }
+    d.subscription = sub
+
+    // Subscribe to turn end to clean up
+    turnTopic := dnd5eEvents.TurnEndTopic.On(bus)
+    _, err = turnTopic.Subscribe(ctx, d.onTurnEnd)
+    return err
+}
+
+func (d *Disengaged) onOpportunityAttackCheck(ctx context.Context, event *dnd5eEvents.OpportunityAttackCheckEvent) {
+    if event.TargetID == d.characterID {
+        event.Cancel("target disengaged this turn")
+    }
+}
+
+func (d *Disengaged) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnEndEvent) {
+    if event.CharacterID == d.characterID {
+        // Clean up subscription
+        if d.subscription != nil {
+            d.subscription.Unsubscribe()
+        }
+    }
+}
+```
+
+## 11. Opportunity Attack Check Event
+
+```go
+// rulebooks/dnd5e/events/events.go
+
+// OpportunityAttackCheckEvent is published when checking if an AoO should trigger
+type OpportunityAttackCheckEvent struct {
+    AttackerID string  // Entity that would make the AoO
+    TargetID   string  // Entity leaving threatened square
+    cancelled  bool
+    reason     string
+}
+
+// Cancel prevents the opportunity attack from triggering
+func (e *OpportunityAttackCheckEvent) Cancel(reason string) {
+    e.cancelled = true
+    e.reason = reason
+}
+
+// IsCancelled returns true if the AoO was cancelled
+func (e *OpportunityAttackCheckEvent) IsCancelled() bool {
+    return e.cancelled
+}
+
+// CancelReason returns why the AoO was cancelled
+func (e *OpportunityAttackCheckEvent) CancelReason() string {
+    return e.reason
+}
+
+var OpportunityAttackCheckTopic = events.DefineTypedTopic[*OpportunityAttackCheckEvent](
+    "dnd5e.combat.opportunity_attack.check")
+```
+
+**Note:** Event uses pointer so condition can mutate `cancelled` field.
+
+## File Summary
+
+| File | Changes |
+|------|---------|
+| core/combat/types.go | Add ActionType type |
+| rulebooks/dnd5e/combat/action_types.go | New - ActionType constants (only ones with use cases) |
+| rulebooks/dnd5e/combat/action_record.go | New - ActionRecord struct |
+| rulebooks/dnd5e/combat/action_history.go | New - ActionHistory struct with query helpers |
+| rulebooks/dnd5e/combat/action_economy.go | Add Taken *ActionHistory, replace Use* with UseFor* |
+| rulebooks/dnd5e/features/types.go | Add ActionType to FeatureInput |
+| rulebooks/dnd5e/features/activation.go | New - ActivationChoice, ActivationChoiceProvider |
+| rulebooks/dnd5e/features/step_of_the_wind.go | Implement choices, apply condition |
+| rulebooks/dnd5e/features/patient_defense.go | Update to use new API |
+| rulebooks/dnd5e/events/events.go | Add FeatureActivatedTopic, OpportunityAttackCheckTopic |
+| rulebooks/dnd5e/conditions/disengaged.go | New - turn-scoped condition |

--- a/docs/ideas/action-economy-history/progress.json
+++ b/docs/ideas/action-economy-history/progress.json
@@ -1,0 +1,145 @@
+{
+  "idea": "action-economy-history",
+  "status": "issues_created",
+  "summary": "Track what actions were taken during a turn, not just how many remain",
+  "trigger": "Step of Wind allows Disengage OR Dash - later logic (AoO checks) needs to know which was chosen",
+  "phases": {
+    "brainstorm": {
+      "status": "completed",
+      "date": "2024-12-06",
+      "file": "brainstorm.md",
+      "notes": "Established core design: extend ActionEconomy with history, ActionType in core, ActionRecord with core.Ref source"
+    },
+    "use_cases": {
+      "status": "completed",
+      "date": "2024-12-06",
+      "file": "use-cases.md",
+      "notes": "End-to-end flows revealed proto changes, feature choice interface, and event consolidation needs. Identified condition approach for downstream effects."
+    },
+    "architecture": {
+      "status": "skipped",
+      "reason": "Extends existing ActionEconomy pattern in rulebooks/dnd5e/combat, no new architectural decisions needed"
+    },
+    "design": {
+      "status": "completed",
+      "date": "2024-12-06",
+      "files": ["design-protos.md", "design-toolkit.md", "design-api.md"],
+      "notes": "Three design docs covering proto changes, toolkit implementation, and game server integration"
+    },
+    "issues": {
+      "status": "completed",
+      "date": "2025-12-06",
+      "links": [
+        "https://github.com/KirkDiggler/rpg-api-protos/issues/81",
+        "https://github.com/KirkDiggler/rpg-toolkit/issues/399",
+        "https://github.com/KirkDiggler/rpg-api/issues/266"
+      ]
+    }
+  },
+  "decisions": [
+    {
+      "question": "Where does ActionType live?",
+      "answer": "Type in core/combat, constants in rulebooks/dnd5e/combat",
+      "reason": "Follows established pattern - core defines types, rulebooks define constants"
+    },
+    {
+      "question": "Where does history live?",
+      "answer": "On ActionEconomy itself",
+      "reason": "Budget and history go together naturally. TurnContext is a higher layer orchestrating multiple characters' economies"
+    },
+    {
+      "question": "Source field type in ActionRecord?",
+      "answer": "core.Ref",
+      "reason": "Typed, validated, consistent with rest of system - not a string with typo risk"
+    },
+    {
+      "question": "Keep old UseAction/UseBonusAction methods?",
+      "answer": "Remove them, only UseActionFor/UseBonusActionFor",
+      "reason": "Pre-release, no backwards compatibility needed. Forces all callers to record what they're using actions for"
+    },
+    {
+      "question": "ActionEconomy pointer or value in FeatureInput?",
+      "answer": "Pointer",
+      "reason": "Allows distinguishing 'not provided' from 'provided but empty'. Zero-value ActionEconomy gives misleading errors"
+    },
+    {
+      "question": "How does a feature declare its choices?",
+      "answer": "Feature interface gains GetActivationChoices() method",
+      "reason": "Features self-describe. Game server calls method, empty slice means no choices needed. Connects to existing choice system."
+    },
+    {
+      "question": "How does game server know which features require choices?",
+      "answer": "Call GetActivationChoices() - returns empty slice if none needed",
+      "reason": "No separate flag needed, the method itself is the check"
+    },
+    {
+      "question": "Who validates ActionType input?",
+      "answer": "Feature validates its own requirements",
+      "reason": "Same pattern as resource validation. Feature knows what it accepts."
+    },
+    {
+      "question": "Per-feature event topics?",
+      "answer": "No - one FeatureActivatedTopic for all features",
+      "reason": "Doesn't scale. Homebrew/external modules can't add topics. Subscribers filter by FeatureRef if needed."
+    },
+    {
+      "question": "ActionType string or enum?",
+      "answer": "Enum in protos and toolkit",
+      "reason": "Type safety, no typos, UI gets exactly the valid options"
+    },
+    {
+      "question": "Query ActionEconomy vs Turn-scoped Conditions for downstream effects?",
+      "answer": "Turn-scoped conditions for effects like Disengage (cancels AoO)",
+      "reason": "Fits event-driven architecture. Conditions subscribe to events and cancel them. Less coupling than direct queries. Dash speed bonus can still use query since it's a simple calculation."
+    }
+  ],
+  "open_questions": [
+    {
+      "question": "Should ActionRecord include sequence/timestamp?",
+      "options": [
+        "Yes - for ordering when it matters",
+        "No - turn is atomic, order doesn't matter"
+      ],
+      "status": "open"
+    }
+  ],
+  "affected_projects": [
+    {
+      "project": "rpg-api-protos",
+      "changes": [
+        "ActionType enum in enums.proto",
+        "New activation.proto with ActivationChoice/ActivationOption",
+        "ActivateFeatureRequest.action_type field",
+        "TurnState with action history (ActionRecord)",
+        "Breaking: TurnState bools replaced with counts"
+      ],
+      "design": "design-protos.md"
+    },
+    {
+      "project": "rpg-toolkit",
+      "changes": [
+        "ActionType type in core/combat",
+        "ActionType constants in rulebooks/dnd5e/combat",
+        "ActionRecord struct",
+        "ActionEconomy with history",
+        "ActivationChoiceProvider interface",
+        "FeatureInput.ActionType field",
+        "FeatureActivatedTopic (replaces per-feature topics)",
+        "OpportunityAttackCheckTopic",
+        "Disengaged condition (turn-scoped)"
+      ],
+      "design": "design-toolkit.md"
+    },
+    {
+      "project": "rpg-api",
+      "changes": [
+        "GetCharacter includes activation choices",
+        "ActivateFeature passes ActionType through",
+        "ActionType conversion helpers",
+        "TurnState ↔ ActionEconomy conversion",
+        "Movement publishes AoO check events"
+      ],
+      "design": "design-api.md"
+    }
+  ]
+}

--- a/docs/ideas/action-economy-history/use-cases.md
+++ b/docs/ideas/action-economy-history/use-cases.md
@@ -1,0 +1,393 @@
+# Action Economy History - Use Cases
+
+End-to-end flows from UI to toolkit and back.
+
+## Use Case 1: Step of the Wind Activation
+
+### Context
+
+A Monk wants to use Step of the Wind. This feature costs 1 Ki and grants either Disengage or Dash as a bonus action. The user must choose which one.
+
+### Flow
+
+#### 1. UI Gets Character (includes features with choices)
+
+Character data includes features and their activation requirements:
+
+```protobuf
+// Part of GetCharacter response
+message Feature {
+  string id = 1;
+  Ref ref = 2;
+  string name = 3;
+  repeated ActivationChoice choices = 4;  // Empty if no choices needed
+}
+
+message ActivationChoice {
+  string id = 1;           // "action_type"
+  string description = 2;  // "Choose your action"
+  repeated ActivationOption options = 3;
+}
+
+message ActivationOption {
+  ActionType action_type = 1;  // Enum value
+  string label = 2;            // "Disengage"
+  string description = 3;      // "Avoid opportunity attacks"
+}
+```
+
+#### 2. UI Presents Choice
+
+User sees:
+- "Step of the Wind (1 Ki, Bonus Action)"
+- Options: [Disengage] [Dash]
+
+User clicks [Disengage].
+
+#### 3. UI Sends Activation Request
+
+```protobuf
+message ActivateFeatureRequest {
+  string encounter_id = 1;
+  string character_id = 2;
+  string feature_id = 3;
+  ActionType action_type = 4;  // ACTION_TYPE_DISENGAGE
+}
+```
+
+#### 4. Game Server Processes
+
+Game server:
+1. Loads character, encounter, room
+2. Creates GameContext (read-only snapshot)
+3. Gets ActionEconomy for this turn (from TurnState)
+4. Calls feature.Activate() with FeatureInput
+
+```go
+input := FeatureInput{
+    Bus:           bus,
+    ActionEconomy: economy,
+    ActionType:    req.ActionType,  // Passed through, not interpreted
+}
+err := feature.Activate(ctx, character, input)
+```
+
+#### 5. Feature Executes
+
+```go
+func (s *StepOfTheWind) Activate(ctx context.Context, owner core.Entity, input FeatureInput) error {
+    // Validate choice - feature validates its own requirements
+    if input.ActionType != ActionDisengage && input.ActionType != ActionDash {
+        return rpgerr.InvalidArgument("action_type must be disengage or dash")
+    }
+
+    // Consume Ki
+    ki := accessor.GetResource(resources.Ki)
+    if err := ki.Use(1); err != nil {
+        return err
+    }
+
+    // Consume bonus action with record
+    record := ActionRecord{
+        Source:     refs.Features.StepOfTheWind(),
+        ActionType: input.ActionType,
+    }
+    if err := input.ActionEconomy.UseBonusActionFor(record); err != nil {
+        return err
+    }
+
+    // Publish generic feature activated event
+    FeatureActivatedTopic.On(input.Bus).Publish(ctx, FeatureActivatedEvent{
+        CharacterID: owner.GetID(),
+        FeatureRef:  refs.Features.StepOfTheWind(),
+        ActionType:  input.ActionType,
+    })
+
+    return nil
+}
+```
+
+**Note:** Uses `FeatureActivatedTopic` not `StepOfTheWindActivatedTopic`. One topic for all features.
+
+#### 6. Game Server Returns Result
+
+```protobuf
+message ActivateFeatureResponse {
+  bool success = 1;
+  string message = 2;
+  TurnState updated_turn_state = 3;  // Includes action history
+}
+```
+
+---
+
+## Resolved Questions
+
+### Q1: How does a feature declare its choices?
+
+**Answer:** Feature interface gains `GetActivationChoices() []ActivationChoice` method.
+
+```go
+func (s *StepOfTheWind) GetActivationChoices() []ActivationChoice {
+    return []ActivationChoice{
+        {
+            ID:          "action_type",
+            Description: "Choose your action",
+            Options: []ActivationOption{
+                {ActionType: ActionDisengage, Label: "Disengage", Description: "Avoid opportunity attacks"},
+                {ActionType: ActionDash, Label: "Dash", Description: "Double your movement"},
+            },
+        },
+    }
+}
+```
+
+### Q2: How does game server know which features require choices?
+
+**Answer:** Call `GetActivationChoices()` - returns empty slice if no choices needed.
+
+### Q3: ActionType validation
+
+**Answer:** Feature validates it has what it needs. Same pattern as resource validation.
+
+### Q4: Event payload
+
+**Answer:** Use `ActionType` enum, not string. One `FeatureActivatedTopic` for all features.
+
+---
+
+## Use Case 2: Movement After Disengage
+
+### Context
+
+Monk used Step of the Wind (Disengage). Now they move away from an adjacent enemy.
+
+### Alternative Approaches
+
+There are two ways to implement the "no AoO after Disengage" behavior:
+
+#### Approach A: Query ActionEconomy History
+
+Movement processor queries the action history directly:
+
+```go
+func (s *MovementService) shouldTriggerAoO(ctx context.Context, mover *Character, enemy *Character) bool {
+    // Get mover's action economy from context
+    economy := gamectx.GetActionEconomy(ctx, mover.ID)
+
+    // Did they Disengage this turn?
+    if economy.HasTakenAction(ActionDisengage) || economy.HasTakenBonusAction(ActionDisengage) {
+        return false
+    }
+
+    // Other checks...
+    return enemy.ActionEconomy.CanUseReaction()
+}
+```
+
+**Pros:**
+- Simple, direct query
+- No extra state to manage
+
+**Cons:**
+- Movement logic needs to know about ActionEconomy
+- Tight coupling between systems
+
+#### Approach B: Turn-Scoped Condition
+
+Feature activation applies a condition that lasts until end of turn:
+
+```go
+func (s *StepOfTheWind) Activate(ctx context.Context, owner core.Entity, input FeatureInput) error {
+    // ... Ki and bonus action consumption ...
+
+    if input.ActionType == ActionDisengage {
+        // Apply "Disengaged" condition that cancels AoO
+        condition := conditions.NewDisengaged(owner.GetID())
+        condition.Apply(ctx, input.Bus)  // Subscribes to AoO events, cancels them
+    }
+
+    // ... publish event ...
+}
+```
+
+The condition subscribes to movement/AoO events and cancels opportunity attacks:
+
+```go
+func (d *DisengagedCondition) onOpportunityAttackCheck(ctx context.Context, event OpportunityAttackCheckEvent) {
+    if event.TargetID == d.CharacterID {
+        event.Cancel("target disengaged this turn")
+    }
+}
+```
+
+**Pros:**
+- Movement logic stays simple - just fires events
+- Conditions handle the rules (existing pattern)
+- Extensible - other effects can also cancel AoO
+
+**Cons:**
+- More moving parts
+- Condition needs cleanup at end of turn
+
+#### Which to choose?
+
+Both are valid. The condition approach fits better with the event-driven architecture. The query approach is simpler but creates coupling.
+
+**Open question for design phase.**
+
+---
+
+## Use Case 3: Dash Speed Bonus
+
+### Context
+
+Monk uses Step of the Wind (Dash). Their movement should be doubled.
+
+### Alternative Approaches
+
+#### Approach A: Query ActionEconomy History
+
+```go
+func (s *MovementService) GetMaxMovement(ctx context.Context, character *Character) int {
+    base := character.Speed
+
+    economy := gamectx.GetActionEconomy(ctx, character.ID)
+    if economy.HasTakenAction(ActionDash) || economy.HasTakenBonusAction(ActionDash) {
+        base *= 2
+    }
+
+    return base
+}
+```
+
+#### Approach B: Turn-Scoped Condition
+
+Feature applies a "Dashing" condition that modifies speed:
+
+```go
+func (d *DashingCondition) onSpeedCalculation(ctx context.Context, event SpeedCalculationEvent) {
+    if event.CharacterID == d.CharacterID {
+        event.Multiplier *= 2
+    }
+}
+```
+
+**Note:** This may be overkill for Dash since it's a simple calculation. Approach A might be better here.
+
+---
+
+## Use Case 4: Patient Defense (Dodge)
+
+### Context
+
+Monk uses Patient Defense. Costs 1 Ki, bonus action, grants Dodge effect (attackers have disadvantage).
+
+### Difference from Step of the Wind
+
+- **No choice needed**: Patient Defense always grants Dodge
+- **Effect needs tracking**: Attackers targeting this character have disadvantage
+
+### Flow
+
+#### 1. UI Requests Activation (No Choice)
+
+```protobuf
+message ActivateFeatureRequest {
+  string encounter_id = 1;
+  string character_id = 2;
+  string feature_id = 3;
+  // action_type not set - no choice needed
+}
+```
+
+#### 2. Feature Executes
+
+```go
+func (p *PatientDefense) Activate(ctx context.Context, owner core.Entity, input FeatureInput) error {
+    // Consume Ki
+    ki := accessor.GetResource(resources.Ki)
+    if err := ki.Use(1); err != nil {
+        return err
+    }
+
+    // Consume bonus action - ActionType is always Dodge
+    record := ActionRecord{
+        Source:     refs.Features.PatientDefense(),
+        ActionType: ActionDodge,
+    }
+    if err := input.ActionEconomy.UseBonusActionFor(record); err != nil {
+        return err
+    }
+
+    // Publish generic event
+    FeatureActivatedTopic.On(input.Bus).Publish(ctx, FeatureActivatedEvent{
+        CharacterID: owner.GetID(),
+        FeatureRef:  refs.Features.PatientDefense(),
+        ActionType:  ActionDodge,
+    })
+
+    return nil
+}
+```
+
+#### 3. Attack Roll Against Dodging Character
+
+Either approach works:
+
+**Approach A: Query history**
+```go
+func (a *AttackResolver) ResolveAttack(ctx context.Context, attacker, target *Character) *AttackResult {
+    economy := gamectx.GetActionEconomy(ctx, target.ID)
+
+    if economy.HasTakenBonusAction(ActionDodge) || economy.HasTakenAction(ActionDodge) {
+        attack.Disadvantage = true
+    }
+    // ...
+}
+```
+
+**Approach B: Condition**
+```go
+// DodgingCondition subscribes to attack events
+func (d *DodgingCondition) onAttackRoll(ctx context.Context, event AttackRollEvent) {
+    if event.TargetID == d.CharacterID {
+        event.AttackerDisadvantage = true
+    }
+}
+```
+
+---
+
+## Summary: What the Use Cases Reveal
+
+### Confirmed Decisions
+
+1. **Features declare their choices via interface** - `GetActivationChoices() []ActivationChoice`
+2. **Feature validates its own input** - same as resource validation
+3. **One FeatureActivatedTopic** - not per-feature topics
+4. **ActionType is an enum** - in protos and toolkit, not string
+
+### New Gaps Identified
+
+1. **Proto changes needed:**
+   - `ActionType` enum in protos
+   - `ActivationChoice`/`ActivationOption` messages
+   - `ActivateFeatureRequest.action_type` field
+   - `TurnState` with action history
+
+2. **Toolkit changes needed:**
+   - `FeatureActivatedTopic` replaces per-feature topics
+   - `GetActivationChoices()` on feature interface
+   - ActionEconomy history (from brainstorm)
+
+3. **Open design choice:**
+   - Query ActionEconomy vs Turn-scoped Conditions for effects like Disengage/Dodge
+   - May need both patterns for different use cases
+
+### Affected Projects
+
+This idea spans:
+- **rpg-api-protos** - ActionType enum, ActivationChoice messages, TurnState updates
+- **rpg-toolkit** - ActionEconomy history, feature interface, events
+- **rpg-api** - Game server orchestration, context setup


### PR DESCRIPTION
## Summary

Introduces `docs/ideas/` for organizing multi-repo feature development that survives context compaction between AI assistant sessions.

### Why this matters

When working on features that span multiple repos (protos → toolkit → api), we lose context between sessions:
- Decisions get re-discussed
- Alternatives get re-explored
- The "why" gets lost

This structure captures:
- **Use cases** - WHY we're building something (stable, drives design)
- **Decisions** - What we chose and why (survives compaction)
- **Per-repo designs** - How each project implements its part
- **Progress tracking** - Machine-readable state for agents

### Structure

```
docs/ideas/<idea-name>/
├── progress.json      # Machine-readable state
├── README.md          # Human summary
├── use-cases.md       # WHY (drives everything)
├── brainstorm.md      # Exploration
├── design-protos.md   # Per-repo design
├── design-toolkit.md
├── design-api.md
```

### First example: action-economy-history

Tracks what actions were taken during a turn, not just budget remaining. Enables:
- Monk Step of Wind (Disengage OR Dash choice)
- Opportunity attack checks
- Speed calculations

Links to existing issues:
- rpg-api-protos#81
- rpg-toolkit#399
- rpg-api#266

## Test plan

- [x] Docs render correctly in GitHub
- [x] progress.json is valid JSON
- [x] Links to issues work

🤖 Generated with [Claude Code](https://claude.com/claude-code)