### PR TITLE
Add Monk Martial Arts condition to Level 1 grants

### DIFF
--- a/rulebooks/dnd5e/character/unarmored_defense_ac_test.go
+++ b/rulebooks/dnd5e/character/unarmored_defense_ac_test.go
@@ -33,6 +33,11 @@ func (s *UnarmoredDefenseACTestSuite) SetupTest() {
 	s.bus = events.NewEventBus()
 }
 
+// SetupSubTest creates a fresh event bus for each subtest in table-driven tests
+func (s *UnarmoredDefenseACTestSuite) SetupSubTest() {
+	s.bus = events.NewEventBus()
+}
+
 func TestUnarmoredDefenseACTestSuite(t *testing.T) {
 	suite.Run(t, new(UnarmoredDefenseACTestSuite))
 }

--- a/rulebooks/dnd5e/classes/grant.go
+++ b/rulebooks/dnd5e/classes/grant.go
@@ -163,12 +163,16 @@ func getMonkGrants() []Grant {
 				proficiencies.WeaponShortsword,
 			},
 			// Note: Tool proficiency (artisan's tool OR musical instrument) is a CHOICE, not a grant
-			// Note: Martial Arts feature does not exist yet in the codebase
 			// Unarmored Defense condition (monk variant - uses WIS instead of CON)
+			// Martial Arts condition (grants DEX for unarmed/monk weapons, scales damage)
 			Conditions: []ConditionRef{
 				{
 					Ref:    refs.Conditions.UnarmoredDefense().String(),
 					Config: json.RawMessage(`{"variant": "monk"}`),
+				},
+				{
+					Ref:    refs.Conditions.MartialArts().String(),
+					Config: json.RawMessage(`{"monk_level": 1}`),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes #452 - Monk's Martial Arts condition now correctly granted at Level 1.

The `MartialArtsCondition` already existed and was fully implemented, but was not being granted to Monks. The grant.go file even had a comment incorrectly stating "Martial Arts feature does not exist yet in the codebase".

**Changes:**
- Added MartialArts condition ref to Monk Level 1 grants in `grant.go`
- Removed incorrect comment about Martial Arts not existing
- Added test verifying Monk receives both UnarmoredDefense and MartialArts conditions
- Added `SetupSubTest` to AC tests to prevent state sharing between table-driven subtests

## Martial Arts Feature (D&D 5e)
- Use DEX instead of STR for unarmed strikes and monk weapons
- Unarmed strike damage scales: 1d4 (L1-4), 1d6 (L5-10), 1d8 (L11-16), 1d10 (L17+)
- Monk weapons: shortsword + simple melee weapons without Heavy/Two-Handed

## Test plan

- [x] Monk character receives MartialArts condition at Level 1
- [x] MartialArts is configured for monk_level: 1
- [x] Monk still receives UnarmoredDefense condition
- [x] All existing tests pass
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)