### PR TITLE
Implement DodgingCondition (#558)

### DIFF
--- a/rulebooks/dnd5e/conditions/dodging.go
+++ b/rulebooks/dnd5e/conditions/dodging.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// DodgingConditionData is the serializable form of the dodging condition.
+// This is stored by the game server as an opaque JSON blob.
+type DodgingConditionData struct {
+	Ref         *core.Ref `json:"ref"`
+	CharacterID string    `json:"character_id"`
+}
+
+// DodgingCondition grants disadvantage on attack rolls against the character
+// and advantage on DEX saving throws. This condition is applied when a
+// character uses the Dodge combat ability and automatically removes itself
+// at the start of the character's next turn.
+type DodgingCondition struct {
+	CharacterID     string
+	bus             events.EventBus
+	subscriptionIDs []string
+}
+
+// Ensure DodgingCondition implements dnd5eEvents.ConditionBehavior
+var _ dnd5eEvents.ConditionBehavior = (*DodgingCondition)(nil)
+
+// NewDodgingCondition creates a new Dodging condition for the specified character.
+// The condition grants disadvantage on attacks targeting this character and
+// advantage on DEX saves, and removes itself at the start of the character's next turn.
+func NewDodgingCondition(characterID string) *DodgingCondition {
+	return &DodgingCondition{
+		CharacterID: characterID,
+	}
+}
+
+// IsApplied returns true if this condition is currently applied.
+func (d *DodgingCondition) IsApplied() bool {
+	return d.bus != nil
+}
+
+// Apply subscribes this condition to AttackChain, SavingThrowChain, and TurnStart events.
+// AttackChain subscription adds disadvantage when this character is targeted.
+// SavingThrowChain subscription adds advantage on DEX saves for this character.
+// TurnStart subscription removes the condition at the start of the character's next turn.
+func (d *DodgingCondition) Apply(ctx context.Context, bus events.EventBus) error {
+	if d.IsApplied() {
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "dodging condition already applied")
+	}
+	d.bus = bus
+
+	// Subscribe to AttackChain to impose disadvantage on attacks targeting this character
+	attackChain := dnd5eEvents.AttackChain.On(bus)
+	subID1, err := attackChain.SubscribeWithChain(ctx, d.onAttackChain)
+	if err != nil {
+		d.bus = nil
+		return rpgerr.Wrap(err, "failed to subscribe to attack chain")
+	}
+	d.subscriptionIDs = append(d.subscriptionIDs, subID1)
+
+	// Subscribe to SavingThrowChain to grant advantage on DEX saves
+	saveChain := dnd5eEvents.SavingThrowChain.On(bus)
+	subID2, err := saveChain.SubscribeWithChain(ctx, d.onSavingThrowChain)
+	if err != nil {
+		_ = d.Remove(ctx, bus)
+		return rpgerr.Wrap(err, "failed to subscribe to saving throw chain")
+	}
+	d.subscriptionIDs = append(d.subscriptionIDs, subID2)
+
+	// Subscribe to TurnStart to remove condition at the start of the character's next turn
+	turnStartTopic := dnd5eEvents.TurnStartTopic.On(bus)
+	subID3, err := turnStartTopic.Subscribe(ctx, d.onTurnStart)
+	if err != nil {
+		_ = d.Remove(ctx, bus)
+		return rpgerr.Wrap(err, "failed to subscribe to turn start topic")
+	}
+	d.subscriptionIDs = append(d.subscriptionIDs, subID3)
+
+	return nil
+}
+
+// Remove unsubscribes this condition from all events.
+func (d *DodgingCondition) Remove(ctx context.Context, bus events.EventBus) error {
+	if d.bus == nil {
+		return nil // Not applied, nothing to remove
+	}
+
+	for _, subID := range d.subscriptionIDs {
+		if err := bus.Unsubscribe(ctx, subID); err != nil {
+			return rpgerr.Wrap(err, "failed to unsubscribe from event")
+		}
+	}
+
+	d.subscriptionIDs = nil
+	d.bus = nil
+	return nil
+}
+
+// ToJSON converts the condition to JSON for persistence.
+func (d *DodgingCondition) ToJSON() (json.RawMessage, error) {
+	data := DodgingConditionData{
+		Ref:         refs.Conditions.Dodging(),
+		CharacterID: d.CharacterID,
+	}
+	return json.Marshal(data)
+}
+
+// loadJSON loads dodging condition state from JSON.
+func (d *DodgingCondition) loadJSON(data json.RawMessage) error {
+	var dodgingData DodgingConditionData
+	if err := json.Unmarshal(data, &dodgingData); err != nil {
+		return rpgerr.Wrap(err, "failed to unmarshal dodging data")
+	}
+
+	d.CharacterID = dodgingData.CharacterID
+	return nil
+}
+
+// onAttackChain handles attack events to impose disadvantage when this character is targeted.
+func (d *DodgingCondition) onAttackChain(
+	_ context.Context,
+	event dnd5eEvents.AttackChainEvent,
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	// Only apply when this character is the target
+	if event.TargetID != d.CharacterID {
+		return c, nil
+	}
+
+	// Add disadvantage at the conditions stage
+	modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+		e.DisadvantageSources = append(e.DisadvantageSources, dnd5eEvents.AttackModifierSource{
+			SourceRef: refs.Conditions.Dodging(),
+			SourceID:  d.CharacterID,
+			Reason:    "Dodging",
+		})
+		return e, nil
+	}
+
+	if err := c.Add(combat.StageConditions, "dodging_disadvantage", modifyAttack); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add dodging disadvantage modifier for character %s", d.CharacterID)
+	}
+
+	return c, nil
+}
+
+// onSavingThrowChain handles saving throw events to grant advantage on DEX saves.
+func (d *DodgingCondition) onSavingThrowChain(
+	_ context.Context,
+	event *dnd5eEvents.SavingThrowChainEvent,
+	c chain.Chain[*dnd5eEvents.SavingThrowChainEvent],
+) (chain.Chain[*dnd5eEvents.SavingThrowChainEvent], error) {
+	// Only apply to this character's saves
+	if event.SaverID != d.CharacterID {
+		return c, nil
+	}
+
+	// Only apply to DEX saves
+	if event.Ability != abilities.DEX {
+		return c, nil
+	}
+
+	// Add advantage at the conditions stage
+	modifySave := func(_ context.Context, e *dnd5eEvents.SavingThrowChainEvent) (*dnd5eEvents.SavingThrowChainEvent, error) {
+		e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.SaveModifierSource{
+			Name:       "Dodging",
+			SourceType: "condition",
+			SourceRef:  refs.Conditions.Dodging(),
+			EntityID:   d.CharacterID,
+		})
+		return e, nil
+	}
+
+	if err := c.Add(combat.StageConditions, "dodging_dex_advantage", modifySave); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add dodging DEX advantage modifier for character %s", d.CharacterID)
+	}
+
+	return c, nil
+}
+
+// onTurnStart handles turn start events to remove this condition at the start of the character's next turn.
+func (d *DodgingCondition) onTurnStart(ctx context.Context, event dnd5eEvents.TurnStartEvent) error {
+	// Only remove on this character's turn start
+	if event.CharacterID != d.CharacterID {
+		return nil
+	}
+
+	if d.bus == nil {
+		return nil
+	}
+
+	// Publish condition removed event
+	removals := dnd5eEvents.ConditionRemovedTopic.On(d.bus)
+	err := removals.Publish(ctx, dnd5eEvents.ConditionRemovedEvent{
+		CharacterID:  d.CharacterID,
+		ConditionRef: refs.Conditions.Dodging().String(),
+		Reason:       "turn_start",
+	})
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to publish dodging removal for character %s", d.CharacterID)
+	}
+
+	// Actually remove the condition (unsubscribe from events)
+	return d.Remove(ctx, d.bus)
+}

--- a/rulebooks/dnd5e/conditions/dodging_test.go
+++ b/rulebooks/dnd5e/conditions/dodging_test.go
@@ -1,0 +1,275 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/stretchr/testify/suite"
+)
+
+type DodgingConditionTestSuite struct {
+	suite.Suite
+	ctx         context.Context
+	bus         events.EventBus
+	condition   *DodgingCondition
+	characterID string
+}
+
+func TestDodgingConditionSuite(t *testing.T) {
+	suite.Run(t, new(DodgingConditionTestSuite))
+}
+
+func (s *DodgingConditionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.characterID = "char-dodging"
+	s.condition = NewDodgingCondition(s.characterID)
+}
+
+func (s *DodgingConditionTestSuite) SetupSubTest() {
+	s.bus = events.NewEventBus()
+}
+
+func (s *DodgingConditionTestSuite) TestNewDodgingCondition() {
+	s.Assert().Equal(s.characterID, s.condition.CharacterID)
+	s.Assert().False(s.condition.IsApplied())
+}
+
+func (s *DodgingConditionTestSuite) TestApply() {
+	s.Run("applies successfully", func() {
+		err := s.condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+		s.Assert().True(s.condition.IsApplied())
+		s.Assert().Len(s.condition.subscriptionIDs, 3)
+	})
+
+	s.Run("returns error if already applied", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		err = condition.Apply(s.ctx, s.bus)
+		s.Assert().Error(err)
+		s.Assert().Contains(err.Error(), "already applied")
+	})
+}
+
+func (s *DodgingConditionTestSuite) TestRemove() {
+	s.Run("removes successfully after apply", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		err = condition.Remove(s.ctx, s.bus)
+		s.Require().NoError(err)
+		s.Assert().False(condition.IsApplied())
+		s.Assert().Nil(condition.subscriptionIDs)
+	})
+
+	s.Run("no-op if not applied", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Remove(s.ctx, s.bus)
+		s.Require().NoError(err)
+	})
+}
+
+func (s *DodgingConditionTestSuite) TestAttackChainDisadvantage() {
+	s.Run("adds disadvantage when character is targeted", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		attackEvent := dnd5eEvents.AttackChainEvent{
+			AttackerID: "attacker-1",
+			TargetID:   s.characterID,
+			IsMelee:    true,
+		}
+
+		attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attacks := dnd5eEvents.AttackChain.On(s.bus)
+		modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+		s.Require().NoError(err)
+		s.Assert().Len(finalEvent.DisadvantageSources, 1)
+		s.Assert().Equal(refs.Conditions.Dodging(), finalEvent.DisadvantageSources[0].SourceRef)
+		s.Assert().Equal("Dodging", finalEvent.DisadvantageSources[0].Reason)
+	})
+
+	s.Run("adds disadvantage for ranged attacks too", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		attackEvent := dnd5eEvents.AttackChainEvent{
+			AttackerID: "attacker-1",
+			TargetID:   s.characterID,
+			IsMelee:    false,
+		}
+
+		attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attacks := dnd5eEvents.AttackChain.On(s.bus)
+		modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+		s.Require().NoError(err)
+		s.Assert().Len(finalEvent.DisadvantageSources, 1)
+	})
+
+	s.Run("does not add disadvantage when another character is targeted", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		attackEvent := dnd5eEvents.AttackChainEvent{
+			AttackerID: "attacker-1",
+			TargetID:   "other-character",
+			IsMelee:    true,
+		}
+
+		attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+		attacks := dnd5eEvents.AttackChain.On(s.bus)
+		modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+		s.Require().NoError(err)
+		s.Assert().Empty(finalEvent.DisadvantageSources)
+	})
+}
+
+func (s *DodgingConditionTestSuite) TestSavingThrowChainAdvantage() {
+	s.Run("adds advantage on DEX saves for this character", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		saveEvent := &dnd5eEvents.SavingThrowChainEvent{
+			SaverID: s.characterID,
+			Ability: abilities.DEX,
+			DC:      15,
+		}
+
+		saveChain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+		saves := dnd5eEvents.SavingThrowChain.On(s.bus)
+		modifiedChain, err := saves.PublishWithChain(s.ctx, saveEvent, saveChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, saveEvent)
+		s.Require().NoError(err)
+		s.Assert().Len(finalEvent.AdvantageSources, 1)
+		s.Assert().Equal(refs.Conditions.Dodging(), finalEvent.AdvantageSources[0].SourceRef)
+		s.Assert().Equal("Dodging", finalEvent.AdvantageSources[0].Name)
+	})
+
+	s.Run("does not add advantage on non-DEX saves", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		saveEvent := &dnd5eEvents.SavingThrowChainEvent{
+			SaverID: s.characterID,
+			Ability: abilities.CON,
+			DC:      15,
+		}
+
+		saveChain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+		saves := dnd5eEvents.SavingThrowChain.On(s.bus)
+		modifiedChain, err := saves.PublishWithChain(s.ctx, saveEvent, saveChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, saveEvent)
+		s.Require().NoError(err)
+		s.Assert().Empty(finalEvent.AdvantageSources)
+	})
+
+	s.Run("does not add advantage for other characters", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		saveEvent := &dnd5eEvents.SavingThrowChainEvent{
+			SaverID: "other-character",
+			Ability: abilities.DEX,
+			DC:      15,
+		}
+
+		saveChain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+		saves := dnd5eEvents.SavingThrowChain.On(s.bus)
+		modifiedChain, err := saves.PublishWithChain(s.ctx, saveEvent, saveChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, saveEvent)
+		s.Require().NoError(err)
+		s.Assert().Empty(finalEvent.AdvantageSources)
+	})
+}
+
+func (s *DodgingConditionTestSuite) TestTurnStartRemoval() {
+	s.Run("removes condition on character turn start", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+		s.Assert().True(condition.IsApplied())
+
+		// Track condition removed event
+		var removedEvent *dnd5eEvents.ConditionRemovedEvent
+		_, err = dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx, func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removedEvent = &event
+			return nil
+		})
+		s.Require().NoError(err)
+
+		// Publish turn start for this character
+		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
+			CharacterID: s.characterID,
+			Round:       1,
+		})
+		s.Require().NoError(err)
+
+		// Condition should be removed
+		s.Assert().False(condition.IsApplied())
+		s.Require().NotNil(removedEvent)
+		s.Assert().Equal(s.characterID, removedEvent.CharacterID)
+		s.Assert().Equal(refs.Conditions.Dodging().String(), removedEvent.ConditionRef)
+		s.Assert().Equal("turn_start", removedEvent.Reason)
+	})
+
+	s.Run("does not remove on other character turn start", func() {
+		condition := NewDodgingCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		// Publish turn start for different character
+		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
+			CharacterID: "other-character",
+			Round:       1,
+		})
+		s.Require().NoError(err)
+
+		// Condition should still be applied
+		s.Assert().True(condition.IsApplied())
+	})
+}
+
+func (s *DodgingConditionTestSuite) TestToJSON() {
+	condition := NewDodgingCondition(s.characterID)
+	data, err := condition.ToJSON()
+	s.Require().NoError(err)
+
+	// Load it back
+	loaded := &DodgingCondition{}
+	err = loaded.loadJSON(data)
+	s.Require().NoError(err)
+	s.Assert().Equal(s.characterID, loaded.CharacterID)
+}

--- a/rulebooks/dnd5e/conditions/factory.go
+++ b/rulebooks/dnd5e/conditions/factory.go
@@ -96,6 +96,8 @@ func CreateFromRef(input *CreateFromRefInput) (*CreateFromRefOutput, error) {
 		condition, err = createSneakAttack(input.Config, input.CharacterID)
 	case refs.Conditions.Disengaging().ID:
 		condition = NewDisengagingCondition(input.CharacterID)
+	case refs.Conditions.Dodging().ID:
+		condition = NewDodgingCondition(input.CharacterID)
 	default:
 		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition: %s", ref.ID)
 	}

--- a/rulebooks/dnd5e/conditions/loader.go
+++ b/rulebooks/dnd5e/conditions/loader.go
@@ -125,6 +125,13 @@ func LoadJSON(data json.RawMessage) (dnd5eEvents.ConditionBehavior, error) {
 		}
 		return disengaging, nil
 
+	case refs.Conditions.Dodging().ID:
+		dodging := &DodgingCondition{}
+		if err := dodging.loadJSON(data); err != nil {
+			return nil, rpgerr.Wrap(err, "failed to load dodging condition")
+		}
+		return dodging, nil
+
 	default:
 		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition ref: %s", peek.Ref.ID)
 	}


### PR DESCRIPTION
## Summary

- Implements `DodgingCondition` following the established pattern from `DisengagingCondition`
- Subscribes to `AttackChain` to impose disadvantage on attacks targeting the dodging character
- Subscribes to `SavingThrowChain` to grant advantage on DEX saving throws
- Auto-removes at the start of the character's next turn via `TurnStartTopic`
- Registered in factory (`CreateFromRef`) and loader (`LoadJSON`) for persistence

## Test plan

- [x] Apply/Remove lifecycle tests
- [x] Disadvantage on melee attacks targeting character
- [x] Disadvantage on ranged attacks targeting character
- [x] No disadvantage when other character is targeted
- [x] Advantage on DEX saves for character
- [x] No advantage on non-DEX saves
- [x] No advantage for other characters
- [x] Removal on character's turn start
- [x] No removal on other character's turn start
- [x] JSON serialization round-trip
- [x] Full dnd5e test suite passes

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)