### PR TITLE
feat(encounter): death detection + entity removal + encounter end (Wave 2.10)

### DIFF
--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -234,6 +234,12 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "TurnStartedEvent"
 	case *events.TurnEndedEvent:
 		typeName = "TurnEndedEvent"
+	case *events.EntityDiedEvent:
+		typeName = "EntityDiedEvent"
+	case *events.EntityRemovedEvent:
+		typeName = "EntityRemovedEvent"
+	case *events.EncounterEndedEvent:
+		typeName = "EncounterEndedEvent"
 	default:
 		return nil, fmt.Errorf("unknown event type %T", evt)
 	}
@@ -312,6 +318,24 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "TurnEndedEvent":
 		var e events.TurnEndedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "EntityDiedEvent":
+		var e events.EntityDiedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "EntityRemovedEvent":
+		var e events.EntityRemovedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "EncounterEndedEvent":
+		var e events.EncounterEndedEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -78,6 +78,15 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 	if mode == core.ModeUnspecified {
 		return errors.New("mode unspecified")
 	}
+	if mode == core.ModeEnded {
+		// Terminal state is gameplay-driven (Encounter.checkEncounterEnd
+		// fires when the last hostile dies), never set externally. Reject
+		// so callers don't accidentally bypass the kill chain.
+		return errors.New("ModeEnded is set internally by checkEncounterEnd, not via SetMode")
+	}
+	if e.data.Mode == core.ModeEnded {
+		return ErrEncounterEnded
+	}
 	from := e.data.Mode
 	if from == mode {
 		return fmt.Errorf("mode is already %s", mode)
@@ -207,6 +216,7 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 		return fmt.Errorf("%w: %q", ErrUnknownTarget, target.EntityID)
 	}
 
+	hpBefore := monster.HP
 	res := e.resolveAttack(player.AttackBonus, monster.AC, player.DamageDice)
 	if res.hit {
 		monster.HP -= res.damage
@@ -226,10 +236,13 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 	); err != nil {
 		return err
 	}
