### PR TITLE
fix(encounter): prevent double damage application on NPC attacks (#684)

### DIFF
--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -145,7 +145,7 @@ func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) er
 	capturedDmg = dmgSlice
 	unsubDmg = dmgUnsub
 
-	if err := e.applyCapturedAttacks(mon, *captured); err != nil {
+	if err := e.applyCapturedAttacks(mon, *captured, capturedDmg); err != nil {
 		// errNPCPausedForReaction propagates as-is; the orchestrator
 		// detects it via IsNPCPausedForReaction. Other captured-event
 		// processing (damage, conditions) is skipped because the early
@@ -153,6 +153,10 @@ func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) er
 		// chain itself is suspended awaiting the player's response.
 		return err
 	}
+	// applyCapturedAttacks drained the resolver's internal DamageReceivedEvents
+	// from capturedDmg (#684). Any remaining events are from non-attack damage
+	// sources (e.g., a future breath-weapon monster action using DealDamage
+	// directly) and must still be processed here.
 	if err := e.applyCapturedDamage(mon, *capturedDmg); err != nil {
 		return err
 	}
@@ -326,7 +330,26 @@ func (e *Encounter) applyNPCMovementSteps(mon *MonsterData, path []encountercore
 // Death is published only on the HP transition (hpBefore > 0 && hpAfter == 0),
 // not whenever HP happens to be 0 — so multi-attack NPCs and re-hits on a
 // downed player do not duplicate EntityDiedEvent.
-func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents.AttackEvent) error {
+//
+// #684 consume semantics: capturedDmg is the live slice that the NPCAct
+// outer subscribeDamage listener writes into. After each attack resolves,
+// this function drains whatever the resolver added to that slice — those
+// events are the rulebook's internal DamageReceivedEvent notify step
+// (combat.ApplyAttackOutcome publishes one after running the damage chain).
+// HP and the encounter-side DamageDealtEvent are already handled by
+// applyAndPublishNPCOutcome; draining prevents applyCapturedDamage from
+// re-applying the same damage a second time.
+//
+// applyCapturedDamage remains in place for the speculative future case
+// where a monster action deals damage via DealDamage (not ResolveAttack)
+// — e.g., a breath weapon action. That path would publish a
+// DamageReceivedEvent without a preceding AttackEvent, so it would not be
+// consumed here and would correctly flow through applyCapturedDamage.
+func (e *Encounter) applyCapturedAttacks(
+	mon *MonsterData,
+	attacks []dnd5eEvents.AttackEvent,
+	capturedDmg *[]dnd5eEvents.DamageReceivedEvent,
+) error {
 	for _, atk := range attacks {
 		targetID := encountercore.EntityID(atk.TargetID)
 		targetPlayer := e.findPlayerByEntityID(targetID)
@@ -344,6 +367,13 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 			TargetAC:            targetPlayer.AC,
 			EventBus:            e.bus,
 		}
+
+		// Snapshot the damage slice length before the resolver runs. The
+		// resolver publishes DamageReceivedEvent internally (the "notify"
+		// step in combat.ApplyAttackOutcome). We drain those events after
+		// applyAndPublishNPCOutcome so applyCapturedDamage doesn't re-apply
+		// them. See #684.
+		dmgLenBefore := len(*capturedDmg)
 
 		// Wave 2.11d: route NPC attacks through the phased path when the
 		// resolver supports it so player Shield prompts can fire on hits
@@ -370,6 +400,15 @@ func (e *Encounter) applyCapturedAttacks(mon *MonsterData, attacks []dnd5eEvents
 		if err := e.applyAndPublishNPCOutcome(mon, targetPlayer, outcome); err != nil {
 			return err
 		}
+
+		// Drain the DamageReceivedEvents the resolver published during this
+		// attack's resolution window. applyAndPublishNPCOutcome has already
+		// applied HP and emitted the encounter-side DamageDealtEvent (with
+		// full Components); these captured events are the rulebook's internal
+		// notify step and must not flow through applyCapturedDamage again.
+		// We keep only events that appeared before this attack ran (i.e., any
+		// that future non-attack monster actions may add after this loop).
+		*capturedDmg = (*capturedDmg)[:dmgLenBefore]
 	}
 	return nil
 }
@@ -544,9 +583,13 @@ func (e *Encounter) PendingPhasedAttackContext(reactorPlayerID encountercore.Pla
 }
 
 // applyCapturedDamage translates each dnd5e DamageReceivedEvent into an
-// encounter DamageDealtEvent. Today no shipped action publishes one
-// through this bus, but the wiring is in place so downstream changes
-// flow automatically.
+// encounter DamageDealtEvent. In the standard NPC-attack path this slice
+// is empty (applyCapturedAttacks drains the resolver's internal notify
+// events — see #684). This function is the future-facing path for monster
+// actions that deal damage via DealDamage rather than ResolveAttack (e.g.,
+// breath weapons or environmental hazards). Those actions publish a
+// DamageReceivedEvent without a preceding AttackEvent, so they are not
+// consumed by applyCapturedAttacks and correctly arrive here.
 //
 // Target resolution: tries player → monster. If neither matches, the
 // damage event is skipped (no DamageDealtEvent published) — emitting

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -586,10 +586,12 @@ func (e *Encounter) PendingPhasedAttackContext(reactorPlayerID encountercore.Pla
 // encounter DamageDealtEvent. In the standard NPC-attack path this slice
 // is empty (applyCapturedAttacks drains the resolver's internal notify
 // events — see #684). This function is the future-facing path for monster
-// actions that deal damage via DealDamage rather than ResolveAttack (e.g.,
-// breath weapons or environmental hazards). Those actions publish a
-// DamageReceivedEvent without a preceding AttackEvent, so they are not
-// consumed by applyCapturedAttacks and correctly arrive here.
+// actions that deal direct damage via DealDamage rather than through
+// ResolveAttack (e.g., a goblin's breath weapon or a splash damage action).
+// Those actions publish a DamageReceivedEvent without a preceding AttackEvent,
+// so they are not consumed by applyCapturedAttacks and correctly arrive here.
+// The function is NPC-scoped: mon.Position is used for the per-viewer LoS
+// projection, so only NPC-originated damage belongs in this path.
 //
 // Target resolution: tries player → monster. If neither matches, the
 // damage event is skipped (no DamageDealtEvent published) — emitting

--- a/encounter/npc_test.go
+++ b/encounter/npc_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	encevents "github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
@@ -251,4 +252,115 @@ func (s *NPCSuite) TestNPCAct_MovementOA_AppliesDamageOnce() {
 	s.Require().NotNil(mon, "goblin must still be present (5 damage on 7 HP is non-lethal)")
 	s.Equal(startHP-oaDamage, mon.HP,
 		"OA damage must apply exactly once on the NPCAct path (no double-apply)")
+}
+
+// busPublishingResolver is a test CombatResolver that mimics the production
+// dnd5e resolver: it returns an AttackOutcome AND publishes a
+// DamageReceivedEvent on the encounter bus (the "notify" step that
+// combat.ApplyAttackOutcome performs after running the damage chain).
+// This is the minimal reproducer for #684 — the standard alwaysHitResolver
+// does NOT publish on the bus and so cannot trigger the double-apply.
+type busPublishingResolver struct {
+	damage     int
+	damageType string
+}
+
+func (r busPublishingResolver) ResolveAttack(input encounter.AttackInput) (*encounter.AttackOutcome, error) {
+	if input.EventBus != nil {
+		topic := dnd5eEvents.DamageReceivedTopic.On(input.EventBus)
+		_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
+			TargetID:   string(input.TargetID),
+			SourceID:   string(input.AttackerID),
+			Amount:     r.damage,
+			DamageType: damage.Type(r.damageType),
+		})
+	}
+	return &encounter.AttackOutcome{
+		Hit:         true,
+		AttackRoll:  20,
+		AttackBonus: 4,
+		TargetAC:    10,
+		Damage:      r.damage,
+		DamageType:  r.damageType,
+	}, nil
+}
+
+// TestNPCAct_SingleDamageDealtEvent_PerAttack is the regression guard for
+// #684: a single NPC attack must produce exactly one DamageDealtEvent and
+// apply HP exactly once. Before the fix, the resolver's internal
+// DamageReceivedEvent notify was captured by the outer subscribeDamage
+// listener in NPCAct and then re-applied by applyCapturedDamage, producing
+// a second DamageDealtEvent with empty Components and a second HP mutation.
+//
+// This test uses busPublishingResolver which reproduces the production
+// resolver pattern: returns AttackOutcome AND publishes DamageReceivedEvent
+// on the encounter bus. Without the #684 fix, alice (12 HP) would take 10
+// HP of damage from a 5-damage hit and be at 2 HP; with the fix she is at 7.
+func (s *NPCSuite) TestNPCAct_SingleDamageDealtEvent_PerAttack() {
+	const attackDamage = 5
+	const aliceStartHP = 12
+
+	gob := monster.NewGoblin(gobEntityID)
+	gobData := gob.ToData()
+	dataJSON, err := json.Marshal(gobData)
+	s.Require().NoError(err)
+
+	// Build a fresh encounter with the bus-publishing resolver so the
+	// DamageReceivedEvent notify fires during the attack-resolution window.
+	enc := encounter.New("enc-npc-single-dmg", s.broker,
+		encounter.WithCombatResolver(busPublishingResolver{damage: attackDamage, damageType: damageSlashing}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: aliceStartHP, MaxHP: aliceStartHP, AC: 14,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  monsterRefGoblin,
+		DataJSON:    dataJSON,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	sub, subErr := s.broker.Subscribe("enc-npc-single-dmg", alicePlayerID)
+	s.Require().NoError(subErr)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(sub, 100*time.Millisecond)
+
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+
+	// Collect all events delivered to alice from the NPC attack.
+	var dmgEvents []*encevents.DamageDealtEvent
+	deadline := time.After(time.Second)
+drainLoop:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoop
+			}
+			if de, isDmg := evt.(*encevents.DamageDealtEvent); isDmg {
+				dmgEvents = append(dmgEvents, de)
+			}
+		case <-deadline:
+			break drainLoop
+		}
+	}
+
+	// ASSERT: exactly one DamageDealtEvent (not two).
+	s.Require().Len(dmgEvents, 1,
+		"exactly one DamageDealtEvent per NPC attack (#684: before fix, two events fire — "+
+			"one from publishAttackOutcome with Components, one from applyCapturedDamage without)")
+
+	// ASSERT: HP applied exactly once — alice goes from 12 → 7, not 12 → 2.
+	aliceAfter := enc.ToData().Players[alicePlayerID]
+	s.Equal(aliceStartHP-attackDamage, aliceAfter.HP,
+		"HP must drop by damage exactly once; if 12→2, applyCapturedDamage double-applied (#684)")
 }


### PR DESCRIPTION
## Summary

- **Bug:** A single NPC melee attack applied HP damage twice and emitted two `DamageDealtEvent`s — once via `applyAndPublishNPCOutcome` (rich, with Components) and once via `applyCapturedDamage` (empty Components). The second application was the rulebook resolver's internal `DamageReceivedEvent` notify step being re-processed as independent damage.
- **Fix:** `applyCapturedAttacks` now accepts the live `capturedDmg` slice and uses consume semantics — after each attack resolves, it drains the events the resolver added during that attack's window. `applyCapturedDamage` is preserved for future non-attack damage sources (e.g., breath weapons via `DealDamage`).
- **Regression guard:** `TestNPCAct_SingleDamageDealtEvent_PerAttack` uses `busPublishingResolver` to reproduce the production resolver pattern (returns `AttackOutcome` AND publishes `DamageReceivedEvent` on the bus). Asserts exactly one `DamageDealtEvent` and single HP application per attack.

## Root cause trace

1. `NPCAct` installs `subscribeDamage` on the encounter bus (after movement).
2. `applyCapturedAttacks` → `npcResolveAttackPhased` → resolver fires → `combat.ApplyAttackOutcome` publishes `DamageReceivedEvent` on the **shared** encounter bus as its internal notify step.
3. That event lands in `capturedDmg`.
4. `applyAndPublishNPCOutcome` applies HP and emits `DamageDealtEvent` (with Components). **Canonical.**
5. `applyCapturedDamage` sees the captured notify event, calls `applyDamageToTarget` again, emits a second `DamageDealtEvent` (empty Components). **Bug.**

## What's preserved

- `applyCapturedDamage` is not removed — it's the correct path for future monster actions that deal damage via `DealDamage` (not `ResolveAttack`), e.g., breath weapons.
- Kill chain / death-event path unchanged — `applyAndPublishNPCOutcome` handles the `>0 → 0` transition; `applyCapturedDamage` only sees an already-drained (empty) slice.
- Movement-OA path unaffected — `applyMoveDamage` handles that, not `applyCapturedDamage`.

## Follow-up

Filed #685 for the underlying smell: `subscribeDamage` indiscriminately capturing the resolver's internal notify events. Deferred — out of scope for Wave 3, no current action triggers the latent secondary-damage hazard described there.

## Test plan

- [x] `TestNPCAct_SingleDamageDealtEvent_PerAttack` — new regression guard passes
- [x] Full `encounter` suite green with `-race`: `go test -race ./... -count=1`
- [x] `golangci-lint run` — no new issues (pre-existing `goconst` in other test files not introduced by this PR)

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)