### PR TITLE
feat(encounter): event spine — causation, game-event time, resolved-action event (#697)

### DIFF
--- a/docs/adr/0031-encounter-event-spine-causation-and-game-time.md
+++ b/docs/adr/0031-encounter-event-spine-causation-and-game-time.md
@@ -1,0 +1,104 @@
+# ADR-0031: Encounter event spine — causation, game-event time, and the resolved-action event
+
+Date: 2026-06-01
+
+## Status
+
+Accepted
+
+## Context
+
+The encounter event spine (`encounter/events`) is the canonical record of what
+happened in a fight — it is what a toolkit-owned combat log (North-Star
+Invariant 3) will be reassembled from, and what rpg-api projects to the wire.
+Before this change the spine carried only `EncounterID()`, `Sequence()`, and
+`Audience()` per event. Three gaps blocked a faithful, reassemblable story (the
+TakeAction wave, rpg-project#54 / rpg-toolkit#697):
+
+1. **No causation link.** The only thing tying an `AttackResolvedEvent` to its
+   `DamageDealtEvent` was adjacent `nextSeq()` values — fragile and implicit
+   (Invariant 8). Insert any event between them, or reorder, and the link
+   breaks.
+2. **No game-event time.** The spine carried only a sequence number; rpg-api
+   stamped `now` at translate-time, which is wire-delivery order, not game order
+   (Invariant 5).
+3. **No first-class "an action was taken" event.** Only attack-shaped
+   `AttackResolvedEvent` existed. Non-attack actions (Dodge, Dash, the Monk
+   bonus strike) had no canonical beat, and even an attack scattered its meaning
+   across roll-detail + damage events with no umbrella record carrying the
+   action ref or what it cost the economy (Invariant 9).
+
+## Decision
+
+Add three things to the spine, shaped now to be forward-compatible with a
+durable combat log (persistence itself stays deferred, Invariant 13):
+
+- **`OccurredAt() time.Time` + `CorrelationID() core.CorrelationID` +
+  `Stamp(at, corr)` on the `EncounterEvent` interface.** All three are
+  single-sourced on an embedded `eventMeta` struct, so every concrete event
+  satisfies them for free and adding a future spine field touches one struct,
+  not all ~17 events. The two fields serialize inline via an embedded `metaWire`
+  (`occurred_at`, `correlation_id`).
+
+- **The `Broker` is the single timestamp authority.** `Broker.Publish` stamps
+  game-event time from an injected `core.Clock` at the literal publish moment,
+  preserving any correlation id the encounter already set. Production uses
+  `SystemClock`; tests inject `FixedClock` via `NewBrokerWithClock` and assert
+  `OccurredAt` exactly. "Game-event time at publish" is therefore literal, with
+  no per-call-site boilerplate across the ~23 publish sites.
+
+- **`ActionResolvedEvent` — a first-class resolved-action event.** Carries
+  `ActorID`, `ActionRef` (string, so the SDK stays free of rulebook ref types),
+  optional `TargetID`, and `EconomyConsumed` (actions / bonus actions /
+  reactions / movement + a `granted_consumed` map). It is the cause beat every
+  action emits; attack roll detail stays on the parallel `AttackResolvedEvent`.
+  The encounter sets one correlation id — derived from this event's own
+  `(encID, sequence)` identity — on the resolved-action event and every effect
+  event of the same resolution.
+
+The correlation id is derived from the existing monotonic sequence
+(`corr-<encID>-<seq>`) rather than a UUID: deterministic, dependency-free, and
+trivially assertable in tests, while still unique per action within an
+encounter.
+
+## Consequences
+
+### Positive
+- A consumer reassembles "this damage came from that action" from the
+  correlation id, not from sequence adjacency — the combat log is buildable
+  later (Inv 3) with no retrofitting (Inv 8).
+- Event order reflects game time, not delivery time (Inv 5), deterministically
+  testable via the injected clock.
+- Every action — attack and non-attack — has one canonical event carrying its
+  ref and economy cost (Inv 9), which the menu/economy unification PR populates
+  with richer consumption.
+- Adding spine fields later is a one-struct change (`eventMeta`).
+
+### Negative
+- Every event now carries two extra fields on the wire (`occurred_at`,
+  `correlation_id`); `correlation_id` is `omitempty` for events not part of a
+  correlated action group (mode changes, turn boundaries).
+- The proto envelope must mirror the two new fields + the new `ActionResolved`
+  oneof variant before rpg-api stops suppressing — a proto gap to close
+  (Inv 7), tracked under the wave, not a permitted drop.
+
+### Neutral
+- `EconomyConsumed` on the attack path reports the honest known cost today
+  (`Actions: 1`); the menu/economy unification PR sources the richer two-level
+  consumption from the character action economy.
+- The attack publish path threads a single `attackActionRef` constant for now;
+  the unification PR generalizes `applyAndPublishOutcome` to carry the actor's
+  submitted ref so non-attack actions report their own.
+
+## Example
+
+```go
+// Broker stamps game-event time at the literal publish moment.
+broker := encounter.NewBrokerWithClock(transport, core.FixedClock{At: gameTime})
+
+// During one TakeAction resolution the encounter publishes a correlated group:
+//   ActionResolvedEvent{ActionRef:"dnd5e:action:attack", EconomyConsumed:{Actions:1}}
+//   AttackResolvedEvent{Hit:true, AttackRoll:17, ...}
+//   DamageDealtEvent{Amount:8, ...}
+// all three sharing corr-<encID>-<actionSeq> and OccurredAt == gameTime.
+```

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -32,13 +32,16 @@ One Go module with three subpackages forming a linear DAG (`core ← events ← 
 
 - `Encounter` — transient. Constructed per-call from `Data`. Verbs (`Move`, `OpenDoor`) compute per-player projections, mutate state, publish events.
 - `Data` — persisted shape. Carries Players (with `View`), Doors, monotonic Sequence counter.
-- `Broker` — process-scoped, holds in-process subscription registry (keyed by `(encID, playerID)`), routes via Transport.
-- `EncounterEvent` — sealed sum interface. Concrete events implement `isEncounterEvent()`, `EncounterID()`, `Sequence()`, `Audience()`.
+- `Broker` — process-scoped, holds in-process subscription registry (keyed by `(encID, playerID)`), routes via Transport. The **single publish authority**: `Broker.Publish` stamps each event's game-event time from an injected `core.Clock` (default `SystemClock`; `NewBrokerWithClock` injects a `FixedClock` in tests) at the literal publish moment, preserving any correlation id the encounter set on it. See ADR-0031.
+- `EncounterEvent` — sealed sum interface. Concrete events implement `isEncounterEvent()`, `EncounterID()`, `Sequence()`, `Audience()`, plus the spine metadata `OccurredAt()` (game-event time, Inv 5), `CorrelationID()` (causation grouping, Inv 8), and `Stamp(at, corr)`. The last three are single-sourced on the embedded `eventMeta` so adding a spine field touches one struct, not every event.
+- `ActionResolvedEvent` — first-class "an action was taken" event (Inv 9): `ActorID`, `ActionRef` (string), optional `TargetID`, and `EconomyConsumed` (actions/bonus/reactions/movement + a `granted_consumed` map). Emitted for every player-facing action as the cause beat; attack-specific roll detail stays on the parallel `AttackResolvedEvent`. The effect events of one action share the `ActionResolvedEvent`'s correlation id so the toolkit-owned combat log is reassemblable.
 - `Transport` — pluggable bytes-level pub/sub. Channel keys opaque (`enc:<id>`); payloads opaque bytes; encoding is the Broker's concern.
 
 ## Cause vs effect events
 
-Action events (cause) describe what happened in the world — `MoveEvent`, `DoorOpenedEvent`. Effect events describe perception changes — `HexRevealedEvent`. **The two are decoupled**: any cause that changes vision (Move, OpenDoor, future LightChanged, future ConditionRemoved) emits the same `HexRevealedEvent` shape alongside its action event. New cause types don't touch existing event types. Symmetric `HexHiddenEvent` is reserved for vision-loss cases (walking out of LoS, lights out, gaining Blinded) — not in slice 1.
+Action events (cause) describe what happened in the world — `MoveEvent`, `DoorOpenedEvent`, `ActionResolvedEvent`. Effect events describe perception/state changes — `HexRevealedEvent`, `DamageDealtEvent`, `ConditionAppliedEvent`. **The two are decoupled**: any cause that changes vision (Move, OpenDoor, future LightChanged, future ConditionRemoved) emits the same `HexRevealedEvent` shape alongside its action event. New cause types don't touch existing event types. Symmetric `HexHiddenEvent` is reserved for vision-loss cases (walking out of LoS, lights out, gaining Blinded) — not in slice 1.
+
+**Causation (Inv 8):** the `ActionResolvedEvent` and every effect event it produces in one resolution carry the same `CorrelationID` (derived from the resolved-action event's `(encID, sequence)` identity — deterministic, rides the existing monotonic sequence, no extra dependency). A consumer reassembles "this damage came from that attack" from the correlation id, not from adjacent sequence numbers. See ADR-0031.
 
 ## Combatant hydration cascade (#689)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-05-30
+updated: 2026-06-01
 confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code
 ---
 
@@ -10,6 +10,21 @@ confidence: medium — seeded from full repo read, test run, go.mod inspection, 
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**#697 (TakeAction wave, event-faithfulness PR) — encounter event spine:
+causation + game-event time + resolved-action event (2026-06-01).**
+Added `OccurredAt()` / `CorrelationID()` / `Stamp()` to the `EncounterEvent`
+interface (single-sourced on an embedded `eventMeta`), made `Broker.Publish` the
+single game-event-time stamp authority via an injected `core.Clock`
+(`NewBrokerWithClock`; default `SystemClock`, tests use `FixedClock`), and added
+the first-class `ActionResolvedEvent` (`action_ref` + `economy_consumed`).
+Attack resolution now publishes a correlated `ActionResolved → AttackResolved →
+DamageDealt` group sharing one correlation id. See ADR-0031. This is the FIRST
+of two separable #697 PRs; the menu/economy unification (reconcile the encounter
+verb path with the character action menu, non-attack actions, validate+deduct)
+is the next chunk. Proto mirror (new `ActionResolved` oneof variant +
+`occurred_at`/`correlation_id` on the envelope) is the dependency-ordered
+follow-on before rpg-api un-suppresses.
 
 **#689 — encounter owns combatant hydration via the LoadFromData cascade
 (2026-05-30, cross-repo unit with rpg-api#582; NOT yet merged).**

--- a/encounter/action_resolved_test.go
+++ b/encounter/action_resolved_test.go
@@ -1,0 +1,129 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+)
+
+// ActionResolvedSuite proves the resolved-action event spine on the REAL
+// TakeAction path (broker subscription, not a stub): every action emits a
+// first-class ActionResolvedEvent (Inv 9) carrying action_ref + economy
+// consumed, the attack's effect events share its correlation id (Inv 8), and
+// the broker stamps a deterministic game-event time (Inv 5).
+type ActionResolvedSuite struct {
+	suite.Suite
+	clockAt   time.Time
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	enc       *encounter.Encounter
+	aliceSub  *encounter.Subscription
+}
+
+func TestActionResolvedSuite(t *testing.T) {
+	suite.Run(t, new(ActionResolvedSuite))
+}
+
+func (s *ActionResolvedSuite) SetupTest() {
+	s.clockAt = time.Date(2026, 6, 1, 15, 4, 5, 0, time.UTC)
+	s.transport = encounter.NewInMemoryTransport()
+	// Inject a deterministic clock so OccurredAt is asserted exactly.
+	s.broker = encounter.NewBrokerWithClock(s.transport, core.FixedClock{At: s.clockAt})
+	s.enc = encounter.New(context.Background(), "enc-ar", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  monsterRefGoblin,
+		AttackBonus: 4, DamageDice: "1d6+2", DamageType: damageSlashing,
+	}))
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe("enc-ar", alicePlayerID)
+	s.Require().NoError(err)
+}
+
+func (s *ActionResolvedSuite) TearDownTest() {
+	if s.aliceSub != nil {
+		_ = s.aliceSub.Close()
+	}
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// A real TakeAction attack emits ActionResolved + AttackResolved + DamageDealt;
+// all three share one correlation id, the ActionResolved carries action_ref +
+// economy_consumed, and every event is stamped with the fixed clock time.
+func (s *ActionResolvedSuite) TestTakeAction_EmitsCorrelatedResolvedAction() {
+	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
+	for s.enc.ActiveActor() != aliceEntityID {
+		_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+	drainSub(s.aliceSub, 100*time.Millisecond)
+
+	err := s.enc.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.Require().NoError(err)
+
+	evts := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
+
+	var (
+		action *events.ActionResolvedEvent
+		attack *events.AttackResolvedEvent
+		damage *events.DamageDealtEvent
+	)
+	for _, e := range evts {
+		switch ev := e.(type) {
+		case *events.ActionResolvedEvent:
+			action = ev
+		case *events.AttackResolvedEvent:
+			attack = ev
+		case *events.DamageDealtEvent:
+			damage = ev
+		}
+	}
+
+	s.Require().NotNil(action, "ActionResolvedEvent must be emitted for every action (Inv 9)")
+	s.Require().NotNil(attack, "AttackResolvedEvent rides alongside")
+	s.Require().NotNil(damage, "alwaysHitResolver hits, so DamageDealtEvent rides alongside")
+
+	// Inv 9: the resolved-action event carries action_ref + economy_consumed.
+	s.Equal(core.EntityID(aliceEntityID), action.ActorID)
+	s.Equal("dnd5e:action:attack", action.ActionRef)
+	s.Equal(core.EntityID(gobEntityID), action.TargetID)
+	s.Equal(1, action.EconomyConsumed.Actions)
+
+	// Inv 8: the cause event and its effects share one correlation id.
+	s.NotEmpty(action.CorrelationID(), "resolved-action event must carry a correlation id")
+	s.Equal(action.CorrelationID(), attack.CorrelationID(),
+		"attack-resolved must share the action's correlation id")
+	s.Equal(action.CorrelationID(), damage.CorrelationID(),
+		"damage-dealt must share the action's correlation id")
+
+	// Inv 5: the broker stamps game-event time at publish from the clock.
+	s.Equal(s.clockAt, action.OccurredAt())
+	s.Equal(s.clockAt, attack.OccurredAt())
+	s.Equal(s.clockAt, damage.OccurredAt())
+
+	// The resolved-action event leads its effects in sequence (cause first).
+	s.Less(action.Sequence(), attack.Sequence())
+	s.Less(attack.Sequence(), damage.Sequence())
+}

--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -15,6 +15,7 @@ import (
 // to distribute event bytes (locally and, in future, across processes).
 type Broker struct {
 	transport Transport
+	clock     core.Clock
 
 	mu          sync.Mutex
 	subscribers map[subscriberKey][]*Subscription
@@ -28,18 +29,36 @@ type subscriberKey struct {
 	PlayerID core.PlayerID
 }
 
-// NewBroker constructs a Broker over the given Transport.
+// NewBroker constructs a Broker over the given Transport, stamping events with
+// the system wall clock at publish. Use NewBrokerWithClock to inject a
+// deterministic clock in tests.
 func NewBroker(t Transport) *Broker {
+	return NewBrokerWithClock(t, core.SystemClock{})
+}
+
+// NewBrokerWithClock constructs a Broker that stamps each published event's
+// game-event time (Invariant 5) from the supplied clock. A nil clock falls
+// back to the system wall clock.
+func NewBrokerWithClock(t Transport, clock core.Clock) *Broker {
+	if clock == nil {
+		clock = core.SystemClock{}
+	}
 	return &Broker{
 		transport:   t,
+		clock:       clock,
 		subscribers: make(map[subscriberKey][]*Subscription),
 		listeners:   make(map[core.EncounterID]TransportSubscription),
 	}
 }
 
-// Publish encodes the event and writes it to the encounter's transport channel.
-// Encounters call this from inside verb methods.
+// Publish stamps the event with game-event time at the literal publish moment
+// (Invariant 5), preserving any correlation id the encounter set on it
+// (Invariant 8), then encodes and writes it to the encounter's transport
+// channel. The broker is the single publish authority, so stamping here makes
+// "game-event time at publish" literal for every event with no per-call-site
+// boilerplate. Encounters call this from inside verb methods.
 func (b *Broker) Publish(evt events.EncounterEvent) error {
+	evt.Stamp(b.clock.Now(), evt.CorrelationID())
 	payload, err := encodeEvent(evt)
 	if err != nil {
 		return fmt.Errorf("encode event: %w", err)
@@ -222,6 +241,8 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "EntityAppearedEvent"
 	case *events.EntityDisappearedEvent:
 		typeName = "EntityDisappearedEvent"
+	case *events.ActionResolvedEvent:
+		typeName = "ActionResolvedEvent"
 	case *events.AttackResolvedEvent:
 		typeName = "AttackResolvedEvent"
 	case *events.DamageDealtEvent:
@@ -292,6 +313,12 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "EntityDisappearedEvent":
 		var e events.EntityDisappearedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "ActionResolvedEvent":
+		var e events.ActionResolvedEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
@@ -53,6 +54,24 @@ const damageTypeUntyped = "untyped"
 // attack. Used as AttackInput.ActionRef.ID for both the player path
 // (TakeAction) and the NPC path (NPCAct / npcActScripted).
 const actionIDAttack = "attack"
+
+// attackActionRef is the canonical ref string the ActionResolvedEvent carries
+// for a standard attack. Mirrors the {Module:"dnd5e", Type:"action",
+// ID:"attack"} shape the SDK threads into AttackInput.ActionRef (npc.go), in
+// the toolkit-canonical "module:type:id" string form so the encounter SDK
+// stays free of rulebook ref types. The menu/economy unification PR will
+// generalize the attack publish path to carry the actor's submitted ref so
+// non-attack actions (Dodge / Dash / the Monk bonus strike) report their own.
+const attackActionRef = "dnd5e:action:attack"
+
+// attackEconomyConsumed reports the turn-economy cost the event-faithfulness
+// wave attributes to a standard attack: one standard action. This is the
+// honest cost the attack path knows today; the menu/economy unification PR
+// sources richer consumption (the two-level "Attack ability grants attacks,
+// each strike consumes one" model) from the character action economy.
+func attackEconomyConsumed() events.EconomyConsumed {
+	return events.EconomyConsumed{Actions: 1}
+}
 
 // isPlayerCombatant reports whether a player seat carries the minimum
 // combat snapshot required for TakeAction. PlayerInput documents that a
@@ -280,9 +299,22 @@ func rollD20(r dice.Roller) int {
 	return v
 }
 
-// publishAttackOutcome emits the AttackResolvedEvent (always) plus the
-// DamageDealtEvent (only on hit) with per-viewer projection determined by
-// LoS to attacker OR target.
+// publishAttackOutcome emits the first-class ActionResolvedEvent (the cause
+// beat, Invariant 9), the AttackResolvedEvent (attack roll detail, always),
+// and the DamageDealtEvent (only on hit) with per-viewer projection determined
+// by LoS to attacker OR target.
+//
+// All three events share one correlation id (Invariant 8), derived from the
+// ActionResolvedEvent's own (encounter id + sequence) identity so the
+// toolkit-owned combat log can group "this damage came from that action"
+// without relying on adjacent sequence numbers. The correlation id is set on
+// each event before publish; the broker stamps game-event time at the publish
+// moment (Invariant 5).
+//
+// actionRef names the action taken (e.g. "dnd5e:actions:strike") and consumed
+// reports what it spent off the turn economy. Wave: the inline attack path
+// supplies the known cost; the menu/economy unification PR will source richer
+// consumption.
 //
 // Audience routing matches Move / OpenDoor: viewers who cannot perceive
 // the attacker or the target are omitted from PerPlayer entirely (and so
@@ -294,7 +326,10 @@ func (e *Encounter) publishAttackOutcome(
 	targetHPAfter, targetMaxHP int,
 	damageType string,
 	attackerPos, targetPos core.Hex,
+	actionRef string,
+	consumed events.EconomyConsumed,
 ) error {
+	actionPerPlayer := make(map[core.PlayerID]events.ActionResolvedSlice)
 	attackPerPlayer := make(map[core.PlayerID]events.AttackResolvedSlice)
 	damagePerPlayer := make(map[core.PlayerID]events.DamageDealtSlice)
 	for viewerID, viewer := range e.data.Players {
@@ -302,17 +337,32 @@ func (e *Encounter) publishAttackOutcome(
 			!perception.CanSeeAt(viewer.View, targetPos) {
 			continue
 		}
+		actionPerPlayer[viewerID] = events.ActionResolvedSlice{Visible: true}
 		attackPerPlayer[viewerID] = events.AttackResolvedSlice{Visible: true}
 		if outcome.Hit {
 			damagePerPlayer[viewerID] = events.DamageDealtSlice{Visible: true}
 		}
 	}
-	if err := e.broker.Publish(events.NewAttackResolvedEvent(
+
+	// The resolved-action event is the cause beat; its identity seeds the
+	// correlation id every effect of this action carries.
+	actionSeq := e.nextSeq()
+	corrID := e.correlationFor(actionSeq)
+	actionEvt := events.NewActionResolvedEvent(
+		e.data.ID, actionSeq,
+		attackerID, actionRef, targetID,
+		consumed, actionPerPlayer,
+	)
+	if err := e.publishCorrelated(actionEvt, corrID); err != nil {
+		return fmt.Errorf("publish action resolved: %w", err)
+	}
+
+	if err := e.publishCorrelated(events.NewAttackResolvedEvent(
 		e.data.ID, e.nextSeq(),
 		attackerID, targetID,
 		outcome.Hit, outcome.Critical, outcome.AttackRoll, outcome.AttackBonus, outcome.TargetAC,
 		attackPerPlayer,
-	)); err != nil {
+	), corrID); err != nil {
 		return fmt.Errorf("publish attack resolved: %w", err)
 	}
 	if outcome.Hit {
@@ -324,11 +374,28 @@ func (e *Encounter) publishAttackOutcome(
 			damagePerPlayer,
 		)
 		evt.Components = outcome.Components
-		if err := e.broker.Publish(evt); err != nil {
+		if err := e.publishCorrelated(evt, corrID); err != nil {
 			return fmt.Errorf("publish damage dealt: %w", err)
 		}
 	}
 	return nil
+}
+
+// correlationFor derives the correlation id for an action-resolution group
+// from the resolved-action event's own (encounter, sequence) identity. Riding
+// the existing monotonic sequence keeps it deterministic (no new dependency,
+// trivially assertable in tests) and unique per action within an encounter.
+func (e *Encounter) correlationFor(actionSeq uint64) core.CorrelationID {
+	return core.CorrelationID(fmt.Sprintf("corr-%s-%d", e.data.ID, actionSeq))
+}
+
+// publishCorrelated sets the correlation id on an event (Invariant 8) and
+// publishes it through the broker, which stamps game-event time (Invariant 5).
+// The OccurredAt arg to Stamp is zero here — the broker overwrites it at the
+// literal publish moment, preserving the correlation id we set.
+func (e *Encounter) publishCorrelated(evt events.EncounterEvent, corrID core.CorrelationID) error {
+	evt.Stamp(time.Time{}, corrID)
+	return e.broker.Publish(evt)
 }
 
 // allViewersModeChanged builds a per-player slice marking every player as

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -331,6 +331,7 @@ func (e *Encounter) applyAndPublishNPCOutcome(monster *MonsterData, player *Play
 		monster.ID, player.EntityID, outcome,
 		player.HP, player.MaxHP, damageType,
 		monster.Position, player.View.Position,
+		attackActionRef, attackEconomyConsumed(),
 	); err != nil {
 		return err
 	}
@@ -367,6 +368,7 @@ func (e *Encounter) applyAndPublishOutcome(player *PlayerData, monster *MonsterD
 		player.EntityID, monster.ID, outcome,
 		monster.HP, monster.MaxHP, damageType,
 		player.View.Position, monster.Position,
+		attackActionRef, attackEconomyConsumed(),
 	); err != nil {
 		return err
 	}

--- a/encounter/core/clock.go
+++ b/encounter/core/clock.go
@@ -1,0 +1,35 @@
+package core
+
+import "time"
+
+// Clock is the source of game-event time the encounter stamps onto events at
+// publish (North-Star Invariant 5: events carry game-event time, not
+// wire-delivery time). Injecting it keeps the spine deterministic and
+// testable — a test supplies a FixedClock so event timestamps are asserted
+// exactly, and production uses the real wall clock.
+type Clock interface {
+	// Now returns the current game-event time.
+	Now() time.Time
+}
+
+// SystemClock is the production Clock backed by the wall clock.
+type SystemClock struct{}
+
+// Now returns the current wall-clock time.
+func (SystemClock) Now() time.Time { return time.Now() }
+
+// FixedClock is a deterministic Clock that always returns the same instant.
+// Tests use it so a published event's OccurredAt can be asserted exactly.
+type FixedClock struct {
+	// At is the instant Now returns.
+	At time.Time
+}
+
+// Now returns the fixed instant.
+func (c FixedClock) Now() time.Time { return c.At }
+
+// compile-time checks that both clocks satisfy Clock.
+var (
+	_ Clock = SystemClock{}
+	_ Clock = FixedClock{}
+)

--- a/encounter/core/ids.go
+++ b/encounter/core/ids.go
@@ -9,3 +9,14 @@ type PlayerID string
 // EntityID uniquely identifies any entity in an encounter (player char,
 // monster, prop, door, ...).
 type EntityID string
+
+// CorrelationID ties together the events produced by a single causal action.
+// Every event the encounter publishes while resolving one action (the
+// resolved-action event plus its effect events — damage, condition, resource)
+// carries the same CorrelationID, so a downstream consumer (the toolkit-owned
+// combat log per North-Star Invariant 8) can reassemble "this damage came from
+// that attack" without relying on adjacent sequence numbers.
+//
+// Empty when an event is not part of a correlated action group (e.g. mode
+// changes, turn boundaries — emitted outside any single action's resolution).
+type CorrelationID string

--- a/encounter/events/action_resolved.go
+++ b/encounter/events/action_resolved.go
@@ -1,0 +1,146 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ActionResolvedEvent is the first-class "an action was taken" event
+// (North-Star Invariant 9). Every player-facing action — attack, Dodge, Dash,
+// the Monk bonus-action strike — emits one of these as the canonical record of
+// the action itself, distinct from the scattered effect events (damage,
+// condition, resource) it may cause. Those effects carry the same
+// CorrelationID (via the embedded eventMeta) so the toolkit-owned combat log
+// reassembles "this damage came from that action."
+//
+// It is intentionally action-shaped, not attack-shaped: ActionRef names what
+// was done and EconomyConsumed reports what the action cost off the actor's
+// turn economy. Attack-specific roll detail (hit / crit / roll / AC) stays on
+// the parallel AttackResolvedEvent for an attack action; ActionResolvedEvent is
+// the umbrella beat that every action shares.
+type ActionResolvedEvent struct {
+	eventMeta
+	encID core.EncounterID
+	seq   uint64
+	// ActorID is the entity that took the action.
+	ActorID core.EntityID
+	// ActionRef is the canonical ref of the action taken, e.g.
+	// "dnd5e:actions:strike" / "dnd5e:combat_abilities:dodge". String form on
+	// the wire so the encounter SDK stays free of rulebook ref types.
+	ActionRef string
+	// TargetID is the primary target, when the action has one. Empty for
+	// self / no-target actions (Dodge, Dash).
+	TargetID core.EntityID
+	// EconomyConsumed reports what this action spent off the turn economy.
+	EconomyConsumed EconomyConsumed
+	// PerPlayer is the per-viewer visibility projection.
+	PerPlayer map[core.PlayerID]ActionResolvedSlice
+}
+
+// EconomyConsumed reports the turn-economy cost an action paid. Each field is
+// the count consumed by THIS action (0 when the action did not touch that
+// slot). The toolkit owns the deduction (Invariant 2/3); this is the faithful
+// record of what was spent, which rpg-api projects verbatim and the web renders
+// as the economy decrementing.
+type EconomyConsumed struct {
+	// Actions is the number of standard actions consumed (0 or 1 today).
+	Actions int `json:"actions"`
+	// BonusActions is the number of bonus actions consumed (0 or 1 today) —
+	// the field the Monk Martial Arts bonus strike exercises.
+	BonusActions int `json:"bonus_actions"`
+	// Reactions is the number of reactions consumed.
+	Reactions int `json:"reactions"`
+	// Movement is the movement consumed, in the encounter's movement unit.
+	Movement int `json:"movement"`
+	// GrantedConsumed maps a granted-capacity key (e.g. "attacks",
+	// "martial_arts_bonus") to the count this action drew from it. Nil when the
+	// action consumed no granted capacity. String keys keep the encounter SDK
+	// free of rulebook capacity-key types.
+	GrantedConsumed map[string]int `json:"granted_consumed,omitempty"`
+}
+
+// ActionResolvedSlice is each viewer's projection. Visible says whether the
+// player perceived the action at all (via LoS to the actor or target).
+type ActionResolvedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewActionResolvedEvent constructs an ActionResolvedEvent. The encounter
+// stamps the encounter id and sequence; OccurredAt + CorrelationID are stamped
+// at publish via Stamp.
+func NewActionResolvedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	actorID core.EntityID,
+	actionRef string,
+	targetID core.EntityID,
+	consumed EconomyConsumed,
+	perPlayer map[core.PlayerID]ActionResolvedSlice,
+) *ActionResolvedEvent {
+	return &ActionResolvedEvent{
+		encID:           encID,
+		seq:             seq,
+		ActorID:         actorID,
+		ActionRef:       actionRef,
+		TargetID:        targetID,
+		EconomyConsumed: consumed,
+		PerPlayer:       perPlayer,
+	}
+}
+
+func (*ActionResolvedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *ActionResolvedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *ActionResolvedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who can perceive the action, derived
+// from PerPlayer keys.
+func (e *ActionResolvedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type actionResolvedWire struct {
+	metaWire
+	EncID           core.EncounterID                      `json:"encounter_id"`
+	Seq             uint64                                `json:"sequence"`
+	ActorID         core.EntityID                         `json:"actor_id"`
+	ActionRef       string                                `json:"action_ref"`
+	TargetID        core.EntityID                         `json:"target_id,omitempty"`
+	EconomyConsumed EconomyConsumed                       `json:"economy_consumed"`
+	PerPlayer       map[core.PlayerID]ActionResolvedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *ActionResolvedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(actionResolvedWire{
+		metaWire:        e.toWire(),
+		EncID:           e.encID,
+		Seq:             e.seq,
+		ActorID:         e.ActorID,
+		ActionRef:       e.ActionRef,
+		TargetID:        e.TargetID,
+		EconomyConsumed: e.EconomyConsumed,
+		PerPlayer:       e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *ActionResolvedEvent) UnmarshalJSON(b []byte) error {
+	var w actionResolvedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.fromWire(w.metaWire)
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.ActorID = w.ActorID
+	e.ActionRef = w.ActionRef
+	e.TargetID = w.TargetID
+	e.EconomyConsumed = w.EconomyConsumed
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/attack_resolved.go
+++ b/encounter/events/attack_resolved.go
@@ -11,6 +11,7 @@ import (
 // does not itself describe the HP outcome — that lives on the parallel
 // DamageDealtEvent published alongside on hit.
 type AttackResolvedEvent struct {
+	eventMeta
 	encID       core.EncounterID
 	seq         uint64
 	AttackerID  core.EntityID
@@ -69,6 +70,7 @@ func (e *AttackResolvedEvent) Sequence() uint64 { return e.seq }
 func (e *AttackResolvedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type attackResolvedWire struct {
+	metaWire
 	EncID       core.EncounterID                      `json:"encounter_id"`
 	Seq         uint64                                `json:"sequence"`
 	AttackerID  core.EntityID                         `json:"attacker_id"`
@@ -85,6 +87,7 @@ type attackResolvedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *AttackResolvedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(attackResolvedWire{
+		metaWire:    e.toWire(),
 		EncID:       e.encID,
 		Seq:         e.seq,
 		AttackerID:  e.AttackerID,
@@ -105,6 +108,7 @@ func (e *AttackResolvedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.AttackerID = w.AttackerID

--- a/encounter/events/condition_applied.go
+++ b/encounter/events/condition_applied.go
@@ -9,6 +9,7 @@ import (
 // ConditionAppliedEvent is the effect event published when a condition is
 // applied to an entity. Maps to the proto StatusApplied wire shape.
 type ConditionAppliedEvent struct {
+	eventMeta
 	encID          core.EncounterID
 	seq            uint64
 	TargetID       core.EntityID
@@ -58,6 +59,7 @@ func (e *ConditionAppliedEvent) Sequence() uint64 { return e.seq }
 func (e *ConditionAppliedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type conditionAppliedWire struct {
+	metaWire
 	EncID          core.EncounterID                        `json:"encounter_id"`
 	Seq            uint64                                  `json:"sequence"`
 	TargetID       core.EntityID                           `json:"target_id"`
@@ -71,6 +73,7 @@ type conditionAppliedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *ConditionAppliedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(conditionAppliedWire{
+		metaWire:       e.toWire(),
 		EncID:          e.encID,
 		Seq:            e.seq,
 		TargetID:       e.TargetID,
@@ -88,6 +91,7 @@ func (e *ConditionAppliedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.TargetID = w.TargetID

--- a/encounter/events/damage_dealt.go
+++ b/encounter/events/damage_dealt.go
@@ -9,6 +9,7 @@ import (
 // DamageDealtEvent is the effect event published when an entity takes damage
 // from an attack. Maps to the proto EntityDamaged wire shape.
 type DamageDealtEvent struct {
+	eventMeta
 	encID      core.EncounterID
 	seq        uint64
 	TargetID   core.EntityID
@@ -67,6 +68,7 @@ func (e *DamageDealtEvent) Sequence() uint64 { return e.seq }
 func (e *DamageDealtEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type damageDealtWire struct {
+	metaWire
 	EncID      core.EncounterID                   `json:"encounter_id"`
 	Seq        uint64                             `json:"sequence"`
 	TargetID   core.EntityID                      `json:"target_id"`
@@ -83,6 +85,7 @@ type damageDealtWire struct {
 // Implements encoding/json.Marshaler.
 func (e *DamageDealtEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(damageDealtWire{
+		metaWire:   e.toWire(),
 		EncID:      e.encID,
 		Seq:        e.seq,
 		TargetID:   e.TargetID,
@@ -103,6 +106,7 @@ func (e *DamageDealtEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.TargetID = w.TargetID

--- a/encounter/events/door_opened.go
+++ b/encounter/events/door_opened.go
@@ -13,6 +13,7 @@ import (
 // HexRevealedEvent published alongside this one — see the decoupled
 // cause/effect decision.
 type DoorOpenedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	DoorID    core.EntityID
@@ -56,6 +57,7 @@ func (e *DoorOpenedEvent) Sequence() uint64 { return e.seq }
 func (e *DoorOpenedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type doorOpenedWire struct {
+	metaWire
 	EncID     core.EncounterID                        `json:"encounter_id"`
 	Seq       uint64                                  `json:"sequence"`
 	DoorID    core.EntityID                           `json:"door_id"`
@@ -67,7 +69,8 @@ type doorOpenedWire struct {
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *DoorOpenedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(doorOpenedWire{
-		EncID: e.encID, Seq: e.seq,
+		metaWire: e.toWire(),
+		EncID:    e.encID, Seq: e.seq,
 		DoorID: e.DoorID, OpenedBy: e.OpenedBy,
 		PerPlayer: e.PerPlayer,
 	})
@@ -80,6 +83,7 @@ func (e *DoorOpenedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.DoorID = w.DoorID

--- a/encounter/events/encounter_ended.go
+++ b/encounter/events/encounter_ended.go
@@ -19,6 +19,7 @@ import (
 //
 // Maps to the proto EncounterEnded wire shape.
 type EncounterEndedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	Reason    string
@@ -59,6 +60,7 @@ func (e *EncounterEndedEvent) Sequence() uint64 { return e.seq }
 func (e *EncounterEndedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type encounterEndedWire struct {
+	metaWire
 	EncID     core.EncounterID                      `json:"encounter_id"`
 	Seq       uint64                                `json:"sequence"`
 	Reason    string                                `json:"reason,omitempty"`
@@ -69,6 +71,7 @@ type encounterEndedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *EncounterEndedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(encounterEndedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		Reason:    e.Reason,
@@ -83,6 +86,7 @@ func (e *EncounterEndedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.Reason = w.Reason

--- a/encounter/events/entity_appeared.go
+++ b/encounter/events/entity_appeared.go
@@ -18,6 +18,7 @@ import (
 // first visible one), Move() emits one EntityAppearedEvent per distinct Position
 // with the viewers for that position grouped into PerPlayer.
 type EntityAppearedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	Entity    core.EntityID
@@ -57,6 +58,7 @@ func (e *EntityAppearedEvent) Audience() AudienceSet { return audienceFromMap(e.
 
 // entityAppearedWire is the on-wire shape — used only by MarshalJSON / UnmarshalJSON.
 type entityAppearedWire struct {
+	metaWire
 	EncID     core.EncounterID           `json:"encounter_id"`
 	Seq       uint64                     `json:"sequence"`
 	Entity    core.EntityID              `json:"entity"`
@@ -68,6 +70,7 @@ type entityAppearedWire struct {
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *EntityAppearedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(entityAppearedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		Entity:    e.Entity,
@@ -83,6 +86,7 @@ func (e *EntityAppearedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.Entity = w.Entity

--- a/encounter/events/entity_died.go
+++ b/encounter/events/entity_died.go
@@ -18,6 +18,7 @@ import (
 // Maps to the proto EntityDied wire shape. Cause-only — see
 // EntityRemovedEvent for the state mutation.
 type EntityDiedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	EntityID  core.EntityID
@@ -62,6 +63,7 @@ func (e *EntityDiedEvent) Sequence() uint64 { return e.seq }
 func (e *EntityDiedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type entityDiedWire struct {
+	metaWire
 	EncID     core.EncounterID                  `json:"encounter_id"`
 	Seq       uint64                            `json:"sequence"`
 	EntityID  core.EntityID                     `json:"entity_id"`
@@ -73,6 +75,7 @@ type entityDiedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *EntityDiedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(entityDiedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		EntityID:  e.EntityID,
@@ -88,6 +91,7 @@ func (e *EntityDiedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.EntityID = w.EntityID

--- a/encounter/events/entity_disappeared.go
+++ b/encounter/events/entity_disappeared.go
@@ -16,6 +16,7 @@ import (
 // move), so per-viewer last-known position is required. For movement-driven
 // disappearance this is the last hex of that viewer's SeenSegments.
 type EntityDisappearedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	Entity    core.EntityID
@@ -52,6 +53,7 @@ func (e *EntityDisappearedEvent) Audience() AudienceSet { return audienceFromMap
 
 // entityDisappearedWire is the on-wire shape — used only by MarshalJSON / UnmarshalJSON.
 type entityDisappearedWire struct {
+	metaWire
 	EncID     core.EncounterID           `json:"encounter_id"`
 	Seq       uint64                     `json:"sequence"`
 	Entity    core.EntityID              `json:"entity"`
@@ -62,6 +64,7 @@ type entityDisappearedWire struct {
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *EntityDisappearedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(entityDisappearedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		Entity:    e.Entity,
@@ -76,6 +79,7 @@ func (e *EntityDisappearedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.Entity = w.Entity

--- a/encounter/events/entity_removed.go
+++ b/encounter/events/entity_removed.go
@@ -19,6 +19,7 @@ import (
 //
 // Maps to the proto EntityRemoved wire shape.
 type EntityRemovedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	EntityID  core.EntityID
@@ -62,6 +63,7 @@ func (e *EntityRemovedEvent) Sequence() uint64 { return e.seq }
 func (e *EntityRemovedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type entityRemovedWire struct {
+	metaWire
 	EncID     core.EncounterID                     `json:"encounter_id"`
 	Seq       uint64                               `json:"sequence"`
 	EntityID  core.EntityID                        `json:"entity_id"`
@@ -73,6 +75,7 @@ type entityRemovedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *EntityRemovedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(entityRemovedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		EntityID:  e.EntityID,
@@ -88,6 +91,7 @@ func (e *EntityRemovedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.EntityID = w.EntityID

--- a/encounter/events/events.go
+++ b/encounter/events/events.go
@@ -1,17 +1,31 @@
 package events
 
-import "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+import (
+	"time"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
 
 // EncounterEvent is the sealed sum type of events the broker carries.
 //
 // External packages cannot implement this interface — the marker method
 // isEncounterEvent() is unexported, and only types declared in this
 // package can satisfy it. Consumers type-switch on the concrete type.
+//
+// OccurredAt and CorrelationID are the spine metadata added for the TakeAction
+// wave (North-Star Invariants 5 and 8): every event is stamped with game-event
+// time at publish, and effect events carry the correlation id of the action
+// that caused them so the toolkit-owned combat log is reassemblable. Stamp is
+// the single mutator the encounter calls just before broker.Publish. All three
+// are satisfied for free by the embedded events.eventMeta.
 type EncounterEvent interface {
 	isEncounterEvent()
 	EncounterID() core.EncounterID
 	Sequence() uint64
 	Audience() AudienceSet
+	OccurredAt() time.Time
+	CorrelationID() core.CorrelationID
+	Stamp(at time.Time, corr core.CorrelationID)
 }
 
 // AudienceSet is the set of player IDs that can perceive an event.

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -3,6 +3,7 @@ package events_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
@@ -34,6 +35,92 @@ func (s *EventsSuite) TestConcretes_SatisfyInterface() {
 	var _ events.EncounterEvent = (*events.EntityRemovedEvent)(nil)
 	var _ events.EncounterEvent = (*events.EncounterEndedEvent)(nil)
 	var _ events.EncounterEvent = (*events.ResourceChangedEvent)(nil)
+	var _ events.EncounterEvent = (*events.ActionResolvedEvent)(nil)
+}
+
+// Every event exposes the spine metadata accessors (Invariants 5, 8) via the
+// embedded eventMeta — and Stamp sets them. A representative sample is enough;
+// the methods are single-sourced on eventMeta so what holds for one holds for
+// all.
+func (s *EventsSuite) TestSpineMeta_StampAndAccessors() {
+	at := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	corr := core.CorrelationID("corr-enc-1-7")
+
+	samples := []events.EncounterEvent{
+		events.NewMoveEvent("enc-1", 1, "bob", nil, nil),
+		events.NewAttackResolvedEvent("enc-1", 2, "a", "b", true, false, 1, 1, 1, nil),
+		events.NewDamageDealtEvent("enc-1", 3, "a", "b", 1, "slashing", 1, 1, nil),
+		events.NewActionResolvedEvent("enc-1", 4, "a", "dnd5e:action:attack", "b",
+			events.EconomyConsumed{Actions: 1}, nil),
+	}
+	for _, e := range samples {
+		s.Equal(time.Time{}, e.OccurredAt(), "unstamped event has zero time")
+		s.Equal(core.CorrelationID(""), e.CorrelationID(), "unstamped event has empty correlation")
+		e.Stamp(at, corr)
+		s.Equal(at, e.OccurredAt())
+		s.Equal(corr, e.CorrelationID())
+	}
+}
+
+// The spine metadata survives the JSON round-trip on an existing event — proves
+// the embedded metaWire serializes inline under stable field names.
+func (s *EventsSuite) TestSpineMeta_JSONRoundTrip() {
+	at := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	corr := core.CorrelationID("corr-enc-1-11")
+
+	original := events.NewAttackResolvedEvent(
+		"enc-1", 11, "char-alice", "goblin-1",
+		true, false, 17, 4, 15,
+		map[core.PlayerID]events.AttackResolvedSlice{"alice": {Visible: true}},
+	)
+	original.Stamp(at, corr)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+	s.Contains(string(payload), `"occurred_at"`)
+	s.Contains(string(payload), `"correlation_id"`)
+
+	var decoded events.AttackResolvedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+	s.Equal(at, decoded.OccurredAt())
+	s.Equal(corr, decoded.CorrelationID())
+}
+
+// ActionResolvedEvent JSON round-trip — action_ref + economy_consumed + spine
+// meta all survive encoding; audience derives from PerPlayer keys.
+func (s *EventsSuite) TestActionResolvedEvent_JSONRoundTrip() {
+	at := time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC)
+	corr := core.CorrelationID("corr-enc-1-21")
+
+	original := events.NewActionResolvedEvent(
+		"enc-1", 21, "char-alice", "dnd5e:actions:strike", "goblin-1",
+		events.EconomyConsumed{
+			Actions:         1,
+			GrantedConsumed: map[string]int{"attacks": 1},
+		},
+		map[core.PlayerID]events.ActionResolvedSlice{
+			"alice": {Visible: true},
+			"bob":   {Visible: false},
+		},
+	)
+	original.Stamp(at, corr)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.ActionResolvedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(21), decoded.Sequence())
+	s.Equal(core.EntityID("char-alice"), decoded.ActorID)
+	s.Equal("dnd5e:actions:strike", decoded.ActionRef)
+	s.Equal(core.EntityID("goblin-1"), decoded.TargetID)
+	s.Equal(1, decoded.EconomyConsumed.Actions)
+	s.Equal(1, decoded.EconomyConsumed.GrantedConsumed["attacks"])
+	s.Equal(at, decoded.OccurredAt())
+	s.Equal(corr, decoded.CorrelationID())
+	s.ElementsMatch(events.AudienceSet{"alice", "bob"}, decoded.Audience())
 }
 
 // MoveEvent.Audience derives from PerPlayer keys; absent players are not in audience.

--- a/encounter/events/hex_revealed.go
+++ b/encounter/events/hex_revealed.go
@@ -14,6 +14,7 @@ import (
 // The cause stays in the parallel action event; this event describes the
 // effect on perception with the same shape across all causes.
 type HexRevealedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	PerPlayer map[core.PlayerID]HexRevealedSlice
@@ -62,6 +63,7 @@ func (e *HexRevealedEvent) Sequence() uint64 { return e.seq }
 func (e *HexRevealedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type hexRevealedWire struct {
+	metaWire
 	EncID     core.EncounterID                   `json:"encounter_id"`
 	Seq       uint64                             `json:"sequence"`
 	PerPlayer map[core.PlayerID]HexRevealedSlice `json:"per_player"`
@@ -70,7 +72,12 @@ type hexRevealedWire struct {
 // MarshalJSON exposes encID and seq under stable JSON field names without
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *HexRevealedEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hexRevealedWire{EncID: e.encID, Seq: e.seq, PerPlayer: e.PerPlayer})
+	return json.Marshal(hexRevealedWire{
+		metaWire:  e.toWire(),
+		EncID:     e.encID,
+		Seq:       e.seq,
+		PerPlayer: e.PerPlayer,
+	})
 }
 
 // UnmarshalJSON populates the unexported fields from JSON.
@@ -80,6 +87,7 @@ func (e *HexRevealedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.PerPlayer = w.PerPlayer

--- a/encounter/events/input_required_delivered.go
+++ b/encounter/events/input_required_delivered.go
@@ -30,6 +30,7 @@ import (
 // 2.9-style skill checks could reuse this with kind "skill_check" (today
 // they ride the response payload directly).
 type InputRequiredDeliveredEvent struct {
+	eventMeta
 	encID      core.EncounterID
 	seq        uint64
 	ReactorID  core.PlayerID
@@ -72,6 +73,7 @@ func (e *InputRequiredDeliveredEvent) Audience() AudienceSet {
 }
 
 type inputRequiredDeliveredWire struct {
+	metaWire
 	EncID      core.EncounterID `json:"encounter_id"`
 	Seq        uint64           `json:"sequence"`
 	ReactorID  core.PlayerID    `json:"reactor_id"`
@@ -82,6 +84,7 @@ type inputRequiredDeliveredWire struct {
 // Implements encoding/json.Marshaler.
 func (e *InputRequiredDeliveredEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(inputRequiredDeliveredWire{
+		metaWire:   e.toWire(),
 		EncID:      e.encID,
 		Seq:        e.seq,
 		ReactorID:  e.ReactorID,
@@ -96,6 +99,7 @@ func (e *InputRequiredDeliveredEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.ReactorID = w.ReactorID

--- a/encounter/events/meta.go
+++ b/encounter/events/meta.go
@@ -1,0 +1,62 @@
+package events
+
+import (
+	"time"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// eventMeta is the spine metadata every encounter event carries beyond its
+// encounter id and sequence: the game-event timestamp stamped at publish
+// (Invariant 5) and the correlation id tying effect events to their causing
+// action (Invariant 8).
+//
+// Concrete events embed eventMeta so the OccurredAt / CorrelationID accessors
+// and the Stamp mutator are single-sourced here — adding a field to the spine
+// touches one struct, not every event. Embedding also satisfies the new
+// EncounterEvent interface methods for free, so no per-event boilerplate.
+//
+// Each event's own MarshalJSON / UnmarshalJSON wire struct routes these
+// through stable JSON field names (`occurred_at`, `correlation_id`) via the
+// toWire / fromWire helpers; the promoted methods stay the read/write surface
+// for code. Fields are unexported and prefixed to avoid colliding with the
+// promoted OccurredAt / CorrelationID method names.
+type eventMeta struct {
+	eventOccurredAt    time.Time
+	eventCorrelationID core.CorrelationID
+}
+
+// OccurredAt returns the game-event time this event was stamped with at
+// publish (Invariant 5). Promoted onto every embedding event; part of the
+// EncounterEvent interface.
+func (m *eventMeta) OccurredAt() time.Time { return m.eventOccurredAt }
+
+// CorrelationID returns the correlation id grouping this event with the other
+// events of the action that caused it (Invariant 8). Empty when the event is
+// not part of a correlated action group. Part of the EncounterEvent interface.
+func (m *eventMeta) CorrelationID() core.CorrelationID { return m.eventCorrelationID }
+
+// Stamp sets the publish-time spine metadata. Called once by the encounter
+// just before handing the event to the broker — the single stamp point that
+// makes "game-event time at publish" literal. Part of the EncounterEvent
+// interface (callers in the encounter package stamp via this).
+func (m *eventMeta) Stamp(at time.Time, corr core.CorrelationID) {
+	m.eventOccurredAt = at
+	m.eventCorrelationID = corr
+}
+
+// metaWire is the JSON shape for the spine metadata, embedded into each
+// event's own wire struct so the two fields serialize under stable names.
+type metaWire struct {
+	OccurredAt    time.Time          `json:"occurred_at"`
+	CorrelationID core.CorrelationID `json:"correlation_id,omitempty"`
+}
+
+func (m *eventMeta) toWire() metaWire {
+	return metaWire{OccurredAt: m.eventOccurredAt, CorrelationID: m.eventCorrelationID}
+}
+
+func (m *eventMeta) fromWire(w metaWire) {
+	m.eventOccurredAt = w.OccurredAt
+	m.eventCorrelationID = w.CorrelationID
+}

--- a/encounter/events/meta.go
+++ b/encounter/events/meta.go
@@ -36,10 +36,16 @@ func (m *eventMeta) OccurredAt() time.Time { return m.eventOccurredAt }
 // not part of a correlated action group. Part of the EncounterEvent interface.
 func (m *eventMeta) CorrelationID() core.CorrelationID { return m.eventCorrelationID }
 
-// Stamp sets the publish-time spine metadata. Called once by the encounter
-// just before handing the event to the broker — the single stamp point that
-// makes "game-event time at publish" literal. Part of the EncounterEvent
-// interface (callers in the encounter package stamp via this).
+// Stamp sets the spine metadata. Two callers, two responsibilities:
+//   - The encounter sets the correlation id before publish (via
+//     publishCorrelated, passing a zero time) so an action's effect events
+//     group under one id (Invariant 8).
+//   - The Broker re-stamps at the literal publish moment to set game-event time
+//     (Invariant 5), preserving the correlation id already set. The broker is
+//     therefore the single timestamp authority; "game-event time at publish" is
+//     literal because the broker is the one publish point.
+//
+// Part of the EncounterEvent interface.
 func (m *eventMeta) Stamp(at time.Time, corr core.CorrelationID) {
 	m.eventOccurredAt = at
 	m.eventCorrelationID = corr

--- a/encounter/events/mode_changed.go
+++ b/encounter/events/mode_changed.go
@@ -9,6 +9,7 @@ import (
 // ModeChangedEvent is published when the encounter mode flips (e.g.
 // FREE_ROAM <-> TURN_BASED). Audience is all players in the encounter.
 type ModeChangedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	From      core.EncounterMode
@@ -55,6 +56,7 @@ func (e *ModeChangedEvent) Sequence() uint64 { return e.seq }
 func (e *ModeChangedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type modeChangedWire struct {
+	metaWire
 	EncID     core.EncounterID                   `json:"encounter_id"`
 	Seq       uint64                             `json:"sequence"`
 	From      core.EncounterMode                 `json:"from"`
@@ -67,6 +69,7 @@ type modeChangedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *ModeChangedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(modeChangedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		From:      e.From,
@@ -83,6 +86,7 @@ func (e *ModeChangedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.From = w.From

--- a/encounter/events/move.go
+++ b/encounter/events/move.go
@@ -12,6 +12,7 @@ import (
 // parallel HexRevealedEvent published alongside this one. See the decoupled
 // cause/effect decision in sdk-direction.md.
 type MoveEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	Mover     core.EntityID
@@ -64,6 +65,7 @@ func (e *MoveEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer)
 // the construction invariant: only NewMoveEvent and UnmarshalJSON can set
 // the encounter ID and sequence number.
 type moveEventWire struct {
+	metaWire
 	EncID     core.EncounterID                  `json:"encounter_id"`
 	Seq       uint64                            `json:"sequence"`
 	Mover     core.EntityID                     `json:"mover"`
@@ -75,6 +77,7 @@ type moveEventWire struct {
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *MoveEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(moveEventWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		Mover:     e.Mover,
@@ -90,6 +93,7 @@ func (e *MoveEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.Mover = w.Mover

--- a/encounter/events/resource_changed.go
+++ b/encounter/events/resource_changed.go
@@ -10,6 +10,7 @@ import (
 // resource (e.g. rage charges, ki) changes during an encounter verb.
 // Maps to the proto ResourceChanged wire shape.
 type ResourceChangedEvent struct {
+	eventMeta
 	encID       core.EncounterID
 	seq         uint64
 	EntityID    core.EntityID
@@ -57,6 +58,7 @@ func (e *ResourceChangedEvent) Sequence() uint64 { return e.seq }
 func (e *ResourceChangedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type resourceChangedWire struct {
+	metaWire
 	EncID       core.EncounterID                       `json:"encounter_id"`
 	Seq         uint64                                 `json:"sequence"`
 	EntityID    core.EntityID                          `json:"entity_id"`
@@ -70,6 +72,7 @@ type resourceChangedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *ResourceChangedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(resourceChangedWire{
+		metaWire:    e.toWire(),
 		EncID:       e.encID,
 		Seq:         e.seq,
 		EntityID:    e.EntityID,
@@ -87,6 +90,7 @@ func (e *ResourceChangedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.EntityID = w.EntityID

--- a/encounter/events/turn_ended.go
+++ b/encounter/events/turn_ended.go
@@ -9,6 +9,7 @@ import (
 // TurnEndedEvent is published when an actor's turn ends, before initiative
 // advances to the next actor. Audience is all players in the encounter.
 type TurnEndedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	ActorID   core.EntityID
@@ -49,6 +50,7 @@ func (e *TurnEndedEvent) Sequence() uint64 { return e.seq }
 func (e *TurnEndedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type turnEndedWire struct {
+	metaWire
 	EncID     core.EncounterID                 `json:"encounter_id"`
 	Seq       uint64                           `json:"sequence"`
 	ActorID   core.EntityID                    `json:"actor_id"`
@@ -59,6 +61,7 @@ type turnEndedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *TurnEndedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(turnEndedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		ActorID:   e.ActorID,
@@ -73,6 +76,7 @@ func (e *TurnEndedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.ActorID = w.ActorID

--- a/encounter/events/turn_started.go
+++ b/encounter/events/turn_started.go
@@ -10,6 +10,7 @@ import (
 // TurnStartedEvent is published when initiative advances to a new actor.
 // Audience is all players in the encounter.
 type TurnStartedEvent struct {
+	eventMeta
 	encID     core.EncounterID
 	seq       uint64
 	ActorID   core.EntityID
@@ -53,6 +54,7 @@ func (e *TurnStartedEvent) Sequence() uint64 { return e.seq }
 func (e *TurnStartedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
 
 type turnStartedWire struct {
+	metaWire
 	EncID     core.EncounterID                   `json:"encounter_id"`
 	Seq       uint64                             `json:"sequence"`
 	ActorID   core.EntityID                      `json:"actor_id"`
@@ -64,6 +66,7 @@ type turnStartedWire struct {
 // Implements encoding/json.Marshaler.
 func (e *TurnStartedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(turnStartedWire{
+		metaWire:  e.toWire(),
 		EncID:     e.encID,
 		Seq:       e.seq,
 		ActorID:   e.ActorID,
@@ -79,6 +82,7 @@ func (e *TurnStartedEvent) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
+	e.fromWire(w.metaWire)
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.ActorID = w.ActorID


### PR DESCRIPTION
First of two **separable** TakeAction-wave PRs — the **event-faithfulness** piece. This is the additive engine work the proto/api lanes mirror, and per the wave doc it lands **before** rpg-api stops suppressing (otherwise the un-suppress throws `ErrUnknownEventType`).

Wave doc: `rpg-project/ideas/encounter/v1alpha2/take-action/design.md`. Validated against the North-Star Invariants (`.../v1alpha2/design.md`).

## What this PR does

- **`EncounterEvent` interface** gains `OccurredAt()` (game-event time, **Inv 5**), `CorrelationID()` (causation grouping, **Inv 8**), and `Stamp(at, corr)`. All three are single-sourced on an embedded `eventMeta` struct — adding a future spine field touches one struct, not all ~17 events. The two fields serialize **flat** via an embedded `metaWire` (`occurred_at`, `correlation_id`).
- **`Broker.Publish` is the single game-event-time stamp authority** via an injected `core.Clock` (`NewBrokerWithClock`; default `SystemClock`, tests inject `FixedClock`), preserving any correlation id the encounter set. "Game-event time at publish" is literal, with no per-call-site boilerplate across the ~23 publish sites.
- **New first-class `events.ActionResolvedEvent`** (**Inv 9**): `ActorID`, `ActionRef` (string), optional `TargetID`, `EconomyConsumed` (actions/bonus/reactions/movement + `granted_consumed` map). Registered in the broker codec (encode + decode).
- **Attack resolution publishes a correlated group** — `ActionResolved → AttackResolved → DamageDealt` — all sharing one correlation id derived from the resolved-action event's `(encID, seq)` identity (deterministic, dependency-free, trivially assertable).

## Proof

`encounter/action_resolved_test.go` drives a **real `TakeAction`** through the broker (subscription, not a stub) with a `FixedClock` and asserts: the `ActionResolvedEvent` carries `action_ref` + `economy_consumed`; the attack + damage effects share its correlation id; every event's `OccurredAt` equals the fixed clock; and the cause leads its effects in sequence. Plus events-package round-trip tests for the new event and the spine meta. `go test -race ./...` green; production code lint-clean.

## CONTRACT for the other lanes to mirror

- **Spine meta (every event):** `occurred_at: time.Time` (stamped at publish), `correlation_id: string` (`omitempty`; format `corr-<encID>-<seq>`).
- **`ActionResolvedEvent`:** `actor_id`, `action_ref: string`, `target_id` (`omitempty`), `economy_consumed`, `per_player`.
- **`EconomyConsumed`:** `actions`, `bonus_actions`, `reactions`, `movement` (ints), `granted_consumed: map[string]int` (`omitempty`).
- Proto mirror needed before rpg-api un-suppresses: new `ActionResolved` variant in the `EncounterEvent` oneof + `occurred_at`/`correlation_id` on the envelope.

## Scope / what remains for the next #697 chunk

The **menu/economy unification** (reconcile the encounter verb path with the `character` action menu/economy, expose the menu as data incl. target-kind, non-attack actions + Monk bonus strike, validate+deduct) is the second separable PR. `EconomyConsumed` on the attack path reports the honest known cost today (`Actions: 1`); the unification PR sources the richer two-level consumption.

Docs: ADR-0031; `docs/architecture/components/encounter.md` + `docs/status.md` updated in this PR.

Part of #697 (the event-faithfulness piece; #697 closes with the menu/economy unification PR).
Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
