### PR TITLE
feat(encounter): encounter-scoped bus + persistent conditions + reaction-readiness foundation (Wave 2.11c — 1 of 3)

### DIFF
--- a/docs/adr/0027-attack-resolution-and-reactions.md
+++ b/docs/adr/0027-attack-resolution-and-reactions.md
@@ -1,10 +1,154 @@
 # ADR-0027: Attack Resolution and Reactions
 
-Date: 2024-12-25
+Date: 2024-12-25 (proposed) / 2026-05-10 (accepted)
 
 ## Status
 
-Proposed
+Accepted
+
+## Confirmed by shipped code
+
+The three-phase attack model and condition-as-chain-subscriber pattern this ADR
+proposed are now load-bearing in shipped code. Promotion from Proposed to
+Accepted reflects that the seams the ADR predicted are the seams the rulebook
+actually uses:
+
+- **Chain subscription pattern (Phase 1 — RESOLVE ATTACK)** —
+  `rulebooks/dnd5e/combat/attack.go:225-235` builds a `StagedChain[AttackChainEvent]`
+  and calls `attacks.PublishWithChain(ctx, attackEvent, attackChain)` followed
+  by `Execute()`. Conditions subscribe via `AttackChain.On(bus).SubscribeWithChain(...)`
+  and add modifiers at named stages — see `conditions/sneak_attack.go` (subscribes
+  to `DamageChain`, marks eligibility, adds dice at `StageFeatures`) and
+  `conditions/fighting_style_protection.go` (subscribes to `AttackChain`, adds
+  disadvantage + records `ReactionsConsumed` at `StageFeatures`).
+- **gamectx pattern (ADR-0025) is the state-query seam** — `sneak_attack.go:221`
+  calls `gamectx.RequireRoom(ctx)` to query target position; `fighting_style_protection.go:130-152`
+  calls `gamectx.RequireCharacters(ctx)` for shield + reaction-economy lookup
+  and `gamectx.RequireRoom(ctx)` for adjacency. Conditions never bloat events;
+  they query state through gamectx at handler time.
+- **Movement chain + OA prevention primitive** —
+  `rulebooks/dnd5e/combat/movement.go:138-250` ships `MoveEntity` with a
+  `MovementChain` that conditions can modify before opportunity-attack
+  triggering. `conditions/disengaging.go:131-157` is the reference subscriber:
+  it appends to `MovementChainEvent.OAPreventionSources` at `StageConditions`,
+  and `MoveEntity` checks `IsOAPrevented()` before invoking
+  `triggerOpportunityAttack`. The OA-as-condition direction this ADR predicted
+  is partially shipped — Disengage prevents OAs as a condition; the OA *trigger*
+  itself still lives inline in `MoveEntity` rather than as a per-combatant
+  subscriber. Wave 2.11 (`rpg-project/ideas/encounter/v1alpha2/plans/11-wave-2.11-condition-driven-reactions.md`)
+  is the wave that ports the trigger to the same condition pattern.
+- **Reaction consumption inside the chain** — `AttackChainEvent.ReactionsConsumed`
+  (`rulebooks/dnd5e/events/events.go`) is a slice that subscribers append to
+  during chain execution; `combat.ResolveAttack` (`combat/attack.go:296-306`)
+  publishes one `ReactionUsedEvent` per entry after `Execute`. The "reactions
+  are subscribers + record consumption back on the event" model from this ADR
+  is the shipped shape.
+- **AttackTypeOpportunity tag is shipped** —
+  `rulebooks/dnd5e/events/events.go:181-182` defines `AttackTypeOpportunity`,
+  consumed by `combat/movement.go:360-370` (`triggerOpportunityAttack` calls
+  `combat.ResolveAttack` with `AttackType: AttackTypeOpportunity`). Conditions
+  that gate on attack type (Sentinel, Polearm Master) have a stable hook.
+
+## Amendments since proposal
+
+The ADR's intent is correct. Two specific items in the original text are stale
+relative to shipped code; they're noted here rather than rewritten so the
+ADR's narrative remains the design that drove the implementation.
+
+- **Phase 0 events (`AttackDeclaredEvent`) and Phase 2 events
+  (`AttackRolledEvent`, `AttackResolvedEvent`) are not yet published as
+  separate topics.** `combat.ResolveAttack` currently publishes one chain
+  (`AttackChain`) before the roll and emits `DamageReceivedEvent` after damage
+  is applied. The DECLARE / ROLL / DAMAGE windows the ADR describes exist
+  conceptually inside `ResolveAttack` (chain publish → roll → hit determination
+  → damage chain → damage publish) but are not externally observable as
+  reaction-window events yet. **Wave 2.11 ships the missing publish points
+  (Phase 0 declare + Phase 2 post-roll + Phase 3 pre-damage / post-damage) so
+  Sentinel / Shield / Uncanny Dodge / Hellish Rebuke have somewhere to
+  subscribe.** Until then, only Phase 1 (chain) reactions like Protection are
+  expressible.
+- **`OpportunityAttackCheckEvent` is not yet shipped as a typed topic.** The
+  OA-prevention primitive is currently the `OAPreventionSources` slice on
+  `MovementChainEvent`, mutated by chain subscribers (e.g., Disengaging). A
+  separate `OpportunityAttackCheckTopic` was sketched in
+  `docs/ideas/action-economy-history/design-toolkit.md` but did not land. The
+  shipped chain-mutation approach is sufficient for prevention; it's
+  insufficient for *triggering* OAs as conditions (the larger Wave 2.11 OA
+  port). Wave 2.11 evaluates whether to add `OpportunityAttackCheckTopic` or
+  keep the trigger inline in `MoveEntity` and just relocate the geometry +
+  reaction-resource check into a per-combatant `OpportunityAttackCondition`
+  subscriber.
+
+These amendments do not change the architectural decision; they record the
+shipped-code drift between the original proposal and today. The new ADR-0027
+is the shape Wave 2.11 builds against; the amendments call out which pieces
+Wave 2.11 has to ship to honor the full design.
+
+## Amendments since acceptance
+
+### 2026-05-10 — Discrete RPC phases instead of in-process chain pauses; opt-in reaction readiness
+
+The chain pause primitive originally implied by the three-phase model is being
+implemented as **discrete RPC phases orchestrated by the server (rpg-api)**, not
+as in-process chain pauses inside `combat.ResolveAttack`. The toolkit chain
+itself does not gain pause-resume capability; that complexity moves out of the
+toolkit and lives at the RPC boundary, where the encounter snapshot already
+persists naturally.
+
+Concretely:
+
+- `combat.ResolveAttack` is split into `ResolveAttackHit` (phase 1: chain runs
+  end-to-end, returns an `AttackContext` carrying roll, originalAC, wouldHit,
+  etc.) and `ApplyAttackOutcome` (phase 2: chain runs end-to-end with reaction
+  modifiers baked in, recomputes effective AC, applies damage if still a hit,
+  publishes outcome events).
+- Each phase is atomic. No in-flight chain state is serialized. The "pause"
+  lives between RPC calls — the server invokes phase 1, scans for
+  `ReactionTrigger` events the chain published, pushes prompts to ready
+  reactors, awaits responses via `SubmitCheck`, then invokes phase 2 with the
+  player's choice baked in.
+- Conditions still subscribe to the chain at the right window. When their
+  predicate matches AND `gamectx.IsReactionReady(charID, reactionRef)` returns
+  true, they publish a `ReactionTriggerEvent` on the encounter bus that the
+  orchestrator reads after the chain returns. The chain itself runs to
+  completion either way.
+- NPC reactors auto-resolve inline during phase 1 (the modifier is applied
+  directly to the in-flight chain event, no event published). Player reactors
+  with readied reactions emit the trigger event for the server to translate
+  into a prompt.
+
+**Reactions are opt-in via per-character readiness state.** Default: no
+prompts. The condition handler's readiness check gates the trigger event. This
+trades RAW 5e flexibility ("cast Shield reactively without pre-declaring") for
+"no constant prompt mashing" — the right call for asynchronous multiplayer
+without a DM. Default readiness varies by reaction type: free-cost reactions
+(OA) default-on for melee combatants; spell-cost reactions (Shield,
+Counterspell) default-off; class-feature reactions per-feature. Spell-cost
+reactions auto-clear after firing (one-shot); free reactions stay ready until
+canceled.
+
+**Why this beats the implied "chain pause-resume" primitive:**
+
+- Serializing in-flight chain state means serializing a mutable Go struct with
+  registered closures (chain stage handlers). Not JSON-round-trippable without
+  significant refactoring.
+- Shield's mechanic is retroactive — the hit decision already executed at the
+  time Shield triggers. Implementing this with chain-pause-and-mutate means the
+  chain has to be reversible, which is much harder than reversible RPC calls.
+- The discrete-phase split doesn't pause anything inside the chain. Each phase
+  runs end-to-end. The split is at the RPC boundary — where the snapshot
+  persistence already lives.
+- Opt-in readiness means the split rarely happens. The common case stays
+  single-phase end-to-end. When a player has a readied reaction whose
+  predicate matches, the server pays the prompt cost; otherwise the attack
+  runs as today.
+
+The wave-2.11d plan
+(`rpg-project/ideas/encounter/v1alpha2/plans/11-wave-2.11-condition-driven-reactions.md`)
+is the canonical implementation reference. The "Phase 0/1/2/3" framing in this
+ADR remains the design that drove the implementation; the amendment is on
+*how* the windows are surfaced (discrete RPC phases + ReactionTrigger event +
+gamectx-readiness predicate, not in-process chain pause).
 
 ## Context
 

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -233,6 +233,7 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 		AttackerDamageDice:  player.DamageDice,
 		AttackerDamageType:  player.DamageType,
 		TargetAC:            monster.AC,
