### PR TITLE
feat(encounter): flow Help/Hide through TakeAction; pin dnd5e v0.61.0 (#697)

### DIFF
--- a/docs/adr/0032-takeaction-unifies-encounter-verb-with-character-economy.md
+++ b/docs/adr/0032-takeaction-unifies-encounter-verb-with-character-economy.md
@@ -119,11 +119,20 @@ of the Beat-1 goal behavior (action + bonus action, both enforced) hold.
   instance.
 - rpg-api stops seeding the economy and stops authoring the menu; it projects
   `ActorTurnState` field-for-field.
+- **Non-attack catalog complete:** Dodge, Dash, Disengage, **Help, and Hide** are
+  all seeded on every character and flow through the unified verb. Help/Hide
+  constructors landed in the dnd5e half (rpg-toolkit#702, v0.61.0); the encounter
+  module bumped to v0.61.0 and a real-path test proves both flow through
+  `TakeAction` with the right target-kind + standard-action enforcement.
 - **Known gaps left as follow-ups under #54 (not regressions of this wave):**
-  - Activating Dodge spends the action and publishes `DodgeActivatedEvent`, but
-    nothing wires `DodgeActivated → DodgingCondition.Apply`, so Dodge's
-    mechanical effect (attackers get disadvantage) is not yet applied. Beat 1
-    proves the *dispatch* generality, not Dodge's full effect.
+  - The combat-ability *mechanical effects* for Dodge / Help / Hide are not yet
+    applied: Dodge publishes `DodgeActivatedEvent` but nothing wires it to
+    `DodgingCondition.Apply` (attackers' disadvantage); Help publishes
+    `HelpActivatedEvent` with an empty `AllyID` (the ally is not threaded through
+    `ActivateAbility`) and nothing grants the advantage; Hide publishes
+    `HideActivatedEvent` but nothing resolves the Stealth check or applies Hidden.
+    Beat 1 proves the *dispatch* generality + economy spend, not these full
+    effects.
   - Two implementations of the Monk bonus strike coexist (the character-package
     `GrantedMartialArtsBonus` path used here, and the weapon-aware
     `actions.MartialArtsBonusStrike` granter); they are not yet collapsed.

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -290,6 +290,10 @@ granted-capacity actions. No ref is enumerated in the encounter; the character's
 menu is the membership test. The action runs on the `*character.Character` the
 `LoadFromData` cascade already holds on `e.bus` (ADR-0030) — never a re-load.
 
+The non-attack catalog seeded on every character — Dodge, Dash, Disengage, Help,
+Hide — all flow through this one verb. Help/Hide constructors landed in the dnd5e
+half (rpg-toolkit#702, v0.61.0); the encounter module pins v0.61.0.
+
 Turn-start economy seeding moved into the engine: `Encounter` calls
 `character.StartTurn` on the held character at each turn boundary (the
 `SetMode→TURN_BASED` first actor and `EndTurn`'s next actor), so rpg-api no longer

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.60.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.60.0 h1:FcRGzmL9m/1avsnQpGxxb470SwoN3m5V1MnEEgjAVt8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.60.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.0 h1:hFsMEdmblla+W0mDoe6Z/YbyP70a1vXJ4lE0+1YfB0U=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -388,5 +388,47 @@ func (s *TurnStateSuite) TestTakeAction_RejectsUnknownRefOnHydratedCharacter() {
 	s.ErrorIs(err, encounter.ErrUnsupportedAction)
 }
 
+// TestTakeAction_HelpAndHideFlowThroughDelegation proves the Help and Hide
+// combat abilities (the remaining two of the universal catalog, landed in the
+// dnd5e half rpg-toolkit#702 / v0.61.0) reach the held character's rules engine
+// through the SAME unified verb — no per-ref code in the encounter — with the
+// right target-kind exposed on the menu and the standard action enforced.
+// Like Dodge, Beat-1 proves dispatch generality + economy spend, not the full
+// mechanical effect (Help's advantage / Hide's Stealth check are later beats).
+func (s *TurnStateSuite) TestTakeAction_HelpAndHideFlowThroughDelegation() {
+	enc := s.loadedMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().Equal(monkEntityID, enc.ActiveActor())
+
+	// The menu carries Help (single-entity) and Hide (self) with the action slot.
+	ts := enc.ActorTurnState(monkEntityID)
+	byID := map[string]dnd5eCharacter.AvailableAbility{}
+	for _, a := range ts.Abilities {
+		byID[a.Ref.ID] = a
+	}
+	s.Require().Contains(byID, refs.CombatAbilities.Help().ID, "Help must be in the menu")
+	s.Require().Contains(byID, refs.CombatAbilities.Hide().ID, "Hide must be in the menu")
+	s.Equal(dnd5eCharacter.TargetKindSingleEntity, byID[refs.CombatAbilities.Help().ID].TargetKind)
+	s.Equal(dnd5eCharacter.EconomySlotAction, byID[refs.CombatAbilities.Help().ID].EconomySlot)
+	s.Equal(dnd5eCharacter.TargetKindSelf, byID[refs.CombatAbilities.Hide().ID].TargetKind)
+
+	// Take Hide through the unified verb — spends the standard action.
+	err := enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: refs.CombatAbilities.Hide().Type, ID: refs.CombatAbilities.Hide().ID},
+		encounter.ActionTarget{EntityID: monkEntityID},
+	)
+	s.Require().NoError(err, "Hide must flow through the general delegation")
+	s.Equal(0, enc.ActorTurnState(monkEntityID).Economy.ActionsRemaining, "Hide spends the standard action")
+
+	// With the action spent, Help is now unavailable in the menu (no action left).
+	after := enc.ActorTurnState(monkEntityID)
+	for _, a := range after.Abilities {
+		if a.Ref.ID == refs.CombatAbilities.Help().ID {
+			s.False(a.CanUse, "Help is unavailable once the action is spent")
+			s.NotEmpty(a.Reason)
+		}
+	}
+}
+
 // silence unused import if coreCombat ends up unreferenced in future edits.
 var _ = coreCombat.ActionStandard

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -411,6 +411,7 @@ func (s *TurnStateSuite) TestTakeAction_HelpAndHideFlowThroughDelegation() {
 	s.Equal(dnd5eCharacter.TargetKindSingleEntity, byID[refs.CombatAbilities.Help().ID].TargetKind)
 	s.Equal(dnd5eCharacter.EconomySlotAction, byID[refs.CombatAbilities.Help().ID].EconomySlot)
 	s.Equal(dnd5eCharacter.TargetKindSelf, byID[refs.CombatAbilities.Hide().ID].TargetKind)
+	s.Equal(dnd5eCharacter.EconomySlotAction, byID[refs.CombatAbilities.Hide().ID].EconomySlot)
 
 	// Take Hide through the unified verb — spends the standard action.
 	err := enc.TakeAction(monkPlayerID,
@@ -420,14 +421,18 @@ func (s *TurnStateSuite) TestTakeAction_HelpAndHideFlowThroughDelegation() {
 	s.Require().NoError(err, "Hide must flow through the general delegation")
 	s.Equal(0, enc.ActorTurnState(monkEntityID).Economy.ActionsRemaining, "Hide spends the standard action")
 
-	// With the action spent, Help is now unavailable in the menu (no action left).
-	after := enc.ActorTurnState(monkEntityID)
-	for _, a := range after.Abilities {
-		if a.Ref.ID == refs.CombatAbilities.Help().ID {
-			s.False(a.CanUse, "Help is unavailable once the action is spent")
-			s.NotEmpty(a.Reason)
-		}
+	// With the action spent, Help is still LISTED in the menu but unavailable
+	// (no action left) — the menu pre-empts the illegal action rather than
+	// dropping the entry.
+	afterByID := map[string]dnd5eCharacter.AvailableAbility{}
+	for _, a := range enc.ActorTurnState(monkEntityID).Abilities {
+		afterByID[a.Ref.ID] = a
 	}
+	s.Require().Contains(afterByID, refs.CombatAbilities.Help().ID,
+		"Help stays listed after the action is spent (pre-empted, not dropped)")
+	help := afterByID[refs.CombatAbilities.Help().ID]
+	s.False(help.CanUse, "Help is unavailable once the action is spent")
+	s.NotEmpty(help.Reason, "unavailable Help carries a reason")
 }
 
 // silence unused import if coreCombat ends up unreferenced in future edits.


### PR DESCRIPTION
Follow-up completing the **non-attack catalog** of the TakeAction wave (rpg-project#54). The encounter unification (#701) and the dnd5e Help/Hide constructors (#702) are both merged; this bumps the encounter module to the dnd5e **v0.61.0** tag (#702 produced it) and proves Help and Hide flow through the unified `TakeAction` verb.

## What this does

- **Bump `rulebooks/dnd5e` v0.60.0 → v0.61.0** — the tag carrying the Help/Hide constructors + character seeding (#702).
- **Real-path test** (`turn_state_test.go`, no fixture bypass): Help (single-entity) and Hide (self) appear in the menu with the action slot; Hide flows through the unified verb and spends the standard action; Help becomes unavailable once the action is spent. No per-ref code in the encounter — the character menu is the membership test.
- **Docs:** ADR-0032 non-attack catalog marked complete; `encounter.md` notes the full Dodge/Dash/Disengage/Help/Hide catalog + the v0.61.0 pin.

## Verification (actual output)

`cd encounter`, against the **real published dnd5e v0.61.0** (no replace):
- `go build ./...` → clean
- `go clean -testcache && go test -race ./...` → all 4 packages `ok`
- `golangci-lint run ./...` → no non-test findings
- `TestTakeAction_HelpAndHideFlowThroughDelegation` → PASS

## Scope / follow-ups (documented under #54)

Mechanical effects (Help's advantage to the ally, Hide's Stealth check + Hidden condition) remain follow-ups, matching Dodge's bar — this delivers the dispatch + economy generality.

Part of #697 (completes the non-attack catalog).
Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)