### PR TITLE
feat(spatial): add AxialHexGrid for axial-coordinate hex maps

### DIFF
--- a/tools/spatial/hex_grid.go
+++ b/tools/spatial/hex_grid.go
@@ -274,6 +274,253 @@ func (hg *HexGrid) GetCubeNeighbors(pos Position) []CubeCoordinate {
 	return cube.GetNeighbors()
 }
 
+// AxialHexGrid implements Grid for hexagonal maps that store positions in axial
+// coordinates: Position.X = Q (column), Position.Y = R (row), S = -(Q+R).
+//
+// This is the correct grid for encounter SDKs and tactical maps that use axial
+// hex coordinates natively (e.g. rpg-api's encountercore.Hex). The existing
+// HexGrid expects offset coordinates and would produce wrong distances when fed
+// axial positions — AxialHexGrid eliminates that mismatch.
+//
+// Distance uses the cube formula: (|ΔQ| + |ΔR| + |ΔS|) / 2, which correctly
+// counts adjacent hexes as distance 1 regardless of their direction relative to
+// the X/Y axes. This matches D&D 5e adjacency rules for hex maps.
+type AxialHexGrid struct {
+	dimensions Dimensions
+}
+
+// AxialHexGridConfig holds configuration for creating an AxialHexGrid.
+// Width and Height set the bounding box for IsValidPosition checks; pass
+// large values (e.g. 1000×1000) for encounter rooms where position bounds
+// are not meaningful.
+type AxialHexGridConfig struct {
+	Width  float64
+	Height float64
+}
+
+// NewAxialHexGrid creates a new hex grid that treats Position.X/Y as axial
+// Q/R coordinates. Use this instead of NewHexGrid when positions are stored
+// in axial (not offset) form.
+func NewAxialHexGrid(config AxialHexGridConfig) *AxialHexGrid {
+	return &AxialHexGrid{
+		dimensions: Dimensions(config),
+	}
+}
+
+// GetShape returns GridShapeHex.
+func (a *AxialHexGrid) GetShape() GridShape {
+	return GridShapeHex
+}
+
+// GetDimensions returns the configured bounding-box dimensions.
+func (a *AxialHexGrid) GetDimensions() Dimensions {
+	return a.dimensions
+}
+
+// IsValidPosition reports whether the position falls within the configured
+// bounding box. Axial Q/R can be negative, so the check is symmetric around
+// the origin: |X| < Width/2 and |Y| < Height/2. Pass Width=Height=1000 (or
+// similar) when you do not want meaningful bounds.
+func (a *AxialHexGrid) IsValidPosition(pos Position) bool {
+	half := a.dimensions.Width / 2
+	halfH := a.dimensions.Height / 2
+	return pos.X >= -half && pos.X < half && pos.Y >= -halfH && pos.Y < halfH
+}
+
+// Distance returns the hex distance between two axial positions.
+// Interprets Position.X as Q and Position.Y as R; derives S = -(Q+R).
+// Uses the cube formula: (|ΔQ| + |ΔR| + |ΔS|) / 2.
+func (a *AxialHexGrid) Distance(from, to Position) float64 {
+	fromCube := axialToCube(from)
+	toCube := axialToCube(to)
+	return float64(fromCube.Distance(toCube))
+}
+
+// GetNeighbors returns the 6 axial positions adjacent to pos.
+func (a *AxialHexGrid) GetNeighbors(pos Position) []Position {
+	cube := axialToCube(pos)
+	neighborCubes := cube.GetNeighbors()
+	neighbors := make([]Position, 0, 6)
+	for _, nc := range neighborCubes {
+		np := cubeToAxial(nc)
+		if a.IsValidPosition(np) {
+			neighbors = append(neighbors, np)
+		}
+	}
+	return neighbors
+}
+
+// IsAdjacent reports whether two positions are adjacent (hex distance == 1).
+func (a *AxialHexGrid) IsAdjacent(pos1, pos2 Position) bool {
+	return a.Distance(pos1, pos2) <= 1
+}
+
+// GetLineOfSight returns hex positions along the line from from to to using
+// cube-coordinate linear interpolation (standard hex line algorithm).
+func (a *AxialHexGrid) GetLineOfSight(from, to Position) []Position {
+	if from.Equals(to) {
+		return []Position{from}
+	}
+	fromCube := axialToCube(from)
+	toCube := axialToCube(to)
+	dist := fromCube.Distance(toCube)
+	positions := make([]Position, 0, dist+1)
+	for i := 0; i <= dist; i++ {
+		t := float64(i) / float64(dist)
+		lerped := lerpCubeAxial(fromCube, toCube, t)
+		rounded := roundCubeAxial(lerped)
+		pos := cubeToAxial(rounded)
+		if a.IsValidPosition(pos) {
+			positions = append(positions, pos)
+		}
+	}
+	return positions
+}
+
+// GetPositionsInRange returns all valid axial positions within radius hex
+// steps of center.
+func (a *AxialHexGrid) GetPositionsInRange(center Position, radius float64) []Position {
+	centerCube := axialToCube(center)
+	iRadius := int(radius)
+	positions := make([]Position, 0)
+	for dq := -iRadius; dq <= iRadius; dq++ {
+		rMin := intMax(-iRadius, -dq-iRadius)
+		rMax := intMin(iRadius, -dq+iRadius)
+		for dr := rMin; dr <= rMax; dr++ {
+			ds := -dq - dr
+			candidate := CubeCoordinate{X: centerCube.X + dq, Y: centerCube.Y + dr, Z: centerCube.Z + ds}
+			pos := cubeToAxial(candidate)
+			if a.IsValidPosition(pos) {
+				positions = append(positions, pos)
+			}
+		}
+	}
+	return positions
+}
+
+// GetPositionsInRectangle returns all valid axial positions within the given
+// rectangle (treating X as Q and Y as R for the bounding box).
+func (a *AxialHexGrid) GetPositionsInRectangle(rect Rectangle) []Position {
+	positions := make([]Position, 0)
+	minQ := rect.Position.X
+	maxQ := rect.Position.X + rect.Dimensions.Width - 1
+	minR := rect.Position.Y
+	maxR := rect.Position.Y + rect.Dimensions.Height - 1
+	for q := minQ; q <= maxQ; q++ {
+		for r := minR; r <= maxR; r++ {
+			pos := Position{X: q, Y: r}
+			if a.IsValidPosition(pos) {
+				positions = append(positions, pos)
+			}
+		}
+	}
+	return positions
+}
+
+// GetPositionsInCircle returns all valid axial positions within the given circle.
+func (a *AxialHexGrid) GetPositionsInCircle(circle Circle) []Position {
+	return a.GetPositionsInRange(circle.Center, circle.Radius)
+}
+
+// GetPositionsInLine returns the positions along a line from from to to.
+func (a *AxialHexGrid) GetPositionsInLine(from, to Position) []Position {
+	return a.GetLineOfSight(from, to)
+}
+
+// GetPositionsInCone returns axial positions within a cone.
+func (a *AxialHexGrid) GetPositionsInCone(origin, direction Position, length, angle float64) []Position {
+	dirLength := math.Sqrt(direction.X*direction.X + direction.Y*direction.Y)
+	if dirLength == 0 {
+		return nil
+	}
+	dirX := direction.X / dirLength
+	dirY := direction.Y / dirLength
+	candidates := a.GetPositionsInRange(origin, length)
+	positions := make([]Position, 0, len(candidates))
+	for _, pos := range candidates {
+		if pos.Equals(origin) {
+			positions = append(positions, pos)
+			continue
+		}
+		posX := pos.X - origin.X
+		posY := pos.Y - origin.Y
+		posLen := math.Sqrt(posX*posX + posY*posY)
+		if posLen == 0 {
+			continue
+		}
+		dot := (dirX*posX + dirY*posY) / posLen
+		if math.Acos(math.Max(-1, math.Min(1, dot))) <= angle/2 {
+			positions = append(positions, pos)
+		}
+	}
+	return positions
+}
+
+// axialToCube converts an axial Position (X=Q, Y=R) to a CubeCoordinate.
+func axialToCube(pos Position) CubeCoordinate {
+	q := int(pos.X)
+	r := int(pos.Y)
+	return CubeCoordinate{X: q, Y: r, Z: -q - r}
+}
+
+// cubeToAxial converts a CubeCoordinate back to an axial Position (X=Q, Y=R).
+func cubeToAxial(c CubeCoordinate) Position {
+	return Position{X: float64(c.X), Y: float64(c.Y)}
+}
+
+// lerpCubeAxial linearly interpolates between two CubeCoordinates.
+// Uses float arithmetic before rounding so the cube invariant is preserved.
+func lerpCubeAxial(from, to CubeCoordinate, t float64) cubeFloat {
+	return cubeFloat{
+		x: float64(from.X) + t*float64(to.X-from.X),
+		y: float64(from.Y) + t*float64(to.Y-from.Y),
+		z: float64(from.Z) + t*float64(to.Z-from.Z),
+	}
+}
+
+// cubeFloat is a floating-point cube coordinate used only during line
+// interpolation to avoid premature integer truncation.
+type cubeFloat struct{ x, y, z float64 }
+
+// roundCubeAxial rounds a floating-point cube to the nearest valid hex,
+// preserving the cube constraint x+y+z=0.
+func roundCubeAxial(c cubeFloat) CubeCoordinate {
+	rx := math.Round(c.x)
+	ry := math.Round(c.y)
+	rz := math.Round(c.z)
+	xDiff := math.Abs(rx - c.x)
+	yDiff := math.Abs(ry - c.y)
+	zDiff := math.Abs(rz - c.z)
+	switch {
+	case xDiff > yDiff && xDiff > zDiff:
+		rx = -ry - rz
+	case yDiff > zDiff:
+		ry = -rx - rz
+	default:
+		rz = -rx - ry
+	}
+	return CubeCoordinate{X: int(rx), Y: int(ry), Z: int(rz)}
+}
+
+// intMax returns the larger of two ints.
+func intMax(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// intMin returns the smaller of two ints.
+func intMin(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// compile-time check: AxialHexGrid satisfies the Grid interface.
+var _ Grid = (*AxialHexGrid)(nil)
+
 // lerpCube performs linear interpolation between two cube coordinates
 func (hg *HexGrid) lerpCube(from, to CubeCoordinate, t float64) CubeCoordinate {
 	return CubeCoordinate{

--- a/tools/spatial/hex_grid.go
+++ b/tools/spatial/hex_grid.go
@@ -290,12 +290,15 @@ type AxialHexGrid struct {
 }
 
 // AxialHexGridConfig holds configuration for creating an AxialHexGrid.
-// Width and Height set the bounding box for IsValidPosition checks; pass
-// large values (e.g. 1000×1000) for encounter rooms where position bounds
-// are not meaningful.
+// SpanWidth and SpanHeight define the total span of valid axial coordinates.
+// IsValidPosition checks are centered on the origin — a position (Q, R) is
+// valid when Q ∈ [-SpanWidth/2, SpanWidth/2) and R ∈ [-SpanHeight/2,
+// SpanHeight/2). This differs from SquareGrid/HexGrid, whose Width/Height
+// are one-sided bounds starting at (0,0). Pass large values (e.g. 1000×1000)
+// for encounter rooms where position bounds are not meaningful.
 type AxialHexGridConfig struct {
-	Width  float64
-	Height float64
+	SpanWidth  float64
+	SpanHeight float64
 }
 
 // NewAxialHexGrid creates a new hex grid that treats Position.X/Y as axial
@@ -303,7 +306,7 @@ type AxialHexGridConfig struct {
 // in axial (not offset) form.
 func NewAxialHexGrid(config AxialHexGridConfig) *AxialHexGrid {
 	return &AxialHexGrid{
-		dimensions: Dimensions(config),
+		dimensions: Dimensions{Width: config.SpanWidth, Height: config.SpanHeight},
 	}
 }
 
@@ -317,10 +320,10 @@ func (a *AxialHexGrid) GetDimensions() Dimensions {
 	return a.dimensions
 }
 
-// IsValidPosition reports whether the position falls within the configured
-// bounding box. Axial Q/R can be negative, so the check is symmetric around
-// the origin: |X| < Width/2 and |Y| < Height/2. Pass Width=Height=1000 (or
-// similar) when you do not want meaningful bounds.
+// IsValidPosition reports true when (Q, R) falls within ±SpanWidth/2 along Q
+// and ±SpanHeight/2 along R. The check is centered on the origin because axial
+// hex coordinates are symmetric — positions can have negative Q or R. This
+// differs from SquareGrid/HexGrid whose bounds start at (0,0).
 func (a *AxialHexGrid) IsValidPosition(pos Position) bool {
 	half := a.dimensions.Width / 2
 	halfH := a.dimensions.Height / 2
@@ -350,7 +353,7 @@ func (a *AxialHexGrid) GetNeighbors(pos Position) []Position {
 	return neighbors
 }
 
-// IsAdjacent reports whether two positions are adjacent (hex distance == 1).
+// IsAdjacent reports whether two positions are adjacent (hex distance <= 1).
 func (a *AxialHexGrid) IsAdjacent(pos1, pos2 Position) bool {
 	return a.Distance(pos1, pos2) <= 1
 }
@@ -431,7 +434,7 @@ func (a *AxialHexGrid) GetPositionsInLine(from, to Position) []Position {
 func (a *AxialHexGrid) GetPositionsInCone(origin, direction Position, length, angle float64) []Position {
 	dirLength := math.Sqrt(direction.X*direction.X + direction.Y*direction.Y)
 	if dirLength == 0 {
-		return nil
+		return []Position{}
 	}
 	dirX := direction.X / dirLength
 	dirY := direction.Y / dirLength

--- a/tools/spatial/hex_grid_test.go
+++ b/tools/spatial/hex_grid_test.go
@@ -411,8 +411,8 @@ type AxialHexGridTestSuite struct {
 // SetupTest creates a large-bounds grid matching typical encounter usage.
 func (s *AxialHexGridTestSuite) SetupTest() {
 	s.grid = spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{
-		Width:  1000,
-		Height: 1000,
+		SpanWidth:  1000,
+		SpanHeight: 1000,
 	})
 }
 
@@ -444,13 +444,15 @@ func (s *AxialHexGridTestSuite) TestAxialHexGridDistance() {
 		})
 	}
 
-	// Positions that are distance-2 in cube space (NOT adjacent).
-	// These were distance √2≈1.414 in Euclidean, causing the original bug.
+	// Positions that are axial hex-distance 2 from the origin (NOT adjacent).
+	// These span a range of Cartesian distances: (2,0) is Euclidean-distance 2,
+	// (2,-1) is Euclidean-distance √5≈2.24 — but all are uniformly hex-distance
+	// 2 in cube coordinates. None should be treated as adjacent.
 	distance2 := []spatial.Position{
-		{X: 2, Y: 0},  // two Q-steps away
-		{X: 0, Y: 2},  // two R-steps away
-		{X: 2, Y: -1}, // Q+2, R-1: also non-adjacent
-		{X: 1, Y: -2}, // Q+1, R-2
+		{X: 2, Y: 0},  // two Q-steps away; Euclidean 2
+		{X: 0, Y: 2},  // two R-steps away; Euclidean 2
+		{X: 2, Y: -1}, // Q+2, R-1; Euclidean √5≈2.24
+		{X: 1, Y: -2}, // Q+1, R-2; Euclidean √5≈2.24
 	}
 	for _, pos := range distance2 {
 		s.Run("distance-2 position "+pos.String(), func() {

--- a/tools/spatial/hex_grid_test.go
+++ b/tools/spatial/hex_grid_test.go
@@ -399,3 +399,108 @@ func (s *HexGridTestSuite) TestCoordinateConversionMethods() {
 func TestHexGridSuite(t *testing.T) {
 	suite.Run(t, new(HexGridTestSuite))
 }
+
+// AxialHexGridTestSuite tests the AxialHexGrid which treats Position.X as Q
+// and Position.Y as R (axial cube coordinates). This is the grid used by
+// rpg-api's encounter hex map adapter.
+type AxialHexGridTestSuite struct {
+	suite.Suite
+	grid *spatial.AxialHexGrid
+}
+
+// SetupTest creates a large-bounds grid matching typical encounter usage.
+func (s *AxialHexGridTestSuite) SetupTest() {
+	s.grid = spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{
+		Width:  1000,
+		Height: 1000,
+	})
+}
+
+// TestAxialHexGridShape confirms the grid reports GridShapeHex.
+func (s *AxialHexGridTestSuite) TestAxialHexGridShape() {
+	s.Equal(spatial.GridShapeHex, s.grid.GetShape())
+}
+
+// TestAxialHexGridDistance verifies the cube-formula distance for axial positions.
+// All 6 immediate neighbors of the origin must be exactly distance 1.
+func (s *AxialHexGridTestSuite) TestAxialHexGridDistance() {
+	origin := spatial.Position{X: 0, Y: 0}
+
+	// The 6 axial neighbors of (0,0) in cube coordinates:
+	// (+1,0), (-1,0), (0,+1), (0,-1), (+1,-1), (-1,+1)
+	adjacentNeighbors := []spatial.Position{
+		{X: 1, Y: 0},  // Q+1
+		{X: -1, Y: 0}, // Q-1
+		{X: 0, Y: 1},  // R+1
+		{X: 0, Y: -1}, // R-1
+		{X: 1, Y: -1}, // Q+1, R-1  — the "diagonal" that Euclidean gets wrong
+		{X: -1, Y: 1}, // Q-1, R+1  — same
+	}
+	for _, neighbor := range adjacentNeighbors {
+		s.Run("adjacent neighbor "+neighbor.String(), func() {
+			dist := s.grid.Distance(origin, neighbor)
+			s.Equal(1.0, dist,
+				"hex neighbor %v must be distance 1 from origin; got %v", neighbor, dist)
+		})
+	}
+
+	// Positions that are distance-2 in cube space (NOT adjacent).
+	// These were distance √2≈1.414 in Euclidean, causing the original bug.
+	distance2 := []spatial.Position{
+		{X: 2, Y: 0},  // two Q-steps away
+		{X: 0, Y: 2},  // two R-steps away
+		{X: 2, Y: -1}, // Q+2, R-1: also non-adjacent
+		{X: 1, Y: -2}, // Q+1, R-2
+	}
+	for _, pos := range distance2 {
+		s.Run("distance-2 position "+pos.String(), func() {
+			dist := s.grid.Distance(origin, pos)
+			s.Equal(2.0, dist,
+				"position %v must be distance 2 from origin; got %v", pos, dist)
+		})
+	}
+}
+
+// TestAxialHexGridDistance_PlaytestScenario is the exact pair that broke the
+// Wave 2.11e MCP playtest: goblin at Q=2,R=-1 vs alice at Q=1,R=0. In
+// axial coords the hex distance is 1 (adjacent). The previous Euclidean
+// check returned √2≈1.414 and failed the ≤1.0 gate, suppressing the OA.
+func (s *AxialHexGridTestSuite) TestAxialHexGridDistance_PlaytestScenario() {
+	goblin := spatial.Position{X: 2, Y: -1} // goblin at (Q=2, R=-1)
+	alice := spatial.Position{X: 1, Y: 0}   // alice at (Q=1, R=0)
+	dist := s.grid.Distance(goblin, alice)
+	s.Equal(1.0, dist,
+		"goblin at (2,-1) and alice at (1,0) must be hex-adjacent (distance 1); "+
+			"Euclidean would give √2≈1.414 which incorrectly fails the reach check")
+}
+
+// TestAxialHexGridNeighbors verifies exactly 6 neighbors are returned for an
+// interior origin, all at distance 1.
+func (s *AxialHexGridTestSuite) TestAxialHexGridNeighbors() {
+	origin := spatial.Position{X: 0, Y: 0}
+	neighbors := s.grid.GetNeighbors(origin)
+	s.Len(neighbors, 6, "interior hex must have exactly 6 neighbors")
+	for _, n := range neighbors {
+		s.Equal(1.0, s.grid.Distance(origin, n),
+			"all neighbors of origin must be distance 1; got %v for %v", s.grid.Distance(origin, n), n)
+	}
+}
+
+// TestAxialHexGridIsAdjacent spot-checks the adjacency predicate.
+func (s *AxialHexGridTestSuite) TestAxialHexGridIsAdjacent() {
+	origin := spatial.Position{X: 0, Y: 0}
+	s.True(s.grid.IsAdjacent(origin, spatial.Position{X: 1, Y: -1}), "diagonal neighbor must be adjacent")
+	s.False(s.grid.IsAdjacent(origin, spatial.Position{X: 2, Y: 0}), "two hexes away must not be adjacent")
+}
+
+// TestAxialHexGridImplementsGrid is a compile-time witness that AxialHexGrid
+// satisfies the Grid interface; the test itself just calls a method.
+func (s *AxialHexGridTestSuite) TestAxialHexGridImplementsGrid() {
+	var g spatial.Grid = s.grid
+	s.Equal(spatial.GridShapeHex, g.GetShape())
+}
+
+// Run the axial grid test suite.
+func TestAxialHexGridSuite(t *testing.T) {
+	suite.Run(t, new(AxialHexGridTestSuite))
+}


### PR DESCRIPTION
## Summary

- Adds `AxialHexGrid` / `AxialHexGridConfig` / `NewAxialHexGrid` to `tools/spatial/hex_grid.go` as the canonical `Grid` implementation for axial (cube-coordinate) hex maps.
- Uses the cube-distance formula `(|ΔQ|+|ΔR|+|ΔS|)/2` so all 6 adjacent hexes register as distance 1, including the 2 neighbors whose XY-Euclidean distance is √2.
- Adds `AxialHexGridTestSuite` in `hex_grid_test.go` covering all 6 neighbors, the previously-broken playtest geometry, and `var _ Grid = (*AxialHexGrid)(nil)` interface compliance.

## Bug context (rpg-api Wave 2.11e #539 / PR #544)

During end-to-end verification of the Wave 2.11e movement resolver, MCP playtest revealed that Opportunity Attacks (OA) did not fire when a player retreated past a diagonally-adjacent goblin. Investigation traced the bug to `encounterHexRoom.GetEntitiesInRange` in rpg-api, which used XY-Euclidean distance. The encounter SDK uses axial (Q,R,S) coordinates mapped Q→X, R→Y; two of the six hex neighbors have XY-Euclidean distance √2 ≈ 1.414 > 1.0 and were incorrectly excluded from the melee threat check, so `triggerOpportunityAttack` never fired for those positions.

The fix belongs in the toolkit as the canonical hex distance implementation rather than a local workaround in rpg-api. rpg-api PR #544 updates `hex_room.GetGrid()` to return `AxialHexGrid` and is gated on this PR merging.

## Test plan

- [ ] `cd tools/spatial && go test -race ./...` passes (all `AxialHexGridTestSuite` cases including `TestAxialHexGridDistance_PlaytestScenario`)
- [ ] `golangci-lint run ./...` clean on new code in `hex_grid.go` (pre-existing `goconst` in `connection_helpers.go` / `room.go` are not introduced by this PR)
- [ ] `var _ Grid = (*AxialHexGrid)(nil)` compile-time interface assertion in `hex_grid.go`
- [ ] CI passes on changed module (`tools/spatial`)

## References

- rpg-api PR #544 (Wave 2.11e movement resolver — consumer of this grid)
- rpg-api issue #539 (movement resolver feature that exposed the OA bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)