### PR TITLE
Add ADR-0028: Typed Activatable Actions

### DIFF
--- a/docs/adr/0028-typed-activatable-actions.md
+++ b/docs/adr/0028-typed-activatable-actions.md
@@ -181,6 +181,8 @@ func (f *FlurryStrike) onTurnEnd(ctx context.Context, event combat.TurnEndEvent)
    → Roll to hit, damage on hit
    → UsesRemaining decrements to 0
    → Action removes itself
+4. Player clicks "Flurry Strike 1", selects target
+   → Action.Activate(target) called
 
 5. Player clicks "Flurry Strike 2", selects different target
    → Same resolution
@@ -210,6 +212,8 @@ TWF off-hand attack could be modeled as a granted action:
 ```
 
 ## Example: Rage Flow
+4. Player clicks "Flurry Strike 1", selects target
+   → Action.Activate(target) called
 
 Rage grants a condition, not actions:
 
@@ -225,7 +229,9 @@ Rage grants a condition, not actions:
    → TurnEnd (check if raged this turn)
    → Rest (remove on rest)
 
-3. Condition passively modifies damage/resistance
+3. UI shows "raging" in active conditions
+
+4. Condition passively modifies damage/resistance
    → No player interaction needed
 ```
 


### PR DESCRIPTION
## Summary

Documents the architecture for Features, Actions, and Conditions:

- **Features** grant actions and/or conditions (Rage, Flurry of Blows)
- **Actions** are first-class, grantable, can be temporary (Attack, Flurry Strike)
- **Conditions** are passive effects, not activatable (Raging, Poisoned)

**Key insight:** Features grant. Actions do. Conditions modify.

Both Actions and Conditions use the Apply/Remove event pattern for lifecycle management.

## Examples Covered

| Feature | What It Grants |
|---------|----------------|
| Rage | Raging condition (passive modifier) |
| Flurry of Blows | 2 Flurry Strike actions (temporary) |
| TWF main attack | Off-Hand Strike action (temporary) |

## Implementation Order

1. Define `Action` interface with `ActionInput`
2. Add `actions []Action` to Character
3. Implement `AddAction()`, `RemoveAction()`, `GetActions()`
4. Create `FlurryStrike` as proof of concept
5. Update `FlurryOfBlows` feature to grant actions
6. Add turn end cleanup via events

🤖 Generated with [Claude Code](https://claude.com/claude-code)