### PR TITLE
fix(encounter): OA resolution emits attackResolved always, damage only on hit

### DIFF
--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -582,7 +582,12 @@ func (e *Encounter) iterateMovementStepsForEntity(
 		// is torn down via defer even if the resolver panics. Without
 		// this, a panic in the rulebook chain would leak the subscription
 		// and pollute subsequent encounter operations.
-		result, capturedDmg, stepErr := func() (*MovementStepResult, []dnd5eEvents.DamageReceivedEvent, error) {
+		type stepCapture struct {
+			result *MovementStepResult
+			rolls  []dnd5eEvents.PostAttackRollEvent
+			dmg    []dnd5eEvents.DamageReceivedEvent
+		}
+		capture, stepErr := func() (stepCapture, error) {
 			// Install a buffered subscriber on ReactionTriggerTopic per
 			// step. The subscriber catches any triggers that chain
 			// subscribers publish during this step's resolver call. In
@@ -592,7 +597,7 @@ func (e *Encounter) iterateMovementStepsForEntity(
 			// flush subscriptions cleanly per step.
 			_, drainCleanup, err := e.installTriggerBuffer()
 			if err != nil {
-				return nil, nil, fmt.Errorf("install trigger buffer: %w", err)
+				return stepCapture{}, fmt.Errorf("install trigger buffer: %w", err)
 			}
 			defer drainCleanup()
 
@@ -605,9 +610,24 @@ func (e *Encounter) iterateMovementStepsForEntity(
 			ctx := context.Background()
 			dmgCaptured, unsubDmg, err := subscribeDamage(ctx, e.bus)
 			if err != nil {
-				return nil, nil, fmt.Errorf("subscribe move damage: %w", err)
+				return stepCapture{}, fmt.Errorf("subscribe move damage: %w", err)
 			}
 			defer func() { _ = unsubDmg() }()
+
+			// #715: capture PostAttackRollEvent published by
+			// combat.ResolveAttackHit — unconditionally, hit or miss —
+			// alongside the damage subscription above. This is the only
+			// bus-observable signal that an OA resolved with the roll
+			// detail (roll, bonus, AC) needed to publish AttackResolvedEvent
+			// in the same shape as the normal attack path (attackResolved
+			// always, damage only on hit). The resolver interface itself
+			// returns only Prevented/PreventReason — it does not surface
+			// attack outcomes directly.
+			rollsCaptured, unsubRolls, err := subscribeAttackRolls(ctx, e.bus)
+			if err != nil {
+				return stepCapture{}, fmt.Errorf("subscribe move attack rolls: %w", err)
+			}
+			defer func() { _ = unsubRolls() }()
 
 			res, err := e.movementResolver.ResolveStep(MovementStepInput{
 				EntityID: moverID,
@@ -616,25 +636,30 @@ func (e *Encounter) iterateMovementStepsForEntity(
 				EventBus: e.bus,
 				Mover:    e.combatantFor(moverID),
 			})
-			var dmgCopy []dnd5eEvents.DamageReceivedEvent
+			out := stepCapture{result: res}
 			if dmgCaptured != nil {
-				dmgCopy = *dmgCaptured
+				out.dmg = *dmgCaptured
 			}
-			return res, dmgCopy, err
+			if rollsCaptured != nil {
+				out.rolls = *rollsCaptured
+			}
+			return out, err
 		}()
 		if stepErr != nil {
 			return traveled, fmt.Errorf("resolve movement step: %w", stepErr)
 		}
+		result := capture.result
 		if result == nil {
 			return traveled, fmt.Errorf("movement resolver: nil result with nil error")
 		}
 
-		// Apply any OA damage captured during this step. Done before the
-		// Prevented check because OAs fire whether or not the chain ends
-		// up preventing the step — damage applies either way.
-		if len(capturedDmg) > 0 {
-			if err := e.applyMoveDamage(capturedDmg); err != nil {
-				return traveled, fmt.Errorf("apply move damage: %w", err)
+		// Apply any OA attack outcomes captured during this step. Done
+		// before the Prevented check because OAs fire whether or not the
+		// chain ends up preventing the step — the attack (and any damage)
+		// applies either way.
+		if len(capture.rolls) > 0 || len(capture.dmg) > 0 {
+			if err := e.applyMoveAttackOutcomes(capture.rolls, capture.dmg); err != nil {
+				return traveled, fmt.Errorf("apply move attack outcomes: %w", err)
 			}
 		}
 

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -536,6 +536,44 @@ func (s *MovementResolverSuite) TestNPCMove_ResolverPublishesTrigger_BufferDrain
 // combat.MoveEntity's triggerOpportunityAttack path) and verify the SDK
 // dispatches HP + DamageDealtEvent.
 
+// oaHitAttackRoll, oaHitAttackBonus, oaHitTargetAC are the fixed roll
+// detail publishOAHit uses for every simulated OA hit (18 + 4 = 22 beats
+// AC 15 across every fixture in this file). Only attacker/target/amount
+// vary between call sites.
+const (
+	oaHitAttackRoll  = 18
+	oaHitAttackBonus = 4
+	oaHitTargetAC    = 15
+)
+
+// publishOAHit publishes the pair of bus events a real resolver publishes
+// for one OA hit — combat.ResolveAttackHit's PostAttackRollEvent (always)
+// followed by combat.ApplyAttackOutcome's DamageReceivedEvent (hit only).
+// Test stubs simulate both, in that order, matching production's
+// synchronous ResolveAttack call. See #715: before the fix, tests only
+// simulated the damage half, which masked the OA path never publishing
+// AttackResolvedEvent at all.
+func publishOAHit(bus dnd5events.EventBus, attackerID, targetID string, amount int) {
+	rolls := dnd5eEvents.PostAttackRollChain.On(bus)
+	_, _ = rolls.PublishWithChain(context.Background(), &dnd5eEvents.PostAttackRollEvent{
+		AttackerID:  attackerID,
+		TargetID:    targetID,
+		OriginalAC:  oaHitTargetAC,
+		AttackRoll:  oaHitAttackRoll,
+		AttackBonus: oaHitAttackBonus,
+		TotalAttack: oaHitAttackRoll + oaHitAttackBonus,
+		WouldHit:    true,
+	}, dnd5events.NewStagedChain[*dnd5eEvents.PostAttackRollEvent](nil))
+
+	dmg := dnd5eEvents.DamageReceivedTopic.On(bus)
+	_ = dmg.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
+		TargetID:   targetID,
+		SourceID:   attackerID,
+		Amount:     amount,
+		DamageType: damage.Slashing,
+	})
+}
+
 // TestMove_PlayerMoves_OADamagesPlayer verifies the player-mover direction:
 // alice moves past goblin (who has an OA condition); resolver publishes a
 // DamageReceivedEvent targeting alice during step 0; encounter SDK applies
@@ -549,18 +587,12 @@ func (s *MovementResolverSuite) TestMove_PlayerMoves_OADamagesPlayer() {
 	aliceBefore.HP = 20
 	aliceBefore.MaxHP = 20
 
-	// Stub publishes a DamageReceivedEvent on the bus during step 0 — the
+	// Stub publishes the roll + damage pair on the bus during step 0 — the
 	// step where alice leaves the goblin's reach (the rulebook fires
 	// triggerOpportunityAttack → ResolveAttack here).
 	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
 		if stepIdx == 0 {
-			topic := dnd5eEvents.DamageReceivedTopic.On(bus)
-			_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
-				TargetID:   string(aliceEntityID),
-				SourceID:   string(gobEntityID),
-				Amount:     6,
-				DamageType: damage.Slashing,
-			})
+			publishOAHit(bus, string(gobEntityID), string(aliceEntityID), 6)
 		}
 	}
 
@@ -620,17 +652,12 @@ func (s *MovementResolverSuite) TestNPCMove_NPCMoves_OADamagesMonster() {
 	aliceBefore.HP = 20
 	aliceBefore.MaxHP = 20
 
-	// Stub publishes DamageReceivedEvent on step 0: alice (player) hits the
-	// goblin (NPC) on its way out. Source = alice (player), Target = goblin.
+	// Stub publishes the roll + damage pair on step 0: alice (player) hits
+	// the goblin (NPC) on its way out. Source = alice (player), Target =
+	// goblin.
 	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
 		if stepIdx == 0 {
-			topic := dnd5eEvents.DamageReceivedTopic.On(bus)
-			_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
-				TargetID:   string(gobEntityID),
-				SourceID:   string(aliceEntityID),
-				Amount:     5,
-				DamageType: damage.Slashing,
-			})
+			publishOAHit(bus, string(aliceEntityID), string(gobEntityID), 5)
 		}
 	}
 
@@ -684,13 +711,7 @@ func (s *MovementResolverSuite) TestMove_OAKillsMonster_FiresKillChain() {
 	// Stub damage exceeds goblin's HP (7) so the kill chain triggers.
 	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
 		if stepIdx == 0 {
-			topic := dnd5eEvents.DamageReceivedTopic.On(bus)
-			_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
-				TargetID:   string(gobEntityID),
-				SourceID:   string(aliceEntityID),
-				Amount:     10,
-				DamageType: damage.Slashing,
-			})
+			publishOAHit(bus, string(aliceEntityID), string(gobEntityID), 10)
 		}
 	}
 
