### PR TITLE
feat(refs): implement singleton refs for pointer identity comparison

### DIFF
--- a/rulebooks/dnd5e/combat/attack.go
+++ b/rulebooks/dnd5e/combat/attack.go
@@ -397,16 +397,13 @@ func calculateAttackAbilityModifier(weapon *weapons.Weapon, scores shared.Abilit
 	return scores.Modifier(abilities.STR)
 }
 
-// weaponToRef converts a weapon to its core.Ref
+// weaponToRef converts a weapon to its singleton core.Ref.
+// Returns the singleton ref for pointer identity comparison, or nil if weapon is nil.
 func weaponToRef(weapon *weapons.Weapon) *core.Ref {
 	if weapon == nil {
 		return nil
 	}
-	return &core.Ref{
-		Module: refs.Module,
-		Type:   refs.TypeWeapons,
-		ID:     weapon.ID,
-	}
+	return refs.Weapons.ByID(weapon.ID)
 }
 
 // abilityToRef converts an ability to its core.Ref

--- a/rulebooks/dnd5e/refs/abilities.go
+++ b/rulebooks/dnd5e/refs/abilities.go
@@ -3,15 +3,26 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Ability singletons - unexported for controlled access via methods
+var (
+	abilityStrength     = &core.Ref{Module: Module, Type: TypeAbilities, ID: "str"}
+	abilityDexterity    = &core.Ref{Module: Module, Type: TypeAbilities, ID: "dex"}
+	abilityConstitution = &core.Ref{Module: Module, Type: TypeAbilities, ID: "con"}
+	abilityIntelligence = &core.Ref{Module: Module, Type: TypeAbilities, ID: "int"}
+	abilityWisdom       = &core.Ref{Module: Module, Type: TypeAbilities, ID: "wis"}
+	abilityCharisma     = &core.Ref{Module: Module, Type: TypeAbilities, ID: "cha"}
+)
+
 // Abilities provides type-safe, discoverable references to D&D 5e abilities.
 // Use IDE autocomplete: refs.Abilities.<tab> to discover available abilities.
-var Abilities = abilitiesNS{ns{TypeAbilities}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Abilities.Strength()).
+var Abilities = abilitiesNS{}
 
-type abilitiesNS struct{ ns }
+type abilitiesNS struct{}
 
-func (n abilitiesNS) Strength() *core.Ref     { return n.ref("str") }
-func (n abilitiesNS) Dexterity() *core.Ref    { return n.ref("dex") }
-func (n abilitiesNS) Constitution() *core.Ref { return n.ref("con") }
-func (n abilitiesNS) Intelligence() *core.Ref { return n.ref("int") }
-func (n abilitiesNS) Wisdom() *core.Ref       { return n.ref("wis") }
-func (n abilitiesNS) Charisma() *core.Ref     { return n.ref("cha") }
+func (n abilitiesNS) Strength() *core.Ref     { return abilityStrength }
+func (n abilitiesNS) Dexterity() *core.Ref    { return abilityDexterity }
+func (n abilitiesNS) Constitution() *core.Ref { return abilityConstitution }
+func (n abilitiesNS) Intelligence() *core.Ref { return abilityIntelligence }
+func (n abilitiesNS) Wisdom() *core.Ref       { return abilityWisdom }
+func (n abilitiesNS) Charisma() *core.Ref     { return abilityCharisma }

--- a/rulebooks/dnd5e/refs/armor.go
+++ b/rulebooks/dnd5e/refs/armor.go
@@ -3,29 +3,54 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Armor singletons - unexported for controlled access via methods
+var (
+	// Light Armor
+	armorPadded         = &core.Ref{Module: Module, Type: TypeArmor, ID: "padded"}
+	armorLeather        = &core.Ref{Module: Module, Type: TypeArmor, ID: "leather"}
+	armorStuddedLeather = &core.Ref{Module: Module, Type: TypeArmor, ID: "studded-leather"}
+
+	// Medium Armor
+	armorHide        = &core.Ref{Module: Module, Type: TypeArmor, ID: "hide"}
+	armorChainShirt  = &core.Ref{Module: Module, Type: TypeArmor, ID: "chain-shirt"}
+	armorScaleMail   = &core.Ref{Module: Module, Type: TypeArmor, ID: "scale-mail"}
+	armorBreastplate = &core.Ref{Module: Module, Type: TypeArmor, ID: "breastplate"}
+	armorHalfPlate   = &core.Ref{Module: Module, Type: TypeArmor, ID: "half-plate"}
+
+	// Heavy Armor
+	armorRingMail  = &core.Ref{Module: Module, Type: TypeArmor, ID: "ring-mail"}
+	armorChainMail = &core.Ref{Module: Module, Type: TypeArmor, ID: "chain-mail"}
+	armorSplint    = &core.Ref{Module: Module, Type: TypeArmor, ID: "splint"}
+	armorPlate     = &core.Ref{Module: Module, Type: TypeArmor, ID: "plate"}
+
+	// Shield
+	armorShield = &core.Ref{Module: Module, Type: TypeArmor, ID: "shield"}
+)
+
 // Armor provides type-safe, discoverable references to D&D 5e armor.
 // Use IDE autocomplete: refs.Armor.<tab> to discover available armor.
-var Armor = armorNS{ns{TypeArmor}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Armor.Plate()).
+var Armor = armorNS{}
 
-type armorNS struct{ ns }
+type armorNS struct{}
 
 // Light Armor
-func (n armorNS) Padded() *core.Ref         { return n.ref("padded") }
-func (n armorNS) Leather() *core.Ref        { return n.ref("leather") }
-func (n armorNS) StuddedLeather() *core.Ref { return n.ref("studded-leather") }
+func (n armorNS) Padded() *core.Ref         { return armorPadded }
+func (n armorNS) Leather() *core.Ref        { return armorLeather }
+func (n armorNS) StuddedLeather() *core.Ref { return armorStuddedLeather }
 
 // Medium Armor
-func (n armorNS) Hide() *core.Ref        { return n.ref("hide") }
-func (n armorNS) ChainShirt() *core.Ref  { return n.ref("chain-shirt") }
-func (n armorNS) ScaleMail() *core.Ref   { return n.ref("scale-mail") }
-func (n armorNS) Breastplate() *core.Ref { return n.ref("breastplate") }
-func (n armorNS) HalfPlate() *core.Ref   { return n.ref("half-plate") }
+func (n armorNS) Hide() *core.Ref        { return armorHide }
+func (n armorNS) ChainShirt() *core.Ref  { return armorChainShirt }
+func (n armorNS) ScaleMail() *core.Ref   { return armorScaleMail }
+func (n armorNS) Breastplate() *core.Ref { return armorBreastplate }
+func (n armorNS) HalfPlate() *core.Ref   { return armorHalfPlate }
 
 // Heavy Armor
-func (n armorNS) RingMail() *core.Ref  { return n.ref("ring-mail") }
-func (n armorNS) ChainMail() *core.Ref { return n.ref("chain-mail") }
-func (n armorNS) Splint() *core.Ref    { return n.ref("splint") }
-func (n armorNS) Plate() *core.Ref     { return n.ref("plate") }
+func (n armorNS) RingMail() *core.Ref  { return armorRingMail }
+func (n armorNS) ChainMail() *core.Ref { return armorChainMail }
+func (n armorNS) Splint() *core.Ref    { return armorSplint }
+func (n armorNS) Plate() *core.Ref     { return armorPlate }
 
 // Shield
-func (n armorNS) Shield() *core.Ref { return n.ref("shield") }
+func (n armorNS) Shield() *core.Ref { return armorShield }

--- a/rulebooks/dnd5e/refs/backgrounds.go
+++ b/rulebooks/dnd5e/refs/backgrounds.go
@@ -3,29 +3,54 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Background singletons - unexported for controlled access via methods
+var (
+	// Base Backgrounds
+	backgroundAcolyte      = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "acolyte"}
+	backgroundCharlatan    = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "charlatan"}
+	backgroundCriminal     = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "criminal"}
+	backgroundEntertainer  = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "entertainer"}
+	backgroundFolkHero     = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "folk-hero"}
+	backgroundGuildArtisan = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "guild-artisan"}
+	backgroundHermit       = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "hermit"}
+	backgroundNoble        = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "noble"}
+	backgroundOutlander    = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "outlander"}
+	backgroundSage         = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "sage"}
+	backgroundSailor       = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "sailor"}
+	backgroundSoldier      = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "soldier"}
+	backgroundUrchin       = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "urchin"}
+
+	// Variants
+	backgroundSpy           = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "spy"}
+	backgroundPirate        = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "pirate"}
+	backgroundKnight        = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "knight"}
+	backgroundGuildMerchant = &core.Ref{Module: Module, Type: TypeBackgrounds, ID: "guild-merchant"}
+)
+
 // Backgrounds provides type-safe, discoverable references to D&D 5e backgrounds.
 // Use IDE autocomplete: refs.Backgrounds.<tab> to discover available backgrounds.
-var Backgrounds = backgroundsNS{ns{TypeBackgrounds}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Backgrounds.Soldier()).
+var Backgrounds = backgroundsNS{}
 
-type backgroundsNS struct{ ns }
+type backgroundsNS struct{}
 
 // Base Backgrounds
-func (n backgroundsNS) Acolyte() *core.Ref      { return n.ref("acolyte") }
-func (n backgroundsNS) Charlatan() *core.Ref    { return n.ref("charlatan") }
-func (n backgroundsNS) Criminal() *core.Ref     { return n.ref("criminal") }
-func (n backgroundsNS) Entertainer() *core.Ref  { return n.ref("entertainer") }
-func (n backgroundsNS) FolkHero() *core.Ref     { return n.ref("folk-hero") }
-func (n backgroundsNS) GuildArtisan() *core.Ref { return n.ref("guild-artisan") }
-func (n backgroundsNS) Hermit() *core.Ref       { return n.ref("hermit") }
-func (n backgroundsNS) Noble() *core.Ref        { return n.ref("noble") }
-func (n backgroundsNS) Outlander() *core.Ref    { return n.ref("outlander") }
-func (n backgroundsNS) Sage() *core.Ref         { return n.ref("sage") }
-func (n backgroundsNS) Sailor() *core.Ref       { return n.ref("sailor") }
-func (n backgroundsNS) Soldier() *core.Ref      { return n.ref("soldier") }
-func (n backgroundsNS) Urchin() *core.Ref       { return n.ref("urchin") }
+func (n backgroundsNS) Acolyte() *core.Ref      { return backgroundAcolyte }
+func (n backgroundsNS) Charlatan() *core.Ref    { return backgroundCharlatan }
+func (n backgroundsNS) Criminal() *core.Ref     { return backgroundCriminal }
+func (n backgroundsNS) Entertainer() *core.Ref  { return backgroundEntertainer }
+func (n backgroundsNS) FolkHero() *core.Ref     { return backgroundFolkHero }
+func (n backgroundsNS) GuildArtisan() *core.Ref { return backgroundGuildArtisan }
+func (n backgroundsNS) Hermit() *core.Ref       { return backgroundHermit }
+func (n backgroundsNS) Noble() *core.Ref        { return backgroundNoble }
+func (n backgroundsNS) Outlander() *core.Ref    { return backgroundOutlander }
+func (n backgroundsNS) Sage() *core.Ref         { return backgroundSage }
+func (n backgroundsNS) Sailor() *core.Ref       { return backgroundSailor }
+func (n backgroundsNS) Soldier() *core.Ref      { return backgroundSoldier }
+func (n backgroundsNS) Urchin() *core.Ref       { return backgroundUrchin }
 
 // Variants
-func (n backgroundsNS) Spy() *core.Ref           { return n.ref("spy") }
-func (n backgroundsNS) Pirate() *core.Ref        { return n.ref("pirate") }
-func (n backgroundsNS) Knight() *core.Ref        { return n.ref("knight") }
-func (n backgroundsNS) GuildMerchant() *core.Ref { return n.ref("guild-merchant") }
+func (n backgroundsNS) Spy() *core.Ref           { return backgroundSpy }
+func (n backgroundsNS) Pirate() *core.Ref        { return backgroundPirate }
+func (n backgroundsNS) Knight() *core.Ref        { return backgroundKnight }
+func (n backgroundsNS) GuildMerchant() *core.Ref { return backgroundGuildMerchant }

--- a/rulebooks/dnd5e/refs/classes.go
+++ b/rulebooks/dnd5e/refs/classes.go
@@ -3,21 +3,38 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Class singletons - unexported for controlled access via methods
+var (
+	classBarbarian = &core.Ref{Module: Module, Type: TypeClasses, ID: "barbarian"}
+	classBard      = &core.Ref{Module: Module, Type: TypeClasses, ID: "bard"}
+	classCleric    = &core.Ref{Module: Module, Type: TypeClasses, ID: "cleric"}
+	classDruid     = &core.Ref{Module: Module, Type: TypeClasses, ID: "druid"}
+	classFighter   = &core.Ref{Module: Module, Type: TypeClasses, ID: "fighter"}
+	classMonk      = &core.Ref{Module: Module, Type: TypeClasses, ID: "monk"}
+	classPaladin   = &core.Ref{Module: Module, Type: TypeClasses, ID: "paladin"}
+	classRanger    = &core.Ref{Module: Module, Type: TypeClasses, ID: "ranger"}
+	classRogue     = &core.Ref{Module: Module, Type: TypeClasses, ID: "rogue"}
+	classSorcerer  = &core.Ref{Module: Module, Type: TypeClasses, ID: "sorcerer"}
+	classWarlock   = &core.Ref{Module: Module, Type: TypeClasses, ID: "warlock"}
+	classWizard    = &core.Ref{Module: Module, Type: TypeClasses, ID: "wizard"}
+)
+
 // Classes provides type-safe, discoverable references to D&D 5e classes.
 // Use IDE autocomplete: refs.Classes.<tab> to discover available classes.
-var Classes = classesNS{ns{TypeClasses}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Classes.Fighter()).
+var Classes = classesNS{}
 
-type classesNS struct{ ns }
+type classesNS struct{}
 
-func (n classesNS) Barbarian() *core.Ref { return n.ref("barbarian") }
-func (n classesNS) Bard() *core.Ref      { return n.ref("bard") }
-func (n classesNS) Cleric() *core.Ref    { return n.ref("cleric") }
-func (n classesNS) Druid() *core.Ref     { return n.ref("druid") }
-func (n classesNS) Fighter() *core.Ref   { return n.ref("fighter") }
-func (n classesNS) Monk() *core.Ref      { return n.ref("monk") }
-func (n classesNS) Paladin() *core.Ref   { return n.ref("paladin") }
-func (n classesNS) Ranger() *core.Ref    { return n.ref("ranger") }
-func (n classesNS) Rogue() *core.Ref     { return n.ref("rogue") }
-func (n classesNS) Sorcerer() *core.Ref  { return n.ref("sorcerer") }
-func (n classesNS) Warlock() *core.Ref   { return n.ref("warlock") }
-func (n classesNS) Wizard() *core.Ref    { return n.ref("wizard") }
+func (n classesNS) Barbarian() *core.Ref { return classBarbarian }
+func (n classesNS) Bard() *core.Ref      { return classBard }
+func (n classesNS) Cleric() *core.Ref    { return classCleric }
+func (n classesNS) Druid() *core.Ref     { return classDruid }
+func (n classesNS) Fighter() *core.Ref   { return classFighter }
+func (n classesNS) Monk() *core.Ref      { return classMonk }
+func (n classesNS) Paladin() *core.Ref   { return classPaladin }
+func (n classesNS) Ranger() *core.Ref    { return classRanger }
+func (n classesNS) Rogue() *core.Ref     { return classRogue }
+func (n classesNS) Sorcerer() *core.Ref  { return classSorcerer }
+func (n classesNS) Warlock() *core.Ref   { return classWarlock }
+func (n classesNS) Wizard() *core.Ref    { return classWizard }

