### PR TITLE
Update spatial to core v0.9.6, events v0.6.2, game v0.1.0

### DIFF
--- a/tools/spatial/go.mod
+++ b/tools/spatial/go.mod
@@ -5,9 +5,9 @@ go 1.24
 toolchain go1.24.5
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.9.0
-	github.com/KirkDiggler/rpg-toolkit/events v0.6.0
-	github.com/KirkDiggler/rpg-toolkit/game v0.0.0-20250725235802-69ff839b4774
+	github.com/KirkDiggler/rpg-toolkit/core v0.9.6
+	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
+	github.com/KirkDiggler/rpg-toolkit/game v0.1.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/tools/spatial/go.sum
+++ b/tools/spatial/go.sum
@@ -1,9 +1,9 @@
-github.com/KirkDiggler/rpg-toolkit/core v0.9.0 h1:kXj1i2Wa9gGb76aznk1GB9ogsDSTkSjENPuMVJEAjK8=
-github.com/KirkDiggler/rpg-toolkit/core v0.9.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
-github.com/KirkDiggler/rpg-toolkit/events v0.6.0 h1:7tAo5ddnaBk2nLeLY3wwa5zVx93ntA5FOgi+NNF4rmk=
-github.com/KirkDiggler/rpg-toolkit/events v0.6.0/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
-github.com/KirkDiggler/rpg-toolkit/game v0.0.0-20250725235802-69ff839b4774 h1:4JExBP4mYUaq+NjGYZpwr1mbhZvW2pbGVlY81EcWdhk=
-github.com/KirkDiggler/rpg-toolkit/game v0.0.0-20250725235802-69ff839b4774/go.mod h1:6k+SKiGEAjeI4JRaQtVKOcsUsp3O/sDDee4GH9rl+WM=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.6 h1:Mqd7jxxiXOfD0vQYzoOrtoa+fqKbVGIY5/Oo7pqbGBk=
+github.com/KirkDiggler/rpg-toolkit/core v0.9.6/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
+github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
+github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
+github.com/KirkDiggler/rpg-toolkit/game v0.1.0/go.mod h1:6k+SKiGEAjeI4JRaQtVKOcsUsp3O/sDDee4GH9rl+WM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## Summary

Updates dependencies to latest tagged versions:
- core: v0.9.0 → v0.9.6
- events: v0.6.0 → v0.6.2
- game: pseudo-version → v0.1.0

## Test plan

- [x] All existing tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)