### PR TITLE
feat(encounter): fold NPCAct onto CombatResolver; drop in-package resolveAttack (Wave 2.11b)

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -42,6 +42,11 @@ var (
 // maps this to the proto's UNSPECIFIED damage type.
 const damageTypeUntyped = "untyped"
 
+// actionIDAttack is the canonical action ID for a standard melee/ranged
+// attack. Used as AttackInput.ActionRef.ID for both the player path
+// (TakeAction) and the NPC path (NPCAct / npcActScripted).
+const actionIDAttack = "attack"
+
 // isPlayerCombatant reports whether a player seat carries the minimum
 // combat snapshot required for TakeAction. PlayerInput documents that a
 // zero combat snapshot opts a seat out of combat verbs; this helper is
@@ -202,7 +207,7 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 	if active := e.ActiveActor(); active != player.EntityID {
 		return fmt.Errorf("%w: active=%q got=%q", ErrNotYourTurn, active, player.EntityID)
 	}
-	if ref.ID != "attack" {
+	if ref.ID != actionIDAttack {
 		return fmt.Errorf("%w: %q", ErrUnsupportedAction, ref.ID)
 	}
 	if !isPlayerCombatant(player) {

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -238,16 +238,8 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 		// here keeps a misbehaving implementation from panicking the verb.
 		return fmt.Errorf("combat resolver: nil outcome with nil error")
 	}
-	res := attackResolution{
-		hit:         outcome.Hit,
-		critical:    outcome.Critical,
-		attackRoll:  outcome.AttackRoll,
-		attackBonus: outcome.AttackBonus,
-		targetAC:    outcome.TargetAC,
-		damage:      outcome.Damage,
-	}
-	if res.hit {
-		monster.HP -= res.damage
+	if outcome.Hit {
+		monster.HP -= outcome.Damage
 		if monster.HP < 0 {
 			monster.HP = 0
 		}
@@ -261,7 +253,7 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 		damageType = damageTypeUntyped
 	}
 	if err := e.publishAttackOutcome(
-		player.EntityID, target.EntityID, res,
+		player.EntityID, target.EntityID, outcome,
 		monster.HP, monster.MaxHP, damageType,
 		player.View.Position, monster.Position,
 	); err != nil {
@@ -273,7 +265,7 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 	// out, but the gate is cheap insurance for future paths) does
 	// NOT re-fire death events. killEntity also runs the
 	// encounter-end predicate which may transition mode to ModeEnded.
-	if res.hit && hpBefore > 0 && monster.HP == 0 {
+	if outcome.Hit && hpBefore > 0 && monster.HP == 0 {
 		if err := e.killEntity(target.EntityID, player.EntityID); err != nil {
 			return err
 		}
@@ -319,70 +311,6 @@ func rollD20(r dice.Roller) int {
 	return v
 }
 
-// attackResolution captures one resolved attack — used by both TakeAction
-// (player attacks monster) and NPCAct (monster attacks player). Stand-in
-// for the proper combat.ResolveAttack chain (followup).
-type attackResolution struct {
-	hit         bool
-	critical    bool
-	attackRoll  int
-	attackBonus int
-	targetAC    int
-	damage      int
-}
-
-// resolveAttack rolls a d20+attackBonus attack against targetAC and, on hit,
-// rolls damage from the supplied dice notation. Nat-20 is a critical (double
-// damage dice). Nat-1 misses regardless of bonus. Empty notation defaults to
-// "1d4".
-func (e *Encounter) resolveAttack(attackBonus, targetAC int, damageNotation string) attackResolution {
-	roll := rollD20(e.roller)
-	res := attackResolution{
-		attackRoll:  roll,
-		attackBonus: attackBonus,
-		targetAC:    targetAC,
-		critical:    roll == 20,
-	}
-	switch roll {
-	case 1:
-		res.hit = false
-	case 20:
-		res.hit = true
-	default:
-		res.hit = roll+attackBonus >= targetAC
-	}
-	if !res.hit {
-		return res
-	}
-	notation := damageNotation
-	if notation == "" {
-		notation = "1d4"
-	}
-	pool, err := dice.ParseNotation(notation)
-	if err != nil {
-		// Indeterminate damage — fall back to 1 to keep the verb non-blocking.
-		res.damage = 1
-		return res
-	}
-	rolled := pool.RollContext(context.Background(), e.roller)
-	if rolled.Error() != nil {
-		res.damage = 1
-		return res
-	}
-	dmg := rolled.Total()
-	if res.critical {
-		// Crit doubles dice (additive of the dice portion). The simple
-		// approximation here is total*2 - modifier; close enough for the
-		// stand-in. Followup: full crit-damage chain.
-		dmg += rolled.Total() - rolled.Modifier()
-	}
-	if dmg < 0 {
-		dmg = 0
-	}
-	res.damage = dmg
-	return res
-}
-
 // publishAttackOutcome emits the AttackResolvedEvent (always) plus the
 // DamageDealtEvent (only on hit) with per-viewer projection determined by
 // LoS to attacker OR target.
@@ -393,7 +321,7 @@ func (e *Encounter) resolveAttack(attackBonus, targetAC int, damageNotation stri
 // viewers, which prevents fog-of-war leakage of out-of-LoS combat.
 func (e *Encounter) publishAttackOutcome(
 	attackerID, targetID core.EntityID,
-	res attackResolution,
+	outcome *AttackOutcome,
 	targetHPAfter, targetMaxHP int,
 	damageType string,
 	attackerPos, targetPos core.Hex,
@@ -406,23 +334,23 @@ func (e *Encounter) publishAttackOutcome(
 			continue
 		}
 		attackPerPlayer[viewerID] = events.AttackResolvedSlice{Visible: true}
-		if res.hit {
+		if outcome.Hit {
 			damagePerPlayer[viewerID] = events.DamageDealtSlice{Visible: true}
 		}
 	}
 	if err := e.broker.Publish(events.NewAttackResolvedEvent(
 		e.data.ID, e.nextSeq(),
 		attackerID, targetID,
-		res.hit, res.critical, res.attackRoll, res.attackBonus, res.targetAC,
+		outcome.Hit, outcome.Critical, outcome.AttackRoll, outcome.AttackBonus, outcome.TargetAC,
 		attackPerPlayer,
 	)); err != nil {
 		return fmt.Errorf("publish attack resolved: %w", err)
 	}
-	if res.hit {
+	if outcome.Hit {
 		if err := e.broker.Publish(events.NewDamageDealtEvent(
 			e.data.ID, e.nextSeq(),
 			targetID, attackerID,
-			res.damage, damageType,
+			outcome.Damage, damageType,
 			targetHPAfter, targetMaxHP,
 			damagePerPlayer,
 		)); err != nil {

--- a/encounter/combat_resolver.go
+++ b/encounter/combat_resolver.go
@@ -23,11 +23,11 @@ var ErrNoCombatResolver = errors.New("no combat resolver wired")
 // rulebook (today: dnd5e). The encounter SDK never imports rulebook
 // packages — keeping the boundary clean across rulebooks.
 //
-// Wave 2.11a wires ResolveAttack for the player-attack path
-// (combat.TakeAction). NPCAct continues to use the legacy stand-in path
-// until Wave 2.11b adds monster rulebook adapters and OA / multiattack
-// support; method additions on this interface in 2.11b are explicit
-// breaking changes flagged in the encounter module's release notes.
+// Wave 2.11a wired ResolveAttack for the player-attack path (TakeAction).
+// Wave 2.11b (encounter v0.7.0) folds NPCAct onto the same resolver — both
+// player and monster attack paths share this single injection seam. The
+// in-package resolveAttack helper has been removed; hosts that previously
+// relied on it must wire a resolver via WithCombatResolver.
 type CombatResolver interface {
 	// ResolveAttack evaluates one attack from attacker to target and
 	// returns the outcome. The resolver is responsible for looking up
@@ -45,8 +45,8 @@ type CombatResolver interface {
 // The orchestrator's resolver implementation translates this to the
 // rulebook's native AttackInput shape (e.g., dnd5e/combat.AttackInput).
 type AttackInput struct {
-	// AttackerID is the entity making the attack — could be a player
-	// (combat.TakeAction path) or a monster (future NPCAct migration).
+	// AttackerID is the entity making the attack — a player entity ID on
+	// the TakeAction path, or a monster entity ID on the NPCAct path.
 	AttackerID encountercore.EntityID
 
 	// TargetID is the entity being attacked.

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -22,12 +22,10 @@ import (
 // to capture the dnd5e events the action publishes, and re-publishes them
 // as encounter-scoped per-viewer events.
 //
-// Wave 2.8 only handles single-target melee attacks (the shape goblin /
-// scimitar / bite emit). For each captured dnd5e.AttackEvent, the
-// encounter SDK resolves hit/damage with its own roller (since the
-// dnd5e action layer does not run resolution itself today — see issue
-// followups), mutates the target player's HP, and emits AttackResolved
-// + DamageDealt encounter events.
+// For each captured dnd5e.AttackEvent, the encounter SDK resolves hit/damage
+// by delegating to the wired CombatResolver — the same resolver used by the
+// player-attack path (TakeAction). NPCAct returns ErrNoCombatResolver if no
+// resolver has been wired via WithCombatResolver.
 //
 // Position is updated from TurnResult.Movement; a MoveEvent is emitted
 // per-viewer for the NPC's path.
@@ -46,6 +44,9 @@ func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) er
 	mon, ok := e.data.Monsters[npcID]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrUnknownTarget, npcID)
+	}
+	if e.combatResolver == nil {
+		return ErrNoCombatResolver
 	}
 	if len(mon.DataJSON) == 0 {
 		// No rehydratable monster — fall back to a minimal scripted attack
@@ -196,7 +197,7 @@ func (e *Encounter) applyNPCMovement(mon *MonsterData, movement []spatial.CubeCo
 }
 
 // applyCapturedAttacks resolves each captured dnd5e AttackEvent (cause-only)
-// using the encounter's stand-in resolver, mutates the target player's HP,
+// through the wired CombatResolver, mutates the target player's HP,
 // and emits AttackResolved + DamageDealt encounter events.
 //
 // Wave 2.10: when an NPC's attack drops a player to HP=0, also publishes
@@ -220,15 +221,31 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 			dmgType = damageTypeUntyped
 		}
 		hpBefore := targetPlayer.HP
-		res := e.resolveAttack(mon.AttackBonus, targetPlayer.AC, mon.DamageDice)
-		if res.hit {
-			targetPlayer.HP -= res.damage
+		outcome, err := e.combatResolver.ResolveAttack(AttackInput{
+			AttackerID:          mon.ID,
+			TargetID:            targetID,
+			AttackerAttackBonus: mon.AttackBonus,
+			AttackerDamageDice:  mon.DamageDice,
+			AttackerDamageType:  mon.DamageType,
+			TargetAC:            targetPlayer.AC,
+		})
+		if err != nil {
+			return fmt.Errorf("combat resolver: %w", err)
+		}
+		if outcome == nil {
+			return fmt.Errorf("combat resolver: nil outcome with nil error")
+		}
+		if outcome.Hit {
+			targetPlayer.HP -= outcome.Damage
 			if targetPlayer.HP < 0 {
 				targetPlayer.HP = 0
 			}
 		}
+		if outcome.DamageType != "" {
+			dmgType = outcome.DamageType
+		}
 		if err := e.publishAttackOutcome(
-			mon.ID, targetID, res,
+			mon.ID, targetID, outcome,
 			targetPlayer.HP, targetPlayer.MaxHP, dmgType,
 			mon.Position, targetPlayer.View.Position,
 		); err != nil {
@@ -238,7 +255,7 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 		// HP transition (avoids duplicates from multi-attack NPCs or hits
 		// on an already-downed player). No EntityRemoved / no initiative
 		// splice / no encounter-end.
-		if res.hit && hpBefore > 0 && targetPlayer.HP == 0 {
+		if outcome.Hit && hpBefore > 0 && targetPlayer.HP == 0 {
 			if err := e.publishPlayerDied(targetID, mon.ID); err != nil {
 				return err
 			}
@@ -384,6 +401,10 @@ func (e *Encounter) applyCapturedConditions(mon *MonsterData, conds []dnd5eEvent
 // the monster has no DataJSON to rehydrate. Used for tests and
 // orchestrator-seeded fixtures that don't carry a serialized monster.
 //
+// Delegates to the wired CombatResolver (same as applyCapturedAttacks and
+// TakeAction). The resolver guard at NPCAct entry ensures combatResolver
+// is non-nil before this path is reached.
+//
 // Wave 2.10: same partial player-death semantics as applyCapturedAttacks
 // — fires EntityDiedEvent on a player kill (only on HP transition, not
 // whenever HP is 0) but does not remove the player or end the encounter.
@@ -397,21 +418,37 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 		dmgType = damageTypeUntyped
 	}
 	hpBefore := target.HP
-	res := e.resolveAttack(mon.AttackBonus, target.AC, mon.DamageDice)
-	if res.hit {
-		target.HP -= res.damage
+	outcome, err := e.combatResolver.ResolveAttack(AttackInput{
+		AttackerID:          mon.ID,
+		TargetID:            target.EntityID,
+		AttackerAttackBonus: mon.AttackBonus,
+		AttackerDamageDice:  mon.DamageDice,
+		AttackerDamageType:  mon.DamageType,
+		TargetAC:            target.AC,
+	})
+	if err != nil {
+		return fmt.Errorf("combat resolver: %w", err)
+	}
+	if outcome == nil {
+		return fmt.Errorf("combat resolver: nil outcome with nil error")
+	}
+	if outcome.Hit {
+		target.HP -= outcome.Damage
 		if target.HP < 0 {
 			target.HP = 0
 		}
 	}
+	if outcome.DamageType != "" {
+		dmgType = outcome.DamageType
+	}
 	if err := e.publishAttackOutcome(
-		mon.ID, target.EntityID, res,
+		mon.ID, target.EntityID, outcome,
 		target.HP, target.MaxHP, dmgType,
 		mon.Position, target.View.Position,
 	); err != nil {
 		return err
 	}
-	if res.hit && hpBefore > 0 && target.HP == 0 {
+	if outcome.Hit && hpBefore > 0 && target.HP == 0 {
 		if err := e.publishPlayerDied(target.EntityID, mon.ID); err != nil {
 			return err
 		}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -224,6 +224,7 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 		outcome, err := e.combatResolver.ResolveAttack(AttackInput{
 			AttackerID:          mon.ID,
 			TargetID:            targetID,
+			ActionRef:           core.Ref{Module: "dnd5e", Type: "action", ID: actionIDAttack},
 			AttackerAttackBonus: mon.AttackBonus,
 			AttackerDamageDice:  mon.DamageDice,
 			AttackerDamageType:  mon.DamageType,
@@ -421,6 +422,7 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	outcome, err := e.combatResolver.ResolveAttack(AttackInput{
 		AttackerID:          mon.ID,
 		TargetID:            target.EntityID,
+		ActionRef:           core.Ref{Module: "dnd5e", Type: "action", ID: "attack"},
 		AttackerAttackBonus: mon.AttackBonus,
 		AttackerDamageDice:  mon.DamageDice,
 		AttackerDamageType:  mon.DamageType,

--- a/encounter/npc_test.go
+++ b/encounter/npc_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 )
 
+// monsterRefGoblin is the canonical monster ref used across NPC fixtures.
+const monsterRefGoblin = "dnd5e:monsters:goblin"
+
 // NPCSuite covers the full NPCAct path through monster.TakeTurn —
 // distinct from CombatSuite which uses the scripted DataJSON-less path.
 type NPCSuite struct {
@@ -32,7 +35,9 @@ func (s *NPCSuite) SetupTest() {
 	s.ctx = context.Background()
 	s.transport = encounter.NewInMemoryTransport()
 	s.broker = encounter.NewBroker(s.transport)
-	s.enc = encounter.New("enc-npc", s.broker)
+	s.enc = encounter.New("enc-npc", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 4, damageType: damageSlashing}),
+	)
 
 	// Build a goblin and serialize it.
 	gob := monster.NewGoblin(gobEntityID)
@@ -42,7 +47,7 @@ func (s *NPCSuite) SetupTest() {
 
 	// Alice adjacent to goblin so the goblin can attack on its turn.
 	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: "alice", EntityID: aliceEntityID,
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
 		HP: 12, MaxHP: 12, AC: 14,
 	}))
@@ -50,12 +55,12 @@ func (s *NPCSuite) SetupTest() {
 		ID:       gobEntityID,
 		Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
-		MonsterRef:  "dnd5e:monsters:goblin",
+		MonsterRef:  monsterRefGoblin,
 		DataJSON:    dataJSON,
-		AttackBonus: 4, DamageDice: "1d6+2", DamageType: "slashing",
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
 	}))
 
-	s.aliceSub, err = s.broker.Subscribe("enc-npc", "alice")
+	s.aliceSub, err = s.broker.Subscribe("enc-npc", alicePlayerID)
 	s.Require().NoError(err)
 }
 
@@ -91,7 +96,8 @@ func (s *NPCSuite) TestNPCAct_RequiresTurnBased() {
 	s.ErrorIs(err, encounter.ErrNotTurnBased)
 }
 
-// NPCAct against an unknown id returns ErrUnknownTarget when in TURN_BASED.
+// NPCAct against an unknown id returns ErrNotYourTurn (the active-actor
+// check fires before the existence check).
 func (s *NPCSuite) TestNPCAct_RejectsUnknownNPC() {
 	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	// Cycle to goblin to satisfy the active-actor gate, then try to act
@@ -103,4 +109,62 @@ func (s *NPCSuite) TestNPCAct_RejectsUnknownNPC() {
 	}
 	err := s.enc.NPCAct(s.ctx, "ghost")
 	s.ErrorIs(err, encounter.ErrNotYourTurn)
+}
+
+// NPCAct returns ErrNoCombatResolver when no CombatResolver is wired.
+// Mirrors the guard on TakeAction (player path) — production must wire one
+// via WithCombatResolver.
+func (s *NPCSuite) TestNPCAct_ErrNoCombatResolver() {
+	gob := monster.NewGoblin(gobEntityID)
+	gobData := gob.ToData()
+	dataJSON, err := json.Marshal(gobData)
+	s.Require().NoError(err)
+
+	enc := encounter.New("enc-npc-no-resolver", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef: monsterRefGoblin,
+		DataJSON:   dataJSON,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	err = enc.NPCAct(s.ctx, gobEntityID)
+	s.ErrorIs(err, encounter.ErrNoCombatResolver)
+}
+
+// NPCAct (scripted path — no DataJSON) returns ErrNoCombatResolver when
+// no resolver is wired.
+func (s *NPCSuite) TestNPCAct_Scripted_ErrNoCombatResolver() {
+	enc := encounter.New("enc-npc-scripted-no-resolver", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	// No DataJSON — triggers the scripted path.
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	err := enc.NPCAct(s.ctx, gobEntityID)
+	s.ErrorIs(err, encounter.ErrNoCombatResolver)
 }


### PR DESCRIPTION
## Summary

- Routes `Encounter.NPCAct`'s two attack paths (`applyCapturedAttacks` and `npcActScripted`) through the wired `CombatResolver`, matching the player path (`TakeAction`) introduced in v0.6.0 / PR #644.
- Deletes the in-package `resolveAttack` helper and `attackResolution` struct from `combat.go` — there is now one combat math path behind the resolver seam, not two.
- Adds `ErrNoCombatResolver` guard to `NPCAct` entry (mirrors `TakeAction`'s guard at `combat.go:218`). Godoc updated.
- Refactors `publishAttackOutcome` to accept `*AttackOutcome` directly, eliminating the intermediate `attackResolution` conversion that was the only consumer of the now-deleted struct.

## Breaking change (encounter/v0.7.0)

`Encounter.NPCAct` now requires a wired `CombatResolver` (same requirement as `TakeAction` since v0.6.0). Hosts that previously relied on the in-package `resolveAttack` stand-in path must inject a resolver via `WithCombatResolver`. Tests use `alwaysHitResolver` from `combat_resolver_test.go` as the pattern.

The rpg-api side already wires `StandInCombatResolver` at all 6 encounter construction sites (PR #519), so no rpg-api change is needed to compile against v0.7.0 — Wave 2.11b's #523 will swap the rpg-api side from StandIn to the real chain.

## Closes

Closes #645

## Test plan

- [ ] `go test ./...` from `encounter/` — all suites pass (NPCSuite: 5 tests including 2 new resolver-guard tests; CombatSuite, DeathSuite, IntegrationSuite all green)
- [ ] `golangci-lint run ./...` from `encounter/` — no new lint issues introduced (21 pre-existing goconst warnings unchanged from main)
- [ ] `git grep 'resolveAttack' encounter/combat.go encounter/npc.go` — returns nothing
- [ ] `git grep 'attackResolution' encounter/` — returns nothing
- [ ] `TestNPCAct_ErrNoCombatResolver` — NPCAct with DataJSON path returns `ErrNoCombatResolver` when no resolver wired
- [ ] `TestNPCAct_Scripted_ErrNoCombatResolver` — NPCAct scripted (no DataJSON) path returns `ErrNoCombatResolver` when no resolver wired
- [ ] `TestNPCAct_GoblinTakeTurn_PublishesAttack` — goblin DataJSON path routes through `alwaysHitResolver` and publishes `AttackResolvedEvent`
- [ ] `TestNPCAct_ScriptedAttackPublishes` (CombatSuite) — scripted path (goblin without DataJSON) routes through `alwaysHitResolver` and publishes `AttackResolvedEvent`
- [ ] `TestSlice_PlayerDies_PartialOnly` and `TestSlice_PlayerDeath_NotRePublishedOnReHit` (DeathSuite) — NPCAct death-path semantics unchanged

Note: tags `encounter/v0.7.0` on merge via the auto-tag workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)