### PR TITLE
docs: Add design-api.md to type-safe-refs idea

### DIFF
--- a/docs/ideas/type-safe-refs/README.md
+++ b/docs/ideas/type-safe-refs/README.md
@@ -29,6 +29,7 @@ Building the combat UI revealed that damage sources need to be displayable ("War
 | Brainstorm | [brainstorm.md](./brainstorm.md) | Flat enum vs oneof exploration |
 | Design | [design-protos.md](./design-protos.md) | Proto changes (SourceRef, ConditionId) |
 | Design | [design-toolkit.md](./design-toolkit.md) | Toolkit DamageComponent changes |
+| Design | [design-api.md](./design-api.md) | Game server conversion layer |
 | Design | [design-web.md](./design-web.md) | React enum display components |
 
 ## Affected Projects

--- a/docs/ideas/type-safe-refs/design-api.md
+++ b/docs/ideas/type-safe-refs/design-api.md
@@ -1,0 +1,228 @@
+# Design: Game Server (rpg-api) Changes for Type-Safe Damage Sources
+
+## Overview
+
+Game server changes to convert toolkit's `DamageComponent` to proto `DamageComponent` with the new `SourceRef` field.
+
+**Key principle:** rpg-api stores data and orchestrates. rpg-toolkit handles rules. Conversion happens at the boundary.
+
+## Conversion Layer
+
+### DamageComponent Conversion
+
+```go
+// internal/orchestrators/encounter/converters.go
+
+import (
+    v1alpha1 "github.com/KirkDiggler/rpg-api-protos/gen/go/dnd5e/api/v1alpha1"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// toProtoDamageComponent converts toolkit DamageComponent to proto
+func toProtoDamageComponent(tc *combat.DamageComponent) *v1alpha1.DamageComponent {
+    return &v1alpha1.DamageComponent{
+        SourceRef:         tc.ToProtoSourceRef(), // Toolkit provides conversion
+        OriginalDiceRolls: toInt32Slice(tc.OriginalDiceRolls),
+        FinalDiceRolls:    toInt32Slice(tc.FinalDiceRolls),
+        Rerolls:           toProtoRerolls(tc.Rerolls),
+        FlatBonus:         int32(tc.FlatBonus),
+        DamageType:        toProtoDamageType(tc.DamageType),
+        IsCritical:        tc.IsCritical,
+    }
+}
+
+// toProtoDamageBreakdown converts toolkit DamageBreakdown to proto
+func toProtoDamageBreakdown(tb *combat.DamageBreakdown) *v1alpha1.DamageBreakdown {
+    if tb == nil {
+        return nil
+    }
+
+    components := make([]*v1alpha1.DamageComponent, len(tb.Components))
+    for i, c := range tb.Components {
+        components[i] = toProtoDamageComponent(&c)
+    }
+
+    return &v1alpha1.DamageBreakdown{
+        Components:  components,
+        AbilityUsed: tb.AbilityUsed,
+        TotalDamage: int32(tb.TotalDamage),
+    }
+}
+```
+
+### AttackResult Conversion
+
+```go
+// toProtoAttackResult converts toolkit AttackResult to proto
+func toProtoAttackResult(ar *combat.AttackResult) *v1alpha1.AttackResult {
+    return &v1alpha1.AttackResult{
+        Hit:             ar.Hit,
+        Critical:        ar.Critical,
+        AttackRoll:      toProtoRollResult(ar.AttackRoll),
+        DamageBreakdown: toProtoDamageBreakdown(ar.Breakdown),
+        TargetAc:        int32(ar.TargetAC),
+    }
+}
+```
+
+## Migration Strategy
+
+During transition, populate both old and new fields:
+
+```go
+func toProtoDamageComponent(tc *combat.DamageComponent) *v1alpha1.DamageComponent {
+    proto := &v1alpha1.DamageComponent{
+        // NEW: Type-safe source reference
+        SourceRef: tc.ToProtoSourceRef(),
+
+        // DEPRECATED: Keep for backwards compatibility during migration
+        Source: string(tc.Source),
+
+        // ... other fields
+    }
+    return proto
+}
+```
+
+Clients can migrate at their own pace:
+1. Old clients read `source` string
+2. New clients read `source_ref` oneof
+3. After all clients migrate, remove `source` field
+
+## Handler Integration
+
+Handlers don't change - they already call orchestrators which return proto types:
+
+```go
+// internal/handlers/dnd5e/v1alpha1/encounter/handler.go
+
+func (h *Handler) Attack(
+    ctx context.Context,
+    req *v1alpha1.AttackRequest,
+) (*v1alpha1.AttackResponse, error) {
+    // ... validation ...
+
+    output, err := h.encounterService.Attack(ctx, &encounter.AttackInput{
+        EncounterID: req.GetEncounterId(),
+        AttackerID:  req.GetAttackerId(),
+        TargetID:    req.GetTargetId(),
+        WeaponID:    req.GetWeaponId(),
+    })
+    if err != nil {
+        return nil, errors.ToGRPCError(err)
+    }
+
+    // Orchestrator already converted to proto types
+    return &v1alpha1.AttackResponse{
+        Result:       output.AttackResult,  // Already proto type
+        CombatState:  output.CombatState,
+    }, nil
+}
+```
+
+## Orchestrator Changes
+
+Orchestrators need to pass weapon/ability context to toolkit:
+
+```go
+// internal/orchestrators/encounter/attack.go
+
+func (o *Orchestrator) Attack(
+    ctx context.Context,
+    input *AttackInput,
+) (*AttackOutput, error) {
+    // ... load entities ...
+
+    // Get weapon enum for SourceRef
+    weaponEnum := toProtoWeapon(weapon.ID)
+
+    // Get ability used (STR or DEX based on weapon/finesse)
+    abilityEnum := toProtoAbility(attackAbility)
+
+    // Execute attack
+    result, err := o.attackResolver.ResolveAttack(ctx, &combat.AttackInput{
+        Attacker:      attacker,
+        Target:        target,
+        Weapon:        weapon,
+        WeaponEnum:    weaponEnum,    // Pass for SourceRef
+        AbilityEnum:   abilityEnum,   // Pass for SourceRef
+    })
+    if err != nil {
+        return nil, err
+    }
+
+    // Convert to proto
+    return &AttackOutput{
+        AttackResult: toProtoAttackResult(result),
+        CombatState:  toProtoCombatState(encounter.CombatState),
+    }, nil
+}
+```
+
+## Enum Conversion Helpers
+
+```go
+// internal/handlers/dnd5e/v1alpha1/encounter/converters.go
+
+func toProtoWeapon(weaponID string) v1alpha1.Weapon {
+    // Map toolkit weapon IDs to proto enum
+    switch weaponID {
+    case "longsword":
+        return v1alpha1.Weapon_WEAPON_LONGSWORD
+    case "warhammer":
+        return v1alpha1.Weapon_WEAPON_WARHAMMER
+    case "greataxe":
+        return v1alpha1.Weapon_WEAPON_GREATAXE
+    // ... other weapons
+    default:
+        return v1alpha1.Weapon_WEAPON_UNSPECIFIED
+    }
+}
+
+func toProtoAbility(ability string) v1alpha1.Ability {
+    switch ability {
+    case "STR", "strength":
+        return v1alpha1.Ability_ABILITY_STRENGTH
+    case "DEX", "dexterity":
+        return v1alpha1.Ability_ABILITY_DEXTERITY
+    // ... other abilities
+    default:
+        return v1alpha1.Ability_ABILITY_UNSPECIFIED
+    }
+}
+
+func toProtoConditionId(source combat.DamageSourceType) v1alpha1.ConditionId {
+    switch source {
+    case combat.DamageSourceRage:
+        return v1alpha1.ConditionId_CONDITION_ID_RAGING
+    case combat.DamageSourceBrutalCritical:
+        return v1alpha1.ConditionId_CONDITION_ID_BRUTAL_CRITICAL
+    case combat.DamageSourceDueling:
+        return v1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_DUELING
+    case combat.DamageSourceTwoWeaponFighting:
+        return v1alpha1.ConditionId_CONDITION_ID_FIGHTING_STYLE_TWO_WEAPON_FIGHTING
+    case combat.DamageSourceSneakAttack:
+        return v1alpha1.ConditionId_CONDITION_ID_SNEAK_ATTACK
+    case combat.DamageSourceDivineSmite:
+        return v1alpha1.ConditionId_CONDITION_ID_DIVINE_SMITE
+    default:
+        return v1alpha1.ConditionId_CONDITION_ID_UNSPECIFIED
+    }
+}
+```
+
+## File Summary
+
+| Layer | File | Changes |
+|-------|------|---------|
+| Orchestrator | orchestrators/encounter/attack.go | Pass weapon/ability enums to toolkit |
+| Orchestrator | orchestrators/encounter/converters.go | toProtoDamageComponent, toProtoDamageBreakdown |
+| Handler | handlers/dnd5e/v1alpha1/encounter/converters.go | toProtoWeapon, toProtoAbility, toProtoConditionId |
+
+## Key Principles
+
+1. **Conversion at boundary** - Toolkit stays proto-agnostic, API handles conversion
+2. **Toolkit provides helpers** - `ToProtoSourceRef()` method on DamageComponent
+3. **Pass context through** - Weapon/ability enums flow from request to toolkit to response
+4. **Backwards compatibility** - Populate both fields during migration
+5. **Handlers stay thin** - Orchestrators do the work

--- a/docs/ideas/type-safe-refs/progress.json
+++ b/docs/ideas/type-safe-refs/progress.json
@@ -1,6 +1,6 @@
 {
   "idea": "type-safe-refs",
-  "status": "design_complete",
+  "status": "in_progress",
   "summary": "Replace loose string damage sources with type-safe enums and structured references",
   "trigger": "Combat UI needs displayable damage breakdowns; loose strings prevent this",
   "phases": {
@@ -23,16 +23,19 @@
     "design": {
       "status": "completed",
       "date": "2025-12-07",
-      "files": ["design-protos.md", "design-toolkit.md", "design-web.md"],
-      "notes": "SourceRef with oneof, ConditionId enum, no homebrew escape hatch. Full designs for protos, toolkit, and React components."
+      "files": ["design-protos.md", "design-toolkit.md", "design-api.md", "design-web.md"],
+      "notes": "SourceRef with oneof, ConditionId/FeatureId enums, Spell support. Full designs for protos, toolkit, api, and React components."
     },
     "issues": {
       "status": "completed",
       "date": "2025-12-07",
       "links": [
-        "https://github.com/KirkDiggler/rpg-api-protos/issues/83"
+        "https://github.com/KirkDiggler/rpg-api-protos/issues/83",
+        "https://github.com/KirkDiggler/rpg-api-protos/pull/84",
+        "https://github.com/KirkDiggler/rpg-toolkit/issues/401",
+        "https://github.com/KirkDiggler/rpg-dnd5e-web/issues/231"
       ],
-      "notes": "Design comment added to issue with full rationale"
+      "notes": "All three projects have issues/PRs linked"
     }
   },
   "decisions": [
@@ -48,13 +51,23 @@
     },
     {
       "question": "Separate FeatureId and ConditionId enums?",
-      "answer": "ConditionId only for now",
-      "reason": "Damage comes from active conditions (raging, brutal_critical), not passive features. Features activate conditions. Only add FeatureId when use case requires it."
+      "answer": "Yes - both needed",
+      "reason": "ConditionId for damage modifiers (rage bonus, sneak attack dice). FeatureId for features that directly deal damage when activated (breath weapon, radiance of dawn). Different use cases."
+    },
+    {
+      "question": "Include Spell in SourceRef?",
+      "answer": "Yes",
+      "reason": "Spells are a primary damage source. Spell enum already exists in protos. Fireball damage needs source attribution."
     },
     {
       "question": "What conditions to include in ConditionId?",
       "answer": "Only ones with concrete use cases from toolkit's DamageSourceType",
       "reason": "YAGNI - raging, brutal_critical, fighting_style_dueling, fighting_style_two_weapon_fighting, sneak_attack, divine_smite"
+    },
+    {
+      "question": "What features to include in FeatureId?",
+      "answer": "Features that directly deal damage when activated",
+      "reason": "breath_weapon, hellish_rebuke, radiance_of_dawn, wrath_of_the_storm, destructive_wrath, deflect_missiles, starry_form_archer"
     },
     {
       "question": "Where does SourceRef message live?",
@@ -68,32 +81,49 @@
       "project": "rpg-api-protos",
       "changes": [
         "ConditionId enum in enums.proto",
-        "SourceRef message in common.proto with oneof",
-        "DamageComponent.source changes from string to SourceRef"
+        "FeatureId enum in enums.proto",
+        "SourceRef message in common.proto with oneof (weapon, ability, condition, feature, spell)",
+        "DamageComponent.source_ref added, source string deprecated"
       ],
       "design": "design-protos.md",
-      "issue": "https://github.com/KirkDiggler/rpg-api-protos/issues/83"
+      "issue": "https://github.com/KirkDiggler/rpg-api-protos/issues/83",
+      "pr": "https://github.com/KirkDiggler/rpg-api-protos/pull/84",
+      "status": "in_review"
     },
     {
       "project": "rpg-toolkit",
       "changes": [
-        "Add SourceWeapon/SourceAbility fields to DamageComponent",
-        "Add ToProtoSourceRef() conversion method",
-        "Map DamageSourceType constants to ConditionId"
+        "Add SourceRef *core.Ref to DamageComponent",
+        "Populate SourceRef during damage calculations",
+        "rpg-api converts core.Ref to proto SourceRef"
       ],
       "design": "design-toolkit.md",
-      "issue": null
+      "issue": "https://github.com/KirkDiggler/rpg-toolkit/issues/401",
+      "status": "open"
+    },
+    {
+      "project": "rpg-api",
+      "changes": [
+        "toProtoDamageComponent conversion with SourceRef",
+        "toProtoWeapon, toProtoAbility, toProtoConditionId helpers",
+        "Pass weapon/ability context through orchestrators",
+        "Backwards compatibility: populate both source and source_ref during migration"
+      ],
+      "design": "design-api.md",
+      "issue": null,
+      "status": "pending"
     },
     {
       "project": "rpg-dnd5e-web",
       "changes": [
-        "Enum display maps (WEAPON_DISPLAY, ABILITY_DISPLAY, CONDITION_DISPLAY)",
-        "WeaponDisplay, AbilityDisplay, ConditionDisplay components",
+        "Enum display maps (WEAPON_DISPLAY, ABILITY_DISPLAY, CONDITION_DISPLAY, FEATURE_DISPLAY, SPELL_DISPLAY)",
+        "WeaponDisplay, AbilityDisplay, ConditionDisplay, FeatureDisplay, SpellDisplay components",
         "DamageSourceBadge component using oneof pattern",
         "DamageBreakdown component for combat UI"
       ],
       "design": "design-web.md",
-      "issue": null
+      "issue": "https://github.com/KirkDiggler/rpg-dnd5e-web/issues/231",
+      "status": "open"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the missing design-api.md to the type-safe-refs idea, completing the full implementation picture.

### What's Added

- **design-api.md** - Game server conversion layer documentation:
  - toProtoDamageComponent conversion with SourceRef
  - Enum conversion helpers (weapon, ability, condition)
  - Backwards compatibility strategy during migration
  - Pass weapon/ability context through orchestrators

### Updates

- README.md - Added design-api.md to documents table
- progress.json - Added rpg-api to affected_projects with design link

### Context

The parallel session implementing the protos merged PR #408 before this doc was added. This PR completes the full design picture with all four repos covered:

1. ✅ design-protos.md (in #408)
2. ✅ design-toolkit.md (in #408)
3. ✅ design-web.md (in #408)
4. ✅ **design-api.md** (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)