### PR TITLE
fix(dnd5e/conditions): persist SneakAttack.UsedThisTurn across JSON round-trips

### DIFF
--- a/rulebooks/dnd5e/conditions/sneak_attack.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack.go
@@ -20,12 +20,19 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
-// SneakAttackData is the JSON structure for persisting sneak attack condition state
+// SneakAttackData is the JSON structure for persisting sneak attack condition state.
+//
+// UsedThisTurn is persisted (not just runtime) because each Encounter.TakeAction
+// RPC call goes through LoadFromData → fresh condition instance from JSON. Without
+// persisting the once-per-turn flag, a rogue would sneak-attack on every TakeAction
+// call, breaking the once-per-turn semantic across separate RPCs in the same turn.
+// See rpg-toolkit#654 for the broader sustainable-per-turn-state pattern.
 type SneakAttackData struct {
-	Ref         *core.Ref `json:"ref"`
-	CharacterID string    `json:"character_id"`
-	Level       int       `json:"level"`
-	DamageDice  int       `json:"damage_dice"`
+	Ref          *core.Ref `json:"ref"`
+	CharacterID  string    `json:"character_id"`
+	Level        int       `json:"level"`
+	DamageDice   int       `json:"damage_dice"`
+	UsedThisTurn bool      `json:"used_this_turn"`
 }
 
 // SneakAttackCondition represents the rogue's sneak attack feature.
@@ -258,10 +265,11 @@ func (s *SneakAttackCondition) checkSneakAttackConditions(
 // ToJSON converts the condition to JSON for persistence
 func (s *SneakAttackCondition) ToJSON() (json.RawMessage, error) {
 	data := SneakAttackData{
-		Ref:         refs.Features.SneakAttack(),
-		CharacterID: s.CharacterID,
-		Level:       s.Level,
-		DamageDice:  s.DamageDice,
+		Ref:          refs.Features.SneakAttack(),
+		CharacterID:  s.CharacterID,
+		Level:        s.Level,
+		DamageDice:   s.DamageDice,
+		UsedThisTurn: s.UsedThisTurn,
 	}
 
 	bytes, err := json.Marshal(data)
@@ -282,6 +290,7 @@ func (s *SneakAttackCondition) loadJSON(data json.RawMessage) error {
 	s.CharacterID = sneakData.CharacterID
 	s.Level = sneakData.Level
 	s.DamageDice = sneakData.DamageDice
+	s.UsedThisTurn = sneakData.UsedThisTurn
 
 	return nil
 }

--- a/rulebooks/dnd5e/conditions/sneak_attack_test.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack_test.go
@@ -246,6 +246,53 @@ func (s *SneakAttackTestSuite) TestSneakAttackResetsOnTurnEnd() {
 	s.Require().Len(finalEvent.Components, 2, "Should have sneak attack after turn reset")
 }
 
+// TestSneakAttackUsedThisTurnPersistsAcrossJSONRoundTrip is the regression
+// guard for the bug fixed in this PR. Before the fix, ToJSON / loadJSON dropped
+// UsedThisTurn, so an Encounter.TakeAction RPC that did Character.LoadFromData
+// would always start with UsedThisTurn=false — letting a rogue sneak-attack on
+// every TakeAction within a turn instead of once per turn.
+func (s *SneakAttackTestSuite) TestSneakAttackUsedThisTurnPersistsAcrossJSONRoundTrip() {
+	sneak := NewSneakAttackCondition(SneakAttackInput{
+		CharacterID: "rogue-1",
+		Level:       3,
+	})
+	sneak.UsedThisTurn = true
+
+	raw, err := sneak.ToJSON()
+	s.Require().NoError(err)
+
+	loaded := &SneakAttackCondition{}
+	err = loaded.loadJSON(raw)
+	s.Require().NoError(err)
+
+	s.True(loaded.UsedThisTurn,
+		"UsedThisTurn must survive ToJSON → loadJSON; otherwise the once-per-turn gate is silently broken across LoadFromData cycles")
+	s.Equal("rogue-1", loaded.CharacterID, "CharacterID still round-trips")
+	s.Equal(3, loaded.Level, "Level still round-trips")
+	s.Equal(2, loaded.DamageDice, "DamageDice still round-trips (level 3 → 2d6)")
+}
+
+// TestSneakAttackUsedThisTurnFalseRoundTrips guards against the inverse bug —
+// if loadJSON forgot to read the field, a fresh condition would always have
+// UsedThisTurn=false regardless of the persisted value.
+func (s *SneakAttackTestSuite) TestSneakAttackUsedThisTurnFalseRoundTrips() {
+	sneak := NewSneakAttackCondition(SneakAttackInput{
+		CharacterID: "rogue-1",
+		Level:       1,
+	})
+	// UsedThisTurn defaults to false; explicit for the test.
+	sneak.UsedThisTurn = false
+
+	raw, err := sneak.ToJSON()
+	s.Require().NoError(err)
+
+	loaded := &SneakAttackCondition{}
+	err = loaded.loadJSON(raw)
+	s.Require().NoError(err)
+
+	s.False(loaded.UsedThisTurn, "UsedThisTurn=false must round-trip as false")
+}
+
 func (s *SneakAttackTestSuite) TestSneakAttackRequiresFinesseWeapon() {
 	sneak := NewSneakAttackCondition(SneakAttackInput{
 		CharacterID: "rogue-1",


### PR DESCRIPTION
## Summary

\`SneakAttackData\` previously omitted \`UsedThisTurn\`, so the runtime once-per-turn flag was silently lost on every \`Character.LoadFromData\` → fresh condition cycle. Each \`Encounter.TakeAction\` RPC goes through that cycle, which meant a rogue could sneak-attack on **every** TakeAction call within a turn — the once-per-turn gate only worked within a single chain run, not across separate RPCs.

## Fix

Add \`UsedThisTurn\` to \`SneakAttackData\`, persist in \`ToJSON\`, restore in \`loadJSON\`.

Tiny fix; the condition's own JSON state is the right place for per-condition turn tracking.

## Discovered

PR KirkDiggler/rpg-api#532 (Wave 2.11c sign-off). The HP-delta integration test exposed that goblin took the same damage on attacks 1 and 2 in the same turn — sneak attack was firing every time because UsedThisTurn reset on each TakeAction.

## Out of scope

The broader **sustainable per-turn condition state pattern** (so future class features — Action Surge, Lucky, reactions — don't hit this trap by silently forgetting to persist a flag) is tracked in **#654** as an R&D issue.

## Test plan

- [x] Existing condition tests pass
- [x] Toolkit \`go build ./...\` clean
- [ ] Wave 2.11c HP-delta tests in rpg-api#532 will verify end-to-end via local replace

🤖 Generated with [Claude Code](https://claude.com/claude-code)