### PR TITLE
feat(encounter): MovementResolver SDK for per-step movement + OA triggering (Wave 2.11e, #658)

### DIFF
--- a/docs/adr/0027-attack-resolution-and-reactions.md
+++ b/docs/adr/0027-attack-resolution-and-reactions.md
@@ -104,6 +104,30 @@ actually uses:
     Player→player and monster→monster attacks return
     `ErrUnsupportedAttackDirection` until a wave adds the corresponding
     publish helper; the SDK surface stays the same.
+  - **MovementResolver (Wave 2.11e, 2026-05-24).** Second instance of
+    the resolver-per-verb pattern. `Encounter.Move` delegates per-step
+    movement mechanics (MovementChain execution, OA triggering) to a
+    rulebook implementation via `MovementResolver.ResolveStep`. When a
+    resolver is wired, `Move` iterates per-step with a buffered
+    subscriber on `ReactionTriggerTopic` installed per step; chain
+    subscribers (`OpportunityAttackCondition.onMovementChain`, Disengage
+    marker) fire per step and the resolver impl resolves NPC OAs inline
+    via combat.MoveEntity → triggerOpportunityAttack → ResolveAttack.
+    The legacy single-jump path is preserved when no resolver is wired
+    (non-combat encounters). Truncated-traveled-path events: when chain
+    prevention blocks a step, the published `MoveEvent` carries only
+    the actually-traveled segments — wire clients see the truthful
+    outcome, not the intent. NPC-OA-only scope; player-pause branch
+    (Sentinel-shape / spell reactions like Shield-during-movement)
+    deferred to issue
+    [#665](https://github.com/KirkDiggler/rpg-toolkit/issues/665).
+
+  **The resolver-per-verb pattern is now the canonical seam for any
+  future SDK verbs that need rulebook-aware chain execution.** Define a
+  resolver interface in the encounter package, wire it via a `WithX`
+  option, and the verb iterates with a trigger buffer per atomic
+  operation. `PhasedCombatResolver` (attacks) and `MovementResolver`
+  (movement) are the two shipped instances.
 
   See `rulebooks/dnd5e/conditions/opportunity_attack.go` and
   `shield_spell.go` for the canonical reaction-condition implementations

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -135,9 +135,10 @@ type MovementStepInput struct {
 type MovementStepResult struct {
     Prevented     bool
     PreventReason string
-    Triggers      []ReactionTrigger
 }
 ```
+
+Triggers flow via the buffered bus subscription only — there is intentionally no resolver-returned trigger slot on the result. Chain subscribers (Disengage marker, OA condition) publish `ReactionTriggerEvent`s on the encounter bus during `ResolveStep`; the SDK installs a buffered subscriber per step to observe them. The bus path is canonical for OA/reaction handoff and matches `PhasedCombatResolver`'s shape applied to attack reactions.
 
 The orchestrator (rpg-api) wires a resolver via `WithMovementResolver(...)`. The orchestrator's implementation wraps the rulebook's `combat.MoveEntity` so chain subscribers (Disengage marker, OpportunityAttackCondition) fire per step and OAs resolve inline via the rulebook's `triggerOpportunityAttack` → `combat.ResolveAttack` path.
 

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter module
-description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, discrete-phase combat orchestration
-updated: 2026-05-23
-confidence: high — Wave 2.11d shipped the discrete-phase combat surface; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction (verified by shipped tests + ADR-0027 cross-reference)
+description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, discrete-phase combat orchestration, MovementResolver seam
+updated: 2026-05-24
+confidence: high — Wave 2.11d shipped the discrete-phase combat surface; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement (NPC-OA scope; player-pause deferred to #665)
 ---
 
 # encounter module
@@ -116,6 +116,57 @@ The Wave 2.11e fix resolves direction polymorphically by checking the AttackerID
 The single SDK call site is unchanged from the orchestrator's perspective: rpg-api's `submit_check_reaction.go` calls `enc.CompleteTakeAction(phasedCtx, modifiers)` regardless of direction. The SDK figures out which `applyAndPublish*` to dispatch from `attackCtx.AttackerID`.
 
 PvP and monster-vs-monster directions return `ErrUnsupportedAttackDirection` (maps to gRPC `Unimplemented`). A future wave that wants either direction would add the corresponding `applyAndPublish*` helper to the dispatch switch; the SDK surface stays the same.
+
+## MovementResolver (Wave 2.11e)
+
+`MovementResolver` is the second instance of the resolver-per-verb pattern that `PhasedCombatResolver` established. It lets the encounter SDK delegate per-step movement mechanics (MovementChain execution, OA triggering) to a rulebook implementation without importing rulebook packages.
+
+```go
+type MovementResolver interface {
+    ResolveStep(input MovementStepInput) (*MovementStepResult, error)
+}
+
+type MovementStepInput struct {
+    EntityID encountercore.EntityID
+    FromHex  encountercore.Hex
+    ToHex    encountercore.Hex
+}
+
+type MovementStepResult struct {
+    Prevented     bool
+    PreventReason string
+    Triggers      []ReactionTrigger
+}
+```
+
+The orchestrator (rpg-api) wires a resolver via `WithMovementResolver(...)`. The orchestrator's implementation wraps the rulebook's `combat.MoveEntity` so chain subscribers (Disengage marker, OpportunityAttackCondition) fire per step and OAs resolve inline via the rulebook's `triggerOpportunityAttack` → `combat.ResolveAttack` path.
+
+### Per-step iteration vs legacy single-jump
+
+`Encounter.Move` has two paths gated on resolver presence:
+
+| Resolver wired? | Path | Position updates | Chain executes | OA fires |
+|---|---|---|---|---|
+| No | Legacy single-jump | once, to `path[-1]` | never | never |
+| Yes | Per-step iteration | per step, to each `ToHex` | per step via resolver | inline (NPC-OA scope) |
+
+When no resolver is wired, the legacy single-jump behavior is preserved for non-combat encounters (free-roam, social). The shape was load-bearing for Wave 2.11d's verification gate: the active.md B8 probe asserted that movement without a resolver does NOT trigger OAs. The new per-step path activates only when a resolver is explicitly supplied.
+
+### Truncated-traveled-path event publication
+
+When chain prevention (Disengage, etc.) blocks a step mid-path, the encounter SDK stops at the previous successfully-traveled hex. The `MoveEvent` published carries only the actually-traveled segments, NOT the requested path. Same for `HexRevealedEvent` (computed from the final traveled hex) and `EntityAppeared/Disappeared` events. Wire clients see the truthful outcome, not the intent.
+
+`applyAndPublishMove` is the helper shared between the legacy single-jump path (called with `traveledPath = requested path`) and the per-step path (called with `traveledPath = actually-moved subset`).
+
+### Trigger buffer drain
+
+The SDK installs a buffered subscriber on `ReactionTriggerTopic` per step. Chain subscribers (`OpportunityAttackCondition.onMovementChain`) publish `ReactionTriggerEvent`s when their predicate matches; the buffered subscriber catches them. In Wave 2.11e NPC-OA-only scope the SDK does not partition or act on captured triggers — NPC OAs are resolved inline by the resolver impl during the same `ResolveStep` call (combat.MoveEntity → triggerOpportunityAttack → ResolveAttack runs end-to-end, applying damage + publishing AttackResolved on the bus before ResolveStep returns).
+
+The buffer infrastructure is installed for shape parity with `TakeActionPhased` and to flush subscriptions cleanly per step. The second-branch consumer (player-pause for Sentinel-shape or spell reactions) is deferred to issue #665.
+
+### Scope deferred (#665)
+
+When a player-bearer reaction becomes a goal-shaped feature (Sentinel feat, Shield/Counterspell, etc.), the per-step iteration loop gains a second branch: partition triggers by reactor type, persist `PendingReactionPrompt` for player-bearer triggers, publish a sentinel `errPlayerPausedForReactionDuringMove`, and resume via the existing `SubmitCheck{take_reaction}` path. The design sketch lives on #665; the structural seam is already in place (the per-step iteration + buffer drain are the load-bearing infrastructure).
 
 ## Implementation notes worth keeping
 

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -145,10 +145,12 @@ The orchestrator (rpg-api) wires a resolver via `WithMovementResolver(...)`. The
 
 `Encounter.Move` has two paths gated on resolver presence:
 
-| Resolver wired? | Path | Position updates | Chain executes | OA fires |
+| Resolver wired? | Path | Encounter SDK position update | Chain executes | OA fires |
 |---|---|---|---|---|
 | No | Legacy single-jump | once, to `path[-1]` | never | never |
-| Yes | Per-step iteration | per step, to each `ToHex` | per step via resolver | inline (NPC-OA scope) |
+| Yes | Per-step iteration | once, to the final hex of the traveled path (after loop completes) | per step via resolver | inline (NPC-OA scope) |
+
+The per-step path accumulates `traveled` as it iterates; the SDK only mutates `Player.View.Position` once, after the loop, via `applyAndPublishMove`. Step-by-step position mutation happens externally in the resolver impl (combat.MoveEntity calls `room.MoveEntity` per step on the spatial-room side), but the encounter SDK keeps its own position state in sync by committing once at the end.
 
 When no resolver is wired, the legacy single-jump behavior is preserved for non-combat encounters (free-roam, social). The shape was load-bearing for Wave 2.11d's verification gate: the active.md B8 probe asserted that movement without a resolver does NOT trigger OAs. The new per-step path activates only when a resolver is explicitly supplied.
 

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -413,11 +413,12 @@ func (e *Encounter) nextSeq() uint64 {
 //
 // Wave 2.11e: when a MovementResolver is wired (WithMovementResolver),
 // Move iterates per-step calling resolver.ResolveStep per hex with a
-// buffered subscriber on ReactionTriggerTopic active for the duration.
-// This is the seam that lets the rulebook run MovementChain per step (so
-// OA conditions fire) without the encounter SDK importing rulebook
-// packages. When no resolver is wired, the legacy single-jump behavior
-// is preserved for non-combat encounters.
+// fresh buffered subscriber on ReactionTriggerTopic installed and torn
+// down around each step (see iterateMovementSteps). This is the seam
+// that lets the rulebook run MovementChain per step (so OA conditions
+// fire) without the encounter SDK importing rulebook packages. When no
+// resolver is wired, the legacy single-jump behavior is preserved for
+// non-combat encounters.
 //
 // Slice scope: no action economy, no turn-order enforcement, no
 // path-contiguity validation beyond non-empty.
@@ -469,26 +470,32 @@ func (e *Encounter) iterateMovementSteps(
 	traveled := make([]core.Hex, 0, len(path))
 	from := moverStart
 	for _, to := range path {
-		// Install a buffered subscriber on ReactionTriggerTopic per step.
-		// The subscriber catches any triggers that chain subscribers
-		// publish during this step's resolver call. In NPC-OA-only scope
-		// the SDK doesn't act on captured triggers (the resolver impl
-		// resolves them inline), but the buffer is installed for shape
-		// parity with TakeActionPhased and to flush subscriptions
-		// cleanly per step.
-		_, drainCleanup, err := e.installTriggerBuffer()
-		if err != nil {
-			return traveled, fmt.Errorf("install trigger buffer: %w", err)
-		}
+		// Each step runs inside an inner func so the buffered subscriber
+		// is torn down via defer even if the resolver panics. Without
+		// this, a panic in the rulebook chain would leak the subscription
+		// and pollute subsequent encounter operations.
+		result, stepErr := func() (*MovementStepResult, error) {
+			// Install a buffered subscriber on ReactionTriggerTopic per
+			// step. The subscriber catches any triggers that chain
+			// subscribers publish during this step's resolver call. In
+			// NPC-OA-only scope the SDK doesn't act on captured triggers
+			// (the resolver impl resolves them inline), but the buffer is
+			// installed for shape parity with TakeActionPhased and to
+			// flush subscriptions cleanly per step.
+			_, drainCleanup, err := e.installTriggerBuffer()
+			if err != nil {
+				return nil, fmt.Errorf("install trigger buffer: %w", err)
+			}
+			defer drainCleanup()
 
-		result, resolveErr := e.movementResolver.ResolveStep(MovementStepInput{
-			EntityID: p.EntityID,
-			FromHex:  from,
-			ToHex:    to,
-		})
-		drainCleanup()
-		if resolveErr != nil {
-			return traveled, fmt.Errorf("resolve movement step: %w", resolveErr)
+			return e.movementResolver.ResolveStep(MovementStepInput{
+				EntityID: p.EntityID,
+				FromHex:  from,
+				ToHex:    to,
+			})
+		}()
+		if stepErr != nil {
+			return traveled, fmt.Errorf("resolve movement step: %w", stepErr)
 		}
 		if result == nil {
 			return traveled, fmt.Errorf("movement resolver: nil result with nil error")

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -28,11 +28,12 @@ const OAReactionRef = "dnd5e:conditions:opportunity_attack"
 // accumulate correctly within a turn and reset at turn boundaries.
 // The bus is reconstructed at LoadFromData — it is not serialized.
 type Encounter struct {
-	data           *Data
-	broker         *Broker
-	roller         dice.Roller
-	resolver       CharacterResolver
-	combatResolver CombatResolver
+	data             *Data
+	broker           *Broker
+	roller           dice.Roller
+	resolver         CharacterResolver
+	combatResolver   CombatResolver
+	movementResolver MovementResolver
 	// bus is the encounter-scoped dnd5e event bus. Conditions subscribe
 	// once at rehydration and remain subscribed for the encounter's lifetime.
 	// Reconstructed (not serialized) at each LoadFromData call.
@@ -79,6 +80,20 @@ func WithCharacterResolver(r CharacterResolver) Option {
 func WithCombatResolver(r CombatResolver) Option {
 	return func(e *Encounter) {
 		e.combatResolver = r
+	}
+}
+
+// WithMovementResolver injects a MovementResolver used by Encounter.Move
+// to delegate per-step movement mechanics (MovementChain execution, OA
+// triggering) to a rulebook implementation. Wave 2.11e (#658).
+//
+// Optional — when not supplied, Encounter.Move uses the legacy single-
+// jump behavior that mutates position to path[-1] without per-step chain
+// execution. Non-combat encounters (free-roam, social) don't need a
+// resolver and don't pay the per-step iteration cost.
+func WithMovementResolver(r MovementResolver) Option {
+	return func(e *Encounter) {
+		e.movementResolver = r
 	}
 }
 
@@ -396,6 +411,14 @@ func (e *Encounter) nextSeq() uint64 {
 // player position, and publishes the cause event (MoveEvent) plus a
 // HexRevealedEvent for any viewer whose vision grew.
 //
+// Wave 2.11e: when a MovementResolver is wired (WithMovementResolver),
+// Move iterates per-step calling resolver.ResolveStep per hex with a
+// buffered subscriber on ReactionTriggerTopic active for the duration.
+// This is the seam that lets the rulebook run MovementChain per step (so
+// OA conditions fire) without the encounter SDK importing rulebook
+// packages. When no resolver is wired, the legacy single-jump behavior
+// is preserved for non-combat encounters.
+//
 // Slice scope: no action economy, no turn-order enforcement, no
 // path-contiguity validation beyond non-empty.
 func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
@@ -407,14 +430,100 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		return fmt.Errorf("player %q not in encounter", playerID)
 	}
 
-	// 1. Capture starting position and compute the mover's reveal delta BEFORE
-	//    mutating position/view.
+	moverStart := p.View.Position
+
+	// Determine the actually-traveled path. Without a resolver, the legacy
+	// single-jump path is the entire requested path. With a resolver, the
+	// per-step iteration may truncate when chain subscribers prevent a
+	// step (Disengage no-op, etc.).
+	traveledPath := path
+	if e.movementResolver != nil {
+		traveled, err := e.iterateMovementSteps(p, moverStart, path)
+		if err != nil {
+			return err
+		}
+		traveledPath = traveled
+		if len(traveledPath) == 0 {
+			// Movement was prevented at the very first step. Nothing to
+			// publish — position unchanged, no events fire.
+			return nil
+		}
+	}
+
+	return e.applyAndPublishMove(p, playerID, moverStart, traveledPath)
+}
+
+// iterateMovementSteps walks the path one hex at a time, calling the
+// resolver per step and draining the ReactionTriggerTopic buffer. Returns
+// the actually-traveled segment of the path (may be shorter than the
+// input if a step was Prevented).
+//
+// Wave 2.11e NPC-OA-only scope (per director signoff on #658): the SDK
+// drains triggers but does not partition or act on them. NPC OAs are
+// resolved inline by the resolver impl (combat.MoveEntity →
+// triggerOpportunityAttack → ResolveAttack runs end-to-end). Player-pause
+// branch deferred to #665.
+func (e *Encounter) iterateMovementSteps(
+	p *PlayerData, moverStart core.Hex, path []core.Hex,
+) ([]core.Hex, error) {
+	traveled := make([]core.Hex, 0, len(path))
+	from := moverStart
+	for _, to := range path {
+		// Install a buffered subscriber on ReactionTriggerTopic per step.
+		// The subscriber catches any triggers that chain subscribers
+		// publish during this step's resolver call. In NPC-OA-only scope
+		// the SDK doesn't act on captured triggers (the resolver impl
+		// resolves them inline), but the buffer is installed for shape
+		// parity with TakeActionPhased and to flush subscriptions
+		// cleanly per step.
+		_, drainCleanup, err := e.installTriggerBuffer()
+		if err != nil {
+			return traveled, fmt.Errorf("install trigger buffer: %w", err)
+		}
+
+		result, resolveErr := e.movementResolver.ResolveStep(MovementStepInput{
+			EntityID: p.EntityID,
+			FromHex:  from,
+			ToHex:    to,
+		})
+		drainCleanup()
+		if resolveErr != nil {
+			return traveled, fmt.Errorf("resolve movement step: %w", resolveErr)
+		}
+		if result == nil {
+			return traveled, fmt.Errorf("movement resolver: nil result with nil error")
+		}
+
+		if result.Prevented {
+			// Chain subscriber blocked the step. Stop here; do not advance
+			// to `to`. The traveled slice so far is the actually-moved path.
+			break
+		}
+
+		traveled = append(traveled, to)
+		from = to
+	}
+	return traveled, nil
+}
+
+// applyAndPublishMove mutates the player's position to the final hex of
+// traveledPath, computes per-viewer projections, and publishes the move +
+// reveal + visibility-transition events. Shared between the legacy
+// single-jump path (traveledPath = full input) and the resolver-mediated
+// per-step path (traveledPath = actually-moved segments, possibly
+// truncated by chain prevention).
+//
+// Wave 2.11e (#658 Q3): events carry the truncated traveled path, not the
+// requested path. Wire clients see the actual outcome, not the intent.
+func (e *Encounter) applyAndPublishMove(
+	p *PlayerData, playerID core.PlayerID, moverStart core.Hex, traveledPath []core.Hex,
+) error {
+	// 1. Compute the mover's reveal delta BEFORE mutating position/view.
 	//    - moverStart is needed for visibility-transition detection (so viewers
 	//      can determine if the mover was visible to them before the move).
 	//    - The reveal delta = (visible-from-new-position) MINUS (already-revealed).
 	//      Critical: if we apply the reveal first, the diff is always empty.
-	moverStart := p.View.Position
-	end := path[len(path)-1]
+	end := traveledPath[len(traveledPath)-1]
 	newVisible := perception.VisibleHexesAt(end, p.View.SightRange)
 	moverNewHexes := diffHexes(p.View.RevealedHexes, newVisible)
 
@@ -429,7 +538,7 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	// The mover always sees their own move; their reveal is the delta we
 	// just computed.
 	movePerPlayer[playerID] = events.MovePlayerSlice{
-		SeenSegments: append([]core.Hex(nil), path...),
+		SeenSegments: append([]core.Hex(nil), traveledPath...),
 	}
 	if len(moverNewHexes) > 0 {
 		revealPerPlayer[playerID] = events.HexRevealedSlice{Hexes: moverNewHexes}
@@ -450,7 +559,7 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		}
 		// ProjectMove returns the visible set so we can pass it directly to
 		// ProjectVisibilityTransition without recomputing VisibleHexesAt.
-		moveSlice, revealSlice, visible := perception.ProjectMove(p.EntityID, path, other.View)
+		moveSlice, revealSlice, visible := perception.ProjectMove(p.EntityID, traveledPath, other.View)
 		if moveSlice != nil {
 			movePerPlayer[otherID] = *moveSlice
 		}
@@ -467,7 +576,7 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 			seenSegments = moveSlice.SeenSegments
 		}
 		appearedAt, disappearedAt := perception.ProjectVisibilityTransition(
-			moverStart, path, seenSegments, other.View, visible,
+			moverStart, traveledPath, seenSegments, other.View, visible,
 		)
 		if appearedAt != nil {
 			if appearedByHex[*appearedAt] == nil {
@@ -483,7 +592,7 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	// 4. Publish — cause event always; effect event only when someone's
 	//    vision changed. The two events get sequential sequence numbers.
 	if err := e.broker.Publish(events.NewMoveEvent(
-		e.data.ID, e.nextSeq(), p.EntityID, path, movePerPlayer,
+		e.data.ID, e.nextSeq(), p.EntityID, traveledPath, movePerPlayer,
 	)); err != nil {
 		return fmt.Errorf("publish move: %w", err)
 	}

--- a/encounter/move_resolver.go
+++ b/encounter/move_resolver.go
@@ -50,8 +50,10 @@ type MovementResolver interface {
 	// triggers — they were already resolved.
 	//
 	// The resolver MUST NOT mutate encounter SDK state directly. The SDK
-	// updates Player.View.Position based on the step's ToHex when the
-	// result is not Prevented; the resolver only signals chain outcomes.
+	// accumulates a traveled path across successful step calls and applies
+	// the final position + publishes events once after the loop (see
+	// applyAndPublishMove). The resolver only signals chain outcomes per
+	// step; the SDK owns when state is committed.
 	ResolveStep(input MovementStepInput) (*MovementStepResult, error)
 }
 
@@ -72,9 +74,12 @@ type MovementStepInput struct {
 // MovementStepResult is the per-step output shape for MovementResolver.
 type MovementStepResult struct {
 	// Prevented is true when chain subscribers (Disengage, etc.) blocked
-	// the step. The encounter SDK stops the move at FromHex and does not
-	// advance to ToHex. The encounter publishes its MoveEvent with the
-	// truncated traveled-path (hexes up to and including FromHex).
+	// the step. The encounter SDK stops the move and does NOT advance to
+	// ToHex. The MoveEvent then carries the traveled segments — the ToHexes
+	// of all successfully-completed steps before this one (which equals
+	// the prevented step's FromHex for any non-first step). If prevention
+	// fires on the very first step, no MoveEvent is published and position
+	// is unchanged.
 	Prevented bool
 
 	// PreventReason is a human-readable explanation when Prevented is true.

--- a/encounter/move_resolver.go
+++ b/encounter/move_resolver.go
@@ -1,0 +1,91 @@
+package encounter
+
+// Wave 2.11e — MovementResolver SDK interface.
+//
+// MovementResolver bridges Encounter.Move to a rulebook implementation of
+// per-step movement mechanics (MovementChain execution, OA triggering).
+// Optional — when not supplied, Encounter.Move uses the legacy single-jump
+// behavior that mutates position to path[-1] without running any chain.
+//
+// Wave 2.11e ships NPC-OA-only scope per director signoff on #658 (Q1=b):
+// per-step iteration + trigger buffer drain. NPC OA triggers are resolved
+// inline by the resolver impl (rpg-api wraps combat.MoveEntity which calls
+// triggerOpportunityAttack → ResolveAttack end-to-end). Player-pause
+// branch (Sentinel-shape / spell reactions) deferred to #665.
+//
+// Pattern parallel: this is the second instance of the resolver-per-verb
+// pattern that PhasedCombatResolver established. ADR-0027 names it as the
+// canonical seam for any future SDK verbs that need rulebook-aware chain
+// execution.
+
+import (
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// MovementResolver bridges the encounter SDK to a rulebook implementation
+// of per-step movement mechanics. The orchestrator (rpg-api) implements
+// this interface against a specific rulebook (today: dnd5e wrapping
+// combat.MoveEntity); the encounter SDK never imports rulebook packages.
+//
+// Optional — when no resolver is wired, Encounter.Move falls back to the
+// legacy single-jump path that mutates position directly without per-step
+// chain execution. Non-combat encounters (free-roam, social) don't need a
+// resolver and don't pay the per-step iteration cost.
+type MovementResolver interface {
+	// ResolveStep runs the rulebook's MovementChain for a single step
+	// (FromHex → ToHex). Chain subscribers (Disengage marker, OA condition)
+	// may mutate prevention sources and publish ReactionTriggerEvents on
+	// the encounter bus.
+	//
+	// The encounter SDK installs a buffered subscriber on
+	// ReactionTriggerTopic before this call, so triggers published by chain
+	// subscribers are seen even if the resolver doesn't include them in
+	// MovementStepResult.Triggers. Returning Triggers explicitly is a
+	// defensive pattern (matches PhasedCombatResolver.ResolveAttackHit).
+	//
+	// NPC OAs are resolved inline by the resolver impl: combat.MoveEntity
+	// → triggerOpportunityAttack → ResolveAttack runs end-to-end, applying
+	// damage and publishing AttackResolved events on the bus before
+	// ResolveStep returns. The encounter SDK does not need to act on NPC
+	// triggers — they were already resolved.
+	//
+	// The resolver MUST NOT mutate encounter SDK state directly. The SDK
+	// updates Player.View.Position based on the step's ToHex when the
+	// result is not Prevented; the resolver only signals chain outcomes.
+	ResolveStep(input MovementStepInput) (*MovementStepResult, error)
+}
+
+// MovementStepInput is the per-step input shape for MovementResolver.
+type MovementStepInput struct {
+	// EntityID is the moving entity (player or monster). The encounter SDK
+	// passes the player's EntityID (not PlayerID) so the resolver can look
+	// up rulebook state by the same key the rest of the bus uses.
+	EntityID encountercore.EntityID
+
+	// FromHex is the entity's position before this step.
+	FromHex encountercore.Hex
+
+	// ToHex is the entity's destination after this step.
+	ToHex encountercore.Hex
+}
+
+// MovementStepResult is the per-step output shape for MovementResolver.
+type MovementStepResult struct {
+	// Prevented is true when chain subscribers (Disengage, etc.) blocked
+	// the step. The encounter SDK stops the move at FromHex and does not
+	// advance to ToHex. The encounter publishes its MoveEvent with the
+	// truncated traveled-path (hexes up to and including FromHex).
+	Prevented bool
+
+	// PreventReason is a human-readable explanation when Prevented is true.
+	// Optional; the SDK does not interpret it.
+	PreventReason string
+
+	// Triggers are reaction triggers the resolver explicitly captured
+	// during the step (in addition to whatever the SDK's buffered
+	// subscriber catches on the bus). Defensive pattern — lets the
+	// resolver surface triggers even if the bus subscription has issues.
+	// The SDK partitions but does not act on triggers in Wave 2.11e
+	// (NPC-OA only).
+	Triggers []ReactionTrigger
+}

--- a/encounter/move_resolver.go
+++ b/encounter/move_resolver.go
@@ -39,9 +39,9 @@ type MovementResolver interface {
 	//
 	// The encounter SDK installs a buffered subscriber on
 	// ReactionTriggerTopic before this call, so triggers published by chain
-	// subscribers are seen even if the resolver doesn't include them in
-	// MovementStepResult.Triggers. Returning Triggers explicitly is a
-	// defensive pattern (matches PhasedCombatResolver.ResolveAttackHit).
+	// subscribers are observed via the bus. Triggers flow via the buffered
+	// bus subscription only — the resolver does not return them in the
+	// step result. The bus path is canonical for OA/reaction handoff.
 	//
 	// NPC OAs are resolved inline by the resolver impl: combat.MoveEntity
 	// → triggerOpportunityAttack → ResolveAttack runs end-to-end, applying
@@ -72,6 +72,16 @@ type MovementStepInput struct {
 }
 
 // MovementStepResult is the per-step output shape for MovementResolver.
+//
+// Triggers flow via the buffered bus subscription only — the SDK installs
+// a buffered subscriber on ReactionTriggerTopic per step and drains it
+// after ResolveStep returns. Chain subscribers (Disengage marker, OA
+// condition) publish ReactionTriggerEvents on the encounter bus; the SDK
+// observes them through the buffer. There is intentionally no
+// resolver-returned trigger slot: a second channel would invite
+// implementers to silently drop bus triggers, and the bus path is
+// canonical for OA/reaction handoff (see PhasedCombatResolver for the
+// same shape applied to attack reactions).
 type MovementStepResult struct {
 	// Prevented is true when chain subscribers (Disengage, etc.) blocked
 	// the step. The encounter SDK stops the move and does NOT advance to
@@ -85,12 +95,4 @@ type MovementStepResult struct {
 	// PreventReason is a human-readable explanation when Prevented is true.
 	// Optional; the SDK does not interpret it.
 	PreventReason string
-
-	// Triggers are reaction triggers the resolver explicitly captured
-	// during the step (in addition to whatever the SDK's buffered
-	// subscriber catches on the bus). Defensive pattern — lets the
-	// resolver surface triggers even if the bus subscription has issues.
-	// The SDK partitions but does not act on triggers in Wave 2.11e
-	// (NPC-OA only).
-	Triggers []ReactionTrigger
 }

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -269,10 +269,11 @@ func (s *MovementResolverSuite) TestMove_ResolverPublishesEvents_TruncatedPath()
 	err = s.enc.Move(alicePlayerID, path)
 	s.Require().NoError(err)
 
-	// Drain the alice subscription with a small timeout (broker forwards
-	// events via a goroutine; default-select would race with forwarding).
+	// Drain the alice subscription with a generous timeout (broker forwards
+	// events via a goroutine; default-select would race with forwarding,
+	// and a tight deadline can flake under CI load).
 	var moveEvt *events.MoveEvent
-	deadline := time.After(200 * time.Millisecond)
+	deadline := time.After(2 * time.Second)
 drainLoop:
 	for {
 		select {

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -44,12 +44,10 @@ type stubMovementResolver struct {
 
 	// publishOnStep, when set, is invoked at each ResolveStep call with the
 	// bus + step index so tests can simulate OA condition triggers firing
-	// during the step.
+	// during the step. Triggers flow exclusively through the bus
+	// subscription per director review on PR #667 — there is no
+	// resolver-returned trigger slot to stub.
 	publishOnStep func(bus dnd5events.EventBus, stepIdx int)
-
-	// returnTriggersByStep returns explicit Triggers from a specific step's
-	// MovementStepResult (in addition to bus-buffered ones).
-	returnTriggersByStep map[int][]tkenc.ReactionTrigger
 
 	// bus is captured from the first call so we can publish into it.
 	bus dnd5events.EventBus
@@ -70,9 +68,6 @@ func (s *stubMovementResolver) ResolveStep(input tkenc.MovementStepInput) (*tken
 	if s.preventAtCall != nil && stepIdx == *s.preventAtCall {
 		result.Prevented = true
 		result.PreventReason = s.preventReason
-	}
-	if triggers, ok := s.returnTriggersByStep[stepIdx]; ok {
-		result.Triggers = triggers
 	}
 	return result, nil
 }

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -1,0 +1,301 @@
+package encounter_test
+
+// Wave 2.11e — MovementResolver tests.
+//
+// The MovementResolver is the encounter SDK's seam for delegating per-step
+// movement mechanics (MovementChain execution, OA triggering) to a rulebook
+// implementation. Without a resolver, Encounter.Move uses the legacy
+// single-jump behavior (mutate position to path[-1], no chain). With a
+// resolver, Move iterates per-step, calling resolver.ResolveStep per hex
+// and draining ReactionTriggerEvents from the encounter bus.
+//
+// Wave 2.11e scope: NPC-OA-only (Q1=(b) per director signoff on #658).
+// Player-pause branch deferred to #665.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// stubMovementResolver implements MovementResolver and records ResolveStep
+// calls. It can optionally publish a ReactionTriggerEvent on the encounter
+// bus during ResolveStep (simulating an OA condition's onMovementChain
+// subscriber). The resolver can also be configured to mark Prevented on a
+// specific step index to simulate Disengage-prevention or a similar block.
+type stubMovementResolver struct {
+	calls []tkenc.MovementStepInput
+
+	// preventAtCall, when non-nil, sets Prevented=true on the call at the
+	// given 0-based step index. The SDK should stop the move at that step's
+	// FromHex (not advance to ToHex).
+	preventAtCall *int
+
+	// preventReason is the human-readable reason set when Prevented fires.
+	preventReason string
+
+	// publishOnStep, when set, is invoked at each ResolveStep call with the
+	// bus + step index so tests can simulate OA condition triggers firing
+	// during the step.
+	publishOnStep func(bus dnd5events.EventBus, stepIdx int)
+
+	// returnTriggersByStep returns explicit Triggers from a specific step's
+	// MovementStepResult (in addition to bus-buffered ones).
+	returnTriggersByStep map[int][]tkenc.ReactionTrigger
+
+	// bus is captured from the first call so we can publish into it.
+	bus dnd5events.EventBus
+}
+
+func (s *stubMovementResolver) ResolveStep(input tkenc.MovementStepInput) (*tkenc.MovementStepResult, error) {
+	stepIdx := len(s.calls)
+	s.calls = append(s.calls, input)
+
+	// Stub captures the bus from the encounter's WithMovementResolver wiring
+	// path. Real resolvers know their own bus; the stub uses whatever is
+	// stashed by SetupTest.
+	if s.publishOnStep != nil && s.bus != nil {
+		s.publishOnStep(s.bus, stepIdx)
+	}
+
+	result := &tkenc.MovementStepResult{}
+	if s.preventAtCall != nil && stepIdx == *s.preventAtCall {
+		result.Prevented = true
+		result.PreventReason = s.preventReason
+	}
+	if triggers, ok := s.returnTriggersByStep[stepIdx]; ok {
+		result.Triggers = triggers
+	}
+	return result, nil
+}
+
+type MovementResolverSuite struct {
+	suite.Suite
+	transport *tkenc.InMemoryTransport
+	broker    *tkenc.Broker
+	enc       *tkenc.Encounter
+	resolver  *stubMovementResolver
+}
+
+func TestMovementResolverSuite(t *testing.T) {
+	suite.Run(t, new(MovementResolverSuite))
+}
+
+// SetupTestNoResolver builds an encounter without a MovementResolver wired.
+// Used by the legacy-fallback regression test below.
+func (s *MovementResolverSuite) setupNoResolver() {
+	s.transport = tkenc.NewInMemoryTransport()
+	s.broker = tkenc.NewBroker(s.transport)
+	s.enc = tkenc.New("enc-moveres", s.broker)
+	s.Require().NoError(s.enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: encountercore.Hex{}, SightRange: 10,
+	}))
+}
+
+// SetupTest is the default; wires a stubMovementResolver and seeds alice +
+// bob. Most tests use this shape; the no-resolver test calls
+// setupNoResolver() explicitly.
+func (s *MovementResolverSuite) SetupTest() {
+	s.transport = tkenc.NewInMemoryTransport()
+	s.broker = tkenc.NewBroker(s.transport)
+	s.resolver = &stubMovementResolver{}
+	s.enc = tkenc.New("enc-moveres", s.broker,
+		tkenc.WithMovementResolver(s.resolver))
+
+	// Stash the bus on the resolver so publishOnStep can inject triggers.
+	// The Encounter's bus is exposed via EventBus() (Wave 2.11d).
+	s.resolver.bus = s.enc.EventBus()
+
+	s.Require().NoError(s.enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: encountercore.Hex{}, SightRange: 10,
+	}))
+	s.Require().NoError(s.enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: encountercore.Hex{Q: 5, R: 0, S: -5}, SightRange: 10,
+	}))
+}
+
+// TestMove_NoResolver_LegacyBehavior verifies the regression-guard shape
+// from active.md B8: when no MovementResolver is wired, Encounter.Move
+// mutates position directly without per-step iteration and does not call
+// any per-step rulebook machinery. This is the existing single-jump
+// behavior for non-combat encounters.
+func (s *MovementResolverSuite) TestMove_NoResolver_LegacyBehavior() {
+	s.setupNoResolver()
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+		{Q: 3, R: 0, S: -3},
+	}
+	err := s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err)
+
+	// Alice landed at the final hex (single-jump).
+	aliceData := s.enc.ToData().Players[alicePlayerID]
+	s.Require().NotNil(aliceData)
+	s.Equal(encountercore.Hex{Q: 3, R: 0, S: -3}, aliceData.View.Position,
+		"no-resolver path should jump straight to path[-1]")
+}
+
+// TestMove_ResolverNoTriggers_FullPath verifies that with a resolver wired
+// and no triggers/prevention, Move iterates per-step (one ResolveStep call
+// per path hex) and alice lands at the final hex with the full path
+// recorded.
+func (s *MovementResolverSuite) TestMove_ResolverNoTriggers_FullPath() {
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+		{Q: 3, R: 0, S: -3},
+	}
+	err := s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err)
+
+	// One ResolveStep call per hex in the path.
+	s.Require().Len(s.resolver.calls, 3, "expected one ResolveStep per path hex")
+
+	// Each call records the correct From → To for the step.
+	s.Equal(encountercore.Hex{}, s.resolver.calls[0].FromHex)
+	s.Equal(encountercore.Hex{Q: 1, R: 0, S: -1}, s.resolver.calls[0].ToHex)
+	s.Equal(encountercore.Hex{Q: 1, R: 0, S: -1}, s.resolver.calls[1].FromHex)
+	s.Equal(encountercore.Hex{Q: 2, R: 0, S: -2}, s.resolver.calls[1].ToHex)
+	s.Equal(encountercore.Hex{Q: 2, R: 0, S: -2}, s.resolver.calls[2].FromHex)
+	s.Equal(encountercore.Hex{Q: 3, R: 0, S: -3}, s.resolver.calls[2].ToHex)
+
+	// Alice's EntityID is correctly threaded through.
+	s.Equal(encountercore.EntityID(aliceEntityID), s.resolver.calls[0].EntityID)
+
+	// Alice landed at the final hex.
+	aliceData := s.enc.ToData().Players[alicePlayerID]
+	s.Equal(encountercore.Hex{Q: 3, R: 0, S: -3}, aliceData.View.Position)
+}
+
+// TestMove_ResolverPrevented_TruncatesPath verifies that when the resolver
+// signals Prevented mid-path, Move stops at the previous hex and does not
+// advance further. The truncated traveled path is reflected in the
+// encounter's published events.
+func (s *MovementResolverSuite) TestMove_ResolverPrevented_TruncatesPath() {
+	preventAt := 1 // prevent on step 2 (0-indexed = 1)
+	s.resolver.preventAtCall = &preventAt
+	s.resolver.preventReason = "stub prevention for test"
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+		{Q: 3, R: 0, S: -3},
+	}
+	err := s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err, "Prevented is not an error; movement just stops")
+
+	// ResolveStep called twice: once succeeded, once prevented. No third call.
+	s.Require().Len(s.resolver.calls, 2,
+		"resolver should be called for step 1 (succeeded) and step 2 (prevented), not step 3")
+
+	// Alice stopped at hex (1,0,-1) — the position before the prevented step.
+	aliceData := s.enc.ToData().Players[alicePlayerID]
+	s.Equal(encountercore.Hex{Q: 1, R: 0, S: -1}, aliceData.View.Position,
+		"position should stop at the last successfully-traveled hex")
+}
+
+// TestMove_ResolverPublishesTrigger_BufferDrainedCleanly verifies that when
+// the resolver publishes a ReactionTriggerEvent on the encounter bus during
+// ResolveStep (simulating an OA condition firing), the SDK's trigger buffer
+// catches it without erroring. In NPC-OA-only scope the SDK does not act on
+// the trigger (the resolver impl resolves NPC OAs inline), but it MUST drain
+// the buffer cleanly to avoid leaked subscriptions across steps.
+//
+// Regression guard from active.md B8: the probe test asserted triggerCount
+// == 0 when no resolver was supplied. With a resolver, the SDK should
+// install the buffer subscription, see the trigger, and drop it (NPC-OA
+// scope) — without leaking subscriptions.
+func (s *MovementResolverSuite) TestMove_ResolverPublishesTrigger_BufferDrainedCleanly() {
+	// Stub publishes a ReactionTriggerEvent on the bus during step 1.
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			topic := dnd5eEvents.ReactionTriggerTopic.On(bus)
+			_ = topic.Publish(context.Background(), dnd5eEvents.ReactionTriggerEvent{
+				ReactorID:    gobEntityID, // NPC reactor (not in players map)
+				ConditionRef: "dnd5e:conditions:opportunity_attack",
+				TriggerKind:  dnd5eEvents.TriggerKindMovementOA,
+				SourceEntity: aliceEntityID,
+			})
+		}
+	}
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+	}
+	err := s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err, "NPC triggers in buffer should NOT cause Move to error")
+
+	// All steps still ran (NPC trigger doesn't pause movement in 2.11e scope).
+	s.Require().Len(s.resolver.calls, 2)
+
+	// Alice reached the final hex.
+	aliceData := s.enc.ToData().Players[alicePlayerID]
+	s.Equal(encountercore.Hex{Q: 2, R: 0, S: -2}, aliceData.View.Position)
+}
+
+// TestMove_ResolverPublishesEvents_TruncatedPath verifies that when
+// movement is truncated (Prevented mid-path), the encounter SDK publishes
+// the MoveEvent with the actually-traveled hexes only, not the full
+// requested path. This keeps the wire payload truthful per Q3 signoff.
+func (s *MovementResolverSuite) TestMove_ResolverPublishesEvents_TruncatedPath() {
+	// Subscribe alice to her own viewer stream so we can observe the move
+	// event for her.
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	preventAt := 2 // prevent on step 3 (0-indexed = 2)
+	s.resolver.preventAtCall = &preventAt
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+		{Q: 3, R: 0, S: -3},
+	}
+	err = s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err)
+
+	// Drain the alice subscription with a small timeout (broker forwards
+	// events via a goroutine; default-select would race with forwarding).
+	var moveEvt *events.MoveEvent
+	deadline := time.After(200 * time.Millisecond)
+drainLoop:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoop
+			}
+			if me, isMove := evt.(*events.MoveEvent); isMove {
+				moveEvt = me
+			}
+		case <-deadline:
+			break drainLoop
+		}
+	}
+	s.Require().NotNil(moveEvt, "MoveEvent should have been published")
+
+	// The MoveEvent should carry only the traveled segments (hexes 1 + 2),
+	// not the full requested path of 3 hexes.
+	moverSlice, ok := moveEvt.PerPlayer[alicePlayerID]
+	s.Require().True(ok, "alice should see her own move")
+	s.Equal([]encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+	}, moverSlice.SeenSegments,
+		"MoveEvent should carry only the actually-traveled segments")
+}


### PR DESCRIPTION
## Summary

- New `MovementResolver` interface in `encounter/move_resolver.go` — second instance of the resolver-per-verb pattern. Lets the encounter SDK delegate per-step movement mechanics to a rulebook implementation without importing rulebook packages.
- `Encounter.Move` refactored: legacy single-jump preserved when no resolver wired; per-step iteration when a resolver is supplied. Extracted `applyAndPublishMove` helper shared by both paths.
- `applyAndPublishMove` publishes events with `traveledPath` (truncated when chain prevention fires mid-path) — truthful wire payload per Q3 signoff.
- ADR-0027 amendment + encounter component doc updated in-PR per `feedback_toolkit_docs_close_the_loop`.

**Scope** (per director signoff on #658, Q1=(b)): NPC-OA-only. Player-pause branch (Sentinel-shape / spell reactions) deferred to issue #665. The trigger buffer is installed for shape parity with TakeActionPhased and to flush subscriptions cleanly; in this scope the SDK doesn't partition or act on captured triggers (NPC OAs resolved inline by the resolver impl during the same `ResolveStep` call).

## Test plan

5 cases on `MovementResolverSuite` (encounter/move_resolver_test.go):

- [x] `TestMove_NoResolver_LegacyBehavior` — regression guard from active.md B8 probe: movement without a resolver does NOT trigger OAs; single-jump preserved
- [x] `TestMove_ResolverNoTriggers_FullPath` — per-step iteration calls `ResolveStep` once per hex; alice lands at `path[-1]`
- [x] `TestMove_ResolverPrevented_TruncatesPath` — `Prevented=true` on step 2 stops movement; alice stops at the previous hex
- [x] `TestMove_ResolverPublishesTrigger_BufferDrainedCleanly` — bus trigger published during step; no error, all steps still iterate
- [x] `TestMove_ResolverPublishesEvents_TruncatedPath` — `MoveEvent.SeenSegments` carries only actually-traveled hexes, not requested
- [x] Full `encounter/...` test suite passes (17s)
- [x] `golangci-lint run ./...` reports 0 issues in files touched by this PR
- [ ] Wired through in companion PR rpg-api#539 — pending this PR merging + autotag (`encounter/v0.11.0`)

## Wave 2.11e sequencing

1. ~~rpg-toolkit#664~~ (merged) — polymorphic CompleteTakeAction (Shield resume direction shipped + waiting for future spells project)
2. **rpg-toolkit#658 (this PR)** — MovementResolver SDK
3. **rpg-toolkit#666** (next) — Disengage action + OA predicate suppression (monk Step of the Wind goal-shape)
4. **rpg-api#539** — wire MovementResolver in rpg-api, add monk-Disengage integration test + MCP playtest

Wave tracker: rpg-project#50.

## Pre-existing pre-commit issues NOT addressed here

Same root cause as #664 (half-migrated `.golangci.yml` v2 schema):

- 36 goconst hits in untouched encounter test files (`integration_test.go`, `prompts_test.go`, `reaction_readiness_test.go`, `visibility_transition_test.go`) — none from files touched by this PR
- Makefile coverage parser bug — `cd core && coverage=$(go test ... ; go tool cover ...)` mixes stdout streams; feeds garbage to `bc`
- Core coverage threshold tripped by zero-test subpackages (core/chain, core/combat, core/damage, core/effect, core/features, core/resources, core/spells)

Same accepted state as the #664 merge. Proper fix is a separate `.golangci.yml` v2-schema migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)