### PR TITLE
feat(encounter): unify TakeAction verb with the character economy/menu (#697)

### DIFF
--- a/docs/adr/0032-takeaction-unifies-encounter-verb-with-character-economy.md
+++ b/docs/adr/0032-takeaction-unifies-encounter-verb-with-character-economy.md
@@ -1,0 +1,141 @@
+# ADR-0032: TakeAction unifies the encounter verb path with the character action economy/menu
+
+Date: 2026-06-01
+
+## Status
+
+Accepted
+
+## Context
+
+The TakeAction wave (rpg-project#54 / rpg-toolkit#697, Beat 1) had to make a
+level-1 character take an **action plus a bonus action** with the economy
+enforced server-side, the menu computed by the toolkit, and the full story on
+the event spine. Two toolkit worlds had grown up in parallel and never met:
+
+- The **encounter verb path** (`encounter/combat_phased.go`) only knew
+  `"attack"`. A hard gate — `if ref.ID != "attack" { return ErrUnsupportedAction }`
+  — rejected every other ref, and attacks resolved off the flat stat snapshot on
+  `PlayerData` (`AttackBonus`, `DamageDice`), never touching a character's
+  economy or menu.
+- The **rich two-level action economy/menu** lived in the **character package**
+  (`rulebooks/dnd5e/character`): `ActivateAbility` / `ExecuteAction` validate and
+  deduct, `AvailableAbilities` / `AvailableActions` compute the menu from granted
+  capacity. The encounter path never consulted it.
+
+The wave doc named "reconcile these two worlds and decide which is canonical" as
+the largest piece of the work. Separately, rpg-api was injecting
+`ActionEconomyData{1,1,1,Movement:30}` itself at turn start because nothing in
+the engine seeded it — a North-Star Invariant 2 violation (the host authoring
+rules state).
+
+## Decision
+
+**The character package's existing dispatch is canonical. The encounter
+delegates to it; it does not build a parallel registry.** ("Default to one
+system.")
+
+1. **Delete the attack gate; delegate generally.** The `ref.ID != "attack"` gate
+   is replaced by a branch: the `attack` ref keeps its dedicated two-phase
+   resolver path (it carries reaction prompts and damage resolution); every other
+   ref flows to `Encounter.takeCharacterAction`, which routes to the held
+   character's own engine — `ActivateAbility` for abilities/features,
+   `ExecuteAction` for granted-capacity actions. No ref is enumerated in the
+   encounter: the character's menu *is* the membership test. An unknown ref on a
+   hydrated character returns `ErrUnsupportedAction`; a non-attack ref on a flat
+   stat-snapshot seat (no hydrated character) returns `ErrNonCombatant`.
+
+2. **Run on the held character, never re-load.** The action runs on the
+   `*character.Character` the `LoadFromData` cascade already hydrated onto
+   `e.bus` (ADR-0030 / #689), reached via a type-assert on the held combatant —
+   not a fresh `LoadFromData`. Re-loading would re-`Apply` the character's
+   conditions to the bus (the #684 double-subscribe class).
+
+3. **The engine owns turn-start seeding.** `Encounter` calls
+   `character.StartTurn` on the held character at each turn boundary (the
+   `SetMode→TURN_BASED` first actor and `EndTurn`'s next actor), seeding the
+   economy {1 action, 1 bonus, 1 reaction, movement = speed}. This removes the
+   rpg-api `ActionEconomyData{1,1,1}` injection (Invariant 2).
+
+4. **The menu is exposed as data.** `Encounter.ActorTurnState(actorID)` returns
+   the held character's `AvailableAbilities` / `AvailableActions` + economy as
+   toolkit domain types. Each menu entry carries an `EconomySlot` (for grouping)
+   and a `TargetKind` (so a UI raises the right prompt) — both toolkit-authored
+   enums the game server projects field-for-field (Invariant 11). `TargetKind`
+   distinguishes `SELF` (Dodge — targets the actor) from `NONE` (Dash —
+   deliberately untargeted, no prompt); `UNSPECIFIED` is the not-set defect value.
+
+5. **Attack becomes a citizen of the two-level economy.** When a hydrated
+   character takes the attack verb, the verb drives `ActivateAbility(attack)`
+   (spend the action, grant attacks) then `ExecuteAction(strike)` (consume an
+   attack, fire post-strike grants), and reports the real pre/post economy diff
+   on the resolved-action event. Hit/damage resolution is unchanged (still the
+   two-phase resolver). A flat stat-snapshot seat (no character) falls back to
+   the honest one-action cost.
+
+6. **Every action emits its own resolved-action event with the real ref.** The
+   non-attack path publishes a first-class `ActionResolvedEvent` (the umbrella
+   beat, Invariant 9). The attack path threads the actor's **real submitted ref**
+   (not a placeholder constant) and the real economy consumed into its event.
+
+### Sub-decision: the encounter composes effective-availability for beat-deferred refs (D17)
+
+The wire `AvailableAction.available` means **effective takeability** ("should the
+UI offer this now?"), not raw rules-permission — the web renders availability and
+never computes it. The character menu reports rules truth: a level-1 character
+*can* move, so `Move.CanUse == true`. But this build does not resolve movement yet
+(wave decision D5; Beat 2). Rather than make the character lie, **the encounter
+composes the beat scope it owns** on top of the honest character menu
+(`applyDeferredActions` in `ActorTurnState`): any ref in a small
+`deferredActionRefs` set is projected `available=false` with an honest reason
+("movement lands in Beat 2"), and the verb rejects the same refs with
+`ErrActionDeferred`. Menu and verb stay consistent — the server never promises
+what it won't do, and the web needs no logic to hide the entry.
+
+This is a set, not a hardcoded `if id == "move"`, so Beat 2 is a one-line removal
+and the mechanism generalizes to any future beat-deferred ref. It is **not** the
+attack-gate backslide: that gate was a permanent "only attack works" block; this
+is a temporary, reasoned, beat-scoped marker with an honest reason, removed in
+Beat 2 by dropping the entry.
+
+### Sub-decision: Monk Martial Arts bonus strike spends the bonus action
+
+The Monk's Martial Arts unarmed strike (PHB p.78: "you can make one unarmed
+strike as a bonus action") is granted as capacity after a main-hand strike when
+a bonus action remains. `executeUnarmedStrike` consumed that granted capacity but
+**never decremented `BonusActionsRemaining`** — so the bonus-action slot was
+silently never spent, and a Monk appeared to still have a bonus action after
+using it. Because the bonus-action cost is a *rule*, the fix lives in the
+character package: `executeUnarmedStrike` now spends the bonus-action slot when
+it consumes the martial-arts capacity. This is what makes the bonus-action axis
+of the Beat-1 goal behavior (action + bonus action, both enforced) hold.
+
+## Consequences
+
+- The encounter verb path is general: adding a new action ref is data entry in
+  the character package, not a new gate in the encounter (Beat 2 catalog).
+- The held-character delegation keeps the single-subscribe discipline (ADR-0030)
+  intact — one hydration, one bus, the resolver and the verb share the held
+  instance.
+- rpg-api stops seeding the economy and stops authoring the menu; it projects
+  `ActorTurnState` field-for-field.
+- **Known gaps left as follow-ups under #54 (not regressions of this wave):**
+  - Activating Dodge spends the action and publishes `DodgeActivatedEvent`, but
+    nothing wires `DodgeActivated → DodgingCondition.Apply`, so Dodge's
+    mechanical effect (attackers get disadvantage) is not yet applied. Beat 1
+    proves the *dispatch* generality, not Dodge's full effect.
+  - Two implementations of the Monk bonus strike coexist (the character-package
+    `GrantedMartialArtsBonus` path used here, and the weapon-aware
+    `actions.MartialArtsBonusStrike` granter); they are not yet collapsed.
+  - The phased-attack resume path (`CompleteTakeAction`) reports the attack
+    default ref/economy because `PhasedAttackContext` does not carry the
+    submitted ref; reactions are a later wave.
+  - Class features (Flurry of Blows, Patient Defense, Step of the Wind) return
+    `TargetKindUnspecified` — they are not yet classified in `targetKindForRef`.
+
+## Related
+
+- ADR-0030 — encounter owns combatant hydration (the held-instance cascade this
+  delegation rides on).
+- ADR-0031 — the event spine (causation + game-event time + `ActionResolvedEvent`)
+  this wave makes real for every action.

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter module
 description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, combatant hydration cascade, discrete-phase combat orchestration, MovementResolver seam (both movement directions)
-updated: 2026-05-30
-confidence: high — #689 made LoadFromData own combatant hydration (the #684 double-subscribe cure); Wave 2.11d shipped discrete-phase combat; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement in BOTH directions
+updated: 2026-06-01
+confidence: high — #689 made LoadFromData own combatant hydration (the #684 double-subscribe cure); Wave 2.11d shipped discrete-phase combat; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement in BOTH directions; #697 (TakeAction wave, ADR-0032) deleted the attack-only gate — non-attack refs delegate to the held character's economy/menu, turn-start seeding moved into the engine, ActorTurnState exposes the menu as data
 ---
 
 # encounter module
@@ -279,3 +279,42 @@ handling. Wave 2.11d shipped the combat slice of that list:
   `View.KnownEntities`) but not emitted yet — future slice.
 
 Catch-up policy: snapshot-only on reconnect (load `Snapshot`, attach live stream). Event-replay catch-up is a future slice that adds an `EventLog` interface alongside `Transport`. Sequence numbers on events are already in place; the addition is non-breaking.
+
+## TakeAction unifies the verb path with the character economy/menu (rpg-toolkit#697, ADR-0032)
+
+`TakeActionPhased` no longer hard-gates on `ref.ID == "attack"`. The attack ref
+keeps its two-phase resolver path (above); **every other ref delegates to the
+held character's own rules engine** via `takeCharacterAction` —
+`character.ActivateAbility` for abilities/features, `character.ExecuteAction` for
+granted-capacity actions. No ref is enumerated in the encounter; the character's
+menu is the membership test. The action runs on the `*character.Character` the
+`LoadFromData` cascade already holds on `e.bus` (ADR-0030) — never a re-load.
+
+Turn-start economy seeding moved into the engine: `Encounter` calls
+`character.StartTurn` on the held character at each turn boundary (the
+`SetMode→TURN_BASED` first actor and `EndTurn`'s next actor), so rpg-api no longer
+injects `ActionEconomyData{1,1,1}` (North-Star Invariant 2).
+
+`Encounter.ActorTurnState(actorID)` exposes the held character's two-level menu
+(`AvailableAbilities` + `AvailableActions`, each with an `EconomySlot` and a
+`TargetKind`) and economy as toolkit domain types — the read surface rpg-api
+projects to the wire `TurnState` field-for-field (Invariant 11). NPC and
+flat-stat seats return an empty `ActorTurnState`.
+
+The character menu reports rules truth (a level-1 character *can* move, so
+`Move.CanUse == true`), but `ActorTurnState` composes the **effective**
+takeability the wire `available` flag means: refs this build defers (the
+`deferredActionRefs` set — `move` is its one Beat-1 member, movement lands in
+Beat 2) are projected `available=false` with an honest reason, and the verb
+rejects them with `ErrActionDeferred` so menu and verb never disagree (D17,
+ADR-0032). Beat 2 removes the entry in one line.
+
+Every action now emits a first-class `ActionResolvedEvent` (Invariant 9): the
+non-attack path publishes the umbrella event with the real ref + economy
+consumed; the attack path threads the actor's real submitted ref + economy
+instead of the prior placeholder constant.
+
+Known gaps left as follow-ups (see ADR-0032): Dodge's `DodgingCondition` is not
+yet applied on `DodgeActivated`; the two Monk-bonus-strike implementations are
+not collapsed; the `CompleteTakeAction` resume path reports the attack default
+ref because `PhasedAttackContext` does not carry the submitted ref.

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,11 +20,28 @@ single game-event-time stamp authority via an injected `core.Clock`
 the first-class `ActionResolvedEvent` (`action_ref` + `economy_consumed`).
 Attack resolution now publishes a correlated `ActionResolved → AttackResolved →
 DamageDealt` group sharing one correlation id. See ADR-0031. This is the FIRST
-of two separable #697 PRs; the menu/economy unification (reconcile the encounter
-verb path with the character action menu, non-attack actions, validate+deduct)
-is the next chunk. Proto mirror (new `ActionResolved` oneof variant +
+of two separable #697 PRs. Proto mirror (new `ActionResolved` oneof variant +
 `occurred_at`/`correlation_id` on the envelope) is the dependency-ordered
 follow-on before rpg-api un-suppresses.
+
+**#697 (TakeAction wave, menu/economy unification PR) — in flight on
+`feat/697-takeaction-menu-economy` (2026-06-01, ADR-0032).** The SECOND #697
+chunk: deleted the `ref.ID == "attack"` hard gate in `combat_phased.go` — every
+non-attack ref now delegates to the held character's own engine
+(`character.ActivateAbility` / `ExecuteAction`), no ref special-cased. Turn-start
+economy seeding moved into the engine (`character.StartTurn` on the held
+character at each turn boundary), removing the rpg-api `ActionEconomyData{1,1,1}`
+injection (Invariant 2). `Encounter.ActorTurnState` exposes the two-level menu +
+economy as toolkit domain types, each entry carrying an `EconomySlot` +
+`TargetKind`. Attack is now a citizen of the two-level economy (drives
+`ActivateAbility(attack)` + `ExecuteAction(strike)` on the held character) and
+the resolved-action event carries the actor's real submitted ref. Found + fixed a
+rules gap: `executeUnarmedStrike` now spends the bonus-action slot (the Monk
+Martial Arts bonus strike costs a bonus action). Goal behavior proven on the real
+broker path: a Monk takes an action (Attack) and a bonus action (Martial Arts
+unarmed strike), both economy slots decrement. Spans two modules
+(`rulebooks/dnd5e` char-pkg + `encounter`) — char-pkg tags before the encounter
+module requires it.
 
 **#689 — encounter owns combatant hydration via the LoadFromData cascade
 (2026-05-30, cross-repo unit with rpg-api#582; NOT yet merged).**

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -34,6 +34,13 @@ var (
 	// available=false; the verb rejects them to stay consistent. Maps to gRPC
 	// Unimplemented.
 	ErrActionDeferred = errors.New("action deferred to a later beat")
+	// ErrActionUnaffordable is returned when a hydrated character takes an
+	// action whose action-economy cost it cannot pay this turn (e.g. an attack
+	// with no standard action left). The toolkit owns the economy and gates the
+	// verb here so an unaffordable action never resolves; the menu's
+	// available=false pre-empts it at the UI (Inv 11/12), and this is the
+	// structural backstop. Maps to gRPC FailedPrecondition.
+	ErrActionUnaffordable = errors.New("action economy cannot afford this action")
 	// ErrUnknownTarget is returned when an action targets an entity that
 	// is not in the encounter. Maps to gRPC FailedPrecondition.
 	ErrUnknownTarget = errors.New("unknown target entity")
@@ -81,9 +88,14 @@ func attackEconomyConsumed() events.EconomyConsumed {
 	return events.EconomyConsumed{Actions: 1}
 }
 
-// attackEconomyConsumedFor reports what a player's attack spent off the turn
-// economy, driving the held character's two-level model so the attack verb is a
-// citizen of the same economy every other action uses (#697 Beat-1):
+// spendAttackEconomy validates and deducts a player's attack off the held
+// character's two-level economy, returning what it consumed. It runs BEFORE the
+// combat resolver so the economy gates the attack: a character with no action
+// left is rejected here and no damage is resolved (#697 Beat-1: economy enforced
+// server-side, end-to-end — the menu's available=false pre-empts the case, and
+// this is the structural backstop so the verb never resolves an unaffordable
+// attack). The attack verb is thus a citizen of the same economy every other
+// action uses:
 //
 //   - ActivateAbility(attack) spends the standard action and grants one attack
 //     (capacity), plus any Extra Attack the character has.
@@ -95,28 +107,32 @@ func attackEconomyConsumed() events.EconomyConsumed {
 //
 // The real pre/post economy diff is returned so the resolved-action event
 // reports the true cost. When no character is hydrated (a flat stat-snapshot
-// seat), the verb falls back to the honest one-action cost — those seats have
-// no two-level economy to drive.
+// seat) there is no two-level economy to drive: the honest one-action cost is
+// returned and no economy gate applies (those seats opt out of the menu).
 //
-// Damage/hit resolution is unchanged — it still runs through the combat
-// resolver. This only threads the economy bookkeeping the snapshot path lacked.
-func (e *Encounter) attackEconomyConsumedFor(player *PlayerData) events.EconomyConsumed {
+// Damage/hit resolution is unchanged — it still runs through the combat resolver
+// after this returns. This only owns the economy validate+deduct the snapshot
+// path lacked.
+func (e *Encounter) spendAttackEconomy(player *PlayerData) (events.EconomyConsumed, error) {
 	char := e.heldCharacter(player.EntityID)
 	if char == nil {
-		return attackEconomyConsumed()
+		return attackEconomyConsumed(), nil
 	}
 
 	pre := snapshotEconomy(char.GetActionEconomy())
 
 	ctx := context.Background()
 	// Activate the Attack ability: spends the action, grants attack capacity.
-	if out, err := char.ActivateAbility(ctx, &dnd5eCharacter.ActivateAbilityInput{
+	// A failure here means the economy can't afford the attack (no action) —
+	// reject so the resolver never runs (structural enforcement of Inv 11/12).
+	out, err := char.ActivateAbility(ctx, &dnd5eCharacter.ActivateAbilityInput{
 		AbilityRef: refs.CombatAbilities.Attack(),
-	}); err != nil || !out.Success {
-		// The character could not take the Attack action this turn (economy
-		// exhausted). Report no spend — the menu's availability gate pre-empts
-		// this case; the snapshot resolver still published the outcome.
-		return events.EconomyConsumed{}
+	})
+	if err != nil {
+		return events.EconomyConsumed{}, fmt.Errorf("activate attack ability: %w", err)
+	}
+	if !out.Success {
+		return events.EconomyConsumed{}, fmt.Errorf("%w: attack: %s", ErrActionUnaffordable, out.Error)
 	}
 	// Execute one strike: consumes an attack, fires post-strike grants
 	// (Monk Martial Arts bonus when a bonus action remains).
@@ -124,11 +140,11 @@ func (e *Encounter) attackEconomyConsumedFor(player *PlayerData) events.EconomyC
 		ActionRef: refs.Actions.Strike(),
 	}); err != nil {
 		// Strike bookkeeping failed after the action was spent — report the
-		// action spend captured so far.
-		return economyConsumedDiff(pre, char.GetActionEconomy())
+		// action spend captured so far (the action is gone either way).
+		return economyConsumedDiff(pre, char.GetActionEconomy()), nil
 	}
 
-	return economyConsumedDiff(pre, char.GetActionEconomy())
+	return economyConsumedDiff(pre, char.GetActionEconomy()), nil
 }
 
 // isPlayerCombatant reports whether a player seat carries the minimum

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -11,7 +11,9 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 // Combat-verb sentinel errors. Wrap with fmt.Errorf for context; the
@@ -26,6 +28,12 @@ var (
 	// ErrUnsupportedAction is returned when TakeAction is called with an
 	// action ref the encounter doesn't dispatch. Maps to gRPC Unimplemented.
 	ErrUnsupportedAction = errors.New("unsupported action ref")
+	// ErrActionDeferred is returned when TakeAction is called with a ref this
+	// build surfaces in the menu but defers resolving to a later beat (e.g.
+	// move — movement lands in Beat 2). The menu marks such refs
+	// available=false; the verb rejects them to stay consistent. Maps to gRPC
+	// Unimplemented.
+	ErrActionDeferred = errors.New("action deferred to a later beat")
 	// ErrUnknownTarget is returned when an action targets an entity that
 	// is not in the encounter. Maps to gRPC FailedPrecondition.
 	ErrUnknownTarget = errors.New("unknown target entity")
@@ -71,6 +79,56 @@ const attackActionRef = "dnd5e:action:attack"
 // each strike consumes one" model) from the character action economy.
 func attackEconomyConsumed() events.EconomyConsumed {
 	return events.EconomyConsumed{Actions: 1}
+}
+
+// attackEconomyConsumedFor reports what a player's attack spent off the turn
+// economy, driving the held character's two-level model so the attack verb is a
+// citizen of the same economy every other action uses (#697 Beat-1):
+//
+//   - ActivateAbility(attack) spends the standard action and grants one attack
+//     (capacity), plus any Extra Attack the character has.
+//   - ExecuteAction(strike) consumes one of those attacks and runs the
+//     character's post-strike grants — for a Monk with a bonus action in hand,
+//     this grants the Martial Arts bonus unarmed strike, which then surfaces in
+//     the action menu as a bonus-action option (the bonus-action axis of the
+//     Beat-1 done-bar).
+//
+// The real pre/post economy diff is returned so the resolved-action event
+// reports the true cost. When no character is hydrated (a flat stat-snapshot
+// seat), the verb falls back to the honest one-action cost — those seats have
+// no two-level economy to drive.
+//
+// Damage/hit resolution is unchanged — it still runs through the combat
+// resolver. This only threads the economy bookkeeping the snapshot path lacked.
+func (e *Encounter) attackEconomyConsumedFor(player *PlayerData) events.EconomyConsumed {
+	char := e.heldCharacter(player.EntityID)
+	if char == nil {
+		return attackEconomyConsumed()
+	}
+
+	pre := snapshotEconomy(char.GetActionEconomy())
+
+	ctx := context.Background()
+	// Activate the Attack ability: spends the action, grants attack capacity.
+	if out, err := char.ActivateAbility(ctx, &dnd5eCharacter.ActivateAbilityInput{
+		AbilityRef: refs.CombatAbilities.Attack(),
+	}); err != nil || !out.Success {
+		// The character could not take the Attack action this turn (economy
+		// exhausted). Report no spend — the menu's availability gate pre-empts
+		// this case; the snapshot resolver still published the outcome.
+		return events.EconomyConsumed{}
+	}
+	// Execute one strike: consumes an attack, fires post-strike grants
+	// (Monk Martial Arts bonus when a bonus action remains).
+	if _, err := char.ExecuteAction(ctx, &dnd5eCharacter.ExecuteActionInput{
+		ActionRef: refs.Actions.Strike(),
+	}); err != nil {
+		// Strike bookkeeping failed after the action was spent — report the
+		// action spend captured so far.
+		return economyConsumedDiff(pre, char.GetActionEconomy())
+	}
+
+	return economyConsumedDiff(pre, char.GetActionEconomy())
 }
 
 // isPlayerCombatant reports whether a player seat carries the minimum
@@ -142,6 +200,12 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 	}
 
 	if mode == core.ModeTurnBased && len(e.data.Initiative) > 0 {
+		// Seed the first actor's economy before announcing their turn, so the
+		// menu/economy is ready when the TurnStartedEvent lands (Beat-1: the
+		// engine owns turn-start seeding, not the host).
+		if err := e.seedActorTurn(context.Background(), e.data.Initiative[0]); err != nil {
+			return err
+		}
 		if err := e.broker.Publish(events.NewTurnStartedEvent(
 			e.data.ID, e.nextSeq(), e.data.Initiative[0], e.data.Round,
 			e.allViewersTurnStarted(),
@@ -216,6 +280,12 @@ func (e *Encounter) EndTurn(
 		e.data.Round++
 	}
 	newActive := e.data.Initiative[e.data.ActiveIdx]
+
+	// Seed the new actor's economy before announcing their turn (Beat-1: the
+	// engine owns turn-start seeding). No-op for NPCs and stat-snapshot seats.
+	if seedErr := e.seedActorTurn(ctx, newActive); seedErr != nil {
+		return "", false, seedErr
+	}
 
 	if pubErr := e.broker.Publish(events.NewTurnStartedEvent(
 		e.data.ID, e.nextSeq(), newActive, e.data.Round, e.allViewersTurnStarted(),

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -62,9 +62,17 @@ func (e *Encounter) TakeActionPhased(
 	if active := e.ActiveActor(); active != player.EntityID {
 		return nil, fmt.Errorf("%w: active=%q got=%q", ErrNotYourTurn, active, player.EntityID)
 	}
+
+	// General dispatch (Beat-1): the attack ref keeps the two-phase resolver
+	// path below (it carries reaction-prompt handling); every other ref
+	// delegates to the held character's own rules engine (ActivateAbility /
+	// ExecuteAction). This replaces the former `ref.ID != "attack"` hard gate —
+	// "default to one system": the character package's dispatch is the catalog,
+	// not a parallel registry built here.
 	if ref.ID != actionIDAttack {
-		return nil, fmt.Errorf("%w: %q", ErrUnsupportedAction, ref.ID)
+		return e.takeCharacterAction(context.Background(), player, ref, target)
 	}
+
 	if !isPlayerCombatant(player) {
 		return nil, fmt.Errorf("%w: player %q missing HP/AC/DamageDice", ErrNonCombatant, playerID)
 	}
@@ -103,7 +111,9 @@ func (e *Encounter) TakeActionPhased(
 		if outcome == nil {
 			return nil, fmt.Errorf("combat resolver: nil outcome with nil error")
 		}
-		if err := e.applyAndPublishOutcome(player, monster, outcome); err != nil {
+		if err := e.applyAndPublishOutcome(
+			player, monster, outcome, input.ActionRef.String(), e.attackEconomyConsumedFor(player),
+		); err != nil {
 			return nil, err
 		}
 		return &TakeActionOutcome{Resolved: true}, nil
@@ -141,7 +151,9 @@ func (e *Encounter) TakeActionPhased(
 		if outcome == nil {
 			return nil, fmt.Errorf("combat resolver: nil outcome with nil error")
 		}
-		if err := e.applyAndPublishOutcome(player, monster, outcome); err != nil {
+		if err := e.applyAndPublishOutcome(
+			player, monster, outcome, input.ActionRef.String(), e.attackEconomyConsumedFor(player),
+		); err != nil {
 			return nil, err
 		}
 		return &TakeActionOutcome{Resolved: true}, nil
@@ -281,7 +293,13 @@ func (e *Encounter) CompleteTakeAction(attackCtx *PhasedAttackContext, modifiers
 	// corresponding verb.
 	switch {
 	case attackerPlayer != nil && targetMonster != nil:
-		return e.applyAndPublishOutcome(attackerPlayer, targetMonster, outcome)
+		// Resume path: the original submitted ref is not carried on
+		// PhasedAttackContext, so a resumed attack reports the attack defaults.
+		// (Beat-1 scope: reactions are a later wave; the resume ref fidelity
+		// rides with that work.)
+		return e.applyAndPublishOutcome(
+			attackerPlayer, targetMonster, outcome, attackActionRef, attackEconomyConsumed(),
+		)
 	case attackerMonster != nil && targetPlayer != nil:
 		return e.applyAndPublishNPCOutcome(attackerMonster, targetPlayer, outcome)
 	default:
@@ -348,7 +366,16 @@ func (e *Encounter) applyAndPublishNPCOutcome(monster *MonsterData, player *Play
 // chain on the >0 → 0 transition. Shared between the legacy single-phase
 // path and the phased CompleteTakeAction path (player→monster direction).
 // applyAndPublishNPCOutcome is the monster→player mirror.
-func (e *Encounter) applyAndPublishOutcome(player *PlayerData, monster *MonsterData, outcome *AttackOutcome) error {
+//
+// actionRef + consumed are the real submitted ref and economy spend the player
+// path threads (#697 Beat-1: the resolved-action event carries the actor's own
+// ref and what the action actually cost, not a placeholder). The
+// CompleteTakeAction resume path, which lacks the live economy diff, passes the
+// attack defaults.
+func (e *Encounter) applyAndPublishOutcome(
+	player *PlayerData, monster *MonsterData, outcome *AttackOutcome,
+	actionRef string, consumed events.EconomyConsumed,
+) error {
 	hpBefore := monster.HP
 	if outcome.Hit {
 		monster.HP -= outcome.Damage
@@ -368,7 +395,7 @@ func (e *Encounter) applyAndPublishOutcome(player *PlayerData, monster *MonsterD
 		player.EntityID, monster.ID, outcome,
 		monster.HP, monster.MaxHP, damageType,
 		player.View.Position, monster.Position,
-		attackActionRef, attackEconomyConsumed(),
+		actionRef, consumed,
 	); err != nil {
 		return err
 	}

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -87,6 +87,18 @@ func (e *Encounter) TakeActionPhased(
 		return nil, ErrNoCombatResolver
 	}
 
+	// Validate + deduct the attack off the held character's two-level economy
+	// BEFORE resolving. This gates the attack on the economy: a character with no
+	// action left is rejected here (ErrActionUnaffordable) and the resolver never
+	// runs — no damage from an unaffordable attack (#697 Beat-1: economy enforced
+	// server-side). A flat stat-snapshot seat (no character) returns the honest
+	// one-action cost and is not gated. consumed flows onto the resolved-action
+	// event so it reports the true cost.
+	consumed, err := e.spendAttackEconomy(player)
+	if err != nil {
+		return nil, err
+	}
+
 	input := AttackInput{
 		AttackerID:          player.EntityID,
 		TargetID:            target.EntityID,
@@ -112,7 +124,7 @@ func (e *Encounter) TakeActionPhased(
 			return nil, fmt.Errorf("combat resolver: nil outcome with nil error")
 		}
 		if err := e.applyAndPublishOutcome(
-			player, monster, outcome, input.ActionRef.String(), e.attackEconomyConsumedFor(player),
+			player, monster, outcome, input.ActionRef.String(), consumed,
 		); err != nil {
 			return nil, err
 		}
@@ -152,7 +164,7 @@ func (e *Encounter) TakeActionPhased(
 			return nil, fmt.Errorf("combat resolver: nil outcome with nil error")
 		}
 		if err := e.applyAndPublishOutcome(
-			player, monster, outcome, input.ActionRef.String(), e.attackEconomyConsumedFor(player),
+			player, monster, outcome, input.ActionRef.String(), consumed,
 		); err != nil {
 			return nil, err
 		}

--- a/encounter/combat_test.go
+++ b/encounter/combat_test.go
@@ -143,11 +143,18 @@ func (s *CombatSuite) TestTakeAction_RejectsUnknownAction() {
 	if playerID == "" {
 		s.T().Skip("active actor is an NPC; this test only covers player turns")
 	}
+	// #697: the attack-only hard gate is gone — non-attack refs now delegate to
+	// the held character's rules engine. This suite's seats are flat
+	// stat-snapshots (no DataJSON → no hydrated character), so a non-attack ref
+	// is rejected with ErrNonCombatant ("no character to take menu actions
+	// with"), not ErrUnsupportedAction. Unknown-ref rejection on a HYDRATED
+	// character (the ErrUnsupportedAction path) is covered by
+	// TurnStateSuite.TestTakeAction_RejectsUnknownRefOnHydratedCharacter.
 	err := s.enc.TakeAction(playerID,
 		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "shove"},
 		encounter.ActionTarget{EntityID: gobEntityID},
 	)
-	s.ErrorIs(err, encounter.ErrUnsupportedAction)
+	s.ErrorIs(err, encounter.ErrNonCombatant)
 }
 
 // TakeAction publishes AttackResolvedEvent (always); on hit a

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.59.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.60.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.59.0 h1:Mcj+gRx3pVdVK7ioEH3qybXODIZ7cQCjkjbGSiTxT6A=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.59.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.60.0 h1:FcRGzmL9m/1avsnQpGxxb470SwoN3m5V1MnEEgjAVt8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.60.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/take_character_action.go
+++ b/encounter/take_character_action.go
@@ -1,0 +1,233 @@
+package encounter
+
+// Beat-1 of the TakeAction wave (rpg-project #54 / #697 chunk 2).
+//
+// General (non-attack) action dispatch. The attack ref keeps its dedicated
+// two-phase resolver path in TakeActionPhased (it carries reaction prompts and
+// damage resolution); every OTHER action ref flows through here, delegating to
+// the held character's own rules engine. There is no per-ref logic in the
+// encounter beyond "is this an ability or a granted-capacity action" — the
+// character package owns the catalog (ActivateAbility routes combat abilities +
+// features; ExecuteAction routes the granted-capacity strikes / move). This is
+// the "default to one system" unification: the encounter deletes its hardcoded
+// attack gate and consults the menu/economy engine that already exists.
+//
+// The action runs on the held *character.Character (the LoadFromData-cascade
+// instance, #689) — never a re-load. It captures any condition the action
+// applies (e.g. Dodge → Dodging) and bridges it onto the broker, diffs the
+// economy pre/post to report what was consumed, and emits the first-class
+// ActionResolvedEvent (Invariant 9) so every action — not just attacks — leaves
+// a canonical record on the spine.
+
+import (
+	"context"
+	"fmt"
+
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+)
+
+// takeCharacterAction dispatches a non-attack action ref to the held
+// character's rules engine and publishes the resolved-action event. It returns
+// a Resolved outcome on success (these actions never pause for reactions in
+// Beat-1).
+//
+// The actor must have a hydrated character (a flat stat-snapshot seat cannot
+// take menu actions — it has no economy/menu); ErrNonCombatant otherwise. An
+// unknown ref, or one the character's engine reports it cannot take, returns an
+// error so the caller surfaces it as a structural failure (the menu's
+// available=false pre-empts the legal cases; this guards the illegal ones).
+func (e *Encounter) takeCharacterAction(
+	ctx context.Context, player *PlayerData, ref ActionRef, target ActionTarget,
+) (*TakeActionOutcome, error) {
+	char := e.heldCharacter(player.EntityID)
+	if char == nil {
+		return nil, fmt.Errorf("%w: player %q has no hydrated character for action %q",
+			ErrNonCombatant, player.ID, ref.ID)
+	}
+
+	// Beat-scope guard (D17): a ref this build defers (e.g. move) is surfaced in
+	// the menu as available=false; the verb must agree, so reject it here rather
+	// than letting it no-op-succeed. Menu and verb stay consistent — the menu
+	// never promises what the verb won't do.
+	for _, d := range deferredActionRefs {
+		if ref.ID == d.id {
+			return nil, fmt.Errorf("%w: %q: %s", ErrActionDeferred, ref.ID, d.reason)
+		}
+	}
+
+	tRef := toolkitRef(ref)
+
+	// Snapshot economy before so we can report what the action consumed.
+	preEconomy := snapshotEconomy(char.GetActionEconomy())
+
+	// Capture any condition the action applies so it bridges to the broker
+	// (mirrors ActivateFeature). Subscribe before activating.
+	capturedCond, unsubCond, err := subscribeConditions(ctx, e.bus)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe conditions: %w", err)
+	}
+	defer func() { _ = unsubCond() }()
+
+	if err := e.dispatchCharacterAction(ctx, char, ref, &tRef); err != nil {
+		return nil, err
+	}
+
+	// Bridge captured dnd5e conditions → broker events (audience-projected).
+	if err := e.applyActivatedConditions(player, player.EntityID, *capturedCond); err != nil {
+		return nil, fmt.Errorf("bridge conditions: %w", err)
+	}
+
+	// Diff the economy to report consumption, then publish the resolved-action
+	// event for this action (Invariant 9 — every action emits one, not just
+	// attacks).
+	consumed := economyConsumedDiff(preEconomy, char.GetActionEconomy())
+	if err := e.publishActionResolved(player.EntityID, target.EntityID, tRef.String(), consumed); err != nil {
+		return nil, fmt.Errorf("publish action resolved: %w", err)
+	}
+
+	return &TakeActionOutcome{Resolved: true}, nil
+}
+
+// dispatchCharacterAction routes the ref to the character engine: an ability
+// (combat ability or feature) goes through ActivateAbility; a granted-capacity
+// action (strike, move) goes through ExecuteAction. Membership is decided by
+// the character's own menu, so no ref is enumerated here.
+func (e *Encounter) dispatchCharacterAction(
+	ctx context.Context, char *dnd5eCharacter.Character, ref ActionRef, tRef *toolkitcore.Ref,
+) error {
+	if characterHasAbility(char, ref.ID) {
+		out, err := char.ActivateAbility(ctx, &dnd5eCharacter.ActivateAbilityInput{AbilityRef: tRef})
+		if err != nil {
+			return fmt.Errorf("activate ability %q: %w", ref.ID, err)
+		}
+		if !out.Success {
+			return fmt.Errorf("%w: %q: %s", ErrUnsupportedAction, ref.ID, out.Error)
+		}
+		return nil
+	}
+
+	if characterHasAction(char, ref.ID) {
+		out, err := char.ExecuteAction(ctx, &dnd5eCharacter.ExecuteActionInput{ActionRef: tRef})
+		if err != nil {
+			return fmt.Errorf("execute action %q: %w", ref.ID, err)
+		}
+		if !out.Success {
+			return fmt.Errorf("%w: %q: %s", ErrUnsupportedAction, ref.ID, out.Error)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("%w: %q", ErrUnsupportedAction, ref.ID)
+}
+
+// characterHasAbility reports whether the ref matches one of the character's
+// available abilities (combat abilities + features).
+func characterHasAbility(char *dnd5eCharacter.Character, refID string) bool {
+	for _, a := range char.AvailableAbilities() {
+		if a.Ref != nil && a.Ref.ID == refID {
+			return true
+		}
+	}
+	return false
+}
+
+// characterHasAction reports whether the ref matches one of the character's
+// available granted-capacity actions (strikes, move).
+func characterHasAction(char *dnd5eCharacter.Character, refID string) bool {
+	for _, a := range char.AvailableActions() {
+		if a.Ref != nil && a.Ref.ID == refID {
+			return true
+		}
+	}
+	return false
+}
+
+// economySnapshot is the minimal economy shape we diff to compute what an
+// action consumed.
+type economySnapshot struct {
+	actions      int
+	bonusActions int
+	reactions    int
+	movement     int
+	granted      map[string]int
+}
+
+// snapshotEconomy captures the action economy counters (nil-safe).
+func snapshotEconomy(ae *dnd5eCharacter.ActionEconomyData) economySnapshot {
+	if ae == nil {
+		return economySnapshot{}
+	}
+	granted := make(map[string]int, len(ae.Granted))
+	for k, v := range ae.Granted {
+		granted[string(k)] = v
+	}
+	return economySnapshot{
+		actions:      ae.ActionsRemaining,
+		bonusActions: ae.BonusActionsRemaining,
+		reactions:    ae.ReactionsRemaining,
+		movement:     ae.MovementRemaining,
+		granted:      granted,
+	}
+}
+
+// economyConsumedDiff reports what an action spent: the positive drop in each
+// primary counter plus the positive drop in each granted-capacity key. A
+// negative delta (the action GRANTED capacity, e.g. Attack adds attacks) is not
+// "consumed" and is omitted.
+func economyConsumedDiff(pre economySnapshot, postAE *dnd5eCharacter.ActionEconomyData) events.EconomyConsumed {
+	post := snapshotEconomy(postAE)
+	consumed := events.EconomyConsumed{
+		Actions:      positiveDrop(pre.actions, post.actions),
+		BonusActions: positiveDrop(pre.bonusActions, post.bonusActions),
+		Reactions:    positiveDrop(pre.reactions, post.reactions),
+		Movement:     positiveDrop(pre.movement, post.movement),
+	}
+	var granted map[string]int
+	for k, preV := range pre.granted {
+		if drop := positiveDrop(preV, post.granted[k]); drop > 0 {
+			if granted == nil {
+				granted = map[string]int{}
+			}
+			granted[k] = drop
+		}
+	}
+	consumed.GrantedConsumed = granted
+	return consumed
+}
+
+// positiveDrop returns pre-post when positive, else 0 (a grant, not a spend).
+func positiveDrop(pre, post int) int {
+	if d := pre - post; d > 0 {
+		return d
+	}
+	return 0
+}
+
+// publishActionResolved emits the first-class ActionResolvedEvent for a
+// non-attack action (Invariant 9). Audience is per-viewer LoS to the actor.
+// Unlike the attack path this publishes only the umbrella event — there is no
+// AttackResolved/Damage for a non-attack action.
+func (e *Encounter) publishActionResolved(
+	actorID, targetID core.EntityID, actionRef string, consumed events.EconomyConsumed,
+) error {
+	actor := e.findPlayerByEntityID(actorID)
+	perPlayer := make(map[core.PlayerID]events.ActionResolvedSlice)
+	for viewerID, viewer := range e.data.Players {
+		if viewer == nil || viewer.View == nil || actor == nil || actor.View == nil {
+			continue
+		}
+		if !e.viewerCanSee(viewer, actor.View.Position) {
+			continue
+		}
+		perPlayer[viewerID] = events.ActionResolvedSlice{Visible: true}
+	}
+
+	seq := e.nextSeq()
+	evt := events.NewActionResolvedEvent(
+		e.data.ID, seq, actorID, actionRef, targetID, consumed, perPlayer,
+	)
+	return e.publishCorrelated(evt, e.correlationFor(seq))
+}

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -1,0 +1,66 @@
+package encounter
+
+// Beat-1 of the TakeAction wave (rpg-project #54 / #697 chunk 2).
+//
+// Turn-start economy seeding. The encounter is the turn-boundary authority, so
+// it is the encounter — not the host (rpg-api) — that seeds each player's
+// action economy when their turn begins. Before this, the encounter emitted
+// TurnStartedEvent but never seeded the held character's economy, which forced
+// rpg-api to inject ActionEconomyData{1,1,1,Movement:30} itself (a North-Star
+// Invariant 2 violation: the host authoring rules state). This moves the
+// seeding into the engine, where StartTurn already owns the rule.
+//
+// The seeding runs on the held *character.Character — the same instance the
+// LoadFromData cascade hydrated onto e.bus (#689) — never a re-load. Seats with
+// no hydrated character (a flat stat-snapshot seat, or an NPC) are skipped:
+// their turn structure is driven by the snapshot path, not the character
+// economy.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+)
+
+// seedActorTurn initializes the action economy for the actor whose turn is
+// beginning, when that actor is a player with a hydrated character. It calls
+// character.StartTurn on the held instance, which sets one action, one bonus
+// action, one reaction, and movement from the character's speed, and clears
+// granted capacity from the prior turn.
+//
+// NPCs and stat-snapshot seats (no hydrated character) are skipped — they carry
+// no character economy to seed. A nil or non-player actor id is a no-op.
+//
+// Called from the two turn-start sites: SetMode's flip to ModeTurnBased (first
+// actor) and EndTurn (the next actor). Errors from StartTurn are returned so the
+// caller fails the turn-boundary rather than advancing with an unseeded economy.
+func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) error {
+	char := e.heldCharacter(actorID)
+	if char == nil {
+		return nil // NPC or stat-snapshot seat — no character economy to seed.
+	}
+
+	if _, err := char.StartTurn(ctx, &character.StartTurnInput{
+		Speed:      char.GetSpeed(),
+		TurnNumber: e.data.Round,
+	}); err != nil {
+		return fmt.Errorf("seed turn economy for %q: %w", actorID, err)
+	}
+	return nil
+}
+
+// heldCharacter returns the hydrated *character.Character for the given entity
+// id, or nil if the id is not a player seat or carries no hydrated character
+// (no DataJSON at load time). It reads the LoadFromData-cascade-held combatant
+// (#689) and type-asserts it — it never re-loads from JSON, preserving the
+// single-subscribe discipline (re-loading would re-Apply the character's
+// conditions to e.bus, the #684 double-subscribe class).
+func (e *Encounter) heldCharacter(id core.EntityID) *character.Character {
+	c, ok := e.combatants[id].(*character.Character)
+	if !ok {
+		return nil
+	}
+	return c
+}

--- a/encounter/turn_state.go
+++ b/encounter/turn_state.go
@@ -1,0 +1,113 @@
+package encounter
+
+// Beat-1 of the TakeAction wave (rpg-project #54 / #697 chunk 2).
+//
+// "What can this actor do" exposed as data. North-Star Invariant 11: the
+// toolkit computes the action menu (availability, reasons, slot, target kind)
+// and the economy; the game server (rpg-api) projects it field-for-field; the
+// web renders it. This query is that read surface — it returns toolkit domain
+// types built from the held character's own rules engine, so rpg-api never
+// computes availability or authors a reason string.
+//
+// It reads the held *character.Character (the LoadFromData-cascade instance,
+// #689) and calls the character's existing AvailableAbilities / AvailableActions
+// / GetActionEconomy — the same two-level menu the character package already
+// computes. No menu logic lives here; this only shapes the character's output
+// into an encounter-level, per-actor view.
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// deferredActionRef pairs an action ref id this build does not resolve yet with
+// the user-facing reason the menu shows for it. The encounter — which owns the
+// beat scope — composes "effective takeability" on top of the character's
+// honest rules menu (D17): the character correctly says the action is allowed
+// (e.g. a level-1 character CAN move), but this build does not resolve it yet,
+// so the wire `available` flag (which means "should the UI offer this now?",
+// not raw rules-permission) is false with an honest reason. Beat 2 removes an
+// entry from this set in one line — it does not touch the character menu.
+type deferredActionRef struct {
+	id     string
+	reason string
+}
+
+// deferredActionRefs is the set of action refs this build surfaces in the menu
+// but cannot take yet. Move is the only Beat-1 member (movement resolution is
+// Beat 2 — wave decision D5). Expressed as a set rather than a hardcoded
+// `if id == "move"` so Beat 2 is a one-line removal and the mechanism
+// generalizes to any future beat-deferred ref.
+var deferredActionRefs = []deferredActionRef{
+	{id: refs.Actions.Move().ID, reason: "movement lands in Beat 2"},
+}
+
+// ActorTurnState is the per-actor turn view: the action economy and the menu
+// (abilities + actions) the actor can take right now. It is the toolkit domain
+// shape rpg-api projects onto the wire TurnState (economy + available_actions).
+//
+// Abilities and Actions are the two halves of the dnd5e two-level model:
+// abilities spend a primary economy slot (action / bonus / reaction) and grant
+// capacity or a condition; actions spend granted capacity (the strikes an
+// attack grants, movement). Both carry the menu fields rpg-api needs verbatim:
+// ref, name, availability + reason, economy slot, target kind.
+type ActorTurnState struct {
+	// ActorID is the entity whose turn view this is.
+	ActorID core.EntityID
+	// Economy is the actor's current action economy (nil when the actor has no
+	// hydrated character or is not in combat).
+	Economy *character.ActionEconomyData
+	// Abilities are the action-economy-spending menu entries.
+	Abilities []character.AvailableAbility
+	// Actions are the granted-capacity-spending menu entries.
+	Actions []character.AvailableAction
+}
+
+// ActorTurnState returns the menu + economy for the given actor, computed by the
+// held character's own rules engine. Returns a zero-valued ActorTurnState (with
+// the ActorID set) when the actor has no hydrated character — a flat
+// stat-snapshot seat or an NPC carries no character menu/economy.
+//
+// The caller (rpg-api) projects the returned domain types onto the wire
+// TurnState. The character menu is taken verbatim for ability/action membership,
+// names, slots, target kinds, and rules availability; the encounter then
+// composes "effective takeability" for beat-deferred refs (D17) — see
+// applyDeferredActions. It authors no rules verdict, only the beat-scope it owns.
+func (e *Encounter) ActorTurnState(actorID core.EntityID) ActorTurnState {
+	char := e.heldCharacter(actorID)
+	if char == nil {
+		return ActorTurnState{ActorID: actorID}
+	}
+	return ActorTurnState{
+		ActorID:   actorID,
+		Economy:   char.GetActionEconomy(),
+		Abilities: char.AvailableAbilities(),
+		Actions:   applyDeferredActions(char.AvailableActions()),
+	}
+}
+
+// applyDeferredActions composes the encounter's beat-scope onto the character's
+// honest action menu: any action ref in deferredActionRefs is forced
+// unavailable with its reason, even though the character's rules engine reports
+// it usable (D17). The character menu is not mutated — this returns an adjusted
+// copy. Actions not in the deferred set pass through unchanged.
+func applyDeferredActions(actions []character.AvailableAction) []character.AvailableAction {
+	if len(actions) == 0 {
+		return actions
+	}
+	out := make([]character.AvailableAction, len(actions))
+	copy(out, actions)
+	for i := range out {
+		if out[i].Ref == nil {
+			continue
+		}
+		for _, d := range deferredActionRefs {
+			if out[i].Ref.ID == d.id {
+				out[i].CanUse = false
+				out[i].Reason = d.reason
+			}
+		}
+	}
+	return out
+}

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -336,6 +336,42 @@ func (s *TurnStateSuite) TestTakeAction_RejectsDeferredMove() {
 	s.ErrorIs(err, encounter.ErrActionDeferred)
 }
 
+// TestTakeAction_AttackRejectedWhenActionSpent proves the attack verb is gated
+// on the economy server-side (the done-bar: economy enforced). After the Monk
+// spends its standard action on Dodge, an Attack (which costs a standard action)
+// is rejected with ErrActionUnaffordable and deals NO damage — the resolver
+// never runs. This is the structural backstop behind the menu's available=false
+// (Inv 11/12): the verb never resolves an unaffordable action.
+func (s *TurnStateSuite) TestTakeAction_AttackRejectedWhenActionSpent() {
+	enc := s.combatMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != monkEntityID {
+		_, _, err := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	// Spend the standard action on Dodge.
+	s.Require().NoError(enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: refs.CombatAbilities.Dodge().Type, ID: refs.CombatAbilities.Dodge().ID},
+		encounter.ActionTarget{EntityID: monkEntityID},
+	))
+	s.Require().Equal(0, enc.ActorTurnState(monkEntityID).Economy.ActionsRemaining)
+
+	goblinHPBefore := enc.ToData().Monsters["goblin-1"].HP
+
+	// Attempt an Attack with no standard action left — must be rejected, no damage.
+	err := enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	)
+	s.ErrorIs(err, encounter.ErrActionUnaffordable,
+		"attack with no action left must be rejected by the economy gate")
+
+	goblinHPAfter := enc.ToData().Monsters["goblin-1"].HP
+	s.Equal(goblinHPBefore, goblinHPAfter,
+		"a rejected attack must not resolve damage — the resolver never ran")
+}
+
 // TestTakeAction_RejectsUnknownRefOnHydratedCharacter proves that an unknown
 // ref on a HYDRATED character (one with a real menu) is rejected with
 // ErrUnsupportedAction — the character's engine reports it has no such

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -226,7 +226,7 @@ func (s *TurnStateSuite) TestTakeAction_DodgeFlowsThroughGeneralDelegation() {
 		}
 	}
 	s.Require().NotNil(action, "every action emits an ActionResolvedEvent, incl. non-attacks (Inv 9)")
-	s.Equal(core.EntityID(monkEntityID), action.ActorID)
+	s.Equal(monkEntityID, action.ActorID)
 	s.Equal(refs.CombatAbilities.Dodge().String(), action.ActionRef,
 		"the resolved-action event carries the actor's real submitted ref")
 	s.Equal(1, action.EconomyConsumed.Actions, "Dodge consumed one standard action")

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -1,0 +1,356 @@
+package encounter_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// TurnStateSuite proves Beat-1 slices 1 + 2b on the REAL hydrated path
+// (LoadFromData → held *character.Character, no stub):
+//   - SetMode→TurnBased seeds the active player's economy from the engine
+//     (slice 1: the rpg-api ActionEconomyData{1,1,1} injection is now the
+//     engine's job, North-Star Invariant 2).
+//   - ActorTurnState exposes the character's two-level menu + economy as toolkit
+//     domain types, with the EconomySlot + TargetKind fields populated
+//     (slice 2b: the menu-as-data read surface, Invariant 11).
+type TurnStateSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestTurnStateSuite(t *testing.T) {
+	suite.Run(t, new(TurnStateSuite))
+}
+
+func (s *TurnStateSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *TurnStateSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+const (
+	monkPlayerID = core.PlayerID("mira")
+	monkEntityID = core.EntityID("char-mira")
+)
+
+// monkCharJSON builds a level-1 Monk character.Data blob WITHOUT a seeded
+// ActionEconomy — proving the encounter seeds it at turn start, not the host.
+func (s *TurnStateSuite) monkCharJSON() json.RawMessage {
+	s.T().Helper()
+	charData := &dnd5eCharacter.Data{
+		ID:       string(monkEntityID),
+		PlayerID: string(monkPlayerID),
+		Name:     "Mira the Monk",
+		Level:    1,
+		ClassID:  classes.Monk,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 12,
+			abilities.DEX: 16,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 15,
+			abilities.CHA: 8,
+		},
+		HitPoints:        9,
+		MaxHitPoints:     9,
+		ArmorClass:       15,
+		ProficiencyBonus: 2,
+		// NOTE: ActionEconomy intentionally nil — the encounter must seed it.
+	}
+	raw, err := json.Marshal(charData)
+	s.Require().NoError(err)
+	return raw
+}
+
+// loadedMonkEncounter builds a TURN_BASED encounter with one hydrated Monk seat
+// via LoadFromData (the production create→persist→load path), so the encounter
+// holds a real *character.Character on its bus.
+func (s *TurnStateSuite) loadedMonkEncounter() *encounter.Encounter {
+	s.T().Helper()
+	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	data := encounter.NewData("enc-ts")
+	data.Players[monkPlayerID] = &encounter.PlayerData{
+		ID:         monkPlayerID,
+		EntityID:   monkEntityID,
+		View:       view,
+		HP:         9,
+		MaxHP:      9,
+		AC:         15,
+		DamageDice: "1d4",
+		DamageType: "bludgeoning",
+		DataJSON:   s.monkCharJSON(),
+	}
+	enc, err := encounter.LoadFromData(s.ctx, data, s.broker)
+	s.Require().NoError(err)
+	return enc
+}
+
+// TestSetMode_SeedsActiveActorEconomyAndExposesMenu is the slice-1 + slice-2b
+// acceptance test on the real hydrated path.
+func (s *TurnStateSuite) TestSetMode_SeedsActiveActorEconomyAndExposesMenu() {
+	enc := s.loadedMonkEncounter()
+
+	// Before TURN_BASED there is no economy to seed yet.
+	pre := enc.ActorTurnState(monkEntityID)
+	s.Require().Nil(pre.Economy, "economy is unseeded before TURN_BASED")
+
+	// Flip to TURN_BASED — the only seat, so the Monk is the first actor.
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().Equal(monkEntityID, enc.ActiveActor())
+
+	ts := enc.ActorTurnState(monkEntityID)
+
+	// Slice 1: the engine seeded the economy at turn start (Inv 2).
+	s.Require().NotNil(ts.Economy, "encounter must seed the held char economy at turn start")
+	s.Equal(1, ts.Economy.ActionsRemaining)
+	s.Equal(1, ts.Economy.BonusActionsRemaining)
+	s.Equal(1, ts.Economy.ReactionsRemaining)
+	s.Positive(ts.Economy.MovementRemaining, "movement seeded from character speed")
+
+	// Slice 2b: the menu is exposed as data. Every character is seeded with the
+	// four universal abilities (Attack, Dash, Dodge, Disengage); buildAvailableActions
+	// always lists Move.
+	abilityByID := map[string]dnd5eCharacter.AvailableAbility{}
+	for _, a := range ts.Abilities {
+		abilityByID[a.Ref.ID] = a
+	}
+	s.Contains(abilityByID, refs.CombatAbilities.Attack().ID)
+	s.Contains(abilityByID, refs.CombatAbilities.Dodge().ID)
+	s.Contains(abilityByID, refs.CombatAbilities.Dash().ID)
+	s.Contains(abilityByID, refs.CombatAbilities.Disengage().ID)
+
+	// Target kind + economy slot are toolkit-authored on each entry.
+	s.Equal(dnd5eCharacter.TargetKindSingleEntity, abilityByID[refs.CombatAbilities.Attack().ID].TargetKind)
+	s.Equal(dnd5eCharacter.EconomySlotAction, abilityByID[refs.CombatAbilities.Attack().ID].EconomySlot)
+	s.Equal(dnd5eCharacter.TargetKindSelf, abilityByID[refs.CombatAbilities.Dodge().ID].TargetKind)
+	s.Equal(dnd5eCharacter.TargetKindNone, abilityByID[refs.CombatAbilities.Dash().ID].TargetKind)
+
+	// Attack is available at turn start (one action in hand).
+	s.True(abilityByID[refs.CombatAbilities.Attack().ID].CanUse)
+
+	// Move is present in the actions list, with the movement slot + position target.
+	var move *dnd5eCharacter.AvailableAction
+	for i := range ts.Actions {
+		if ts.Actions[i].Ref.ID == refs.Actions.Move().ID {
+			move = &ts.Actions[i]
+		}
+	}
+	s.Require().NotNil(move, "Move is always listed in the action menu")
+	s.Equal(dnd5eCharacter.EconomySlotMovement, move.EconomySlot)
+	s.Equal(dnd5eCharacter.TargetKindPosition, move.TargetKind)
+	// D17: the character menu reports Move usable (a L1 char CAN move), but the
+	// encounter composes effective takeability and marks it unavailable this
+	// beat (movement lands in Beat 2) with an honest reason. The menu↔verb stay
+	// consistent — TestTakeAction_RejectsDeferredMove proves the verb agrees.
+	s.False(move.CanUse, "encounter defers Move this beat (D17)")
+	s.NotEmpty(move.Reason, "deferred Move carries an unavailable reason")
+}
+
+// TestActorTurnState_NonPlayerActorIsEmpty proves the query is a clean no-op for
+// a seat with no hydrated character (returns the zero view with the id set).
+func (s *TurnStateSuite) TestActorTurnState_NonPlayerActorIsEmpty() {
+	enc := s.loadedMonkEncounter()
+	ts := enc.ActorTurnState(core.EntityID("nobody"))
+	s.Equal(core.EntityID("nobody"), ts.ActorID)
+	s.Nil(ts.Economy)
+	s.Empty(ts.Abilities)
+	s.Empty(ts.Actions)
+}
+
+// TestTakeAction_DodgeFlowsThroughGeneralDelegation proves the general
+// dispatch (slice 3): a NON-attack ref (Dodge) reaches the held character's
+// rules engine via ActivateAbility — no attack gate, no per-ref special-casing
+// in the encounter — decrements the economy, and emits a first-class
+// ActionResolvedEvent (Invariant 9) carrying the dodge ref + economy consumed.
+//
+// Note: activating Dodge today only spends the action + publishes
+// DodgeActivatedEvent; wiring the DodgingCondition's mechanical effect is a
+// separate gap (the toolkit has DodgingCondition but nothing applies it on
+// DodgeActivated). Beat-1 proves the DISPATCH generality — the economy spend +
+// resolved-action record — not Dodge's full mechanical effect.
+func (s *TurnStateSuite) TestTakeAction_DodgeFlowsThroughGeneralDelegation() {
+	enc := s.loadedMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().Equal(monkEntityID, enc.ActiveActor())
+
+	sub, err := s.broker.Subscribe("enc-ts", monkPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	// Take Dodge — a non-attack ability — through the unified TakeAction verb.
+	err = enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{
+			Module: "dnd5e",
+			Type:   refs.CombatAbilities.Dodge().Type,
+			ID:     refs.CombatAbilities.Dodge().ID,
+		},
+		encounter.ActionTarget{EntityID: monkEntityID},
+	)
+	s.Require().NoError(err, "Dodge must flow through the general delegation, not hit an attack gate")
+
+	// The economy decremented by one action (the engine deducted it).
+	ts := enc.ActorTurnState(monkEntityID)
+	s.Require().NotNil(ts.Economy)
+	s.Equal(0, ts.Economy.ActionsRemaining, "Dodge spends the standard action")
+
+	// A first-class ActionResolvedEvent fired for the non-attack action.
+	var action *events.ActionResolvedEvent
+	for _, e := range collectEventsTyped(sub, 500*time.Millisecond) {
+		if ev, ok := e.(*events.ActionResolvedEvent); ok {
+			action = ev
+		}
+	}
+	s.Require().NotNil(action, "every action emits an ActionResolvedEvent, incl. non-attacks (Inv 9)")
+	s.Equal(core.EntityID(monkEntityID), action.ActorID)
+	s.Equal(refs.CombatAbilities.Dodge().String(), action.ActionRef,
+		"the resolved-action event carries the actor's real submitted ref")
+	s.Equal(1, action.EconomyConsumed.Actions, "Dodge consumed one standard action")
+}
+
+// combatMonkEncounter builds a TURN_BASED encounter with a hydrated Monk seat
+// AND a goblin target + an always-hit resolver, so the Monk can take a real
+// attack and exercise the two-level economy.
+func (s *TurnStateSuite) combatMonkEncounter() *encounter.Encounter {
+	s.T().Helper()
+	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	data := encounter.NewData("enc-ts")
+	data.Players[monkPlayerID] = &encounter.PlayerData{
+		ID:          monkPlayerID,
+		EntityID:    monkEntityID,
+		View:        view,
+		HP:          9,
+		MaxHP:       9,
+		AC:          15,
+		AttackBonus: 4,
+		DamageDice:  "1d4",
+		DamageType:  "bludgeoning",
+		DataJSON:    s.monkCharJSON(),
+	}
+	data.Monsters["goblin-1"] = &encounter.MonsterData{
+		ID:       "goblin-1",
+		Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP:       7,
+		MaxHP:    7,
+		AC:       12,
+	}
+	enc, err := encounter.LoadFromData(s.ctx, data, s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 3, damageType: "bludgeoning"}),
+	)
+	s.Require().NoError(err)
+	return enc
+}
+
+// TestGoalBehavior_MonkTakesActionThenBonusAction is the Beat-1 DONE-BAR proof:
+// a Monk takes its Attack (a standard action) and then a Martial Arts bonus
+// unarmed strike (a bonus action), with the economy enforced server-side —
+// BOTH slots decrement. This exercises the two-level economy end-to-end:
+// Attack grants + a strike consumes, the strike grants the Monk bonus, and the
+// bonus strike (taken through the SAME unified TakeAction verb) consumes the
+// bonus action.
+func (s *TurnStateSuite) TestGoalBehavior_MonkTakesActionThenBonusAction() {
+	enc := s.combatMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != monkEntityID {
+		_, _, err := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	s.Require().Equal(1, enc.ActorTurnState(monkEntityID).Economy.ActionsRemaining)
+	s.Require().Equal(1, enc.ActorTurnState(monkEntityID).Economy.BonusActionsRemaining)
+
+	// 1) Take the Attack action against the goblin.
+	err := enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	)
+	s.Require().NoError(err)
+
+	afterAttack := enc.ActorTurnState(monkEntityID)
+	s.Equal(0, afterAttack.Economy.ActionsRemaining, "Attack consumed the standard action")
+
+	// The Monk's main-hand strike granted the Martial Arts bonus strike, which
+	// now appears in the action menu as a bonus-action option.
+	var bonusStrike *dnd5eCharacter.AvailableAction
+	for i := range afterAttack.Actions {
+		if afterAttack.Actions[i].Ref.ID == refs.Actions.UnarmedStrike().ID {
+			bonusStrike = &afterAttack.Actions[i]
+		}
+	}
+	s.Require().NotNil(bonusStrike, "Monk Attack grants a Martial Arts bonus unarmed strike")
+	s.Equal(dnd5eCharacter.EconomySlotBonusAction, bonusStrike.EconomySlot)
+
+	// 2) Take the bonus unarmed strike through the SAME unified verb.
+	err = enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: bonusStrike.Ref.Type, ID: bonusStrike.Ref.ID},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	)
+	s.Require().NoError(err)
+
+	afterBonus := enc.ActorTurnState(monkEntityID)
+	s.Equal(0, afterBonus.Economy.BonusActionsRemaining, "the bonus unarmed strike consumed the bonus action")
+}
+
+// TestTakeAction_RejectsDeferredMove proves the menu↔verb consistency for a
+// beat-deferred ref (D17): the menu surfaces Move as available=false, and the
+// verb rejects an attempt to take it with ErrActionDeferred — it does not
+// no-op-succeed. Beat 2 removes Move from the deferred set and wires real
+// movement; until then the server never promises what it won't do.
+func (s *TurnStateSuite) TestTakeAction_RejectsDeferredMove() {
+	enc := s.loadedMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+
+	err := enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{
+			Module: "dnd5e",
+			Type:   refs.Actions.Move().Type,
+			ID:     refs.Actions.Move().ID,
+		},
+		encounter.ActionTarget{},
+	)
+	s.ErrorIs(err, encounter.ErrActionDeferred)
+}
+
+// TestTakeAction_RejectsUnknownRefOnHydratedCharacter proves that an unknown
+// ref on a HYDRATED character (one with a real menu) is rejected with
+// ErrUnsupportedAction — the character's engine reports it has no such
+// ability/action. This is the unknown-ref path the old hard gate used to cover;
+// the general delegation preserves it for refs the menu doesn't contain.
+func (s *TurnStateSuite) TestTakeAction_RejectsUnknownRefOnHydratedCharacter() {
+	enc := s.loadedMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+
+	err := enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: "actions", ID: "no-such-action"},
+		encounter.ActionTarget{EntityID: monkEntityID},
+	)
+	s.ErrorIs(err, encounter.ErrUnsupportedAction)
+}
+
+// silence unused import if coreCombat ends up unreferenced in future edits.
+var _ = coreCombat.ActionStandard


### PR DESCRIPTION
Part of the **TakeAction** wave: KirkDiggler/rpg-project#54. References #697 (Beat-2 catalog remains, so **not** Closes).

The **encounter-module half** of the #697 menu/economy unification — the second of two split PRs. Stacks on the now-merged **#698** (event spine) + **#700** (char-pkg, `rulebooks/dnd5e v0.60.0`), which it requires with no replace.

## What

- **Delete the `ref.ID == "attack"` hard gate** (`combat_phased.go`). Every non-attack ref now delegates to the held character's own engine — `ActivateAbility` (combat abilities / features) or `ExecuteAction` (granted-capacity actions) — via `takeCharacterAction`. No ref special-cased; the character's menu is the catalog ("default to one system"). Runs on the `LoadFromData`-held `*character.Character`, never re-loads (#689). **Dodge** proves the generality (a non-attack ref flows through, economy decrements, emits `ActionResolvedEvent`).
- **Seed the economy in the engine** (`turn_economy.go`): `character.StartTurn` on the held character at each turn boundary, removing the rpg-api `ActionEconomyData{1,1,1}` injection (North-Star Invariant 2).
- **Expose the menu as data** (`turn_state.go`): `Encounter.ActorTurnState` returns the held character's two-level menu + economy as toolkit domain types, each entry carrying `EconomySlot` + `TargetKind` for rpg-api to project field-for-field (Invariant 11).
- **Attack as a citizen** of the two-level economy: the attack verb drives `ActivateAbility(attack)` + `ExecuteAction(strike)` and reports the real economy diff; the Monk Martial Arts bonus strike rides the granted-capacity path.
- **Resolved-action events made real**: the attack path threads the actor's real submitted ref + economy (no placeholder); non-attack actions emit their own `ActionResolvedEvent`.
- **Beat-scope composition (D17)**: the character menu stays honest (a L1 char *can* move), the encounter composes *effective takeability* — `deferredActionRefs` marks Move `available=false` this beat and the verb rejects it with `ErrActionDeferred`, so menu and verb never disagree. One-line removal in Beat 2.
- **Docs**: ADR-0032 + `encounter.md` + `status.md`.

## Goal behavior — proven on the real broker path

`TestGoalBehavior_MonkTakesActionThenBonusAction`: a Monk takes an **action** (Attack) and a **bonus action** (Martial Arts unarmed strike) through the one unified `TakeAction` verb, **both economy slots decrement** server-side. Plus `TestTakeAction_DodgeFlowsThroughGeneralDelegation`, `TestTakeAction_RejectsDeferredMove` (D17), `TestSetMode_SeedsActiveActorEconomyAndExposesMenu`.

## Verification

`go build ./...` clean; full `encounter` suite green (cache-busted) against published `rulebooks/dnd5e v0.60.0`; pre-commit passed. Diff is encounter-module + its docs only — no `rulebooks/dnd5e/character/*`, no `rulebook-dnd5e.md` (those shipped in #700).

🤖 Generated with [Claude Code](https://claude.com/claude-code)