### PR TITLE
Consolidate D&D 5e events into events/events.go

### DIFF
--- a/rulebooks/dnd5e/combat/attack_test.go
+++ b/rulebooks/dnd5e/combat/attack_test.go
@@ -98,7 +98,7 @@ func (s *AttackTestSuite) TestResolveAttack_BasicMeleeHit() {
 	s.Equal([]int{5}, result.DamageRolls)
 	s.Equal(3, result.DamageBonus, "STR modifier")
 	s.Equal(8, result.TotalDamage)
-	s.Equal("slashing", result.DamageType)
+	s.Equal(damage.Slashing, result.DamageType)
 }
 
 func (s *AttackTestSuite) TestResolveAttack_NaturalTwenty() {
@@ -227,5 +227,5 @@ func (s *AttackTestSuite) TestResolveAttack_PublishesEvents() {
 	s.Equal("goblin-1", damageEvent.TargetID)
 	s.Equal("barbarian-1", damageEvent.SourceID)
 	s.Equal(8, damageEvent.Amount)
-	s.Equal("slashing", damageEvent.DamageType)
+	s.Equal(damage.Slashing, damageEvent.DamageType)
 }

--- a/rulebooks/dnd5e/combat/breakdown_test.go
+++ b/rulebooks/dnd5e/combat/breakdown_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
@@ -96,7 +97,7 @@ func (s *BreakdownTestSuite) TestResolveAttack_DamageBreakdown_BasicMelee() {
 
 	// Verify weapon component
 	weaponComp := result.Breakdown.Components[0]
-	s.Equal(combat.DamageSourceWeapon, weaponComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceWeapon, weaponComp.Source)
 	s.Equal([]int{5}, weaponComp.OriginalDiceRolls, "Original dice rolls should match")
 	s.Equal([]int{5}, weaponComp.FinalDiceRolls, "Final dice rolls should match (no rerolls)")
 	s.Equal(0, weaponComp.FlatBonus, "Weapon component has no flat bonus")
@@ -104,7 +105,7 @@ func (s *BreakdownTestSuite) TestResolveAttack_DamageBreakdown_BasicMelee() {
 
 	// Verify ability component
 	abilityComp := result.Breakdown.Components[1]
-	s.Equal(combat.DamageSourceAbility, abilityComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceAbility, abilityComp.Source)
 	s.Nil(abilityComp.OriginalDiceRolls, "Ability has no dice")
 	s.Nil(abilityComp.FinalDiceRolls, "Ability has no dice")
 	s.Equal(3, abilityComp.FlatBonus, "STR modifier is +3")
@@ -181,18 +182,18 @@ func (s *BreakdownTestSuite) TestResolveAttack_DamageBreakdown_WithRage() {
 
 	// Verify weapon component
 	weaponComp := result.Breakdown.Components[0]
-	s.Equal(combat.DamageSourceWeapon, weaponComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceWeapon, weaponComp.Source)
 	s.Equal(6, weaponComp.Total(), "Weapon damage should be 6")
 
 	// Verify ability component
 	abilityComp := result.Breakdown.Components[1]
-	s.Equal(combat.DamageSourceAbility, abilityComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceAbility, abilityComp.Source)
 	s.Equal(3, abilityComp.FlatBonus, "STR modifier is +3")
 	s.Equal(3, abilityComp.Total(), "Ability bonus should be 3")
 
 	// Verify rage component
 	rageComp := result.Breakdown.Components[2]
-	s.Equal(combat.DamageSourceRage, rageComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceCondition, rageComp.Source)
 	s.Equal(2, rageComp.FlatBonus, "Rage adds +2 at level 1")
 	s.Nil(rageComp.OriginalDiceRolls, "Rage has no dice")
 	s.Nil(rageComp.FinalDiceRolls, "Rage has no dice")
@@ -259,12 +260,12 @@ func (s *BreakdownTestSuite) TestResolveAttack_DamageBreakdown_FinesseWeapon() {
 
 	// Verify weapon component
 	weaponComp := result.Breakdown.Components[0]
-	s.Equal(combat.DamageSourceWeapon, weaponComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceWeapon, weaponComp.Source)
 	s.Equal(5, weaponComp.Total(), "Weapon damage should be 5")
 
 	// Verify ability component uses DEX
 	abilityComp := result.Breakdown.Components[1]
-	s.Equal(combat.DamageSourceAbility, abilityComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceAbility, abilityComp.Source)
 	s.Equal(4, abilityComp.FlatBonus, "Should use DEX +4, not STR +1")
 	s.Equal(4, abilityComp.Total(), "Ability bonus should be 4")
 
@@ -325,14 +326,14 @@ func (s *BreakdownTestSuite) TestResolveAttack_DamageBreakdown_CriticalHit() {
 
 	// Verify weapon component has doubled dice
 	weaponComp := result.Breakdown.Components[0]
-	s.Equal(combat.DamageSourceWeapon, weaponComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceWeapon, weaponComp.Source)
 	s.Equal([]int{6, 6}, weaponComp.FinalDiceRolls, "Should have two dice rolls for critical")
 	s.True(weaponComp.IsCritical, "Weapon component should be marked as critical")
 	s.Equal(12, weaponComp.Total(), "Critical: 6 + 6 = 12")
 
 	// Verify ability component is NOT doubled
 	abilityComp := result.Breakdown.Components[1]
-	s.Equal(combat.DamageSourceAbility, abilityComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceAbility, abilityComp.Source)
 	s.Equal(2, abilityComp.FlatBonus, "STR modifier (not doubled)")
 	s.True(abilityComp.IsCritical, "Ability component should be marked as critical (even though not doubled)")
 	s.Equal(2, abilityComp.Total(), "Bonuses are NOT doubled on crit")

--- a/rulebooks/dnd5e/conditions/brutal_critical.go
+++ b/rulebooks/dnd5e/conditions/brutal_critical.go
@@ -86,7 +86,7 @@ func (b *BrutalCriticalCondition) Apply(ctx context.Context, bus events.EventBus
 	b.bus = bus
 
 	// Subscribe to damage chain to add extra dice on crits
-	damageChain := combat.DamageChain.On(bus)
+	damageChain := dnd5eEvents.DamageChain.On(bus)
 	subID, err := damageChain.SubscribeWithChain(ctx, b.onDamageChain)
 	if err != nil {
 		return rpgerr.Wrap(err, "failed to subscribe to damage chain")
@@ -142,9 +142,9 @@ func (b *BrutalCriticalCondition) loadJSON(data json.RawMessage) error {
 // onDamageChain adds extra weapon damage dice on critical hits
 func (b *BrutalCriticalCondition) onDamageChain(
 	_ context.Context,
-	event *combat.DamageChainEvent,
-	c chain.Chain[*combat.DamageChainEvent],
-) (chain.Chain[*combat.DamageChainEvent], error) {
+	event *dnd5eEvents.DamageChainEvent,
+	c chain.Chain[*dnd5eEvents.DamageChainEvent],
+) (chain.Chain[*dnd5eEvents.DamageChainEvent], error) {
 	// Only add extra dice if:
 	// 1. We're the attacker
 	// 2. This is a critical hit
@@ -164,7 +164,7 @@ func (b *BrutalCriticalCondition) onDamageChain(
 	}
 
 	// Add brutal critical modifier at StageFeatures
-	modifyDamage := func(modCtx context.Context, e *combat.DamageChainEvent) (*combat.DamageChainEvent, error) {
+	modifyDamage := func(modCtx context.Context, e *dnd5eEvents.DamageChainEvent) (*dnd5eEvents.DamageChainEvent, error) {
 		// Roll extra dice
 		roller := b.roller
 		if roller == nil {
@@ -177,8 +177,9 @@ func (b *BrutalCriticalCondition) onDamageChain(
 		}
 
 		// Append brutal critical damage component
-		e.Components = append(e.Components, combat.DamageComponent{
-			Source:            combat.DamageSourceBrutalCritical,
+		e.Components = append(e.Components, dnd5eEvents.DamageComponent{
+			Source:            dnd5eEvents.DamageSourceCondition,
+			SourceRef:         refs.Conditions.BrutalCritical(),
 			OriginalDiceRolls: extraRolls,
 			FinalDiceRolls:    extraRolls,
 			Rerolls:           nil,

--- a/rulebooks/dnd5e/conditions/brutal_critical_test.go
+++ b/rulebooks/dnd5e/conditions/brutal_critical_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
 
 // BrutalCriticalTestSuite tests the BrutalCriticalCondition behavior
@@ -48,39 +51,38 @@ func (s *BrutalCriticalTestSuite) executeCriticalDamageChain(
 	attackerID string,
 	weaponDamage string,
 	isCritical bool,
-) (*combat.DamageChainEvent, error) {
+) (*dnd5eEvents.DamageChainEvent, error) {
 	// Create weapon component with base damage (already doubled for crit in real flow)
-	weaponComp := combat.DamageComponent{
-		Source:            combat.DamageSourceWeapon,
+	weaponComp := dnd5eEvents.DamageComponent{
+		Source:            dnd5eEvents.DamageSourceWeapon,
 		OriginalDiceRolls: []int{6, 4}, // 2d8 rolled (crit doubles dice)
 		FinalDiceRolls:    []int{6, 4},
 		FlatBonus:         0,
-		DamageType:        "slashing",
+		DamageType:        damage.Slashing,
 		IsCritical:        isCritical,
 	}
 
 	// Create ability component
-	abilityComp := combat.DamageComponent{
-		Source:            combat.DamageSourceAbility,
+	abilityComp := dnd5eEvents.DamageComponent{
+		Source:            dnd5eEvents.DamageSourceAbility,
 		OriginalDiceRolls: nil,
 		FinalDiceRolls:    nil,
 		FlatBonus:         4, // STR modifier
-		DamageType:        "slashing",
+		DamageType:        damage.Slashing,
 		IsCritical:        isCritical,
 	}
 
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID:   attackerID,
 		TargetID:     "goblin-1",
-		Components:   []combat.DamageComponent{weaponComp, abilityComp},
-		DamageType:   "slashing",
+		Components:   []dnd5eEvents.DamageComponent{weaponComp, abilityComp},
+		DamageType:   damage.Slashing,
 		IsCritical:   isCritical,
 		WeaponDamage: weaponDamage,
-		AbilityUsed:  "str",
 	}
 
-	chain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damageTopic := combat.DamageChain.On(s.bus)
+	chain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damageTopic := dnd5eEvents.DamageChain.On(s.bus)
 
 	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
 	if err != nil {
@@ -116,7 +118,7 @@ func (s *BrutalCriticalTestSuite) TestBrutalCriticalAddsExtraDieLevel9() {
 
 	// Verify brutal critical component
 	brutalComp := finalEvent.Components[2]
-	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceCondition, brutalComp.Source)
 	s.Equal([]int{5}, brutalComp.FinalDiceRolls, "Should have rolled 1 extra d8")
 	s.Equal(5, brutalComp.Total(), "Brutal critical should add 5 damage")
 }
@@ -143,7 +145,7 @@ func (s *BrutalCriticalTestSuite) TestBrutalCriticalAddsExtraDiceLevel13() {
 	s.Require().Len(finalEvent.Components, 3)
 
 	brutalComp := finalEvent.Components[2]
-	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceCondition, brutalComp.Source)
 	s.Equal([]int{5, 7}, brutalComp.FinalDiceRolls, "Should have rolled 2 extra d8s")
 	s.Equal(12, brutalComp.Total(), "Brutal critical should add 12 damage (5+7)")
 }
@@ -170,7 +172,7 @@ func (s *BrutalCriticalTestSuite) TestBrutalCriticalAddsExtraDiceLevel17() {
 	s.Require().Len(finalEvent.Components, 3)
 
 	brutalComp := finalEvent.Components[2]
-	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceCondition, brutalComp.Source)
 	s.Equal([]int{3, 6, 8}, brutalComp.FinalDiceRolls, "Should have rolled 3 extra d8s")
 	s.Equal(17, brutalComp.Total(), "Brutal critical should add 17 damage (3+6+8)")
 }
@@ -208,26 +210,26 @@ func (s *BrutalCriticalTestSuite) TestBrutalCriticalOnlyAffectsOwnAttacks() {
 	// No mock expectation - RollN should NOT be called for other characters
 
 	// Create critical damage chain for a DIFFERENT attacker
-	weaponComp := combat.DamageComponent{
-		Source:            combat.DamageSourceWeapon,
+	weaponComp := dnd5eEvents.DamageComponent{
+		Source:            dnd5eEvents.DamageSourceWeapon,
 		OriginalDiceRolls: []int{6, 4},
 		FinalDiceRolls:    []int{6, 4},
-		DamageType:        "slashing",
+		DamageType:        damage.Slashing,
 		IsCritical:        true,
 	}
 
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID:   "barbarian-2", // Different character
 		TargetID:     "goblin-1",
-		Components:   []combat.DamageComponent{weaponComp},
-		DamageType:   "slashing",
+		Components:   []dnd5eEvents.DamageComponent{weaponComp},
+		DamageType:   damage.Slashing,
 		IsCritical:   true,
 		WeaponDamage: "1d8",
-		AbilityUsed:  "str",
+		AbilityUsed:  abilities.STR,
 	}
 
-	chain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damageTopic := combat.DamageChain.On(s.bus)
+	chain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damageTopic := dnd5eEvents.DamageChain.On(s.bus)
 
 	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
 	s.Require().NoError(err)
@@ -255,26 +257,25 @@ func (s *BrutalCriticalTestSuite) TestBrutalCriticalWorksWithDifferentWeaponDice
 		Return([]int{10}, nil)
 
 	// Use a greataxe (1d12)
-	weaponComp := combat.DamageComponent{
-		Source:            combat.DamageSourceWeapon,
+	weaponComp := dnd5eEvents.DamageComponent{
+		Source:            dnd5eEvents.DamageSourceWeapon,
 		OriginalDiceRolls: []int{8, 11}, // 2d12 for crit
 		FinalDiceRolls:    []int{8, 11},
-		DamageType:        "slashing",
+		DamageType:        damage.Slashing,
 		IsCritical:        true,
 	}
 
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID:   "barbarian-1",
 		TargetID:     "goblin-1",
-		Components:   []combat.DamageComponent{weaponComp},
-		DamageType:   "slashing",
+		Components:   []dnd5eEvents.DamageComponent{weaponComp},
+		DamageType:   damage.Slashing,
 		IsCritical:   true,
 		WeaponDamage: "1d12", // Greataxe
-		AbilityUsed:  "str",
 	}
 
-	chain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damageTopic := combat.DamageChain.On(s.bus)
+	chain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damageTopic := dnd5eEvents.DamageChain.On(s.bus)
 
 	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
 	s.Require().NoError(err)
@@ -285,7 +286,7 @@ func (s *BrutalCriticalTestSuite) TestBrutalCriticalWorksWithDifferentWeaponDice
 	s.Require().Len(finalEvent.Components, 2)
 
 	brutalComp := finalEvent.Components[1]
-	s.Equal(combat.DamageSourceBrutalCritical, brutalComp.Source)
+	s.Equal(dnd5eEvents.DamageSourceCondition, brutalComp.Source)
 	s.Equal([]int{10}, brutalComp.FinalDiceRolls, "Should roll extra d12 for greataxe")
 }
 

--- a/rulebooks/dnd5e/conditions/fighting_style_test.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/fightingstyles"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
@@ -97,7 +100,7 @@ func (s *FightingStyleTestSuite) TestArcheryBonusApplication() {
 			s.Require().NoError(err)
 
 			// Create attack chain event
-			attackEvent := combat.AttackChainEvent{
+			attackEvent := dnd5eEvents.AttackChainEvent{
 				AttackerID:      "fighter-1",
 				TargetID:        "goblin-1",
 				AttackRoll:      15,
@@ -108,8 +111,8 @@ func (s *FightingStyleTestSuite) TestArcheryBonusApplication() {
 			}
 
 			// Publish through attack chain
-			attackChain := events.NewStagedChain[combat.AttackChainEvent](combat.ModifierStages)
-			attacks := combat.AttackChain.On(s.bus)
+			attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+			attacks := dnd5eEvents.AttackChain.On(s.bus)
 			modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
 			s.Require().NoError(err)
 
@@ -146,28 +149,28 @@ func (s *FightingStyleTestSuite) TestGreatWeaponFightingRerolls() {
 	s.mockRoller.EXPECT().Roll(gomock.Any(), 6).Return(4, nil).Times(1) // Reroll second die
 
 	// Create damage chain event with weapon damage containing 1s and 2s
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{1, 2, 6}, // Two dice need rerolling
 				FinalDiceRolls:    []int{1, 2, 6},
 				Rerolls:           nil,
 				FlatBonus:         0,
-				DamageType:        "slashing",
+				DamageType:        damage.Slashing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "slashing",
+		DamageType:   damage.Slashing,
 		IsCritical:   false,
 		WeaponDamage: "2d6", // Greatsword
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
@@ -214,28 +217,28 @@ func (s *FightingStyleTestSuite) TestGreatWeaponFightingDoesNotRerollHighNumbers
 	// No mock expectations because nothing should be rerolled
 
 	// Create damage chain event with all high rolls
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{5, 6}, // No rerolls needed
 				FinalDiceRolls:    []int{5, 6},
 				Rerolls:           nil,
 				FlatBonus:         0,
-				DamageType:        "slashing",
+				DamageType:        damage.Slashing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "slashing",
+		DamageType:   damage.Slashing,
 		IsCritical:   false,
 		WeaponDamage: "2d6",
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
@@ -380,28 +383,28 @@ func (s *FightingStyleTestSuite) TestDuelingBonusWithOneHandedWeapon() {
 	}()
 
 	// Create damage chain event with weapon damage
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{6},
 				FinalDiceRolls:    []int{6},
 				Rerolls:           nil,
 				FlatBonus:         3, // STR modifier
-				DamageType:        "slashing",
+				DamageType:        damage.Slashing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "slashing",
+		DamageType:   damage.Slashing,
 		IsCritical:   false,
 		WeaponDamage: "1d8",
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
@@ -416,7 +419,7 @@ func (s *FightingStyleTestSuite) TestDuelingBonusWithOneHandedWeapon() {
 	// Verify Dueling added a separate component
 	s.Require().Len(finalEvent.Components, 2, "Should have weapon + dueling components")
 	duelingComponent := finalEvent.Components[1]
-	s.Equal(combat.DamageSourceDueling, duelingComponent.Source, "Second component should be from Dueling")
+	s.Equal(dnd5eEvents.DamageSourceCondition, duelingComponent.Source, "Second component should be from Dueling")
 	s.Equal(2, duelingComponent.FlatBonus, "Dueling should add +2 damage")
 }
 
@@ -469,28 +472,28 @@ func (s *FightingStyleTestSuite) TestDuelingBonusWithShield() {
 	}()
 
 	// Create damage chain event with weapon damage
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{6},
 				FinalDiceRolls:    []int{6},
 				Rerolls:           nil,
 				FlatBonus:         3, // STR modifier
-				DamageType:        "slashing",
+				DamageType:        damage.Slashing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "slashing",
+		DamageType:   damage.Slashing,
 		IsCritical:   false,
 		WeaponDamage: "1d8",
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
@@ -505,7 +508,7 @@ func (s *FightingStyleTestSuite) TestDuelingBonusWithShield() {
 	// Verify Dueling added a separate component (shields don't count as weapons)
 	s.Require().Len(finalEvent.Components, 2, "Should have weapon + dueling components")
 	duelingComponent := finalEvent.Components[1]
-	s.Equal(combat.DamageSourceDueling, duelingComponent.Source, "Second component should be from Dueling")
+	s.Equal(dnd5eEvents.DamageSourceCondition, duelingComponent.Source, "Second component should be from Dueling")
 	s.Equal(2, duelingComponent.FlatBonus, "Dueling should add +2 damage even with shield")
 }
 
@@ -548,28 +551,28 @@ func (s *FightingStyleTestSuite) TestDuelingNoBonusWithTwoHandedWeapon() {
 	}()
 
 	// Create damage chain event with weapon damage
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{6, 5},
 				FinalDiceRolls:    []int{6, 5},
 				Rerolls:           nil,
 				FlatBonus:         3, // STR modifier
-				DamageType:        "slashing",
+				DamageType:        damage.Slashing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "slashing",
+		DamageType:   damage.Slashing,
 		IsCritical:   false,
 		WeaponDamage: "2d6",
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
@@ -632,28 +635,28 @@ func (s *FightingStyleTestSuite) TestDuelingNoBonusWithDualWield() {
 	}()
 
 	// Create damage chain event with weapon damage
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{5},
 				FinalDiceRolls:    []int{5},
 				Rerolls:           nil,
 				FlatBonus:         3, // STR modifier
-				DamageType:        "piercing",
+				DamageType:        damage.Piercing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "piercing",
+		DamageType:   damage.Piercing,
 		IsCritical:   false,
 		WeaponDamage: "1d6",
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
@@ -713,32 +716,31 @@ func (s *FightingStyleTestSuite) TestTwoWeaponFightingOffHandBonus() {
 		_ = fs.Remove(ctx, s.bus)
 	}()
 
-	// Import abilities for testing
 	// Create damage chain event for off-hand attack (using DEX, modifier +3)
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{5},
 				FinalDiceRolls:    []int{5},
 				Rerolls:           nil,
 				FlatBonus:         0, // Normally off-hand doesn't get ability modifier
-				DamageType:        "piercing",
+				DamageType:        damage.Piercing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "piercing",
+		DamageType:   damage.Piercing,
 		IsCritical:   false,
 		WeaponDamage: "1d6",
-		AbilityUsed:  "dex", // DEX is used for finesse weapons
-		WeaponRef:    "shortsword-2",
+		AbilityUsed:  abilities.DEX, // DEX is used for finesse weapons
+		WeaponRef:    &core.Ref{ID: core.ID("shortsword-2")},
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
@@ -753,7 +755,7 @@ func (s *FightingStyleTestSuite) TestTwoWeaponFightingOffHandBonus() {
 	// Verify Two-Weapon Fighting added a separate component with ability modifier
 	s.Require().Len(finalEvent.Components, 2, "Should have weapon + two-weapon fighting components")
 	twfComponent := finalEvent.Components[1]
-	s.Equal(combat.DamageSourceTwoWeaponFighting, twfComponent.Source,
+	s.Equal(dnd5eEvents.DamageSourceCondition, twfComponent.Source,
 		"Second component should be from Two-Weapon Fighting")
 	s.Equal(3, twfComponent.FlatBonus, "Two-Weapon Fighting should add +3 (DEX modifier)")
 }
@@ -805,30 +807,30 @@ func (s *FightingStyleTestSuite) TestTwoWeaponFightingNoMainHandBonus() {
 	}()
 
 	// Create damage chain event for MAIN-hand attack
-	damageEvent := &combat.DamageChainEvent{
+	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
-		Components: []combat.DamageComponent{
+		Components: []dnd5eEvents.DamageComponent{
 			{
-				Source:            combat.DamageSourceWeapon,
+				Source:            dnd5eEvents.DamageSourceWeapon,
 				OriginalDiceRolls: []int{5},
 				FinalDiceRolls:    []int{5},
 				Rerolls:           nil,
 				FlatBonus:         3, // Main hand already gets ability modifier
-				DamageType:        "piercing",
+				DamageType:        damage.Piercing,
 				IsCritical:        false,
 			},
 		},
-		DamageType:   "piercing",
+		DamageType:   damage.Piercing,
 		IsCritical:   false,
 		WeaponDamage: "1d6",
-		AbilityUsed:  "dex",
-		WeaponRef:    "shortsword-1", // MAIN HAND weapon
+		AbilityUsed:  abilities.DEX,
+		WeaponRef:    &core.Ref{ID: core.ID("shortsword-1")}, // MAIN HAND weapon
 	}
 
 	// Publish through damage chain
-	damageChain := events.NewStagedChain[*combat.DamageChainEvent](combat.ModifierStages)
-	damages := combat.DamageChain.On(s.bus)
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
 	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/improved_critical.go
+++ b/rulebooks/dnd5e/conditions/improved_critical.go
@@ -48,7 +48,7 @@ func (ic *ImprovedCriticalCondition) Apply(ctx context.Context, bus events.Event
 	ic.bus = bus
 
 	// Subscribe to AttackChain to modify critical threshold
-	attackChain := combat.AttackChain.On(bus)
+	attackChain := dnd5eEvents.AttackChain.On(bus)
 	subID, err := attackChain.SubscribeWithChain(ctx, ic.onAttackChain)
 	if err != nil {
 		return rpgerr.Wrap(err, "failed to subscribe to attack chain")
@@ -109,16 +109,16 @@ func (ic *ImprovedCriticalCondition) loadJSON(data json.RawMessage) error {
 // onAttackChain modifies the critical threshold for attacks by this character
 func (ic *ImprovedCriticalCondition) onAttackChain(
 	_ context.Context,
-	event combat.AttackChainEvent,
-	c chain.Chain[combat.AttackChainEvent],
-) (chain.Chain[combat.AttackChainEvent], error) {
+	event dnd5eEvents.AttackChainEvent,
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
 	// Only modify attacks by this character
 	if event.AttackerID != ic.CharacterID {
 		return c, nil
 	}
 
 	// Modify critical threshold at StageFeatures
-	modifyThreshold := func(_ context.Context, e combat.AttackChainEvent) (combat.AttackChainEvent, error) {
+	modifyThreshold := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
 		// Only lower the threshold, never raise it
 		if ic.Threshold < e.CriticalThreshold {
 			e.CriticalThreshold = ic.Threshold

--- a/rulebooks/dnd5e/conditions/improved_critical_test.go
+++ b/rulebooks/dnd5e/conditions/improved_critical_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
@@ -92,7 +93,7 @@ func (s *ImprovedCriticalTestSuite) TestCriticalThresholdModification() {
 	s.Require().NoError(err)
 
 	s.Run("lowers threshold to 19 for champion attacks", func() {
-		event := combat.AttackChainEvent{
+		event := dnd5eEvents.AttackChainEvent{
 			AttackerID:        "champion-fighter",
 			TargetID:          "goblin",
 			AttackRoll:        19,
@@ -104,8 +105,8 @@ func (s *ImprovedCriticalTestSuite) TestCriticalThresholdModification() {
 		}
 
 		// Create and execute chain
-		chain := events.NewStagedChain[combat.AttackChainEvent](combat.ModifierStages)
-		attackChain := combat.AttackChain.On(s.bus)
+		chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attackChain := dnd5eEvents.AttackChain.On(s.bus)
 
 		modifiedChain, err := attackChain.PublishWithChain(ctx, event, chain)
 		s.Require().NoError(err)
@@ -118,7 +119,7 @@ func (s *ImprovedCriticalTestSuite) TestCriticalThresholdModification() {
 	})
 
 	s.Run("does not modify attacks by other characters", func() {
-		event := combat.AttackChainEvent{
+		event := dnd5eEvents.AttackChainEvent{
 			AttackerID:        "other-fighter",
 			TargetID:          "goblin",
 			AttackRoll:        19,
@@ -129,8 +130,8 @@ func (s *ImprovedCriticalTestSuite) TestCriticalThresholdModification() {
 			CriticalThreshold: 20,
 		}
 
-		chain := events.NewStagedChain[combat.AttackChainEvent](combat.ModifierStages)
-		attackChain := combat.AttackChain.On(s.bus)
+		chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attackChain := dnd5eEvents.AttackChain.On(s.bus)
 
 		modifiedChain, err := attackChain.PublishWithChain(ctx, event, chain)
 		s.Require().NoError(err)
@@ -161,7 +162,7 @@ func (s *ImprovedCriticalTestSuite) TestCriticalThresholdModification() {
 			_ = s.condition.Apply(ctx, s.bus)
 		}()
 
-		event := combat.AttackChainEvent{
+		event := dnd5eEvents.AttackChainEvent{
 			AttackerID:        "champion-fighter",
 			TargetID:          "goblin",
 			AttackRoll:        18,
@@ -172,8 +173,8 @@ func (s *ImprovedCriticalTestSuite) TestCriticalThresholdModification() {
 			CriticalThreshold: 20,
 		}
 
-		chain := events.NewStagedChain[combat.AttackChainEvent](combat.ModifierStages)
-		attackChain := combat.AttackChain.On(s.bus)
+		chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attackChain := dnd5eEvents.AttackChain.On(s.bus)
 
 		modifiedChain, err := attackChain.PublishWithChain(ctx, event, chain)
 		s.Require().NoError(err)
@@ -290,7 +291,7 @@ func (s *ImprovedCriticalTestSuite) TestIntegrationWithAttackChain() {
 	s.Require().NoError(err)
 
 	s.Run("roll of 19 becomes critical for champion", func() {
-		event := combat.AttackChainEvent{
+		event := dnd5eEvents.AttackChainEvent{
 			AttackerID:        "champion-fighter",
 			TargetID:          "goblin",
 			AttackRoll:        19,
@@ -301,8 +302,8 @@ func (s *ImprovedCriticalTestSuite) TestIntegrationWithAttackChain() {
 			CriticalThreshold: 20,
 		}
 
-		chain := events.NewStagedChain[combat.AttackChainEvent](combat.ModifierStages)
-		attackChain := combat.AttackChain.On(s.bus)
+		chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attackChain := dnd5eEvents.AttackChain.On(s.bus)
 
 		modifiedChain, err := attackChain.PublishWithChain(ctx, event, chain)
 		s.Require().NoError(err)
@@ -317,7 +318,7 @@ func (s *ImprovedCriticalTestSuite) TestIntegrationWithAttackChain() {
 	})
 
 	s.Run("roll of 18 is not critical for improved critical", func() {
-		event := combat.AttackChainEvent{
+		event := dnd5eEvents.AttackChainEvent{
 			AttackerID:        "champion-fighter",
 			TargetID:          "goblin",
 			AttackRoll:        18,
@@ -328,8 +329,8 @@ func (s *ImprovedCriticalTestSuite) TestIntegrationWithAttackChain() {
 			CriticalThreshold: 20,
 		}
 
-		chain := events.NewStagedChain[combat.AttackChainEvent](combat.ModifierStages)
-		attackChain := combat.AttackChain.On(s.bus)
+		chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attackChain := dnd5eEvents.AttackChain.On(s.bus)
 
 		modifiedChain, err := attackChain.PublishWithChain(ctx, event, chain)
 		s.Require().NoError(err)
@@ -342,7 +343,7 @@ func (s *ImprovedCriticalTestSuite) TestIntegrationWithAttackChain() {
 	})
 
 	s.Run("roll of 20 is still critical", func() {
-		event := combat.AttackChainEvent{
+		event := dnd5eEvents.AttackChainEvent{
 			AttackerID:        "champion-fighter",
 			TargetID:          "goblin",
 			AttackRoll:        20,
@@ -353,8 +354,8 @@ func (s *ImprovedCriticalTestSuite) TestIntegrationWithAttackChain() {
 			CriticalThreshold: 20,
 		}
 
-		chain := events.NewStagedChain[combat.AttackChainEvent](combat.ModifierStages)
-		attackChain := combat.AttackChain.On(s.bus)
+		chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attackChain := dnd5eEvents.AttackChain.On(s.bus)
 
 		modifiedChain, err := attackChain.PublishWithChain(ctx, event, chain)
 		s.Require().NoError(err)

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -86,7 +86,7 @@ func (r *RagingCondition) Apply(ctx context.Context, bus events.EventBus) error 
 	r.subscriptionIDs = append(r.subscriptionIDs, subID3)
 
 	// Subscribe to damage chain to add rage damage bonus and track successful hits
-	damageChain := combat.DamageChain.On(bus)
+	damageChain := dnd5eEvents.DamageChain.On(bus)
 	subID4, err := damageChain.SubscribeWithChain(ctx, r.onDamageChain)
 	if err != nil {
 		// Rollback: unsubscribe from previous subscriptions
@@ -219,9 +219,9 @@ func (r *RagingCondition) endRage(ctx context.Context, reason string) error {
 // and tracks that we successfully hit an enemy this turn (for rage maintenance)
 func (r *RagingCondition) onDamageChain(
 	_ context.Context,
-	event *combat.DamageChainEvent,
-	c chain.Chain[*combat.DamageChainEvent],
-) (chain.Chain[*combat.DamageChainEvent], error) {
+	event *dnd5eEvents.DamageChainEvent,
+	c chain.Chain[*dnd5eEvents.DamageChainEvent],
+) (chain.Chain[*dnd5eEvents.DamageChainEvent], error) {
 	// Only add bonus if we're the attacker
 	if event.AttackerID != r.CharacterID {
 		return c, nil
@@ -232,10 +232,11 @@ func (r *RagingCondition) onDamageChain(
 	r.DidAttackThisTurn = true
 
 	// Add rage damage modifier in the StageFeatures stage
-	modifyDamage := func(_ context.Context, e *combat.DamageChainEvent) (*combat.DamageChainEvent, error) {
+	modifyDamage := func(_ context.Context, e *dnd5eEvents.DamageChainEvent) (*dnd5eEvents.DamageChainEvent, error) {
 		// Append rage damage component
-		e.Components = append(e.Components, combat.DamageComponent{
-			Source:            combat.DamageSourceRage,
+		e.Components = append(e.Components, dnd5eEvents.DamageComponent{
+			Source:            dnd5eEvents.DamageSourceCondition,
+			SourceRef:         refs.Conditions.Raging(),
 			OriginalDiceRolls: nil, // No dice
 			FinalDiceRolls:    nil,
 			Rerolls:           nil,

--- a/rulebooks/dnd5e/weapons/weapons_test.go
+++ b/rulebooks/dnd5e/weapons/weapons_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
 
@@ -25,7 +26,7 @@ func TestWeaponLookup(t *testing.T) {
 				Category:   weapons.CategoryMartialMelee,
 				Cost:       "15 gp",
 				Damage:     "1d8",
-				DamageType: "slashing",
+				DamageType: damage.Slashing,
 				Weight:     3,
 				Properties: []weapons.WeaponProperty{weapons.PropertyVersatile},
 			},
@@ -40,7 +41,7 @@ func TestWeaponLookup(t *testing.T) {
 				Category:   weapons.CategorySimpleMelee,
 				Cost:       "2 gp",
 				Damage:     "1d4",
-				DamageType: "piercing",
+				DamageType: damage.Piercing,
 				Weight:     1,
 				Properties: []weapons.WeaponProperty{weapons.PropertyFinesse, weapons.PropertyLight, weapons.PropertyThrown},
 				Range:      &weapons.Range{Normal: 20, Long: 60},


### PR DESCRIPTION
## Summary
- Move `DamageComponent`, `DamageSourceType`, `AttackChainEvent`, `DamageChainEvent` to `events/events.go`
- Move chain topic definitions (`AttackChain`, `DamageChain`) to events package
- Enhance `DamageReceivedEvent` with `SourceRef *core.Ref` for proper source tracking
- Simplify ability handling (use string directly instead of `abilityToRef`)

## Motivation
Events should live together in one place. This consolidation:
1. Makes the event system easier to understand
2. Reduces import complexity (one package for all D&D 5e events)
3. Prepares for proper damage source tracking with `SourceRef`

## Changes
- `events/events.go` - Added damage chain types and topics
- `combat/attack.go` - Removed types now in events, simplified damage calculation
- All conditions and tests updated to use `dnd5eEvents` package types

## Test plan
- [x] All existing tests pass
- [x] Linter passes (only pre-existing `shared/types.go` warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)