--- a/rulebooks/dnd5e/refs/conditions.go
+++ b/rulebooks/dnd5e/refs/conditions.go
@@ -3,32 +3,60 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Condition singletons - unexported for controlled access via methods
+var (
+	// Class-based conditions
+	conditionRaging           = &core.Ref{Module: Module, Type: TypeConditions, ID: "raging"}
+	conditionBrutalCritical   = &core.Ref{Module: Module, Type: TypeConditions, ID: "brutal_critical"}
+	conditionUnarmoredDefense = &core.Ref{Module: Module, Type: TypeConditions, ID: "unarmored_defense"}
+	conditionFightingStyle    = &core.Ref{Module: Module, Type: TypeConditions, ID: "fighting_style"}
+	conditionImprovedCritical = &core.Ref{Module: Module, Type: TypeConditions, ID: "improved_critical"}
+
+	// Standard D&D 5e Conditions
+	conditionBlinded       = &core.Ref{Module: Module, Type: TypeConditions, ID: "blinded"}
+	conditionCharmed       = &core.Ref{Module: Module, Type: TypeConditions, ID: "charmed"}
+	conditionDeafened      = &core.Ref{Module: Module, Type: TypeConditions, ID: "deafened"}
+	conditionFrightened    = &core.Ref{Module: Module, Type: TypeConditions, ID: "frightened"}
+	conditionGrappled      = &core.Ref{Module: Module, Type: TypeConditions, ID: "grappled"}
+	conditionIncapacitated = &core.Ref{Module: Module, Type: TypeConditions, ID: "incapacitated"}
+	conditionInvisible     = &core.Ref{Module: Module, Type: TypeConditions, ID: "invisible"}
+	conditionParalyzed     = &core.Ref{Module: Module, Type: TypeConditions, ID: "paralyzed"}
+	conditionPetrified     = &core.Ref{Module: Module, Type: TypeConditions, ID: "petrified"}
+	conditionPoisoned      = &core.Ref{Module: Module, Type: TypeConditions, ID: "poisoned"}
+	conditionProne         = &core.Ref{Module: Module, Type: TypeConditions, ID: "prone"}
+	conditionRestrained    = &core.Ref{Module: Module, Type: TypeConditions, ID: "restrained"}
+	conditionStunned       = &core.Ref{Module: Module, Type: TypeConditions, ID: "stunned"}
+	conditionUnconscious   = &core.Ref{Module: Module, Type: TypeConditions, ID: "unconscious"}
+	conditionExhaustion    = &core.Ref{Module: Module, Type: TypeConditions, ID: "exhaustion"}
+)
+
 // Conditions provides type-safe, discoverable references to D&D 5e conditions.
 // Use IDE autocomplete: refs.Conditions.<tab> to discover available conditions.
-var Conditions = conditionsNS{ns{TypeConditions}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Conditions.Raging()).
+var Conditions = conditionsNS{}
 
-type conditionsNS struct{ ns }
+type conditionsNS struct{}
 
 // Class-based conditions
-func (n conditionsNS) Raging() *core.Ref           { return n.ref("raging") }
-func (n conditionsNS) BrutalCritical() *core.Ref   { return n.ref("brutal_critical") }
-func (n conditionsNS) UnarmoredDefense() *core.Ref { return n.ref("unarmored_defense") }
-func (n conditionsNS) FightingStyle() *core.Ref    { return n.ref("fighting_style") }
-func (n conditionsNS) ImprovedCritical() *core.Ref { return n.ref("improved_critical") }
+func (n conditionsNS) Raging() *core.Ref           { return conditionRaging }
+func (n conditionsNS) BrutalCritical() *core.Ref   { return conditionBrutalCritical }
+func (n conditionsNS) UnarmoredDefense() *core.Ref { return conditionUnarmoredDefense }
+func (n conditionsNS) FightingStyle() *core.Ref    { return conditionFightingStyle }
+func (n conditionsNS) ImprovedCritical() *core.Ref { return conditionImprovedCritical }
 
 // Standard D&D 5e Conditions
-func (n conditionsNS) Blinded() *core.Ref       { return n.ref("blinded") }
-func (n conditionsNS) Charmed() *core.Ref       { return n.ref("charmed") }
-func (n conditionsNS) Deafened() *core.Ref      { return n.ref("deafened") }
-func (n conditionsNS) Frightened() *core.Ref    { return n.ref("frightened") }
-func (n conditionsNS) Grappled() *core.Ref      { return n.ref("grappled") }
-func (n conditionsNS) Incapacitated() *core.Ref { return n.ref("incapacitated") }
-func (n conditionsNS) Invisible() *core.Ref     { return n.ref("invisible") }
-func (n conditionsNS) Paralyzed() *core.Ref     { return n.ref("paralyzed") }
-func (n conditionsNS) Petrified() *core.Ref     { return n.ref("petrified") }
-func (n conditionsNS) Poisoned() *core.Ref      { return n.ref("poisoned") }
-func (n conditionsNS) Prone() *core.Ref         { return n.ref("prone") }
-func (n conditionsNS) Restrained() *core.Ref    { return n.ref("restrained") }
-func (n conditionsNS) Stunned() *core.Ref       { return n.ref("stunned") }
-func (n conditionsNS) Unconscious() *core.Ref   { return n.ref("unconscious") }
-func (n conditionsNS) Exhaustion() *core.Ref    { return n.ref("exhaustion") }
+func (n conditionsNS) Blinded() *core.Ref       { return conditionBlinded }
+func (n conditionsNS) Charmed() *core.Ref       { return conditionCharmed }
+func (n conditionsNS) Deafened() *core.Ref      { return conditionDeafened }
+func (n conditionsNS) Frightened() *core.Ref    { return conditionFrightened }
+func (n conditionsNS) Grappled() *core.Ref      { return conditionGrappled }
+func (n conditionsNS) Incapacitated() *core.Ref { return conditionIncapacitated }
+func (n conditionsNS) Invisible() *core.Ref     { return conditionInvisible }
+func (n conditionsNS) Paralyzed() *core.Ref     { return conditionParalyzed }
+func (n conditionsNS) Petrified() *core.Ref     { return conditionPetrified }
+func (n conditionsNS) Poisoned() *core.Ref      { return conditionPoisoned }
+func (n conditionsNS) Prone() *core.Ref         { return conditionProne }
+func (n conditionsNS) Restrained() *core.Ref    { return conditionRestrained }
+func (n conditionsNS) Stunned() *core.Ref       { return conditionStunned }
+func (n conditionsNS) Unconscious() *core.Ref   { return conditionUnconscious }
+func (n conditionsNS) Exhaustion() *core.Ref    { return conditionExhaustion }

--- a/rulebooks/dnd5e/refs/damage_types.go
+++ b/rulebooks/dnd5e/refs/damage_types.go
@@ -3,27 +3,50 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// DamageType singletons - unexported for controlled access via methods
+var (
+	// Physical Damage Types
+	damageTypeBludgeoning = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "bludgeoning"}
+	damageTypePiercing    = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "piercing"}
+	damageTypeSlashing    = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "slashing"}
+
+	// Elemental Damage Types
+	damageTypeAcid      = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "acid"}
+	damageTypeCold      = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "cold"}
+	damageTypeFire      = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "fire"}
+	damageTypeLightning = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "lightning"}
+	damageTypeThunder   = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "thunder"}
+
+	// Magical Damage Types
+	damageTypeForce    = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "force"}
+	damageTypeNecrotic = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "necrotic"}
+	damageTypePoison   = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "poison"}
+	damageTypePsychic  = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "psychic"}
+	damageTypeRadiant  = &core.Ref{Module: Module, Type: TypeDamageTypes, ID: "radiant"}
+)
+
 // DamageTypes provides type-safe, discoverable references to D&D 5e damage types.
 // Use IDE autocomplete: refs.DamageTypes.<tab> to discover available damage types.
-var DamageTypes = damageTypesNS{ns{TypeDamageTypes}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.DamageTypes.Fire()).
+var DamageTypes = damageTypesNS{}
 
-type damageTypesNS struct{ ns }
+type damageTypesNS struct{}
 
 // Physical Damage Types
-func (n damageTypesNS) Bludgeoning() *core.Ref { return n.ref("bludgeoning") }
-func (n damageTypesNS) Piercing() *core.Ref    { return n.ref("piercing") }
-func (n damageTypesNS) Slashing() *core.Ref    { return n.ref("slashing") }
+func (n damageTypesNS) Bludgeoning() *core.Ref { return damageTypeBludgeoning }
+func (n damageTypesNS) Piercing() *core.Ref    { return damageTypePiercing }
+func (n damageTypesNS) Slashing() *core.Ref    { return damageTypeSlashing }
 
 // Elemental Damage Types
-func (n damageTypesNS) Acid() *core.Ref      { return n.ref("acid") }
-func (n damageTypesNS) Cold() *core.Ref      { return n.ref("cold") }
-func (n damageTypesNS) Fire() *core.Ref      { return n.ref("fire") }
-func (n damageTypesNS) Lightning() *core.Ref { return n.ref("lightning") }
-func (n damageTypesNS) Thunder() *core.Ref   { return n.ref("thunder") }
+func (n damageTypesNS) Acid() *core.Ref      { return damageTypeAcid }
+func (n damageTypesNS) Cold() *core.Ref      { return damageTypeCold }
+func (n damageTypesNS) Fire() *core.Ref      { return damageTypeFire }
+func (n damageTypesNS) Lightning() *core.Ref { return damageTypeLightning }
+func (n damageTypesNS) Thunder() *core.Ref   { return damageTypeThunder }
 
 // Magical Damage Types
-func (n damageTypesNS) Force() *core.Ref    { return n.ref("force") }
-func (n damageTypesNS) Necrotic() *core.Ref { return n.ref("necrotic") }
-func (n damageTypesNS) Poison() *core.Ref   { return n.ref("poison") }
-func (n damageTypesNS) Psychic() *core.Ref  { return n.ref("psychic") }
-func (n damageTypesNS) Radiant() *core.Ref  { return n.ref("radiant") }
+func (n damageTypesNS) Force() *core.Ref    { return damageTypeForce }
+func (n damageTypesNS) Necrotic() *core.Ref { return damageTypeNecrotic }
+func (n damageTypesNS) Poison() *core.Ref   { return damageTypePoison }
+func (n damageTypesNS) Psychic() *core.Ref  { return damageTypePsychic }
+func (n damageTypesNS) Radiant() *core.Ref  { return damageTypeRadiant }

--- a/rulebooks/dnd5e/refs/features.go
+++ b/rulebooks/dnd5e/refs/features.go
@@ -3,22 +3,40 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Feature singletons - unexported for controlled access via methods
+var (
+	// Barbarian
+	featureRage           = &core.Ref{Module: Module, Type: TypeFeatures, ID: "rage"}
+	featureBrutalCritical = &core.Ref{Module: Module, Type: TypeFeatures, ID: "brutal_critical"}
+
+	// Fighter
+	featureSecondWind  = &core.Ref{Module: Module, Type: TypeFeatures, ID: "second_wind"}
+	featureActionSurge = &core.Ref{Module: Module, Type: TypeFeatures, ID: "action_surge"}
+
+	// Rogue
+	featureSneakAttack = &core.Ref{Module: Module, Type: TypeFeatures, ID: "sneak_attack"}
+
+	// Paladin
+	featureDivineSmite = &core.Ref{Module: Module, Type: TypeFeatures, ID: "divine_smite"}
+)
+
 // Features provides type-safe, discoverable references to D&D 5e features.
 // Use IDE autocomplete: refs.Features.<tab> to discover available features.
-var Features = featuresNS{ns{TypeFeatures}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Features.Rage()).
+var Features = featuresNS{}
 
-type featuresNS struct{ ns }
+type featuresNS struct{}
 
 // Barbarian
-func (n featuresNS) Rage() *core.Ref           { return n.ref("rage") }
-func (n featuresNS) BrutalCritical() *core.Ref { return n.ref("brutal_critical") }
+func (n featuresNS) Rage() *core.Ref           { return featureRage }
+func (n featuresNS) BrutalCritical() *core.Ref { return featureBrutalCritical }
 
 // Fighter
-func (n featuresNS) SecondWind() *core.Ref  { return n.ref("second_wind") }
-func (n featuresNS) ActionSurge() *core.Ref { return n.ref("action_surge") }
+func (n featuresNS) SecondWind() *core.Ref  { return featureSecondWind }
+func (n featuresNS) ActionSurge() *core.Ref { return featureActionSurge }
 
 // Rogue
-func (n featuresNS) SneakAttack() *core.Ref { return n.ref("sneak_attack") }
+func (n featuresNS) SneakAttack() *core.Ref { return featureSneakAttack }
 
 // Paladin
-func (n featuresNS) DivineSmite() *core.Ref { return n.ref("divine_smite") }
+func (n featuresNS) DivineSmite() *core.Ref { return featureDivineSmite }

--- a/rulebooks/dnd5e/refs/fighting_styles.go
+++ b/rulebooks/dnd5e/refs/fighting_styles.go
@@ -3,15 +3,26 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// FightingStyle singletons - unexported for controlled access via methods
+var (
+	fightingStyleArchery             = &core.Ref{Module: Module, Type: TypeFightingStyles, ID: "archery"}
+	fightingStyleDefense             = &core.Ref{Module: Module, Type: TypeFightingStyles, ID: "defense"}
+	fightingStyleDueling             = &core.Ref{Module: Module, Type: TypeFightingStyles, ID: "dueling"}
+	fightingStyleGreatWeaponFighting = &core.Ref{Module: Module, Type: TypeFightingStyles, ID: "great_weapon_fighting"}
+	fightingStyleProtection          = &core.Ref{Module: Module, Type: TypeFightingStyles, ID: "protection"}
+	fightingStyleTwoWeaponFighting   = &core.Ref{Module: Module, Type: TypeFightingStyles, ID: "two_weapon_fighting"}
+)
+
 // FightingStyles provides type-safe, discoverable references to D&D 5e fighting styles.
 // Use IDE autocomplete: refs.FightingStyles.<tab> to discover available fighting styles.
-var FightingStyles = fightingStylesNS{ns{TypeFightingStyles}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.FightingStyles.Dueling()).
+var FightingStyles = fightingStylesNS{}
 
-type fightingStylesNS struct{ ns }
+type fightingStylesNS struct{}
 
-func (n fightingStylesNS) Archery() *core.Ref             { return n.ref("archery") }
-func (n fightingStylesNS) Defense() *core.Ref             { return n.ref("defense") }
-func (n fightingStylesNS) Dueling() *core.Ref             { return n.ref("dueling") }
-func (n fightingStylesNS) GreatWeaponFighting() *core.Ref { return n.ref("great_weapon_fighting") }
-func (n fightingStylesNS) Protection() *core.Ref          { return n.ref("protection") }
-func (n fightingStylesNS) TwoWeaponFighting() *core.Ref   { return n.ref("two_weapon_fighting") }
+func (n fightingStylesNS) Archery() *core.Ref             { return fightingStyleArchery }
+func (n fightingStylesNS) Defense() *core.Ref             { return fightingStyleDefense }
+func (n fightingStylesNS) Dueling() *core.Ref             { return fightingStyleDueling }
+func (n fightingStylesNS) GreatWeaponFighting() *core.Ref { return fightingStyleGreatWeaponFighting }
+func (n fightingStylesNS) Protection() *core.Ref          { return fightingStyleProtection }
+func (n fightingStylesNS) TwoWeaponFighting() *core.Ref   { return fightingStyleTwoWeaponFighting }

