### PR TITLE
fix(character): toolkit-owned strike ActionRef -> weapon mapping

### DIFF
--- a/rulebooks/dnd5e/character/weapon_selection.go
+++ b/rulebooks/dnd5e/character/weapon_selection.go
@@ -1,0 +1,175 @@
+package character
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// WeaponSelection is the toolkit-owned resolution of "which weapon does this
+// strike ActionRef swing" for a specific character (rpg-toolkit#712).
+//
+// Before this, the combat resolver picked the attack weapon from the
+// equipped slot / AttackHand alone and never consulted the submitted
+// ActionRef: a weapon-holding Monk's unarmed_strike swung the equipped
+// weapon instead of resolving unarmed, and off_hand_strike swung the
+// main-hand weapon. Callers MUST build combat.AttackInput /
+// ResolveAttackHitInput from a WeaponSelection instead of re-deriving the
+// weapon choice themselves — "which weapon does this ref swing" is rules
+// knowledge the toolkit owns, not something a resolver switches on.
+type WeaponSelection struct {
+	// Weapon is the resolved weapon to pass on AttackInput.Weapon /
+	// ResolveAttackHitInput.Weapon.
+	Weapon *weapons.Weapon
+
+	// AttackHand is the hand to pass on AttackInput.AttackHand /
+	// ResolveAttackHitInput.AttackHand.
+	AttackHand combat.AttackHand
+
+	// TwoWeapon is non-nil iff AttackHand is AttackHandOff. The resolver
+	// MUST install it on the resolve context via
+	// combat.WithTwoWeaponContext(ctx, sel.TwoWeapon) before calling
+	// ResolveAttackHit / ResolveAttack, or the rulebook's off-hand
+	// validation hard-fails with "two-weapon context not available".
+	//
+	// Its GetActionEconomy returns a disposable stand-in ActionEconomy, NOT
+	// the character's live one: a granted off_hand_strike already paid its
+	// bonus-action cost through the character's own economy (ExecuteAction,
+	// upstream of weapon selection — see encounter.spendStrikeEconomy).
+	// Wiring the live economy here would consume the bonus action a second
+	// time. The stand-in still reports the character's REAL main/off hand
+	// weapon IDs, so the rulebook's light-weapon check validates against
+	// reality.
+	TwoWeapon combat.TwoWeaponContext
+}
+
+// WeaponForActionRef resolves the weapon (hand + optional two-weapon
+// context) a strike ActionRef swings with. This is the toolkit-owned
+// ref-to-weapon mapping:
+//
+//   - unarmed_strike / flurry_strike: always the canonical unarmed-strike
+//     weapon, regardless of what is equipped. A Monk's Martial Arts /
+//     Flurry of Blows strikes are unarmed even when holding a weapon.
+//   - off_hand_strike: the equipped off-hand weapon (falling back to
+//     unarmed if the slot is empty), AttackHand set to "off", with a
+//     TwoWeapon context populated so the resolver's off-hand validation
+//     does not hard-fail.
+//   - anything else (the standard attack/strike refs): the equipped
+//     main-hand weapon, falling back to unarmed if the slot is empty —
+//     unchanged behavior for the normal attack path.
+//
+// Returns an error if ref is nil.
+func (c *Character) WeaponForActionRef(ref *core.Ref) (*WeaponSelection, error) {
+	if ref == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "WeaponForActionRef: ref is nil")
+	}
+
+	switch ref.ID {
+	case refs.Actions.UnarmedStrike().ID, refs.Actions.FlurryStrike().ID:
+		return &WeaponSelection{
+			Weapon:     unarmedStrikeWeapon(),
+			AttackHand: combat.AttackHandMain,
+		}, nil
+	case refs.Actions.OffHandStrike().ID:
+		return c.offHandWeaponSelection(), nil
+	default:
+		return c.mainHandWeaponSelection(), nil
+	}
+}
+
+// mainHandWeaponSelection resolves the equipped main-hand weapon, falling
+// back to the canonical unarmed-strike weapon when the slot is empty.
+func (c *Character) mainHandWeaponSelection() *WeaponSelection {
+	weapon := unarmedStrikeWeapon()
+	if equipped := c.GetEquippedSlot(SlotMainHand); equipped != nil {
+		if w := equipped.AsWeapon(); w != nil {
+			weapon = w
+		}
+	}
+	return &WeaponSelection{Weapon: weapon, AttackHand: combat.AttackHandMain}
+}
+
+// offHandWeaponSelection resolves the equipped off-hand weapon, falling
+// back to the canonical unarmed-strike weapon when the slot is empty, and
+// builds the disposable TwoWeaponContext the rulebook's off-hand validation
+// requires.
+func (c *Character) offHandWeaponSelection() *WeaponSelection {
+	weapon := unarmedStrikeWeapon()
+	var offInfo *combat.EquippedWeaponInfo
+	if equipped := c.GetEquippedSlot(SlotOffHand); equipped != nil {
+		if w := equipped.AsWeapon(); w != nil {
+			weapon = w
+			offInfo = &combat.EquippedWeaponInfo{WeaponID: w.ID}
+		}
+	}
+
+	var mainInfo *combat.EquippedWeaponInfo
+	if equipped := c.GetEquippedSlot(SlotMainHand); equipped != nil {
+		if w := equipped.AsWeapon(); w != nil {
+			mainInfo = &combat.EquippedWeaponInfo{WeaponID: w.ID}
+		}
+	}
+
+	return &WeaponSelection{
+		Weapon:     weapon,
+		AttackHand: combat.AttackHandOff,
+		TwoWeapon: &grantedOffHandContext{
+			characterID: c.id,
+			mainHand:    mainInfo,
+			offHand:     offInfo,
+		},
+	}
+}
+
+// unarmedStrikeWeapon returns the canonical unarmed-strike weapon
+// definition from the toolkit catalog. Using the catalog entry (not an ad
+// hoc stub) matters: the Martial Arts damage-dice upgrade
+// (rulebooks/dnd5e/conditions/martial_arts.go) classifies an attack as
+// unarmed by matching the weapon ref against refs.Weapons.UnarmedStrike(),
+// so a look-alike stub with a different ID would silently skip the Monk's
+// dice upgrade.
+func unarmedStrikeWeapon() *weapons.Weapon {
+	w, _ := weapons.GetByID(weapons.UnarmedStrike) // always present in weapons.SpecialWeapons
+	return &w
+}
+
+// grantedOffHandContext is a disposable combat.TwoWeaponContext scoped to
+// one character, built fresh at WeaponForActionRef time. It satisfies the
+// rulebook's off-hand validation (light-weapon check + bonus-action gate)
+// without reading or mutating the character's live ActionEconomy — the
+// granted off_hand_strike's bonus-action cost is already paid via the
+// character's own ExecuteAction before weapon selection runs.
+type grantedOffHandContext struct {
+	characterID string
+	mainHand    *combat.EquippedWeaponInfo
+	offHand     *combat.EquippedWeaponInfo
+}
+
+// GetMainHandWeapon implements combat.TwoWeaponContext.
+func (g *grantedOffHandContext) GetMainHandWeapon(characterID string) *combat.EquippedWeaponInfo {
+	if characterID != g.characterID {
+		return nil
+	}
+	return g.mainHand
+}
+
+// GetOffHandWeapon implements combat.TwoWeaponContext.
+func (g *grantedOffHandContext) GetOffHandWeapon(characterID string) *combat.EquippedWeaponInfo {
+	if characterID != g.characterID {
+		return nil
+	}
+	return g.offHand
+}
+
+// GetActionEconomy implements combat.TwoWeaponContext. It returns a fresh
+// stand-in ActionEconomy (bonus action available) rather than the
+// character's live economy — see the TwoWeapon field doc on WeaponSelection
+// for why.
+func (g *grantedOffHandContext) GetActionEconomy(characterID string) *combat.ActionEconomy {
+	if characterID != g.characterID {
+		return nil
+	}
+	return combat.NewActionEconomy()
+}

--- a/rulebooks/dnd5e/character/weapon_selection_test.go
+++ b/rulebooks/dnd5e/character/weapon_selection_test.go
@@ -1,0 +1,214 @@
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// WeaponSelectionTestSuite tests Character.WeaponForActionRef — the
+// toolkit-owned strike-ActionRef-to-weapon mapping (rpg-toolkit#712).
+type WeaponSelectionTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	bus events.EventBus
+}
+
+func (s *WeaponSelectionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+func TestWeaponSelectionTestSuite(t *testing.T) {
+	suite.Run(t, new(WeaponSelectionTestSuite))
+}
+
+// createArmedMonkCharacter creates a Monk holding a quarterstaff in the main
+// hand — a weapon-holding Monk is exactly the case #712 broke: the resolver
+// picked the equipped quarterstaff for unarmed_strike/flurry_strike instead
+// of resolving unarmed.
+func createArmedMonkCharacter(t *testing.T, bus events.EventBus) *Character {
+	t.Helper()
+
+	char := createTestMonkCharacter(t, bus)
+	quarterstaff := weapons.All[weapons.Quarterstaff]
+	char.inventory = []InventoryItem{
+		{Equipment: &quarterstaff, Quantity: 1},
+	}
+	char.equipmentSlots = EquipmentSlots{
+		SlotMainHand: weapons.Quarterstaff,
+	}
+	return char
+}
+
+// --- WeaponForActionRef: nil ref ---
+
+func (s *WeaponSelectionTestSuite) TestWeaponForActionRef_NilRef_ReturnsError() {
+	char := createTestMonkCharacter(s.T(), s.bus)
+
+	sel, err := char.WeaponForActionRef(nil)
+
+	s.Require().Error(err)
+	s.Nil(sel)
+}
+
+// --- unarmed_strike / flurry_strike ignore what's equipped ---
+
+func (s *WeaponSelectionTestSuite) TestUnarmedStrike_WeaponHoldingMonk_ResolvesUnarmed() {
+	char := createArmedMonkCharacter(s.T(), s.bus)
+
+	sel, err := char.WeaponForActionRef(refs.Actions.UnarmedStrike())
+
+	s.Require().NoError(err)
+	s.Require().NotNil(sel)
+	s.Require().NotNil(sel.Weapon)
+	s.Equal(weapons.UnarmedStrike, sel.Weapon.ID, "unarmed_strike must resolve the canonical unarmed weapon, not the equipped quarterstaff")
+	s.Equal(combat.AttackHandMain, sel.AttackHand)
+	s.Nil(sel.TwoWeapon)
+}
+
+func (s *WeaponSelectionTestSuite) TestFlurryStrike_WeaponHoldingMonk_ResolvesUnarmed() {
+	char := createArmedMonkCharacter(s.T(), s.bus)
+
+	sel, err := char.WeaponForActionRef(refs.Actions.FlurryStrike())
+
+	s.Require().NoError(err)
+	s.Require().NotNil(sel)
+	s.Require().NotNil(sel.Weapon)
+	s.Equal(weapons.UnarmedStrike, sel.Weapon.ID, "flurry_strike must resolve the canonical unarmed weapon, not the equipped quarterstaff")
+	s.Equal(combat.AttackHandMain, sel.AttackHand)
+	s.Nil(sel.TwoWeapon)
+}
+
+func (s *WeaponSelectionTestSuite) TestUnarmedStrike_UnarmedCharacter_ResolvesUnarmed() {
+	// A character with nothing equipped should also resolve unarmed —
+	// unarmed_strike never depends on equipment state either way.
+	char := createTestMonkCharacter(s.T(), s.bus)
+
+	sel, err := char.WeaponForActionRef(refs.Actions.UnarmedStrike())
+
+	s.Require().NoError(err)
+	s.Equal(weapons.UnarmedStrike, sel.Weapon.ID)
+	s.Equal(combat.AttackHandMain, sel.AttackHand)
+}
+
+// --- off_hand_strike selects the off-hand weapon and wires a working context ---
+
+func (s *WeaponSelectionTestSuite) TestOffHandStrike_SelectsOffHandWeapon() {
+	char := createTWFCharacter(s.T(), s.bus) // shortsword main, dagger off (both light)
+
+	sel, err := char.WeaponForActionRef(refs.Actions.OffHandStrike())
+
+	s.Require().NoError(err)
+	s.Require().NotNil(sel)
+	s.Require().NotNil(sel.Weapon)
+	s.Equal(weapons.Dagger, sel.Weapon.ID, "off_hand_strike must resolve the off-hand weapon, not the main-hand shortsword")
+	s.Equal(combat.AttackHandOff, sel.AttackHand)
+	s.Require().NotNil(sel.TwoWeapon, "off-hand resolution must populate a TwoWeaponContext or the rulebook hard-fails")
+}
+
+func (s *WeaponSelectionTestSuite) TestOffHandStrike_TwoWeaponContext_ReflectsRealEquippedWeapons() {
+	char := createTWFCharacter(s.T(), s.bus)
+
+	sel, err := char.WeaponForActionRef(refs.Actions.OffHandStrike())
+	s.Require().NoError(err)
+	s.Require().NotNil(sel.TwoWeapon)
+
+	mainHand := sel.TwoWeapon.GetMainHandWeapon(char.GetID())
+	offHand := sel.TwoWeapon.GetOffHandWeapon(char.GetID())
+	s.Require().NotNil(mainHand)
+	s.Require().NotNil(offHand)
+	s.Equal(weapons.Shortsword, mainHand.WeaponID)
+	s.Equal(weapons.Dagger, offHand.WeaponID)
+
+	// Unknown character id must not leak this character's equipment.
+	s.Nil(sel.TwoWeapon.GetMainHandWeapon("someone-else"))
+	s.Nil(sel.TwoWeapon.GetOffHandWeapon("someone-else"))
+}
+
+func (s *WeaponSelectionTestSuite) TestOffHandStrike_TwoWeaponContext_DoesNotChargeLiveEconomy() {
+	// The granted off_hand_strike's bonus action was already spent through
+	// the character's own economy upstream of weapon selection (see
+	// encounter.spendStrikeEconomy). The TwoWeaponContext handed to the
+	// rulebook's off-hand validation must be a disposable stand-in, not the
+	// character's live economy, or the validation would double-charge (and
+	// with a real economy already at 0 bonus actions, hard-fail).
+	char := createTWFCharacter(s.T(), s.bus)
+	char.actionEconomy = &ActionEconomyData{
+		ActionsRemaining:      1,
+		BonusActionsRemaining: 0, // already spent on the granted strike
+		ReactionsRemaining:    1,
+	}
+
+	sel, err := char.WeaponForActionRef(refs.Actions.OffHandStrike())
+	s.Require().NoError(err)
+	s.Require().NotNil(sel.TwoWeapon)
+
+	econ := sel.TwoWeapon.GetActionEconomy(char.GetID())
+	s.Require().NotNil(econ)
+	s.True(econ.CanUseBonusAction(), "TwoWeaponContext must hand the rulebook a usable stand-in, not the character's already-spent live economy")
+	s.Require().NoError(econ.UseBonusAction(), "off-hand validation's bonus-action gate must not hard-fail")
+
+	// The character's real economy must be untouched by that call.
+	s.Equal(0, char.actionEconomy.BonusActionsRemaining)
+}
+
+// TestOffHandStrike_ResolvesThroughAttackChain_NoHardFail drives the
+// selection through the real rulebook chain (combat.ResolveAttackHit) to
+// prove end-to-end that off_hand_strike no longer hard-fails for lack of a
+// TwoWeaponContext — the exact failure #712 called out.
+func (s *WeaponSelectionTestSuite) TestOffHandStrike_ResolvesThroughAttackChain_NoHardFail() {
+	attacker := createTWFCharacter(s.T(), s.bus)
+	defender := createTestFighterCharacter(s.T(), s.bus)
+
+	sel, err := attacker.WeaponForActionRef(refs.Actions.OffHandStrike())
+	s.Require().NoError(err)
+	s.Require().NotNil(sel.TwoWeapon)
+
+	reg := gamectx.NewCombatantRegistry()
+	reg.Add(attacker)
+	reg.Add(defender)
+	ctx := combat.WithCombatantLookup(s.ctx, reg)
+	ctx = combat.WithTwoWeaponContext(ctx, sel.TwoWeapon)
+
+	_, err = combat.ResolveAttackHit(ctx, &combat.ResolveAttackHitInput{
+		AttackerID: attacker.GetID(),
+		TargetID:   defender.GetID(),
+		Weapon:     sel.Weapon,
+		EventBus:   s.bus,
+		AttackHand: sel.AttackHand,
+	})
+
+	s.Require().NoError(err, "off_hand_strike must not hard-fail once a WeaponSelection-built TwoWeaponContext is wired")
+}
+
+// --- normal attack/strike refs are unchanged: main-hand weapon ---
+
+func (s *WeaponSelectionTestSuite) TestNormalAttackRef_ResolvesMainHandWeapon() {
+	char := createTWFCharacter(s.T(), s.bus)
+
+	sel, err := char.WeaponForActionRef(refs.Actions.Strike())
+
+	s.Require().NoError(err)
+	s.Require().NotNil(sel.Weapon)
+	s.Equal(weapons.Shortsword, sel.Weapon.ID)
+	s.Equal(combat.AttackHandMain, sel.AttackHand)
+	s.Nil(sel.TwoWeapon)
+}
+
+func (s *WeaponSelectionTestSuite) TestNormalAttackRef_UnarmedCharacter_FallsBackToUnarmed() {
+	char := createTestMonkCharacter(s.T(), s.bus) // nothing equipped
+
+	sel, err := char.WeaponForActionRef(refs.Actions.Strike())
+
+	s.Require().NoError(err)
+	s.Equal(weapons.UnarmedStrike, sel.Weapon.ID)
+	s.Equal(combat.AttackHandMain, sel.AttackHand)
+}


### PR DESCRIPTION
## Root cause

rpg-api's `Dnd5eCombatResolver.resolveWeapon` (`internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver.go`) picks the attack weapon from the character's equipped slot (main/off, selected by `AttackInput.AttackHand`) and never consults `AttackInput.ActionRef`. Consequences:

- `dnd5e:actions:unarmed_strike` / `dnd5e:actions:flurry_strike` by a Monk who is *holding* a weapon swings the equipped weapon instead of resolving unarmed (Martial Arts dice/flavor drift). It happened to look correct for the wave-2-monk fixture only because that monk has nothing equipped.
- `dnd5e:actions:off_hand_strike` swings the main-hand weapon. Naively passing `AttackHand="off"` today hard-fails: `prepareHeldAttack` never wires a `combat.TwoWeaponContext` into the resolve context, so `validateOffHandAttack` rejects with "two-weapon context not available" — and even if it reused the character's *live* `ActionEconomy`, it would double-charge the bonus action the granted strike's own `ExecuteAction` already spent (`encounter.spendStrikeEconomy`, from #708/#711).

"Which weapon does this action ref swing" is rules knowledge — it belongs in the toolkit, not in a resolver's equipped-slot switch (per #712).

## Fix

Added `Character.WeaponForActionRef(ref *core.Ref) (*WeaponSelection, error)` in `rulebooks/dnd5e/character/weapon_selection.go` — the toolkit-owned ref → weapon/attack-profile mapping:

| ActionRef | Weapon | AttackHand | TwoWeapon context |
|---|---|---|---|
| `unarmed_strike` / `flurry_strike` | canonical `weapons.GetByID(weapons.UnarmedStrike)`, regardless of what's equipped | `Main` | nil |
| `off_hand_strike` | equipped off-hand weapon (unarmed fallback) | `Off` | populated (see below) |
| anything else (attack/strike refs) | equipped main-hand weapon (unarmed fallback) | `Main` | nil — **unchanged** |

Notes on the design:

- **Unarmed uses the real catalog weapon**, not an ad hoc stub — `weapons.GetByID(weapons.UnarmedStrike)` has ID `"unarmed-strike"`, which is exactly what `rulebooks/dnd5e/conditions/martial_arts.go`'s `martialArtsWeaponKind` matches against to apply the Monk's dice upgrade. A look-alike stub (e.g. rpg-api's current ad hoc `unarmedStubWeapon()` with ID `"unarmed"`) would silently skip that upgrade.
- **The off-hand `TwoWeapon` context is a disposable stand-in**, not the character's live economy. `GetMainHandWeapon`/`GetOffHandWeapon` report the character's *real* equipped weapons (so the rulebook's light-weapon check validates against reality), but `GetActionEconomy` returns a fresh `combat.NewActionEconomy()` — because the granted strike's bonus-action cost was already paid through the character's real economy upstream (`spendStrikeEconomy` → `ExecuteAction`). Reusing the live economy here would either double-charge or (since it's already at 0) hard-fail the very case we're fixing.
- **Lives in the `character` package, not `combat`** — `character` already imports `combat` (for `AttackHand`, `TwoWeaponContext`, `ActionEconomy`, etc.), so `combat` importing `character` back would cycle. This mirrors the existing pattern of character-consuming helpers living in `character`/`actions` (e.g. `CheckAndGrantOffHandStrike`).

## Scope: toolkit-side only

This PR is the toolkit-owned mapping + full test coverage, as scoped. Wiring rpg-api's `Dnd5eCombatResolver` to call `WeaponForActionRef` instead of its own `resolveWeapon`/`characterWeapon` switch is a small follow-up "consumption bump" — already anticipated by #712's own description. It does **not** require any new wire/API data: `AttackInput.ActionRef` already flows end-to-end through `TakeAction` today (added in #708/#711), so the follow-up is a pure call-site swap in rpg-api, not a new capability. No API change was needed to make this toolkit fix possible, and none is blocking it.

## Tests (TDD — written against the new function, verified to fail when ref dispatch is bypassed)

All in `rulebooks/dnd5e/character/weapon_selection_test.go`:

- `TestUnarmedStrike_WeaponHoldingMonk_ResolvesUnarmed`
- `TestFlurryStrike_WeaponHoldingMonk_ResolvesUnarmed`
- `TestUnarmedStrike_UnarmedCharacter_ResolvesUnarmed`
- `TestOffHandStrike_SelectsOffHandWeapon`
- `TestOffHandStrike_TwoWeaponContext_ReflectsRealEquippedWeapons`
- `TestOffHandStrike_TwoWeaponContext_DoesNotChargeLiveEconomy`
- `TestOffHandStrike_ResolvesThroughAttackChain_NoHardFail` — drives the real `combat.ResolveAttackHit` chain end-to-end with the returned `TwoWeaponContext` wired in, proving the off-hand path no longer hard-fails
- `TestNormalAttackRef_ResolvesMainHandWeapon`
- `TestNormalAttackRef_UnarmedCharacter_FallsBackToUnarmed`
- `TestWeaponForActionRef_NilRef_ReturnsError`

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./...` (whole `rulebooks/dnd5e` module) — all green
- `golangci-lint run ./character/...` — 0 issues
- `go mod tidy` — no diff
- `make pre-commit` fails identically on pristine `origin/main` (core-module coverage-calc script breaks on the `core/mock` coverage line — pre-existing, unrelated to this change, confirmed via a throwaway worktree on unmodified `origin/main`)

## Test plan

- [x] Unit tests cover all four ref-mapping branches + nil-ref error
- [x] Integration-style test proves the off-hand path resolves through the real rulebook chain without hard-failing
- [ ] rpg-api follow-up: wire `Dnd5eCombatResolver` to consume `WeaponForActionRef`, then re-verify via playtest (deferred per this wave's scope)

Closes #712
Part of KirkDiggler/rpg-project#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm