### PR TITLE
feat: Add monster refs and Ref field to Monster struct

### DIFF
--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -23,6 +24,7 @@ type Monster struct {
 	id          string
 	name        string
 	monsterType string
+	ref         *core.Ref // Type reference (e.g., refs.Monsters.Skeleton())
 
 	// Stats
 	hp            int
@@ -53,6 +55,7 @@ type Monster struct {
 type Config struct {
 	ID            string
 	Name          string
+	Ref           *core.Ref // Type reference (e.g., refs.Monsters.Skeleton())
 	HP            int
 	AC            int
 	AbilityScores shared.AbilityScores
@@ -63,6 +66,7 @@ func New(config Config) *Monster {
 	return &Monster{
 		id:            config.ID,
 		name:          config.Name,
+		ref:           config.Ref,
 		hp:            config.HP,
 		maxHP:         config.HP,
 		ac:            config.AC,
@@ -83,6 +87,11 @@ func (m *Monster) GetType() core.EntityType {
 // Name returns the monster's name
 func (m *Monster) Name() string {
 	return m.name
+}
+
+// Ref returns the monster's type reference (e.g., refs.Monsters.Skeleton())
+func (m *Monster) Ref() *core.Ref {
+	return m.ref
 }
 
 // HP returns current hit points
@@ -128,6 +137,7 @@ func NewGoblin(id string) *Monster {
 	m := New(Config{
 		ID:   id,
 		Name: "Goblin",
+		Ref:  refs.Monsters.Goblin(),
 		HP:   7,  // 2d6 average
 		AC:   15, // Leather armor + DEX
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/bandit.go
+++ b/rulebooks/dnd5e/monster/monsters/bandit.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -17,6 +18,7 @@ func NewBanditMelee(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Bandit",
+		Ref:  refs.Monsters.Bandit(),
 		HP:   11, // 2d8+2
 		AC:   12, // Leather armor
 		AbilityScores: shared.AbilityScores{
@@ -49,6 +51,7 @@ func NewBanditRanged(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Bandit",
+		Ref:  refs.Monsters.BanditArcher(),
 		HP:   11, // 2d8+2
 		AC:   12, // Leather armor
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/brown_bear.go
+++ b/rulebooks/dnd5e/monster/monsters/brown_bear.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -16,6 +17,7 @@ func NewBrownBear(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Brown Bear",
+		Ref:  refs.Monsters.BrownBear(),
 		HP:   34, // 4d10+12
 		AC:   11, // Natural armor
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/ghoul.go
+++ b/rulebooks/dnd5e/monster/monsters/ghoul.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -16,6 +17,7 @@ func NewGhoul(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Ghoul",
+		Ref:  refs.Monsters.Ghoul(),
 		HP:   22, // 5d8
 		AC:   12, // Natural armor
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/giant_rat.go
+++ b/rulebooks/dnd5e/monster/monsters/giant_rat.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -16,6 +17,7 @@ func NewGiantRat(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Giant Rat",
+		Ref:  refs.Monsters.GiantRat(),
 		HP:   7,  // 2d6
 		AC:   12, // Natural armor
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/skeleton.go
+++ b/rulebooks/dnd5e/monster/monsters/skeleton.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -16,6 +17,7 @@ func NewSkeleton(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Skeleton",
+		Ref:  refs.Monsters.Skeleton(),
 		HP:   13, // 2d8+4
 		AC:   13, // Armor scraps
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/thug.go
+++ b/rulebooks/dnd5e/monster/monsters/thug.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -16,6 +17,7 @@ func NewThug(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Thug",
+		Ref:  refs.Monsters.Thug(),
 		HP:   32, // 5d8+10
 		AC:   11, // Leather armor
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/wolf.go
+++ b/rulebooks/dnd5e/monster/monsters/wolf.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -16,6 +17,7 @@ func NewWolf(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Wolf",
+		Ref:  refs.Monsters.Wolf(),
 		HP:   11, // 2d8+2
 		AC:   13, // Natural armor
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/monster/monsters/zombie.go
+++ b/rulebooks/dnd5e/monster/monsters/zombie.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -16,6 +17,7 @@ func NewZombie(id string) *monster.Monster {
 	m := monster.New(monster.Config{
 		ID:   id,
 		Name: "Zombie",
+		Ref:  refs.Monsters.Zombie(),
 		HP:   22, // 3d8+9
 		AC:   8,  // No armor
 		AbilityScores: shared.AbilityScores{

--- a/rulebooks/dnd5e/refs/module.go
+++ b/rulebooks/dnd5e/refs/module.go
@@ -37,4 +37,5 @@ const (
 	TypeTools         core.Type = "tools"
 	TypeArmor         core.Type = "armor"
 	TypeMonsterTraits core.Type = "monster_traits"
+	TypeMonsters      core.Type = "monsters"
 )

--- a/rulebooks/dnd5e/refs/monsters.go
+++ b/rulebooks/dnd5e/refs/monsters.go
@@ -1,0 +1,56 @@
+//nolint:dupl // Namespace pattern intentional for IDE discoverability
+package refs
+
+import "github.com/KirkDiggler/rpg-toolkit/core"
+
+// Monster singletons - unexported for controlled access via methods
+var (
+	// Undead (Crypt theme)
+	monsterSkeleton        = &core.Ref{Module: Module, Type: TypeMonsters, ID: "skeleton"}
+	monsterZombie          = &core.Ref{Module: Module, Type: TypeMonsters, ID: "zombie"}
+	monsterSkeletonArcher  = &core.Ref{Module: Module, Type: TypeMonsters, ID: "skeleton-archer"}
+	monsterSkeletonCaptain = &core.Ref{Module: Module, Type: TypeMonsters, ID: "skeleton-captain"}
+	monsterGhoul           = &core.Ref{Module: Module, Type: TypeMonsters, ID: "ghoul"}
+
+	// Beasts (Cave theme)
+	monsterGiantRat        = &core.Ref{Module: Module, Type: TypeMonsters, ID: "giant-rat"}
+	monsterGiantSpider     = &core.Ref{Module: Module, Type: TypeMonsters, ID: "giant-spider"}
+	monsterGiantWolfSpider = &core.Ref{Module: Module, Type: TypeMonsters, ID: "giant-wolf-spider"}
+	monsterWolf            = &core.Ref{Module: Module, Type: TypeMonsters, ID: "wolf"}
+	monsterBrownBear       = &core.Ref{Module: Module, Type: TypeMonsters, ID: "brown-bear"}
+
+	// Humanoids (Bandit Lair theme)
+	monsterBandit        = &core.Ref{Module: Module, Type: TypeMonsters, ID: "bandit"}
+	monsterBanditArcher  = &core.Ref{Module: Module, Type: TypeMonsters, ID: "bandit-archer"}
+	monsterBanditCaptain = &core.Ref{Module: Module, Type: TypeMonsters, ID: "bandit-captain"}
+	monsterThug          = &core.Ref{Module: Module, Type: TypeMonsters, ID: "thug"}
+	monsterGoblin        = &core.Ref{Module: Module, Type: TypeMonsters, ID: "goblin"}
+)
+
+// Monsters provides type-safe, discoverable references to D&D 5e monsters.
+// Use IDE autocomplete: refs.Monsters.<tab> to discover available monsters.
+// Methods return singleton pointers enabling identity comparison (ref == refs.Monsters.Skeleton()).
+var Monsters = monstersNS{}
+
+type monstersNS struct{}
+
+// Undead (Crypt theme)
+func (n monstersNS) Skeleton() *core.Ref        { return monsterSkeleton }
+func (n monstersNS) Zombie() *core.Ref          { return monsterZombie }
+func (n monstersNS) SkeletonArcher() *core.Ref  { return monsterSkeletonArcher }
+func (n monstersNS) SkeletonCaptain() *core.Ref { return monsterSkeletonCaptain }
+func (n monstersNS) Ghoul() *core.Ref           { return monsterGhoul }
+
+// Beasts (Cave theme)
+func (n monstersNS) GiantRat() *core.Ref        { return monsterGiantRat }
+func (n monstersNS) GiantSpider() *core.Ref     { return monsterGiantSpider }
+func (n monstersNS) GiantWolfSpider() *core.Ref { return monsterGiantWolfSpider }
+func (n monstersNS) Wolf() *core.Ref            { return monsterWolf }
+func (n monstersNS) BrownBear() *core.Ref       { return monsterBrownBear }
+
+// Humanoids (Bandit Lair theme)
+func (n monstersNS) Bandit() *core.Ref        { return monsterBandit }
+func (n monstersNS) BanditArcher() *core.Ref  { return monsterBanditArcher }
+func (n monstersNS) BanditCaptain() *core.Ref { return monsterBanditCaptain }
+func (n monstersNS) Thug() *core.Ref          { return monsterThug }
+func (n monstersNS) Goblin() *core.Ref        { return monsterGoblin }


### PR DESCRIPTION
## Summary
- Adds `refs.Monsters` namespace with type-safe references for all theme monsters
- Adds `Ref` field to `Monster` struct
- Updates all monster constructors to set the Ref

## Monster Refs Added

| Category | Refs |
|----------|------|
| Undead | Skeleton, Zombie, SkeletonArcher, SkeletonCaptain, Ghoul |
| Beasts | GiantRat, GiantSpider, GiantWolfSpider, Wolf, BrownBear |
| Humanoids | Bandit, BanditArcher, BanditCaptain, Thug, Goblin |

## Usage
```go
// Get monster ref
skeleton := refs.Monsters.Skeleton() // returns *core.Ref

// Monster instance has ref
m := monsters.NewSkeleton("instance-123")
m.Ref() // returns refs.Monsters.Skeleton()
m.Ref().ID // "skeleton"
```

## Why
Enables rpg-api to map monster types to proto `MonsterType` enum for UI texture selection. The monster's Ref provides the type identifier without magic strings.

## Related
- rpg-api-protos PR #106 (merged) - Added MonsterType enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)