--- a/rulebooks/dnd5e/refs/languages.go
+++ b/rulebooks/dnd5e/refs/languages.go
@@ -3,28 +3,52 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Language singletons - unexported for controlled access via methods
+var (
+	// Standard Languages
+	languageCommon   = &core.Ref{Module: Module, Type: TypeLanguages, ID: "common"}
+	languageDwarvish = &core.Ref{Module: Module, Type: TypeLanguages, ID: "dwarvish"}
+	languageElvish   = &core.Ref{Module: Module, Type: TypeLanguages, ID: "elvish"}
+	languageGiant    = &core.Ref{Module: Module, Type: TypeLanguages, ID: "giant"}
+	languageGnomish  = &core.Ref{Module: Module, Type: TypeLanguages, ID: "gnomish"}
+	languageGoblin   = &core.Ref{Module: Module, Type: TypeLanguages, ID: "goblin"}
+	languageHalfling = &core.Ref{Module: Module, Type: TypeLanguages, ID: "halfling"}
+	languageOrc      = &core.Ref{Module: Module, Type: TypeLanguages, ID: "orc"}
+
+	// Exotic Languages
+	languageAbyssal     = &core.Ref{Module: Module, Type: TypeLanguages, ID: "abyssal"}
+	languageCelestial   = &core.Ref{Module: Module, Type: TypeLanguages, ID: "celestial"}
+	languageDraconic    = &core.Ref{Module: Module, Type: TypeLanguages, ID: "draconic"}
+	languageDeepSpeech  = &core.Ref{Module: Module, Type: TypeLanguages, ID: "deep-speech"}
+	languageInfernal    = &core.Ref{Module: Module, Type: TypeLanguages, ID: "infernal"}
+	languagePrimordial  = &core.Ref{Module: Module, Type: TypeLanguages, ID: "primordial"}
+	languageSylvan      = &core.Ref{Module: Module, Type: TypeLanguages, ID: "sylvan"}
+	languageUndercommon = &core.Ref{Module: Module, Type: TypeLanguages, ID: "undercommon"}
+)
+
 // Languages provides type-safe, discoverable references to D&D 5e languages.
 // Use IDE autocomplete: refs.Languages.<tab> to discover available languages.
-var Languages = languagesNS{ns{TypeLanguages}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Languages.Common()).
+var Languages = languagesNS{}
 
-type languagesNS struct{ ns }
+type languagesNS struct{}
 
 // Standard Languages
-func (n languagesNS) Common() *core.Ref   { return n.ref("common") }
-func (n languagesNS) Dwarvish() *core.Ref { return n.ref("dwarvish") }
-func (n languagesNS) Elvish() *core.Ref   { return n.ref("elvish") }
-func (n languagesNS) Giant() *core.Ref    { return n.ref("giant") }
-func (n languagesNS) Gnomish() *core.Ref  { return n.ref("gnomish") }
-func (n languagesNS) Goblin() *core.Ref   { return n.ref("goblin") }
-func (n languagesNS) Halfling() *core.Ref { return n.ref("halfling") }
-func (n languagesNS) Orc() *core.Ref      { return n.ref("orc") }
+func (n languagesNS) Common() *core.Ref   { return languageCommon }
+func (n languagesNS) Dwarvish() *core.Ref { return languageDwarvish }
+func (n languagesNS) Elvish() *core.Ref   { return languageElvish }
+func (n languagesNS) Giant() *core.Ref    { return languageGiant }
+func (n languagesNS) Gnomish() *core.Ref  { return languageGnomish }
+func (n languagesNS) Goblin() *core.Ref   { return languageGoblin }
+func (n languagesNS) Halfling() *core.Ref { return languageHalfling }
+func (n languagesNS) Orc() *core.Ref      { return languageOrc }
 
 // Exotic Languages
-func (n languagesNS) Abyssal() *core.Ref     { return n.ref("abyssal") }
-func (n languagesNS) Celestial() *core.Ref   { return n.ref("celestial") }
-func (n languagesNS) Draconic() *core.Ref    { return n.ref("draconic") }
-func (n languagesNS) DeepSpeech() *core.Ref  { return n.ref("deep-speech") }
-func (n languagesNS) Infernal() *core.Ref    { return n.ref("infernal") }
-func (n languagesNS) Primordial() *core.Ref  { return n.ref("primordial") }
-func (n languagesNS) Sylvan() *core.Ref      { return n.ref("sylvan") }
-func (n languagesNS) Undercommon() *core.Ref { return n.ref("undercommon") }
+func (n languagesNS) Abyssal() *core.Ref     { return languageAbyssal }
+func (n languagesNS) Celestial() *core.Ref   { return languageCelestial }
+func (n languagesNS) Draconic() *core.Ref    { return languageDraconic }
+func (n languagesNS) DeepSpeech() *core.Ref  { return languageDeepSpeech }
+func (n languagesNS) Infernal() *core.Ref    { return languageInfernal }
+func (n languagesNS) Primordial() *core.Ref  { return languagePrimordial }
+func (n languagesNS) Sylvan() *core.Ref      { return languageSylvan }
+func (n languagesNS) Undercommon() *core.Ref { return languageUndercommon }

--- a/rulebooks/dnd5e/refs/module.go
+++ b/rulebooks/dnd5e/refs/module.go
@@ -38,13 +38,3 @@ const (
 	TypeTools          core.Type = "tools"
 	TypeArmor          core.Type = "armor"
 )
-
-// ns is a helper for building namespace refs. Embed this in namespace structs
-// to get a ref() method that creates refs with the correct module and type.
-type ns struct {
-	t core.Type
-}
-
-func (n ns) ref(id core.ID) *core.Ref {
-	return &core.Ref{Module: Module, Type: n.t, ID: id}
-}

--- a/rulebooks/dnd5e/refs/races.go
+++ b/rulebooks/dnd5e/refs/races.go
@@ -3,36 +3,68 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Race singletons - unexported for controlled access via methods
+var (
+	// Base Races
+	raceHuman      = &core.Ref{Module: Module, Type: TypeRaces, ID: "human"}
+	raceElf        = &core.Ref{Module: Module, Type: TypeRaces, ID: "elf"}
+	raceDwarf      = &core.Ref{Module: Module, Type: TypeRaces, ID: "dwarf"}
+	raceHalfling   = &core.Ref{Module: Module, Type: TypeRaces, ID: "halfling"}
+	raceDragonborn = &core.Ref{Module: Module, Type: TypeRaces, ID: "dragonborn"}
+	raceGnome      = &core.Ref{Module: Module, Type: TypeRaces, ID: "gnome"}
+	raceHalfElf    = &core.Ref{Module: Module, Type: TypeRaces, ID: "half-elf"}
+	raceHalfOrc    = &core.Ref{Module: Module, Type: TypeRaces, ID: "half-orc"}
+	raceTiefling   = &core.Ref{Module: Module, Type: TypeRaces, ID: "tiefling"}
+
+	// Elf Subraces
+	raceHighElf = &core.Ref{Module: Module, Type: TypeRaces, ID: "high-elf"}
+	raceWoodElf = &core.Ref{Module: Module, Type: TypeRaces, ID: "wood-elf"}
+	raceDarkElf = &core.Ref{Module: Module, Type: TypeRaces, ID: "dark-elf"}
+
+	// Dwarf Subraces
+	raceMountainDwarf = &core.Ref{Module: Module, Type: TypeRaces, ID: "mountain-dwarf"}
+	raceHillDwarf     = &core.Ref{Module: Module, Type: TypeRaces, ID: "hill-dwarf"}
+
+	// Halfling Subraces
+	raceLightfootHalfling = &core.Ref{Module: Module, Type: TypeRaces, ID: "lightfoot-halfling"}
+	raceStoutHalfling     = &core.Ref{Module: Module, Type: TypeRaces, ID: "stout-halfling"}
+
+	// Gnome Subraces
+	raceForestGnome = &core.Ref{Module: Module, Type: TypeRaces, ID: "forest-gnome"}
+	raceRockGnome   = &core.Ref{Module: Module, Type: TypeRaces, ID: "rock-gnome"}
+)
+
 // Races provides type-safe, discoverable references to D&D 5e races.
 // Use IDE autocomplete: refs.Races.<tab> to discover available races.
-var Races = racesNS{ns{TypeRaces}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Races.Human()).
+var Races = racesNS{}
 
-type racesNS struct{ ns }
+type racesNS struct{}
 
 // Base Races
-func (n racesNS) Human() *core.Ref      { return n.ref("human") }
-func (n racesNS) Elf() *core.Ref        { return n.ref("elf") }
-func (n racesNS) Dwarf() *core.Ref      { return n.ref("dwarf") }
-func (n racesNS) Halfling() *core.Ref   { return n.ref("halfling") }
-func (n racesNS) Dragonborn() *core.Ref { return n.ref("dragonborn") }
-func (n racesNS) Gnome() *core.Ref      { return n.ref("gnome") }
-func (n racesNS) HalfElf() *core.Ref    { return n.ref("half-elf") }
-func (n racesNS) HalfOrc() *core.Ref    { return n.ref("half-orc") }
-func (n racesNS) Tiefling() *core.Ref   { return n.ref("tiefling") }
+func (n racesNS) Human() *core.Ref      { return raceHuman }
+func (n racesNS) Elf() *core.Ref        { return raceElf }
+func (n racesNS) Dwarf() *core.Ref      { return raceDwarf }
+func (n racesNS) Halfling() *core.Ref   { return raceHalfling }
+func (n racesNS) Dragonborn() *core.Ref { return raceDragonborn }
+func (n racesNS) Gnome() *core.Ref      { return raceGnome }
+func (n racesNS) HalfElf() *core.Ref    { return raceHalfElf }
+func (n racesNS) HalfOrc() *core.Ref    { return raceHalfOrc }
+func (n racesNS) Tiefling() *core.Ref   { return raceTiefling }
 
 // Elf Subraces
-func (n racesNS) HighElf() *core.Ref { return n.ref("high-elf") }
-func (n racesNS) WoodElf() *core.Ref { return n.ref("wood-elf") }
-func (n racesNS) DarkElf() *core.Ref { return n.ref("dark-elf") }
+func (n racesNS) HighElf() *core.Ref { return raceHighElf }
+func (n racesNS) WoodElf() *core.Ref { return raceWoodElf }
+func (n racesNS) DarkElf() *core.Ref { return raceDarkElf }
 
 // Dwarf Subraces
-func (n racesNS) MountainDwarf() *core.Ref { return n.ref("mountain-dwarf") }
-func (n racesNS) HillDwarf() *core.Ref     { return n.ref("hill-dwarf") }
+func (n racesNS) MountainDwarf() *core.Ref { return raceMountainDwarf }
+func (n racesNS) HillDwarf() *core.Ref     { return raceHillDwarf }
 
 // Halfling Subraces
-func (n racesNS) LightfootHalfling() *core.Ref { return n.ref("lightfoot-halfling") }
-func (n racesNS) StoutHalfling() *core.Ref     { return n.ref("stout-halfling") }
+func (n racesNS) LightfootHalfling() *core.Ref { return raceLightfootHalfling }
+func (n racesNS) StoutHalfling() *core.Ref     { return raceStoutHalfling }
 
 // Gnome Subraces
-func (n racesNS) ForestGnome() *core.Ref { return n.ref("forest-gnome") }
-func (n racesNS) RockGnome() *core.Ref   { return n.ref("rock-gnome") }
+func (n racesNS) ForestGnome() *core.Ref { return raceForestGnome }
+func (n racesNS) RockGnome() *core.Ref   { return raceRockGnome }

--- a/rulebooks/dnd5e/refs/refs_test.go
+++ b/rulebooks/dnd5e/refs/refs_test.go
@@ -390,3 +390,109 @@ func TestExpandedConditionsNamespace(t *testing.T) {
 		})
 	}
 }
+
+// TestSingletonIdentity verifies that refs return the same pointer instance
+// enabling pointer comparison (ref == refs.Abilities.Strength())
+func TestSingletonIdentity(t *testing.T) {
+	t.Run("Abilities return same pointer", func(t *testing.T) {
+		ref1 := refs.Abilities.Strength()
+		ref2 := refs.Abilities.Strength()
+		assert.Same(t, ref1, ref2, "Strength() should return the same pointer")
+
+		ref3 := refs.Abilities.Dexterity()
+		ref4 := refs.Abilities.Dexterity()
+		assert.Same(t, ref3, ref4, "Dexterity() should return the same pointer")
+
+		// Different refs should be different pointers
+		assert.NotSame(t, ref1, ref3, "Strength and Dexterity should be different pointers")
+	})
+
+	t.Run("Weapons return same pointer", func(t *testing.T) {
+		ref1 := refs.Weapons.Longsword()
+		ref2 := refs.Weapons.Longsword()
+		assert.Same(t, ref1, ref2, "Longsword() should return the same pointer")
+
+		ref3 := refs.Weapons.Greataxe()
+		ref4 := refs.Weapons.Greataxe()
+		assert.Same(t, ref3, ref4, "Greataxe() should return the same pointer")
+	})
+
+	t.Run("Conditions return same pointer", func(t *testing.T) {
+		ref1 := refs.Conditions.Raging()
+		ref2 := refs.Conditions.Raging()
+		assert.Same(t, ref1, ref2, "Raging() should return the same pointer")
+	})
+
+	t.Run("Features return same pointer", func(t *testing.T) {
+		ref1 := refs.Features.Rage()
+		ref2 := refs.Features.Rage()
+		assert.Same(t, ref1, ref2, "Rage() should return the same pointer")
+	})
+
+	t.Run("Classes return same pointer", func(t *testing.T) {
+		ref1 := refs.Classes.Fighter()
+		ref2 := refs.Classes.Fighter()
+		assert.Same(t, ref1, ref2, "Fighter() should return the same pointer")
+	})
+
+	t.Run("Spells return same pointer", func(t *testing.T) {
+		ref1 := refs.Spells.Fireball()
+		ref2 := refs.Spells.Fireball()
+		assert.Same(t, ref1, ref2, "Fireball() should return the same pointer")
+	})
+}
+
+// TestSingletonSwitchPattern demonstrates the intended usage pattern
+func TestSingletonSwitchPattern(t *testing.T) {
+	// This test demonstrates how singletons enable switch on ref directly
+	ref := refs.Abilities.Strength()
+
+	var matched bool
+	switch ref {
+	case refs.Abilities.Strength():
+		matched = true
+	case refs.Abilities.Dexterity():
+		matched = false
+	default:
+		matched = false
+	}
+
+	assert.True(t, matched, "Switch on singleton ref should work via pointer comparison")
+}
+
+// TestWeaponsByID verifies the ByID lookup returns singleton refs
+func TestWeaponsByID(t *testing.T) {
+	t.Run("ByID returns same pointer as named method", func(t *testing.T) {
+		// This is the critical test: ByID must return the SAME singleton
+		// that the named method returns, enabling pointer comparison
+		longswordByID := refs.Weapons.ByID("longsword")
+		longswordNamed := refs.Weapons.Longsword()
+		assert.Same(t, longswordByID, longswordNamed, "ByID should return same singleton as named method")
+
+		greataxeByID := refs.Weapons.ByID("greataxe")
+		greataxeNamed := refs.Weapons.Greataxe()
+		assert.Same(t, greataxeByID, greataxeNamed, "ByID should return same singleton as named method")
+	})
+
+	t.Run("ByID returns nil for unknown weapon", func(t *testing.T) {
+		unknown := refs.Weapons.ByID("unknown-weapon-id")
+		assert.Nil(t, unknown, "ByID should return nil for unknown weapon ID")
+	})
+
+	t.Run("ByID enables weapon pointer comparison in converters", func(t *testing.T) {
+		// Simulates the weaponToRef helper usage
+		weaponID := "longsword"
+		ref := refs.Weapons.ByID(weaponID)
+
+		// This should work via pointer comparison
+		var matched bool
+		switch ref {
+		case refs.Weapons.Longsword():
+			matched = true
+		default:
+			matched = false
+		}
+
+		assert.True(t, matched, "ByID ref should match singleton in switch")
+	})
+}

--- a/rulebooks/dnd5e/refs/skills.go
+++ b/rulebooks/dnd5e/refs/skills.go
@@ -3,27 +3,50 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Skill singletons - unexported for controlled access via methods
+var (
+	skillAcrobatics     = &core.Ref{Module: Module, Type: TypeSkills, ID: "acrobatics"}
+	skillAnimalHandling = &core.Ref{Module: Module, Type: TypeSkills, ID: "animal-handling"}
+	skillArcana         = &core.Ref{Module: Module, Type: TypeSkills, ID: "arcana"}
+	skillAthletics      = &core.Ref{Module: Module, Type: TypeSkills, ID: "athletics"}
+	skillDeception      = &core.Ref{Module: Module, Type: TypeSkills, ID: "deception"}
+	skillHistory        = &core.Ref{Module: Module, Type: TypeSkills, ID: "history"}
+	skillInsight        = &core.Ref{Module: Module, Type: TypeSkills, ID: "insight"}
+	skillIntimidation   = &core.Ref{Module: Module, Type: TypeSkills, ID: "intimidation"}
+	skillInvestigation  = &core.Ref{Module: Module, Type: TypeSkills, ID: "investigation"}
+	skillMedicine       = &core.Ref{Module: Module, Type: TypeSkills, ID: "medicine"}
+	skillNature         = &core.Ref{Module: Module, Type: TypeSkills, ID: "nature"}
+	skillPerception     = &core.Ref{Module: Module, Type: TypeSkills, ID: "perception"}
+	skillPerformance    = &core.Ref{Module: Module, Type: TypeSkills, ID: "performance"}
+	skillPersuasion     = &core.Ref{Module: Module, Type: TypeSkills, ID: "persuasion"}
+	skillReligion       = &core.Ref{Module: Module, Type: TypeSkills, ID: "religion"}
+	skillSleightOfHand  = &core.Ref{Module: Module, Type: TypeSkills, ID: "sleight-of-hand"}
+	skillStealth        = &core.Ref{Module: Module, Type: TypeSkills, ID: "stealth"}
+	skillSurvival       = &core.Ref{Module: Module, Type: TypeSkills, ID: "survival"}
+)
+
 // Skills provides type-safe, discoverable references to D&D 5e skills.
 // Use IDE autocomplete: refs.Skills.<tab> to discover available skills.
