### PR TITLE
Add GetSpeed and GetExtraAttacksCount to Character (#546)

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -124,6 +124,39 @@ func (c *Character) GetLevel() int {
 	return c.level
 }
 
+// GetSpeed returns the character's base walking speed in feet from their race.
+// This is the base speed before condition modifiers (e.g., Unarmored Movement).
+// Condition-based speed modifiers are applied through the MovementChain.
+func (c *Character) GetSpeed() int {
+	raceData := races.GetData(c.raceID)
+	if raceData == nil {
+		return 30 // Default speed if race data not found
+	}
+	return raceData.Speed
+}
+
+// GetExtraAttacksCount returns the number of extra attacks granted by class features.
+// This is used by the Attack combat ability to determine total attacks per action.
+// 0 = 1 attack (normal), 1 = 2 attacks (Extra Attack), 2 = 3 attacks, etc.
+func (c *Character) GetExtraAttacksCount() int {
+	switch c.classID {
+	case classes.Fighter:
+		switch {
+		case c.level >= 20:
+			return 3
+		case c.level >= 11:
+			return 2
+		case c.level >= 5:
+			return 1
+		}
+	case classes.Barbarian, classes.Monk, classes.Paladin, classes.Ranger:
+		if c.level >= 5 {
+			return 1
+		}
+	}
+	return 0
+}
+
 // GetAbilityScore returns the character's ability score (including racial modifiers)
 func (c *Character) GetAbilityScore(ability abilities.Ability) int {
 	return c.abilityScores[ability]

--- a/rulebooks/dnd5e/character/speed_attacks_test.go
+++ b/rulebooks/dnd5e/character/speed_attacks_test.go
@@ -1,0 +1,148 @@
+package character
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/stretchr/testify/suite"
+)
+
+// SpeedAttacksTestSuite tests GetSpeed and GetExtraAttacksCount methods
+type SpeedAttacksTestSuite struct {
+	suite.Suite
+}
+
+func TestSpeedAttacksSuite(t *testing.T) {
+	suite.Run(t, new(SpeedAttacksTestSuite))
+}
+
+// GetSpeed tests
+
+func (s *SpeedAttacksTestSuite) TestGetSpeed_Human() {
+	char := &Character{raceID: races.Human}
+	s.Assert().Equal(30, char.GetSpeed())
+}
+
+func (s *SpeedAttacksTestSuite) TestGetSpeed_Dwarf() {
+	char := &Character{raceID: races.Dwarf}
+	s.Assert().Equal(25, char.GetSpeed())
+}
+
+func (s *SpeedAttacksTestSuite) TestGetSpeed_Elf() {
+	char := &Character{raceID: races.Elf}
+	s.Assert().Equal(30, char.GetSpeed())
+}
+
+func (s *SpeedAttacksTestSuite) TestGetSpeed_Halfling() {
+	char := &Character{raceID: races.Halfling}
+	s.Assert().Equal(25, char.GetSpeed())
+}
+
+func (s *SpeedAttacksTestSuite) TestGetSpeed_Gnome() {
+	char := &Character{raceID: races.Gnome}
+	s.Assert().Equal(25, char.GetSpeed())
+}
+
+func (s *SpeedAttacksTestSuite) TestGetSpeed_UnknownRace_DefaultsTo30() {
+	char := &Character{raceID: "nonexistent"}
+	s.Assert().Equal(30, char.GetSpeed())
+}
+
+// GetExtraAttacksCount tests - Fighter
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Fighter_Level1() {
+	char := &Character{classID: classes.Fighter, level: 1}
+	s.Assert().Equal(0, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Fighter_Level4() {
+	char := &Character{classID: classes.Fighter, level: 4}
+	s.Assert().Equal(0, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Fighter_Level5() {
+	char := &Character{classID: classes.Fighter, level: 5}
+	s.Assert().Equal(1, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Fighter_Level10() {
+	char := &Character{classID: classes.Fighter, level: 10}
+	s.Assert().Equal(1, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Fighter_Level11() {
+	char := &Character{classID: classes.Fighter, level: 11}
+	s.Assert().Equal(2, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Fighter_Level19() {
+	char := &Character{classID: classes.Fighter, level: 19}
+	s.Assert().Equal(2, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Fighter_Level20() {
+	char := &Character{classID: classes.Fighter, level: 20}
+	s.Assert().Equal(3, char.GetExtraAttacksCount())
+}
+
+// GetExtraAttacksCount tests - Martial classes (Extra Attack at level 5)
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Barbarian_Level4() {
+	char := &Character{classID: classes.Barbarian, level: 4}
+	s.Assert().Equal(0, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Barbarian_Level5() {
+	char := &Character{classID: classes.Barbarian, level: 5}
+	s.Assert().Equal(1, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Monk_Level5() {
+	char := &Character{classID: classes.Monk, level: 5}
+	s.Assert().Equal(1, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Paladin_Level5() {
+	char := &Character{classID: classes.Paladin, level: 5}
+	s.Assert().Equal(1, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Ranger_Level5() {
+	char := &Character{classID: classes.Ranger, level: 5}
+	s.Assert().Equal(1, char.GetExtraAttacksCount())
+}
+
+// GetExtraAttacksCount tests - Non-martial classes
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Rogue_Level5() {
+	char := &Character{classID: classes.Rogue, level: 5}
+	s.Assert().Equal(0, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Wizard_Level20() {
+	char := &Character{classID: classes.Wizard, level: 20}
+	s.Assert().Equal(0, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Cleric_Level5() {
+	char := &Character{classID: classes.Cleric, level: 5}
+	s.Assert().Equal(0, char.GetExtraAttacksCount())
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Warlock_Level5() {
+	char := &Character{classID: classes.Warlock, level: 5}
+	s.Assert().Equal(0, char.GetExtraAttacksCount())
+}
+
+// GetExtraAttacksCount tests - Martial classes don't get more than 1 extra
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Barbarian_Level20() {
+	char := &Character{classID: classes.Barbarian, level: 20}
+	s.Assert().Equal(1, char.GetExtraAttacksCount(), "barbarian caps at 1 extra attack")
+}
+
+func (s *SpeedAttacksTestSuite) TestExtraAttacks_Monk_Level20() {
+	char := &Character{classID: classes.Monk, level: 20}
+	s.Assert().Equal(1, char.GetExtraAttacksCount(), "monk caps at 1 extra attack")
+}


### PR DESCRIPTION
## Summary

- Adds `GetSpeed()` to Character - returns base walking speed from race data (30 for most, 25 for Dwarves/Halflings/Gnomes)
- Adds `GetExtraAttacksCount()` to Character - calculates extra attacks from class/level per D&D 5e rules
- These provide values for `CombatAbilityInput.Speed` and `CombatAbilityInput.ExtraAttacks`

Extra Attack progression:
- Fighter: 1 at L5, 2 at L11, 3 at L20
- Barbarian/Monk/Paladin/Ranger: 1 at L5
- All others: 0

## Test plan

- [x] Speed tests for Human (30), Dwarf (25), Elf (30), Halfling (25), Gnome (25)
- [x] Unknown race defaults to 30
- [x] Fighter level progression (1→0, 4→0, 5→1, 10→1, 11→2, 19→2, 20→3)
- [x] Martial classes get 1 at level 5 (Barbarian, Monk, Paladin, Ranger)
- [x] Non-martial classes get 0 (Rogue, Wizard, Cleric, Warlock)
- [x] Martial classes cap at 1 even at level 20
- [x] Full dnd5e test suite passes
- [x] Lint clean

Partial progress on #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)