### PR TITLE
feat(dnd5e+encounter): Help + Hide mechanical effects (Beat 2)

### DIFF
--- a/encounter/activate_feature.go
+++ b/encounter/activate_feature.go
@@ -200,8 +200,21 @@ func (e *Encounter) publishChangedResources(
 }
 
 // applyActivatedConditions bridges dnd5e ConditionAppliedEvents emitted
-// during a player feature activation to broker ConditionAppliedEvents.
+// during a player feature/ability activation to broker ConditionAppliedEvents.
 // Template: applyCapturedConditions (npc.go:776).
+//
+// R1 fix (rpg-toolkit#716): this used to hardcode targetID := actorID and
+// project the audience from the ACTOR's position — correct for self-applying
+// conditions (Rage, Dodge) but wrong for a cross-entity condition like Help's
+// HelpedCondition, whose Target is the ally, not the helper. Both the label
+// and the audience now read from each cond.Target — the same
+// core.Entity every condition (self- or cross-targeting) already sets — and
+// fall back to the actor only when a condition's Target IS the actor
+// (self-applying conditions resolve to the same PlayerData either way, so
+// there's no behavior change for Rage/Dodge). This mirrors
+// applyCapturedConditions's existing cond.Target.GetID() + findPlayerByEntityID
+// resolution for the monster path exactly — the player path just hadn't
+// caught up to it yet.
 func (e *Encounter) applyActivatedConditions(
 	actor *PlayerData,
 	actorID encountercore.EntityID,
@@ -209,7 +222,22 @@ func (e *Encounter) applyActivatedConditions(
 ) error {
 	for _, cond := range conds {
 		targetID := actorID
+		if cond.Target != nil {
+			targetID = encountercore.EntityID(cond.Target.GetID())
+		}
 		condRef := string(cond.Type)
+
+		var targetPos encountercore.Hex
+		haveTargetPos := false
+		if targetID == actorID {
+			if actor != nil && actor.View != nil {
+				targetPos = actor.View.Position
+				haveTargetPos = true
+			}
+		} else if p := e.findPlayerByEntityID(targetID); p != nil && p.View != nil {
+			targetPos = p.View.Position
+			haveTargetPos = true
+		}
 
 		condPerPlayer := make(map[encountercore.PlayerID]events.ConditionAppliedSlice)
 		for viewerID, viewer := range e.data.Players {
@@ -217,11 +245,10 @@ func (e *Encounter) applyActivatedConditions(
 			if viewer == nil || viewer.View == nil {
 				continue
 			}
-			// Nil-guard: skip if actor has no View (malformed encounter data).
-			if actor == nil || actor.View == nil {
-				break
+			if !haveTargetPos {
+				continue
 			}
-			if !e.viewerCanSee(viewer, actor.View.Position) {
+			if !e.viewerCanSee(viewer, targetPos) {
 				continue
 			}
 			condPerPlayer[viewerID] = events.ConditionAppliedSlice{Visible: true}

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260703234914-b9981de57285
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -12,6 +12,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68 h1:SvgGmbVUoM1M5fX7Lkv2HkNuyEi3iBPN5x5p4Wzm7+0=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260703234914-b9981de57285 h1:b+z/Ols+0gY+j/SMaSLvayJVme/BAq1BbqOXNvYICPs=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260703234914-b9981de57285/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,6 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68 h1:SvgGmbVUoM1M5fX7Lkv2HkNuyEi3iBPN5x5p4Wzm7+0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260703234914-b9981de57285 h1:b+z/Ols+0gY+j/SMaSLvayJVme/BAq1BbqOXNvYICPs=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260703234914-b9981de57285/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=

--- a/encounter/take_character_action.go
+++ b/encounter/take_character_action.go
@@ -29,6 +29,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 )
 
 // takeCharacterAction dispatches a non-attack action ref to the held
@@ -73,7 +74,7 @@ func (e *Encounter) takeCharacterAction(
 	}
 	defer func() { _ = unsubCond() }()
 
-	if err := e.dispatchCharacterAction(ctx, char, ref, &tRef); err != nil {
+	if err := e.dispatchCharacterAction(ctx, char, ref, &tRef, target); err != nil {
 		return nil, err
 	}
 
@@ -107,11 +108,29 @@ func (e *Encounter) takeCharacterAction(
 // this path — TakeActionPhased routes them down the attack-resolver path
 // (spendStrikeEconomy owns their ExecuteAction spend) so they swing (#708);
 // today only move (deferred) and future non-attack granted actions land here.
+//
+// Target-threading (rpg-toolkit#716 R1): target.EntityID is resolved to a
+// core.Entity via e.heldCharacter before dispatch — this is the fix for
+// Help's ally target, which the character package cannot resolve itself (it
+// has no combatant registry). Populated unconditionally for every ability,
+// not just Help — mirrors the file's "no per-ref logic" stance; abilities
+// that don't need a target simply ignore the field.
 func (e *Encounter) dispatchCharacterAction(
-	ctx context.Context, char *dnd5eCharacter.Character, ref ActionRef, tRef *toolkitcore.Ref,
+	ctx context.Context, char *dnd5eCharacter.Character, ref ActionRef, tRef *toolkitcore.Ref, target ActionTarget,
 ) error {
 	if characterHasAbility(char, ref.ID) {
-		out, err := char.ActivateAbility(ctx, &dnd5eCharacter.ActivateAbilityInput{AbilityRef: tRef})
+		activateInput := &dnd5eCharacter.ActivateAbilityInput{
+			AbilityRef:                 tRef,
+			ObserverPassivePerceptions: e.observerPassivePerceptions(char.GetID()),
+		}
+		if target.EntityID != "" {
+			activateInput.TargetID = string(target.EntityID)
+			if targetChar := e.heldCharacter(target.EntityID); targetChar != nil {
+				activateInput.Target = targetChar
+			}
+		}
+
+		out, err := char.ActivateAbility(ctx, activateInput)
 		if err != nil {
 			return fmt.Errorf("activate ability %q: %w", ref.ID, err)
 		}
@@ -133,6 +152,36 @@ func (e *Encounter) dispatchCharacterAction(
 	}
 
 	return fmt.Errorf("%w: %q", ErrUnsupportedAction, ref.ID)
+}
+
+// observerPassivePerceptions returns the passive Perception of every
+// opposing combatant that could observe hiderID, gathered via
+// combat.Combatant.PassivePerception() — never recomputed inline; the
+// accessor is the seam between the position-aware SDK and the rules-aware
+// rulebook (see the interface's own guardrail comment).
+//
+// Wave 2 Beat 2 (rpg-toolkit#716): monsters carry no sight-range/View data
+// (players have perception.View.SightRange; MonsterData has no analog), so —
+// mirroring buildPerception's existing "every player is a visible enemy"
+// simplification for the monster-perceives-player direction — every monster
+// combatant is treated as a potential observer, with no LOS/range gate. Real
+// LOS for monster observers is future work; Hide's observer-set computation
+// inherits perception.CanSeeAt's range-only-stub limitation the same way the
+// rest of the encounter SDK already does (named, not hidden, per the design
+// doc's non-goals).
+func (e *Encounter) observerPassivePerceptions(hiderID string) []int {
+	var out []int
+	for id, c := range e.combatants {
+		if string(id) == hiderID {
+			continue
+		}
+		mon, ok := c.(*monster.Monster)
+		if !ok {
+			continue // only opposing (monster) combatants observe a player hiding
+		}
+		out = append(out, mon.PassivePerception())
+	}
+	return out
 }
 
 // characterHasAbility reports whether the ref matches one of the character's

--- a/encounter/take_character_action.go
+++ b/encounter/take_character_action.go
@@ -170,7 +170,7 @@ func (e *Encounter) dispatchCharacterAction(
 // rest of the encounter SDK already does (named, not hidden, per the design
 // doc's non-goals).
 func (e *Encounter) observerPassivePerceptions(hiderID string) []int {
-	var out []int
+	out := make([]int, 0, len(e.combatants))
 	for id, c := range e.combatants {
 		if string(id) == hiderID {
 			continue

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
@@ -721,3 +722,229 @@ func (s *TurnStateSuite) TestTakeAction_HelpAndHideFlowThroughDelegation() {
 
 // silence unused import if coreCombat ends up unreferenced in future edits.
 var _ = coreCombat.ActionStandard
+
+// allyCharJSON builds a minimal level-1 Fighter character.Data blob, used as
+// the cross-entity target for Help (rpg-toolkit#716). It doesn't need its
+// own combat abilities exercised in these tests — only a valid hydrated
+// identity so e.heldCharacter can resolve it as a core.Entity.
+func (s *TurnStateSuite) allyCharJSON(id, name string) json.RawMessage {
+	s.T().Helper()
+	charData := &dnd5eCharacter.Data{
+		ID:       id,
+		PlayerID: id,
+		Name:     name,
+		Level:    1,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 15,
+			abilities.DEX: 13,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 10,
+			abilities.CHA: 10,
+		},
+		HitPoints:        11,
+		MaxHitPoints:     11,
+		ArmorClass:       16,
+		ProficiencyBonus: 2,
+	}
+	raw, err := json.Marshal(charData)
+	s.Require().NoError(err)
+	return raw
+}
+
+// helpTargetingEncounter builds a TURN_BASED-ready encounter with three
+// seats, positioned specifically to exercise the R1 audience/label fix
+// (rpg-toolkit#716):
+//   - the Monk (helper) at the origin
+//   - a Fighter ally far from the Monk
+//   - a Rogue viewer next to the Fighter but out of sight of the Monk
+//
+// Under the pre-fix bug, applyActivatedConditions projected the broker
+// audience from the ACTOR's (helper's) position — the Rogue would never see
+// the condition, since they can't see the Monk. The fix projects audience
+// from the condition's Target (the ally), which the Rogue CAN see.
+func (s *TurnStateSuite) helpTargetingEncounter() (
+	enc *encounter.Encounter, fighterID core.EntityID, roguePlayerID core.PlayerID,
+) {
+	s.T().Helper()
+
+	monkView := perception.NewView(monkPlayerID, core.Hex{}, 5)
+	monkView.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 5))
+
+	fighterPos := core.Hex{Q: 20, R: 0, S: -20}
+	fighterEntityID := core.EntityID("char-fighter")
+	fighterPlayerID := core.PlayerID("finn")
+	fighterView := perception.NewView(fighterPlayerID, fighterPos, 5)
+	fighterView.ApplyReveal(perception.VisibleHexesAt(fighterPos, 5))
+
+	roguePos := core.Hex{Q: 21, R: 0, S: -21} // adjacent to the fighter, far from the monk
+	rogueEntityID := core.EntityID("char-rogue")
+	roguePlID := core.PlayerID("remy")
+	rogueView := perception.NewView(roguePlID, roguePos, 5)
+	rogueView.ApplyReveal(perception.VisibleHexesAt(roguePos, 5))
+
+	data := encounter.NewData("enc-help")
+	data.Players[monkPlayerID] = &encounter.PlayerData{
+		ID: monkPlayerID, EntityID: monkEntityID, View: monkView,
+		HP: 9, MaxHP: 9, AC: 15, DamageDice: "1d4", DamageType: "bludgeoning",
+		DataJSON: s.monkCharJSON(),
+	}
+	data.Players[fighterPlayerID] = &encounter.PlayerData{
+		ID: fighterPlayerID, EntityID: fighterEntityID, View: fighterView,
+		HP: 11, MaxHP: 11, AC: 16, DamageDice: "1d8", DamageType: "slashing",
+		DataJSON: s.allyCharJSON(string(fighterEntityID), "Finn the Fighter"),
+	}
+	data.Players[roguePlID] = &encounter.PlayerData{
+		ID: roguePlID, EntityID: rogueEntityID, View: rogueView,
+		HP: 8, MaxHP: 8, AC: 13, DamageDice: "1d6", DamageType: "piercing",
+		// No DataJSON — a pure viewer for the audience assertion, not an actor.
+	}
+
+	e, err := encounter.LoadFromData(s.ctx, data, s.broker)
+	s.Require().NoError(err)
+	return e, fighterEntityID, roguePlID
+}
+
+// makeMonkActive cycles EndTurn until the Monk is the active actor,
+// tolerating the other seats' random initiative placement.
+func (s *TurnStateSuite) makeMonkActive(enc *encounter.Encounter) {
+	for i := 0; i < 10 && enc.ActiveActor() != monkEntityID; i++ {
+		_, _, err := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+	s.Require().Equal(monkEntityID, enc.ActiveActor(), "monk must be active for this test")
+}
+
+// TestTakeAction_Help_LabelsAndProjectsAudienceFromAllyPosition is the R1
+// regression test (rpg-toolkit#716): applyActivatedConditions used to
+// hardcode targetID := actorID (labeling the broker event with the HELPER,
+// not the ally) and project the viewer audience from the actor's position.
+// Both bugs are exercised here at once: the Rogue can see the ally (Finn)
+// but NOT the helper (the Monk), so under the old code the Rogue would never
+// receive this event at all, and the event's TargetID would have named the
+// Monk instead of Finn.
+func (s *TurnStateSuite) TestTakeAction_Help_LabelsAndProjectsAudienceFromAllyPosition() {
+	enc, fighterID, roguePlayerID := s.helpTargetingEncounter()
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.makeMonkActive(enc)
+
+	sub, err := s.broker.Subscribe("enc-help", roguePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	err = enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: refs.CombatAbilities.Help().Type, ID: refs.CombatAbilities.Help().ID},
+		encounter.ActionTarget{EntityID: fighterID},
+	)
+	s.Require().NoError(err, "Help must succeed with a hydrated ally target")
+
+	var condApplied *events.ConditionAppliedEvent
+	for _, e := range collectEventsTyped(sub, 500*time.Millisecond) {
+		if ev, ok := e.(*events.ConditionAppliedEvent); ok {
+			condApplied = ev
+		}
+	}
+	s.Require().NotNil(condApplied,
+		"the Rogue (sees the ally, not the helper) must still receive the event — "+
+			"the pre-fix code projected audience from the HELPER's position and would have dropped this viewer")
+	s.Equal(fighterID, condApplied.TargetID,
+		"the condition must be labeled with the ALLY's id, not the helper's (the pre-fix targetID:=actorID bug)")
+	s.Equal(refs.Conditions.Helped().ID, condApplied.ConditionRef)
+}
+
+// TestTakeAction_Help_ViewerWhoSeesNeitherPartyGetsNothing is the audience
+// negative-control: a viewer with line of sight to neither the helper nor
+// the ally must NOT receive the ConditionAppliedEvent — proving the R1 fix
+// is real position-based filtering, not "broadcast to everyone".
+func (s *TurnStateSuite) TestTakeAction_Help_ViewerWhoSeesNeitherPartyGetsNothing() {
+	enc, fighterID, _ := s.helpTargetingEncounter()
+
+	farView := perception.NewView("nomi", core.Hex{Q: -50, R: 0, S: 50}, 5)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "nomi", EntityID: "char-nomi",
+		Position: farView.Position, SightRange: 5,
+		HP: 6, MaxHP: 6, AC: 11, DamageDice: "1d4",
+	}))
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.makeMonkActive(enc)
+
+	sub, err := s.broker.Subscribe("enc-help", "nomi")
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	err = enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: refs.CombatAbilities.Help().Type, ID: refs.CombatAbilities.Help().ID},
+		encounter.ActionTarget{EntityID: fighterID},
+	)
+	s.Require().NoError(err)
+
+	for _, e := range collectEventsTyped(sub, 300*time.Millisecond) {
+		if _, ok := e.(*events.ConditionAppliedEvent); ok {
+			s.Fail("a viewer who sees neither party must not receive the ConditionAppliedEvent")
+		}
+	}
+}
+
+// TestTakeAction_Hide_AppliesHiddenConditionAgainstLowObserverPerception
+// proves the encounter SDK gathers the observer set's passive Perception
+// (via Combatant.PassivePerception(), never inlining the formula) and
+// threads it into Hide's Stealth check: a goblin observer with passive
+// Perception 1 lets the Monk's check succeed virtually unconditionally,
+// applying HiddenCondition end-to-end through the unified TakeAction verb.
+func (s *TurnStateSuite) TestTakeAction_Hide_AppliesHiddenConditionAgainstLowObserverPerception() {
+	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+
+	data := encounter.NewData("enc-hide")
+	data.Players[monkPlayerID] = &encounter.PlayerData{
+		ID: monkPlayerID, EntityID: monkEntityID, View: view,
+		HP: 9, MaxHP: 9, AC: 15, DamageDice: "1d4", DamageType: "bludgeoning",
+		DataJSON: s.monkCharJSON(),
+	}
+
+	monData := &monster.Data{
+		ID: "goblin-1", Name: "Goblin", HitPoints: 7, MaxHitPoints: 7, ArmorClass: 12,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 8, abilities.DEX: 14, abilities.CON: 10,
+			abilities.INT: 10, abilities.WIS: 8, abilities.CHA: 8,
+		},
+		Senses: monster.SensesData{PassivePerception: 1},
+	}
+	monJSON, err := json.Marshal(monData)
+	s.Require().NoError(err)
+	data.Monsters["goblin-1"] = &encounter.MonsterData{
+		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 12,
+		DataJSON: monJSON,
+	}
+
+	enc, err := encounter.LoadFromData(s.ctx, data, s.broker)
+	s.Require().NoError(err)
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.makeMonkActive(enc)
+
+	sub, err := s.broker.Subscribe("enc-hide", monkPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	err = enc.TakeAction(monkPlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: refs.CombatAbilities.Hide().Type, ID: refs.CombatAbilities.Hide().ID},
+		encounter.ActionTarget{EntityID: monkEntityID},
+	)
+	s.Require().NoError(err, "Hide must flow through the general delegation")
+	s.Equal(0, enc.ActorTurnState(monkEntityID).Economy.ActionsRemaining, "Hide spends the standard action")
+
+	var condApplied *events.ConditionAppliedEvent
+	for _, e := range collectEventsTyped(sub, 500*time.Millisecond) {
+		if ev, ok := e.(*events.ConditionAppliedEvent); ok {
+			condApplied = ev
+		}
+	}
+	s.Require().NotNil(condApplied,
+		"Hide should succeed against a passive Perception of 1 and apply HiddenCondition")
+	s.Equal(monkEntityID, condApplied.TargetID)
+	s.Equal(refs.Conditions.Hidden().ID, condApplied.ConditionRef)
+}

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -345,15 +345,19 @@ func (c *Character) buildAvailableActions() []AvailableAction {
 
 // activateCombatAbility uses the bridge pattern to activate a combat ability.
 // Converts ActionEconomyData to toolkit ActionEconomy, calls the ability, then syncs back.
-func (c *Character) activateCombatAbility(ca combatabilities.CombatAbility, _ *ActivateAbilityInput) (*ActivateAbilityOutput, error) {
+func (c *Character) activateCombatAbility(
+	ca combatabilities.CombatAbility, activateInput *ActivateAbilityInput,
+) (*ActivateAbilityOutput, error) {
 	ae := c.toToolkitActionEconomy()
 
 	ctx := context.Background()
 	input := combatabilities.CombatAbilityInput{
-		Bus:           c.bus,
-		ActionEconomy: ae,
-		Speed:         c.GetSpeed(),
-		ExtraAttacks:  c.GetExtraAttacksCount(),
+		Bus:                        c.bus,
+		ActionEconomy:              ae,
+		Speed:                      c.GetSpeed(),
+		ExtraAttacks:               c.GetExtraAttacksCount(),
+		Target:                     activateInput.Target,
+		ObserverPassivePerceptions: activateInput.ObserverPassivePerceptions,
 	}
 
 	// Check if ability can be activated

--- a/rulebooks/dnd5e/character/action_economy_types.go
+++ b/rulebooks/dnd5e/character/action_economy_types.go
@@ -115,6 +115,22 @@ type StartTurnOutput struct {
 // ActivateAbilityInput provides input for activating a combat ability or feature.
 type ActivateAbilityInput struct {
 	AbilityRef *core.Ref // which ability to activate
+
+	// TargetID is the target entity ID (for abilities like Help that target
+	// an ally). Mirrors ExecuteActionInput.TargetID.
+	TargetID string
+
+	// Target is the resolved target entity, required alongside TargetID when
+	// the ability needs to construct a cross-entity effect (e.g. Help's
+	// ConditionAppliedEvent{Target: ally}). The caller (encounter SDK)
+	// resolves this via its own combatant registry — Character has no entity
+	// lookup of its own, so it cannot derive Target from TargetID alone.
+	Target core.Entity
+
+	// ObserverPassivePerceptions is the passive Perception of every opposing
+	// combatant that could observe this activation (e.g. Hide's Stealth
+	// check DC). Gathered by the caller via Combatant.PassivePerception().
+	ObserverPassivePerceptions []int
 }
 
 // ActivateAbilityOutput contains the result of activating an ability.

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -197,6 +197,12 @@ func (c *Character) GetSkillModifier(skill skills.Skill) int {
 	return modifier
 }
 
+// PassivePerception returns the character's passive Perception score
+// (10 + Perception skill modifier). Implements combat.Combatant.
+func (c *Character) PassivePerception() int {
+	return 10 + c.GetSkillModifier(skills.Perception)
+}
+
 // GetSavingThrowModifier returns the total modifier for a saving throw
 func (c *Character) GetSavingThrowModifier(ability abilities.Ability) int {
 	modifier := c.GetAbilityModifier(ability)

--- a/rulebooks/dnd5e/character/integration_test.go
+++ b/rulebooks/dnd5e/character/integration_test.go
@@ -1142,6 +1142,7 @@ func (g *testGoblin) AbilityScores() shared.AbilityScores {
 		abilities.DEX: 14, // +2
 	}
 }
+func (g *testGoblin) PassivePerception() int { return 10 }
 func (g *testGoblin) ApplyDamage(_ context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {
 	total := 0
 	for _, inst := range input.Instances {

--- a/rulebooks/dnd5e/checks/checks.go
+++ b/rulebooks/dnd5e/checks/checks.go
@@ -1,0 +1,215 @@
+// Package checks implements D&D 5e ability check mechanics.
+// Mirrors rulebooks/dnd5e/saves: same roller + modifier + chain-sourced
+// advantage/disadvantage/bonuses shape, applied to skill checks instead of
+// saving throws.
+package checks
+
+import (
+	"context"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+)
+
+// AbilityCheckInput contains all parameters needed to make an ability check.
+type AbilityCheckInput struct {
+	// Roller is the dice roller to use. If nil, defaults to dice.NewRoller().
+	// Pass a mock roller here for testing.
+	Roller dice.Roller
+
+	// EventBus is the event bus for chain modifiers. If nil, no chain events
+	// are fired. This allows conditions like Hidden to grant advantage on
+	// checks.
+	EventBus events.EventBus
+
+	// CheckerID is the ID of the entity making the check.
+	// Required when EventBus is provided.
+	CheckerID string
+
+	// Skill is the skill being checked (Stealth, Perception, etc).
+	Skill skills.Skill
+
+	// DC is the Difficulty Class that must be met or exceeded (e.g. the
+	// highest observer passive Perception for a Hide check).
+	DC int
+
+	// Modifier is the total bonus/penalty to add to the roll
+	// (typically ability modifier + proficiency bonus if proficient)
+	Modifier int
+
+	// HasAdvantage indicates rolling two d20s and taking the higher result
+	HasAdvantage bool
+
+	// HasDisadvantage indicates rolling two d20s and taking the lower result
+	// Note: If both HasAdvantage and HasDisadvantage are true, they cancel out
+	// and a single d20 is rolled (D&D 5e rule)
+	HasDisadvantage bool
+}
+
+// AbilityCheckResult contains the outcome of an ability check.
+type AbilityCheckResult struct {
+	// Roll is the actual d20 roll result used (highest/lowest if advantage/disadvantage)
+	Roll int
+
+	// Total is the final value (Roll + Modifier + ChainBonuses)
+	Total int
+
+	// DC is the Difficulty Class that was tested against
+	DC int
+
+	// Success indicates whether the check succeeded (Total >= DC)
+	Success bool
+
+	// IsNat1 indicates if the d20 roll was a natural 1
+	IsNat1 bool
+
+	// IsNat20 indicates if the d20 roll was a natural 20
+	IsNat20 bool
+
+	// AdvantageSources contains the sources that granted advantage on this check
+	AdvantageSources []dnd5eEvents.CheckModifierSource
+
+	// DisadvantageSources contains the sources that imposed disadvantage on this check
+	DisadvantageSources []dnd5eEvents.CheckModifierSource
+
+	// BonusSources contains the sources that added bonuses to this check
+	BonusSources []dnd5eEvents.CheckBonusSource
+}
+
+// MakeAbilityCheck executes an ability check using the input parameters.
+//
+// The function handles:
+//   - Normal rolls (single d20)
+//   - Advantage (roll 2d20, take higher)
+//   - Disadvantage (roll 2d20, take lower)
+//   - Advantage + Disadvantage cancellation (single d20)
+//   - Natural 1 and natural 20 detection
+//   - Chain event modifiers (advantage, disadvantage, bonuses from conditions/features)
+//
+// If input.Roller is nil, a default CryptoRoller is used.
+// If input.EventBus is provided, the AbilityCheckChain is fired to collect modifiers.
+// Returns an error if the dice roller fails or chain execution fails.
+func MakeAbilityCheck(ctx context.Context, input *AbilityCheckInput) (*AbilityCheckResult, error) {
+	if input == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "input cannot be nil")
+	}
+
+	roller := input.Roller
+	if roller == nil {
+		roller = dice.NewRoller()
+	}
+
+	// Initialize modifier tracking from input
+	hasAdvantage := input.HasAdvantage
+	hasDisadvantage := input.HasDisadvantage
+	bonusFromChain := 0
+	var advantageSources []dnd5eEvents.CheckModifierSource
+	var disadvantageSources []dnd5eEvents.CheckModifierSource
+	var bonusSources []dnd5eEvents.CheckBonusSource
+
+	// Track input-provided advantage/disadvantage as sources for auditability
+	if input.HasAdvantage {
+		advantageSources = append(advantageSources, dnd5eEvents.CheckModifierSource{
+			Name:       "Input",
+			SourceType: "input",
+		})
+	}
+	if input.HasDisadvantage {
+		disadvantageSources = append(disadvantageSources, dnd5eEvents.CheckModifierSource{
+			Name:       "Input",
+			SourceType: "input",
+		})
+	}
+
+	// Fire chain event if EventBus is provided
+	if input.EventBus != nil {
+		chainEvent := &dnd5eEvents.AbilityCheckChainEvent{
+			CheckerID: input.CheckerID,
+			Skill:     input.Skill,
+			DC:        input.DC,
+		}
+
+		// Create chain and fire through subscribers
+		checkChain := events.NewStagedChain[*dnd5eEvents.AbilityCheckChainEvent](combat.ModifierStages)
+		chainTopic := dnd5eEvents.AbilityCheckChain.On(input.EventBus)
+
+		modifiedChain, err := chainTopic.PublishWithChain(ctx, chainEvent, checkChain)
+		if err != nil {
+			return nil, rpgerr.Wrap(err, "failed to publish ability check chain event")
+		}
+
+		// Execute chain to apply all modifiers
+		result, err := modifiedChain.Execute(ctx, chainEvent)
+		if err != nil {
+			return nil, rpgerr.Wrap(err, "failed to execute ability check chain")
+		}
+
+		// Collect modifiers from chain (append to input sources)
+		if result.HasAdvantage() {
+			hasAdvantage = true
+			advantageSources = append(advantageSources, result.AdvantageSources...)
+		}
+		if result.HasDisadvantage() {
+			hasDisadvantage = true
+			disadvantageSources = append(disadvantageSources, result.DisadvantageSources...)
+		}
+		bonusFromChain = result.TotalBonus()
+		bonusSources = append(bonusSources, result.BonusSources...)
+	}
+
+	var roll int
+	var err error
+
+	// D&D 5e Rule: Advantage and Disadvantage cancel each other out
+	effectiveAdvantage := hasAdvantage && !hasDisadvantage
+	effectiveDisadvantage := hasDisadvantage && !hasAdvantage
+
+	switch {
+	case effectiveAdvantage:
+		// Roll with advantage: 2d20, take higher
+		rolls, rollErr := roller.RollN(ctx, 2, 20)
+		if rollErr != nil {
+			return nil, rollErr
+		}
+		roll = max(rolls[0], rolls[1])
+	case effectiveDisadvantage:
+		// Roll with disadvantage: 2d20, take lower
+		rolls, rollErr := roller.RollN(ctx, 2, 20)
+		if rollErr != nil {
+			return nil, rollErr
+		}
+		roll = min(rolls[0], rolls[1])
+	default:
+		// Normal roll: 1d20
+		roll, err = roller.Roll(ctx, 20)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Calculate total (base modifier + chain bonuses)
+	total := roll + input.Modifier + bonusFromChain
+
+	// Determine success
+	success := total >= input.DC
+
+	// Detect natural 1 and natural 20
+	isNat1 := roll == 1
+	isNat20 := roll == 20
+
+	return &AbilityCheckResult{
+		Roll:                roll,
+		Total:               total,
+		DC:                  input.DC,
+		Success:             success,
+		IsNat1:              isNat1,
+		IsNat20:             isNat20,
+		AdvantageSources:    advantageSources,
+		DisadvantageSources: disadvantageSources,
+		BonusSources:        bonusSources,
+	}, nil
+}

--- a/rulebooks/dnd5e/checks/checks.go
+++ b/rulebooks/dnd5e/checks/checks.go
@@ -22,12 +22,17 @@ type AbilityCheckInput struct {
 	Roller dice.Roller
 
 	// EventBus is the event bus for chain modifiers. If nil, no chain events
-	// are fired. This allows conditions like Hidden to grant advantage on
-	// checks.
+	// are fired. This allows conditions/features that subscribe to
+	// AbilityCheckChain to grant advantage, disadvantage, or bonuses on
+	// checks (no condition subscribes to it yet this wave — see R4 in
+	// rpg-toolkit#716 — but the chain exists so future ones can, the same
+	// way SavingThrowChain fires whether or not a subscriber exists).
 	EventBus events.EventBus
 
 	// CheckerID is the ID of the entity making the check.
-	// Required when EventBus is provided.
+	// Required when EventBus is provided — MakeAbilityCheck rejects the
+	// combination of a non-nil EventBus with an empty CheckerID, since chain
+	// subscribers key off this id.
 	CheckerID string
 
 	// Skill is the skill being checked (Stealth, Perception, etc).
@@ -96,6 +101,9 @@ type AbilityCheckResult struct {
 func MakeAbilityCheck(ctx context.Context, input *AbilityCheckInput) (*AbilityCheckResult, error) {
 	if input == nil {
 		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "input cannot be nil")
+	}
+	if input.EventBus != nil && input.CheckerID == "" {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "CheckerID is required when EventBus is provided")
 	}
 
 	roller := input.Roller

--- a/rulebooks/dnd5e/checks/checks_test.go
+++ b/rulebooks/dnd5e/checks/checks_test.go
@@ -1,0 +1,295 @@
+package checks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+)
+
+type AbilityCheckTestSuite struct {
+	suite.Suite
+	ctrl       *gomock.Controller
+	ctx        context.Context
+	mockRoller *mock_dice.MockRoller
+}
+
+func TestAbilityCheckSuite(t *testing.T) {
+	suite.Run(t, new(AbilityCheckTestSuite))
+}
+
+func (s *AbilityCheckTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.ctx = context.Background()
+	s.mockRoller = mock_dice.NewMockRoller(s.ctrl)
+}
+
+func (s *AbilityCheckTestSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// TestBasicSuccess tests that a check succeeds when roll + modifier >= DC.
+// This is the Hide-success shape: Stealth roll beats the observer's passive
+// Perception (used as the DC).
+func (s *AbilityCheckTestSuite) TestBasicSuccess() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(14, nil)
+
+	input := &AbilityCheckInput{
+		Roller:   s.mockRoller,
+		Skill:    skills.Stealth,
+		DC:       15, // observer's passive Perception
+		Modifier: 3,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(14, result.Roll)
+	s.Equal(17, result.Total, "total should be 14 + 3 = 17")
+	s.Equal(15, result.DC)
+	s.True(result.Success, "17 should succeed against DC 15")
+	s.False(result.IsNat1)
+	s.False(result.IsNat20)
+}
+
+// TestBasicFailure tests the Hide-failure branch (R6): Stealth total below
+// the observer's passive Perception. This is exercised as a unit test with
+// a mock roller because the live orchestrator has no deterministic-roller
+// seam (crypto-random roller, no seed in devseed).
+func (s *AbilityCheckTestSuite) TestBasicFailure() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(5, nil)
+
+	input := &AbilityCheckInput{
+		Roller:   s.mockRoller,
+		Skill:    skills.Stealth,
+		DC:       15,
+		Modifier: 3,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(5, result.Roll)
+	s.Equal(8, result.Total, "total should be 5 + 3 = 8")
+	s.Equal(15, result.DC)
+	s.False(result.Success, "8 should fail against DC 15")
+}
+
+func (s *AbilityCheckTestSuite) TestAdvantage() {
+	s.mockRoller.EXPECT().RollN(s.ctx, 2, 20).Return([]int{8, 15}, nil)
+
+	input := &AbilityCheckInput{
+		Roller:       s.mockRoller,
+		Skill:        skills.Stealth,
+		DC:           12,
+		Modifier:     2,
+		HasAdvantage: true,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(15, result.Roll, "should use higher roll of 8 and 15")
+	s.Equal(17, result.Total)
+	s.True(result.Success)
+}
+
+func (s *AbilityCheckTestSuite) TestDisadvantage() {
+	s.mockRoller.EXPECT().RollN(s.ctx, 2, 20).Return([]int{18, 5}, nil)
+
+	input := &AbilityCheckInput{
+		Roller:          s.mockRoller,
+		Skill:           skills.Stealth,
+		DC:              15,
+		Modifier:        4,
+		HasDisadvantage: true,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(5, result.Roll, "should use lower roll of 18 and 5")
+	s.Equal(9, result.Total)
+	s.False(result.Success)
+}
+
+func (s *AbilityCheckTestSuite) TestAdvantageAndDisadvantageCancelOut() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(11, nil)
+
+	input := &AbilityCheckInput{
+		Roller:          s.mockRoller,
+		Skill:           skills.Stealth,
+		DC:              15,
+		Modifier:        2,
+		HasAdvantage:    true,
+		HasDisadvantage: true,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(11, result.Roll)
+	s.Equal(13, result.Total)
+	s.False(result.Success)
+}
+
+func (s *AbilityCheckTestSuite) TestNatural1AndNatural20() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(1, nil)
+
+	result, err := MakeAbilityCheck(s.ctx, &AbilityCheckInput{
+		Roller:   s.mockRoller,
+		Skill:    skills.Stealth,
+		DC:       5,
+		Modifier: 10,
+	})
+	s.Require().NoError(err)
+	s.True(result.IsNat1)
+	s.False(result.IsNat20)
+}
+
+func (s *AbilityCheckTestSuite) TestNilInput() {
+	result, err := MakeAbilityCheck(s.ctx, nil)
+	s.Require().Error(err)
+	s.Nil(result)
+	s.Contains(err.Error(), "input cannot be nil")
+}
+
+// TestChainGrantsAdvantage tests that a chain subscriber (e.g. a future
+// Hidden-on-check condition) can grant advantage via AbilityCheckChain.
+func (s *AbilityCheckTestSuite) TestChainGrantsAdvantage() {
+	s.mockRoller.EXPECT().RollN(s.ctx, 2, 20).Return([]int{8, 15}, nil)
+
+	bus := events.NewEventBus()
+
+	checkChain := dnd5eEvents.AbilityCheckChain.On(bus)
+	_, err := checkChain.SubscribeWithChain(s.ctx,
+		func(_ context.Context, event *dnd5eEvents.AbilityCheckChainEvent,
+			c chain.Chain[*dnd5eEvents.AbilityCheckChainEvent],
+		) (chain.Chain[*dnd5eEvents.AbilityCheckChainEvent], error) {
+			if event.Skill == skills.Stealth {
+				addErr := c.Add(combat.StageConditions, "guidance",
+					func(_ context.Context, e *dnd5eEvents.AbilityCheckChainEvent,
+					) (*dnd5eEvents.AbilityCheckChainEvent, error) {
+						e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.CheckModifierSource{
+							Name:       "Guidance",
+							SourceType: "spell",
+							EntityID:   "hero",
+						})
+						return e, nil
+					})
+				if addErr != nil {
+					return c, addErr
+				}
+			}
+			return c, nil
+		})
+	s.Require().NoError(err)
+
+	input := &AbilityCheckInput{
+		Roller:    s.mockRoller,
+		EventBus:  bus,
+		CheckerID: "hero",
+		Skill:     skills.Stealth,
+		DC:        15,
+		Modifier:  2,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(15, result.Roll, "should use higher roll due to advantage")
+	s.Equal(17, result.Total)
+	s.True(result.Success)
+	s.Len(result.AdvantageSources, 1)
+	s.Equal("Guidance", result.AdvantageSources[0].Name)
+}
+
+// TestChainAddsBonus tests that a chain subscriber can add bonuses to the roll.
+func (s *AbilityCheckTestSuite) TestChainAddsBonus() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(10, nil)
+
+	bus := events.NewEventBus()
+
+	checkChain := dnd5eEvents.AbilityCheckChain.On(bus)
+	_, err := checkChain.SubscribeWithChain(s.ctx,
+		func(_ context.Context, _ *dnd5eEvents.AbilityCheckChainEvent,
+			c chain.Chain[*dnd5eEvents.AbilityCheckChainEvent],
+		) (chain.Chain[*dnd5eEvents.AbilityCheckChainEvent], error) {
+			addErr := c.Add(combat.StageConditions, "bless",
+				func(_ context.Context, e *dnd5eEvents.AbilityCheckChainEvent,
+				) (*dnd5eEvents.AbilityCheckChainEvent, error) {
+					e.BonusSources = append(e.BonusSources, dnd5eEvents.CheckBonusSource{
+						CheckModifierSource: dnd5eEvents.CheckModifierSource{
+							Name:       "Bless",
+							SourceType: "spell",
+							EntityID:   "cleric",
+						},
+						Bonus: 3,
+					})
+					return e, nil
+				})
+			if addErr != nil {
+				return c, addErr
+			}
+			return c, nil
+		})
+	s.Require().NoError(err)
+
+	input := &AbilityCheckInput{
+		Roller:    s.mockRoller,
+		EventBus:  bus,
+		CheckerID: "hero",
+		Skill:     skills.Stealth,
+		DC:        15,
+		Modifier:  2,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(10, result.Roll)
+	s.Equal(15, result.Total, "total should be 10 + 2 (modifier) + 3 (bless) = 15")
+	s.True(result.Success)
+	s.Len(result.BonusSources, 1)
+	s.Equal("Bless", result.BonusSources[0].Name)
+	s.Equal(3, result.BonusSources[0].Bonus)
+}
+
+// TestNoEventBusStillWorks tests that MakeAbilityCheck works without an EventBus.
+func (s *AbilityCheckTestSuite) TestNoEventBusStillWorks() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(15, nil)
+
+	input := &AbilityCheckInput{
+		Roller:   s.mockRoller,
+		EventBus: nil,
+		Skill:    skills.Stealth,
+		DC:       12,
+		Modifier: 3,
+	}
+
+	result, err := MakeAbilityCheck(s.ctx, input)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Equal(15, result.Roll)
+	s.Equal(18, result.Total)
+	s.True(result.Success)
+	s.Empty(result.AdvantageSources)
+	s.Empty(result.DisadvantageSources)
+	s.Empty(result.BonusSources)
+}

--- a/rulebooks/dnd5e/combat/combatant.go
+++ b/rulebooks/dnd5e/combat/combatant.go
@@ -79,6 +79,13 @@ type Combatant interface {
 
 	// ProficiencyBonus returns the proficiency bonus for attack calculations
 	ProficiencyBonus() int
+
+	// PassivePerception returns the combatant's passive Perception score
+	// (10 + Perception modifier, or a monster's fixed sense value). This is a
+	// rulebook computation — callers (e.g. the encounter SDK's observer-set
+	// gathering for Hide) must call this accessor rather than inlining the
+	// 10+WIS+proficiency formula themselves.
+	PassivePerception() int
 }
 
 // EffectiveACCalculator is implemented by combatants that support dynamic AC calculation.

--- a/rulebooks/dnd5e/combat/combatant_dirty_test.go
+++ b/rulebooks/dnd5e/combat/combatant_dirty_test.go
@@ -39,6 +39,7 @@ func (m *mockDirtyCombatant) IsDirty() bool                       { return m.dir
 func (m *mockDirtyCombatant) MarkClean()                          { m.dirty = false }
 func (m *mockDirtyCombatant) AbilityScores() shared.AbilityScores { return m.abilityScores }
 func (m *mockDirtyCombatant) ProficiencyBonus() int               { return m.proficiencyBonus }
+func (m *mockDirtyCombatant) PassivePerception() int              { return 10 }
 
 func (m *mockDirtyCombatant) ApplyDamage(ctx context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {
 	prev := m.hp

--- a/rulebooks/dnd5e/combat/damage_test.go
+++ b/rulebooks/dnd5e/combat/damage_test.go
@@ -35,6 +35,7 @@ func (m *mockCombatant) IsDirty() bool                       { return m.dirty }
 func (m *mockCombatant) MarkClean()                          { m.dirty = false }
 func (m *mockCombatant) AbilityScores() shared.AbilityScores { return m.abilityScores }
 func (m *mockCombatant) ProficiencyBonus() int               { return m.proficiencyBonus }
+func (m *mockCombatant) PassivePerception() int              { return 10 }
 
 func (m *mockCombatant) ApplyDamage(_ context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {
 	if input == nil {

--- a/rulebooks/dnd5e/combat/integration_test.go
+++ b/rulebooks/dnd5e/combat/integration_test.go
@@ -690,6 +690,7 @@ func (m *mockEntity) IsDirty() bool                       { return false }
 func (m *mockEntity) MarkClean()                          {}
 func (m *mockEntity) AbilityScores() shared.AbilityScores { return m.abilityScores }
 func (m *mockEntity) ProficiencyBonus() int               { return m.proficiencyBonus }
+func (m *mockEntity) PassivePerception() int              { return 10 }
 
 func (m *mockEntity) ApplyDamage(_ context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {
 	if input == nil {
@@ -860,6 +861,7 @@ func (m *mockCombatantTarget) IsDirty() bool                       { return m.di
 func (m *mockCombatantTarget) MarkClean()                          { m.dirty = false }
 func (m *mockCombatantTarget) AbilityScores() shared.AbilityScores { return m.abilityScores }
 func (m *mockCombatantTarget) ProficiencyBonus() int               { return m.proficiencyBonus }
+func (m *mockCombatantTarget) PassivePerception() int              { return 10 }
 
 func (m *mockCombatantTarget) ApplyDamage(_ context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {
 	if input == nil {

--- a/rulebooks/dnd5e/combat/mock/mock_combatant.go
+++ b/rulebooks/dnd5e/combat/mock/mock_combatant.go
@@ -152,6 +152,20 @@ func (mr *MockCombatantMockRecorder) MarkClean() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkClean", reflect.TypeOf((*MockCombatant)(nil).MarkClean))
 }
 
+// PassivePerception mocks base method.
+func (m *MockCombatant) PassivePerception() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PassivePerception")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// PassivePerception indicates an expected call of PassivePerception.
+func (mr *MockCombatantMockRecorder) PassivePerception() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PassivePerception", reflect.TypeOf((*MockCombatant)(nil).PassivePerception))
+}
+
 // ProficiencyBonus mocks base method.
 func (m *MockCombatant) ProficiencyBonus() int {
 	m.ctrl.T.Helper()

--- a/rulebooks/dnd5e/combatabilities/help.go
+++ b/rulebooks/dnd5e/combatabilities/help.go
@@ -11,21 +11,21 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 // Help represents the Help combat ability (PHB p.192).
-// When activated, it consumes 1 action and publishes a HelpActivatedEvent.
-// The helped ally gains advantage on their next ability check, or (when helping
-// against a creature within 5 feet) advantage on their next attack roll against
-// that creature before the start of the helper's next turn.
+// When activated, it consumes 1 action, publishes a HelpActivatedEvent, and
+// grants the targeted ally advantage on their next attack roll via
+// HelpedCondition.
 //
-// Mirrors the Dodge/Disengage bar: this consumes the action and emits the
-// activation signal. Applying the advantage to the ally (and threading which
-// ally is helped) is a later beat — the ally target is not yet carried through
-// the character ActivateAbility path, so HelpActivatedEvent.AllyID is empty for
-// now (documented gap).
+// Beat 2 (rpg-project#75) scopes Help to the ATTACK branch only — advantage
+// on an ally's next ability check (the "helping a task" branch of PHB p.192)
+// is explicitly deferred (R4): the fixture that would exercise it doesn't
+// exist yet, and HelpedCondition ships with no AbilityCheckChain subscriber
+// this wave.
 type Help struct {
 	*BaseCombatAbility
 }
@@ -51,7 +51,7 @@ func NewHelp(id string) *Help {
 }
 
 // CanActivate checks if the Help ability can be activated.
-// Requires an available action and an event bus.
+// Requires an available action, an event bus, and a target ally.
 func (h *Help) CanActivate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
 	if err := h.BaseCombatAbility.CanActivate(ctx, owner, input); err != nil {
 		return err
@@ -59,23 +59,47 @@ func (h *Help) CanActivate(ctx context.Context, owner core.Entity, input CombatA
 	if input.Bus == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Help")
 	}
+	if input.Target == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "target ally required for Help")
+	}
 	return nil
 }
 
-// Activate consumes 1 action and publishes a HelpActivatedEvent.
-// A subscriber in a later beat applies the advantage to the helped ally.
+// Activate consumes 1 action, publishes a HelpActivatedEvent, and applies
+// HelpedCondition to the targeted ally via a cross-entity
+// ConditionAppliedEvent{Target: input.Target} — the same
+// ConditionAppliedTopic path Rage uses for self-targeting, extended to a
+// target other than the activator.
 func (h *Help) Activate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
 	if input.Bus == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Help")
 	}
+	if input.Target == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "target ally required for Help")
+	}
 	if err := h.BaseCombatAbility.Activate(ctx, owner, input); err != nil {
 		return err
 	}
+
+	allyID := input.Target.GetID()
+
 	if err := dnd5eEvents.HelpActivatedTopic.On(input.Bus).Publish(ctx, dnd5eEvents.HelpActivatedEvent{
 		CharacterID: owner.GetID(),
+		AllyID:      allyID,
 	}); err != nil {
 		return fmt.Errorf("failed to publish help activated event: %w", err)
 	}
+
+	helpedCondition := conditions.NewHelpedCondition(allyID, owner.GetID())
+	if err := dnd5eEvents.ConditionAppliedTopic.On(input.Bus).Publish(ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    input.Target,
+		Type:      dnd5eEvents.ConditionHelped,
+		Source:    dnd5eEvents.ConditionSourceCombatAbility,
+		Condition: helpedCondition,
+	}); err != nil {
+		return fmt.Errorf("failed to publish helped condition applied event: %w", err)
+	}
+
 	return nil
 }
 

--- a/rulebooks/dnd5e/combatabilities/help_hide_test.go
+++ b/rulebooks/dnd5e/combatabilities/help_hide_test.go
@@ -5,25 +5,65 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combatabilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
-	"github.com/stretchr/testify/suite"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
 )
 
-// HelpAbilityTestSuite covers the Help combat ability (#697 Beat-1): it consumes
-// the standard action and publishes HelpActivatedEvent. The mechanical effect
-// (advantage to the ally) is a later beat — these tests cover the constructor,
-// economy spend, activation signal, and persistence round-trip.
+// fakeStealthOwner implements core.Entity plus GetSkillModifier, satisfying
+// Hide's stealthChecker interface. Named per the project's hand-written
+// test-double convention (fakeX, not mockX — mockX is reserved for gomock).
+type fakeStealthOwner struct {
+	id             string
+	skillModifiers map[skills.Skill]int
+}
+
+func (f *fakeStealthOwner) GetID() string            { return f.id }
+func (f *fakeStealthOwner) GetType() core.EntityType { return "character" }
+func (f *fakeStealthOwner) GetSkillModifier(skill skills.Skill) int {
+	return f.skillModifiers[skill]
+}
+
+// captureConditionApplied subscribes to ConditionAppliedTopic and returns a
+// pointer to the growing slice of captured events — the caller reads
+// (*captured) after the action under test runs. A bare returned pointer
+// would snapshot the pre-publish nil value; the slice-pointer indirection
+// mirrors the encounter package's subscribeConditions helper.
+func captureConditionApplied(
+	t *testing.T, ctx context.Context, bus events.EventBus,
+) *[]dnd5eEvents.ConditionAppliedEvent {
+	t.Helper()
+	captured := &[]dnd5eEvents.ConditionAppliedEvent{}
+	_, err := dnd5eEvents.ConditionAppliedTopic.On(bus).Subscribe(ctx,
+		func(_ context.Context, e dnd5eEvents.ConditionAppliedEvent) error {
+			*captured = append(*captured, e)
+			return nil
+		})
+	require.NoError(t, err, "subscribe to ConditionAppliedTopic should not fail")
+	return captured
+}
+
+// HelpAbilityTestSuite covers the Help combat ability: it consumes the
+// standard action, publishes HelpActivatedEvent with the target ally's id,
+// and applies HelpedCondition to the ally via a cross-entity
+// ConditionAppliedEvent (target-threading, rpg-toolkit#716).
 type HelpAbilityTestSuite struct {
 	suite.Suite
 	ctx           context.Context
 	bus           events.EventBus
 	owner         *mockOwner
+	ally          *mockOwner
 	actionEconomy *combat.ActionEconomy
 	help          *combatabilities.Help
 }
@@ -36,6 +76,7 @@ func (s *HelpAbilityTestSuite) SetupTest() {
 	s.ctx = context.Background()
 	s.bus = events.NewEventBus()
 	s.owner = &mockOwner{id: "test-helper"}
+	s.ally = &mockOwner{id: "test-ally"}
 	s.actionEconomy = combat.NewActionEconomy()
 	s.help = combatabilities.NewHelp("test-help")
 }
@@ -50,7 +91,7 @@ func (s *HelpAbilityTestSuite) TestNewHelp_Properties() {
 
 func (s *HelpAbilityTestSuite) TestCanActivate_Success() {
 	err := s.help.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
-		ActionEconomy: s.actionEconomy, Bus: s.bus,
+		ActionEconomy: s.actionEconomy, Bus: s.bus, Target: s.ally,
 	})
 	s.Require().NoError(err)
 }
@@ -58,16 +99,24 @@ func (s *HelpAbilityTestSuite) TestCanActivate_Success() {
 func (s *HelpAbilityTestSuite) TestCanActivate_NoActionsRemaining() {
 	s.Require().NoError(s.actionEconomy.UseAction())
 	err := s.help.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
-		ActionEconomy: s.actionEconomy, Bus: s.bus,
+		ActionEconomy: s.actionEconomy, Bus: s.bus, Target: s.ally,
 	})
 	s.Require().Error(err)
 }
 
 func (s *HelpAbilityTestSuite) TestCanActivate_RequiresEventBus() {
 	err := s.help.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
-		ActionEconomy: s.actionEconomy, Bus: nil,
+		ActionEconomy: s.actionEconomy, Bus: nil, Target: s.ally,
 	})
 	s.Require().Error(err)
+}
+
+func (s *HelpAbilityTestSuite) TestCanActivate_RequiresTarget() {
+	err := s.help.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus,
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "target ally required")
 }
 
 func (s *HelpAbilityTestSuite) TestActivate_ConsumesActionAndPublishes() {
@@ -84,19 +133,51 @@ func (s *HelpAbilityTestSuite) TestActivate_ConsumesActionAndPublishes() {
 	s.Require().NoError(err)
 
 	err = s.help.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
-		ActionEconomy: s.actionEconomy, Bus: s.bus,
+		ActionEconomy: s.actionEconomy, Bus: s.bus, Target: s.ally,
 	})
 	s.Require().NoError(err)
 	s.Equal(0, s.actionEconomy.ActionsRemaining, "Help consumes the standard action")
 	s.True(received, "HelpActivatedEvent should be published")
 	s.Equal(s.owner.GetID(), got.CharacterID)
+	s.Equal(s.ally.GetID(), got.AllyID, "AllyID should be the target's id, not empty")
+}
+
+// TestActivate_AppliesHelpedConditionToAlly is the regression test for R1's
+// label fix: the condition is attributed to the ALLY (the target), not the
+// helper.
+func (s *HelpAbilityTestSuite) TestActivate_AppliesHelpedConditionToAlly() {
+	captured := captureConditionApplied(s.T(), s.ctx, s.bus)
+
+	err := s.help.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus, Target: s.ally,
+	})
+	s.Require().NoError(err)
+
+	s.Require().Len(*captured, 1, "ConditionAppliedEvent should be published")
+	got := (*captured)[0]
+	s.Equal(s.ally.GetID(), got.Target.GetID(), "condition targets the ally, not the helper")
+	s.Equal(dnd5eEvents.ConditionHelped, got.Type)
+	s.Equal(dnd5eEvents.ConditionSourceCombatAbility, got.Source)
+
+	helped, ok := got.Condition.(*conditions.HelpedCondition)
+	s.Require().True(ok, "condition should be a *HelpedCondition")
+	s.Equal(s.ally.GetID(), helped.CharacterID)
+	s.Equal(s.owner.GetID(), helped.HelperID, "HelperID tracks the safety-net turn trigger")
 }
 
 func (s *HelpAbilityTestSuite) TestActivate_NoEventBus() {
 	err := s.help.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
-		ActionEconomy: s.actionEconomy,
+		ActionEconomy: s.actionEconomy, Target: s.ally,
 	})
 	s.Require().Error(err)
+}
+
+func (s *HelpAbilityTestSuite) TestActivate_RequiresTarget() {
+	err := s.help.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus,
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "target ally required")
 }
 
 func (s *HelpAbilityTestSuite) TestToJSON_AndLoadRoundTrip() {
@@ -114,16 +195,19 @@ func (s *HelpAbilityTestSuite) TestToJSON_AndLoadRoundTrip() {
 	s.Equal(refs.CombatAbilities.Help().ID, loaded.Ref().ID)
 }
 
-// HideAbilityTestSuite covers the Hide combat ability (#697 Beat-1): it consumes
-// the standard action and publishes HideActivatedEvent. The Stealth check + the
-// Hidden condition are a later beat.
+// HideAbilityTestSuite covers the Hide combat ability: it consumes the
+// standard action, makes a Stealth check via checks.MakeAbilityCheck against
+// the caller-gathered observer passive Perceptions, and applies
+// HiddenCondition on success only.
 type HideAbilityTestSuite struct {
 	suite.Suite
+	ctrl          *gomock.Controller
 	ctx           context.Context
 	bus           events.EventBus
-	owner         *mockOwner
+	owner         *fakeStealthOwner
 	actionEconomy *combat.ActionEconomy
 	hide          *combatabilities.Hide
+	mockRoller    *mock_dice.MockRoller
 }
 
 func TestHideAbilityTestSuite(t *testing.T) {
@@ -131,11 +215,17 @@ func TestHideAbilityTestSuite(t *testing.T) {
 }
 
 func (s *HideAbilityTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
 	s.ctx = context.Background()
 	s.bus = events.NewEventBus()
-	s.owner = &mockOwner{id: "test-sneak"}
+	s.owner = &fakeStealthOwner{id: "test-sneak", skillModifiers: map[skills.Skill]int{skills.Stealth: 3}}
 	s.actionEconomy = combat.NewActionEconomy()
 	s.hide = combatabilities.NewHide("test-hide")
+	s.mockRoller = mock_dice.NewMockRoller(s.ctrl)
+}
+
+func (s *HideAbilityTestSuite) TearDownTest() {
+	s.ctrl.Finish()
 }
 
 func (s *HideAbilityTestSuite) TestNewHide_Properties() {
@@ -146,7 +236,28 @@ func (s *HideAbilityTestSuite) TestNewHide_Properties() {
 	s.Equal(refs.CombatAbilities.Hide(), s.hide.Ref())
 }
 
-func (s *HideAbilityTestSuite) TestActivate_ConsumesActionAndPublishes() {
+func (s *HideAbilityTestSuite) TestCanActivate_RequiresEventBus() {
+	err := s.hide.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: nil,
+	})
+	s.Require().Error(err)
+}
+
+func (s *HideAbilityTestSuite) TestCanActivate_RequiresStealthChecker() {
+	plainOwner := &mockOwner{id: "no-skills"}
+	err := s.hide.CanActivate(s.ctx, plainOwner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy, Bus: s.bus,
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "skill checks")
+}
+
+// TestActivate_Success covers the Hide-success path (the live MCP playtest
+// shape, R6): a Stealth total that beats the highest observer passive
+// Perception applies HiddenCondition.
+func (s *HideAbilityTestSuite) TestActivate_Success() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(14, nil) // 14 + 3 modifier = 17
+
 	received := false
 	var got dnd5eEvents.HideActivatedEvent
 	_, err := dnd5eEvents.HideActivatedTopic.On(s.bus).Subscribe(
@@ -158,21 +269,74 @@ func (s *HideAbilityTestSuite) TestActivate_ConsumesActionAndPublishes() {
 		},
 	)
 	s.Require().NoError(err)
+	captured := captureConditionApplied(s.T(), s.ctx, s.bus)
 
 	err = s.hide.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
-		ActionEconomy: s.actionEconomy, Bus: s.bus,
+		ActionEconomy:              s.actionEconomy,
+		Bus:                        s.bus,
+		Roller:                     s.mockRoller,
+		ObserverPassivePerceptions: []int{12, 15}, // highest is 15; 17 beats it
 	})
 	s.Require().NoError(err)
 	s.Equal(0, s.actionEconomy.ActionsRemaining, "Hide consumes the standard action")
 	s.True(received, "HideActivatedEvent should be published")
 	s.Equal(s.owner.GetID(), got.CharacterID)
+
+	s.Require().Len(*captured, 1, "a successful Hide applies HiddenCondition")
+	gotCond := (*captured)[0]
+	s.Equal(s.owner.GetID(), gotCond.Target.GetID())
+	s.Equal(dnd5eEvents.ConditionHidden, gotCond.Type)
+	s.Equal(dnd5eEvents.ConditionSourceCombatAbility, gotCond.Source)
+
+	hidden, ok := gotCond.Condition.(*conditions.HiddenCondition)
+	s.Require().True(ok, "condition should be a *HiddenCondition")
+	s.Equal(s.owner.GetID(), hidden.CharacterID)
 }
 
-func (s *HideAbilityTestSuite) TestCanActivate_RequiresEventBus() {
-	err := s.hide.CanActivate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
-		ActionEconomy: s.actionEconomy, Bus: nil,
+// TestActivate_Failure covers the R6-deferred failure branch as a unit test
+// (the design doc explicitly punts this to checks.MakeAbilityCheck coverage
+// since the live orchestrator has no deterministic-roller seam — this test
+// exercises the same branch one layer up, through Hide.Activate).
+func (s *HideAbilityTestSuite) TestActivate_Failure_NoConditionApplied() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(2, nil) // 2 + 3 modifier = 5
+
+	received := false
+	_, err := dnd5eEvents.HideActivatedTopic.On(s.bus).Subscribe(
+		s.ctx,
+		func(_ context.Context, _ dnd5eEvents.HideActivatedEvent) error {
+			received = true
+			return nil
+		},
+	)
+	s.Require().NoError(err)
+	captured := captureConditionApplied(s.T(), s.ctx, s.bus)
+
+	err = s.hide.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy:              s.actionEconomy,
+		Bus:                        s.bus,
+		Roller:                     s.mockRoller,
+		ObserverPassivePerceptions: []int{15},
 	})
-	s.Require().Error(err)
+	s.Require().NoError(err, "a failed Hide check is not an error — the action is still spent")
+	s.Equal(0, s.actionEconomy.ActionsRemaining, "the action is consumed even on a failed check")
+	s.True(received, "HideActivatedEvent still fires on failure")
+	s.Empty(*captured, "no HiddenCondition on a failed check")
+}
+
+// TestActivate_NoObservers covers the empty-observer-set case: DC defaults
+// to 0, so the check trivially succeeds.
+func (s *HideAbilityTestSuite) TestActivate_NoObservers() {
+	s.mockRoller.EXPECT().Roll(s.ctx, 20).Return(1, nil) // even a nat 1 (1+3=4) beats DC 0
+
+	captured := captureConditionApplied(s.T(), s.ctx, s.bus)
+
+	err := s.hide.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy,
+		Bus:           s.bus,
+		Roller:        s.mockRoller,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(*captured, 1, "no observers means the check trivially succeeds")
 }
 
 func (s *HideAbilityTestSuite) TestToJSON_AndLoadRoundTrip() {

--- a/rulebooks/dnd5e/combatabilities/hide.go
+++ b/rulebooks/dnd5e/combatabilities/hide.go
@@ -131,9 +131,11 @@ func (h *Hide) Activate(ctx context.Context, owner core.Entity, input CombatAbil
 }
 
 // highestPassivePerception returns the highest value in observerPP, or 0 if
-// empty (no observers means the Stealth check trivially succeeds). Hide's
-// own "beat the highest" comparison — the caller only gathers the raw
-// values via Combatant.PassivePerception(), never the DC itself.
+// empty (no observers means DC 0 — the check still rolls, but a Stealth
+// total below 0 is essentially unreachable in practice, not structurally
+// impossible). Hide's own "beat the highest" comparison — the caller only
+// gathers the raw values via Combatant.PassivePerception(), never the DC
+// itself.
 func highestPassivePerception(observerPP []int) int {
 	highest := 0
 	for _, pp := range observerPP {

--- a/rulebooks/dnd5e/combatabilities/hide.go
+++ b/rulebooks/dnd5e/combatabilities/hide.go
@@ -11,22 +11,35 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/checks"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
 )
 
 // Hide represents the Hide combat ability (PHB p.192).
-// When activated, it consumes 1 action and publishes a HideActivatedEvent.
-// The character attempts to become hidden — a Dexterity (Stealth) check against
-// observers' passive Perception. On success the character is Hidden (unseen and
-// unheard) until they are discovered, make noise, attack, or move into the open.
+// When activated, it consumes 1 action, publishes a HideActivatedEvent, and
+// makes a Dexterity (Stealth) check via checks.MakeAbilityCheck against the
+// highest passive Perception among input.ObserverPassivePerceptions (binary
+// success/fail — not per-observer; see the design doc's "Hide's success
+// granularity" decision). On success the character becomes Hidden
+// (HiddenCondition): advantage on their attacks, disadvantage on attacks
+// against them, until they attack.
 //
-// Mirrors the Dodge/Disengage bar: this consumes the action and emits the
-// activation signal. Resolving the Stealth check and applying the Hidden
-// condition is a later beat (the toolkit has the proficiency/check machinery;
-// nothing yet wires HideActivated → a check → the Hidden condition).
+// The DC is the caller's responsibility to gather (the encounter SDK
+// computes the observer set via perception.CanSeeAt and calls each
+// observer's Combatant.PassivePerception() — Hide only does the "beat the
+// highest" comparison, never the position/LOS work).
 type Hide struct {
 	*BaseCombatAbility
+}
+
+// stealthChecker is implemented by entities that can make a Stealth check.
+// Character satisfies this. The interface keeps Hide decoupled from a direct
+// dependency on the character package (owner arrives as core.Entity).
+type stealthChecker interface {
+	GetSkillModifier(skill skills.Skill) int
 }
 
 // HideData is the JSON structure for persisting Hide ability state.
@@ -50,7 +63,8 @@ func NewHide(id string) *Hide {
 }
 
 // CanActivate checks if the Hide ability can be activated.
-// Requires an available action and an event bus.
+// Requires an available action, an event bus, and an owner that can make
+// skill checks.
 func (h *Hide) CanActivate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
 	if err := h.BaseCombatAbility.CanActivate(ctx, owner, input); err != nil {
 		return err
@@ -58,24 +72,76 @@ func (h *Hide) CanActivate(ctx context.Context, owner core.Entity, input CombatA
 	if input.Bus == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Hide")
 	}
+	if _, ok := owner.(stealthChecker); !ok {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "Hide requires a character that can make skill checks")
+	}
 	return nil
 }
 
-// Activate consumes 1 action and publishes a HideActivatedEvent.
-// A subscriber in a later beat resolves the Stealth check and applies Hidden.
+// Activate consumes 1 action, publishes a HideActivatedEvent, makes the
+// Stealth check, and — on success — applies HiddenCondition. A failed check
+// still consumes the action (RAW: no condition applied, no do-over).
 func (h *Hide) Activate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
 	if input.Bus == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus required for Hide")
 	}
+	sc, ok := owner.(stealthChecker)
+	if !ok {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "Hide requires a character that can make skill checks")
+	}
 	if err := h.BaseCombatAbility.Activate(ctx, owner, input); err != nil {
 		return err
 	}
+
+	dc := highestPassivePerception(input.ObserverPassivePerceptions)
+
+	result, err := checks.MakeAbilityCheck(ctx, &checks.AbilityCheckInput{
+		Roller:    input.Roller,
+		EventBus:  input.Bus,
+		CheckerID: owner.GetID(),
+		Skill:     skills.Stealth,
+		DC:        dc,
+		Modifier:  sc.GetSkillModifier(skills.Stealth),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to make stealth check: %w", err)
+	}
+
 	if err := dnd5eEvents.HideActivatedTopic.On(input.Bus).Publish(ctx, dnd5eEvents.HideActivatedEvent{
 		CharacterID: owner.GetID(),
 	}); err != nil {
 		return fmt.Errorf("failed to publish hide activated event: %w", err)
 	}
+
+	if !result.Success {
+		return nil
+	}
+
+	hiddenCondition := conditions.NewHiddenCondition(owner.GetID())
+	if err := dnd5eEvents.ConditionAppliedTopic.On(input.Bus).Publish(ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    owner,
+		Type:      dnd5eEvents.ConditionHidden,
+		Source:    dnd5eEvents.ConditionSourceCombatAbility,
+		Condition: hiddenCondition,
+	}); err != nil {
+		return fmt.Errorf("failed to publish hidden condition applied event: %w", err)
+	}
+
 	return nil
+}
+
+// highestPassivePerception returns the highest value in observerPP, or 0 if
+// empty (no observers means the Stealth check trivially succeeds). Hide's
+// own "beat the highest" comparison — the caller only gathers the raw
+// values via Combatant.PassivePerception(), never the DC itself.
+func highestPassivePerception(observerPP []int) int {
+	highest := 0
+	for _, pp := range observerPP {
+		if pp > highest {
+			highest = pp
+		}
+	}
+	return highest
 }
 
 // ToJSON converts the Hide ability to JSON for persistence.

--- a/rulebooks/dnd5e/combatabilities/input.go
+++ b/rulebooks/dnd5e/combatabilities/input.go
@@ -1,6 +1,8 @@
 package combatabilities
 
 import (
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
@@ -34,4 +36,24 @@ type CombatAbilityInput struct {
 	// 0 = normal (1 attack), 1 = Extra Attack (2 attacks), etc.
 	// Required for the Attack ability to set correct attack capacity.
 	ExtraAttacks int `json:"-"`
+
+	// Target is the resolved target entity for abilities that target someone
+	// other than the owner (e.g. Help). Required for Help.Activate, which
+	// publishes a cross-entity ConditionAppliedEvent{Target: ...} — the
+	// ability needs the entity, not just an id. The caller (encounter SDK)
+	// resolves this via its own combatant registry; Character has no entity
+	// lookup of its own.
+	Target core.Entity `json:"-"`
+
+	// ObserverPassivePerceptions is the passive Perception of every opposing
+	// combatant that could observe this ability's actor, gathered by the
+	// caller via Combatant.PassivePerception() (never recomputed here).
+	// Required for Hide, which succeeds only if its Stealth total beats the
+	// highest value in this slice (binary success, not per-observer).
+	ObserverPassivePerceptions []int `json:"-"`
+
+	// Roller is the dice roller to use for abilities that roll checks (e.g.
+	// Hide's Stealth check). If nil, defaults to dice.NewRoller(). Pass a
+	// mock roller here for deterministic tests.
+	Roller dice.Roller `json:"-"`
 }

--- a/rulebooks/dnd5e/conditions/factory.go
+++ b/rulebooks/dnd5e/conditions/factory.go
@@ -98,6 +98,10 @@ func CreateFromRef(input *CreateFromRefInput) (*CreateFromRefOutput, error) {
 		condition = NewDisengagingCondition(input.CharacterID)
 	case refs.Conditions.Dodging().ID:
 		condition = NewDodgingCondition(input.CharacterID)
+	case refs.Conditions.Hidden().ID:
+		condition = NewHiddenCondition(input.CharacterID)
+	case refs.Conditions.Helped().ID:
+		condition, err = createHelped(input.Config, input.CharacterID)
 	default:
 		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown condition: %s", ref.ID)
 	}
@@ -299,4 +303,27 @@ func createSneakAttack(config json.RawMessage, characterID string) (*SneakAttack
 		Level:       level,
 		// Roller is nil - will use default roller when needed
 	}), nil
+}
+
+// helpedConfig is the config structure for the helped condition
+type helpedConfig struct {
+	HelperID string `json:"helper_id"`
+}
+
+// createHelped creates a helped condition from config. HelperID identifies
+// whose next turn is the safety-net removal trigger (PHB p.192: "before the
+// start of your [the helper's] next turn").
+func createHelped(config json.RawMessage, characterID string) (*HelpedCondition, error) {
+	var cfg helpedConfig
+	if len(config) > 0 {
+		if err := json.Unmarshal(config, &cfg); err != nil {
+			return nil, rpgerr.Wrap(err, "failed to parse helped config")
+		}
+	}
+
+	if cfg.HelperID == "" {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "helped config requires 'helper_id' field")
+	}
+
+	return NewHelpedCondition(characterID, cfg.HelperID), nil
 }

--- a/rulebooks/dnd5e/conditions/helped.go
+++ b/rulebooks/dnd5e/conditions/helped.go
@@ -1,0 +1,205 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// HelpedConditionData is the serializable form of the helped condition.
+// This is stored by the game server as an opaque JSON blob.
+type HelpedConditionData struct {
+	Ref         *core.Ref `json:"ref"`
+	CharacterID string    `json:"character_id"`
+	HelperID    string    `json:"helper_id"`
+}
+
+// HelpedCondition grants advantage on the helped ally's next attack roll
+// (PHB p.192 Help, attack branch). Applied when a character uses the Help
+// combat ability targeting an ally. Beat 2 (rpg-project#75) scopes this to
+// the attack branch only — the ability-check branch and its chain subscriber
+// are explicitly deferred (R4); see the design doc's Resolved Decisions.
+//
+// Two removal paths:
+//   - Consumed on the ally's next attack (AttackChain, same self-consuming
+//     shape as HiddenCondition's attacker branch).
+//   - Safety-net removal at the HELPER's next turn if the ally never attacks
+//     (TurnStartTopic keyed on HelperID, not CharacterID — this is the one
+//     place a condition's own turn-boundary trigger is a DIFFERENT actor than
+//     the condition's owner).
+type HelpedCondition struct {
+	CharacterID     string // the ally who benefits from the advantage
+	HelperID        string // the helper; their next turn is the safety-net removal trigger
+	bus             events.EventBus
+	subscriptionIDs []string
+}
+
+// Ensure HelpedCondition implements dnd5eEvents.ConditionBehavior
+var _ dnd5eEvents.ConditionBehavior = (*HelpedCondition)(nil)
+
+// NewHelpedCondition creates a new Helped condition granting the given ally
+// advantage, with removal tied to the helper's next turn as a safety net.
+func NewHelpedCondition(characterID, helperID string) *HelpedCondition {
+	return &HelpedCondition{
+		CharacterID: characterID,
+		HelperID:    helperID,
+	}
+}
+
+// IsApplied returns true if this condition is currently applied.
+func (h *HelpedCondition) IsApplied() bool {
+	return h.bus != nil
+}
+
+// Apply subscribes this condition to AttackChain (grants + consumes on the
+// ally's next attack) and TurnStartTopic (safety-net removal at the
+// helper's next turn if unused). No AbilityCheckChain subscriber this wave
+// (R4 — attack branch only).
+func (h *HelpedCondition) Apply(ctx context.Context, bus events.EventBus) error {
+	if h.IsApplied() {
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "helped condition already applied")
+	}
+	h.bus = bus
+
+	attackChain := dnd5eEvents.AttackChain.On(bus)
+	subID1, err := attackChain.SubscribeWithChain(ctx, h.onAttackChain)
+	if err != nil {
+		h.bus = nil
+		return rpgerr.Wrap(err, "failed to subscribe to attack chain")
+	}
+	h.subscriptionIDs = append(h.subscriptionIDs, subID1)
+
+	turnStartTopic := dnd5eEvents.TurnStartTopic.On(bus)
+	subID2, err := turnStartTopic.Subscribe(ctx, h.onTurnStart)
+	if err != nil {
+		_ = h.Remove(ctx, bus)
+		return rpgerr.Wrap(err, "failed to subscribe to turn start topic")
+	}
+	h.subscriptionIDs = append(h.subscriptionIDs, subID2)
+
+	return nil
+}
+
+// Remove unsubscribes this condition from all events.
+func (h *HelpedCondition) Remove(ctx context.Context, bus events.EventBus) error {
+	if h.bus == nil {
+		return nil // Not applied, nothing to remove
+	}
+
+	total := len(h.subscriptionIDs)
+	var errs []error
+	for _, subID := range h.subscriptionIDs {
+		if err := bus.Unsubscribe(ctx, subID); err != nil {
+			errs = append(errs, fmt.Errorf("unsubscribe %s: %w", subID, err))
+		}
+	}
+
+	h.subscriptionIDs = nil
+	h.bus = nil
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to unsubscribe %d/%d subscriptions: %w", len(errs), total, errors.Join(errs...))
+	}
+	return nil
+}
+
+// ToJSON converts the condition to JSON for persistence.
+func (h *HelpedCondition) ToJSON() (json.RawMessage, error) {
+	data := HelpedConditionData{
+		Ref:         refs.Conditions.Helped(),
+		CharacterID: h.CharacterID,
+		HelperID:    h.HelperID,
+	}
+	return json.Marshal(data)
+}
+
+// loadJSON loads helped condition state from JSON.
+func (h *HelpedCondition) loadJSON(data json.RawMessage) error {
+	var helpedData HelpedConditionData
+	if err := json.Unmarshal(data, &helpedData); err != nil {
+		return rpgerr.Wrap(err, "failed to unmarshal helped data")
+	}
+
+	h.CharacterID = helpedData.CharacterID
+	h.HelperID = helpedData.HelperID
+	return nil
+}
+
+// onAttackChain grants advantage when the helped ally attacks, then consumes
+// the condition — mirrors HiddenCondition's self-consuming attacker branch.
+// Unsubscribing here is safe mid-dispatch: events.simpleEventBus.Publish
+// snapshots subscribers before invoking handlers.
+func (h *HelpedCondition) onAttackChain(
+	ctx context.Context,
+	event dnd5eEvents.AttackChainEvent,
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	if event.AttackerID != h.CharacterID {
+		return c, nil
+	}
+
+	modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+		e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.AttackModifierSource{
+			SourceRef: refs.Conditions.Helped(),
+			SourceID:  h.HelperID,
+			Reason:    "Helped",
+		})
+		return e, nil
+	}
+	if err := c.Add(combat.StageConditions, "helped_advantage", modifyAttack); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add helped advantage modifier for character %s", h.CharacterID)
+	}
+
+	if h.bus != nil {
+		removals := dnd5eEvents.ConditionRemovedTopic.On(h.bus)
+		if err := removals.Publish(ctx, dnd5eEvents.ConditionRemovedEvent{
+			CharacterID:  h.CharacterID,
+			ConditionRef: refs.Conditions.Helped().String(),
+			Reason:       "consumed",
+		}); err != nil {
+			return c, rpgerr.Wrapf(err, "failed to publish helped removal for character %s", h.CharacterID)
+		}
+		if err := h.Remove(ctx, h.bus); err != nil {
+			return c, rpgerr.Wrapf(err, "failed to remove helped condition for character %s", h.CharacterID)
+		}
+	}
+
+	return c, nil
+}
+
+// onTurnStart is the safety-net removal: if the ally never attacks, Helped
+// is removed at the start of the HELPER's next turn (not the ally's —
+// PHB p.192: "before the start of your [the helper's] next turn").
+func (h *HelpedCondition) onTurnStart(ctx context.Context, event dnd5eEvents.TurnStartEvent) error {
+	if event.CharacterID != h.HelperID {
+		return nil
+	}
+
+	if h.bus == nil {
+		return nil
+	}
+
+	removals := dnd5eEvents.ConditionRemovedTopic.On(h.bus)
+	err := removals.Publish(ctx, dnd5eEvents.ConditionRemovedEvent{
+		CharacterID:  h.CharacterID,
+		ConditionRef: refs.Conditions.Helped().String(),
+		Reason:       "turn_start",
+	})
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to publish helped removal for character %s", h.CharacterID)
+	}
+
+	return h.Remove(ctx, h.bus)
+}

--- a/rulebooks/dnd5e/conditions/helped_test.go
+++ b/rulebooks/dnd5e/conditions/helped_test.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+type HelpedConditionTestSuite struct {
+	suite.Suite
+	ctx         context.Context
+	bus         events.EventBus
+	condition   *HelpedCondition
+	characterID string
+	helperID    string
+}
+
+func TestHelpedConditionSuite(t *testing.T) {
+	suite.Run(t, new(HelpedConditionTestSuite))
+}
+
+func (s *HelpedConditionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.characterID = "ally-1"
+	s.helperID = "helper-1"
+	s.condition = NewHelpedCondition(s.characterID, s.helperID)
+}
+
+func (s *HelpedConditionTestSuite) TestNewHelpedCondition() {
+	s.Equal(s.characterID, s.condition.CharacterID)
+	s.Equal(s.helperID, s.condition.HelperID)
+	s.False(s.condition.IsApplied())
+}
+
+func (s *HelpedConditionTestSuite) TestApply() {
+	s.Run("applies successfully", func() {
+		err := s.condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+		s.True(s.condition.IsApplied())
+		s.Len(s.condition.subscriptionIDs, 2)
+	})
+
+	s.Run("returns error if already applied", func() {
+		condition := NewHelpedCondition(s.characterID, s.helperID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		err = condition.Apply(s.ctx, s.bus)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "already applied")
+	})
+}
+
+func (s *HelpedConditionTestSuite) TestRemove() {
+	s.Run("removes successfully after apply", func() {
+		condition := NewHelpedCondition(s.characterID, s.helperID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		err = condition.Remove(s.ctx, s.bus)
+		s.Require().NoError(err)
+		s.False(condition.IsApplied())
+	})
+
+	s.Run("no-op if not applied", func() {
+		condition := NewHelpedCondition(s.characterID, s.helperID)
+		err := condition.Remove(s.ctx, s.bus)
+		s.Require().NoError(err)
+	})
+}
+
+func (s *HelpedConditionTestSuite) TestAttackChain_AllyAttackGetsAdvantageAndConsumes() {
+	condition := NewHelpedCondition(s.characterID, s.helperID)
+	err := condition.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	_, err = dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removedEvent = &event
+			return nil
+		})
+	s.Require().NoError(err)
+
+	attackEvent := dnd5eEvents.AttackChainEvent{
+		AttackerID: s.characterID,
+		TargetID:   "goblin-1",
+	}
+	attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	attacks := dnd5eEvents.AttackChain.On(s.bus)
+	modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+	s.Require().NoError(err)
+
+	s.Require().Len(finalEvent.AdvantageSources, 1, "the helped ally's attack gets advantage")
+	s.Equal(refs.Conditions.Helped(), finalEvent.AdvantageSources[0].SourceRef)
+	s.Equal(s.helperID, finalEvent.AdvantageSources[0].SourceID, "advantage is attributed to the helper")
+
+	s.False(condition.IsApplied(), "Helped is consumed on the ally's attack")
+	s.Require().NotNil(removedEvent)
+	s.Equal(s.characterID, removedEvent.CharacterID)
+	s.Equal("consumed", removedEvent.Reason)
+}
+
+func (s *HelpedConditionTestSuite) TestAttackChain_OtherCharacterAttackIsUntouched() {
+	condition := NewHelpedCondition(s.characterID, s.helperID)
+	err := condition.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	attackEvent := dnd5eEvents.AttackChainEvent{
+		AttackerID: "someone-else",
+		TargetID:   "goblin-1",
+	}
+	attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	attacks := dnd5eEvents.AttackChain.On(s.bus)
+	modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+	s.Require().NoError(err)
+
+	s.Empty(finalEvent.AdvantageSources)
+	s.True(condition.IsApplied())
+}
+
+func (s *HelpedConditionTestSuite) TestTurnStartRemoval_SafetyNetAtHelpersTurn() {
+	condition := NewHelpedCondition(s.characterID, s.helperID)
+	err := condition.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	_, err = dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removedEvent = &event
+			return nil
+		})
+	s.Require().NoError(err)
+
+	s.Run("does not remove on the ally's own turn start", func() {
+		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
+			CharacterID: s.characterID,
+			Round:       1,
+		})
+		s.Require().NoError(err)
+		s.True(condition.IsApplied(), "the trigger is the HELPER's turn, not the ally's")
+	})
+
+	s.Run("removes on the helper's turn start", func() {
+		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
+			CharacterID: s.helperID,
+			Round:       1,
+		})
+		s.Require().NoError(err)
+		s.False(condition.IsApplied())
+		s.Require().NotNil(removedEvent)
+		s.Equal(s.characterID, removedEvent.CharacterID)
+		s.Equal("turn_start", removedEvent.Reason)
+	})
+}
+
+func (s *HelpedConditionTestSuite) TestToJSON() {
+	condition := NewHelpedCondition(s.characterID, s.helperID)
+	data, err := condition.ToJSON()
+	s.Require().NoError(err)
+
+	loaded := &HelpedCondition{}
+	err = loaded.loadJSON(data)
+	s.Require().NoError(err)
+	s.Equal(s.characterID, loaded.CharacterID)
+	s.Equal(s.helperID, loaded.HelperID)
+}
+
+// TestLoaderRoundTrip proves HelpedCondition is registered in loader.go (R3).
+func (s *HelpedConditionTestSuite) TestLoaderRoundTrip() {
+	original := NewHelpedCondition(s.characterID, s.helperID)
+	data, err := original.ToJSON()
+	s.Require().NoError(err)
+
+	loaded, err := LoadJSON(data)
+	s.Require().NoError(err)
+
+	helped, ok := loaded.(*HelpedCondition)
+	s.Require().True(ok, "loaded condition should be a *HelpedCondition")
+	s.Equal(s.characterID, helped.CharacterID)
+	s.Equal(s.helperID, helped.HelperID)
+
+	err = helped.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(helped.IsApplied())
+
+	attackEvent := dnd5eEvents.AttackChainEvent{AttackerID: s.characterID, TargetID: "goblin-1"}
+	attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	attacks := dnd5eEvents.AttackChain.On(s.bus)
+	modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+	s.Require().NoError(err)
+	finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+	s.Require().NoError(err)
+	s.Require().Len(finalEvent.AdvantageSources, 1, "reloaded condition still grants advantage")
+}
+
+// TestFactoryRoundTrip proves HelpedCondition is registered in factory.go (R3).
+func (s *HelpedConditionTestSuite) TestFactoryRoundTrip() {
+	output, err := CreateFromRef(&CreateFromRefInput{
+		Ref:         refs.Conditions.Helped().String(),
+		Config:      json.RawMessage(`{"helper_id":"` + s.helperID + `"}`),
+		CharacterID: s.characterID,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+
+	helped, ok := output.Condition.(*HelpedCondition)
+	s.Require().True(ok)
+	s.Equal(s.characterID, helped.CharacterID)
+	s.Equal(s.helperID, helped.HelperID)
+}

--- a/rulebooks/dnd5e/conditions/hidden.go
+++ b/rulebooks/dnd5e/conditions/hidden.go
@@ -1,0 +1,180 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// HiddenConditionData is the serializable form of the hidden condition.
+// This is stored by the game server as an opaque JSON blob.
+type HiddenConditionData struct {
+	Ref         *core.Ref `json:"ref"`
+	CharacterID string    `json:"character_id"`
+}
+
+// HiddenCondition grants advantage on the hidden character's attacks and
+// disadvantage on attacks against them. This condition is applied when a
+// character succeeds a Hide stealth check and removes itself when the
+// hidden character makes their own attack (PHB p.192: Hidden ends when you
+// attack). Both directions subscribe to the same AttackChain — mirrors
+// DodgingCondition's registration shape but adds a self-consuming attacker
+// branch DodgingCondition doesn't need.
+type HiddenCondition struct {
+	CharacterID     string
+	bus             events.EventBus
+	subscriptionIDs []string
+}
+
+// Ensure HiddenCondition implements dnd5eEvents.ConditionBehavior
+var _ dnd5eEvents.ConditionBehavior = (*HiddenCondition)(nil)
+
+// NewHiddenCondition creates a new Hidden condition for the specified character.
+func NewHiddenCondition(characterID string) *HiddenCondition {
+	return &HiddenCondition{
+		CharacterID: characterID,
+	}
+}
+
+// IsApplied returns true if this condition is currently applied.
+func (h *HiddenCondition) IsApplied() bool {
+	return h.bus != nil
+}
+
+// Apply subscribes this condition to AttackChain in both directions:
+// advantage when the hidden character attacks (which also ends Hidden),
+// disadvantage when the hidden character is attacked.
+func (h *HiddenCondition) Apply(ctx context.Context, bus events.EventBus) error {
+	if h.IsApplied() {
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "hidden condition already applied")
+	}
+	h.bus = bus
+
+	attackChain := dnd5eEvents.AttackChain.On(bus)
+	subID, err := attackChain.SubscribeWithChain(ctx, h.onAttackChain)
+	if err != nil {
+		h.bus = nil
+		return rpgerr.Wrap(err, "failed to subscribe to attack chain")
+	}
+	h.subscriptionIDs = append(h.subscriptionIDs, subID)
+
+	return nil
+}
+
+// Remove unsubscribes this condition from all events.
+func (h *HiddenCondition) Remove(ctx context.Context, bus events.EventBus) error {
+	if h.bus == nil {
+		return nil // Not applied, nothing to remove
+	}
+
+	total := len(h.subscriptionIDs)
+	var errs []error
+	for _, subID := range h.subscriptionIDs {
+		if err := bus.Unsubscribe(ctx, subID); err != nil {
+			errs = append(errs, fmt.Errorf("unsubscribe %s: %w", subID, err))
+		}
+	}
+
+	h.subscriptionIDs = nil
+	h.bus = nil
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to unsubscribe %d/%d subscriptions: %w", len(errs), total, errors.Join(errs...))
+	}
+	return nil
+}
+
+// ToJSON converts the condition to JSON for persistence.
+func (h *HiddenCondition) ToJSON() (json.RawMessage, error) {
+	data := HiddenConditionData{
+		Ref:         refs.Conditions.Hidden(),
+		CharacterID: h.CharacterID,
+	}
+	return json.Marshal(data)
+}
+
+// loadJSON loads hidden condition state from JSON.
+func (h *HiddenCondition) loadJSON(data json.RawMessage) error {
+	var hiddenData HiddenConditionData
+	if err := json.Unmarshal(data, &hiddenData); err != nil {
+		return rpgerr.Wrap(err, "failed to unmarshal hidden data")
+	}
+
+	h.CharacterID = hiddenData.CharacterID
+	return nil
+}
+
+// onAttackChain handles attack events in both directions:
+//   - When the hidden character is the attacker, grants advantage on that
+//     attack, then removes Hidden (PHB p.192: attacking ends Hidden). The
+//     removal happens after the modifier is queued on the chain, so this
+//     attack still gets its advantage — Remove only stops FUTURE events from
+//     reaching this condition (see events.simpleEventBus.Publish, which
+//     snapshots subscribers before invoking handlers, so unsubscribing here
+//     is safe mid-dispatch).
+//   - When the hidden character is the target, imposes disadvantage on the
+//     attacker. This does not end Hidden (no "seen" break trigger this wave).
+func (h *HiddenCondition) onAttackChain(
+	ctx context.Context,
+	event dnd5eEvents.AttackChainEvent,
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	switch h.CharacterID {
+	case event.AttackerID:
+		modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+			e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.AttackModifierSource{
+				SourceRef: refs.Conditions.Hidden(),
+				SourceID:  h.CharacterID,
+				Reason:    "Hidden",
+			})
+			return e, nil
+		}
+		if err := c.Add(combat.StageConditions, "hidden_attacker_advantage", modifyAttack); err != nil {
+			return c, rpgerr.Wrapf(err, "failed to add hidden advantage modifier for character %s", h.CharacterID)
+		}
+
+		// Hidden ends when the hidden character attacks. Publish the removal
+		// signal and unsubscribe now — the advantage modifier above is already
+		// queued on the chain and will still apply to this attack.
+		if h.bus != nil {
+			removals := dnd5eEvents.ConditionRemovedTopic.On(h.bus)
+			if err := removals.Publish(ctx, dnd5eEvents.ConditionRemovedEvent{
+				CharacterID:  h.CharacterID,
+				ConditionRef: refs.Conditions.Hidden().String(),
+				Reason:       "attacked",
+			}); err != nil {
+				return c, rpgerr.Wrapf(err, "failed to publish hidden removal for character %s", h.CharacterID)
+			}
+			if err := h.Remove(ctx, h.bus); err != nil {
+				return c, rpgerr.Wrapf(err, "failed to remove hidden condition for character %s", h.CharacterID)
+			}
+		}
+
+	case event.TargetID:
+		modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+			e.DisadvantageSources = append(e.DisadvantageSources, dnd5eEvents.AttackModifierSource{
+				SourceRef: refs.Conditions.Hidden(),
+				SourceID:  h.CharacterID,
+				Reason:    "Hidden",
+			})
+			return e, nil
+		}
+		if err := c.Add(combat.StageConditions, "hidden_target_disadvantage", modifyAttack); err != nil {
+			return c, rpgerr.Wrapf(err, "failed to add hidden disadvantage modifier for character %s", h.CharacterID)
+		}
+	}
+
+	return c, nil
+}