-var Skills = skillsNS{ns{TypeSkills}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Skills.Stealth()).
+var Skills = skillsNS{}
 
-type skillsNS struct{ ns }
+type skillsNS struct{}
 
-func (n skillsNS) Acrobatics() *core.Ref     { return n.ref("acrobatics") }
-func (n skillsNS) AnimalHandling() *core.Ref { return n.ref("animal-handling") }
-func (n skillsNS) Arcana() *core.Ref         { return n.ref("arcana") }
-func (n skillsNS) Athletics() *core.Ref      { return n.ref("athletics") }
-func (n skillsNS) Deception() *core.Ref      { return n.ref("deception") }
-func (n skillsNS) History() *core.Ref        { return n.ref("history") }
-func (n skillsNS) Insight() *core.Ref        { return n.ref("insight") }
-func (n skillsNS) Intimidation() *core.Ref   { return n.ref("intimidation") }
-func (n skillsNS) Investigation() *core.Ref  { return n.ref("investigation") }
-func (n skillsNS) Medicine() *core.Ref       { return n.ref("medicine") }
-func (n skillsNS) Nature() *core.Ref         { return n.ref("nature") }
-func (n skillsNS) Perception() *core.Ref     { return n.ref("perception") }
-func (n skillsNS) Performance() *core.Ref    { return n.ref("performance") }
-func (n skillsNS) Persuasion() *core.Ref     { return n.ref("persuasion") }
-func (n skillsNS) Religion() *core.Ref       { return n.ref("religion") }
-func (n skillsNS) SleightOfHand() *core.Ref  { return n.ref("sleight-of-hand") }
-func (n skillsNS) Stealth() *core.Ref        { return n.ref("stealth") }
-func (n skillsNS) Survival() *core.Ref       { return n.ref("survival") }
+func (n skillsNS) Acrobatics() *core.Ref     { return skillAcrobatics }
+func (n skillsNS) AnimalHandling() *core.Ref { return skillAnimalHandling }
+func (n skillsNS) Arcana() *core.Ref         { return skillArcana }
+func (n skillsNS) Athletics() *core.Ref      { return skillAthletics }
+func (n skillsNS) Deception() *core.Ref      { return skillDeception }
+func (n skillsNS) History() *core.Ref        { return skillHistory }
+func (n skillsNS) Insight() *core.Ref        { return skillInsight }
+func (n skillsNS) Intimidation() *core.Ref   { return skillIntimidation }
+func (n skillsNS) Investigation() *core.Ref  { return skillInvestigation }
+func (n skillsNS) Medicine() *core.Ref       { return skillMedicine }
+func (n skillsNS) Nature() *core.Ref         { return skillNature }
+func (n skillsNS) Perception() *core.Ref     { return skillPerception }
+func (n skillsNS) Performance() *core.Ref    { return skillPerformance }
+func (n skillsNS) Persuasion() *core.Ref     { return skillPersuasion }
+func (n skillsNS) Religion() *core.Ref       { return skillReligion }
+func (n skillsNS) SleightOfHand() *core.Ref  { return skillSleightOfHand }
+func (n skillsNS) Stealth() *core.Ref        { return skillStealth }
+func (n skillsNS) Survival() *core.Ref       { return skillSurvival }

--- a/rulebooks/dnd5e/refs/spells.go
+++ b/rulebooks/dnd5e/refs/spells.go
@@ -3,186 +3,368 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Spell singletons - unexported for controlled access via methods
+var (
+	// Cantrips - Damage
+	spellFireBolt        = &core.Ref{Module: Module, Type: TypeSpells, ID: "fire-bolt"}
+	spellRayOfFrost      = &core.Ref{Module: Module, Type: TypeSpells, ID: "ray-of-frost"}
+	spellShockingGrasp   = &core.Ref{Module: Module, Type: TypeSpells, ID: "shocking-grasp"}
+	spellAcidSplash      = &core.Ref{Module: Module, Type: TypeSpells, ID: "acid-splash"}
+	spellPoisonSpray     = &core.Ref{Module: Module, Type: TypeSpells, ID: "poison-spray"}
+	spellChillTouch      = &core.Ref{Module: Module, Type: TypeSpells, ID: "chill-touch"}
+	spellSacredFlame     = &core.Ref{Module: Module, Type: TypeSpells, ID: "sacred-flame"}
+	spellTollTheDead     = &core.Ref{Module: Module, Type: TypeSpells, ID: "toll-the-dead"}
+	spellWordOfRadiance  = &core.Ref{Module: Module, Type: TypeSpells, ID: "word-of-radiance"}
+	spellEldritchBlast   = &core.Ref{Module: Module, Type: TypeSpells, ID: "eldritch-blast"}
+	spellFrostbite       = &core.Ref{Module: Module, Type: TypeSpells, ID: "frostbite"}
+	spellPrimalSavagery  = &core.Ref{Module: Module, Type: TypeSpells, ID: "primal-savagery"}
+	spellThornWhip       = &core.Ref{Module: Module, Type: TypeSpells, ID: "thorn-whip"}
+	spellCreateBonfire   = &core.Ref{Module: Module, Type: TypeSpells, ID: "create-bonfire"}
+	spellDruidcraft      = &core.Ref{Module: Module, Type: TypeSpells, ID: "druidcraft"}
+	spellInfestation     = &core.Ref{Module: Module, Type: TypeSpells, ID: "infestation"}
+	spellMagicStone      = &core.Ref{Module: Module, Type: TypeSpells, ID: "magic-stone"}
+	spellMoldEarth       = &core.Ref{Module: Module, Type: TypeSpells, ID: "mold-earth"}
+	spellShapeWater      = &core.Ref{Module: Module, Type: TypeSpells, ID: "shape-water"}
+	spellBoomingBlade    = &core.Ref{Module: Module, Type: TypeSpells, ID: "booming-blade"}
+	spellControlFlames   = &core.Ref{Module: Module, Type: TypeSpells, ID: "control-flames"}
+	spellGreenFlameBlade = &core.Ref{Module: Module, Type: TypeSpells, ID: "green-flame-blade"}
+	spellGust            = &core.Ref{Module: Module, Type: TypeSpells, ID: "gust"}
+	spellSwordBurst      = &core.Ref{Module: Module, Type: TypeSpells, ID: "sword-burst"}
+
+	// Cantrips - Utility
+	spellMageHand         = &core.Ref{Module: Module, Type: TypeSpells, ID: "mage-hand"}
+	spellMinorIllusion    = &core.Ref{Module: Module, Type: TypeSpells, ID: "minor-illusion"}
+	spellPrestidigitation = &core.Ref{Module: Module, Type: TypeSpells, ID: "prestidigitation"}
+	spellLight            = &core.Ref{Module: Module, Type: TypeSpells, ID: "light"}
+	spellGuidance         = &core.Ref{Module: Module, Type: TypeSpells, ID: "guidance"}
+	spellResistance       = &core.Ref{Module: Module, Type: TypeSpells, ID: "resistance"}
+	spellThaumaturgy      = &core.Ref{Module: Module, Type: TypeSpells, ID: "thaumaturgy"}
+	spellSpareTheDying    = &core.Ref{Module: Module, Type: TypeSpells, ID: "spare-the-dying"}
+	spellBladeWard        = &core.Ref{Module: Module, Type: TypeSpells, ID: "blade-ward"}
+	spellDancingLights    = &core.Ref{Module: Module, Type: TypeSpells, ID: "dancing-lights"}
+	spellFriends          = &core.Ref{Module: Module, Type: TypeSpells, ID: "friends"}
+	spellMending          = &core.Ref{Module: Module, Type: TypeSpells, ID: "mending"}
+	spellMessage          = &core.Ref{Module: Module, Type: TypeSpells, ID: "message"}
+	spellTrueStrike       = &core.Ref{Module: Module, Type: TypeSpells, ID: "true-strike"}
+	spellViciousMockery   = &core.Ref{Module: Module, Type: TypeSpells, ID: "vicious-mockery"}
+
+	// Level 1 - Damage
+	spellMagicMissile    = &core.Ref{Module: Module, Type: TypeSpells, ID: "magic-missile"}
+	spellBurningHands    = &core.Ref{Module: Module, Type: TypeSpells, ID: "burning-hands"}
+	spellChromaticOrb    = &core.Ref{Module: Module, Type: TypeSpells, ID: "chromatic-orb"}
+	spellThunderwave     = &core.Ref{Module: Module, Type: TypeSpells, ID: "thunderwave"}
+	spellIceKnife        = &core.Ref{Module: Module, Type: TypeSpells, ID: "ice-knife"}
+	spellWitchBolt       = &core.Ref{Module: Module, Type: TypeSpells, ID: "witch-bolt"}
+	spellGuidingBolt     = &core.Ref{Module: Module, Type: TypeSpells, ID: "guiding-bolt"}
+	spellInflictWounds   = &core.Ref{Module: Module, Type: TypeSpells, ID: "inflict-wounds"}
+	spellHailOfThorns    = &core.Ref{Module: Module, Type: TypeSpells, ID: "hail-of-thorns"}
+	spellEnsnaringStrike = &core.Ref{Module: Module, Type: TypeSpells, ID: "ensnaring-strike"}
+	spellHellishRebuke   = &core.Ref{Module: Module, Type: TypeSpells, ID: "hellish-rebuke"}
+	spellArmsOfHadar     = &core.Ref{Module: Module, Type: TypeSpells, ID: "arms-of-hadar"}
+	spellHex             = &core.Ref{Module: Module, Type: TypeSpells, ID: "hex"}
+	spellSearingSmite    = &core.Ref{Module: Module, Type: TypeSpells, ID: "searing-smite"}
+	spellThunderousSmite = &core.Ref{Module: Module, Type: TypeSpells, ID: "thunderous-smite"}
+	spellWrathfulSmite   = &core.Ref{Module: Module, Type: TypeSpells, ID: "wrathful-smite"}
+
+	// Level 1 - Utility
+	spellShield              = &core.Ref{Module: Module, Type: TypeSpells, ID: "shield"}
+	spellSleep               = &core.Ref{Module: Module, Type: TypeSpells, ID: "sleep"}
+	spellCharmPerson         = &core.Ref{Module: Module, Type: TypeSpells, ID: "charm-person"}
+	spellDetectMagic         = &core.Ref{Module: Module, Type: TypeSpells, ID: "detect-magic"}
+	spellIdentify            = &core.Ref{Module: Module, Type: TypeSpells, ID: "identify"}
+	spellCureWounds          = &core.Ref{Module: Module, Type: TypeSpells, ID: "cure-wounds"}
+	spellHealingWord         = &core.Ref{Module: Module, Type: TypeSpells, ID: "healing-word"}
+	spellBless               = &core.Ref{Module: Module, Type: TypeSpells, ID: "bless"}
+	spellBane                = &core.Ref{Module: Module, Type: TypeSpells, ID: "bane"}
+	spellShieldOfFaith       = &core.Ref{Module: Module, Type: TypeSpells, ID: "shield-of-faith"}
+	spellAnimalFriendship    = &core.Ref{Module: Module, Type: TypeSpells, ID: "animal-friendship"}
+	spellCommand             = &core.Ref{Module: Module, Type: TypeSpells, ID: "command"}
+	spellDisguiseSelf        = &core.Ref{Module: Module, Type: TypeSpells, ID: "disguise-self"}
+	spellDivineFavor         = &core.Ref{Module: Module, Type: TypeSpells, ID: "divine-favor"}
+	spellFaerieFire          = &core.Ref{Module: Module, Type: TypeSpells, ID: "faerie-fire"}
+	spellFalseLife           = &core.Ref{Module: Module, Type: TypeSpells, ID: "false-life"}
+	spellFogCloud            = &core.Ref{Module: Module, Type: TypeSpells, ID: "fog-cloud"}
+	spellRayOfSickness       = &core.Ref{Module: Module, Type: TypeSpells, ID: "ray-of-sickness"}
+	spellSpeakWithAnimals    = &core.Ref{Module: Module, Type: TypeSpells, ID: "speak-with-animals"}
+	spellComprehendLanguages = &core.Ref{Module: Module, Type: TypeSpells, ID: "comprehend-languages"}
+	spellFeatherFall         = &core.Ref{Module: Module, Type: TypeSpells, ID: "feather-fall"}
+	spellHeroism             = &core.Ref{Module: Module, Type: TypeSpells, ID: "heroism"}
+	spellHideousLaughter     = &core.Ref{Module: Module, Type: TypeSpells, ID: "hideous-laughter"}
+	spellIllusoryScript      = &core.Ref{Module: Module, Type: TypeSpells, ID: "illusory-script"}
+	spellLongstrider         = &core.Ref{Module: Module, Type: TypeSpells, ID: "longstrider"}
+	spellSilentImage         = &core.Ref{Module: Module, Type: TypeSpells, ID: "silent-image"}
+	spellUnseenServant       = &core.Ref{Module: Module, Type: TypeSpells, ID: "unseen-servant"}
+	spellAbsorbElements      = &core.Ref{Module: Module, Type: TypeSpells, ID: "absorb-elements"}
+	spellBeastBond           = &core.Ref{Module: Module, Type: TypeSpells, ID: "beast-bond"}
+	spellEntangle            = &core.Ref{Module: Module, Type: TypeSpells, ID: "entangle"}
+	spellGoodberry           = &core.Ref{Module: Module, Type: TypeSpells, ID: "goodberry"}
+	spellJump                = &core.Ref{Module: Module, Type: TypeSpells, ID: "jump"}
+	spellPurifyFood          = &core.Ref{Module: Module, Type: TypeSpells, ID: "purify-food-and-drink"}
+	spellCatapult            = &core.Ref{Module: Module, Type: TypeSpells, ID: "catapult"}
+	spellCauseFear           = &core.Ref{Module: Module, Type: TypeSpells, ID: "cause-fear"}
+	spellColorSpray          = &core.Ref{Module: Module, Type: TypeSpells, ID: "color-spray"}
+	spellDistortValue        = &core.Ref{Module: Module, Type: TypeSpells, ID: "distort-value"}
+	spellEarthTremor         = &core.Ref{Module: Module, Type: TypeSpells, ID: "earth-tremor"}
+	spellExpeditiousRetreat  = &core.Ref{Module: Module, Type: TypeSpells, ID: "expeditious-retreat"}
+	spellProtectionEvil      = &core.Ref{Module: Module, Type: TypeSpells, ID: "protection-from-evil-and-good"}
+
+	// Level 2 - Damage
+	spellScorchingRay       = &core.Ref{Module: Module, Type: TypeSpells, ID: "scorching-ray"}
+	spellShatter            = &core.Ref{Module: Module, Type: TypeSpells, ID: "shatter"}
+	spellAganazzarsScorcher = &core.Ref{Module: Module, Type: TypeSpells, ID: "aganazzars-scorcher"}
+	spellCloudOfDaggers     = &core.Ref{Module: Module, Type: TypeSpells, ID: "cloud-of-daggers"}
+	spellMelfsAcidArrow     = &core.Ref{Module: Module, Type: TypeSpells, ID: "melfs-acid-arrow"}
+	spellMoonbeam           = &core.Ref{Module: Module, Type: TypeSpells, ID: "moonbeam"}
+	spellSpiritualWeapon    = &core.Ref{Module: Module, Type: TypeSpells, ID: "spiritual-weapon"}
+	spellFlamingSphere      = &core.Ref{Module: Module, Type: TypeSpells, ID: "flaming-sphere"}
+	spellGustOfWind         = &core.Ref{Module: Module, Type: TypeSpells, ID: "gust-of-wind"}
+	spellRayOfEnfeeblement  = &core.Ref{Module: Module, Type: TypeSpells, ID: "ray-of-enfeeblement"}
+
+	// Level 2 - Utility
+	spellAugury            = &core.Ref{Module: Module, Type: TypeSpells, ID: "augury"}
+	spellBarkskin          = &core.Ref{Module: Module, Type: TypeSpells, ID: "barkskin"}
+	spellBlindnessDeafness = &core.Ref{Module: Module, Type: TypeSpells, ID: "blindness-deafness"}
+	spellLesserRestoration = &core.Ref{Module: Module, Type: TypeSpells, ID: "lesser-restoration"}
+	spellMagicWeapon       = &core.Ref{Module: Module, Type: TypeSpells, ID: "magic-weapon"}
+	spellMirrorImage       = &core.Ref{Module: Module, Type: TypeSpells, ID: "mirror-image"}
+	spellPassWithoutTrace  = &core.Ref{Module: Module, Type: TypeSpells, ID: "pass-without-trace"}
+	spellSpikeGrowth       = &core.Ref{Module: Module, Type: TypeSpells, ID: "spike-growth"}
+	spellSuggestion        = &core.Ref{Module: Module, Type: TypeSpells, ID: "suggestion"}
+
+	// Level 3 - Damage
+	spellFireball        = &core.Ref{Module: Module, Type: TypeSpells, ID: "fireball"}
+	spellLightningBolt   = &core.Ref{Module: Module, Type: TypeSpells, ID: "lightning-bolt"}
+	spellCallLightning   = &core.Ref{Module: Module, Type: TypeSpells, ID: "call-lightning"}
+	spellVampiricTouch   = &core.Ref{Module: Module, Type: TypeSpells, ID: "vampiric-touch"}
+	spellSleetStorm      = &core.Ref{Module: Module, Type: TypeSpells, ID: "sleet-storm"}
+	spellSpiritGuardians = &core.Ref{Module: Module, Type: TypeSpells, ID: "spirit-guardians"}
+
+	// Level 3 - Utility
+	spellAnimateDead     = &core.Ref{Module: Module, Type: TypeSpells, ID: "animate-dead"}
+	spellBeaconOfHope    = &core.Ref{Module: Module, Type: TypeSpells, ID: "beacon-of-hope"}
+	spellBlink           = &core.Ref{Module: Module, Type: TypeSpells, ID: "blink"}
+	spellCrusadersMantle = &core.Ref{Module: Module, Type: TypeSpells, ID: "crusaders-mantle"}
+	spellDaylight        = &core.Ref{Module: Module, Type: TypeSpells, ID: "daylight"}
+	spellDispelMagic     = &core.Ref{Module: Module, Type: TypeSpells, ID: "dispel-magic"}
+	spellNondetection    = &core.Ref{Module: Module, Type: TypeSpells, ID: "nondetection"}
+	spellPlantGrowth     = &core.Ref{Module: Module, Type: TypeSpells, ID: "plant-growth"}
+	spellRevivify        = &core.Ref{Module: Module, Type: TypeSpells, ID: "revivify"}
+	spellSpeakWithDead   = &core.Ref{Module: Module, Type: TypeSpells, ID: "speak-with-dead"}
+	spellWindWall        = &core.Ref{Module: Module, Type: TypeSpells, ID: "wind-wall"}
+
+	// Level 4
+	spellArcaneEye         = &core.Ref{Module: Module, Type: TypeSpells, ID: "arcane-eye"}
+	spellBlight            = &core.Ref{Module: Module, Type: TypeSpells, ID: "blight"}
+	spellConfusion         = &core.Ref{Module: Module, Type: TypeSpells, ID: "confusion"}
+	spellControlWater      = &core.Ref{Module: Module, Type: TypeSpells, ID: "control-water"}
+	spellDeathWard         = &core.Ref{Module: Module, Type: TypeSpells, ID: "death-ward"}
+	spellDimensionDoor     = &core.Ref{Module: Module, Type: TypeSpells, ID: "dimension-door"}
+	spellDominateBeast     = &core.Ref{Module: Module, Type: TypeSpells, ID: "dominate-beast"}
+	spellFreedomOfMovement = &core.Ref{Module: Module, Type: TypeSpells, ID: "freedom-of-movement"}
+	spellGraspingVine      = &core.Ref{Module: Module, Type: TypeSpells, ID: "grasping-vine"}
+	spellGuardianOfFaith   = &core.Ref{Module: Module, Type: TypeSpells, ID: "guardian-of-faith"}
+	spellIceStorm          = &core.Ref{Module: Module, Type: TypeSpells, ID: "ice-storm"}
+	spellPolymorph         = &core.Ref{Module: Module, Type: TypeSpells, ID: "polymorph"}
+	spellStoneskin         = &core.Ref{Module: Module, Type: TypeSpells, ID: "stoneskin"}
+	spellWallOfFire        = &core.Ref{Module: Module, Type: TypeSpells, ID: "wall-of-fire"}
+
+	// Level 5
+	spellAntiLifeShell   = &core.Ref{Module: Module, Type: TypeSpells, ID: "antilife-shell"}
+	spellCloudkill       = &core.Ref{Module: Module, Type: TypeSpells, ID: "cloudkill"}
+	spellDestructiveWave = &core.Ref{Module: Module, Type: TypeSpells, ID: "destructive-wave"}
+	spellDominatePerson  = &core.Ref{Module: Module, Type: TypeSpells, ID: "dominate-person"}
+	spellFlameStrike     = &core.Ref{Module: Module, Type: TypeSpells, ID: "flame-strike"}
+	spellHoldMonster     = &core.Ref{Module: Module, Type: TypeSpells, ID: "hold-monster"}
+	spellInsectPlague    = &core.Ref{Module: Module, Type: TypeSpells, ID: "insect-plague"}
+	spellLegendLore      = &core.Ref{Module: Module, Type: TypeSpells, ID: "legend-lore"}
+	spellMassCureWounds  = &core.Ref{Module: Module, Type: TypeSpells, ID: "mass-cure-wounds"}
+	spellModifyMemory    = &core.Ref{Module: Module, Type: TypeSpells, ID: "modify-memory"}
+	spellRaiseDead       = &core.Ref{Module: Module, Type: TypeSpells, ID: "raise-dead"}
+	spellScrying         = &core.Ref{Module: Module, Type: TypeSpells, ID: "scrying"}
+	spellTreeStride      = &core.Ref{Module: Module, Type: TypeSpells, ID: "tree-stride"}
+)
+
 // Spells provides type-safe, discoverable references to D&D 5e spells.
 // Use IDE autocomplete: refs.Spells.<tab> to discover available spells.
-var Spells = spellsNS{ns{TypeSpells}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Spells.Fireball()).
+var Spells = spellsNS{}
 
-type spellsNS struct{ ns }
+type spellsNS struct{}
 
 // Cantrips - Damage
-func (n spellsNS) FireBolt() *core.Ref        { return n.ref("fire-bolt") }
-func (n spellsNS) RayOfFrost() *core.Ref      { return n.ref("ray-of-frost") }
-func (n spellsNS) ShockingGrasp() *core.Ref   { return n.ref("shocking-grasp") }
-func (n spellsNS) AcidSplash() *core.Ref      { return n.ref("acid-splash") }
-func (n spellsNS) PoisonSpray() *core.Ref     { return n.ref("poison-spray") }
-func (n spellsNS) ChillTouch() *core.Ref      { return n.ref("chill-touch") }
-func (n spellsNS) SacredFlame() *core.Ref     { return n.ref("sacred-flame") }
-func (n spellsNS) TollTheDead() *core.Ref     { return n.ref("toll-the-dead") }
-func (n spellsNS) WordOfRadiance() *core.Ref  { return n.ref("word-of-radiance") }
-func (n spellsNS) EldritchBlast() *core.Ref   { return n.ref("eldritch-blast") }
-func (n spellsNS) Frostbite() *core.Ref       { return n.ref("frostbite") }
-func (n spellsNS) PrimalSavagery() *core.Ref  { return n.ref("primal-savagery") }
-func (n spellsNS) ThornWhip() *core.Ref       { return n.ref("thorn-whip") }
-func (n spellsNS) CreateBonfire() *core.Ref   { return n.ref("create-bonfire") }
-func (n spellsNS) Druidcraft() *core.Ref      { return n.ref("druidcraft") }
-func (n spellsNS) Infestation() *core.Ref     { return n.ref("infestation") }
-func (n spellsNS) MagicStone() *core.Ref      { return n.ref("magic-stone") }
-func (n spellsNS) MoldEarth() *core.Ref       { return n.ref("mold-earth") }
-func (n spellsNS) ShapeWater() *core.Ref      { return n.ref("shape-water") }
-func (n spellsNS) BoomingBlade() *core.Ref    { return n.ref("booming-blade") }
-func (n spellsNS) ControlFlames() *core.Ref   { return n.ref("control-flames") }
-func (n spellsNS) GreenFlameBlade() *core.Ref { return n.ref("green-flame-blade") }
-func (n spellsNS) Gust() *core.Ref            { return n.ref("gust") }
-func (n spellsNS) SwordBurst() *core.Ref      { return n.ref("sword-burst") }
+func (n spellsNS) FireBolt() *core.Ref        { return spellFireBolt }
+func (n spellsNS) RayOfFrost() *core.Ref      { return spellRayOfFrost }
+func (n spellsNS) ShockingGrasp() *core.Ref   { return spellShockingGrasp }
+func (n spellsNS) AcidSplash() *core.Ref      { return spellAcidSplash }
+func (n spellsNS) PoisonSpray() *core.Ref     { return spellPoisonSpray }
+func (n spellsNS) ChillTouch() *core.Ref      { return spellChillTouch }
+func (n spellsNS) SacredFlame() *core.Ref     { return spellSacredFlame }
+func (n spellsNS) TollTheDead() *core.Ref     { return spellTollTheDead }
+func (n spellsNS) WordOfRadiance() *core.Ref  { return spellWordOfRadiance }
+func (n spellsNS) EldritchBlast() *core.Ref   { return spellEldritchBlast }
+func (n spellsNS) Frostbite() *core.Ref       { return spellFrostbite }
+func (n spellsNS) PrimalSavagery() *core.Ref  { return spellPrimalSavagery }
+func (n spellsNS) ThornWhip() *core.Ref       { return spellThornWhip }
+func (n spellsNS) CreateBonfire() *core.Ref   { return spellCreateBonfire }
+func (n spellsNS) Druidcraft() *core.Ref      { return spellDruidcraft }
+func (n spellsNS) Infestation() *core.Ref     { return spellInfestation }
+func (n spellsNS) MagicStone() *core.Ref      { return spellMagicStone }
+func (n spellsNS) MoldEarth() *core.Ref       { return spellMoldEarth }
+func (n spellsNS) ShapeWater() *core.Ref      { return spellShapeWater }
+func (n spellsNS) BoomingBlade() *core.Ref    { return spellBoomingBlade }
+func (n spellsNS) ControlFlames() *core.Ref   { return spellControlFlames }
+func (n spellsNS) GreenFlameBlade() *core.Ref { return spellGreenFlameBlade }
+func (n spellsNS) Gust() *core.Ref            { return spellGust }
+func (n spellsNS) SwordBurst() *core.Ref      { return spellSwordBurst }
 
 // Cantrips - Utility
-func (n spellsNS) MageHand() *core.Ref         { return n.ref("mage-hand") }
-func (n spellsNS) MinorIllusion() *core.Ref    { return n.ref("minor-illusion") }
-func (n spellsNS) Prestidigitation() *core.Ref { return n.ref("prestidigitation") }
-func (n spellsNS) Light() *core.Ref            { return n.ref("light") }
-func (n spellsNS) Guidance() *core.Ref         { return n.ref("guidance") }
-func (n spellsNS) Resistance() *core.Ref       { return n.ref("resistance") }
-func (n spellsNS) Thaumaturgy() *core.Ref      { return n.ref("thaumaturgy") }
-func (n spellsNS) SpareTheDying() *core.Ref    { return n.ref("spare-the-dying") }
-func (n spellsNS) BladeWard() *core.Ref        { return n.ref("blade-ward") }
-func (n spellsNS) DancingLights() *core.Ref    { return n.ref("dancing-lights") }
-func (n spellsNS) Friends() *core.Ref          { return n.ref("friends") }
-func (n spellsNS) Mending() *core.Ref          { return n.ref("mending") }
-func (n spellsNS) Message() *core.Ref          { return n.ref("message") }
-func (n spellsNS) TrueStrike() *core.Ref       { return n.ref("true-strike") }
-func (n spellsNS) ViciousMockery() *core.Ref   { return n.ref("vicious-mockery") }
+func (n spellsNS) MageHand() *core.Ref         { return spellMageHand }
+func (n spellsNS) MinorIllusion() *core.Ref    { return spellMinorIllusion }
+func (n spellsNS) Prestidigitation() *core.Ref { return spellPrestidigitation }
+func (n spellsNS) Light() *core.Ref            { return spellLight }
+func (n spellsNS) Guidance() *core.Ref         { return spellGuidance }
+func (n spellsNS) Resistance() *core.Ref       { return spellResistance }
+func (n spellsNS) Thaumaturgy() *core.Ref      { return spellThaumaturgy }
+func (n spellsNS) SpareTheDying() *core.Ref    { return spellSpareTheDying }
+func (n spellsNS) BladeWard() *core.Ref        { return spellBladeWard }
+func (n spellsNS) DancingLights() *core.Ref    { return spellDancingLights }
+func (n spellsNS) Friends() *core.Ref          { return spellFriends }
+func (n spellsNS) Mending() *core.Ref          { return spellMending }
+func (n spellsNS) Message() *core.Ref          { return spellMessage }
+func (n spellsNS) TrueStrike() *core.Ref       { return spellTrueStrike }
+func (n spellsNS) ViciousMockery() *core.Ref   { return spellViciousMockery }
 
 // Level 1 - Damage
-func (n spellsNS) MagicMissile() *core.Ref    { return n.ref("magic-missile") }
-func (n spellsNS) BurningHands() *core.Ref    { return n.ref("burning-hands") }
-func (n spellsNS) ChromaticOrb() *core.Ref    { return n.ref("chromatic-orb") }
-func (n spellsNS) Thunderwave() *core.Ref     { return n.ref("thunderwave") }
-func (n spellsNS) IceKnife() *core.Ref        { return n.ref("ice-knife") }
-func (n spellsNS) WitchBolt() *core.Ref       { return n.ref("witch-bolt") }
-func (n spellsNS) GuidingBolt() *core.Ref     { return n.ref("guiding-bolt") }
-func (n spellsNS) InflictWounds() *core.Ref   { return n.ref("inflict-wounds") }
-func (n spellsNS) HailOfThorns() *core.Ref    { return n.ref("hail-of-thorns") }
-func (n spellsNS) EnsnaringStrike() *core.Ref { return n.ref("ensnaring-strike") }
-func (n spellsNS) HellishRebuke() *core.Ref   { return n.ref("hellish-rebuke") }
-func (n spellsNS) ArmsOfHadar() *core.Ref     { return n.ref("arms-of-hadar") }
-func (n spellsNS) Hex() *core.Ref             { return n.ref("hex") }
-func (n spellsNS) SearingSmite() *core.Ref    { return n.ref("searing-smite") }
-func (n spellsNS) ThunderousSmite() *core.Ref { return n.ref("thunderous-smite") }
-func (n spellsNS) WrathfulSmite() *core.Ref   { return n.ref("wrathful-smite") }
+func (n spellsNS) MagicMissile() *core.Ref    { return spellMagicMissile }
+func (n spellsNS) BurningHands() *core.Ref    { return spellBurningHands }
+func (n spellsNS) ChromaticOrb() *core.Ref    { return spellChromaticOrb }
+func (n spellsNS) Thunderwave() *core.Ref     { return spellThunderwave }
+func (n spellsNS) IceKnife() *core.Ref        { return spellIceKnife }
+func (n spellsNS) WitchBolt() *core.Ref       { return spellWitchBolt }
+func (n spellsNS) GuidingBolt() *core.Ref     { return spellGuidingBolt }
+func (n spellsNS) InflictWounds() *core.Ref   { return spellInflictWounds }
+func (n spellsNS) HailOfThorns() *core.Ref    { return spellHailOfThorns }
+func (n spellsNS) EnsnaringStrike() *core.Ref { return spellEnsnaringStrike }
+func (n spellsNS) HellishRebuke() *core.Ref   { return spellHellishRebuke }
+func (n spellsNS) ArmsOfHadar() *core.Ref     { return spellArmsOfHadar }
+func (n spellsNS) Hex() *core.Ref             { return spellHex }
+func (n spellsNS) SearingSmite() *core.Ref    { return spellSearingSmite }
+func (n spellsNS) ThunderousSmite() *core.Ref { return spellThunderousSmite }
+func (n spellsNS) WrathfulSmite() *core.Ref   { return spellWrathfulSmite }
 
 // Level 1 - Utility
-func (n spellsNS) Shield() *core.Ref              { return n.ref("shield") }
-func (n spellsNS) Sleep() *core.Ref               { return n.ref("sleep") }
-func (n spellsNS) CharmPerson() *core.Ref         { return n.ref("charm-person") }
-func (n spellsNS) DetectMagic() *core.Ref         { return n.ref("detect-magic") }
-func (n spellsNS) Identify() *core.Ref            { return n.ref("identify") }
-func (n spellsNS) CureWounds() *core.Ref          { return n.ref("cure-wounds") }
-func (n spellsNS) HealingWord() *core.Ref         { return n.ref("healing-word") }
-func (n spellsNS) Bless() *core.Ref               { return n.ref("bless") }
-func (n spellsNS) Bane() *core.Ref                { return n.ref("bane") }
-func (n spellsNS) ShieldOfFaith() *core.Ref       { return n.ref("shield-of-faith") }
-func (n spellsNS) AnimalFriendship() *core.Ref    { return n.ref("animal-friendship") }
-func (n spellsNS) Command() *core.Ref             { return n.ref("command") }
-func (n spellsNS) DisguiseSelf() *core.Ref        { return n.ref("disguise-self") }
-func (n spellsNS) DivineFavor() *core.Ref         { return n.ref("divine-favor") }
-func (n spellsNS) FaerieFire() *core.Ref          { return n.ref("faerie-fire") }
-func (n spellsNS) FalseLife() *core.Ref           { return n.ref("false-life") }
-func (n spellsNS) FogCloud() *core.Ref            { return n.ref("fog-cloud") }
-func (n spellsNS) RayOfSickness() *core.Ref       { return n.ref("ray-of-sickness") }
-func (n spellsNS) SpeakWithAnimals() *core.Ref    { return n.ref("speak-with-animals") }
-func (n spellsNS) ComprehendLanguages() *core.Ref { return n.ref("comprehend-languages") }
-func (n spellsNS) FeatherFall() *core.Ref         { return n.ref("feather-fall") }
-func (n spellsNS) Heroism() *core.Ref             { return n.ref("heroism") }
-func (n spellsNS) HideousLaughter() *core.Ref     { return n.ref("hideous-laughter") }
-func (n spellsNS) IllusoryScript() *core.Ref      { return n.ref("illusory-script") }
-func (n spellsNS) Longstrider() *core.Ref         { return n.ref("longstrider") }
-func (n spellsNS) SilentImage() *core.Ref         { return n.ref("silent-image") }
-func (n spellsNS) UnseenServant() *core.Ref       { return n.ref("unseen-servant") }
-func (n spellsNS) AbsorbElements() *core.Ref      { return n.ref("absorb-elements") }
-func (n spellsNS) BeastBond() *core.Ref           { return n.ref("beast-bond") }
-func (n spellsNS) Entangle() *core.Ref            { return n.ref("entangle") }
-func (n spellsNS) Goodberry() *core.Ref           { return n.ref("goodberry") }
-func (n spellsNS) Jump() *core.Ref                { return n.ref("jump") }
-func (n spellsNS) PurifyFood() *core.Ref          { return n.ref("purify-food-and-drink") }
-func (n spellsNS) Catapult() *core.Ref            { return n.ref("catapult") }
-func (n spellsNS) CauseFear() *core.Ref           { return n.ref("cause-fear") }
-func (n spellsNS) ColorSpray() *core.Ref          { return n.ref("color-spray") }
-func (n spellsNS) DistortValue() *core.Ref        { return n.ref("distort-value") }
-func (n spellsNS) EarthTremor() *core.Ref         { return n.ref("earth-tremor") }
-func (n spellsNS) ExpeditiousRetreat() *core.Ref  { return n.ref("expeditious-retreat") }
-func (n spellsNS) ProtectionEvil() *core.Ref      { return n.ref("protection-from-evil-and-good") }
+func (n spellsNS) Shield() *core.Ref              { return spellShield }
+func (n spellsNS) Sleep() *core.Ref               { return spellSleep }
+func (n spellsNS) CharmPerson() *core.Ref         { return spellCharmPerson }
+func (n spellsNS) DetectMagic() *core.Ref         { return spellDetectMagic }
+func (n spellsNS) Identify() *core.Ref            { return spellIdentify }
+func (n spellsNS) CureWounds() *core.Ref          { return spellCureWounds }
+func (n spellsNS) HealingWord() *core.Ref         { return spellHealingWord }
+func (n spellsNS) Bless() *core.Ref               { return spellBless }
+func (n spellsNS) Bane() *core.Ref                { return spellBane }
+func (n spellsNS) ShieldOfFaith() *core.Ref       { return spellShieldOfFaith }
+func (n spellsNS) AnimalFriendship() *core.Ref    { return spellAnimalFriendship }
+func (n spellsNS) Command() *core.Ref             { return spellCommand }
+func (n spellsNS) DisguiseSelf() *core.Ref        { return spellDisguiseSelf }
+func (n spellsNS) DivineFavor() *core.Ref         { return spellDivineFavor }
+func (n spellsNS) FaerieFire() *core.Ref          { return spellFaerieFire }
+func (n spellsNS) FalseLife() *core.Ref           { return spellFalseLife }
+func (n spellsNS) FogCloud() *core.Ref            { return spellFogCloud }
+func (n spellsNS) RayOfSickness() *core.Ref       { return spellRayOfSickness }
+func (n spellsNS) SpeakWithAnimals() *core.Ref    { return spellSpeakWithAnimals }
+func (n spellsNS) ComprehendLanguages() *core.Ref { return spellComprehendLanguages }
+func (n spellsNS) FeatherFall() *core.Ref         { return spellFeatherFall }
+func (n spellsNS) Heroism() *core.Ref             { return spellHeroism }
+func (n spellsNS) HideousLaughter() *core.Ref     { return spellHideousLaughter }
+func (n spellsNS) IllusoryScript() *core.Ref      { return spellIllusoryScript }
+func (n spellsNS) Longstrider() *core.Ref         { return spellLongstrider }
+func (n spellsNS) SilentImage() *core.Ref         { return spellSilentImage }
+func (n spellsNS) UnseenServant() *core.Ref       { return spellUnseenServant }
+func (n spellsNS) AbsorbElements() *core.Ref      { return spellAbsorbElements }
+func (n spellsNS) BeastBond() *core.Ref           { return spellBeastBond }
+func (n spellsNS) Entangle() *core.Ref            { return spellEntangle }
+func (n spellsNS) Goodberry() *core.Ref           { return spellGoodberry }
+func (n spellsNS) Jump() *core.Ref                { return spellJump }
+func (n spellsNS) PurifyFood() *core.Ref          { return spellPurifyFood }
+func (n spellsNS) Catapult() *core.Ref            { return spellCatapult }
+func (n spellsNS) CauseFear() *core.Ref           { return spellCauseFear }
+func (n spellsNS) ColorSpray() *core.Ref          { return spellColorSpray }
+func (n spellsNS) DistortValue() *core.Ref        { return spellDistortValue }
+func (n spellsNS) EarthTremor() *core.Ref         { return spellEarthTremor }
+func (n spellsNS) ExpeditiousRetreat() *core.Ref  { return spellExpeditiousRetreat }
+func (n spellsNS) ProtectionEvil() *core.Ref      { return spellProtectionEvil }
 
 // Level 2 - Damage
-func (n spellsNS) ScorchingRay() *core.Ref       { return n.ref("scorching-ray") }
-func (n spellsNS) Shatter() *core.Ref            { return n.ref("shatter") }
-func (n spellsNS) AganazzarsScorcher() *core.Ref { return n.ref("aganazzars-scorcher") }
-func (n spellsNS) CloudOfDaggers() *core.Ref     { return n.ref("cloud-of-daggers") }
-func (n spellsNS) MelfsAcidArrow() *core.Ref     { return n.ref("melfs-acid-arrow") }
-func (n spellsNS) Moonbeam() *core.Ref           { return n.ref("moonbeam") }
-func (n spellsNS) SpiritualWeapon() *core.Ref    { return n.ref("spiritual-weapon") }
-func (n spellsNS) FlamingSphere() *core.Ref      { return n.ref("flaming-sphere") }
-func (n spellsNS) GustOfWind() *core.Ref         { return n.ref("gust-of-wind") }
-func (n spellsNS) RayOfEnfeeblement() *core.Ref  { return n.ref("ray-of-enfeeblement") }
+func (n spellsNS) ScorchingRay() *core.Ref       { return spellScorchingRay }
+func (n spellsNS) Shatter() *core.Ref            { return spellShatter }
+func (n spellsNS) AganazzarsScorcher() *core.Ref { return spellAganazzarsScorcher }
+func (n spellsNS) CloudOfDaggers() *core.Ref     { return spellCloudOfDaggers }
+func (n spellsNS) MelfsAcidArrow() *core.Ref     { return spellMelfsAcidArrow }
+func (n spellsNS) Moonbeam() *core.Ref           { return spellMoonbeam }
+func (n spellsNS) SpiritualWeapon() *core.Ref    { return spellSpiritualWeapon }
+func (n spellsNS) FlamingSphere() *core.Ref      { return spellFlamingSphere }
+func (n spellsNS) GustOfWind() *core.Ref         { return spellGustOfWind }
+func (n spellsNS) RayOfEnfeeblement() *core.Ref  { return spellRayOfEnfeeblement }
 
 // Level 2 - Utility
-func (n spellsNS) Augury() *core.Ref            { return n.ref("augury") }
-func (n spellsNS) Barkskin() *core.Ref          { return n.ref("barkskin") }
-func (n spellsNS) BlindnessDeafness() *core.Ref { return n.ref("blindness-deafness") }
-func (n spellsNS) LesserRestoration() *core.Ref { return n.ref("lesser-restoration") }
-func (n spellsNS) MagicWeapon() *core.Ref       { return n.ref("magic-weapon") }
-func (n spellsNS) MirrorImage() *core.Ref       { return n.ref("mirror-image") }
-func (n spellsNS) PassWithoutTrace() *core.Ref  { return n.ref("pass-without-trace") }
-func (n spellsNS) SpikeGrowth() *core.Ref       { return n.ref("spike-growth") }
-func (n spellsNS) Suggestion() *core.Ref        { return n.ref("suggestion") }
+func (n spellsNS) Augury() *core.Ref            { return spellAugury }
+func (n spellsNS) Barkskin() *core.Ref          { return spellBarkskin }
+func (n spellsNS) BlindnessDeafness() *core.Ref { return spellBlindnessDeafness }
+func (n spellsNS) LesserRestoration() *core.Ref { return spellLesserRestoration }
+func (n spellsNS) MagicWeapon() *core.Ref       { return spellMagicWeapon }
+func (n spellsNS) MirrorImage() *core.Ref       { return spellMirrorImage }
+func (n spellsNS) PassWithoutTrace() *core.Ref  { return spellPassWithoutTrace }
+func (n spellsNS) SpikeGrowth() *core.Ref       { return spellSpikeGrowth }
+func (n spellsNS) Suggestion() *core.Ref        { return spellSuggestion }
 
 // Level 3 - Damage
-func (n spellsNS) Fireball() *core.Ref        { return n.ref("fireball") }
-func (n spellsNS) LightningBolt() *core.Ref   { return n.ref("lightning-bolt") }
-func (n spellsNS) CallLightning() *core.Ref   { return n.ref("call-lightning") }
-func (n spellsNS) VampiricTouch() *core.Ref   { return n.ref("vampiric-touch") }
-func (n spellsNS) SleetStorm() *core.Ref      { return n.ref("sleet-storm") }
-func (n spellsNS) SpiritGuardians() *core.Ref { return n.ref("spirit-guardians") }
+func (n spellsNS) Fireball() *core.Ref        { return spellFireball }
+func (n spellsNS) LightningBolt() *core.Ref   { return spellLightningBolt }
+func (n spellsNS) CallLightning() *core.Ref   { return spellCallLightning }
+func (n spellsNS) VampiricTouch() *core.Ref   { return spellVampiricTouch }
+func (n spellsNS) SleetStorm() *core.Ref      { return spellSleetStorm }
+func (n spellsNS) SpiritGuardians() *core.Ref { return spellSpiritGuardians }
 
 // Level 3 - Utility
-func (n spellsNS) AnimateDead() *core.Ref     { return n.ref("animate-dead") }
-func (n spellsNS) BeaconOfHope() *core.Ref    { return n.ref("beacon-of-hope") }
-func (n spellsNS) Blink() *core.Ref           { return n.ref("blink") }
-func (n spellsNS) CrusadersMantle() *core.Ref { return n.ref("crusaders-mantle") }
-func (n spellsNS) Daylight() *core.Ref        { return n.ref("daylight") }
-func (n spellsNS) DispelMagic() *core.Ref     { return n.ref("dispel-magic") }
-func (n spellsNS) Nondetection() *core.Ref    { return n.ref("nondetection") }
-func (n spellsNS) PlantGrowth() *core.Ref     { return n.ref("plant-growth") }
-func (n spellsNS) Revivify() *core.Ref        { return n.ref("revivify") }
-func (n spellsNS) SpeakWithDead() *core.Ref   { return n.ref("speak-with-dead") }
-func (n spellsNS) WindWall() *core.Ref        { return n.ref("wind-wall") }
+func (n spellsNS) AnimateDead() *core.Ref     { return spellAnimateDead }
+func (n spellsNS) BeaconOfHope() *core.Ref    { return spellBeaconOfHope }
+func (n spellsNS) Blink() *core.Ref           { return spellBlink }
+func (n spellsNS) CrusadersMantle() *core.Ref { return spellCrusadersMantle }
+func (n spellsNS) Daylight() *core.Ref        { return spellDaylight }
+func (n spellsNS) DispelMagic() *core.Ref     { return spellDispelMagic }
+func (n spellsNS) Nondetection() *core.Ref    { return spellNondetection }
+func (n spellsNS) PlantGrowth() *core.Ref     { return spellPlantGrowth }
+func (n spellsNS) Revivify() *core.Ref        { return spellRevivify }
+func (n spellsNS) SpeakWithDead() *core.Ref   { return spellSpeakWithDead }
+func (n spellsNS) WindWall() *core.Ref        { return spellWindWall }
 
 // Level 4
-func (n spellsNS) ArcaneEye() *core.Ref         { return n.ref("arcane-eye") }
-func (n spellsNS) Blight() *core.Ref            { return n.ref("blight") }
-func (n spellsNS) Confusion() *core.Ref         { return n.ref("confusion") }
-func (n spellsNS) ControlWater() *core.Ref      { return n.ref("control-water") }
-func (n spellsNS) DeathWard() *core.Ref         { return n.ref("death-ward") }
-func (n spellsNS) DimensionDoor() *core.Ref     { return n.ref("dimension-door") }
-func (n spellsNS) DominateBeast() *core.Ref     { return n.ref("dominate-beast") }
-func (n spellsNS) FreedomOfMovement() *core.Ref { return n.ref("freedom-of-movement") }
-func (n spellsNS) GraspingVine() *core.Ref      { return n.ref("grasping-vine") }
-func (n spellsNS) GuardianOfFaith() *core.Ref   { return n.ref("guardian-of-faith") }
-func (n spellsNS) IceStorm() *core.Ref          { return n.ref("ice-storm") }
-func (n spellsNS) Polymorph() *core.Ref         { return n.ref("polymorph") }
-func (n spellsNS) Stoneskin() *core.Ref         { return n.ref("stoneskin") }
-func (n spellsNS) WallOfFire() *core.Ref        { return n.ref("wall-of-fire") }
+func (n spellsNS) ArcaneEye() *core.Ref         { return spellArcaneEye }
+func (n spellsNS) Blight() *core.Ref            { return spellBlight }
+func (n spellsNS) Confusion() *core.Ref         { return spellConfusion }
+func (n spellsNS) ControlWater() *core.Ref      { return spellControlWater }
+func (n spellsNS) DeathWard() *core.Ref         { return spellDeathWard }
+func (n spellsNS) DimensionDoor() *core.Ref     { return spellDimensionDoor }
+func (n spellsNS) DominateBeast() *core.Ref     { return spellDominateBeast }
+func (n spellsNS) FreedomOfMovement() *core.Ref { return spellFreedomOfMovement }
+func (n spellsNS) GraspingVine() *core.Ref      { return spellGraspingVine }
+func (n spellsNS) GuardianOfFaith() *core.Ref   { return spellGuardianOfFaith }
+func (n spellsNS) IceStorm() *core.Ref          { return spellIceStorm }
+func (n spellsNS) Polymorph() *core.Ref         { return spellPolymorph }
+func (n spellsNS) Stoneskin() *core.Ref         { return spellStoneskin }
+func (n spellsNS) WallOfFire() *core.Ref        { return spellWallOfFire }
 
 // Level 5
-func (n spellsNS) AntiLifeShell() *core.Ref   { return n.ref("antilife-shell") }
-func (n spellsNS) Cloudkill() *core.Ref       { return n.ref("cloudkill") }
-func (n spellsNS) DestructiveWave() *core.Ref { return n.ref("destructive-wave") }
-func (n spellsNS) DominatePerson() *core.Ref  { return n.ref("dominate-person") }
-func (n spellsNS) FlameStrike() *core.Ref     { return n.ref("flame-strike") }
-func (n spellsNS) HoldMonster() *core.Ref     { return n.ref("hold-monster") }
-func (n spellsNS) InsectPlague() *core.Ref    { return n.ref("insect-plague") }
-func (n spellsNS) LegendLore() *core.Ref      { return n.ref("legend-lore") }
-func (n spellsNS) MassCureWounds() *core.Ref  { return n.ref("mass-cure-wounds") }
-func (n spellsNS) ModifyMemory() *core.Ref    { return n.ref("modify-memory") }
-func (n spellsNS) RaiseDead() *core.Ref       { return n.ref("raise-dead") }
-func (n spellsNS) Scrying() *core.Ref         { return n.ref("scrying") }
-func (n spellsNS) TreeStride() *core.Ref      { return n.ref("tree-stride") }
+func (n spellsNS) AntiLifeShell() *core.Ref   { return spellAntiLifeShell }
+func (n spellsNS) Cloudkill() *core.Ref       { return spellCloudkill }
+func (n spellsNS) DestructiveWave() *core.Ref { return spellDestructiveWave }
+func (n spellsNS) DominatePerson() *core.Ref  { return spellDominatePerson }
+func (n spellsNS) FlameStrike() *core.Ref     { return spellFlameStrike }
+func (n spellsNS) HoldMonster() *core.Ref     { return spellHoldMonster }
+func (n spellsNS) InsectPlague() *core.Ref    { return spellInsectPlague }
+func (n spellsNS) LegendLore() *core.Ref      { return spellLegendLore }
+func (n spellsNS) MassCureWounds() *core.Ref  { return spellMassCureWounds }
+func (n spellsNS) ModifyMemory() *core.Ref    { return spellModifyMemory }
+func (n spellsNS) RaiseDead() *core.Ref       { return spellRaiseDead }
+func (n spellsNS) Scrying() *core.Ref         { return spellScrying }
+func (n spellsNS) TreeStride() *core.Ref      { return spellTreeStride }

--- a/rulebooks/dnd5e/refs/tools.go
+++ b/rulebooks/dnd5e/refs/tools.go
@@ -3,55 +3,106 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Tool singletons - unexported for controlled access via methods
+var (
+	// Artisan's Tools
+	toolAlchemistSupplies    = &core.Ref{Module: Module, Type: TypeTools, ID: "alchemist-supplies"}
+	toolBrewerSupplies       = &core.Ref{Module: Module, Type: TypeTools, ID: "brewer-supplies"}
+	toolCalligrapherSupplies = &core.Ref{Module: Module, Type: TypeTools, ID: "calligrapher-supplies"}
+	toolCarpenterTools       = &core.Ref{Module: Module, Type: TypeTools, ID: "carpenter-tools"}
+	toolCartographerTools    = &core.Ref{Module: Module, Type: TypeTools, ID: "cartographer-tools"}
+	toolCobblerTools         = &core.Ref{Module: Module, Type: TypeTools, ID: "cobbler-tools"}
+	toolCookUtensils         = &core.Ref{Module: Module, Type: TypeTools, ID: "cook-utensils"}
+	toolGlassblowerTools     = &core.Ref{Module: Module, Type: TypeTools, ID: "glassblower-tools"}
+	toolJewelerTools         = &core.Ref{Module: Module, Type: TypeTools, ID: "jeweler-tools"}
+	toolLeatherworkerTools   = &core.Ref{Module: Module, Type: TypeTools, ID: "leatherworker-tools"}
+	toolMasonTools           = &core.Ref{Module: Module, Type: TypeTools, ID: "mason-tools"}
+	toolPainterSupplies      = &core.Ref{Module: Module, Type: TypeTools, ID: "painter-supplies"}
+	toolPotterTools          = &core.Ref{Module: Module, Type: TypeTools, ID: "potter-tools"}
+	toolSmithTools           = &core.Ref{Module: Module, Type: TypeTools, ID: "smith-tools"}
+	toolTinkerTools          = &core.Ref{Module: Module, Type: TypeTools, ID: "tinker-tools"}
+	toolWeaverTools          = &core.Ref{Module: Module, Type: TypeTools, ID: "weaver-tools"}
+	toolWoodcarverTools      = &core.Ref{Module: Module, Type: TypeTools, ID: "woodcarver-tools"}
+
+	// Gaming Sets
+	toolDiceSet         = &core.Ref{Module: Module, Type: TypeTools, ID: "dice-set"}
+	toolDragonchessSet  = &core.Ref{Module: Module, Type: TypeTools, ID: "dragonchess-set"}
+	toolPlayingCardSet  = &core.Ref{Module: Module, Type: TypeTools, ID: "playing-card-set"}
+	toolThreeDragonAnte = &core.Ref{Module: Module, Type: TypeTools, ID: "three-dragon-ante"}
+
+	// Musical Instruments
+	toolBagpipes = &core.Ref{Module: Module, Type: TypeTools, ID: "bagpipes"}
+	toolDrum     = &core.Ref{Module: Module, Type: TypeTools, ID: "drum"}
+	toolDulcimer = &core.Ref{Module: Module, Type: TypeTools, ID: "dulcimer"}
+	toolFlute    = &core.Ref{Module: Module, Type: TypeTools, ID: "flute"}
+	toolLute     = &core.Ref{Module: Module, Type: TypeTools, ID: "lute"}
+	toolLyre     = &core.Ref{Module: Module, Type: TypeTools, ID: "lyre"}
+	toolHorn     = &core.Ref{Module: Module, Type: TypeTools, ID: "horn"}
+	toolPanFlute = &core.Ref{Module: Module, Type: TypeTools, ID: "pan-flute"}
+	toolShawm    = &core.Ref{Module: Module, Type: TypeTools, ID: "shawm"}
+	toolViol     = &core.Ref{Module: Module, Type: TypeTools, ID: "viol"}
+
+	// Other Tools
+	toolDisguiseKit    = &core.Ref{Module: Module, Type: TypeTools, ID: "disguise-kit"}
+	toolForgeryKit     = &core.Ref{Module: Module, Type: TypeTools, ID: "forgery-kit"}
+	toolHerbalismKit   = &core.Ref{Module: Module, Type: TypeTools, ID: "herbalism-kit"}
+	toolNavigatorTools = &core.Ref{Module: Module, Type: TypeTools, ID: "navigator-tools"}
+	toolPoisonerKit    = &core.Ref{Module: Module, Type: TypeTools, ID: "poisoner-kit"}
+	toolThievesTools   = &core.Ref{Module: Module, Type: TypeTools, ID: "thieves-tools"}
+	toolVehiclesLand   = &core.Ref{Module: Module, Type: TypeTools, ID: "vehicles-land"}
+	toolVehiclesWater  = &core.Ref{Module: Module, Type: TypeTools, ID: "vehicles-water"}
+)
+
 // Tools provides type-safe, discoverable references to D&D 5e tools.
 // Use IDE autocomplete: refs.Tools.<tab> to discover available tools.
-var Tools = toolsNS{ns{TypeTools}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Tools.ThievesTools()).
+var Tools = toolsNS{}
 
-type toolsNS struct{ ns }
+type toolsNS struct{}
 
 // Artisan's Tools
-func (n toolsNS) AlchemistSupplies() *core.Ref    { return n.ref("alchemist-supplies") }
-func (n toolsNS) BrewerSupplies() *core.Ref       { return n.ref("brewer-supplies") }
-func (n toolsNS) CalligrapherSupplies() *core.Ref { return n.ref("calligrapher-supplies") }
-func (n toolsNS) CarpenterTools() *core.Ref       { return n.ref("carpenter-tools") }
-func (n toolsNS) CartographerTools() *core.Ref    { return n.ref("cartographer-tools") }
-func (n toolsNS) CobblerTools() *core.Ref         { return n.ref("cobbler-tools") }
-func (n toolsNS) CookUtensils() *core.Ref         { return n.ref("cook-utensils") }
-func (n toolsNS) GlassblowerTools() *core.Ref     { return n.ref("glassblower-tools") }
-func (n toolsNS) JewelerTools() *core.Ref         { return n.ref("jeweler-tools") }
-func (n toolsNS) LeatherworkerTools() *core.Ref   { return n.ref("leatherworker-tools") }
-func (n toolsNS) MasonTools() *core.Ref           { return n.ref("mason-tools") }
-func (n toolsNS) PainterSupplies() *core.Ref      { return n.ref("painter-supplies") }
-func (n toolsNS) PotterTools() *core.Ref          { return n.ref("potter-tools") }
-func (n toolsNS) SmithTools() *core.Ref           { return n.ref("smith-tools") }
-func (n toolsNS) TinkerTools() *core.Ref          { return n.ref("tinker-tools") }
-func (n toolsNS) WeaverTools() *core.Ref          { return n.ref("weaver-tools") }
-func (n toolsNS) WoodcarverTools() *core.Ref      { return n.ref("woodcarver-tools") }
+func (n toolsNS) AlchemistSupplies() *core.Ref    { return toolAlchemistSupplies }
+func (n toolsNS) BrewerSupplies() *core.Ref       { return toolBrewerSupplies }
+func (n toolsNS) CalligrapherSupplies() *core.Ref { return toolCalligrapherSupplies }
+func (n toolsNS) CarpenterTools() *core.Ref       { return toolCarpenterTools }
+func (n toolsNS) CartographerTools() *core.Ref    { return toolCartographerTools }
+func (n toolsNS) CobblerTools() *core.Ref         { return toolCobblerTools }
+func (n toolsNS) CookUtensils() *core.Ref         { return toolCookUtensils }
+func (n toolsNS) GlassblowerTools() *core.Ref     { return toolGlassblowerTools }
+func (n toolsNS) JewelerTools() *core.Ref         { return toolJewelerTools }
+func (n toolsNS) LeatherworkerTools() *core.Ref   { return toolLeatherworkerTools }
+func (n toolsNS) MasonTools() *core.Ref           { return toolMasonTools }
+func (n toolsNS) PainterSupplies() *core.Ref      { return toolPainterSupplies }
+func (n toolsNS) PotterTools() *core.Ref          { return toolPotterTools }
+func (n toolsNS) SmithTools() *core.Ref           { return toolSmithTools }
+func (n toolsNS) TinkerTools() *core.Ref          { return toolTinkerTools }
+func (n toolsNS) WeaverTools() *core.Ref          { return toolWeaverTools }
+func (n toolsNS) WoodcarverTools() *core.Ref      { return toolWoodcarverTools }
 
 // Gaming Sets
-func (n toolsNS) DiceSet() *core.Ref         { return n.ref("dice-set") }
-func (n toolsNS) DragonchessSet() *core.Ref  { return n.ref("dragonchess-set") }
-func (n toolsNS) PlayingCardSet() *core.Ref  { return n.ref("playing-card-set") }
-func (n toolsNS) ThreeDragonAnte() *core.Ref { return n.ref("three-dragon-ante") }
+func (n toolsNS) DiceSet() *core.Ref         { return toolDiceSet }
+func (n toolsNS) DragonchessSet() *core.Ref  { return toolDragonchessSet }
+func (n toolsNS) PlayingCardSet() *core.Ref  { return toolPlayingCardSet }
+func (n toolsNS) ThreeDragonAnte() *core.Ref { return toolThreeDragonAnte }
 
 // Musical Instruments
-func (n toolsNS) Bagpipes() *core.Ref { return n.ref("bagpipes") }
-func (n toolsNS) Drum() *core.Ref     { return n.ref("drum") }
-func (n toolsNS) Dulcimer() *core.Ref { return n.ref("dulcimer") }
-func (n toolsNS) Flute() *core.Ref    { return n.ref("flute") }
-func (n toolsNS) Lute() *core.Ref     { return n.ref("lute") }
-func (n toolsNS) Lyre() *core.Ref     { return n.ref("lyre") }
-func (n toolsNS) Horn() *core.Ref     { return n.ref("horn") }
-func (n toolsNS) PanFlute() *core.Ref { return n.ref("pan-flute") }
-func (n toolsNS) Shawm() *core.Ref    { return n.ref("shawm") }
-func (n toolsNS) Viol() *core.Ref     { return n.ref("viol") }
+func (n toolsNS) Bagpipes() *core.Ref { return toolBagpipes }
+func (n toolsNS) Drum() *core.Ref     { return toolDrum }
+func (n toolsNS) Dulcimer() *core.Ref { return toolDulcimer }
+func (n toolsNS) Flute() *core.Ref    { return toolFlute }
+func (n toolsNS) Lute() *core.Ref     { return toolLute }
+func (n toolsNS) Lyre() *core.Ref     { return toolLyre }
+func (n toolsNS) Horn() *core.Ref     { return toolHorn }
+func (n toolsNS) PanFlute() *core.Ref { return toolPanFlute }
+func (n toolsNS) Shawm() *core.Ref    { return toolShawm }
+func (n toolsNS) Viol() *core.Ref     { return toolViol }
 
 // Other Tools
-func (n toolsNS) DisguiseKit() *core.Ref    { return n.ref("disguise-kit") }
-func (n toolsNS) ForgeryKit() *core.Ref     { return n.ref("forgery-kit") }
-func (n toolsNS) HerbalismKit() *core.Ref   { return n.ref("herbalism-kit") }
-func (n toolsNS) NavigatorTools() *core.Ref { return n.ref("navigator-tools") }
-func (n toolsNS) PoisonerKit() *core.Ref    { return n.ref("poisoner-kit") }
-func (n toolsNS) ThievesTools() *core.Ref   { return n.ref("thieves-tools") }
-func (n toolsNS) VehiclesLand() *core.Ref   { return n.ref("vehicles-land") }
-func (n toolsNS) VehiclesWater() *core.Ref  { return n.ref("vehicles-water") }
+func (n toolsNS) DisguiseKit() *core.Ref    { return toolDisguiseKit }
+func (n toolsNS) ForgeryKit() *core.Ref     { return toolForgeryKit }
+func (n toolsNS) HerbalismKit() *core.Ref   { return toolHerbalismKit }
+func (n toolsNS) NavigatorTools() *core.Ref { return toolNavigatorTools }
+func (n toolsNS) PoisonerKit() *core.Ref    { return toolPoisonerKit }
+func (n toolsNS) ThievesTools() *core.Ref   { return toolThievesTools }
+func (n toolsNS) VehiclesLand() *core.Ref   { return toolVehiclesLand }
+func (n toolsNS) VehiclesWater() *core.Ref  { return toolVehiclesWater }

