### PR TITLE
Update selectables to dice v0.3.2, core v0.9.6, events v0.6.2

### DIFF
--- a/tools/selectables/basic_table.go
+++ b/tools/selectables/basic_table.go
@@ -287,7 +287,7 @@ func (t *BasicTable[T]) Select(ctx SelectionContext) (T, error) {
 	}
 
 	// Perform weighted random selection
-	rollValue, err := roller.Roll(totalWeight)
+	rollValue, err := roller.Roll(context.Background(), totalWeight)
 	if err != nil {
 		selectionErr := NewSelectionError("select", t.id, ctx, err)
 		if t.config.EnableEvents && t.connectedTopics.selectionFailed != nil {
@@ -498,7 +498,7 @@ func (t *BasicTable[T]) SelectUnique(ctx SelectionContext, count int) ([]T, erro
 
 		// Perform selection
 		roller := ctx.GetDiceRoller()
-		rollValue, err := roller.Roll(totalWeight)
+		rollValue, err := roller.Roll(context.Background(), totalWeight)
 		if err != nil {
 			selectionErr := NewSelectionError("select_unique", t.id, ctx, err)
 			if t.config.EnableEvents && t.connectedTopics.selectionFailed != nil {
@@ -736,12 +736,13 @@ func (t *BasicTable[T]) clearWeightCache() {
 func (t *BasicTable[T]) parseDiceExpression(expression string, roller dice.Roller) (int, error) {
 	// Very simple parser for basic dice expressions
 	// More sophisticated parsing can be added later
+	ctx := context.Background()
 
 	// Handle simple cases first
 	switch expression {
 	case "1d1-1":
 		// Special case: 1d1-1 could result in 0, but we ensure minimum of 1
-		result, err := roller.Roll(1)
+		result, err := roller.Roll(ctx, 1)
 		if err != nil {
 			return 0, err
 		}
@@ -751,25 +752,25 @@ func (t *BasicTable[T]) parseDiceExpression(expression string, roller dice.Rolle
 		}
 		return result, nil
 	case "1d4":
-		return roller.Roll(4)
+		return roller.Roll(ctx, 4)
 	case "1d6":
-		return roller.Roll(6)
+		return roller.Roll(ctx, 6)
 	case "1d8":
-		return roller.Roll(8)
+		return roller.Roll(ctx, 8)
 	case "1d10":
-		return roller.Roll(10)
+		return roller.Roll(ctx, 10)
 	case "1d10+2":
-		result, err := roller.Roll(10)
+		result, err := roller.Roll(ctx, 10)
 		if err != nil {
 			return 0, err
 		}
 		return result + 2, nil
 	case "1d12":
-		return roller.Roll(12)
+		return roller.Roll(ctx, 12)
 	case "1d20":
-		return roller.Roll(20)
+		return roller.Roll(ctx, 20)
 	case "2d4":
-		results, err := roller.RollN(2, 4)
+		results, err := roller.RollN(ctx, 2, 4)
 		if err != nil {
 			return 0, err
 		}
@@ -779,7 +780,7 @@ func (t *BasicTable[T]) parseDiceExpression(expression string, roller dice.Rolle
 		}
 		return sum, nil
 	case "2d6":
-		results, err := roller.RollN(2, 6)
+		results, err := roller.RollN(ctx, 2, 6)
 		if err != nil {
 			return 0, err
 		}
@@ -789,7 +790,7 @@ func (t *BasicTable[T]) parseDiceExpression(expression string, roller dice.Rolle
 		}
 		return sum, nil
 	case "3d6":
-		results, err := roller.RollN(3, 6)
+		results, err := roller.RollN(ctx, 3, 6)
 		if err != nil {
 			return 0, err
 		}

--- a/tools/selectables/go.mod
+++ b/tools/selectables/go.mod
@@ -5,9 +5,9 @@ go 1.24
 toolchain go1.24.5
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.9.0
-	github.com/KirkDiggler/rpg-toolkit/dice v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/events v0.6.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.9.6
+	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
+	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/tools/selectables/go.sum
+++ b/tools/selectables/go.sum
@@ -1,9 +1,9 @@
-github.com/KirkDiggler/rpg-toolkit/core v0.9.0 h1:kXj1i2Wa9gGb76aznk1GB9ogsDSTkSjENPuMVJEAjK8=
-github.com/KirkDiggler/rpg-toolkit/core v0.9.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
-github.com/KirkDiggler/rpg-toolkit/dice v0.1.0 h1:/tpfvSeV2NeaerItinsd1cc1I680cq3lkBL3EsV5Wz4=
-github.com/KirkDiggler/rpg-toolkit/dice v0.1.0/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
-github.com/KirkDiggler/rpg-toolkit/events v0.6.0 h1:7tAo5ddnaBk2nLeLY3wwa5zVx93ntA5FOgi+NNF4rmk=
-github.com/KirkDiggler/rpg-toolkit/events v0.6.0/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.6 h1:Mqd7jxxiXOfD0vQYzoOrtoa+fqKbVGIY5/Oo7pqbGBk=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.6/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
+github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
+github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
+github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tools/selectables/test_helpers.go
+++ b/tools/selectables/test_helpers.go
@@ -1,6 +1,7 @@
 package selectables
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/dice"
@@ -26,7 +27,7 @@ func NewTestRoller(values []int) dice.Roller {
 }
 
 // Roll returns the next predefined value, cycling through the values array
-func (t *TestRoller) Roll(size int) (int, error) {
+func (t *TestRoller) Roll(_ context.Context, size int) (int, error) {
 	if size <= 0 {
 		return 0, fmt.Errorf("dice: invalid die size %d", size)
 	}
@@ -47,7 +48,7 @@ func (t *TestRoller) Roll(size int) (int, error) {
 }
 
 // RollN rolls multiple dice, each returning the next value in sequence
-func (t *TestRoller) RollN(count, size int) ([]int, error) {
+func (t *TestRoller) RollN(ctx context.Context, count, size int) ([]int, error) {
 	if size <= 0 {
 		return nil, fmt.Errorf("dice: invalid die size %d", size)
 	}
@@ -57,7 +58,7 @@ func (t *TestRoller) RollN(count, size int) ([]int, error) {
 
 	results := make([]int, count)
 	for i := 0; i < count; i++ {
-		roll, err := t.Roll(size)
+		roll, err := t.Roll(ctx, size)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- Updates dice dependency from v0.1.0 to v0.3.2 (breaking change)
- Updates core dependency from v0.9.0 to v0.9.6
- Updates events dependency from v0.6.0 to v0.6.2

The dice.Roller interface changed to require context.Context:
- `Roll(ctx, size)` instead of `Roll(size)`
- `RollN(ctx, count, size)` instead of `RollN(count, size)`

All call sites updated to use `context.Background()` since selection operations are quick and don't need cancellation support.

## Test plan

- [x] All existing tests pass
- [x] Linter passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)