### PR TITLE
fix(dnd5e): Martial Arts applies the DEX swap to the attack roll, not just damage

### DIFF
--- a/rulebooks/dnd5e/conditions/martial_arts.go
+++ b/rulebooks/dnd5e/conditions/martial_arts.go
@@ -62,6 +62,17 @@ func (ma *MartialArtsCondition) Apply(ctx context.Context, bus events.EventBus) 
 	}
 	ma.subscriptionIDs = append(ma.subscriptionIDs, subID)
 
+	// Subscribe to AttackChain so the ATTACK ROLL uses DEX when it is higher,
+	// matching the damage swap above — attack and damage must agree on the
+	// governing ability (#709: the swap applied to damage only, so a DEX monk
+	// attacked at STR + prof while its damage credited DEX).
+	attackChain := dnd5eEvents.AttackChain.On(bus)
+	attackSubID, err := attackChain.SubscribeWithChain(ctx, ma.onAttackChain)
+	if err != nil {
+		return rpgerr.Wrap(err, "failed to subscribe to attack chain")
+	}
+	ma.subscriptionIDs = append(ma.subscriptionIDs, attackSubID)
+
 	return nil
 }
 
@@ -137,19 +148,10 @@ func (ma *MartialArtsCondition) onDamageChain(
 	}
 
 	// Check if this is an unarmed strike or monk weapon
-	isUnarmed := event.WeaponRef == nil || event.WeaponRef == refs.Weapons.UnarmedStrike()
-	isMonkWeaponAttack := false
-
-	if !isUnarmed && event.WeaponRef != nil {
-		// Try to get the weapon to check if it's a monk weapon
-		weapon, err := weapons.GetByID(event.WeaponRef.ID)
-		if err == nil {
-			isMonkWeaponAttack = isMonkWeapon(&weapon)
-		}
-	}
+	isUnarmed, monkWeapon := martialArtsWeaponKind(event.WeaponRef)
 
 	// Only modify if it's an unarmed strike or monk weapon
-	if !isUnarmed && !isMonkWeaponAttack {
+	if !isUnarmed && monkWeapon == nil {
 		return c, nil
 	}
 
@@ -230,6 +232,76 @@ func (ma *MartialArtsCondition) onDamageChain(
 	}
 
 	return c, nil
+}
+
+// onAttackChain swaps the attack roll's governing ability to DEX for unarmed
+// strikes and monk weapons when DEX is higher — the attack-roll mirror of the
+// damage swap in onDamageChain, so attack and damage agree on the governing
+// ability (#709: the swap applied to damage only, leaving the attack at STR).
+func (ma *MartialArtsCondition) onAttackChain(
+	ctx context.Context,
+	event dnd5eEvents.AttackChainEvent,
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	// Only modify attacks by this character
+	if event.AttackerID != ma.CharacterID {
+		return c, nil
+	}
+
+	// Get character registry to check ability scores
+	registry, err := gamectx.RequireCharacters(ctx)
+	if err != nil {
+		return c, err
+	}
+	abilityScores := registry.GetCharacterAbilityScores(ma.CharacterID)
+	if abilityScores == nil {
+		return c, nil
+	}
+
+	// Only modify if it's an unarmed strike or monk weapon
+	isUnarmed, monkWeapon := martialArtsWeaponKind(event.WeaponRef)
+	if !isUnarmed && monkWeapon == nil {
+		return c, nil
+	}
+
+	// Finesse monk weapons (e.g. shortsword) already attack with the higher of
+	// STR/DEX on the base path — adjusting again would double-count DEX.
+	if monkWeapon != nil && monkWeapon.HasProperty(weapons.PropertyFinesse) {
+		return c, nil
+	}
+
+	modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+		dexMod := abilityScores.DexterityMod()
+		strMod := abilityScores.StrengthMod()
+		if dexMod > strMod {
+			// The base bonus used STR (melee, non-finesse); replace it with
+			// DEX by applying the difference — same rule the damage chain
+			// applies to the ability component.
+			e.AttackBonus += dexMod - strMod
+		}
+		return e, nil
+	}
+
+	if err = c.Add(combat.StageFeatures, "martial_arts", modifyAttack); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to apply martial arts attack bonus for character %s", ma.CharacterID)
+	}
+
+	return c, nil
+}
+
+// martialArtsWeaponKind classifies an attack's weapon for Martial Arts
+// purposes: whether it is an unarmed strike (nil ref or the unarmed-strike
+// ref), and otherwise whether it is a monk weapon (returned so callers can
+// inspect properties, e.g. Finesse). A non-monk weapon returns (false, nil).
+func martialArtsWeaponKind(weaponRef *core.Ref) (isUnarmed bool, monkWeapon *weapons.Weapon) {
+	if weaponRef == nil || weaponRef.ID == refs.Weapons.UnarmedStrike().ID {
+		return true, nil
+	}
+	weapon, err := weapons.GetByID(weaponRef.ID)
+	if err != nil || !isMonkWeapon(&weapon) {
+		return false, nil
+	}
+	return false, &weapon
 }
 
 // getMartialArtsDice returns the damage dice for unarmed strikes based on monk level

--- a/rulebooks/dnd5e/conditions/martial_arts.go
+++ b/rulebooks/dnd5e/conditions/martial_arts.go
@@ -58,6 +58,7 @@ func (ma *MartialArtsCondition) Apply(ctx context.Context, bus events.EventBus) 
 	damageChain := dnd5eEvents.DamageChain.On(bus)
 	subID, err := damageChain.SubscribeWithChain(ctx, ma.onDamageChain)
 	if err != nil {
+		ma.bus = nil
 		return rpgerr.Wrap(err, "failed to subscribe to damage chain")
 	}
 	ma.subscriptionIDs = append(ma.subscriptionIDs, subID)
@@ -69,6 +70,9 @@ func (ma *MartialArtsCondition) Apply(ctx context.Context, bus events.EventBus) 
 	attackChain := dnd5eEvents.AttackChain.On(bus)
 	attackSubID, err := attackChain.SubscribeWithChain(ctx, ma.onAttackChain)
 	if err != nil {
+		// Roll back the damage-chain subscription so a failed Apply leaves no
+		// partial state (mirrors DodgingCondition.Apply).
+		_ = ma.Remove(ctx, bus)
 		return rpgerr.Wrap(err, "failed to subscribe to attack chain")
 	}
 	ma.subscriptionIDs = append(ma.subscriptionIDs, attackSubID)

--- a/rulebooks/dnd5e/conditions/martial_arts_test.go
+++ b/rulebooks/dnd5e/conditions/martial_arts_test.go
@@ -689,6 +689,158 @@ func (s *MartialArtsTestSuite) TestNonMonkWeaponNotModified() {
 	s.Equal(abilities.STR, finalEvent.AbilityUsed)
 }
 
