### PR TITLE
docs(components): rewrite architecture/components/ against rpg-api usage (PR 2 of 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ and never imports rpg-api or rpg-api-protos.
 
 - `docs/architecture/overview.md` — layer rules (Core → Events → Mechanics → Tools → Rulebooks), module map, boundary with rpg-api, named violations
 - `docs/architecture/data-model.md` — ToData/LoadFromData pattern, entity shapes, chain/breakdown output
-- `docs/architecture/components/` — one doc per major module (core, events, mechanics, tools-spatial, tools-environments, tools-spawn, rulebook-dnd5e, items)
+- `docs/architecture/components/` — one doc per major module (core, events, dice, mechanics, tools-spatial, tools-environments, tools-spawn, rulebook-dnd5e, refs, items)
 - `docs/status.md` — current health: active work, paused items, known rough edges, per-subsystem confidence
 - `docs/quality.md` — A-D scorecard with rationale per module
 - `docs/adr/` — architectural decisions (32 ADRs). New decisions add new ADRs; superseded ones stay with a "Superseded by ADR-NNN" note. Never archive an ADR.

--- a/docs/architecture/components/core.md
+++ b/docs/architecture/components/core.md
@@ -1,8 +1,8 @@
 ---
 name: core module
-description: Fundamental interfaces and types that every other module depends on
+description: Fundamental interfaces and types every other module depends on — entity, ref, action, errors, plus core/combat and core/resources sub-packages
 updated: 2026-05-04
-confidence: high — verified by reading all files in core/
+confidence: high — verified by reading core/ source and rpg-api import graph (audit 049)
 ---
 
 # core module
@@ -11,32 +11,48 @@ confidence: high — verified by reading all files in core/
 **Module:** `github.com/KirkDiggler/rpg-toolkit/core`
 **Grade:** A-
 
-The foundation. Every other toolkit module imports `core`. It defines the minimum shared vocabulary for game objects, identifiers, errors, and actions.
+The foundation. Every other toolkit module imports `core`. It defines the minimum
+shared vocabulary for game objects, identifiers, errors, and actions.
 
-## Files
+## What rpg-api consumes
+
+Per the audit at `docs/journey/049-rpg-api-toolkit-usage-audit.md`, rpg-api
+imports the top-level `core` package from 8 files. The hot path is:
+
+| Symbol | Where rpg-api uses it | Histogram |
+|---|---|---|
+| `core.Ref` | converters, entity types, encounter events | 46 occurrences |
+| `core.Entity` | perception, registry plumbing | 5 |
+| `core.EntityType` | perception filters, mocks | 2 |
+
+`core.Action` does **not** appear directly in rpg-api. It's a toolkit-internal
+contract — see "Action vs ConditionBehavior" below.
+
+Two sub-packages of `core/` are also imported directly by rpg-api:
+
+- `core/combat` — 1 file, used only for proto enum mapping (`combat.ActionType` and the standard/bonus/reaction/free constants).
+- `core/resources` — 1 file (integration helper), aliased as `coreResources` to disambiguate from `rulebooks/dnd5e/resources`.
+
+Both are folded into this doc rather than split into separate component pages.
+
+## Files in core/
 
 | File | Purpose |
 |---|---|
-| `entity.go` | `Entity` interface, `EntityType` named string type |
-| `ref.go` | `Ref`, `TypedRef`, `SourcedRef`, `Source`, `SourceCategory` |
-| `action.go` | `Action` interface — activatable game actions |
+| `entity.go` | `Entity` interface, `EntityType` named string |
+| `ref.go` | `Ref`, `SourcedRef`, `Source`, `SourceCategory` |
+| `action.go` | `Action[T any]` — the activation contract (toolkit-internal) |
 | `typed_ref.go` | Generic `TypedRef[T]` for domain-typed identifiers |
 | `errors.go` | `ErrNotFound`, `ErrInvalid`, `ErrConflict`, `ErrUnauthorized` |
-| `topic.go` | `Topic` interface — the key type for event bus subscriptions |
-| `generate.go` | `//go:generate` for mocks |
-| `chain/` | `Chain`, `ChainResult` — modifier pipeline types |
-| `combat/` | Combat-domain type aliases |
+| `topic.go` | `Topic` (a `string` type used as the event-bus routing key) |
+| `chain/` | Generic `Chain[T]` interface and `Stage` type |
+| `combat/` | Type aliases for combat constants (see below) |
 | `damage/` | `DamageType` constants |
-| `effect/` | `Effect` type |
-| `features/` | `Feature` type alias |
-| `resources/` | `Resource` type alias |
-| `spells/` | Spell type aliases |
-| `events/` | Event type aliases |
+| `effect/`, `features/`, `resources/`, `spells/`, `events/` | Domain type aliases — no executable logic |
 | `mock/` | `MockEntity` — gomock implementation |
 
-## Key types
+## Entity
 
-### Entity
 ```go
 type EntityType string
 
@@ -46,35 +62,173 @@ type Entity interface {
 }
 ```
 
-`EntityType` is a distinct named type (`core.EntityType`), not a raw `string`. This distinction is load-bearing: any mock or test double that returns `string` from `GetType()` will fail to satisfy `core.Entity` (a previous mock in `items/validation/basic_validator_test.go` had this drift; resolved per issue #612).
+`EntityType` is a distinct named type (`core.EntityType`), not a raw `string`.
+This distinction is load-bearing: any mock or test double that returns `string`
+from `GetType()` will fail to satisfy `core.Entity` (a previous mock in
+`items/validation/basic_validator_test.go` had this drift; resolved per issue
+#612).
 
-### Ref
+## Ref — the boundary key
+
 ```go
 type Ref struct {
     Module string  // e.g., "dnd5e"
     Type   string  // e.g., "features"
-    Value  string  // e.g., "rage"
+    ID     string  // e.g., "rage"
 }
 ```
 
-The routing key for all toolkit content. rpg-api passes these; toolkit routes them to implementations. String form: `"dnd5e:features:rage"`.
+The routing key for all toolkit content. rpg-api passes these; the toolkit
+routes them to implementations. String form: `"dnd5e:features:rage"`.
 
-### SourcedRef
+`SourcedRef` carries provenance:
+
 ```go
 type SourcedRef struct {
-    Ref
+    Ref    *Ref
     Source *Source  // Category + Name (class, background, race, etc.)
-    Label  string   // Human-readable display name for breakdowns
 }
 ```
 
-Carries provenance through modifier chains so UI can explain "this +2 came from Barbarian Rage."
+So a UI can later explain "this +2 came from Barbarian Rage." The `Source`
+struct has a `Category` (`SourceCategory`) and `Name`.
 
-## Sub-packages (types-only, no executable logic)
+The dnd5e `refs/` package wraps these constructors into a typed namespace
+(`refs.Features.Rage()`, `refs.Conditions.Raging()`, etc.) — see
+`refs.md` and `rulebook-dnd5e.md` for that surface.
 
-`core/chain`, `core/combat`, `core/damage`, `core/effect`, `core/features`, `core/resources`, `core/spells`, `core/events` — all define type aliases or constants that callers use. None have executable methods beyond value types. None have test files. Risk is low (no logic), but type changes here will only be caught when a downstream module fails its tests.
+## Action vs ConditionBehavior — the activation surface
+
+This is the most important architectural distinction in the toolkit, and the
+audit's load-bearing correction (`docs/journey/049-rpg-api-toolkit-usage-audit.md`,
+Section 3 Claim 1).
+
+`core/action.go` defines the activation contract:
+
+```go
+type Action[T any] interface {
+    Entity                                                // GetID, GetType
+    CanActivate(ctx context.Context, owner Entity, input T) error
+    Activate(ctx context.Context, owner Entity, input T) error
+}
+```
+
+**Features implement `core.Action[T]`.** Example: `Rage` at
+`rulebooks/dnd5e/features/rage.go` declares `// CanActivate implements
+core.Action[FeatureInput]` and `// Activate implements core.Action[FeatureInput]`
+on its method receivers.
+
+**Conditions do NOT implement `core.Action`.** They implement a separate
+interface in the dnd5e events package:
+
+```go
+// rulebooks/dnd5e/events/events.go (around line 85)
+type ConditionBehavior interface {
+    IsApplied() bool
+    Apply(ctx context.Context, bus events.EventBus) error
+    Remove(ctx context.Context, bus events.EventBus) error
+    ToJSON() (json.RawMessage, error)
+}
+```
+
+`RagingCondition` at `rulebooks/dnd5e/conditions/raging.go` asserts this with
+`var _ dnd5eEvents.ConditionBehavior = (*RagingCondition)(nil)` and implements
+Apply/Remove (subscribing handlers to the bus) — never CanActivate/Activate.
+
+**Mental model:**
+
+- **`core.Action[T]`** is the *activation* half — "thing a player or DM triggers" (Rage feature, Strike, Dodge as combat ability). Lives in `core/`.
+- **`dnd5eEvents.ConditionBehavior`** is the *passive/listener* half — "thing that subscribes to the bus and modifies chains while applied" (RagingCondition, Defense fighting style, Unconscious). Lives in `rulebooks/dnd5e/events/`.
+
+A feature can both implement Action **and** apply a Condition as part of its
+Activate flow. Rage is the canonical case: `Rage.Activate` (an Action)
+constructs and applies a `RagingCondition` (a ConditionBehavior). They are
+**related but distinct interfaces** — not "the same thing under the hood."
+
+The toolkit also defines a generic `events.BusEffect` interface (in the
+top-level events package) with the same Apply/Remove/IsApplied shape. Inside
+the dnd5e rulebook, `ConditionBehavior` is the concrete cousin — it adds
+`ToJSON` for the per-condition serialization pattern documented in the
+toolkit-root CLAUDE.md.
+
+## core/combat — proto-enum mapping for action types
+
+`core/combat` is types-only; no executable logic. rpg-api's converter file uses
+it to map proto enums to/from toolkit constants:
+
+```go
+type ActionType string
+const (
+    ActionStandard ActionType = "action"
+    ActionBonus    ActionType = "bonus_action"
+    ActionReaction ActionType = "reaction"
+    ActionFree     ActionType = "free"
+    ActionMovement ActionType = "movement"
+)
+```
+
+This is exactly the boundary pattern rpg-api should use: rpg-api maps proto
+enums to typed toolkit constants, the toolkit owns what each constant means.
+The same package also defines `AttackType`, `WeaponProperty`, and `ArmorType`
+constants for similar enum-mapping purposes; rpg-api currently only consumes
+`ActionType`.
+
+## core/resources — the ResourceAccessor contract
+
+`core/resources` defines the minimal interface a feature needs to consume from
+its owner's resource pool:
+
+```go
+type ResourceAccessor interface {
+    IsResourceAvailable(key ResourceKey) bool
+    UseResource(key ResourceKey, amount int) error
+}
+
+type ResourceKey string  // e.g., "rage_uses"
+type ResetType string    // ResetShortRest, ResetLongRest, ResetDawn, ResetDusk, ResetNever, ResetManual
+```
+
+A `Character` implements `ResourceAccessor`; `Rage.CanActivate` type-asserts
+its owner to `coreResources.ResourceAccessor` and asks `IsResourceAvailable`.
+That pattern — feature owns the rule, character owns the resource pool — is
+how the toolkit keeps features decoupled from concrete character types.
+
+rpg-api imports `core/resources` from one integration-test helper
+(`internal/integration/encounter/helpers.go`) under the alias `coreResources`
+to disambiguate from `rulebooks/dnd5e/resources`. Production code reaches the
+resources surface through the dnd5e package.
+
+## Sub-packages without executable logic
+
+`core/chain`, `core/damage`, `core/effect`, `core/features`, `core/spells`,
+`core/events` — all define type aliases or constants that callers use. None
+have executable methods beyond value types. None have test files. Risk is low
+(no logic), but type changes here will only be caught when a downstream module
+fails its tests.
+
+`core/chain` is the exception in importance: it defines the generic
+`Chain[T any]` interface and the `Stage` type. The events package's
+`StagedChain[T]` implements `chain.Chain[T]`. See `events.md` for how the
+chain pattern is realized.
 
 ## Known gaps
 
 - The sub-packages (`chain/`, `combat/`, `damage/`, etc.) have no test files. Changes to these types will not be caught by CI in the `core` module itself — only when downstream consumers fail.
-- No doc on when to use `rpgerr` vs `fmt.Errorf`. The answer: use `rpgerr` when the error will be accumulated (multiple validation failures) or when RPG-domain context (entity type, ref, source) adds value for debugging. Use `fmt.Errorf` for simple wrapping.
+- No doc on when to use `rpgerr` (toolkit's error-accumulation package) vs `fmt.Errorf`. The answer: use `rpgerr` when the error will be accumulated (multiple validation failures) or when RPG-domain context (entity type, ref, source) adds value for debugging. Use `fmt.Errorf` for simple wrapping.
+
+## Verification
+
+```sh
+# Action interface and Rage's implementation
+grep -n 'type Action\[T any\] interface' /home/kirk/personal/rpg-toolkit/core/action.go
+grep -n 'core\.Action\[FeatureInput\]\|CanActivate\|Activate implements' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/features/rage.go
+
+# ConditionBehavior interface and Raging's implementation
+grep -n 'type ConditionBehavior interface' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/events/events.go
+grep -n 'ConditionBehavior\|func .* Apply\|func .* Remove' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/conditions/raging.go
+
+# rpg-api's core surface
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/core"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 8
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/core/combat"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 1
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/core/resources"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 1
+```

--- a/docs/architecture/components/dice.md
+++ b/docs/architecture/components/dice.md
@@ -1,0 +1,128 @@
+---
+name: dice module
+description: Dice rolling infrastructure — Roller interface, dice notation parser, mockable randomness for tests
+updated: 2026-05-04
+confidence: high — verified by reading dice/*.go and rpg-api's import callsites per audit 049
+---
+
+# dice module
+
+**Path:** `dice/`
+**Module:** `github.com/KirkDiggler/rpg-toolkit/dice`
+**Grade:** B+ (no scorecard yet, baseline grade)
+
+The randomness primitive. Every roll in the toolkit (attack rolls, damage,
+saves, ability checks, initiative) goes through this module. Crypto-backed by
+default; mockable in tests via the `dice/mock` sub-package.
+
+## What rpg-api consumes
+
+Per audit Section 1, rpg-api imports `dice` from 3 production files plus 3
+test files:
+
+| Symbol | Where rpg-api uses it |
+|---|---|
+| `dice.Roller` | `internal/orchestrators/dice/orchestrator.go` (field type) |
+| `dice.NewRoller` | `internal/orchestrators/dice/orchestrator.go` (constructor) |
+| `dice/mock.MockRoller`, `dice/mock.NewMockRoller` | encounter and dice tests |
+
+rpg-api consumes the toolkit's dice as a **library** (the `Roller` interface).
+The "dice service" inside rpg-api (with `Service`, `RollDiceInput`,
+`RollDiceOutput`, `GetRollSession`, etc.) is rpg-api's own service shape — it
+wraps the toolkit `Roller` and adds session persistence, but those Service
+types are defined in `internal/orchestrators/dice/types.go`, not in this
+module.
+
+The boundary: rpg-api owns dice-session persistence (Redis-backed); the
+toolkit owns randomness and notation parsing.
+
+## Module surface
+
+Verified by `grep -nE '^func [A-Z]|^type [A-Z]' dice/*.go` (excluding tests):
+
+| File | Exported |
+|---|---|
+| `roller.go` | `Roller` interface, `CryptoRoller` struct |
+| `roller_new.go` | `NewRoller()`, `NewMockableRoller(r Roller)` |
+| `pool.go` | `Pool`, `Spec`, `NewPool`, `SimplePool` |
+| `notation.go` | `ParseNotation`, `MustParseNotation` |
+| `lazy.go` | `Lazy`, `NewLazy`, `NewLazyWithRoller`, `LazyFromNotation` |
+| `modifier.go` | `Roll`, `NewRoll`, `NewRollWithRoller`, `D4`, `D6`, `D8`, `D10`, `D12`, `D20`, `D100` |
+| `result.go` | `Result` |
+| `errors.go` | dice-specific errors |
+| `mock/mock_roller.go` | `MockRoller`, `NewMockRoller`, `MockRollerMockRecorder` |
+
+## The Roller interface
+
+```go
+type Roller interface {
+    // Roll returns a random number from 1 to size (inclusive).
+    Roll(ctx context.Context, size int) (int, error)
+
+    // RollN rolls count dice of the given size.
+    RollN(ctx context.Context, count, size int) ([]int, error)
+}
+```
+
+`CryptoRoller` is the production implementation (uses `crypto/rand`).
+`NewRoller()` returns a `*CryptoRoller`. `NewMockableRoller(r Roller)` lets
+test code inject any `Roller` implementation — typically a `MockRoller` from
+the `mock/` sub-package.
+
+The `RollN` contract honors context cancellation (returns
+`dice: rolling cancelled` if ctx is done mid-rolls).
+
+## Dice notation
+
+`ParseNotation(notation string)` parses standard dice strings (`"3d6"`,
+`"1d20+5"`, `"4d6kh3"` — keep highest 3) into a `*Pool`. The Pool can be
+rolled to produce a `Result`.
+
+`MustParseNotation` panics on parse error — for compile-time-known dice
+strings only.
+
+## Lazy rolls
+
+`Lazy` defers the actual roll until `Result()` is called. Useful when a
+modifier ("Bless adds 1d4") needs a fresh roll *each time* it's applied —
+constructing a `Lazy` once and re-rolling it on each use is the toolkit's
+standard pattern for "fresh dice per use" bonuses.
+
+`LazyFromNotation(notation)` is the convenience constructor.
+
+## Mock package
+
+`dice/mock/mock_roller.go` is gomock-generated. Tests construct `MockRoller`
+via `NewMockRoller(ctrl)` and use the `*MockRollerMockRecorder` to assert
+expectations:
+
+```go
+mockRoller := mock_dice.NewMockRoller(ctrl)
+mockRoller.EXPECT().Roll(gomock.Any(), 20).Return(15, nil)
+```
+
+rpg-api uses this in encounter and dice-orchestrator tests to make attack
+rolls deterministic.
+
+## go.mod status
+
+Clean. No replace directives.
+
+## Known gaps
+
+- The lazy/pool/notation surfaces have unit tests, but their interaction with `Roller` injection is not exhaustively tested across all combinators (e.g., `Lazy` + `MockableRoller` + parser-edge-case strings).
+- No documented behavior contract for what happens when `RollN` receives `count: 0` — current implementation returns an empty slice, which is reasonable but unstated.
+
+## Verification
+
+```sh
+# Module surface (production files)
+grep -nE "^func [A-Z]|^type [A-Z]" /home/kirk/personal/rpg-toolkit/dice/*.go | grep -v _test
+
+# rpg-api's dice imports
+grep -rn '"github.com/KirkDiggler/rpg-toolkit/dice' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go"
+
+# Production file count vs mock file count
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/dice"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | grep -v _test | wc -l    # expect 3 (or close)
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/dice/mock"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l               # expect 3
+```

--- a/docs/architecture/components/events.md
+++ b/docs/architecture/components/events.md
@@ -1,8 +1,8 @@
 ---
 name: events module
-description: Type-safe pub/sub event bus — EventBus, BusEffect, TypedTopic, ChainedTopic
-updated: 2026-05-02
-confidence: high — verified by reading bus.go, bus_effect.go, typed_topic.go, chained_topic.go, chain.go
+description: Type-safe pub/sub — EventBus, BusEffect, TypedTopic, ChainedTopic, StagedChain — and the chain pattern that drives combat resolution
+updated: 2026-05-04
+confidence: high — verified by reading all events/*.go and tracing the attack-chain worked example through rulebooks/dnd5e/combat/attack.go
 ---
 
 # events module
@@ -11,71 +11,209 @@ confidence: high — verified by reading bus.go, bus_effect.go, typed_topic.go, 
 **Module:** `github.com/KirkDiggler/rpg-toolkit/events`
 **Grade:** B+
 
-The pub/sub infrastructure that connects all game mechanics. Typed topics give compile-time safety; chained topics implement the modifier pipeline (the "chain pattern").
+The pub/sub infrastructure that connects all game mechanics. Typed topics give
+compile-time safety; chained topics implement the modifier pipeline that drives
+combat resolution.
 
-## Files
+## What rpg-api consumes
 
-| File | Purpose |
+Per audit Section 1, rpg-api imports the top-level `events` package from 4
+files. The hot path is intentionally narrow:
+
+| Symbol | Where rpg-api uses it | Histogram |
+|---|---|---|
+| `events.NewEventBus` | `internal/orchestrators/encounter/monster_turns.go` and other resolution paths | 10 |
+| `events.EventBus` | helper return types (e.g. `internal/orchestrators/encounter/orchestrator.go`) | 1 |
+
+rpg-api creates a fresh bus per attack/round of resolution (not one global bus)
+and passes it into toolkit calls. **It does not subscribe handlers to the bus
+itself** — that's a toolkit responsibility. Conditions, features, and combat
+ability listeners are subscribed inside the toolkit (see "ConditionBehavior" in
+`core.md`).
+
+## Module surface
+
+Exported symbols in `events/*.go` (verified by `grep -nE '^func [A-Z]|^type [A-Z]|^var [A-Z]'`):
+
+| File | Exported |
 |---|---|
-| `bus.go` | `EventBus` interface + `NewEventBus()` |
-| `bus_effect.go` | `BusEffect` interface — subscribe/unsubscribe lifecycle |
-| `topic.go` | `Topic` interface |
-| `topic_def.go` | `TopicDef` — named topic definitions |
-| `typed_topic.go` | `TypedTopic[T]` — generic typed topic |
-| `chained_topic.go` | `ChainedTopic` — modifier chain topic |
-| `chain.go` | `Chain`, `ChainResult` types |
-| `errors.go` | Event-specific errors |
-| `CHAIN_PATTERN.md` | In-tree documentation of the chain pattern |
+| `bus.go` | `EventBus` interface, `NewEventBus()` |
+| `bus_effect.go` | `BusEffect` interface (Apply / Remove / IsApplied) |
+| `topic.go` | `Topic` (a `string` type — the routing key) |
+| `topic_def.go` | `TypedTopicDef[T]`, `ChainedTopicDef[T]`, `DefineTypedTopic[T]`, `DefineChainedTopic[T]` |
+| `typed_topic.go` | `TypedTopic[T]` interface |
+| `chained_topic.go` | `ChainedTopic[T]` interface |
+| `chain.go` | `StagedChain[T]`, `NewStagedChain[T]`, `ErrDuplicateID`, `ErrIDNotFound` |
+| `errors.go` | `ErrDuplicateRef` |
 
-## The dual-bus pattern
+`StagedChain[T]` implements `core/chain.Chain[T]` — the generic chain interface
+lives in `core/chain/types.go`.
 
-There are two distinct concepts in this module:
+## EventBus
 
-**`EventBus`** (`bus.go`) — plain notification bus. Any subscriber on a topic gets called when an event is published. Used for "something happened" notifications (entity moved, condition applied, turn ended).
+```go
+type EventBus interface {
+    Subscribe(ctx context.Context, topic Topic, handler any) (string, error)
+    Unsubscribe(ctx context.Context, id string) error
+    Publish(ctx context.Context, topic Topic, event any) error
+}
 
-**`BusEffect`** (`bus_effect.go`) — a lifecycle interface for game mechanics that need to subscribe and unsubscribe as they become active/inactive:
+func NewEventBus() EventBus { /* ... */ }
+```
+
+A plain pub/sub bus — `Subscribe` returns a subscription ID for cleanup. The
+underlying implementation (`simpleEventBus`) is in-memory and goroutine-safe.
+
+## TypedTopic — typed notification
+
+```go
+type TypedTopic[T any] interface {
+    Subscribe(ctx context.Context, handler func(context.Context, T) error) (string, error)
+    Unsubscribe(ctx context.Context, id string) error
+    Publish(ctx context.Context, event T) error
+}
+```
+
+A typed topic is a thin wrapper around `EventBus` for events of a known type
+`T`. The `.On(bus)` pattern connects a topic-definition (compile-time singleton)
+to a specific bus (runtime instance):
+
+```go
+turnEnds := dnd5eEvents.TurnEndTopic.On(bus)
+turnEnds.Subscribe(ctx, handleTurnEnd)
+turnEnds.Publish(ctx, dnd5eEvents.TurnEndEvent{ /* ... */ })
+```
+
+rpg-api uses this exact pattern at
+`/home/kirk/personal/rpg-api/internal/orchestrators/encounter/orchestrator.go`
+to publish `TurnEndEvent` after each turn (the only place rpg-api itself drives
+a typed topic).
+
+## ChainedTopic + StagedChain — the modifier pipeline
+
+This is the load-bearing combat architecture. Per audit Section 3 Claim 4, the
+chain pattern is the toolkit's answer to "Bless adds 1d4 to attacks, Rage adds
++2 to damage, Defense adds +1 to AC, all without those features knowing about
+each other."
+
+Three pieces cooperate:
+
+1. **`core/chain.Chain[T]`** — the generic chain interface. Defined in
+   `core/chain/types.go`: `Add(stage, id, modifier)`, `Remove(id)`,
+   `Execute(ctx, T)`. Stage-ordered, ID-keyed.
+
+2. **`events.StagedChain[T]`** — the concrete implementation. Built with
+   `events.NewStagedChain(stages)`. Source: `events/chain.go`.
+
+3. **`events.ChainedTopic[T]`** — the publish surface. Each subscriber receives
+   the event and the running chain, may add modifiers, returns the chain.
+   Source: `events/chained_topic.go`.
+
+```go
+type ChainedTopic[T any] interface {
+    SubscribeWithChain(ctx context.Context,
+        handler func(context.Context, T, chain.Chain[T]) (chain.Chain[T], error)) (string, error)
+    PublishWithChain(ctx context.Context, event T, chain chain.Chain[T]) (chain.Chain[T], error)
+    Unsubscribe(ctx context.Context, id string) error
+}
+```
+
+### Worked example: the attack chain
+
+The worked example lives in `rulebooks/dnd5e/combat/attack.go`. Stages are
+defined in `rulebooks/dnd5e/combat/stages.go`:
+
+```go
+const (
+    StageBase       chain.Stage = "base"        // dice rolls, proficiency, ability mod
+    StageFeatures   chain.Stage = "features"    // rage damage, sneak attack
+    StageConditions chain.Stage = "conditions"  // bless, bane, prone
+    StageEquipment  chain.Stage = "equipment"   // magic weapon bonuses
+    StageFinal      chain.Stage = "final"       // resistance/vulnerability, caps
+)
+
+var ModifierStages = []chain.Stage{
+    StageBase, StageFeatures, StageConditions, StageEquipment, StageFinal,
+}
+```
+
+`combat.ResolveAttack` (in `rulebooks/dnd5e/combat/attack.go`, search for the
+`func ResolveAttack` symbol) builds the chain and publishes:
+
+```go
+attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](ModifierStages)
+attacks := dnd5eEvents.AttackChain.On(input.EventBus)
+
+// Publish through chain to collect modifiers
+modifiedAttackChain, err := attacks.PublishWithChain(ctx, attackEvent, attackChain)
+// Execute chain to get final attack event with all modifiers
+finalAttackEvent, err := modifiedAttackChain.Execute(ctx, attackEvent)
+```
+
+Subscribers along the chain include condition handlers (e.g.
+`RagingCondition.onDamageReceived` in `rulebooks/dnd5e/conditions/raging.go`)
+that were registered when the condition was Apply'd to the bus. After the
+chain returns, `ResolveAttack` resolves hit/damage and publishes a
+`DamageReceivedEvent` so condition handlers (rage resistance, etc.) modify
+incoming damage before it lands.
+
+## BusEffect — the lifecycle interface
+
 ```go
 type BusEffect interface {
-    Apply(bus EventBus) error    // subscribe handlers, mark active
-    Remove(bus EventBus) error   // unsubscribe handlers, mark inactive
+    Apply(ctx context.Context, bus EventBus) error
+    Remove(ctx context.Context, bus EventBus) error
     IsApplied() bool
 }
 ```
 
-A `RagingCondition` implements `BusEffect`. When Rage activates, `Apply()` subscribes a damage modifier handler on the damage chain topic. When Rage ends, `Remove()` unsubscribes it. The character's condition slice stores `BusEffect` implementations.
+`BusEffect` is the toolkit-internal pattern for any mechanic that needs to
+subscribe and unsubscribe as it becomes active/inactive. `dnd5eEvents.ConditionBehavior`
+(in `rulebooks/dnd5e/events/events.go`) is a near-clone with one extra method
+(`ToJSON`) for the per-condition serialization pattern. Conditions in the
+dnd5e rulebook implement `ConditionBehavior`, not `BusEffect` directly — but
+the lifecycle is identical.
 
-**The dual-bus split is not documented in any ADR.** ADR-0024 covers typed topics but not when to use `EventBus` directly vs. routing through `BusEffect`. This is a real contributor gap.
+`BusEffect` is **not visible to rpg-api**. It's the contract toolkit-internal
+mechanics use to manage their bus subscriptions.
 
-## TypedTopic
+## Rewrite history (issue #617)
 
-```go
-type TypedTopic[T any] interface {
-    Topic
-    On(bus EventBus) BoundTopic[T]  // bind to a specific bus
-}
+The events module was rewritten from a typed-event API (`Event`,
+`HandlerFunc`, `event.Context().GetString()`, `event.Context().AddModifier()`)
+to the current typed-topic API (`TypedTopic[T]`, `ChainedTopic[T]`,
+`BusEffect`, `StagedChain`). Several modules under `mechanics/*`
+(`mechanics/conditions`, `mechanics/effects`, `mechanics/features`,
+`mechanics/spells`) still carry source written against the old shape — they
+reference `events.Event` and `events.HandlerFunc` symbols that no longer exist
+on the published events module. Those modules ship with `replace` directives
+in their `go.mod` pointing `events` at a local path so the build can find the
+old symbols.
 
-// Usage
-attacks := combat.AttackTopic.On(bus)
-attacks.Subscribe(ctx, handleAttack)
-attacks.Publish(ctx, attackEvent)
-```
-
-`On(bus)` returns a `BoundTopic[T]` — a topic bound to a specific event bus instance. This makes the bus connection explicit and allows the same topic definition to work with different buses (e.g., per-encounter bus vs. global bus).
-
-## ChainedTopic
-
-The modifier pipeline. Each handler receives the running chain, adds its modifier, and returns the updated chain. The final handler collects the accumulated `Breakdown`.
-
-```go
-// A D&D 5e attack roll chain might look like:
-// base roll → proficiency bonus → ability modifier → condition modifiers → final total
-attackRollChain := ChainedTopic[AttackRollChainEvent]
-```
-
-All the "chain" references in `overview.md` refer to this mechanism. The chain pattern is what makes "Bless adds 1d4" work without the bless implementation knowing about attack resolution.
+Closing #617 means rewriting those mechanics modules against the typed-topic
+API. The 4-class playtest doesn't exercise them directly (rpg-api consumes
+their refactored cousins through `rulebooks/dnd5e/*`), so the migration is
+deferred. See `mechanics.md` and the components-doc audit
+(`docs/journey/049-rpg-api-toolkit-usage-audit.md`) for the consumer view.
 
 ## Known gaps
 
-- **No ADR for the EventBus vs. BusEffect split.** New contributors will default to whichever they find first. The right heuristic: use `EventBus` for stateless observers; use `BusEffect` for stateful game mechanics that have a lifecycle (applied/removed).
+- **No ADR for the EventBus vs. BusEffect split.** New contributors will default to whichever they find first. The right heuristic: use `EventBus` for stateless observers; use `BusEffect` (or `ConditionBehavior` inside dnd5e) for stateful game mechanics that have a lifecycle (applied/removed).
 - Example tests (`example_journey_test.go`, `example_magic_test.go`) are not in suite pattern — acceptable for examples but inconsistent with the rest of the repo.
-- `events v0.1.1` is pinned by the `game` module while newer modules use `v0.6.2`. This version spread means `game.Context` passes older `EventBus` types than what `tools/spatial` expects.
+- Version spread across the toolkit: the `game` module pins `events v0.1.1` while newer modules use `v0.6.2`. Until #617 closes, mixing modules with different events versions can produce subtle subscription-shape mismatches.
+
+## Verification
+
+```sh
+# Module surface
+grep -nE "^func [A-Z]|^type [A-Z]|^var [A-Z]" /home/kirk/personal/rpg-toolkit/events/*.go | grep -v _test
+
+# Worked example
+grep -n 'func ResolveAttack\|PublishWithChain\|NewStagedChain' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/combat/attack.go
+
+# Stage definitions
+cat /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/combat/stages.go
+
+# rpg-api's events surface
+grep -rn '"github.com/KirkDiggler/rpg-toolkit/events"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 4
+```

--- a/docs/architecture/components/events.md
+++ b/docs/architecture/components/events.md
@@ -174,8 +174,10 @@ subscribe and unsubscribe as it becomes active/inactive. `dnd5eEvents.ConditionB
 dnd5e rulebook implement `ConditionBehavior`, not `BusEffect` directly — but
 the lifecycle is identical.
 
-`BusEffect` is **not visible to rpg-api**. It's the contract toolkit-internal
-mechanics use to manage their bus subscriptions.
+`BusEffect` is exported, so any consumer that imports `events` could reference
+it — but **rpg-api does not import it**. It's the contract toolkit-internal
+mechanics use to manage their bus subscriptions, and per the audit rpg-api
+relies on `EventBus` and `NewEventBus` only.
 
 ## Rewrite history (issue #617)
 
@@ -185,15 +187,19 @@ to the current typed-topic API (`TypedTopic[T]`, `ChainedTopic[T]`,
 `BusEffect`, `StagedChain`). Several modules under `mechanics/*`
 (`mechanics/conditions`, `mechanics/effects`, `mechanics/features`,
 `mechanics/spells`) still carry source written against the old shape — they
-reference `events.Event` and `events.HandlerFunc` symbols that no longer exist
-on the published events module. Those modules ship with `replace` directives
-in their `go.mod` pointing `events` at a local path so the build can find the
-old symbols.
+reference `events.Event` and `events.HandlerFunc` symbols that no longer
+exist on either the local or any published events module. Those modules
+carry `replace` directives in their `go.mod` pointing `events => ../../events`,
+but since the local `events` only exposes the typed-topic API, the directives
+don't actually let those modules build against the old symbols — running
+`go mod tidy` or `go build ./...` inside them fails. The directives are a
+holdover from before the events rewrite landed.
 
 Closing #617 means rewriting those mechanics modules against the typed-topic
-API. The 4-class playtest doesn't exercise them directly (rpg-api consumes
-their refactored cousins through `rulebooks/dnd5e/*`), so the migration is
-deferred. See `mechanics.md` and the components-doc audit
+API — a real refactor, not a version bump. The 4-class playtest doesn't
+exercise them directly (rpg-api consumes their refactored cousins through
+`rulebooks/dnd5e/*`), so the migration is deferred. See `mechanics.md` and
+the components-doc audit
 (`docs/journey/049-rpg-api-toolkit-usage-audit.md`) for the consumer view.
 
 ## Known gaps

--- a/docs/architecture/components/items.md
+++ b/docs/architecture/components/items.md
@@ -1,8 +1,8 @@
 ---
 name: items module
-description: Item interface definitions — infrastructure only, no implementations
+description: Item interface definitions — toolkit-internal infrastructure; rpg-api consumes equipment via rulebooks/dnd5e/{weapons, armor, equipment}
 updated: 2026-05-04
-confidence: high — verified by reading item.go, go.mod, and items/validation/basic_validator_test.go
+confidence: high — verified by reading item.go, go.mod, items/validation/*, and rpg-api import graph per audit 049
 ---
 
 # items module
@@ -11,7 +11,19 @@ confidence: high — verified by reading item.go, go.mod, and items/validation/b
 **Module:** `github.com/KirkDiggler/rpg-toolkit/items`
 **Grade:** C
 
-Interface definitions for game items. No implementing structs in the base module — those live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`, etc. The base module is intentionally thin. Its tests compile (#612 resolved 2026-05-04) and its go.mod no longer carries a replace directive (#613 resolved 2026-05-04, pinned to `core v0.10.0`).
+> **Consumer status (per audit 049): rpg-api does NOT directly import the
+> base `items` module.** Equipment that rpg-api consumes flows through
+> `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`,
+> `rulebooks/dnd5e/equipment`, etc. The base `items` module defines the
+> interface layer those concrete implementations satisfy. From the rpg-api
+> boundary view this is implementation detail, but it is real infrastructure
+> the rulebook depends on.
+
+Interface definitions for game items. No implementing structs in the base
+module — those live in `rulebooks/dnd5e/weapons`, `rulebooks/dnd5e/armor`,
+etc. The base module is intentionally thin. Its tests compile (#612 resolved
+2026-05-04) and its go.mod no longer carries a replace directive (#613
+resolved 2026-05-04, pinned to `core v0.10.0`).
 
 ## Files
 
@@ -48,4 +60,17 @@ type EquippableItem interface {
 // WeaponItem, ArmorItem, ConsumableItem follow same pattern
 ```
 
-The interfaces are well-designed: composable, minimal, no business logic. The implementation gap is in the test layer.
+The interfaces are well-designed: composable, minimal, no business logic.
+The implementation gap is in the test layer — and concrete consumption
+happens at the rulebook level.
+
+## Verification
+
+```sh
+# rpg-api does not import base items
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/items"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 0
+
+# Concrete items consumption is via the rulebook
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"' /home/kirk/personal/rpg-api/internal/ --include="*.go" | wc -l   # expect 5
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"' /home/kirk/personal/rpg-api/internal/ --include="*.go" | wc -l    # expect 3
+```

--- a/docs/architecture/components/mechanics.md
+++ b/docs/architecture/components/mechanics.md
@@ -13,12 +13,13 @@ confidence: medium-high — verified by reading go.mod files, key source files, 
 > the rpg-api boundary view, mechanics is implementation detail.
 >
 > Several mechanics modules carry `replace` directives in their `go.mod`
-> because their source still uses the old typed-event events API
-> (`events.Event`, `events.HandlerFunc`) that the published events module no
-> longer exposes. Closing **issue #617** means rewriting these against the
-> typed-topic API (`TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`,
-> `StagedChain`). The 4-class playtest doesn't exercise these modules
-> directly, so the migration is deferred.
+> pointing `events => ../../events`. Their source still references old-API
+> symbols (`events.Event`, `events.HandlerFunc`) that neither the local nor
+> any published events module exposes today, so these modules don't build
+> against either pinned or local events. Closing **issue #617** means
+> rewriting them against the typed-topic API (`TypedTopic[T]`,
+> `ChainedTopic[T]`, `BusEffect`, `StagedChain`). The 4-class playtest
+> doesn't exercise these modules directly, so the migration is deferred.
 >
 > See `events.md` for the new events API and `docs/journey/049-rpg-api-toolkit-usage-audit.md`
 > for the consumer-side usage data.
@@ -59,17 +60,18 @@ Condition manager plus simple/enhanced condition types.
 - `EnhancedCondition` — SimpleCondition with stacking and duration support
 
 ### go.mod state (issue #617)
-`mechanics/conditions/go.mod` carries four committed `replace` directives.
-Resolution deferred to **issue #617**: the source uses old-API events symbols
-(`events.Event`, `events.HandlerFunc`, `event.Context().GetString` /
-`.AddModifier()`) that don't exist in any published events version. The
-replace directives point `events => ../../events` so the build can find these
-symbols. Closing #617 means rewriting conditions against the new typed-topic
-events API (`TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`, `StagedChain`)
-— a real refactor, not a version bump. The 4-class playtest doesn't exercise
-this module (it consumes `rulebooks/dnd5e/conditions` instead, which already
-runs against the new API), so this is on hold until the base module is
-needed.
+`mechanics/conditions/go.mod` carries four committed `replace` directives,
+including `events => ../../events`. The local `events` module on this branch
+exposes only the typed-topic API (`TypedTopic[T]`, `ChainedTopic[T]`,
+`BusEffect`, `StagedChain`) — not the old `events.Event` / `events.HandlerFunc`
+/ `event.Context().GetString` / `.AddModifier()` symbols this module's source
+still references. So the replace directives don't actually let this module
+build today; running `go mod tidy` or `go build ./...` inside
+`mechanics/conditions` fails. Resolution is deferred to **issue #617**, which
+means rewriting the source against the typed-topic API — a real refactor, not
+a version bump. The 4-class playtest doesn't exercise this module (it
+consumes `rulebooks/dnd5e/conditions` instead, which already runs against the
+new API), so this is on hold until the base module is needed.
 
 ### Coverage note
 Good behavior coverage at the `rulebooks/dnd5e` level (raging, dodging,

--- a/docs/architecture/components/mechanics.md
+++ b/docs/architecture/components/mechanics.md
@@ -1,20 +1,38 @@
 ---
 name: mechanics modules
-description: Conditions, effects, features, proficiency, resources, spells — the modifier pipeline infrastructure
+description: Conditions, effects, features, proficiency, resources, spells — the modifier pipeline infrastructure (toolkit-internal; not directly imported by rpg-api)
 updated: 2026-05-04
-confidence: medium-high — verified by reading go.mod files, key source files, and test runs per module
+confidence: medium-high — verified by reading go.mod files, key source files, and the rpg-api import graph per audit 049
 ---
 
 # mechanics modules
 
-Six sub-modules that implement the D&D/RPG modifier pipeline infrastructure. All depend on `core` and `events`; none depend on `rulebooks/dnd5e`.
+> **Consumer status (per audit 049): rpg-api does NOT directly import any
+> `mechanics/*` module.** These modules are toolkit-internal architecture —
+> depended on by `rulebooks/dnd5e/*`, which is the consumer-facing layer. From
+> the rpg-api boundary view, mechanics is implementation detail.
+>
+> Several mechanics modules carry `replace` directives in their `go.mod`
+> because their source still uses the old typed-event events API
+> (`events.Event`, `events.HandlerFunc`) that the published events module no
+> longer exposes. Closing **issue #617** means rewriting these against the
+> typed-topic API (`TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`,
+> `StagedChain`). The 4-class playtest doesn't exercise these modules
+> directly, so the migration is deferred.
+>
+> See `events.md` for the new events API and `docs/journey/049-rpg-api-toolkit-usage-audit.md`
+> for the consumer-side usage data.
+
+Six sub-modules that implement the D&D/RPG modifier pipeline infrastructure.
+All depend on `core` and `events`; none depend on `rulebooks/dnd5e`.
 
 ## mechanics/effects — B
 
 **Path:** `mechanics/effects/`
 **Module:** `github.com/KirkDiggler/rpg-toolkit/mechanics/effects`
 
-Shared infrastructure for conditions and proficiencies. Provides `EffectTracker`, effect behaviors, and a composed condition base type.
+Shared infrastructure for conditions and proficiencies. Provides
+`EffectTracker`, effect behaviors, and a composed condition base type.
 
 ### Key types
 - `EffectTracker` — tracks applied/removed effects with deduplication
@@ -41,10 +59,23 @@ Condition manager plus simple/enhanced condition types.
 - `EnhancedCondition` — SimpleCondition with stacking and duration support
 
 ### go.mod state (issue #617)
-`mechanics/conditions/go.mod` carries four committed `replace` directives. Resolution deferred to **issue #617**: the source uses old-API events symbols (`events.Event`, `events.HandlerFunc`, `event.Context().GetString` / `.AddModifier()`) that don't exist in any published events version. The replace directives point `events => ../../events` so the build can find these symbols. Closing #617 means rewriting conditions against the new typed-topic events API (`TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`, `StagedChain`) — a real refactor, not a version bump. The 4-class playtest doesn't exercise conditions, so this is on hold until conditions are needed.
+`mechanics/conditions/go.mod` carries four committed `replace` directives.
+Resolution deferred to **issue #617**: the source uses old-API events symbols
+(`events.Event`, `events.HandlerFunc`, `event.Context().GetString` /
+`.AddModifier()`) that don't exist in any published events version. The
+replace directives point `events => ../../events` so the build can find these
+symbols. Closing #617 means rewriting conditions against the new typed-topic
+events API (`TypedTopic[T]`, `ChainedTopic[T]`, `BusEffect`, `StagedChain`)
+— a real refactor, not a version bump. The 4-class playtest doesn't exercise
+this module (it consumes `rulebooks/dnd5e/conditions` instead, which already
+runs against the new API), so this is on hold until the base module is
+needed.
 
 ### Coverage note
-Good behavior coverage at the `rulebooks/dnd5e` level (raging, dodging, unconscious, etc. all exercised in integration tests), but the base `Manager`/`SimpleCondition`/`EnhancedCondition` tests are flat and not suite-pattern.
+Good behavior coverage at the `rulebooks/dnd5e` level (raging, dodging,
+unconscious, etc. all exercised in integration tests), but the base
+`Manager`/`SimpleCondition`/`EnhancedCondition` tests are flat and not
+suite-pattern.
 
 ---
 
@@ -60,7 +91,9 @@ Resource pools and counters for finite game resources.
 - `Counter` — simpler counter (rage uses, second wind)
 
 ### Status
-No go.mod issues. Tests cover happy paths. Edge cases (refill to zero, consume past limit) not explicitly tested, but the pool logic is straightforward enough that this is low risk.
+No go.mod issues. Tests cover happy paths. Edge cases (refill to zero,
+consume past limit) not explicitly tested, but the pool logic is
+straightforward enough that this is low risk.
 
 ---
 
@@ -69,7 +102,8 @@ No go.mod issues. Tests cover happy paths. Edge cases (refill to zero, consume p
 **Path:** `mechanics/features/`
 **Module:** `github.com/KirkDiggler/rpg-toolkit/mechanics/features`
 
-Feature loader infrastructure. The base module provides the routing layer; rulebooks provide implementations.
+Feature loader infrastructure. The base module provides the routing layer;
+rulebooks provide implementations.
 
 ### Key types
 - `FeatureData` interface — gives loaders access to a feature's `Ref()` and `JSON()`
@@ -80,9 +114,15 @@ Feature loader infrastructure. The base module provides the routing layer; ruleb
 Clean dependencies — only `core`.
 
 ### Critical gap (issue #615 adjacent)
-`loader.go`, `feature.go`, `simple_feature.go` — **zero test files in the base module.** Only `mock/` exists. The feature loader routing logic and error paths are untested at the module level. Indirect coverage exists through `rulebooks/dnd5e/features`, but a bug in `Loader.Route()` error handling would not be caught by running `cd mechanics/features && go test ./...` — that command prints "no test files."
+`loader.go`, `feature.go`, `simple_feature.go` — **zero test files in the base
+module.** Only `mock/` exists. The feature loader routing logic and error
+paths are untested at the module level. Indirect coverage exists through
+`rulebooks/dnd5e/features`, but a bug in `Loader.Route()` error handling
+would not be caught by running `cd mechanics/features && go test ./...` —
+that command prints "no test files."
 
-Grade would move to B with tests that exercise the loader routing and error paths.
+Grade would move to B with tests that exercise the loader routing and error
+paths.
 
 ---
 
@@ -91,14 +131,17 @@ Grade would move to B with tests that exercise the loader routing and error path
 **Path:** `mechanics/proficiency/`
 **Module:** `github.com/KirkDiggler/rpg-toolkit/mechanics/proficiency`
 
-Proficiency system. Tracks what an entity is proficient with and calculates proficiency-bonus-adjusted modifiers.
+Proficiency system. Tracks what an entity is proficient with and calculates
+proficiency-bonus-adjusted modifiers.
 
 ### Key types
 - `Proficiency` interface
 - `SimpleProfiler` — concrete implementation
 
 ### go.mod: clean (issue #613 resolved 2026-05-04)
-Pinned to published `core v0.9.3`, `events v0.1.0`, `mechanics/effects v0.2.1`, `dice v0.1.0`. No replace directives. `go test -race ./...` passes against published versions.
+Pinned to published `core v0.9.3`, `events v0.1.0`, `mechanics/effects v0.2.1`,
+`dice v0.1.0`. No replace directives. `go test -race ./...` passes against
+published versions.
 
 ---
 
@@ -115,7 +158,12 @@ Spell slots, concentration tracking, spell lists.
 - `SpellList` — list of known/prepared spells
 
 ### go.mod state (issue #617)
-Six replace directives committed to main. Same situation as `mechanics/conditions`: source uses old-API events symbols that don't exist in any published events version. Closing #617 means rewriting against the new typed-topic API. Tracked in **issue #617**, deferred until the playtest exercises spells.
+Six replace directives committed to main. Same situation as
+`mechanics/conditions`: source uses old-API events symbols that don't exist
+in any published events version. Closing #617 means rewriting against the
+new typed-topic API. Tracked in **issue #617**, deferred until the playtest
+exercises spells.
 
 ### Coverage note
-Concentration logic, spell events, and slot management all have test files and pass. Test style is mostly flat (not suite pattern). No known logic bugs.
+Concentration logic, spell events, and slot management all have test files
+and pass. Test style is mostly flat (not suite pattern). No known logic bugs.

--- a/docs/architecture/components/refs.md
+++ b/docs/architecture/components/refs.md
@@ -1,0 +1,166 @@
+---
+name: rulebooks/dnd5e/refs package
+description: The boundary key — typed namespaces of *core.Ref singletons that rpg-api uses to tell the toolkit what to do
+updated: 2026-05-04
+confidence: high — verified by reading refs/*.go and rpg-api's symbol histogram per audit 049
+---
+
+# refs package
+
+**Path:** `rulebooks/dnd5e/refs/`
+**Module:** `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs` (sub-package of `rulebooks/dnd5e`)
+
+The boundary rule of the project — "client sends references, never
+calculations" — makes `refs/` the literal API surface between rpg-api and
+the toolkit. This is broken out into its own component doc because of how
+heavily rpg-api depends on it (the audit found 12 files in rpg-api importing
+it, with ~400 ref usages across the symbol histogram).
+
+A `*core.Ref` is the routing key for any toolkit content (feature, condition,
+weapon, action, monster, etc.). The `refs/` package wraps the raw `core.Ref`
+constructors into typed, IDE-discoverable namespaces.
+
+## Why this exists as its own package
+
+Per the package doc comment in `rulebooks/dnd5e/refs/module.go`:
+
+> This package is a leaf package — it only imports core to ensure all other
+> dnd5e packages can import it without cycles.
+
+That's the architectural reason. The user-facing reason is IDE autocomplete:
+typing `refs.Features.<tab>` discovers every D&D 5e feature; typing
+`refs.Conditions.<tab>` discovers every condition. No magic strings.
+
+## How rpg-api uses it
+
+| Namespace | Refs in rpg-api | Example callsite |
+|---|---|---|
+| `refs.Weapons` | 96 | converters mapping proto weapon enums |
+| `refs.Features` | 85 | `refs.Features.Rage()` in feature handlers |
+| `refs.Conditions` | 51 | condition state mapping |
+| `refs.Actions` | 45 | action mapping |
+| `refs.Monsters` | 43 | encounter handler |
+| `refs.Tools` | 35 | choice mapping |
+| `refs.CombatAbilities` | 31 | combat-ability mapping |
+| `refs.Abilities` | 15 | DEX/STR/CON ability score mapping |
+| `refs.Module`, `refs.Armor` | 14, 13 | misc |
+
+The full call shape: rpg-api receives a proto enum (e.g. `Feature.RAGE`),
+maps it to `refs.Features.Rage()`, and passes the resulting `*core.Ref` to a
+toolkit factory or activation call. The toolkit owns "what Rage does"; rpg-api
+just routes by ref.
+
+## The namespace pattern
+
+Every namespace is a struct singleton with methods returning unexported
+`*core.Ref` variables. Example from `refs/features.go`:
+
+```go
+// Feature singletons - unexported for controlled access via methods
+var (
+    featureRage           = &core.Ref{Module: Module, Type: TypeFeatures, ID: "rage"}
+    featureBrutalCritical = &core.Ref{Module: Module, Type: TypeFeatures, ID: "brutal_critical"}
+    // ... more features ...
+)
+
+// Features provides type-safe, discoverable references to D&D 5e features.
+var Features = featuresNS{}
+
+type featuresNS struct{}
+
+func (n featuresNS) Rage() *core.Ref           { return featureRage }
+func (n featuresNS) BrutalCritical() *core.Ref { return featureBrutalCritical }
+// ...
+```
+
+Two architectural properties fall out of this pattern:
+
+1. **Singleton identity.** Methods return the same pointer every call. So
+   `ref == refs.Features.Rage()` is a valid identity comparison — useful for
+   switch-by-ref dispatch inside the toolkit.
+
+2. **Module-namespaced.** Every ref carries `Module: "dnd5e"`. Future modules
+   (e.g., a Pathfinder rulebook) can define their own `refs/` packages with
+   `Module: "pathfinder"` and the same IDs won't collide.
+
+The Module constant and Type constants are defined in `refs/module.go`:
+
+```go
+const Module core.Module = "dnd5e"
+
+const (
+    TypeFeatures        core.Type = "features"
+    TypeConditions      core.Type = "conditions"
+    TypeActions         core.Type = "actions"
+    TypeWeapons         core.Type = "weapons"
+    // ... more types ...
+)
+```
+
+## Available namespaces
+
+Verified by `grep -nE '^var [A-Z]' refs/*.go`:
+
+| Namespace | File | Purpose |
+|---|---|---|
+| `refs.Abilities` | `abilities.go` | DEX/STR/CON/WIS/INT/CHA |
+| `refs.Actions` | `actions.go` | Strike, Dodge, etc. |
+| `refs.Armor` | `armor.go` | Armor by ID |
+| `refs.Backgrounds` | `backgrounds.go` | Soldier, Acolyte, etc. |
+| `refs.Classes` | `classes.go` | Fighter, Barbarian, etc. |
+| `refs.CombatAbilities` | `combat_abilities.go` | Attack, Dash, Disengage |
+| `refs.Conditions` | `conditions.go` | Raging, Dodging, etc. |
+| `refs.DamageTypes` | `damage_types.go` | Slashing, Bludgeoning, etc. |
+| `refs.Features` | `features.go` | Rage, Second Wind, etc. |
+| `refs.Languages` | `languages.go` | Common, Elvish, etc. |
+| `refs.MonsterActions` | `monster_actions.go` | Bite, Multiattack, etc. |
+| `refs.MonsterTraits` | `monster_traits.go` | Pack Tactics, etc. |
+| `refs.Monsters` | `monsters.go` | Goblin, Brown Bear, etc. |
+| `refs.Races` | `races.go` | Human, Elf, etc. |
+| `refs.Skills` | `skills.go` | Athletics, Stealth, etc. |
+| `refs.Spells` | `spells.go` | Sleep, Magic Missile, etc. |
+| `refs.Tools` | `tools.go` | Smith's tools, etc. |
+| `refs.Weapons` | `weapons.go` | Longsword, Shortbow, etc. |
+
+## Relationship to core.Ref and core.SourcedRef
+
+`refs/` is a constructor layer over `core.Ref` (defined in `core/ref.go`).
+The `Ref` struct itself has three fields:
+
+```go
+type Ref struct {
+    Module string  // "dnd5e"
+    Type   string  // "features"
+    ID     string  // "rage"
+}
+```
+
+Stringified form: `"dnd5e:features:rage"`.
+
+`core.SourcedRef` adds provenance:
+
+```go
+type SourcedRef struct {
+    Ref    *Ref
+    Source *Source  // Category + Name (class, background, race, etc.)
+}
+```
+
+`SourcedRef` is what the toolkit uses to track *where* a modifier came from
+(e.g., "this +2 came from Barbarian Rage") so UI breakdowns can explain a
+final number. `refs/` constructors return plain `*core.Ref`; the toolkit
+wraps them in `SourcedRef` when it needs provenance.
+
+## Verification
+
+```sh
+# All refs namespaces
+grep -nE '^var [A-Z]' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/refs/*.go | grep -v _test
+
+# Module/Type constants
+grep -nE '^\tType[A-Z]' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/refs/module.go
+
+# rpg-api's import count and top namespaces
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 12
+grep -rohE 'refs\.(Weapons|Features|Conditions|Actions|Monsters)' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | sort | uniq -c | sort -rn
+```

--- a/docs/architecture/components/rulebook-dnd5e.md
+++ b/docs/architecture/components/rulebook-dnd5e.md
@@ -1,6 +1,6 @@
 ---
 name: rulebooks/dnd5e module
-description: D&D 5e rules implementation — the consumer-facing surface rpg-api imports across 24 sub-packages
+description: D&D 5e rules implementation — the consumer-facing surface rpg-api imports across 31 sub-packages (character/ alone in 24 files)
 updated: 2026-05-04
 confidence: high — verified by directory listing, grep over public symbols, and rpg-api import-graph audit 049
 ---
@@ -18,11 +18,17 @@ initiative, features (Rage, Second Wind, Martial Arts, etc.), conditions
 
 ## What rpg-api consumes
 
-Per audit Section 1, rpg-api imports **30 sub-packages** of `rulebooks/dnd5e`
-(the audit's intro narrative reads "24 sub-packages" — that count is for the
-`character/` package itself, which is imported from 24 rpg-api files; the
-total sub-package count from Section 1's listing is 30, with the
-`monster/actions` and `monster/monsters` siblings imported zero times).
+Per a fresh grep on 2026-05-04, rpg-api imports **31 sub-packages** of
+`rulebooks/dnd5e` (the `character/` package alone is imported by 24 rpg-api
+files, which is where the audit's intro narrative's "24 sub-packages"
+phrasing comes from — that count is files-importing-`character`, not
+total sub-packages). The audit Section 1 marks
+`monster/actions` and `monster/monsters` as 0 files each; that's wrong —
+both are imported (`monster/actions` from
+`internal/orchestrators/encounter/monster_turns.go`; `monster/monsters` from
+`internal/components/dungeon/monster_factory.go` and
+`internal/orchestrators/encounter/orchestrator_test.go`). Audit needs a
+follow-up correction; this doc's table reflects the fresh count.
 
 This is the dominant consumer-facing surface. The top imports by file count:
 
@@ -212,11 +218,16 @@ notes are in `character/choices/CHOICES_SYSTEM.md`.
 
 ## monster/ — note on sibling sub-packages
 
-`monster/` is imported by 14 rpg-api files. **Important nuance** (per audit
-Section 1): `monster/actions` and `monster/monsters` are **sibling sub-packages**
-of `monster/`, not subdirectories in the import sense. They cannot be reached
-through `monster/` because of an import cycle, and rpg-api does not import
-either sibling directly.
+`monster/` is imported by 14 rpg-api files. **Important nuance**:
+`monster/actions` and `monster/monsters` are **sibling sub-packages** of
+`monster/`, not subdirectories in the import sense — they cannot be reached
+through `monster/` because of an import cycle. rpg-api imports them directly
+where it needs them: `monster/actions` from
+`internal/orchestrators/encounter/monster_turns.go` (1 file) and
+`monster/monsters` from `internal/components/dungeon/monster_factory.go` and
+`internal/orchestrators/encounter/orchestrator_test.go` (2 files). The audit
+at `docs/journey/049-rpg-api-toolkit-usage-audit.md` Section 1 incorrectly
+records both as 0 files; this needs a follow-up correction to the audit.
 
 The built-in monster factory functions like `NewGoblin` live in
 `rulebooks/dnd5e/monster/monster.go` (search for `func NewGoblin`), **not** in

--- a/docs/architecture/components/rulebook-dnd5e.md
+++ b/docs/architecture/components/rulebook-dnd5e.md
@@ -1,8 +1,8 @@
 ---
 name: rulebooks/dnd5e module
-description: Full D&D 5e rules implementation — character, combat, initiative, spells, monsters, dungeon, features, conditions
-updated: 2026-05-02
-confidence: high — verified by directory listing, go.mod, test runs, and reading key source files
+description: D&D 5e rules implementation — the consumer-facing surface rpg-api imports across 24 sub-packages
+updated: 2026-05-04
+confidence: high — verified by directory listing, grep over public symbols, and rpg-api import-graph audit 049
 ---
 
 # rulebooks/dnd5e module
@@ -11,16 +11,56 @@ confidence: high — verified by directory listing, go.mod, test runs, and readi
 **Module:** `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e`
 **Grade:** B+
 
-The top of the dependency tree. Most actively worked module. Implements all D&D 5e game rules: character creation and leveling, combat resolution, initiative, features (Rage, Second Wind, Martial Arts, etc.), conditions (Raging, Dodging, Unconscious, etc.), spells, monsters, and dungeon layouts.
+The top of the dependency tree. The most actively worked module. Implements
+all D&D 5e game rules: character creation and leveling, combat resolution,
+initiative, features (Rage, Second Wind, Martial Arts, etc.), conditions
+(Raging, Dodging, Unconscious, etc.), spells, monsters, and dungeon layouts.
 
-## Sub-package map
+## What rpg-api consumes
+
+Per audit Section 1, rpg-api imports **30 sub-packages** of `rulebooks/dnd5e`
+(the audit's intro narrative reads "24 sub-packages" — that count is for the
+`character/` package itself, which is imported from 24 rpg-api files; the
+total sub-package count from Section 1's listing is 30, with the
+`monster/actions` and `monster/monsters` siblings imported zero times).
+
+This is the dominant consumer-facing surface. The top imports by file count:
+
+| Sub-package | Files in rpg-api | Notes |
+|---|---|---|
+| `character/` | 24 | Character/Draft lifecycle, ToData/LoadFromData |
+| `monster/` | 14 | Monster data, NewGoblin, perception |
+| `refs/` | 12 | The boundary key — `refs.Weapons.Longsword()`, `refs.Features.Rage()`, etc. |
+| `classes/` | 11 | Typed class constants |
+| `abilities/` | 10 | DEX/STR/CON/WIS/INT/CHA constants |
+| `shared/` | 9 | Cross-cutting types (`AbilityScores`, `SelectionID`) |
+| `races/` | 8 | Typed race constants |
+| `initiative/` | 7 | Tracker, Roll, Participant |
+| `character/choices/` | 6 | Service-shaped choice/validation surface |
+| `combat/` | 5 | `ResolveAttack`, `WithCombatantLookup`, action-economy types |
+| `weapons/` | 5 | Weapon data |
+| `backgrounds/` | 4 | Typed background constants |
+| `damage/` | 3 | Damage type constants |
+| `spells/` | 3 | Spell typed constants (resolution is internal) |
+| `armor/` | 3 | Armor data |
+| `gamectx/` | 3 | Combatant registry — the integration shim for chain resolution |
+| `skills/` | 2 | Skill constants and `Skill` type |
+| `monstertraits/` | 2 | `LoadMonsterConditions` |
+| `fightingstyles/` | 2 | Fighting style constants |
+| `languages/` | 2 | Language constants |
+| `ammunition/`, `packs/`, `tools/`, `proficiencies/`, `saves/`, `equipment/`, `features/`, `actions/`, `events/`, `resources/` | 1 each | narrow imports — see audit Section 1 |
+
+Most rpg-api callsites send **refs in** and receive **rich breakdowns out**.
+The toolkit owns the rules; rpg-api orchestrates load → call → save.
+
+## Sub-package map (toolkit-side)
 
 | Sub-package | Purpose | Test coverage |
 |---|---|---|
 | `character/` | Character struct, ToData/LoadFromData, finalization | High — full suite with fixture-driven tests |
 | `character/choices/` | Choice system (class/race at creation) | Medium — testdata from external API |
 | `combat/` | AC chain, attack resolution, damage, healing, action economy | High — integration and unit tests |
-| `combatabilities/` | Attack, Dash, Disengage, Dodge, Hide, Move | Medium — move.go minimally tested |
+| `combatabilities/` | Attack, Dash, Disengage, Dodge, Hide, Move | Medium — `move.go` minimally tested |
 | `actions/` | Strike, OffHandStrike, CheckAndGrant | High — used in integration tests |
 | `features/` | Feature loader for dnd5e features | High — Rage, SecondWind, MartialArts, etc. |
 | `conditions/` | Condition loader + all named conditions | High — loader test, individual condition tests |
@@ -28,76 +68,208 @@ The top of the dependency tree. Most actively worked module. Implements all D&D 
 | `saves/` | Saving throw resolution | Medium |
 | `skills/` | Skill check resolution | Medium |
 | `monster/` | Monster stat block + turn execution | High — used in integration tests |
+| `monster/actions/` | Bite, melee, ranged, multiattack — sibling of `monster/` | High |
+| `monster/monsters/` | Bandit, Brown Bear, Ghoul — sibling of `monster/` | High |
 | `monstertraits/` | Special monster abilities | Medium |
 | `resources/` | Resource loading (ki, rage uses, spell slots) | Medium |
 | `spells/` | Spell list, slot management | Medium |
 | `equipment/` | Equipment slots + item interface | Medium |
 | `weapons/` | Weapon definitions and proficiencies | High — used in combat tests |
 | `dungeon/` | Procedural dungeon: room types, wall perimeters, door spawning | Medium (336 test lines) |
-| `gamectx/` | D&D-specific game context helpers | Low |
+| `gamectx/` | D&D-specific game-context plumbing — combatant registry, characters, room | Low |
 | `refs/` | Typed ref constructors (`refs.Features.Rage()`) | Medium |
 | `shared/` | Shared type aliases (EquipmentID, etc.) | — |
+| `events/` | dnd5e event payloads, topics, `ConditionBehavior`, `ActionBehavior` | High |
 | `integration/` | Full encounter integration tests (Barbarian/Fighter/Monk/Rogue) | High |
-| **Data packages (no logic)** | | |
-| `abilities/` | Ability score constants | None |
-| `ammunition/` | Ammunition type constants | None |
-| `armor/` | Armor type constants | None |
-| `damage/` | Damage type constants | None |
-| `effects/` | Effect constants | None |
-| `fightingstyles/` | Fighting style constants | None |
-| `languages/` | Language constants | None |
-| `packs/` | Equipment pack constants | None |
-| `proficiencies/` | Proficiency type constants | None |
-| `race/` | Race constants | None |
-| **Logic packages, no tests** | | |
-| `backgrounds/` | Background data + `grants.go` | None — issue #615 |
-| `races/` | Race data + `grants.go` | None — issue #615 |
-| `items/` | Item type constants | None |
-| `classes/` | Class definitions | None |
 
 ## go.mod status
+
 Clean. All published versions. No replace directives.
 
-Dependencies:
-- `core v0.10.0`
-- `dice v0.3.2`
-- `events v0.6.2`
-- `mechanics/resources v0.3.1`
-- `rpgerr v0.1.1`
-- `tools/environments v0.4.0`
-- `tools/spatial v0.4.0`
+Key dependencies: `core`, `dice`, `events`, `mechanics/resources`, `rpgerr`,
+`tools/environments`, `tools/spatial`.
 
-## Integration tests
+## refs/ — the boundary key
 
-`integration/` contains full encounter simulations. Each file creates a character, enters combat, and exercises the full rule pipeline:
-- `barbarian_encounter_test.go` — Rage activation, reckless attack, extra attack
-- `fighter_encounter_test.go` — Second Wind, Action Surge, Fighting Style
-- `monk_encounter_test.go` — Martial Arts, Flurry of Blows, ki expenditure, Unarmored Defense
-- `rogue_encounter_test.go` — Sneak Attack, Cunning Action, DEX-based combat
+The single biggest non-character import (12 files in rpg-api, ~400 ref usages
+across the histogram). The boundary rule of the project — "client sends
+references, never calculations" — makes `refs/` the literal API surface
+between rpg-api and the toolkit.
 
-These are the most valuable tests in the toolkit. They exercise the full chain: character creation → finalization → combat entry → feature activation → attack resolution → resource consumption.
+The `refs/` package exposes namespaced constructors:
 
-## Known gaps
+```go
+refs.Features.Rage()           // *core.Ref{Module: "dnd5e", Type: "features", ID: "rage"}
+refs.Conditions.Raging()       // *core.Ref{Module: "dnd5e", Type: "conditions", ID: "raging"}
+refs.CombatAbilities.Attack()  // *core.Ref{Module: "dnd5e", Type: "combat_abilities", ID: "attack"}
+refs.Actions.Strike()          // *core.Ref{Module: "dnd5e", Type: "actions", ID: "strike"}
+```
 
-### Untested grant logic (issue #615)
-`backgrounds/grants.go` (172 lines) implements `GetGrants(bg Background) *Grant` — a switch on 13 background types returning skill proficiencies, tool proficiencies, and language grants. **No test file.** The switch is straightforward data-mapping but is non-trivial: wrong skill assignments break character creation in rpg-api.
+Methods return **singleton pointers**, enabling identity comparison
+(`ref == refs.Features.Rage()` is true if both came from the same
+constructor). Every namespace (`Features`, `Conditions`, `Actions`,
+`CombatAbilities`, `Weapons`, `Armor`, `Spells`, `Monsters`, `Classes`,
+`Races`, `Backgrounds`, `Skills`, `Abilities`, `Tools`, `DamageTypes`,
+`Languages`, `MonsterActions`, `MonsterTraits`) is a struct singleton with
+methods returning unexported `*core.Ref` variables.
 
-`races/grants.go` (109 lines) implements `GetGrants(race Race) *Grant` — racial language grants, skill proficiencies (e.g., Half-Orc's Intimidation from Menacing), weapon/armor proficiencies (not yet populated). **No test file.**
+The histogram from rpg-api's source (audit Section 1):
 
-Both are called during character creation finalization. A bug here silently produces a character with wrong proficiencies.
+| Namespace | Refs in rpg-api |
+|---|---|
+| `refs.Weapons` | 96 |
+| `refs.Features` | 85 |
+| `refs.Conditions` | 51 |
+| `refs.Actions` | 45 |
+| `refs.Monsters` | 43 |
+| `refs.Tools` | 35 |
+| `refs.CombatAbilities` | 31 |
+| `refs.Abilities` | 15 |
+| `refs.Module`, `refs.Armor` | 14, 13 |
 
-### dungeon/ location (planned move)
-`rulebooks/dnd5e/dungeon/` implements procedural dungeon generation: room shape selection, hex-perimeter wall calculation, door spawning, theme-based layout. It uses `tools/environments` and `tools/spatial` (correct direction — lower layers), but living inside the rulebook means rpg-api must import the full dnd5e module to use dungeon logic. The planned move is to `tools/dungeon/` or a standalone module. No issue filed yet.
+How the boundary rule looks in practice: rpg-api passes `refs.Features.Rage()`
+to a toolkit factory or activation call; the toolkit looks up the
+implementation by ref, owns the rule, and returns a result. rpg-api never
+implements "what Rage does."
 
-### character/choices testdata provenance
-`character/choices/testdata/api/classes/` and `testdata/api/races/` contain JSON fixtures from an external API. No note documents when they were fetched, from which URL, or how to refresh them. If the upstream API changes its schema, tests silently test stale data.
+The full `refs/` surface and how it composes with `core.Ref` /
+`core.SourcedRef` is documented separately in `refs.md`.
 
-### combatabilities/move.go
-`move.go` (movement action) is tested minimally — no test for stopping reasons, multi-leg paths, or movement exhaustion mid-turn. This matters for the multi-room dungeon when movement spans a door.
+## gamectx/ — the integration shim for chain resolution
 
-## The LoadFromData round-trip
+`gamectx/` is the most surprising omission from the previous version of this
+doc (per audit "things discovered off-script"). It owns the combatant registry
+and the context-key plumbing that lets toolkit chain resolution look up
+combatants by ID during an attack.
 
-The character serialization round-trip is well-tested. The pattern:
+Key types (verified by `grep` over `gamectx/*.go`):
+
+| Symbol | File | Role |
+|---|---|---|
+| `GameContext`, `GameContextConfig`, `NewGameContext` | `gamectx.go` | aggregate game-context value carried in `context.Context` |
+| `WithGameContext`, `Characters`, `RequireCharacters` | `require.go` | context-key plumbing for the character registry |
+| `CharacterRegistry`, `BasicCharacterRegistry`, `NewBasicCharacterRegistry` | `gamectx.go`, `characters.go` | per-character registry (weapons, ability scores) |
+| `CombatantRegistry`, `NewCombatantRegistry`, `WithCombatants`, `GetCombatant` | `combatant.go` | the registry the attack chain consults during resolution |
+| `EquippedWeapon`, `CharacterWeapons`, `SlotMainHand`, `SlotOffHand` | `characters.go` | weapon-slot plumbing |
+| `WithRoom`, `Room`, `RequireRoom` | `room.go` | spatial context |
+| `CombatState`, `WithCombatState` | `combat.go` | per-encounter combat state |
+
+rpg-api drives this from `internal/orchestrators/encounter/orchestrator.go`:
+
+```go
+ctx = gamectx.WithGameContext(ctx, gameCtx)
+registry := gamectx.NewCombatantRegistry()
+// ... populate registry ...
+ctx = combat.WithCombatantLookup(ctx, registry)
+result, err := combat.ResolveAttack(ctx, &combat.AttackInput{ /* ... */ })
+```
+
+Inside `combat.ResolveAttack` (and inside subscriber handlers along the attack
+chain), code calls `combat.GetCombatantFromContext(ctx, id)` — which reads
+back through the context keys gamectx sets up. Without this shim the chain
+has no way to find "what is the attacker's STR mod" or "is the target
+prone."
+
+## combat/ — the chain entry point
+
+`combat/` is where the attack chain entry point lives. The worked example for
+the chain pattern (see `events.md`) is `combat.ResolveAttack` in
+`rulebooks/dnd5e/combat/attack.go` — search for the `func ResolveAttack`
+symbol.
+
+Top symbols rpg-api consumes:
+
+| Symbol | Role |
+|---|---|
+| `combat.AttackInput`, `combat.ResolveAttack` | the chain entry point |
+| `combat.WithCombatantLookup` | wires the gamectx registry into context |
+| `combat.AttackHandMain`, `combat.AttackHandOff`, `combat.AttackHand` | which hand is attacking |
+| `combat.AttackResult`, `combat.DamageBreakdown` | return shape with rich modifier provenance |
+| `combat.NewActionEconomy`, `combat.CapacityFlurryStrike` | action-economy support |
+
+The chain stages (`StageBase`, `StageFeatures`, `StageConditions`,
+`StageEquipment`, `StageFinal`) are defined in
+`rulebooks/dnd5e/combat/stages.go`. See `events.md` for how `StagedChain[T]`
+and `ChainedTopic[T]` cooperate to drive the chain.
+
+## character/choices/ — service-shaped surface
+
+`character/choices/` is its own service-shaped surface inside the rulebook
+(6 files in rpg-api). rpg-api treats it like a service: ask for requirements,
+post a validation request, get a `ValidationResult`. Hot path:
+
+| Symbol | Role |
+|---|---|
+| `choices.ValidationResult`, `choices.ValidationError` | return shape (11, 2 references) |
+| `choices.GetClassRequirements`, `choices.GetClassRequirementsAtLevel`, `choices.GetClassRequirementsWithSubclass`, `choices.GetRaceRequirements` | per-step requirement queries |
+| `choices.Requirements`, `choices.ChoiceData`, `choices.ChoiceID` | request shape |
+| Class-specific selectors (`choices.FighterPack`, `choices.WizardWeaponsPrimary`, etc.) | typed equipment-choice constants |
+| `choices.SkillRequirement`, `choices.ToolRequirement`, `choices.FightingStyleRequirement`, `choices.EquipmentRequirement` | requirement-type taxonomy |
+
+Subclass modifications live in `subclass_modifications.go`. The `submissions.go`
+file is the input shape rpg-api converts proto requests into. Implementation
+notes are in `character/choices/CHOICES_SYSTEM.md`.
+
+## monster/ — note on sibling sub-packages
+
+`monster/` is imported by 14 rpg-api files. **Important nuance** (per audit
+Section 1): `monster/actions` and `monster/monsters` are **sibling sub-packages**
+of `monster/`, not subdirectories in the import sense. They cannot be reached
+through `monster/` because of an import cycle, and rpg-api does not import
+either sibling directly.
+
+The built-in monster factory functions like `NewGoblin` live in
+`rulebooks/dnd5e/monster/monster.go` (search for `func NewGoblin`), **not** in
+`monster/monsters/`. `monster/monsters/` contains `Bandit`, `BrownBear`, and
+`Ghoul` — newer additions. `monster/actions/` contains `Bite`, `Melee`,
+`Ranged`, `Multiattack` — the action types monsters compose into their
+turns.
+
+Top symbols rpg-api consumes from `monster/`:
+
+| Symbol | Role |
+|---|---|
+| `monster.Data` | persisted monster shape (62 references; deprecation comment in rpg-api repository at `internal/repositories/encounters/repository.go` flags migration in flight) |
+| `monster.LoadFromData` | reconstitute a Monster from Data + bus |
+| `monster.PerceivedEntity`, `monster.PerceptionData` | perception output |
+| `monster.NewGoblin`, `monster.ScimitarConfig` | encounter-setup helpers |
+| `monster.ActionData`, `monster.TypeMeleeAttack`, `monster.TypeRangedAttack`, `monster.TakeDamage` | action plumbing |
+
+## initiative/ — round/turn tracker
+
+7 files in rpg-api. The tracker is reconstituted from data in repository load
+paths:
+
+| Symbol | Role |
+|---|---|
+| `initiative.TrackerData` | the persisted shape (54 references) |
+| `initiative.EntityData` | per-entity entry in the tracker |
+| `initiative.NewParticipant` | participant constructor |
+| `initiative.Roll` | typed roll result |
+| `initiative.New` | tracker constructor |
+| `initiative.RollForOrder` | roll all initiatives at once |
+| `initiative.LoadFromData` | reconstitute from `TrackerData` |
+
+Persistence pattern matches the broader `ToData`/`LoadFromData` convention
+(see `docs/architecture/data-model.md`).
+
+## character/ — the dominant import
+
+24 files in rpg-api. This module owns the character domain model:
+
+| Symbol | Role |
+|---|---|
+| `character.Data` | the persisted character shape (47 references) |
+| `character.Character`, `character.LoadFromData` | runtime character |
+| `character.DraftData`, `character.DraftConfig`, `character.NewDraft`, `character.LoadDraftFromData` | draft lifecycle |
+| `character.SetRaceInput`, `character.SetClassInput`, `character.SetBackgroundInput`, `character.SetAbilityScoresInput`, `character.SetNameInput` | per-step setters |
+| `character.Progress`, `character.ProgressClass`, `character.ProgressRace`, `character.ProgressName` | draft progress |
+| `character.EquipmentSlots`, `character.SlotMainHand`, `character.SlotOffHand` | equipment slots |
+| `character.ActionEconomyData`, `character.GrantedActionKey` | action-economy |
+| `character.ClassChoices`, `character.RaceChoices` | choice-data conversion |
+| `character.GetCharacterInput`, `character.DeleteCharacterInput` | service-shape inputs |
+
+The canonical `ToData` / `LoadFromData` round-trip lives here:
 
 ```go
 // Create and finalize
@@ -109,7 +281,107 @@ data := char.ToData()
 
 // Reconstitute (what rpg-api does before any rule call)
 newChar, err := character.LoadFromData(ctx, data, bus)
-// newChar has the same conditions, features, and resources as char
 ```
 
-`LoadFromData` reconnects the event bus — conditions and features resubscribe their handlers on reconstruct. This is the critical step that makes the toolkit stateless from rpg-api's perspective.
+`LoadFromData` reconnects the event bus — conditions and features resubscribe
+their handlers on reconstruct. This is the critical step that makes the
+toolkit stateless from rpg-api's perspective.
+
+## Activation surface — features Activate, conditions Apply
+
+Per audit Section 3 Claim 1, the activation surface has **two halves**:
+
+- **Features** implement `core.Action[T]` (Activate / CanActivate). When a player triggers Rage, rpg-api calls into the feature's Activate flow.
+- **Conditions** implement `dnd5eEvents.ConditionBehavior` (Apply / Remove / IsApplied / ToJSON). They subscribe to the bus when applied and modify chains as events flow through.
+
+A feature can both implement Action **and** apply a Condition as part of its
+Activate flow. Rage is the canonical case: `Rage.Activate` (an Action)
+constructs and applies a `RagingCondition` (a ConditionBehavior). The feature
+is "do something now"; the condition is "be present on the bus while
+applied."
+
+This nuance is also covered in `core.md` (the interface definitions) and
+`events.md` (how the condition's subscriptions interact with the chain
+during attack resolution). The split is real and architectural: it lets the
+toolkit's combat resolution stay ignorant of which specific features or
+conditions are active — the chain just publishes, and whichever subscribers
+were Apply'd respond.
+
+## Integration tests
+
+`integration/` contains full encounter simulations. Each file creates a
+character, enters combat, and exercises the full rule pipeline:
+- `barbarian_encounter_test.go` — Rage activation, reckless attack, extra attack
+- `fighter_encounter_test.go` — Second Wind, Action Surge, Fighting Style
+- `monk_encounter_test.go` — Martial Arts, Flurry of Blows, ki expenditure, Unarmored Defense
+- `rogue_encounter_test.go` — Sneak Attack, Cunning Action, DEX-based combat
+
+These are the most valuable tests in the toolkit. They exercise the full
+chain: character creation → finalization → combat entry → feature
+activation → attack resolution → resource consumption.
+
+## Known gaps
+
+### Untested grant logic (issue #615)
+
+`backgrounds/grants.go` (172 lines) implements `GetGrants(bg Background)
+*Grant` — a switch on 13 background types returning skill proficiencies, tool
+proficiencies, and language grants. **No test file.** The switch is
+straightforward data-mapping but is non-trivial: wrong skill assignments
+break character creation in rpg-api.
+
+`races/grants.go` (109 lines) implements `GetGrants(race Race) *Grant` —
+racial language grants, skill proficiencies (e.g., Half-Orc's Intimidation
+from Menacing), weapon/armor proficiencies (not yet populated). **No test
+file.**
+
+Both are called during character creation finalization. A bug here silently
+produces a character with wrong proficiencies.
+
+### dungeon/ location (planned move)
+
+`rulebooks/dnd5e/dungeon/` implements procedural dungeon generation: room
+shape selection, hex-perimeter wall calculation, door spawning, theme-based
+layout. It uses `tools/environments` and `tools/spatial` (correct direction —
+lower layers), but living inside the rulebook means rpg-api must import the
+full dnd5e module to use dungeon logic. The planned move is to
+`tools/dungeon/` or a standalone module. No issue filed yet.
+
+### character/choices testdata provenance
+
+`character/choices/testdata/api/classes/` and `testdata/api/races/` contain
+JSON fixtures from an external API. No note documents when they were fetched,
+from which URL, or how to refresh them. If the upstream API changes its
+schema, tests silently test stale data.
+
+### combatabilities/move.go
+
+`move.go` (movement action) is tested minimally — no test for stopping
+reasons, multi-leg paths, or movement exhaustion mid-turn. This matters for
+the multi-room dungeon when movement spans a door.
+
+### monster.Data deprecation comment
+
+The audit flagged a deprecation comment on `monster.Data` in rpg-api's
+repository file (`internal/repositories/encounters/repository.go`) — "DEPRECATED:
+migrating to Entities." Whether that migration is in flight or stalled wasn't
+verified. Track separately when the migration's status is clarified.
+
+## Verification
+
+```sh
+# Sub-package import surface
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # 24
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l    # 14
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l       # 12
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l    # 3
+
+# Combat chain entry point
+grep -n 'combat.ResolveAttack\|combat.WithCombatantLookup' /home/kirk/personal/rpg-api/internal/orchestrators/encounter/orchestrator.go | head
+
+# NewGoblin location (NOT in monster/monsters)
+grep -n 'func NewGoblin' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/monster/monster.go
+
+# refs surface
+grep -nE '^var [A-Z]' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/refs/*.go | grep -v _test
+```

--- a/docs/architecture/components/tools-environments.md
+++ b/docs/architecture/components/tools-environments.md
@@ -1,8 +1,8 @@
 ---
 name: tools/environments module
-description: Environment persistence, multi-room dungeon graph generation, pathfinding across rooms
-updated: 2026-05-02
-confidence: high — verified by reading environment_persistence.go, environment_data.go, graph_generator.go
+description: Multi-room environment graph, persistence, generation — rpg-api consumes a narrow slice (ConnectionEdge, RoomShape, ConnectionPoint)
+updated: 2026-05-04
+confidence: high — verified by reading environment_persistence.go, environment_data.go, graph_generator.go, and rpg-api dungeon-entity callsites per audit 049
 ---
 
 # tools/environments module
@@ -11,7 +11,28 @@ confidence: high — verified by reading environment_persistence.go, environment
 **Module:** `github.com/KirkDiggler/rpg-toolkit/tools/environments`
 **Grade:** B
 
-Builds on `tools/spatial` to provide a multi-room environment graph: how rooms connect (passages, doors), how to persist the entire dungeon layout, and how to find paths across connected rooms.
+Builds on `tools/spatial` to provide a multi-room environment graph: how rooms
+connect (passages, doors), how to persist the entire dungeon layout, and how
+to find paths across connected rooms.
+
+## What rpg-api consumes
+
+Per audit Section 1, rpg-api imports `tools/environments` from 6 files but
+uses **only** a narrow slice of the surface:
+
+| Symbol | Where rpg-api uses it | Histogram |
+|---|---|---|
+| `environments.ConnectionEdge` | `internal/entities/dungeon.go` | 10 |
+| `environments.RoomShape` | dungeon entity | 5 |
+| `environments.GetDefaultShapes` | dungeon construction | 1 |
+| `environments.ConnectionPoint` | dungeon entity | 1 |
+
+rpg-api uses environments for **dungeon-graph data only** — storing which
+rooms connect via which edges, and what shape each room is. The bulk of this
+module (graph generators, wall patterns, environment persistence,
+pathfinding) is **toolkit-internal infrastructure** that rpg-api does not
+import directly. Most of what's documented below is "what the toolkit can do
+for you," not "what rpg-api currently uses."
 
 ## Files (key ones)
 
@@ -20,14 +41,15 @@ Builds on `tools/spatial` to provide a multi-room environment graph: how rooms c
 | `environment.go` | `BasicEnvironment` — the environment aggregate |
 | `environment_data.go` | `EnvironmentData`, `RoomData`, `PassageData`, `OriginData` |
 | `environment_persistence.go` | `ToData()`, `LoadFromData()`, absolute-position entity tracking |
-| `graph_generator.go` | Procedural room graph generation algorithms |
+| `graph_generator.go` | Procedural room graph generation algorithms (toolkit-internal) |
 | `room_builder.go` | Fluent API for constructing rooms with walls, passages |
-| `wall_patterns.go` | Pre-defined wall configurations (perimeter, cross, T-junction) |
-| `pathfinding.go` | `FindPathCube` — hex A* across connected rooms |
+| `wall_patterns.go` | Pre-defined wall configurations (perimeter, cross, T-junction) (toolkit-internal) |
+| `pathfinding.go` | `FindPathCube` — hex A* across connected rooms (toolkit-internal) |
 
-## Persistence pattern
+## Persistence pattern (toolkit-internal)
 
-`BasicEnvironment` is stateful — it holds rooms, connections, and entity positions. It follows the `ToData`/`LoadFromData` convention:
+`BasicEnvironment` is stateful — it holds rooms, connections, and entity
+positions. It follows the `ToData`/`LoadFromData` convention:
 
 ```go
 // Serialize: all room positions converted to dungeon-absolute coordinates
@@ -37,23 +59,48 @@ data := env.ToData()
 env, err := environments.LoadFromData(ctx, LoadFromDataInput{Data: data, EventBus: bus})
 ```
 
-Entity positions are stored in absolute (dungeon-wide) coordinates in `EnvironmentData`, not room-local coordinates. The persistence layer converts between absolute and room-local on save/load.
+Entity positions are stored in absolute (dungeon-wide) coordinates in
+`EnvironmentData`, not room-local coordinates. The persistence layer converts
+between absolute and room-local on save/load.
 
-## Pathfinding
+rpg-api does not currently exercise this persistence path. Its dungeon entity
+stores `[]*environments.ConnectionEdge` directly and reconstructs the graph
+itself.
 
-`FindPathCube(start, goal CubeCoordinate) ([]CubeCoordinate, error)` finds a path in cube (hex) coordinates across connected rooms. It uses the hex pathfinder from `tools/spatial`. This is the authoritative cross-room pathfinder for hex-grid dungeons.
+## Pathfinding (toolkit-internal)
 
-**Square-grid cross-room pathfinding:** Not provided. Same gap as in `tools/spatial` — there is no square-grid pathfinder at any layer.
+`FindPathCube(start, goal CubeCoordinate) ([]CubeCoordinate, error)` finds a
+path in cube (hex) coordinates across connected rooms. It uses the hex
+pathfinder from `tools/spatial`. This is the authoritative cross-room
+pathfinder for hex-grid dungeons.
 
-## Graph generation
+**Square-grid cross-room pathfinding:** Not provided. Same gap as in
+`tools/spatial` — there is no square-grid pathfinder at any layer.
 
-`graph_generator.go` is substantial (~400 lines, estimated). It generates connected room graphs with configurable parameters (room count, connection density, branching factor). **It has no direct unit tests.** It is tested indirectly through the `BasicEnvironment` creation tests in `environment_persistence_test.go`.
+## Graph generation (toolkit-internal)
+
+`graph_generator.go` is substantial (~400 lines). It generates connected room
+graphs with configurable parameters (room count, connection density,
+branching factor). **It has no direct unit tests.** It is tested indirectly
+through the `BasicEnvironment` creation tests in
+`environment_persistence_test.go`.
 
 ## go.mod status
+
 Clean. Published versions, no replace directives.
 
 ## Known gaps
 
 - `graph_generator.go` is load-bearing but untested in isolation.
-- No test for `SelectablesTable` integration within environment generation (mentioned as "missing" in quality.md).
-- Large environments (100+ rooms) are not load-tested. Performance is extrapolated from small (4–8 room) tests.
+- No test for `SelectablesTable` integration within environment generation (mentioned as "missing" in `quality.md`).
+- Large environments (100+ rooms) are not load-tested. Performance is extrapolated from small (4-8 room) tests.
+
+## Verification
+
+```sh
+# rpg-api's narrow import surface
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/tools/environments"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 6
+
+# Specific symbols rpg-api consumes
+grep -rn 'environments\.\(ConnectionEdge\|RoomShape\|ConnectionPoint\|GetDefaultShapes\)' /home/kirk/personal/rpg-api/internal/ --include="*.go" | head
+```

--- a/docs/architecture/components/tools-environments.md
+++ b/docs/architecture/components/tools-environments.md
@@ -1,6 +1,6 @@
 ---
 name: tools/environments module
-description: Multi-room environment graph, persistence, generation — rpg-api consumes a narrow slice (ConnectionEdge, RoomShape, ConnectionPoint)
+description: Multi-room environment graph, persistence, generation — rpg-api consumes a narrow slice (ConnectionEdge, RoomShape, GetDefaultShapes, ConnectionPoint)
 updated: 2026-05-04
 confidence: high — verified by reading environment_persistence.go, environment_data.go, graph_generator.go, and rpg-api dungeon-entity callsites per audit 049
 ---

--- a/docs/architecture/components/tools-spatial.md
+++ b/docs/architecture/components/tools-spatial.md
@@ -1,8 +1,8 @@
 ---
 name: tools/spatial module
-description: Hex/Square/Gridless room management, multi-room orchestration, spatial queries, pathfinding
-updated: 2026-05-02
-confidence: high — verified by reading pathfinder.go, orchestrator.go, connection.go, hex_grid.go, square_grid.go, and test files
+description: Hex/Square/Gridless rooms, multi-room orchestration, spatial queries, pathfinding — second-largest rpg-api dependency
+updated: 2026-05-04
+confidence: high — verified by reading pathfinder.go, orchestrator.go, connection.go, hex_grid.go, square_grid.go, and rpg-api's hot-path imports per audit 049
 ---
 
 # tools/spatial module
@@ -11,7 +11,34 @@ confidence: high — verified by reading pathfinder.go, orchestrator.go, connect
 **Module:** `github.com/KirkDiggler/rpg-toolkit/tools/spatial`
 **Grade:** B+
 
-The spatial infrastructure: where entities are, how far apart, how to move between rooms. Does not implement game rules (movement costs, terrain effects, attack of opportunity) — those belong in `rulebooks/dnd5e`.
+The spatial infrastructure: where entities are, how far apart, how to move
+between rooms. Does not implement game rules (movement costs, terrain effects,
+attack of opportunity) — those belong in `rulebooks/dnd5e`.
+
+## What rpg-api consumes
+
+Per audit Section 1, `tools/spatial` is rpg-api's **second-heaviest toolkit
+dependency** (18 files import it). The hot path:
+
+| Symbol | Where rpg-api uses it | Histogram |
+|---|---|---|
+| `spatial.CubeCoordinate` | `internal/entities/merged_grid.go` | 128 |
+| `spatial.RoomData` | `internal/entities/encounter_events.go` | 82 |
+| `spatial.GridTypeHex` | `internal/handlers/dnd5e/v1alpha1/encounter/handler.go` | 52 |
+| `spatial.EntityCubePlacement` | `internal/entities/merged_grid.go` | 45 |
+| `spatial.Position` | `internal/entities/merged_grid.go` | 28 |
+| `spatial.HexOrientationPointyTop` | encounter handler | 19 |
+| `spatial.EntityPlacement` | merged_grid | 11 |
+
+`RoomData`, `EntityCubePlacement`, and the grid-type/hex-orientation
+constants are the dominant surface — rpg-api stores `spatial.RoomData`
+directly (the toolkit's data type is canonical) and reasons in cube
+coordinates throughout.
+
+The orchestrator/pathfinder/connection types described below are toolkit
+infrastructure. rpg-api currently does not import the multi-room
+orchestrator — its dungeon graph lives in `tools/environments` (see
+`tools-environments.md`).
 
 ## Files
 
@@ -32,7 +59,7 @@ The spatial infrastructure: where entities are, how far apart, how to move betwe
 | `query_utils.go` | Filter helpers (`CreateCharacterFilter`, `CreateMonsterFilter`, etc.) |
 | `events.go` | Event types: `EntityPlacedEvent`, `EntityMovedEvent`, `RoomAddedEvent`, etc. |
 | `topics.go` | Typed topic definitions |
-| `data.go` | `RoomData` — serializable room state |
+| `data.go` | `RoomData`, `EntityCubePlacement`, `EntityPlacement` — the serializable surface rpg-api stores |
 | `ids.go` | Typed ID constants |
 
 ## Grid systems
@@ -45,11 +72,29 @@ All three grid types are fully implemented:
 | Square | `SquareCoord` (x, y) | Chebyshev: `max(abs(dx), abs(dy))` | 8 |
 | Gridless | `Position` (float64 x, y) | Euclidean | N/A |
 
-Each grid implements its own distance calculation. `Position` is a data type; the grid decides the math.
+Each grid implements its own distance calculation. `Position` is a data type;
+the grid decides the math.
+
+The hex grid supports two orientations — `HexOrientationPointyTop` (the rpg-api
+default) and `HexOrientationFlatTop`. rpg-api uses pointy-top consistently; the
+flat-top constant exists for future use.
+
+## RoomData and EntityCubePlacement — the persistence shape
+
+`spatial.RoomData` is the serializable form of a room. rpg-api stores instances
+of this struct directly; there is no rpg-api-internal equivalent. That's
+deliberate — the toolkit owns the spatial vocabulary, and the API's job is to
+persist and pass through, not translate.
+
+`spatial.EntityCubePlacement` carries an entity's hex position (cube
+coordinates) and is used in `internal/entities/merged_grid.go` to track which
+entities live where in the encounter grid.
 
 ## Multi-room orchestration
 
-`BasicRoomOrchestrator` tracks multiple rooms and their connections. `FindPath` is room-to-room (which sequence of rooms to traverse), not intra-room.
+`BasicRoomOrchestrator` tracks multiple rooms and their connections.
+`FindPath` is room-to-room (which sequence of rooms to traverse), not
+intra-room.
 
 Connection types (helper constructors in `connection_helpers.go`):
 - `CreateDoorConnection` — standard bidirectional door
@@ -62,28 +107,48 @@ Connection types (helper constructors in `connection_helpers.go`):
 ## Known gaps
 
 ### PathFinder is hex-only (issue #614)
-`pathfinder.go:9`:
+
 ```go
 type PathFinder interface {
     FindPath(start, goal CubeCoordinate, blocked map[CubeCoordinate]bool) []CubeCoordinate
 }
 ```
 
-`CubeCoordinate` is the hex type. There is no `SquarePathFinder` with `SquareCoord` arguments. `SimplePathFinder.FindPath` uses `GetNeighbors()` on `CubeCoordinate` — it has no knowledge of square grid topology.
+`CubeCoordinate` is the hex type. There is no `SquarePathFinder` with
+`SquareCoord` arguments. `SimplePathFinder.FindPath` uses `GetNeighbors()` on
+`CubeCoordinate` — it has no knowledge of square grid topology.
 
-A monster navigating obstacles inside a square room has no toolkit path. The `BasicRoomOrchestrator.FindPath` returns a room sequence, not an intra-room path. Callers must implement their own A* for square-grid intra-room navigation. This is undocumented as a gap in the source. Fix: add `SquarePathFinder` implementing `FindPath(start, goal SquareCoord, blocked map[SquareCoord]bool) []SquareCoord`.
+A monster navigating obstacles inside a square room has no toolkit path. The
+`BasicRoomOrchestrator.FindPath` returns a room sequence, not an intra-room
+path. Callers must implement their own A* for square-grid intra-room
+navigation. This is undocumented as a gap in the source. Fix: add
+`SquarePathFinder` implementing `FindPath(start, goal SquareCoord, blocked
+map[SquareCoord]bool) []SquareCoord`.
 
 ### Unimplemented interfaces with no marker (issue #614 adjacent)
-`orchestrator.go:109` and `orchestrator.go:135` define `LayoutOrchestrator` and `TransitionSystem`:
+
+`orchestrator.go` defines `LayoutOrchestrator` and `TransitionSystem`:
+
 - `LayoutOrchestrator` — auto-position rooms, calculate layout metrics
 - `TransitionSystem` — track in-progress entity transitions between rooms
 
-Both are defined but have no implementation in this package. `tools/spatial/CLAUDE.md` documents them as "future work," but a reader of `orchestrator.go` alone has no indication. There is no `// Not implemented` comment, no `var _ LayoutOrchestrator = (*notImplemented)(nil)` guard, nothing. Risk: a new contributor implements them incorrectly assuming an interface contract that is actually advisory.
+Both are defined but have no implementation in this package.
+`tools/spatial/CLAUDE.md` documents them as "future work," but a reader of
+`orchestrator.go` alone has no indication. There is no `// Not implemented`
+comment, no `var _ LayoutOrchestrator = (*notImplemented)(nil)` guard,
+nothing. Risk: a new contributor implements them incorrectly assuming an
+interface contract that is actually advisory.
 
 ### Test coverage
-`pathfinder_test.go` covers 5 cases: direct path, L-shaped wall, surrounded (no path), same position, blocked goal. No tests for large grids, cycles, or priority queue tie-breaking. For the current use case (small dungeon rooms) this is acceptable, but it is worth noting before scaling to large environments.
+
+`pathfinder_test.go` covers 5 cases: direct path, L-shaped wall, surrounded
+(no path), same position, blocked goal. No tests for large grids, cycles, or
+priority queue tie-breaking. For the current use case (small dungeon rooms)
+this is acceptable, but it is worth noting before scaling to large
+environments.
 
 ## go.mod status
+
 Clean. Uses published versions for all dependencies:
 - `core v0.9.6`
 - `events v0.6.2`
@@ -91,3 +156,16 @@ Clean. Uses published versions for all dependencies:
 - `google/uuid v1.6.0`
 
 No replace directives.
+
+## Verification
+
+```sh
+# rpg-api's import surface
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/tools/spatial"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 18
+
+# Symbol histogram for the hot path
+grep -roE 'spatial\.(RoomData|EntityCubePlacement|GridTypeHex|HexOrientationPointyTop|CubeCoordinate)' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | sort | uniq -c | sort -rn | head
+
+# Toolkit module surface
+grep -nE "^func [A-Z]|^type [A-Z]" /home/kirk/personal/rpg-toolkit/tools/spatial/data.go
+```

--- a/docs/architecture/components/tools-spawn.md
+++ b/docs/architecture/components/tools-spawn.md
@@ -1,8 +1,8 @@
 ---
 name: tools/spawn module
-description: 4-phase entity spawn engine — selection, patterns, constraints, environment integration
-updated: 2026-05-02
-confidence: medium-high — verified by reading go.mod and test file names; logic verified through quality.md first-pass
+description: 4-phase entity spawn engine — selection, patterns, constraints, environment integration (toolkit-internal; not directly imported by rpg-api)
+updated: 2026-05-04
+confidence: medium-high — verified by reading go.mod and test file names; logic verified through quality.md first-pass; consumer view per audit 049
 ---
 
 # tools/spawn module
@@ -11,7 +11,14 @@ confidence: medium-high — verified by reading go.mod and test file names; logi
 **Module:** `github.com/KirkDiggler/rpg-toolkit/tools/spawn`
 **Grade:** B
 
-Four-phase spawn engine for placing entities in rooms during dungeon generation. Each phase adds capability; all four are implemented and tested.
+> **Consumer status (per audit 049): rpg-api does NOT directly import
+> `tools/spawn`.** Spawning is reached through the dnd5e dungeon flow
+> (`rulebooks/dnd5e/dungeon` and friends), which then invokes the spawn
+> engine internally. From the rpg-api boundary view this module is
+> toolkit-internal infrastructure.
+
+Four-phase spawn engine for placing entities in rooms during dungeon
+generation. Each phase adds capability; all four are implemented and tested.
 
 ## Phases
 
@@ -30,7 +37,8 @@ Four-phase spawn engine for placing entities in rooms during dungeon generation.
 - **Player choice** — deferred placement until player decides
 - **Clustered** — density-based spawning with proximity constraints
 
-These patterns have **no standalone tests** — they are exercised through the basic engine integration tests. This is the primary quality gap.
+These patterns have **no standalone tests** — they are exercised through the
+basic engine integration tests. This is the primary quality gap.
 
 ## Constraints (Phase 3)
 
@@ -48,6 +56,7 @@ These patterns have **no standalone tests** — they are exercised through the b
 - Split-room recommendations when capacity is exceeded
 
 ## go.mod status
+
 Clean. Uses published versions:
 - `tools/spatial v0.2.1`
 - `tools/environments v0.1.2`
@@ -58,3 +67,10 @@ No replace directives. This is the cleanest dependency chain in the tools layer.
 
 - `spawning_patterns.go` and `capacity_analysis.go` have no standalone tests. A bug in formation logic would not be caught until it manifests in the encounter.
 - No documented behavior for spawning in gridless rooms — the spawn engine was designed with hex/square rooms in mind.
+
+## Verification
+
+```sh
+# rpg-api does not import tools/spawn
+grep -rln '"github.com/KirkDiggler/rpg-toolkit/tools/spawn"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 0
+```


### PR DESCRIPTION
## Summary

PR 2 of 2 in the components/ doc re-grounding. PR 1 (the audit) merged as
[#619](https://github.com/KirkDiggler/rpg-toolkit/pull/619); this PR rewrites
the component docs informed by that audit.

The audit lives at
[docs/journey/049-rpg-api-toolkit-usage-audit.md](https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/journey/049-rpg-api-toolkit-usage-audit.md).
The Phase 1 plan is at
[rpg-project/ideas/autonomous-waves/design.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/autonomous-waves/design.md).

Each component doc now has a "What rpg-api consumes" section alongside the
existing toolkit-internal architecture coverage, so the docs serve both
audiences (toolkit contributors and rpg-api integrators).

## Files changed

| File | Change | One-line description |
|---|---|---|
| `docs/architecture/components/core.md` | Edit | Lead with rpg-api's `Ref`/`Entity`/`EntityType` surface; add `core/combat` and `core/resources` subsections; correct Action vs ConditionBehavior framing |
| `docs/architecture/components/events.md` | Edit | Accurate typed-topic surface; chain pattern made load-bearing with worked example from `combat/attack.go`; rewrite history (issue #617) |
| `docs/architecture/components/tools-spatial.md` | Edit | Add hot-path callout (`RoomData`, `EntityCubePlacement`, grid types, hex orientations) |
| `docs/architecture/components/tools-environments.md` | Edit | Add narrow-surface callout — rpg-api uses only `ConnectionEdge`, `RoomShape`, `ConnectionPoint`, `GetDefaultShapes` |
| `docs/architecture/components/rulebook-dnd5e.md` | Edit | Full sub-package map; dedicated subsections for `refs/`, `gamectx/`, `combat/`, `character/choices/`, `monster/`, `initiative/`, `character/`; Activation surface section; fix the 24 vs 30 sub-package count |
| `docs/architecture/components/refs.md` | Create | The boundary key — typed namespaces of `*core.Ref` singletons |
| `docs/architecture/components/dice.md` | Create | `dice` module surface (`Roller`, `NewRoller`, mock package); distinguishes toolkit library from rpg-api's own service shape |
| `docs/architecture/components/mechanics.md` | Keep + callout | Consumer status: rpg-api does NOT directly import any `mechanics/*` (issue #617) |
| `docs/architecture/components/items.md` | Keep + callout | Consumer status: rpg-api consumes equipment via `rulebooks/dnd5e/{weapons, armor, equipment}` |
| `docs/architecture/components/tools-spawn.md` | Keep + callout | Consumer status: rpg-api does NOT directly import; reached via dnd5e dungeon flow |
| `CLAUDE.md` | Edit | Update "Where things live" to list new `refs.md` and `dice.md` |

10 component docs total; CLAUDE.md inventory matches.

## Verification

The orchestrator can spot-check these claims:

```sh
# Events module surface (verify what events.md describes)
grep -nE "^func [A-Z]|^type [A-Z]|^var [A-Z]" /home/kirk/personal/rpg-toolkit/events/bus.go /home/kirk/personal/rpg-toolkit/events/bus_effect.go /home/kirk/personal/rpg-toolkit/events/topic.go /home/kirk/personal/rpg-toolkit/events/topic_def.go /home/kirk/personal/rpg-toolkit/events/typed_topic.go /home/kirk/personal/rpg-toolkit/events/chained_topic.go /home/kirk/personal/rpg-toolkit/events/chain.go /home/kirk/personal/rpg-toolkit/events/errors.go

# Action interface (used in core.md)
grep -n 'type Action\[T any\] interface' /home/kirk/personal/rpg-toolkit/core/action.go
grep -n 'core\.Action\[FeatureInput\]\|CanActivate implements\|Activate implements' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/features/rage.go

# ConditionBehavior interface (used in core.md and rulebook-dnd5e.md)
grep -n 'type ConditionBehavior interface' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/events/events.go
grep -n 'ConditionBehavior\|var _ ' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/conditions/raging.go

# Chain stages and worked attack flow (used in events.md and rulebook-dnd5e.md)
grep -n 'chain\.Stage' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/combat/stages.go
grep -n 'PublishWithChain\|NewStagedChain\|func ResolveAttack' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/combat/attack.go

# rpg-api file counts (used in every doc's hot-path table)
grep -rln '"github.com/KirkDiggler/rpg-toolkit/core"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l        # expect 8
grep -rln '"github.com/KirkDiggler/rpg-toolkit/events"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l      # expect 4
grep -rln '"github.com/KirkDiggler/rpg-toolkit/tools/spatial"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 18
grep -rln '"github.com/KirkDiggler/rpg-toolkit/tools/environments"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l  # expect 6
grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 12
grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l # expect 3
grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l # expect 24
grep -rln '"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 14

# Negative checks: rpg-api does not directly import these (callout claims)
grep -rln '"github.com/KirkDiggler/rpg-toolkit/mechanics' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 0
grep -rln '"github.com/KirkDiggler/rpg-toolkit/items"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l    # expect 0
grep -rln '"github.com/KirkDiggler/rpg-toolkit/tools/spawn"' /home/kirk/personal/rpg-api/internal/ /home/kirk/personal/rpg-api/cmd/ --include="*.go" | wc -l   # expect 0

# refs/ namespaces (used in refs.md and rulebook-dnd5e.md)
grep -nE '^var [A-Z]' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/refs/*.go | grep -v _test

# NewGoblin lives in monster.go, not monster/monsters/
grep -n 'func NewGoblin' /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/monster/monster.go
ls /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e/monster/monsters/   # bandit / brown_bear / ghoul, no goblin
```

## Things I could not verify

- Whether the dnd5e events package's `dnd5eEvents.NewEventBus` import in the audit's histogram is a re-export or a false positive — I left the text in events.md describing the top-level `events.NewEventBus` only, since that's what rpg-api actually consumes per direct grep (4 files, 10 references).
- The `monster.Data` deprecation comment in rpg-api at `internal/repositories/encounters/repository.go` — flagged in the rulebook-dnd5e.md "Known gaps" section but the migration's actual status (in flight vs stalled) is unverified.
- `core/chain` and the other `core/*` sub-packages have no test files — I noted this as a known gap but didn't run a test sweep, only a static grep.

## Things I discovered off-script

- **The audit's narrative said "24 sub-packages imported" for `rulebook-dnd5e.md` (Section 2 table), but Section 1's per-module listing actually shows 30 imported sub-packages.** The 24 was the file count for `character/` itself, conflated upward. I've corrected this in the doc with an explicit note explaining the discrepancy.
- **The previous `core.md` had wrong field names**: it documented `Ref` with field `Value` (it's actually `ID`) and `SourcedRef` with a `Label` field that doesn't exist (the real shape is `{Ref *Ref, Source *Source}`). Fixed.
- **The previous `core.md` described `topic.go` as defining a `Topic interface`** — `Topic` is actually a `string` named type used as the event-bus routing key, not an interface. Fixed.
- **`core.Topic` and `events.Topic` both exist** — both are `type Topic string` declarations. The events one is the bus-routing key; the core one appears unused by the rest of the toolkit and may be a candidate for removal. Not in scope here, just flagging.
- **The previous `events.md` described a "dual-bus" pattern** (`EventBus` vs `BusEffect`) as if `BusEffect` were a parallel bus — it's actually a lifecycle interface for subscribers, not a bus. Reframed in the new events.md.

## Test plan

- [ ] Run the verification commands above; counts and symbol locations match
- [ ] Spot-check that internal cross-references (`see core.md`, `see refs.md`, etc.) all resolve to existing files
- [ ] Confirm the Action vs ConditionBehavior framing reads consistently across `core.md`, `events.md`, and `rulebook-dnd5e.md` (no contradiction between docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)