### PR TITLE
feat(dnd5e): implement Help and Hide combat abilities (#697)

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -594,6 +594,8 @@ func initStandardCombatAbilities(char *Character) {
 	_ = char.AddCombatAbility(combatabilities.NewDash(char.id + "-dash"))
 	_ = char.AddCombatAbility(combatabilities.NewDodge(char.id + "-dodge"))
 	_ = char.AddCombatAbility(combatabilities.NewDisengage(char.id + "-disengage"))
+	_ = char.AddCombatAbility(combatabilities.NewHelp(char.id + "-help"))
+	_ = char.AddCombatAbility(combatabilities.NewHide(char.id + "-hide"))
 }
 
 // GetCombatAbility returns a specific combat ability by ID, or nil if not found.

--- a/rulebooks/dnd5e/character/combat_abilities_test.go
+++ b/rulebooks/dnd5e/character/combat_abilities_test.go
@@ -153,16 +153,16 @@ func (s *CombatAbilitiesTestSuite) TestCharacterGetsStandardCombatAbilities() {
 		s.Assert().Equal("Disengage", disengageAbility.Name())
 	})
 
-	s.Run("finalized character has all four standard combat abilities", func() {
+	s.Run("finalized character has all standard combat abilities", func() {
 		draft := s.createFighterDraft()
 
 		char, err := draft.ToCharacter(s.ctx, "char-005", s.bus)
 		s.Require().NoError(err)
 
 		abilities := char.GetCombatAbilities()
-		s.Assert().Len(abilities, 4, "character should have exactly 4 standard combat abilities")
+		s.Assert().Len(abilities, 6, "character should have exactly 6 standard combat abilities")
 
-		// Verify all four are present
+		// Verify all six are present
 		abilityNames := make(map[string]bool)
 		for _, ability := range abilities {
 			abilityNames[ability.Name()] = true
@@ -172,6 +172,8 @@ func (s *CombatAbilitiesTestSuite) TestCharacterGetsStandardCombatAbilities() {
 		s.Assert().True(abilityNames["Dash"], "should have Dash")
 		s.Assert().True(abilityNames["Dodge"], "should have Dodge")
 		s.Assert().True(abilityNames["Disengage"], "should have Disengage")
+		s.Assert().True(abilityNames["Help"], "should have Help")
+		s.Assert().True(abilityNames["Hide"], "should have Hide")
 	})
 }
 

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -1592,6 +1592,14 @@ func (d *Draft) initializeStandardCombatAbilities(char *Character) {
 	// Disengage - consumes action economy to grant Disengaging condition
 	disengageAbility := combatabilities.NewDisengage(char.id + "-disengage")
 	_ = char.AddCombatAbility(disengageAbility)
+
+	// Help - consumes action economy to aid an ally (advantage on their next roll)
+	helpAbility := combatabilities.NewHelp(char.id + "-help")
+	_ = char.AddCombatAbility(helpAbility)
+
+	// Hide - consumes action economy to attempt a Stealth check (become hidden)
+	hideAbility := combatabilities.NewHide(char.id + "-hide")
+	_ = char.AddCombatAbility(hideAbility)
 }
 
 // initializeStandardActions adds standard permanent actions to the character.

--- a/rulebooks/dnd5e/character/integration_test.go
+++ b/rulebooks/dnd5e/character/integration_test.go
@@ -249,7 +249,7 @@ func (s *FullAttackFlowIntegrationSuite) TestFullAttackFlow() {
 		// =====================================================================
 
 		combatAbilities := char.GetCombatAbilities()
-		s.Assert().Len(combatAbilities, 4, "character should have 4 standard combat abilities")
+		s.Assert().Len(combatAbilities, 6, "character should have 6 standard combat abilities")
 
 		attackAbility := char.GetCombatAbility("fighter-001-attack")
 		s.Require().NotNil(attackAbility, "character should have Attack ability")

--- a/rulebooks/dnd5e/combat/turn_manager_test.go
+++ b/rulebooks/dnd5e/combat/turn_manager_test.go
@@ -530,7 +530,7 @@ func (s *TurnManagerTestSuite) TestGetAvailableAbilities() {
 		s.Require().NoError(err)
 
 		available := tm.GetAvailableAbilities(s.ctx)
-		s.Require().Len(available, 4) // Attack, Dash, Disengage, Dodge
+		s.Require().Len(available, 6) // Attack, Dash, Disengage, Dodge, Help, Hide
 
 		// All should be usable initially
 		for _, a := range available {

--- a/rulebooks/dnd5e/combatabilities/base.go
+++ b/rulebooks/dnd5e/combatabilities/base.go
@@ -216,12 +216,18 @@ func LoadJSON(data json.RawMessage) (CombatAbility, error) {
 		return disengage, nil
 
 	case refs.CombatAbilities.Help().ID:
-		// Help ability will be implemented in a future phase
-		return nil, fmt.Errorf("help ability not yet implemented")
+		help := &Help{}
+		if err := help.loadJSON(data); err != nil {
+			return nil, fmt.Errorf("failed to load help ability: %w", err)
+		}
+		return help, nil
 
 	case refs.CombatAbilities.Hide().ID:
-		// Hide ability will be implemented in a future phase
-		return nil, fmt.Errorf("hide ability not yet implemented")
+		hide := &Hide{}
+		if err := hide.loadJSON(data); err != nil {
+			return nil, fmt.Errorf("failed to load hide ability: %w", err)
+		}
+		return hide, nil
 
 	case refs.CombatAbilities.Ready().ID:
 		// Ready ability will be implemented in a future phase

--- a/rulebooks/dnd5e/combatabilities/help.go
+++ b/rulebooks/dnd5e/combatabilities/help.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combatabilities
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// Help represents the Help combat ability (PHB p.192).
+// When activated, it consumes 1 action and publishes a HelpActivatedEvent.
+// The helped ally gains advantage on their next ability check, or (when helping
+// against a creature within 5 feet) advantage on their next attack roll against
+// that creature before the start of the helper's next turn.
+//
+// Mirrors the Dodge/Disengage bar: this consumes the action and emits the
+// activation signal. Applying the advantage to the ally (and threading which
+// ally is helped) is a later beat — the ally target is not yet carried through
+// the character ActivateAbility path, so HelpActivatedEvent.AllyID is empty for
+// now (documented gap).
+type Help struct {
+	*BaseCombatAbility
+}
+
+// HelpData is the JSON structure for persisting Help ability state.
+type HelpData struct {
+	Ref *core.Ref `json:"ref"`
+	ID  string    `json:"id"`
+}
+
+// NewHelp creates a new Help combat ability that uses a standard action.
+// This is the default Help action available to all characters.
+func NewHelp(id string) *Help {
+	return &Help{
+		BaseCombatAbility: NewBaseCombatAbility(BaseCombatAbilityConfig{
+			ID:          id,
+			Name:        "Help",
+			Description: "Aid an ally: their next check or attack against a foe near you gains advantage.",
+			ActionType:  coreCombat.ActionStandard,
+			Ref:         refs.CombatAbilities.Help(),
+		}),
+	}
+}
+
+// CanActivate checks if the Help ability can be activated.
+// Requires an available action and an event bus.
+func (h *Help) CanActivate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
+	if err := h.BaseCombatAbility.CanActivate(ctx, owner, input); err != nil {
+		return err
+	}
+	if input.Bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Help")
+	}
+	return nil
+}
+
+// Activate consumes 1 action and publishes a HelpActivatedEvent.
+// A subscriber in a later beat applies the advantage to the helped ally.
+func (h *Help) Activate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
+	if input.Bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Help")
+	}
+	if err := h.BaseCombatAbility.Activate(ctx, owner, input); err != nil {
+		return err
+	}
+	if err := dnd5eEvents.HelpActivatedTopic.On(input.Bus).Publish(ctx, dnd5eEvents.HelpActivatedEvent{
+		CharacterID: owner.GetID(),
+	}); err != nil {
+		return fmt.Errorf("failed to publish help activated event: %w", err)
+	}
+	return nil
+}
+
+// ToJSON converts the Help ability to JSON for persistence.
+func (h *Help) ToJSON() (json.RawMessage, error) {
+	data := HelpData{Ref: h.Ref(), ID: h.GetID()}
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal help ability data: %w", err)
+	}
+	return bytes, nil
+}
+
+// loadJSON deserializes a Help ability from JSON.
+func (h *Help) loadJSON(data json.RawMessage) error {
+	var helpData HelpData
+	if err := json.Unmarshal(data, &helpData); err != nil {
+		return fmt.Errorf("failed to unmarshal help ability data: %w", err)
+	}
+	h.BaseCombatAbility = NewBaseCombatAbility(BaseCombatAbilityConfig{
+		ID:          helpData.ID,
+		Name:        "Help",
+		Description: "Aid an ally: their next check or attack against a foe near you gains advantage.",
+		ActionType:  coreCombat.ActionStandard,
+		Ref:         refs.CombatAbilities.Help(),
+	})
+	return nil
+}

--- a/rulebooks/dnd5e/combatabilities/help_hide_test.go
+++ b/rulebooks/dnd5e/combatabilities/help_hide_test.go
@@ -1,0 +1,191 @@
+package combatabilities_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combatabilities"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/stretchr/testify/suite"
+)
+
+// HelpAbilityTestSuite covers the Help combat ability (#697 Beat-1): it consumes
+// the standard action and publishes HelpActivatedEvent. The mechanical effect
+// (advantage to the ally) is a later beat — these tests cover the constructor,
+// economy spend, activation signal, and persistence round-trip.
+type HelpAbilityTestSuite struct {
+	suite.Suite
+	ctx           context.Context
+	bus           events.EventBus
+	owner         *mockOwner
+	actionEconomy *combat.ActionEconomy
+	help          *combatabilities.Help
+}
+
+func TestHelpAbilityTestSuite(t *testing.T) {
+	suite.Run(t, new(HelpAbilityTestSuite))
+}
+
+func (s *HelpAbilityTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.owner = &mockOwner{id: "test-helper"}
+	s.actionEconomy = combat.NewActionEconomy()
+	s.help = combatabilities.NewHelp("test-help")
+}
+
+func (s *HelpAbilityTestSuite) TestNewHelp_Properties() {
+	s.Equal("test-help", s.help.GetID())
+	s.Equal(core.EntityType("combat_ability"), s.help.GetType())
+	s.Equal("Help", s.help.Name())
+	s.Equal(coreCombat.ActionStandard, s.help.ActionType())
+	s.Equal(refs.CombatAbilities.Help(), s.help.Ref())
+}
+
+func (s *HelpAbilityTestSuite) TestCanActivate_Success() {
+	err := s.help.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus,
+	})
+	s.Require().NoError(err)
+}
+
+func (s *HelpAbilityTestSuite) TestCanActivate_NoActionsRemaining() {
+	s.Require().NoError(s.actionEconomy.UseAction())
+	err := s.help.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus,
+	})
+	s.Require().Error(err)
+}
+
+func (s *HelpAbilityTestSuite) TestCanActivate_RequiresEventBus() {
+	err := s.help.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: nil,
+	})
+	s.Require().Error(err)
+}
+
+func (s *HelpAbilityTestSuite) TestActivate_ConsumesActionAndPublishes() {
+	received := false
+	var got dnd5eEvents.HelpActivatedEvent
+	_, err := dnd5eEvents.HelpActivatedTopic.On(s.bus).Subscribe(
+		s.ctx,
+		func(_ context.Context, e dnd5eEvents.HelpActivatedEvent) error {
+			received = true
+			got = e
+			return nil
+		},
+	)
+	s.Require().NoError(err)
+
+	err = s.help.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus,
+	})
+	s.Require().NoError(err)
+	s.Equal(0, s.actionEconomy.ActionsRemaining, "Help consumes the standard action")
+	s.True(received, "HelpActivatedEvent should be published")
+	s.Equal(s.owner.GetID(), got.CharacterID)
+}
+
+func (s *HelpAbilityTestSuite) TestActivate_NoEventBus() {
+	err := s.help.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy,
+	})
+	s.Require().Error(err)
+}
+
+func (s *HelpAbilityTestSuite) TestToJSON_AndLoadRoundTrip() {
+	jsonData, err := s.help.ToJSON()
+	s.Require().NoError(err)
+
+	var data combatabilities.HelpData
+	s.Require().NoError(json.Unmarshal(jsonData, &data))
+	s.Equal("test-help", data.ID)
+	s.Equal(refs.CombatAbilities.Help(), data.Ref)
+
+	loaded, err := combatabilities.LoadJSON(jsonData)
+	s.Require().NoError(err)
+	s.Equal("Help", loaded.Name())
+	s.Equal(refs.CombatAbilities.Help().ID, loaded.Ref().ID)
+}
+
+// HideAbilityTestSuite covers the Hide combat ability (#697 Beat-1): it consumes
+// the standard action and publishes HideActivatedEvent. The Stealth check + the
+// Hidden condition are a later beat.
+type HideAbilityTestSuite struct {
+	suite.Suite
+	ctx           context.Context
+	bus           events.EventBus
+	owner         *mockOwner
+	actionEconomy *combat.ActionEconomy
+	hide          *combatabilities.Hide
+}
+
+func TestHideAbilityTestSuite(t *testing.T) {
+	suite.Run(t, new(HideAbilityTestSuite))
+}
+
+func (s *HideAbilityTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.owner = &mockOwner{id: "test-sneak"}
+	s.actionEconomy = combat.NewActionEconomy()
+	s.hide = combatabilities.NewHide("test-hide")
+}
+
+func (s *HideAbilityTestSuite) TestNewHide_Properties() {
+	s.Equal("test-hide", s.hide.GetID())
+	s.Equal(core.EntityType("combat_ability"), s.hide.GetType())
+	s.Equal("Hide", s.hide.Name())
+	s.Equal(coreCombat.ActionStandard, s.hide.ActionType())
+	s.Equal(refs.CombatAbilities.Hide(), s.hide.Ref())
+}
+
+func (s *HideAbilityTestSuite) TestActivate_ConsumesActionAndPublishes() {
+	received := false
+	var got dnd5eEvents.HideActivatedEvent
+	_, err := dnd5eEvents.HideActivatedTopic.On(s.bus).Subscribe(
+		s.ctx,
+		func(_ context.Context, e dnd5eEvents.HideActivatedEvent) error {
+			received = true
+			got = e
+			return nil
+		},
+	)
+	s.Require().NoError(err)
+
+	err = s.hide.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus,
+	})
+	s.Require().NoError(err)
+	s.Equal(0, s.actionEconomy.ActionsRemaining, "Hide consumes the standard action")
+	s.True(received, "HideActivatedEvent should be published")
+	s.Equal(s.owner.GetID(), got.CharacterID)
+}
+
+func (s *HideAbilityTestSuite) TestCanActivate_RequiresEventBus() {
+	err := s.hide.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: nil,
+	})
+	s.Require().Error(err)
+}
+
+func (s *HideAbilityTestSuite) TestToJSON_AndLoadRoundTrip() {
+	jsonData, err := s.hide.ToJSON()
+	s.Require().NoError(err)
+
+	var data combatabilities.HideData
+	s.Require().NoError(json.Unmarshal(jsonData, &data))
+	s.Equal("test-hide", data.ID)
+	s.Equal(refs.CombatAbilities.Hide(), data.Ref)
+
+	loaded, err := combatabilities.LoadJSON(jsonData)
+	s.Require().NoError(err)
+	s.Equal("Hide", loaded.Name())
+	s.Equal(refs.CombatAbilities.Hide().ID, loaded.Ref().ID)
+}

