### PR TITLE
fix(character): re-init Granted map on LoadFromData to fix nil-map panic (#706)

### DIFF
--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -373,7 +373,17 @@ func (s *ActionEconomyTestSuite) TestSeededEconomy_RoundTrip_ActivateAbility_NoN
 	data := char.ToData()
 	raw, err := json.Marshal(data)
 	s.Require().NoError(err)
-	s.NotContains(string(raw), `"granted"`, "empty Granted is omitted from the JSON (omitempty)")
+
+	// Assert the omitempty drop precisely on the action_economy object (a
+	// substring scan of the whole blob could false-fail on an unrelated
+	// "granted" key in some other serialized field).
+	var envelope struct {
+		ActionEconomy map[string]json.RawMessage `json:"action_economy"`
+	}
+	s.Require().NoError(json.Unmarshal(raw, &envelope))
+	s.Require().NotNil(envelope.ActionEconomy, "action_economy is present in the JSON")
+	s.NotContains(envelope.ActionEconomy, "granted",
+		"empty Granted is omitted from the action_economy JSON (omitempty)")
 
 	var reloadedData Data
 	s.Require().NoError(json.Unmarshal(raw, &reloadedData))

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -351,6 +351,56 @@ func (s *ActionEconomyTestSuite) TestLoadFromData_RoundTrip() {
 	s.Equal(2, roundTripped.ActionEconomy.Granted[GrantedAttacks])
 }
 
+// TestSeededEconomy_RoundTrip_ActivateAbility_NoNilMapPanic is the #706
+// regression: StartTurn seeds an EMPTY Granted map, which json:"granted,omitempty"
+// drops from the serialized JSON, so after a full JSON round-trip the loaded
+// character's Granted is nil. Activating an ability then writes into Granted via
+// fromToolkitActionEconomy and would panic ("assignment to entry in nil map")
+// without the LoadFromData re-init. Reproduces the api seeding path (#598) — and
+// the toolkit's own EndTurn→persist→reload — by marshaling to JSON and back, not
+// just passing the struct.
+func (s *ActionEconomyTestSuite) TestSeededEconomy_RoundTrip_ActivateAbility_NoNilMapPanic() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+
+	// Seed the turn economy — this sets Granted to an empty map.
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{Speed: 30})
+	s.Require().NoError(err)
+	s.Require().NotNil(char.actionEconomy)
+	s.Require().Empty(char.actionEconomy.Granted, "StartTurn seeds an empty Granted map")
+
+	// Serialize → JSON → back, faithfully reproducing the omitempty drop the
+	// host (rpg-api) hits when it persists and reloads the character.
+	data := char.ToData()
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+	s.NotContains(string(raw), `"granted"`, "empty Granted is omitted from the JSON (omitempty)")
+
+	var reloadedData Data
+	s.Require().NoError(json.Unmarshal(raw, &reloadedData))
+	s.Nil(reloadedData.ActionEconomy.Granted, "Granted comes back nil after the omitempty round-trip")
+
+	loaded, err := LoadFromData(s.ctx, &reloadedData, events.NewEventBus())
+	s.Require().NoError(err)
+
+	// The fix: the loaded economy's Granted is a fresh writable map, not nil.
+	s.Require().NotNil(loaded.GetActionEconomy())
+	s.NotNil(loaded.GetActionEconomy().Granted, "LoadFromData must re-init a writable Granted map (#706)")
+
+	// Activating the Attack ability writes into Granted (grants attacks). This
+	// is the line that panicked on the nil map before the fix.
+	s.Require().NotPanics(func() {
+		out, actErr := loaded.ActivateAbility(s.ctx, &ActivateAbilityInput{
+			AbilityRef: refs.CombatAbilities.Attack(),
+		})
+		s.Require().NoError(actErr)
+		s.True(out.Success, "Attack should activate after a seeded-economy round-trip")
+	})
+
+	// The granted capacity was recorded (proves Granted is live, not just non-nil).
+	s.Positive(loaded.GetActionEconomy().Granted[GrantedAttacks],
+		"activating Attack must grant attack capacity into the reloaded economy")
+}
+
 func (s *ActionEconomyTestSuite) TestLoadFromData_NilActionEconomy() {
 	// Create minimal valid Data without action economy
 	data := &Data{

--- a/rulebooks/dnd5e/character/data.go
+++ b/rulebooks/dnd5e/character/data.go
@@ -159,11 +159,19 @@ func LoadFromData(ctx context.Context, d *Data, bus events.EventBus) (*Character
 		resources:       make(map[coreResources.ResourceKey]*combat.RecoverableResource),
 	}
 
-	// Deep-copy action economy state to avoid aliasing mutable Granted map
+	// Deep-copy action economy state to avoid aliasing mutable Granted map.
+	// Granted is tagged json:"granted,omitempty", so a freshly-StartTurn-seeded
+	// EMPTY map is omitted from the serialized JSON and comes back nil after a
+	// round-trip. fromToolkitActionEconomy writes into Granted unconditionally,
+	// so a nil map there panics ("assignment to entry in nil map") on the next
+	// ability activation. Always re-init: clone when non-nil, else make a fresh
+	// empty map so the loaded economy is immediately writable (#706).
 	if d.ActionEconomy != nil {
 		aeCopy := *d.ActionEconomy
 		if d.ActionEconomy.Granted != nil {
 			aeCopy.Granted = maps.Clone(d.ActionEconomy.Granted)
+		} else {
+			aeCopy.Granted = make(map[GrantedActionKey]int)
 		}
 		char.actionEconomy = &aeCopy
 	}


### PR DESCRIPTION
Part of the **TakeAction** wave (rpg-project#54). **Unblocks the api seeding gap-closer (rpg-api #598).**

## Bug

`StartTurn` seeds `ActionEconomyData.Granted` as an empty map. `Granted` is tagged `json:"granted,omitempty"`, so an **empty** map is **omitted** from the serialized JSON and comes back **nil** after a round-trip. `LoadFromData` only cloned `Granted` when non-nil, so the loaded character's `Granted` stayed nil — and the next ability activation (`fromToolkitActionEconomy` writes `Granted[...]` unconditionally) panicked `assignment to entry in nil map`.

It bites ANY seeded-economy round-trip — the toolkit's own EndTurn→persist→reload AND the api seeding path — and was blocking rpg-api #598.

## Fix (~5 lines, `data.go`)

`LoadFromData` always re-inits `Granted`: clone when non-nil, else `make` a fresh empty map so the loaded economy is immediately writable.

```go
if d.ActionEconomy.Granted != nil {
    aeCopy.Granted = maps.Clone(d.ActionEconomy.Granted)
} else {
    aeCopy.Granted = make(map[GrantedActionKey]int)
}
```

## Regression test

`TestSeededEconomy_RoundTrip_ActivateAbility_NoNilMapPanic`: seed economy → `ToData` → JSON marshal/unmarshal (faithfully reproducing the `omitempty` drop, asserting `"granted"` is absent + comes back nil) → `LoadFromData` → `ActivateAbility(attack)`. Asserts no panic + the granted capacity is recorded. **Verified the test panics without the fix** (`assignment to entry in nil map`).

## Verification (actual output)

`cd rulebooks/dnd5e`:
- `go build ./...` → BUILD OK
- `go clean -testcache && go test -race ./...` → 0 FAILs (all packages `ok`)
- `golangci-lint run ./character/...` → no non-`goconst` findings; no go.mod drift

Closes #706
Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)