### PR TITLE
Add attack resolution integration tests (#505)

### DIFF
--- a/rulebooks/dnd5e/character/integration_test.go
+++ b/rulebooks/dnd5e/character/integration_test.go
@@ -1038,22 +1038,26 @@ func (s *AttackResolutionIntegrationSuite) TestTurnEndCleanup() {
 			ID:       "draft-cleanup-test",
 			PlayerID: "player-cleanup",
 		})
-		_ = draft.SetName(&character.SetNameInput{Name: "Test Fighter"})
-		_ = draft.SetAbilityScores(&character.SetAbilityScoresInput{
+		err := draft.SetName(&character.SetNameInput{Name: "Test Fighter"})
+		s.Require().NoError(err)
+		err = draft.SetAbilityScores(&character.SetAbilityScoresInput{
 			Scores: shared.AbilityScores{
 				abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
 				abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 10,
 			},
 		})
-		_ = draft.SetRace(&character.SetRaceInput{
+		s.Require().NoError(err)
+		err = draft.SetRace(&character.SetRaceInput{
 			RaceID:  races.Human,
 			Choices: character.RaceChoices{Languages: []languages.Language{languages.Elvish}},
 		})
-		_ = draft.SetBackground(&character.SetBackgroundInput{
+		s.Require().NoError(err)
+		err = draft.SetBackground(&character.SetBackgroundInput{
 			BackgroundID: backgrounds.Soldier,
 			Choices:      character.BackgroundChoices{},
 		})
-		_ = draft.SetClass(&character.SetClassInput{
+		s.Require().NoError(err)
+		err = draft.SetClass(&character.SetClassInput{
 			ClassID: classes.Fighter,
 			Choices: character.ClassChoices{
 				Skills: []skills.Skill{skills.Athletics, skills.Intimidation},
@@ -1067,6 +1071,7 @@ func (s *AttackResolutionIntegrationSuite) TestTurnEndCleanup() {
 				FightingStyle: fightingstyles.TwoWeaponFighting,
 			},
 		})
+		s.Require().NoError(err)
 
 		char, err := draft.ToCharacter(s.ctx, "fighter-cleanup", s.bus)
 		s.Require().NoError(err)


### PR DESCRIPTION
## Summary
- Adds `AttackResolutionIntegrationSuite` to `character/integration_test.go` proving the full attack pipeline works end-to-end with real Characters and Conditions (no mocks)
- Tests: raging barbarian vs dodging defender (AttackChain disadvantage + DamageChain rage bonus), disadvantage miss, normal attack baseline, critical hit doubling dice, turn-end temporary action cleanup
- Adds `sequenceRoller` (deterministic dice) and `combatantRegistry` (real CombatantLookup) as test helpers

## Context
Discovery: `combat.ResolveAttack()` was already fully implemented. These integration tests serve as the gate before moving attack resolution up to the API layer - they prove the full pipeline works with printed output showing each step.

## Test plan
- [x] `go test ./character/ -run TestAttackResolution -v` passes with printed output
- [x] `go test ./character/` full suite passes
- [x] `golangci-lint run ./character/` clean
- [x] `go vet ./character/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)