### PR TITLE
feat(encounter): add DamageComponent breakdown to AttackOutcome and DamageDealtEvent

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -288,13 +288,15 @@ func (e *Encounter) publishAttackOutcome(
 		return fmt.Errorf("publish attack resolved: %w", err)
 	}
 	if outcome.Hit {
-		if err := e.broker.Publish(events.NewDamageDealtEvent(
+		evt := events.NewDamageDealtEvent(
 			e.data.ID, e.nextSeq(),
 			targetID, attackerID,
 			outcome.Damage, damageType,
 			targetHPAfter, targetMaxHP,
 			damagePerPlayer,
-		)); err != nil {
+		)
+		evt.Components = outcome.Components
+		if err := e.broker.Publish(evt); err != nil {
 			return fmt.Errorf("publish damage dealt: %w", err)
 		}
 	}

--- a/encounter/combat_resolver.go
+++ b/encounter/combat_resolver.go
@@ -237,6 +237,13 @@ type AttackOutcome struct {
 	// to the entity's stored damage type if the resolver leaves it
 	// empty on a hit.
 	DamageType string
+
+	// Components is the optional per-source breakdown of the total Damage.
+	// Rulebook resolvers populate this when they have rich breakdown data
+	// (e.g. weapon damage + sneak attack). The encounter SDK forwards it to
+	// DamageDealtEvent.Components without inspecting it; nil is valid and
+	// means "no breakdown available".
+	Components []encountercore.DamageComponent
 }
 
 // toolkitRef converts the encounter SDK's local ActionRef shape (plain

--- a/encounter/core/damage.go
+++ b/encounter/core/damage.go
@@ -1,0 +1,20 @@
+package core
+
+// DamageComponent is the encounter-SDK-level descriptor of a single damage
+// source within a hit. Rulebook resolvers populate []DamageComponent on
+// AttackOutcome so the encounter SDK can forward the breakdown to
+// DamageDealtEvent without importing rulebook-specific types.
+//
+// Source is an opaque identifier the wire layer uses to label each line.
+// Convention: use the toolkit's SourceRef.String() for named sources (e.g.
+// "dnd5e:conditions:sneak_attack") or a category string ("weapon", "ability")
+// for generic sources. Amount is the component's total contribution (dice +
+// flat bonus after chain modifiers). DamageType mirrors the top-level
+// DamageDealtEvent field for components that carry a distinct damage type.
+// IsCritical flags components that were doubled for a critical hit.
+type DamageComponent struct {
+	Source     string
+	Amount     int
+	DamageType string
+	IsCritical bool
+}

--- a/encounter/core/damage.go
+++ b/encounter/core/damage.go
@@ -13,8 +13,8 @@ package core
 // DamageDealtEvent field for components that carry a distinct damage type.
 // IsCritical flags components that were doubled for a critical hit.
 type DamageComponent struct {
-	Source     string
-	Amount     int
-	DamageType string
-	IsCritical bool
+	Source     string `json:"source"`
+	Amount     int    `json:"amount"`
+	DamageType string `json:"damage_type,omitempty"`
+	IsCritical bool   `json:"is_critical,omitempty"`
 }

--- a/encounter/events/damage_dealt.go
+++ b/encounter/events/damage_dealt.go
@@ -18,6 +18,9 @@ type DamageDealtEvent struct {
 	HPAfter    int
 	MaxHP      int
 	PerPlayer  map[core.PlayerID]DamageDealtSlice
+	// Components is the optional per-source breakdown forwarded from the
+	// combat resolver's AttackOutcome.Components. Nil means no breakdown.
+	Components []core.DamageComponent
 }
 
 // DamageDealtSlice is each viewer's projection. Visible says whether the

--- a/encounter/events/damage_dealt.go
+++ b/encounter/events/damage_dealt.go
@@ -76,6 +76,7 @@ type damageDealtWire struct {
 	HPAfter    int                                `json:"hp_after"`
 	MaxHP      int                                `json:"max_hp"`
 	PerPlayer  map[core.PlayerID]DamageDealtSlice `json:"per_player"`
+	Components []core.DamageComponent             `json:"components,omitempty"`
 }
 
 // MarshalJSON exposes encID and seq under stable JSON field names.
@@ -91,6 +92,7 @@ func (e *DamageDealtEvent) MarshalJSON() ([]byte, error) {
 		HPAfter:    e.HPAfter,
 		MaxHP:      e.MaxHP,
 		PerPlayer:  e.PerPlayer,
+		Components: e.Components,
 	})
 }
 
@@ -110,5 +112,6 @@ func (e *DamageDealtEvent) UnmarshalJSON(b []byte) error {
 	e.HPAfter = w.HPAfter
 	e.MaxHP = w.MaxHP
 	e.PerPlayer = w.PerPlayer
+	e.Components = w.Components
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `core.DamageComponent` to `encounter/core` — opaque breakdown type safe for the encounter SDK to use without importing rulebook types
- `AttackOutcome` gains `Components []core.DamageComponent` for rulebook resolvers to populate
- `publishAttackOutcome` forwards `outcome.Components` to `DamageDealtEvent.Components` so the wire layer can propagate it

## Context

Part of Chapter 2 Wave 1 cross-repo damage_breakdown wiring. Prerequisite for rpg-api issue #556 (populate breakdown in translate.go) and ultimately rpg-api-protos issue #160 (add `damage_breakdown` to v1alpha2 `EntityDamaged`).

The `DamageComponent` type lives in `encounter/core` (already imported by `encounter/events`) to avoid a circular import if it lived in the `encounter` package.

## Implementation note

`DamageComponent` requires JSON struct tags on every field — without them, the broker's `encodeEvent`/`decodeEvent` JSON round-trip silently drops them. Discovered during local end-to-end verification of Wave 1 damage breakdown wiring.

## Test plan

- [x] `encounter/core` builds with no lint issues
- [x] `encounter` module tests all pass (`go test ./...`)
- [x] No breaking changes — `Components` is an optional additive field; all existing callers that don't set it get `nil` (no breakdown)

Closes #683
Rolls up to rpg-api#550 (Chapter 2 Wave 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)