### PR TITLE
fix(monster): Convert speed from feet to hexes in moveTowardEnemy

### DIFF
--- a/rulebooks/dnd5e/monster/behavior_test.go
+++ b/rulebooks/dnd5e/monster/behavior_test.go
@@ -301,7 +301,7 @@ func (s *BehaviorTestSuite) TestToData() {
 			abilities.WIS: 8,
 			abilities.CHA: 8,
 		},
-		Speed:  SpeedData{Walk: 6}, // 6 hexes (was 30 feet)
+		Speed:  SpeedData{Walk: 30}, // 30 feet = 6 hexes
 		Senses: SensesData{Darkvision: 60},
 		Proficiencies: []ProficiencyData{
 			{Skill: "stealth", Bonus: 6},
@@ -323,7 +323,7 @@ func (s *BehaviorTestSuite) TestToData() {
 	s.Equal(4, outputData.HitPoints) // 7 - 3 = 4
 	s.Equal(7, outputData.MaxHitPoints)
 	s.Equal(15, outputData.ArmorClass)
-	s.Equal(6, outputData.Speed.Walk) // 6 hexes
+	s.Equal(30, outputData.Speed.Walk) // 30 feet = 6 hexes
 	s.Equal(60, outputData.Senses.Darkvision)
 
 	// Check proficiencies preserved

--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -496,9 +496,10 @@ func (m *Monster) moveTowardEnemy(input *TurnInput, result *TurnResult) {
 	}
 
 	// Calculate how far we can move (use input speed, fall back to monster's speed)
+	// input.Speed is already in hexes, but m.speed.Walk is in feet (5 feet per hex)
 	speed := input.Speed
 	if speed == 0 {
-		speed = m.speed.Walk
+		speed = m.speed.Walk / 5 // Convert feet to hexes
 	}
 	if speed == 0 {
 		return // Can't move


### PR DESCRIPTION
## Summary

- Fixed bug where monsters could move unlimited hexes per turn
- Monster speeds are stored in feet (30, 40, 20 per D&D 5e), but `moveTowardEnemy()` was using the raw value as hexes
- Added feet-to-hexes conversion (`/ 5`) when falling back to monster's stored speed
- Updated test data to use feet (30) instead of hexes (6) for consistency

## Root Cause

When `TurnInput.Speed` is not provided, the code falls back to `m.speed.Walk`. Since monster speeds are stored in feet (e.g., Goblin = 30 ft), and the code treats it as hexes, monsters could move 30 hexes per turn instead of 6.

## Test plan

- [x] Run `go test ./monster/...` - all tests pass
- [x] Run `golangci-lint run ./monster/...` - 0 issues
- [x] Pre-commit hooks pass

Related to #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)