### PR TITLE
feat(encounter): CombatResolver interface for player attacks (Wave 2.11a)

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -232,6 +232,12 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 	if err != nil {
 		return fmt.Errorf("combat resolver: %w", err)
 	}
+	if outcome == nil {
+		// Defensive: a well-behaved CombatResolver returns either a non-nil
+		// outcome or a non-nil error per the interface contract. Guarding
+		// here keeps a misbehaving implementation from panicking the verb.
+		return fmt.Errorf("combat resolver: nil outcome with nil error")
+	}
 	res := attackResolution{
 		hit:         outcome.Hit,
 		critical:    outcome.Critical,

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -215,9 +215,31 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrUnknownTarget, target.EntityID)
 	}
+	if e.combatResolver == nil {
+		return ErrNoCombatResolver
+	}
 
 	hpBefore := monster.HP
-	res := e.resolveAttack(player.AttackBonus, monster.AC, player.DamageDice)
+	outcome, err := e.combatResolver.ResolveAttack(AttackInput{
+		AttackerID:          player.EntityID,
+		TargetID:            target.EntityID,
+		ActionRef:           toolkitRef(ref),
+		AttackerAttackBonus: player.AttackBonus,
+		AttackerDamageDice:  player.DamageDice,
+		AttackerDamageType:  player.DamageType,
+		TargetAC:            monster.AC,
+	})
+	if err != nil {
+		return fmt.Errorf("combat resolver: %w", err)
+	}
+	res := attackResolution{
+		hit:         outcome.Hit,
+		critical:    outcome.Critical,
+		attackRoll:  outcome.AttackRoll,
+		attackBonus: outcome.AttackBonus,
+		targetAC:    outcome.TargetAC,
+		damage:      outcome.Damage,
+	}
 	if res.hit {
 		monster.HP -= res.damage
 		if monster.HP < 0 {
@@ -225,7 +247,10 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 		}
 	}
 
-	damageType := player.DamageType
+	damageType := outcome.DamageType
+	if damageType == "" {
+		damageType = player.DamageType
+	}
 	if damageType == "" {
 		damageType = damageTypeUntyped
 	}

