### PR TITLE
feat(features): Add ActionType() method to Feature interface

### DIFF
--- a/rulebooks/dnd5e/features/action_surge.go
+++ b/rulebooks/dnd5e/features/action_surge.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eCombat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
@@ -19,8 +20,8 @@ import (
 type ActionSurge struct {
 	id          string
 	name        string
-	characterID string                      // Character this feature belongs to
-	resource    *combat.RecoverableResource // Tracks action surge uses (1 per short/long rest)
+	characterID string                           // Character this feature belongs to
+	resource    *dnd5eCombat.RecoverableResource // Tracks action surge uses (1 per short/long rest)
 }
 
 // ActionSurgeData is the JSON structure for persisting Action Surge state
@@ -100,7 +101,7 @@ func (a *ActionSurge) loadJSON(data json.RawMessage) error {
 	a.characterID = actionSurgeData.CharacterID
 
 	// Set up recoverable resource with current and max uses
-	a.resource = combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+	a.resource = dnd5eCombat.NewRecoverableResource(dnd5eCombat.RecoverableResourceConfig{
 		ID:          refs.Features.ActionSurge().ID,
 		Maximum:     actionSurgeData.MaxUses,
 		CharacterID: actionSurgeData.CharacterID,
@@ -133,4 +134,9 @@ func (a *ActionSurge) ToJSON() (json.RawMessage, error) {
 	}
 
 	return bytes, nil
+}
+
+// ActionType returns the action economy cost to activate action surge (free - it grants an extra action)
+func (a *ActionSurge) ActionType() combat.ActionType {
+	return combat.ActionFree
 }

--- a/rulebooks/dnd5e/features/deflect_missiles.go
+++ b/rulebooks/dnd5e/features/deflect_missiles.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
@@ -208,4 +209,9 @@ func (d *DeflectMissiles) ToJSON() (json.RawMessage, error) {
 	}
 
 	return bytes, nil
+}
+
+// ActionType returns the action economy cost to activate deflect missiles (reaction)
+func (d *DeflectMissiles) ActionType() combat.ActionType {
+	return combat.ActionReaction
 }

--- a/rulebooks/dnd5e/features/flurry_of_blows.go
+++ b/rulebooks/dnd5e/features/flurry_of_blows.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eCombat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
@@ -17,7 +18,7 @@ import (
 
 // ResourceAccessor provides access to character resources without circular import
 type ResourceAccessor interface {
-	GetResource(key coreResources.ResourceKey) *combat.RecoverableResource
+	GetResource(key coreResources.ResourceKey) *dnd5eCombat.RecoverableResource
 }
 
 // FlurryOfBlows represents the monk's Flurry of Blows feature.
@@ -129,4 +130,9 @@ func (f *FlurryOfBlows) ToJSON() (json.RawMessage, error) {
 	}
 
 	return bytes, nil
+}
+
+// ActionType returns the action economy cost to activate flurry of blows (bonus action)
+func (f *FlurryOfBlows) ActionType() combat.ActionType {
+	return combat.ActionBonus
 }

--- a/rulebooks/dnd5e/features/loader.go
+++ b/rulebooks/dnd5e/features/loader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
@@ -12,6 +13,7 @@ import (
 type Feature interface {
 	core.Action[FeatureInput] // Can be activated
 	ToJSON() (json.RawMessage, error)
+	ActionType() combat.ActionType // Returns action economy cost to activate
 }
 
 // LoadJSON loads a feature from JSON based on its ref

--- a/rulebooks/dnd5e/features/loader_test.go
+++ b/rulebooks/dnd5e/features/loader_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 type LoaderTestSuite struct {
@@ -79,6 +81,62 @@ func (s *LoaderTestSuite) TestRoundTripThroughJSON() {
 	s.Equal(originalRage.level, loadedRage.level)
 	s.Equal(originalRage.resource.Current, loadedRage.resource.Current)
 	s.Equal(originalRage.resource.Maximum, loadedRage.resource.Maximum)
+}
+
+func (s *LoaderTestSuite) TestActionTypes() {
+	// Test that each feature returns the correct action type per D&D 5e rules
+	testCases := []struct {
+		name       string
+		ref        string
+		wantAction combat.ActionType
+	}{
+		{
+			name:       "Rage is bonus action",
+			ref:        refs.Features.Rage().String(),
+			wantAction: combat.ActionBonus,
+		},
+		{
+			name:       "Second Wind is bonus action",
+			ref:        refs.Features.SecondWind().String(),
+			wantAction: combat.ActionBonus,
+		},
+		{
+			name:       "Action Surge is free (grants extra action)",
+			ref:        refs.Features.ActionSurge().String(),
+			wantAction: combat.ActionFree,
+		},
+		{
+			name:       "Flurry of Blows is bonus action",
+			ref:        refs.Features.FlurryOfBlows().String(),
+			wantAction: combat.ActionBonus,
+		},
+		{
+			name:       "Patient Defense is bonus action",
+			ref:        refs.Features.PatientDefense().String(),
+			wantAction: combat.ActionBonus,
+		},
+		{
+			name:       "Step of the Wind is bonus action",
+			ref:        refs.Features.StepOfTheWind().String(),
+			wantAction: combat.ActionBonus,
+		},
+		{
+			name:       "Deflect Missiles is reaction",
+			ref:        refs.Features.DeflectMissiles().String(),
+			wantAction: combat.ActionReaction,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			output, err := CreateFromRef(&CreateFromRefInput{
+				Ref:         tc.ref,
+				CharacterID: "test-char",
+			})
+			s.Require().NoError(err)
+			s.Equal(tc.wantAction, output.Feature.ActionType())
+		})
+	}
 }
 
 func TestLoaderTestSuite(t *testing.T) {

--- a/rulebooks/dnd5e/features/patient_defense.go
+++ b/rulebooks/dnd5e/features/patient_defense.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
@@ -121,4 +122,9 @@ func (p *PatientDefense) ToJSON() (json.RawMessage, error) {
 	}
 
 	return bytes, nil
+}
+
+// ActionType returns the action economy cost to activate patient defense (bonus action)
+func (p *PatientDefense) ActionType() combat.ActionType {
+	return combat.ActionBonus
 }

--- a/rulebooks/dnd5e/features/rage.go
+++ b/rulebooks/dnd5e/features/rage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/mechanics/resources"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
@@ -167,4 +168,9 @@ func (r *Rage) ToJSON() (json.RawMessage, error) {
 // RestoreOnLongRest restores all rage uses on a long rest
 func (r *Rage) RestoreOnLongRest() {
 	r.resource.RestoreToFull()
+}
+
+// ActionType returns the action economy cost to activate rage (bonus action)
+func (r *Rage) ActionType() combat.ActionType {
+	return combat.ActionBonus
 }

--- a/rulebooks/dnd5e/features/second_wind.go
+++ b/rulebooks/dnd5e/features/second_wind.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eCombat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
@@ -21,9 +22,9 @@ import (
 type SecondWind struct {
 	id          string
 	name        string
-	level       int                         // Fighter level for healing calculation
-	characterID string                      // Character this feature belongs to
-	resource    *combat.RecoverableResource // Tracks second wind uses (1 per short/long rest)
+	level       int                              // Fighter level for healing calculation
+	characterID string                           // Character this feature belongs to
+	resource    *dnd5eCombat.RecoverableResource // Tracks second wind uses (1 per short/long rest)
 }
 
 // SecondWindData is the JSON structure for persisting Second Wind state
@@ -127,7 +128,7 @@ func (s *SecondWind) loadJSON(data json.RawMessage) error {
 	s.characterID = secondWindData.CharacterID
 
 	// Set up recoverable resource with current and max uses
-	s.resource = combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+	s.resource = dnd5eCombat.NewRecoverableResource(dnd5eCombat.RecoverableResourceConfig{
 		ID:          refs.Features.SecondWind().ID,
 		Maximum:     secondWindData.MaxUses,
 		CharacterID: secondWindData.CharacterID,
@@ -161,4 +162,9 @@ func (s *SecondWind) ToJSON() (json.RawMessage, error) {
 	}
 
 	return bytes, nil
+}
+
+// ActionType returns the action economy cost to activate second wind (bonus action)
+func (s *SecondWind) ActionType() combat.ActionType {
+	return combat.ActionBonus
 }

--- a/rulebooks/dnd5e/features/step_of_the_wind.go
+++ b/rulebooks/dnd5e/features/step_of_the_wind.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
@@ -133,4 +134,9 @@ func (s *StepOfTheWind) ToJSON() (json.RawMessage, error) {
 	}
 
 	return bytes, nil
+}
+
+// ActionType returns the action economy cost to activate step of the wind (bonus action)
+func (s *StepOfTheWind) ActionType() combat.ActionType {
+	return combat.ActionBonus
 }


### PR DESCRIPTION
## Summary

- Adds `ActionType()` method to the `Feature` interface
- Each feature now exposes its action economy cost per D&D 5e rules:
  - Rage: `bonus_action`
  - Second Wind: `bonus_action`
  - Action Surge: `free` (grants extra action, no cost itself)
  - Flurry of Blows: `bonus_action`
  - Patient Defense: `bonus_action`
  - Step of the Wind: `bonus_action`
  - Deflect Missiles: `reaction`

This enables the API to populate the `action_type` field when building `CharacterFeature` messages for the web client to display features grouped by action type.

## Test plan

- [x] All existing feature tests pass
- [x] New `TestActionTypes` test verifies each feature returns correct action type
- [x] Pre-commit checks pass

Closes #482
Unblocks rpg-api#318

🤖 Generated with [Claude Code](https://claude.com/claude-code)