### PR TITLE
Add Rogue expertise and Fighter fighting style validation (#474, #475)

### DIFF
--- a/rulebooks/dnd5e/character/features_test.go
+++ b/rulebooks/dnd5e/character/features_test.go
@@ -10,10 +10,14 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/backgrounds"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/fightingstyles"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/languages"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
 
 type FeaturesTestSuite struct {
@@ -43,7 +47,9 @@ func (s *FeaturesTestSuite) TestBarbarianGetsRageFeature() {
 	err = draft.SetRace(&SetRaceInput{
 		RaceID:    races.Human,
 		SubraceID: "", // Human has no subrace
-		Choices:   RaceChoices{},
+		Choices: RaceChoices{
+			Languages: []languages.Language{languages.Elvish},
+		},
 	})
 	s.Require().NoError(err)
 
@@ -54,7 +60,12 @@ func (s *FeaturesTestSuite) TestBarbarianGetsRageFeature() {
 			Skills: []skills.Skill{
 				skills.Athletics,
 				skills.Survival,
-			}, // Barbarian needs to choose 2 skills
+			},
+			Equipment: []EquipmentChoiceSelection{
+				{ChoiceID: choices.BarbarianWeaponsPrimary, OptionID: choices.BarbarianWeaponGreataxe},
+				{ChoiceID: choices.BarbarianWeaponsSecondary, OptionID: choices.BarbarianSecondaryHandaxes},
+				{ChoiceID: choices.BarbarianPack, OptionID: choices.BarbarianPackExplorer},
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -115,7 +126,9 @@ func (s *FeaturesTestSuite) TestFighterGetsSecondWindFeature() {
 	err = draft.SetRace(&SetRaceInput{
 		RaceID:    races.Human,
 		SubraceID: "",
-		Choices:   RaceChoices{},
+		Choices: RaceChoices{
+			Languages: []languages.Language{languages.Elvish},
+		},
 	})
 	s.Require().NoError(err)
 
@@ -126,7 +139,18 @@ func (s *FeaturesTestSuite) TestFighterGetsSecondWindFeature() {
 			Skills: []skills.Skill{
 				skills.Athletics,
 				skills.History,
-			}, // Fighter needs to choose 2 skills
+			},
+			Equipment: []EquipmentChoiceSelection{
+				{ChoiceID: choices.FighterArmor, OptionID: choices.FighterArmorChainMail},
+				{
+					ChoiceID:           choices.FighterWeaponsPrimary,
+					OptionID:           choices.FighterWeaponMartialShield,
+					CategorySelections: []shared.EquipmentID{weapons.Longsword},
+				},
+				{ChoiceID: choices.FighterWeaponsSecondary, OptionID: choices.FighterRangedCrossbow},
+				{ChoiceID: choices.FighterPack, OptionID: choices.FighterPackDungeoneer},
+			},
+			FightingStyle: fightingstyles.Defense,
 		},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/character/inputs.go
+++ b/rulebooks/dnd5e/character/inputs.go
@@ -29,6 +29,7 @@ type RaceChoices struct {
 	Languages []languages.Language `json:"languages,omitempty"`
 	Skills    []skills.Skill       `json:"skills,omitempty"`
 	Cantrips  []spells.Spell       `json:"cantrips,omitempty"`
+	Tools     []shared.SelectionID `json:"tools,omitempty"` // Tool proficiency choices (Dwarf)
 }
 
 // SetClassInput contains the input for setting a character's class

--- a/rulebooks/dnd5e/character/languages_test.go
+++ b/rulebooks/dnd5e/character/languages_test.go
@@ -126,6 +126,9 @@ func (s *LanguagesSuite) TestDwarfDefaultLanguages() {
 	s.Require().NoError(draft.SetRace(&SetRaceInput{
 		RaceID:    races.Dwarf,
 		SubraceID: races.HillDwarf,
+		Choices: RaceChoices{
+			Tools: []shared.SelectionID{"smiths-tools"}, // Dwarves choose 1 artisan's tool
+		},
 	}))
 	s.Require().NoError(draft.SetClass(&SetClassInput{
 		ClassID: classes.Barbarian,

--- a/rulebooks/dnd5e/character/proficiencies_test.go
+++ b/rulebooks/dnd5e/character/proficiencies_test.go
@@ -255,6 +255,7 @@ func (s *ProficienciesSuite) TestMonkProficiencies() {
 				{ChoiceID: choices.MonkWeaponsPrimary, OptionID: choices.MonkWeaponShortsword},
 				{ChoiceID: choices.MonkPack, OptionID: choices.MonkPackExplorer},
 			},
+			Tools: []shared.SelectionID{"brewers-supplies"},
 		},
 	}))
 


### PR DESCRIPTION
## Summary

- Implement Rogue expertise feature allowing double proficiency bonus on chosen skills
- Add Fighting Style choice validation for Fighter class at Level 1
- Add ChoiceExpertise handling to ValidateChoices() and getClassSubmissions()
- Add Tools field to RaceChoices for Dwarf tool proficiency selection
- Update tests to provide complete character creation choices

## Test plan

- [x] All existing tests pass
- [x] Rogue expertise tests verify double proficiency bonus calculation
- [x] Rogue can apply expertise to racial skills (e.g., Elf's Perception)
- [x] Expertise validation rejects non-proficient skills
- [x] Fighter validation requires fighting style choice
- [x] Linter passes with no issues

Closes #474
Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)