+		EventBus:            e.bus,
 	})
 	if err != nil {
 		return fmt.Errorf("combat resolver: %w", err)

--- a/encounter/combat_resolver.go
+++ b/encounter/combat_resolver.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
 )
 
 // ErrNoCombatResolver is returned by combat verbs when the encounter was
@@ -73,6 +74,17 @@ type AttackInput struct {
 	AttackerDamageDice  string
 	AttackerDamageType  string
 	TargetAC            int
+
+	// EventBus is the encounter-scoped dnd5e event bus. Wave 2.11c passes
+	// this through so the resolver implementation can fire the attack chain
+	// on the persistent bus (rather than creating a fresh per-attack bus).
+	// Conditions subscribed at character rehydration — Sneak Attack,
+	// Protection, etc. — observe attacks on this bus throughout the
+	// encounter lifetime, enabling once-per-turn semantics to hold.
+	//
+	// May be nil for resolvers that manage their own bus internally.
+	// rpg-api's Dnd5eCombatResolver MUST use this bus when non-nil.
+	EventBus dnd5events.EventBus
 }
 
 // AttackOutcome is the encounter-SDK-side result shape from ResolveAttack.

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -14,6 +14,9 @@ import (
 //
 // Wave 2.9 adds PendingPrompts: at most one in-flight prompt per player,
 // resolved via SubmitCheck.
+//
+// Wave 2.11c adds ReactionReadiness: per-entity, per-reaction readiness
+// flags that persist across attacks within an encounter session.
 type Data struct {
 	ID       core.EncounterID               `json:"id"`
 	Sequence uint64                         `json:"sequence"`
@@ -33,6 +36,14 @@ type Data struct {
 	// future dialogue/target-select) and cleared by SubmitCheck regardless
 	// of outcome. Omitted from the wire when empty.
 	PendingPrompts map[core.PlayerID]*PendingPrompt `json:"pending_prompts,omitempty"`
+
+	// ReactionReadiness tracks per-entity readiness for each named reaction.
+	// Keys are entity IDs; values are maps from reaction ref strings
+	// (e.g. "dnd5e:conditions:opportunity_attack") to ready booleans.
+	// Free-cost reactions (OA) default to true for melee combatants;
+	// spell-cost reactions (Shield, Counterspell) default to false.
+	// Survives ToData/LoadFromData round-trips; omitted from JSON when empty.
+	ReactionReadiness map[core.EntityID]map[string]bool `json:"reaction_readiness,omitempty"`
 }
 
 // PlayerData persists a single player seat.
@@ -112,11 +123,12 @@ type MonsterData struct {
 // ModeFreeRoam; turn-state fields remain at their zero values.
 func NewData(id core.EncounterID) *Data {
 	return &Data{
-		ID:             id,
-		Players:        make(map[core.PlayerID]*PlayerData),
-		Doors:          make(map[core.EntityID]*DoorData),
-		Monsters:       make(map[core.EntityID]*MonsterData),
-		Mode:           core.ModeFreeRoam,
-		PendingPrompts: make(map[core.PlayerID]*PendingPrompt),
+		ID:                id,
+		Players:           make(map[core.PlayerID]*PlayerData),
+		Doors:             make(map[core.EntityID]*DoorData),
+		Monsters:          make(map[core.EntityID]*MonsterData),
+		Mode:              core.ModeFreeRoam,
+		PendingPrompts:    make(map[core.PlayerID]*PendingPrompt),
+		ReactionReadiness: make(map[core.EntityID]map[string]bool),
 	}
 }

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -8,17 +8,35 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
 )
+
+// OAReactionRef is the canonical reaction ref string for Opportunity Attack.
+// Wave 2.11c defines this ref so the readiness map can be seeded for melee
+// combatants. The full OpportunityAttackCondition implementation ships in
+// Wave 2.11d (#649); this constant aligns with the ref that condition will use.
+const OAReactionRef = "dnd5e:conditions:opportunity_attack"
 
 // Encounter is the transient SDK object for one ongoing encounter.
 // Constructed per-call via LoadFromData; mutated by verbs; serialized via
 // ToData and saved.
+//
+// Wave 2.11c: the encounter now owns a single dnd5e EventBus for its
+// lifetime. Conditions Apply()'d during character rehydration subscribe
+// to this bus once and stay subscribed across attacks, enabling persistent
+// state (SneakAttack.UsedThisTurn, Protection reaction consumption) to
+// accumulate correctly within a turn and reset at turn boundaries.
+// The bus is reconstructed at LoadFromData — it is not serialized.
 type Encounter struct {
 	data           *Data
 	broker         *Broker
 	roller         dice.Roller
 	resolver       CharacterResolver
 	combatResolver CombatResolver
+	// bus is the encounter-scoped dnd5e event bus. Conditions subscribe
+	// once at rehydration and remain subscribed for the encounter's lifetime.
+	// Reconstructed (not serialized) at each LoadFromData call.
+	bus dnd5events.EventBus
 }
 
 // Option configures an Encounter at construction.
@@ -107,6 +125,7 @@ func New(id core.EncounterID, b *Broker, opts ...Option) *Encounter {
 		data:   NewData(id),
 		broker: b,
 		roller: dice.NewRoller(),
+		bus:    dnd5events.NewEventBus(),
 	}
 	for _, o := range opts {
 		o(e)
@@ -115,6 +134,10 @@ func New(id core.EncounterID, b *Broker, opts ...Option) *Encounter {
 }
 
 // LoadFromData rehydrates an encounter from persisted state.
+//
+// Wave 2.11c: a fresh encounter-scoped dnd5e EventBus is created at this
+// point. Callers (typically rpg-api) then rehydrate character conditions
+// via the bus exposed by EventBus() so subscriptions persist across attacks.
 func LoadFromData(data *Data, b *Broker, opts ...Option) (*Encounter, error) {
 	if data == nil {
 		return nil, errors.New("nil Data")
@@ -131,10 +154,18 @@ func LoadFromData(data *Data, b *Broker, opts ...Option) (*Encounter, error) {
 	if data.PendingPrompts == nil {
 		data.PendingPrompts = make(map[core.PlayerID]*PendingPrompt)
 	}
+	if data.ReactionReadiness == nil {
+		data.ReactionReadiness = make(map[core.EntityID]map[string]bool)
+	}
 	if data.Mode == core.ModeUnspecified {
 		data.Mode = core.ModeFreeRoam
 	}
-	e := &Encounter{data: data, broker: b, roller: dice.NewRoller()}
+	e := &Encounter{
+		data:   data,
+		broker: b,
+		roller: dice.NewRoller(),
+		bus:    dnd5events.NewEventBus(),
+	}
 	for _, o := range opts {
 		o(e)
 	}
@@ -143,6 +174,12 @@ func LoadFromData(data *Data, b *Broker, opts ...Option) (*Encounter, error) {
 
 // AddPlayer registers a new player seat with a fresh PerceptionView.
 // The player sees their starting position and surrounding hexes immediately.
+//
+// Wave 2.11c: if the player seat carries combat stats (DamageDice set), the
+// Opportunity Attack reaction is seeded as ready-by-default. OA is a
+// free-cost reaction; players should not need to opt in per-fight.
+// Spell-cost reactions (Shield, Counterspell) are seeded false and require
+// the player to opt in via SetReactionReady.
 func (e *Encounter) AddPlayer(input PlayerInput) error {
 	if _, exists := e.data.Players[input.PlayerID]; exists {
 		return fmt.Errorf("player %q already in encounter", input.PlayerID)
@@ -161,6 +198,11 @@ func (e *Encounter) AddPlayer(input PlayerInput) error {
 		DamageDice:  input.DamageDice,
 		DamageType:  input.DamageType,
 	}
+	// Seed default OA readiness for combatants. Free-cost reactions default
+	// on so players do not need to opt in every fight.
+	if input.DamageDice != "" && input.EntityID != "" {
+		e.seedOAReadiness(input.EntityID)
+	}
 	return nil
 }
 
@@ -172,6 +214,11 @@ func (e *Encounter) AddDoor(id core.EntityID, position core.Hex, open bool) {
 
 // AddMonster registers a monster seat. Mirrors AddPlayer / AddDoor and is
 // the primary fixture verb for tests and orchestrator-driven seeding.
+//
+// Wave 2.11c: if the monster carries combat stats (DamageDice set), the
+// Opportunity Attack reaction is seeded as ready-by-default. NPCs with
+// melee capability auto-fire their OA reaction — no prompt needed for NPC
+// reactors per the wave's architectural call.
 func (e *Encounter) AddMonster(input MonsterInput) error {
 	if input.ID == "" {
 		return errors.New("monster ID required")
@@ -192,7 +239,21 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 		DamageDice:  input.DamageDice,
 		DamageType:  input.DamageType,
 	}
+	// Seed default OA readiness for combatant monsters.
+	if input.DamageDice != "" {
+		e.seedOAReadiness(input.ID)
+	}
 	return nil
+}
+
+// seedOAReadiness initialises an entity's readiness map (if needed) and
+// sets Opportunity Attack to ready=true. Idempotent — safe to call multiple
+// times for the same entity.
+func (e *Encounter) seedOAReadiness(id core.EntityID) {
+	if e.data.ReactionReadiness[id] == nil {
+		e.data.ReactionReadiness[id] = make(map[string]bool)
+	}
+	e.data.ReactionReadiness[id][OAReactionRef] = true
 }
 
 // Mode returns the encounter's current mode.
@@ -250,6 +311,70 @@ type Snapshot struct {
 
 // ToData returns the persisted shape. Caller saves this to the KV store.
 func (e *Encounter) ToData() *Data { return e.data }
+
+// EventBus returns the encounter-scoped dnd5e event bus. Callers (rpg-api)
+// use this bus to Apply() character conditions during rehydration so that
+// subscriptions survive across attacks within the encounter lifetime.
+//
+// The bus is NOT serialized — it is reconstructed fresh at each LoadFromData.
+// Condition state that must survive serialization (e.g. SneakAttack level)
+// is persisted via character.Data.Conditions JSON blobs and re-Apply()'d
+// each time the encounter is rehydrated from the KV store.
+func (e *Encounter) EventBus() dnd5events.EventBus { return e.bus }
+
+// SetReactionReady sets the readiness flag for a specific reaction on a
+// specific entity. Returns an error if the entity is not in the encounter.
+//
+// charID must be an EntityID (not a PlayerID) — the same identifier used
+// in AttackInput.AttackerID / TargetID.
+//
+// reactionRef is the canonical ref string for the reaction (e.g.
+// OAReactionRef for Opportunity Attack, or "dnd5e:conditions:shield" for
+// the Shield spell). The convention matches core.Ref.String().
+//
+// This setter is the toolkit-side implementation of the SetReactionReady RPC
+// (Wave 2.11d, #531). The RPC handler in rpg-api calls this method after
+// rehydrating the encounter from the KV store and before saving it back.
+func (e *Encounter) SetReactionReady(charID core.EntityID, reactionRef string, ready bool) error {
+	if charID == "" {
+		return errors.New("charID must not be empty")
+	}
+	if reactionRef == "" {
+		return errors.New("reactionRef must not be empty")
+	}
+	// Validate the entity exists in the encounter (player entity or monster).
+	if !e.entityExists(charID) {
+		return fmt.Errorf("entity %q not in encounter", charID)
+	}
+	if e.data.ReactionReadiness[charID] == nil {
+		e.data.ReactionReadiness[charID] = make(map[string]bool)
+	}
+	e.data.ReactionReadiness[charID][reactionRef] = ready
+	return nil
+}
+
+// IsReactionReady reports whether the named reaction is currently ready for
+// the given entity. Returns false for any unknown entity or reaction ref —
+// not-ready is the safe default (no accidental reaction fires).
+func (e *Encounter) IsReactionReady(charID core.EntityID, reactionRef string) bool {
+	m, ok := e.data.ReactionReadiness[charID]
+	if !ok {
+		return false
+	}
+	return m[reactionRef]
+}
+
+// entityExists reports whether an entity ID belongs to a player seat or
+// a monster seat in this encounter.
+func (e *Encounter) entityExists(id core.EntityID) bool {
+	for _, p := range e.data.Players {
+		if p.EntityID == id {
+			return true
+		}
+	}
+	_, isMonster := e.data.Monsters[id]
+	return isMonster
+}
 
 // nextSeq advances and returns the encounter's monotonic sequence counter.
 // Used to stamp events on publish.

--- a/encounter/integration_test.go
+++ b/encounter/integration_test.go
@@ -2,11 +2,13 @@ package encounter_test
 
 import (
 	"encoding/json"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -151,4 +153,162 @@ func drainSub(sub *encounter.Subscription, timeout time.Duration) {
 			return
 		}
 	}
+}
+
+// --- Wave 2.11c integration tests ---
+
+// busCapturingResolver is a CombatResolver test double that records the
+// EventBus it receives on each ResolveAttack call. Used to verify the
+// encounter SDK passes the same bus instance across multiple attacks.
+type busCapturingResolver struct {
+	callCount atomic.Int32
+	buses     []dnd5events.EventBus
+	damage    int
+}
+
+func (r *busCapturingResolver) ResolveAttack(input encounter.AttackInput) (*encounter.AttackOutcome, error) {
+	r.callCount.Add(1)
+	r.buses = append(r.buses, input.EventBus)
+	return &encounter.AttackOutcome{
+		Hit:        true,
+		AttackRoll: 15,
+		TargetAC:   10,
+		Damage:     r.damage,
+		DamageType: "slashing",
+	}, nil
+}
+
+// ConditionPersistenceSuite verifies Wave 2.11c foundation:
+// - The encounter-scoped bus is the same instance across attacks.
+// - The resolver receives the bus on every call.
+// - Reaction readiness round-trips through ToData/LoadFromData.
+type ConditionPersistenceSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestConditionPersistenceSuite(t *testing.T) {
+	suite.Run(t, new(ConditionPersistenceSuite))
+}
+
+func (s *ConditionPersistenceSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *ConditionPersistenceSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// TestSlice_ConditionStatePersistsAcrossAttacks validates that the encounter
+// SDK passes the same EventBus instance to the resolver on every attack call.
+// This is the foundational guarantee that conditions Apply()'d once at
+// rehydration remain subscribed across all attacks in the encounter (enabling
+// SneakAttack.UsedThisTurn to hold for a whole turn, etc.).
+func (s *ConditionPersistenceSuite) TestSlice_ConditionStatePersistsAcrossAttacks() {
+	resolver := &busCapturingResolver{damage: 3}
+	enc := encounter.New("enc-bus-test", s.broker,
+		encounter.WithCombatResolver(resolver),
+	)
+
+	aliceSub, err := s.broker.Subscribe("enc-bus-test", "alice")
+	s.Require().NoError(err)
+	defer func() { _ = aliceSub.Close() }()
+
+	// Add combatants.
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{}, SightRange: 10,
+		HP: 20, MaxHP: 20, AC: 14,
+		DamageDice: "1d8", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:         "goblin-1",
+		Position:   core.Hex{Q: 1},
+		HP:         20, MaxHP: 20, AC: 12,
+		DamageDice: "1d6", DamageType: "piercing",
+	}))
+
+	// Start combat — alice must go first for the test to be deterministic.
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != "char-alice" {
+		_, _, err := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	// First attack.
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	))
+
+	// Second attack (same turn — encounter SDK does not enforce multi-attack
+	// limits; that's the resolver's job).
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	))
+
+	// Both calls must have gone to the resolver.
+	s.EqualValues(2, resolver.callCount.Load(), "resolver must be called for both attacks")
+
+	// Both calls must carry the same bus instance (encounter-scoped, not per-attack).
+	s.Require().Len(resolver.buses, 2)
+	s.Equal(resolver.buses[0], resolver.buses[1],
+		"encounter SDK must pass the same EventBus instance across attacks within an encounter")
+
+	// The bus must not be nil.
+	s.NotNil(resolver.buses[0], "encounter bus passed to resolver must not be nil")
+}
+
+// TestSlice_ReactionReadinessPersistsThroughRoundTrip verifies that the
+// ReactionReadiness map survives a ToData/LoadFromData cycle and that the
+// resolver receives a non-nil bus after rehydration.
+func (s *ConditionPersistenceSuite) TestSlice_ReactionReadinessPersistsThroughRoundTrip() {
+	resolver := &busCapturingResolver{damage: 2}
+	enc := encounter.New("enc-rt-test", s.broker,
+		encounter.WithCombatResolver(resolver),
+	)
+
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{}, SightRange: 4,
+		HP: 15, MaxHP: 15, AC: 13,
+		DamageDice: "1d6", DamageType: "slashing",
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:         "goblin-1",
+		Position:   core.Hex{Q: 1},
+		HP:         10, MaxHP: 10, AC: 11,
+		DamageDice: "1d4", DamageType: "piercing",
+	}))
+
+	// Mutate readiness before serialising.
+	s.Require().NoError(enc.SetReactionReady("char-alice", encounter.OAReactionRef, false))
+	s.Require().NoError(enc.SetReactionReady("char-alice", "dnd5e:conditions:shield", true))
+
+	// Serialize.
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+
+	// Rehydrate.
+	var restored encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &restored))
+	enc2, err := encounter.LoadFromData(&restored, s.broker,
+		encounter.WithCombatResolver(resolver),
+	)
+	s.Require().NoError(err)
+
+	// Readiness map survived.
+	s.False(enc2.IsReactionReady("char-alice", encounter.OAReactionRef),
+		"alice opted out of OA before serialise — must persist")
+	s.True(enc2.IsReactionReady("char-alice", "dnd5e:conditions:shield"),
+		"alice opted into Shield before serialise — must persist")
+	s.True(enc2.IsReactionReady("goblin-1", encounter.OAReactionRef),
+		"goblin default OA ready must survive round-trip")
+
+	// The rehydrated encounter has a non-nil bus.
+	s.NotNil(enc2.EventBus(), "rehydrated encounter must have a non-nil EventBus")
 }

--- a/encounter/integration_test.go
+++ b/encounter/integration_test.go
@@ -226,9 +226,9 @@ func (s *ConditionPersistenceSuite) TestSlice_ConditionStatePersistsAcrossAttack
 		DamageDice: "1d8", DamageType: "slashing",
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID:         "goblin-1",
-		Position:   core.Hex{Q: 1},
-		HP:         20, MaxHP: 20, AC: 12,
+		ID:       "goblin-1",
+		Position: core.Hex{Q: 1},
+		HP:       20, MaxHP: 20, AC: 12,
 		DamageDice: "1d6", DamageType: "piercing",
 	}))
 
@@ -285,9 +285,9 @@ func (s *ConditionPersistenceSuite) TestSlice_ReactionReadinessPersistsThroughRo
 		DamageDice: "1d6", DamageType: "slashing",
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID:         "goblin-1",
-		Position:   core.Hex{Q: 1},
-		HP:         10, MaxHP: 10, AC: 11,
+		ID:       "goblin-1",
+		Position: core.Hex{Q: 1},
+		HP:       10, MaxHP: 10, AC: 11,
 		DamageDice: "1d4", DamageType: "piercing",
 	}))
 

--- a/encounter/integration_test.go
+++ b/encounter/integration_test.go
@@ -2,6 +2,7 @@ package encounter_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -255,9 +256,14 @@ func (s *ConditionPersistenceSuite) TestSlice_ConditionStatePersistsAcrossAttack
 	s.EqualValues(2, resolver.callCount.Load(), "resolver must be called for both attacks")
 
 	// Both calls must carry the same bus instance (encounter-scoped, not per-attack).
