### PR TITLE
feat(encounter): push TurnStateChangedEvent on turn-state/economy mutation (#704)

### DIFF
--- a/docs/adr/0033-turn-state-changed-push-refresh-event.md
+++ b/docs/adr/0033-turn-state-changed-push-refresh-event.md
@@ -1,0 +1,91 @@
+# ADR-0033: TurnStateChangedEvent — push-refresh the menu/economy
+
+Date: 2026-06-01
+
+## Status
+
+Accepted
+
+## Context
+
+North-Star Invariant 12: *"economy/menu refresh is pushed as a delta event — the
+menu never goes silently stale."* After the TakeAction unification (ADR-0032)
+the toolkit computes the per-actor action menu + economy and exposes it as a read
+surface (`Encounter.ActorTurnState`), but nothing **pushed** it: a client would
+have to poll `ActorTurnState` to learn its menu changed after taking an action.
+
+The encounter broker only carries toolkit `EncounterEvent` types. So rpg-api
+could not push a `TurnStateChanged` to the web on its own — synthesizing one in
+the API would author rules-state and bypass the spine (Invariant 2). The
+push-refresh is therefore a toolkit gap: the engine must emit the delta event.
+
+## Decision
+
+Add a `TurnStateChangedEvent` to the encounter spine (`encounter/events`) and
+publish it whenever an actor's turn state mutates.
+
+- **Rulebook-agnostic snapshot.** The spine must not import rulebook types
+  (`encounter/events` carries none today). The event carries a flattened
+  `TurnStateSnapshot` — economy counters (ints) + a `[]MenuEntry` of
+  ref/name/economy-slot/target-kind/available/reason primitives — exactly the
+  `EconomyConsumed`-style flattening already used on the spine. The encounter
+  builds the snapshot from its rulebook-aware `ActorTurnState` at publish time
+  (`buildTurnStateSnapshot`).
+- **Emitted on every turn-state mutation.** Turn start (`seedActorTurn`, after
+  `character.StartTurn`) and every action taken — the non-attack path
+  (`takeCharacterAction`, after the economy diff) and the attack path
+  (`applyAndPublishOutcome`, after `publishAttackOutcome`). One helper,
+  `Encounter.publishTurnStateChanged`, owns the build + publish.
+- **Audience is the actor's controlling player.** Turn state is that player's
+  private "what can I do now" view, so the push is audience-of-one. A no-op for
+  NPCs (no controlling seat) and flat-stat seats (no character menu/economy).
+- **Correlated to its cause (Invariant 8).** The post-action push carries the
+  same correlation id as the `ActionResolvedEvent` that triggered it (the
+  attack/non-attack publish helpers now return the corr id they stamped). The
+  turn-start push carries no correlation id — it is not caused by an action.
+- **Stamped with game-event time (Invariant 5)** via the embedded `eventMeta`,
+  like every spine event; registered in the broker codec.
+
+rpg-api translates this to the proto `TurnStateChanged` (envelope field 45,
+already on the wire), field-for-field.
+
+## Consequences
+
+### Positive
+- The client menu/economy updates live off the stream; it never goes silently
+  stale (Inv 12). No polling.
+- The push is a full snapshot, not a diff — the client always has the complete
+  current menu and cannot drift from missed deltas.
+- The spine stays rulebook-agnostic (primitives only); any rulebook host can
+  consume the event.
+- The post-action push is reassemblable into the combat log with its action via
+  the shared correlation id (Inv 8).
+
+### Negative
+- A full-snapshot push is larger on the wire than a minimal delta. Acceptable:
+  the menu is small and correctness/simplicity (no drift) outweigh the bytes.
+- One more event type the broker codec + any consumer must handle.
+
+### Neutral
+- Movement-step economy deltas (Beat 2) will reuse the same event from the
+  movement path when that lands — no new event shape needed.
+
+## Example
+
+```go
+// After any turn-state mutation the encounter pushes the fresh snapshot:
+//   seedActorTurn  -> publishTurnStateChanged(actor, "")        // turn start
+//   takeCharacterAction -> publishTurnStateChanged(actor, corr) // non-attack
+//   applyAndPublishOutcome -> publishTurnStateChanged(actor, corr) // attack
+//
+// TurnStateChangedEvent{ ActorID, State:{InCombat, economy counters, Menu:[...]} }
+// audience = the actor's controlling player; OccurredAt stamped at publish;
+// CorrelationID = the causing action's id (empty for turn start).
+```
+
+## Related
+
+- ADR-0031 — the event spine (causation id + game-event time + embedded
+  `eventMeta`) this event is built on.
+- ADR-0032 — the TakeAction unification that produced `ActorTurnState`, the read
+  surface this event snapshots.

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -305,6 +305,17 @@ injects `ActionEconomyData{1,1,1}` (North-Star Invariant 2).
 projects to the wire `TurnState` field-for-field (Invariant 11). NPC and
 flat-stat seats return an empty `ActorTurnState`.
 
+**Turn state is push-refreshed, never silently stale (Invariant 12, ADR-0033).**
+Whenever an actor's turn state mutates — turn start (seeding) and every action
+taken (economy deducted) — the encounter publishes a `TurnStateChangedEvent`
+through the broker carrying a full snapshot (economy + menu) of
+`ActorTurnState`, flattened to rulebook-agnostic primitives
+(`events.TurnStateSnapshot` / `MenuEntry`) so the spine stays rulebook-free.
+Audience is the actor's own controlling player (their private "what can I do
+now" view). The post-action push shares the causing action's correlation id
+(Invariant 8); the turn-start push carries none (not caused by an action).
+rpg-api projects this onto the proto `TurnStateChanged` (envelope field 45).
+
 The character menu reports rules truth (a level-1 character *can* move, so
 `Move.CanUse == true`), but `ActorTurnState` composes the **effective**
 takeability the wire `available` flag means: refs this build defers (the

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,6 +11,17 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
+**#704 (TakeAction wave) — encounter pushes TurnStateChangedEvent on
+turn-state/economy mutation (2026-06-01, ADR-0033).** Closes the push-refresh
+gap (North-Star Invariant 12): the encounter now emits a `TurnStateChangedEvent`
+through the broker on turn start and every action taken, carrying a
+rulebook-agnostic snapshot (economy + flattened menu) built from
+`ActorTurnState`. Audience is the actor's controlling player; the post-action
+push shares the causing action's correlation id (Inv 8), turn-start carries
+none. rpg-api projects it onto the proto `TurnStateChanged` (envelope field 45).
+Registered in the broker codec; real-path tests prove the push fires on
+non-attack, attack, and turn-start.
+
 **#697 (TakeAction wave, event-faithfulness PR) — encounter event spine:
 causation + game-event time + resolved-action event (2026-06-01).**
 Added `OccurredAt()` / `CorrelationID()` / `Stamp()` to the `EncounterEvent`

--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -243,6 +243,8 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "EntityDisappearedEvent"
 	case *events.ActionResolvedEvent:
 		typeName = "ActionResolvedEvent"
+	case *events.TurnStateChangedEvent:
+		typeName = "TurnStateChangedEvent"
 	case *events.AttackResolvedEvent:
 		typeName = "AttackResolvedEvent"
 	case *events.DamageDealtEvent:
@@ -319,6 +321,12 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "ActionResolvedEvent":
 		var e events.ActionResolvedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "TurnStateChangedEvent":
+		var e events.TurnStateChangedEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -228,6 +228,12 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 		)); err != nil {
 			return fmt.Errorf("publish first turn started: %w", err)
 		}
+		// Push the fresh turn state after announcing the turn (Invariant 12):
+		// cause (turn started) before the menu/economy refresh. No correlation
+		// id — a turn-start refresh is not caused by an action.
+		if err := e.publishTurnStateChanged(e.data.Initiative[0], ""); err != nil {
+			return fmt.Errorf("publish first turn state: %w", err)
+		}
 	}
 	return nil
 }
@@ -307,6 +313,11 @@ func (e *Encounter) EndTurn(
 		e.data.ID, e.nextSeq(), newActive, e.data.Round, e.allViewersTurnStarted(),
 	)); pubErr != nil {
 		return "", false, fmt.Errorf("publish turn started: %w", pubErr)
+	}
+	// Push the new actor's fresh turn state after announcing their turn
+	// (Invariant 12). No-op for NPCs / stat-snapshot seats. No correlation id.
+	if tsErr := e.publishTurnStateChanged(newActive, ""); tsErr != nil {
+		return "", false, fmt.Errorf("publish turn state: %w", tsErr)
 	}
 
 	return newActive, e.IsNPC(newActive), nil
@@ -414,7 +425,7 @@ func (e *Encounter) publishAttackOutcome(
 	attackerPos, targetPos core.Hex,
 	actionRef string,
 	consumed events.EconomyConsumed,
-) error {
+) (core.CorrelationID, error) {
 	actionPerPlayer := make(map[core.PlayerID]events.ActionResolvedSlice)
 	attackPerPlayer := make(map[core.PlayerID]events.AttackResolvedSlice)
 	damagePerPlayer := make(map[core.PlayerID]events.DamageDealtSlice)
@@ -440,7 +451,7 @@ func (e *Encounter) publishAttackOutcome(
 		consumed, actionPerPlayer,
 	)
 	if err := e.publishCorrelated(actionEvt, corrID); err != nil {
-		return fmt.Errorf("publish action resolved: %w", err)
+		return corrID, fmt.Errorf("publish action resolved: %w", err)
 	}
 
 	if err := e.publishCorrelated(events.NewAttackResolvedEvent(
@@ -449,7 +460,7 @@ func (e *Encounter) publishAttackOutcome(
 		outcome.Hit, outcome.Critical, outcome.AttackRoll, outcome.AttackBonus, outcome.TargetAC,
 		attackPerPlayer,
 	), corrID); err != nil {
-		return fmt.Errorf("publish attack resolved: %w", err)
+		return corrID, fmt.Errorf("publish attack resolved: %w", err)
 	}
 	if outcome.Hit {
 		evt := events.NewDamageDealtEvent(
@@ -461,10 +472,10 @@ func (e *Encounter) publishAttackOutcome(
 		)
 		evt.Components = outcome.Components
 		if err := e.publishCorrelated(evt, corrID); err != nil {
-			return fmt.Errorf("publish damage dealt: %w", err)
+			return corrID, fmt.Errorf("publish damage dealt: %w", err)
 		}
 	}
-	return nil
+	return corrID, nil
 }
 
 // correlationFor derives the correlation id for an action-resolution group

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -357,7 +357,9 @@ func (e *Encounter) applyAndPublishNPCOutcome(monster *MonsterData, player *Play
 	if damageType == "" {
 		damageType = damageTypeUntyped
 	}
-	if err := e.publishAttackOutcome(
+	// NPC attacker has no action menu/economy to refresh, so the corr id is
+	// discarded — no turn-state push for the monster.
+	if _, err := e.publishAttackOutcome(
 		monster.ID, player.EntityID, outcome,
 		player.HP, player.MaxHP, damageType,
 		monster.Position, player.View.Position,
@@ -403,12 +405,18 @@ func (e *Encounter) applyAndPublishOutcome(
 	if damageType == "" {
 		damageType = damageTypeUntyped
 	}
-	if err := e.publishAttackOutcome(
+	corrID, err := e.publishAttackOutcome(
 		player.EntityID, monster.ID, outcome,
 		monster.HP, monster.MaxHP, damageType,
 		player.View.Position, monster.Position,
 		actionRef, consumed,
-	); err != nil {
+	)
+	if err != nil {
+		return err
+	}
+	// Push the post-attack turn state so the attacker's menu/economy refreshes
+	// live (Invariant 12), correlated to the attack that caused it (Invariant 8).
+	if err := e.publishTurnStateChanged(player.EntityID, corrID); err != nil {
 		return err
 	}
 	if outcome.Hit && hpBefore > 0 && monster.HP == 0 {

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -36,6 +36,65 @@ func (s *EventsSuite) TestConcretes_SatisfyInterface() {
 	var _ events.EncounterEvent = (*events.EncounterEndedEvent)(nil)
 	var _ events.EncounterEvent = (*events.ResourceChangedEvent)(nil)
 	var _ events.EncounterEvent = (*events.ActionResolvedEvent)(nil)
+	var _ events.EncounterEvent = (*events.TurnStateChangedEvent)(nil)
+}
+
+// TurnStateChangedEvent JSON round-trip — the nested economy + menu snapshot and
+// spine meta all survive encoding; audience derives from PerPlayer keys.
+func (s *EventsSuite) TestTurnStateChangedEvent_JSONRoundTrip() {
+	at := time.Date(2026, 6, 1, 10, 15, 0, 0, time.UTC)
+	corr := core.CorrelationID("corr-enc-1-31")
+
+	original := events.NewTurnStateChangedEvent(
+		"enc-1", 31, "char-alice",
+		events.TurnStateSnapshot{
+			InCombat:              true,
+			TurnNumber:            2,
+			ActionsRemaining:      0,
+			BonusActionsRemaining: 1,
+			ReactionsRemaining:    1,
+			MovementRemaining:     30,
+			Menu: []events.MenuEntry{
+				{
+					Ref: "dnd5e:combat_abilities:attack", Name: "Attack",
+					EconomySlot: "action", TargetKind: "single_entity",
+					Available: false, Reason: "no action remaining",
+				},
+				{
+					Ref: "dnd5e:actions:move", Name: "Move",
+					EconomySlot: "movement", TargetKind: "position", Available: true,
+				},
+			},
+		},
+		map[core.PlayerID]events.TurnStateChangedSlice{"alice": {Visible: true}},
+	)
+	original.Stamp(at, corr)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.TurnStateChangedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(31), decoded.Sequence())
+	s.Equal(core.EntityID("char-alice"), decoded.ActorID)
+	s.True(decoded.State.InCombat)
+	s.Equal(2, decoded.State.TurnNumber)
+	s.Equal(0, decoded.State.ActionsRemaining)
+	s.Equal(1, decoded.State.BonusActionsRemaining)
+	s.Equal(30, decoded.State.MovementRemaining)
+	s.Require().Len(decoded.State.Menu, 2)
+	s.Equal("dnd5e:combat_abilities:attack", decoded.State.Menu[0].Ref)
+	s.Equal("action", decoded.State.Menu[0].EconomySlot)
+	s.Equal("single_entity", decoded.State.Menu[0].TargetKind)
+	s.False(decoded.State.Menu[0].Available)
+	s.Equal("no action remaining", decoded.State.Menu[0].Reason)
+	s.Equal("dnd5e:actions:move", decoded.State.Menu[1].Ref)
+	s.True(decoded.State.Menu[1].Available)
+	s.Equal(at, decoded.OccurredAt())
+	s.Equal(corr, decoded.CorrelationID())
+	s.ElementsMatch(events.AudienceSet{"alice"}, decoded.Audience())
 }
 
 // Every event exposes the spine metadata accessors (Invariants 5, 8) via the

--- a/encounter/events/turn_state_changed.go
+++ b/encounter/events/turn_state_changed.go
@@ -1,0 +1,156 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// TurnStateChangedEvent is the push-refresh event for an actor's turn state
+// (North-Star Invariant 12: "economy/menu refresh is pushed as a delta event —
+// the menu never goes silently stale"). The encounter publishes it whenever the
+// actor's economy / available menu mutates — turn start (seeding) and every
+// action taken (economy deducted) — so the client updates the menu live off the
+// stream instead of polling.
+//
+// It carries a full snapshot (not a diff): the actor's current economy plus the
+// available abilities/actions menu. rpg-api projects this verbatim onto the
+// proto TurnStateChanged (envelope field 45); the web renders it without knowing
+// rules. The toolkit owns the snapshot (Inv 11) — the API authors nothing.
+//
+// The snapshot is flattened to primitives (strings/ints), NOT rulebook types:
+// the encounter spine stays rulebook-agnostic, exactly as EconomyConsumed does.
+// The encounter builds the snapshot from its rulebook-aware ActorTurnState at
+// publish time.
+type TurnStateChangedEvent struct {
+	eventMeta
+	encID core.EncounterID
+	seq   uint64
+	// ActorID is the entity whose turn state this snapshot describes.
+	ActorID core.EntityID
+	// State is the actor's current turn-state snapshot (economy + menu).
+	State TurnStateSnapshot
+	// PerPlayer is the per-viewer projection. Turn state is the actor's own
+	// private "what can I do now" view, so the audience is the actor's
+	// controlling player.
+	PerPlayer map[core.PlayerID]TurnStateChangedSlice
+}
+
+// TurnStateSnapshot is the rulebook-agnostic, wire-ready snapshot of an actor's
+// turn state: the action economy plus the available menu. All fields are
+// primitives so the encounter spine carries no rulebook types.
+type TurnStateSnapshot struct {
+	// InCombat reports whether the actor has an active economy this turn. When
+	// false the economy fields are zero and Menu is empty (e.g. the actor has no
+	// hydrated character, or is not in combat).
+	InCombat bool `json:"in_combat"`
+	// TurnNumber is the economy's turn counter (0 when not in combat).
+	TurnNumber int `json:"turn_number"`
+	// ActionsRemaining / BonusActionsRemaining / ReactionsRemaining /
+	// MovementRemaining are the current economy counters.
+	ActionsRemaining      int `json:"actions_remaining"`
+	BonusActionsRemaining int `json:"bonus_actions_remaining"`
+	ReactionsRemaining    int `json:"reactions_remaining"`
+	MovementRemaining     int `json:"movement_remaining"`
+	// Menu is the available abilities + actions the actor can take right now,
+	// flattened into one ordered list (abilities first, then granted-capacity
+	// actions). Each entry is the menu data the UI renders.
+	Menu []MenuEntry `json:"menu"`
+}
+
+// MenuEntry is one option in an actor's action menu, flattened to primitives.
+// Mirrors the toolkit-authored AvailableAbility / AvailableAction fields the
+// game server projects field-for-field (Inv 11): ref, name, economy slot,
+// target kind, and effective availability + reason.
+type MenuEntry struct {
+	// Ref is the canonical ref string of the option, e.g.
+	// "dnd5e:combat_abilities:attack" / "dnd5e:actions:strike".
+	Ref string `json:"ref"`
+	// Name is the display name, e.g. "Attack".
+	Name string `json:"name"`
+	// EconomySlot is which slot the option draws from (menu grouping):
+	// "action" / "bonus_action" / "reaction" / "movement" / "free".
+	EconomySlot string `json:"economy_slot"`
+	// TargetKind is what target the UI must prompt for:
+	// "self" / "single_entity" / "position" / "area" / "none".
+	TargetKind string `json:"target_kind"`
+	// Available is the effective takeability ("should the UI offer this now?").
+	Available bool `json:"available"`
+	// Reason is why Available is false (empty when available).
+	Reason string `json:"reason,omitempty"`
+}
+
+// TurnStateChangedSlice is each viewer's projection. Visible says whether the
+// player receives this turn-state refresh (the actor's own controlling player).
+type TurnStateChangedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewTurnStateChangedEvent constructs a TurnStateChangedEvent. The encounter
+// stamps the encounter id and sequence; OccurredAt + CorrelationID are stamped
+// at publish via Stamp.
+func NewTurnStateChangedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	actorID core.EntityID,
+	state TurnStateSnapshot,
+	perPlayer map[core.PlayerID]TurnStateChangedSlice,
+) *TurnStateChangedEvent {
+	return &TurnStateChangedEvent{
+		encID:     encID,
+		seq:       seq,
+		ActorID:   actorID,
+		State:     state,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*TurnStateChangedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *TurnStateChangedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *TurnStateChangedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who receive this turn-state refresh,
+// derived from PerPlayer keys.
+func (e *TurnStateChangedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type turnStateChangedWire struct {
+	metaWire
+	EncID     core.EncounterID                        `json:"encounter_id"`
+	Seq       uint64                                  `json:"sequence"`
+	ActorID   core.EntityID                           `json:"actor_id"`
+	State     TurnStateSnapshot                       `json:"state"`
+	PerPlayer map[core.PlayerID]TurnStateChangedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *TurnStateChangedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(turnStateChangedWire{
+		metaWire:  e.toWire(),
+		EncID:     e.encID,
+		Seq:       e.seq,
+		ActorID:   e.ActorID,
+		State:     e.State,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *TurnStateChangedEvent) UnmarshalJSON(b []byte) error {
+	var w turnStateChangedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.fromWire(w.metaWire)
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.ActorID = w.ActorID
+	e.State = w.State
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/take_character_action.go
+++ b/encounter/take_character_action.go
@@ -84,8 +84,15 @@ func (e *Encounter) takeCharacterAction(
 	// event for this action (Invariant 9 — every action emits one, not just
 	// attacks).
 	consumed := economyConsumedDiff(preEconomy, char.GetActionEconomy())
-	if err := e.publishActionResolved(player.EntityID, target.EntityID, tRef.String(), consumed); err != nil {
+	corrID, err := e.publishActionResolved(player.EntityID, target.EntityID, tRef.String(), consumed)
+	if err != nil {
 		return nil, fmt.Errorf("publish action resolved: %w", err)
+	}
+
+	// Push the post-action turn state so the menu/economy refreshes live
+	// (Invariant 12), correlated to the action that caused it (Invariant 8).
+	if err := e.publishTurnStateChanged(player.EntityID, corrID); err != nil {
+		return nil, fmt.Errorf("publish turn-state changed: %w", err)
 	}
 
 	return &TakeActionOutcome{Resolved: true}, nil
@@ -210,9 +217,12 @@ func positiveDrop(pre, post int) int {
 // non-attack action (Invariant 9). Audience is per-viewer LoS to the actor.
 // Unlike the attack path this publishes only the umbrella event — there is no
 // AttackResolved/Damage for a non-attack action.
+//
+// Returns the correlation id stamped on the event so the caller can tie the
+// follow-on turn-state refresh to the same action (Invariant 8).
 func (e *Encounter) publishActionResolved(
 	actorID, targetID core.EntityID, actionRef string, consumed events.EconomyConsumed,
-) error {
+) (core.CorrelationID, error) {
 	actor := e.findPlayerByEntityID(actorID)
 	perPlayer := make(map[core.PlayerID]events.ActionResolvedSlice)
 	for viewerID, viewer := range e.data.Players {
@@ -226,8 +236,9 @@ func (e *Encounter) publishActionResolved(
 	}
 
 	seq := e.nextSeq()
+	corrID := e.correlationFor(seq)
 	evt := events.NewActionResolvedEvent(
 		e.data.ID, seq, actorID, actionRef, targetID, consumed, perPlayer,
 	)
-	return e.publishCorrelated(evt, e.correlationFor(seq))
+	return corrID, e.publishCorrelated(evt, corrID)
 }

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -48,6 +48,9 @@ func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) er
 	}); err != nil {
 		return fmt.Errorf("seed turn economy for %q: %w", actorID, err)
 	}
+	// The TurnStateChangedEvent push happens at the call site AFTER the
+	// TurnStartedEvent, so the client sees the cause (turn started) before the
+	// menu/economy refresh (Invariant 12) — seedActorTurn only mutates.
 	return nil
 }
 

--- a/encounter/turn_state.go
+++ b/encounter/turn_state.go
@@ -16,7 +16,9 @@ package encounter
 // into an encounter-level, per-actor view.
 
 import (
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
@@ -85,6 +87,95 @@ func (e *Encounter) ActorTurnState(actorID core.EntityID) ActorTurnState {
 		Abilities: char.AvailableAbilities(),
 		Actions:   applyDeferredActions(char.AvailableActions()),
 	}
+}
+
+// publishTurnStateChanged emits a TurnStateChangedEvent for the actor whose
+// turn state just mutated (North-Star Invariant 12: the menu/economy refresh is
+// pushed, never silently stale). Called after every turn-state mutation: turn
+// start (seeding) and each action taken (economy deducted).
+//
+// The snapshot is built from the actor's own rules engine via ActorTurnState
+// and flattened to the rulebook-agnostic events.TurnStateSnapshot. Audience is
+// the actor's controlling player — turn state is that player's private "what can
+// I do now" view. A no-op for actors with no controlling player seat (NPCs) or
+// no hydrated character (stat-snapshot seats): there is no menu to push.
+//
+// corrID ties a post-action refresh to the action that caused it (Invariant 8);
+// pass an empty corrID for turn-start refreshes (not caused by an action).
+func (e *Encounter) publishTurnStateChanged(actorID core.EntityID, corrID core.CorrelationID) error {
+	actor := e.findPlayerByEntityID(actorID)
+	if actor == nil {
+		return nil // NPC or unknown — no controlling player to refresh.
+	}
+	char := e.heldCharacter(actorID)
+	if char == nil {
+		return nil // Stat-snapshot seat — no character menu/economy to push.
+	}
+
+	snapshot := buildTurnStateSnapshot(e.ActorTurnState(actorID))
+	evt := events.NewTurnStateChangedEvent(
+		e.data.ID, e.nextSeq(), actorID, snapshot,
+		map[core.PlayerID]events.TurnStateChangedSlice{actor.ID: {Visible: true}},
+	)
+	return e.publishCorrelated(evt, corrID)
+}
+
+// buildTurnStateSnapshot flattens an ActorTurnState (which holds rulebook types)
+// into the rulebook-agnostic events.TurnStateSnapshot the spine carries. The
+// menu is one ordered list: abilities first, then granted-capacity actions —
+// each flattened to ref/name/slot/target-kind/availability primitives.
+func buildTurnStateSnapshot(ts ActorTurnState) events.TurnStateSnapshot {
+	snap := events.TurnStateSnapshot{}
+	if ts.Economy != nil {
+		snap.InCombat = true
+		snap.TurnNumber = ts.Economy.TurnNumber
+		snap.ActionsRemaining = ts.Economy.ActionsRemaining
+		snap.BonusActionsRemaining = ts.Economy.BonusActionsRemaining
+		snap.ReactionsRemaining = ts.Economy.ReactionsRemaining
+		snap.MovementRemaining = ts.Economy.MovementRemaining
+	}
+	menu := make([]events.MenuEntry, 0, len(ts.Abilities)+len(ts.Actions))
+	for _, a := range ts.Abilities {
+		menu = append(menu, abilityMenuEntry(a))
+	}
+	for _, a := range ts.Actions {
+		menu = append(menu, actionMenuEntry(a))
+	}
+	snap.Menu = menu
+	return snap
+}
+
+// abilityMenuEntry flattens an AvailableAbility to the agnostic MenuEntry.
+func abilityMenuEntry(a character.AvailableAbility) events.MenuEntry {
+	return events.MenuEntry{
+		Ref:         refString(a.Ref),
+		Name:        a.Name,
+		EconomySlot: string(a.EconomySlot),
+		TargetKind:  string(a.TargetKind),
+		Available:   a.CanUse,
+		Reason:      a.Reason,
+	}
+}
+
+// actionMenuEntry flattens an AvailableAction to the agnostic MenuEntry.
+func actionMenuEntry(a character.AvailableAction) events.MenuEntry {
+	return events.MenuEntry{
+		Ref:         refString(a.Ref),
+		Name:        a.Name,
+		EconomySlot: string(a.EconomySlot),
+		TargetKind:  string(a.TargetKind),
+		Available:   a.CanUse,
+		Reason:      a.Reason,
+	}
+}
+
+// refString renders a *core.Ref to its canonical "module:type:id" string, or
+// "" when nil.
+func refString(ref *toolkitcore.Ref) string {
+	if ref == nil {
+		return ""
+	}
+	return ref.String()
 }
 
 // applyDeferredActions composes the encounter's beat-scope onto the character's

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -232,6 +232,104 @@ func (s *TurnStateSuite) TestTakeAction_DodgeFlowsThroughGeneralDelegation() {
 	s.Equal(1, action.EconomyConsumed.Actions, "Dodge consumed one standard action")
 }
 
+// TestTakeAction_PushesTurnStateChanged is the push-refresh proof (North-Star
+// Invariant 12): taking an action emits a TurnStateChangedEvent on the broker
+// carrying the post-action economy + menu snapshot, correlated to the action
+// that caused it (Invariant 8). The client refreshes the menu off the stream —
+// it never goes silently stale.
+func (s *TurnStateSuite) TestTakeAction_PushesTurnStateChanged() {
+	enc := s.loadedMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().Equal(monkEntityID, enc.ActiveActor())
+
+	sub, err := s.broker.Subscribe("enc-ts", monkPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	err = enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: refs.CombatAbilities.Dodge().Type, ID: refs.CombatAbilities.Dodge().ID},
+		encounter.ActionTarget{EntityID: monkEntityID},
+	)
+	s.Require().NoError(err)
+
+	var (
+		action *events.ActionResolvedEvent
+		ts     *events.TurnStateChangedEvent
+	)
+	for _, e := range collectEventsTyped(sub, 500*time.Millisecond) {
+		switch ev := e.(type) {
+		case *events.ActionResolvedEvent:
+			action = ev
+		case *events.TurnStateChangedEvent:
+			ts = ev
+		}
+	}
+
+	s.Require().NotNil(ts, "taking an action must push a TurnStateChangedEvent (Inv 12)")
+	s.Equal(monkEntityID, ts.ActorID)
+
+	// The snapshot reflects the POST-action economy (the standard action is gone).
+	s.True(ts.State.InCombat)
+	s.Equal(0, ts.State.ActionsRemaining, "pushed snapshot reflects the spent action")
+	s.NotEmpty(ts.State.Menu, "pushed snapshot carries the refreshed menu")
+
+	// The menu marks Attack unavailable now (no action left) with a reason —
+	// the pushed delta pre-empts the illegal action (Inv 12), not a stale menu.
+	var attack *events.MenuEntry
+	for i := range ts.State.Menu {
+		if ts.State.Menu[i].Ref == refs.CombatAbilities.Attack().String() {
+			attack = &ts.State.Menu[i]
+		}
+	}
+	s.Require().NotNil(attack, "Attack stays listed in the pushed menu")
+	s.False(attack.Available, "Attack is unavailable in the pushed snapshot (action spent)")
+	s.NotEmpty(attack.Reason)
+
+	// The push is correlated to the action that caused it (Inv 8).
+	s.Require().NotNil(action)
+	s.NotEmpty(ts.CorrelationID())
+	s.Equal(action.CorrelationID(), ts.CorrelationID(),
+		"the turn-state push shares the causing action's correlation id")
+}
+
+// TestSetMode_PushesTurnStateChangedAtTurnStart proves turn-start seeding also
+// pushes a TurnStateChangedEvent (Inv 12) so the menu is live the moment the
+// turn begins — with no correlation id (not caused by an action).
+func (s *TurnStateSuite) TestSetMode_PushesTurnStateChangedAtTurnStart() {
+	enc := s.loadedMonkEncounter()
+
+	sub, err := s.broker.Subscribe("enc-ts", monkPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+
+	var (
+		ts      *events.TurnStateChangedEvent
+		started *events.TurnStartedEvent
+	)
+	for _, e := range collectEventsTyped(sub, 500*time.Millisecond) {
+		switch ev := e.(type) {
+		case *events.TurnStateChangedEvent:
+			ts = ev
+		case *events.TurnStartedEvent:
+			started = ev
+		}
+	}
+	s.Require().NotNil(ts, "turn start must push a TurnStateChangedEvent (Inv 12)")
+	s.Equal(monkEntityID, ts.ActorID)
+	s.True(ts.State.InCombat, "turn-start snapshot is in combat with a seeded economy")
+	s.Equal(1, ts.State.ActionsRemaining, "fresh turn: one standard action")
+	s.Equal(1, ts.State.BonusActionsRemaining)
+	s.Empty(ts.CorrelationID(), "turn-start refresh is not caused by an action — no correlation id")
+
+	// Ordering: the cause (TurnStarted) precedes the consequence (the menu
+	// refresh) in sequence, so a consumer sees "turn started" before the menu.
+	s.Require().NotNil(started, "TurnStartedEvent is delivered to the actor's player")
+	s.Less(started.Sequence(), ts.Sequence(),
+		"TurnStarted must precede the turn-state refresh in sequence")
+}
+
 // combatMonkEncounter builds a TURN_BASED encounter with a hydrated Monk seat
 // AND a goblin target + an always-hit resolver, so the Monk can take a real
 // attack and exercise the two-level economy.
@@ -314,6 +412,56 @@ func (s *TurnStateSuite) TestGoalBehavior_MonkTakesActionThenBonusAction() {
 
 	afterBonus := enc.ActorTurnState(monkEntityID)
 	s.Equal(0, afterBonus.Economy.BonusActionsRemaining, "the bonus unarmed strike consumed the bonus action")
+}
+
+// TestTakeAction_AttackPushesTurnStateChanged proves the ATTACK path also pushes
+// a TurnStateChangedEvent (Inv 12) with the post-attack economy, correlated to
+// the attack (Inv 8) — the attack verb is a citizen of the same push-refresh as
+// every other action.
+func (s *TurnStateSuite) TestTakeAction_AttackPushesTurnStateChanged() {
+	enc := s.combatMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != monkEntityID {
+		_, _, err := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	sub, err := s.broker.Subscribe("enc-ts", monkPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	))
+
+	var (
+		action *events.ActionResolvedEvent
+		ts     *events.TurnStateChangedEvent
+	)
+	for _, e := range collectEventsTyped(sub, 500*time.Millisecond) {
+		switch ev := e.(type) {
+		case *events.ActionResolvedEvent:
+			action = ev
+		case *events.TurnStateChangedEvent:
+			ts = ev
+		}
+	}
+	s.Require().NotNil(ts, "the attack path must push a TurnStateChangedEvent (Inv 12)")
+	s.Equal(monkEntityID, ts.ActorID)
+	s.Equal(0, ts.State.ActionsRemaining, "pushed snapshot reflects the attack's spent action")
+	// The Monk's Martial Arts bonus strike now appears in the pushed menu.
+	var bonus *events.MenuEntry
+	for i := range ts.State.Menu {
+		if ts.State.Menu[i].Ref == refs.Actions.UnarmedStrike().String() {
+			bonus = &ts.State.Menu[i]
+		}
+	}
+	s.Require().NotNil(bonus, "pushed menu surfaces the granted Martial Arts bonus strike")
+	s.Equal("bonus_action", bonus.EconomySlot)
+	s.Require().NotNil(action)
+	s.Equal(action.CorrelationID(), ts.CorrelationID(),
+		"the attack's turn-state push shares the attack's correlation id")
 }
 
 // TestTakeAction_RejectsDeferredMove proves the menu↔verb consistency for a


### PR DESCRIPTION
Part of the **TakeAction** wave (rpg-project#54). Closes the push-refresh gap surfaced by the api lane.

**North-Star Invariant 12:** *"economy/menu refresh is pushed as a delta event — the menu never goes silently stale."* The encounter spine emitted no turn-state event, so rpg-api could not push a `TurnStateChanged` without authoring rules-state and bypassing the spine (Inv 2). This adds the toolkit-emitted event.

## What this does

- **New `events.TurnStateChangedEvent`** on the encounter spine. **Rulebook-agnostic:** carries a flattened `TurnStateSnapshot` (economy counters + `[]MenuEntry` of ref/name/economy-slot/target-kind/available/reason primitives) so the spine imports no rulebook types — exactly like `EconomyConsumed`. Embeds `eventMeta` (game-time timestamp + correlation id). Registered in the broker codec (encode + decode).
- **`Encounter.publishTurnStateChanged`** builds the snapshot from `ActorTurnState` (`buildTurnStateSnapshot` flattens the rulebook types) and publishes it. **Audience is the actor's controlling player** (their private "what can I do now" view); no-op for NPCs and stat-snapshot seats.
- **Emitted on every turn-state mutation:** turn start (after `TurnStartedEvent`, so the cause precedes the refresh) and every action taken (non-attack + attack paths). The post-action push **shares the causing action's correlation id** (Inv 8); the turn-start push carries none. `publishAttackOutcome` / `publishActionResolved` now return the corr id they stamped so the push reuses it.
- rpg-api projects this onto the proto `TurnStateChanged` (envelope field 45, already on the wire).

## Verification (actual output)

`cd encounter`:
- `go build ./...` → clean
- `go clean -testcache && go test -race ./...` → all 4 packages `ok`
- `golangci-lint run ./...` → no production findings; no non-`goconst` test findings (the `goconst`-on-test noise is the local-linter-version quirk CI's pinned linter excludes)

Real-path tests (broker subscription, no fixture bypass): the push fires on a non-attack action (`TestTakeAction_PushesTurnStateChanged`), on an attack with the Monk bonus strike surfacing in the pushed menu (`TestTakeAction_AttackPushesTurnStateChanged`), and at turn start with `TurnStarted` preceding it in sequence (`TestSetMode_PushesTurnStateChangedAtTurnStart`); the pushed snapshot reflects the post-action economy and pre-empts the now-unaffordable action in the menu. Plus the events-package JSON round-trip.

## Contract for the api lane

`TurnStateChangedEvent`: `{ actor_id, state: TurnStateSnapshot, per_player }`.
`TurnStateSnapshot`: `{ in_combat, turn_number, actions_remaining, bonus_actions_remaining, reactions_remaining, movement_remaining, menu: []MenuEntry }`.
`MenuEntry`: `{ ref, name, economy_slot, target_kind, available, reason }` — same vocabularies as the existing menu (EconomySlot/TargetKind). Plus the spine `occurred_at` + `correlation_id`.

## Scope / follow-ups

Movement-step economy deltas (Beat 2) will reuse this event from the movement path. Proto/api translation is the api lane.

Docs: ADR-0033; `encounter.md` push-refresh section; `status.md`.

Closes #704
Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)