### PR TITLE
feat(encounter): add EventBus to MovementStepInput (Wave 2.11e, #673)

### DIFF
--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -512,6 +512,7 @@ func (e *Encounter) iterateMovementStepsForEntity(
 				EntityID: moverID,
 				FromHex:  from,
 				ToHex:    to,
+				EventBus: e.bus,
 			})
 		}()
 		if stepErr != nil {

--- a/encounter/move_resolver.go
+++ b/encounter/move_resolver.go
@@ -20,6 +20,7 @@ package encounter
 
 import (
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
 )
 
 // MovementResolver bridges the encounter SDK to a rulebook implementation
@@ -69,6 +70,15 @@ type MovementStepInput struct {
 
 	// ToHex is the entity's destination after this step.
 	ToHex encountercore.Hex
+
+	// EventBus is the encounter's rulebook event bus, populated by the SDK
+	// at call time (mirrors AttackInput.EventBus). The resolver impl uses
+	// this when it needs to publish on the bus chain subscribers are
+	// listening on — e.g., wrapping rulebooks/dnd5e/combat.MoveEntity which
+	// requires a bus to publish MovementChain so OA/Disengage conditions
+	// can fire. Wave 2.11e (#673) — added after #658 design surfaced the
+	// publish-side gap when implementing rpg-api#539's Dnd5eMovementResolver.
+	EventBus events.EventBus
 }
 
 // MovementStepResult is the per-step output shape for MovementResolver.

--- a/encounter/move_resolver.go
+++ b/encounter/move_resolver.go
@@ -20,7 +20,7 @@ package encounter
 
 import (
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
-	"github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
 )
 
 // MovementResolver bridges the encounter SDK to a rulebook implementation
@@ -78,7 +78,11 @@ type MovementStepInput struct {
 	// requires a bus to publish MovementChain so OA/Disengage conditions
 	// can fire. Wave 2.11e (#673) — added after #658 design surfaced the
 	// publish-side gap when implementing rpg-api#539's Dnd5eMovementResolver.
-	EventBus events.EventBus
+	//
+	// Import aliased as dnd5events to avoid confusion with encounter/events
+	// (the SDK's own event package). Convention used throughout the
+	// encounter package (see encounter.go, combat_resolver.go).
+	EventBus dnd5events.EventBus
 }
 
 // MovementStepResult is the per-step output shape for MovementResolver.

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -48,20 +48,18 @@ type stubMovementResolver struct {
 	// subscription per director review on PR #667 — there is no
 	// resolver-returned trigger slot to stub.
 	publishOnStep func(bus dnd5events.EventBus, stepIdx int)
-
-	// bus is captured from the first call so we can publish into it.
-	bus dnd5events.EventBus
 }
 
 func (s *stubMovementResolver) ResolveStep(input tkenc.MovementStepInput) (*tkenc.MovementStepResult, error) {
 	stepIdx := len(s.calls)
 	s.calls = append(s.calls, input)
 
-	// Stub captures the bus from the encounter's WithMovementResolver wiring
-	// path. Real resolvers know their own bus; the stub uses whatever is
-	// stashed by SetupTest.
-	if s.publishOnStep != nil && s.bus != nil {
-		s.publishOnStep(s.bus, stepIdx)
+	// Bus arrives via input.EventBus (Wave 2.11e #673). Pre-#673 the stub
+	// captured the bus from a post-construction setter — that test-only
+	// hack masked the production gap until rpg-api#539's resolver impl
+	// surfaced it.
+	if s.publishOnStep != nil && input.EventBus != nil {
+		s.publishOnStep(input.EventBus, stepIdx)
 	}
 
 	result := &tkenc.MovementStepResult{}
@@ -105,10 +103,6 @@ func (s *MovementResolverSuite) SetupTest() {
 	s.resolver = &stubMovementResolver{}
 	s.enc = tkenc.New("enc-moveres", s.broker,
 		tkenc.WithMovementResolver(s.resolver))
-
-	// Stash the bus on the resolver so publishOnStep can inject triggers.
-	// The Encounter's bus is exposed via EventBus() (Wave 2.11d).
-	s.resolver.bus = s.enc.EventBus()
 
 	s.Require().NoError(s.enc.AddPlayer(tkenc.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,


### PR DESCRIPTION
## Summary

Small fix-up for the Wave 2.11e SDK gap surfaced while implementing rpg-api#539's `Dnd5eMovementResolver`. The resolver impl needs an `EventBus` to call `combat.MoveEntity` (which publishes `MovementChain` for OA / Disengaging conditions to subscribe to) — but `MovementStepInput` from #658 didn't carry one. The CombatResolver pattern already passes bus via `AttackInput.EventBus`; this PR adds the symmetric field.

Without this fix, #539's resolver impl can't call `combat.MoveEntity` because the encounter's bus isn't reachable at resolver-construction time (resolver is built BEFORE `LoadFromData` creates the encounter + bus).

## Test plan

- [x] Add `EventBus events.EventBus` field to `MovementStepInput`
- [x] `iterateMovementStepsForEntity` populates `EventBus: e.bus` per call (mirrors `combat_phased.go` populating `AttackInput.EventBus = e.bus`)
- [x] Test stub uses `input.EventBus` instead of the post-construction setter hack
- [x] All 12 `MovementResolverSuite` tests pass
- [x] Full encounter test suite green (19s)

## Backward compatibility

Additive struct field — old callers compile.

## Self-correction

At #658 design time I focused on the trigger-flow direction (chain → SDK via buffer) but didn't trace the publish-side requirement (resolver impl → chain via `combat.MoveEntity`). The stub having a `bus` field set post-construction masked the gap until rpg-api#539's resolver impl surfaced it. Adding "verify the SDK contract matches what production impls need at call time" to my pre-impl orientation discipline.

## Wave 2.11e sequencing

This unblocks rpg-api#539 (the final Wave 2.11e PR). Once #673 merges + autotags (`encounter/v0.13.0`), #539 bumps the dep and proceeds with `Dnd5eMovementResolver` impl + wiring + integration tests + MCP playtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)