--- a/rulebooks/dnd5e/combatabilities/hide.go
+++ b/rulebooks/dnd5e/combatabilities/hide.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combatabilities
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// Hide represents the Hide combat ability (PHB p.192).
+// When activated, it consumes 1 action and publishes a HideActivatedEvent.
+// The character attempts to become hidden — a Dexterity (Stealth) check against
+// observers' passive Perception. On success the character is Hidden (unseen and
+// unheard) until they are discovered, make noise, attack, or move into the open.
+//
+// Mirrors the Dodge/Disengage bar: this consumes the action and emits the
+// activation signal. Resolving the Stealth check and applying the Hidden
+// condition is a later beat (the toolkit has the proficiency/check machinery;
+// nothing yet wires HideActivated → a check → the Hidden condition).
+type Hide struct {
+	*BaseCombatAbility
+}
+
+// HideData is the JSON structure for persisting Hide ability state.
+type HideData struct {
+	Ref *core.Ref `json:"ref"`
+	ID  string    `json:"id"`
+}
+
+// NewHide creates a new Hide combat ability that uses a standard action.
+// This is the default Hide action available to all characters.
+func NewHide(id string) *Hide {
+	return &Hide{
+		BaseCombatAbility: NewBaseCombatAbility(BaseCombatAbilityConfig{
+			ID:          id,
+			Name:        "Hide",
+			Description: "Make a Stealth check to become hidden from creatures that can't see you.",
+			ActionType:  coreCombat.ActionStandard,
+			Ref:         refs.CombatAbilities.Hide(),
+		}),
+	}
+}
+
+// CanActivate checks if the Hide ability can be activated.
+// Requires an available action and an event bus.
+func (h *Hide) CanActivate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
+	if err := h.BaseCombatAbility.CanActivate(ctx, owner, input); err != nil {
+		return err
+	}
+	if input.Bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Hide")
+	}
+	return nil
+}
+
+// Activate consumes 1 action and publishes a HideActivatedEvent.
+// A subscriber in a later beat resolves the Stealth check and applies Hidden.
+func (h *Hide) Activate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
+	if input.Bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Hide")
+	}
+	if err := h.BaseCombatAbility.Activate(ctx, owner, input); err != nil {
+		return err
+	}
+	if err := dnd5eEvents.HideActivatedTopic.On(input.Bus).Publish(ctx, dnd5eEvents.HideActivatedEvent{
+		CharacterID: owner.GetID(),
+	}); err != nil {
+		return fmt.Errorf("failed to publish hide activated event: %w", err)
+	}
+	return nil
+}
+
+// ToJSON converts the Hide ability to JSON for persistence.
+func (h *Hide) ToJSON() (json.RawMessage, error) {
+	data := HideData{Ref: h.Ref(), ID: h.GetID()}
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal hide ability data: %w", err)
+	}
+	return bytes, nil
+}
+
+// loadJSON deserializes a Hide ability from JSON.
+func (h *Hide) loadJSON(data json.RawMessage) error {
+	var hideData HideData
+	if err := json.Unmarshal(data, &hideData); err != nil {
+		return fmt.Errorf("failed to unmarshal hide ability data: %w", err)
+	}
+	h.BaseCombatAbility = NewBaseCombatAbility(BaseCombatAbilityConfig{
+		ID:          hideData.ID,
+		Name:        "Hide",
+		Description: "Make a Stealth check to become hidden from creatures that can't see you.",
+		ActionType:  coreCombat.ActionStandard,
+		Ref:         refs.CombatAbilities.Hide(),
+	})
+	return nil
+}

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -742,6 +742,24 @@ type DisengageActivatedEvent struct {
 	CharacterID string // ID of the character who is disengaging
 }
 