+	// Use pointer identity — DeepEqual on an interface could match two
+	// structurally identical but distinct bus objects.
 	s.Require().Len(resolver.buses, 2)
-	s.Equal(resolver.buses[0], resolver.buses[1],
-		"encounter SDK must pass the same EventBus instance across attacks within an encounter")
+	s.Equal(
+		reflect.ValueOf(resolver.buses[0]).Pointer(),
+		reflect.ValueOf(resolver.buses[1]).Pointer(),
+		"encounter SDK must pass the same EventBus instance across attacks within an encounter",
+	)
 
 	// The bus must not be nil.
 	s.NotNil(resolver.buses[0], "encounter bus passed to resolver must not be nil")

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -229,6 +229,7 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 			AttackerDamageDice:  mon.DamageDice,
 			AttackerDamageType:  mon.DamageType,
 			TargetAC:            targetPlayer.AC,
+			EventBus:            e.bus,
 		})
 		if err != nil {
 			return fmt.Errorf("combat resolver: %w", err)
@@ -427,6 +428,7 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 		AttackerDamageDice:  mon.DamageDice,
 		AttackerDamageType:  mon.DamageType,
 		TargetAC:            target.AC,
+		EventBus:            e.bus,
 	})
 	if err != nil {
 		return fmt.Errorf("combat resolver: %w", err)

--- a/encounter/reaction_readiness_test.go
+++ b/encounter/reaction_readiness_test.go
@@ -2,6 +2,7 @@ package encounter_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
@@ -34,11 +35,13 @@ func (s *ReactionReadinessSuite) TearDownTest() {
 }
 
 // addCombatPlayer is a helper that adds a player with combat stats so
-// OA default seeding fires.
-func (s *ReactionReadinessSuite) addCombatPlayer(playerID, entityID string) {
+// OA default seeding fires. playerID is derived from entityID (the player
+// seat key); all assertions target the entityID, which is what the
+// readiness map indexes.
+func (s *ReactionReadinessSuite) addCombatPlayer(entityID string) {
 	s.T().Helper()
 	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
-		PlayerID:   core.PlayerID(playerID),
+		PlayerID:   core.PlayerID("player-" + entityID),
 		EntityID:   core.EntityID(entityID),
 		Position:   core.Hex{},
 		SightRange: 4,
@@ -68,7 +71,7 @@ func (s *ReactionReadinessSuite) addCombatMonster(id string) {
 // --- Default OA Seeding ---
 
 func (s *ReactionReadinessSuite) TestAddPlayer_WithCombatStats_SeedsOAReadiness() {
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	s.True(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef),
 		"melee combatant should default-on for OA")
 }
@@ -106,7 +109,7 @@ func (s *ReactionReadinessSuite) TestAddMonster_WithoutCombatStats_DoesNotSeedOA
 // --- SetReactionReady ---
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_SetsTrue() {
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	// Initially OA is true; verify we can also set an arbitrary reaction.
 	const shieldRef = "dnd5e:conditions:shield"
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", shieldRef, true))
@@ -114,14 +117,14 @@ func (s *ReactionReadinessSuite) TestSetReactionReady_SetsTrue() {
 }
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_SetsFalse() {
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	// OA starts true; player can opt out.
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, false))
 	s.False(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef))
 }
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_Idempotent() {
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, true))
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, true))
 	s.True(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef))