@@ -746,4 +767,164 @@ drainLoop:
 	s.Equal(encountercore.EntityID(aliceEntityID), diedEvt.KillerID)
 	s.True(sawRemoved, "EntityRemovedEvent should fire after EntityDied")
 	s.True(sawEnded, "EncounterEndedEvent should fire when last monster dies")
+}
+
+// --- Issue #715 — Move-path OA emits the same shape as the normal attack
+// path: AttackResolvedEvent always (hit or miss), DamageDealtEvent only on
+// hit.
+//
+// Before this fix, iterateMovementStepsForEntity only observed
+// DamageReceivedTopic: a miss (which combat.ApplyAttackOutcome never
+// publishes damage for) produced no encounter event at all, and a hit
+// produced a bare DamageDealtEvent with no AttackResolvedEvent alongside
+// it — a different shape than TakeAction's publishAttackOutcome, which
+// always emits AttackResolvedEvent and gates DamageDealtEvent on Hit.
+//
+// combat.ResolveAttackHit unconditionally publishes one PostAttackRollEvent
+// per attack (hit or miss) via PostAttackRollChain; these tests simulate
+// that real behavior directly through the stub resolver.
+
+// TestMove_OAMisses_EmitsAttackResolvedNoDamage verifies that an OA miss
+// triggered during Move publishes AttackResolvedEvent{Hit: false} with the
+// roll detail, and does NOT publish DamageDealtEvent. Mirrors the normal
+// attack path's miss shape (attackResolved only, HP unchanged).
+func (s *MovementResolverSuite) TestMove_OAMisses_EmitsAttackResolvedNoDamage() {
+	s.addGoblinForNPCMovementTests()
+
+	aliceBefore := s.enc.ToData().Players[alicePlayerID]
+	s.Require().NotNil(aliceBefore)
+	aliceBefore.HP = 20
+	aliceBefore.MaxHP = 20
+
+	// Stub publishes ONLY a PostAttackRollEvent with WouldHit=false — no
+	// DamageReceivedEvent, matching combat.ApplyAttackOutcome's `if !hit {
+	// return }` early-out (attack_phases.go) which never reaches the
+	// damage-publish step on a miss.
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			rolls := dnd5eEvents.PostAttackRollChain.On(bus)
+			_, _ = rolls.PublishWithChain(context.Background(), &dnd5eEvents.PostAttackRollEvent{
+				AttackerID:  string(gobEntityID),
+				TargetID:    string(aliceEntityID),
+				OriginalAC:  15,
+				AttackRoll:  8,
+				AttackBonus: 4,
+				TotalAttack: 12,
+				WouldHit:    false,
+			}, dnd5events.NewStagedChain[*dnd5eEvents.PostAttackRollEvent](nil))
+		}
+	}
+
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+	}
+	err = s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err)
+
+	// HP unchanged.
+	aliceAfter := s.enc.ToData().Players[alicePlayerID]
+	s.Equal(20, aliceAfter.HP, "a miss must not change HP")
+
+	var attackEvt *events.AttackResolvedEvent
+	var dmgEvt *events.DamageDealtEvent
+	deadline := time.After(2 * time.Second)
+drainLoopMiss:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoopMiss
+			}
+			switch e := evt.(type) {
+			case *events.AttackResolvedEvent:
+				attackEvt = e
+			case *events.DamageDealtEvent:
+				dmgEvt = e
+			}
+		case <-deadline:
+			break drainLoopMiss
+		}
+	}
+
+	s.Require().NotNil(attackEvt, "AttackResolvedEvent must be published on an OA miss")
+	s.False(attackEvt.Hit, "attack-resolved must report the miss")
+	s.Equal(encountercore.EntityID(gobEntityID), attackEvt.AttackerID)
+	s.Equal(encountercore.EntityID(aliceEntityID), attackEvt.TargetID)
+	s.Equal(8, attackEvt.AttackRoll)
+	s.Equal(4, attackEvt.AttackBonus)
+	s.Equal(15, attackEvt.TargetAC)
+	s.Nil(dmgEvt, "a miss must not publish DamageDealtEvent")
+}
+
+// TestMove_OAHits_EmitsAttackResolvedAndDamage verifies that an OA hit
+// triggered during Move publishes BOTH AttackResolvedEvent{Hit: true} and
+// DamageDealtEvent, matching the normal attack path's hit shape.
+func (s *MovementResolverSuite) TestMove_OAHits_EmitsAttackResolvedAndDamage() {
+	s.addGoblinForNPCMovementTests()
+
+	aliceBefore := s.enc.ToData().Players[alicePlayerID]
+	s.Require().NotNil(aliceBefore)
+	aliceBefore.HP = 20
+	aliceBefore.MaxHP = 20
+
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			publishOAHit(bus, string(gobEntityID), string(aliceEntityID), 6)
+		}
+	}
+
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+	}
+	err = s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err)
+
+	aliceAfter := s.enc.ToData().Players[alicePlayerID]
+	s.Equal(14, aliceAfter.HP, "alice HP should drop by OA damage amount (6)")
+
+	var attackEvt *events.AttackResolvedEvent
+	var dmgEvt *events.DamageDealtEvent
+	deadline := time.After(2 * time.Second)
+drainLoopHit:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoopHit
+			}
+			switch e := evt.(type) {
+			case *events.AttackResolvedEvent:
+				attackEvt = e
+			case *events.DamageDealtEvent:
+				dmgEvt = e
+			}
+			if attackEvt != nil && dmgEvt != nil {
+				break drainLoopHit
+			}
+		case <-deadline:
+			break drainLoopHit
+		}
+	}
+
+	s.Require().NotNil(attackEvt, "AttackResolvedEvent must be published on an OA hit")
+	s.True(attackEvt.Hit)
+	s.Equal(18, attackEvt.AttackRoll)
+	s.Equal(4, attackEvt.AttackBonus)
+	s.Equal(15, attackEvt.TargetAC)
+
+	s.Require().NotNil(dmgEvt, "DamageDealtEvent must be published on an OA hit")
+	s.Equal(encountercore.EntityID(aliceEntityID), dmgEvt.TargetID)
+	s.Equal(encountercore.EntityID(gobEntityID), dmgEvt.SourceID)
+	s.Equal(6, dmgEvt.Amount)
+	s.Equal(14, dmgEvt.HPAfter)
 }

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -928,3 +928,69 @@ drainLoopHit:
 	s.Equal(6, dmgEvt.Amount)
 	s.Equal(14, dmgEvt.HPAfter)
 }
