### PR TITLE
Fix Unarmored Defense not applied to character AC calculation

### DIFF
--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -563,6 +563,17 @@ func (d *Draft) ToCharacter(ctx context.Context, characterID string, bus events.
 	if err != nil {
 		return nil, rpgerr.Wrapf(err, "failed to compile conditions")
 	}
+
+	// Check for Unarmored Defense condition and apply its AC calculation
+	// Barbarian: AC = 10 + DEX + CON
+	// Monk: AC = 10 + DEX + WIS
+	for _, cond := range initialConditions {
+		if ud, ok := cond.(*conditions.UnarmoredDefenseCondition); ok {
+			char.armorClass = ud.CalculateAC(finalScores)
+			break
+		}
+	}
+
 	conditionTopic := dnd5eEvents.ConditionAppliedTopic.On(bus)
 	for _, cond := range initialConditions {
 		if err := conditionTopic.Publish(ctx, dnd5eEvents.ConditionAppliedEvent{

--- a/rulebooks/dnd5e/character/unarmored_defense_ac_test.go
+++ b/rulebooks/dnd5e/character/unarmored_defense_ac_test.go
@@ -1,0 +1,133 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/backgrounds"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+)
+
+// UnarmoredDefenseACTestSuite tests that Unarmored Defense is correctly applied
+// to character AC during character creation.
+// Issue #450: Character AC should use UnarmoredDefenseCondition.CalculateAC()
+// for Barbarians and Monks instead of hardcoded 10 + DEX.
+type UnarmoredDefenseACTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	bus events.EventBus
+}
+
+func (s *UnarmoredDefenseACTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+func TestUnarmoredDefenseACTestSuite(t *testing.T) {
+	suite.Run(t, new(UnarmoredDefenseACTestSuite))
+}
+
+// TestUnarmoredDefenseAC tests AC calculation for classes with and without Unarmored Defense
+func (s *UnarmoredDefenseACTestSuite) TestUnarmoredDefenseAC() {
+	testCases := []struct {
+		name          string
+		class         classes.Class
+		classSkills   []skills.Skill
+		background    backgrounds.Background
+		scores        shared.AbilityScores
+		expectedAC    int
+		acExplanation string
+	}{
+		{
+			name:        "Barbarian gets CON bonus to AC",
+			class:       classes.Barbarian,
+			classSkills: []skills.Skill{skills.Athletics, skills.Intimidation},
+			background:  backgrounds.Soldier,
+			scores: shared.AbilityScores{
+				abilities.STR: 15,
+				abilities.DEX: 14, // +2 modifier
+				abilities.CON: 16, // +3 modifier
+				abilities.INT: 8,
+				abilities.WIS: 10,
+				abilities.CHA: 10,
+			},
+			expectedAC:    15,
+			acExplanation: "10 + DEX (+2) + CON (+3) = 15",
+		},
+		{
+			name:        "Monk gets WIS bonus to AC",
+			class:       classes.Monk,
+			classSkills: []skills.Skill{skills.Acrobatics, skills.Stealth},
+			background:  backgrounds.Hermit,
+			scores: shared.AbilityScores{
+				abilities.STR: 10,
+				abilities.DEX: 16, // +3 modifier
+				abilities.CON: 12,
+				abilities.INT: 10,
+				abilities.WIS: 14, // +2 modifier
+				abilities.CHA: 8,
+			},
+			expectedAC:    15,
+			acExplanation: "10 + DEX (+3) + WIS (+2) = 15",
+		},
+		{
+			name:        "Fighter uses base AC (no Unarmored Defense)",
+			class:       classes.Fighter,
+			classSkills: []skills.Skill{skills.Athletics, skills.Intimidation},
+			background:  backgrounds.Soldier,
+			scores: shared.AbilityScores{
+				abilities.STR: 16,
+				abilities.DEX: 14, // +2 modifier
+				abilities.CON: 14, // +2 modifier (not used for AC)
+				abilities.INT: 10,
+				abilities.WIS: 10,
+				abilities.CHA: 10,
+			},
+			expectedAC:    12,
+			acExplanation: "10 + DEX (+2) = 12",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Arrange
+			draft := LoadDraftFromData(&DraftData{
+				ID:       "test-char",
+				PlayerID: "player1",
+			})
+
+			s.Require().NoError(draft.SetName(&SetNameInput{Name: "Test Character"}))
+			s.Require().NoError(draft.SetRace(&SetRaceInput{RaceID: races.Human}))
+			s.Require().NoError(draft.SetClass(&SetClassInput{
+				ClassID: tc.class,
+				Choices: ClassChoices{Skills: tc.classSkills},
+			}))
+			s.Require().NoError(draft.SetBackground(&SetBackgroundInput{
+				BackgroundID: tc.background,
+			}))
+			s.Require().NoError(draft.SetAbilityScores(&SetAbilityScoresInput{
+				Scores: tc.scores,
+			}))
+
+			// Act
+			char, err := draft.ToCharacter(s.ctx, "char-test", s.bus)
+			s.Require().NoError(err)
+			s.Require().NotNil(char)
+
+			// Assert
+			data := char.ToData()
+			s.Equal(tc.expectedAC, data.ArmorClass,
+				"AC should be %s, but got %d", tc.acExplanation, data.ArmorClass)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #450 - Barbarians and Monks now correctly get their class-specific AC calculation during character creation.

**Changes:**
- Added logic in `ToCharacter()` to check compiled conditions for `UnarmoredDefenseCondition`
- Uses the condition's `CalculateAC()` method instead of hardcoded `10 + DEX`
- Barbarian: AC = 10 + DEX + CON
- Monk: AC = 10 + DEX + WIS
- Other classes (Fighter, etc.) still use base AC = 10 + DEX

## Test plan

- [x] Barbarian with DEX 14 (+2), CON 16 (+3) → AC 15 ✓
- [x] Monk with DEX 16 (+3), WIS 14 (+2) → AC 15 ✓
- [x] Fighter with DEX 14 (+2) → AC 12 (base, no unarmored defense) ✓
- [x] All existing tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)