### PR TITLE
feat(monster): Replace MonsterType string with Ref on Data struct

### DIFF
--- a/rulebooks/dnd5e/monster/actions/integration_test.go
+++ b/rulebooks/dnd5e/monster/actions/integration_test.go
@@ -36,7 +36,7 @@ func (s *IntegrationTestSuite) TestLoadFromData() {
 	data := &monster.Data{
 		ID:           "goblin-1",
 		Name:         "Goblin",
-		MonsterType:  "goblin",
+		Ref:          refs.Monsters.Goblin(),
 		HitPoints:    7,
 		MaxHitPoints: 7,
 		ArmorClass:   15,

--- a/rulebooks/dnd5e/monster/behavior_test.go
+++ b/rulebooks/dnd5e/monster/behavior_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -288,7 +289,7 @@ func (s *BehaviorTestSuite) TestToData() {
 	data := &Data{
 		ID:           "goblin-1",
 		Name:         "Goblin",
-		MonsterType:  "goblin",
+		Ref:          refs.Monsters.Goblin(),
 		HitPoints:    7,
 		MaxHitPoints: 7,
 		ArmorClass:   15,
@@ -318,7 +319,7 @@ func (s *BehaviorTestSuite) TestToData() {
 
 	s.Equal("goblin-1", outputData.ID)
 	s.Equal("Goblin", outputData.Name)
-	s.Equal("goblin", outputData.MonsterType)
+	s.Equal("goblin", outputData.Ref.ID)
 	s.Equal(4, outputData.HitPoints) // 7 - 3 = 4
 	s.Equal(7, outputData.MaxHitPoints)
 	s.Equal(15, outputData.ArmorClass)

--- a/rulebooks/dnd5e/monster/data.go
+++ b/rulebooks/dnd5e/monster/data.go
@@ -14,11 +14,9 @@ import (
 // This is what gets stored in the database - pure JSON, no logic.
 type Data struct {
 	// Identity
-	ID   string `json:"id"`
-	Name string `json:"name"`
-
-	// What kind of monster (for behavior lookup, display, etc.)
-	MonsterType string `json:"monster_type"` // "goblin", "orc", "dragon"
+	ID   string    `json:"id"`
+	Name string    `json:"name"`
+	Ref  *core.Ref `json:"ref,omitempty"` // Type reference (e.g., refs.Monsters.Skeleton())
 
 	// Core stats
 	HitPoints     int                  `json:"hit_points"`

--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -21,10 +21,9 @@ import (
 // This is the runtime representation with event bus wiring.
 type Monster struct {
 	// Identity
-	id          string
-	name        string
-	monsterType string
-	ref         *core.Ref // Type reference (e.g., refs.Monsters.Skeleton())
+	id   string
+	name string
+	ref  *core.Ref // Type reference (e.g., refs.Monsters.Skeleton())
 
 	// Stats
 	hp            int
@@ -211,7 +210,7 @@ func LoadFromData(ctx context.Context, d *Data, bus events.EventBus) (*Monster, 
 	m := &Monster{
 		id:              d.ID,
 		name:            d.Name,
-		monsterType:     d.MonsterType,
+		ref:             d.Ref,
 		hp:              d.HitPoints,
 		maxHP:           d.MaxHitPoints,
 		ac:              d.ArmorClass,
@@ -569,7 +568,7 @@ func (m *Monster) ToData() *Data {
 	data := &Data{
 		ID:            m.id,
 		Name:          m.name,
-		MonsterType:   m.monsterType,
+		Ref:           m.ref,
 		HitPoints:     m.hp,
 		MaxHitPoints:  m.maxHP,
 		ArmorClass:    m.ac,


### PR DESCRIPTION
## Summary

- `Data.MonsterType string` replaced with `Data.Ref *core.Ref`
- `Monster.monsterType` field removed (redundant with `ref.ID`)
- `ToData()` now copies `m.ref` directly
- `LoadFromData()` reads `d.Ref` instead of `d.MonsterType`

The Ref provides full context (module, type, id) rather than just the id string. Use `data.Ref.ID` to get the monster type for lookups.

## Test plan

- [x] All monster package tests pass
- [x] Integration tests updated to use `refs.Monsters.Goblin()` instead of string

🤖 Generated with [Claude Code](https://claude.com/claude-code)