+// runAttackChain publishes an AttackChainEvent through the attack modifier
+// chain and returns the executed (final) event.
+func (s *MartialArtsTestSuite) runAttackChain(event dnd5eEvents.AttackChainEvent) dnd5eEvents.AttackChainEvent {
+	s.T().Helper()
+	attackChain := dnd5eEvents.AttackChain.On(s.bus)
+	chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+
+	modifiedChain, err := attackChain.PublishWithChain(s.ctx, event, chain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, event)
+	s.Require().NoError(err)
+	return finalEvent
+}
+
+// TestAttackBonusUsesDEX is the regression test for
+// https://github.com/KirkDiggler/rpg-toolkit/issues/709: the Martial Arts
+// "use DEX when higher" swap applied to the damage chain but NOT the attack
+// chain, so a DEX monk's unarmed attack rolled with STR + prof while its
+// damage credited DEX — attack and damage disagreed on the governing ability.
+func (s *MartialArtsTestSuite) TestAttackBonusUsesDEX() {
+	s.Run("unarmed strike with DEX > STR - attack bonus swaps to DEX", func() {
+		// Registry has DEX=16 (+3), STR=10 (+0); base bonus = STR 0 + prof 2.
+		condition := NewMartialArtsCondition(MartialArtsInput{
+			CharacterID: s.characterID,
+			MonkLevel:   1,
+		})
+		s.Require().NoError(condition.Apply(s.ctx, s.bus))
+		defer func() { _ = condition.Remove(s.ctx, s.bus) }()
+
+		finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+			AttackerID:  s.characterID,
+			TargetID:    "target-1",
+			WeaponRef:   refs.Weapons.UnarmedStrike(),
+			IsMelee:     true,
+			AttackBonus: 2, // STR (+0) + proficiency (+2)
+			TargetAC:    12,
+		})
+
+		// DEX (+3) replaces STR (+0): 2 - 0 + 3 = 5, matching the damage swap.
+		s.Equal(5, finalEvent.AttackBonus,
+			"attack bonus must use DEX + prof when DEX is higher (same governing ability as damage)")
+	})
+
+	s.Run("unarmed strike with STR >= DEX - attack bonus unchanged", func() {
+		strongMonk := "monk-str-attack"
+		s.registry.AddAbilityScores(strongMonk, &gamectx.AbilityScores{
+			Strength:  16, // +3
+			Dexterity: 14, // +2
+		})
+		condition := NewMartialArtsCondition(MartialArtsInput{
+			CharacterID: strongMonk,
+			MonkLevel:   1,
+		})
+		s.Require().NoError(condition.Apply(s.ctx, s.bus))
+		defer func() { _ = condition.Remove(s.ctx, s.bus) }()
+
+		finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+			AttackerID:  strongMonk,
+			TargetID:    "target-1",
+			WeaponRef:   refs.Weapons.UnarmedStrike(),
+			IsMelee:     true,
+			AttackBonus: 5, // STR (+3) + proficiency (+2)
+			TargetAC:    12,
+		})
+
+		s.Equal(5, finalEvent.AttackBonus, "STR stays when DEX is not higher")
+	})
+
+	s.Run("non-finesse monk weapon (quarterstaff) - attack bonus swaps to DEX", func() {
+		condition := NewMartialArtsCondition(MartialArtsInput{
+			CharacterID: s.characterID,
+			MonkLevel:   1,
+		})
+		s.Require().NoError(condition.Apply(s.ctx, s.bus))
+		defer func() { _ = condition.Remove(s.ctx, s.bus) }()
+
+		finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+			AttackerID:  s.characterID,
+			TargetID:    "target-1",
+			WeaponRef:   refs.Weapons.Quarterstaff(),
+			IsMelee:     true,
+			AttackBonus: 2, // STR (+0) + proficiency (+2)
+			TargetAC:    12,
+		})
+
+		s.Equal(5, finalEvent.AttackBonus, "monk weapons use DEX when higher")
+	})
+
+	s.Run("finesse monk weapon (shortsword) - not double-adjusted", func() {
+		// The base attack path already picks the higher mod for finesse
+		// weapons; Martial Arts must not add the delta a second time.
+		condition := NewMartialArtsCondition(MartialArtsInput{
+			CharacterID: s.characterID,
+			MonkLevel:   1,
+		})
+		s.Require().NoError(condition.Apply(s.ctx, s.bus))
+		defer func() { _ = condition.Remove(s.ctx, s.bus) }()
+
+		finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+			AttackerID:  s.characterID,
+			TargetID:    "target-1",
+			WeaponRef:   refs.Weapons.Shortsword(),
+			IsMelee:     true,
+			AttackBonus: 5, // finesse base already used DEX (+3) + prof (+2)
+			TargetAC:    12,
+		})
+
+		s.Equal(5, finalEvent.AttackBonus, "finesse weapons already use the higher mod")
+	})
+
+	s.Run("non-monk weapon (greatsword) - attack bonus unchanged", func() {
+		condition := NewMartialArtsCondition(MartialArtsInput{
+			CharacterID: s.characterID,
+			MonkLevel:   1,
+		})
+		s.Require().NoError(condition.Apply(s.ctx, s.bus))
+		defer func() { _ = condition.Remove(s.ctx, s.bus) }()
+
+		finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+			AttackerID:  s.characterID,
+			TargetID:    "target-1",
+			WeaponRef:   refs.Weapons.Greatsword(),
+			IsMelee:     true,
+			AttackBonus: 2,
+			TargetAC:    12,
+		})
+
+		s.Equal(2, finalEvent.AttackBonus, "Martial Arts does not apply to non-monk weapons")
+	})
+
+	s.Run("other character's attack - unchanged", func() {
+		condition := NewMartialArtsCondition(MartialArtsInput{
+			CharacterID: s.characterID,
+			MonkLevel:   1,
+		})
+		s.Require().NoError(condition.Apply(s.ctx, s.bus))
+		defer func() { _ = condition.Remove(s.ctx, s.bus) }()
+
+		finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+			AttackerID:  "someone-else",
+			TargetID:    "target-1",
+			WeaponRef:   refs.Weapons.UnarmedStrike(),
+			IsMelee:     true,
+			AttackBonus: 2,
+			TargetAC:    12,
+		})
+
+		s.Equal(2, finalEvent.AttackBonus, "only this monk's attacks are modified")
+	})
+}
+
 // TestSerialization tests JSON serialization round-trip
 func (s *MartialArtsTestSuite) TestSerialization() {
 	original := NewMartialArtsCondition(MartialArtsInput{


### PR DESCRIPTION
Closes #709
Part of KirkDiggler/rpg-project#54

## What

Playtest evidence (fixture wave-2-monk: L1 monk, STR 10 / DEX 16, prof +2, unarmed): the monk's attack decoded `attackResolved{attackBonus:2}` (STR 0 + prof 2) while the SAME swing's `entityDamaged.damageBreakdown` correctly credited `dnd5e:abilities:dex: +3`. Expected attack bonus 5 (DEX 3 + prof 2). Attack and damage disagreed on the governing ability.

Root cause: `MartialArtsCondition.Apply` subscribed **only to DamageChain**. The attack bonus stayed at the base from `calculateAttackAbilityModifier` — STR for melee non-finesse weapons, which includes unarmed strikes.

## Fix

- Subscribe to `AttackChain` as well. For unarmed strikes and **non-finesse** monk weapons, when DEX mod > STR mod, replace the STR contribution in the attack bonus (`+= dexMod - strMod`) at `StageFeatures` — the exact mirror of the damage-chain ability-component swap.
- Finesse monk weapons (shortsword) are deliberately skipped: the base attack path already uses the higher of STR/DEX for finesse, so adjusting again would double-count DEX.
- Weapon classification factored into `martialArtsWeaponKind`, now shared by both chain handlers (was duplicated inline in `onDamageChain`). Note: unarmed detection moved from ref **pointer** equality to ref **ID** equality — strictly more robust (prod refs are singletons so behavior is unchanged there).

The gamectx character-registry requirement matches the existing damage handler; rpg-api's resolver wires the registry into both phase-1 and phase-2 contexts (`prepareHeldAttack`).

## Tests (failing-first)

`TestAttackBonusUsesDEX` (conditions/martial_arts_test.go), driving the real attack chain:
- unarmed, DEX > STR → bonus 2 → 5 *(failed on main: stayed 2)*
- unarmed, STR ≥ DEX → unchanged
- quarterstaff (non-finesse monk weapon) → 2 → 5 *(failed on main)*
- shortsword (finesse monk weapon) → unchanged (no double-count)
- greatsword (non-monk weapon) → unchanged
- other character's attack → unchanged

Full rulebooks/dnd5e suite green (`-race` on conditions/combat/character); golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm