### PR TITLE
fix(encounter): Move verb enforces and spends the movement budget

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-06-01
-confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code
+updated: 2026-07-02
+confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02
 ---
 
 # rpg-toolkit: Where We Are
@@ -10,6 +10,22 @@ confidence: medium — seeded from full repo read, test run, go.mod inspection, 
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**#714 — encounter Move verb enforces + spends the movement budget
+(2026-07-02, PR #720).** `Encounter.Move` had no economy accounting at all (its
+own doc said "Slice scope: no action economy") — `movement_remaining` never
+decremented and a second move landed in full after the first was already spent
+(live playtest: 40ft on a 30ft speed). Move now, for an in-combat hydrated
+mover, pre-checks the requested path's cost (hex-distance × 5ft) against
+`MovementRemaining` before any per-step chain runs (over budget →
+`ErrInsufficientMovement`, no mutation), spends the *actual* traveled distance
+via `character.ExecuteAction(Move, Distance)`, and pushes a `TurnStateChanged`
+with the new budget (Inv 12). `character.executeMove` gained a `Distance` arg
+and rejects non-positive distances. Also added `MoveEvent.From` (true origin —
+`Path` is destinations-only). Spans two modules (`rulebooks/dnd5e` char-pkg +
+`encounter`). Deferred: player wire moves carry `actualPath:[from,to]` only vs
+NPC hex-by-hex — budget math is granularity-independent, so this is an rpg-api
+follow-up, not a toolkit gap.
 
 **#704 (TakeAction wave) — encounter pushes TurnStateChangedEvent on
 turn-state/economy mutation (2026-06-01, ADR-0033).** Closes the push-refresh

--- a/encounter/broker_test.go
+++ b/encounter/broker_test.go
@@ -38,7 +38,7 @@ func (s *BrokerSuite) TestPublish_RoutesByAudience() {
 	bobSub, err := s.broker.Subscribe("enc:1", "bob")
 	s.Require().NoError(err)
 
-	move := events.NewMoveEvent("enc:1", 1, "monster-1",
+	move := events.NewMoveEvent("enc:1", 1, "monster-1", core.Hex{},
 		[]core.Hex{{Q: 0, R: 0, S: 0}},
 		map[core.PlayerID]events.MovePlayerSlice{
 			"alice": {SeenSegments: []core.Hex{{Q: 0, R: 0, S: 0}}},
@@ -56,7 +56,7 @@ func (s *BrokerSuite) TestPublish_IsolatesEncounters() {
 	sub1, _ := s.broker.Subscribe("enc:1", "alice")
 	sub2, _ := s.broker.Subscribe("enc:2", "alice")
 
-	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x",
+	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x", core.Hex{},
 		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}})))
 
 	s.assertReceivesType(sub1, "*events.MoveEvent")
@@ -68,7 +68,7 @@ func (s *BrokerSuite) TestSubscribe_MultiSubsForSamePlayer() {
 	a1, _ := s.broker.Subscribe("enc:1", "alice")
 	a2, _ := s.broker.Subscribe("enc:1", "alice")
 
-	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x",
+	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x", core.Hex{},
 		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}})))
 
 	s.assertReceivesType(a1, "*events.MoveEvent")
@@ -81,7 +81,7 @@ func (s *BrokerSuite) TestClose_RemovesOnlyClosedSub() {
 	a2, _ := s.broker.Subscribe("enc:1", "alice")
 	s.Require().NoError(a1.Close())
 
-	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x",
+	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x", core.Hex{},
 		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}})))
 
 	// a2 still receives — the meaningful assertion.

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -58,6 +58,14 @@ var (
 	// player and monster→monster are out of scope until a wave adds the
 	// corresponding verb. Maps to gRPC Unimplemented.
 	ErrUnsupportedAttackDirection = errors.New("unsupported attack direction")
+	// ErrInsufficientMovement is returned by Move when the requested path
+	// costs more feet than the mover's remaining movement budget for the
+	// turn (rpg-toolkit#714). The move is rejected outright — no partial
+	// move, no state mutation, no chain execution — rather than silently
+	// accepted. A hydrated character not currently in combat (economy
+	// unseeded) is not gated; this only fires once a turn economy exists.
+	// Maps to gRPC FailedPrecondition.
+	ErrInsufficientMovement = errors.New("insufficient movement remaining")
 )
 
 // damageTypeUntyped is the fallback damage type emitted when an attacker's

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -588,27 +588,54 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		}
 	}
 
+	// Spend the movement budget BEFORE mutating encounter-side state or
+	// publishing the MoveEvent (#714 review). The affordability gate is the
+	// pre-check above — it runs before ANY side effect and is the only place an
+	// over-budget move is rejected ("rejected outright, no state mutation").
+	// This spend is structurally guaranteed to succeed (actualCost <=
+	// requestedCost, already checked against remaining), so ordering it first
+	// means an unreachable spend failure cannot leave a published MoveEvent
+	// behind it. actualCost may be less than requestedCost when a chain
+	// subscriber truncated the path; a zero-cost move (a degenerate path back
+	// to the same hex) spends nothing and is not sent to the rules layer, which
+	// rejects non-positive distances.
+	//
+	// Full atomicity is not achievable at this seam and is not claimed: the
+	// MovementResolver already applied physical side effects (room position,
+	// OA damage) during iterateMovementSteps, before the traveled distance —
+	// and thus the spend — could be known. The pre-check is the atomic gate;
+	// this is the accounting that follows a move that physically happened.
+	spentMovement := false
+	if tracksMovement {
+		if actualCost := pathCostFeet(moverStart, traveledPath); actualCost > 0 {
+			out, err := char.ExecuteAction(context.Background(), &dnd5eCharacter.ExecuteActionInput{
+				ActionRef: refs.Actions.Move(),
+				Distance:  actualCost,
+			})
+			if err != nil {
+				return fmt.Errorf("spend movement economy: %w", err)
+			}
+			if !out.Success {
+				// Structurally unreachable: actualCost <= requestedCost, and
+				// requestedCost was already checked against remaining above.
+				// Surfaced rather than swallowed so a future divergence between
+				// the pre-check and the spend is loud, not silent.
+				return fmt.Errorf("%w: %s", ErrInsufficientMovement, out.Error)
+			}
+			spentMovement = true
+		}
+	}
+
 	corrID, err := e.applyAndPublishMove(p, playerID, moverStart, traveledPath)
 	if err != nil {
 		return err
 	}
 