--- a/rulebooks/dnd5e/conditions/hidden_test.go
+++ b/rulebooks/dnd5e/conditions/hidden_test.go
@@ -1,0 +1,205 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+type HiddenConditionTestSuite struct {
+	suite.Suite
+	ctx         context.Context
+	bus         events.EventBus
+	condition   *HiddenCondition
+	characterID string
+}
+
+func TestHiddenConditionSuite(t *testing.T) {
+	suite.Run(t, new(HiddenConditionTestSuite))
+}
+
+func (s *HiddenConditionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.characterID = "char-hidden"
+	s.condition = NewHiddenCondition(s.characterID)
+}
+
+func (s *HiddenConditionTestSuite) TestNewHiddenCondition() {
+	s.Equal(s.characterID, s.condition.CharacterID)
+	s.False(s.condition.IsApplied())
+}
+
+func (s *HiddenConditionTestSuite) TestApply() {
+	s.Run("applies successfully", func() {
+		err := s.condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+		s.True(s.condition.IsApplied())
+		s.Len(s.condition.subscriptionIDs, 1)
+	})
+
+	s.Run("returns error if already applied", func() {
+		condition := NewHiddenCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		err = condition.Apply(s.ctx, s.bus)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "already applied")
+	})
+}
+
+func (s *HiddenConditionTestSuite) TestRemove() {
+	s.Run("removes successfully after apply", func() {
+		condition := NewHiddenCondition(s.characterID)
+		err := condition.Apply(s.ctx, s.bus)
+		s.Require().NoError(err)
+
+		err = condition.Remove(s.ctx, s.bus)
+		s.Require().NoError(err)
+		s.False(condition.IsApplied())
+		s.Nil(condition.subscriptionIDs)
+	})
+
+	s.Run("no-op if not applied", func() {
+		condition := NewHiddenCondition(s.characterID)
+		err := condition.Remove(s.ctx, s.bus)
+		s.Require().NoError(err)
+	})
+}
+
+func (s *HiddenConditionTestSuite) runAttackChain(event dnd5eEvents.AttackChainEvent) dnd5eEvents.AttackChainEvent {
+	attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	attacks := dnd5eEvents.AttackChain.On(s.bus)
+	modifiedChain, err := attacks.PublishWithChain(s.ctx, event, attackChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, event)
+	s.Require().NoError(err)
+	return finalEvent
+}
+
+func (s *HiddenConditionTestSuite) TestAttackChain_HiddenCharacterAttacks() {
+	condition := NewHiddenCondition(s.characterID)
+	err := condition.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	_, err = dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removedEvent = &event
+			return nil
+		})
+	s.Require().NoError(err)
+
+	finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+		AttackerID: s.characterID,
+		TargetID:   "goblin-1",
+	})
+
+	s.Require().Len(finalEvent.AdvantageSources, 1, "hidden attacker gets advantage on their attack")
+	s.Equal(refs.Conditions.Hidden(), finalEvent.AdvantageSources[0].SourceRef)
+
+	s.False(condition.IsApplied(), "Hidden ends when the hider attacks")
+	s.Require().NotNil(removedEvent)
+	s.Equal(s.characterID, removedEvent.CharacterID)
+	s.Equal(refs.Conditions.Hidden().String(), removedEvent.ConditionRef)
+	s.Equal("attacked", removedEvent.Reason)
+}
+
+func (s *HiddenConditionTestSuite) TestAttackChain_HiddenCharacterIsTargeted() {
+	condition := NewHiddenCondition(s.characterID)
+	err := condition.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+		AttackerID: "goblin-1",
+		TargetID:   s.characterID,
+	})
+
+	s.Require().Len(finalEvent.DisadvantageSources, 1, "attacks against the hidden character have disadvantage")
+	s.Equal(refs.Conditions.Hidden(), finalEvent.DisadvantageSources[0].SourceRef)
+
+	s.True(condition.IsApplied(), "being attacked does not end Hidden this wave")
+}
+
+func (s *HiddenConditionTestSuite) TestAttackChain_UnrelatedAttackIsUntouched() {
+	condition := NewHiddenCondition(s.characterID)
+	err := condition.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+		AttackerID: "goblin-1",
+		TargetID:   "goblin-2",
+	})
+
+	s.Empty(finalEvent.AdvantageSources)
+	s.Empty(finalEvent.DisadvantageSources)
+	s.True(condition.IsApplied())
+}
+
+func (s *HiddenConditionTestSuite) TestToJSON() {
+	condition := NewHiddenCondition(s.characterID)
+	data, err := condition.ToJSON()
+	s.Require().NoError(err)
+
+	loaded := &HiddenCondition{}
+	err = loaded.loadJSON(data)
+	s.Require().NoError(err)
+	s.Equal(s.characterID, loaded.CharacterID)
+}
+
+// TestLoaderRoundTrip proves HiddenCondition is registered in loader.go — an
+// unregistered condition would fail here with "unknown condition ref"
+// instead of round-tripping. This is the RPC-boundary regression test named
+// by R3: Hide's Stealth→attack flow crosses a turn boundary, so a condition
+// that doesn't survive ToJSON→LoadJSON would silently evaporate before the
+// attack it's supposed to affect.
+func (s *HiddenConditionTestSuite) TestLoaderRoundTrip() {
+	original := NewHiddenCondition(s.characterID)
+	data, err := original.ToJSON()
+	s.Require().NoError(err)
+
+	loaded, err := LoadJSON(data)
+	s.Require().NoError(err)
+
+	hidden, ok := loaded.(*HiddenCondition)
+	s.Require().True(ok, "loaded condition should be a *HiddenCondition")
+	s.Equal(s.characterID, hidden.CharacterID)
+	s.False(hidden.IsApplied(), "a freshly loaded condition is not yet applied to a bus")
+
+	// Reconstitute it onto a bus and confirm it still subscribes and functions —
+	// this is the "still functioning after reload" half of R3's round trip.
+	err = hidden.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(hidden.IsApplied())
+
+	finalEvent := s.runAttackChain(dnd5eEvents.AttackChainEvent{
+		AttackerID: "goblin-1",
+		TargetID:   s.characterID,
+	})
+	s.Require().Len(finalEvent.DisadvantageSources, 1, "reloaded condition still grants disadvantage to attackers")
+}
+
+// TestFactoryRoundTrip proves HiddenCondition is registered in factory.go.
+func (s *HiddenConditionTestSuite) TestFactoryRoundTrip() {
+	output, err := CreateFromRef(&CreateFromRefInput{
+		Ref:         refs.Conditions.Hidden().String(),
+		CharacterID: s.characterID,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(output)
+
+	hidden, ok := output.Condition.(*HiddenCondition)
+	s.Require().True(ok)
+	s.Equal(s.characterID, hidden.CharacterID)
+}

--- a/rulebooks/dnd5e/conditions/loader.go
+++ b/rulebooks/dnd5e/conditions/loader.go
@@ -139,6 +139,20 @@ func LoadJSON(data json.RawMessage) (dnd5eEvents.ConditionBehavior, error) {
 		}
 		return dodging, nil
 
+	case refs.Conditions.Hidden().ID:
+		hidden := &HiddenCondition{}
+		if err := hidden.loadJSON(data); err != nil {
+			return nil, rpgerr.Wrap(err, "failed to load hidden condition")
+		}
+		return hidden, nil
+
+	case refs.Conditions.Helped().ID:
+		helped := &HelpedCondition{}
+		if err := helped.loadJSON(data); err != nil {
+			return nil, rpgerr.Wrap(err, "failed to load helped condition")
+		}
+		return helped, nil
+
 	case refs.Conditions.Unconscious().ID:
 		uc := &UnconsciousCondition{}
 		if err := uc.loadJSON(data); err != nil {

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
 )
 
 // ConditionType represents D&D 5e conditions
@@ -68,6 +69,16 @@ const (
 
 	// ConditionFightingStyle represents an active fighting style
 	ConditionFightingStyle ConditionType = "fighting_style"
+
+	// ConditionHidden is applied when a character successfully hides
+	// (a Stealth check beating observers' passive Perception). Grants
+	// advantage on the hidden character's attacks and disadvantage on
+	// attacks against them; removed when the hider makes their own attack.
+	ConditionHidden ConditionType = "hidden"
+	// ConditionHelped is applied to the ally targeted by the Help combat
+	// ability. Grants advantage on the ally's next attack roll; removed
+	// when consumed or at the helper's next turn if unused.
+	ConditionHelped ConditionType = "helped"
 )
 
 // ConditionSource identifies where a condition originated
@@ -78,6 +89,9 @@ const (
 	ConditionSourceClass ConditionSource = "class"
 	// ConditionSourceFeature indicates condition from feature activation (e.g., rage)
 	ConditionSourceFeature ConditionSource = "feature"
+	// ConditionSourceCombatAbility indicates condition from a universal combat
+	// ability activation (e.g., Hide, Help)
+	ConditionSourceCombatAbility ConditionSource = "combat_ability"
 )
 
 // ConditionBehavior represents the behavior of an active condition.
@@ -321,6 +335,58 @@ func (e *SavingThrowChainEvent) HasDisadvantage() bool {
 
 // TotalBonus returns the sum of all bonus sources
 func (e *SavingThrowChainEvent) TotalBonus() int {
+	total := 0
+	for _, source := range e.BonusSources {
+		total += source.Bonus
+	}
+	return total
+}
+
+// =============================================================================
+// Ability Check Chain Types
+// =============================================================================
+
+// CheckModifierSource tracks the source of an ability check modifier.
+// Mirrors SaveModifierSource.
+type CheckModifierSource struct {
+	Name       string    // Display name (e.g., "Hidden", "Guidance")
+	SourceType string    // Type of source ("condition", "feature", "spell", etc)
+	SourceRef  *core.Ref // Reference to the source
+	EntityID   string    // ID of entity providing the modifier
+}
+
+// CheckBonusSource tracks a bonus to an ability check.
+// Mirrors SaveBonusSource.
+type CheckBonusSource struct {
+	CheckModifierSource     // Embedded modifier source
+	Bonus               int // The bonus amount
+}
+
+// AbilityCheckChainEvent represents an ability check flowing through the
+// modifier chain. This event fires BEFORE the d20 roll to allow
+// advantage/disadvantage/bonuses to be collected. Mirrors SavingThrowChainEvent.
+type AbilityCheckChainEvent struct {
+	CheckerID string       // ID of the entity making the check
+	Skill     skills.Skill // The skill being checked (Stealth, Perception, etc)
+	DC        int          // Difficulty class (or the value being beaten)
+
+	AdvantageSources    []CheckModifierSource // Sources granting advantage
+	DisadvantageSources []CheckModifierSource // Sources imposing disadvantage
+	BonusSources        []CheckBonusSource    // Sources adding bonuses to the roll
+}
+
+// HasAdvantage returns true if any advantage sources have been added to this event
+func (e *AbilityCheckChainEvent) HasAdvantage() bool {
+	return len(e.AdvantageSources) > 0
+}
+
+// HasDisadvantage returns true if any disadvantage sources have been added to this event
+func (e *AbilityCheckChainEvent) HasDisadvantage() bool {
+	return len(e.DisadvantageSources) > 0
+}
+
+// TotalBonus returns the sum of all bonus sources
+func (e *AbilityCheckChainEvent) TotalBonus() int {
 	total := 0
 	for _, source := range e.BonusSources {
 		total += source.Bonus
@@ -907,4 +973,10 @@ var (
 	// Disengaging to prevent opportunity attacks, or features like Sentinel
 	// to stop movement entirely.
 	MovementChain = events.DefineChainedTopic[*MovementChainEvent]("dnd5e.combat.movement.chain")
+
+	// AbilityCheckChain provides typed chained topic for ability check modifiers
+	// (advantage/disadvantage/bonuses). Mirrors SavingThrowChain. Fired by
+	// checks.MakeAbilityCheck whenever an EventBus is provided — the same
+	// pattern SavingThrowChain uses, whether or not any subscriber exists.
+	AbilityCheckChain = events.DefineChainedTopic[*AbilityCheckChainEvent]("dnd5e.checks.chain")
 )

--- a/rulebooks/dnd5e/gamectx/gamectx_test.go
+++ b/rulebooks/dnd5e/gamectx/gamectx_test.go
@@ -735,6 +735,7 @@ func (m *mockCombatant) IsDirty() bool                       { return m.dirty }
 func (m *mockCombatant) MarkClean()                          { m.dirty = false }
 func (m *mockCombatant) AbilityScores() shared.AbilityScores { return m.abilityScores }
 func (m *mockCombatant) ProficiencyBonus() int               { return m.proficiencyBonus }
+func (m *mockCombatant) PassivePerception() int              { return 10 }
 
 func (m *mockCombatant) ApplyDamage(_ context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {
 	if input == nil {

--- a/rulebooks/dnd5e/integration/fighter_encounter_test.go
+++ b/rulebooks/dnd5e/integration/fighter_encounter_test.go
@@ -78,6 +78,7 @@ func (m *mockFighterCharacter) GetMaxHitPoints() int                           {
 func (m *mockFighterCharacter) AC() int                                        { return m.armorClass }
 func (m *mockFighterCharacter) IsDirty() bool                                  { return false }
 func (m *mockFighterCharacter) MarkClean()                                     {}
+func (m *mockFighterCharacter) PassivePerception() int                         { return 10 }
 func (m *mockFighterCharacter) GetConditions() []dnd5eEvents.ConditionBehavior { return m.conditions }
 
 func (m *mockFighterCharacter) ApplyDamage(_ context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {

--- a/rulebooks/dnd5e/integration/rogue_encounter_test.go
+++ b/rulebooks/dnd5e/integration/rogue_encounter_test.go
@@ -77,6 +77,7 @@ func (m *mockRogueCharacter) GetMaxHitPoints() int                           { r
 func (m *mockRogueCharacter) AC() int                                        { return m.armorClass }
 func (m *mockRogueCharacter) IsDirty() bool                                  { return false }
 func (m *mockRogueCharacter) MarkClean()                                     {}
+func (m *mockRogueCharacter) PassivePerception() int                         { return 10 }
 func (m *mockRogueCharacter) GetConditions() []dnd5eEvents.ConditionBehavior { return m.conditions }
 
 func (m *mockRogueCharacter) ApplyDamage(_ context.Context, input *combat.ApplyDamageInput) *combat.ApplyDamageResult {

--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -200,6 +200,12 @@ func (m *Monster) ProficiencyBonus() int {
 	return m.proficiencyBonus
 }
 
+// PassivePerception returns the monster's passive Perception score, from the
+// static Senses field seeded at load time. Implements combat.Combatant.
+func (m *Monster) PassivePerception() int {
+	return m.senses.PassivePerception
+}
+
 // TakeDamage reduces HP (returns actual damage taken)
 func (m *Monster) TakeDamage(amount int) int {
 	if amount < 0 {

--- a/rulebooks/dnd5e/refs/conditions.go
+++ b/rulebooks/dnd5e/refs/conditions.go
@@ -39,6 +39,10 @@ var (
 	conditionDodging     = &core.Ref{Module: Module, Type: TypeConditions, ID: "dodging"}
 	conditionDisengaging = &core.Ref{Module: Module, Type: TypeConditions, ID: "disengaging"}
 
+	// Combat-ability conditions (Beat 2: Help + Hide)
+	conditionHidden = &core.Ref{Module: Module, Type: TypeConditions, ID: "hidden"}
+	conditionHelped = &core.Ref{Module: Module, Type: TypeConditions, ID: "helped"}
+
 	// Reaction conditions (Wave 2.11d) — universal-by-default reactions that
 	// subscribe to the appropriate chain and publish ReactionTriggerEvents
 	// when their predicate matches AND gamectx.IsReactionReady returns true.
@@ -94,6 +98,14 @@ func (n conditionsNS) FightingStyleTwoWeaponFighting() *core.Ref {
 // Turn-based conditions (from actions)
 func (n conditionsNS) Dodging() *core.Ref     { return conditionDodging }
 func (n conditionsNS) Disengaging() *core.Ref { return conditionDisengaging }
+
+// Hidden returns the ref for the HiddenCondition, applied on a successful
+// Hide stealth check.
+func (n conditionsNS) Hidden() *core.Ref { return conditionHidden }
+
+// Helped returns the ref for the HelpedCondition, applied to the ally
+// targeted by the Help combat ability.
+func (n conditionsNS) Helped() *core.Ref { return conditionHelped }
 
 // OpportunityAttack returns the ref for the OpportunityAttackCondition
 // applied by default to every melee combatant. The condition subscribes to


### PR DESCRIPTION
## Summary

Implements **Help + Hide mechanical effects** for rpg-toolkit#716, the largest PR of Beat 2 (KirkDiggler/rpg-project#75). Scope follows the design's adversarial-review re-scope (R1/R3/R4/R6) named in the issue's last comment.

Two commits, one per Go module (this repo has no `go.work`; cross-module deps are pinned pseudo-versions — the second commit bumps `encounter`'s `rulebooks/dnd5e` requirement to the first commit's SHA):

### `rulebooks/dnd5e` — new spine + Help/Hide wiring

- **New `checks` package** (`rulebooks/dnd5e/checks`): `MakeAbilityCheck` mirrors `saves.MakeSavingThrow` exactly (roller, modifier, advantage/disadvantage/cancellation, nat-1/nat-20, chain-sourced bonuses). New `AbilityCheckChainEvent`/`AbilityCheckChain` topic in `events.go`, with `CheckModifierSource`/`CheckBonusSource` mirroring `SaveModifierSource`/`SaveBonusSource`. Justified by Hide's own Stealth roll alone — the chain fires whether or not a subscriber exists, same as `SavingThrowChain`.
- **Cross-entity condition targeting (R1)**: `ActivateAbilityInput` gains `TargetID string` + `Target core.Entity` (mirrors `ExecuteActionInput.TargetID`), threaded into `combatabilities.CombatAbilityInput.Target`. `Help.CanActivate`/`Activate` now require and use a real target ally — publishing `HelpActivatedEvent.AllyID` and a `ConditionAppliedEvent{Target: ally}` instead of only ever self-targeting.
- **Two new conditions, registered per R3** (mirrors `DodgingCondition` exactly — `ToJSON`/`loadJSON` + `loader.go`/`factory.go` + a round-trip test each, since an unregistered condition evaporates at the next RPC boundary):
  - `HiddenCondition` — subscribes `AttackChain` in both directions: advantage when the hidden character attacks (which also ends Hidden, PHB p.192, self-consuming), disadvantage on attacks against them (does not end Hidden — no "seen" trigger this wave).
  - `HelpedCondition` — `AttackChain` **only** (R4: the ability-check branch and its subscriber are explicitly deferred; no fixture exercises it yet). Grants advantage on the ally's next attack, consumed on that roll, with a safety-net removal at the **helper's** next turn (`TurnStartTopic` keyed on `HelperID`, not the ally) if never used.
- **`Hide.Activate`** makes a real Stealth check via `checks.MakeAbilityCheck` against the caller-gathered observer passive Perceptions (highest wins — binary success, not per-observer, per the design's stated simplification). Applies `HiddenCondition` only on success; a failed check still consumes the action. The failure branch (**R6**) is covered by unit tests with a mock roller — no deterministic-roller seam added to the live path.
- **`PassivePerception()`** added to `Character` (`10 + Perception skill modifier`), `Monster` (from the existing static `Senses` field), and the `Combatant` interface — the interface doc comment states the guardrail explicitly: callers must use this accessor, never inline the `10+WIS+prof` formula.
- Taxonomy additions to `events.go` (append-style — `#699`'s Dodge work touches the same const blocks in parallel): `ConditionHidden`, `ConditionHelped`, `ConditionSourceCombatAbility`. New `refs.Conditions.Hidden()`/`.Helped()`.
- Regenerated `combat/mock/mock_combatant.go` (mockgen) and updated five hand-written test-double `Combatant` implementers across the module for the new interface method.

### `encounter` — R1 audience/label fix + target/observer threading

- **R1 fix**: `applyActivatedConditions` hardcoded `targetID := actorID` and projected the broker audience from the **actor's** position — correct for self-applying conditions (Rage, Dodge) but wrong for Help's cross-entity `HelpedCondition`, whose `Target` is the ally. Fixed by reading both the label and the audience from each captured `cond.Target` via `findPlayerByEntityID` — the exact resolution `applyCapturedConditions` (the monster/NPC path) already uses; the player path just hadn't caught up.
- `dispatchCharacterAction` resolves `ActionTarget.EntityID` to a `*character.Character` via `e.heldCharacter` and threads it into `ActivateAbilityInput.Target`, populated unconditionally for every ability dispatch (keeps the file's existing "no per-ref logic" stance).
- Computes `ObserverPassivePerceptions` for Hide by gathering every hydrated monster's `PassivePerception()`. **Scope note**: monsters carry no sight-range/View data the way players do (no `MonsterData.SightRange` field exists), so — mirroring `buildPerception`'s existing "every player is a visible enemy" simplification for the reverse direction — every monster is currently treated as a potential observer with no LOS/range gate. Named here, not hidden: real LOS for monster observers is future work, the same limitation the rest of the encounter SDK already carries via `perception.CanSeeAt`'s range-only stub.

## Test plan

- [x] `rulebooks/dnd5e`: `go test ./...` — all green, incl. new `checks`, `hidden_test.go`, `helped_test.go` (loader/factory round trips), rewritten `help_hide_test.go`.
- [x] `encounter`: `go test ./...` — all green, incl. new R1 regression tests in `turn_state_test.go`.
- [x] R1 regression verified adversarially: temporarily reverted the `activate_feature.go` fix and confirmed `TestTakeAction_Help_LabelsAndProjectsAudienceFromAllyPosition` fails against the old code, then re-verified it passes with the fix restored.
- [x] `gofmt -s`, `goimports`, `go vet`, `golangci-lint run` clean on both modules (only pre-existing `goconst` debt remains, confirmed identical against `main` baseline — nothing new introduced).
- [x] `go test -race ./...` clean on both modules.

Closes KirkDiggler/rpg-toolkit#716.
Part of KirkDiggler/rpg-project#75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2xgbzQbNgFvkhBkmB3xQE