### PR TITLE
Implement two-weapon fighting validation for off-hand attacks

### DIFF
--- a/docs/plans/2026-01-02-two-weapon-fighting-design.md
+++ b/docs/plans/2026-01-02-two-weapon-fighting-design.md
@@ -1,0 +1,122 @@
+# Two-Weapon Fighting Design
+
+**Issue:** #508
+**Date:** 2026-01-02
+**Status:** Implemented
+
+## Overview
+
+Enable off-hand bonus action attacks for two-weapon fighting. The toolkit validates weapon requirements and manages action economy - the API just passes `AttackHand: Off`.
+
+## Implementation Summary
+
+### New Types in `combat/attack.go`
+
+```go
+// AttackHand indicates which hand is making the attack
+type AttackHand string
+
+const (
+    AttackHandMain AttackHand = "main"  // Default - standard action attack
+    AttackHandOff  AttackHand = "off"   // Bonus action off-hand attack
+)
+
+// EquippedWeaponInfo provides weapon information for validation
+type EquippedWeaponInfo struct {
+    WeaponID weapons.WeaponID
+}
+
+// TwoWeaponContext provides character weapon and action economy information
+// Satisfied by gamectx adapter - avoids circular import between combat and gamectx
+type TwoWeaponContext interface {
+    GetMainHandWeapon(characterID string) *EquippedWeaponInfo
+    GetOffHandWeapon(characterID string) *EquippedWeaponInfo
+    GetActionEconomy(characterID string) *ActionEconomy
+}
+```
+
+### AttackInput Changes
+
+```go
+type AttackInput struct {
+    // ... existing fields (Attacker, Defender, Weapon, etc.)
+    AttackHand AttackHand  // Which hand is attacking (default: main)
+}
+```
+
+### Weapon Lookup via WeaponID
+
+Added `WeaponID` field to `gamectx.EquippedWeapon`:
+
+```go
+type EquippedWeapon struct {
+    ID        string            // Instance ID ("shortsword-1")
+    WeaponID  weapons.WeaponID  // Weapon definition ("shortsword") for property lookup
+    // ...
+}
+```
+
+Validation uses `weapons.GetByID(weaponID)` to look up properties from the rulebook.
+
+### ResolveAttack Flow (when AttackHand == Off)
+
+1. Get `TwoWeaponContext` from context via `GetTwoWeaponContext(ctx)`
+2. Validate main-hand weapon exists and is light via `weapons.GetByID()`
+3. Validate off-hand weapon exists and is light via `weapons.GetByID()`
+4. Check and consume bonus action via `ActionEconomy.UseBonusAction()`
+5. Set `IsOffHandAttack = true` on `ResolveDamageInput`
+6. Flag passes through to `DamageChainEvent`
+7. TWF condition adds ability modifier when flag is true
+
+### Error Cases
+
+| Condition | Error |
+|-----------|-------|
+| No TwoWeaponContext in context | "two-weapon context not available for off-hand attack validation" |
+| No main-hand weapon equipped | "no weapon in main hand" |
+| No off-hand weapon equipped | "no weapon in off hand" |
+| Main-hand weapon not light | "main hand weapon must be light for two-weapon fighting" |
+| Off-hand weapon not light | "off hand weapon must be light for two-weapon fighting" |
+| No bonus action available | "bonus action" (CodeResourceExhausted) |
+
+## Files Modified
+
+1. **`gamectx/characters.go`**
+   - Added `WeaponID weapons.WeaponID` field to `EquippedWeapon`
+   - Deprecated `IsTwoHanded`, `IsMelee` (use weapon lookup instead)
+
+2. **`combat/attack.go`**
+   - Added `AttackHand` type and constants
+   - Added `TwoWeaponContext` interface
+   - Added `WithTwoWeaponContext()` / `GetTwoWeaponContext()`
+   - Added `AttackHand` field to `AttackInput`
+   - Added `validateOffHandAttack()` function
+   - Updated `ResolveAttack` to call validation for off-hand attacks
+
+3. **`combat/damage.go`**
+   - Added `IsOffHandAttack` and `AbilityModifier` to `ResolveDamageInput`
+   - Pass fields through to `DamageChainEvent`
+
+4. **`combat/two_weapon_fighting_test.go`** (new)
+   - Tests for all validation scenarios
+   - Tests for bonus action consumption
+
+## Architecture Decision: TwoWeaponContext Interface
+
+We avoided circular imports between `combat` and `gamectx` by defining `TwoWeaponContext` interface in `combat`. The API creates an adapter that implements this interface using `gamectx` data, then passes it via context.
+
+This pattern:
+- Keeps combat package focused on rules
+- Avoids gamectx importing combat (which would create a cycle)
+- Allows testing with mocks without needing gamectx
+
+## Future Considerations
+
+**Dual Wielder Feat** (out of scope):
+- Removes light weapon requirement
+- Add check in `validateOffHandAttack`: "has Dual Wielder feat? skip light validation"
+
+**API Integration** (Issue #359):
+- API creates adapter implementing `TwoWeaponContext`
+- Passes via `combat.WithTwoWeaponContext(ctx, adapter)`
+- Maps proto `AttackHand` to toolkit's `AttackHand`

--- a/rulebooks/dnd5e/combat/damage.go
+++ b/rulebooks/dnd5e/combat/damage.go
@@ -215,6 +215,10 @@ type ResolveDamageInput struct {
 	// HasAdvantage indicates if the attack had advantage
 	HasAdvantage bool
 
+	// IsOffHandAttack indicates this is a bonus action off-hand attack (two-weapon fighting).
+	// When true, the Two-Weapon Fighting style condition will add ability modifier to damage.
+	IsOffHandAttack bool
+
 	// EventBus is the event bus for publishing chain events
 	EventBus events.EventBus
 
@@ -228,6 +232,10 @@ type ResolveDamageInput struct {
 
 	// WeaponRef is a reference to the weapon used
 	WeaponRef *core.Ref
+
+	// AbilityModifier is the ability modifier for this attack (STR or DEX mod).
+	// Used by Two-Weapon Fighting style to add modifier to off-hand damage.
+	AbilityModifier int
 }
 
 // ResolveDamageOutput contains the result of damage resolution (before HP application).
@@ -259,12 +267,14 @@ func ResolveDamage(ctx context.Context, input *ResolveDamageInput) (*ResolveDama
 
 	// Publish through DamageChain for modifiers
 	damageEvent := &dnd5eEvents.DamageChainEvent{
-		AttackerID:   input.AttackerID,
-		TargetID:     input.TargetID,
-		Components:   input.Components,
-		DamageType:   primaryType,
-		IsCritical:   input.IsCritical,
-		HasAdvantage: input.HasAdvantage,
+		AttackerID:      input.AttackerID,
+		TargetID:        input.TargetID,
+		Components:      input.Components,
+		DamageType:      primaryType,
+		IsCritical:      input.IsCritical,
+		HasAdvantage:    input.HasAdvantage,
+		IsOffHandAttack: input.IsOffHandAttack,
+		AbilityModifier: input.AbilityModifier,
 		// Attack-specific fields (for modifiers like GWF that need weapon info)
 		WeaponDamage: input.WeaponDamage,
 		AbilityUsed:  input.AbilityUsed,

--- a/rulebooks/dnd5e/combat/two_weapon_fighting_test.go
+++ b/rulebooks/dnd5e/combat/two_weapon_fighting_test.go
@@ -1,0 +1,403 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// mockTwoWeaponContext implements combat.TwoWeaponContext for testing
+type mockTwoWeaponContext struct {
+	mainHand      *combat.EquippedWeaponInfo
+	offHand       *combat.EquippedWeaponInfo
+	actionEconomy *combat.ActionEconomy
+}
+
+func (m *mockTwoWeaponContext) GetMainHandWeapon(_ string) *combat.EquippedWeaponInfo {
+	return m.mainHand
+}
+
+func (m *mockTwoWeaponContext) GetOffHandWeapon(_ string) *combat.EquippedWeaponInfo {
+	return m.offHand
+}
+
+func (m *mockTwoWeaponContext) GetActionEconomy(_ string) *combat.ActionEconomy {
+	return m.actionEconomy
+}
+
+// TwoWeaponFightingTestSuite tests two-weapon fighting validation
+type TwoWeaponFightingTestSuite struct {
+	suite.Suite
+	ctrl       *gomock.Controller
+	ctx        context.Context
+	bus        events.EventBus
+	mockRoller *mock_dice.MockRoller
+}
+
+func (s *TwoWeaponFightingTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.mockRoller = mock_dice.NewMockRoller(s.ctrl)
+}
+
+func (s *TwoWeaponFightingTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func (s *TwoWeaponFightingTestSuite) TestOffHandAttackWithLightWeapons() {
+	// Setup: Fighter with shortsword (light) in main hand, dagger (light) in off hand
+	twc := &mockTwoWeaponContext{
+		mainHand:      &combat.EquippedWeaponInfo{WeaponID: weapons.Shortsword},
+		offHand:       &combat.EquippedWeaponInfo{WeaponID: weapons.Dagger},
+		actionEconomy: combat.NewActionEconomy(),
+	}
+	ctx := combat.WithTwoWeaponContext(s.ctx, twc)
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	// Get the dagger for the off-hand attack
+	dagger, err := weapons.GetByID(weapons.Dagger)
+	s.Require().NoError(err)
+
+	// Mock rolls: 15 for attack, 4 for damage
+	s.mockRoller.EXPECT().Roll(gomock.Any(), 20).Return(15, nil)
+	s.mockRoller.EXPECT().RollN(gomock.Any(), 1, 4).Return([]int{4}, nil) // 1d4 dagger damage
+
+	scores := shared.AbilityScores{
+		abilities.STR: 10,
+		abilities.DEX: 16, // +3
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &dagger,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandOff,
+	}
+
+	result, err := combat.ResolveAttack(ctx, input)
+
+	s.Require().NoError(err)
+	s.True(result.Hit, "Attack should hit with roll 15 + 5 = 20 vs AC 12")
+
+	// Verify bonus action was consumed
+	s.False(twc.actionEconomy.CanUseBonusAction(), "Bonus action should be consumed")
+}
+
+func (s *TwoWeaponFightingTestSuite) TestOffHandAttackWithNonLightMainHand() {
+	// Setup: Fighter with longsword (NOT light) in main hand, dagger (light) in off hand
+	twc := &mockTwoWeaponContext{
+		mainHand:      &combat.EquippedWeaponInfo{WeaponID: weapons.Longsword}, // NOT light
+		offHand:       &combat.EquippedWeaponInfo{WeaponID: weapons.Dagger},
+		actionEconomy: combat.NewActionEconomy(),
+	}
+	ctx := combat.WithTwoWeaponContext(s.ctx, twc)
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	dagger, err := weapons.GetByID(weapons.Dagger)
+	s.Require().NoError(err)
+
+	scores := shared.AbilityScores{
+		abilities.STR: 10,
+		abilities.DEX: 16,
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &dagger,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandOff,
+	}
+
+	_, err = combat.ResolveAttack(ctx, input)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "main hand weapon must be light")
+}
+
+func (s *TwoWeaponFightingTestSuite) TestOffHandAttackWithNonLightOffHand() {
+	// Setup: Fighter with shortsword (light) in main hand, longsword (NOT light) in off hand
+	twc := &mockTwoWeaponContext{
+		mainHand:      &combat.EquippedWeaponInfo{WeaponID: weapons.Shortsword},
+		offHand:       &combat.EquippedWeaponInfo{WeaponID: weapons.Longsword}, // NOT light
+		actionEconomy: combat.NewActionEconomy(),
+	}
+	ctx := combat.WithTwoWeaponContext(s.ctx, twc)
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	longsword, err := weapons.GetByID(weapons.Longsword)
+	s.Require().NoError(err)
+
+	scores := shared.AbilityScores{
+		abilities.STR: 10,
+		abilities.DEX: 16,
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &longsword,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandOff,
+	}
+
+	_, err = combat.ResolveAttack(ctx, input)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "off hand weapon must be light")
+}
+
+func (s *TwoWeaponFightingTestSuite) TestOffHandAttackWithNoMainHand() {
+	// Setup: No main hand weapon
+	twc := &mockTwoWeaponContext{
+		mainHand:      nil, // No main hand weapon
+		offHand:       &combat.EquippedWeaponInfo{WeaponID: weapons.Dagger},
+		actionEconomy: combat.NewActionEconomy(),
+	}
+	ctx := combat.WithTwoWeaponContext(s.ctx, twc)
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	dagger, err := weapons.GetByID(weapons.Dagger)
+	s.Require().NoError(err)
+
+	scores := shared.AbilityScores{
+		abilities.STR: 10,
+		abilities.DEX: 16,
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &dagger,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandOff,
+	}
+
+	_, err = combat.ResolveAttack(ctx, input)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "no weapon in main hand")
+}
+
+func (s *TwoWeaponFightingTestSuite) TestOffHandAttackWithNoOffHand() {
+	// Setup: No off hand weapon
+	twc := &mockTwoWeaponContext{
+		mainHand:      &combat.EquippedWeaponInfo{WeaponID: weapons.Shortsword},
+		offHand:       nil, // No off hand weapon
+		actionEconomy: combat.NewActionEconomy(),
+	}
+	ctx := combat.WithTwoWeaponContext(s.ctx, twc)
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	shortsword, err := weapons.GetByID(weapons.Shortsword)
+	s.Require().NoError(err)
+
+	scores := shared.AbilityScores{
+		abilities.STR: 10,
+		abilities.DEX: 16,
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &shortsword,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandOff,
+	}
+
+	_, err = combat.ResolveAttack(ctx, input)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "no weapon in off hand")
+}
+
+func (s *TwoWeaponFightingTestSuite) TestOffHandAttackWithNoBonusAction() {
+	// Setup: Valid weapons but no bonus action available
+	ae := combat.NewActionEconomy()
+	_ = ae.UseBonusAction() // Consume bonus action
+
+	twc := &mockTwoWeaponContext{
+		mainHand:      &combat.EquippedWeaponInfo{WeaponID: weapons.Shortsword},
+		offHand:       &combat.EquippedWeaponInfo{WeaponID: weapons.Dagger},
+		actionEconomy: ae,
+	}
+	ctx := combat.WithTwoWeaponContext(s.ctx, twc)
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	dagger, err := weapons.GetByID(weapons.Dagger)
+	s.Require().NoError(err)
+
+	scores := shared.AbilityScores{
+		abilities.STR: 10,
+		abilities.DEX: 16,
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &dagger,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandOff,
+	}
+
+	_, err = combat.ResolveAttack(ctx, input)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "bonus action")
+}
+
+func (s *TwoWeaponFightingTestSuite) TestOffHandAttackWithNoContext() {
+	// Setup: No TwoWeaponContext in context
+	ctx := s.ctx // No TwoWeaponContext
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	dagger, err := weapons.GetByID(weapons.Dagger)
+	s.Require().NoError(err)
+
+	scores := shared.AbilityScores{
+		abilities.STR: 10,
+		abilities.DEX: 16,
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &dagger,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandOff,
+	}
+
+	_, err = combat.ResolveAttack(ctx, input)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "two-weapon context not available")
+}
+
+func (s *TwoWeaponFightingTestSuite) TestMainHandAttackDoesNotRequireContext() {
+	// Main hand attacks should work without TwoWeaponContext
+	ctx := s.ctx // No TwoWeaponContext
+
+	attacker := &mockEntity{id: "fighter-1", name: "Fighter"}
+	defender := &mockEntity{id: "goblin-1", name: "Goblin"}
+
+	longsword, err := weapons.GetByID(weapons.Longsword)
+	s.Require().NoError(err)
+
+	// Mock rolls: 15 for attack, 6 for damage
+	s.mockRoller.EXPECT().Roll(gomock.Any(), 20).Return(15, nil)
+	s.mockRoller.EXPECT().RollN(gomock.Any(), 1, 8).Return([]int{6}, nil) // 1d8 longsword
+
+	scores := shared.AbilityScores{
+		abilities.STR: 16, // +3
+		abilities.DEX: 10,
+		abilities.CON: 10,
+		abilities.INT: 10,
+		abilities.WIS: 10,
+		abilities.CHA: 10,
+	}
+
+	input := &combat.AttackInput{
+		Attacker:         attacker,
+		Defender:         defender,
+		Weapon:           &longsword,
+		AttackerScores:   scores,
+		DefenderAC:       12,
+		ProficiencyBonus: 2,
+		EventBus:         s.bus,
+		Roller:           s.mockRoller,
+		AttackHand:       combat.AttackHandMain, // Main hand (default)
+	}
+
+	result, err := combat.ResolveAttack(ctx, input)
+
+	s.Require().NoError(err)
+	s.True(result.Hit, "Main hand attack should work without TwoWeaponContext")
+}
+
+func TestTwoWeaponFightingSuite(t *testing.T) {
+	suite.Run(t, new(TwoWeaponFightingTestSuite))
+}

--- a/rulebooks/dnd5e/gamectx/characters.go
+++ b/rulebooks/dnd5e/gamectx/characters.go
@@ -3,7 +3,10 @@
 
 package gamectx
 
-import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
 
 // Slot constants for weapon equipment positions
 const (
@@ -18,6 +21,10 @@ type EquippedWeapon struct {
 	// ID is the unique identifier for this weapon instance
 	ID string
 
+	// WeaponID is the weapon definition ID for property lookups.
+	// Use weapons.GetByID(WeaponID) to get full weapon properties.
+	WeaponID weapons.WeaponID
+
 	// Name is the display name of the weapon
 	Name string
 
@@ -29,9 +36,11 @@ type EquippedWeapon struct {
 	IsShield bool
 
 	// IsTwoHanded indicates if this weapon requires both hands to wield
+	// Deprecated: Use weapons.GetByID(WeaponID).IsTwoHanded instead
 	IsTwoHanded bool
 
 	// IsMelee indicates if this is a melee weapon (vs ranged)
+	// Deprecated: Use weapons.GetByID(WeaponID).IsMelee instead
 	IsMelee bool
 }
 


### PR DESCRIPTION
## Summary

Closes #508

- Added `AttackHand` type (main/off) to `AttackInput` for specifying which hand is attacking
- Added `TwoWeaponContext` interface to avoid circular imports between combat and gamectx
- Added `validateOffHandAttack()` that validates light weapon requirement and consumes bonus action
- Added `WeaponID` field to `EquippedWeapon` for rulebook property lookups via `weapons.GetByID()`
- Wired `IsOffHandAttack` and `AbilityModifier` through to `DamageChainEvent` for TWF style

The toolkit validates weapon requirements and manages action economy - the API just passes `AttackHand: Off`.

## Test plan

- [x] Tests for valid off-hand attack with dual light weapons
- [x] Tests for non-light main hand weapon rejection
- [x] Tests for non-light off hand weapon rejection  
- [x] Tests for missing main hand weapon
- [x] Tests for missing off hand weapon
- [x] Tests for bonus action exhausted
- [x] Tests for missing TwoWeaponContext
- [x] Tests that main hand attacks work without context

🤖 Generated with [Claude Code](https://claude.com/claude-code)