### PR TITLE
feat(gamectx): add CombatState context for combat tracking

### DIFF
--- a/rulebooks/dnd5e/gamectx/combat.go
+++ b/rulebooks/dnd5e/gamectx/combat.go
@@ -61,7 +61,7 @@ func CombatStateFromContext(ctx context.Context) (*CombatState, bool) {
 	return nil, false
 }
 
-// RequireCombatState retrieves the CombatState from the context.
+// MustCombatState retrieves the CombatState from the context.
 // Panics if no CombatState is present in the context.
 //
 // Purpose: For code paths that absolutely require combat state to function.
@@ -69,12 +69,12 @@ func CombatStateFromContext(ctx context.Context) (*CombatState, bool) {
 //
 // Example:
 //
-//	state := gamectx.RequireCombatState(ctx)
+//	state := gamectx.MustCombatState(ctx)
 //	currentRound := state.Round
-func RequireCombatState(ctx context.Context) *CombatState {
+func MustCombatState(ctx context.Context) *CombatState {
 	state, ok := CombatStateFromContext(ctx)
 	if !ok {
-		panic("RequireCombatState: no CombatState found in context")
+		panic("MustCombatState: no CombatState found in context")
 	}
 	return state
 }

--- a/rulebooks/dnd5e/gamectx/gamectx_test.go
+++ b/rulebooks/dnd5e/gamectx/gamectx_test.go
@@ -638,7 +638,7 @@ func (s *CombatStateTestSuite) TestCombatStateFromContextNotFound() {
 	s.Nil(state)
 }
 
-func (s *CombatStateTestSuite) TestRequireCombatStateSuccess() {
+func (s *CombatStateTestSuite) TestMustCombatStateSuccess() {
 	// Create combat state
 	state := &gamectx.CombatState{
 		EncounterID:      "enc-789",
@@ -648,18 +648,18 @@ func (s *CombatStateTestSuite) TestRequireCombatStateSuccess() {
 	}
 	wrappedCtx := gamectx.WithCombatState(s.ctx, state)
 
-	// RequireCombatState should succeed
-	retrievedState := gamectx.RequireCombatState(wrappedCtx)
+	// MustCombatState should succeed
+	retrievedState := gamectx.MustCombatState(wrappedCtx)
 	s.Require().NotNil(retrievedState)
 	s.Equal("enc-789", retrievedState.EncounterID)
 	s.Equal(5, retrievedState.Round)
 }
 
-func (s *CombatStateTestSuite) TestRequireCombatStatePanics() {
-	// RequireCombatState should panic when no CombatState is present
+func (s *CombatStateTestSuite) TestMustCombatStatePanics() {
+	// MustCombatState should panic when no CombatState is present
 	s.Require().Panics(func() {
-		gamectx.RequireCombatState(s.ctx)
-	}, "RequireCombatState should panic when no CombatState is in context")
+		gamectx.MustCombatState(s.ctx)
+	}, "MustCombatState should panic when no CombatState is in context")
 }
 
 func (s *CombatStateTestSuite) TestCombatStateWithRoomAndGameContext() {


### PR DESCRIPTION
## Summary
- Adds `CombatState` struct to track combat context during event processing
- Provides `WithCombatState`, `CombatStateFromContext`, and `RequireCombatState` helpers
- Enables rpg-api to pass combat state (round, active entity, encounter ID) through context to condition/feature handlers

This allows conditions like Rage to query combat state when processing events (e.g., checking if multiple rounds have passed).

## Test plan
- [x] Added `CombatStateTestSuite` with tests for all context operations
- [x] All tests pass (`go test ./...`)
- [x] Pre-commit checks pass

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)