### PR TITLE
Implement DisengagingCondition

### DIFF
--- a/rulebooks/dnd5e/conditions/disengaging.go
+++ b/rulebooks/dnd5e/conditions/disengaging.go
@@ -1,0 +1,175 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// DisengagingConditionData is the serializable form of the disengaging condition.
+// This is stored by the game server as an opaque JSON blob.
+type DisengagingConditionData struct {
+	Ref         *core.Ref `json:"ref"`
+	CharacterID string    `json:"character_id"`
+}
+
+// DisengagingCondition prevents opportunity attacks against the character
+// until the end of their current turn. This condition is applied when
+// a character uses the Disengage combat ability and automatically
+// removes itself when the character's turn ends.
+type DisengagingCondition struct {
+	CharacterID     string
+	bus             events.EventBus
+	subscriptionIDs []string
+}
+
+// Ensure DisengagingCondition implements dnd5eEvents.ConditionBehavior
+var _ dnd5eEvents.ConditionBehavior = (*DisengagingCondition)(nil)
+
+// NewDisengagingCondition creates a new Disengaging condition for the specified character.
+// The condition will prevent opportunity attacks when the character moves and will
+// automatically remove itself at the end of the character's turn.
+func NewDisengagingCondition(characterID string) *DisengagingCondition {
+	return &DisengagingCondition{
+		CharacterID: characterID,
+	}
+}
+
+// IsApplied returns true if this condition is currently applied.
+func (d *DisengagingCondition) IsApplied() bool {
+	return d.bus != nil
+}
+
+// Apply subscribes this condition to MovementChain and TurnEnd events.
+// MovementChain subscription adds OA prevention when this character moves.
+// TurnEnd subscription removes the condition when the character's turn ends.
+func (d *DisengagingCondition) Apply(ctx context.Context, bus events.EventBus) error {
+	if d.IsApplied() {
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "disengaging condition already applied")
+	}
+	d.bus = bus
+
+	// Subscribe to MovementChain to prevent opportunity attacks
+	movementChain := dnd5eEvents.MovementChain.On(bus)
+	subID1, err := movementChain.SubscribeWithChain(ctx, d.onMovementChain)
+	if err != nil {
+		d.bus = nil
+		return rpgerr.Wrap(err, "failed to subscribe to movement chain")
+	}
+	d.subscriptionIDs = append(d.subscriptionIDs, subID1)
+
+	// Subscribe to TurnEnd to remove condition when turn ends
+	turnEndTopic := dnd5eEvents.TurnEndTopic.On(bus)
+	subID2, err := turnEndTopic.Subscribe(ctx, d.onTurnEnd)
+	if err != nil {
+		// Rollback: unsubscribe from previous subscriptions
+		_ = d.Remove(ctx, bus)
+		return rpgerr.Wrap(err, "failed to subscribe to turn end topic")
+	}
+	d.subscriptionIDs = append(d.subscriptionIDs, subID2)
+
+	return nil
+}
+
+// Remove unsubscribes this condition from all events.
+func (d *DisengagingCondition) Remove(ctx context.Context, bus events.EventBus) error {
+	if d.bus == nil {
+		return nil // Not applied, nothing to remove
+	}
+
+	for _, subID := range d.subscriptionIDs {
+		if err := bus.Unsubscribe(ctx, subID); err != nil {
+			return rpgerr.Wrap(err, "failed to unsubscribe from event")
+		}
+	}
+
+	d.subscriptionIDs = nil
+	d.bus = nil
+	return nil
+}
+
+// ToJSON converts the condition to JSON for persistence.
+func (d *DisengagingCondition) ToJSON() (json.RawMessage, error) {
+	data := DisengagingConditionData{
+		Ref:         refs.Conditions.Disengaging(),
+		CharacterID: d.CharacterID,
+	}
+	return json.Marshal(data)
+}
+
+// loadJSON loads disengaging condition state from JSON.
+func (d *DisengagingCondition) loadJSON(data json.RawMessage) error {
+	var disengagingData DisengagingConditionData
+	if err := json.Unmarshal(data, &disengagingData); err != nil {
+		return rpgerr.Wrap(err, "failed to unmarshal disengaging data")
+	}
+
+	d.CharacterID = disengagingData.CharacterID
+	return nil
+}
+
+// onMovementChain handles movement events to add OA prevention for this character.
+// When the moving entity is this character, adds an OA prevention source to the event.
+func (d *DisengagingCondition) onMovementChain(
+	_ context.Context,
+	event *dnd5eEvents.MovementChainEvent,
+	c chain.Chain[*dnd5eEvents.MovementChainEvent],
+) (chain.Chain[*dnd5eEvents.MovementChainEvent], error) {
+	// Only apply to this character's movement
+	if event.EntityID != d.CharacterID {
+		return c, nil
+	}
+
+	// Add OA prevention at the conditions stage
+	modifyMovement := func(_ context.Context, e *dnd5eEvents.MovementChainEvent) (*dnd5eEvents.MovementChainEvent, error) {
+		e.OAPreventionSources = append(e.OAPreventionSources, dnd5eEvents.MovementModifierSource{
+			Name:       "Disengaging",
+			SourceType: "condition",
+			SourceRef:  refs.Conditions.Disengaging(),
+			EntityID:   d.CharacterID,
+		})
+		return e, nil
+	}
+
+	if err := c.Add(combat.StageConditions, "disengaging", modifyMovement); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add disengaging modifier for character %s", d.CharacterID)
+	}
+
+	return c, nil
+}
+
+// onTurnEnd handles turn end events to remove this condition when the character's turn ends.
+func (d *DisengagingCondition) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnEndEvent) error {
+	// Only remove on this character's turn end
+	if event.CharacterID != d.CharacterID {
+		return nil
+	}
+
+	if d.bus == nil {
+		return nil
+	}
+
+	// Publish condition removed event
+	removals := dnd5eEvents.ConditionRemovedTopic.On(d.bus)
+	err := removals.Publish(ctx, dnd5eEvents.ConditionRemovedEvent{
+		CharacterID:  d.CharacterID,
+		ConditionRef: refs.Conditions.Disengaging().String(),
+		Reason:       "turn_end",
+	})
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to publish disengaging removal for character %s", d.CharacterID)
+	}
+
+	// Actually remove the condition (unsubscribe from events)
+	return d.Remove(ctx, d.bus)
+}

