### PR TITLE
fix(encounter): granted strikes resolve as real attacks, not economy no-ops

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -147,6 +147,67 @@ func (e *Encounter) spendAttackEconomy(player *PlayerData) (events.EconomyConsum
 	return economyConsumedDiff(pre, char.GetActionEconomy()), nil
 }
 
+// isGrantedStrikeRef reports whether the ref is one of the granted-capacity
+// strike actions (Strike / Off-Hand Strike / Flurry Strike / the Monk's
+// Martial Arts bonus Unarmed Strike). A granted strike is a REAL attack —
+// it resolves through the same combat-resolver path as the attack ref
+// (attack roll, damage, reaction prompts), not just an economy deduction
+// (#708: before this, granted strikes consumed capacity but never swung).
+func isGrantedStrikeRef(ref ActionRef) bool {
+	switch ref.ID {
+	case refs.Actions.Strike().ID,
+		refs.Actions.OffHandStrike().ID,
+		refs.Actions.FlurryStrike().ID,
+		refs.Actions.UnarmedStrike().ID:
+		return true
+	default:
+		return false
+	}
+}
+
+// spendStrikeEconomy validates and deducts a granted strike off the held
+// character's two-level economy, returning what it consumed. The strike-path
+// mirror of spendAttackEconomy: it runs BEFORE the combat resolver so the
+// economy gates the swing — a strike with no granted capacity (or, for the
+// Monk bonus strike, no bonus action) is rejected with ErrActionUnaffordable
+// and the resolver never runs.
+//
+// The spend goes through the character's own engine (ExecuteAction), which
+// owns the per-strike rules: which capacity key it draws from, any slot cost
+// (the Monk bonus strike also spends the bonus action), and post-strike
+// grants (a main-hand Strike re-checks Martial Arts / two-weapon grants).
+// The request's target is passed through on ExecuteActionInput.TargetID.
+//
+// Unlike the attack ref, a granted strike only exists on a hydrated
+// character's economy — a flat stat-snapshot seat has no granted capacity to
+// spend, so ErrNonCombatant is returned rather than a permissive fallback.
+func (e *Encounter) spendStrikeEconomy(
+	player *PlayerData, ref ActionRef, target ActionTarget,
+) (events.EconomyConsumed, error) {
+	char := e.heldCharacter(player.EntityID)
+	if char == nil {
+		return events.EconomyConsumed{}, fmt.Errorf(
+			"%w: player %q has no hydrated character for strike %q",
+			ErrNonCombatant, player.ID, ref.ID)
+	}
+
+	pre := snapshotEconomy(char.GetActionEconomy())
+
+	tRef := toolkitRef(ref)
+	out, err := char.ExecuteAction(context.Background(), &dnd5eCharacter.ExecuteActionInput{
+		ActionRef: &tRef,
+		TargetID:  string(target.EntityID),
+	})
+	if err != nil {
+		return events.EconomyConsumed{}, fmt.Errorf("execute strike %q: %w", ref.ID, err)
+	}
+	if !out.Success {
+		return events.EconomyConsumed{}, fmt.Errorf("%w: %q: %s", ErrActionUnaffordable, ref.ID, out.Error)
+	}
+
+	return economyConsumedDiff(pre, char.GetActionEconomy()), nil
+}
+
 // isPlayerCombatant reports whether a player seat carries the minimum
 // combat snapshot required for TakeAction. PlayerInput documents that a
 // zero combat snapshot opts a seat out of combat verbs; this helper is

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -63,13 +63,16 @@ func (e *Encounter) TakeActionPhased(
 		return nil, fmt.Errorf("%w: active=%q got=%q", ErrNotYourTurn, active, player.EntityID)
 	}
 
-	// General dispatch (Beat-1): the attack ref keeps the two-phase resolver
-	// path below (it carries reaction-prompt handling); every other ref
+	// General dispatch (Beat-1): the attack ref AND the granted-capacity
+	// strike refs resolve as attacks through the two-phase resolver path below
+	// (attack roll, damage, reaction-prompt handling) — a granted strike is a
+	// real swing, not an economy bookkeeping entry (#708). Every other ref
 	// delegates to the held character's own rules engine (ActivateAbility /
 	// ExecuteAction). This replaces the former `ref.ID != "attack"` hard gate —
 	// "default to one system": the character package's dispatch is the catalog,
 	// not a parallel registry built here.
-	if ref.ID != actionIDAttack {
+	isStrike := isGrantedStrikeRef(ref)
+	if ref.ID != actionIDAttack && !isStrike {
 		return e.takeCharacterAction(context.Background(), player, ref, target)
 	}
 
@@ -92,9 +95,19 @@ func (e *Encounter) TakeActionPhased(
 	// action left is rejected here (ErrActionUnaffordable) and the resolver never
 	// runs — no damage from an unaffordable attack (#697 Beat-1: economy enforced
 	// server-side). A flat stat-snapshot seat (no character) returns the honest
-	// one-action cost and is not gated. consumed flows onto the resolved-action
-	// event so it reports the true cost.
-	consumed, err := e.spendAttackEconomy(player)
+	// one-action cost and is not gated (attack ref only — a granted strike has
+	// no snapshot equivalent). consumed flows onto the resolved-action event so
+	// it reports the true cost.
+	var consumed events.EconomyConsumed
+	var err error
+	if isStrike {
+		// A granted strike spends its capacity (plus any slot cost — the Monk
+		// bonus strike also spends the bonus action) via the character's own
+		// engine, then swings through the same resolver path below (#708).
+		consumed, err = e.spendStrikeEconomy(player, ref, target)
+	} else {
+		consumed, err = e.spendAttackEconomy(player)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/encounter/take_character_action.go
+++ b/encounter/take_character_action.go
@@ -2,15 +2,17 @@ package encounter
 
 // Beat-1 of the TakeAction wave (rpg-project #54 / #697 chunk 2).
 //
-// General (non-attack) action dispatch. The attack ref keeps its dedicated
-// two-phase resolver path in TakeActionPhased (it carries reaction prompts and
-// damage resolution); every OTHER action ref flows through here, delegating to
-// the held character's own rules engine. There is no per-ref logic in the
-// encounter beyond "is this an ability or a granted-capacity action" — the
-// character package owns the catalog (ActivateAbility routes combat abilities +
-// features; ExecuteAction routes the granted-capacity strikes / move). This is
-// the "default to one system" unification: the encounter deletes its hardcoded
-// attack gate and consults the menu/economy engine that already exists.
+// General (non-attack) action dispatch. The attack ref AND the granted-capacity
+// strike refs keep their dedicated two-phase resolver path in TakeActionPhased
+// (they carry attack rolls, damage resolution, and reaction prompts — #708);
+// every OTHER action ref flows through here, delegating to the held
+// character's own rules engine. There is no per-ref logic in the encounter
+// beyond "is this an ability or a granted-capacity action" — the character
+// package owns the catalog (ActivateAbility routes combat abilities +
+// features; ExecuteAction routes the remaining granted-capacity actions, e.g.
+// move). This is the "default to one system" unification: the encounter
+// deletes its hardcoded attack gate and consults the menu/economy engine that
+// already exists.
 //
 // The action runs on the held *character.Character (the LoadFromData-cascade
 // instance, #689) — never a re-load. It captures any condition the action
@@ -100,8 +102,11 @@ func (e *Encounter) takeCharacterAction(
 
 // dispatchCharacterAction routes the ref to the character engine: an ability
 // (combat ability or feature) goes through ActivateAbility; a granted-capacity
-// action (strike, move) goes through ExecuteAction. Membership is decided by
-// the character's own menu, so no ref is enumerated here.
+// action goes through ExecuteAction. Membership is decided by the character's
+// own menu, so no ref is enumerated here. Note the granted STRIKES never reach
+// this path — TakeActionPhased routes them down the attack-resolver path
+// (spendStrikeEconomy owns their ExecuteAction spend) so they swing (#708);
+// today only move (deferred) and future non-attack granted actions land here.
 func (e *Encounter) dispatchCharacterAction(
 	ctx context.Context, char *dnd5eCharacter.Character, ref ActionRef, tRef *toolkitcore.Ref,
 ) error {

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -414,6 +414,142 @@ func (s *TurnStateSuite) TestGoalBehavior_MonkTakesActionThenBonusAction() {
 	s.Equal(0, afterBonus.Economy.BonusActionsRemaining, "the bonus unarmed strike consumed the bonus action")
 }
 
+// recordingResolver wraps alwaysHitResolver and records every AttackInput it
+// receives, so tests can assert WHICH refs reached the resolver (a granted
+// strike must swing through the resolver, not just book economy — #708).
+type recordingResolver struct {
+	alwaysHitResolver
+	inputs []encounter.AttackInput
+}
+
+func (r *recordingResolver) ResolveAttack(input encounter.AttackInput) (*encounter.AttackOutcome, error) {
+	r.inputs = append(r.inputs, input)
+	return r.alwaysHitResolver.ResolveAttack(input)
+}
+
+// TestTakeAction_GrantedStrikeResolvesAttack is the #708 regression proof: a
+// granted strike (the Monk's Martial Arts bonus unarmed strike) taken through
+// TakeAction is a REAL attack — it reaches the combat resolver with the
+// strike's own ref + target, deals damage (target HP drops), and publishes the
+// full attack event group (ActionResolved + AttackResolved + DamageDealt on
+// one correlation id) — in addition to consuming the granted capacity and the
+// bonus action. Before the fix the strike consumed economy and emitted only
+// ActionResolved: no attack roll, no damage (economy-only no-op).
+func (s *TurnStateSuite) TestTakeAction_GrantedStrikeResolvesAttack() {
+	resolver := &recordingResolver{alwaysHitResolver: alwaysHitResolver{damage: 3, damageType: "bludgeoning"}}
+	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	data := encounter.NewData("enc-ts")
+	data.Players[monkPlayerID] = &encounter.PlayerData{
+		ID:         monkPlayerID,
+		EntityID:   monkEntityID,
+		View:       view,
+		HP:         9,
+		MaxHP:      9,
+		AC:         15,
+		DamageDice: "1d4",
+		DamageType: "bludgeoning",
+		DataJSON:   s.monkCharJSON(),
+	}
+	data.Monsters["goblin-1"] = &encounter.MonsterData{
+		ID:       "goblin-1",
+		Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP:       7,
+		MaxHP:    7,
+		AC:       12,
+	}
+	enc, err := encounter.LoadFromData(s.ctx, data, s.broker, encounter.WithCombatResolver(resolver))
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != monkEntityID {
+		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	// 1) Attack grants the Monk's Martial Arts bonus strike (and damages 7→4).
+	s.Require().NoError(enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	))
+	s.Require().Equal(4, enc.ToData().Monsters["goblin-1"].HP, "the Attack itself dealt damage")
+
+	sub, err := s.broker.Subscribe("enc-ts", monkPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	// 2) The granted bonus unarmed strike — this must SWING, not just book economy.
+	strikeRef := refs.Actions.UnarmedStrike()
+	s.Require().NoError(enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: strikeRef.Type, ID: strikeRef.ID},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	))
+
+	// The strike reached the resolver with its own ref + target (#708).
+	s.Require().Len(resolver.inputs, 2, "attack AND bonus strike must both reach the resolver")
+	strikeInput := resolver.inputs[1]
+	s.Equal(strikeRef.ID, strikeInput.ActionRef.ID, "the strike's own ref reaches the resolver")
+	s.Equal(core.EntityID("goblin-1"), strikeInput.TargetID, "the request's target reaches the resolver")
+
+	// The strike dealt damage: goblin HP dropped again (4 → 1).
+	s.Equal(1, enc.ToData().Monsters["goblin-1"].HP, "the granted strike must deal damage")
+
+	// Economy: the granted capacity AND the bonus action are spent.
+	after := enc.ActorTurnState(monkEntityID)
+	s.Equal(0, after.Economy.BonusActionsRemaining, "the bonus strike consumed the bonus action")
+
+	// The full attack event group fired for the strike, on ONE correlation id,
+	// with the resolved-action event carrying the strike's ref + real spend.
+	var (
+		action *events.ActionResolvedEvent
+		attack *events.AttackResolvedEvent
+		damage *events.DamageDealtEvent
+	)
+	for _, e := range collectEventsTyped(sub, 500*time.Millisecond) {
+		switch ev := e.(type) {
+		case *events.ActionResolvedEvent:
+			action = ev
+		case *events.AttackResolvedEvent:
+			attack = ev
+		case *events.DamageDealtEvent:
+			damage = ev
+		}
+	}
+	s.Require().NotNil(action, "the strike emits ActionResolved (Inv 9)")
+	s.Equal(strikeRef.String(), action.ActionRef, "ActionResolved carries the strike's own ref")
+	s.Equal(1, action.EconomyConsumed.BonusActions, "the strike's real economy spend is reported")
+	s.Equal(1, action.EconomyConsumed.GrantedConsumed["martial_arts_bonus"],
+		"the granted capacity spend is reported")
+	s.Require().NotNil(attack, "the strike emits AttackResolved — it is a real attack")
+	s.Require().NotNil(damage, "the strike emits DamageDealt on hit")
+	s.Equal(action.CorrelationID(), attack.CorrelationID(), "one correlation id for the group")
+	s.Equal(action.CorrelationID(), damage.CorrelationID(), "one correlation id for the group")
+}
+
+// TestTakeAction_GrantedStrikeRejectedWithoutGrant proves the economy gate on
+// the strike path: a bonus unarmed strike with NO granted capacity (no Attack
+// taken this turn) is rejected with ErrActionUnaffordable and deals no damage —
+// the resolver never runs.
+func (s *TurnStateSuite) TestTakeAction_GrantedStrikeRejectedWithoutGrant() {
+	enc := s.combatMonkEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != monkEntityID {
+		_, _, err := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	hpBefore := enc.ToData().Monsters["goblin-1"].HP
+	strikeRef := refs.Actions.UnarmedStrike()
+	err := enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: strikeRef.Type, ID: strikeRef.ID},
+		encounter.ActionTarget{EntityID: "goblin-1"},
+	)
+	s.ErrorIs(err, encounter.ErrActionUnaffordable,
+		"a strike without granted capacity must be rejected by the economy gate")
+	s.Equal(hpBefore, enc.ToData().Monsters["goblin-1"].HP,
+		"a rejected strike must not resolve damage")
+}
+
 // TestTakeAction_AttackPushesTurnStateChanged proves the ATTACK path also pushes
 // a TurnStateChangedEvent (Inv 12) with the post-attack economy, correlated to
 // the attack (Inv 8) — the attack verb is a citizen of the same push-refresh as


### PR DESCRIPTION
Closes #708
Part of KirkDiggler/rpg-project#54

## What

Granted-capacity strikes (`strike`, `off_hand_strike`, `flurry_strike`, `unarmed_strike`) taken through `TakeAction` were economy-only no-ops: they consumed the granted capacity (and the Monk bonus strike's bonus action), emitted ActionResolved + TurnStateChanged, **but never produced an attack roll or damage**. Confirmed in the live MCP playtest (fixture wave-2-monk): `TakeAction(dnd5e:actions:unarmed_strike)` left the goblin's HP unchanged in Redis.

Root cause: `takeCharacterAction` dispatched strike refs to `char.ExecuteAction` without the request's target (despite `ExecuteActionInput.TargetID` existing "for strikes"), and nothing resolved the attack afterward — `ExecuteActionOutput`'s contract says attack resolution is the caller's job, and the encounter caller never did it.

## Fix

- `TakeActionPhased` now routes the four granted strike refs down the **same two-phase resolver path as the attack ref** (attack roll, damage, death chain, reaction prompts, per-viewer projection).
- New `spendStrikeEconomy` mirrors `spendAttackEconomy`: validates + deducts the strike via the character's own `ExecuteAction` (with the target on `TargetID`) **before** the resolver runs — an unaffordable strike (no grant / no bonus action) is rejected with `ErrActionUnaffordable` and never swings.
- The resolver input carries the strike's own ref; ActionResolved reports the real economy diff (`grantedConsumed` + slot cost). All three events share one correlation id.

## Tests (failing-first)

- `TestTakeAction_GrantedStrikeResolvesAttack` — Monk Attack → granted bonus unarmed strike reaches the resolver with its own ref + target, target HP drops, ActionResolved + AttackResolved + DamageDealt share one correlation id, bonus action + granted capacity consumed. (Failed on main: strike never reached the resolver, HP unchanged.)
- `TestTakeAction_GrantedStrikeRejectedWithoutGrant` — strike without granted capacity → `ErrActionUnaffordable`, no damage. (Failed on main: `ErrUnsupportedAction` from menu-membership fallthrough.)

Full encounter suite green with `-race`.

## Known gap left open (noted, not fixed here)

Weapon fidelity for strike refs at the resolver: rpg-api's `Dnd5eCombatResolver.resolveWeapon` selects by `AttackHand`/equipped slot and ignores `ActionRef`, so an `unarmed_strike` by a weapon-holding monk would resolve with the main-hand weapon, and `off_hand_strike` with the main-hand weapon (setting `AttackHand="off"` today would hard-fail: the resolver prep doesn't wire `TwoWeaponContext`). Correct for the wave fixture (unarmed monk); the ref→weapon mapping is rules knowledge that should be exposed by the toolkit and consumed by the resolver — follow-up filed as #712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm