### PR TITLE
fix(items): mock GetType returns core.EntityType (unblocks main CI)

### DIFF
--- a/docs/architecture/components/core.md
+++ b/docs/architecture/components/core.md
@@ -1,7 +1,7 @@
 ---
 name: core module
 description: Fundamental interfaces and types that every other module depends on
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: high — verified by reading all files in core/
 ---
 

--- a/docs/architecture/components/core.md
+++ b/docs/architecture/components/core.md
@@ -46,7 +46,7 @@ type Entity interface {
 }
 ```
 
-`EntityType` is a distinct named type (`core.EntityType`), not a raw `string`. This distinction is load-bearing: the `items/validation` test compile failure (`items/validation/basic_validator_test.go:27`) is caused by a mock that returns `string` where `EntityType` is required.
+`EntityType` is a distinct named type (`core.EntityType`), not a raw `string`. This distinction is load-bearing: any mock or test double that returns `string` from `GetType()` will fail to satisfy `core.Entity` (a previous mock in `items/validation/basic_validator_test.go` had this drift; resolved per issue #612).
 
 ### Ref
 ```go

--- a/docs/architecture/components/items.md
+++ b/docs/architecture/components/items.md
@@ -1,7 +1,7 @@
 ---
 name: items module
-description: Item interface definitions — infrastructure only, no implementations, tests broken
-updated: 2026-05-02
+description: Item interface definitions — infrastructure only, no implementations
+updated: 2026-05-04
 confidence: high — verified by reading item.go, go.mod, and items/validation/basic_validator_test.go
 ---
 
@@ -9,9 +9,9 @@ confidence: high — verified by reading item.go, go.mod, and items/validation/b
 
 **Path:** `items/`
 **Module:** `github.com/KirkDiggler/rpg-toolkit/items`
-**Grade:** D
+**Grade:** C
 
-Interface definitions for game items. No implementing structs in the base module — those live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`, etc. The base module is intentionally thin, but its test layer is broken and its go.mod carries a replace directive.
+Interface definitions for game items. No implementing structs in the base module — those live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`, etc. The base module is intentionally thin. Its tests now compile (issue #612 resolved); the go.mod still carries a `replace` directive (issue #613).
 
 ## Files
 
@@ -21,37 +21,9 @@ Interface definitions for game items. No implementing structs in the base module
 | `doc.go` | Package documentation |
 | `validation/` | `BasicValidator`, `Validator` interface |
 | `validation/basic_validator.go` | Validates item fields |
-| `validation/basic_validator_test.go` | **Does not compile** |
+| `validation/basic_validator_test.go` | Tests for `BasicValidator` |
 | `validation/edge_cases_test.go` | Tests for edge cases |
 | `validation/validator.go` | `Validator` interface |
-
-## The compile failure (issue #612)
-
-`items/validation/basic_validator_test.go:27`:
-```go
-func (m *mockItem) GetType() string { return m.itemType }
-```
-
-`core.Entity.GetType()` returns `core.EntityType` (a named type, `core/entity.go:8`):
-```go
-type EntityType string
-type Entity interface {
-    GetID() string
-    GetType() EntityType  // NOT string
-}
-```
-
-`mockItem` embeds `mockItem` which implements `Item` which embeds `core.Entity`. The mock's `GetType()` returns `string`, not `core.EntityType`. Go's type system treats these as distinct — the mock does not satisfy the interface.
-
-Running `go test ./...` from the `items/` directory exits with:
-```
-./validation/basic_validator_test.go:27:6: cannot use type mockItem as type core.Entity in assignment:
-	mockItem does not implement core.Entity (wrong type for GetType method)
-```
-
-Production code (`item.go`) builds correctly — the issue is only in the test mock.
-
-**Fix:** Change `GetType() string` to `GetType() core.EntityType` in the mock. Also update `itemType string` field to `core.EntityType`. Estimated: 15–30 minutes of work.
 
 ## go.mod violation (issue #613)
 
@@ -59,7 +31,7 @@ Production code (`item.go`) builds correctly — the issue is only in the test m
 replace github.com/KirkDiggler/rpg-toolkit/core => ../core
 ```
 
-One committed replace directive. Combined with the broken tests, this module cannot pass CI in its current state.
+One committed replace directive remaining. The mocks now satisfy `core.Entity`, so `go test ./...` builds and runs from the items directory.
 
 ## What items provides
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-toolkit data model
 description: Entity types, serialization structures, the chain/breakdown pattern, and known type-system gaps
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: high — verified by reading core/entity.go, rulebooks/dnd5e/character/, tools/spatial/data.go, tools/environments/environment_data.go
 ---
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -22,7 +22,7 @@ type Entity interface {
 }
 ```
 
-`EntityType` is a distinct named type (not `string`). This is the source of the compile failure in `items/validation/basic_validator_test.go:27` where the mock returns `string` instead of `EntityType`.
+`EntityType` is a distinct named type (not `string`). Mocks and test doubles must declare `GetType() core.EntityType`; returning raw `string` does not satisfy `core.Entity`. (A previous mock-drift bug at `items/validation/basic_validator_test.go:27` was resolved per issue #612.)
 
 Domain packages define `EntityType` constants:
 - `core` defines `EntityTypeCharacter`, `EntityTypeItem`, etc.
@@ -223,7 +223,7 @@ Combat
 ## Known data model gaps
 
 ### `items` module: no implementation types
-`items/item.go` defines `Item`, `EquippableItem`, `WeaponItem`, `ArmorItem`, `ConsumableItem` as interfaces. There are no implementing structs in the base `items` module — implementations live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`, etc. This is intentional (the base module is infrastructure), but the `items` module's test layer is broken because the mock uses `GetType() string` where `core.Entity.GetType()` returns `core.EntityType`. See `items/validation/basic_validator_test.go:27`.
+`items/item.go` defines `Item`, `EquippableItem`, `WeaponItem`, `ArmorItem`, `ConsumableItem` as interfaces. There are no implementing structs in the base `items` module — implementations live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`, etc. This is intentional (the base module is infrastructure).
 
 ### `game` module: version spread
 `game` is pinned at `v0.1.0` across all consumers but carries no replace directive. However the module's dependency on `events v0.1.1` means it receives older event types than the spatial or dnd5e modules. This has not caused a runtime issue but creates a version spread that makes it hard to know "which events interface does game.Context use." Watch for this when upgrading events past v0.6.x.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -113,10 +113,6 @@ Toolkit's job ends when it returns a `Breakdown` struct. The breakdown contains 
 
 Tracked in issue #613. These work locally but break CI because published module resolution fails when directives are present.
 
-### Rule: Tests must compile
-**Violated by `items/validation/basic_validator_test.go`:**
-The mock at `items/validation/basic_validator_test.go:27` implements `GetType() string`, but `core.Entity.GetType()` returns `core.EntityType` (a distinct named type defined in `core/entity.go:8`). The test does not compile. `go test ./...` from the `items/` directory exits with a build failure. Production code builds correctly. No open PR as of 2026-05-02. Tracked in issue #612.
-
 ### Rule: Higher layers only; Tools is not Rulebooks
 **Potential violation: `rulebooks/dnd5e/dungeon/` inside the rulebook:**
 The `dungeon/` package (`dungeon.go`, `dungeon_data.go`, `types.go`) provides procedural dungeon generation that architecturally belongs at the Tools layer (so rpg-api can use dungeon logic without importing the full dnd5e rulebook). It uses `tools/environments` and `tools/spatial` (both lower layers — that direction is correct), but its location makes `rulebooks/dnd5e` the only consumer path. The planned move is to `tools/dungeon/` or a new top-level module. No issue or branch exists yet.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-toolkit architecture overview
 description: Layer rules, module map, persistence pattern, and boundary with rpg-api
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: high — verified by full code read-through of go.mod files, key source files, and test suites
 ---
 

--- a/docs/how-to/run-tests.md
+++ b/docs/how-to/run-tests.md
@@ -39,14 +39,6 @@ cd /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e && go test -race ./...
 ### Modules with known issues
 
 ```bash
-# items — DO NOT run without expecting build failure
-cd /home/kirk/personal/rpg-toolkit/items && go test ./...
-# Result: build failure in items/validation/basic_validator_test.go:27
-# GetType() string does not satisfy core.Entity.GetType() EntityType
-# Tracked: issue #612
-```
-
-```bash
 # mechanics/conditions — runs but emits go.mod warning
 cd /home/kirk/personal/rpg-toolkit/mechanics/conditions && go test ./...
 # Emits: go: updates to go.mod needed (before printing test results)
@@ -106,5 +98,4 @@ If the command changes `go.mod` or `go.sum`, commit those changes. CI runs `go m
 
 - `make pre-commit` passes today for core + events.
 - `mechanics/conditions`, `mechanics/spells` tests pass locally but CI fails because `go mod tidy` would change their go.mod (replace directives present, issue #613).
-- `items` module: `go test ./...` build failure (issue #612).
-- Running `make test-all` will fail at `items/` — this is expected and tracked.
+- `items` module tests now compile and pass (resolved per issue #612).

--- a/docs/how-to/run-tests.md
+++ b/docs/how-to/run-tests.md
@@ -1,7 +1,7 @@
 ---
 name: how to run tests
 description: Per-module test commands, known failures, pre-commit targets
-updated: 2026-05-02
+updated: 2026-05-04
 ---
 
 # How to run tests

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-toolkit quality scorecard
 description: Per-module grade with rationale — graded from code read, test run, and go.mod inspection 2026-05-02
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: medium — first-pass grades from read-through and live test run; no coverage tooling run; should be reviewed by Kirk
 ---
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -217,16 +217,13 @@ conditions.
 
 ## Items
 
-### items — D
+### items — C
 
-The base `items` module has **no test files** (only `validation/`). The
-`validation/basic_validator_test.go` **does not compile** — mock types implement
-`GetType() string` but the current `core.Entity` interface requires
-`GetType() EntityType`. The module's go.mod pins `core v0.1.0` and uses a local
-replace directive. This means `go test ./...` from the items directory prints a
-build failure. No open PR to fix it. This is the only module in the repo where
-tests are actively broken. Production code builds correctly; only the test layer
-is broken.
+The base `items` module has **no test files** (only `validation/`).
+`validation/basic_validator_test.go` now compiles (issue #612 resolved — mock
+types updated to return `core.EntityType` instead of `string`). Held back from
+B by the committed `replace` directive in `items/go.mod` (issue #613) and the
+absence of any tests at the base-module level.
 
 ---
 
@@ -245,8 +242,7 @@ is broken.
 | B+ | game, events, mechanics/resources, tools/spatial, tools/selectables, rulebooks/dnd5e |
 | B | mechanics/effects, mechanics/conditions, tools/environments, tools/spawn |
 | B- | mechanics/proficiency, mechanics/spells |
-| C | mechanics/features |
-| D | items |
+| C | mechanics/features, items |
 
 ## How to use this doc
 
@@ -254,7 +250,7 @@ Grades are a starting point from 2026-05-02 read-through. When a grade changes,
 record the reason. Don't just move the letter.
 
 Suggested signals to watch:
-- `go test ./...` in each module — catches the items build failure
+- `go test ./...` in each module — catches mock-vs-interface drift like #612
 - `go mod tidy` diff — catches the replace directive / go.sum drift
 - New sub-packages with no test files — check grants.go in backgrounds/races
 - Pathfinder coverage — add square-grid intra-room test before multi-room dungeon

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; needs Kirk's correction pass on any items that have already moved
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -53,14 +53,6 @@ They are not merged and likely not resumable as-is. See "Paused / on hold" below
 
 ### Module hygiene — active build failures
 
-- **`items/validation` tests do not compile.** The mock in
-  `items/validation/basic_validator_test.go` implements `GetType() string` but
-  `core.Entity` requires `GetType() EntityType`. The `items` module pins
-  `core v0.1.0` and has a local `replace` directive pointing to `../../core`.
-  The current `core` at that path defines `EntityType`, so the mocks in the test
-  are simply stale. This is a broken test, not broken production code, but it
-  means `go test ./...` from the items module fails at compile. No open PR.
-
 - **`mechanics/conditions/go.mod` and `mechanics/spells/go.mod` need `go mod tidy`.**
   Both have local `replace` directives and pinned versions that have drifted.
   Running tests works today but CI will flag a diff in go.mod. Confirmed: running
@@ -146,7 +138,7 @@ See quality.md for grade and rationale.
 | rulebooks/dnd5e (core) | High — character, combat, conditions, features all tested |
 | rulebooks/dnd5e/integration | High — Barbarian, Fighter, Monk, Rogue encounter tests all pass |
 | rulebooks/dnd5e/dungeon | Medium — tests present; planned to move out of rulebook |
-| items | Low — base module has no tests; validation tests do not compile |
+| items | Low — base module has no tests; validation tests pass after issue #612 fix |
 | rpgerr | High — scenario tests and accumulation tests cover the patterns |
 | game | Medium-high — context pattern tested |
 | behavior | Low — empty implementation, ADR only |
@@ -163,11 +155,6 @@ will:
 - Require updating all callers in rpg-api.
 
 No issue or branch exists yet. Treat this as pre-planned but unscheduled.
-
-### Items module repair
-
-`items/validation` tests need mock types updated to use `core.EntityType`. Likely
-a 30-minute fix but needs an issue.
 
 ### go.mod replace directive cleanup
 

--- a/items/validation/basic_validator_test.go
+++ b/items/validation/basic_validator_test.go
@@ -15,7 +15,7 @@ import (
 // mockItem implements items.Item
 type mockItem struct {
 	id         string
-	itemType   string
+	itemType   core.EntityType
 	weight     float64
 	value      int
 	properties []string
@@ -23,13 +23,13 @@ type mockItem struct {
 	maxStack   int
 }
 
-func (m *mockItem) GetID() string           { return m.id }
-func (m *mockItem) GetType() string         { return m.itemType }
-func (m *mockItem) GetWeight() float64      { return m.weight }
-func (m *mockItem) GetValue() int           { return m.value }
-func (m *mockItem) GetProperties() []string { return m.properties }
-func (m *mockItem) IsStackable() bool       { return m.stackable }
-func (m *mockItem) GetMaxStack() int        { return m.maxStack }
+func (m *mockItem) GetID() string            { return m.id }
+func (m *mockItem) GetType() core.EntityType { return m.itemType }
+func (m *mockItem) GetWeight() float64       { return m.weight }
+func (m *mockItem) GetValue() int            { return m.value }
+func (m *mockItem) GetProperties() []string  { return m.properties }
+func (m *mockItem) IsStackable() bool        { return m.stackable }
+func (m *mockItem) GetMaxStack() int         { return m.maxStack }
 
 // mockEquippableItem implements items.EquippableItem
 type mockEquippableItem struct {


### PR DESCRIPTION
## Summary

- `items/validation/basic_validator_test.go` mock implemented `GetType() string`; `core.Entity` requires `GetType() core.EntityType`. Tests stopped compiling when the core interface tightened.
- Main CI has been failing on every push since the docs PR #611 merged — verified on the latest run for commit `bd994ec`.
- Updated the mock's `itemType` field and `GetType()` return type. String literals in test fixtures auto-convert. `gofmt` re-aligned struct column widths.

Closes #612. Wave 1 P1 of [Chapter 1: Architecture Honesty](https://github.com/users/KirkDiggler/projects/11).

## Doc updates in the same PR

7 docs previously framed this as a current break; updated to reflect the fix:
- `docs/status.md` — removed rough-edge entry; updated per-subsystem table; removed dedicated repair entry from upcoming-work
- `docs/architecture/overview.md` — \"Tests must compile\" violation entry cleared
- `docs/architecture/components/core.md` — phrasing updated to past tense
- `docs/architecture/components/items.md` — grade D → C; full rewrite of the compile-failure section as historical note; #613 (replace directive) still flagged
- `docs/architecture/data-model.md` — phrasing updated
- `docs/how-to/run-tests.md` — \"items module: build failure\" line replaced with pass note
- `docs/quality.md` — items grade D → C; grade distribution table updated; suggested-signals line generalized

## Test plan

- [x] `go test -race ./...` from `items/` passes locally
- [x] `gofmt`, `go mod tidy` clean
- [x] No other test files in `items/` had the same drift (grep confirmed)
- [ ] CI on this PR is green
- [ ] Main CI returns to green after merge

## Pre-existing lint findings (NOT in scope)

`golangci-lint run ./...` flags 23 `goconst` issues in `items/validation/edge_cases_test.go` (string literals \"heavy_armor\", \"martial_weapons\" repeated). These pre-date this PR and are not introduced by the fix. Worth a follow-up issue if not already tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)