### PR TITLE
feat(encounter): emit EntityAppeared/EntityDisappeared when movement crosses viewer LoS

### DIFF
--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -218,6 +218,10 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "HexRevealedEvent"
 	case *events.DoorOpenedEvent:
 		typeName = "DoorOpenedEvent"
+	case *events.EntityAppearedEvent:
+		typeName = "EntityAppearedEvent"
+	case *events.EntityDisappearedEvent:
+		typeName = "EntityDisappearedEvent"
 	default:
 		return nil, fmt.Errorf("unknown event type %T", evt)
 	}
@@ -248,6 +252,18 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "DoorOpenedEvent":
 		var e events.DoorOpenedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "EntityAppearedEvent":
+		var e events.EntityAppearedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "EntityDisappearedEvent":
+		var e events.EntityDisappearedEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -124,9 +124,13 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		return fmt.Errorf("player %q not in encounter", playerID)
 	}
 
-	// 1. Compute the mover's reveal delta BEFORE mutating position/view.
-	//    The delta = (visible-from-new-position) MINUS (already-revealed).
-	//    Critical: if we apply the reveal first, the diff is always empty.
+	// 1. Capture starting position and compute the mover's reveal delta BEFORE
+	//    mutating position/view.
+	//    - moverStart is needed for visibility-transition detection (so viewers
+	//      can determine if the mover was visible to them before the move).
+	//    - The reveal delta = (visible-from-new-position) MINUS (already-revealed).
+	//      Critical: if we apply the reveal first, the diff is always empty.
+	moverStart := p.View.Position
 	end := path[len(path)-1]
 	newVisible := perception.VisibleHexesAt(end, p.View.SightRange)
 	moverNewHexes := diffHexes(p.View.RevealedHexes, newVisible)
@@ -149,6 +153,14 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	}
 
 	// Other players: project the move from their current view.
+	//
+	// Also accumulate visibility-transition data for EntityAppeared /
+	// EntityDisappeared events. appearedByHex maps the hex where the mover
+	// became visible to the set of viewers who see the appearance at that hex.
+	// disappearedPerPlayer maps each viewer to the hex where they last saw the mover.
+	appearedByHex := make(map[core.Hex]map[core.PlayerID]struct{})
+	disappearedPerPlayer := make(map[core.PlayerID]core.Hex)
+
 	for otherID, other := range e.data.Players {
 		if otherID == playerID {
 			continue
@@ -162,6 +174,22 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 				other.View.ApplyReveal(revealSlice.Hexes)
 			}
 			revealPerPlayer[otherID] = *revealSlice
+		}
+
+		// Determine visibility transitions for this viewer.
+		var seenSegments []core.Hex
+		if moveSlice != nil {
+			seenSegments = moveSlice.SeenSegments
+		}
+		appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, other.View)
+		if appearedAt != nil {
+			if appearedByHex[*appearedAt] == nil {
+				appearedByHex[*appearedAt] = make(map[core.PlayerID]struct{})
+			}
+			appearedByHex[*appearedAt][otherID] = struct{}{}
+		}
+		if disappearedAt != nil {
+			disappearedPerPlayer[otherID] = *disappearedAt
 		}
 	}
 
@@ -177,6 +205,30 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 			e.data.ID, e.nextSeq(), revealPerPlayer,
 		)); err != nil {
 			return fmt.Errorf("publish reveal: %w", err)
+		}
+	}
+
+	// Emit EntityAppearedEvent once per distinct appeared-at hex, grouping
+	// viewers who share the same appearance position. Under the endpoints-only
+	// model this is typically a single hex (path[len-1] for enter-LoS), but
+	// pass-through viewers at different positions can yield different
+	// SeenSegments[0] hexes, producing distinct groups.
+	for hex, viewers := range appearedByHex {
+		if err := e.broker.Publish(events.NewEntityAppearedEvent(
+			e.data.ID, e.nextSeq(), p.EntityID, hex, viewers,
+		)); err != nil {
+			return fmt.Errorf("publish entity appeared: %w", err)
+		}
+	}
+
+	// Emit EntityDisappearedEvent as a single event carrying per-viewer
+	// last-known hexes (different viewers may have last seen the mover at
+	// different hexes during a pass-through move).
+	if len(disappearedPerPlayer) > 0 {
+		if err := e.broker.Publish(events.NewEntityDisappearedEvent(
+			e.data.ID, e.nextSeq(), p.EntityID, disappearedPerPlayer,
+		)); err != nil {
+			return fmt.Errorf("publish entity disappeared: %w", err)
 		}
 	}
 	return nil

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -165,7 +165,9 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		if otherID == playerID {
 			continue
 		}
-		moveSlice, revealSlice := perception.ProjectMove(p.EntityID, path, other.View)
+		// ProjectMove returns the visible set so we can pass it directly to
+		// ProjectVisibilityTransition without recomputing VisibleHexesAt.
+		moveSlice, revealSlice, visible := perception.ProjectMove(p.EntityID, path, other.View)
 		if moveSlice != nil {
 			movePerPlayer[otherID] = *moveSlice
 		}
@@ -181,7 +183,9 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		if moveSlice != nil {
 			seenSegments = moveSlice.SeenSegments
 		}
