### PR TITLE
Add monster action serialization, default goblin actions, and movement behavior

### DIFF
--- a/rulebooks/dnd5e/monster/action.go
+++ b/rulebooks/dnd5e/monster/action.go
@@ -51,6 +51,9 @@ type MonsterAction interface {
 
 	// ActionType returns the category of action for target selection
 	ActionType() ActionType
+
+	// ToData converts the action to its serializable form for persistence
+	ToData() ActionData
 }
 
 // PerceptionData represents what the monster perceives about the battlefield.
@@ -115,6 +118,7 @@ type TurnInput struct {
 	ActionEconomy *combat.ActionEconomy
 	Perception    *PerceptionData
 	Roller        dice.Roller
+	Speed         int // Movement speed in feet (typically 30 for most creatures)
 }
 
 // TurnResult represents the outcome of a monster's turn

--- a/rulebooks/dnd5e/monster/scimitar_action.go
+++ b/rulebooks/dnd5e/monster/scimitar_action.go
@@ -5,10 +5,12 @@ package monster
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 const scimitarActionID = "scimitar"
@@ -116,4 +118,20 @@ func (s *ScimitarAction) Activate(ctx context.Context, owner core.Entity, input 
 	}
 
 	return nil
+}
+
+// ToData converts the action to its serializable form
+func (s *ScimitarAction) ToData() ActionData {
+	config := ScimitarConfig{
+		ID:          s.id,
+		AttackBonus: s.attackBonus,
+		DamageDice:  s.damageDice,
+		DamageBonus: s.damageBonus,
+	}
+	configJSON, _ := json.Marshal(config)
+
+	return ActionData{
+		Ref:    *refs.MonsterActions.Scimitar(),
+		Config: configJSON,
+	}
 }


### PR DESCRIPTION
## Summary

- Add `ToData()` method to `MonsterAction` interface enabling action persistence
- Implement action serialization on `ScimitarAction` for round-trip data conversion
- `NewGoblin()` now creates combat-ready goblins with default scimitar (+4/1d6+2) and 30ft speed
- Monsters move toward closest enemy before selecting actions in `TakeTurn()`
- Rename `GetActions()` to `Actions()` for idiomatic Go

## Test plan

- [x] `TestNewGoblinHasDefaultActions` - Factory creates goblin with scimitar
- [x] `TestActionRoundTrip` - Actions survive Data → Monster → Data cycle
- [x] `TestTakeTurnMovesAndAttacks` - Goblin at 35ft moves 30ft and attacks
- [x] `TestTakeTurnAlreadyAdjacent` - No movement when already in melee range
- [x] `TestTakeTurnEnemyTooFar` - Moves but doesn't attack when out of range
- [x] Verified working in rpg-api combat flow

Fixes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)