+// HelpActivatedEvent is published when a character uses the Help action.
+// The helper aids an ally: the next ability check or attack roll the ally makes
+// (against the helped target, for attacks) gains advantage. The mechanical
+// effect (granting advantage) is applied by a subscriber in a later beat; this
+// event is the activation signal.
+type HelpActivatedEvent struct {
+	CharacterID string // ID of the character taking the Help action
+	AllyID      string // ID of the ally being helped (the action's target)
+}
+
+// HideActivatedEvent is published when a character uses the Hide action.
+// The character attempts to become hidden (a Stealth check vs observers' passive
+// Perception). The check + the resulting Hidden condition are resolved by a
+// subscriber in a later beat; this event is the activation signal.
+type HideActivatedEvent struct {
+	CharacterID string // ID of the character taking the Hide action
+}
+
 // =============================================================================
 // Topic Definitions
 // =============================================================================
@@ -827,6 +845,12 @@ var (
 
 	// DisengageActivatedTopic provides typed pub/sub for Disengage ability activation
 	DisengageActivatedTopic = events.DefineTypedTopic[DisengageActivatedEvent]("dnd5e.ability.disengage.activated")
+
+	// HelpActivatedTopic provides typed pub/sub for Help ability activation
+	HelpActivatedTopic = events.DefineTypedTopic[HelpActivatedEvent]("dnd5e.ability.help.activated")
+
+	// HideActivatedTopic provides typed pub/sub for Hide ability activation
+	HideActivatedTopic = events.DefineTypedTopic[HideActivatedEvent]("dnd5e.ability.hide.activated")
 
 	// StrikeExecutedTopic provides typed pub/sub for Strike action execution
 	StrikeExecutedTopic = events.DefineTypedTopic[StrikeExecutedEvent]("dnd5e.action.strike.executed")


### PR DESCRIPTION
Part of the **TakeAction** wave (rpg-project#54). This is the **rulebook half** the encounter menu/economy unification (#697 Beat-1) depends on — split out so the encounter PR can pin a real dnd5e tag (the monorepo auto-tags dnd5e on merge; the encounter PR stacks on that tag).

## Context

The unification seeds every character with the universal combat abilities and flows them through one unified `TakeAction` verb. Help and Hide had refs and were already classified in `targetKindForRef` (#700), but had **no constructors** — the combat ability `LoadJSON` router returned `"not yet implemented"` for them.

## What this does

- **`combatabilities/help.go` + `hide.go`** at the same bar as Dodge/Disengage: `CanActivate` checks action economy + bus; `Activate` consumes the **standard action** and publishes a telemetry activated event. Wired into the `LoadJSON` router (`base.go`).
- **Seed Help + Hide on every character** — `initStandardCombatAbilities` (LoadFromData re-seed) and `draft.initializeStandardCombatAbilities` (creation). `AddCombatAbility` is idempotent, so the load-time re-seed doesn't double-register.
- **New `HelpActivatedTopic` / `HideActivatedTopic`** + event structs.
- **Tests:** `help_hide_test.go` — properties, economy spend, activation signal, persistence round-trip. Updated the three "exactly 4 standard abilities" assertions to **6** (character + combat packages).

## Verification (actual output)

`cd rulebooks/dnd5e`:
- `go build ./...` → clean
- `go test ./...` → 0 FAILs (all packages `ok`)
- `gofmt -l` → clean; `golangci-lint run ./combatabilities/...` → `0 issues`

## Scope / follow-ups (documented under #54)

Mechanical effects are a follow-up, matching Dodge's bar: Help's advantage to the ally (and threading which ally — `HelpActivatedEvent.AllyID` is empty for now, as `ActivateAbility` doesn't carry a target) and Hide's Stealth check + Hidden condition are not yet applied. This delivers the **dispatch + economy** bar so the abilities flow through the unified verb.

Part of #697 (the rulebook half; #697 closes with the encounter unification PR).
Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)