-		appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, other.View)
+		appearedAt, disappearedAt := perception.ProjectVisibilityTransition(
+			moverStart, path, seenSegments, other.View, visible,
+		)
 		if appearedAt != nil {
 			if appearedByHex[*appearedAt] == nil {
 				appearedByHex[*appearedAt] = make(map[core.PlayerID]struct{})

--- a/encounter/events/entity_appeared.go
+++ b/encounter/events/entity_appeared.go
@@ -1,0 +1,92 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// EntityAppearedEvent is published when a moving entity enters one or more
+// viewers' lines of sight during a move. This event lets consumers show entity
+// markers for viewers who could not see the mover before.
+//
+// Position is the hex where the mover became visible. Under the endpoints-only
+// visibility model, all viewers in the audience will see the mover appear at
+// the same hex (path[len-1] for enter-LoS; SeenSegments[0] for pass-through).
+// If two viewers share different appearedAt hexes (only possible in pass-through
+// when viewers sit at different positions and thus differ in which hex was the
+// first visible one), Move() emits one EntityAppearedEvent per distinct Position
+// with the viewers for that position grouped into PerPlayer.
+type EntityAppearedEvent struct {
+	encID     core.EncounterID
+	seq       uint64
+	Entity    core.EntityID
+	Position  core.Hex
+	PerPlayer map[core.PlayerID]struct{}
+}
+
+// NewEntityAppearedEvent constructs an EntityAppearedEvent. The encounter is
+// responsible for stamping the encounter ID and sequence number.
+func NewEntityAppearedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	entity core.EntityID,
+	position core.Hex,
+	perPlayer map[core.PlayerID]struct{},
+) *EntityAppearedEvent {
+	return &EntityAppearedEvent{
+		encID:     encID,
+		seq:       seq,
+		Entity:    entity,
+		Position:  position,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*EntityAppearedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *EntityAppearedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *EntityAppearedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who newly see the entity, derived from
+// the keys of PerPlayer.
+func (e *EntityAppearedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+// entityAppearedWire is the on-wire shape — used only by MarshalJSON / UnmarshalJSON.
+type entityAppearedWire struct {
+	EncID     core.EncounterID           `json:"encounter_id"`
+	Seq       uint64                     `json:"sequence"`
+	Entity    core.EntityID              `json:"entity"`
+	Position  core.Hex                   `json:"position"`
+	PerPlayer map[core.PlayerID]struct{} `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names without
+// making the Go fields exported. Implements encoding/json.Marshaler.
+func (e *EntityAppearedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(entityAppearedWire{
+		EncID:     e.encID,
+		Seq:       e.seq,
+		Entity:    e.Entity,
+		Position:  e.Position,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *EntityAppearedEvent) UnmarshalJSON(b []byte) error {
+	var w entityAppearedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.Entity = w.Entity
+	e.Position = w.Position
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/entity_disappeared.go
+++ b/encounter/events/entity_disappeared.go
@@ -1,0 +1,84 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// EntityDisappearedEvent is published when a moving entity leaves one or more
+// viewers' lines of sight during a move. This event lets consumers clear or
+// freeze entity markers at each viewer's last-known position.
+//
+// PerPlayer maps each affected viewer's PlayerID to the last hex at which that
+// viewer saw the entity. Different viewers may have last seen the entity at
+// different hexes (e.g. two viewers in different positions during a pass-through
+// move), so per-viewer last-known position is required. For movement-driven
+// disappearance this is the last hex of that viewer's SeenSegments.
+type EntityDisappearedEvent struct {
+	encID     core.EncounterID
+	seq       uint64
+	Entity    core.EntityID
+	PerPlayer map[core.PlayerID]core.Hex
+}
+
+// NewEntityDisappearedEvent constructs an EntityDisappearedEvent. The encounter
+// is responsible for stamping the encounter ID and sequence number.
+func NewEntityDisappearedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	entity core.EntityID,
+	perPlayer map[core.PlayerID]core.Hex,
+) *EntityDisappearedEvent {
+	return &EntityDisappearedEvent{
+		encID:     encID,
+		seq:       seq,
+		Entity:    entity,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*EntityDisappearedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *EntityDisappearedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *EntityDisappearedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who lost sight of the entity, derived
+// from the keys of PerPlayer.
+func (e *EntityDisappearedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+// entityDisappearedWire is the on-wire shape — used only by MarshalJSON / UnmarshalJSON.
+type entityDisappearedWire struct {
+	EncID     core.EncounterID           `json:"encounter_id"`
+	Seq       uint64                     `json:"sequence"`
+	Entity    core.EntityID              `json:"entity"`
+	PerPlayer map[core.PlayerID]core.Hex `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names without
+// making the Go fields exported. Implements encoding/json.Marshaler.
+func (e *EntityDisappearedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(entityDisappearedWire{
+		EncID:     e.encID,
+		Seq:       e.seq,
+		Entity:    e.Entity,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *EntityDisappearedEvent) UnmarshalJSON(b []byte) error {
+	var w entityDisappearedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.Entity = w.Entity
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -22,6 +22,8 @@ func (s *EventsSuite) TestConcretes_SatisfyInterface() {
 	var _ events.EncounterEvent = (*events.MoveEvent)(nil)
 	var _ events.EncounterEvent = (*events.HexRevealedEvent)(nil)
 	var _ events.EncounterEvent = (*events.DoorOpenedEvent)(nil)
+	var _ events.EncounterEvent = (*events.EntityAppearedEvent)(nil)
+	var _ events.EncounterEvent = (*events.EntityDisappearedEvent)(nil)
 }
 
 // MoveEvent.Audience derives from PerPlayer keys; absent players are not in audience.
@@ -83,12 +85,63 @@ func (s *EventsSuite) TestHexRevealedEvent_JSONRoundTrip() {
 	s.True(aliceSlice.Hexes.Has(core.Hex{Q: 1, R: 0, S: -1}))
 }
 
+// EntityAppearedEvent JSON round-trip — audience derived from PerPlayer keys.
+func (s *EventsSuite) TestEntityAppearedEvent_JSONRoundTrip() {
+	original := events.NewEntityAppearedEvent(
+		"enc-1", 9, "char-alice",
+		core.Hex{Q: 2, R: 0, S: -2},
+		map[core.PlayerID]struct{}{"bob": {}, "carol": {}},
+	)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EntityAppearedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(9), decoded.Sequence())
+	s.Equal(core.EntityID("char-alice"), decoded.Entity)
+	s.Equal(core.Hex{Q: 2, R: 0, S: -2}, decoded.Position)
+	s.Contains(decoded.PerPlayer, core.PlayerID("bob"))
+	s.Contains(decoded.PerPlayer, core.PlayerID("carol"))
+	s.ElementsMatch(events.AudienceSet{"bob", "carol"}, decoded.Audience())
+}
+
+// EntityDisappearedEvent JSON round-trip — per-viewer hex map survives encoding.
+func (s *EventsSuite) TestEntityDisappearedEvent_JSONRoundTrip() {
+	original := events.NewEntityDisappearedEvent(
+		"enc-1", 10, "char-alice",
+		map[core.PlayerID]core.Hex{
+			"bob":   {Q: 3, R: 0, S: -3},
+			"carol": {Q: 1, R: 1, S: -2},
+		},
+	)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EntityDisappearedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(10), decoded.Sequence())
+	s.Equal(core.EntityID("char-alice"), decoded.Entity)
+	s.Require().Contains(decoded.PerPlayer, core.PlayerID("bob"))
+	s.Equal(core.Hex{Q: 3, R: 0, S: -3}, decoded.PerPlayer[core.PlayerID("bob")])
+	s.Require().Contains(decoded.PerPlayer, core.PlayerID("carol"))
+	s.Equal(core.Hex{Q: 1, R: 1, S: -2}, decoded.PerPlayer[core.PlayerID("carol")])
+	s.ElementsMatch(events.AudienceSet{"bob", "carol"}, decoded.Audience())
+}
+
 // Type switch returns the concrete type.
 func (s *EventsSuite) TestTypeSwitch_RecoversConcrete() {
 	evts := []events.EncounterEvent{
 		events.NewMoveEvent("enc-1", 1, "bob", nil, nil),
 		events.NewHexRevealedEvent("enc-1", 2, nil),
 		events.NewDoorOpenedEvent("enc-1", 3, "door-1", "bob", nil),
+		events.NewEntityAppearedEvent("enc-1", 4, "bob", core.Hex{}, nil),
+		events.NewEntityDisappearedEvent("enc-1", 5, "bob", nil),
 	}
 
 	var seen []string
@@ -100,9 +153,13 @@ func (s *EventsSuite) TestTypeSwitch_RecoversConcrete() {
 			seen = append(seen, "revealed")
 		case *events.DoorOpenedEvent:
 			seen = append(seen, "door")
+		case *events.EntityAppearedEvent:
+			seen = append(seen, "appeared")
+		case *events.EntityDisappearedEvent:
+			seen = append(seen, "disappeared")
 		default:
 			s.FailNow("unhandled event type")
 		}
 	}
-	s.Equal([]string{"move", "revealed", "door"}, seen)
+	s.Equal([]string{"move", "revealed", "door", "appeared", "disappeared"}, seen)
 }

--- a/encounter/perception/project.go
+++ b/encounter/perception/project.go
@@ -5,6 +5,73 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 )
 
+// ProjectVisibilityTransition determines whether the mover entered or left the
+// viewer's line of sight during this move, given the mover's starting position,
+// their path (list of destination hexes), and the move slice already projected
+// by ProjectMove.
+//
+// Design: endpoints + SeenSegments boundaries (the simple "slice-1" approach).
+// For each viewer, only the move endpoints and the seen-segment boundaries are
+// checked — no per-hex timeline along the path. This is correct under the
+// Manhattan stub LoS (monotonic visibility from a fixed viewer). Future real-LoS
+// work can revisit; that is a follow-up issue.
+//
+//   - visibleAtStart = moverStart is in viewer's current LoS
+//   - visibleAtEnd   = path[len-1] is in viewer's current LoS (the destination)
+//   - (false, true)  → appearedAt = path[len-1]
+//   - (true, false)  → disappearedAt = last hex of seenSegments
+//   - (false, false) && seenSegments non-empty → pass-through: both
+//     appearedAt = seenSegments[0], disappearedAt = seenSegments[len-1]
+//   - (true, true)   → no visibility transition
+//
+// moverStart is the mover's position before the move (not in path; path contains
+// only the destination hexes the mover traverses).
+//
+// Returns (appearedAt, disappearedAt) — either may be nil for "no transition of
+// that kind."
+func ProjectVisibilityTransition(
+	moverStart core.Hex,
+	path []core.Hex,
+	seenSegments []core.Hex,
+	viewer *View,
+) (appearedAt, disappearedAt *core.Hex) {
+	if viewer == nil || len(path) == 0 {
+		return nil, nil
+	}
+
+	visible := VisibleHexesAt(viewer.Position, viewer.SightRange)
+	visibleAtStart := visible.Has(moverStart)
+	visibleAtEnd := visible.Has(path[len(path)-1])
+
+	switch {
+	case !visibleAtStart && visibleAtEnd:
+		// Mover entered LoS: appeared at path end (destination).
+		h := path[len(path)-1]
+		return &h, nil
+
+	case visibleAtStart && !visibleAtEnd:
+		// Mover left LoS: disappeared at last seen hex.
+		if len(seenSegments) == 0 {
+			// Should not happen if visibleAtStart is true and path is non-empty,
+			// but guard defensively.
+			return nil, nil
+		}
+		h := seenSegments[len(seenSegments)-1]
+		return nil, &h
+
+	case !visibleAtStart && !visibleAtEnd && len(seenSegments) > 0:
+		// Pass-through: mover traversed the viewer's LoS but is outside at both
+		// endpoints. Both events fire.
+		first := seenSegments[0]
+		last := seenSegments[len(seenSegments)-1]
+		return &first, &last
+
+	default:
+		// (true, true) or (false, false) with empty seen: no transition.
+		return nil, nil
+	}
+}
+
 // ProjectMove computes a viewer's move slice and reveal slice when an entity
 // moves along path. Returns (moveSlice, revealSlice). Either may be nil if
 // the viewer perceives nothing of the move or has no vision change.

--- a/encounter/perception/project.go
+++ b/encounter/perception/project.go
@@ -7,8 +7,9 @@ import (
 
 // ProjectVisibilityTransition determines whether the mover entered or left the
 // viewer's line of sight during this move, given the mover's starting position,
-// their path (list of destination hexes), and the move slice already projected
-// by ProjectMove.
+// their path (list of destination hexes), the move slice already projected by
+// ProjectMove, and the viewer's precomputed visible hex set (from ProjectMove's
+// same VisibleHexesAt call, passed here to avoid recomputation).
 //
 // Design: endpoints + SeenSegments boundaries (the simple "slice-1" approach).
 // For each viewer, only the move endpoints and the seen-segment boundaries are
@@ -19,13 +20,19 @@ import (
 //   - visibleAtStart = moverStart is in viewer's current LoS
 //   - visibleAtEnd   = path[len-1] is in viewer's current LoS (the destination)
 //   - (false, true)  → appearedAt = path[len-1]
-//   - (true, false)  → disappearedAt = last hex of seenSegments
+//   - (true, false)  → disappearedAt = last hex of seenSegments, or moverStart
+//     if seenSegments is empty (mover was visible at start but left immediately)
 //   - (false, false) && seenSegments non-empty → pass-through: both
 //     appearedAt = seenSegments[0], disappearedAt = seenSegments[len-1]
 //   - (true, true)   → no visibility transition
 //
 // moverStart is the mover's position before the move (not in path; path contains
 // only the destination hexes the mover traverses).
+//
+// visible is the precomputed result of VisibleHexesAt(viewer.Position,
+// viewer.SightRange) — the same set used by ProjectMove for this viewer/path
+// combination. Passing it in avoids a redundant O(range²) set construction per
+// viewer per move.
 //
 // Returns (appearedAt, disappearedAt) — either may be nil for "no transition of
 // that kind."
@@ -34,12 +41,12 @@ func ProjectVisibilityTransition(
 	path []core.Hex,
 	seenSegments []core.Hex,
 	viewer *View,
+	visible core.HexSet,
 ) (appearedAt, disappearedAt *core.Hex) {
 	if viewer == nil || len(path) == 0 {
 		return nil, nil
 	}
 
-	visible := VisibleHexesAt(viewer.Position, viewer.SightRange)
 	visibleAtStart := visible.Has(moverStart)
 	visibleAtEnd := visible.Has(path[len(path)-1])
 
@@ -50,11 +57,11 @@ func ProjectVisibilityTransition(
 		return &h, nil
 
 	case visibleAtStart && !visibleAtEnd:
-		// Mover left LoS: disappeared at last seen hex.
+		// Mover left LoS: disappeared at last seen hex. When seenSegments is
+		// empty the mover's start position itself was visible but no destination
+		// hex in the path was, so moverStart is the last-known hex.
 		if len(seenSegments) == 0 {
-			// Should not happen if visibleAtStart is true and path is non-empty,
-			// but guard defensively.
-			return nil, nil
+			return nil, &moverStart
 		}
 		h := seenSegments[len(seenSegments)-1]
 		return nil, &h
@@ -72,9 +79,14 @@ func ProjectVisibilityTransition(
 	}
 }
 
-// ProjectMove computes a viewer's move slice and reveal slice when an entity
-// moves along path. Returns (moveSlice, revealSlice). Either may be nil if
-// the viewer perceives nothing of the move or has no vision change.
+// ProjectMove computes a viewer's move slice, reveal slice, and visible hex set
+// when an entity moves along path. Returns (moveSlice, revealSlice, visible).
+// moveSlice and revealSlice may be nil if the viewer perceives nothing of the
+// move or has no vision change. visible is always non-nil.
+//
+// The visible set is returned so callers can pass it directly to
+// ProjectVisibilityTransition without recomputing VisibleHexesAt (O(range²))
+// a second time for the same viewer.
 //
 // Slice 1 stub: viewer's visibility is computed from their CURRENT position.
 // Real LoS will be position-aware-per-segment. Slice 1 does NOT emit
@@ -86,11 +98,11 @@ func ProjectMove(
 	_ core.EntityID, // mover — reserved for future-slice entity-visibility
 	path []core.Hex,
 	viewer *View,
-) (moveSlice *events.MovePlayerSlice, revealSlice *events.HexRevealedSlice) {
+) (moveSlice *events.MovePlayerSlice, revealSlice *events.HexRevealedSlice, visible core.HexSet) {
 	if viewer == nil || len(path) == 0 {
-		return nil, nil
+		return nil, nil, make(core.HexSet)
 	}
-	visible := VisibleHexesAt(viewer.Position, viewer.SightRange)
+	visible = VisibleHexesAt(viewer.Position, viewer.SightRange)
 
 	var seen []core.Hex
 	for _, hex := range path {
@@ -105,7 +117,7 @@ func ProjectMove(
 	// own position didn't change, so under the stub LoS no new hexes are
 	// revealed. Future slices handle entity-visibility deltas (mover entering
 	// the viewer's vision becomes a EntityVisibility entry on the slice).
-	return moveSlice, nil
+	return moveSlice, nil, visible
 }
 
 // ProjectDoorOpen computes per-viewer slices when a door opens.

--- a/encounter/perception/project_test.go
+++ b/encounter/perception/project_test.go
@@ -24,7 +24,7 @@ func (s *ProjectSuite) TestProjectMove_ViewerInRange() {
 		{Q: 2, R: 0, S: -2},
 		{Q: 3, R: 0, S: -3},
 	}
-	moveSlice, _ := perception.ProjectMove("bob", path, viewer)
+	moveSlice, _, _ := perception.ProjectMove("bob", path, viewer)
 
 	s.Require().NotNil(moveSlice)
 	s.Equal(path, moveSlice.SeenSegments)
@@ -37,7 +37,7 @@ func (s *ProjectSuite) TestProjectMove_ViewerOutOfRange() {
 		{Q: 5, R: -2, S: -3},
 		{Q: 6, R: -2, S: -4},
 	}
-	moveSlice, revealSlice := perception.ProjectMove("bob", path, viewer)
+	moveSlice, revealSlice, _ := perception.ProjectMove("bob", path, viewer)
 
 	s.Nil(moveSlice)
 	s.Nil(revealSlice)
@@ -76,12 +76,12 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_EnterLoS() {
 	pathEnd := core.Hex{Q: 3, R: 0, S: -3}
 	path := []core.Hex{pathEnd}
 
-	// seenSegments from ProjectMove: path end is visible.
-	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	// Use ProjectMove to get both seenSegments and the precomputed visible set.
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
-	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer, visible)
 
 	s.Require().NotNil(appearedAt, "mover entered LoS — appearedAt must not be nil")
 	s.Equal(pathEnd, *appearedAt)
@@ -99,11 +99,11 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_LeaveLoS() {
 		{Q: 10, R: 0, S: -10}, // outside
 	}
 
-	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
-	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer, visible)
 
 	s.Nil(appearedAt)
 	s.Require().NotNil(disappearedAt, "mover left LoS — disappearedAt must not be nil")
@@ -112,22 +112,22 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_LeaveLoS() {
 }
 
 // Mover starts outside, passes through viewer's LoS, ends outside → both events.
+// Path contains only destination hexes; moverStart supplies the initial position.
 func (s *ProjectSuite) TestProjectVisibilityTransition_PassThrough() {
 	viewer := perception.NewView("bob", core.Hex{}, 4)
 
-	moverStart := core.Hex{Q: -10, R: 0, S: 10} // outside
+	moverStart := core.Hex{Q: -10, R: 0, S: 10} // outside — NOT in path
 	path := []core.Hex{
-		{Q: -10, R: 0, S: 10}, // outside (same as start, included explicitly)
-		{Q: -3, R: 0, S: 3},   // inside (dist 3)
+		{Q: -3, R: 0, S: 3},   // first destination — inside (dist 3)
 		{Q: 4, R: 0, S: -4},   // inside (dist 4)
 		{Q: 10, R: 0, S: -10}, // outside
 	}
 
-	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
-	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer, visible)
 
 	s.Require().NotNil(appearedAt)
 	s.Require().NotNil(disappearedAt)
@@ -142,11 +142,11 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_StaysVisible() {
 	moverStart := core.Hex{Q: 1, R: 0, S: -1} // inside
 	path := []core.Hex{{Q: 2, R: 0, S: -2}}   // inside
 
-	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
-	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer, visible)
 
 	s.Nil(appearedAt, "no enter-LoS transition when mover stays visible")
 	s.Nil(disappearedAt, "no leave-LoS transition when mover stays visible")
@@ -159,13 +159,33 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_NeverVisible() {
 	moverStart := core.Hex{Q: 10, R: 0, S: -10}
 	path := []core.Hex{{Q: 15, R: 0, S: -15}}
 
-	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
-	s.Nil(moveSlice, "viewer out of range — no move slice")
+	_, _, visible := perception.ProjectMove("alice", path, viewer)
 
-	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, nil, viewer)
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, nil, viewer, visible)
 
 	s.Nil(appearedAt)
 	s.Nil(disappearedAt)
+}
+
+// Mover starts visible but path has no visible destination hexes (immediate leave) →
+// last-known hex falls back to moverStart rather than silently dropping the event.
+func (s *ProjectSuite) TestProjectVisibilityTransition_LeaveLoS_EmptySeenSegments() {
+	viewer := perception.NewView("bob", core.Hex{}, 4)
+
+	// moverStart is inside viewer's range; path has only one hex outside range.
+	moverStart := core.Hex{Q: 2, R: 0, S: -2}
+	path := []core.Hex{{Q: 10, R: 0, S: -10}} // single destination, outside
+
+	_, _, visible := perception.ProjectMove("alice", path, viewer)
+
+	// seenSegments will be empty because the single path hex is out of range.
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, nil, viewer, visible)
+
+	s.Nil(appearedAt)
+	s.Require().NotNil(disappearedAt,
+		"disappearedAt must not be nil when mover was visible at start but seenSegments is empty")
+	s.Equal(moverStart, *disappearedAt,
+		"last-known hex falls back to moverStart when no path hex was visible")
 }
 
 func (s *ProjectSuite) TestView_ApplyRevealIdempotent() {

--- a/encounter/perception/project_test.go
+++ b/encounter/perception/project_test.go
@@ -65,6 +65,109 @@ func (s *ProjectSuite) TestProjectDoorOpen_ViewerOutOfRange() {
 	s.Nil(revealSlice)
 }
 
+// ─── ProjectVisibilityTransition unit tests ────────────────────────────────
+
+// Mover starts outside viewer's LoS and ends inside → appearedAt = path end.
+func (s *ProjectSuite) TestProjectVisibilityTransition_EnterLoS() {
+	viewer := perception.NewView("bob", core.Hex{}, 4)
+
+	// moverStart is outside viewer's sight range.
+	moverStart := core.Hex{Q: -10, R: 0, S: 10}
+	pathEnd := core.Hex{Q: 3, R: 0, S: -3}
+	path := []core.Hex{pathEnd}
+
+	// seenSegments from ProjectMove: path end is visible.
+	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	s.Require().NotNil(moveSlice)
+	seenSegments := moveSlice.SeenSegments
+
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+
+	s.Require().NotNil(appearedAt, "mover entered LoS — appearedAt must not be nil")
+	s.Equal(pathEnd, *appearedAt)
+	s.Nil(disappearedAt)
+}
+
+// Mover starts inside viewer's LoS and ends outside → disappearedAt = last seen hex.
+func (s *ProjectSuite) TestProjectVisibilityTransition_LeaveLoS() {
+	viewer := perception.NewView("bob", core.Hex{}, 4)
+
+	moverStart := core.Hex{Q: 2, R: 0, S: -2} // inside viewer's range of 4
+	path := []core.Hex{
+		{Q: 3, R: 0, S: -3},   // visible (dist 3)
+		{Q: 4, R: 0, S: -4},   // visible (dist 4, edge)
+		{Q: 10, R: 0, S: -10}, // outside
+	}
+
+	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	s.Require().NotNil(moveSlice)
+	seenSegments := moveSlice.SeenSegments
+
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+
+	s.Nil(appearedAt)
+	s.Require().NotNil(disappearedAt, "mover left LoS — disappearedAt must not be nil")
+	s.Equal(core.Hex{Q: 4, R: 0, S: -4}, *disappearedAt,
+		"last seen hex should be the boundary of viewer's sight range")
+}
+
+// Mover starts outside, passes through viewer's LoS, ends outside → both events.
+func (s *ProjectSuite) TestProjectVisibilityTransition_PassThrough() {
+	viewer := perception.NewView("bob", core.Hex{}, 4)
+
+	moverStart := core.Hex{Q: -10, R: 0, S: 10} // outside
+	path := []core.Hex{
+		{Q: -10, R: 0, S: 10}, // outside (same as start, included explicitly)
+		{Q: -3, R: 0, S: 3},   // inside (dist 3)
+		{Q: 4, R: 0, S: -4},   // inside (dist 4)
+		{Q: 10, R: 0, S: -10}, // outside
+	}
+
+	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	s.Require().NotNil(moveSlice)
+	seenSegments := moveSlice.SeenSegments
+
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+
+	s.Require().NotNil(appearedAt)
+	s.Require().NotNil(disappearedAt)
+	s.Equal(core.Hex{Q: -3, R: 0, S: 3}, *appearedAt, "appeared at first visible hex")
+	s.Equal(core.Hex{Q: 4, R: 0, S: -4}, *disappearedAt, "disappeared at last visible hex")
+}
+
+// Mover starts and ends inside viewer's LoS → no transition events.
+func (s *ProjectSuite) TestProjectVisibilityTransition_StaysVisible() {
+	viewer := perception.NewView("bob", core.Hex{}, 4)
+
+	moverStart := core.Hex{Q: 1, R: 0, S: -1} // inside
+	path := []core.Hex{{Q: 2, R: 0, S: -2}}   // inside
+
+	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	s.Require().NotNil(moveSlice)
+	seenSegments := moveSlice.SeenSegments
+
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, seenSegments, viewer)
+
+	s.Nil(appearedAt, "no enter-LoS transition when mover stays visible")
+	s.Nil(disappearedAt, "no leave-LoS transition when mover stays visible")
+}
+
+// Mover has no intersection with viewer's LoS → no events, empty seenSegments.
+func (s *ProjectSuite) TestProjectVisibilityTransition_NeverVisible() {
+	viewer := perception.NewView("bob", core.Hex{}, 2)
+
+	moverStart := core.Hex{Q: 10, R: 0, S: -10}
+	path := []core.Hex{{Q: 15, R: 0, S: -15}}
+
+	moveSlice, _ := perception.ProjectMove("alice", path, viewer)
+	s.Nil(moveSlice, "viewer out of range — no move slice")
+
+	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, nil, viewer)
+
+	s.Nil(appearedAt)
+	s.Nil(disappearedAt)
+}
+
 func (s *ProjectSuite) TestView_ApplyRevealIdempotent() {
 	viewer := perception.NewView("alice", core.Hex{}, 3)
 	h := core.Hex{Q: 1, R: 0, S: -1}

--- a/encounter/visibility_transition_test.go
+++ b/encounter/visibility_transition_test.go
@@ -103,7 +103,7 @@ func (s *VisibilityTransitionSuite) assertHasType(evts []events.EncounterEvent, 
 			return e
 		}
 	}
-	var names []string
+	names := make([]string, 0, len(evts))
 	for _, e := range evts {
 		names = append(names, typeNameOf(e))
 	}

--- a/encounter/visibility_transition_test.go
+++ b/encounter/visibility_transition_test.go
@@ -209,15 +209,14 @@ func (s *VisibilityTransitionSuite) TestPassThrough_BothEventsFired() {
 		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
 	}))
 
-	// Alice's path: starts outside bob's view, enters it, then leaves.
+	// Alice's path (destination hexes only; her starting position {Q:-10,...} is
+	// held by Alice's View.Position, not included in path):
 	// Under stub LoS bob sees hexes within distance 4 of origin.
-	// path[0]={-10,...} outside, path[1]={-3,...} inside (dist=3), path[2]={4,...} inside (dist=4),
-	// path[3]={10,...} outside.
+	// {-3,...} is inside (dist=3), {4,...} is inside (dist=4), {10,...} is outside.
 	path := []core.Hex{
-		{Q: -10, R: 0, S: 10}, // outside
-		{Q: -3, R: 0, S: 3},   // inside (dist 3)
+		{Q: -3, R: 0, S: 3},   // inside (dist 3) — first destination
 		{Q: 4, R: 0, S: -4},   // inside (dist 4, on edge)
-		{Q: 10, R: 0, S: -10}, // outside
+		{Q: 10, R: 0, S: -10}, // outside — destination
 	}
 	s.Require().NoError(s.enc.Move("alice", path))
 

--- a/encounter/visibility_transition_test.go
+++ b/encounter/visibility_transition_test.go
@@ -1,0 +1,360 @@
+package encounter_test
+
+// visibility_transition_test.go covers the five acceptance-criteria scenarios
+// from issue #629:
+//   1. Enter LoS   — A starts outside B's view, ends inside → EntityAppearedEvent
+//   2. Leave LoS   — A starts inside B's view, ends outside → EntityDisappearedEvent
+//   3. Pass through — A starts outside, traverses through, ends outside → BOTH events
+//   4. Stays visible — A visible at start and end → NO appear/disappear events
+//   5. Negative audience — Viewer C shares no LoS → receives neither MoveEvent nor
+//      EntityAppeared/EntityDisappeared
+//
+// It also covers ToData/LoadFromData round-trips for both new event types
+// (mirrors the patterns in encounter/events/events_test.go).
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/stretchr/testify/suite"
+)
+
+// typeNameOf returns the fmt %T type name string for an event — e.g.
+// "*events.MoveEvent". Mirrors the pattern used in collectTypes.
+func typeNameOf(e events.EncounterEvent) string {
+	return fmt.Sprintf("%T", e)
+}
+
+type VisibilityTransitionSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	enc       *encounter.Encounter
+
+	// alice is the mover in most tests.
+	// bob   is close to alice (within sight range of some positions).
+	// carol is far away and should never see anything.
+	aliceSub *encounter.Subscription
+	bobSub   *encounter.Subscription
+	carolSub *encounter.Subscription
+}
+
+func TestVisibilityTransitionSuite(t *testing.T) {
+	suite.Run(t, new(VisibilityTransitionSuite))
+}
+
+func (s *VisibilityTransitionSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	s.enc = encounter.New("enc-vis", s.broker)
+
+	// carol is far away — she will never see alice in any test.
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "carol", EntityID: "char-carol",
+		Position: core.Hex{Q: 100, R: -50, S: -50}, SightRange: 3,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe("enc-vis", "alice")
+	s.Require().NoError(err)
+	s.bobSub, err = s.broker.Subscribe("enc-vis", "bob")
+	s.Require().NoError(err)
+	s.carolSub, err = s.broker.Subscribe("enc-vis", "carol")
+	s.Require().NoError(err)
+}
+
+func (s *VisibilityTransitionSuite) TearDownTest() {
+	_ = s.aliceSub.Close()
+	_ = s.bobSub.Close()
+	_ = s.carolSub.Close()
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// collectEventsTyped collects all events from a subscription within the given
+// timeout and returns them typed so callers can inspect both type names and
+// concrete event fields.
+func collectEventsTyped(sub *encounter.Subscription, timeout time.Duration) []events.EncounterEvent {
+	var out []events.EncounterEvent
+	deadline := time.After(timeout)
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				return out
+			}
+			out = append(out, evt)
+		case <-deadline:
+			return out
+		}
+	}
+}
+
+// assertHasType returns the first event of the given type name, or fails.
+func (s *VisibilityTransitionSuite) assertHasType(evts []events.EncounterEvent, typeName string) events.EncounterEvent {
+	s.T().Helper()
+	for _, e := range evts {
+		if typeName == typeNameOf(e) {
+			return e
+		}
+	}
+	var names []string
+	for _, e := range evts {
+		names = append(names, typeNameOf(e))
+	}
+	s.FailNowf("event not found", "want %s, got %v", typeName, names)
+	return nil
+}
+
+// assertLacksType fails if any event with the given type name is found.
+func (s *VisibilityTransitionSuite) assertLacksType(evts []events.EncounterEvent, typeName string) {
+	s.T().Helper()
+	for _, e := range evts {
+		if typeNameOf(e) == typeName {
+			s.FailNowf("unexpected event", "got %s but expected none", typeName)
+		}
+	}
+}
+
+// ─── Case 1: Enter LoS ────────────────────────────────────────────────────────
+//
+// Alice starts at Q=-10 (far from bob), bob at origin with sightRange=4.
+// Alice moves to Q=3 which is inside bob's view.
+// Expected: bob receives EntityAppearedEvent with Position == path end.
+func (s *VisibilityTransitionSuite) TestEnterLoS_EntityAppearedEventFired() {
+	// Alice starts outside bob's view (Q=-10).
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: -10, R: 0, S: 10}, SightRange: 4,
+	}))
+	// Bob at origin with sight range 4.
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+
+	// Alice moves to Q=3 which is within bob's sight range of 4.
+	pathEnd := core.Hex{Q: 3, R: 0, S: -3}
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{pathEnd}))
+
+	bobEvts := collectEventsTyped(s.bobSub, 500*time.Millisecond)
+
+	evt := s.assertHasType(bobEvts, "*events.EntityAppearedEvent")
+	appeared := evt.(*events.EntityAppearedEvent)
+	s.Equal(core.EntityID("char-alice"), appeared.Entity)
+	s.Equal(pathEnd, appeared.Position, "position should be where mover became visible (path end)")
+	s.Contains(appeared.PerPlayer, core.PlayerID("bob"))
+}
+
+// ─── Case 2: Leave LoS ────────────────────────────────────────────────────────
+//
+// Alice starts at Q=2 (within bob's view), moves to Q=10 (outside view).
+// Expected: bob receives EntityDisappearedEvent with PerPlayer[bob] == last visible hex.
+func (s *VisibilityTransitionSuite) TestLeaveLoS_EntityDisappearedEventFired() {
+	// Alice starts inside bob's view (Q=2, bob has sightRange=4).
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 2, R: 0, S: -2}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+
+	// Alice moves to Q=10 which is outside bob's sight range of 4.
+	// Path crosses from visible to not-visible. We pick a path that stays
+	// inside bob's view for the first few hexes, then exits.
+	// Q=4 is the boundary of bob's sight range (distance 4 from origin).
+	// Q=10 is clearly outside.
+	path := []core.Hex{
+		{Q: 3, R: 0, S: -3},   // distance 3 from bob — still visible
+		{Q: 4, R: 0, S: -4},   // distance 4 from bob — on the edge (still visible under stub LoS)
+		{Q: 10, R: 0, S: -10}, // distance 10 — outside
+	}
+	s.Require().NoError(s.enc.Move("alice", path))
+
+	bobEvts := collectEventsTyped(s.bobSub, 500*time.Millisecond)
+
+	evt := s.assertHasType(bobEvts, "*events.EntityDisappearedEvent")
+	disappeared := evt.(*events.EntityDisappearedEvent)
+	s.Equal(core.EntityID("char-alice"), disappeared.Entity)
+	s.Require().Contains(disappeared.PerPlayer, core.PlayerID("bob"),
+		"bob should be in PerPlayer as a viewer who lost sight")
+
+	// The last-known hex for bob must be the last visible hex from bob's SeenSegments.
+	// Under the stub LoS, bob's sight range is 4 from origin.
+	// path[0]={3,0,-3} distance=3 ✓, path[1]={4,0,-4} distance=4 ✓, path[2]={10,0,-10} ✗
+	// So bob's SeenSegments = [{3,0,-3}, {4,0,-4}]. Last visible = {4,0,-4}.
+	s.Equal(core.Hex{Q: 4, R: 0, S: -4}, disappeared.PerPlayer[core.PlayerID("bob")],
+		"last-known hex must match the last visible hex from bob's SeenSegments")
+}
+
+// ─── Case 3: Pass through ─────────────────────────────────────────────────────
+//
+// Alice starts at Q=-10 (outside bob's view), passes through it (Q=2), then
+// exits at Q=10. Expected: bob receives BOTH EntityAppearedEvent AND
+// EntityDisappearedEvent with appropriate hexes.
+func (s *VisibilityTransitionSuite) TestPassThrough_BothEventsFired() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: -10, R: 0, S: 10}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+
+	// Alice's path: starts outside bob's view, enters it, then leaves.
+	// Under stub LoS bob sees hexes within distance 4 of origin.
+	// path[0]={-10,...} outside, path[1]={-3,...} inside (dist=3), path[2]={4,...} inside (dist=4),
+	// path[3]={10,...} outside.
+	path := []core.Hex{
+		{Q: -10, R: 0, S: 10}, // outside
+		{Q: -3, R: 0, S: 3},   // inside (dist 3)
+		{Q: 4, R: 0, S: -4},   // inside (dist 4, on edge)
+		{Q: 10, R: 0, S: -10}, // outside
+	}
+	s.Require().NoError(s.enc.Move("alice", path))
+
+	bobEvts := collectEventsTyped(s.bobSub, 500*time.Millisecond)
+
+	// Both events should be present.
+	appearedEvt := s.assertHasType(bobEvts, "*events.EntityAppearedEvent")
+	disappearedEvt := s.assertHasType(bobEvts, "*events.EntityDisappearedEvent")
+
+	appeared := appearedEvt.(*events.EntityAppearedEvent)
+	disappeared := disappearedEvt.(*events.EntityDisappearedEvent)
+
+	s.Equal(core.EntityID("char-alice"), appeared.Entity)
+	s.Equal(core.EntityID("char-alice"), disappeared.Entity)
+
+	// Appeared at the first visible hex (SeenSegments[0] = {-3,0,3}).
+	s.Equal(core.Hex{Q: -3, R: 0, S: 3}, appeared.Position,
+		"appeared position should be first visible hex (SeenSegments[0]) for pass-through")
+
+	// Disappeared at the last visible hex (SeenSegments[len-1] = {4,0,-4}).
+	s.Require().Contains(disappeared.PerPlayer, core.PlayerID("bob"))
+	s.Equal(core.Hex{Q: 4, R: 0, S: -4}, disappeared.PerPlayer[core.PlayerID("bob")],
+		"last-known hex should be last visible hex (SeenSegments[last]) for pass-through")
+}
+
+// ─── Case 4: Stays visible ────────────────────────────────────────────────────
+//
+// Alice starts within bob's view, moves a short distance, stays within view.
+// Expected: bob receives MoveEvent but NO EntityAppeared/EntityDisappeared.
+func (s *VisibilityTransitionSuite) TestStaysVisible_NoAppearDisappearEvents() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+
+	// Alice moves from Q=1 to Q=2, staying well inside bob's view.
+	path := []core.Hex{{Q: 2, R: 0, S: -2}}
+	s.Require().NoError(s.enc.Move("alice", path))
+
+	bobEvts := collectEventsTyped(s.bobSub, 500*time.Millisecond)
+
+	// Bob should receive MoveEvent but NOT appear/disappear.
+	s.assertHasType(bobEvts, "*events.MoveEvent")
+	s.assertLacksType(bobEvts, "*events.EntityAppearedEvent")
+	s.assertLacksType(bobEvts, "*events.EntityDisappearedEvent")
+}
+
+// ─── Case 5: Negative audience ────────────────────────────────────────────────
+//
+// Carol is at Q=100 (far from everything). Alice moves near bob.
+// Expected: carol receives NO events at all.
+func (s *VisibilityTransitionSuite) TestNegativeAudience_CarolReceivesNoEvents() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: -10, R: 0, S: 10}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+
+	// Alice moves into bob's view; carol is at Q=100 and should receive nothing.
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{{Q: 3, R: 0, S: -3}}))
+
+	carolEvts := collectEventsTyped(s.carolSub, 300*time.Millisecond)
+	s.Empty(carolEvts, "carol shares no LoS with alice's path and should receive no events")
+}
+
+// ─── Round-trip tests ─────────────────────────────────────────────────────────
+
+// TestEntityAppearedEvent_JSONRoundTrip verifies that all fields, including the
+// unexported encID and seq, survive a JSON marshal/unmarshal cycle.
+func (s *VisibilityTransitionSuite) TestEntityAppearedEvent_JSONRoundTrip() {
+	original := events.NewEntityAppearedEvent(
+		"enc-1", 11, "char-alice",
+		core.Hex{Q: 3, R: 0, S: -3},
+		map[core.PlayerID]struct{}{"bob": {}, "carol": {}},
+	)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EntityAppearedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(11), decoded.Sequence())
+	s.Equal(core.EntityID("char-alice"), decoded.Entity)
+	s.Equal(core.Hex{Q: 3, R: 0, S: -3}, decoded.Position)
+	s.Contains(decoded.PerPlayer, core.PlayerID("bob"))
+	s.Contains(decoded.PerPlayer, core.PlayerID("carol"))
+	s.ElementsMatch(
+		events.AudienceSet{"bob", "carol"},
+		decoded.Audience(),
+	)
+}
+
+// TestEntityDisappearedEvent_JSONRoundTrip verifies that all fields survive a
+// JSON marshal/unmarshal cycle, including the per-viewer last-known hex map.
+func (s *VisibilityTransitionSuite) TestEntityDisappearedEvent_JSONRoundTrip() {
+	original := events.NewEntityDisappearedEvent(
+		"enc-1", 12, "char-alice",
+		map[core.PlayerID]core.Hex{
+			"bob":   {Q: 4, R: 0, S: -4},
+			"carol": {Q: 2, R: -1, S: -1},
+		},
+	)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EntityDisappearedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(12), decoded.Sequence())
+	s.Equal(core.EntityID("char-alice"), decoded.Entity)
+	s.Require().Contains(decoded.PerPlayer, core.PlayerID("bob"))
+	s.Equal(core.Hex{Q: 4, R: 0, S: -4}, decoded.PerPlayer[core.PlayerID("bob")])
+	s.Require().Contains(decoded.PerPlayer, core.PlayerID("carol"))
+	s.Equal(core.Hex{Q: 2, R: -1, S: -1}, decoded.PerPlayer[core.PlayerID("carol")])
+	s.ElementsMatch(
+		events.AudienceSet{"bob", "carol"},
+		decoded.Audience(),
+	)
+}
+
+// TestEntityAppearedEvent_SatisfiesInterface verifies the sealed interface constraint.
+func (s *VisibilityTransitionSuite) TestEntityAppearedEvent_SatisfiesInterface() {
+	var _ events.EncounterEvent = (*events.EntityAppearedEvent)(nil)
+}
+
+// TestEntityDisappearedEvent_SatisfiesInterface verifies the sealed interface constraint.
+func (s *VisibilityTransitionSuite) TestEntityDisappearedEvent_SatisfiesInterface() {
+	var _ events.EncounterEvent = (*events.EntityDisappearedEvent)(nil)
+}


