### PR TITLE
feat(encounter): add ResourceChangedEvent + ActivateFeature verb (Wave 0)

### DIFF
--- a/encounter/activate_feature.go
+++ b/encounter/activate_feature.go
@@ -80,6 +80,17 @@ func (e *Encounter) ActivateFeature(ctx context.Context, in *ActivateFeatureInpu
 		return nil, fmt.Errorf("unmarshal character data: %w", err)
 	}
 
+	// Validate that CharDataJSON belongs to the actor. This is the SDK's own
+	// consistency guard: events are published under ActorID, so mismatched
+	// data would produce condition/resource events for the wrong identity.
+	// Player-ownership (ActorID == request.EntityID) stays at the rpg-api layer.
+	if charData.ID != string(in.ActorID) {
+		return nil, fmt.Errorf(
+			"CharDataJSON identity mismatch: data.ID=%q does not match ActorID=%q",
+			charData.ID, in.ActorID,
+		)
+	}
+
 	// Snapshot the full resource set before activation so we can diff post.
 	preSources := snapshotResources(charData.Resources)
 
@@ -90,6 +101,13 @@ func (e *Encounter) ActivateFeature(ctx context.Context, in *ActivateFeatureInpu
 	if err != nil {
 		return nil, fmt.Errorf("load character: %w", err)
 	}
+	// Tear down the character's bus subscriptions after the verb completes so
+	// that repeated ActivateFeature calls on the same Encounter object (e.g. in
+	// tests) do not accumulate duplicate subscribers on e.bus.
+	// In production each RPC creates a fresh Encounter via LoadFromData (fresh
+	// e.bus), but the SDK must be safe regardless. Mirrors the defer unsubCond()
+	// pattern already used for the condition-capture subscriber.
+	defer func() { _ = char.Cleanup(ctx) }()
 
 	// Capture the condition the character's bus will emit during ActivateAbility.
 	capturedCond, unsubCond, err := subscribeConditions(ctx, e.bus)

--- a/encounter/activate_feature.go
+++ b/encounter/activate_feature.go
@@ -1,0 +1,251 @@
+package encounter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// ActivateFeatureInput is the request shape for Encounter.ActivateFeature.
+//
+// CharDataJSON is the caller-supplied serialized dnd5e character data (from the
+// host's character store). It mirrors the MonsterInput/MonsterData.DataJSON
+// pattern used by NPCAct — the encounter SDK does not store character data
+// internally; the host (rpg-api) fetches it from its character store and passes
+// it in, just as it does when seeding MonsterData.DataJSON for NPCAct.
+type ActivateFeatureInput struct {
+	// ActorID is the entity ID of the player character activating the feature.
+	ActorID encountercore.EntityID
+
+	// FeatureRef is the canonical ref string for the feature to activate,
+	// e.g. "dnd5e:features:rage". Passed through to character.ActivateAbility.
+	FeatureRef string
+
+	// CharDataJSON is the serialized dnd5e character.Data for the actor.
+	// Must include ActionEconomy (so the character is InCombat) and current
+	// resource state. The verb loads the character from this data, runs
+	// ActivateAbility, and returns the updated serialization in the output.
+	CharDataJSON json.RawMessage
+}
+
+// ActivateFeatureOutput is the result shape for Encounter.ActivateFeature.
+type ActivateFeatureOutput struct {
+	// UpdatedCharData is the serialized dnd5e character.Data after the feature
+	// activation (resource decremented, action economy consumed). The host
+	// (rpg-api) persists this to its character store.
+	UpdatedCharData json.RawMessage
+}
+
+// ActivateFeature activates a character feature in-encounter. It:
+//  1. Validates the actor is a player seat in this encounter.
+//  2. Loads the dnd5e character from CharDataJSON.
+//  3. Subscribes to the encounter-scoped dnd5e bus to capture any
+//     ConditionAppliedEvent that ActivateAbility publishes.
+//  4. Calls char.ActivateAbility({AbilityRef: featureRef}).
+//  5. Bridges each captured dnd5e ConditionAppliedEvent → broker
+//     ConditionAppliedEvent (following the applyCapturedConditions template).
+//  6. Diffs the full pre/post resource set and publishes a broker
+//     ResourceChangedEvent for every resource whose current value changed.
+//  7. Returns the updated character serialization for the host to persist.
+//
+// Design note: the encounter SDK already imports rulebooks/dnd5e/monster and
+// calls monster.LoadFromData directly in NPCAct. ActivateFeature follows that
+// same precedent, importing rulebooks/dnd5e/character and calling
+// character.LoadFromData. Director accepted the NPCAct-precedent coupling for
+// Wave 0; fully agnostic SDK is tracked separately.
+func (e *Encounter) ActivateFeature(ctx context.Context, in *ActivateFeatureInput) (*ActivateFeatureOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("ActivateFeatureInput is nil")
+	}
+	if len(in.CharDataJSON) == 0 {
+		return nil, fmt.Errorf("CharDataJSON is required")
+	}
+
+	// Validate the actor exists in this encounter.
+	p := e.findPlayerByEntityID(in.ActorID)
+	if p == nil {
+		return nil, fmt.Errorf("actor %q not found in encounter", in.ActorID)
+	}
+
+	// Deserialize the character data.
+	var charData dnd5eCharacter.Data
+	if err := json.Unmarshal(in.CharDataJSON, &charData); err != nil {
+		return nil, fmt.Errorf("unmarshal character data: %w", err)
+	}
+
+	// Snapshot the full resource set before activation so we can diff post.
+	preSources := snapshotResources(charData.Resources)
+
+	// Load the character onto the encounter-scoped dnd5e bus so that any
+	// conditions already Applied at rehydration time (e.g. Sneak Attack) can
+	// observe the activation event on the same persistent bus.
+	char, err := dnd5eCharacter.LoadFromData(ctx, &charData, e.bus)
+	if err != nil {
+		return nil, fmt.Errorf("load character: %w", err)
+	}
+
+	// Capture the condition the character's bus will emit during ActivateAbility.
+	capturedCond, unsubCond, err := subscribeConditions(ctx, e.bus)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe conditions: %w", err)
+	}
+	defer func() { _ = unsubCond() }()
+
+	// Parse the feature ref string to a core.Ref.
+	featureRef, err := core.ParseString(in.FeatureRef)
+	if err != nil {
+		return nil, fmt.Errorf("parse feature ref %q: %w", in.FeatureRef, err)
+	}
+
+	// Activate the feature via the character's own rules engine.
+	out, err := char.ActivateAbility(ctx, &dnd5eCharacter.ActivateAbilityInput{
+		AbilityRef: featureRef,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("activate ability: %w", err)
+	}
+	if !out.Success {
+		return nil, fmt.Errorf("activate ability failed: %s", out.Error)
+	}
+
+	// Bridge captured dnd5e ConditionAppliedEvents → broker ConditionAppliedEvents.
+	// Mirrors applyCapturedConditions (npc.go:776) — same template.
+	if err := e.applyActivatedConditions(p, in.ActorID, *capturedCond); err != nil {
+		return nil, fmt.Errorf("bridge conditions: %w", err)
+	}
+
+	// Serialize updated character data (post-activation).
+	updatedData, err := json.Marshal(char.ToData())
+	if err != nil {
+		return nil, fmt.Errorf("marshal updated character: %w", err)
+	}
+
+	// Diff the full resource set and publish a ResourceChangedEvent for every
+	// resource whose current value changed. Generic over all features — no
+	// feature-specific hardcoding here.
+	var postData dnd5eCharacter.Data
+	if err := json.Unmarshal(updatedData, &postData); err != nil {
+		return nil, fmt.Errorf("unmarshal updated character for resource diff: %w", err)
+	}
+	postSources := snapshotResources(postData.Resources)
+	if err := e.publishChangedResources(in.ActorID, preSources, postSources); err != nil {
+		return nil, fmt.Errorf("publish resource changes: %w", err)
+	}
+
+	return &ActivateFeatureOutput{
+		UpdatedCharData: updatedData,
+	}, nil
+}
+
+// resourceSnapshot is the pre/post shape for a single resource.
+type resourceSnapshot struct {
+	current int
+	maximum int
+}
+
+// snapshotResources converts the character.Data.Resources map into a keyed
+// snapshot map for pre/post diffing.
+func snapshotResources(
+	src map[coreResources.ResourceKey]dnd5eCharacter.RecoverableResourceData,
+) map[coreResources.ResourceKey]resourceSnapshot {
+	out := make(map[coreResources.ResourceKey]resourceSnapshot, len(src))
+	for k, v := range src {
+		out[k] = resourceSnapshot{current: v.Current, maximum: v.Maximum}
+	}
+	return out
+}
+
+// publishChangedResources emits a broker ResourceChangedEvent for every resource
+// key whose Current value changed between pre and post snapshots. Generic over
+// all features — no feature-specific key hardcoded.
+func (e *Encounter) publishChangedResources(
+	actorID encountercore.EntityID,
+	pre, post map[coreResources.ResourceKey]resourceSnapshot,
+) error {
+	for key, postSnap := range post {
+		preSnap, exists := pre[key]
+		if !exists || postSnap.current == preSnap.current {
+			continue
+		}
+		if err := e.publishResourceChanged(actorID, string(key), postSnap.current, postSnap.maximum); err != nil {
+			return fmt.Errorf("publish resource changed for %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// applyActivatedConditions bridges dnd5e ConditionAppliedEvents emitted
+// during a player feature activation to broker ConditionAppliedEvents.
+// Template: applyCapturedConditions (npc.go:776).
+func (e *Encounter) applyActivatedConditions(
+	actor *PlayerData,
+	actorID encountercore.EntityID,
+	conds []dnd5eEvents.ConditionAppliedEvent,
+) error {
+	for _, cond := range conds {
+		targetID := actorID
+		condRef := string(cond.Type)
+
+		condPerPlayer := make(map[encountercore.PlayerID]events.ConditionAppliedSlice)
+		for viewerID, viewer := range e.data.Players {
+			// Nil-guard: skip viewer if View is missing (malformed encounter data).
+			if viewer == nil || viewer.View == nil {
+				continue
+			}
+			// Nil-guard: skip if actor has no View (malformed encounter data).
+			if actor == nil || actor.View == nil {
+				break
+			}
+			if !e.viewerCanSee(viewer, actor.View.Position) {
+				continue
+			}
+			condPerPlayer[viewerID] = events.ConditionAppliedSlice{Visible: true}
+		}
+
+		if err := e.broker.Publish(events.NewConditionAppliedEvent(
+			e.data.ID, e.nextSeq(),
+			targetID, actorID, condRef, 0, condPerPlayer,
+		)); err != nil {
+			return fmt.Errorf("publish condition applied: %w", err)
+		}
+	}
+	return nil
+}
+
+// publishResourceChanged emits a broker ResourceChangedEvent for the given
+// entity and resource. All players who can see the actor are included in
+// the audience.
+func (e *Encounter) publishResourceChanged(
+	actorID encountercore.EntityID,
+	resourceRef string,
+	newCurrent, maxVal int,
+) error {
+	actor := e.findPlayerByEntityID(actorID)
+	resPerPlayer := make(map[encountercore.PlayerID]events.ResourceChangedSlice)
+	for viewerID, viewer := range e.data.Players {
+		// Nil-guard: skip viewer or actor with missing View.
+		if viewer == nil || viewer.View == nil {
+			continue
+		}
+		if actor == nil || actor.View == nil {
+			break
+		}
+		if e.viewerCanSee(viewer, actor.View.Position) {
+			resPerPlayer[viewerID] = events.ResourceChangedSlice{Visible: true}
+		}
+	}
+
+	return e.broker.Publish(events.NewResourceChangedEvent(
+		e.data.ID, e.nextSeq(),
+		actorID, resourceRef,
+		newCurrent, maxVal,
+		resPerPlayer,
+	))
+}

--- a/encounter/activate_feature_test.go
+++ b/encounter/activate_feature_test.go
@@ -170,6 +170,104 @@ func (s *ActivateFeatureSuite) TestActivateFeature_MissingCharData() {
 	s.Require().Error(err)
 }
 
+// TestActivateFeature_CharDataMismatch returns an error when CharDataJSON belongs
+// to a different character than ActorID.
+func (s *ActivateFeatureSuite) TestActivateFeature_CharDataMismatch() {
+	e, charJSON := s.barbEnc()
+
+	_, err := e.ActivateFeature(s.ctx, &encounter.ActivateFeatureInput{
+		// ActorID deliberately mismatched: encounter has bobEntityID, data has bobEntityID too,
+		// so we spoof a different ActorID to trigger the guard.
+		// aliceEntityID is not in the encounter, so findPlayerByEntityID returns nil first.
+		ActorID:      aliceEntityID,
+		FeatureRef:   rageFeatureRef,
+		CharDataJSON: charJSON,
+	})
+	s.Require().Error(err)
+}
+
+// TestActivateFeature_CharDataIDMismatch exercises the identity-mismatch guard when
+// the actor IS in the encounter but CharDataJSON carries a different character ID.
+func (s *ActivateFeatureSuite) TestActivateFeature_CharDataIDMismatch() {
+	e, charJSON := s.barbEnc()
+
+	// Also add alice so the actor-lookup passes, then pass bob's JSON.
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID:   alicePlayerID,
+		EntityID:   aliceEntityID,
+		Position:   core.Hex{Q: 1, R: 0, S: -1},
+		HP:         10,
+		MaxHP:      10,
+		AC:         12,
+		DamageDice: "1d12", // same as barbarian above; just needs to be non-empty
+	}))
+
+	_, err := e.ActivateFeature(s.ctx, &encounter.ActivateFeatureInput{
+		ActorID:      aliceEntityID, // alice is in the encounter
+		FeatureRef:   rageFeatureRef,
+		CharDataJSON: charJSON, // but charJSON has ID=bobEntityID
+	})
+	s.Require().Error(err, "expected error when CharDataJSON.ID != ActorID")
+	s.ErrorContains(err, "mismatch")
+}
+
+// TestActivateFeature_NoSubscriptionAccumulation is the regression test for the
+// bus double-fire / subscription-accumulation class of bugs (#684 class).
+// Two sequential ActivateFeature calls on the SAME Encounter object (same e.bus)
+// must each produce exactly one ConditionAppliedEvent and one ResourceChangedEvent,
+// not two of each from accumulated subscribers.
+//
+// Call 1: rage_charges 2→1, publishes ConditionApplied(raging)+ResourceChanged.
+// Call 2 uses UpdatedCharData from call 1 (charge=1→0). Because Rage is already
+// active, ActivateAbility should fail (no charges or already raging) — but the
+// key assertion is that NO spurious extra events fire from call 1's residual
+// subscriptions. We verify this by counting total events: call 2 emits 0 events
+// (activation fails), not 2 (which would indicate leaked handlers from call 1).
+func (s *ActivateFeatureSuite) TestActivateFeature_NoSubscriptionAccumulation() {
+	e, charJSON := s.barbEnc()
+
+	sub, err := s.broker.Subscribe("enc-1", bobPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	// Call 1: should succeed, rage_charges 2→1.
+	out1, err := e.ActivateFeature(s.ctx, &encounter.ActivateFeatureInput{
+		ActorID:      bobEntityID,
+		FeatureRef:   rageFeatureRef,
+		CharDataJSON: charJSON,
+	})
+	s.Require().NoError(err)
+
+	// Drain the 2 events from call 1 (ConditionApplied + ResourceChanged).
+	call1Events := s.drainEvents(sub, 2, time.Second)
+	s.Require().Len(call1Events, 2, "call 1 should produce exactly 2 events")
+
+	// Call 2: attempt to activate again on the same encounter.
+	// With charge=1 remaining and rage already applied, ActivateAbility will
+	// either fail (already raging) or succeed (charge 1→0).
+	// Either way, the event count from call 2 must NOT exceed what the activation
+	// itself would produce — never 2× due to leaked call-1 subscribers.
+	_, _ = e.ActivateFeature(s.ctx, &encounter.ActivateFeatureInput{
+		ActorID:      bobEntityID,
+		FeatureRef:   rageFeatureRef,
+		CharDataJSON: out1.UpdatedCharData,
+	})
+
+	// Allow up to 500ms for any events that might fire from accumulated handlers.
+	// With proper Cleanup, zero events should arrive (activation fails because
+	// character is already raging). Without Cleanup, stale subscribers could
+	// re-fire the raging ConditionAppliedEvent from call 1's loaded conditions.
+	call2Events := s.drainEvents(sub, 10, 200*time.Millisecond)
+
+	// The only acceptable count is 0 (failed activation, nothing published)
+	// or the legitimate count from a successful activation (≤2: ConditionApplied
+	// + ResourceChanged if charge 1→0 succeeded). It must NOT be 4+ which would
+	// indicate doubled-up subscribers from call 1.
+	s.LessOrEqual(len(call2Events), 2,
+		"call 2 must not produce extra events from accumulated bus subscribers; "+
+			"got %d events (expected ≤2)", len(call2Events))
+}
+
 // TestActivateFeature_ActorNotInEncounter returns an error for unknown actor.
 func (s *ActivateFeatureSuite) TestActivateFeature_ActorNotInEncounter() {
 	e, charJSON := s.barbEnc()

--- a/encounter/activate_feature_test.go
+++ b/encounter/activate_feature_test.go
@@ -1,0 +1,207 @@
+package encounter_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	rageFeatureRef = "dnd5e:features:rage"
+	rageFeatID     = "rage-feat-1"
+)
+
+type ActivateFeatureSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestActivateFeatureSuite(t *testing.T) {
+	suite.Run(t, new(ActivateFeatureSuite))
+}
+
+func (s *ActivateFeatureSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *ActivateFeatureSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// barbEnc builds a loaded encounter with one barbarian player seat
+// and returns the encounter plus the character's JSON data.
+func (s *ActivateFeatureSuite) barbEnc() (*encounter.Encounter, json.RawMessage) {
+	s.T().Helper()
+
+	rageFeatureJSON := json.RawMessage(
+		`{"ref":{"module":"dnd5e","type":"features","id":"rage"},` +
+			`"id":"` + rageFeatID + `","name":"Rage","level":1}`,
+	)
+	charData := &dnd5eCharacter.Data{
+		ID:       bobEntityID, // reuse const from combat_test.go in same package
+		PlayerID: bobPlayerID,
+		Name:     "Bob the Barbarian",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 8,
+			abilities.WIS: 12,
+			abilities.CHA: 10,
+		},
+		HitPoints:        13,
+		MaxHitPoints:     13,
+		ArmorClass:       14,
+		ProficiencyBonus: 2,
+		Features:         []json.RawMessage{rageFeatureJSON},
+		Resources: map[coreResources.ResourceKey]dnd5eCharacter.RecoverableResourceData{
+			"rage_charges": {Current: 2, Maximum: 2, ResetType: coreResources.ResetLongRest},
+		},
+		// ActionEconomy must be set so char.InCombat() == true
+		ActionEconomy: &dnd5eCharacter.ActionEconomyData{
+			TurnNumber:            1,
+			ActionsRemaining:      1,
+			BonusActionsRemaining: 1,
+			ReactionsRemaining:    1,
+			MovementRemaining:     30,
+		},
+	}
+
+	charJSON, err := json.Marshal(charData)
+	s.Require().NoError(err)
+
+	e := encounter.New("enc-1", s.broker)
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID:   bobPlayerID,
+		EntityID:   bobEntityID,
+		Position:   core.Hex{Q: 0, R: 0, S: 0},
+		HP:         13,
+		MaxHP:      13,
+		AC:         14,
+		DamageDice: "1d12",
+	}))
+
+	return e, json.RawMessage(charJSON)
+}
+
+// TestActivateFeature_PublishesBrokerEventsAndDecrementsCharge is the primary
+// acceptance test: activating Rage on a barbarian with 2 charges should
+// (a) decrement charges 2→1, (b) publish a ConditionAppliedEvent (raging),
+// (c) publish a ResourceChangedEvent (rage_charges, new_current=1).
+func (s *ActivateFeatureSuite) TestActivateFeature_PublishesBrokerEventsAndDecrementsCharge() {
+	e, charJSON := s.barbEnc()
+
+	// Subscribe before activating so we capture all published events.
+	sub, err := s.broker.Subscribe("enc-1", bobPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	out, err := e.ActivateFeature(s.ctx, &encounter.ActivateFeatureInput{
+		ActorID:      bobEntityID,
+		FeatureRef:   rageFeatureRef,
+		CharDataJSON: charJSON,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+	s.NotEmpty(out.UpdatedCharData)
+
+	// Collect up to 2 events within 1s (ConditionApplied + ResourceChanged).
+	received := s.drainEvents(sub, 2, time.Second)
+
+	var condApplied *events.ConditionAppliedEvent
+	var resChanged *events.ResourceChangedEvent
+	for _, evt := range received {
+		switch ev := evt.(type) {
+		case *events.ConditionAppliedEvent:
+			condApplied = ev
+		case *events.ResourceChangedEvent:
+			resChanged = ev
+		}
+	}
+
+	// Assert ConditionApplied (raging)
+	s.Require().NotNil(condApplied, "expected a ConditionAppliedEvent for raging")
+	s.Equal(core.EntityID(bobEntityID), condApplied.TargetID)
+	s.Equal("raging", condApplied.ConditionRef)
+
+	// Assert ResourceChanged (rage_charges 2→1)
+	s.Require().NotNil(resChanged, "expected a ResourceChangedEvent for rage_charges")
+	s.Equal(core.EntityID(bobEntityID), resChanged.EntityID)
+	s.Equal("rage_charges", resChanged.ResourceRef)
+	s.Equal(1, resChanged.NewCurrent)
+	s.Equal(2, resChanged.Max)
+
+	// Assert the returned updated char data has charge 1 persisted.
+	var updatedData dnd5eCharacter.Data
+	s.Require().NoError(json.Unmarshal(out.UpdatedCharData, &updatedData))
+	rageRes := updatedData.Resources["rage_charges"]
+	s.Equal(1, rageRes.Current, "persisted charge should be 1 after activation")
+}
+
+// TestActivateFeature_MissingCharData returns an error without publishing events.
+func (s *ActivateFeatureSuite) TestActivateFeature_MissingCharData() {
+	e, _ := s.barbEnc()
+
+	_, err := e.ActivateFeature(s.ctx, &encounter.ActivateFeatureInput{
+		ActorID:    bobEntityID,
+		FeatureRef: rageFeatureRef,
+		// CharDataJSON intentionally empty
+	})
+	s.Require().Error(err)
+}
+
+// TestActivateFeature_ActorNotInEncounter returns an error for unknown actor.
+func (s *ActivateFeatureSuite) TestActivateFeature_ActorNotInEncounter() {
+	e, charJSON := s.barbEnc()
+
+	_, err := e.ActivateFeature(s.ctx, &encounter.ActivateFeatureInput{
+		ActorID:      "char-unknown",
+		FeatureRef:   rageFeatureRef,
+		CharDataJSON: charJSON,
+	})
+	s.Require().Error(err)
+}
+
+// drainEvents collects up to want events within the timeout, returning early
+// when want events have arrived.
+func (s *ActivateFeatureSuite) drainEvents(
+	sub *encounter.Subscription,
+	want int,
+	timeout time.Duration,
+) []events.EncounterEvent {
+	s.T().Helper()
+	deadline := time.After(timeout)
+	var collected []events.EncounterEvent
+	for len(collected) < want {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				return collected
+			}
+			collected = append(collected, evt)
+		case <-deadline:
+			return collected
+		}
+	}
+	return collected
+}

--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -242,6 +242,8 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "EncounterEndedEvent"
 	case *events.InputRequiredDeliveredEvent:
 		typeName = "InputRequiredDeliveredEvent"
+	case *events.ResourceChangedEvent:
+		typeName = "ResourceChangedEvent"
 	default:
 		return nil, fmt.Errorf("unknown event type %T", evt)
 	}
@@ -350,6 +352,12 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "InputRequiredDeliveredEvent":
 		var e events.InputRequiredDeliveredEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "ResourceChangedEvent":
+		var e events.ResourceChangedEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/broker_test.go
+++ b/encounter/broker_test.go
@@ -147,3 +147,39 @@ func (s *BrokerSuite) assertNoReceive(sub *encounter.Subscription) {
 		// expected
 	}
 }
+
+// ResourceChangedEvent round-trips through the broker codec (encode→transport→decode).
+func (s *BrokerSuite) TestBrokerCodec_ResourceChangedEvent_RoundTrip() {
+	sub, err := s.broker.Subscribe("enc:1", "p-alice")
+	s.Require().NoError(err)
+
+	original := events.NewResourceChangedEvent(
+		"enc:1", 7,
+		"char-bob",
+		"rage_charges",
+		1, 2,
+		map[core.PlayerID]events.ResourceChangedSlice{
+			"p-alice": {Visible: true},
+		},
+	)
+	s.Require().NoError(s.broker.Publish(original))
+
+	var received *events.ResourceChangedEvent
+	select {
+	case evt, ok := <-sub.Events():
+		s.Require().True(ok, "channel closed unexpectedly")
+		casted, ok := evt.(*events.ResourceChangedEvent)
+		s.Require().True(ok, "expected *events.ResourceChangedEvent, got %T", evt)
+		received = casted
+	case <-time.After(time.Second):
+		s.FailNow("did not receive ResourceChangedEvent in 1s")
+	}
+
+	s.Equal(core.EncounterID("enc:1"), received.EncounterID())
+	s.Equal(uint64(7), received.Sequence())
+	s.Equal(core.EntityID("char-bob"), received.EntityID)
+	s.Equal("rage_charges", received.ResourceRef)
+	s.Equal(1, received.NewCurrent)
+	s.Equal(2, received.Max)
+	s.True(received.PerPlayer["p-alice"].Visible)
+}

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -33,6 +33,7 @@ func (s *EventsSuite) TestConcretes_SatisfyInterface() {
 	var _ events.EncounterEvent = (*events.EntityDiedEvent)(nil)
 	var _ events.EncounterEvent = (*events.EntityRemovedEvent)(nil)
 	var _ events.EncounterEvent = (*events.EncounterEndedEvent)(nil)
+	var _ events.EncounterEvent = (*events.ResourceChangedEvent)(nil)
 }
 
 // MoveEvent.Audience derives from PerPlayer keys; absent players are not in audience.

--- a/encounter/events/resource_changed.go
+++ b/encounter/events/resource_changed.go
@@ -1,0 +1,98 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ResourceChangedEvent is the broker event published when a character's
+// resource (e.g. rage charges, ki) changes during an encounter verb.
+// Maps to the proto ResourceChanged wire shape.
+type ResourceChangedEvent struct {
+	encID       core.EncounterID
+	seq         uint64
+	EntityID    core.EntityID
+	ResourceRef string
+	NewCurrent  int
+	Max         int
+	PerPlayer   map[core.PlayerID]ResourceChangedSlice
+}
+
+// ResourceChangedSlice is each viewer's projection of the resource change.
+type ResourceChangedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewResourceChangedEvent constructs a ResourceChangedEvent.
+func NewResourceChangedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	entityID core.EntityID,
+	resourceRef string,
+	newCurrent, maxVal int,
+	perPlayer map[core.PlayerID]ResourceChangedSlice,
+) *ResourceChangedEvent {
+	return &ResourceChangedEvent{
+		encID:       encID,
+		seq:         seq,
+		EntityID:    entityID,
+		ResourceRef: resourceRef,
+		NewCurrent:  newCurrent,
+		Max:         maxVal,
+		PerPlayer:   perPlayer,
+	}
+}
+
+func (*ResourceChangedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *ResourceChangedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *ResourceChangedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who can perceive the resource change,
+// derived from PerPlayer keys.
+func (e *ResourceChangedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type resourceChangedWire struct {
+	EncID       core.EncounterID                       `json:"encounter_id"`
+	Seq         uint64                                 `json:"sequence"`
+	EntityID    core.EntityID                          `json:"entity_id"`
+	ResourceRef string                                 `json:"resource_ref"`
+	NewCurrent  int                                    `json:"new_current"`
+	Max         int                                    `json:"max"`
+	PerPlayer   map[core.PlayerID]ResourceChangedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *ResourceChangedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(resourceChangedWire{
+		EncID:       e.encID,
+		Seq:         e.seq,
+		EntityID:    e.EntityID,
+		ResourceRef: e.ResourceRef,
+		NewCurrent:  e.NewCurrent,
+		Max:         e.Max,
+		PerPlayer:   e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *ResourceChangedEvent) UnmarshalJSON(b []byte) error {
+	var w resourceChangedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.EntityID = w.EntityID
+	e.ResourceRef = w.ResourceRef
+	e.NewCurrent = w.NewCurrent
+	e.Max = w.Max
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/resource_changed_test.go
+++ b/encounter/events/resource_changed_test.go
@@ -1,0 +1,70 @@
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testResPlayerAlice = "p-alice"
+	testResPlayerCarol = "p-carol"
+)
+
+type ResourceChangedEventSuite struct {
+	suite.Suite
+}
+
+func TestResourceChangedEventSuite(t *testing.T) {
+	suite.Run(t, new(ResourceChangedEventSuite))
+}
+
+// ResourceChangedEvent satisfies EncounterEvent.
+func (s *ResourceChangedEventSuite) TestSatisfiesInterface() {
+	var _ events.EncounterEvent = (*events.ResourceChangedEvent)(nil)
+}
+
+// JSON round-trip preserves all fields including unexported encID/seq.
+func (s *ResourceChangedEventSuite) TestJSONRoundTrip() {
+	original := events.NewResourceChangedEvent(
+		"enc-1", 42,
+		"char-bob",
+		"rage_charges",
+		1, 2,
+		map[core.PlayerID]events.ResourceChangedSlice{
+			testResPlayerAlice: {Visible: true},
+		},
+	)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.ResourceChangedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(42), decoded.Sequence())
+	s.Equal(core.EntityID("char-bob"), decoded.EntityID)
+	s.Equal("rage_charges", decoded.ResourceRef)
+	s.Equal(1, decoded.NewCurrent)
+	s.Equal(2, decoded.Max)
+	s.True(decoded.PerPlayer[testResPlayerAlice].Visible)
+}
+
+// Audience derives from PerPlayer keys.
+func (s *ResourceChangedEventSuite) TestAudience_DerivedFromPerPlayer() {
+	evt := events.NewResourceChangedEvent(
+		"enc-1", 1, "char-bob", "rage_charges", 1, 2,
+		map[core.PlayerID]events.ResourceChangedSlice{
+			testResPlayerAlice: {Visible: true},
+			testResPlayerCarol: {Visible: false},
+		},
+	)
+	s.ElementsMatch(
+		events.AudienceSet{testResPlayerAlice, testResPlayerCarol},
+		evt.Audience(),
+	)
+}


### PR DESCRIPTION
## Summary

- **Task 2**: Add `ResourceChangedEvent` broker type (`encounter/events/resource_changed.go`) with JSON round-trip, per-player audience, and encode/decode cases in the broker codec.
- **Task 3**: Add `Encounter.ActivateFeature(ctx, *ActivateFeatureInput) (*ActivateFeatureOutput, error)` — the Wave 0 generic feature activation verb. Resolves the actor's `*character.Character` from caller-supplied `CharDataJSON`, calls `char.ActivateAbility`, bridges the dnd5e-bus `ConditionAppliedEvent` → broker `ConditionAppliedEvent` (following the `applyCapturedConditions` template in `npc.go:776`), and diffs the full pre/post resource set to emit a `ResourceChangedEvent` for every changed resource key.

## Boundary decision (director-accepted)

The verb imports `rulebooks/dnd5e/character` and calls `character.LoadFromData` directly, following the exact precedent of `NPCAct` importing `rulebooks/dnd5e/monster`. The `encounter/go.mod` already requires `rulebooks/dnd5e`; no new module dependency is added. Director accepted this NPCAct-precedent coupling for Wave 0; a fully agnostic SDK is tracked separately.

## Design notes

- **Generic resource delta**: the verb diffs `charData.Resources` (pre) vs `char.ToData().Resources` (post) and emits `ResourceChangedEvent` for every key whose `Current` changed. No feature-specific key hardcoding — works for Rage, Second Wind, Ki, or any future resource-consuming feature.
- **Single broker-publish authority**: rpg-api never touches the broker. The verb is the sole publisher of `ConditionAppliedEvent` + `ResourceChangedEvent` to the encounter broker.
- **No dual-channel trap**: `ActivateAbility` publishes on the dnd5e bus; the verb bridges those events to the broker. The dnd5e bus and the encounter broker are distinct channels with a one-way bridge.
- **Nil-guards**: `actor.View` and `viewer.View` are nil-checked in both `applyActivatedConditions` and `publishResourceChanged` to prevent panic on malformed encounter data.

## Test plan

- [x] `TestResourceChangedEventSuite/TestJSONRoundTrip` — broker codec round-trip for new event type
- [x] `TestBrokerSuite/TestBrokerCodec_ResourceChangedEvent_RoundTrip` — encode→transport→decode via live broker
- [x] `TestActivateFeatureSuite/TestActivateFeature_PublishesBrokerEventsAndDecrementsCharge` — activating Rage publishes broker `ConditionAppliedEvent` (raging) + `ResourceChangedEvent` (rage_charges 2→1), and persisted charge is 1
- [x] `TestActivateFeatureSuite/TestActivateFeature_MissingCharData` — error on empty CharDataJSON
- [x] `TestActivateFeatureSuite/TestActivateFeature_ActorNotInEncounter` — error for unknown actor
- [x] All existing encounter tests still pass (`go test -race ./...`)
- [x] No lint regressions in new files (`golangci-lint run ./...`)

## Files changed

| File | Change |
|---|---|
| `encounter/events/resource_changed.go` | New — `ResourceChangedEvent` type + JSON marshal/unmarshal |
| `encounter/events/resource_changed_test.go` | New — round-trip + interface + audience tests |
| `encounter/broker.go` | Add `ResourceChangedEvent` encode/decode cases |
| `encounter/broker_test.go` | Add broker codec round-trip test |
| `encounter/activate_feature.go` | New — `ActivateFeature` verb + helpers |
| `encounter/activate_feature_test.go` | New — TDD acceptance + error-path tests |
| `encounter/events/events_test.go` | Add `ResourceChangedEvent` to interface-satisfaction compile check |

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)