### PR TITLE
chore: bump CI Go version to 1.25.x

### DIFF
--- a/.github/workflows/ci-enhanced.yml
+++ b/.github/workflows/ci-enhanced.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.24.x'
+  GO_VERSION: '1.25.x'
   GOLANGCI_VERSION: 'v2.2.1'
 
 jobs:

--- a/.github/workflows/ci-enhanced.yml
+++ b/.github/workflows/ci-enhanced.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   GO_VERSION: '1.25.x'
   GOLANGCI_VERSION: 'v2.2.1'
+  GOTOOLCHAIN: local
 
 jobs:
   detect-modules:

--- a/.github/workflows/ci-optimized.yml
+++ b/.github/workflows/ci-optimized.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   # Detect what changed
   changes:

--- a/.github/workflows/ci-optimized.yml
+++ b/.github/workflows/ci-optimized.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         module: ${{ fromJson(needs.changes.outputs.modules) }}
-        go-version: ['1.24.x']
+        go-version: ['1.25.x']
     
     steps:
     - uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.24.x']
+        go-version: ['1.25.x']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   test:
     # Skip this workflow - using optimized workflow instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.24.x']
+        go-version: ['1.25.x']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release-module.yml
+++ b/.github/workflows/release-module.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: write
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-module.yml
+++ b/.github/workflows/release-module.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.x'
+        go-version: '1.25.x'
     
     - name: Test module
       run: |


### PR DESCRIPTION
## Summary
- Bump all workflows from Go 1.24.x → 1.25.x
- Module `go.mod` declarations untouched; bump per-module when new stdlib features are needed

Closes #626
Closes #625 

## Files
- `.github/workflows/ci.yml`
- `.github/workflows/ci-enhanced.yml`
- `.github/workflows/ci-optimized.yml`
- `.github/workflows/release-module.yml`

## Test plan
- [ ] CI runs green on 1.25.x across all modules
- [ ] No deprecation warnings introduced by the toolchain bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)