### PR TITLE
fix: Room generation - ensure traversable paths and valid spawn positions

### DIFF
--- a/tools/environments/wall_patterns_test.go
+++ b/tools/environments/wall_patterns_test.go
@@ -175,10 +175,9 @@ func (s *WallPatternsTestSuite) TestRandomPattern() {
 		// Should maintain minimum open space
 		s.Assert().True(hasMinimumOpenSpace(walls, s.testShape, s.testSize, s.testParams.Safety.MinOpenSpace))
 
-		// Should not block connections
-		for _, conn := range s.testShape.Connections {
-			s.Assert().True(isConnectionAccessible(walls, conn, s.testParams.Safety.EntitySize))
-		}
+		// Should pass full path safety validation (A* pathfinding between all connections)
+		err = validatePathSafety(walls, s.testShape, s.testSize, s.testParams.Safety)
+		s.Assert().NoError(err)
 	})
 }
 

--- a/tools/spawn/constraints.go
+++ b/tools/spawn/constraints.go
@@ -69,10 +69,20 @@ func (cs *ConstraintSolver) FindValidPositions(
 		return cs.findValidPositionsGridless(room, entity, constraints, existingEntities, maxPositions)
 	}
 
+	// Get room dimensions from grid
+	dimensions := roomGrid.GetDimensions()
+	maxX := dimensions.Width
+	maxY := dimensions.Height
+
 	// For grid-based rooms: align to grid positions
-	for x := 1.0; x < 10.0 && len(validPositions) < maxPositions; x += 0.5 {
-		for y := 1.0; y < 10.0 && len(validPositions) < maxPositions; y += 0.5 {
+	for x := 1.0; x < maxX && len(validPositions) < maxPositions; x += 1.0 {
+		for y := 1.0; y < maxY && len(validPositions) < maxPositions; y += 1.0 {
 			position := spatial.Position{X: x, Y: y}
+
+			// Check if position is blocked by existing entities (walls, obstacles)
+			if !room.CanPlaceEntity(entity, position) {
+				continue
+			}
 
 			if cs.ValidatePosition(room, position, entity, constraints, existingEntities) == nil {
 				validPositions = append(validPositions, position)
@@ -346,6 +356,12 @@ func (cs *ConstraintSolver) findValidPositionsGridless(
 		x := margin + (roomDimensions.Width-2*margin)*cs.random.Float64()
 		y := margin + (roomDimensions.Height-2*margin)*cs.random.Float64()
 		position := spatial.Position{X: x, Y: y}
+
+		// Check if position is blocked by existing entities (walls, obstacles)
+		if !room.CanPlaceEntity(entity, position) {
+			attempts++
+			continue
+		}
 
 		if cs.ValidatePosition(room, position, entity, constraints, existingEntities) == nil {
 			validPositions = append(validPositions, position)


### PR DESCRIPTION
## Summary

Two bugs fixed that were making dungeon rooms unplayable:

1. **Wall validation now uses hex A* pathfinding** (#537)
   - Previously used line-intersection math which didn't match actual hex grid obstacles
   - Now discretizes wall segments to hex positions first
   - Runs A* pathfinding between all door pairs using `spatial.SimplePathFinder`
   - Iteratively removes blocking walls until all connections are reachable

2. **Spawn placement now checks for blocked hexes** (#538)
   - Added `room.CanPlaceEntity()` check before selecting spawn positions
   - Prevents monsters from spawning on wall positions
   - Works for both grid-based and gridless rooms

## Changes

- `tools/environments/wall_patterns.go` - Rewrote `validatePathSafety()` and `validateAndFixPathfinding()` to use hex A* pathfinding; removed old unused line-intersection functions
- `tools/environments/wall_patterns_test.go` - Updated test to use new validation function
- `tools/spawn/constraints.go` - Added blocked hex check in `FindValidPositions()` for both grid and gridless rooms

## Test plan

- [x] `go test ./...` passes in environments package
- [x] `go test ./...` passes in spawn package
- [x] `golangci-lint run ./...` passes in both packages
- [ ] Manual test in game to verify rooms are traversable
- [ ] Manual test to verify monsters don't spawn on walls

Closes #537
Closes #538

🤖 Generated with [Claude Code](https://claude.ai/code)