### PR TITLE
feat(dnd5e+encounter): AttackOutcome/AttackResolvedEvent gain has_advantage/has_disadvantage fields

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -527,6 +527,7 @@ func (e *Encounter) publishAttackOutcome(
 		e.data.ID, e.nextSeq(),
 		attackerID, targetID,
 		outcome.Hit, outcome.Critical, outcome.AttackRoll, outcome.AttackBonus, outcome.TargetAC,
+		outcome.HasAdvantage, outcome.HasDisadvantage, outcome.AdvantageSources, outcome.DisadvantageSources,
 		attackPerPlayer,
 	), corrID); err != nil {
 		return corrID, fmt.Errorf("publish attack resolved: %w", err)

--- a/encounter/combat_resolver.go
+++ b/encounter/combat_resolver.go
@@ -245,6 +245,16 @@ type AttackOutcome struct {
 	// attack (after the AC chain — Shield spell, cover, etc.).
 	TargetAC int
 
+	// HasAdvantage/HasDisadvantage report whether the attack roll was made
+	// with advantage/disadvantage. AdvantageSources/DisadvantageSources name
+	// the granting/imposing condition(s) (e.g. refs.Conditions.Dodging()),
+	// for narration. The resolver copies these verbatim from the rulebook's
+	// AttackResult (e.g. dnd5e/combat.AttackResult) — never recomputed here.
+	HasAdvantage        bool
+	HasDisadvantage     bool
+	AdvantageSources    []*core.Ref
+	DisadvantageSources []*core.Ref
+
 	// Damage is the final damage dealt on a hit. Zero on miss.
 	Damage int
 

--- a/encounter/combat_resolver_test.go
+++ b/encounter/combat_resolver_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
@@ -19,16 +20,29 @@ import (
 type alwaysHitResolver struct {
 	damage     int
 	damageType string
+
+	// hasAdvantage/hasDisadvantage/advantageSources/disadvantageSources let
+	// tests configure the canned AttackOutcome the same way a real resolver
+	// would copy them from combat.AttackResult (#726). Zero values (false,
+	// nil) preserve every existing caller's behavior.
+	hasAdvantage        bool
+	hasDisadvantage     bool
+	advantageSources    []*toolkitcore.Ref
+	disadvantageSources []*toolkitcore.Ref
 }
 
 func (r alwaysHitResolver) ResolveAttack(_ encounter.AttackInput) (*encounter.AttackOutcome, error) {
 	return &encounter.AttackOutcome{
-		Hit:         true,
-		AttackRoll:  20,
-		AttackBonus: 4,
-		TargetAC:    10,
-		Damage:      r.damage,
-		DamageType:  r.damageType,
+		Hit:                 true,
+		AttackRoll:          20,
+		AttackBonus:         4,
+		TargetAC:            10,
+		Damage:              r.damage,
+		DamageType:          r.damageType,
+		HasAdvantage:        r.hasAdvantage,
+		HasDisadvantage:     r.hasDisadvantage,
+		AdvantageSources:    r.advantageSources,
+		DisadvantageSources: r.disadvantageSources,
 	}, nil
 }
 

--- a/encounter/combat_test.go
+++ b/encounter/combat_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
@@ -176,6 +177,71 @@ func (s *CombatSuite) TestTakeAction_PublishesAttackOutcome() {
 
 	seenAlice := collectTypes(s.aliceSub, 500*time.Millisecond)
 	s.Contains(seenAlice, "*events.AttackResolvedEvent")
+}
+
+// TakeAction copies HasAdvantage/HasDisadvantage/AdvantageSources/
+// DisadvantageSources from the resolver's AttackOutcome onto the published
+// AttackResolvedEvent verbatim (#726). The stub resolver here hands back
+// canned values the same way rpg-api's real resolver copies them from
+// combat.AttackResult -- this proves the encounter-side plumbing does not
+// drop or recompute them, not that any rule fired.
+func (s *CombatSuite) TestTakeAction_PublishesAdvantageDisadvantageOnAttackResolved() {
+	dodgingRef := &toolkitcore.Ref{Module: "dnd5e", Type: "conditions", ID: "dodging"}
+	enc := encounter.New(context.Background(), "enc-adv", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{
+			damage: 8, damageType: damageSlashing,
+			hasDisadvantage:     true,
+			disadvantageSources: []*toolkitcore.Ref{dodgingRef},
+		}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: "1d8+2", DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, err := enc.EndTurn(context.Background(), enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+
+	sub, err := s.broker.Subscribe(enc.ID(), "alice")
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+
+	var attackEvt *events.AttackResolvedEvent
+	deadline := time.After(2 * time.Second)
+drainLoop:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoop
+			}
+			if ae, isAttack := evt.(*events.AttackResolvedEvent); isAttack {
+				attackEvt = ae
+				break drainLoop
+			}
+		case <-deadline:
+			break drainLoop
+		}
+	}
+	s.Require().NotNil(attackEvt, "AttackResolvedEvent should have been published")
+	s.False(attackEvt.HasAdvantage)
+	s.True(attackEvt.HasDisadvantage)
+	s.Require().Len(attackEvt.DisadvantageSources, 1)
+	s.Equal(dodgingRef, attackEvt.DisadvantageSources[0])
+	s.Empty(attackEvt.AdvantageSources)
 }
 
 // TakeAction returns ErrNonCombatant when the active player has no

--- a/encounter/events/attack_resolved.go
+++ b/encounter/events/attack_resolved.go
@@ -3,6 +3,7 @@ package events
 import (
 	"encoding/json"
 
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
 
@@ -21,7 +22,17 @@ type AttackResolvedEvent struct {
 	AttackRoll  int
 	AttackBonus int
 	TargetAC    int
-	PerPlayer   map[core.PlayerID]AttackResolvedSlice
+
+	// HasAdvantage/HasDisadvantage report whether the attack roll was made
+	// with advantage/disadvantage. AdvantageSources/DisadvantageSources name
+	// the granting/imposing condition(s) (e.g. Dodging), for narration.
+	// Sourced verbatim from the rulebook's AttackResult -- never recomputed.
+	HasAdvantage        bool
+	HasDisadvantage     bool
+	AdvantageSources    []*toolkitcore.Ref
+	DisadvantageSources []*toolkitcore.Ref
+
+	PerPlayer map[core.PlayerID]AttackResolvedSlice
 }
 
 // AttackResolvedSlice is each viewer's projection. Visible says whether the
@@ -41,19 +52,27 @@ func NewAttackResolvedEvent(
 	attackRoll int,
 	attackBonus int,
 	targetAC int,
+	hasAdvantage bool,
+	hasDisadvantage bool,
+	advantageSources []*toolkitcore.Ref,
+	disadvantageSources []*toolkitcore.Ref,
 	perPlayer map[core.PlayerID]AttackResolvedSlice,
 ) *AttackResolvedEvent {
 	return &AttackResolvedEvent{
-		encID:       encID,
-		seq:         seq,
-		AttackerID:  attackerID,
-		TargetID:    targetID,
-		Hit:         hit,
-		Critical:    critical,
-		AttackRoll:  attackRoll,
-		AttackBonus: attackBonus,
-		TargetAC:    targetAC,
-		PerPlayer:   perPlayer,
+		encID:               encID,
+		seq:                 seq,
+		AttackerID:          attackerID,
+		TargetID:            targetID,
+		Hit:                 hit,
+		Critical:            critical,
+		AttackRoll:          attackRoll,
+		AttackBonus:         attackBonus,
+		TargetAC:            targetAC,
+		HasAdvantage:        hasAdvantage,
+		HasDisadvantage:     hasDisadvantage,
+		AdvantageSources:    advantageSources,
+		DisadvantageSources: disadvantageSources,
+		PerPlayer:           perPlayer,
 	}
 }
 
@@ -71,33 +90,41 @@ func (e *AttackResolvedEvent) Audience() AudienceSet { return audienceFromMap(e.
 
 type attackResolvedWire struct {
 	metaWire
-	EncID       core.EncounterID                      `json:"encounter_id"`
-	Seq         uint64                                `json:"sequence"`
-	AttackerID  core.EntityID                         `json:"attacker_id"`
-	TargetID    core.EntityID                         `json:"target_id"`
-	Hit         bool                                  `json:"hit"`
-	Critical    bool                                  `json:"critical"`
-	AttackRoll  int                                   `json:"attack_roll"`
-	AttackBonus int                                   `json:"attack_bonus"`
-	TargetAC    int                                   `json:"target_ac"`
-	PerPlayer   map[core.PlayerID]AttackResolvedSlice `json:"per_player"`
+	EncID               core.EncounterID                      `json:"encounter_id"`
+	Seq                 uint64                                `json:"sequence"`
+	AttackerID          core.EntityID                         `json:"attacker_id"`
+	TargetID            core.EntityID                         `json:"target_id"`
+	Hit                 bool                                  `json:"hit"`
+	Critical            bool                                  `json:"critical"`
+	AttackRoll          int                                   `json:"attack_roll"`
+	AttackBonus         int                                   `json:"attack_bonus"`
+	TargetAC            int                                   `json:"target_ac"`
+	HasAdvantage        bool                                  `json:"has_advantage"`
+	HasDisadvantage     bool                                  `json:"has_disadvantage"`
+	AdvantageSources    []*toolkitcore.Ref                    `json:"advantage_sources,omitempty"`
+	DisadvantageSources []*toolkitcore.Ref                    `json:"disadvantage_sources,omitempty"`
+	PerPlayer           map[core.PlayerID]AttackResolvedSlice `json:"per_player"`
 }
 
 // MarshalJSON exposes encID and seq under stable JSON field names.
 // Implements encoding/json.Marshaler.
 func (e *AttackResolvedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(attackResolvedWire{
-		metaWire:    e.toWire(),
-		EncID:       e.encID,
-		Seq:         e.seq,
-		AttackerID:  e.AttackerID,
-		TargetID:    e.TargetID,
-		Hit:         e.Hit,
-		Critical:    e.Critical,
-		AttackRoll:  e.AttackRoll,
-		AttackBonus: e.AttackBonus,
-		TargetAC:    e.TargetAC,
-		PerPlayer:   e.PerPlayer,
+		metaWire:            e.toWire(),
+		EncID:               e.encID,
+		Seq:                 e.seq,
+		AttackerID:          e.AttackerID,
+		TargetID:            e.TargetID,
+		Hit:                 e.Hit,
+		Critical:            e.Critical,
+		AttackRoll:          e.AttackRoll,
+		AttackBonus:         e.AttackBonus,
+		TargetAC:            e.TargetAC,
+		HasAdvantage:        e.HasAdvantage,
+		HasDisadvantage:     e.HasDisadvantage,
+		AdvantageSources:    e.AdvantageSources,
+		DisadvantageSources: e.DisadvantageSources,
+		PerPlayer:           e.PerPlayer,
 	})
 }
 
@@ -118,6 +145,10 @@ func (e *AttackResolvedEvent) UnmarshalJSON(b []byte) error {
 	e.AttackRoll = w.AttackRoll
 	e.AttackBonus = w.AttackBonus
 	e.TargetAC = w.TargetAC
+	e.HasAdvantage = w.HasAdvantage
+	e.HasDisadvantage = w.HasDisadvantage
+	e.AdvantageSources = w.AdvantageSources
+	e.DisadvantageSources = w.DisadvantageSources
 	e.PerPlayer = w.PerPlayer
 	return nil
 }

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -107,7 +107,7 @@ func (s *EventsSuite) TestSpineMeta_StampAndAccessors() {
 
 	samples := []events.EncounterEvent{
 		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil),
-		events.NewAttackResolvedEvent("enc-1", 2, "a", "b", true, false, 1, 1, 1, nil),
+		events.NewAttackResolvedEvent("enc-1", 2, "a", "b", true, false, 1, 1, 1, false, false, nil, nil, nil),
 		events.NewDamageDealtEvent("enc-1", 3, "a", "b", 1, "slashing", 1, 1, nil),
 		events.NewActionResolvedEvent("enc-1", 4, "a", "dnd5e:action:attack", "b",
 			events.EconomyConsumed{Actions: 1}, nil),
@@ -130,6 +130,7 @@ func (s *EventsSuite) TestSpineMeta_JSONRoundTrip() {
 	original := events.NewAttackResolvedEvent(
 		"enc-1", 11, "char-alice", "goblin-1",
 		true, false, 17, 4, 15,
+		false, false, nil, nil,
 		map[core.PlayerID]events.AttackResolvedSlice{"alice": {Visible: true}},
 	)
 	original.Stamp(at, corr)
@@ -330,6 +331,7 @@ func (s *EventsSuite) TestAttackResolvedEvent_JSONRoundTrip() {
 	original := events.NewAttackResolvedEvent(
 		"enc-1", 11, "char-alice", "goblin-1",
 		true, false, 17, 4, 15,
+		false, false, nil, nil,
 		map[core.PlayerID]events.AttackResolvedSlice{
 			"alice": {Visible: true},
 			"bob":   {Visible: false},

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704014436-948902adc2f1
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68 h1:SvgGmbVUoM1M5fX7Lkv2HkNuyEi3iBPN5x5p4Wzm7+0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09 h1:/CTlY+D4yosu2nWBkinyyjrGOvQc41fMg6YSNZST9d4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -12,6 +12,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09 h1:/CTlY+D4yosu2nWBkinyyjrGOvQc41fMg6YSNZST9d4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704014436-948902adc2f1 h1:G6RJq5mOY2wB3jZgKQnKb7EUzCg3V0OFLl0cMlqaA0o=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704014436-948902adc2f1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,6 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09 h1:/CTlY+D4yosu2nWBkinyyjrGOvQc41fMg6YSNZST9d4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704003057-ab7510610e09/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704014436-948902adc2f1 h1:G6RJq5mOY2wB3jZgKQnKb7EUzCg3V0OFLl0cMlqaA0o=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704014436-948902adc2f1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
 	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
 	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
@@ -636,6 +637,70 @@ drainLoop:
 	s.Equal(6, dmgEvt.Amount)
 	s.Equal("slashing", dmgEvt.DamageType)
 	s.Equal(14, dmgEvt.HPAfter)
+}
+
+// TestMove_OAAttackResolved_CarriesAdvantageDisadvantage verifies the
+// Move-path OA route (npc.go's publishMoveAttackResolved, distinct from the
+// TakeAction path's publishAttackOutcome) also threads HasDisadvantage +
+// DisadvantageSources onto its AttackResolvedEvent (#726). This route
+// builds the event straight from dnd5eEvents.PostAttackRollEvent -- not
+// from AttackOutcome/CombatResolver -- so it needs its own field-threading
+// check; PostAttackRollEvent gained the same two bool + two ref-slice
+// fields for exactly this reason.
+func (s *MovementResolverSuite) TestMove_OAAttackResolved_CarriesAdvantageDisadvantage() {
+	s.addGoblinForNPCMovementTests()
+
+	dodgingRef := &toolkitcore.Ref{Module: refModuleDnd5e, Type: "conditions", ID: "dodging"}
+	s.resolver.publishOnStep = func(bus dnd5events.EventBus, stepIdx int) {
+		if stepIdx != 0 {
+			return
+		}
+		rolls := dnd5eEvents.PostAttackRollChain.On(bus)
+		_, _ = rolls.PublishWithChain(context.Background(), &dnd5eEvents.PostAttackRollEvent{
+			AttackerID:          string(gobEntityID),
+			TargetID:            string(aliceEntityID),
+			OriginalAC:          oaHitTargetAC,
+			AttackRoll:          5,
+			AttackBonus:         oaHitAttackBonus,
+			TotalAttack:         5 + oaHitAttackBonus,
+			WouldHit:            false,
+			HasDisadvantage:     true,
+			DisadvantageSources: []*toolkitcore.Ref{dodgingRef},
+		}, dnd5events.NewStagedChain[*dnd5eEvents.PostAttackRollEvent](nil))
+	}
+
+	sub, err := s.broker.Subscribe(s.enc.ID(), alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	path := []encountercore.Hex{
+		{Q: 1, R: 0, S: -1},
+		{Q: 2, R: 0, S: -2},
+	}
+	s.Require().NoError(s.enc.Move(alicePlayerID, path))
+
+	var attackEvt *events.AttackResolvedEvent
+	deadline := time.After(2 * time.Second)
+drainLoop:
+	for {
+		select {
+		case evt, ok := <-sub.Events():
+			if !ok {
+				break drainLoop
+			}
+			if ae, isAttack := evt.(*events.AttackResolvedEvent); isAttack {
+				attackEvt = ae
+				break drainLoop
+			}
+		case <-deadline:
+			break drainLoop
+		}
+	}
+	s.Require().NotNil(attackEvt, "AttackResolvedEvent should have been published for the OA roll")
+	s.False(attackEvt.HasAdvantage)
+	s.True(attackEvt.HasDisadvantage)
+	s.Require().Len(attackEvt.DisadvantageSources, 1)
+	s.Equal(dodgingRef, attackEvt.DisadvantageSources[0])
 }
 
 // TestNPCMove_NPCMoves_OADamagesMonster verifies the NPC-mover direction:

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -790,6 +790,7 @@ func (e *Encounter) publishMoveAttackResolved(
 		attackerID, targetID,
 		roll.WouldHit, roll.IsNaturalTwenty,
 		roll.AttackRoll, roll.AttackBonus, roll.OriginalAC,
+		roll.HasAdvantage, roll.HasDisadvantage, roll.AdvantageSources, roll.DisadvantageSources,
 		attackPerPlayer,
 	)
 	if err := e.publishCorrelated(evt, corrID); err != nil {

--- a/rulebooks/dnd5e/combat/attack.go
+++ b/rulebooks/dnd5e/combat/attack.go
@@ -142,6 +142,12 @@ type AttackResult struct {
 	HasAdvantage    bool  // True if rolled with advantage
 	HasDisadvantage bool  // True if rolled with disadvantage
 
+	// AdvantageSources/DisadvantageSources name the condition(s)/feature(s)
+	// that granted advantage or imposed disadvantage (e.g. refs.Conditions.Dodging()),
+	// for narration. Copied verbatim from AttackContext -- never recomputed.
+	AdvantageSources    []*core.Ref
+	DisadvantageSources []*core.Ref
+
 	// Damage details
 	DamageRolls []int       // Individual damage dice rolls (flattened)
 	DamageBonus int         // Total damage bonus

--- a/rulebooks/dnd5e/combat/attack_phases.go
+++ b/rulebooks/dnd5e/combat/attack_phases.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
@@ -14,6 +15,21 @@ import (
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
+
+// attackModifierRefs extracts the SourceRef of each AttackModifierSource,
+// preserving order and skipping any nil refs. Used to carry forward (never
+// recompute) the condition/feature refs that granted advantage or imposed
+// disadvantage, for narration on the encounter-side AttackOutcome/
+// AttackResolvedEvent.
+func attackModifierRefs(sources []dnd5eEvents.AttackModifierSource) []*core.Ref {
+	var refs []*core.Ref
+	for _, src := range sources {
+		if src.SourceRef != nil {
+			refs = append(refs, src.SourceRef)
+		}
+	}
+	return refs
+}
 
 // AttackContext carries the complete state of a phase-1 (hit determination)
 // attack through the RPC boundary to phase 2 (damage application).
@@ -49,6 +65,13 @@ type AttackContext struct {
 	// Advantage/disadvantage (carried to phase 2 for damage chain context)
 	HasAdvantage    bool
 	HasDisadvantage bool
+
+	// AdvantageSources/DisadvantageSources name the condition(s)/feature(s)
+	// that granted advantage or imposed disadvantage (e.g. refs.Conditions.Dodging()),
+	// for narration. Populated verbatim from the attack chain event's
+	// AttackModifierSource.SourceRef entries -- never recomputed here.
+	AdvantageSources    []*core.Ref
+	DisadvantageSources []*core.Ref
 
 	// Chain outputs (carried to phase 2 for damage chain)
 	CriticalThreshold int // Roll >= this value is a critical hit (default 20)
@@ -259,6 +282,8 @@ func ResolveAttackHit(ctx context.Context, input *ResolveAttackHitInput) (*Attac
 	// Determine advantage/disadvantage and roll
 	hasAdvantage := len(finalAttackEvent.AdvantageSources) > 0
 	hasDisadvantage := len(finalAttackEvent.DisadvantageSources) > 0
+	advantageSources := attackModifierRefs(finalAttackEvent.AdvantageSources)
+	disadvantageSources := attackModifierRefs(finalAttackEvent.DisadvantageSources)
 
 	var attackRoll int
 	var allRolls []int
@@ -272,6 +297,8 @@ func ResolveAttackHit(ctx context.Context, input *ResolveAttackHitInput) (*Attac
 		allRolls = []int{attackRoll}
 		hasAdvantage = false
 		hasDisadvantage = false
+		advantageSources = nil
+		disadvantageSources = nil
 	case hasAdvantage:
 		allRolls, err = roller.RollN(ctx, 2, 20)
 		if err != nil {
@@ -328,15 +355,19 @@ func ResolveAttackHit(ctx context.Context, input *ResolveAttackHitInput) (*Attac
 	// typically do not modify the chain — the AC bonus from a taken Shield
 	// reaction is applied in phase 2 (ApplyAttackOutcome) via ReactionModifier.
 	postRollEvent := &dnd5eEvents.PostAttackRollEvent{
-		AttackerID:      input.AttackerID,
-		TargetID:        input.TargetID,
-		OriginalAC:      defenderAC,
-		AttackRoll:      attackRoll,
-		AttackBonus:     finalAttackEvent.AttackBonus,
-		TotalAttack:     totalAttack,
-		WouldHit:        wouldHit,
-		IsNaturalTwenty: isNatural20,
-		IsNaturalOne:    isNatural1,
+		AttackerID:          input.AttackerID,
+		TargetID:            input.TargetID,
+		OriginalAC:          defenderAC,
+		AttackRoll:          attackRoll,
+		AttackBonus:         finalAttackEvent.AttackBonus,
+		TotalAttack:         totalAttack,
+		WouldHit:            wouldHit,
+		IsNaturalTwenty:     isNatural20,
+		IsNaturalOne:        isNatural1,
+		HasAdvantage:        hasAdvantage,
+		HasDisadvantage:     hasDisadvantage,
+		AdvantageSources:    advantageSources,
+		DisadvantageSources: disadvantageSources,
 	}
 	postRollChain := events.NewStagedChain[*dnd5eEvents.PostAttackRollEvent](ModifierStages)
 	postRolls := dnd5eEvents.PostAttackRollChain.On(input.EventBus)
@@ -345,24 +376,26 @@ func ResolveAttackHit(ctx context.Context, input *ResolveAttackHitInput) (*Attac
 	}
 
 	return &AttackContext{
-		AttackerID:        input.AttackerID,
-		TargetID:          input.TargetID,
-		Weapon:            input.Weapon,
-		OriginalAC:        defenderAC,
-		WouldHit:          wouldHit,
-		AttackRoll:        attackRoll,
-		AttackBonus:       finalAttackEvent.AttackBonus,
-		TotalAttack:       totalAttack,
-		IsNaturalTwenty:   isNatural20,
-		IsNaturalOne:      isNatural1,
-		AllRolls:          allRolls,
-		HasAdvantage:      hasAdvantage,
-		HasDisadvantage:   hasDisadvantage,
-		CriticalThreshold: finalAttackEvent.CriticalThreshold,
-		ReactionsConsumed: finalAttackEvent.ReactionsConsumed,
-		AbilityMod:        abilityMod,
-		AbilityUsed:       determineAbilityUsed(input.Weapon, attackerScores),
-		IsOffHandAttack:   isOffHandAttack,
+		AttackerID:          input.AttackerID,
+		TargetID:            input.TargetID,
+		Weapon:              input.Weapon,
+		OriginalAC:          defenderAC,
+		WouldHit:            wouldHit,
+		AttackRoll:          attackRoll,
+		AttackBonus:         finalAttackEvent.AttackBonus,
+		TotalAttack:         totalAttack,
+		IsNaturalTwenty:     isNatural20,
+		IsNaturalOne:        isNatural1,
+		AllRolls:            allRolls,
+		HasAdvantage:        hasAdvantage,
+		HasDisadvantage:     hasDisadvantage,
+		AdvantageSources:    advantageSources,
+		DisadvantageSources: disadvantageSources,
+		CriticalThreshold:   finalAttackEvent.CriticalThreshold,
+		ReactionsConsumed:   finalAttackEvent.ReactionsConsumed,
+		AbilityMod:          abilityMod,
+		AbilityUsed:         determineAbilityUsed(input.Weapon, attackerScores),
+		IsOffHandAttack:     isOffHandAttack,
 	}, nil
 }
 
@@ -415,18 +448,20 @@ func ApplyAttackOutcome(ctx context.Context, input *ApplyAttackOutcomeInput) (*A
 	isCritical := hit && ac.AttackRoll >= ac.CriticalThreshold
 
 	result := &AttackResult{
-		AttackRoll:      ac.AttackRoll,
-		AttackBonus:     ac.AttackBonus,
-		TotalAttack:     ac.TotalAttack,
-		TargetAC:        effectiveAC,
-		Hit:             hit,
-		Critical:        isCritical,
-		IsNaturalTwenty: ac.IsNaturalTwenty,
-		IsNaturalOne:    ac.IsNaturalOne,
-		AllRolls:        ac.AllRolls,
-		HasAdvantage:    ac.HasAdvantage,
-		HasDisadvantage: ac.HasDisadvantage,
-		DamageType:      ac.Weapon.DamageType,
+		AttackRoll:          ac.AttackRoll,
+		AttackBonus:         ac.AttackBonus,
+		TotalAttack:         ac.TotalAttack,
+		TargetAC:            effectiveAC,
+		Hit:                 hit,
+		Critical:            isCritical,
+		IsNaturalTwenty:     ac.IsNaturalTwenty,
+		IsNaturalOne:        ac.IsNaturalOne,
+		AllRolls:            ac.AllRolls,
+		HasAdvantage:        ac.HasAdvantage,
+		HasDisadvantage:     ac.HasDisadvantage,
+		AdvantageSources:    ac.AdvantageSources,
+		DisadvantageSources: ac.DisadvantageSources,
+		DamageType:          ac.Weapon.DamageType,
 	}
 
 	if !hit {

--- a/rulebooks/dnd5e/combat/attack_test.go
+++ b/rulebooks/dnd5e/combat/attack_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	mock_combat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/mock"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
@@ -365,6 +367,9 @@ func (s *AttackTestSuite) TestResolveAttack_WithDisadvantage() {
 	s.Equal([]int{18, 5}, result.AllRolls, "should record both rolls")
 	s.False(result.HasAdvantage)
 	s.True(result.HasDisadvantage, "should indicate disadvantage was used")
+	s.Require().Len(result.DisadvantageSources, 1)
+	s.Equal(&core.Ref{Module: "dnd5e", Type: "fighting_styles", ID: "protection"}, result.DisadvantageSources[0])
+	s.Empty(result.AdvantageSources)
 
 	// Attack: 5 (roll) + 2 (STR) + 2 (prof) = 9 vs AC 15
 	s.Equal(9, result.TotalAttack)
@@ -440,10 +445,68 @@ func (s *AttackTestSuite) TestResolveAttack_AdvantageAndDisadvantageCancelOut() 
 	s.Equal([]int{12}, result.AllRolls, "should only have one roll when cancelled")
 	s.False(result.HasAdvantage, "advantage should be cancelled")
 	s.False(result.HasDisadvantage, "disadvantage should be cancelled")
+	s.Empty(result.AdvantageSources, "advantage sources should be cleared when cancelled")
+	s.Empty(result.DisadvantageSources, "disadvantage sources should be cleared when cancelled")
 
 	// Attack: 12 (roll) + 2 (STR) + 2 (prof) = 16 vs AC 15
 	s.Equal(16, result.TotalAttack)
 	s.True(result.Hit)
+}
+
+// TestResolveAttack_DodgingConditionSurfacesDisadvantageSource proves the
+// real DodgingCondition's disadvantage -- and the SourceRef it stamps
+// (refs.Conditions.Dodging()) -- rides all the way out to AttackResult
+// verbatim. DodgingCondition itself already computes this correctly
+// (rulebooks/dnd5e/conditions/dodging.go); this test guards against it being
+// dropped anywhere between the attack chain and the returned AttackResult.
+func (s *AttackTestSuite) TestResolveAttack_DodgingConditionSurfacesDisadvantageSource() {
+	attacker := mock_combat.NewMockCombatant(s.ctrl)
+	attacker.EXPECT().GetID().Return("fighter-1").AnyTimes()
+	attacker.EXPECT().AbilityScores().Return(shared.AbilityScores{
+		abilities.STR: 14, // +2 modifier
+	}).AnyTimes()
+	attacker.EXPECT().ProficiencyBonus().Return(2).AnyTimes()
+
+	goblin := mock_combat.NewMockCombatant(s.ctrl)
+	goblin.EXPECT().GetID().Return("goblin-1").AnyTimes()
+	goblin.EXPECT().AC().Return(15).AnyTimes()
+
+	s.lookup.EXPECT().Get("fighter-1").Return(attacker, nil).AnyTimes()
+	s.lookup.EXPECT().Get("goblin-1").Return(goblin, nil).AnyTimes()
+
+	longsword := &weapons.Weapon{
+		ID:         weapons.Longsword,
+		Name:       "Longsword",
+		Damage:     "1d8",
+		DamageType: damage.Slashing,
+	}
+
+	// Goblin is Dodging -- the real condition subscribes itself onto the
+	// attack chain and imposes disadvantage on attacks targeting it.
+	dodging := conditions.NewDodgingCondition("goblin-1")
+	s.Require().NoError(dodging.Apply(s.ctx, s.eventBus))
+
+	// Disadvantage roll: take the lower of 18 and 5.
+	mockRoller := mock_dice.NewMockRoller(s.ctrl)
+	mockRoller.EXPECT().RollN(s.ctx, 2, 20).Return([]int{18, 5}, nil)
+	// 5 + 2 (STR) + 2 (prof) = 9, misses AC 15 -- no damage roll expected.
+
+	input := &combat.AttackInput{
+		AttackerID: "fighter-1",
+		TargetID:   "goblin-1",
+		Weapon:     longsword,
+		EventBus:   s.eventBus,
+		Roller:     mockRoller,
+	}
+
+	result, err := combat.ResolveAttack(s.ctx, input)
+	s.Require().NoError(err)
+
+	s.False(result.HasAdvantage)
+	s.True(result.HasDisadvantage, "Dodging should impose disadvantage")
+	s.Require().Len(result.DisadvantageSources, 1)
+	s.Equal(refs.Conditions.Dodging(), result.DisadvantageSources[0],
+		"Dodging's SourceRef should ride the AttackResult verbatim, not be recomputed")
 }
 
 func (s *AttackTestSuite) TestResolveAttack_ReactionsConsumedPublishesEvents() {

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -599,6 +599,17 @@ type PostAttackRollEvent struct {
 
 	// IsNaturalOne is true if the natural d20 was 1 (always misses).
 	IsNaturalOne bool
+
+	// HasAdvantage is true if the roll was made with advantage.
+	HasAdvantage bool
+
+	// HasDisadvantage is true if the roll was made with disadvantage.
+	HasDisadvantage bool
+
+	// AdvantageSources/DisadvantageSources name the condition(s)/feature(s)
+	// that granted advantage or imposed disadvantage, for narration.
+	AdvantageSources    []*core.Ref
+	DisadvantageSources []*core.Ref
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`combat.AttackResult` already computed `HasAdvantage`/`HasDisadvantage` correctly (`ResolveAttack` -> `ResolveAttackHit`/`ApplyAttackOutcome`), but the outer layers had no slot for it:

- `encounter.AttackOutcome` (the `CombatResolver` return contract) had no such fields.
- `encounter.AttackResolvedEvent` had no such fields either, so `publishAttackOutcome` couldn't stamp them even if it wanted to.
- The attack chain's `AdvantageSources`/`DisadvantageSources` (which name the granting/imposing condition, e.g. `refs.Conditions.Dodging()`) were computed and then discarded after the boolean check -- only the two bools survived even one hop out (`AttackContext`/`AttackResult`).

This PR is pure field-threading -- no change to attack resolution logic:

- **rulebooks/dnd5e**: `AttackContext` and `AttackResult` gain `AdvantageSources`/`DisadvantageSources []*core.Ref`, carried forward from the attack chain event's already-computed `AttackModifierSource.SourceRef` entries (cleared together with the booleans when advantage+disadvantage cancel out). `PostAttackRollEvent` gains all four fields too, since the Move-path OA route (`npc.go`'s `publishMoveAttackResolved`) builds its `AttackResolvedEvent` directly from that event, not from `AttackOutcome`.
- **encounter**: `AttackOutcome` and `AttackResolvedEvent` gain `HasAdvantage`/`HasDisadvantage`/`AdvantageSources`/`DisadvantageSources`, threaded through `publishAttackOutcome` (TakeAction/NPCAct path) and `publishMoveAttackResolved` (Move-path OA route). `encounter/go.mod` bumped to the `rulebooks/dnd5e` pseudo-version carrying this PR's own rulebook commit.

Scoped under KirkDiggler/rpg-project#75 (Beat 2 wave), closes KirkDiggler/rpg-toolkit#726.

## Test plan

- [x] `TestResolveAttack_DodgingConditionSurfacesDisadvantageSource` (new, rulebooks/dnd5e/combat) -- the real `DodgingCondition` imposes disadvantage; `AttackResult.HasDisadvantage` + `DisadvantageSources[0] == refs.Conditions.Dodging()`. Verified red before the fix (assertion failure), green after.
- [x] `TestResolveAttack_WithDisadvantage` / `TestResolveAttack_AdvantageAndDisadvantageCancelOut` extended to assert `*Sources` populate/clear alongside the existing bools.
- [x] `TestTakeAction_PublishesAdvantageDisadvantageOnAttackResolved` (new, encounter) -- stub resolver hands back a canned `HasDisadvantage`/`DisadvantageSources`; asserts the published `AttackResolvedEvent` carries them verbatim. Verified red before the fix, green after.
- [x] `TestMove_OAAttackResolved_CarriesAdvantageDisadvantage` (new, encounter) -- same proof for the Move-path OA route (`publishMoveAttackResolved`), which builds its event from `PostAttackRollEvent` rather than `AttackOutcome`. Verified red before the fix, green after.
- [x] `go build ./...`, `go vet ./...`, `go test ./... -count=1` clean on both `rulebooks/dnd5e` and `encounter` modules.
- [x] `gofmt -s -l` / `goimports -l` clean on all touched files.
- [x] `golangci-lint run ./...` on both modules: 0 new issues (one pre-existing `goconst` hit from `main` on an unrelated line was net-fixed by reusing an existing constant in my new test; remaining `goconst` findings are pre-existing debt on files/lines I did not touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2xgbzQbNgFvkhBkmB3xQE