+
+// TestMove_DamageWithoutRoll_StillApplies is the Copilot review regression
+// guard from PR #718: a MovementResolver implementation that publishes
+// DamageReceivedEvent WITHOUT a preceding PostAttackRollEvent (a non-attack
+// movement hazard, or a resolver that doesn't route through
+// combat.ResolveAttackHit) must still have its damage applied — a strict
+// roll-driven loop would otherwise silently drop the HP delta because the
+// damage has no roll to pair with. Verifies HP still applies and
+// DamageDealtEvent still publishes even with zero captured rolls.
+func (s *MovementResolverSuite) TestMove_DamageWithoutRoll_StillApplies() {
+	s.addGoblinForNPCMovementTests()
+
+	aliceBefore := s.enc.ToData().Players[alicePlayerID]
+	s.Require().NotNil(aliceBefore)
+	aliceBefore.HP = 20
+	aliceBefore.MaxHP = 20
+
+	// Stub publishes ONLY a DamageReceivedEvent — no PostAttackRollEvent —
+	// simulating a resolver/damage-source that doesn't produce roll detail.
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx == 0 {
+			topic := dnd5eEvents.DamageReceivedTopic.On(bus)
+			_ = topic.Publish(context.Background(), dnd5eEvents.DamageReceivedEvent{
+				TargetID:   string(aliceEntityID),
+				SourceID:   string(gobEntityID),
+				Amount:     4,
+				DamageType: damage.Slashing,
+			})
+		}
+	}
+
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+	}
+	err = s.enc.Move(alicePlayerID, path)
+	s.Require().NoError(err)
+
+	aliceAfter := s.enc.ToData().Players[alicePlayerID]
+	s.Equal(16, aliceAfter.HP, "unpaired damage must still apply, not be silently dropped")
+
+	var dmgEvt *events.DamageDealtEvent
+	deadline := time.After(2 * time.Second)
+drainLoopUnpaired:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoopUnpaired
+			}
+			if de, isDmg := evt.(*events.DamageDealtEvent); isDmg {
+				dmgEvt = de
+				break drainLoopUnpaired
+			}
+		case <-deadline:
+			break drainLoopUnpaired
+		}
+	}
+	s.Require().NotNil(dmgEvt, "DamageDealtEvent must still publish for unpaired damage")
+	s.Equal(4, dmgEvt.Amount)
+	s.Equal(16, dmgEvt.HPAfter)
+}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -698,6 +698,18 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 // the same synchronous combat.ResolveAttack call, and OAs resolve one at a
 // time (not concurrently). So within a step, the two captured slices line
 // up positionally: the Nth hit roll consumes the Nth entry in damages.
