### PR TITLE
feat(encounter): MovementResolver for NPC-initiated movement (Wave 2.11e, #668)

### DIFF
--- a/docs/adr/0027-attack-resolution-and-reactions.md
+++ b/docs/adr/0027-attack-resolution-and-reactions.md
@@ -104,10 +104,12 @@ actually uses:
     Player→player and monster→monster attacks return
     `ErrUnsupportedAttackDirection` until a wave adds the corresponding
     publish helper; the SDK surface stays the same.
-  - **MovementResolver (Wave 2.11e, 2026-05-24).** Second instance of
-    the resolver-per-verb pattern. `Encounter.Move` delegates per-step
-    movement mechanics (MovementChain execution, OA triggering) to a
-    rulebook implementation via `MovementResolver.ResolveStep`. When a
+  - **MovementResolver (Wave 2.11e, 2026-05-24, both directions).**
+    Second instance of the resolver-per-verb pattern. `Encounter.Move`
+    (player-direction, #667) AND `Encounter.applyNPCMovement` (NPC-
+    direction, #668) both delegate per-step movement mechanics
+    (MovementChain execution, OA triggering) to a rulebook
+    implementation via `MovementResolver.ResolveStep`. When a
     resolver is wired, `Move` iterates per-step with a buffered
     subscriber on `ReactionTriggerTopic` installed per step; chain
     subscribers (`OpportunityAttackCondition.onMovementChain`, Disengage
@@ -117,9 +119,11 @@ actually uses:
     (non-combat encounters). Truncated-traveled-path events: when chain
     prevention blocks a step, the published `MoveEvent` carries only
     the actually-traveled segments — wire clients see the truthful
-    outcome, not the intent. NPC-OA-only scope; player-pause branch
-    (Sentinel-shape / spell reactions like Shield-during-movement)
-    deferred to issue
+    outcome, not the intent. Both directions share the
+    `iterateMovementStepsForEntity` helper; the SDK is direction-
+    agnostic (no `EntityType` field on `MovementStepInput`). NPC-OA-only
+    scope; player-pause branch (Sentinel-shape / spell reactions like
+    Shield-during-movement) deferred to issue
     [#665](https://github.com/KirkDiggler/rpg-toolkit/issues/665).
 
   **The resolver-per-verb pattern is now the canonical seam for any

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter module
-description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, discrete-phase combat orchestration, MovementResolver seam
+description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, discrete-phase combat orchestration, MovementResolver seam (both movement directions)
 updated: 2026-05-24
-confidence: high — Wave 2.11d shipped the discrete-phase combat surface; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement (NPC-OA scope; player-pause deferred to #665)
+confidence: high — Wave 2.11d shipped discrete-phase combat; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement in BOTH directions (player-Move and NPC applyNPCMovement; NPC-OA scope; player-pause deferred to #665)
 ---
 
 # encounter module
@@ -142,16 +142,22 @@ Triggers flow via the buffered bus subscription only — there is intentionally 
 
 The orchestrator (rpg-api) wires a resolver via `WithMovementResolver(...)`. The orchestrator's implementation wraps the rulebook's `combat.MoveEntity` so chain subscribers (Disengage marker, OpportunityAttackCondition) fire per step and OAs resolve inline via the rulebook's `triggerOpportunityAttack` → `combat.ResolveAttack` path.
 
-### Per-step iteration vs legacy single-jump
+### Per-step iteration vs legacy single-jump (both movement directions)
 
-`Encounter.Move` has two paths gated on resolver presence:
+`Encounter.Move` (player direction) and `Encounter.applyNPCMovement` (NPC direction, called from `NPCAct` with `monster.TakeTurn`'s movement output) both branch on resolver presence using the same shared `iterateMovementStepsForEntity` helper:
 
-| Resolver wired? | Path | Encounter SDK position update | Chain executes | OA fires |
-|---|---|---|---|---|
-| No | Legacy single-jump | once, to `path[-1]` | never | never |
-| Yes | Per-step iteration | once, to the final hex of the traveled path (after loop completes) | per step via resolver | inline (NPC-OA scope) |
+| Mover | Caller | Resolver wired? | Path | SDK position update | Chain executes | OA fires |
+|---|---|---|---|---|---|---|
+| Player | `Encounter.Move` | No | Legacy single-jump | once, to `path[-1]` | never | never |
+| Player | `Encounter.Move` | Yes | Per-step iteration | once, to the final hex of the traveled path | per step via resolver | inline (NPC reactor) |
+| NPC | `Encounter.applyNPCMovement` | No | Legacy single-jump | once, to `path[-1]` | never | never |
+| NPC | `Encounter.applyNPCMovement` | Yes | Per-step iteration | once, to the final hex of the traveled path | per step via resolver | inline (player reactor) |
 
-The per-step path accumulates `traveled` as it iterates; the SDK only mutates `Player.View.Position` once, after the loop, via `applyAndPublishMove`. Step-by-step position mutation happens externally in the resolver impl (combat.MoveEntity calls `room.MoveEntity` per step on the spatial-room side), but the encounter SDK keeps its own position state in sync by committing once at the end.
+Wave 2.11e #667 shipped the player-direction iteration; Wave 2.11e #668 shipped the NPC-direction mirror. Same `MovementStepInput`/`MovementStepResult` types in both directions; the SDK is direction-agnostic per #658 Q4 signoff (no `EntityType` field on the input — the resolver impl differentiates from its own lookup).
+
+The per-step path accumulates `traveled` as it iterates; the SDK only mutates position (Player.View.Position or MonsterData.Position) once, after the loop. Step-by-step position mutation in the spatial room happens externally in the resolver impl (combat.MoveEntity calls `room.MoveEntity` per step), but the encounter SDK keeps its own position state in sync by committing once at the end.
+
+For tests that need to drive NPC movement with a deterministic path (rather than depending on `monster.TakeTurn`'s AI output), `Encounter.MoveNPCSteps(npcID, path)` is the public seam that calls into the same iteration mechanics.
 
 When no resolver is wired, the legacy single-jump behavior is preserved for non-combat encounters (free-roam, social). The shape was load-bearing for Wave 2.11d's verification gate: the active.md B8 probe asserted that movement without a resolver does NOT trigger OAs. The new per-step path activates only when a resolver is explicitly supplied.
 

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -454,18 +454,38 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	return e.applyAndPublishMove(p, playerID, moverStart, traveledPath)
 }
 
-// iterateMovementSteps walks the path one hex at a time, calling the
-// resolver per step and draining the ReactionTriggerTopic buffer. Returns
-// the actually-traveled segment of the path (may be shorter than the
-// input if a step was Prevented).
+// iterateMovementSteps walks the path one hex at a time for the given
+// PlayerData mover, calling the resolver per step and draining the
+// ReactionTriggerTopic buffer. Returns the actually-traveled segment of
+// the path (may be shorter than the input if a step was Prevented).
 //
 // Wave 2.11e NPC-OA-only scope (per director signoff on #658): the SDK
 // drains triggers but does not partition or act on them. NPC OAs are
 // resolved inline by the resolver impl (combat.MoveEntity →
 // triggerOpportunityAttack → ResolveAttack runs end-to-end). Player-pause
 // branch deferred to #665.
+//
+// Thin player-mover wrapper around iterateMovementStepsForEntity — kept so
+// the player-direction call site (Encounter.Move) reads as before, while
+// the NPC-direction (applyNPCMovement via #668) reuses the shared
+// entity-agnostic walker.
 func (e *Encounter) iterateMovementSteps(
 	p *PlayerData, moverStart core.Hex, path []core.Hex,
+) ([]core.Hex, error) {
+	return e.iterateMovementStepsForEntity(p.EntityID, moverStart, path)
+}
+
+// iterateMovementStepsForEntity is the entity-agnostic per-step walker
+// added in Wave 2.11e (#668). Same shape as iterateMovementSteps but
+// takes the mover's EntityID directly so the NPC-direction caller
+// (applyNPCMovement) can reuse the iteration mechanics without a
+// PlayerData wrapper.
+//
+// Per #658 Q4 signoff: MovementStepInput carries no EntityType field —
+// the SDK is direction-agnostic. The resolver impl differentiates by
+// looking the entity up itself.
+func (e *Encounter) iterateMovementStepsForEntity(
+	moverID core.EntityID, moverStart core.Hex, path []core.Hex,
 ) ([]core.Hex, error) {
 	traveled := make([]core.Hex, 0, len(path))
 	from := moverStart
@@ -489,7 +509,7 @@ func (e *Encounter) iterateMovementSteps(
 			defer drainCleanup()
 
 			return e.movementResolver.ResolveStep(MovementStepInput{
-				EntityID: p.EntityID,
+				EntityID: moverID,
 				FromHex:  from,
 				ToHex:    to,
 			})

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -295,3 +295,162 @@ drainLoop:
 	}, moverSlice.SeenSegments,
 		"MoveEvent should carry only the actually-traveled segments")
 }
+
+// --- Wave 2.11e (#668) — NPC-movement direction tests ---
+//
+// The wave-goal-refined sentence (#50) names BOTH movement directions:
+// player→enemy AND enemy→player. PR #667 shipped the player direction
+// via Encounter.Move; this slice ships the mirror through
+// Encounter.applyNPCMovement (the path NPCAct uses for monster.TakeTurn's
+// movement output). Same MovementResolver seam; same per-step iteration;
+// same buffered trigger drain.
+//
+// Tests below drive NPC movement via Encounter.MoveNPCSteps — a small
+// public seam that bypasses the full NPCAct → monster.TakeTurn flow so we
+// can pin the movement path exactly (rather than depending on the
+// monster's AI targeting). The same internal iteration code runs either
+// way; the seam just gives tests deterministic input.
+
+// addGoblinForNPCMovementTests adds a goblin combatant to the encounter
+// so NPC-movement tests have a real MonsterData to push through the
+// resolver-mediated iteration.
+func (s *MovementResolverSuite) addGoblinForNPCMovementTests() {
+	s.Require().NoError(s.enc.AddMonster(tkenc.MonsterInput{
+		ID:       gobEntityID,
+		Position: encountercore.Hex{Q: 10, R: 0, S: -10},
+		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4,
+		DamageDice:  damage1d6plus1,
+		DamageType:  damageSlashing,
+	}))
+}
+
+// TestNPCMove_NoResolver_LegacyBehavior verifies the regression-guard B8
+// MIRROR shape (#668 issue body): without a MovementResolver wired,
+// applyNPCMovement single-jumps the goblin to the final hex without per-
+// step iteration and does not invoke any chain machinery.
+func (s *MovementResolverSuite) TestNPCMove_NoResolver_LegacyBehavior() {
+	// Setup without resolver — rebuild the encounter wiring-free.
+	s.transport = tkenc.NewInMemoryTransport()
+	s.broker = tkenc.NewBroker(s.transport)
+	s.enc = tkenc.New("enc-moveres-npc", s.broker)
+	s.Require().NoError(s.enc.AddPlayer(tkenc.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: encountercore.Hex{}, SightRange: 10,
+	}))
+	s.addGoblinForNPCMovementTests()
+
+	path := []encountercore.Hex{
+		{Q: 9, R: 0, S: -9},
+		{Q: 8, R: 0, S: -8},
+		{Q: 7, R: 0, S: -7},
+	}
+	err := s.enc.MoveNPCSteps(gobEntityID, path)
+	s.Require().NoError(err)
+
+	// Goblin landed at the final hex (single-jump).
+	mon := s.enc.ToData().Monsters[gobEntityID]
+	s.Require().NotNil(mon)
+	s.Equal(encountercore.Hex{Q: 7, R: 0, S: -7}, mon.Position,
+		"no-resolver NPC path should jump straight to path[-1]")
+}
+
+// TestNPCMove_ResolverNoTriggers_FullPath verifies per-step iteration
+// when a resolver is wired: one ResolveStep call per hex; goblin lands
+// at the final hex.
+func (s *MovementResolverSuite) TestNPCMove_ResolverNoTriggers_FullPath() {
+	s.addGoblinForNPCMovementTests()
+	startHex := encountercore.Hex{Q: 10, R: 0, S: -10}
+
+	path := []encountercore.Hex{
+		{Q: 9, R: 0, S: -9},
+		{Q: 8, R: 0, S: -8},
+		{Q: 7, R: 0, S: -7},
+	}
+	err := s.enc.MoveNPCSteps(gobEntityID, path)
+	s.Require().NoError(err)
+
+	// One ResolveStep call per hex.
+	s.Require().Len(s.resolver.calls, 3,
+		"expected one ResolveStep per NPC path hex")
+
+	// First step from goblin's start hex.
+	s.Equal(startHex, s.resolver.calls[0].FromHex)
+	s.Equal(path[0], s.resolver.calls[0].ToHex)
+	s.Equal(encountercore.EntityID(gobEntityID), s.resolver.calls[0].EntityID,
+		"resolver call must carry the NPC's entity ID as mover")
+
+	// Goblin landed at the final hex.
+	mon := s.enc.ToData().Monsters[gobEntityID]
+	s.Equal(path[2], mon.Position)
+}
+
+// TestNPCMove_ResolverPrevented_TruncatesPath verifies that when the
+// resolver signals Prevented mid-path, the NPC stops at the previous hex
+// and does not advance further (mirror of the player-direction truncation
+// test).
+func (s *MovementResolverSuite) TestNPCMove_ResolverPrevented_TruncatesPath() {
+	s.addGoblinForNPCMovementTests()
+
+	preventAt := 1 // prevent on step 2 (0-indexed = 1)
+	s.resolver.preventAtCall = &preventAt
+	s.resolver.preventReason = "stub prevention for npc test"
+
+	path := []encountercore.Hex{
+		{Q: 9, R: 0, S: -9},
+		{Q: 8, R: 0, S: -8},
+		{Q: 7, R: 0, S: -7},
+	}
+	err := s.enc.MoveNPCSteps(gobEntityID, path)
+	s.Require().NoError(err, "Prevented is not an error; movement just stops")
+
+	// Two calls — step 1 succeeded, step 2 returned Prevented; step 3 skipped.
+	s.Require().Len(s.resolver.calls, 2,
+		"resolver should be called for step 1 (succeeded) and step 2 (prevented), not step 3")
+
+	// Goblin stopped at step 1's destination — did not advance to step 2.
+	mon := s.enc.ToData().Monsters[gobEntityID]
+	s.Equal(encountercore.Hex{Q: 9, R: 0, S: -9}, mon.Position,
+		"NPC position should stop at the last successfully-traveled hex")
+}
+
+// TestNPCMove_ResolverPublishesTrigger_BufferDrainedCleanly mirrors the
+// player-direction buffer-drain regression guard. When the resolver
+// publishes a ReactionTriggerEvent on the encounter bus during ResolveStep
+// (simulating a player's OA condition firing against the moving NPC),
+// the SDK's trigger buffer catches it without erroring. In NPC-OA-only
+// scope the SDK does not act on the trigger (the resolver impl resolves
+// player OAs inline against the NPC), but the buffer MUST drain cleanly
+// to avoid leaked subscriptions across steps.
+func (s *MovementResolverSuite) TestNPCMove_ResolverPublishesTrigger_BufferDrainedCleanly() {
+	s.addGoblinForNPCMovementTests()
+
+	// Stub publishes a ReactionTriggerEvent during step 1 — simulates
+	// alice's OA condition firing because the goblin is leaving her reach.
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			topic := dnd5eEvents.ReactionTriggerTopic.On(bus)
+			_ = topic.Publish(context.Background(), dnd5eEvents.ReactionTriggerEvent{
+				ReactorID:    aliceEntityID, // player reactor (in players map)
+				ConditionRef: "dnd5e:conditions:opportunity_attack",
+				TriggerKind:  dnd5eEvents.TriggerKindMovementOA,
+				SourceEntity: gobEntityID,
+			})
+		}
+	}
+
+	path := []encountercore.Hex{
+		{Q: 9, R: 0, S: -9},
+		{Q: 8, R: 0, S: -8},
+	}
+	err := s.enc.MoveNPCSteps(gobEntityID, path)
+	s.Require().NoError(err,
+		"player-reactor triggers in buffer should NOT cause NPC Move to error in NPC-OA-only scope")
+
+	// All steps still ran.
+	s.Require().Len(s.resolver.calls, 2)
+
+	// Goblin reached the final hex.
+	mon := s.enc.ToData().Monsters[gobEntityID]
+	s.Equal(path[1], mon.Position)
+}

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -414,6 +414,78 @@ func (s *MovementResolverSuite) TestNPCMove_ResolverPrevented_TruncatesPath() {
 		"NPC position should stop at the last successfully-traveled hex")
 }
 
+// TestNPCMove_StartHexInPath_TrimmedCorrectly verifies the trim shape
+// for monster.TakeTurn's output: TurnResult.Movement includes the start
+// hex per its contract (monster/monster.go:645 — "include start
+// position, then each hex moved to"). Without trimming, the per-step
+// iteration would see a no-op FromHex==ToHex first step and could
+// misinterpret "prevented on first real move" as a non-empty traveled
+// path. Copilot review on PR #672 flagged this; the fix lives in
+// applyNPCMovementSteps and benefits both call sites.
+//
+// Test drives MoveNPCSteps with a start-included path (matching
+// TakeTurn's shape) and asserts:
+//   - resolver.calls equals len(path) - 1 (not len(path) — the start
+//     hex was trimmed before iteration)
+//   - first ResolveStep call has FromHex == startHex, ToHex == path[1]
+//   - goblin lands at the final destination
+func (s *MovementResolverSuite) TestNPCMove_StartHexInPath_TrimmedCorrectly() {
+	s.addGoblinForNPCMovementTests()
+	startHex := encountercore.Hex{Q: 10, R: 0, S: -10}
+
+	// Start-included path — mirrors monster.TakeTurn's TurnResult.Movement
+	// shape (start hex followed by destination hexes).
+	path := []encountercore.Hex{
+		startHex, // path[0] = current position (TakeTurn includes this)
+		{Q: 9, R: 0, S: -9},
+		{Q: 8, R: 0, S: -8},
+	}
+	err := s.enc.MoveNPCSteps(gobEntityID, path)
+	s.Require().NoError(err)
+
+	// Only 2 ResolveStep calls — the start hex was trimmed.
+	s.Require().Len(s.resolver.calls, 2,
+		"start hex must be trimmed; expected 2 calls for 3-hex path")
+
+	// First call is the FIRST REAL step (from startHex to path[1]).
+	s.Equal(startHex, s.resolver.calls[0].FromHex,
+		"first call's FromHex should be the start hex")
+	s.Equal(encountercore.Hex{Q: 9, R: 0, S: -9}, s.resolver.calls[0].ToHex,
+		"first call's ToHex should be path[1] (path[0] was trimmed)")
+
+	// Goblin landed at the final destination.
+	mon := s.enc.ToData().Monsters[gobEntityID]
+	s.Equal(encountercore.Hex{Q: 8, R: 0, S: -8}, mon.Position)
+}
+
+// TestNPCMove_OnlyStartHex_NoOp verifies the edge case where the path
+// consists solely of the start hex (caller asked the NPC to "move" to
+// where they already are). After trimming, the path is empty → no-op,
+// no events fired.
+func (s *MovementResolverSuite) TestNPCMove_OnlyStartHex_NoOp() {
+	s.addGoblinForNPCMovementTests()
+	startHex := encountercore.Hex{Q: 10, R: 0, S: -10}
+
+	err := s.enc.MoveNPCSteps(gobEntityID, []encountercore.Hex{startHex})
+	s.Require().NoError(err, "single-start-hex path is a no-op, not an error")
+
+	s.Empty(s.resolver.calls, "no ResolveStep calls — nothing real to iterate")
+
+	mon := s.enc.ToData().Monsters[gobEntityID]
+	s.Equal(startHex, mon.Position, "position unchanged")
+}
+
+// TestMoveNPCSteps_EmptyPath_Errors verifies MoveNPCSteps aligns with
+// Encounter.Move's empty-path convention — returns an error instead of
+// silently no-op'ing. Copilot review flag on PR #672.
+func (s *MovementResolverSuite) TestMoveNPCSteps_EmptyPath_Errors() {
+	s.addGoblinForNPCMovementTests()
+
+	err := s.enc.MoveNPCSteps(gobEntityID, nil)
+	s.Require().Error(err, "empty path must error, matching Encounter.Move convention")
+	s.Contains(err.Error(), "empty path")
+}
+
 // TestNPCMove_ResolverPublishesTrigger_BufferDrainedCleanly mirrors the
 // player-direction buffer-drain regression guard. When the resolver
 // publishes a ReactionTriggerEvent on the encounter bus during ResolveStep

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -203,9 +203,15 @@ func (e *Encounter) applyNPCMovement(mon *MonsterData, movement []spatial.CubeCo
 // shapes without depending on monster.TakeTurn's AI to produce a
 // specific movement. Production callers go through NPCAct which calls
 // applyNPCMovement with monster.TakeTurn's Movement output.
+//
+// Returns an error on empty path, matching Encounter.Move's convention
+// (Copilot review on PR #672 flagged the silent-no-op divergence). If
+// the caller passes a leading hex that equals the NPC's current
+// position, it is trimmed (matching the TakeTurn output shape — see
+// applyNPCMovementSteps).
 func (e *Encounter) MoveNPCSteps(npcID encountercore.EntityID, path []encountercore.Hex) error {
 	if len(path) == 0 {
-		return nil
+		return errors.New("empty path")
 	}
 	mon, ok := e.data.Monsters[npcID]
 	if !ok {
@@ -219,8 +225,27 @@ func (e *Encounter) MoveNPCSteps(npcID encountercore.EntityID, path []encounterc
 // on movementResolver presence: per-step iteration when wired,
 // single-jump when not. Either way, ends by publishing a MoveEvent with
 // the truncated traveled path.
+//
+// Normalizes the input path by trimming a leading hex that equals the
+// NPC's current position. monster.TakeTurn's TurnResult.Movement
+// includes the start hex per its contract
+// (rulebooks/dnd5e/monster/monster.go:645 "include start position, then
+// each hex moved to"); without trimming, the per-step iteration would
+// see a no-op FromHex==ToHex first step and could incorrectly treat
+// "prevented on first real move" as a non-empty traveled path. Copilot
+// review on PR #672 flagged this; trimming at this shared seam makes
+// both call sites (applyNPCMovement + MoveNPCSteps) forgiving of the
+// TakeTurn shape.
 func (e *Encounter) applyNPCMovementSteps(mon *MonsterData, path []encountercore.Hex) error {
 	moverStart := mon.Position
+
+	// Trim leading start-hex if monster.TakeTurn included it.
+	if len(path) > 0 && path[0] == moverStart {
+		path = path[1:]
+	}
+	if len(path) == 0 {
+		return nil // No real movement — moving to where you already are.
+	}
 
 	traveledPath := path
 	if e.movementResolver != nil {

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -171,22 +171,82 @@ func syncMonsterDataFromSnapshot(data *monster.Data, snap *MonsterData) {
 	}
 }
 
-// applyNPCMovement walks the NPC to the final hex from the captured
-// movement path and emits a MoveEvent for any viewer who saw any segment.
+// applyNPCMovement walks the NPC along the captured movement path. When
+// a MovementResolver is wired (Wave 2.11e #668), iterates per-step so
+// chain subscribers (player OA conditions in particular) fire and
+// inline OAs against the moving NPC resolve via the resolver impl
+// (combat.MoveEntity → triggerOpportunityAttack → ResolveAttack). When
+// no resolver is wired, preserves the legacy single-jump behavior for
+// non-combat encounters that don't need chain mediation.
+//
+// Wave 2.11e #668 closes the symmetric B8-shape gap: pre-#668,
+// applyNPCMovement bypassed the chain entirely, so player OA conditions
+// watching for "leaver moves out of threatened range" never saw a chain
+// when an NPC fled their reach. The fix mirrors #667's player-direction
+// shape via the shared iterateMovementStepsForEntity helper.
 func (e *Encounter) applyNPCMovement(mon *MonsterData, movement []spatial.CubeCoordinate) error {
 	if len(movement) == 0 {
 		return nil
 	}
-	final := movement[len(movement)-1]
-	mon.Position = encountercore.Hex{Q: final.X, R: final.Y, S: final.Z}
+	// Convert the rulebook-side spatial.CubeCoordinate path to the
+	// encounter SDK's core.Hex path.
 	path := make([]encountercore.Hex, 0, len(movement))
 	for _, hop := range movement {
 		path = append(path, encountercore.Hex{Q: hop.X, R: hop.Y, S: hop.Z})
 	}
+	return e.applyNPCMovementSteps(mon, path)
+}
+
+// MoveNPCSteps is a public seam (Wave 2.11e #668) that drives the
+// NPC-direction MovementResolver path with a known per-hex path. Used
+// by tests to verify per-step iteration + buffer drain + truncation
+// shapes without depending on monster.TakeTurn's AI to produce a
+// specific movement. Production callers go through NPCAct which calls
+// applyNPCMovement with monster.TakeTurn's Movement output.
+func (e *Encounter) MoveNPCSteps(npcID encountercore.EntityID, path []encountercore.Hex) error {
+	if len(path) == 0 {
+		return nil
+	}
+	mon, ok := e.data.Monsters[npcID]
+	if !ok {
+		return fmt.Errorf("monster %q not in encounter", npcID)
+	}
+	return e.applyNPCMovementSteps(mon, path)
+}
+
+// applyNPCMovementSteps is the shared body used by applyNPCMovement
+// (production NPCAct path) and MoveNPCSteps (test public seam). Branches
+// on movementResolver presence: per-step iteration when wired,
+// single-jump when not. Either way, ends by publishing a MoveEvent with
+// the truncated traveled path.
+func (e *Encounter) applyNPCMovementSteps(mon *MonsterData, path []encountercore.Hex) error {
+	moverStart := mon.Position
+
+	traveledPath := path
+	if e.movementResolver != nil {
+		traveled, err := e.iterateMovementStepsForEntity(mon.ID, moverStart, path)
+		if err != nil {
+			return err
+		}
+		traveledPath = traveled
+		if len(traveledPath) == 0 {
+			// Movement prevented at the very first step. Position unchanged,
+			// no event fires — matches the player-direction shape from #667.
+			return nil
+		}
+	}
+
+	// Commit final position.
+	finalHex := traveledPath[len(traveledPath)-1]
+	mon.Position = finalHex
+
+	// Per-viewer projection — NPC visibility model is simpler than the
+	// player path (no Player.View on MonsterData, no EntityAppeared/
+	// Disappeared transitions for NPCs in this slice; future work).
 	movePerPlayer := make(map[encountercore.PlayerID]events.MovePlayerSlice)
 	for viewerID, viewer := range e.data.Players {
-		seen := make([]encountercore.Hex, 0, len(path))
-		for _, h := range path {
+		seen := make([]encountercore.Hex, 0, len(traveledPath))
+		for _, h := range traveledPath {
 			if e.viewerCanSee(viewer, h) {
 				seen = append(seen, h)
 			}
@@ -199,7 +259,7 @@ func (e *Encounter) applyNPCMovement(mon *MonsterData, movement []spatial.CubeCo
 		return nil
 	}
 	if err := e.broker.Publish(events.NewMoveEvent(
-		e.data.ID, e.nextSeq(), mon.ID, path, movePerPlayer,
+		e.data.ID, e.nextSeq(), mon.ID, traveledPath, movePerPlayer,
 	)); err != nil {
 		return fmt.Errorf("publish npc move: %w", err)
 	}


### PR DESCRIPTION
## Summary

Symmetric B8-shape fix for the NPC-direction movement OA path. Pre-#668, `applyNPCMovement` bypassed the chain entirely, so player OA conditions never saw a `MovementChain` when an NPC fled their reach → fighter's OA didn't fire when goblin retreats. Wave 2.11e goal sentence (rpg-project#50 refinement) explicitly names both movement directions.

- Extracted `iterateMovementStepsForEntity` from the existing `iterateMovementSteps` — entity-agnostic per-step walker shared by both `Encounter.Move` (player) and `applyNPCMovement` (NPC)
- `applyNPCMovement` branches on resolver presence: per-step iteration when wired, legacy single-jump when not (preserves non-combat encounter behavior)
- New `Encounter.MoveNPCSteps(npcID, path)` public seam for tests to drive NPC iteration with a deterministic path (production callers go through `NPCAct` → `applyNPCMovement`)
- Docs updated in-PR per `feedback_toolkit_docs_close_the_loop`

**Toolkit dep**: No bump needed — this PR is encounter-package-internal.

## Test plan

9 total on `MovementResolverSuite` (5 from #667 + 4 new for the NPC direction):

- [x] `TestNPCMove_NoResolver_LegacyBehavior` — B8 mirror regression guard
- [x] `TestNPCMove_ResolverNoTriggers_FullPath` — per-step iteration with NPC EntityID
- [x] `TestNPCMove_ResolverPrevented_TruncatesPath` — Prevented mid-path stops NPC
- [x] `TestNPCMove_ResolverPublishesTrigger_BufferDrainedCleanly` — player-reactor trigger on bus during NPC step; SDK drains cleanly without erroring
- [x] All 5 existing player-direction tests still pass
- [x] Full encounter test suite (19s)
- [x] `golangci-lint` clean

End-to-end goal verification (rpg-api#539 owns): `TestPlayerOA_OnNPCFleeing` — fighter ready with OA, goblin adjacent → goblin moves out of reach → ReactionTriggerEvent fires → fighter's OA attack resolves → goblin takes damage.

## What's NOT in scope (per director brief)

- Player-pause branch (#665 — auto-fire NPC OAs in MVP)
- Disengage rule logic (#666; OA predicate already respects `IsOAPrevented()` for both directions because `DisengagingCondition` adds the prevention source per-step on the mover's MovementChain regardless of mover type)
- rpg-api wiring + end-to-end integration (rpg-api#539)
- NPC visibility transitions (future slice — kept simpler shape)

## Wave 2.11e sequencing

1. ~~rpg-toolkit#664~~ merged — CompleteTakeAction polymorphism
2. ~~rpg-toolkit#667~~ merged — MovementResolver SDK (player direction)
3. ~~rpg-toolkit#670~~ merged — Disengage condition application
4. **rpg-toolkit#668 (this PR)** — MovementResolver NPC-direction mirror
5. **rpg-api#539** — wire MovementResolver in rpg-api + 4 integration tests (both directions) + MCP playtest

Wave tracker: rpg-project#50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)