--- a/rulebooks/dnd5e/refs/weapons.go
+++ b/rulebooks/dnd5e/refs/weapons.go
@@ -3,58 +3,167 @@ package refs
 
 import "github.com/KirkDiggler/rpg-toolkit/core"
 
+// Weapon singletons - unexported for controlled access via methods
+var (
+	// Simple Melee Weapons
+	weaponClub         = &core.Ref{Module: Module, Type: TypeWeapons, ID: "club"}
+	weaponDagger       = &core.Ref{Module: Module, Type: TypeWeapons, ID: "dagger"}
+	weaponGreatclub    = &core.Ref{Module: Module, Type: TypeWeapons, ID: "greatclub"}
+	weaponHandaxe      = &core.Ref{Module: Module, Type: TypeWeapons, ID: "handaxe"}
+	weaponJavelin      = &core.Ref{Module: Module, Type: TypeWeapons, ID: "javelin"}
+	weaponLightHammer  = &core.Ref{Module: Module, Type: TypeWeapons, ID: "light-hammer"}
+	weaponMace         = &core.Ref{Module: Module, Type: TypeWeapons, ID: "mace"}
+	weaponQuarterstaff = &core.Ref{Module: Module, Type: TypeWeapons, ID: "quarterstaff"}
+	weaponSickle       = &core.Ref{Module: Module, Type: TypeWeapons, ID: "sickle"}
+	weaponSpear        = &core.Ref{Module: Module, Type: TypeWeapons, ID: "spear"}
+
+	// Simple Ranged Weapons
+	weaponLightCrossbow = &core.Ref{Module: Module, Type: TypeWeapons, ID: "light-crossbow"}
+	weaponDart          = &core.Ref{Module: Module, Type: TypeWeapons, ID: "dart"}
+	weaponShortbow      = &core.Ref{Module: Module, Type: TypeWeapons, ID: "shortbow"}
+	weaponSling         = &core.Ref{Module: Module, Type: TypeWeapons, ID: "sling"}
+
+	// Martial Melee Weapons
+	weaponBattleaxe   = &core.Ref{Module: Module, Type: TypeWeapons, ID: "battleaxe"}
+	weaponFlail       = &core.Ref{Module: Module, Type: TypeWeapons, ID: "flail"}
+	weaponGlaive      = &core.Ref{Module: Module, Type: TypeWeapons, ID: "glaive"}
+	weaponGreataxe    = &core.Ref{Module: Module, Type: TypeWeapons, ID: "greataxe"}
+	weaponGreatsword  = &core.Ref{Module: Module, Type: TypeWeapons, ID: "greatsword"}
+	weaponHalberd     = &core.Ref{Module: Module, Type: TypeWeapons, ID: "halberd"}
+	weaponLance       = &core.Ref{Module: Module, Type: TypeWeapons, ID: "lance"}
+	weaponLongsword   = &core.Ref{Module: Module, Type: TypeWeapons, ID: "longsword"}
+	weaponMaul        = &core.Ref{Module: Module, Type: TypeWeapons, ID: "maul"}
+	weaponMorningstar = &core.Ref{Module: Module, Type: TypeWeapons, ID: "morningstar"}
+	weaponPike        = &core.Ref{Module: Module, Type: TypeWeapons, ID: "pike"}
+	weaponRapier      = &core.Ref{Module: Module, Type: TypeWeapons, ID: "rapier"}
+	weaponScimitar    = &core.Ref{Module: Module, Type: TypeWeapons, ID: "scimitar"}
+	weaponShortsword  = &core.Ref{Module: Module, Type: TypeWeapons, ID: "shortsword"}
+	weaponTrident     = &core.Ref{Module: Module, Type: TypeWeapons, ID: "trident"}
+	weaponWarPick     = &core.Ref{Module: Module, Type: TypeWeapons, ID: "war-pick"}
+	weaponWarhammer   = &core.Ref{Module: Module, Type: TypeWeapons, ID: "warhammer"}
+	weaponWhip        = &core.Ref{Module: Module, Type: TypeWeapons, ID: "whip"}
+
+	// Martial Ranged Weapons
+	weaponBlowgun       = &core.Ref{Module: Module, Type: TypeWeapons, ID: "blowgun"}
+	weaponHandCrossbow  = &core.Ref{Module: Module, Type: TypeWeapons, ID: "hand-crossbow"}
+	weaponHeavyCrossbow = &core.Ref{Module: Module, Type: TypeWeapons, ID: "heavy-crossbow"}
+	weaponLongbow       = &core.Ref{Module: Module, Type: TypeWeapons, ID: "longbow"}
+	weaponNet           = &core.Ref{Module: Module, Type: TypeWeapons, ID: "net"}
+
+	// Category placeholders
+	weaponAnySimple  = &core.Ref{Module: Module, Type: TypeWeapons, ID: "simple-weapon"}
+	weaponAnyMartial = &core.Ref{Module: Module, Type: TypeWeapons, ID: "martial-weapon"}
+	weaponAny        = &core.Ref{Module: Module, Type: TypeWeapons, ID: "any-weapon"}
+)
+
 // Weapons provides type-safe, discoverable references to D&D 5e weapons.
 // Use IDE autocomplete: refs.Weapons.<tab> to discover available weapons.
-var Weapons = weaponsNS{ns{TypeWeapons}}
+// Methods return singleton pointers enabling identity comparison (ref == refs.Weapons.Longsword()).
+var Weapons = weaponsNS{}
 
-type weaponsNS struct{ ns }
+type weaponsNS struct{}
 
 // Simple Melee Weapons
-func (n weaponsNS) Club() *core.Ref         { return n.ref("club") }
-func (n weaponsNS) Dagger() *core.Ref       { return n.ref("dagger") }
-func (n weaponsNS) Greatclub() *core.Ref    { return n.ref("greatclub") }
-func (n weaponsNS) Handaxe() *core.Ref      { return n.ref("handaxe") }
-func (n weaponsNS) Javelin() *core.Ref      { return n.ref("javelin") }
-func (n weaponsNS) LightHammer() *core.Ref  { return n.ref("light-hammer") }
-func (n weaponsNS) Mace() *core.Ref         { return n.ref("mace") }
-func (n weaponsNS) Quarterstaff() *core.Ref { return n.ref("quarterstaff") }
-func (n weaponsNS) Sickle() *core.Ref       { return n.ref("sickle") }
-func (n weaponsNS) Spear() *core.Ref        { return n.ref("spear") }
+func (n weaponsNS) Club() *core.Ref         { return weaponClub }
+func (n weaponsNS) Dagger() *core.Ref       { return weaponDagger }
+func (n weaponsNS) Greatclub() *core.Ref    { return weaponGreatclub }
+func (n weaponsNS) Handaxe() *core.Ref      { return weaponHandaxe }
+func (n weaponsNS) Javelin() *core.Ref      { return weaponJavelin }
+func (n weaponsNS) LightHammer() *core.Ref  { return weaponLightHammer }
+func (n weaponsNS) Mace() *core.Ref         { return weaponMace }
+func (n weaponsNS) Quarterstaff() *core.Ref { return weaponQuarterstaff }
+func (n weaponsNS) Sickle() *core.Ref       { return weaponSickle }
+func (n weaponsNS) Spear() *core.Ref        { return weaponSpear }
 
 // Simple Ranged Weapons
-func (n weaponsNS) LightCrossbow() *core.Ref { return n.ref("light-crossbow") }
-func (n weaponsNS) Dart() *core.Ref          { return n.ref("dart") }
-func (n weaponsNS) Shortbow() *core.Ref      { return n.ref("shortbow") }
-func (n weaponsNS) Sling() *core.Ref         { return n.ref("sling") }
+func (n weaponsNS) LightCrossbow() *core.Ref { return weaponLightCrossbow }
+func (n weaponsNS) Dart() *core.Ref          { return weaponDart }
+func (n weaponsNS) Shortbow() *core.Ref      { return weaponShortbow }
+func (n weaponsNS) Sling() *core.Ref         { return weaponSling }
 
 // Martial Melee Weapons
-func (n weaponsNS) Battleaxe() *core.Ref   { return n.ref("battleaxe") }
-func (n weaponsNS) Flail() *core.Ref       { return n.ref("flail") }
-func (n weaponsNS) Glaive() *core.Ref      { return n.ref("glaive") }
-func (n weaponsNS) Greataxe() *core.Ref    { return n.ref("greataxe") }
-func (n weaponsNS) Greatsword() *core.Ref  { return n.ref("greatsword") }
-func (n weaponsNS) Halberd() *core.Ref     { return n.ref("halberd") }
-func (n weaponsNS) Lance() *core.Ref       { return n.ref("lance") }
-func (n weaponsNS) Longsword() *core.Ref   { return n.ref("longsword") }
-func (n weaponsNS) Maul() *core.Ref        { return n.ref("maul") }
-func (n weaponsNS) Morningstar() *core.Ref { return n.ref("morningstar") }
-func (n weaponsNS) Pike() *core.Ref        { return n.ref("pike") }
-func (n weaponsNS) Rapier() *core.Ref      { return n.ref("rapier") }
-func (n weaponsNS) Scimitar() *core.Ref    { return n.ref("scimitar") }
-func (n weaponsNS) Shortsword() *core.Ref  { return n.ref("shortsword") }
-func (n weaponsNS) Trident() *core.Ref     { return n.ref("trident") }
-func (n weaponsNS) WarPick() *core.Ref     { return n.ref("war-pick") }
-func (n weaponsNS) Warhammer() *core.Ref   { return n.ref("warhammer") }
-func (n weaponsNS) Whip() *core.Ref        { return n.ref("whip") }
+func (n weaponsNS) Battleaxe() *core.Ref   { return weaponBattleaxe }
+func (n weaponsNS) Flail() *core.Ref       { return weaponFlail }
+func (n weaponsNS) Glaive() *core.Ref      { return weaponGlaive }
+func (n weaponsNS) Greataxe() *core.Ref    { return weaponGreataxe }
+func (n weaponsNS) Greatsword() *core.Ref  { return weaponGreatsword }
+func (n weaponsNS) Halberd() *core.Ref     { return weaponHalberd }
+func (n weaponsNS) Lance() *core.Ref       { return weaponLance }
+func (n weaponsNS) Longsword() *core.Ref   { return weaponLongsword }
+func (n weaponsNS) Maul() *core.Ref        { return weaponMaul }
+func (n weaponsNS) Morningstar() *core.Ref { return weaponMorningstar }
+func (n weaponsNS) Pike() *core.Ref        { return weaponPike }
+func (n weaponsNS) Rapier() *core.Ref      { return weaponRapier }
+func (n weaponsNS) Scimitar() *core.Ref    { return weaponScimitar }
+func (n weaponsNS) Shortsword() *core.Ref  { return weaponShortsword }
+func (n weaponsNS) Trident() *core.Ref     { return weaponTrident }
+func (n weaponsNS) WarPick() *core.Ref     { return weaponWarPick }
+func (n weaponsNS) Warhammer() *core.Ref   { return weaponWarhammer }
+func (n weaponsNS) Whip() *core.Ref        { return weaponWhip }
 
 // Martial Ranged Weapons
-func (n weaponsNS) Blowgun() *core.Ref       { return n.ref("blowgun") }
-func (n weaponsNS) HandCrossbow() *core.Ref  { return n.ref("hand-crossbow") }
-func (n weaponsNS) HeavyCrossbow() *core.Ref { return n.ref("heavy-crossbow") }
-func (n weaponsNS) Longbow() *core.Ref       { return n.ref("longbow") }
-func (n weaponsNS) Net() *core.Ref           { return n.ref("net") }
+func (n weaponsNS) Blowgun() *core.Ref       { return weaponBlowgun }
+func (n weaponsNS) HandCrossbow() *core.Ref  { return weaponHandCrossbow }
+func (n weaponsNS) HeavyCrossbow() *core.Ref { return weaponHeavyCrossbow }
+func (n weaponsNS) Longbow() *core.Ref       { return weaponLongbow }
+func (n weaponsNS) Net() *core.Ref           { return weaponNet }
 
 // Category placeholders
-func (n weaponsNS) AnySimpleWeapon() *core.Ref  { return n.ref("simple-weapon") }
-func (n weaponsNS) AnyMartialWeapon() *core.Ref { return n.ref("martial-weapon") }
-func (n weaponsNS) AnyWeapon() *core.Ref        { return n.ref("any-weapon") }
+func (n weaponsNS) AnySimpleWeapon() *core.Ref  { return weaponAnySimple }
+func (n weaponsNS) AnyMartialWeapon() *core.Ref { return weaponAnyMartial }
+func (n weaponsNS) AnyWeapon() *core.Ref        { return weaponAny }
+
+// weaponByID maps weapon ID strings to singleton refs for O(1) lookup
+var weaponByID = map[string]*core.Ref{
+	// Simple Melee Weapons
+	"club":         weaponClub,
+	"dagger":       weaponDagger,
+	"greatclub":    weaponGreatclub,
+	"handaxe":      weaponHandaxe,
+	"javelin":      weaponJavelin,
+	"light-hammer": weaponLightHammer,
+	"mace":         weaponMace,
+	"quarterstaff": weaponQuarterstaff,
+	"sickle":       weaponSickle,
+	"spear":        weaponSpear,
+	// Simple Ranged Weapons
+	"light-crossbow": weaponLightCrossbow,
+	"dart":           weaponDart,
+	"shortbow":       weaponShortbow,
+	"sling":          weaponSling,
+	// Martial Melee Weapons
+	"battleaxe":   weaponBattleaxe,
+	"flail":       weaponFlail,
+	"glaive":      weaponGlaive,
+	"greataxe":    weaponGreataxe,
+	"greatsword":  weaponGreatsword,
+	"halberd":     weaponHalberd,
+	"lance":       weaponLance,
+	"longsword":   weaponLongsword,
+	"maul":        weaponMaul,
+	"morningstar": weaponMorningstar,
+	"pike":        weaponPike,
+	"rapier":      weaponRapier,
+	"scimitar":    weaponScimitar,
+	"shortsword":  weaponShortsword,
+	"trident":     weaponTrident,
+	"war-pick":    weaponWarPick,
+	"warhammer":   weaponWarhammer,
+	"whip":        weaponWhip,
+	// Martial Ranged Weapons
+	"blowgun":        weaponBlowgun,
+	"hand-crossbow":  weaponHandCrossbow,
+	"heavy-crossbow": weaponHeavyCrossbow,
+	"longbow":        weaponLongbow,
+	"net":            weaponNet,
+	// Category placeholders
+	"simple-weapon":  weaponAnySimple,
+	"martial-weapon": weaponAnyMartial,
+	"any-weapon":     weaponAny,
+}
+
+// ByID returns the singleton ref for the given weapon ID, or nil if not found.
+// This enables toolkit code to get singleton refs from weapon IDs.
+func (n weaponsNS) ByID(id string) *core.Ref {
+	return weaponByID[id]
+}


### PR DESCRIPTION
## Summary

- Convert all 14 refs namespace files to use package-level singleton vars for pointer identity comparison
- Add `Weapons.ByID()` lookup method for O(1) singleton lookup by weapon ID
- Update `weaponToRef()` in combat/attack.go to use singleton lookup
- Remove unused `ns` struct helper from module.go

## Why

Enables type-safe switch statements in converters using pointer comparison instead of string comparison:

```go
// Before: string comparison with magic strings
switch ref.ID {
case "str":
    return Ability_ABILITY_STRENGTH
}

// After: pointer comparison with IDE autocomplete
switch ref {
case refs.Abilities.Strength():
    return Ability_ABILITY_STRENGTH
}
```

## Test plan

- [x] `TestSingletonIdentity` - verifies same pointer returned each call
- [x] `TestSingletonSwitchPattern` - demonstrates switch on ref pointer
- [x] `TestWeaponsByID` - verifies ByID returns same singleton as named methods
- [x] All existing tests pass

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)