--- a/encounter/combat_resolver.go
+++ b/encounter/combat_resolver.go
@@ -1,0 +1,121 @@
+package encounter
+
+import (
+	"errors"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ErrNoCombatResolver is returned by combat verbs when the encounter was
+// constructed without a CombatResolver. The orchestrator (rpg-api) wires
+// one via WithCombatResolver; tests stub it. Without one, the encounter
+// SDK has no way to evaluate attack mechanics — it does not embed
+// rulebook logic itself.
+var ErrNoCombatResolver = errors.New("no combat resolver wired")
+
+// CombatResolver bridges the encounter SDK to a rulebook implementation
+// of combat mechanics. The encounter SDK orchestrates state and flow
+// (initiative, turn cycling, per-viewer event projection) but delegates
+// "did this attack hit and how much damage" to the resolver.
+//
+// The orchestrator (rpg-api) implements this interface against a specific
+// rulebook (today: dnd5e). The encounter SDK never imports rulebook
+// packages — keeping the boundary clean across rulebooks.
+//
+// Wave 2.11a wires ResolveAttack for the player-attack path
+// (combat.TakeAction). NPCAct continues to use the legacy stand-in path
+// until Wave 2.11b adds monster rulebook adapters and OA / multiattack
+// support; method additions on this interface in 2.11b are explicit
+// breaking changes flagged in the encounter module's release notes.
+type CombatResolver interface {
+	// ResolveAttack evaluates one attack from attacker to target and
+	// returns the outcome. The resolver is responsible for looking up
+	// rich rulebook state (ability scores, weapon, AC chain) from
+	// whatever store the orchestrator wires in; the encounter SDK only
+	// passes IDs and the action ref.
+	//
+	// The resolver MUST NOT mutate encounter state directly. The
+	// encounter SDK applies HP changes + publishes events from the
+	// returned AttackOutcome.
+	ResolveAttack(input AttackInput) (*AttackOutcome, error)
+}
+
+// AttackInput is the encounter-SDK-side request shape for ResolveAttack.
+// The orchestrator's resolver implementation translates this to the
+// rulebook's native AttackInput shape (e.g., dnd5e/combat.AttackInput).
+type AttackInput struct {
+	// AttackerID is the entity making the attack — could be a player
+	// (combat.TakeAction path) or a monster (future NPCAct migration).
+	AttackerID encountercore.EntityID
+
+	// TargetID is the entity being attacked.
+	TargetID encountercore.EntityID
+
+	// ActionRef identifies the action being taken. For Wave 2.11a this
+	// is always {Module:"dnd5e", Type:"action", ID:"attack"}; future
+	// waves extend the action vocabulary.
+	ActionRef core.Ref
+
+	// AttackHand is the optional hand for two-weapon fighting. Empty or
+	// "main" defaults to main-hand; "off" triggers off-hand validation.
+	// The resolver implementation interprets this against the rulebook's
+	// AttackHand vocabulary.
+	AttackHand string
+
+	// Combat-stat snapshots, populated by the encounter SDK from
+	// PlayerData / MonsterData at attack time. Stand-in resolver
+	// implementations use these directly to compute d20+bonus vs AC.
+	// Real rulebook resolver implementations may ignore these and look
+	// up richer state (ability scores, AC chain, equipped weapon) from
+	// their own character/monster store.
+	AttackerAttackBonus int
+	AttackerDamageDice  string
+	AttackerDamageType  string
+	TargetAC            int
+}
+
+// AttackOutcome is the encounter-SDK-side result shape from ResolveAttack.
+// The resolver implementation translates the rulebook's native result
+// (e.g., dnd5e/combat.AttackResult) to this shape. The encounter SDK uses
+// it to publish AttackResolvedEvent + (on hit) DamageDealtEvent and to
+// mutate target HP.
+type AttackOutcome struct {
+	// Hit is true if the attack landed.
+	Hit bool
+
+	// Critical is true if the attack landed as a critical hit.
+	Critical bool
+
+	// AttackRoll is the final d20 attack roll (after advantage /
+	// disadvantage resolution).
+	AttackRoll int
+
+	// AttackBonus is the total bonus added to the attack roll.
+	AttackBonus int
+
+	// TargetAC is the target's effective AC at the moment of the
+	// attack (after the AC chain — Shield spell, cover, etc.).
+	TargetAC int
+
+	// Damage is the final damage dealt on a hit. Zero on miss.
+	Damage int
+
+	// DamageType identifies the kind of damage dealt (e.g.,
+	// "slashing", "fire"). Empty on miss; encounter SDK falls back
+	// to the entity's stored damage type if the resolver leaves it
+	// empty on a hit.
+	DamageType string
+}
+
+// toolkitRef converts the encounter SDK's local ActionRef shape (plain
+// strings) to the toolkit-canonical core.Ref shape (typed Module/Type/ID).
+// The resolver implementation receives the canonical shape so it can pass
+// it directly to rulebook lookups without re-parsing.
+func toolkitRef(r ActionRef) core.Ref {
+	return core.Ref{
+		Module: r.Module,
+		Type:   r.Type,
+		ID:     r.ID,
+	}
+}

--- a/encounter/combat_resolver_test.go
+++ b/encounter/combat_resolver_test.go
@@ -1,0 +1,115 @@
+package encounter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// alwaysHitResolver is a deterministic CombatResolver test helper that
+// always returns a hit with a configurable damage value. Used by combat
+// and death tests where the only thing that matters is that an attack
+// lands and produces a known damage amount (e.g., enough to kill the
+// monster in one hit). Real rulebook chains run in rpg-api integration
+// tests, not here.
+type alwaysHitResolver struct {
+	damage     int
+	damageType string
+}
+
+func (r alwaysHitResolver) ResolveAttack(_ encounter.AttackInput) (*encounter.AttackOutcome, error) {
+	return &encounter.AttackOutcome{
+		Hit:         true,
+		AttackRoll:  20,
+		AttackBonus: 4,
+		TargetAC:    10,
+		Damage:      r.damage,
+		DamageType:  r.damageType,
+	}, nil
+}
+
+// CombatResolverWiringSuite covers the wiring contract for CombatResolver
+// (the encounter SDK side of the Wave 2.11a integration). The resolver
+// implementation itself is exercised through the rpg-api integration tests.
+type CombatResolverWiringSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestCombatResolverWiringSuite(t *testing.T) {
+	suite.Run(t, new(CombatResolverWiringSuite))
+}
+
+func (s *CombatResolverWiringSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *CombatResolverWiringSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// TakeAction returns ErrNoCombatResolver when no CombatResolver is
+// wired. Production must wire one via WithCombatResolver; this guards
+// against misconfiguration.
+func (s *CombatResolverWiringSuite) TestTakeAction_ErrNoCombatResolver() {
+	enc := encounter.New("enc-no-resolver", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, err := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	err := enc.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.ErrorIs(err, encounter.ErrNoCombatResolver)
+}
+
+// TakeAction calls the wired CombatResolver and uses its outcome to
+// mutate state and publish events.
+func (s *CombatResolverWiringSuite) TestTakeAction_UsesResolverOutcome() {
+	enc := encounter.New("enc-resolver", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 5, damageType: damageSlashing}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, err := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	s.Require().NoError(enc.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+
+	// Resolver dealt 5 damage; goblin started at 7 HP → should be at 2.
+	persisted := enc.ToData()
+	s.Equal(2, persisted.Monsters[gobEntityID].HP)
+}

--- a/encounter/combat_test.go
+++ b/encounter/combat_test.go
@@ -14,11 +14,15 @@ import (
 
 // Test-package fixture identifiers (extracted to satisfy goconst).
 const (
+	alicePlayerID  = "alice"
+	bobPlayerID    = "bob"
 	aliceEntityID  = "char-alice"
 	bobEntityID    = "char-bob"
 	gobEntityID    = "goblin-1"
 	gob2EntityID   = "goblin-2"
 	damageSlashing = "slashing"
+	refModuleDnd5e = "dnd5e"
+	refTypeAction  = "action"
 )
 
 // CombatSuite covers the Wave 2.8 verbs (SetMode, EndTurn, TakeAction,
@@ -41,7 +45,9 @@ func (s *CombatSuite) SetupTest() {
 	s.ctx = context.Background()
 	s.transport = encounter.NewInMemoryTransport()
 	s.broker = encounter.NewBroker(s.transport)
-	s.enc = encounter.New("enc-combat", s.broker)
+	s.enc = encounter.New("enc-combat", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
 
 	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
@@ -263,7 +269,9 @@ func (s *CombatSuite) TestNPCAct_ScriptedAttackPublishes() {
 // entirely so the broker does not deliver to them. Mirrors Move /
 // OpenDoor audience-routing.
 func (s *CombatSuite) TestTakeAction_OmitsNonViewersFromAudience() {
-	enc := encounter.New("enc-combat-2", s.broker)
+	enc := encounter.New("enc-combat-2", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,

--- a/encounter/death_test.go
+++ b/encounter/death_test.go
@@ -73,7 +73,8 @@ func (s *DeathSuite) TearDownTest() {
 // the fixed-max roller and pre-flipped to ModeTurnBased on alice's turn.
 // Returns the encounter; subscriptions are written into the suite fields.
 func (s *DeathSuite) newSingleMonsterEnc(encID core.EncounterID) *encounter.Encounter {
-	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
@@ -175,7 +176,8 @@ func (s *DeathSuite) TestSlice_PostEnd_ErrEncounterEnded() {
 // does NOT publish EncounterEndedEvent.
 func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 	encID := core.EncounterID("enc-death-3")
-	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
@@ -240,7 +242,8 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 // (NOT the dead goblin). Regression for ActiveIdx splice math.
 func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 	encID := core.EncounterID("enc-death-4")
-	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
@@ -290,7 +293,8 @@ func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 // player (PerPlayer covers all of them, regardless of LoS to the kill).
 func (s *DeathSuite) TestSlice_EncounterEndedBroadcastsToAll() {
 	encID := core.EncounterID("enc-death-5")
-	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
@@ -343,7 +347,8 @@ func (s *DeathSuite) TestSlice_EncounterEndedBroadcastsToAll() {
 // encounter (TPK is Wave 2.11+).
 func (s *DeathSuite) TestSlice_PlayerDies_PartialOnly() {
 	encID := core.EncounterID("enc-death-6")
-	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 	// alice has 1 HP — guaranteed kill on first NPC hit.
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
@@ -457,7 +462,8 @@ func (s *DeathSuite) TestSlice_EncounterEndedReasonAllHostilesDefeated() {
 // the death event" risk Copilot raised on the first review pass.
 func (s *DeathSuite) TestSlice_PlayerDeath_NotRePublishedOnReHit() {
 	encID := core.EncounterID("enc-death-rehit-player")
-	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	enc := encounter.New(encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -14,10 +14,11 @@ import (
 // Constructed per-call via LoadFromData; mutated by verbs; serialized via
 // ToData and saved.
 type Encounter struct {
-	data     *Data
-	broker   *Broker
-	roller   dice.Roller
-	resolver CharacterResolver
+	data           *Data
+	broker         *Broker
+	roller         dice.Roller
+	resolver       CharacterResolver
+	combatResolver CombatResolver
 }
 
 // Option configures an Encounter at construction.
@@ -42,6 +43,18 @@ func WithRoller(r dice.Roller) Option {
 func WithCharacterResolver(r CharacterResolver) Option {
 	return func(e *Encounter) {
 		e.resolver = r
+	}
+}
+
+// WithCombatResolver injects a CombatResolver used by combat verbs
+// (today: TakeAction's player-attack path; future waves extend) to
+// evaluate attack mechanics through a rulebook implementation. The
+// encounter SDK never embeds rulebook logic; the orchestrator (rpg-api)
+// wires this against the dnd5e rulebook in production. Tests supply
+// a stub. TakeAction returns ErrNoCombatResolver if invoked without one.
+func WithCombatResolver(r CombatResolver) Option {
+	return func(e *Encounter) {
+		e.combatResolver = r
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces the encounter SDK's stand-in attack resolver with a `CombatResolver` interface that hosts implement and inject. Wave 2.11a covers the **player-attack path only**; NPC attacks remain on the in-package stand-in until 2.11b.

## Motivation

The encounter SDK should stay rulebook-agnostic. The pre-2.11a stand-in attack math (d20+bonus vs AC, damage notation roll) lived inside `combat.go` as a placeholder. Surfacing it as an interface lets rpg-api wire its `dnd5e/combat.ResolveAttack` chain without dragging rulebook imports into the SDK.

## Wire shape

- `encounter.CombatResolver` interface — single method `ResolveAttack(AttackInput) (*AttackOutcome, error)`
- `AttackInput` carries the combat-stat snapshot (attacker bonus + damage dice/type, target AC) plus a canonical `core.Ref` for the action — resolver doesn't need an encounter back-pointer
- `AttackOutcome` carries hit/crit/damage breakdown ready to map onto the existing `attackResolution`
- Wired via `WithCombatResolver(r)` Option, parallel to Wave 2.9's `WithCharacterResolver`
- `ErrNoCombatResolver` returned from `TakeAction` if no resolver is wired

## What changes (player-attack path)

`combat.go:217` — `TakeAction` now:
1. Returns `ErrNoCombatResolver` if `e.combatResolver == nil`
2. Calls `e.combatResolver.ResolveAttack(...)` with the input snapshot
3. Maps the outcome onto `attackResolution` for the existing `publishAttackOutcome` path

The stand-in `resolveAttack` (lines 307-378) is **retained** — still called by `NPCAct` in `npc.go`. Wave 2.11b folds NPCs onto the resolver.

## Out of scope (deferred to 2.11b)

- NPC attacks (npc.go) — still uses in-package stand-in
- Real `dnd5e/combat.ResolveAttack` integration — happens on the rpg-api side in the companion PR via a `StandInCombatResolver` that mimics pre-2.11a math, then progressively swaps in real combat lookups

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [x] New `CombatResolverWiringSuite`:
  - `TestTakeAction_ErrNoCombatResolver` — no-resolver returns sentinel
  - `TestTakeAction_UsesResolverOutcome` — wired resolver's damage lands on the target's HP
- [x] Existing `CombatSuite` and `DeathSuite` updated to wire `alwaysHitResolver` test helper
- [ ] rpg-api integration tests pass against the new contract (verified locally on companion branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)