@@ -139,7 +142,7 @@ func (s *ReactionReadinessSuite) TestSetReactionReady_EmptyCharID_ReturnsError()
 }
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_EmptyRef_ReturnsError() {
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	err := s.enc.SetReactionReady("char-alice", "", true)
 	s.Error(err)
 }
@@ -152,7 +155,7 @@ func (s *ReactionReadinessSuite) TestIsReactionReady_UnknownEntity_ReturnsFalse(
 }
 
 func (s *ReactionReadinessSuite) TestIsReactionReady_UnknownRef_ReturnsFalse() {
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	s.False(s.enc.IsReactionReady("char-alice", "dnd5e:conditions:shield"),
 		"reaction not yet set should return false (safe default)")
 }
@@ -168,7 +171,7 @@ func (s *ReactionReadinessSuite) TestSetReactionReady_MonsterEntity() {
 // --- ToData / LoadFromData round-trip ---
 
 func (s *ReactionReadinessSuite) TestReactionReadiness_RoundTrip() {
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	s.addCombatMonster("goblin-1")
 	const shieldRef = "dnd5e:conditions:shield"
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", shieldRef, true))
@@ -221,10 +224,16 @@ func (s *ReactionReadinessSuite) TestEventBus_NotNil() {
 func (s *ReactionReadinessSuite) TestEventBus_SameInstanceAfterVerbs() {
 	// The bus must be the same object between calls (encounter-scoped, not
 	// per-verb). Conditions subscribe once and stay subscribed.
+	// Use pointer identity — DeepEqual on an interface could match two
+	// structurally identical but distinct bus objects.
 	bus1 := s.enc.EventBus()
-	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatPlayer("char-alice")
 	bus2 := s.enc.EventBus()
-	s.Equal(bus1, bus2, "EventBus must return the same instance throughout the encounter's lifetime")
+	s.Equal(
+		reflect.ValueOf(bus1).Pointer(),
+		reflect.ValueOf(bus2).Pointer(),
+		"EventBus must return the same instance throughout the encounter's lifetime",
+	)
 }
 
 func (s *ReactionReadinessSuite) TestEventBus_RestoredAfterLoadFromData() {

--- a/encounter/reaction_readiness_test.go
+++ b/encounter/reaction_readiness_test.go
@@ -34,15 +34,14 @@ func (s *ReactionReadinessSuite) TearDownTest() {
 	_ = s.transport.Close()
 }
 
-// addCombatPlayer is a helper that adds a player with combat stats so
-// OA default seeding fires. playerID is derived from entityID (the player
-// seat key); all assertions target the entityID, which is what the
-// readiness map indexes.
-func (s *ReactionReadinessSuite) addCombatPlayer(entityID string) {
+// addCombatPlayer adds the standard fixture combatant (alice / char-alice)
+// with full combat stats so OA default seeding fires. All tests in this
+// suite assert against the hardcoded entity ID "char-alice".
+func (s *ReactionReadinessSuite) addCombatPlayer() {
 	s.T().Helper()
 	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
-		PlayerID:   core.PlayerID("player-" + entityID),
-		EntityID:   core.EntityID(entityID),
+		PlayerID:   "alice",
+		EntityID:   "char-alice",
 		Position:   core.Hex{},
 		SightRange: 4,
 		HP:         20,
@@ -71,7 +70,7 @@ func (s *ReactionReadinessSuite) addCombatMonster(id string) {
 // --- Default OA Seeding ---
 
 func (s *ReactionReadinessSuite) TestAddPlayer_WithCombatStats_SeedsOAReadiness() {
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	s.True(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef),
 		"melee combatant should default-on for OA")
 }
@@ -109,7 +108,7 @@ func (s *ReactionReadinessSuite) TestAddMonster_WithoutCombatStats_DoesNotSeedOA
 // --- SetReactionReady ---
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_SetsTrue() {
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	// Initially OA is true; verify we can also set an arbitrary reaction.
 	const shieldRef = "dnd5e:conditions:shield"
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", shieldRef, true))
@@ -117,14 +116,14 @@ func (s *ReactionReadinessSuite) TestSetReactionReady_SetsTrue() {
 }
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_SetsFalse() {
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	// OA starts true; player can opt out.
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, false))
 	s.False(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef))
 }
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_Idempotent() {
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, true))
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, true))
 	s.True(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef))
