### PR TITLE
feat(encounter): apply OA damage during Move iteration (Wave 2.11e #675)

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -185,6 +185,17 @@ The fix mirrors the `applyCapturedDamage` shape used by `NPCAct` (which has the 
 
 The capture/apply happens BEFORE the `Prevented` check: OAs fire whether or not the chain ends up preventing the step, so damage applies either way.
 
+### Subscriber-window scoping in NPCAct (#677)
+
+`NPCAct` owns two windows that publish `DamageReceivedEvent` on the encounter bus: the **movement window** (`applyNPCMovement` → `iterateMovementStepsForEntity` → resolver fires OAs that go through `combat.ResolveAttack`) and the **attack-resolution window** (`applyCapturedAttacks` → `combat.ResolveAttack`). Each window has its own subscriber installed at the right scope:
+
+- **Inner per-step** subscriber (from #675) owns the movement window. It applies HP delta + publishes encounter-side events via `applyMoveDamage` before the next step runs.
+- **Outer** subscriber (the original `subscribeDamage` at NPCAct setup) owns the attack-resolution window. It applies HP delta via `applyCapturedDamage` after `applyCapturedAttacks` returns.
+
+The outer is installed AFTER `applyNPCMovement` returns, not at NPCAct entry. If it were installed at entry, both subscribers would fire on the same movement-OA `DamageReceivedEvent` — `applyMoveDamage` would apply HP during iteration, then `applyCapturedDamage` would apply the same delta again after movement returns. A 7-HP goblin hit by a 5-damage OA would land at -3 HP (clamped to 0) and the kill chain would fire twice. Wave-2.11e-goal-blocking double-apply bug — caught by director review of #677.
+
+Tests cover the production path explicitly (`TestNPCAct_MovementOA_AppliesDamageOnce` in `npc_test.go`). The earlier movement tests in `move_resolver_test.go` exercise `MoveNPCSteps` directly, which bypasses NPCAct's outer subscriber entirely — useful for walker-level coverage, but not a substitute for the production-path regression guard.
+
 ### Scope deferred (#665)
 
 When a player-bearer reaction becomes a goal-shaped feature (Sentinel feat, Shield/Counterspell, etc.), the per-step iteration loop gains a second branch: partition triggers by reactor type, persist `PendingReactionPrompt` for player-bearer triggers, publish a sentinel `errPlayerPausedForReactionDuringMove`, and resume via the existing `SubmitCheck{take_reaction}` path. The design sketch lives on #665; the structural seam is already in place (the per-step iteration + buffer drain are the load-bearing infrastructure).

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -173,6 +173,18 @@ The SDK installs a buffered subscriber on `ReactionTriggerTopic` per step. Chain
 
 The buffer infrastructure is installed for shape parity with `TakeActionPhased` and to flush subscriptions cleanly per step. The second-branch consumer (player-pause for Sentinel-shape or spell reactions) is deferred to issue #665.
 
+### Damage application during Move iteration (#675)
+
+OAs that fire inside `combat.MoveEntity` resolve hit + damage end-to-end (combat.ResolveAttack runs synchronously inside `triggerOpportunityAttack`) and publish `DamageReceivedEvent` on the rulebook bus before `ResolveStep` returns. But the encounter SDK owns HP state — without an explicit hand-off the events would fire on the bus, no subscriber would translate them to encounter-side state, and the goal-sentence verification "OA fires AND damage applies" would silently fail (chain works, dice roll, target's HP doesn't budge).
+
+The fix mirrors the `applyCapturedDamage` shape used by `NPCAct` (which has the same surface — captured rulebook events post-action need encounter-side translation):
+
+1. `iterateMovementStepsForEntity` installs a `subscribeDamage` buffer on the encounter bus per step, alongside the `ReactionTriggerTopic` buffer. The defer chain inside the inner step closure tears both buffers down on return — even on resolver panic.
+2. After `ResolveStep` returns, the SDK reads the captured `DamageReceivedEvent` slice and dispatches each through `applyMoveDamage`.
+3. `applyMoveDamage` mirrors `applyCapturedDamage` but resolves source position dynamically (`findEntityPosition`) because Move-path OAs fire from EITHER direction (player attacker on a fleeing NPC, or NPC attacker on a fleeing player) — the per-viewer LoS projection key varies by attacker type. The HP delta + encounter-side `DamageDealtEvent` + kill-chain on `>0 → 0` transition all go through the same code path as the NPCAct equivalents.
+
+The capture/apply happens BEFORE the `Prevented` check: OAs fire whether or not the chain ends up preventing the step, so damage applies either way.
+
 ### Scope deferred (#665)
 
 When a player-bearer reaction becomes a goal-shaped feature (Sentinel feat, Shield/Counterspell, etc.), the per-step iteration loop gains a second branch: partition triggers by reactor type, persist `PendingReactionPrompt` for player-bearer triggers, publish a sentinel `errPlayerPausedForReactionDuringMove`, and resume via the existing `SubmitCheck{take_reaction}` path. The design sketch lives on #665; the structural seam is already in place (the per-step iteration + buffer drain are the load-bearing infrastructure).

--- a/docs/status.md
+++ b/docs/status.md
@@ -69,6 +69,9 @@ See "Paused / on hold" below.
   helper. Without this, Move-path OAs fired and rolled but never moved target HP — the
   goal sentence "OA-class reactions work end-to-end" silently failed at the encounter
   boundary. Mirror of `applyCapturedDamage` pattern with polymorphic source lookup.
+  Director-review fix-up (#677) scoped NPCAct's outer damage subscriber to the
+  attack-resolution window only, eliminating a double-apply path where movement-OA
+  damage flowed through both the inner per-step subscriber AND the outer subscriber.
 - **Monk Unarmored Defense WIS AC chain** — PR #609 (2026-04-05) — adds WIS modifier
   to AC when Monk is unarmored and has no shield; test covers the full chain.
 - **Martial Arts DEX label fix** — PR #607 (2026-04-05) — `SourceRef.Label` was

--- a/docs/status.md
+++ b/docs/status.md
@@ -62,6 +62,13 @@ See "Paused / on hold" below.
 
 ## Recently landed (last 30 days, highlights)
 
+- **Move-iteration OA damage application** — PR for issue #675 (2026-05-24) — Wave 2.11e
+  SDK seam: `iterateMovementStepsForEntity` now captures `DamageReceivedEvent` on the
+  encounter bus per step (alongside the existing `ReactionTriggerTopic` buffer) and
+  dispatches HP delta + encounter-side `DamageDealtEvent` via new `applyMoveDamage`
+  helper. Without this, Move-path OAs fired and rolled but never moved target HP — the
+  goal sentence "OA-class reactions work end-to-end" silently failed at the encounter
+  boundary. Mirror of `applyCapturedDamage` pattern with polymorphic source lookup.
 - **Monk Unarmored Defense WIS AC chain** — PR #609 (2026-04-05) — adds WIS modifier
   to AC when Monk is unarmored and has no shield; test covers the full chain.
 - **Martial Arts DEX label fix** — PR #607 (2026-04-05) — `SourceRef.Label` was

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -1,6 +1,7 @@
 package encounter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
 
 // OAReactionRef is the canonical reaction ref string for Opportunity Attack.
@@ -494,7 +496,7 @@ func (e *Encounter) iterateMovementStepsForEntity(
 		// is torn down via defer even if the resolver panics. Without
 		// this, a panic in the rulebook chain would leak the subscription
 		// and pollute subsequent encounter operations.
-		result, stepErr := func() (*MovementStepResult, error) {
+		result, capturedDmg, stepErr := func() (*MovementStepResult, []dnd5eEvents.DamageReceivedEvent, error) {
 			// Install a buffered subscriber on ReactionTriggerTopic per
 			// step. The subscriber catches any triggers that chain
 			// subscribers publish during this step's resolver call. In
@@ -504,22 +506,49 @@ func (e *Encounter) iterateMovementStepsForEntity(
 			// flush subscriptions cleanly per step.
 			_, drainCleanup, err := e.installTriggerBuffer()
 			if err != nil {
-				return nil, fmt.Errorf("install trigger buffer: %w", err)
+				return nil, nil, fmt.Errorf("install trigger buffer: %w", err)
 			}
 			defer drainCleanup()
 
-			return e.movementResolver.ResolveStep(MovementStepInput{
+			// Wave 2.11e (#675): capture DamageReceivedEvent published by
+			// the resolver's chain (combat.MoveEntity →
+			// triggerOpportunityAttack → ResolveAttack). OA fires AND
+			// resolves end-to-end inside the rulebook; the encounter SDK
+			// observes the damage post-hoc on the bus and applies HP delta
+			// + encounter-side DamageDealtEvent below.
+			ctx := context.Background()
+			dmgCaptured, unsubDmg, err := subscribeDamage(ctx, e.bus)
+			if err != nil {
+				return nil, nil, fmt.Errorf("subscribe move damage: %w", err)
+			}
+			defer func() { _ = unsubDmg() }()
+
+			res, err := e.movementResolver.ResolveStep(MovementStepInput{
 				EntityID: moverID,
 				FromHex:  from,
 				ToHex:    to,
 				EventBus: e.bus,
 			})
+			var dmgCopy []dnd5eEvents.DamageReceivedEvent
+			if dmgCaptured != nil {
+				dmgCopy = *dmgCaptured
+			}
+			return res, dmgCopy, err
 		}()
 		if stepErr != nil {
 			return traveled, fmt.Errorf("resolve movement step: %w", stepErr)
 		}
 		if result == nil {
 			return traveled, fmt.Errorf("movement resolver: nil result with nil error")
+		}
+
+		// Apply any OA damage captured during this step. Done before the
+		// Prevented check because OAs fire whether or not the chain ends
+		// up preventing the step — damage applies either way.
+		if len(capturedDmg) > 0 {
+			if err := e.applyMoveDamage(capturedDmg); err != nil {
+				return traveled, fmt.Errorf("apply move damage: %w", err)
+			}
 		}
 
 		if result.Prevented {

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -705,14 +705,15 @@ func (s *MovementResolverSuite) TestMove_OAKillsMonster_FiresKillChain() {
 	err = s.enc.MoveNPCSteps(gobEntityID, path)
 	s.Require().NoError(err)
 
-	// HP clamped at 0.
-	monAfter := s.enc.ToData().Monsters[gobEntityID]
-	if monAfter != nil {
-		s.Equal(0, monAfter.HP, "goblin HP should clamp at 0 after lethal OA")
-	}
+	// Goblin removed from encounter state (killEntity drops the entry).
+	_, stillPresent := s.enc.ToData().Monsters[gobEntityID]
+	s.False(stillPresent, "goblin should be removed from encounter state after lethal OA")
 
-	// EntityDiedEvent observed in alice's stream.
+	// Full kill chain observed in alice's stream: EntityDied → EntityRemoved
+	// → EncounterEnded (goblin was the lone monster).
 	var diedEvt *events.EntityDiedEvent
+	sawRemoved := false
+	sawEnded := false
 	deadline := time.After(2 * time.Second)
 drainLoop:
 	for {
@@ -721,8 +722,13 @@ drainLoop:
 			if !ok {
 				break drainLoop
 			}
-			if de, isDied := evt.(*events.EntityDiedEvent); isDied {
-				diedEvt = de
+			switch e := evt.(type) {
+			case *events.EntityDiedEvent:
+				diedEvt = e
+			case *events.EntityRemovedEvent:
+				sawRemoved = true
+			case *events.EncounterEndedEvent:
+				sawEnded = true
 				break drainLoop
 			}
 		case <-deadline:
@@ -732,4 +738,6 @@ drainLoop:
 	s.Require().NotNil(diedEvt, "EntityDiedEvent should fire on >0 → 0 transition")
 	s.Equal(encountercore.EntityID(gobEntityID), diedEvt.EntityID)
 	s.Equal(encountercore.EntityID(aliceEntityID), diedEvt.KillerID)
+	s.True(sawRemoved, "EntityRemovedEvent should fire after EntityDied")
+	s.True(sawEnded, "EncounterEndedEvent should fire when last monster dies")
 }

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -23,6 +23,7 @@ import (
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
 
@@ -519,4 +520,216 @@ func (s *MovementResolverSuite) TestNPCMove_ResolverPublishesTrigger_BufferDrain
 	// Goblin reached the final hex.
 	mon := s.enc.ToData().Monsters[gobEntityID]
 	s.Equal(path[1], mon.Position)
+}
+
+// --- Wave 2.11e (#675) — Move-iteration OA damage application ---
+//
+// The goal-sentence direction for #675: when an OA fires mid-Move (player
+// or NPC mover provokes a reaction attack that the rulebook resolves
+// inline), the encounter SDK must observe the resulting damage on the bus
+// and apply HP delta + publish encounter-side DamageDealtEvent. Without
+// this, the goal sentence "OA-class reactions work end-to-end" doesn't
+// hold — chain fires, dice roll, but target's HP never moves.
+//
+// These tests use the stub resolver to publish DamageReceivedEvent on the
+// bus during ResolveStep (simulating combat.ResolveAttack inside
+// combat.MoveEntity's triggerOpportunityAttack path) and verify the SDK
+// dispatches HP + DamageDealtEvent.
+
+// TestMove_PlayerMoves_OADamagesPlayer verifies the player-mover direction:
+// alice moves past goblin (who has an OA condition); resolver publishes a
+// DamageReceivedEvent targeting alice during step 0; encounter SDK applies
+// HP delta to alice + publishes DamageDealtEvent.
+func (s *MovementResolverSuite) TestMove_PlayerMoves_OADamagesPlayer() {
+	s.addGoblinForNPCMovementTests()
+
+	// Seed alice's HP so we can detect the delta.
+	aliceBefore := s.enc.ToData().Players[alicePlayerID]
+	s.Require().NotNil(aliceBefore)
+	aliceBefore.HP = 20
+	aliceBefore.MaxHP = 20
+
+	// Stub publishes a DamageReceivedEvent on the bus during step 0 — the
+	// step where alice leaves the goblin's reach (the rulebook fires
+	// triggerOpportunityAttack → ResolveAttack here).
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			topic := dnd5eEvents.DamageReceivedTopic.On(bus)
+			_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
+				TargetID:   string(aliceEntityID),
+				SourceID:   string(gobEntityID),
+				Amount:     6,
+				DamageType: damage.Slashing,
+			})
+		}
+	}
+
+	// Subscribe alice to her own viewer stream to observe DamageDealtEvent.
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+	}
+	err = s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err)
+
+	// HP applied: alice 20 → 14.
+	aliceAfter := s.enc.ToData().Players[alicePlayerID]
+	s.Equal(14, aliceAfter.HP, "alice HP should drop by OA damage amount (6)")
+
+	// DamageDealtEvent published with target=alice, source=goblin, amount=6.
+	var dmgEvt *events.DamageDealtEvent
+	deadline := time.After(2 * time.Second)
+drainLoop:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoop
+			}
+			if de, isDmg := evt.(*events.DamageDealtEvent); isDmg {
+				dmgEvt = de
+				break drainLoop
+			}
+		case <-deadline:
+			break drainLoop
+		}
+	}
+	s.Require().NotNil(dmgEvt, "DamageDealtEvent should have been published")
+	s.Equal(encountercore.EntityID(aliceEntityID), dmgEvt.TargetID)
+	s.Equal(encountercore.EntityID(gobEntityID), dmgEvt.SourceID)
+	s.Equal(6, dmgEvt.Amount)
+	s.Equal("slashing", dmgEvt.DamageType)
+	s.Equal(14, dmgEvt.HPAfter)
+}
+
+// TestNPCMove_NPCMoves_OADamagesMonster verifies the NPC-mover direction:
+// goblin retreats past alice (who has an OA condition); resolver publishes
+// a DamageReceivedEvent targeting goblin during step 0; encounter SDK
+// applies HP delta to the monster + publishes DamageDealtEvent.
+func (s *MovementResolverSuite) TestNPCMove_NPCMoves_OADamagesMonster() {
+	s.addGoblinForNPCMovementTests()
+
+	// Seed alice in melee range so the OA fiction makes sense (positions
+	// are not validated by the SDK in this test — pure event flow).
+	aliceBefore := s.enc.ToData().Players[alicePlayerID]
+	s.Require().NotNil(aliceBefore)
+	aliceBefore.HP = 20
+	aliceBefore.MaxHP = 20
+
+	// Stub publishes DamageReceivedEvent on step 0: alice (player) hits the
+	// goblin (NPC) on its way out. Source = alice (player), Target = goblin.
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			topic := dnd5eEvents.DamageReceivedTopic.On(bus)
+			_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
+				TargetID:   string(gobEntityID),
+				SourceID:   string(aliceEntityID),
+				Amount:     5,
+				DamageType: damage.Slashing,
+			})
+		}
+	}
+
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	path := []encountercore.Hex{
+		{Q: 9, R: 0, S: -9},
+		{Q: 8, R: 0, S: -8},
+	}
+	err = s.enc.MoveNPCSteps(gobEntityID, path)
+	s.Require().NoError(err)
+
+	// HP applied: goblin 7 → 2.
+	monAfter := s.enc.ToData().Monsters[gobEntityID]
+	s.Equal(2, monAfter.HP, "goblin HP should drop by OA damage amount (5)")
+
+	// DamageDealtEvent published with target=goblin, source=alice, amount=5.
+	var dmgEvt *events.DamageDealtEvent
+	deadline := time.After(2 * time.Second)
+drainLoop:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoop
+			}
+			if de, isDmg := evt.(*events.DamageDealtEvent); isDmg {
+				dmgEvt = de
+				break drainLoop
+			}
+		case <-deadline:
+			break drainLoop
+		}
+	}
+	s.Require().NotNil(dmgEvt, "DamageDealtEvent should have been published for NPC-target OA")
+	s.Equal(encountercore.EntityID(gobEntityID), dmgEvt.TargetID)
+	s.Equal(encountercore.EntityID(aliceEntityID), dmgEvt.SourceID)
+	s.Equal(5, dmgEvt.Amount)
+	s.Equal(2, dmgEvt.HPAfter)
+}
+
+// TestMove_OAKillsMonster_FiresKillChain verifies that when Move-path OA
+// damage drops a monster's HP from >0 to 0, the SDK fires the kill chain
+// (EntityDiedEvent + EntityRemovedEvent + checkEncounterEnd) — the same
+// chain applyCapturedDamage drives for NPCAct-path damage.
+func (s *MovementResolverSuite) TestMove_OAKillsMonster_FiresKillChain() {
+	s.addGoblinForNPCMovementTests()
+
+	// Stub damage exceeds goblin's HP (7) so the kill chain triggers.
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			topic := dnd5eEvents.DamageReceivedTopic.On(bus)
+			_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
+				TargetID:   string(gobEntityID),
+				SourceID:   string(aliceEntityID),
+				Amount:     10,
+				DamageType: damage.Slashing,
+			})
+		}
+	}
+
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	path := []encountercore.Hex{
+		{Q: 9, R: 0, S: -9},
+		{Q: 8, R: 0, S: -8},
+	}
+	err = s.enc.MoveNPCSteps(gobEntityID, path)
+	s.Require().NoError(err)
+
+	// HP clamped at 0.
+	monAfter := s.enc.ToData().Monsters[gobEntityID]
+	if monAfter != nil {
+		s.Equal(0, monAfter.HP, "goblin HP should clamp at 0 after lethal OA")
+	}
+
+	// EntityDiedEvent observed in alice's stream.
+	var diedEvt *events.EntityDiedEvent
+	deadline := time.After(2 * time.Second)
+drainLoop:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoop
+			}
+			if de, isDied := evt.(*events.EntityDiedEvent); isDied {
+				diedEvt = de
+				break drainLoop
+			}
+		case <-deadline:
+			break drainLoop
+		}
+	}
+	s.Require().NotNil(diedEvt, "EntityDiedEvent should fire on >0 → 0 transition")
+	s.Equal(encountercore.EntityID(gobEntityID), diedEvt.EntityID)
+	s.Equal(encountercore.EntityID(aliceEntityID), diedEvt.KillerID)
 }

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -710,7 +710,13 @@ func (s *MovementResolverSuite) TestMove_OAKillsMonster_FiresKillChain() {
 	s.False(stillPresent, "goblin should be removed from encounter state after lethal OA")
 
 	// Full kill chain observed in alice's stream: EntityDied → EntityRemoved
-	// → EncounterEnded (goblin was the lone monster).
+	// → EncounterEnded (goblin was the lone monster). The drain breaks on
+	// EncounterEndedEvent — safe because killEntity publishes in order
+	// (Died, Removed, then encounterEnd-check triggers EncounterEnded), so
+	// by the time we see EncounterEnded the prior two must have fired. The
+	// order-dependence is noted in case a future refactor changes the
+	// publish sequence; if so, this drain needs to be widened to read past
+	// EncounterEnded.
 	var diedEvt *events.EntityDiedEvent
 	sawRemoved := false
 	sawEnded := false

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -598,18 +598,16 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 // side DamageDealtEvent here, plus the kill/death chain on the >0 → 0
 // transition.
 //
-// Source resolution: tries player → monster. If neither matches, the
-// damage event is skipped (no DamageDealtEvent published). The same skip
-// rule as applyCapturedDamage applies for unknown targets.
+// Source resolution: tries player → monster. If neither matches, HP is
+// still applied (damage application is more important than the wire
+// event) but the per-viewer LoS projection falls back to target-only
+// visibility — viewers who can see the target see the event, viewers
+// who can't, don't. The same skip rule as applyCapturedDamage applies
+// for unknown targets (we can't mutate HP on something we can't find).
 func (e *Encounter) applyMoveDamage(damages []dnd5eEvents.DamageReceivedEvent) error {
 	for _, dmg := range damages {
 		targetID := encountercore.EntityID(dmg.TargetID)
 		sourceID := encountercore.EntityID(dmg.SourceID)
-
-		sourcePos, sourceOK := e.findEntityPosition(sourceID)
-		if !sourceOK {
-			continue
-		}
 
 		hpBefore, hpAfter, maxHP, targetPos, isMonster, ok := e.applyDamageToTarget(targetID, dmg.Amount)
 		if !ok {
@@ -619,9 +617,16 @@ func (e *Encounter) applyMoveDamage(damages []dnd5eEvents.DamageReceivedEvent) e
 		if damageType == "" {
 			damageType = damageTypeUntyped
 		}
+		// Per-viewer projection: a viewer is included if they have LoS to
+		// the source OR the target. Source lookup is best-effort — if it
+		// fails (unknown SourceID), the projection falls back to
+		// target-only visibility rather than dropping the event entirely.
+		sourcePos, sourceOK := e.findEntityPosition(sourceID)
 		damagePerPlayer := make(map[encountercore.PlayerID]events.DamageDealtSlice)
 		for viewerID, viewer := range e.data.Players {
-			if !e.viewerCanSee(viewer, sourcePos) && !e.viewerCanSee(viewer, targetPos) {
+			canSeeSource := sourceOK && e.viewerCanSee(viewer, sourcePos)
+			canSeeTarget := e.viewerCanSee(viewer, targetPos)
+			if !canSeeSource && !canSeeTarget {
 				continue
 			}
 			damagePerPlayer[viewerID] = events.DamageDealtSlice{Visible: true}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -68,11 +68,20 @@ func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) er
 	}
 	defer func() { _ = unsubAttack() }()
 
-	capturedDmg, unsubDmg, err := subscribeDamage(ctx, bus)
-	if err != nil {
-		return fmt.Errorf("subscribe dnd5e damage: %w", err)
-	}
-	defer func() { _ = unsubDmg() }()
+	// Outer damage subscriber is installed AFTER applyNPCMovement (see
+	// below). Movement-window OAs are captured by the inner per-step
+	// subscriber in iterateMovementStepsForEntity (#675); installing the
+	// outer before movement would double-capture and double-apply HP via
+	// applyCapturedDamage. The outer's purpose is the attack-resolution
+	// window (applyCapturedAttacks → ResolveAttack → DamageReceivedEvent).
+	// Wave 2.11e (#677 director review).
+	var capturedDmg *[]dnd5eEvents.DamageReceivedEvent
+	var unsubDmg func() error
+	defer func() {
+		if unsubDmg != nil {
+			_ = unsubDmg()
+		}
+	}()
 
 	capturedCond, unsubCond, err := subscribeConditions(ctx, bus)
 	if err != nil {
@@ -123,6 +132,19 @@ func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) er
 	if err := e.applyNPCMovement(mon, result.Movement); err != nil {
 		return err
 	}
+
+	// Install the outer damage subscriber AFTER movement, scoped to the
+	// upcoming attack-resolution window (applyCapturedAttacks).
+	// iterateMovementStepsForEntity owned the movement window via its own
+	// per-step subscribers (#675). Installing here means movement-OA
+	// damage doesn't double-flow through applyCapturedDamage below.
+	dmgSlice, dmgUnsub, err := subscribeDamage(ctx, bus)
+	if err != nil {
+		return fmt.Errorf("subscribe damage for attack-resolution window: %w", err)
+	}
+	capturedDmg = dmgSlice
+	unsubDmg = dmgUnsub
+
 	if err := e.applyCapturedAttacks(mon, *captured); err != nil {
 		// errNPCPausedForReaction propagates as-is; the orchestrator
 		// detects it via IsNPCPausedForReaction. Other captured-event

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -582,6 +582,88 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 	return nil
 }
 
+// applyMoveDamage translates each dnd5e DamageReceivedEvent captured
+// during a movement step into an encounter DamageDealtEvent. Mirrors
+// applyCapturedDamage but resolves the source position dynamically from
+// the event's SourceID: Move-path OAs fire from EITHER direction (player
+// attacker on a fleeing NPC, or NPC attacker on a fleeing player), so
+// the per-viewer LoS projection key cannot be hard-coded to a single
+// source type.
+//
+// Wave 2.11e (#675): MovementResolver path damage application.
+// combat.MoveEntity → triggerOpportunityAttack → combat.ResolveAttack
+// publishes DamageReceivedEvent on the bus mid-iterate; the encounter
+// SDK captures the events around ResolveStep
+// (iterateMovementStepsForEntity) and dispatches HP delta + encounter-
+// side DamageDealtEvent here, plus the kill/death chain on the >0 → 0
+// transition.
+//
+// Source resolution: tries player → monster. If neither matches, the
+// damage event is skipped (no DamageDealtEvent published). The same skip
+// rule as applyCapturedDamage applies for unknown targets.
+func (e *Encounter) applyMoveDamage(damages []dnd5eEvents.DamageReceivedEvent) error {
+	for _, dmg := range damages {
+		targetID := encountercore.EntityID(dmg.TargetID)
+		sourceID := encountercore.EntityID(dmg.SourceID)
+
+		sourcePos, sourceOK := e.findEntityPosition(sourceID)
+		if !sourceOK {
+			continue
+		}
+
+		hpBefore, hpAfter, maxHP, targetPos, isMonster, ok := e.applyDamageToTarget(targetID, dmg.Amount)
+		if !ok {
+			continue
+		}
+		damageType := string(dmg.DamageType)
+		if damageType == "" {
+			damageType = damageTypeUntyped
+		}
+		damagePerPlayer := make(map[encountercore.PlayerID]events.DamageDealtSlice)
+		for viewerID, viewer := range e.data.Players {
+			if !e.viewerCanSee(viewer, sourcePos) && !e.viewerCanSee(viewer, targetPos) {
+				continue
+			}
+			damagePerPlayer[viewerID] = events.DamageDealtSlice{Visible: true}
+		}
+		if err := e.broker.Publish(events.NewDamageDealtEvent(
+			e.data.ID, e.nextSeq(),
+			targetID, sourceID,
+			dmg.Amount, damageType,
+			hpAfter, maxHP,
+			damagePerPlayer,
+		)); err != nil {
+			return fmt.Errorf("publish damage dealt: %w", err)
+		}
+		if hpBefore > 0 && hpAfter == 0 {
+			if isMonster {
+				if err := e.killEntity(targetID, sourceID); err != nil {
+					return err
+				}
+			} else {
+				if err := e.publishPlayerDied(targetID, sourceID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// findEntityPosition resolves the current Hex of the entity with id —
+// player or monster. Returns (Hex{}, false) when the id matches neither.
+// Used by applyMoveDamage to pick the source position for per-viewer LoS
+// projection (the source could be a player or NPC for OAs).
+func (e *Encounter) findEntityPosition(id encountercore.EntityID) (encountercore.Hex, bool) {
+	if p := e.findPlayerByEntityID(id); p != nil && p.View != nil {
+		return p.View.Position, true
+	}
+	if m, ok := e.data.Monsters[id]; ok {
+		return m.Position, true
+	}
+	return encountercore.Hex{}, false
+}
+
 // applyDamageToTarget mutates HP on a player or monster matching id and
 // returns its pre-damage HP, post-damage HP, MaxHP, position, and whether
 // the target was a monster (vs a player). hpBefore lets callers detect

--- a/encounter/npc_test.go
+++ b/encounter/npc_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 )
 
@@ -167,4 +170,85 @@ func (s *NPCSuite) TestNPCAct_Scripted_ErrNoCombatResolver() {
 
 	err := enc.NPCAct(s.ctx, gobEntityID)
 	s.ErrorIs(err, encounter.ErrNoCombatResolver)
+}
+
+// TestNPCAct_MovementOA_AppliesDamageOnce is the production-path regression
+// guard from PR #677 director review: NPCAct installs outer subscribeAttack/
+// subscribeDamage listeners for the entire call, and applyNPCMovement runs
+// INSIDE that window. Without per-window scoping, an OA-triggered
+// DamageReceivedEvent published during the movement step is captured by
+// BOTH the inner per-step subscriber (iterateMovementStepsForEntity, #675)
+// and the outer NPCAct subscriber — HP delta then applies twice when
+// applyCapturedDamage runs after applyNPCMovement returns. A 5-damage OA
+// drops a 7-HP goblin to -3 HP and fires the kill chain twice.
+//
+// The earlier TestNPCMove_NPCMoves_OADamagesMonster used MoveNPCSteps
+// which bypasses NPCAct's outer subscribers entirely, so the double-apply
+// passed test review unnoticed. This test exercises NPCAct directly with
+// a MovementResolver wired, simulating an OA during movement, and asserts
+// HP delta applies exactly once.
+func (s *NPCSuite) TestNPCAct_MovementOA_AppliesDamageOnce() {
+	gob := monster.NewGoblin(gobEntityID)
+	gobData := gob.ToData()
+	dataJSON, err := json.Marshal(gobData)
+	s.Require().NoError(err)
+
+	// Stub MovementResolver that publishes a DamageReceivedEvent targeting
+	// the goblin (mover) during step 0 — simulating an OA the player has
+	// already taken against the retreating monster. combat.ResolveAttack
+	// would do this in production.
+	const oaDamage = 5
+	resolver := &stubMovementResolver{
+		publishOnStep: func(bus dnd5events.EventBus, stepIdx int) {
+			if stepIdx == 0 {
+				topic := dnd5eEvents.DamageReceivedTopic.On(bus)
+				_ = topic.Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+					TargetID:   string(gobEntityID),
+					SourceID:   string(aliceEntityID),
+					Amount:     oaDamage,
+					DamageType: damage.Slashing,
+				})
+			}
+		},
+	}
+
+	// Rebuild an encounter with both the combat resolver (NPCAct guard)
+	// AND the movement resolver wired. Alice at distance 10 so the goblin
+	// AI walks toward her but doesn't enter scimitar reach this turn —
+	// keeps the test focused on the movement-OA path (no attack publishes
+	// to confound the captured-damage slice post-movement).
+	enc := encounter.New("enc-npcact-move-oa", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 4, damageType: damageSlashing}),
+		encounter.WithMovementResolver(resolver),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 10, R: 0, S: -10}, SightRange: 12,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	const startHP = 7
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0},
+		HP:       startHP, MaxHP: startHP, AC: 15, Speed: 6,
+		MonsterRef:  monsterRefGoblin,
+		DataJSON:    dataJSON,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	err = enc.NPCAct(s.ctx, gobEntityID)
+	s.Require().NoError(err)
+
+	// HP applied exactly once: 7 - 5 = 2. If the outer subscriber
+	// double-applied, HP would be -3 (clamped to 0) and the kill chain
+	// would have fired.
+	mon := enc.ToData().Monsters[gobEntityID]
+	s.Require().NotNil(mon, "goblin must still be present (5 damage on 7 HP is non-lethal)")
+	s.Equal(startHP-oaDamage, mon.HP,
+		"OA damage must apply exactly once on the NPCAct path (no double-apply)")
 }


### PR DESCRIPTION
## Summary

Wave 2.11e SDK blocker — closes #675.

OAs that fire inside `combat.MoveEntity` resolve hit + damage end-to-end (combat.ResolveAttack runs synchronously inside `triggerOpportunityAttack`) and publish `DamageReceivedEvent` on the bus, but the encounter SDK had no subscriber in `iterateMovementStepsForEntity` to apply HP delta. Chain fired, dice rolled, target's HP never moved — the goal sentence "OA-class reactions work end-to-end" silently failed at the encounter boundary.

This is the encounter SDK side of Wave 2.11e (rpg-api#539 blocks on it).

## Approach

Mirror of `applyCapturedDamage` shape used by NPCAct:

- `iterateMovementStepsForEntity` installs a `subscribeDamage` buffer per step alongside the existing `ReactionTriggerTopic` buffer; the inner step closure's defer chain tears both down on return (panic-safe).
- After `ResolveStep` returns, captured `DamageReceivedEvent`s dispatch through the new `applyMoveDamage` helper.
- `applyMoveDamage` mirrors `applyCapturedDamage` but resolves source position dynamically (`findEntityPosition`) since Move-path OAs fire from EITHER direction — player attacker on fleeing NPC OR NPC attacker on fleeing player. The per-viewer LoS projection key varies by attacker type.
- HP delta + encounter-side `DamageDealtEvent` + kill-chain on `>0 → 0` transition route through the same code paths as the NPCAct equivalents.

Capture/apply happens BEFORE the `Prevented` check: OAs fire whether or not the chain prevents the step, so damage applies either way.

## Test plan

- [x] `TestMove_PlayerMoves_OADamagesPlayer` — player-mover, NPC-OA path: HP delta + DamageDealtEvent
- [x] `TestNPCMove_NPCMoves_OADamagesMonster` — NPC-mover, player-OA path: HP delta + DamageDealtEvent
- [x] `TestMove_OAKillsMonster_FiresKillChain` — kill chain fires on `>0 → 0` transition
- [x] Full encounter suite passes (`go test ./...`)
- [x] No lint findings (`golangci-lint run ./...`)
- [ ] Verified end-to-end via rpg-api#539 integration tests (next PR; this is the SDK fix #539 blocks on)

## Director signoff trail

- toolkit#675 created with implementer brief surfacing the SDK gap
- Director signoff (2026-05-24): "Wave 2.11e blocker confirmed. Proceed with the ~50 LOC fix. Mirror `applyCapturedAttacks` shape (encounter/npc.go) into the Move iteration path. Install subscribers around `iterateMovementStepsForEntity`. Encounter SDK only (no rulebook touch). Docs: encounter.md MovementResolver section gets a 'Damage application during Move iteration' subsection."

Docs: `docs/architecture/components/encounter.md` gains a `### Damage application during Move iteration (#675)` subsection; `docs/status.md` recently-landed updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)