### PR TITLE
Add MovementChain and opportunity attack triggering

### DIFF
--- a/rulebooks/dnd5e/combat/movement_test.go
+++ b/rulebooks/dnd5e/combat/movement_test.go
@@ -410,6 +410,19 @@ func (s *MovementTestSuite) TestMoveEntity_ValidationErrors() {
 		s.Contains(err.Error(), "EntityID")
 	})
 
+	s.Run("empty entity type", func() {
+		input := &combat.MoveEntityInput{
+			EntityID:   "fighter-1",
+			EntityType: "",
+			Path:       []spatial.Position{{X: 1, Y: 1}},
+			EventBus:   s.eventBus,
+		}
+		result, err := combat.MoveEntity(s.ctx, input)
+		s.Require().Error(err)
+		s.Nil(result)
+		s.Contains(err.Error(), "EntityType")
+	})
+
 	s.Run("empty path", func() {
 		input := &combat.MoveEntityInput{
 			EntityID:   "fighter-1",

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -370,14 +370,19 @@ func (e *MovementChainEvent) IsOAPrevented() bool {
 	return len(e.OAPreventionSources) > 0
 }
 
-// Position represents a 2D position for movement tracking.
+// Position represents a 2D grid position for movement tracking.
 // This mirrors spatial.Position but avoids import cycles.
+// Note: This uses float64 for compatibility with spatial.Position, but grid-based
+// positions are typically exact integers. Direct equality comparison is safe for
+// grid positions that come from exact assignments (not mathematical calculations).
 type Position struct {
 	X float64 `json:"x"`
 	Y float64 `json:"y"`
 }
 
-// Equals checks if two positions are equal.
+// Equals checks if two positions are equal using direct comparison.
+// This is safe for grid-based positions which are typically exact integer values.
+// For positions derived from complex calculations, consider epsilon-based comparison.
 func (p Position) Equals(other Position) bool {
 	return p.X == other.X && p.Y == other.Y
 }


### PR DESCRIPTION
## Summary

- Adds `MovementChain` that fires before each step of movement
- Enables conditions like Disengaging to prevent opportunity attacks
- Triggers OAs when entities leave threat range of hostile combatants

## Why

This infrastructure is required for:
- **#557 Disengaging condition** - prevents OAs by adding to `OAPreventionSources`
- Future Sentinel feat - can stop movement via `MovementPrevented` flag
- Any movement-reactive mechanics

## New Types (events/events.go)

```go
type MovementChainEvent struct {
    EntityID            string
    EntityType          string
    FromPosition        Position
    ToPosition          Position
    ThreateningEntities []string                 // Who threatens this move
    OAPreventionSources []MovementModifierSource // Disengaging adds here
    MovementPrevented   bool                     // Sentinel could set this
    PreventionReason    string
}
```

## How It Works

```
MoveEntity(path: [A, B, C])
    │
    ├─► Step A→B
    │   ├─► Find threatening entities at A
    │   ├─► Fire MovementChain event
    │   ├─► If OA not prevented:
    │   │   └─► For each threat leaving range: trigger OA
    │   └─► Move to B
    │
    └─► Step B→C
        └─► (same process)
```

## Usage Example

```go
// Disengaging condition subscribes to prevent OAs
movementChain := dnd5eEvents.MovementChain.On(bus)
movementChain.SubscribeWithChain(ctx, func(ctx context.Context, event *dnd5eEvents.MovementChainEvent, c chain.Chain[*dnd5eEvents.MovementChainEvent]) (chain.Chain[*dnd5eEvents.MovementChainEvent], error) {
    if event.EntityID == characterWithDisengage {
        c.Add(combat.StageConditions, "disengaging", func(ctx context.Context, e *dnd5eEvents.MovementChainEvent) (*dnd5eEvents.MovementChainEvent, error) {
            e.OAPreventionSources = append(e.OAPreventionSources, dnd5eEvents.MovementModifierSource{
                Name: "Disengaging",
                SourceType: "condition",
            })
            return e, nil
        })
    }
    return c, nil
})
```

## Test Coverage

- [x] Basic movement without threats
- [x] OA triggers when leaving threat range
- [x] Disengaging prevents OA (via chain subscriber)
- [x] Multiple threatening entities
- [x] OA miss doesn't stop movement
- [x] Movement prevention via chain modifier
- [x] MovementChain event fires correctly
- [x] Input validation

Fixes #556
Part of #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)