### PR TITLE
feat(spatial): add PathFinder for A* pathfinding on hex grids

### DIFF
--- a/tools/spatial/pathfinder_test.go
+++ b/tools/spatial/pathfinder_test.go
@@ -94,3 +94,17 @@ func (s *PathFinderTestSuite) TestSamePosition() {
 
 	s.Empty(path, "should return empty path when already at goal")
 }
+
+func (s *PathFinderTestSuite) TestNoPath_GoalBlocked() {
+	start := CubeCoordinate{X: 0, Y: 0, Z: 0}
+	goal := CubeCoordinate{X: 3, Y: 0, Z: -3}
+
+	// Block the goal itself
+	blocked := map[CubeCoordinate]bool{
+		goal: true,
+	}
+
+	path := s.pathFinder.FindPath(start, goal, blocked)
+
+	s.Empty(path, "should return empty path when goal is blocked")
+}


### PR DESCRIPTION
## Summary

Add PathFinder interface and SimplePathFinder (A*) implementation to `tools/spatial` for shared use across all packages.

## Changes

- `PathFinder` interface for pluggable pathfinding algorithms
- `SimplePathFinder` using A* with hex distance heuristic
- Comprehensive tests for pathfinding scenarios

## Why

The PathFinder was previously in `rulebooks/dnd5e/monster/` but is generic spatial infrastructure. Moving it to `tools/spatial` enables:
- `tools/environments` to use it for `FindPathCube` (#526)
- All rulebooks (not just dnd5e) to use shared pathfinding
- Clean dependency direction: `rulebooks → environments → spatial`

## Testing

```
=== RUN   TestPathFinderSuite
=== RUN   TestPathFinderSuite/TestDirectPath_NoObstacles
=== RUN   TestPathFinderSuite/TestNoPath_Surrounded
=== RUN   TestPathFinderSuite/TestPathAroundLShapedWall
=== RUN   TestPathFinderSuite/TestSamePosition
--- PASS: TestPathFinderSuite (0.00s)
```

## Related

- Closes #525
- Design: `docs/plans/2026-01-07-unified-dungeon-pathfinding-design.md`
- Next: #526 (environments FindPathCube), #527 (monster update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)