-	// If the attack reduced the monster to zero, fire the death + removal
-	// + encounter-end chain. killEntity also runs the encounter-end
-	// predicate which may transition mode to ModeEnded.
-	if res.hit && monster.HP == 0 {
+	// Fire the death + removal + encounter-end chain only on the
+	// HP transition (>0 → 0). Re-attacking an already-dead monster
+	// (which can't happen today since dead monsters are spliced
+	// out, but the gate is cheap insurance for future paths) does
+	// NOT re-fire death events. killEntity also runs the
+	// encounter-end predicate which may transition mode to ModeEnded.
+	if res.hit && hpBefore > 0 && monster.HP == 0 {
 		if err := e.killEntity(target.EntityID, player.EntityID); err != nil {
 			return err
 		}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -120,9 +120,13 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 // TurnStartedEvent for the new active actor (with Round incremented when
 // the active index wraps).
 //
-// Returns ErrNoCombatants if Initiative is empty (can happen if SetMode
-// flipped to TURN_BASED with no players or monsters).
+// Returns ErrEncounterEnded when the encounter is in the terminal state
+// (ModeEnded). Returns ErrNoCombatants if Initiative is empty (can happen
+// if SetMode flipped to TURN_BASED with no players or monsters).
 func (e *Encounter) EndTurn(actorID core.EntityID) (newActiveID core.EntityID, isNPC bool, err error) {
+	if e.data.Mode == core.ModeEnded {
+		return "", false, ErrEncounterEnded
+	}
 	if e.data.Mode != core.ModeTurnBased {
 		return "", false, ErrNotTurnBased
 	}
@@ -162,11 +166,20 @@ func (e *Encounter) EndTurn(actorID core.EntityID) (newActiveID core.EntityID, i
 // DamageDealtEvent (per-viewer projection driven by LoS to attacker OR
 // target). On miss, publishes only AttackResolvedEvent.
 //
+// Wave 2.10: when an attack drops the monster's HP to zero, also publishes
+// EntityDiedEvent + EntityRemovedEvent for the monster, and (if it was the
+// last hostile) flips the encounter to ModeEnded and publishes
+// EncounterEndedEvent.
+//
+// Returns ErrEncounterEnded when the encounter is in the terminal state.
 // Returns ErrNonCombatant if the player's combat snapshot
 // (HP / MaxHP / AC / DamageDice) is not populated — i.e. the seat was
 // added without combat fields. PlayerInput documents that a zero combat
 // snapshot opts the player out of combat verbs.
 func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target ActionTarget) error {
+	if e.data.Mode == core.ModeEnded {
+		return ErrEncounterEnded
+	}
 	if e.data.Mode != core.ModeTurnBased {
 		return ErrNotTurnBased
 	}
@@ -206,11 +219,22 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 	if damageType == "" {
 		damageType = damageTypeUntyped
 	}
-	return e.publishAttackOutcome(
+	if err := e.publishAttackOutcome(
 		player.EntityID, target.EntityID, res,
 		monster.HP, monster.MaxHP, damageType,
 		player.View.Position, monster.Position,
-	)
+	); err != nil {
+		return err
+	}
+	// If the attack reduced the monster to zero, fire the death + removal
+	// + encounter-end chain. killEntity also runs the encounter-end
+	// predicate which may transition mode to ModeEnded.
+	if res.hit && monster.HP == 0 {
+		if err := e.killEntity(target.EntityID, player.EntityID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // rollInitiative seeds Initiative with all combatants in d20-roll-desc

--- a/encounter/core/mode.go
+++ b/encounter/core/mode.go
@@ -5,6 +5,7 @@ package core
 // FREE_ROAM: no initiative; players act in any order; the encounter is in
 // exploration / pre-combat. TURN_BASED: initiative order is fixed; one
 // active actor at a time; verbs that mutate combat state require it.
+// ENDED: terminal state; combat verbs reject with ErrEncounterEnded.
 type EncounterMode int
 
 // EncounterMode values.
@@ -15,6 +16,14 @@ const (
 	ModeFreeRoam
 	// ModeTurnBased is initiative-locked combat. Verbs gate on the active actor.
 	ModeTurnBased
+	// ModeEnded is the terminal state for an encounter — entered when the
+	// encounter-end predicate first goes true (Wave 2.10: all hostiles
+	// defeated). Combat verbs (TakeAction, EndTurn, NPCAct) reject with
+	// ErrEncounterEnded; the orchestrator stops dispatching turns. The
+	// encounter persists in storage with this mode so reconnects see the
+	// terminal state via snapshot replay. Initiative / ActiveIdx / Round
+	// are cleared on the transition to ModeEnded.
+	ModeEnded
 )
 
 // String returns a stable label for the mode (for logs and JSON-friendly debug).
@@ -24,6 +33,8 @@ func (m EncounterMode) String() string {
 		return "FREE_ROAM"
 	case ModeTurnBased:
 		return "TURN_BASED"
+	case ModeEnded:
+		return "ENDED"
 	default:
 		return "UNSPECIFIED"
 	}

--- a/encounter/core/mode.go
+++ b/encounter/core/mode.go
@@ -21,8 +21,14 @@ const (
 	// defeated). Combat verbs (TakeAction, EndTurn, NPCAct) reject with
 	// ErrEncounterEnded; the orchestrator stops dispatching turns. The
 	// encounter persists in storage with this mode so reconnects see the
-	// terminal state via snapshot replay. Initiative / ActiveIdx / Round
-	// are cleared on the transition to ModeEnded.
+	// terminal state via snapshot replay.
+	//
+	// The transition to ModeEnded happens inside the kill chain
+	// (Encounter.checkEncounterEnd, in death.go), not via SetMode.
+	// SetMode does NOT accept ModeEnded as a target — terminal state is
+	// always orchestrator-driven through gameplay (last hostile dies),
+	// never through an explicit "set the mode to ended" call. The
+	// transition clears Initiative / ActiveIdx / Round.
 	ModeEnded
 )
 

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -1,0 +1,246 @@
+package encounter
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+)
+
+// ErrEncounterEnded is returned by combat verbs (TakeAction, EndTurn,
+// NPCAct) when called against an encounter whose mode is ModeEnded.
+// Maps to gRPC FailedPrecondition on the rpg-api side.
+var ErrEncounterEnded = errors.New("encounter has ended")
+
+// EntityRemovedReasonDestroyed is the Reason value on EntityRemovedEvent
+// when the entity was removed because its HP reached zero. Future waves
+// add other reasons ("fled", "transformed", etc.).
+const EntityRemovedReasonDestroyed = "destroyed"
+
+// EncounterEndedReasonAllHostilesDefeated is the Reason value on
+// EncounterEndedEvent when the last hostile died. Wave 2.10 ships only
+// this end condition; future waves add others ("fled", "negotiated",
+// "tpk", "time_out", etc.).
+const EncounterEndedReasonAllHostilesDefeated = "all_hostiles_defeated"
+
+// killEntity is the toolkit-side state-mutation helper for "monster died."
+// Callers (post-damage paths in TakeAction and NPCAct) invoke it after a
+// monster's HP is clamped to zero. The helper:
+//
+//  1. Builds the per-viewer projection for EntityDiedEvent (visibility
+//     derived from LoS to the dying monster's last position OR the killer's
+//     position) and publishes it.
+//  2. Removes the monster from data.Monsters.
+//  3. Splices the monster out of data.Initiative; if the removed slot was
+//     before ActiveIdx, decrements ActiveIdx so the active actor pointer
+//     still references the same entity after the shift.
+//  4. Publishes EntityRemovedEvent (broadcast — every player must drop
+//     the entity from local state, even out-of-LoS viewers).
+//  5. Calls checkEncounterEnd which may transition to ModeEnded and
+//     publish EncounterEndedEvent.
+//
+// killEntity is monster-only. Player death is partial in Wave 2.10:
+// EntityDiedEvent fires for the dying player (so the web can surface it),
+// but the player is NOT removed from initiative and EntityRemovedEvent
+// is NOT published — the dying-state machinery is Wave 2.11+. The post-
+// damage path in NPCAct calls publishPlayerDied directly instead of
+// killEntity for that reason.
+//
+// Returns an error if monsterID is not present in data.Monsters (caller
+// bug — the path that triggered the kill should have validated the
+// target). KillerID may be empty for environmental / future indirect kills.
+func (e *Encounter) killEntity(monsterID, killerID core.EntityID) error {
+	mon, ok := e.data.Monsters[monsterID]
+	if !ok {
+		return fmt.Errorf("killEntity: monster %q not in encounter", monsterID)
+	}
+
+	// Snapshot dying-monster position before deletion — needed for the
+	// per-viewer LoS projection on EntityDiedEvent.
+	dyingPos := mon.Position
+	killerPos, killerHasPos := e.positionFor(killerID)
+
+	diedPerPlayer := make(map[core.PlayerID]events.EntityDiedSlice)
+	for viewerID, viewer := range e.data.Players {
+		seesDying := perception.CanSeeAt(viewer.View, dyingPos)
+		seesKiller := killerHasPos && perception.CanSeeAt(viewer.View, killerPos)
+		if !seesDying && !seesKiller {
+			continue
+		}
+		diedPerPlayer[viewerID] = events.EntityDiedSlice{Visible: true}
+	}
+	if err := e.broker.Publish(events.NewEntityDiedEvent(
+		e.data.ID, e.nextSeq(), monsterID, killerID, diedPerPlayer,
+	)); err != nil {
+		return fmt.Errorf("publish entity died: %w", err)
+	}
+
+	// Mutate state: drop from monsters and splice out of initiative.
+	delete(e.data.Monsters, monsterID)
+	e.spliceFromInitiative(monsterID)
+
+	// Broadcast removal — every player must drop the entity from local
+	// state, even those out of LoS at death time. Build PerPlayer over
+	// the full player set with Visible: true.
+	if err := e.broker.Publish(events.NewEntityRemovedEvent(
+		e.data.ID, e.nextSeq(), monsterID, EntityRemovedReasonDestroyed,
+		e.allViewersEntityRemoved(),
+	)); err != nil {
+		return fmt.Errorf("publish entity removed: %w", err)
+	}
+
+	// Check terminal-state predicate; may publish EncounterEndedEvent.
+	if _, err := e.checkEncounterEnd(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// publishPlayerDied fires an EntityDiedEvent for a player whose HP reached
+// zero, with NPC-as-killer visibility projection. It does NOT mutate any
+// state and does NOT publish EntityRemovedEvent — player dying-state is
+// Wave 2.11+ territory. Wave 2.10 limits the player-death surface to a
+// single narrative event so the web can surface "alice was downed by
+// goblin" without committing to a dying-state model that hasn't shipped.
+//
+// Visibility: a viewer is in PerPlayer iff they have LoS to the dying
+// player OR the killing NPC. The dying player themselves are always
+// considered to perceive their own death (their position is, by
+// definition, in their own view).
+func (e *Encounter) publishPlayerDied(playerEntityID, killerID core.EntityID) error {
+	playerData := e.findPlayerByEntityID(playerEntityID)
+	if playerData == nil || playerData.View == nil {
+		return fmt.Errorf("publishPlayerDied: player entity %q not found", playerEntityID)
+	}
+	dyingPos := playerData.View.Position
+	killerPos, killerHasPos := e.positionFor(killerID)
+
+	diedPerPlayer := make(map[core.PlayerID]events.EntityDiedSlice)
+	for viewerID, viewer := range e.data.Players {
+		seesDying := perception.CanSeeAt(viewer.View, dyingPos)
+		seesKiller := killerHasPos && perception.CanSeeAt(viewer.View, killerPos)
+		if !seesDying && !seesKiller {
+			continue
+		}
+		diedPerPlayer[viewerID] = events.EntityDiedSlice{Visible: true}
+	}
+	if err := e.broker.Publish(events.NewEntityDiedEvent(
+		e.data.ID, e.nextSeq(), playerEntityID, killerID, diedPerPlayer,
+	)); err != nil {
+		return fmt.Errorf("publish entity died (player): %w", err)
+	}
+	return nil
+}
+
+// checkEncounterEnd evaluates the encounter-end predicate and, if true,
+// transitions the encounter to ModeEnded and publishes EncounterEndedEvent.
+// Returns (ended, err) — ended is true when the predicate fired this call.
+//
+// Wave 2.10 predicate: len(data.Monsters) == 0 (all hostiles defeated).
+// Encapsulated here so future waves swap the predicate (boss-only kill,
+// fled, negotiated peace, time-out) without touching the kill path.
+//
+// On transition: clears Initiative + ActiveIdx + Round so the verb-gate
+// in EndTurn / TakeAction (which checks len(Initiative)) consistently
+// rejects post-end calls with ErrEncounterEnded once the mode check
+// above also rejects them. The mode check is the primary gate; clearing
+// the turn state keeps the persisted snapshot tidy for clients reading
+// it post-end.
+func (e *Encounter) checkEncounterEnd() (bool, error) {
+	if e.data.Mode == core.ModeEnded {
+		return false, nil
+	}
+	if len(e.data.Monsters) > 0 {
+		return false, nil
+	}
+	e.data.Mode = core.ModeEnded
+	e.data.Initiative = nil
+	e.data.ActiveIdx = 0
+	e.data.Round = 0
+
+	if err := e.broker.Publish(events.NewEncounterEndedEvent(
+		e.data.ID, e.nextSeq(),
+		EncounterEndedReasonAllHostilesDefeated,
+		e.allViewersEncounterEnded(),
+	)); err != nil {
+		return true, fmt.Errorf("publish encounter ended: %w", err)
+	}
+	return true, nil
+}
+
+// spliceFromInitiative removes id from Initiative (if present) and adjusts
+// ActiveIdx to preserve the "currently-active actor" pointer:
+//
+//   - Removed index <  ActiveIdx: everyone after it shifted left, so
+//     ActiveIdx must decrement.
+//   - Removed index == ActiveIdx: the active actor itself was removed.
+//     ActiveIdx stays in place so EndTurn naturally moves to the next
+//     actor on the next call. (Wave 2.10 doesn't expect this in the
+//     monster-killed-by-player path because the active actor is the
+//     attacking player, not the target. NPC-killed-NPC is out of scope.)
+//   - Removed index >  ActiveIdx: no shift affecting the pointer.
+//
+// After removal, if Initiative is shorter than ActiveIdx (e.g. tail
+// removal at the wrap edge), ActiveIdx clamps to 0 to avoid a stale OOB
+// pointer; the next EndTurn will publish a TurnStarted for whichever
+// actor occupies index 0.
+func (e *Encounter) spliceFromInitiative(id core.EntityID) {
+	idx := -1
+	for i, eid := range e.data.Initiative {
+		if eid == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return
+	}
+	e.data.Initiative = append(e.data.Initiative[:idx], e.data.Initiative[idx+1:]...)
+	if idx < e.data.ActiveIdx {
+		e.data.ActiveIdx--
+	}
+	if e.data.ActiveIdx >= len(e.data.Initiative) {
+		// Wrap to the start; if Initiative is now empty the next combat
+		// verb will fail the len(Initiative) > 0 gate first.
+		e.data.ActiveIdx = 0
+	}
+}
+
+// positionFor returns the last-known hex of the entity (player or monster)
+// matching id. The boolean is false when id is unknown — the caller treats
+// "no killer position" as "killer-side LoS contributes nothing to the
+// per-viewer projection."
+func (e *Encounter) positionFor(id core.EntityID) (core.Hex, bool) {
+	if id == "" {
+		return core.Hex{}, false
+	}
+	if p := e.findPlayerByEntityID(id); p != nil && p.View != nil {
+		return p.View.Position, true
+	}
+	if m, ok := e.data.Monsters[id]; ok {
+		return m.Position, true
+	}
+	return core.Hex{}, false
+}
+
+// allViewersEntityRemoved builds a per-player slice marking every player
+// as a viewer of the removal — entity-removal is broadcast.
+func (e *Encounter) allViewersEntityRemoved() map[core.PlayerID]events.EntityRemovedSlice {
+	out := make(map[core.PlayerID]events.EntityRemovedSlice, len(e.data.Players))
+	for id := range e.data.Players {
+		out[id] = events.EntityRemovedSlice{Visible: true}
+	}
+	return out
+}
+
+// allViewersEncounterEnded builds a per-player slice marking every player
+// as a viewer of the terminal transition — encounter-end is broadcast.
+func (e *Encounter) allViewersEncounterEnded() map[core.PlayerID]events.EncounterEndedSlice {
+	out := make(map[core.PlayerID]events.EncounterEndedSlice, len(e.data.Players))
+	for id := range e.data.Players {
+		out[id] = events.EncounterEndedSlice{Visible: true}
+	}
+	return out
+}

--- a/encounter/death_test.go
+++ b/encounter/death_test.go
@@ -452,7 +452,90 @@ func (s *DeathSuite) TestSlice_EncounterEndedReasonAllHostilesDefeated() {
 	s.Equal(encounter.EncounterEndedReasonAllHostilesDefeated, ended.Reason)
 }
 
+// Re-attacking a player who is already at HP=0 must not re-fire
+// EntityDiedEvent. Regression for the "multi-attack NPC could double up
+// the death event" risk Copilot raised on the first review pass.
+func (s *DeathSuite) TestSlice_PlayerDeath_NotRePublishedOnReHit() {
+	encID := core.EncounterID("enc-death-rehit-player")
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	// Goblin's first turn: kills alice. EntityDiedEvent fires.
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+	firstSeen := collectTypes(s.aliceSub, 500*time.Millisecond)
+	s.Equal(1, countOf(firstSeen, "*events.EntityDiedEvent"),
+		"first NPC kill must fire exactly one EntityDiedEvent")
+
+	// Cycle back to the goblin's turn (alice is at 0 HP but still in
+	// initiative per Wave 2.10 partial player-death). NPCAct again —
+	// goblin re-hits the downed player. NO new EntityDiedEvent.
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+	secondSeen := collectTypes(s.aliceSub, 500*time.Millisecond)
+	s.Equal(0, countOf(secondSeen, "*events.EntityDiedEvent"),
+		"re-hitting a downed player must NOT re-fire EntityDiedEvent")
+}
+
+// SetMode rejects ModeEnded — terminal state is internal-only, set by
+// checkEncounterEnd, never via the public SetMode verb.
+func (s *DeathSuite) TestSetMode_RejectsModeEnded() {
+	enc := encounter.New("enc-setmode-end", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+	}))
+	err := enc.SetMode(core.ModeEnded)
+	s.Error(err, "SetMode(ModeEnded) must reject")
+	s.NotEqual(core.ModeEnded, enc.Mode())
+}
+
+// SetMode against an already-ended encounter returns ErrEncounterEnded.
+func (s *DeathSuite) TestSetMode_RejectsAfterEnd() {
+	enc := s.newSingleMonsterEnc("enc-setmode-postend")
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	s.Require().Equal(core.ModeEnded, enc.Mode())
+
+	err := enc.SetMode(core.ModeFreeRoam)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+}
+
 // --- helpers ---
+
+func countOf(haystack []string, needle string) int {
+	n := 0
+	for _, h := range haystack {
+		if h == needle {
+			n++
+		}
+	}
+	return n
+}
 
 func indexOf(haystack []string, needle string) int {
 	for i, h := range haystack {

--- a/encounter/death_test.go
+++ b/encounter/death_test.go
@@ -1,0 +1,524 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+)
+
+// Damage notations reused across the death-path fixtures (extracted so
+// the goconst linter is happy — these are inert string literals).
+const (
+	damage1d8plus2 = "1d8+2"
+	damage1d6plus2 = "1d6+2"
+)
+
+// fixedMaxRoller always returns the maximum face — guarantees nat-20s
+// (auto-hit + crit) on attack rolls and max damage. Lets the death-path
+// tests force a kill in a single attack without depending on the random
+// roller's output.
+type fixedMaxRoller struct{}
+
+func (fixedMaxRoller) Roll(_ context.Context, size int) (int, error) {
+	return size, nil
+}
+
+func (fixedMaxRoller) RollN(_ context.Context, count, size int) ([]int, error) {
+	out := make([]int, count)
+	for i := range out {
+		out[i] = size
+	}
+	return out, nil
+}
+
+// DeathSuite covers the Wave 2.10 death + entity-removal + encounter-end
+// chain hung off TakeAction's post-damage path.
+type DeathSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	aliceSub  *encounter.Subscription
+	bobSub    *encounter.Subscription
+}
+
+func TestDeathSuite(t *testing.T) {
+	suite.Run(t, new(DeathSuite))
+}
+
+func (s *DeathSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *DeathSuite) TearDownTest() {
+	if s.aliceSub != nil {
+		_ = s.aliceSub.Close()
+	}
+	if s.bobSub != nil {
+		_ = s.bobSub.Close()
+	}
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// newSingleMonsterEnc builds a 2-player + 1-monster encounter wired with
+// the fixed-max roller and pre-flipped to ModeTurnBased on alice's turn.
+// Returns the encounter; subscriptions are written into the suite fields.
+func (s *DeathSuite) newSingleMonsterEnc(encID core.EncounterID) *encounter.Encounter {
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: bobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 10, MaxHP: 10, AC: 13, AttackBonus: 3,
+		DamageDice: "1d6+1", DamageType: "piercing",
+	}))
+	// Goblin starts at 1 HP so a single max-roll hit is guaranteed-lethal
+	// regardless of crit math.
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP:       1, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  "dnd5e:monsters:goblin",
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+	s.bobSub, err = s.broker.Subscribe(encID, "bob")
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(s.aliceSub, 100*time.Millisecond)
+	drainSub(s.bobSub, 100*time.Millisecond)
+	return enc
+}
+
+// Killing the lone monster fires EntityDied + EntityRemoved + EncounterEnded
+// (in that order) and flips the encounter to ModeEnded with monsters cleared.
+func (s *DeathSuite) TestSlice_MonsterDies_EncounterEnds() {
+	enc := s.newSingleMonsterEnc("enc-death-1")
+
+	err := enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.Require().NoError(err)
+
+	seen := collectTypes(s.aliceSub, 500*time.Millisecond)
+	s.Contains(seen, "*events.AttackResolvedEvent")
+	s.Contains(seen, "*events.DamageDealtEvent")
+	s.Contains(seen, "*events.EntityDiedEvent")
+	s.Contains(seen, "*events.EntityRemovedEvent")
+	s.Contains(seen, "*events.EncounterEndedEvent")
+
+	// Order check: died precedes removed precedes ended.
+	diedIdx := indexOf(seen, "*events.EntityDiedEvent")
+	removedIdx := indexOf(seen, "*events.EntityRemovedEvent")
+	endedIdx := indexOf(seen, "*events.EncounterEndedEvent")
+	s.Less(diedIdx, removedIdx, "EntityDied should precede EntityRemoved")
+	s.Less(removedIdx, endedIdx, "EntityRemoved should precede EncounterEnded")
+
+	// State: monster gone, mode flipped, initiative cleared.
+	persisted := enc.ToData()
+	s.NotContains(persisted.Monsters, core.EntityID(gobEntityID))
+	s.Equal(core.ModeEnded, enc.Mode())
+	s.Empty(persisted.Initiative)
+	s.Equal(0, persisted.ActiveIdx)
+	s.Equal(0, persisted.Round)
+}
+
+// After the encounter ends, subsequent TakeAction / EndTurn / NPCAct
+// return ErrEncounterEnded.
+func (s *DeathSuite) TestSlice_PostEnd_ErrEncounterEnded() {
+	enc := s.newSingleMonsterEnc("enc-death-2")
+
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	s.Require().Equal(core.ModeEnded, enc.Mode())
+
+	err := enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+
+	_, _, err = enc.EndTurn(aliceEntityID)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+
+	err = enc.NPCAct(s.ctx, gobEntityID)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+}
+
+// Killing one of two monsters fires EntityDied + EntityRemoved for the
+// dead goblin only, leaves the other monster + initiative intact, and
+// does NOT publish EncounterEndedEvent.
+func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
+	encID := core.EncounterID("enc-death-3")
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: bobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 10, MaxHP: 10, AC: 13,
+	}))
+	// Two goblins; goblin-1 has 1 HP (instakill target), goblin-2 has 7.
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+	s.bobSub, err = s.broker.Subscribe(encID, "bob")
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(s.aliceSub, 100*time.Millisecond)
+	drainSub(s.bobSub, 100*time.Millisecond)
+
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+
+	seen := collectTypes(s.aliceSub, 500*time.Millisecond)
+	s.Contains(seen, "*events.EntityDiedEvent")
+	s.Contains(seen, "*events.EntityRemovedEvent")
+	s.NotContains(seen, "*events.EncounterEndedEvent",
+		"second monster still alive — encounter should NOT have ended")
+
+	persisted := enc.ToData()
+	s.NotContains(persisted.Monsters, core.EntityID(gobEntityID))
+	s.Contains(persisted.Monsters, core.EntityID(gob2EntityID))
+	s.Equal(core.ModeTurnBased, enc.Mode())
+	s.NotEmpty(persisted.Initiative)
+	s.NotContains(persisted.Initiative, core.EntityID(gobEntityID),
+		"dead goblin should be spliced out of initiative")
+	s.Contains(persisted.Initiative, core.EntityID(gob2EntityID),
+		"surviving goblin should remain in initiative")
+}
+
+// EndTurn after a monster kill correctly skips the dead actor — the
+// next active actor is whoever was after the dead goblin in initiative
+// (NOT the dead goblin). Regression for ActiveIdx splice math.
+func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
+	encID := core.EncounterID("enc-death-4")
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+
+	// Initiative must no longer contain the dead goblin.
+	persisted := enc.ToData()
+	s.NotContains(persisted.Initiative, core.EntityID(gobEntityID))
+
+	// alice ends her turn; the next active actor must be a live entity
+	// (alice or goblin-2), never the dead goblin.
+	next, _, err := enc.EndTurn(aliceEntityID)
+	s.Require().NoError(err)
+	s.NotEqual(core.EntityID(gobEntityID), next,
+		"EndTurn must not land on the dead goblin")
+	s.Contains([]core.EntityID{aliceEntityID, gob2EntityID}, next)
+}
+
+// When the encounter ends, EncounterEndedEvent is broadcast to every
+// player (PerPlayer covers all of them, regardless of LoS to the kill).
+func (s *DeathSuite) TestSlice_EncounterEndedBroadcastsToAll() {
+	encID := core.EncounterID("enc-death-5")
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	// Bob is far out of LoS of the kill — but encounter-end is broadcast.
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: bobEntityID,
+		Position: core.Hex{Q: 50, R: -25, S: -25}, SightRange: 5,
+		HP: 10, MaxHP: 10, AC: 13,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+	s.bobSub, err = s.broker.Subscribe(encID, "bob")
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(s.aliceSub, 100*time.Millisecond)
+	drainSub(s.bobSub, 100*time.Millisecond)
+
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+
+	aliceSeen := collectTypes(s.aliceSub, 500*time.Millisecond)
+	bobSeen := collectTypes(s.bobSub, 500*time.Millisecond)
+	s.Contains(aliceSeen, "*events.EncounterEndedEvent")
+	s.Contains(bobSeen, "*events.EncounterEndedEvent",
+		"bob is out of LoS but EncounterEndedEvent must broadcast to him")
+	s.Contains(bobSeen, "*events.EntityRemovedEvent",
+		"bob is out of LoS but EntityRemovedEvent must broadcast to him")
+}
+
+// NPCAct that drops a player to 0 HP fires EntityDiedEvent for the
+// player (with the NPC as killer) but does NOT publish EntityRemovedEvent
+// for them, does NOT remove them from initiative, and does NOT end the
+// encounter (TPK is Wave 2.11+).
+func (s *DeathSuite) TestSlice_PlayerDies_PartialOnly() {
+	encID := core.EncounterID("enc-death-6")
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	// alice has 1 HP — guaranteed kill on first NPC hit.
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// Cycle to the goblin's turn.
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(s.aliceSub, 100*time.Millisecond)
+
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+
+	seen := collectTypes(s.aliceSub, 500*time.Millisecond)
+	s.Contains(seen, "*events.AttackResolvedEvent")
+	s.Contains(seen, "*events.DamageDealtEvent")
+	s.Contains(seen, "*events.EntityDiedEvent",
+		"player kill must publish EntityDiedEvent")
+	s.NotContains(seen, "*events.EntityRemovedEvent",
+		"Wave 2.10: player death is partial — no EntityRemovedEvent")
+	s.NotContains(seen, "*events.EncounterEndedEvent",
+		"Wave 2.10: TPK does not auto-end — no EncounterEndedEvent")
+
+	// Player still seated.
+	persisted := enc.ToData()
+	s.Contains(persisted.Players, core.PlayerID("alice"))
+	s.Contains(persisted.Initiative, core.EntityID(aliceEntityID),
+		"player must remain in initiative even at HP=0")
+	s.Equal(core.ModeTurnBased, enc.Mode())
+}
+
+// Post-end Data round-trips through ToData / LoadFromData with mode
+// preserved.
+func (s *DeathSuite) TestSlice_PostEndRoundTrips() {
+	enc := s.newSingleMonsterEnc("enc-death-7")
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+
+	persisted := enc.ToData()
+	s.Equal(core.ModeEnded, persisted.Mode)
+
+	rehydrated, err := encounter.LoadFromData(persisted, s.broker)
+	s.Require().NoError(err)
+	s.Equal(core.ModeEnded, rehydrated.Mode())
+
+	// Verbs against the rehydrated end-state still reject.
+	err = rehydrated.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+}
+
+// EntityDiedEvent for a monster kill carries killer = attacker entity id.
+func (s *DeathSuite) TestSlice_EntityDiedCarriesKillerID() {
+	enc := s.newSingleMonsterEnc("enc-death-8")
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	died := waitForEntityDied(s.T(), s.aliceSub, time.Second)
+	s.Require().NotNil(died)
+	s.Equal(core.EntityID(gobEntityID), died.EntityID)
+	s.Equal(core.EntityID(aliceEntityID), died.KillerID)
+}
+
+// EntityRemovedEvent carries Reason = "destroyed" for HP-zero kills.
+func (s *DeathSuite) TestSlice_EntityRemovedReasonDestroyed() {
+	enc := s.newSingleMonsterEnc("enc-death-9")
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	removed := waitForEntityRemoved(s.T(), s.aliceSub, time.Second)
+	s.Require().NotNil(removed)
+	s.Equal(core.EntityID(gobEntityID), removed.EntityID)
+	s.Equal(encounter.EntityRemovedReasonDestroyed, removed.Reason)
+}
+
+// EncounterEndedEvent carries Reason = "all_hostiles_defeated" for the
+// Wave 2.10 end condition.
+func (s *DeathSuite) TestSlice_EncounterEndedReasonAllHostilesDefeated() {
+	enc := s.newSingleMonsterEnc("enc-death-10")
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	ended := waitForEncounterEnded(s.T(), s.aliceSub, time.Second)
+	s.Require().NotNil(ended)
+	s.Equal(encounter.EncounterEndedReasonAllHostilesDefeated, ended.Reason)
+}
+
+// --- helpers ---
+
+func indexOf(haystack []string, needle string) int {
+	for i, h := range haystack {
+		if h == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+func waitForEntityDied(
+	t *testing.T, sub *encounter.Subscription, timeout time.Duration,
+) *events.EntityDiedEvent {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				return nil
+			}
+			if d, ok := evt.(*events.EntityDiedEvent); ok {
+				return d
+			}
+		case <-deadline:
+			return nil
+		}
+	}
+}
+
+func waitForEntityRemoved(
+	t *testing.T, sub *encounter.Subscription, timeout time.Duration,
+) *events.EntityRemovedEvent {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				return nil
+			}
+			if r, ok := evt.(*events.EntityRemovedEvent); ok {
+				return r
+			}
+		case <-deadline:
+			return nil
+		}
+	}
+}
+
+func waitForEncounterEnded(
+	t *testing.T, sub *encounter.Subscription, timeout time.Duration,
+) *events.EncounterEndedEvent {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				return nil
+			}
+			if e, ok := evt.(*events.EncounterEndedEvent); ok {
+				return e
+			}
+		case <-deadline:
+			return nil
+		}
+	}
+}