+//
+// Copilot review on #718 flagged that a strict roll-driven loop can
+// silently drop damage: a MovementResolver implementation that publishes
+// DamageReceivedEvent without a preceding PostAttackRollEvent (a non-attack
+// movement hazard, or a resolver that doesn't route through
+// combat.ResolveAttackHit) would never reach the loop body, and its HP
+// delta would be lost. Any damages left unconsumed after the roll loop —
+// whether from more damage entries than hit rolls, or no rolls at all —
+// still apply via applyMoveDamage's fallback shape (HP + DamageDealtEvent,
+// no paired AttackResolvedEvent since there's no roll to report). HP
+// correctness takes priority over the attackResolved-shape guarantee when
+// the two signals disagree.
 func (e *Encounter) applyMoveAttackOutcomes(
 	rolls []dnd5eEvents.PostAttackRollEvent, damages []dnd5eEvents.DamageReceivedEvent,
 ) error {
@@ -717,6 +729,13 @@ func (e *Encounter) applyMoveAttackOutcomes(
 			continue
 		}
 		if err := e.applyMoveDamage(*dmg); err != nil {
+			return err
+		}
+	}
+	// Unpaired damage: no matching roll, so no AttackResolvedEvent to
+	// publish alongside it — apply HP + DamageDealtEvent on their own.
+	for _, dmg := range damages[dmgIdx:] {
+		if err := e.applyMoveDamage(dmg); err != nil {
 			return err
 		}
 	}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