-	if tracksMovement {
-		actualCost := pathCostFeet(moverStart, traveledPath)
-		out, err := char.ExecuteAction(context.Background(), &dnd5eCharacter.ExecuteActionInput{
-			ActionRef: refs.Actions.Move(),
-			Distance:  actualCost,
-		})
-		if err != nil {
-			return fmt.Errorf("spend movement economy: %w", err)
-		}
-		if !out.Success {
-			// Structurally unreachable: actualCost <= requestedCost, and
-			// requestedCost was already checked against remaining above.
-			// Surfaced rather than swallowed so a future divergence between
-			// the pre-check and the spend is loud, not silent.
-			return fmt.Errorf("%w: %s", ErrInsufficientMovement, out.Error)
-		}
+	// Push the post-move economy refresh so the client sees the new
+	// movement_remaining live (Invariant 12), correlated to the MoveEvent that
+	// caused it (Invariant 8). Only when movement was actually spent — a
+	// zero-cost move changes no economy, so there is nothing to refresh.
+	if spentMovement {
 		if err := e.publishTurnStateChanged(p.EntityID, corrID); err != nil {
 			return fmt.Errorf("publish turn-state changed: %w", err)
 		}

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -11,8 +11,10 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 // OAReactionRef is the canonical reaction ref string for Opportunity Attack.
@@ -495,6 +497,29 @@ func (e *Encounter) nextSeq() uint64 {
 	return e.data.Sequence
 }
 
+// moveFeetPerHex is the D&D 5e grid unit: one hex step costs 5 feet of
+// movement (mirrors combat.FeetPerGridUnit for the encounter SDK's own
+// cube-coordinate hexes, which the combat package's grid units don't share a
+// type with).
+const moveFeetPerHex = 5
+
+// pathCostFeet sums the cube-coordinate hex distance between consecutive
+// waypoints — moverStart, then each entry in path in turn — and converts to
+// feet. Summing distances (not counting slice length) keeps the cost correct
+// regardless of whether the caller supplies a dense hex-by-hex path or a
+// sparse endpoints-only path (#714): the total feet moved is the same either
+// way, even though the per-step chain iteration below treats each path entry
+// as one resolver step.
+func pathCostFeet(moverStart core.Hex, path []core.Hex) int {
+	hexes := 0
+	from := moverStart
+	for _, to := range path {
+		hexes += perception.HexDistance(from, to)
+		from = to
+	}
+	return hexes * moveFeetPerHex
+}
+
 // Move applies a move action by playerID along path. Validates, mutates
 // player position, and publishes the cause event (MoveEvent) plus a
 // HexRevealedEvent for any viewer whose vision grew.
@@ -508,8 +533,21 @@ func (e *Encounter) nextSeq() uint64 {
 // resolver is wired, the legacy single-jump behavior is preserved for
 // non-combat encounters.
 //
-// Slice scope: no action economy, no turn-order enforcement, no
-// path-contiguity validation beyond non-empty.
+// #714: when the mover has a hydrated, in-combat character (a seeded turn
+// economy), Move enforces and spends its movement budget. The requested
+// path's cost is checked against MovementRemaining BEFORE running any
+// per-step chain — an over-budget request is rejected outright
+// (ErrInsufficientMovement), with no state mutation, no OA triggering, no
+// partial move. Once the move resolves (traveledPath may be shorter than the
+// request if a chain subscriber like Disengage stops it early), the ACTUAL
+// traveled distance is spent from the budget and a TurnStateChangedEvent
+// pushes the new movement_remaining to the client (Invariant 12). A mover
+// with no hydrated character, or one not currently in combat (no seeded
+// economy — free-roam/pre-combat), is not gated: movement stays free, as
+// before.
+//
+// Remaining slice scope: no turn-order enforcement, no path-contiguity
+// validation beyond non-empty.
 func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	if len(path) == 0 {
 		return errors.New("empty path")
@@ -520,6 +558,17 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	}
 
 	moverStart := p.View.Position
+
+	char := e.heldCharacter(p.EntityID)
+	tracksMovement := char != nil && char.InCombat()
+	if tracksMovement {
+		requestedCost := pathCostFeet(moverStart, path)
+		remaining := char.GetActionEconomy().MovementRemaining
+		if requestedCost > remaining {
+			return fmt.Errorf("%w: path costs %dft, %dft remaining",
+				ErrInsufficientMovement, requestedCost, remaining)
+		}
+	}
 
 	// Determine the actually-traveled path. Without a resolver, the legacy
 	// single-jump path is the entire requested path. With a resolver, the
@@ -534,12 +583,38 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		traveledPath = traveled
 		if len(traveledPath) == 0 {
 			// Movement was prevented at the very first step. Nothing to
-			// publish — position unchanged, no events fire.
+			// publish — position unchanged, no events fire, nothing spent.
 			return nil
 		}
 	}
 
-	return e.applyAndPublishMove(p, playerID, moverStart, traveledPath)
+	corrID, err := e.applyAndPublishMove(p, playerID, moverStart, traveledPath)
+	if err != nil {
+		return err
+	}
+
+	if tracksMovement {
+		actualCost := pathCostFeet(moverStart, traveledPath)
+		out, err := char.ExecuteAction(context.Background(), &dnd5eCharacter.ExecuteActionInput{
+			ActionRef: refs.Actions.Move(),
+			Distance:  actualCost,
+		})
+		if err != nil {
+			return fmt.Errorf("spend movement economy: %w", err)
+		}
+		if !out.Success {
+			// Structurally unreachable: actualCost <= requestedCost, and
+			// requestedCost was already checked against remaining above.
+			// Surfaced rather than swallowed so a future divergence between
+			// the pre-check and the spend is loud, not silent.
+			return fmt.Errorf("%w: %s", ErrInsufficientMovement, out.Error)
+		}
+		if err := e.publishTurnStateChanged(p.EntityID, corrID); err != nil {
+			return fmt.Errorf("publish turn-state changed: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // iterateMovementSteps walks the path one hex at a time for the given
@@ -659,9 +734,14 @@ func (e *Encounter) iterateMovementStepsForEntity(
 //
 // Wave 2.11e (#658 Q3): events carry the truncated traveled path, not the
 // requested path. Wire clients see the actual outcome, not the intent.
+//
+// Returns the correlation id derived from the published MoveEvent's sequence
+// (#714) so the caller can tie a follow-on TurnStateChanged economy refresh
+// to the move that caused it (Invariant 8), the same shape
+// publishActionResolved uses for other verbs.
 func (e *Encounter) applyAndPublishMove(
 	p *PlayerData, playerID core.PlayerID, moverStart core.Hex, traveledPath []core.Hex,
-) error {
+) (core.CorrelationID, error) {
 	// 1. Compute the mover's reveal delta BEFORE mutating position/view.
 	//    - moverStart is needed for visibility-transition detection (so viewers
 	//      can determine if the mover was visible to them before the move).
@@ -735,16 +815,18 @@ func (e *Encounter) applyAndPublishMove(
 
 	// 4. Publish — cause event always; effect event only when someone's
 	//    vision changed. The two events get sequential sequence numbers.
+	moveSeq := e.nextSeq()
+	corrID := e.correlationFor(moveSeq)
 	if err := e.broker.Publish(events.NewMoveEvent(
-		e.data.ID, e.nextSeq(), p.EntityID, traveledPath, movePerPlayer,
+		e.data.ID, moveSeq, p.EntityID, moverStart, traveledPath, movePerPlayer,
 	)); err != nil {
-		return fmt.Errorf("publish move: %w", err)
+		return "", fmt.Errorf("publish move: %w", err)
 	}
 	if len(revealPerPlayer) > 0 {
 		if err := e.broker.Publish(events.NewHexRevealedEvent(
 			e.data.ID, e.nextSeq(), revealPerPlayer,
 		)); err != nil {
-			return fmt.Errorf("publish reveal: %w", err)
+			return "", fmt.Errorf("publish reveal: %w", err)
 		}
 	}
 
@@ -757,7 +839,7 @@ func (e *Encounter) applyAndPublishMove(
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), p.EntityID, hex, viewers,
 		)); err != nil {
-			return fmt.Errorf("publish entity appeared: %w", err)
+			return "", fmt.Errorf("publish entity appeared: %w", err)
 		}
 	}
 
@@ -768,10 +850,10 @@ func (e *Encounter) applyAndPublishMove(
 		if err := e.broker.Publish(events.NewEntityDisappearedEvent(
 			e.data.ID, e.nextSeq(), p.EntityID, disappearedPerPlayer,
 		)); err != nil {
-			return fmt.Errorf("publish entity disappeared: %w", err)
+			return "", fmt.Errorf("publish entity disappeared: %w", err)
 		}
 	}
-	return nil
+	return corrID, nil
 }
 
 // OpenDoor applies an open-door action. Marks the door open and publishes

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -106,7 +106,7 @@ func (s *EventsSuite) TestSpineMeta_StampAndAccessors() {
 	corr := core.CorrelationID("corr-enc-1-7")
 
 	samples := []events.EncounterEvent{
-		events.NewMoveEvent("enc-1", 1, "bob", nil, nil),
+		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil),
 		events.NewAttackResolvedEvent("enc-1", 2, "a", "b", true, false, 1, 1, 1, nil),
 		events.NewDamageDealtEvent("enc-1", 3, "a", "b", 1, "slashing", 1, 1, nil),
 		events.NewActionResolvedEvent("enc-1", 4, "a", "dnd5e:action:attack", "b",
@@ -184,7 +184,7 @@ func (s *EventsSuite) TestActionResolvedEvent_JSONRoundTrip() {
 
 // MoveEvent.Audience derives from PerPlayer keys; absent players are not in audience.
 func (s *EventsSuite) TestMoveEvent_AudienceFromPerPlayer() {
-	e := events.NewMoveEvent("enc-1", 7, "bob",
+	e := events.NewMoveEvent("enc-1", 7, "bob", core.Hex{},
 		[]core.Hex{{Q: 0, R: 0, S: 0}},
 		map[core.PlayerID]events.MovePlayerSlice{
 			"alice": {SeenSegments: []core.Hex{{Q: 0, R: 0, S: 0}}},
@@ -197,9 +197,12 @@ func (s *EventsSuite) TestMoveEvent_AudienceFromPerPlayer() {
 	s.ElementsMatch(events.AudienceSet{"alice", "carol"}, e.Audience())
 }
 
-// MoveEvent JSON round-trip preserves all fields, including unexported encID/seq.
+// MoveEvent JSON round-trip preserves all fields, including unexported
+// encID/seq and From (#714 — From is the honest origin hex, distinct from
+// Path[0] which is the first traveled STEP; a real, non-zero From here
+// guards against the two silently collapsing back to the same value).
 func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
-	original := events.NewMoveEvent("enc-1", 42, "bob",
+	original := events.NewMoveEvent("enc-1", 42, "bob", core.Hex{Q: 0, R: 0, S: 0},
 		[]core.Hex{{Q: 1, R: -1, S: 0}, {Q: 2, R: -1, S: -1}},
 		map[core.PlayerID]events.MovePlayerSlice{
 			"alice": {SeenSegments: []core.Hex{{Q: 1, R: -1, S: 0}}},
@@ -215,6 +218,8 @@ func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
 	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
 	s.Equal(uint64(42), decoded.Sequence())
 	s.Equal(core.EntityID("bob"), decoded.Mover)
+	s.Equal(core.Hex{Q: 0, R: 0, S: 0}, decoded.From)
+	s.NotEqual(decoded.Path[0], decoded.From, "From (origin) must differ from Path[0] (first step) in this fixture")
 	s.Equal(original.Path, decoded.Path)
 	s.Require().Contains(decoded.PerPlayer, core.PlayerID("alice"))
 	s.Equal(original.PerPlayer["alice"].SeenSegments, decoded.PerPlayer["alice"].SeenSegments)
@@ -293,7 +298,7 @@ func (s *EventsSuite) TestEntityDisappearedEvent_JSONRoundTrip() {
 // Type switch returns the concrete type.
 func (s *EventsSuite) TestTypeSwitch_RecoversConcrete() {
 	evts := []events.EncounterEvent{
-		events.NewMoveEvent("enc-1", 1, "bob", nil, nil),
+		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil),
 		events.NewHexRevealedEvent("enc-1", 2, nil),
 		events.NewDoorOpenedEvent("enc-1", 3, "door-1", "bob", nil),
 		events.NewEntityAppearedEvent("enc-1", 4, "bob", core.Hex{}, nil),

--- a/encounter/events/move.go
+++ b/encounter/events/move.go
@@ -16,11 +16,13 @@ type MoveEvent struct {
 	encID core.EncounterID
 	seq   uint64
 	Mover core.EntityID
-	// From is the mover's position BEFORE this move (#714). Path never
-	// includes the origin — it is the traveled destinations only, one entry
-	// per completed step — so a consumer deriving "from" via Path[0] gets the
-	// first STEP, not the origin. This field is the honest source: it always
-	// carries the true starting hex, even when Path has a single entry.
+	// From is the mover's position BEFORE this move (#714). Path is the
+	// traveled destinations — the encounter's own publish paths build it from
+	// completed steps and do not prepend the origin — so a consumer deriving
+	// "from" via Path[0] risks reading the first destination, not the origin.
+	// (The SDK does not validate Path contents supplied by callers, so treat
+	// this as guidance, not an invariant.) Use From for the true starting hex
+	// regardless of what Path contains.
 	From      core.Hex
 	Path      []core.Hex
 	PerPlayer map[core.PlayerID]MovePlayerSlice

--- a/encounter/events/move.go
+++ b/encounter/events/move.go
@@ -13,9 +13,15 @@ import (
 // cause/effect decision in sdk-direction.md.
 type MoveEvent struct {
 	eventMeta
-	encID     core.EncounterID
-	seq       uint64
-	Mover     core.EntityID
+	encID core.EncounterID
+	seq   uint64
+	Mover core.EntityID
+	// From is the mover's position BEFORE this move (#714). Path never
+	// includes the origin — it is the traveled destinations only, one entry
+	// per completed step — so a consumer deriving "from" via Path[0] gets the
+	// first STEP, not the origin. This field is the honest source: it always
+	// carries the true starting hex, even when Path has a single entry.
+	From      core.Hex
 	Path      []core.Hex
 	PerPlayer map[core.PlayerID]MovePlayerSlice
 }
@@ -36,6 +42,7 @@ func NewMoveEvent(
 	encID core.EncounterID,
 	seq uint64,
 	mover core.EntityID,
+	from core.Hex,
 	path []core.Hex,
 	perPlayer map[core.PlayerID]MovePlayerSlice,
 ) *MoveEvent {
@@ -43,6 +50,7 @@ func NewMoveEvent(
 		encID:     encID,
 		seq:       seq,
 		Mover:     mover,
+		From:      from,
 		Path:      path,
 		PerPlayer: perPlayer,
 	}
@@ -69,6 +77,7 @@ type moveEventWire struct {
 	EncID     core.EncounterID                  `json:"encounter_id"`
 	Seq       uint64                            `json:"sequence"`
 	Mover     core.EntityID                     `json:"mover"`
+	From      core.Hex                          `json:"from"`
 	Path      []core.Hex                        `json:"path"`
 	PerPlayer map[core.PlayerID]MovePlayerSlice `json:"per_player"`
 }
@@ -81,6 +90,7 @@ func (e *MoveEvent) MarshalJSON() ([]byte, error) {
 		EncID:     e.encID,
 		Seq:       e.seq,
 		Mover:     e.Mover,
+		From:      e.From,
 		Path:      e.Path,
 		PerPlayer: e.PerPlayer,
 	})
@@ -97,6 +107,7 @@ func (e *MoveEvent) UnmarshalJSON(b []byte) error {
 	e.encID = w.EncID
 	e.seq = w.Seq
 	e.Mover = w.Mover
+	e.From = w.From
 	e.Path = w.Path
 	e.PerPlayer = w.PerPlayer
 	return nil

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702161947-9392bfdc1c7f
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702161947-9392bfdc1c7f
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.0 h1:hFsMEdmblla+W0mDoe6Z/YbyP70a1vXJ4lE0+1YfB0U=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.0/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702161947-9392bfdc1c7f h1:vJIaasJG42JtIJmUZombfgmzoIz3uCENtLUcoGpqx9I=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702161947-9392bfdc1c7f/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702161947-9392bfdc1c7f h1:vJIaasJG42JtIJmUZombfgmzoIz3uCENtLUcoGpqx9I=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702161947-9392bfdc1c7f/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68 h1:SvgGmbVUoM1M5fX7Lkv2HkNuyEi3iBPN5x5p4Wzm7+0=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/move_economy_test.go
+++ b/encounter/move_economy_test.go
@@ -1,0 +1,235 @@
+package encounter_test
+
+// rpg-toolkit#714 — the Move verb never accounted movement economy:
+// movement_remaining never decremented, no budget cap (a second move could
+// land in full after the mover's speed was already spent), and no
+// TurnStateChanged followed a move so the client never saw the new budget.
+//
+// These tests exercise the real hydrated path (LoadFromData → held
+// *character.Character, mirrors TurnStateSuite's loadedMonkEncounter) rather
+// than a stub, because the bug lives in how Encounter.Move reads/writes the
+// character's own action economy — a stub combatant has none.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	moveEconPlayerID = core.PlayerID("charli")
+	moveEconEntityID = core.EntityID("char-charli")
+	moveEconDamage   = "1d8"
+)
+
+// MoveEconomySuite proves #714: a hydrated, in-combat mover's Move() spends
+// its distance from MovementRemaining, rejects an over-budget request
+// outright, and pushes a TurnStateChanged carrying the new budget.
+type MoveEconomySuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestMoveEconomySuite(t *testing.T) {
+	suite.Run(t, new(MoveEconomySuite))
+}
+
+func (s *MoveEconomySuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *MoveEconomySuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// charliCharJSON builds a level-1 Human Fighter character.Data blob (30ft
+// base speed) without a seeded ActionEconomy — SetMode(TurnBased) seeds it.
+func (s *MoveEconomySuite) charliCharJSON() json.RawMessage {
+	s.T().Helper()
+	charData := &dnd5eCharacter.Data{
+		ID:       string(moveEconEntityID),
+		PlayerID: string(moveEconPlayerID),
+		Name:     "Charli the Fighter",
+		Level:    1,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        12,
+		MaxHitPoints:     12,
+		ArmorClass:       16,
+		ProficiencyBonus: 2,
+	}
+	raw, err := json.Marshal(charData)
+	s.Require().NoError(err)
+	return raw
+}
+
+// loadedEncounter builds a TURN_BASED encounter with one hydrated Fighter
+// seat via LoadFromData, then flips to turn-based so StartTurn seeds the
+// economy (30ft movement) from the character's own speed.
+func (s *MoveEconomySuite) loadedEncounter() *encounter.Encounter {
+	s.T().Helper()
+	view := perception.NewView(moveEconPlayerID, core.Hex{}, 10)
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	data := encounter.NewData("enc-move-econ")
+	data.Players[moveEconPlayerID] = &encounter.PlayerData{
+		ID:         moveEconPlayerID,
+		EntityID:   moveEconEntityID,
+		View:       view,
+		HP:         12,
+		MaxHP:      12,
+		AC:         16,
+		DamageDice: moveEconDamage,
+		DamageType: damageSlashing,
+		DataJSON:   s.charliCharJSON(),
+	}
+	enc, err := encounter.LoadFromData(s.ctx, data, s.broker)
+	s.Require().NoError(err)
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Require().Equal(moveEconEntityID, enc.ActiveActor())
+	return enc
+}
+
+// hexPath returns a straight-line, hex-by-hex path of n adjacent steps along
+// the Q axis starting from the origin — n hexes, n * 5ft.
+func hexPath(n int) []core.Hex {
+	path := make([]core.Hex, 0, n)
+	for i := 1; i <= n; i++ {
+		path = append(path, core.Hex{Q: i, R: 0, S: -i})
+	}
+	return path
+}
+
+// TestMove_DeductsDistanceFromMovementRemaining is the headline fix: a move
+// must spend its distance, not leave the budget untouched (issue evidence:
+// movement_remaining stayed 30 for the entire turn).
+func (s *MoveEconomySuite) TestMove_DeductsDistanceFromMovementRemaining() {
+	enc := s.loadedEncounter()
+
+	pre := enc.ActorTurnState(moveEconEntityID)
+	s.Require().NotNil(pre.Economy)
+	s.Equal(30, pre.Economy.MovementRemaining, "Human fighter seeds 30ft")
+
+	// One hex = 5ft.
+	s.Require().NoError(enc.Move(moveEconPlayerID, hexPath(1)))
+
+	post := enc.ActorTurnState(moveEconEntityID)
+	s.Require().NotNil(post.Economy)
+	s.Equal(25, post.Economy.MovementRemaining, "a 1-hex move must spend 5ft")
+}
+
+// TestMove_OverBudget_RejectedOutright reproduces the exact playtest bug: a
+// 7-hex (35ft) move must not land in full on a 30ft speed. It must be
+// rejected — no position change, no economy mutation — not silently accepted.
+func (s *MoveEconomySuite) TestMove_OverBudget_RejectedOutright() {
+	enc := s.loadedEncounter()
+
+	err := enc.Move(moveEconPlayerID, hexPath(7)) // 35ft > 30ft budget
+	s.Require().Error(err, "a move costing more than the remaining budget must be rejected")
+	s.ErrorIs(err, encounter.ErrInsufficientMovement)
+
+	post := enc.ActorTurnState(moveEconEntityID)
+	s.Require().NotNil(post.Economy)
+	s.Equal(30, post.Economy.MovementRemaining, "a rejected move must not touch the budget")
+}
+
+// TestMove_SequentialMoves_AccumulateAgainstBudget is the precise repro from
+// the playtest: 1 hex spent (25ft left), then a 7-hex (35ft) move — which the
+// bug accepted in full for 40ft total on a 30ft speed. It must now be
+// rejected against the 25ft actually remaining, and the position must stay
+// at the end of the first (accepted) move.
+func (s *MoveEconomySuite) TestMove_SequentialMoves_AccumulateAgainstBudget() {
+	enc := s.loadedEncounter()
+
+	s.Require().NoError(enc.Move(moveEconPlayerID, hexPath(1)))
+	mid := enc.ActorTurnState(moveEconEntityID)
+	s.Require().Equal(25, mid.Economy.MovementRemaining)
+
+	err := enc.Move(moveEconPlayerID, hexPath(8)) // from hex 1: 7 more hexes = 35ft
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrInsufficientMovement)
+
+	post := enc.ActorTurnState(moveEconEntityID)
+	s.Equal(25, post.Economy.MovementRemaining, "the rejected second move must not spend further")
+}
+
+// TestMove_PublishesTurnStateChangedAfterSuccessfulMove proves the client
+// sees the new movement_remaining live (North-Star Invariant 12) instead of
+// going silently stale — the issue's third symptom.
+func (s *MoveEconomySuite) TestMove_PublishesTurnStateChangedAfterSuccessfulMove() {
+	enc := s.loadedEncounter()
+
+	sub, err := s.broker.Subscribe("enc-move-econ", moveEconPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.Move(moveEconPlayerID, hexPath(2))) // 10ft
+
+	var ts *events.TurnStateChangedEvent
+	deadline := time.After(500 * time.Millisecond)
+	for ts == nil {
+		select {
+		case evt := <-sub.Events():
+			if e, ok := evt.(*events.TurnStateChangedEvent); ok {
+				ts = e
+			}
+		case <-deadline:
+			s.FailNow("no TurnStateChangedEvent received after Move")
+		}
+	}
+	s.Equal(moveEconEntityID, ts.ActorID)
+	s.Equal(20, ts.State.MovementRemaining, "pushed snapshot must carry the post-move budget")
+}
+
+// TestMove_NotInCombat_SkipsEconomyEnforcement proves Move stays usable for a
+// hydrated character with no seeded turn economy (free-roam / pre-combat) —
+// the fix must not regress non-combat movement.
+func (s *MoveEconomySuite) TestMove_NotInCombat_SkipsEconomyEnforcement() {
+	view := perception.NewView(moveEconPlayerID, core.Hex{}, 10)
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	data := encounter.NewData("enc-move-econ-free")
+	data.Players[moveEconPlayerID] = &encounter.PlayerData{
+		ID:         moveEconPlayerID,
+		EntityID:   moveEconEntityID,
+		View:       view,
+		HP:         12,
+		MaxHP:      12,
+		AC:         16,
+		DamageDice: moveEconDamage,
+		DamageType: damageSlashing,
+		DataJSON:   s.charliCharJSON(),
+	}
+	enc, err := encounter.LoadFromData(s.ctx, data, s.broker)
+	s.Require().NoError(err)
+	// Mode intentionally left as-is (not TurnBased) — no economy seeded.
+
+	s.Require().NoError(enc.Move(moveEconPlayerID, hexPath(20)), "no economy to enforce outside combat")
+
+	ts := enc.ActorTurnState(moveEconEntityID)
+	s.Nil(ts.Economy, "still no economy after a free-roam move")
+}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -340,7 +340,7 @@ func (e *Encounter) applyNPCMovementSteps(mon *MonsterData, path []encountercore
 		return nil
 	}
 	if err := e.broker.Publish(events.NewMoveEvent(
-		e.data.ID, e.nextSeq(), mon.ID, traveledPath, movePerPlayer,
+		e.data.ID, e.nextSeq(), mon.ID, moverStart, traveledPath, movePerPlayer,
 	)); err != nil {
 		return fmt.Errorf("publish npc move: %w", err)
 	}

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -541,11 +541,28 @@ func (c *Character) executeUnarmedStrike() (*ExecuteActionOutput, error) {
 // is granted capacity like attacks/strikes (see executeStrike et al.), but the
 // unit is feet rather than a use-count: distance is supplied by the caller
 // (Encounter.Move computes it from the hex path) rather than fixed at 1 per
-// call. Fails without mutating state when distance exceeds
-// MovementRemaining — the caller (Encounter.Move) is expected to have already
-// rejected an over-budget request before running any movement chain, so this
-// is the structural backstop, not the primary gate.
+// call.
+//
+// Rejects (without mutating state) a non-positive distance — a move must
+// cover ground; a zero or negative distance is a caller defect, and negative
+// in particular would otherwise INCREASE the budget (MovementRemaining -=
+// negative), an economy exploit. This is a public rules-layer API, so it
+// guards its own inputs rather than trusting every caller.
+//
+// Also rejects (without mutating state) when distance exceeds
+// MovementRemaining. The encounter caller (Encounter.Move) is expected to
+// have already pre-checked an over-budget request before running any movement
+// chain, so this is the structural backstop, not the primary gate.
 func (c *Character) executeMove(distance int) (*ExecuteActionOutput, error) {
+	if distance <= 0 {
+		return &ExecuteActionOutput{
+			Success:   false,
+			Error:     fmt.Sprintf("movement distance must be positive, got %dft", distance),
+			Abilities: c.buildAvailableAbilities(),
+			Actions:   c.buildAvailableActions(),
+		}, nil
+	}
+
 	if distance > c.actionEconomy.MovementRemaining {
 		return &ExecuteActionOutput{
 			Success: false,

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -135,7 +135,7 @@ func (c *Character) ExecuteAction(_ context.Context, input *ExecuteActionInput) 
 	case refs.Actions.UnarmedStrike().ID:
 		return c.executeUnarmedStrike()
 	case refs.Actions.Move().ID:
-		return c.executeMove()
+		return c.executeMove(input.Distance)
 	default:
 		return &ExecuteActionOutput{
 			Success: false,
@@ -537,19 +537,26 @@ func (c *Character) executeUnarmedStrike() (*ExecuteActionOutput, error) {
 	}, nil
 }
 
-// executeMove handles movement (placeholder - always succeeds if movement remaining).
-func (c *Character) executeMove() (*ExecuteActionOutput, error) {
-	if c.actionEconomy.MovementRemaining <= 0 {
+// executeMove spends distance feet from the movement budget (#714). Movement
+// is granted capacity like attacks/strikes (see executeStrike et al.), but the
+// unit is feet rather than a use-count: distance is supplied by the caller
+// (Encounter.Move computes it from the hex path) rather than fixed at 1 per
+// call. Fails without mutating state when distance exceeds
+// MovementRemaining — the caller (Encounter.Move) is expected to have already
+// rejected an over-budget request before running any movement chain, so this
+// is the structural backstop, not the primary gate.
+func (c *Character) executeMove(distance int) (*ExecuteActionOutput, error) {
+	if distance > c.actionEconomy.MovementRemaining {
 		return &ExecuteActionOutput{
-			Success:   false,
-			Error:     "no movement remaining",
+			Success: false,
+			Error: fmt.Sprintf("insufficient movement: %dft requested, %dft remaining",
+				distance, c.actionEconomy.MovementRemaining),
 			Abilities: c.buildAvailableAbilities(),
 			Actions:   c.buildAvailableActions(),
 		}, nil
 	}
 
-	// Movement amount would be specified by the caller in a real implementation.
-	// For now, this just validates that movement is available.
+	c.actionEconomy.MovementRemaining -= distance
 
 	return &ExecuteActionOutput{
 		Success:   true,

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -611,6 +611,70 @@ func (s *ActionEconomyTestSuite) TestActivateAbility_Dash() {
 	s.Equal(60, char.actionEconomy.MovementRemaining)
 }
 
+// --- #714: ExecuteAction(Move) spends the movement budget ---
+
+// TestExecuteAction_Move_DeductsDistance proves a move consumes exactly its
+// requested distance from MovementRemaining rather than being a no-op
+// (rpg-toolkit#714 — Move verb had no economy accounting).
+func (s *ActionEconomyTestSuite) TestExecuteAction_Move_DeductsDistance() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{Speed: 30})
+	s.Require().NoError(err)
+
+	output, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+		ActionRef: refs.Actions.Move(),
+		Distance:  5,
+	})
+	s.Require().NoError(err)
+	s.True(output.Success)
+	s.Equal(25, char.actionEconomy.MovementRemaining)
+}
+
+// TestExecuteAction_Move_AccumulatesAcrossCalls proves sequential moves keep
+// spending against the same budget instead of each starting fresh — the exact
+// shape of the playtest bug (1 hex then 7 hexes both landing in full).
+func (s *ActionEconomyTestSuite) TestExecuteAction_Move_AccumulatesAcrossCalls() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{Speed: 30})
+	s.Require().NoError(err)
+
+	// First move: 1 hex = 5ft.
+	out1, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+		ActionRef: refs.Actions.Move(),
+		Distance:  5,
+	})
+	s.Require().NoError(err)
+	s.True(out1.Success)
+	s.Equal(25, char.actionEconomy.MovementRemaining)
+
+	// Second move: 7 hexes = 35ft — exceeds the 25ft left. Must be rejected,
+	// not silently accepted (the bug let 40ft happen on a 30ft speed).
+	out2, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+		ActionRef: refs.Actions.Move(),
+		Distance:  35,
+	})
+	s.Require().NoError(err)
+	s.False(out2.Success, "over-budget move must be rejected")
+	s.NotEmpty(out2.Error)
+	s.Equal(25, char.actionEconomy.MovementRemaining, "rejected move must not mutate the budget")
+}
+
+// TestExecuteAction_Move_ExactBudget proves a move costing exactly the
+// remaining movement succeeds and zeroes it out (boundary, not off-by-one).
+func (s *ActionEconomyTestSuite) TestExecuteAction_Move_ExactBudget() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{Speed: 30})
+	s.Require().NoError(err)
+
+	output, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+		ActionRef: refs.Actions.Move(),
+		Distance:  30,
+	})
+	s.Require().NoError(err)
+	s.True(output.Success)
+	s.Equal(0, char.actionEconomy.MovementRemaining)
+}
+
 func (s *ActionEconomyTestSuite) TestActivateAbility_NoActionRemaining() {
 	char := createTestFighterCharacter(s.T(), s.bus)
 

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -675,6 +675,28 @@ func (s *ActionEconomyTestSuite) TestExecuteAction_Move_ExactBudget() {
 	s.Equal(0, char.actionEconomy.MovementRemaining)
 }
 
+// TestExecuteAction_Move_RejectsNonPositiveDistance proves the public
+// rules-layer API guards its input: a zero distance is a no-op defect and a
+// negative distance would otherwise INCREASE the budget (an exploit). Both are
+// rejected without mutating MovementRemaining (Copilot review on #714).
+func (s *ActionEconomyTestSuite) TestExecuteAction_Move_RejectsNonPositiveDistance() {
+	for _, dist := range []int{0, -5} {
+		char := createTestFighterCharacter(s.T(), s.bus)
+		_, err := char.StartTurn(s.ctx, &StartTurnInput{Speed: 30})
+		s.Require().NoError(err)
+
+		out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+			ActionRef: refs.Actions.Move(),
+			Distance:  dist,
+		})
+		s.Require().NoError(err)
+		s.False(out.Success, "distance %d must be rejected", dist)
+		s.NotEmpty(out.Error)
+		s.Equal(30, char.actionEconomy.MovementRemaining,
+			"rejected move (distance %d) must not mutate the budget", dist)
+	}
+}
+
 func (s *ActionEconomyTestSuite) TestActivateAbility_NoActionRemaining() {
 	char := createTestFighterCharacter(s.T(), s.bus)
 

--- a/rulebooks/dnd5e/character/action_economy_types.go
+++ b/rulebooks/dnd5e/character/action_economy_types.go
@@ -130,6 +130,7 @@ type ActivateAbilityOutput struct {
 type ExecuteActionInput struct {
 	ActionRef *core.Ref // which action to execute
 	TargetID  string    // target entity ID (for strikes)
+	Distance  int       // feet of movement to spend (for move; #714)
 }
 
 // ExecuteActionOutput contains the result of executing an action.


### PR DESCRIPTION
## Root cause

`Encounter.Move` never touched the mover's action economy at all — it mutated position and published events, full stop. The function's own doc comment said as much: *"Slice scope: no action economy, no turn-order enforcement..."* Confirmed against the live playtest evidence (fixture `wave-2-monk`): `movement_remaining` stayed 30 for the entire turn, and a second 7-hex move landed in full after 1 hex was already spent (40ft on a 30ft speed) — because nothing ever read or wrote `MovementRemaining`.

Separately, `character.ExecuteAction`'s `executeMove()` was itself a placeholder ("always succeeds if movement remaining", never took a distance, never decremented) — dead code today since the generic `TakeAction(move)` path is deferred (`deferredActionRefs`), but it's the natural place for the rules-layer spend since it already implements the same two-level economy pattern as `executeStrike`/`executeOffHandStrike`/`executeFlurryStrike`.

## What changed

**`rulebooks/dnd5e` module** (`character/action_economy.go`, `action_economy_types.go`):
- `ExecuteActionInput` gains a `Distance int` field (feet), mirroring the existing `TargetID` "for strikes" precedent.
- `executeMove(distance)` now rejects (without mutating state) when `distance > MovementRemaining`, and otherwise spends it.

**`encounter` module** (`encounter.go`, `combat.go`, `events/move.go`, `npc.go`):
- `Move` looks up the mover's held character. When it has a seeded turn economy (in combat): the requested path's cost (hex-distance summed across waypoints × 5ft/hex — `pathCostFeet`) is checked against `MovementRemaining` **before** any per-step chain runs. Over budget → rejected outright (`ErrInsufficientMovement`), no state mutation, no OA triggering, no partial move.
- Once the move resolves (`traveledPath` may be shorter than requested if a chain subscriber like Disengage stops it early), the **actual** traveled distance is spent via `char.ExecuteAction(Move, Distance)`, and a `TurnStateChangedEvent` pushes the new `movement_remaining` to the client (Invariant 12), correlated to the `MoveEvent` that caused it.
- A mover with no hydrated character, or one not currently in combat (free-roam/pre-combat), is not gated — movement stays free, unchanged from before.
- Also fixed the **from-hex wire quirk** named in the issue: `MoveEvent` carried no origin — `Path` is destinations-only (one entry per completed step) — so a consumer deriving "from" via `Path[0]` got the first *step*, not the origin. Added `MoveEvent.From` (the true `moverStart`), populated on both the player and NPC move-publish paths.

**Cross-module note:** `ExecuteActionInput.Distance` lives in the `rulebooks/dnd5e` module; `encounter`'s `go.mod` is bumped to a pseudo-version pointing at this branch's first commit (toolkit convention: no local replace directives, no `go.work` — see `rulebooks/dnd5e/CLAUDE.md`/root `CLAUDE.md`). Two commits, one PR, one logical change.

## Deferred (follow-up, not this PR)

Player moves carry `actualPath:[from,to]` only on the wire, unlike NPC moves' full hex-by-hex path. `Encounter.Move` iterates whatever path granularity it's given — `pathCostFeet` sums hex-distance across waypoints, so the **budget math is correct regardless of granularity** (verified: `TestMove_SequentialMoves_AccumulateAgainstBudget` uses a dense 8-hex path and gets the right answer). But if the wire's `actualPath` should be dense for smoother client rendering, that's `rpg-api`'s `move_entity.go` not computing/forwarding a per-hex path — outside the toolkit's lane (rpg-api is a thin pass-through; it doesn't own pathfinding rules, but it does own what it forwards to the toolkit). Filing a follow-up issue in rpg-api once this merges.

## Tests (TDD, failing-first)

- `rulebooks/dnd5e/character/action_economy_test.go`: `TestExecuteAction_Move_DeductsDistance`, `TestExecuteAction_Move_AccumulatesAcrossCalls`, `TestExecuteAction_Move_ExactBudget`.
- `encounter/move_economy_test.go` (`MoveEconomySuite`, real hydrated `LoadFromData` path — mirrors `TurnStateSuite`): `TestMove_DeductsDistanceFromMovementRemaining`, `TestMove_OverBudget_RejectedOutright`, `TestMove_SequentialMoves_AccumulateAgainstBudget` (the exact playtest repro — 1 hex then 7 hex), `TestMove_PublishesTurnStateChangedAfterSuccessfulMove`, `TestMove_NotInCombat_SkipsEconomyEnforcement` (regression guard).
- `encounter/events/events_test.go`: `MoveEvent.From` covered in JSON round-trip + audience tests.

## Verification

- `go build`, `go vet`, `gofmt`/`goimports`, `go mod tidy` clean on both modules.
- `go test -race ./...` green on both modules (encounter: 23.7s, includes the full existing suite — no regressions).
- `golangci-lint run ./...` on `encounter`: output is **byte-identical** to an `origin/main` baseline run (36 pre-existing `goconst` findings, zero new). `rulebooks/dnd5e/character`: 0 issues, matches main.
- Root `make pre-commit` (covers `core`+`events` only per the Makefile) fails on a pre-existing `core` module coverage gap (76.5%<80%) — confirmed via `git diff origin/main --stat -- core/ events/` that this branch touches neither module. Not this PR's fallout.

Closes #714
Part of KirkDiggler/rpg-project#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm