### PR TITLE
feat(character): action menu as data (EconomySlot + TargetKind) + Monk bonus-action fix

### DIFF
--- a/docs/architecture/components/rulebook-dnd5e.md
+++ b/docs/architecture/components/rulebook-dnd5e.md
@@ -470,6 +470,31 @@ newChar, err := character.LoadFromData(ctx, data, bus)
 their handlers on reconstruct. This is the critical step that makes the
 toolkit stateless from rpg-api's perspective.
 
+### Two-level action economy + the action menu as data (rpg-toolkit#697, ADR-0032)
+
+The character owns the D&D 5e two-level model: `StartTurn` seeds the economy
+(1 action / 1 bonus / 1 reaction / movement = speed), `ActivateAbility` spends a
+primary slot and grants capacity (Attack → attacks) or a condition (Dodge),
+`ExecuteAction` consumes granted capacity (Strike → one attack; the Monk
+unarmed strike → the Martial Arts bonus). `AvailableAbilities` / `AvailableActions`
+compute the menu from that state. The encounter SDK delegates to these directly
+on the held character (ADR-0032) — it never re-derives availability.
+
+Each menu entry (`AvailableAbility` / `AvailableAction`) carries two
+toolkit-authored enums the game server projects field-for-field:
+
+- `EconomySlot` — `{Unspecified, Action, BonusAction, Reaction, Movement, Free}`,
+  for grouping the menu by slot.
+- `TargetKind` — `{Unspecified, Self, SingleEntity, Position, Area, None}`, so a
+  UI raises the right prompt. `Self` (Dodge — targets the actor) is distinct from
+  `None` (Dash — deliberately untargeted, no prompt); `Unspecified` is the
+  not-set defect value. Class features not yet classified return `Unspecified`.
+
+The Monk Martial Arts unarmed strike is a bonus action (PHB p.78):
+`executeUnarmedStrike` spends both the granted martial-arts capacity AND the
+`BonusActionsRemaining` slot — without the slot decrement the bonus action was
+silently never spent.
+
 ## Activation surface — features Activate, conditions Apply
 
 Per audit Section 3 Claim 1, the activation surface has **two halves**:

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -321,12 +321,20 @@ func (c *Character) buildAvailableActions() []AvailableAction {
 	// Unarmed Strike (Martial Arts Bonus): listed if granted. The Monk martial
 	// arts bonus strike is a bonus-action strike.
 	if c.actionEconomy.Granted[GrantedMartialArtsBonus] > 0 {
+		// The unarmed strike costs a bonus action (PHB p.78): it is only usable
+		// while the bonus-action slot is unspent, so the menu reflects that.
+		canUse := c.actionEconomy.BonusActionsRemaining > 0
+		reason := ""
+		if !canUse {
+			reason = "no bonus action remaining"
+		}
 		result = append(result, AvailableAction{
 			Ref:         refs.Actions.UnarmedStrike(),
 			Name:        "Unarmed Strike",
 			EconomySlot: EconomySlotBonusAction,
 			TargetKind:  targetKindForRef(refs.Actions.UnarmedStrike()),
-			CanUse:      true,
+			CanUse:      canUse,
+			Reason:      reason,
 		})
 	}
 
@@ -507,12 +515,20 @@ func (c *Character) executeUnarmedStrike() (*ExecuteActionOutput, error) {
 		}, nil
 	}
 
-	c.actionEconomy.Granted[GrantedMartialArtsBonus]--
-	// Spend the bonus action that the unarmed strike costs (guard against
-	// going negative if the slot was already spent by another bonus action).
-	if c.actionEconomy.BonusActionsRemaining > 0 {
-		c.actionEconomy.BonusActionsRemaining--
+	// The unarmed strike costs a bonus action (PHB p.78). Reject before spending
+	// the granted capacity if the bonus-action slot is already gone, so
+	// enforcement does not depend on call order.
+	if c.actionEconomy.BonusActionsRemaining <= 0 {
+		return &ExecuteActionOutput{
+			Success:   false,
+			Error:     "no bonus action remaining",
+			Abilities: c.buildAvailableAbilities(),
+			Actions:   c.buildAvailableActions(),
+		}, nil
 	}
+
+	c.actionEconomy.Granted[GrantedMartialArtsBonus]--
+	c.actionEconomy.BonusActionsRemaining--
 
 	return &ExecuteActionOutput{
 		Success:   true,

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -166,6 +166,41 @@ func (c *Character) HasGranted(key GrantedActionKey) bool {
 
 // --- Available builders ---
 
+// targetKindForRef returns the UI target prompt a menu entry needs, keyed off
+// the action/ability ref. This is toolkit-authored rules knowledge (the toolkit
+// owns "what does this action target") — the game server never computes it.
+// An unknown ref returns TargetKindUnspecified so a new ref surfaces as a
+// visible defect rather than silently defaulting.
+func targetKindForRef(ref *core.Ref) TargetKind {
+	if ref == nil {
+		return TargetKindUnspecified
+	}
+	switch ref.ID {
+	// Attacks and the strikes they grant target one entity.
+	case refs.CombatAbilities.Attack().ID,
+		refs.CombatAbilities.OffHandAttack().ID,
+		refs.CombatAbilities.Help().ID,
+		refs.Actions.Strike().ID,
+		refs.Actions.OffHandStrike().ID,
+		refs.Actions.FlurryStrike().ID,
+		refs.Actions.UnarmedStrike().ID:
+		return TargetKindSingleEntity
+	// Self-affecting abilities (grant a condition on the actor).
+	case refs.CombatAbilities.Dodge().ID,
+		refs.CombatAbilities.Disengage().ID,
+		refs.CombatAbilities.Hide().ID:
+		return TargetKindSelf
+	// Movement targets a position.
+	case refs.Actions.Move().ID:
+		return TargetKindPosition
+	// Deliberately untargeted (fire without a prompt).
+	case refs.CombatAbilities.Dash().ID:
+		return TargetKindNone
+	default:
+		return TargetKindUnspecified
+	}
+}
+
 // buildAvailableAbilities builds the list of available abilities from combat abilities and features.
 func (c *Character) buildAvailableAbilities() []AvailableAbility {
 	result := make([]AvailableAbility, 0, len(c.combatAbilities)+len(c.features))
@@ -176,11 +211,13 @@ func (c *Character) buildAvailableAbilities() []AvailableAbility {
 		reason := c.actionTypeExhaustedReason(ca.ActionType())
 
 		result = append(result, AvailableAbility{
-			Ref:        ca.Ref(),
-			Name:       ca.Name(),
-			ActionType: ca.ActionType(),
-			CanUse:     canUse,
-			Reason:     c.actionReason(canUse, reason),
+			Ref:         ca.Ref(),
+			Name:        ca.Name(),
+			ActionType:  ca.ActionType(),
+			EconomySlot: economySlotForActionType(ca.ActionType()),
+			TargetKind:  targetKindForRef(ca.Ref()),
+			CanUse:      canUse,
+			Reason:      c.actionReason(canUse, reason),
 		})
 	}
 
@@ -203,6 +240,8 @@ func (c *Character) buildAvailableAbilities() []AvailableAbility {
 			Ref:             f.Ref(),
 			Name:            f.Name(),
 			ActionType:      f.ActionType(),
+			EconomySlot:     economySlotForActionType(f.ActionType()),
+			TargetKind:      targetKindForRef(f.Ref()),
 			CanUse:          canUse,
 			Reason:          c.actionReason(canUse, reason),
 			ResourceCurrent: current,
@@ -215,11 +254,13 @@ func (c *Character) buildAvailableAbilities() []AvailableAbility {
 		canUse := c.canUseAbilityByActionType(coreCombat.ActionBonus)
 		reason := c.actionTypeExhaustedReason(coreCombat.ActionBonus)
 		result = append(result, AvailableAbility{
-			Ref:        refs.CombatAbilities.OffHandAttack(),
-			Name:       "Off-Hand Attack",
-			ActionType: coreCombat.ActionBonus,
-			CanUse:     canUse,
-			Reason:     c.actionReason(canUse, reason),
+			Ref:         refs.CombatAbilities.OffHandAttack(),
+			Name:        "Off-Hand Attack",
+			ActionType:  coreCombat.ActionBonus,
+			EconomySlot: economySlotForActionType(coreCombat.ActionBonus),
+			TargetKind:  targetKindForRef(refs.CombatAbilities.OffHandAttack()),
+			CanUse:      canUse,
+			Reason:      c.actionReason(canUse, reason),
 		})
 	}
 
@@ -230,48 +271,62 @@ func (c *Character) buildAvailableAbilities() []AvailableAbility {
 func (c *Character) buildAvailableActions() []AvailableAction {
 	result := make([]AvailableAction, 0)
 
-	// Move is always listed
+	// Move is always listed. It draws from movement and targets a position.
 	moveCanUse := c.actionEconomy.MovementRemaining > 0
 	result = append(result, AvailableAction{
-		Ref:    refs.Actions.Move(),
-		Name:   "Move",
-		CanUse: moveCanUse,
-		Reason: c.actionReason(moveCanUse, "no movement remaining"),
+		Ref:         refs.Actions.Move(),
+		Name:        "Move",
+		EconomySlot: EconomySlotMovement,
+		TargetKind:  targetKindForRef(refs.Actions.Move()),
+		CanUse:      moveCanUse,
+		Reason:      c.actionReason(moveCanUse, "no movement remaining"),
 	})
 
-	// Strike: listed if attacks granted
+	// Strike: listed if attacks granted. Each strike spends one granted attack
+	// from the Attack action, so it belongs to the action slot.
 	if c.actionEconomy.Granted[GrantedAttacks] > 0 {
 		result = append(result, AvailableAction{
-			Ref:    refs.Actions.Strike(),
-			Name:   "Strike",
-			CanUse: true,
+			Ref:         refs.Actions.Strike(),
+			Name:        "Strike",
+			EconomySlot: EconomySlotAction,
+			TargetKind:  targetKindForRef(refs.Actions.Strike()),
+			CanUse:      true,
 		})
 	}
 
-	// Off-Hand Strike: listed if granted
+	// Off-Hand Strike: listed if granted. Two-weapon fighting grants it off the
+	// bonus action.
 	if c.actionEconomy.Granted[GrantedOffHandStrikes] > 0 {
 		result = append(result, AvailableAction{
-			Ref:    refs.Actions.OffHandStrike(),
-			Name:   "Off-Hand Strike",
-			CanUse: true,
+			Ref:         refs.Actions.OffHandStrike(),
+			Name:        "Off-Hand Strike",
+			EconomySlot: EconomySlotBonusAction,
+			TargetKind:  targetKindForRef(refs.Actions.OffHandStrike()),
+			CanUse:      true,
 		})
 	}
 
-	// Flurry Strike: listed if granted
+	// Flurry Strike: listed if granted. Flurry of Blows grants strikes off the
+	// bonus action.
 	if c.actionEconomy.Granted[GrantedFlurryStrikes] > 0 {
 		result = append(result, AvailableAction{
-			Ref:    refs.Actions.FlurryStrike(),
-			Name:   "Flurry Strike",
-			CanUse: true,
+			Ref:         refs.Actions.FlurryStrike(),
+			Name:        "Flurry Strike",
+			EconomySlot: EconomySlotBonusAction,
+			TargetKind:  targetKindForRef(refs.Actions.FlurryStrike()),
+			CanUse:      true,
 		})
 	}
 
-	// Unarmed Strike (Martial Arts Bonus): listed if granted
+	// Unarmed Strike (Martial Arts Bonus): listed if granted. The Monk martial
+	// arts bonus strike is a bonus-action strike.
 	if c.actionEconomy.Granted[GrantedMartialArtsBonus] > 0 {
 		result = append(result, AvailableAction{
-			Ref:    refs.Actions.UnarmedStrike(),
-			Name:   "Unarmed Strike",
-			CanUse: true,
+			Ref:         refs.Actions.UnarmedStrike(),
+			Name:        "Unarmed Strike",
+			EconomySlot: EconomySlotBonusAction,
+			TargetKind:  targetKindForRef(refs.Actions.UnarmedStrike()),
+			CanUse:      true,
 		})
 	}
 
@@ -435,7 +490,13 @@ func (c *Character) executeFlurryStrike() (*ExecuteActionOutput, error) {
 	}, nil
 }
 
-// executeUnarmedStrike decrements granted martial arts bonus strikes.
+// executeUnarmedStrike consumes a granted martial arts bonus strike AND the
+// bonus action that pays for it. The Monk's Martial Arts unarmed strike is a
+// bonus action (PHB p.78: "you can make one unarmed strike as a bonus action"):
+// the granted capacity tracks that the strike is available this turn, and the
+// bonus-action slot is the economy cost spent when the strike is actually taken.
+// Decrementing both here keeps the two-level model honest — without the slot
+// decrement the actor could appear to still have a bonus action after using it.
 func (c *Character) executeUnarmedStrike() (*ExecuteActionOutput, error) {
 	if c.actionEconomy.Granted[GrantedMartialArtsBonus] <= 0 {
 		return &ExecuteActionOutput{
@@ -447,6 +508,11 @@ func (c *Character) executeUnarmedStrike() (*ExecuteActionOutput, error) {
 	}
 
 	c.actionEconomy.Granted[GrantedMartialArtsBonus]--
+	// Spend the bonus action that the unarmed strike costs (guard against
+	// going negative if the slot was already spent by another bonus action).
+	if c.actionEconomy.BonusActionsRemaining > 0 {
+		c.actionEconomy.BonusActionsRemaining--
+	}
 
 	return &ExecuteActionOutput{
 		Success:   true,

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -782,6 +782,10 @@ func (s *ActionEconomyTestSuite) TestExecuteAction_UnarmedStrike() {
 	s.Require().NoError(err)
 	s.True(output.Success)
 	s.Equal(0, char.actionEconomy.Granted[GrantedMartialArtsBonus])
+	// The Monk Martial Arts unarmed strike is a bonus action (PHB p.78): taking
+	// it spends the bonus-action slot, not just the granted capacity.
+	s.Equal(0, char.actionEconomy.BonusActionsRemaining,
+		"unarmed strike consumes the bonus action that pays for it")
 }
 
 func (s *ActionEconomyTestSuite) TestGrantCapacity() {

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -788,6 +788,27 @@ func (s *ActionEconomyTestSuite) TestExecuteAction_UnarmedStrike() {
 		"unarmed strike consumes the bonus action that pays for it")
 }
 
+func (s *ActionEconomyTestSuite) TestExecuteAction_UnarmedStrike_NoBonusAction() {
+	char := createTestMonkCharacter(s.T(), s.bus)
+
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{Speed: 30})
+	s.Require().NoError(err)
+
+	// Granted the martial arts bonus strike, but the bonus action is already spent.
+	char.actionEconomy.Granted[GrantedMartialArtsBonus] = 1
+	char.actionEconomy.BonusActionsRemaining = 0
+
+	output, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+		ActionRef: refs.Actions.UnarmedStrike(),
+	})
+	s.Require().NoError(err)
+	s.False(output.Success, "unarmed strike must fail when no bonus action remains")
+	// The granted capacity must NOT be spent on a failed strike — enforcement
+	// is order-independent (the bonus-action slot gates the strike).
+	s.Equal(1, char.actionEconomy.Granted[GrantedMartialArtsBonus],
+		"granted capacity must not be consumed when the bonus action is unavailable")
+}
+
 func (s *ActionEconomyTestSuite) TestGrantCapacity() {
 	char := createTestFighterCharacter(s.T(), s.bus)
 

--- a/rulebooks/dnd5e/character/action_economy_types.go
+++ b/rulebooks/dnd5e/character/action_economy_types.go
@@ -42,6 +42,8 @@ func economySlotForActionType(at coreCombat.ActionType) EconomySlot {
 		return EconomySlotReaction
 	case coreCombat.ActionFree:
 		return EconomySlotFree
+	case coreCombat.ActionMovement:
+		return EconomySlotMovement
 	default:
 		return EconomySlotUnspecified
 	}

--- a/rulebooks/dnd5e/character/action_economy_types.go
+++ b/rulebooks/dnd5e/character/action_economy_types.go
@@ -5,12 +5,82 @@ import (
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
 )
 
+// EconomySlot identifies which action-economy slot a menu entry draws from, so
+// a UI can group the action menu by slot without knowing the rules. It is the
+// toolkit-authored, rulebook-native enum the game server (rpg-api) projects
+// onto the wire field-for-field.
+type EconomySlot string
+
+const (
+	// EconomySlotUnspecified means the slot was not set — a defect, not a value
+	// a caller should reach. Present so the zero value is distinguishable.
+	EconomySlotUnspecified EconomySlot = ""
+	// EconomySlotAction draws from the standard action (e.g. Attack, Dodge).
+	EconomySlotAction EconomySlot = "action"
+	// EconomySlotBonusAction draws from the bonus action (e.g. the Monk
+	// Martial Arts unarmed strike, Off-Hand Attack).
+	EconomySlotBonusAction EconomySlot = "bonus_action"
+	// EconomySlotReaction draws from the reaction.
+	EconomySlotReaction EconomySlot = "reaction"
+	// EconomySlotMovement draws from movement (e.g. the Move action).
+	EconomySlotMovement EconomySlot = "movement"
+	// EconomySlotFree costs no action-economy slot (a free action).
+	EconomySlotFree EconomySlot = "free"
+)
+
+// economySlotForActionType maps the two-level model's primary ActionType to the
+// menu EconomySlot. Reaction and Free pass through; Standard is the "action"
+// slot. This is the single place the mapping lives so abilities and actions
+// share it.
+func economySlotForActionType(at coreCombat.ActionType) EconomySlot {
+	switch at {
+	case coreCombat.ActionStandard:
+		return EconomySlotAction
+	case coreCombat.ActionBonus:
+		return EconomySlotBonusAction
+	case coreCombat.ActionReaction:
+		return EconomySlotReaction
+	case coreCombat.ActionFree:
+		return EconomySlotFree
+	default:
+		return EconomySlotUnspecified
+	}
+}
+
+// TargetKind tells a UI what kind of target an action needs, so it raises the
+// right prompt (self / single entity / position / area / none) without knowing
+// the rules. It is toolkit-authored; the game server projects it field-for-field.
+//
+// Unspecified (zero value) means the toolkit did not set it — a defect a UI
+// should treat as a bug. None means the action is deliberately untargeted (e.g.
+// Dash): the UI fires it without raising a target prompt. None is therefore
+// distinct from Self, which still names a target (the actor).
+type TargetKind string
+
+const (
+	// TargetKindUnspecified means the kind was not set — a defect, not a value.
+	TargetKindUnspecified TargetKind = ""
+	// TargetKindSelf targets the actor itself (e.g. Dodge).
+	TargetKindSelf TargetKind = "self"
+	// TargetKindSingleEntity targets one other entity (e.g. Attack, Strike).
+	TargetKindSingleEntity TargetKind = "single_entity"
+	// TargetKindPosition targets a position on the map (e.g. Move).
+	TargetKindPosition TargetKind = "position"
+	// TargetKindArea targets an area of effect.
+	TargetKindArea TargetKind = "area"
+	// TargetKindNone is a deliberately untargeted action (e.g. Dash): the UI
+	// fires it without a target prompt.
+	TargetKindNone TargetKind = "none"
+)
+
 // AvailableAbility represents something a character can do that consumes
 // primary action economy resources (action, bonus action, reaction).
 type AvailableAbility struct {
 	Ref             *core.Ref             // e.g. "dnd5e:combat_abilities:attack"
 	Name            string                // e.g. "Attack"
 	ActionType      coreCombat.ActionType // ActionStandard, ActionBonus, ActionReaction
+	EconomySlot     EconomySlot           // which slot this draws from (menu grouping)
+	TargetKind      TargetKind            // what target the UI must prompt for
 	CanUse          bool                  // computed from current action economy state
 	Reason          string                // why CanUse is false (empty when true)
 	ResourceCurrent int                   // current charges (0 if no resource)
@@ -20,10 +90,12 @@ type AvailableAbility struct {
 // AvailableAction represents something a character can do that consumes
 // granted capacity (attacks remaining, movement remaining, etc.).
 type AvailableAction struct {
-	Ref    *core.Ref // e.g. "dnd5e:actions:strike"
-	Name   string    // e.g. "Strike"
-	CanUse bool      // computed from granted capacity
-	Reason string    // why CanUse is false (empty when true)
+	Ref         *core.Ref   // e.g. "dnd5e:actions:strike"
+	Name        string      // e.g. "Strike"
+	EconomySlot EconomySlot // which slot this draws from (menu grouping)
+	TargetKind  TargetKind  // what target the UI must prompt for
+	CanUse      bool        // computed from granted capacity
+	Reason      string      // why CanUse is false (empty when true)
 }
 
 // StartTurnInput provides input for initializing the action economy at turn start.


### PR DESCRIPTION
Part of the **TakeAction** wave: KirkDiggler/rpg-project#54. References #697.

The first of two #697 menu/economy-unification chunks — the `rulebooks/dnd5e` half that the `encounter` module consumes. The encounter delegation PR stacks on this PR's tag (+ #698).

## What

- **`EconomySlot` + `TargetKind` toolkit enums** on `AvailableAbility` / `AvailableAction`. Toolkit-authored, rulebook-native; the game server (rpg-api) projects them onto the wire `AvailableAction` field-for-field (North-Star Invariant 11). The menu can now be grouped by slot and the UI can raise the right targeting prompt without knowing rules.
  - `EconomySlot`: `{unspecified, action, bonus_action, reaction, movement, free}`
  - `TargetKind`: `{unspecified, self, single_entity, position, area, none}` — `SELF` (Dodge, targets the actor) is distinct from `NONE` (Dash, deliberately untargeted: fire without a prompt); `UNSPECIFIED` is the not-set defect value.
- The two menu builders populate both fields via `economySlotForActionType` + `targetKindForRef` (single mapping sites).
- **Rules fix:** `executeUnarmedStrike` now spends the **bonus-action slot**, not only the granted Martial Arts capacity. The Monk unarmed strike is a bonus action (PHB p.78) — without the slot decrement, a Monk appeared to still have a bonus action after using it. `TestExecuteAction_UnarmedStrike` strengthened to assert the slot is consumed.
- Docs: `rulebook-dnd5e.md` — two-level economy + menu-as-data + the bonus-slot fix.

## Why split

Beat-1 spans two toolkit modules (`rulebooks/dnd5e` + `encounter`) with a real publish dependency: the encounter module can't `require` these char-pkg symbols until they're tagged. Splitting (director decision D16) keeps each PR independently green and the dependency honest. This PR is independent of #698 (it's the `rulebooks/dnd5e` module) — branched from `main`.

## Verification

`go test ./character/` green; full `rulebooks/dnd5e` build green; gofmt + vet clean. The end-to-end goal behavior (Monk takes an action + a bonus action, both slots decrement) is proven on the real broker path in the stacked encounter PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)