@@ -681,21 +682,100 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 	return nil
 }
 
-// applyMoveDamage translates each dnd5e DamageReceivedEvent captured
-// during a movement step into an encounter DamageDealtEvent. Mirrors
-// applyCapturedDamage but resolves the source position dynamically from
-// the event's SourceID: Move-path OAs fire from EITHER direction (player
-// attacker on a fleeing NPC, or NPC attacker on a fleeing player), so
-// the per-viewer LoS projection key cannot be hard-coded to a single
-// source type.
+// applyMoveAttackOutcomes translates the PostAttackRollEvents (and, for
+// hits, the paired DamageReceivedEvents) captured during one movement step
+// into encounter events, mirroring publishAttackOutcome's shape for the
+// TakeAction path: AttackResolvedEvent is published for every roll — hit or
+// miss — and DamageDealtEvent only for rolls that hit. Closes #715: before
+// this, the Move-path OA seam only observed DamageReceivedTopic, so a miss
+// (which combat.ApplyAttackOutcome never publishes damage for) produced no
+// event at all, and a hit produced a bare DamageDealtEvent with no
+// AttackResolvedEvent alongside it.
+//
+// Matching rolls to damages: combat.ResolveAttackHit unconditionally
+// publishes one PostAttackRollEvent before combat.ApplyAttackOutcome
+// conditionally publishes one DamageReceivedEvent (hit only) — both within
+// the same synchronous combat.ResolveAttack call, and OAs resolve one at a
+// time (not concurrently). So within a step, the two captured slices line
+// up positionally: the Nth hit roll consumes the Nth entry in damages.
+func (e *Encounter) applyMoveAttackOutcomes(
+	rolls []dnd5eEvents.PostAttackRollEvent, damages []dnd5eEvents.DamageReceivedEvent,
+) error {
+	dmgIdx := 0
+	for _, roll := range rolls {
+		var dmg *dnd5eEvents.DamageReceivedEvent
+		if roll.WouldHit && dmgIdx < len(damages) {
+			d := damages[dmgIdx]
+			dmg = &d
+			dmgIdx++
+		}
+
+		if err := e.publishMoveAttackResolved(roll); err != nil {
+			return err
+		}
+		if dmg == nil {
+			continue
+		}
+		if err := e.applyMoveDamage(*dmg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// publishMoveAttackResolved publishes an encounter AttackResolvedEvent for
+// one Move-path attack roll (hit or miss). Per-viewer projection mirrors
+// applyMoveDamage: a viewer is included if they can see the attacker or the
+// target. Critical is approximated from IsNaturalTwenty — the rulebook's
+// PostAttackRollEvent does not carry the attacker's CriticalThreshold, so an
+// extended crit range (e.g. Champion's Improved Critical) is not reflected
+// here; that gap exists only for the Move-path OA projection, not the
+// underlying damage roll (which does apply the extended threshold).
+func (e *Encounter) publishMoveAttackResolved(roll dnd5eEvents.PostAttackRollEvent) error {
+	attackerID := encountercore.EntityID(roll.AttackerID)
+	targetID := encountercore.EntityID(roll.TargetID)
+
+	attackerPos, attackerOK := e.findEntityPosition(attackerID)
+	targetPos, targetOK := e.findEntityPosition(targetID)
+
+	attackPerPlayer := make(map[encountercore.PlayerID]events.AttackResolvedSlice)
+	for viewerID, viewer := range e.data.Players {
+		seesAttacker := attackerOK && e.viewerCanSee(viewer, attackerPos)
+		seesTarget := targetOK && e.viewerCanSee(viewer, targetPos)
+		if !seesAttacker && !seesTarget {
+			continue
+		}
+		attackPerPlayer[viewerID] = events.AttackResolvedSlice{Visible: true}
+	}
+
+	if err := e.broker.Publish(events.NewAttackResolvedEvent(
+		e.data.ID, e.nextSeq(),
+		attackerID, targetID,
+		roll.WouldHit, roll.IsNaturalTwenty,
+		roll.AttackRoll, roll.AttackBonus, roll.OriginalAC,
+		attackPerPlayer,
+	)); err != nil {
+		return fmt.Errorf("publish attack resolved: %w", err)
+	}
+	return nil
+}
+
+// applyMoveDamage translates one dnd5e DamageReceivedEvent captured during a
+// movement step into an encounter DamageDealtEvent. Mirrors
+// applyCapturedDamage but resolves the source position dynamically from the
+// event's SourceID: Move-path OAs fire from EITHER direction (player
+// attacker on a fleeing NPC, or NPC attacker on a fleeing player), so the
+// per-viewer LoS projection key cannot be hard-coded to a single source
+// type.
 //
 // Wave 2.11e (#675): MovementResolver path damage application.
 // combat.MoveEntity → triggerOpportunityAttack → combat.ResolveAttack
-// publishes DamageReceivedEvent on the bus mid-iterate; the encounter
-// SDK captures the events around ResolveStep
-// (iterateMovementStepsForEntity) and dispatches HP delta + encounter-
-// side DamageDealtEvent here, plus the kill/death chain on the >0 → 0
-// transition.
+// publishes DamageReceivedEvent on the bus mid-iterate; the encounter SDK
+// captures the events around ResolveStep (iterateMovementStepsForEntity)
+// and dispatches HP delta + encounter-side DamageDealtEvent here, plus the
+// kill/death chain on the >0 → 0 transition. #715: called only for hits —
+// applyMoveAttackOutcomes matches each hit roll to its damage entry and
+// publishes the roll's AttackResolvedEvent before calling in here.
 //
 // Source resolution: tries player → monster. If neither matches, HP is
 // still applied (damage application is more important than the wire
@@ -703,51 +783,49 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 // visibility — viewers who can see the target see the event, viewers
 // who can't, don't. The same skip rule as applyCapturedDamage applies
 // for unknown targets (we can't mutate HP on something we can't find).
-func (e *Encounter) applyMoveDamage(damages []dnd5eEvents.DamageReceivedEvent) error {
-	for _, dmg := range damages {
-		targetID := encountercore.EntityID(dmg.TargetID)
-		sourceID := encountercore.EntityID(dmg.SourceID)
+func (e *Encounter) applyMoveDamage(dmg dnd5eEvents.DamageReceivedEvent) error {
+	targetID := encountercore.EntityID(dmg.TargetID)
+	sourceID := encountercore.EntityID(dmg.SourceID)
 
-		hpBefore, hpAfter, maxHP, targetPos, isMonster, ok := e.applyDamageToTarget(targetID, dmg.Amount)
-		if !ok {
+	hpBefore, hpAfter, maxHP, targetPos, isMonster, ok := e.applyDamageToTarget(targetID, dmg.Amount)
+	if !ok {
+		return nil
+	}
+	damageType := string(dmg.DamageType)
+	if damageType == "" {
+		damageType = damageTypeUntyped
+	}
+	// Per-viewer projection: a viewer is included if they have LoS to
+	// the source OR the target. Source lookup is best-effort — if it
+	// fails (unknown SourceID), the projection falls back to
+	// target-only visibility rather than dropping the event entirely.
+	sourcePos, sourceOK := e.findEntityPosition(sourceID)
+	damagePerPlayer := make(map[encountercore.PlayerID]events.DamageDealtSlice)
+	for viewerID, viewer := range e.data.Players {
+		canSeeSource := sourceOK && e.viewerCanSee(viewer, sourcePos)
+		canSeeTarget := e.viewerCanSee(viewer, targetPos)
+		if !canSeeSource && !canSeeTarget {
 			continue
 		}
-		damageType := string(dmg.DamageType)
-		if damageType == "" {
-			damageType = damageTypeUntyped
-		}
-		// Per-viewer projection: a viewer is included if they have LoS to
-		// the source OR the target. Source lookup is best-effort — if it
-		// fails (unknown SourceID), the projection falls back to
-		// target-only visibility rather than dropping the event entirely.
-		sourcePos, sourceOK := e.findEntityPosition(sourceID)
-		damagePerPlayer := make(map[encountercore.PlayerID]events.DamageDealtSlice)
-		for viewerID, viewer := range e.data.Players {
-			canSeeSource := sourceOK && e.viewerCanSee(viewer, sourcePos)
-			canSeeTarget := e.viewerCanSee(viewer, targetPos)
-			if !canSeeSource && !canSeeTarget {
-				continue
+		damagePerPlayer[viewerID] = events.DamageDealtSlice{Visible: true}
+	}
+	if err := e.broker.Publish(events.NewDamageDealtEvent(
+		e.data.ID, e.nextSeq(),
+		targetID, sourceID,
+		dmg.Amount, damageType,
+		hpAfter, maxHP,
+		damagePerPlayer,
+	)); err != nil {
+		return fmt.Errorf("publish damage dealt: %w", err)
+	}
+	if hpBefore > 0 && hpAfter == 0 {
+		if isMonster {
+			if err := e.killEntity(targetID, sourceID); err != nil {
+				return err
 			}
-			damagePerPlayer[viewerID] = events.DamageDealtSlice{Visible: true}
-		}
-		if err := e.broker.Publish(events.NewDamageDealtEvent(
-			e.data.ID, e.nextSeq(),
-			targetID, sourceID,
-			dmg.Amount, damageType,
-			hpAfter, maxHP,
-			damagePerPlayer,
-		)); err != nil {
-			return fmt.Errorf("publish damage dealt: %w", err)
-		}
-		if hpBefore > 0 && hpAfter == 0 {
-			if isMonster {
-				if err := e.killEntity(targetID, sourceID); err != nil {
-					return err
-				}
-			} else {
-				if err := e.publishPlayerDied(targetID, sourceID); err != nil {
-					return err
-				}
+		} else {
+			if err := e.publishPlayerDied(targetID, sourceID); err != nil {
+				return err
 			}
 		}
 	}
@@ -1015,6 +1093,39 @@ func subscribeDamage(
 	subID, err := topic.Subscribe(ctx, func(_ context.Context, evt dnd5eEvents.DamageReceivedEvent) error {
 		*captured = append(*captured, evt)
 		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	unsub := func() error { return topic.Unsubscribe(ctx, subID) }
+	return captured, unsub, nil
+}
+
+// subscribeAttackRolls attaches a pure observer to the dnd5e
+// PostAttackRollChain. combat.ResolveAttackHit publishes one
+// PostAttackRollEvent per attack — hit or miss — before
+// combat.ApplyAttackOutcome conditionally publishes DamageReceivedEvent
+// (hit only). #715: this is the toolkit-side signal the Move-path OA seam
+// (iterateMovementStepsForEntity) uses to detect attack-roll outcomes;
+// the MovementResolver interface itself only returns Prevented/
+// PreventReason, so roll detail (roll, bonus, AC, hit/miss) only reaches
+// the encounter SDK via the bus.
+//
+// The handler does not modify the chain — it observes and passes it
+// through unchanged, matching the pattern used elsewhere for read-only
+// chain observers (e.g. ShieldSpellCondition.onPostAttackRoll).
+func subscribeAttackRolls(
+	ctx context.Context, bus dnd5events.EventBus,
+) (*[]dnd5eEvents.PostAttackRollEvent, func() error, error) {
+	captured := &[]dnd5eEvents.PostAttackRollEvent{}
+	topic := dnd5eEvents.PostAttackRollChain.On(bus)
+	subID, err := topic.SubscribeWithChain(ctx, func(
+		_ context.Context, evt *dnd5eEvents.PostAttackRollEvent, c chain.Chain[*dnd5eEvents.PostAttackRollEvent],
+	) (chain.Chain[*dnd5eEvents.PostAttackRollEvent], error) {
+		if evt != nil {
+			*captured = append(*captured, *evt)
+		}
+		return c, nil
 	})
 	if err != nil {
 		return nil, nil, err

--- a/encounter/npc_test.go
+++ b/encounter/npc_test.go
@@ -194,21 +194,17 @@ func (s *NPCSuite) TestNPCAct_MovementOA_AppliesDamageOnce() {
 	dataJSON, err := json.Marshal(gobData)
 	s.Require().NoError(err)
 
-	// Stub MovementResolver that publishes a DamageReceivedEvent targeting
-	// the goblin (mover) during step 0 — simulating an OA the player has
-	// already taken against the retreating monster. combat.ResolveAttack
-	// would do this in production.
+	// Stub MovementResolver that publishes the PostAttackRollEvent +
+	// DamageReceivedEvent pair targeting the goblin (mover) during step 0 —
+	// simulating an OA the player has already taken against the retreating
+	// monster. combat.ResolveAttack would do this in production (#715:
+	// ResolveAttackHit always publishes the roll event before
+	// ApplyAttackOutcome conditionally publishes the damage event).
 	const oaDamage = 5
 	resolver := &stubMovementResolver{
 		publishOnStep: func(bus dnd5events.EventBus, stepIdx int) {
 			if stepIdx == 0 {
-				topic := dnd5eEvents.DamageReceivedTopic.On(bus)
-				_ = topic.Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
-					TargetID:   string(gobEntityID),
-					SourceID:   string(aliceEntityID),
-					Amount:     oaDamage,
-					DamageType: damage.Slashing,
-				})
+				publishOAHit(bus, string(aliceEntityID), string(gobEntityID), oaDamage)
 			}
 		},
 	}


### PR DESCRIPTION
## Summary

Closes #715
Part of KirkDiggler/rpg-project#54

- Root cause: the Move-path OA seam (`iterateMovementStepsForEntity`) only observed `DamageReceivedTopic`. `combat.ApplyAttackOutcome` never publishes a damage event on a miss (`if !hit { return }`), so a miss produced **no encounter event at all**, and a hit produced a bare `DamageDealtEvent` with **no `AttackResolvedEvent` alongside it** — a different shape than the normal `TakeAction` path's `publishAttackOutcome`, which always emits `AttackResolvedEvent` and gates `DamageDealtEvent` on `Hit`.
- Fix: subscribe to `dnd5eEvents.PostAttackRollChain` (published unconditionally, hit or miss, by `combat.ResolveAttackHit`) alongside the existing damage subscription during each movement step. `applyMoveAttackOutcomes` now publishes `AttackResolvedEvent` for every captured roll and matches hit rolls to their damage entries positionally (both are published synchronously within the same `combat.ResolveAttack` call, one OA at a time) to publish `DamageDealtEvent` only on hits.
- New helper `subscribeAttackRolls` (`encounter/npc.go`) is a pure chain observer on `PostAttackRollChain`, matching the existing read-only-observer pattern used elsewhere (e.g. `ShieldSpellCondition.onPostAttackRoll`).
- `applyMoveDamage` narrowed from a slice-processing loop to a single-event function, called once per matched hit from `applyMoveAttackOutcomes`.
- Updated 3 pre-existing tests (`TestMove_PlayerMoves_OADamagesPlayer`, `TestNPCMove_NPCMoves_OADamagesMonster`, `TestMove_OAKillsMonster_FiresKillChain`, plus `TestNPCAct_MovementOA_AppliesDamageOnce` in npc_test.go) whose stubs previously simulated only the damage half of what a real resolver publishes — they now publish the paired `PostAttackRollEvent` too, matching production's `combat.ResolveAttack` behavior.

## New tests (TDD)

- `TestMove_OAMisses_EmitsAttackResolvedNoDamage` — an OA miss publishes `AttackResolvedEvent{Hit:false}` with roll detail, and no `DamageDealtEvent`; HP unchanged.
- `TestMove_OAHits_EmitsAttackResolvedAndDamage` — an OA hit publishes both `AttackResolvedEvent{Hit:true}` and `DamageDealtEvent`.

Both fail against pre-fix `origin/main` and pass after the fix.

## Test plan
- [x] `go test ./...` (encounter module) — all green
- [x] `go test -race ./...` (encounter module) — all green
- [x] `golangci-lint run ./...` (encounter module) — 36 pre-existing `goconst` issues only, identical to `origin/main` baseline; no new issues
- [x] `go fmt ./...` / `go mod tidy` — no diff
- [x] `make pre-commit` fails identically on a clean `origin/main` checkout (unrelated `core` module coverage-script bug, `bc`/`awk` parsing error) — not fallout from this change
- [ ] End-to-end playtest — deferred per task scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm