### PR TITLE
fix: Use RecoverableResource for Rage charges (#495)

### DIFF
--- a/rulebooks/dnd5e/features/factory.go
+++ b/rulebooks/dnd5e/features/factory.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
-	"github.com/KirkDiggler/rpg-toolkit/mechanics/resources"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
@@ -97,7 +96,7 @@ type rageConfig struct {
 }
 
 // createRage creates a rage feature from config
-func createRage(config json.RawMessage, _ string) (*Rage, error) {
+func createRage(config json.RawMessage, characterID string) (*Rage, error) {
 	var cfg rageConfig
 	if len(config) > 0 {
 		if err := json.Unmarshal(config, &cfg); err != nil {
@@ -117,14 +116,20 @@ func createRage(config json.RawMessage, _ string) (*Rage, error) {
 		uses = calculateRageUses(level)
 	}
 
-	// Create resource for tracking uses
-	resource := resources.NewResource(refs.Features.Rage().ID, uses)
+	// Create recoverable resource for tracking uses (restores on long rest)
+	resource := combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+		ID:          refs.Features.Rage().ID,
+		Maximum:     uses,
+		CharacterID: characterID,
+		ResetType:   coreResources.ResetLongRest,
+	})
 
 	return &Rage{
-		id:       refs.Features.Rage().ID,
-		name:     "Rage",
-		level:    level,
-		resource: resource,
+		id:          refs.Features.Rage().ID,
+		name:        "Rage",
+		level:       level,
+		characterID: characterID,
+		resource:    resource,
 	}, nil
 }
 

--- a/rulebooks/dnd5e/features/loader_test.go
+++ b/rulebooks/dnd5e/features/loader_test.go
@@ -42,8 +42,8 @@ func (s *LoaderTestSuite) TestLoadRageFeature() {
 	s.True(ok, "Should be a Rage instance")
 	s.Equal("rage", rage.id)
 	s.Equal(5, rage.level)
-	s.Equal(2, rage.resource.Current)
-	s.Equal(3, rage.resource.Maximum)
+	s.Equal(2, rage.resource.Current())
+	s.Equal(3, rage.resource.Maximum())
 
 	// Test that it can be activated
 	owner := &StubEntity{id: "test-barbarian"}
@@ -58,7 +58,7 @@ func (s *LoaderTestSuite) TestLoadUnknownFeature() {
 
 func (s *LoaderTestSuite) TestRoundTripThroughJSON() {
 	// Create a rage feature
-	originalRage := newRageForTest("rage-roundtrip", 7)
+	originalRage := newRageForTest("rage-roundtrip", 7, "test-barbarian")
 
 	// Use one charge
 	owner := &StubEntity{id: "test-barbarian"}
@@ -79,8 +79,8 @@ func (s *LoaderTestSuite) TestRoundTripThroughJSON() {
 	// Verify state was preserved
 	s.Equal(originalRage.id, loadedRage.id)
 	s.Equal(originalRage.level, loadedRage.level)
-	s.Equal(originalRage.resource.Current, loadedRage.resource.Current)
-	s.Equal(originalRage.resource.Maximum, loadedRage.resource.Maximum)
+	s.Equal(originalRage.resource.Current(), loadedRage.resource.Current())
+	s.Equal(originalRage.resource.Maximum(), loadedRage.resource.Maximum())
 }
 
 func (s *LoaderTestSuite) TestActionTypes() {

--- a/rulebooks/dnd5e/features/rage_test.go
+++ b/rulebooks/dnd5e/features/rage_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/events"
-	"github.com/KirkDiggler/rpg-toolkit/mechanics/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
@@ -29,19 +30,25 @@ func (m *StubEntity) GetID() string            { return m.id }
 func (m *StubEntity) GetType() core.EntityType { return "character" }
 
 // newRageForTest creates a rage feature for testing
-func newRageForTest(id string, level int) *Rage {
+func newRageForTest(id string, level int, characterID string) *Rage {
 	maxUses := calculateRageUses(level)
 	return &Rage{
-		id:       id,
-		name:     "Rage",
-		level:    level,
-		resource: resources.NewResource("rage", maxUses),
+		id:          id,
+		name:        "Rage",
+		level:       level,
+		characterID: characterID,
+		resource: combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+			ID:          id,
+			Maximum:     maxUses,
+			CharacterID: characterID,
+			ResetType:   coreResources.ResetLongRest,
+		}),
 	}
 }
 
 func (s *RageTestSuite) SetupTest() {
 	s.bus = events.NewEventBus()
-	s.rage = newRageForTest("rage-feature", 3) // Level 3 barbarian
+	s.rage = newRageForTest("rage-feature", 3, "barbarian-1") // Level 3 barbarian
 	s.ctx = context.Background()
 }
 
@@ -141,7 +148,7 @@ func (s *RageTestSuite) TestRageDamagePerLevel() {
 
 func (s *RageTestSuite) TestUnlimitedRagesAtLevel20() {
 	owner := &StubEntity{id: "barbarian-1"}
-	rage20 := newRageForTest("epic-rage", 20)
+	rage20 := newRageForTest("epic-rage", 20, "barbarian-1")
 
 	// Should be able to activate many times
 	for i := 0; i < 10; i++ {
@@ -159,6 +166,7 @@ func (s *RageTestSuite) TestLoadJSON() {
 		"id": "loaded-rage",
 		"name": "Rage",
 		"level": 5,
+		"character_id": "barbarian-1",
 		"uses": 1,
 		"max_uses": 3
 	}`)
@@ -170,8 +178,9 @@ func (s *RageTestSuite) TestLoadJSON() {
 	s.Equal("loaded-rage", rage.id)
 	s.Equal("Rage", rage.name)
 	s.Equal(5, rage.level)
-	s.Equal(1, rage.resource.Current)
-	s.Equal(3, rage.resource.Maximum)
+	s.Equal("barbarian-1", rage.characterID)
+	s.Equal(1, rage.resource.Current())
+	s.Equal(3, rage.resource.Maximum())
 }
 
 func (s *RageTestSuite) TestToJSON() {
@@ -186,6 +195,60 @@ func (s *RageTestSuite) TestToJSON() {
 	s.Equal(s.rage.id, loaded.id)
 	s.Equal(s.rage.name, loaded.name)
 	s.Equal(s.rage.level, loaded.level)
+}
+
+func (s *RageTestSuite) TestLongRestRecovery() {
+	owner := &StubEntity{id: "barbarian-1"}
+
+	// Apply rage to subscribe to rest events
+	err := s.rage.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// Use all rages (level 3 = 3 uses)
+	for i := 0; i < 3; i++ {
+		err = s.rage.Activate(s.ctx, owner, FeatureInput{Bus: s.bus})
+		s.Require().NoError(err)
+	}
+
+	// Verify rages are exhausted
+	s.Equal(0, s.rage.resource.Current())
+
+	// Publish a long rest event
+	restTopic := dnd5eEvents.RestTopic.On(s.bus)
+	err = restTopic.Publish(s.ctx, dnd5eEvents.RestEvent{
+		RestType:    coreResources.ResetLongRest,
+		CharacterID: "barbarian-1",
+	})
+	s.Require().NoError(err)
+
+	// Verify rages are restored
+	s.Equal(3, s.rage.resource.Current(), "Rage uses should be restored on long rest")
+}
+
+func (s *RageTestSuite) TestShortRestDoesNotRecoverRage() {
+	owner := &StubEntity{id: "barbarian-1"}
+
+	// Apply rage to subscribe to rest events
+	err := s.rage.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	// Use one rage
+	err = s.rage.Activate(s.ctx, owner, FeatureInput{Bus: s.bus})
+	s.Require().NoError(err)
+
+	// Verify one rage is used
+	s.Equal(2, s.rage.resource.Current())
+
+	// Publish a short rest event
+	restTopic := dnd5eEvents.RestTopic.On(s.bus)
+	err = restTopic.Publish(s.ctx, dnd5eEvents.RestEvent{
+		RestType:    coreResources.ResetShortRest,
+		CharacterID: "barbarian-1",
+	})
+	s.Require().NoError(err)
+
+	// Verify rages are NOT restored (rage only restores on long rest)
+	s.Equal(2, s.rage.resource.Current(), "Rage uses should NOT be restored on short rest")
 }
 
 func TestRageTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

- Rage was using plain `*resources.Resource` which doesn't subscribe to rest events
- Changed to use `*combat.RecoverableResource` with `ResetLongRest` so rage charges are automatically restored when `Character.LongRest()` publishes a `RestEvent`
- Follows the same pattern as SecondWind

## Changes

- Rage now uses `RecoverableResource` instead of plain `Resource`
- Added `characterID` field to Rage struct and RageData
- Added `Apply()` and `Remove()` methods for event bus subscription
- Updated factory to pass characterID and use RecoverableResource
- Removed `RestoreOnLongRest()` method (no longer needed - handled by event subscription)
- Added tests for long rest recovery and short rest non-recovery

## Test plan

- [x] Existing rage tests pass
- [x] New `TestLongRestRecovery` verifies rage charges restore on long rest
- [x] New `TestShortRestDoesNotRecoverRage` verifies rage doesn't restore on short rest

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)