### PR TITLE
feat(spatial): Expose cube coordinates for hex grid rendering

### DIFF
--- a/tools/spatial/data.go
+++ b/tools/spatial/data.go
@@ -121,9 +121,9 @@ func (r *BasicRoom) ToData() RoomData {
 		gridType = GridTypeHex
 		// Hex grid shape will always be *HexGrid
 		hexGrid := r.grid.(*HexGrid)
-		// HexGrid.GetOrientation() returns true for pointy-top, false for flat-top
-		// We want HexFlatTop, so invert it
-		hexFlatTop = !hexGrid.GetOrientation()
+		// HexGrid.GetOrientation() returns HexOrientation type
+		// We want hexFlatTop to be true when orientation is flat-top
+		hexFlatTop = hexGrid.GetOrientation() == HexOrientationFlatTop
 	case GridShapeGridless:
 		gridType = GridTypeGridless
 	default:
@@ -181,11 +181,14 @@ func LoadRoomFromContext(_ context.Context, gameCtx game.Context[RoomData]) (*Ba
 		})
 	case GridTypeHex:
 		// HexFlatTop: false = pointy-top (default), true = flat-top
-		// HexGrid.PointyTop is opposite of HexFlatTop
+		orientation := HexOrientationPointyTop
+		if data.HexFlatTop {
+			orientation = HexOrientationFlatTop
+		}
 		grid = NewHexGrid(HexGridConfig{
-			Width:     float64(data.Width),
-			Height:    float64(data.Height),
-			PointyTop: !data.HexFlatTop,
+			Width:       float64(data.Width),
+			Height:      float64(data.Height),
+			Orientation: orientation,
 		})
 	case GridTypeGridless:
 		grid = NewGridlessRoom(GridlessConfig{

--- a/tools/spatial/hex_grid_test.go
+++ b/tools/spatial/hex_grid_test.go
@@ -327,22 +327,33 @@ func (s *HexGridTestSuite) TestSmallHexGrid() {
 
 // TestGetOrientation tests the GetOrientation method
 func (s *HexGridTestSuite) TestGetOrientation() {
-	s.Run("pointy-top orientation", func() {
-		pointyGrid := spatial.NewHexGrid(spatial.HexGridConfig{
-			Width:     5,
-			Height:    5,
-			PointyTop: true,
+	s.Run("default is pointy-top", func() {
+		grid := spatial.NewHexGrid(spatial.HexGridConfig{
+			Width:  5,
+			Height: 5,
 		})
-		s.Assert().True(pointyGrid.GetOrientation())
+		s.Assert().Equal(spatial.HexOrientationPointyTop, grid.GetOrientation())
+		s.Assert().True(grid.IsPointyTop())
 	})
 
-	s.Run("flat-top orientation", func() {
-		flatGrid := spatial.NewHexGrid(spatial.HexGridConfig{
-			Width:     5,
-			Height:    5,
-			PointyTop: false,
+	s.Run("pointy-top orientation via Orientation field", func() {
+		pointyGrid := spatial.NewHexGrid(spatial.HexGridConfig{
+			Width:       5,
+			Height:      5,
+			Orientation: spatial.HexOrientationPointyTop,
 		})
-		s.Assert().False(flatGrid.GetOrientation())
+		s.Assert().Equal(spatial.HexOrientationPointyTop, pointyGrid.GetOrientation())
+		s.Assert().True(pointyGrid.IsPointyTop())
+	})
+
+	s.Run("flat-top orientation via Orientation field", func() {
+		flatGrid := spatial.NewHexGrid(spatial.HexGridConfig{
+			Width:       5,
+			Height:      5,
+			Orientation: spatial.HexOrientationFlatTop,
+		})
+		s.Assert().Equal(spatial.HexOrientationFlatTop, flatGrid.GetOrientation())
+		s.Assert().False(flatGrid.IsPointyTop())
 	})
 }
 

--- a/tools/spatial/topics.go
+++ b/tools/spatial/topics.go
@@ -41,19 +41,22 @@ var (
 
 // EntityPlacedEvent contains data for entity placement events
 type EntityPlacedEvent struct {
-	EntityID string   `json:"entity_id"`
-	Position Position `json:"position"`
-	RoomID   string   `json:"room_id"`
-	GridType string   `json:"grid_type"` // "square", "hex", "gridless"
+	EntityID     string          `json:"entity_id"`
+	Position     Position        `json:"position"`
+	CubePosition *CubeCoordinate `json:"cube_position,omitempty"` // Only set for hex grids
+	RoomID       string          `json:"room_id"`
+	GridType     string          `json:"grid_type"` // "square", "hex", "gridless"
 }
 
 // EntityMovedEvent contains data for entity movement events
 type EntityMovedEvent struct {
-	EntityID     string   `json:"entity_id"`
-	FromPosition Position `json:"from_position"`
-	ToPosition   Position `json:"to_position"`
-	RoomID       string   `json:"room_id"`
-	MovementType string   `json:"movement_type"` // "normal", "teleport", "forced"
+	EntityID         string          `json:"entity_id"`
+	FromPosition     Position        `json:"from_position"`
+	ToPosition       Position        `json:"to_position"`
+	FromCubePosition *CubeCoordinate `json:"from_cube_position,omitempty"` // Only set for hex grids
+	ToCubePosition   *CubeCoordinate `json:"to_cube_position,omitempty"`   // Only set for hex grids
+	RoomID           string          `json:"room_id"`
+	MovementType     string          `json:"movement_type"` // "normal", "teleport", "forced"
 }
 
 // EntityRemovedEvent contains data for entity removal events


### PR DESCRIPTION
## Summary

Implements #418 - exposes cube coordinates in the spatial API for proper hex grid rendering.

### Changes

- **New `HexOrientation` type** with `HexOrientationPointyTop` and `HexOrientationFlatTop` constants
- **Orientation-aware coordinate conversions** - `OffsetCoordinateToCubeWithOrientation` and `ToOffsetCoordinateWithOrientation` functions
- **Updated `HexGrid`** to use orientation consistently in all distance, neighbor, and line-of-sight calculations
- **Cube coordinates in events** - `EntityPlacedEvent` and `EntityMovedEvent` now include cube position data for hex grids
- **New `GetEntityCubePosition` method** on `BasicRoom` for direct cube coordinate queries
- **Deprecated `PointyTop` bool** in favor of the cleaner `Orientation` field

### API Usage

```go
// Create hex grid with flat-top orientation
hexGrid := spatial.NewHexGrid(spatial.HexGridConfig{
    Width:       10,
    Height:      10,
    Orientation: spatial.HexOrientationFlatTop,
})

// Get cube coordinates for an entity
cubePos := room.GetEntityCubePosition("hero-1")
// Returns *CubeCoordinate{X: 3, Y: -1, Z: -2} for hex grids
// Returns nil for non-hex grids

// Events include cube coordinates
spatial.EntityPlacedTopic.On(bus).Subscribe(ctx, func(ctx context.Context, event spatial.EntityPlacedEvent) error {
    if event.CubePosition != nil {
        // Use cube coords for hex rendering
    }
    return nil
})
```

## Test plan

- [x] All existing spatial tests pass
- [x] New tests for cube coordinate functionality
- [x] Tests for orientation-aware conversions
- [x] Tests for cube positions in events
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)