@@ -142,7 +141,7 @@ func (s *ReactionReadinessSuite) TestSetReactionReady_EmptyCharID_ReturnsError()
 }
 
 func (s *ReactionReadinessSuite) TestSetReactionReady_EmptyRef_ReturnsError() {
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	err := s.enc.SetReactionReady("char-alice", "", true)
 	s.Error(err)
 }
@@ -155,7 +154,7 @@ func (s *ReactionReadinessSuite) TestIsReactionReady_UnknownEntity_ReturnsFalse(
 }
 
 func (s *ReactionReadinessSuite) TestIsReactionReady_UnknownRef_ReturnsFalse() {
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	s.False(s.enc.IsReactionReady("char-alice", "dnd5e:conditions:shield"),
 		"reaction not yet set should return false (safe default)")
 }
@@ -171,7 +170,7 @@ func (s *ReactionReadinessSuite) TestSetReactionReady_MonsterEntity() {
 // --- ToData / LoadFromData round-trip ---
 
 func (s *ReactionReadinessSuite) TestReactionReadiness_RoundTrip() {
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	s.addCombatMonster("goblin-1")
 	const shieldRef = "dnd5e:conditions:shield"
 	s.Require().NoError(s.enc.SetReactionReady("char-alice", shieldRef, true))
@@ -227,7 +226,7 @@ func (s *ReactionReadinessSuite) TestEventBus_SameInstanceAfterVerbs() {
 	// Use pointer identity — DeepEqual on an interface could match two
 	// structurally identical but distinct bus objects.
 	bus1 := s.enc.EventBus()
-	s.addCombatPlayer("char-alice")
+	s.addCombatPlayer()
 	bus2 := s.enc.EventBus()
 	s.Equal(
 		reflect.ValueOf(bus1).Pointer(),

--- a/encounter/reaction_readiness_test.go
+++ b/encounter/reaction_readiness_test.go
@@ -1,0 +1,235 @@
+package encounter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/stretchr/testify/suite"
+)
+
+// ReactionReadinessSuite exercises the ReactionReadiness data field and
+// the SetReactionReady / IsReactionReady verbs introduced in Wave 2.11c.
+type ReactionReadinessSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	enc       *encounter.Encounter
+}
+
+func TestReactionReadinessSuite(t *testing.T) {
+	suite.Run(t, new(ReactionReadinessSuite))
+}
+
+func (s *ReactionReadinessSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	s.enc = encounter.New("enc-readiness", s.broker)
+}
+
+func (s *ReactionReadinessSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// addCombatPlayer is a helper that adds a player with combat stats so
+// OA default seeding fires.
+func (s *ReactionReadinessSuite) addCombatPlayer(playerID, entityID string) {
+	s.T().Helper()
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID:   core.PlayerID(playerID),
+		EntityID:   core.EntityID(entityID),
+		Position:   core.Hex{},
+		SightRange: 4,
+		HP:         20,
+		MaxHP:      20,
+		AC:         14,
+		DamageDice: "1d8",
+		DamageType: "slashing",
+	}))
+}
+
+// addCombatMonster is a helper that adds a monster with combat stats so
+// OA default seeding fires.
+func (s *ReactionReadinessSuite) addCombatMonster(id string) {
+	s.T().Helper()
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID:         core.EntityID(id),
+		Position:   core.Hex{Q: 1},
+		HP:         10,
+		MaxHP:      10,
+		AC:         12,
+		DamageDice: "1d6",
+		DamageType: "piercing",
+	}))
+}
+
+// --- Default OA Seeding ---
+
+func (s *ReactionReadinessSuite) TestAddPlayer_WithCombatStats_SeedsOAReadiness() {
+	s.addCombatPlayer("alice", "char-alice")
+	s.True(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef),
+		"melee combatant should default-on for OA")
+}
+
+func (s *ReactionReadinessSuite) TestAddPlayer_WithoutCombatStats_DoesNotSeedOA() {
+	// Observer player — no DamageDice
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID:   "observer",
+		EntityID:   "char-observer",
+		Position:   core.Hex{},
+		SightRange: 4,
+	}))
+	s.False(s.enc.IsReactionReady("char-observer", encounter.OAReactionRef),
+		"non-combatant should not have OA seeded")
+}
+
+func (s *ReactionReadinessSuite) TestAddMonster_WithCombatStats_SeedsOAReadiness() {
+	s.addCombatMonster("goblin-1")
+	s.True(s.enc.IsReactionReady("goblin-1", encounter.OAReactionRef),
+		"combatant monster should default-on for OA")
+}
+
+func (s *ReactionReadinessSuite) TestAddMonster_WithoutCombatStats_DoesNotSeedOA() {
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID:    "prop-1",
+		HP:    5,
+		MaxHP: 5,
+		AC:    10,
+		// No DamageDice — this is a passive prop, not a combatant
+	}))
+	s.False(s.enc.IsReactionReady("prop-1", encounter.OAReactionRef),
+		"non-combatant monster should not have OA seeded")
+}
+
+// --- SetReactionReady ---
+
+func (s *ReactionReadinessSuite) TestSetReactionReady_SetsTrue() {
+	s.addCombatPlayer("alice", "char-alice")
+	// Initially OA is true; verify we can also set an arbitrary reaction.
+	const shieldRef = "dnd5e:conditions:shield"
+	s.Require().NoError(s.enc.SetReactionReady("char-alice", shieldRef, true))
+	s.True(s.enc.IsReactionReady("char-alice", shieldRef))
+}
+
+func (s *ReactionReadinessSuite) TestSetReactionReady_SetsFalse() {
+	s.addCombatPlayer("alice", "char-alice")
+	// OA starts true; player can opt out.
+	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, false))
+	s.False(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef))
+}
+
+func (s *ReactionReadinessSuite) TestSetReactionReady_Idempotent() {
+	s.addCombatPlayer("alice", "char-alice")
+	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, true))
+	s.Require().NoError(s.enc.SetReactionReady("char-alice", encounter.OAReactionRef, true))
+	s.True(s.enc.IsReactionReady("char-alice", encounter.OAReactionRef))
+}
+
+func (s *ReactionReadinessSuite) TestSetReactionReady_UnknownEntity_ReturnsError() {
+	err := s.enc.SetReactionReady("char-unknown", encounter.OAReactionRef, true)
+	s.Error(err, "setting readiness for unknown entity must return error")
+	s.Contains(err.Error(), "char-unknown")
+}
+
+func (s *ReactionReadinessSuite) TestSetReactionReady_EmptyCharID_ReturnsError() {
+	err := s.enc.SetReactionReady("", encounter.OAReactionRef, true)
+	s.Error(err)
+}
+
+func (s *ReactionReadinessSuite) TestSetReactionReady_EmptyRef_ReturnsError() {
+	s.addCombatPlayer("alice", "char-alice")
+	err := s.enc.SetReactionReady("char-alice", "", true)
+	s.Error(err)
+}
+
+// --- IsReactionReady ---
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_UnknownEntity_ReturnsFalse() {
+	s.False(s.enc.IsReactionReady("char-nobody", encounter.OAReactionRef),
+		"unknown entity should return false (safe default)")
+}
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_UnknownRef_ReturnsFalse() {
+	s.addCombatPlayer("alice", "char-alice")
+	s.False(s.enc.IsReactionReady("char-alice", "dnd5e:conditions:shield"),
+		"reaction not yet set should return false (safe default)")
+}
+
+// --- Monster entity readiness ---
+
+func (s *ReactionReadinessSuite) TestSetReactionReady_MonsterEntity() {
+	s.addCombatMonster("goblin-1")
+	s.Require().NoError(s.enc.SetReactionReady("goblin-1", encounter.OAReactionRef, false))
+	s.False(s.enc.IsReactionReady("goblin-1", encounter.OAReactionRef))
+}
+
+// --- ToData / LoadFromData round-trip ---
+
+func (s *ReactionReadinessSuite) TestReactionReadiness_RoundTrip() {
+	s.addCombatPlayer("alice", "char-alice")
+	s.addCombatMonster("goblin-1")
+	const shieldRef = "dnd5e:conditions:shield"
+	s.Require().NoError(s.enc.SetReactionReady("char-alice", shieldRef, true))
+	s.Require().NoError(s.enc.SetReactionReady("goblin-1", encounter.OAReactionRef, false))
+
+	// Serialize
+	data := s.enc.ToData()
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	// Deserialize
+	var restored encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &restored))
+
+	// Rehydrate
+	enc2, err := encounter.LoadFromData(&restored, s.broker)
+	s.Require().NoError(err)
+
+	// Assertions
+	s.True(enc2.IsReactionReady("char-alice", encounter.OAReactionRef),
+		"alice OA default should survive round-trip")
+	s.True(enc2.IsReactionReady("char-alice", shieldRef),
+		"alice shield readiness should survive round-trip")
+	s.False(enc2.IsReactionReady("goblin-1", encounter.OAReactionRef),
+		"goblin OA cleared to false should survive round-trip")
+}
+
+func (s *ReactionReadinessSuite) TestReactionReadiness_EmptyData_RoundTrip() {
+	// An encounter with no readiness entries should round-trip without error.
+	data := s.enc.ToData()
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	var restored encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &restored))
+
+	enc2, err := encounter.LoadFromData(&restored, s.broker)
+	s.Require().NoError(err)
+
+	// No entries — unknown entities return false.
+	s.False(enc2.IsReactionReady("char-alice", encounter.OAReactionRef))
+}
+
+// --- EventBus accessor ---
+
+func (s *ReactionReadinessSuite) TestEventBus_NotNil() {
+	s.NotNil(s.enc.EventBus(), "encounter must provide a non-nil event bus")
+}
+
+func (s *ReactionReadinessSuite) TestEventBus_SameInstanceAfterVerbs() {
+	// The bus must be the same object between calls (encounter-scoped, not
+	// per-verb). Conditions subscribe once and stay subscribed.
+	bus1 := s.enc.EventBus()
+	s.addCombatPlayer("alice", "char-alice")
+	bus2 := s.enc.EventBus()
+	s.Equal(bus1, bus2, "EventBus must return the same instance throughout the encounter's lifetime")
+}
+
+func (s *ReactionReadinessSuite) TestEventBus_RestoredAfterLoadFromData() {
+	data := s.enc.ToData()
+	enc2, err := encounter.LoadFromData(data, s.broker)
+	s.Require().NoError(err)
+	s.NotNil(enc2.EventBus(), "rehydrated encounter must have a non-nil event bus")
+}

--- a/rulebooks/dnd5e/gamectx/reaction_readiness.go
+++ b/rulebooks/dnd5e/gamectx/reaction_readiness.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package gamectx
+
+import "context"
+
+// reactionReadinessKey is the context key for the reaction readiness map.
+type reactionReadinessKey struct{}
+
+// ReactionReadinessMap is a read-only view of per-entity reaction readiness.
+// Keys are entity IDs; values are maps from reaction ref strings
+// (e.g. "dnd5e:conditions:opportunity_attack") to ready booleans.
+//
+// Returned by IsReactionReady when the context carries this value.
+// Populated by the encounter SDK (rpg-api side) before invoking attack chains.
+type ReactionReadinessMap map[string]map[string]bool
+
+// WithReactionReadiness wraps a context.Context with the provided readiness map.
+// Purpose: Enables condition handlers to call IsReactionReady without coupling
+// to rpg-api or the encounter SDK.
+//
+// The caller (rpg-api's CombatResolver) is responsible for passing the
+// encounter's reaction readiness map into the context before invoking the
+// rulebook attack chain.
+//
+// Example:
+//
+//	ctx = gamectx.WithReactionReadiness(ctx, gamectx.ReactionReadinessMap{
+//	    "char-alice": {"dnd5e:conditions:opportunity_attack": true},
+//	})
+func WithReactionReadiness(ctx context.Context, m ReactionReadinessMap) context.Context {
+	return context.WithValue(ctx, reactionReadinessKey{}, m)
+}
+
+// IsReactionReady reports whether the named reaction is currently ready for
+// the given entity. Returns false when:
+//   - no ReactionReadinessMap is present in the context, OR
+//   - the entity is not in the map, OR
+//   - the reaction ref is not in the entity's inner map.
+//
+// Not-ready is the safe default — reactions that haven't been explicitly
+// readied must never fire prompts, preventing accidental spell-slot burns.
+//
+// Condition handlers call this before emitting a ReactionTrigger event:
+//
+//	if !gamectx.IsReactionReady(ctx, s.CharacterID, refs.Conditions.Shield().String()) {
+//	    return c, nil // reaction not readied; run single-phase end-to-end
+//	}
+func IsReactionReady(ctx context.Context, charID, reactionRef string) bool {
+	m, ok := ctx.Value(reactionReadinessKey{}).(ReactionReadinessMap)
+	if !ok || m == nil {
+		return false
+	}
+	inner, ok := m[charID]
+	if !ok {
+		return false
+	}
+	return inner[reactionRef]
+}

--- a/rulebooks/dnd5e/gamectx/reaction_readiness.go
+++ b/rulebooks/dnd5e/gamectx/reaction_readiness.go
@@ -8,12 +8,13 @@ import "context"
 // reactionReadinessKey is the context key for the reaction readiness map.
 type reactionReadinessKey struct{}
 
-// ReactionReadinessMap is a read-only view of per-entity reaction readiness.
-// Keys are entity IDs; values are maps from reaction ref strings
-// (e.g. "dnd5e:conditions:opportunity_attack") to ready booleans.
+// ReactionReadinessMap is the value stored in context by WithReactionReadiness
+// and consumed by IsReactionReady. It holds per-entity reaction readiness:
+// outer keys are entity IDs; inner keys are reaction ref strings
+// (e.g. "dnd5e:conditions:opportunity_attack"); values are ready booleans.
 //
-// Returned by IsReactionReady when the context carries this value.
-// Populated by the encounter SDK (rpg-api side) before invoking attack chains.
+// Populated by the encounter SDK (rpg-api side) before invoking attack chains,
+// typically from Encounter.ToData().ReactionReadiness.
 type ReactionReadinessMap map[string]map[string]bool
 
 // WithReactionReadiness wraps a context.Context with the provided readiness map.

--- a/rulebooks/dnd5e/gamectx/reaction_readiness_test.go
+++ b/rulebooks/dnd5e/gamectx/reaction_readiness_test.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package gamectx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/stretchr/testify/suite"
+)
+
+// ReactionReadinessSuite exercises gamectx.IsReactionReady and
+// gamectx.WithReactionReadiness.
+type ReactionReadinessSuite struct {
+	suite.Suite
+}
+
+func TestReactionReadinessSuite(t *testing.T) {
+	suite.Run(t, new(ReactionReadinessSuite))
+}
+
+const (
+	testOARef     = "dnd5e:conditions:opportunity_attack"
+	testShieldRef = "dnd5e:conditions:shield"
+	testCharAlice = "char-alice"
+	testCharBob   = "char-bob"
+)
+
+// --- No context ---
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_NoContext_ReturnsFalse() {
+	ctx := context.Background()
+	s.False(gamectx.IsReactionReady(ctx, testCharAlice, testOARef),
+		"missing context should return false (safe default)")
+}
+
+// --- With context ---
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_WithReadyReaction_ReturnsTrue() {
+	ctx := gamectx.WithReactionReadiness(context.Background(), gamectx.ReactionReadinessMap{
+		testCharAlice: {testOARef: true},
+	})
+	s.True(gamectx.IsReactionReady(ctx, testCharAlice, testOARef))
+}
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_WithNotReadyReaction_ReturnsFalse() {
+	ctx := gamectx.WithReactionReadiness(context.Background(), gamectx.ReactionReadinessMap{
+		testCharAlice: {testOARef: false},
+	})
+	s.False(gamectx.IsReactionReady(ctx, testCharAlice, testOARef))
+}
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_EntityNotInMap_ReturnsFalse() {
+	ctx := gamectx.WithReactionReadiness(context.Background(), gamectx.ReactionReadinessMap{
+		testCharAlice: {testOARef: true},
+	})
+	s.False(gamectx.IsReactionReady(ctx, testCharBob, testOARef),
+		"entity not in map should return false")
+}
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_ReactionRefNotInInnerMap_ReturnsFalse() {
+	ctx := gamectx.WithReactionReadiness(context.Background(), gamectx.ReactionReadinessMap{
+		testCharAlice: {testOARef: true},
+	})
+	s.False(gamectx.IsReactionReady(ctx, testCharAlice, testShieldRef),
+		"reaction ref not in entity map should return false")
+}
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_EmptyMap_ReturnsFalse() {
+	ctx := gamectx.WithReactionReadiness(context.Background(), gamectx.ReactionReadinessMap{})
+	s.False(gamectx.IsReactionReady(ctx, testCharAlice, testOARef))
+}
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_NilMap_ReturnsFalse() {
+	ctx := gamectx.WithReactionReadiness(context.Background(), nil)
+	s.False(gamectx.IsReactionReady(ctx, testCharAlice, testOARef))
+}
+
+func (s *ReactionReadinessSuite) TestIsReactionReady_MultipleEntities() {
+	ctx := gamectx.WithReactionReadiness(context.Background(), gamectx.ReactionReadinessMap{
+		testCharAlice: {testOARef: true, testShieldRef: false},
+		testCharBob:   {testOARef: false, testShieldRef: true},
+	})
+
+	// alice: OA ready, shield not ready
+	s.True(gamectx.IsReactionReady(ctx, testCharAlice, testOARef))
+	s.False(gamectx.IsReactionReady(ctx, testCharAlice, testShieldRef))
+
+	// bob: OA not ready, shield ready
+	s.False(gamectx.IsReactionReady(ctx, testCharBob, testOARef))
+	s.True(gamectx.IsReactionReady(ctx, testCharBob, testShieldRef))
+}


### PR DESCRIPTION
Closes #647

## Summary

Wave 2.11c foundation. The encounter SDK now owns a persistent dnd5e `EventBus` per encounter lifetime, plus a serialisable `ReactionReadiness` map. This is the seam that conditions (Sneak Attack, Protection, Shield) and the forthcoming Opportunity Attack condition plug into.

- **Encounter-scoped bus.** `New()` and `LoadFromData()` construct a single `dnd5events.EventBus` per encounter. All `ResolveAttack` calls (both `TakeAction` and `NPCAct`/`npcActScripted`) now carry `AttackInput.EventBus` so `rpg-api`'s `Dnd5eCombatResolver` can use it instead of creating a fresh per-attack bus. This fixes the root cause of `SneakAttack.UsedThisTurn` resetting between attacks and `Protection`'s reaction consumption not persisting (latent bugs documented in the wave plan that surface the moment any condition is Apply()'d through the v2 path).

- **`ReactionReadiness` on `Data`.** `map[EntityID]map[reactionRefString]bool` — JSON-serialisable, survives `ToData`/`LoadFromData`. Free-cost reactions (`OAReactionRef`) default to `true` for any combatant added via `AddPlayer` / `AddMonster` with `DamageDice` set. Spell-cost reactions default to `false`.

- **`Encounter.SetReactionReady` / `IsReactionReady`.** Public verbs for the Wave 2.11d `SetReactionReady` RPC handler (rpg-api #531) and for condition handlers gating on opt-in readiness.

- **`OAReactionRef` constant.** `"dnd5e:conditions:opportunity_attack"` defined in the encounter package. Full `OpportunityAttackCondition` ships in #649.

- **`gamectx.IsReactionReady` / `WithReactionReadiness`.** Context-based helper for condition handlers to query readiness without coupling to the encounter SDK. Mirrors the existing `RequireRoom` / `RequireCharacters` pattern.

- **ADR-0027 promoted** from Proposed to Accepted with 2026-05-10 amendment documenting the discrete-RPC-phase + opt-in-readiness model.

## What this does NOT do (deferred per issue scope)

- Does not split `combat.ResolveAttack` into `ResolveAttackHit` / `ApplyAttackOutcome` — that's #648.
- Does not add `OpportunityAttackCondition` — that's #649.
- Does not add reaction-prompt machinery — that's #531.
- Does not touch rpg-api — that's #530.

## Test plan

- [x] `ReactionReadinessSuite` (18 cases): default OA seeding on `AddPlayer`/`AddMonster`, `SetReactionReady` happy + error paths, `IsReactionReady` safe defaults, `ToData`/`LoadFromData` round-trip, `EventBus()` accessor stability
- [x] `ConditionPersistenceSuite` (2 integration cases): `TestSlice_ConditionStatePersistsAcrossAttacks` — same bus instance passed across two attacks; `TestSlice_ReactionReadinessPersistsThroughRoundTrip` — readiness map survives serialise/rehydrate cycle
- [x] `gamectx.ReactionReadinessSuite` (8 cases): `IsReactionReady` returns false on missing context, unknown entity, unknown ref; returns correct values from seeded map
- [x] All pre-existing encounter tests still green (`go test ./... -count=1` from `encounter/`)

## Tag on merge

`encounter/v0.8.0` — minor bump because `AttackInput.EventBus` is additive (existing resolvers ignore the field), but the new public verbs (`EventBus()`, `SetReactionReady`, `IsReactionReady`) and `ReactionReadiness` on `Data` are additive features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)