### PR TITLE
feat(actions): Add MartialArtsBonusStrike action and granter

### DIFF
--- a/rulebooks/dnd5e/actions/martial_arts_bonus_strike.go
+++ b/rulebooks/dnd5e/actions/martial_arts_bonus_strike.go
@@ -183,9 +183,11 @@ func (m *MartialArtsBonusStrike) IsTemporary() bool {
 	return true
 }
 
-// UsesRemaining returns 1 if not used, 0 if used
+// UsesRemaining returns 1 if not used, 0 if used.
+// Note: This only tracks actual usage, not removal state.
+// A removed-but-unused action still reports 1 use remaining.
 func (m *MartialArtsBonusStrike) UsesRemaining() int {
-	if m.used || m.removed {
+	if m.used {
 		return 0
 	}
 	return 1

--- a/rulebooks/dnd5e/actions/martial_arts_granter.go
+++ b/rulebooks/dnd5e/actions/martial_arts_granter.go
@@ -64,7 +64,7 @@ func CheckAndGrantMartialArtsBonusStrike(ctx context.Context, input *MartialArts
 	if input.SourceAbility != "attack" && input.SourceAbility != "" {
 		return &MartialArtsGranterOutput{
 			Granted: false,
-			Reason:  fmt.Sprintf("attack source is %s, not Attack action", input.SourceAbility),
+			Reason:  fmt.Sprintf("source ability is %q, expected Attack action", input.SourceAbility),
 		}, nil
 	}
 


### PR DESCRIPTION
## Summary

Implements the Martial Arts bonus action unarmed strike (PHB p.78):
> When you use the Attack action with an unarmed strike or a monk weapon on your turn, you can make one unarmed strike as a bonus action.

## New Files

- `martial_arts_bonus_strike.go` - The temporary action granted after Attack
- `martial_arts_bonus_strike_test.go` - 12 test cases for action behavior
- `martial_arts_granter.go` - `CheckAndGrantMartialArtsBonusStrike` function
- `martial_arts_granter_test.go` - 13 test cases for granter logic

## Granter Validates

- ✅ Attack came from Attack action (not Flurry, off-hand, etc.)
- ✅ Weapon is unarmed strike or monk weapon
  - Shortsword (explicitly a monk weapon)
  - Simple melee weapons without Heavy or Two-Handed properties
- ✅ Not already granted this turn

## Design

Follows the TWF (Two-Weapon Fighting) granter pattern:
- API calls `CheckAndGrantMartialArtsBonusStrike` after attack resolution
- Granter creates action, applies to event bus, publishes `ActionGrantedEvent`
- Character receives action via event subscription
- Action removes itself after use or at turn end

## Usage

```go
result, err := actions.CheckAndGrantMartialArtsBonusStrike(ctx, &actions.MartialArtsGranterInput{
    CharacterID:            "monk-1",
    IsUnarmed:              true,
    SourceAbility:          "attack",
    AlreadyGrantedThisTurn: false,
    EventBus:               bus,
})
```

Fixes #579