--- a/encounter/events/door_opened.go
+++ b/encounter/events/door_opened.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
 package events
 
 import (

--- a/encounter/events/encounter_ended.go
+++ b/encounter/events/encounter_ended.go
@@ -1,0 +1,91 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// EncounterEndedEvent is the terminal event published once when the
+// encounter-end predicate first goes true. Wave 2.10 emits it with
+// Reason = "all_hostiles_defeated"; future waves may add "fled",
+// "negotiated", "tpk", "time_out", etc.
+//
+// Audience is BROADCAST — every player in the encounter is in PerPlayer.
+// The terminal-state transition affects everyone uniformly: orchestrator
+// stops dispatching turns, UI surfaces an end-state indicator, subsequent
+// combat verbs return ErrEncounterEnded.
+//
+// Maps to the proto EncounterEnded wire shape.
+type EncounterEndedEvent struct {
+	encID     core.EncounterID
+	seq       uint64
+	Reason    string
+	PerPlayer map[core.PlayerID]EncounterEndedSlice
+}
+
+// EncounterEndedSlice is each viewer's projection. Visible is always true
+// for encounter-end events — every player observes the terminal transition.
+type EncounterEndedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewEncounterEndedEvent constructs an EncounterEndedEvent.
+func NewEncounterEndedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	reason string,
+	perPlayer map[core.PlayerID]EncounterEndedSlice,
+) *EncounterEndedEvent {
+	return &EncounterEndedEvent{
+		encID:     encID,
+		seq:       seq,
+		Reason:    reason,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*EncounterEndedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *EncounterEndedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *EncounterEndedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns every player participating in the encounter, since the
+// terminal transition is globally observable.
+func (e *EncounterEndedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type encounterEndedWire struct {
+	EncID     core.EncounterID                      `json:"encounter_id"`
+	Seq       uint64                                `json:"sequence"`
+	Reason    string                                `json:"reason,omitempty"`
+	PerPlayer map[core.PlayerID]EncounterEndedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *EncounterEndedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(encounterEndedWire{
+		EncID:     e.encID,
+		Seq:       e.seq,
+		Reason:    e.Reason,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *EncounterEndedEvent) UnmarshalJSON(b []byte) error {
+	var w encounterEndedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.Reason = w.Reason
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/entity_died.go
+++ b/encounter/events/entity_died.go
@@ -1,0 +1,97 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// EntityDiedEvent is the cause / narrative event published when an entity's
+// HP reaches zero. Wave 2.10 fires it for any entity (player or monster),
+// though only monsters are auto-removed (see EntityRemovedEvent). KillerID
+// carries the entity that landed the killing blow when known; it is empty
+// for environmental damage / poison / future indirect-kill sources that
+// don't track a single attacker. Per-viewer projection: a viewer is in
+// PerPlayer iff they have LoS to the dying entity OR the killer.
+//
+// Maps to the proto EntityDied wire shape. Cause-only — see
+// EntityRemovedEvent for the state mutation.
+type EntityDiedEvent struct {
+	encID     core.EncounterID
+	seq       uint64
+	EntityID  core.EntityID
+	KillerID  core.EntityID
+	PerPlayer map[core.PlayerID]EntityDiedSlice
+}
+
+// EntityDiedSlice is each viewer's projection. Visible says whether the
+// player perceived the death (LoS to dying entity OR killer).
+type EntityDiedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewEntityDiedEvent constructs an EntityDiedEvent. KillerID may be empty
+// when the cause has no single attributable attacker.
+func NewEntityDiedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	entityID core.EntityID,
+	killerID core.EntityID,
+	perPlayer map[core.PlayerID]EntityDiedSlice,
+) *EntityDiedEvent {
+	return &EntityDiedEvent{
+		encID:     encID,
+		seq:       seq,
+		EntityID:  entityID,
+		KillerID:  killerID,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*EntityDiedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *EntityDiedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *EntityDiedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who can perceive the death event,
+// derived from PerPlayer keys.
+func (e *EntityDiedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type entityDiedWire struct {
+	EncID     core.EncounterID                  `json:"encounter_id"`
+	Seq       uint64                            `json:"sequence"`
+	EntityID  core.EntityID                     `json:"entity_id"`
+	KillerID  core.EntityID                     `json:"killer_id,omitempty"`
+	PerPlayer map[core.PlayerID]EntityDiedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *EntityDiedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(entityDiedWire{
+		EncID:     e.encID,
+		Seq:       e.seq,
+		EntityID:  e.EntityID,
+		KillerID:  e.KillerID,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *EntityDiedEvent) UnmarshalJSON(b []byte) error {
+	var w entityDiedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.EntityID = w.EntityID
+	e.KillerID = w.KillerID
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/entity_removed.go
+++ b/encounter/events/entity_removed.go
@@ -1,0 +1,97 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// EntityRemovedEvent is the effect / state-mutation event published when an
+// entity is removed from the encounter's authoritative state. Wave 2.10
+// fires it for monsters whose HP hit zero (Reason = "destroyed"); future
+// waves use it for "fled", "transformed", etc.
+//
+// Audience is BROADCAST — every player in the encounter is in PerPlayer
+// with Visible: true. State removal is a global concept: even players who
+// could not see the death need to drop the entity from their local mirror,
+// otherwise their view diverges from server truth.
+//
+// Maps to the proto EntityRemoved wire shape.
+type EntityRemovedEvent struct {
+	encID     core.EncounterID
+	seq       uint64
+	EntityID  core.EntityID
+	Reason    string
+	PerPlayer map[core.PlayerID]EntityRemovedSlice
+}
+
+// EntityRemovedSlice is each viewer's projection. Visible is always true
+// for entity-removal events — every player observes state mutations.
+type EntityRemovedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewEntityRemovedEvent constructs an EntityRemovedEvent.
+func NewEntityRemovedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	entityID core.EntityID,
+	reason string,
+	perPlayer map[core.PlayerID]EntityRemovedSlice,
+) *EntityRemovedEvent {
+	return &EntityRemovedEvent{
+		encID:     encID,
+		seq:       seq,
+		EntityID:  entityID,
+		Reason:    reason,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*EntityRemovedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *EntityRemovedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *EntityRemovedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns every player who should see the removal — always all
+// players in the encounter, since the entity is globally gone.
+func (e *EntityRemovedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type entityRemovedWire struct {
+	EncID     core.EncounterID                     `json:"encounter_id"`
+	Seq       uint64                               `json:"sequence"`
+	EntityID  core.EntityID                        `json:"entity_id"`
+	Reason    string                               `json:"reason,omitempty"`
+	PerPlayer map[core.PlayerID]EntityRemovedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *EntityRemovedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(entityRemovedWire{
+		EncID:     e.encID,
+		Seq:       e.seq,
+		EntityID:  e.EntityID,
+		Reason:    e.Reason,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *EntityRemovedEvent) UnmarshalJSON(b []byte) error {
+	var w entityRemovedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.EntityID = w.EntityID
+	e.Reason = w.Reason
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -30,6 +30,9 @@ func (s *EventsSuite) TestConcretes_SatisfyInterface() {
 	var _ events.EncounterEvent = (*events.ModeChangedEvent)(nil)
 	var _ events.EncounterEvent = (*events.TurnStartedEvent)(nil)
 	var _ events.EncounterEvent = (*events.TurnEndedEvent)(nil)
+	var _ events.EncounterEvent = (*events.EntityDiedEvent)(nil)
+	var _ events.EncounterEvent = (*events.EntityRemovedEvent)(nil)
+	var _ events.EncounterEvent = (*events.EncounterEndedEvent)(nil)
 }
 
 // MoveEvent.Audience derives from PerPlayer keys; absent players are not in audience.
@@ -265,6 +268,97 @@ func (s *EventsSuite) TestModeChangedEvent_JSONRoundTrip() {
 	s.Equal(core.ModeTurnBased, decoded.To)
 	s.Equal("ambush", decoded.Reason)
 	s.Len(decoded.PerPlayer, 2)
+}
+
+// EntityDiedEvent JSON round-trip — KillerID and PerPlayer survive encoding,
+// audience derives from PerPlayer keys.
+func (s *EventsSuite) TestEntityDiedEvent_JSONRoundTrip() {
+	original := events.NewEntityDiedEvent(
+		"enc-1", 17, "goblin-1", "char-alice",
+		map[core.PlayerID]events.EntityDiedSlice{
+			"alice": {Visible: true},
+			"bob":   {Visible: true},
+		},
+	)
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EntityDiedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(17), decoded.Sequence())
+	s.Equal(core.EntityID("goblin-1"), decoded.EntityID)
+	s.Equal(core.EntityID("char-alice"), decoded.KillerID)
+	s.True(decoded.PerPlayer["alice"].Visible)
+	s.True(decoded.PerPlayer["bob"].Visible)
+	s.ElementsMatch(events.AudienceSet{"alice", "bob"}, decoded.Audience())
+}
+
+// EntityDiedEvent with an empty KillerID round-trips with KillerID still
+// empty (omitempty on the wire) — covers the environmental-damage / future
+// indirect-kill case.
+func (s *EventsSuite) TestEntityDiedEvent_EmptyKillerOmitted() {
+	original := events.NewEntityDiedEvent(
+		"enc-1", 18, "goblin-1", "",
+		map[core.PlayerID]events.EntityDiedSlice{
+			"alice": {Visible: true},
+		},
+	)
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+	s.NotContains(string(payload), `"killer_id"`,
+		"empty KillerID should be omitted from the wire")
+
+	var decoded events.EntityDiedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+	s.Equal(core.EntityID(""), decoded.KillerID)
+}
+
+// EntityRemovedEvent JSON round-trip — Reason and PerPlayer survive encoding.
+func (s *EventsSuite) TestEntityRemovedEvent_JSONRoundTrip() {
+	original := events.NewEntityRemovedEvent(
+		"enc-1", 19, "goblin-1", "destroyed",
+		map[core.PlayerID]events.EntityRemovedSlice{
+			"alice": {Visible: true},
+			"bob":   {Visible: true},
+		},
+	)
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EntityRemovedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(19), decoded.Sequence())
+	s.Equal(core.EntityID("goblin-1"), decoded.EntityID)
+	s.Equal("destroyed", decoded.Reason)
+	s.Len(decoded.PerPlayer, 2)
+	s.True(decoded.PerPlayer["alice"].Visible)
+	s.ElementsMatch(events.AudienceSet{"alice", "bob"}, decoded.Audience())
+}
+
+// EncounterEndedEvent JSON round-trip — Reason and PerPlayer survive encoding.
+func (s *EventsSuite) TestEncounterEndedEvent_JSONRoundTrip() {
+	original := events.NewEncounterEndedEvent(
+		"enc-1", 20, "all_hostiles_defeated",
+		map[core.PlayerID]events.EncounterEndedSlice{
+			"alice": {Visible: true},
+			"bob":   {Visible: true},
+		},
+	)
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EncounterEndedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(20), decoded.Sequence())
+	s.Equal("all_hostiles_defeated", decoded.Reason)
+	s.Len(decoded.PerPlayer, 2)
+	s.ElementsMatch(events.AudienceSet{"alice", "bob"}, decoded.Audience())
 }
 
 // TurnStartedEvent / TurnEndedEvent JSON round-trip.

--- a/encounter/events/turn_started.go
+++ b/encounter/events/turn_started.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
 package events
 
 import (

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -204,6 +204,10 @@ func (e *Encounter) applyNPCMovement(mon *MonsterData, movement []spatial.CubeCo
 // NOT removed from initiative and EntityRemovedEvent is NOT published —
 // player dying-state is Wave 2.11+ territory. The encounter does NOT
 // auto-end on player deaths (TPK is also Wave 2.11+).
+//
+// Death is published only on the HP transition (hpBefore > 0 && hpAfter == 0),
+// not whenever HP happens to be 0 — so multi-attack NPCs and re-hits on a
+// downed player do not duplicate EntityDiedEvent.
 func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents.AttackEvent) error {
 	for _, atk := range attacks {
 		targetID := encountercore.EntityID(atk.TargetID)
@@ -215,6 +219,7 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 		if dmgType == "" {
 			dmgType = damageTypeUntyped
 		}
+		hpBefore := targetPlayer.HP
 		res := e.resolveAttack(mon.AttackBonus, targetPlayer.AC, mon.DamageDice)
 		if res.hit {
 			targetPlayer.HP -= res.damage
@@ -229,9 +234,11 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 		); err != nil {
 			return err
 		}
-		// Wave 2.10 partial player-death: fire EntityDiedEvent only.
-		// No EntityRemoved / no initiative splice / no encounter-end.
-		if res.hit && targetPlayer.HP == 0 {
+		// Wave 2.10 partial player-death: fire EntityDiedEvent only on the
+		// HP transition (avoids duplicates from multi-attack NPCs or hits
+		// on an already-downed player). No EntityRemoved / no initiative
+		// splice / no encounter-end.
+		if res.hit && hpBefore > 0 && targetPlayer.HP == 0 {
 			if err := e.publishPlayerDied(targetID, mon.ID); err != nil {
 				return err
 			}
@@ -250,16 +257,18 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 // with hp_after=0 / zero-hex position would leak garbage values to
 // clients.
 //
-// Wave 2.10: if the captured damage zeroes a monster's HP, fires the
-// kill chain (EntityDied + EntityRemoved + checkEncounterEnd). If it
-// zeroes a player's HP, fires only EntityDiedEvent (partial player-death
-// per Wave 2.10 architectural call).
+// Wave 2.10: if captured damage drops a monster's HP from >0 to 0, fires
+// the kill chain (EntityDied + EntityRemoved + checkEncounterEnd). If it
+// drops a player's HP from >0 to 0, fires only EntityDiedEvent (partial
+// player-death per Wave 2.10 architectural call). Re-applying damage to
+// an already-zero target does NOT re-fire death events — death is gated
+// on the >0 → 0 transition.
 func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.DamageReceivedEvent) error {
 	for _, dmg := range damages {
 		targetID := encountercore.EntityID(dmg.TargetID)
 		sourceID := encountercore.EntityID(dmg.SourceID)
 
-		hpAfter, maxHP, targetPos, isMonster, ok := e.applyDamageToTarget(targetID, dmg.Amount)
+		hpBefore, hpAfter, maxHP, targetPos, isMonster, ok := e.applyDamageToTarget(targetID, dmg.Amount)
 		if !ok {
 			// Unknown target — skip publish rather than emit a stub event.
 			continue
@@ -284,7 +293,7 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 		)); err != nil {
 			return fmt.Errorf("publish damage dealt: %w", err)
 		}
-		if hpAfter == 0 {
+		if hpBefore > 0 && hpAfter == 0 {
 			if isMonster {
 				if err := e.killEntity(targetID, sourceID); err != nil {
 					return err
@@ -300,27 +309,31 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 }
 
 // applyDamageToTarget mutates HP on a player or monster matching id and
-// returns its post-damage HP, MaxHP, position, and whether the target was
-// a monster (vs a player). Returns ok=false if the id matches neither a
-// player nor a monster. HP is clamped at 0.
+// returns its pre-damage HP, post-damage HP, MaxHP, position, and whether
+// the target was a monster (vs a player). hpBefore lets callers detect
+// the >0 → 0 transition so death events fire exactly once per kill, not
+// per "HP happens to be 0 right now" check. Returns ok=false if the id
+// matches neither a player nor a monster. HP is clamped at 0.
 func (e *Encounter) applyDamageToTarget(
 	id encountercore.EntityID, amount int,
-) (hpAfter, maxHP int, pos encountercore.Hex, isMonster bool, ok bool) {
+) (hpBefore, hpAfter, maxHP int, pos encountercore.Hex, isMonster bool, ok bool) {
 	if p := e.findPlayerByEntityID(id); p != nil {
+		hpBefore = p.HP
 		p.HP -= amount
 		if p.HP < 0 {
 			p.HP = 0
 		}
-		return p.HP, p.MaxHP, p.View.Position, false, true
+		return hpBefore, p.HP, p.MaxHP, p.View.Position, false, true
 	}
 	if m, exists := e.data.Monsters[id]; exists {
+		hpBefore = m.HP
 		m.HP -= amount
 		if m.HP < 0 {
 			m.HP = 0
 		}
-		return m.HP, m.MaxHP, m.Position, true, true
+		return hpBefore, m.HP, m.MaxHP, m.Position, true, true
 	}
-	return 0, 0, encountercore.Hex{}, false, false
+	return 0, 0, 0, encountercore.Hex{}, false, false
 }
 
 // applyCapturedConditions translates each dnd5e ConditionAppliedEvent into
@@ -372,8 +385,8 @@ func (e *Encounter) applyCapturedConditions(mon *MonsterData, conds []dnd5eEvent
 // orchestrator-seeded fixtures that don't carry a serialized monster.
 //
 // Wave 2.10: same partial player-death semantics as applyCapturedAttacks
-// — fires EntityDiedEvent on a player kill but does not remove the
-// player or end the encounter.
+// — fires EntityDiedEvent on a player kill (only on HP transition, not
+// whenever HP is 0) but does not remove the player or end the encounter.
 func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	target := e.closestPlayer(mon.Position)
 	if target == nil {
@@ -383,6 +396,7 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	if dmgType == "" {
 		dmgType = damageTypeUntyped
 	}
+	hpBefore := target.HP
 	res := e.resolveAttack(mon.AttackBonus, target.AC, mon.DamageDice)
 	if res.hit {
 		target.HP -= res.damage
@@ -397,7 +411,7 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	); err != nil {
 		return err
 	}
-	if res.hit && target.HP == 0 {
+	if res.hit && hpBefore > 0 && target.HP == 0 {
 		if err := e.publishPlayerDied(target.EntityID, mon.ID); err != nil {
 			return err
 		}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -34,6 +34,9 @@ import (
 //
 // Does NOT auto-cycle the turn — orchestrator calls EndTurn(npcID) next.
 func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) error {
+	if e.data.Mode == encountercore.ModeEnded {
+		return ErrEncounterEnded
+	}
 	if e.data.Mode != encountercore.ModeTurnBased {
 		return ErrNotTurnBased
 	}
@@ -195,6 +198,12 @@ func (e *Encounter) applyNPCMovement(mon *MonsterData, movement []spatial.CubeCo
 // applyCapturedAttacks resolves each captured dnd5e AttackEvent (cause-only)
 // using the encounter's stand-in resolver, mutates the target player's HP,
 // and emits AttackResolved + DamageDealt encounter events.
+//
+// Wave 2.10: when an NPC's attack drops a player to HP=0, also publishes
+// EntityDiedEvent for the player (with the NPC as killer). The player is
+// NOT removed from initiative and EntityRemovedEvent is NOT published —
+// player dying-state is Wave 2.11+ territory. The encounter does NOT
+// auto-end on player deaths (TPK is also Wave 2.11+).
 func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents.AttackEvent) error {
 	for _, atk := range attacks {
 		targetID := encountercore.EntityID(atk.TargetID)
@@ -220,6 +229,13 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 		); err != nil {
 			return err
 		}
+		// Wave 2.10 partial player-death: fire EntityDiedEvent only.
+		// No EntityRemoved / no initiative splice / no encounter-end.
+		if res.hit && targetPlayer.HP == 0 {
+			if err := e.publishPlayerDied(targetID, mon.ID); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -233,12 +249,17 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 // damage event is skipped (no DamageDealtEvent published) — emitting
 // with hp_after=0 / zero-hex position would leak garbage values to
 // clients.
+//
+// Wave 2.10: if the captured damage zeroes a monster's HP, fires the
+// kill chain (EntityDied + EntityRemoved + checkEncounterEnd). If it
+// zeroes a player's HP, fires only EntityDiedEvent (partial player-death
+// per Wave 2.10 architectural call).
 func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.DamageReceivedEvent) error {
 	for _, dmg := range damages {
 		targetID := encountercore.EntityID(dmg.TargetID)
 		sourceID := encountercore.EntityID(dmg.SourceID)
 
-		hpAfter, maxHP, targetPos, ok := e.applyDamageToTarget(targetID, dmg.Amount)
+		hpAfter, maxHP, targetPos, isMonster, ok := e.applyDamageToTarget(targetID, dmg.Amount)
 		if !ok {
 			// Unknown target — skip publish rather than emit a stub event.
 			continue
@@ -263,31 +284,43 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 		)); err != nil {
 			return fmt.Errorf("publish damage dealt: %w", err)
 		}
+		if hpAfter == 0 {
+			if isMonster {
+				if err := e.killEntity(targetID, sourceID); err != nil {
+					return err
+				}
+			} else {
+				if err := e.publishPlayerDied(targetID, sourceID); err != nil {
+					return err
+				}
+			}
+		}
 	}
 	return nil
 }
 
 // applyDamageToTarget mutates HP on a player or monster matching id and
-// returns its post-damage HP, MaxHP, and position. Returns ok=false if
-// the id matches neither a player nor a monster. HP is clamped at 0.
+// returns its post-damage HP, MaxHP, position, and whether the target was
+// a monster (vs a player). Returns ok=false if the id matches neither a
+// player nor a monster. HP is clamped at 0.
 func (e *Encounter) applyDamageToTarget(
 	id encountercore.EntityID, amount int,
-) (hpAfter, maxHP int, pos encountercore.Hex, ok bool) {
+) (hpAfter, maxHP int, pos encountercore.Hex, isMonster bool, ok bool) {
 	if p := e.findPlayerByEntityID(id); p != nil {
 		p.HP -= amount
 		if p.HP < 0 {
 			p.HP = 0
 		}
-		return p.HP, p.MaxHP, p.View.Position, true
+		return p.HP, p.MaxHP, p.View.Position, false, true
 	}
 	if m, exists := e.data.Monsters[id]; exists {
 		m.HP -= amount
 		if m.HP < 0 {
 			m.HP = 0
 		}
-		return m.HP, m.MaxHP, m.Position, true
+		return m.HP, m.MaxHP, m.Position, true, true
 	}
-	return 0, 0, encountercore.Hex{}, false
+	return 0, 0, encountercore.Hex{}, false, false
 }
 
 // applyCapturedConditions translates each dnd5e ConditionAppliedEvent into
@@ -337,6 +370,10 @@ func (e *Encounter) applyCapturedConditions(mon *MonsterData, conds []dnd5eEvent
 // npcActScripted runs a minimal attack against the closest player when
 // the monster has no DataJSON to rehydrate. Used for tests and
 // orchestrator-seeded fixtures that don't carry a serialized monster.
+//
+// Wave 2.10: same partial player-death semantics as applyCapturedAttacks
+// — fires EntityDiedEvent on a player kill but does not remove the
+// player or end the encounter.
 func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	target := e.closestPlayer(mon.Position)
 	if target == nil {
@@ -353,11 +390,19 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 			target.HP = 0
 		}
 	}
-	return e.publishAttackOutcome(
+	if err := e.publishAttackOutcome(
 		mon.ID, target.EntityID, res,
 		target.HP, target.MaxHP, dmgType,
 		mon.Position, target.View.Position,
-	)
+	); err != nil {
+		return err
+	}
+	if res.hit && target.HP == 0 {
+		if err := e.publishPlayerDied(target.EntityID, mon.ID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // buildPerception assembles the PerceptionData a monster needs to choose


### PR DESCRIPTION
## Summary

Closes #642. Wave 2.10 of the v1alpha2 encounter contract — HP=0 becomes a meaningful state transition. Dead monsters fire `EntityDied` then `EntityRemoved`, get spliced out of `Initiative`, and disappear from `data.Monsters`. When the last hostile dies, the encounter fires `EncounterEnded` and stops dispatching turns. All toolkit-side per the boundary rule.

## Design decisions

### Terminal-state field — Option A (`core.ModeEnded`)

Picked Option A from the issue body. Reuses existing mode-gating in combat verbs (`TakeAction`, `EndTurn`, `NPCAct` already check `mode == ModeTurnBased`), doesn't introduce a parallel enum, fits the "mode is the lifecycle field" framing already in place. `String()` extended; `ModeEnded` clears `Initiative + ActiveIdx + Round` on transition.

### Cause/effect split (EntityDied vs EntityRemoved)

Two events; both fire back-to-back today; future waves may delay `EntityRemoved` for corpse/loot mechanics.

- `EntityDiedEvent` — per-viewer (LoS to dying entity OR killer). Cause/narrative — animations, log lines, killer attribution.
- `EntityRemovedEvent` — broadcast (every viewer must drop the entity from local state, even those out of LoS). State mutation.
- `EncounterEndedEvent` — broadcast.

### Kill-helper shape

Single private `(*Encounter).killEntity(monsterID, killerID)` owns the multi-step state mutation (publish died → delete from Monsters → splice from Initiative → publish removed → check encounter-end). Same encapsulation pattern as `OpenDoor`. `publishPlayerDied` is the counterpart for the partial player-death path — fires `EntityDiedEvent` only. `checkEncounterEnd` is the encounter-end predicate (today: `len(data.Monsters) == 0`), encapsulated so future waves swap predicates without touching the kill path.

### Initiative-splice math

`spliceFromInitiative(id)`:
- Removed index `< ActiveIdx` → decrement `ActiveIdx` (everyone shifted left).
- Removed index `== ActiveIdx` → pointer stays in place; if Initiative shrinks below the pointer, wrap to 0.
- Removed index `> ActiveIdx` → no adjustment.

The kill path doesn't expect `== ActiveIdx` in the monster-killed-by-player case (the active actor is the attacker, not the target). Test `TestSlice_EndTurnSkipsDeadActor` validates the splice end-to-end.

### NPC-killed-player handling (partial — Wave 2.10 architectural call)

When NPCAct (or the scripted fallback / captured-damage path) drops a player to HP=0, the toolkit fires `EntityDiedEvent` for the player with the NPC as killer, but does NOT call `killEntity` — the player stays in initiative, `EntityRemovedEvent` does not fire, and the encounter does not auto-end. Player dying-state (death saves / downed-but-stable / TPK) is Wave 2.11+. Documented prominently in `death.go` (`publishPlayerDied`) and `npc.go` (`applyCapturedAttacks`, `npcActScripted`).

### Sentinel error

`var ErrEncounterEnded = errors.New("encounter has ended")` — returned from `TakeAction` / `EndTurn` / `NPCAct` post-end. Maps to `FailedPrecondition` on the rpg-api side.

## Versioning

Tag `encounter/v0.5.0` after merge. Additive — `core.ModeEnded` is a new enum value, three new events, one new sentinel error, two new public reason constants (`EntityRemovedReasonDestroyed`, `EncounterEndedReasonAllHostilesDefeated`). No existing types or events modified incompatibly.

## What tests cover

- `TestSlice_MonsterDies_EncounterEnds` — order check (Died → Removed → Ended), mode flips, monsters cleared, Initiative cleared.
- `TestSlice_PostEnd_ErrEncounterEnded` — TakeAction / EndTurn / NPCAct all return ErrEncounterEnded post-end.
- `TestSlice_OneOfTwoMonstersDies_EncounterContinues` — only the dead goblin gets death events; surviving goblin remains; mode unchanged; no EncounterEndedEvent.
- `TestSlice_EndTurnSkipsDeadActor` — ActiveIdx splice math regression.
- `TestSlice_EncounterEndedBroadcastsToAll` — out-of-LoS bob receives EncounterEnded + EntityRemoved.
- `TestSlice_PlayerDies_PartialOnly` — NPCAct drops alice to 0 HP; EntityDiedEvent fires but no EntityRemoved, alice still in initiative, encounter still TURN_BASED.
- `TestSlice_PostEndRoundTrips` — `ToData` / `LoadFromData` preserves `ModeEnded`; rehydrated encounter still rejects verbs.
- `TestSlice_EntityDiedCarriesKillerID`, `TestSlice_EntityRemovedReasonDestroyed`, `TestSlice_EncounterEndedReasonAllHostilesDefeated` — reason / killer attribution checks.
- Per-event JSON round-trip + sealed-interface coverage in `events/events_test.go`.

## What's deferred

- Player dying-state machinery (death saves / downed-but-stable / stabilization / exhaustion).
- TPK detection (encounter doesn't auto-end on all-players-down in 2.10).
- Indirect-kill / killer-attribution chain (DoT, environmental damage).
- Corpse / loot modeling.
- NPC-on-NPC damage.
- Death animations / VFX (web concern).

## Test plan

- [x] `go test -race ./...` in `encounter/`
- [x] `go fmt ./...` and `go mod tidy` (no diff)
- [x] All new events JSON-round-trip in `events_test.go`
- [x] Existing combat / NPC / prompts tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)