--- a/rulebooks/dnd5e/conditions/disengaging_test.go
+++ b/rulebooks/dnd5e/conditions/disengaging_test.go
@@ -1,0 +1,229 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+type DisengagingConditionTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	bus events.EventBus
+}
+
+func (s *DisengagingConditionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+func TestDisengagingConditionSuite(t *testing.T) {
+	suite.Run(t, new(DisengagingConditionTestSuite))
+}
+
+func (s *DisengagingConditionTestSuite) TestNewDisengagingCondition() {
+	disengaging := conditions.NewDisengagingCondition("rogue-1")
+
+	s.NotNil(disengaging)
+	s.False(disengaging.IsApplied())
+}
+
+func (s *DisengagingConditionTestSuite) TestApplyAndRemove() {
+	disengaging := conditions.NewDisengagingCondition("rogue-1")
+
+	// Apply should succeed
+	err := disengaging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(disengaging.IsApplied())
+
+	// Applying again should fail
+	err = disengaging.Apply(s.ctx, s.bus)
+	s.Error(err)
+
+	// Remove should succeed
+	err = disengaging.Remove(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.False(disengaging.IsApplied())
+}
+
+func (s *DisengagingConditionTestSuite) TestPreventsOpportunityAttacks() {
+	disengaging := conditions.NewDisengagingCondition("rogue-1")
+
+	err := disengaging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = disengaging.Remove(s.ctx, s.bus) }()
+
+	// Create a movement chain event for the disengaging character
+	movementEvent := &dnd5eEvents.MovementChainEvent{
+		EntityID:            "rogue-1",
+		EntityType:          "character",
+		FromPosition:        dnd5eEvents.Position{X: 5, Y: 5},
+		ToPosition:          dnd5eEvents.Position{X: 6, Y: 5},
+		ThreateningEntities: []string{"goblin-1", "goblin-2"},
+		OAPreventionSources: make([]dnd5eEvents.MovementModifierSource, 0),
+	}
+
+	// Execute through movement chain
+	movementChain := events.NewStagedChain[*dnd5eEvents.MovementChainEvent](combat.ModifierStages)
+	movements := dnd5eEvents.MovementChain.On(s.bus)
+	modifiedChain, err := movements.PublishWithChain(s.ctx, movementEvent, movementChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, movementEvent)
+	s.Require().NoError(err)
+
+	// Should have OA prevention added
+	s.Len(finalEvent.OAPreventionSources, 1)
+	s.True(finalEvent.IsOAPrevented())
+	s.Equal("Disengaging", finalEvent.OAPreventionSources[0].Name)
+	s.Equal("condition", finalEvent.OAPreventionSources[0].SourceType)
+	s.Equal(refs.Conditions.Disengaging(), finalEvent.OAPreventionSources[0].SourceRef)
+	s.Equal("rogue-1", finalEvent.OAPreventionSources[0].EntityID)
+}
+
+func (s *DisengagingConditionTestSuite) TestDoesNotAffectOtherCharactersMovement() {
+	disengaging := conditions.NewDisengagingCondition("rogue-1")
+
+	err := disengaging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = disengaging.Remove(s.ctx, s.bus) }()
+
+	// Create a movement chain event for a DIFFERENT character
+	movementEvent := &dnd5eEvents.MovementChainEvent{
+		EntityID:            "fighter-1", // Not the disengaging character
+		EntityType:          "character",
+		FromPosition:        dnd5eEvents.Position{X: 5, Y: 5},
+		ToPosition:          dnd5eEvents.Position{X: 6, Y: 5},
+		ThreateningEntities: []string{"goblin-1"},
+		OAPreventionSources: make([]dnd5eEvents.MovementModifierSource, 0),
+	}
+
+	// Execute through movement chain
+	movementChain := events.NewStagedChain[*dnd5eEvents.MovementChainEvent](combat.ModifierStages)
+	movements := dnd5eEvents.MovementChain.On(s.bus)
+	modifiedChain, err := movements.PublishWithChain(s.ctx, movementEvent, movementChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, movementEvent)
+	s.Require().NoError(err)
+
+	// Should NOT have OA prevention - disengaging doesn't apply to other characters
+	s.Empty(finalEvent.OAPreventionSources)
+	s.False(finalEvent.IsOAPrevented())
+}
+
+func (s *DisengagingConditionTestSuite) TestRemovedOnTurnEnd() {
+	disengaging := conditions.NewDisengagingCondition("rogue-1")
+
+	err := disengaging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(disengaging.IsApplied())
+
+	// Track condition removal
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	removedTopic := dnd5eEvents.ConditionRemovedTopic.On(s.bus)
+	_, err = removedTopic.Subscribe(s.ctx, func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+		removedEvent = &event
+		return nil
+	})
+	s.Require().NoError(err)
+
+	// Publish turn end for the disengaging character
+	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
+	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		CharacterID: "rogue-1",
+		Round:       1,
+	})
+	s.Require().NoError(err)
+
+	// Condition should be removed
+	s.False(disengaging.IsApplied())
+	s.NotNil(removedEvent)
+	s.Equal("rogue-1", removedEvent.CharacterID)
+	s.Equal(refs.Conditions.Disengaging().String(), removedEvent.ConditionRef)
+	s.Equal("turn_end", removedEvent.Reason)
+}
+
+func (s *DisengagingConditionTestSuite) TestNotRemovedOnOtherCharactersTurnEnd() {
+	disengaging := conditions.NewDisengagingCondition("rogue-1")
+
+	err := disengaging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(disengaging.IsApplied())
+
+	// Publish turn end for a DIFFERENT character
+	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
+	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		CharacterID: "fighter-1", // Not the disengaging character
+		Round:       1,
+	})
+	s.Require().NoError(err)
+
+	// Condition should still be applied
+	s.True(disengaging.IsApplied())
+}
+
+func (s *DisengagingConditionTestSuite) TestToJSON() {
+	disengaging := conditions.NewDisengagingCondition("rogue-1")
+
+	jsonData, err := disengaging.ToJSON()
+	s.Require().NoError(err)
+	s.Contains(string(jsonData), refs.Conditions.Disengaging().ID)
+	s.Contains(string(jsonData), "rogue-1")
+}
+
+func (s *DisengagingConditionTestSuite) TestJSONRoundTrip() {
+	// Create and serialize a condition
+	original := conditions.NewDisengagingCondition("rogue-1")
+
+	jsonData, err := original.ToJSON()
+	s.Require().NoError(err)
+
+	// Load it back using the loader
+	loaded, err := conditions.LoadJSON(jsonData)
+	s.Require().NoError(err)
+
+	// Verify we can use it
+	err = loaded.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(loaded.IsApplied())
+
+	// Serialize the loaded condition and compare
+	reserializedData, err := loaded.ToJSON()
+	s.Require().NoError(err)
+
+	// Compare the JSON structures
+	var originalMap, reserializedMap map[string]interface{}
+	err = json.Unmarshal(jsonData, &originalMap)
+	s.Require().NoError(err)
+	err = json.Unmarshal(reserializedData, &reserializedMap)
+	s.Require().NoError(err)
+
+	s.Equal(originalMap["character_id"], reserializedMap["character_id"])
+}
+
+func (s *DisengagingConditionTestSuite) TestCreateFromRef() {
+	// Test factory creation
+	output, err := conditions.CreateFromRef(&conditions.CreateFromRefInput{
+		Ref:         refs.Conditions.Disengaging().String(),
+		CharacterID: "rogue-1",
+	})
+	s.Require().NoError(err)
+	s.NotNil(output.Condition)
+
+	// Apply and verify it works
+	err = output.Condition.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(output.Condition.IsApplied())
+}

