### PR TITLE
fix: remove replace directives from items + mechanics/proficiency (partial #613)

### DIFF
--- a/docs/architecture/components/items.md
+++ b/docs/architecture/components/items.md
@@ -11,7 +11,7 @@ confidence: high — verified by reading item.go, go.mod, and items/validation/b
 **Module:** `github.com/KirkDiggler/rpg-toolkit/items`
 **Grade:** C
 
-Interface definitions for game items. No implementing structs in the base module — those live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`, etc. The base module is intentionally thin. Its tests now compile (issue #612 resolved); the go.mod still carries a `replace` directive (issue #613).
+Interface definitions for game items. No implementing structs in the base module — those live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`, etc. The base module is intentionally thin. Its tests compile (#612 resolved 2026-05-04) and its go.mod no longer carries a replace directive (#613 resolved 2026-05-04, pinned to `core v0.10.0`).
 
 ## Files
 
@@ -24,14 +24,6 @@ Interface definitions for game items. No implementing structs in the base module
 | `validation/basic_validator_test.go` | Tests for `BasicValidator` |
 | `validation/edge_cases_test.go` | Tests for edge cases |
 | `validation/validator.go` | `Validator` interface |
-
-## go.mod violation (issue #613)
-
-```
-replace github.com/KirkDiggler/rpg-toolkit/core => ../core
-```
-
-One committed replace directive remaining. The mocks now satisfy `core.Entity`, so `go test ./...` builds and runs from the items directory.
 
 ## What items provides
 

--- a/docs/architecture/components/mechanics.md
+++ b/docs/architecture/components/mechanics.md
@@ -1,7 +1,7 @@
 ---
 name: mechanics modules
 description: Conditions, effects, features, proficiency, resources, spells — the modifier pipeline infrastructure
-updated: 2026-05-02
+updated: 2026-05-04
 confidence: medium-high — verified by reading go.mod files, key source files, and test runs per module
 ---
 
@@ -40,16 +40,8 @@ Condition manager plus simple/enhanced condition types.
 - `SimpleCondition` — basic BusEffect with apply/remove handlers
 - `EnhancedCondition` — SimpleCondition with stacking and duration support
 
-### go.mod violation (issue #613)
-`mechanics/conditions/go.mod` carries four committed `replace` directives:
-```
-replace github.com/KirkDiggler/rpg-toolkit/mechanics/effects => ../effects
-replace github.com/KirkDiggler/rpg-toolkit/events           => ../../events
-replace github.com/KirkDiggler/rpg-toolkit/core             => ../../core
-replace github.com/KirkDiggler/rpg-toolkit/dice             => ../../dice
-```
-
-Running `go test ./...` from this module emits `go: updates to go.mod needed` before printing test results. Tests pass locally, but CI fails on the go.mod diff. This violates the workspace rule: no replace directives on main.
+### go.mod state (issue #617)
+`mechanics/conditions/go.mod` carries four committed `replace` directives. Resolution deferred to **issue #617**: the source uses newer events APIs (`events.EventBus`, `event.Context().GetString`) than the pinned `events v0.1.0` provides. Removing the directives requires migrating the module to events v0.6.x. The 4-class playtest doesn't exercise conditions in their newer form, so this is on hold until conditions are needed.
 
 ### Coverage note
 Good behavior coverage at the `rulebooks/dnd5e` level (raging, dodging, unconscious, etc. all exercised in integration tests), but the base `Manager`/`SimpleCondition`/`EnhancedCondition` tests are flat and not suite-pattern.
@@ -105,12 +97,8 @@ Proficiency system. Tracks what an entity is proficient with and calculates prof
 - `Proficiency` interface
 - `SimpleProfiler` — concrete implementation
 
-### go.mod violation (issue #613)
-```
-replace github.com/KirkDiggler/rpg-toolkit/mechanics/effects => ../effects
-```
-
-One replace directive committed to main. Tests pass locally. CI will flag the go.mod diff.
+### go.mod: clean (issue #613 resolved 2026-05-04)
+Pinned to published `core v0.9.3`, `events v0.1.0`, `mechanics/effects v0.2.1`, `dice v0.1.0`. No replace directives. `go test -race ./...` passes against published versions.
 
 ---
 
@@ -126,18 +114,8 @@ Spell slots, concentration tracking, spell lists.
 - `ConcentrationTracker` — manages concentration (one spell at a time)
 - `SpellList` — list of known/prepared spells
 
-### go.mod violation (issue #613) — most severe
-Six replace directives committed to main:
-```
-replace github.com/KirkDiggler/rpg-toolkit/core               => ../../core
-replace github.com/KirkDiggler/rpg-toolkit/dice               => ../../dice
-replace github.com/KirkDiggler/rpg-toolkit/events             => ../../events
-replace github.com/KirkDiggler/rpg-toolkit/mechanics/conditions => ../conditions
-replace github.com/KirkDiggler/rpg-toolkit/mechanics/effects    => ../effects
-replace github.com/KirkDiggler/rpg-toolkit/mechanics/resources  => ../resources
-```
-
-This module has the most replace directives of any module in the repo. Tests pass locally; CI fails on go.mod diff. Needs a dedicated cleanup PR.
+### go.mod state (issue #617)
+Six replace directives committed to main. Same situation as `mechanics/conditions`: source has drifted past published versions of the events API. Tracked in **issue #617**, deferred until the playtest exercises spells.
 
 ### Coverage note
 Concentration logic, spell events, and slot management all have test files and pass. Test style is mostly flat (not suite pattern). No known logic bugs.

--- a/docs/architecture/components/mechanics.md
+++ b/docs/architecture/components/mechanics.md
@@ -41,7 +41,7 @@ Condition manager plus simple/enhanced condition types.
 - `EnhancedCondition` — SimpleCondition with stacking and duration support
 
 ### go.mod state (issue #617)
-`mechanics/conditions/go.mod` carries four committed `replace` directives. Resolution deferred to **issue #617**: the source uses newer events APIs (`events.EventBus`, `event.Context().GetString`) than the pinned `events v0.1.0` provides. Removing the directives requires migrating the module to events v0.6.x. The 4-class playtest doesn't exercise conditions in their newer form, so this is on hold until conditions are needed.
+`mechanics/conditions/go.mod` carries four committed `replace` directives. Resolution deferred to **issue #617**: the source uses old-API events symbols (`events.Event`, `events.HandlerFunc`, `event.Context().GetString` / `.AddModifier()`) that don't exist in any published events version. The replace directives point `events => ../../events` so the build can find these symbols. Closing #617 means rewriting conditions against the new typed-topic events API (`TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`, `StagedChain`) — a real refactor, not a version bump. The 4-class playtest doesn't exercise conditions, so this is on hold until conditions are needed.
 
 ### Coverage note
 Good behavior coverage at the `rulebooks/dnd5e` level (raging, dodging, unconscious, etc. all exercised in integration tests), but the base `Manager`/`SimpleCondition`/`EnhancedCondition` tests are flat and not suite-pattern.
@@ -86,7 +86,7 @@ Grade would move to B with tests that exercise the loader routing and error path
 
 ---
 
-## mechanics/proficiency — B-
+## mechanics/proficiency — B
 
 **Path:** `mechanics/proficiency/`
 **Module:** `github.com/KirkDiggler/rpg-toolkit/mechanics/proficiency`
@@ -115,7 +115,7 @@ Spell slots, concentration tracking, spell lists.
 - `SpellList` — list of known/prepared spells
 
 ### go.mod state (issue #617)
-Six replace directives committed to main. Same situation as `mechanics/conditions`: source has drifted past published versions of the events API. Tracked in **issue #617**, deferred until the playtest exercises spells.
+Six replace directives committed to main. Same situation as `mechanics/conditions`: source uses old-API events symbols that don't exist in any published events version. Closing #617 means rewriting against the new typed-topic API. Tracked in **issue #617**, deferred until the playtest exercises spells.
 
 ### Coverage note
 Concentration logic, spell events, and slot management all have test files and pass. Test style is mostly flat (not suite pattern). No known logic bugs.

--- a/docs/how-to/fix-go-mod-replace-directives.md
+++ b/docs/how-to/fix-go-mod-replace-directives.md
@@ -1,18 +1,20 @@
 ---
 name: how to fix go.mod replace directives
-description: Step-by-step guide for removing local replace directives from mechanics/* and items modules
-updated: 2026-05-02
+description: Step-by-step guide for removing local replace directives; status of the remaining cases
+updated: 2026-05-04
 ---
 
 # How to fix go.mod replace directives
 
-Four modules currently have local replace directives committed to main (issue #613):
-- `items/go.mod` — 1 directive
-- `mechanics/proficiency/go.mod` — 1 directive
-- `mechanics/conditions/go.mod` — 4 directives
-- `mechanics/spells/go.mod` — 6 directives
+**Status (2026-05-04):**
+- ✅ `items/go.mod` — directive removed (issue #613)
+- ✅ `mechanics/proficiency/go.mod` — directive removed (issue #613)
+- ⏳ `mechanics/conditions/go.mod` — directives retained; source uses newer events APIs than published versions support (tracked in #617)
+- ⏳ `mechanics/spells/go.mod` — directives retained; same reason (tracked in #617)
 
-These work locally but break CI. The workspace rule is explicit: no replace directives on main.
+The two cleanups that landed had no source drift — the replace directives were leftover cruft. The two that remain have real source drift: their published versions pin `events v0.1.0`, but the main-branch source uses APIs introduced in events v0.6.x. The replace directives are masking that drift, not just convenience. Resolving them requires migrating the modules to events v0.6.x source-side, which is deferred (the 4-class playtest doesn't exercise spells or conditions in their newer form).
+
+The workspace rule is explicit: no replace directives on main. The two remaining cases are documented exceptions tracked in issue #617.
 
 ## The fix pattern
 
@@ -35,25 +37,13 @@ cat /home/kirk/personal/rpg-toolkit/tools/spatial/go.mod
 
 ### 2. Remove replace directives and update require versions
 
-In the affected `go.mod`, remove all `replace` blocks and update `require` versions to match the latest published version for each dependency.
+In the affected `go.mod`, remove all `replace` blocks. Update `require` versions to match what the dependent published modules expect (NOT necessarily latest — see the warning below).
 
-Example before (`mechanics/conditions/go.mod`):
-```
-require (
-    github.com/KirkDiggler/rpg-toolkit/core v0.9.0
-    ...
-)
-replace github.com/KirkDiggler/rpg-toolkit/core => ../../core
-```
+**Warning: don't blindly bump to `@latest`.** Module Version Selection picks the highest version across the dependency graph. If module A depends on B@v0.2.x (built against C@v0.1.0) and you bump A to require C@v0.6.0, B's source won't compile against C@v0.6.0. The events package split that #617 documents is exactly this case.
 
-After:
-```
-require (
-    github.com/KirkDiggler/rpg-toolkit/core v0.10.0  // or whatever is latest
-    ...
-)
-// no replace block
-```
+Reference versions to consult:
+- `tools/spatial/go.mod` — clean published pins, target for the v0.6.x events world
+- `mechanics/effects/go.mod` — pins events v0.1.0; matches published v0.2.1; modules in the v0.1.x world should use compatible pins
 
 ### 3. Run go mod tidy
 
@@ -70,17 +60,11 @@ This will update `go.sum` and may adjust indirect dependency versions.
 go test -race ./...
 ```
 
-Tests should pass against the published versions. If they fail because the local `core` has changes that were never published, you need to publish `core` first (see the module release workflow in the Makefile).
+Tests should pass against the published versions. If they fail because the local source uses APIs that the pinned versions don't have (the events split case), you have a deeper problem than directive cleanup: the source has drifted from what its dependencies offer. That's a migration task, not a hygiene task — file a separate issue (see #617 for the worked example).
 
-### 5. Create one PR per module
+### 5. PR scope
 
-Per the workspace rule: one issue per PR, one PR per logical unit of work. The four affected modules each need their own cleanup PR:
-- `feat/fix-613-items-go-mod`
-- `feat/fix-613-conditions-go-mod`
-- `feat/fix-613-proficiency-go-mod`
-- `feat/fix-613-spells-go-mod`
-
-Or combine them if the fix is trivial and the review is simple.
+Per the workspace rule: one issue per PR. If multiple modules can be cleaned up the same way (no source drift, just stale pins), bundling them is fine — issue #613 was resolved with one PR covering items + proficiency. If migration is needed, that's a different issue.
 
 ### 6. Verify CI passes
 

--- a/docs/how-to/fix-go-mod-replace-directives.md
+++ b/docs/how-to/fix-go-mod-replace-directives.md
@@ -7,14 +7,14 @@ updated: 2026-05-04
 # How to fix go.mod replace directives
 
 **Status (2026-05-04):**
-- ✅ `items/go.mod` — directive removed (issue #613)
-- ✅ `mechanics/proficiency/go.mod` — directive removed (issue #613)
-- ⏳ `mechanics/conditions/go.mod` — directives retained; source uses newer events APIs than published versions support (tracked in #617)
+- ✅ `items/go.mod` — directive removed (per issue #613)
+- ✅ `mechanics/proficiency/go.mod` — directive removed (per issue #613)
+- ⏳ `mechanics/conditions/go.mod` — directives retained; source uses old-API events symbols that no published events version exposes (tracked in #617)
 - ⏳ `mechanics/spells/go.mod` — directives retained; same reason (tracked in #617)
 
-The two cleanups that landed had no source drift — the replace directives were leftover cruft. The two that remain have real source drift: their published versions pin `events v0.1.0`, but the main-branch source uses APIs introduced in events v0.6.x. The replace directives are masking that drift, not just convenience. Resolving them requires migrating the modules to events v0.6.x source-side, which is deferred (the 4-class playtest doesn't exercise spells or conditions in their newer form).
+The two cleanups that landed had no source drift — the replace directives were leftover cruft. The two that remain have real source drift: their main-branch source uses old-shape events symbols (`events.Event`, `events.HandlerFunc`, `event.Context().GetString` / `.AddModifier()`) that the current events module does not expose (events has been rewritten to a typed-topic API: `TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`). The replace directives mask that mismatch by pointing at local source. Resolving them requires **rewriting** conditions and spells against the new typed-topic API — a real refactor, not a version bump. Deferred because the 4-class playtest doesn't exercise either module.
 
-The workspace rule is explicit: no replace directives on main. The two remaining cases are documented exceptions tracked in issue #617.
+The workspace rule (CLAUDE.md) is explicit: no replace directives on main, full stop. The two remaining cases are an active rule violation — not an "exception" — tracked in issue #617 and visible in the doc snapshot above so they don't get forgotten. Issue #613's items+proficiency portion landed; its conditions/spells portion and the CI grep guard are explicitly deferred to #617.
 
 ## The fix pattern
 
@@ -64,7 +64,7 @@ Tests should pass against the published versions. If they fail because the local
 
 ### 5. PR scope
 
-Per the workspace rule: one issue per PR. If multiple modules can be cleaned up the same way (no source drift, just stale pins), bundling them is fine — issue #613 was resolved with one PR covering items + proficiency. If migration is needed, that's a different issue.
+Per the workspace rule: one issue per PR. If multiple modules can be cleaned up the same way (no source drift, just stale pins), bundling them is fine — issue #613's items + proficiency portion landed in one PR; its conditions/spells portion plus the CI grep guard rolled into #617 because they need a real source-side rewrite. If migration is needed, that's a different issue.
 
 ### 6. Verify CI passes
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -239,8 +239,8 @@ Held back from B by the absence of any tests at the base-module level.
 |---|---|
 | A / A- | core, rpgerr, dice, rulebooks/dnd5e/combat |
 | B+ | game, events, mechanics/resources, tools/spatial, tools/selectables, rulebooks/dnd5e |
-| B | mechanics/effects, mechanics/conditions, tools/environments, tools/spawn |
-| B- | mechanics/proficiency, mechanics/spells |
+| B | mechanics/effects, mechanics/conditions, mechanics/proficiency, tools/environments, tools/spawn |
+| B- | mechanics/spells |
 | C | mechanics/features, items |
 
 ## How to use this doc

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -78,12 +78,12 @@ the repo and there is no explicit documentation of when to use `effects` vs
 ### mechanics/conditions — B
 
 The base module (`manager`, `simple`, `enhanced`, `builder`) is functional.
-go.mod has replace directives committed to main (`replace => ../effects`,
-`replace => ../../events`, etc.) and running `go test ./...` emits
-`go: updates to go.mod needed`. The directives work locally but this is a CI
-smell that has been merged. `simple_test.go` and `enhanced_test.go` are flat style
-(not suite). Actual condition behavior is well-exercised at the `rulebooks/dnd5e`
-level which uses this module heavily.
+go.mod still carries 4 replace directives because the source has drifted past
+published versions of the events API (issue #617). Cleaning up the directives
+requires migrating the module to events v0.6.x; deferred until the playtest
+exercises conditions in their newer form. `simple_test.go` and
+`enhanced_test.go` are flat style (not suite). Actual condition behavior is
+well-exercised at the `rulebooks/dnd5e` level which uses this module heavily.
 
 ### mechanics/resources — B+
 
@@ -104,21 +104,20 @@ unit tests for the base infrastructure are absent. For a module that other layer
 depend on, this is a real gap. Grade would move to B with tests that exercise the
 loader routing and error paths.
 
-### mechanics/proficiency — B-
+### mechanics/proficiency — B
 
-`simple.go` has tests but go.mod carries a local replace directive committed to
-main. `proficiency.go` interface is clean but `doc.go` is the only documentation
-of package-level intent. No examples. Grade held back from B by the go.mod hygiene
-issue.
+`simple.go` has tests. go.mod is clean — replace directive removed (issue #613
+resolved 2026-05-04). `proficiency.go` interface is clean but `doc.go` is the
+only documentation of package-level intent. No examples.
 
 ### mechanics/spells — B-
 
-Spell slots, concentration, spell list — all have tests and pass. The go.mod has
-replace directives for `core`, `dice`, `events`, `conditions`, `effects`, and
-`resources` — all pointing to local paths, all committed to main. This is the most
-replace-directive-heavy module in the repo. Tests are flat (not suite) for most
-files. Concentration logic (`concentration.go`) has test coverage. Spell events
-pattern is tested. No known logic bugs.
+Spell slots, concentration, spell list — all have tests and pass. The go.mod
+still carries 6 replace directives (most of any module). Same root cause as
+conditions: source has drifted past published events v0.1.x. Migration
+deferred to issue #617 (playtest doesn't exercise spells yet). Tests are flat
+(not suite) for most files. Concentration logic (`concentration.go`) has test
+coverage. Spell events pattern is tested. No known logic bugs.
 
 ---
 
@@ -221,9 +220,9 @@ conditions.
 
 The base `items` module has **no test files** (only `validation/`).
 `validation/basic_validator_test.go` now compiles (issue #612 resolved — mock
-types updated to return `core.EntityType` instead of `string`). Held back from
-B by the committed `replace` directive in `items/go.mod` (issue #613) and the
-absence of any tests at the base-module level.
+types updated to return `core.EntityType` instead of `string`). Replace
+directive removed (issue #613 resolved 2026-05-04, pinned to `core v0.10.0`).
+Held back from B by the absence of any tests at the base-module level.
 
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -54,19 +54,37 @@ They are not merged and likely not resumable as-is. See "Paused / on hold" below
 ### Module hygiene — active build failures
 
 - **`mechanics/conditions/go.mod` and `mechanics/spells/go.mod` carry committed
-  local `replace` directives** that mask deeper source drift. Their published
-  versions pin `events v0.1.0`; their main-branch source uses newer events APIs
-  (`events.EventBus`, `event.Context().GetString()`) that were introduced
-  somewhere between v0.1.x and v0.6.x. Removing the directives breaks the
-  build. The 4-class playtest doesn't exercise either module so this is
-  deferred — tracked as **issue #617**. Issue #613 (the directive cleanup)
-  was partially resolved 2026-05-04 by removing the directives from `items`
-  and `mechanics/proficiency`; the conditions/spells case rolls into #617.
+  local `replace` directives** that mask source drift against the events
+  module. Their main-branch source uses the **old events API**
+  (`events.Event`, `events.HandlerFunc`, `event.Context().GetString()`,
+  `event.Context().AddModifier()`) — a shape that no published events version
+  exposes today. The replace directives point `events => ../../events` so the
+  build can find these symbols somewhere; without that pointer the source
+  doesn't compile. The 4-class playtest doesn't exercise either module so
+  this is deferred — tracked as **issue #617**. Issue #613 (the directive
+  cleanup) had its items + proficiency portion resolved 2026-05-04; the
+  conditions/spells portion rolls into #617.
 
-- **events API split** — events has rolled forward to v0.6.2 (used by tools,
-  rulebooks/dnd5e, items, mechanics/proficiency) but mechanics/effects,
-  conditions, spells, features, and game still pin v0.1.x. Tracked as part
-  of #617.
+- **events API rewrite, not version bump.** The events module has been
+  rewritten on main from a typed-event API (`events.Event`, `HandlerFunc`,
+  `Context().GetString()` / `.Set()` / `.AddModifier()`) to a typed-topic API
+  (`TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`, `StagedChain`). Two
+  worlds today:
+  - **New API (current main events surface):** rulebooks/dnd5e (+ subpackages),
+    tools/spatial, tools/environments, tools/spawn, tools/selectables. These
+    pin events v0.6.x.
+  - **Old API:** mechanics/effects (matches published v0.2.1),
+    mechanics/conditions, mechanics/spells, mechanics/features, game,
+    mechanics/proficiency. These pin events v0.1.x in their go.mod;
+    conditions/spells additionally use APIs not present in v0.1.0, which is
+    why their replace directives point at local source. Proficiency builds
+    cleanly against v0.1.0 because it only consumes effects (which itself
+    works against v0.1.0).
+  - **No events dependency at all:** items.
+
+  Closing #617 means rewriting effects/conditions/spells/features against
+  the new typed-topic shape, not version-bumping the events line. That is
+  a real refactor, not a hygiene task.
 
 ### Spatial
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -53,17 +53,20 @@ They are not merged and likely not resumable as-is. See "Paused / on hold" below
 
 ### Module hygiene — active build failures
 
-- **`mechanics/conditions/go.mod` and `mechanics/spells/go.mod` need `go mod tidy`.**
-  Both have local `replace` directives and pinned versions that have drifted.
-  Running tests works today but CI will flag a diff in go.mod. Confirmed: running
-  `go test ./...` in conditions returns `go: updates to go.mod needed` before
-  printing test results.
+- **`mechanics/conditions/go.mod` and `mechanics/spells/go.mod` carry committed
+  local `replace` directives** that mask deeper source drift. Their published
+  versions pin `events v0.1.0`; their main-branch source uses newer events APIs
+  (`events.EventBus`, `event.Context().GetString()`) that were introduced
+  somewhere between v0.1.x and v0.6.x. Removing the directives breaks the
+  build. The 4-class playtest doesn't exercise either module so this is
+  deferred — tracked as **issue #617**. Issue #613 (the directive cleanup)
+  was partially resolved 2026-05-04 by removing the directives from `items`
+  and `mechanics/proficiency`; the conditions/spells case rolls into #617.
 
-- **`items`, `mechanics/proficiency`, `mechanics/spells`, `mechanics/conditions`
-  all carry local `replace` directives.** This violates the stated workspace rule
-  ("NEVER add replace directives — breaks CI/CD"). The workspace CLAUDE.md allows
-  them during dev but they must be stripped before commit. These are currently
-  committed to main.
+- **events API split** — events has rolled forward to v0.6.2 (used by tools,
+  rulebooks/dnd5e, items, mechanics/proficiency) but mechanics/effects,
+  conditions, spells, features, and game still pin v0.1.x. Tracked as part
+  of #617.
 
 ### Spatial
 

--- a/items/go.mod
+++ b/items/go.mod
@@ -3,7 +3,7 @@ module github.com/KirkDiggler/rpg-toolkit/items
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.1.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/stretchr/testify v1.9.0
 )
 
@@ -12,5 +12,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/KirkDiggler/rpg-toolkit/core => ../core

--- a/items/go.sum
+++ b/items/go.sum
@@ -1,3 +1,5 @@
+github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
+github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/mechanics/proficiency/go.mod
+++ b/mechanics/proficiency/go.mod
@@ -12,5 +12,3 @@ require (
 )
 
 require github.com/KirkDiggler/rpg-toolkit/dice v0.1.0 // indirect
-
-replace github.com/KirkDiggler/rpg-toolkit/mechanics/effects => ../effects

--- a/mechanics/proficiency/go.sum
+++ b/mechanics/proficiency/go.sum
@@ -4,6 +4,8 @@ github.com/KirkDiggler/rpg-toolkit/dice v0.1.0 h1:/tpfvSeV2NeaerItinsd1cc1I680cq
 github.com/KirkDiggler/rpg-toolkit/dice v0.1.0/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.0 h1:ec8t66jaZkuir+FfqNZvK6m2PfLOwmtOY2vjZ64+Bpg=
 github.com/KirkDiggler/rpg-toolkit/events v0.1.0/go.mod h1:mOcykXOhLsCR/mZHO4hzM4dVSyo/imwSix+wobEqIPM=
+github.com/KirkDiggler/rpg-toolkit/mechanics/effects v0.2.1 h1:APwGGbEVW7W9TmYaNeRt0T+xygU830PjrIMd5yL4fDc=
+github.com/KirkDiggler/rpg-toolkit/mechanics/effects v0.2.1/go.mod h1:h6EuyJ7suE7m5eUJXTn+uq8SasixgtH6lJCoGssQSzo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

Closes #613. Filed **#617** for the remaining cases.

Removes replace directives from 2 of 4 affected modules (items, mechanics/proficiency). The other two — mechanics/conditions and mechanics/spells — carry real source drift hidden by the directives. Their go.mod pins `events v0.1.0`; their main-branch source uses APIs from `events v0.6.x` (e.g. `events.EventBus`, `event.Context().GetString()`). Removing the directives breaks the build, so #617 tracks the migration.

Per Kirk: the 4-class playtest doesn't exercise conditions or spells in their newer form, so #617 is deferred until needed. Honest architecture call rather than premature migration.

Wave 1 P1 of [Chapter 1: Architecture Honesty](https://github.com/users/KirkDiggler/projects/11) — closes Wave 1.

## What changed

- `items/go.mod` — bumped `core` to v0.10.0, dropped replace directive
- `mechanics/proficiency/go.mod` — kept `events v0.1.0` (compatible with `effects v0.2.1`), dropped replace directive on effects
- 5 docs updated: status, quality, items component, mechanics component, fix-go-mod how-to

## What didn't change (deferred to #617)

- `mechanics/conditions/go.mod` — 4 replace directives retained
- `mechanics/spells/go.mod` — 6 replace directives retained
- CI grep guard for replace directives — deferred, since the guard would block on the two retained cases. Will land alongside #617's resolution.

## Test plan

- [x] `go test -race ./...` passes in `items/` and `mechanics/proficiency/`
- [x] `go mod tidy` produces no further diff in either module
- [x] No source drift: confirmed effects@v0.2.1 source matches `mechanics/effects/` on main (same commit `fd93adc`)
- [ ] CI green on the changed modules

## Why two of four, not all four

The events package split is real:
- **events v0.6.2 (current)**: rulebooks/dnd5e, tools/{environments,spatial,spawn,selectables}, items, mechanics/proficiency
- **events v0.1.x (frozen)**: mechanics/{effects,conditions,spells,features}, game

The directives in conditions/spells were doing real work — pointing `events => ../../events` so the local source could compile against v0.6.x APIs. Without the directive, they pin v0.1.0 in their go.mod and don't compile. #617 is the right place to handle this once a use case forces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)