### PR TITLE
fix(character): add tool proficiency choice support for Monk class

### DIFF
--- a/rulebooks/dnd5e/character/inputs.go
+++ b/rulebooks/dnd5e/character/inputs.go
@@ -45,6 +45,7 @@ type ClassChoices struct {
 	Cantrips      []spells.Spell               `json:"cantrips,omitempty"`
 	Spells        []spells.Spell               `json:"spells,omitempty"`
 	Equipment     []EquipmentChoiceSelection   `json:"equipment,omitempty"`
+	Tools         []shared.SelectionID         `json:"tools,omitempty"` // Tool proficiency choices (Monk, Bard)
 }
 
 // EquipmentChoiceSelection represents a player's choice for an equipment requirement


### PR DESCRIPTION
## Summary

Fixes #439 - Monk class creation now properly supports tool proficiency choices.

**Root Cause:** The `ClassChoices` struct was missing a `Tools` field, and `SetClass()` had no code to handle tool proficiency selections. While the Monk's `Tools` requirement was correctly defined in `requirements.go`, there was no way for users to provide their tool selection through the character creation flow.

**Changes:**
- Add `Tools` field to `ClassChoices` struct in `inputs.go`
- Add tool choice recording in `SetClass()` in `draft.go`
- Add tool submission handling in `ValidateChoices()` and `getClassSubmissions()`
- Add `MonkToolProficiencyTestSuite` with tests validating the fix

## Test plan

- [x] `TestMonkToolProficiencyChoice` - Verifies Monk can be created with tool choice
- [x] `TestMonkWithoutToolProficiency_FailsValidation` - Verifies validation fails without tool choice
- [x] All existing tests pass
- [x] Linter passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)