### PR TITLE
Switch gamectx from graceful-nil to error returns

### DIFF
--- a/rulebooks/dnd5e/conditions/fighting_style_dueling.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_dueling.go
@@ -112,10 +112,9 @@ func (f *FightingStyleDuelingCondition) onDamageChain(
 	}
 
 	// Get character registry from context
-	registry, ok := gamectx.Characters(ctx)
-	if !ok {
-		// No character registry available, can't check eligibility
-		return c, nil
+	registry, err := gamectx.RequireCharacters(ctx)
+	if err != nil {
+		return c, err
 	}
 
 	// Get character weapons

--- a/rulebooks/dnd5e/conditions/fighting_style_protection.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_protection.go
@@ -119,9 +119,9 @@ func (f *FightingStyleProtectionCondition) onAttackChain(
 	}
 
 	// Check if we have shield equipped
-	registry, ok := gamectx.Characters(ctx)
-	if !ok {
-		return c, nil
+	registry, err := gamectx.RequireCharacters(ctx)
+	if err != nil {
+		return c, err
 	}
 
 	weapons := registry.GetCharacterWeapons(f.CharacterID)
@@ -141,9 +141,9 @@ func (f *FightingStyleProtectionCondition) onAttackChain(
 	}
 
 	// Check if we're within 5 feet of the target
-	room, ok := gamectx.Room(ctx)
-	if !ok {
-		return c, nil
+	room, err := gamectx.RequireRoom(ctx)
+	if err != nil {
+		return c, err
 	}
 
 	// Get positions of fighter and target

--- a/rulebooks/dnd5e/conditions/martial_arts.go
+++ b/rulebooks/dnd5e/conditions/martial_arts.go
@@ -118,9 +118,9 @@ func (ma *MartialArtsCondition) onDamageChain(
 	}
 
 	// Get character registry to check weapon and ability scores
-	registry, ok := gamectx.Characters(ctx)
-	if !ok {
-		return c, nil
+	registry, err := gamectx.RequireCharacters(ctx)
+	if err != nil {
+		return c, err
 	}
 
 	// Get ability scores for DEX vs STR comparison
@@ -216,8 +216,7 @@ func (ma *MartialArtsCondition) onDamageChain(
 		return e, nil
 	}
 
-	err := c.Add(combat.StageFeatures, "martial_arts", modifyDamage)
-	if err != nil {
+	if err = c.Add(combat.StageFeatures, "martial_arts", modifyDamage); err != nil {
 		return c, rpgerr.Wrapf(err, "failed to apply martial arts for character %s", ma.CharacterID)
 	}
 

--- a/rulebooks/dnd5e/conditions/unarmored_movement_test.go
+++ b/rulebooks/dnd5e/conditions/unarmored_movement_test.go
@@ -137,9 +137,10 @@ func (s *UnarmoredMovementTestSuite) TestCalculateSpeedBonus() {
 }
 
 func (s *UnarmoredMovementTestSuite) TestGetSpeedBonusWithoutContext() {
-	// Without context, should return bonus (assumes unarmored)
-	bonus := s.condition.GetSpeedBonus(s.ctx)
-	s.Assert().Equal(10, bonus, "Level 3 monk should get +10 ft")
+	// Without context, should return error
+	bonus, err := s.condition.GetSpeedBonus(s.ctx)
+	s.Require().Error(err, "Should error when game context is not available")
+	s.Assert().Equal(0, bonus)
 }
 
 func (s *UnarmoredMovementTestSuite) TestGetSpeedBonusUnarmored() {
@@ -154,7 +155,8 @@ func (s *UnarmoredMovementTestSuite) TestGetSpeedBonusUnarmored() {
 	weapons := gamectx.NewCharacterWeapons([]*gamectx.EquippedWeapon{})
 	registry.Add("monk-1", weapons)
 
-	bonus := s.condition.GetSpeedBonus(ctx)
+	bonus, err := s.condition.GetSpeedBonus(ctx)
+	s.Require().NoError(err)
 	s.Assert().Equal(10, bonus, "Unarmored monk should get speed bonus")
 }
 
@@ -178,7 +180,8 @@ func (s *UnarmoredMovementTestSuite) TestGetSpeedBonusWithWeaponNoShield() {
 	})
 	registry.Add("monk-1", weapons)
 
-	bonus := s.condition.GetSpeedBonus(ctx)
+	bonus, err := s.condition.GetSpeedBonus(ctx)
+	s.Require().NoError(err)
 	s.Assert().Equal(10, bonus, "Monk with weapon but no shield should get speed bonus")
 }
 
@@ -201,7 +204,8 @@ func (s *UnarmoredMovementTestSuite) TestGetSpeedBonusWithShieldInMainHand() {
 	})
 	registry.Add("monk-1", weapons)
 
-	bonus := s.condition.GetSpeedBonus(ctx)
+	bonus, err := s.condition.GetSpeedBonus(ctx)
+	s.Require().NoError(err)
 	s.Assert().Equal(0, bonus, "Monk with shield should not get speed bonus")
 }
 
@@ -233,7 +237,8 @@ func (s *UnarmoredMovementTestSuite) TestGetSpeedBonusWithDifferentLevels() {
 				CharacterID: "monk-1",
 				MonkLevel:   tc.monkLevel,
 			})
-			bonus := condition.GetSpeedBonus(ctx)
+			bonus, err := condition.GetSpeedBonus(ctx)
+			s.Require().NoError(err)
 			s.Assert().Equal(tc.expectedBonus, bonus)
 		})
 	}

--- a/rulebooks/dnd5e/gamectx/gamectx_test.go
+++ b/rulebooks/dnd5e/gamectx/gamectx_test.go
@@ -179,7 +179,8 @@ func (s *ContextWrappingTestSuite) TestRequireCharactersSuccess() {
 	wrappedCtx := gamectx.WithGameContext(s.ctx, gameCtx)
 
 	// RequireCharacters should succeed
-	registry := gamectx.RequireCharacters(wrappedCtx)
+	registry, err := gamectx.RequireCharacters(wrappedCtx)
+	s.Require().NoError(err)
 	s.Require().NotNil(registry)
 
 	// Verify we can use the registry
@@ -188,11 +189,12 @@ func (s *ContextWrappingTestSuite) TestRequireCharactersSuccess() {
 	s.Equal("dagger-1", retrievedWeapons.MainHand().ID)
 }
 
-func (s *ContextWrappingTestSuite) TestRequireCharactersPanics() {
-	// RequireCharacters should panic when no GameContext is present
-	s.Require().Panics(func() {
-		gamectx.RequireCharacters(s.ctx)
-	}, "RequireCharacters should panic when no GameContext is in context")
+func (s *ContextWrappingTestSuite) TestRequireCharactersReturnsError() {
+	// RequireCharacters should return error when no GameContext is present
+	registry, err := gamectx.RequireCharacters(s.ctx)
+	s.Require().Error(err)
+	s.Require().Nil(registry)
+	s.ErrorIs(err, gamectx.ErrNoGameContext)
 }
 
 func (s *ContextWrappingTestSuite) TestMultipleContextLayers() {
@@ -309,16 +311,18 @@ func (s *RoomContextTestSuite) TestRequireRoomSuccess() {
 	wrappedCtx := gamectx.WithRoom(s.ctx, room)
 
 	// RequireRoom should succeed
-	retrievedRoom := gamectx.RequireRoom(wrappedCtx)
+	retrievedRoom, err := gamectx.RequireRoom(wrappedCtx)
+	s.Require().NoError(err)
 	s.Require().NotNil(retrievedRoom)
 	s.Equal("required-room", retrievedRoom.GetID())
 }
 
-func (s *RoomContextTestSuite) TestRequireRoomPanics() {
-	// RequireRoom should panic when no Room is present
-	s.Require().Panics(func() {
-		gamectx.RequireRoom(s.ctx)
-	}, "RequireRoom should panic when no Room is in context")
+func (s *RoomContextTestSuite) TestRequireRoomReturnsError() {
+	// RequireRoom should return error when no Room is present
+	room, err := gamectx.RequireRoom(s.ctx)
+	s.Require().Error(err)
+	s.Require().Nil(room)
+	s.ErrorIs(err, gamectx.ErrNoRoom)
 }
 
 func TestRoomContextSuite(t *testing.T) {

--- a/rulebooks/dnd5e/gamectx/require.go
+++ b/rulebooks/dnd5e/gamectx/require.go
@@ -3,7 +3,13 @@
 
 package gamectx
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrNoGameContext is returned when a required GameContext is not found in context.
+var ErrNoGameContext = errors.New("no GameContext found in context")
 
 // gameContextKey is the key type for storing GameContext in context.Context.
 type gameContextKey struct{}
@@ -41,19 +47,22 @@ func Characters(ctx context.Context) (CharacterRegistry, bool) {
 }
 
 // RequireCharacters retrieves the CharacterRegistry from the context.
-// Panics if no GameContext is present in the context.
+// Returns an error if no GameContext is present in the context.
 //
-// Purpose: For code paths that absolutely require game context to function.
-// Use Characters() instead if missing context is a valid scenario.
+// Purpose: For code paths that require game context to function and need
+// explicit error handling rather than silent failures.
 //
 // Example:
 //
-//	registry := gamectx.RequireCharacters(ctx)
+//	registry, err := gamectx.RequireCharacters(ctx)
+//	if err != nil {
+//	    return c, err
+//	}
 //	character := registry.GetCharacter("hero-1")
-func RequireCharacters(ctx context.Context) CharacterRegistry {
+func RequireCharacters(ctx context.Context) (CharacterRegistry, error) {
 	registry, ok := Characters(ctx)
 	if !ok {
-		panic("RequireCharacters: no GameContext found in context")
+		return nil, ErrNoGameContext
 	}
-	return registry
+	return registry, nil
 }

--- a/rulebooks/dnd5e/gamectx/room.go
+++ b/rulebooks/dnd5e/gamectx/room.go
@@ -5,6 +5,7 @@ package gamectx
 
 import (
 	"context"
+	"errors"
 
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -44,19 +45,25 @@ func Room(ctx context.Context) (spatial.Room, bool) {
 }
 
 // RequireRoom retrieves the spatial.Room from the context.
-// Panics if no Room is present in the context.
+// Returns an error if no Room is present in the context.
 //
-// Purpose: For code paths that absolutely require spatial data to function.
-// Use Room() instead if missing room is a valid scenario.
+// Purpose: For code paths that require spatial data to function and need
+// explicit error handling rather than silent failures.
 //
 // Example:
 //
-//	room := gamectx.RequireRoom(ctx)
+//	room, err := gamectx.RequireRoom(ctx)
+//	if err != nil {
+//	    return c, err
+//	}
 //	targetPos, _ := room.GetEntityPosition(targetID)
-func RequireRoom(ctx context.Context) spatial.Room {
+func RequireRoom(ctx context.Context) (spatial.Room, error) {
 	room, ok := Room(ctx)
 	if !ok {
-		panic("RequireRoom: no Room found in context")
+		return nil, ErrNoRoom
 	}
-	return room
+	return room, nil
 }
+
+// ErrNoRoom is returned when a required Room is not found in context.
+var ErrNoRoom = errors.New("no Room found in context")


### PR DESCRIPTION
## Summary

- Changes `RequireCharacters()` and `RequireRoom()` from panic-on-error to return-error pattern
- Updates all conditions to use explicit error returns instead of silent failures
- Adds `ErrNoGameContext` and `ErrNoRoom` error variables for consistent error checking

## Why

The graceful-nil pattern (`if !ok { return c, nil }`) caused silent failures that were difficult to debug. When gamectx isn't set up properly, conditions should fail explicitly so we know something is wrong rather than silently skipping logic.

## Files Changed

**gamectx package:**
- `require.go` - `RequireCharacters` returns `(CharacterRegistry, error)`
- `room.go` - `RequireRoom` returns `(spatial.Room, error)`

**conditions updated:**
- `fighting_style_protection.go` - Uses `RequireCharacters` + `RequireRoom`
- `fighting_style_dueling.go` - Uses `RequireCharacters`
- `martial_arts.go` - Uses `RequireCharacters`
- `sneak_attack.go` - `checkSneakAttackConditions` returns `(bool, error)`
- `unarmored_movement.go` - `GetSpeedBonus` returns `(int, error)`

## Test plan

- [x] All existing tests pass
- [x] New tests verify error returns when context missing
- [x] Linter passes with 0 issues

Fixes #553
Part of #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)