### PR TITLE
feat(encounter): polymorphic CompleteTakeAction for NPC-attacker Shield resume (Wave 2.11e, #662)

### DIFF
--- a/core/action_test.go
+++ b/core/action_test.go
@@ -82,7 +82,7 @@ func (m *MockEntity) GetType() core.EntityType { return m.eType }
 func TestActionInterface(t *testing.T) {
 	t.Run("SimpleAction", func(t *testing.T) {
 		action := &SimpleAction{
-			id:   "rage",
+			id:   testRage,
 			uses: 3,
 		}
 		owner := &MockEntity{id: "barbarian", eType: core.EntityType("character")}
@@ -155,7 +155,7 @@ func TestActionInterface(t *testing.T) {
 		// This demonstrates that different actions have different input types
 		// and they're type-safe at compile time
 
-		simple := &SimpleAction{id: "rage", uses: 1}
+		simple := &SimpleAction{id: testRage, uses: 1}
 		targeted := &TargetedAction{id: "fireball", maxRange: 150}
 
 		owner := &MockEntity{id: "player", eType: core.EntityType("character")}

--- a/core/ref_test.go
+++ b/core/ref_test.go
@@ -21,29 +21,29 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			name:    "valid identifier",
-			value:   "darkvision",
-			module:  "core",
-			idType:  "feature",
+			value:   testDarkvision,
+			module:  testModuleCore,
+			idType:  testTypeFeature,
 			wantErr: false,
 		},
 		{
 			name:    "empty value",
 			value:   "",
-			module:  "core",
-			idType:  "feature",
+			module:  testModuleCore,
+			idType:  testTypeFeature,
 			wantErr: true,
 		},
 		{
 			name:    "empty module",
-			value:   "darkvision",
+			value:   testDarkvision,
 			module:  "",
-			idType:  "feature",
+			idType:  testTypeFeature,
 			wantErr: true,
 		},
 		{
 			name:    "empty type",
-			value:   "darkvision",
-			module:  "core",
+			value:   testDarkvision,
+			module:  testModuleCore,
 			idType:  "",
 			wantErr: true,
 		},
@@ -69,15 +69,15 @@ func TestNew(t *testing.T) {
 }
 
 func TestID_String(t *testing.T) {
-	id := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: "darkvision"})
+	id := core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: testDarkvision})
 	assert.Equal(t, "core:feature:darkvision", id.String())
 }
 
 func TestID_Equals(t *testing.T) {
-	id1 := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: "darkvision"})
-	id2 := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: "darkvision"})
-	id3 := core.MustNewRef(core.RefInput{Module: "core", Type: "proficiency", ID: "darkvision"})
-	id4 := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: "keen_senses"})
+	id1 := core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: testDarkvision})
+	id2 := core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: testDarkvision})
+	id3 := core.MustNewRef(core.RefInput{Module: testModuleCore, Type: "proficiency", ID: testDarkvision})
+	id4 := core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: "keen_senses"})
 
 	assert.True(t, id1.Equals(id2), "identical IDs should be equal")
 	assert.False(t, id1.Equals(id3), "different types should not be equal")
@@ -91,7 +91,7 @@ func TestID_Equals(t *testing.T) {
 }
 
 func TestID_JSONMarshaling(t *testing.T) {
-	original := core.MustNewRef(core.RefInput{Module: "core", Type: "skill", ID: "athletics"})
+	original := core.MustNewRef(core.RefInput{Module: testModuleCore, Type: "skill", ID: "athletics"})
 
 	// Marshal to JSON
 	data, err := json.Marshal(original)
@@ -113,13 +113,13 @@ func TestID_JSONUnmarshal_BackwardCompatibility(t *testing.T) {
 	err := json.Unmarshal([]byte(objectFormat), &id)
 	require.NoError(t, err)
 
-	assert.Equal(t, "darkvision", id.ID)
+	assert.Equal(t, testDarkvision, id.ID)
 	assert.Equal(t, "core", id.Module)
 	assert.Equal(t, "feature", id.Type)
 }
 
 func TestWithSource(t *testing.T) {
-	id := core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: "second_wind"})
+	id := core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: "second_wind"})
 	withSource := core.NewWithSourcedRef(id, &core.Source{
 		Category: core.SourceClass,
 		Name:     "fighter",
@@ -142,7 +142,7 @@ func TestWithSource(t *testing.T) {
 
 func TestMustNew_Panics(t *testing.T) {
 	assert.Panics(t, func() {
-		core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: ""})
+		core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: ""})
 	}, "MustNewRef should panic with invalid input")
 }
 
@@ -158,17 +158,17 @@ func TestParseString(t *testing.T) {
 		{
 			name:  "valid identifier",
 			input: "core:feature:rage",
-			want:  core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: "rage"}),
+			want:  core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: testRage}),
 		},
 		{
 			name:  "valid with underscores",
 			input: "core:feature:sneak_attack",
-			want:  core.MustNewRef(core.RefInput{Module: "core", Type: "feature", ID: "sneak_attack"}),
+			want:  core.MustNewRef(core.RefInput{Module: testModuleCore, Type: testTypeFeature, ID: "sneak_attack"}),
 		},
 		{
 			name:  "valid with dashes",
 			input: "third-party:feature:custom-ability",
-			want:  core.MustNewRef(core.RefInput{Module: "third-party", Type: "feature", ID: "custom-ability"}),
+			want:  core.MustNewRef(core.RefInput{Module: "third-party", Type: testTypeFeature, ID: "custom-ability"}),
 		},
 		{
 			name:         "empty string",
@@ -215,21 +215,21 @@ func TestParseString(t *testing.T) {
 			name:         "invalid characters - spaces",
 			input:        "core:feature:rage bonus",
 			wantErr:      core.ErrInvalidCharacters,
-			wantErrMsg:   "invalid characters",
+			wantErrMsg:   testErrInvalidChar,
 			checkErrType: true,
 		},
 		{
 			name:         "invalid characters - special chars",
 			input:        "core:feature:rage!",
 			wantErr:      core.ErrInvalidCharacters,
-			wantErrMsg:   "invalid characters",
+			wantErrMsg:   testErrInvalidChar,
 			checkErrType: true,
 		},
 		{
 			name:         "invalid characters - dots",
 			input:        "core:feature:rage.bonus",
 			wantErr:      core.ErrInvalidCharacters,
-			wantErrMsg:   "invalid characters",
+			wantErrMsg:   testErrInvalidChar,
 			checkErrType: true,
 		},
 	}

--- a/core/testutil_test.go
+++ b/core/testutil_test.go
@@ -1,0 +1,14 @@
+package core_test
+
+// Shared test fixture constants — extracted to satisfy goconst across
+// action_test.go, ref_test.go, and typed_ref_test.go. Names carry a
+// `test` prefix to avoid shadowing the `core` package import.
+const (
+	testRage           = "rage"
+	testDarkvision     = "darkvision"
+	testModuleCore     = "core"
+	testTypeFeature    = "feature"
+	testModuleCombat   = "combat"
+	testTypeEvent      = "event"
+	testErrInvalidChar = "invalid characters"
+)

--- a/core/typed_ref_test.go
+++ b/core/typed_ref_test.go
@@ -9,7 +9,7 @@ import (
 func TestTypedRef(t *testing.T) {
 	t.Run("String with valid ref", func(t *testing.T) {
 		ref := core.MustNewRef(core.RefInput{
-			Module: "combat",
+			Module: testModuleCombat,
 			Type:   "attack",
 			ID:     "melee",
 		})
@@ -39,16 +39,16 @@ func TestTypedRef(t *testing.T) {
 		// This is useful when the same ref needs different type associations
 		attackRef := core.TypedRef[AttackEvent]{
 			Ref: core.MustNewRef(core.RefInput{
-				Module: "combat",
-				Type:   "event",
+				Module: testModuleCombat,
+				Type:   testTypeEvent,
 				ID:     "attack",
 			}),
 		}
 
 		damageRef := core.TypedRef[DamageEvent]{
 			Ref: core.MustNewRef(core.RefInput{
-				Module: "combat",
-				Type:   "event",
+				Module: testModuleCombat,
+				Type:   testTypeEvent,
 				ID:     "damage",
 			}),
 		}
@@ -73,7 +73,7 @@ func TestTypedRef(t *testing.T) {
 		// Useful for event systems where the same event ID might have different payload types
 		sharedRef := core.MustNewRef(core.RefInput{
 			Module: "game",
-			Type:   "event",
+			Type:   testTypeEvent,
 			ID:     "turn_end",
 		})
 

--- a/docs/adr/0027-attack-resolution-and-reactions.md
+++ b/docs/adr/0027-attack-resolution-and-reactions.md
@@ -91,6 +91,19 @@ actually uses:
     bus + phased path; when a player reactor has a triggered prompt the
     NPC's turn pauses via the `errNPCPausedForReaction` sentinel
     (`IsNPCPausedForReaction` helper for orchestrators).
+  - **Polymorphic `CompleteTakeAction` resume (Wave 2.11e, 2026-05-23).**
+    The resume verb accepts either PvE attack direction. Direction is
+    resolved from `PhasedAttackContext.AttackerID` by looking the entity
+    up against both the Players and the Monsters maps; the SDK then
+    dispatches to `applyAndPublishOutcome` (player→monster) or
+    `applyAndPublishNPCOutcome` (monster→player). The NPC-attacker
+    direction is the only one Shield can fire in PvE scope (the bearer
+    must be the *target* for Shield's predicate to match, and PvE means
+    monster as attacker). Without this polymorphism the Shield resume
+    path was rejected at the resume verb with "attacker not in encounter."
+    Player→player and monster→monster attacks return
+    `ErrUnsupportedAttackDirection` until a wave adds the corresponding
+    publish helper; the SDK surface stays the same.
 
   See `rulebooks/dnd5e/conditions/opportunity_attack.go` and
   `shield_spell.go` for the canonical reaction-condition implementations

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter module
 description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, discrete-phase combat orchestration
-updated: 2026-05-14
-confidence: high — Wave 2.11d shipped the discrete-phase combat surface verified by shipped code + tests + ADR-0027 cross-reference
+updated: 2026-05-23
+confidence: high — Wave 2.11d shipped the discrete-phase combat surface; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction (verified by shipped tests + ADR-0027 cross-reference)
 ---
 
 # encounter module
@@ -97,6 +97,25 @@ if encounter.IsNPCPausedForReaction(err) {
 ```
 
 `IsNPCPausedForReaction` uses `errors.Is` so the helper survives any `%w`-wrapping callers add. The sentinel is unexported deliberately — the helper is the only legitimate detection path.
+
+### NPC-attacker resume direction (Wave 2.11e)
+
+`CompleteTakeAction` accepts either PvE attack direction. The shipped Wave 2.11d shape rejected NPC attackers (the original implementation looked up `attackCtx.AttackerID` only against `data.Players`), which broke the resume path for the only direction Shield can fire in: monster attacks player → player Shield prompt → player chooses Take → resume calls `CompleteTakeAction` with `AttackerID = monsterID`.
+
+The Wave 2.11e fix resolves direction polymorphically by checking the AttackerID against both the Players map and the Monsters map, then dispatching to the appropriate publish helper:
+
+| Direction | AttackerID resolved against | Outcome publish path | Death event |
+|---|---|---|---|
+| player→monster | `data.Players` | `applyAndPublishOutcome(player, monster, outcome)` | `killEntity` (full kill chain — remove from initiative, check encounter-end) |
+| monster→player | `data.Monsters` | `applyAndPublishNPCOutcome(monster, player, outcome)` | `publishPlayerDied` (Wave 2.10 partial — event only, no removal, no encounter-end) |
+| player→player | n/a | rejected with `ErrUnsupportedAttackDirection` | n/a |
+| monster→monster | n/a | rejected with `ErrUnsupportedAttackDirection` | n/a |
+
+`applyAndPublishNPCOutcome` is extracted from the per-attack body of `applyCapturedAttacks` (encounter/npc.go) and re-used from both the inline NPC turn and the Shield-resume direction so the two paths emit identical event shapes. Before this extraction, the inline `applyCapturedAttacks` had a 60-line tail computing damage-type fallback + HP delta + publishAttackOutcome + publishPlayerDied that the resume direction would have to duplicate. The extraction is internal — no change to the resolver interface or any host-visible verb signature.
+
+The single SDK call site is unchanged from the orchestrator's perspective: rpg-api's `submit_check_reaction.go` calls `enc.CompleteTakeAction(phasedCtx, modifiers)` regardless of direction. The SDK figures out which `applyAndPublish*` to dispatch from `attackCtx.AttackerID`.
+
+PvP and monster-vs-monster directions return `ErrUnsupportedAttackDirection` (maps to gRPC `Unimplemented`). A future wave that wants either direction would add the corresponding `applyAndPublish*` helper to the dispatch switch; the SDK surface stays the same.
 
 ## Implementation notes worth keeping
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,11 +1,22 @@
 ---
 name: rpg-toolkit architecture overview
-description: Layer rules, module map, persistence pattern, and boundary with rpg-api
-updated: 2026-05-04
+description: Layer rules, module map, persistence pattern, and boundary with rpg-api — lead-framed with toolkit-as-product
+updated: 2026-05-23
 confidence: high — verified by full code read-through of go.mod files, key source files, and test suites
 ---
 
 # rpg-toolkit architecture overview
+
+## Toolkit as product
+
+rpg-toolkit is the product. Any game host using the toolkit should be able to ship their game by writing UI and content — the engine and its delivery shape should feel small. rpg-api (our reference game server) and rpg-dnd5e-web (our reference Discord Activity UI) are not platform components; they are the worked example for one host shape (gRPC + Redis + React + Discord). A different host — a single-player desktop client, a different multiplayer transport, a tabletop simulator — should be able to point at the same toolkit without touching it.
+
+That framing has two operational consequences worth naming up-front, since they steer every SDK design call:
+
+1. **When rpg-api grows complex, that is signal the toolkit is missing a primitive.** The boundary rule below ("toolkit knows rules, api orchestrates by key") is a constraint that catches drift: any rule logic that finds its way into rpg-api should produce a toolkit issue, not a rpg-api fix.
+2. **Verb shape lives in the SDK, not the orchestrator.** Wave 2.11d's `PhasedCombatResolver` is the canonical example: the host implements a resolver, but the SDK owns the verb sequence (`TakeActionPhased` → `CompleteTakeAction`), the persistence shape (`PendingReactionPrompts`), and the pause-and-resume contract (`errNPCPausedForReaction`). Wave 2.11e extends the same pattern to a second resolver verb (`MovementResolver`). A new host doesn't have to re-derive any of this — they implement the resolver interface and the SDK does the rest.
+
+## Mandate
 
 rpg-toolkit is a Go rules engine for tabletop RPG mechanics. Its mandate is to implement game rules and return rich breakdowns. It never orchestrates data, never persists state, and never knows about rpg-api or proto definitions. If a caller (rpg-api) needs to know what Rage does, it asks the toolkit.
 

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -35,6 +35,12 @@ var (
 	// whose combat snapshot (HP, AC, AttackBonus, DamageDice) is not
 	// fully populated. Maps to gRPC FailedPrecondition.
 	ErrNonCombatant = errors.New("actor is not a combatant")
+	// ErrUnsupportedAttackDirection is returned by CompleteTakeAction when
+	// the (attacker, target) pair encoded in PhasedAttackContext is not a
+	// shipped PvE direction (player→monster or monster→player). Player→
+	// player and monster→monster are out of scope until a wave adds the
+	// corresponding verb. Maps to gRPC Unimplemented.
+	ErrUnsupportedAttackDirection = errors.New("unsupported attack direction")
 )
 
 // damageTypeUntyped is the fallback damage type emitted when an attacker's

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -215,6 +215,14 @@ func (e *Encounter) ClearPendingReactionPrompt(reactorPlayerID core.PlayerID) {
 //
 // Publishes the AttackResolvedEvent + (on hit) DamageDealtEvent and runs the
 // same death/removal chain as the inline path.
+//
+// Wave 2.11e: accepts either PvE attack direction — player→monster (the
+// original 2.11d shape, dispatched via TakeActionPhased) and monster→player
+// (the Shield resume direction, dispatched via NPCAct that paused for a
+// player reaction). The SDK resolves direction from AttackerID lookup
+// against the Players + Monsters maps; the orchestrator passes the
+// PhasedAttackContext through unchanged for either direction. Player→
+// player attacks return ErrUnsupportedAttackDirection.
 func (e *Encounter) CompleteTakeAction(attackCtx *PhasedAttackContext, modifiers []ReactionModifier) error {
 	if attackCtx == nil {
 		return fmt.Errorf("nil attack context")
@@ -227,16 +235,19 @@ func (e *Encounter) CompleteTakeAction(attackCtx *PhasedAttackContext, modifiers
 		return fmt.Errorf("combat resolver does not support phased completion")
 	}
 
-	// Resolve the player + monster from the attack context's IDs. The
-	// caller is the attacker; the target may be either a player (cross-PvP)
-	// or a monster — Wave 2.11d only supports player → monster attacks per
-	// the existing TakeAction contract.
-	player := e.findPlayerByEntityID(attackCtx.AttackerID)
-	if player == nil {
+	// Resolve attacker against both maps; CompleteTakeAction is the only
+	// resume verb so the direction must be inferred from the persisted
+	// context (the orchestrator does not pass a direction hint).
+	attackerPlayer := e.findPlayerByEntityID(attackCtx.AttackerID)
+	attackerMonster := e.data.Monsters[attackCtx.AttackerID]
+	if attackerPlayer == nil && attackerMonster == nil {
 		return fmt.Errorf("attacker %q not in encounter", attackCtx.AttackerID)
 	}
-	monster, ok := e.data.Monsters[attackCtx.TargetID]
-	if !ok {
+
+	// Resolve target against both maps for the symmetric reason.
+	targetMonster := e.data.Monsters[attackCtx.TargetID]
+	targetPlayer := e.findPlayerByEntityID(attackCtx.TargetID)
+	if targetMonster == nil && targetPlayer == nil {
 		return fmt.Errorf("%w: %q", ErrUnknownTarget, attackCtx.TargetID)
 	}
 
@@ -247,13 +258,78 @@ func (e *Encounter) CompleteTakeAction(attackCtx *PhasedAttackContext, modifiers
 	if outcome == nil {
 		return fmt.Errorf("combat resolver: nil outcome with nil error")
 	}
-	return e.applyAndPublishOutcome(player, monster, outcome)
+
+	// Dispatch by the resolved direction. PvE only — player→player and
+	// monster→monster shapes are out of scope until a wave adds the
+	// corresponding verb.
+	switch {
+	case attackerPlayer != nil && targetMonster != nil:
+		return e.applyAndPublishOutcome(attackerPlayer, targetMonster, outcome)
+	case attackerMonster != nil && targetPlayer != nil:
+		return e.applyAndPublishNPCOutcome(attackerMonster, targetPlayer, outcome)
+	default:
+		return fmt.Errorf("%w: %q→%q",
+			ErrUnsupportedAttackDirection, attackCtx.AttackerID, attackCtx.TargetID)
+	}
+}
+
+// applyAndPublishNPCOutcome mutates the target player's HP, publishes the
+// attack/damage events with per-viewer projection, and fires the partial
+// player-death event on the >0 → 0 transition. The NPC-attacker mirror of
+// applyAndPublishOutcome.
+//
+// Wave 2.10 partial player-death semantics apply: a player whose HP hits
+// 0 fires EntityDiedEvent but is NOT removed from initiative and does NOT
+// terminate the encounter — dying-state and TPK are Wave 2.11+ territory.
+//
+// Shared between two call sites:
+//   - applyCapturedAttacks (inline NPC turn that did NOT pause for a
+//     player reaction) — publishes the outcome immediately after the
+//     resolver returns.
+//   - CompleteTakeAction (NPC→player Shield-resume direction) — publishes
+//     the outcome after the player's SubmitCheck{take_reaction} reaches
+//     the SDK via the orchestrator.
+//
+// Wave 2.11e: extracted from the per-attack body of applyCapturedAttacks
+// (encounter/npc.go) so the Shield resume path emits the same shape as
+// the inline path. Without this, NPC-attacker resume would diverge from
+// NPC-attacker inline on death-event emission and damage-type fallback.
+func (e *Encounter) applyAndPublishNPCOutcome(monster *MonsterData, player *PlayerData, outcome *AttackOutcome) error {
+	hpBefore := player.HP
+	if outcome.Hit {
+		player.HP -= outcome.Damage
+		if player.HP < 0 {
+			player.HP = 0
+		}
+	}
+
+	damageType := outcome.DamageType
+	if damageType == "" {
+		damageType = monster.DamageType
+	}
+	if damageType == "" {
+		damageType = damageTypeUntyped
+	}
+	if err := e.publishAttackOutcome(
+		monster.ID, player.EntityID, outcome,
+		player.HP, player.MaxHP, damageType,
+		monster.Position, player.View.Position,
+	); err != nil {
+		return err
+	}
+	if outcome.Hit && hpBefore > 0 && player.HP == 0 {
+		if err := e.publishPlayerDied(player.EntityID, monster.ID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // applyAndPublishOutcome mutates target HP, publishes the attack/damage
 // events with per-viewer projection, and fires the death + encounter-end
 // chain on the >0 → 0 transition. Shared between the legacy single-phase
-// path and the phased CompleteTakeAction path.
+// path and the phased CompleteTakeAction path (player→monster direction).
+// applyAndPublishNPCOutcome is the monster→player mirror.
 func (e *Encounter) applyAndPublishOutcome(player *PlayerData, monster *MonsterData, outcome *AttackOutcome) error {
 	hpBefore := monster.HP
 	if outcome.Hit {

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -238,10 +238,21 @@ func (e *Encounter) CompleteTakeAction(attackCtx *PhasedAttackContext, modifiers
 	// Resolve attacker against both maps; CompleteTakeAction is the only
 	// resume verb so the direction must be inferred from the persisted
 	// context (the orchestrator does not pass a direction hint).
+	//
+	// Cross-map uniqueness of entity IDs is not enforced at AddPlayer /
+	// AddMonster time (PlayerData is keyed by PlayerID with EntityID as a
+	// separate field; MonsterData is keyed by its EntityID directly), so
+	// a player and a monster CAN share an EntityID. If that happens, the
+	// dispatch below is ambiguous — reject the resume call rather than
+	// silently routing to the wrong publish helper.
 	attackerPlayer := e.findPlayerByEntityID(attackCtx.AttackerID)
 	attackerMonster := e.data.Monsters[attackCtx.AttackerID]
 	if attackerPlayer == nil && attackerMonster == nil {
 		return fmt.Errorf("attacker %q not in encounter", attackCtx.AttackerID)
+	}
+	if attackerPlayer != nil && attackerMonster != nil {
+		return fmt.Errorf("ambiguous attacker %q: matches both a player and a monster",
+			attackCtx.AttackerID)
 	}
 
 	// Resolve target against both maps for the symmetric reason.
@@ -249,6 +260,10 @@ func (e *Encounter) CompleteTakeAction(attackCtx *PhasedAttackContext, modifiers
 	targetPlayer := e.findPlayerByEntityID(attackCtx.TargetID)
 	if targetMonster == nil && targetPlayer == nil {
 		return fmt.Errorf("%w: %q", ErrUnknownTarget, attackCtx.TargetID)
+	}
+	if targetMonster != nil && targetPlayer != nil {
+		return fmt.Errorf("ambiguous target %q: matches both a player and a monster",
+			attackCtx.TargetID)
 	}
 
 	outcome, err := phased.ApplyAttackOutcome(attackCtx, modifiers)

--- a/encounter/combat_phased_test.go
+++ b/encounter/combat_phased_test.go
@@ -431,3 +431,52 @@ func hasEventOfType[T events.EncounterEvent](evts []events.EncounterEvent) bool 
 	}
 	return false
 }
+
+// --- Collision guards (Copilot PR #664 review) ---
+//
+// AddPlayer / AddMonster do not enforce cross-map uniqueness of entity
+// IDs, so a player's EntityID and a monster's ID can collide. The
+// dispatch in CompleteTakeAction must reject the resume rather than
+// silently routing to the wrong publish path.
+
+// collidingEntitySuite reuses PhasedTakeActionSuite scaffolding but
+// injects a colliding entity ID on bob (the player) matching the
+// existing goblin's monster ID.
+func (s *PhasedTakeActionSuite) addCollidingPlayerOnGoblinID() {
+	// Re-add bob with EntityID = gobEntityID. AddPlayer guards on
+	// PlayerID, not EntityID, so this is permitted today.
+	s.Require().NoError(s.enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: "carol", EntityID: gobEntityID,
+		Position: encountercore.Hex{Q: 3, R: 0, S: -3}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 12, AttackBonus: 4,
+		DamageDice: "1d4", DamageType: damageSlashing,
+	}))
+}
+
+func (s *PhasedTakeActionSuite) TestCompleteTakeAction_AmbiguousAttacker_Rejected() {
+	s.addCollidingPlayerOnGoblinID()
+
+	// AttackerID = gobEntityID now matches BOTH carol (player) and the
+	// goblin (monster). Resume must reject.
+	err := s.enc.CompleteTakeAction(&tkenc.PhasedAttackContext{
+		Rulebook:   "stub",
+		AttackerID: gobEntityID,
+		TargetID:   bobEntityID,
+	}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "ambiguous attacker", "must surface the collision, not silently dispatch")
+}
+
+func (s *PhasedTakeActionSuite) TestCompleteTakeAction_AmbiguousTarget_Rejected() {
+	s.addCollidingPlayerOnGoblinID()
+
+	// TargetID = gobEntityID matches BOTH carol (player) and the goblin
+	// (monster). Resume must reject.
+	err := s.enc.CompleteTakeAction(&tkenc.PhasedAttackContext{
+		Rulebook:   "stub",
+		AttackerID: aliceEntityID,
+		TargetID:   gobEntityID,
+	}, nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "ambiguous target", "must surface the collision, not silently dispatch")
+}

--- a/encounter/combat_phased_test.go
+++ b/encounter/combat_phased_test.go
@@ -6,15 +6,22 @@ package encounter_test
 // a stubbed PhasedCombatResolver. The stub controls whether ReactionTrigger
 // events are published during phase 1 and whether the reactor is a player
 // (surface) or NPC (auto-resolve).
+//
+// Wave 2.11e — NPC-attacker CompleteTakeAction symmetry tests appended at
+// the bottom of the file. They exercise the only PvE direction Shield can
+// fire in: monster attacks player → player Shield prompt → SubmitCheck
+// resume calls CompleteTakeAction with the NPC as AttackerID.
 
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
@@ -277,4 +284,150 @@ func (s *PhasedTakeActionSuite) TestLegacyResolverFallback() {
 	s.Require().NotNil(out)
 	s.True(out.Resolved, "legacy resolver always Resolved=true")
 	s.Len(resolver.calls, 1)
+}
+
+// --- Wave 2.11e — NPC-attacker CompleteTakeAction symmetry ---
+//
+// The goblin attacks bob; bob's Shield prompt fires; SubmitCheck resumes
+// via CompleteTakeAction with AttackerID=gobEntityID, TargetID=bobEntityID.
+// These tests exercise the only PvE direction Shield can fire in. The
+// existing player-attacker tests above stay; this is parallel coverage,
+// not a replacement.
+//
+// Test scaffolding shape signed off by director B19 (2026-05-23): share
+// the PhasedTakeActionSuite struct + a goblinAttackBobContext() helper
+// builds the PhasedAttackContext directly (bypassing NPCAct since
+// CompleteTakeAction is the surface under test).
+
+// goblinAttackBobContext builds the PhasedAttackContext that the
+// orchestrator would persist when an NPC attack pauses for a player
+// reaction. Direction: monster (goblin) → player (bob).
+func goblinAttackBobContext() *tkenc.PhasedAttackContext {
+	return &tkenc.PhasedAttackContext{
+		Rulebook:   "stub",
+		AttackerID: gobEntityID,
+		TargetID:   bobEntityID,
+	}
+}
+
+func (s *PhasedTakeActionSuite) TestCompleteTakeAction_NPCAttacker_HitPublishes() {
+	bobSub, err := s.broker.Subscribe(s.enc.ID(), bobPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = bobSub.Close() }()
+
+	s.resolver.outcomeReturn = &tkenc.AttackOutcome{
+		Hit:         true,
+		AttackRoll:  16,
+		AttackBonus: 4,
+		TargetAC:    12,
+		Damage:      5,
+		DamageType:  damageSlashing,
+	}
+
+	err = s.enc.CompleteTakeAction(goblinAttackBobContext(), nil)
+	s.Require().NoError(err, "NPC-attacker resume must not be rejected")
+
+	// HP delta on bob: starting 18 - 5 = 13.
+	bobData := s.enc.ToData().Players[bobPlayerID]
+	s.Require().NotNil(bobData, "bob must remain a player in the encounter")
+	s.Equal(13, bobData.HP, "bob HP should drop by outcome.Damage")
+
+	// Events published to bob: AttackResolved + DamageDealt.
+	evts := drainEvents(bobSub, 200*time.Millisecond)
+	s.Require().NotEmpty(evts, "expected at least AttackResolved+DamageDealt events")
+	s.True(hasEventOfType[*events.AttackResolvedEvent](evts), "AttackResolvedEvent expected on hit")
+	s.True(hasEventOfType[*events.DamageDealtEvent](evts), "DamageDealtEvent expected on hit")
+	s.False(hasEventOfType[*events.EntityDiedEvent](evts), "no death — bob still has HP")
+
+	s.Len(s.resolver.outcomeCalls, 1, "phase 2 should run once via NPC-attacker resume")
+}
+
+func (s *PhasedTakeActionSuite) TestCompleteTakeAction_NPCAttacker_MissNoPublish() {
+	bobSub, err := s.broker.Subscribe(s.enc.ID(), bobPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = bobSub.Close() }()
+
+	s.resolver.outcomeReturn = &tkenc.AttackOutcome{
+		Hit:         false,
+		AttackRoll:  5,
+		AttackBonus: 4,
+		TargetAC:    12,
+		Damage:      0,
+		DamageType:  damageSlashing,
+	}
+
+	err = s.enc.CompleteTakeAction(goblinAttackBobContext(), nil)
+	s.Require().NoError(err)
+
+	// HP unchanged on a miss.
+	bobData := s.enc.ToData().Players[bobPlayerID]
+	s.Require().NotNil(bobData)
+	s.Equal(18, bobData.HP, "bob HP unchanged on miss")
+
+	// AttackResolved always fires; DamageDealt only on hit.
+	evts := drainEvents(bobSub, 200*time.Millisecond)
+	s.True(hasEventOfType[*events.AttackResolvedEvent](evts), "AttackResolvedEvent fires on miss too")
+	s.False(hasEventOfType[*events.DamageDealtEvent](evts), "DamageDealtEvent must not fire on miss")
+}
+
+func (s *PhasedTakeActionSuite) TestCompleteTakeAction_NPCAttacker_PlayerDeath() {
+	bobSub, err := s.broker.Subscribe(s.enc.ID(), bobPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = bobSub.Close() }()
+
+	// Damage larger than bob's HP forces a death transition.
+	s.resolver.outcomeReturn = &tkenc.AttackOutcome{
+		Hit:         true,
+		AttackRoll:  20,
+		AttackBonus: 4,
+		TargetAC:    12,
+		Damage:      30,
+		DamageType:  damageSlashing,
+	}
+
+	err = s.enc.CompleteTakeAction(goblinAttackBobContext(), nil)
+	s.Require().NoError(err)
+
+	// HP clamped to 0; player remains in the encounter (Wave 2.10 partial
+	// player-death: no removal, no encounter-end).
+	bobData := s.enc.ToData().Players[bobPlayerID]
+	s.Require().NotNil(bobData, "bob is not removed from encounter on death (Wave 2.10 partial)")
+	s.Equal(0, bobData.HP, "bob HP clamped at 0 after lethal damage")
+
+	evts := drainEvents(bobSub, 200*time.Millisecond)
+	s.True(hasEventOfType[*events.AttackResolvedEvent](evts), "AttackResolved fires on lethal hit")
+	s.True(hasEventOfType[*events.DamageDealtEvent](evts), "DamageDealt fires on lethal hit")
+	s.True(hasEventOfType[*events.EntityDiedEvent](evts),
+		"EntityDiedEvent must fire when player HP transitions >0 → 0")
+}
+
+// drainEvents collects events from a subscription until timeout. Unlike
+// collectEventsTyped (in visibility_transition_test.go) it returns the
+// raw EncounterEvent slice so callers use the generic hasEventOfType
+// helper below for type-shaped assertions.
+func drainEvents(sub *tkenc.Subscription, timeout time.Duration) []events.EncounterEvent {
+	out := []events.EncounterEvent{}
+	deadline := time.After(timeout)
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				return out
+			}
+			out = append(out, evt)
+		case <-deadline:
+			return out
+		}
+	}
+}
+
+// hasEventOfType reports whether any event in the slice has the requested
+// concrete type. Saves the per-test type-switch boilerplate.
+func hasEventOfType[T events.EncounterEvent](evts []events.EncounterEvent) bool {
+	for _, e := range evts {
+		if _, ok := e.(T); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -226,11 +226,6 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 		if targetPlayer == nil {
 			continue
 		}
-		dmgType := mon.DamageType
-		if dmgType == "" {
-			dmgType = damageTypeUntyped
-		}
-		hpBefore := targetPlayer.HP
 
 		input := AttackInput{
 			AttackerID:          mon.ID,
@@ -255,36 +250,18 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 			// Player reactor was prompted. The encounter has the pending
 			// reaction state + prompt event already published. Stop processing
 			// further captured attacks for this NPC turn — the orchestrator
-			// will resume the NPC dispatch after the reactor responds.
+			// will resume the NPC dispatch after the reactor responds via
+			// SubmitCheck → CompleteTakeAction (the NPC-attacker direction
+			// added in Wave 2.11e).
 			return errNPCPausedForReaction
 		}
 		if outcome == nil {
 			return fmt.Errorf("combat resolver: nil outcome with nil error")
 		}
-		if outcome.Hit {
-			targetPlayer.HP -= outcome.Damage
-			if targetPlayer.HP < 0 {
-				targetPlayer.HP = 0
-			}
-		}
-		if outcome.DamageType != "" {
-			dmgType = outcome.DamageType
-		}
-		if err := e.publishAttackOutcome(
-			mon.ID, targetID, outcome,
-			targetPlayer.HP, targetPlayer.MaxHP, dmgType,
-			mon.Position, targetPlayer.View.Position,
-		); err != nil {
+		// Wave 2.11e: share the NPC-attacker outcome publish path with
+		// CompleteTakeAction so inline and resume emit the same shape.
+		if err := e.applyAndPublishNPCOutcome(mon, targetPlayer, outcome); err != nil {
 			return err
-		}
-		// Wave 2.10 partial player-death: fire EntityDiedEvent only on the
-		// HP transition (avoids duplicates from multi-attack NPCs or hits
-		// on an already-downed player). No EntityRemoved / no initiative
-		// splice / no encounter-end.
-		if outcome.Hit && hpBefore > 0 && targetPlayer.HP == 0 {
-			if err := e.publishPlayerDied(targetID, mon.ID); err != nil {
-				return err
-			}
 		}
 	}
 	return nil
@@ -608,15 +585,10 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	if target == nil {
 		return nil
 	}
-	dmgType := mon.DamageType
-	if dmgType == "" {
-		dmgType = damageTypeUntyped
-	}
-	hpBefore := target.HP
 	outcome, err := e.combatResolver.ResolveAttack(AttackInput{
 		AttackerID:          mon.ID,
 		TargetID:            target.EntityID,
-		ActionRef:           core.Ref{Module: "dnd5e", Type: "action", ID: "attack"},
+		ActionRef:           core.Ref{Module: "dnd5e", Type: "action", ID: actionIDAttack},
 		AttackerAttackBonus: mon.AttackBonus,
 		AttackerDamageDice:  mon.DamageDice,
 		AttackerDamageType:  mon.DamageType,
@@ -629,28 +601,10 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	if outcome == nil {
 		return fmt.Errorf("combat resolver: nil outcome with nil error")
 	}
-	if outcome.Hit {
-		target.HP -= outcome.Damage
-		if target.HP < 0 {
-			target.HP = 0
-		}
-	}
-	if outcome.DamageType != "" {
-		dmgType = outcome.DamageType
-	}
-	if err := e.publishAttackOutcome(
-		mon.ID, target.EntityID, outcome,
-		target.HP, target.MaxHP, dmgType,
-		mon.Position, target.View.Position,
-	); err != nil {
-		return err
-	}
-	if outcome.Hit && hpBefore > 0 && target.HP == 0 {
-		if err := e.publishPlayerDied(target.EntityID, mon.ID); err != nil {
-			return err
-		}
-	}
-	return nil
+	// Wave 2.11e: share the NPC-attacker outcome publish path. Same
+	// rationale as applyCapturedAttacks above — inline scripted attacks
+	// and the phased Shield-resume direction must emit identical shapes.
+	return e.applyAndPublishNPCOutcome(mon, target, outcome)
 }
 
 // buildPerception assembles the PerceptionData a monster needs to choose

--- a/events/example_journey_test.go
+++ b/events/example_journey_test.go
@@ -29,23 +29,23 @@ func Example_journey_attackFlow() {
 	}
 
 	// Feature 1: Rage - adds damage when active
-	rage := &RageFeature{ownerID: "barbarian", bonus: 2}
+	rage := &RageFeature{ownerID: testBarbarian, bonus: 2}
 	_ = rage.Apply(bus)
 
 	// Feature 2: Bless - adds to attack and damage
-	bless := &BlessSpell{targets: []string{"barbarian"}, bonus: 4}
+	bless := &BlessSpell{targets: []string{testBarbarian}, bonus: 4}
 	_ = bless.Apply(bus)
 
 	// Feature 3: Magic Weapon - enhances weapon damage
-	magicWeapon := &MagicWeaponFeature{ownerID: "barbarian", bonus: 1}
+	magicWeapon := &MagicWeaponFeature{ownerID: testBarbarian, bonus: 1}
 	_ = magicWeapon.Apply(bus)
 
 	// Now watch the journey unfold...
 
 	// 1. Create the attack event - just data!
 	attack := AttackEvent{
-		AttackerID: "barbarian",
-		TargetID:   "goblin",
+		AttackerID: testBarbarian,
+		TargetID:   testGoblin,
 		Damage:     10, // Base damage
 	}
 
@@ -87,17 +87,17 @@ func Example_journey_saveFlow() {
 	SaveChain := events.DefineChainedTopic[SaveEvent]("combat.save")
 
 	// Feature: Resistance gives advantage (we'll simulate with +5)
-	resistance := &ResistanceFeature{targetID: "hero", bonus: 5}
+	resistance := &ResistanceFeature{targetID: testHero, bonus: 5}
 	saves := SaveChain.On(bus) // Connect to journey
 	_, _ = saves.SubscribeWithChain(ctx, resistance.ModifySave)
 
 	// Feature: Bane spell imposes penalty
-	bane := &BaneSpell{targets: []string{"hero"}, penalty: -2}
+	bane := &BaneSpell{targets: []string{testHero}, penalty: -2}
 	_, _ = saves.SubscribeWithChain(ctx, bane.ModifySave)
 
 	// Create save event
 	save := SaveEvent{
-		TargetID: "hero",
+		TargetID: testHero,
 		SaveType: "wisdom",
 		DC:       15,
 		BaseRoll: 10,
@@ -137,25 +137,25 @@ func Example_journey_damageReduction() {
 	DamageChain := events.DefineChainedTopic[DamageEvent]("combat.damage")
 
 	// Feature: Fire Resistance
-	fireResist := &ResistanceFeature{targetID: "dragon", damageType: "fire"}
+	fireResist := &ResistanceFeature{targetID: testDragon, damageType: "fire"}
 	damages := DamageChain.On(bus) // THE MAGIC CONNECTION
 	_, _ = damages.SubscribeWithChain(ctx, fireResist.ModifyDamage)
 
 	// Feature: Stoneskin spell
-	stoneskin := &StoneskinSpell{targetID: "dragon", reduction: 3}
+	stoneskin := &StoneskinSpell{targetID: testDragon, reduction: 3}
 	_, _ = damages.SubscribeWithChain(ctx, stoneskin.ModifyDamage)
 
 	// Create damage events
 	fireDamage := DamageEvent{
 		SourceID:   "wizard",
-		TargetID:   "dragon",
+		TargetID:   testDragon,
 		Amount:     20,
 		DamageType: "fire",
 	}
 
 	slashDamage := DamageEvent{
 		SourceID:   "fighter",
-		TargetID:   "dragon",
+		TargetID:   testDragon,
 		Amount:     15,
 		DamageType: "slashing",
 	}

--- a/events/example_test.go
+++ b/events/example_test.go
@@ -125,7 +125,7 @@ func ExampleChainedTopic() {
 
 	// Apply rage feature
 	rage := &RageFeature{
-		ownerID: "barbarian",
+		ownerID: testBarbarian,
 		bonus:   2,
 	}
 	err := rage.Apply(bus)
@@ -144,8 +144,8 @@ func ExampleChainedTopic() {
 
 	// Create attack event and chain
 	attack := AttackEvent{
-		AttackerID: "barbarian",
-		TargetID:   "goblin",
+		AttackerID: testBarbarian,
+		TargetID:   testGoblin,
 		Damage:     10,
 	}
 

--- a/events/testutil_test.go
+++ b/events/testutil_test.go
@@ -1,0 +1,12 @@
+package events_test
+
+// Shared test fixture constants — extracted to satisfy goconst across
+// example_journey_test.go, example_test.go, and typed_topic_test.go.
+// Names carry a `test` prefix for namespace clarity.
+const (
+	testBarbarian = "barbarian"
+	testGoblin    = "goblin"
+	testHero      = "hero"
+	testDragon    = "dragon"
+	testIDTest    = "test"
+)

--- a/events/typed_topic_test.go
+++ b/events/typed_topic_test.go
@@ -102,7 +102,7 @@ func (s *TypedTopicTestSuite) TestMultipleSubscribers() {
 	s.Require().NoError(err)
 
 	// Publish once
-	err = s.topic.Publish(s.ctx, TestNotificationEvent{ID: "test"})
+	err = s.topic.Publish(s.ctx, TestNotificationEvent{ID: testIDTest})
 	s.Require().NoError(err)
 
 	// All subscribers should be called
@@ -197,7 +197,7 @@ func (s *TypedTopicTestSuite) TestSameTopicDifferentInstances() {
 	s.Require().NoError(err)
 
 	// Publish from first instance
-	err = topic1.Publish(s.ctx, TestNotificationEvent{ID: "test"})
+	err = topic1.Publish(s.ctx, TestNotificationEvent{ID: testIDTest})
 	s.Require().NoError(err)
 
 	// Both should receive (same bus, same topic ID)
@@ -215,7 +215,7 @@ func (s *TypedTopicTestSuite) TestHandlerError() {
 	s.Require().NoError(err)
 
 	// Publish should propagate the error
-	err = s.topic.Publish(s.ctx, TestNotificationEvent{ID: "test"})
+	err = s.topic.Publish(s.ctx, TestNotificationEvent{ID: testIDTest})
 	s.Error(err)
 	s.Equal(testError, err)
 }


### PR DESCRIPTION
## Summary

- Polymorphic `CompleteTakeAction` accepts either PvE attack direction. The Wave 2.11d shape rejected NPC attackers because the resume verb looked up `attackCtx.AttackerID` only against Players, which broke the only direction Shield can fire in (monster attacks player → player Shield prompt → SubmitCheck resume).
- Extracts `applyAndPublishNPCOutcome` from `applyCapturedAttacks` so the inline NPC turn, the scripted NPC turn, and the Shield-resume direction emit identical event shapes.
- New `ErrUnsupportedAttackDirection` for player→player + monster→monster shapes.
- Docs updated in same PR per `feedback_toolkit_docs_close_the_loop`: encounter component doc + ADR-0027 amendment + toolkit-as-product framing lead on overview.md (per active.md B17).

Bundled fix (separate commit): 18 goconst hits in core/ + events/ test files (pre-existing red on main). Root cause is half-migrated golangci-lint v2 config; full migration deferred.

## Test plan

- [x] 3 new NPC-attacker test cases on `PhasedTakeActionSuite`:
  - `TestCompleteTakeAction_NPCAttacker_HitPublishes` — verifies HP delta + AttackResolved + DamageDealt events for bob
  - `TestCompleteTakeAction_NPCAttacker_MissNoPublish` — AttackResolved fires on miss, DamageDealt does not, HP unchanged
  - `TestCompleteTakeAction_NPCAttacker_PlayerDeath` — verifies EntityDiedEvent on HP transition >0 → 0
- [x] All 5 existing player-attacker tests continue to pass (no regression)
- [x] Full encounter package `go test ./...` passes (17s suite)
- [x] core + events + encounter `golangci-lint` reports 0 hits in files touched by this PR
- [ ] Wired through to rpg-api in companion PR (rpg-api#541) — pending this toolkit PR merging + autotag

## Wave 2.11e sequencing

This is the first of two toolkit SDK extensions in Wave 2.11e:

1. **rpg-toolkit#662 (this PR)** — CompleteTakeAction NPC-attacker symmetry → unblocks the Shield resume direction
2. **rpg-api#541** — bump toolkit tag + wire the 2 deferred Shield integration tests + MCP playtest (wendy Shield ready → blocks NPC attack)
3. **rpg-toolkit#658** — MovementResolver SDK interface (player-OA-on-move) — separate PR
4. **rpg-api#539** — wire MovementResolver + 2 player-OA tests
5. **rpg-api#533** — broaden gamectx CharacterRegistry to include ability scores
6. **rpg-api#540** — multi-reactor aggregation (deferred per issue body)

Wave tracker: rpg-project#50. Discussion threads: rpg-toolkit#662 (signed off by director B19, 2026-05-23).

## Pre-existing pre-commit issues NOT addressed here

`make pre-commit` had two layers of pre-existing red surfaced during this PR's verification gate. Only the goconst layer is fixed here; the rest deserves a config-migration PR:

- ✅ 8 goconst hits in core/ test files (fixed in this PR)
- ✅ 10 goconst hits in events/ test files (fixed in this PR)
- ⚠️ 32 goconst hits in encounter/ test files (pre-existing, in untouched files — same `.golangci.yml` v2 schema bug)
- ⚠️ Makefile coverage parser bug — `cd core && coverage=\$(go test ... ; go tool cover ... )` mixes two command outputs, feeds garbage to `bc`
- ⚠️ Core coverage threshold (80%) tripped by zero-test subpackages (core/chain, core/combat, core/damage, core/effect, core/features, core/resources, core/spells)

Root cause for the lint issues: `.golangci.yml` declares `version: "2"` but uses v1 schema (`issues.exclude-rules` + `linters-settings`), so the test-file exclusion for goconst is silently ignored under golangci-lint v2. Proper fix is a config migration in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)