### PR DESCRIPTION
## Summary

Closes #629

Adds `EntityAppearedEvent` and `EntityDisappearedEvent` to the encounter SDK so consumers can correctly show/clear entity markers when a mover crosses a viewer's line-of-sight threshold during a move.

- `EntityAppearedEvent` — emitted when a mover enters a viewer's LoS; carries `Entity`, `Position` (where they became visible), and `PerPlayer` audience set
- `EntityDisappearedEvent` — emitted when a mover leaves a viewer's LoS; carries `Entity` and a per-viewer `PerPlayer map[PlayerID]Hex` (last-known hex, which differs per viewer during pass-through)
- Both ride the same broker audience filter as `MoveEvent`
- Broker codec registers both new types for transport encode/decode

## Design choices

### Visibility detection: endpoints + SeenSegments boundaries (slice-1)

`ProjectVisibilityTransition` uses the mover's starting position (`moverStart`, captured from `p.View.Position` before mutation) and the path destination vs. each viewer's `SeenSegments` from `ProjectMove`. No per-hex timeline along the path is computed. This is correct under the Manhattan stub LoS (monotonic visibility from fixed viewers). Real LoS multi-transition handling is a follow-up issue.

### EntityAppearedEvent.Position grouping

`EntityAppearedEvent` has a single `Position` field (not per-viewer), because viewers who see an entity appear during the same move typically see it appear at the same hex. In the simple endpoints model:
- Enter-LoS: all viewers see `path[len-1]` → one event
- Pass-through: each viewer's `SeenSegments[0]` is the first visible hex, which differs if viewers are at different positions

`Move()` groups viewers by their `appearedAt` hex and emits one `EntityAppearedEvent` per distinct hex. This is noted in the doc comment. The issue's "Proposed events" section described `PerPlayer map[PlayerID]struct{}` which is consistent — `Position` is the key grouping, `PerPlayer` carries the audience for that position.

### moverStart vs path[0]

`Encounter.Move()` accepts `path` as destination hexes (not including the starting position), consistent with existing usage in `encounter_test.go` and `integration_test.go`. `ProjectVisibilityTransition` therefore takes `moverStart` as a separate parameter, captured before `p.View.Position` is updated.

## Test plan

- [x] **Enter LoS**: Alice starts at Q=-10 (outside bob's sight), moves to Q=3 (inside) → bob receives `EntityAppearedEvent` with `Position == {Q:3}` and `PerPlayer` contains bob
- [x] **Leave LoS**: Alice starts at Q=2 (inside bob's sight range 4), moves to Q=10 (outside) → bob receives `EntityDisappearedEvent` with `PerPlayer[bob] == {Q:4}` (last visible boundary hex)
- [x] **Pass through**: Alice starts Q=-10 (outside), traverses Q=-3 and Q=4 (inside), ends Q=10 (outside) → bob receives BOTH events: appeared at `{Q:-3}`, disappeared at `{Q:4}`
- [x] **Stays visible**: Alice moves from Q=1 to Q=2, both inside bob's sight range 4 → bob receives `MoveEvent` only, no appear/disappear
- [x] **Negative audience**: Carol at Q=100 (far from everything) → receives zero events when alice moves near bob
- [x] `EntityAppearedEvent` JSON round-trip (events_test.go + visibility_transition_test.go)
- [x] `EntityDisappearedEvent` JSON round-trip (events_test.go + visibility_transition_test.go)
- [x] `ProjectVisibilityTransition` unit tests: enter-LoS, leave-LoS, pass-through, stays-visible, never-visible (perception/project_test.go)

## Files changed

- `encounter/events/entity_appeared.go` — new event type
- `encounter/events/entity_disappeared.go` — new event type
- `encounter/events/events_test.go` — type switch + round-trip tests for new events
- `encounter/perception/project.go` — `ProjectVisibilityTransition` function
- `encounter/perception/project_test.go` — unit tests for `ProjectVisibilityTransition`
- `encounter/encounter.go` — wire transitions into `Move()`, capture `moverStart`
- `encounter/broker.go` — register new event types in codec
- `encounter/visibility_transition_test.go` — 5 integration acceptance cases + round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)