--- a/rulebooks/dnd5e/conditions/factory.go
+++ b/rulebooks/dnd5e/conditions/factory.go
@@ -94,6 +94,8 @@ func CreateFromRef(input *CreateFromRefInput) (*CreateFromRefOutput, error) {
 		condition, err = createUnarmoredMovement(input.Config, input.CharacterID)
 	case refs.Conditions.SneakAttack().ID:
 		condition, err = createSneakAttack(input.Config, input.CharacterID)
+	case refs.Conditions.Disengaging().ID:
+		condition = NewDisengagingCondition(input.CharacterID)
 	default:
 		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition: %s", ref.ID)
 	}

--- a/rulebooks/dnd5e/conditions/loader.go
+++ b/rulebooks/dnd5e/conditions/loader.go
@@ -118,6 +118,13 @@ func LoadJSON(data json.RawMessage) (dnd5eEvents.ConditionBehavior, error) {
 		}
 		return sneak, nil
 
+	case refs.Conditions.Disengaging().ID:
+		disengaging := &DisengagingCondition{}
+		if err := disengaging.loadJSON(data); err != nil {
+			return nil, rpgerr.Wrap(err, "failed to load disengaging condition")
+		}
+		return disengaging, nil
+
 	default:
 		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition ref: %s", peek.Ref.ID)
 	}


### PR DESCRIPTION
## Summary

- Adds `DisengagingCondition` that prevents opportunity attacks when moving
- Subscribes to `MovementChain` to add OA prevention
- Auto-removes on turn end via `TurnEndTopic` subscription

## Why

Completes the Disengage combat ability. When a character takes the Disengage action:
1. `DisengageActivatedEvent` is published (already exists)
2. `DisengagingCondition` is applied
3. Character can move without provoking opportunity attacks
4. Condition removes itself at end of turn

## Implementation

```go
// When character moves, prevent OAs
func (d *DisengagingCondition) onMovementChain(...) {
    if event.EntityID != d.CharacterID {
        return c, nil  // Only affect this character
    }
    
    e.OAPreventionSources = append(e.OAPreventionSources, MovementModifierSource{
        Name:       "Disengaging",
        SourceType: "condition",
        SourceRef:  refs.Conditions.Disengaging(),
    })
}

// When turn ends, remove condition
func (d *DisengagingCondition) onTurnEnd(...) {
    if event.EntityID != d.CharacterID {
        return  // Only remove on this character's turn end
    }
    d.Remove(ctx, d.bus)
    // Publish ConditionRemovedEvent
}
```

## Test Coverage

- [x] Apply/Remove lifecycle
- [x] OA prevention added for correct character
- [x] Does not affect other characters' movement
- [x] Removes on turn end
- [x] Does not remove on other characters' turn end
- [x] JSON round-trip serialization
- [x] Factory creation via `CreateFromRef`

## Dependencies

Built on:
- #554 - AttackType and CancellationSources
- #556 - MovementChain and OA triggering

Fixes #557
Part of #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)