### PR TITLE
feat(dnd5e+encounter): Dodge + turn-start revival

### DIFF
--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704040433-37513a763402
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704041353-89fdb18db972
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704040433-37513a763402
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704041353-89fdb18db972
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68 h1:SvgGmbVUoM1M5fX7Lkv2HkNuyEi3iBPN5x5p4Wzm7+0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.3-0.20260702170442-8c9b3b8aba68/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704040433-37513a763402 h1:W4ZdlMEMUA3B6KMv7Xuy5OnzwD6N7UnVQaJmUlSYMhQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704040433-37513a763402/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704040433-37513a763402 h1:W4ZdlMEMUA3B6KMv7Xuy5OnzwD6N7UnVQaJmUlSYMhQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.61.6-0.20260704040433-37513a763402/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704041353-89fdb18db972 h1:KJNA30NhrtrTvgyBBwzupvSjTA+AP7lylNSmrJivC+E=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704041353-89fdb18db972/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704041353-89fdb18db972 h1:KJNA30NhrtrTvgyBBwzupvSjTA+AP7lylNSmrJivC+E=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.62.1-0.20260704041353-89fdb18db972/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81 h1:zpTdUnwxZyFxXVN76J7yTxehNK5ZLNmOOespt9kKJBs=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -15,6 +15,19 @@ package encounter
 // no hydrated character (a flat stat-snapshot seat, or an NPC) are skipped:
 // their turn structure is driven by the snapshot path, not the character
 // economy.
+//
+// rpg-project#75 (Beat 2, #699): seedActorTurn also revives the rulebook
+// turn-start boundary signal (dnd5eEvents.TurnStartTopic) on e.bus, mirroring
+// EndTurn's existing dnd5eEvents.TurnEndTopic publish (combat.go) — same bus,
+// same not-best-effort error handling. This wakes THREE dormant subscribers,
+// not just Dodging: DodgingCondition's self-removal (dodging.go), Barbarian
+// RecklessAttackCondition's self-removal (reckless_attack.go — this wave does
+// not touch Reckless Attack's code, but its lifecycle now actually fires), and
+// UnconsciousCondition's auto-death-save roll (unconscious.go) — the mechanism
+// behind the wave's own player-gets-hit/death-gate playtest beat (rpg-api#612).
+// The publish is unconditional (unlike the economy-seed below it), because
+// conditions key off event.CharacterID == their own owner id regardless of
+// whether that actor has a hydrated *character.Character.
 
 import (
 	"context"
@@ -22,21 +35,36 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
 
-// seedActorTurn initializes the action economy for the actor whose turn is
-// beginning, when that actor is a player with a hydrated character. It calls
-// character.StartTurn on the held instance, which sets one action, one bonus
-// action, one reaction, and movement from the character's speed, and clears
-// granted capacity from the prior turn.
+// seedActorTurn publishes the rulebook turn-start boundary for the actor whose
+// turn is beginning, then — when that actor is a player with a hydrated
+// character — initializes their action economy. It calls character.StartTurn
+// on the held instance, which sets one action, one bonus action, one reaction,
+// and movement from the character's speed, and clears granted capacity from
+// the prior turn.
 //
-// NPCs and stat-snapshot seats (no hydrated character) are skipped — they carry
-// no character economy to seed. A nil or non-player actor id is a no-op.
+// NPCs and stat-snapshot seats (no hydrated character) still receive the
+// turn-start boundary publish (see package doc above) but skip economy
+// seeding — they carry no character economy to seed.
 //
 // Called from the two turn-start sites: SetMode's flip to ModeTurnBased (first
-// actor) and EndTurn (the next actor). Errors from StartTurn are returned so the
-// caller fails the turn-boundary rather than advancing with an unseeded economy.
+// actor) and EndTurn (the next actor). Errors are returned so the caller fails
+// the turn-boundary rather than advancing with an unseeded economy or a
+// silently-dropped turn-start signal.
 func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) error {
+	// NOT best-effort: the same failure semantics as EndTurn's TurnEndTopic
+	// publish. If this fails, Dodging/RecklessAttack never self-remove and
+	// Unconscious never auto-rolls death saves for this turn — a real error,
+	// not something to swallow.
+	if pubErr := dnd5eEvents.TurnStartTopic.On(e.bus).Publish(ctx, dnd5eEvents.TurnStartEvent{
+		CharacterID: string(actorID),
+		Round:       e.data.Round,
+	}); pubErr != nil {
+		return fmt.Errorf("publish turn boundary (turn start) for %q: %w", actorID, pubErr)
+	}
+
 	char := e.heldCharacter(actorID)
 	if char == nil {
 		return nil // NPC or stat-snapshot seat — no character economy to seed.

--- a/encounter/turn_start_revival_test.go
+++ b/encounter/turn_start_revival_test.go
@@ -1,0 +1,373 @@
+package encounter_test
+
+// rpg-project#75 (Beat 2) / rpg-toolkit#699 — turn-start revival regression
+// coverage. seedActorTurn (turn_economy.go) now publishes dnd5eEvents.
+// TurnStartTopic on the encounter-held bus, mirroring EndTurn's existing
+// TurnEndTopic publish. This wakes THREE dormant subscribers, not just
+// Dodging: DodgingCondition's self-removal, Barbarian RecklessAttackCondition's
+// self-removal, and UnconsciousCondition's auto-death-save roll (the mechanism
+// behind rpg-api#612's death-gate playtest beat). These tests prove all three
+// fire at the OWNING character's own next turn start and NOT at another
+// actor's turn start, on the real cascade-hydrated encounter bus (not a bare
+// condition-level unit test).
+//
+// Initiative order is roll-dependent (see hydration_test.go's own comment on
+// this), so tests either drive to a known actor via advanceUntilActive before
+// asserting, or branch on which actor rolled first rather than assuming a
+// fixed order.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	dnd5events "github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	dnd5eCombat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eConditions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	tsrDodgerPlayerID = encountercore.PlayerID("tsr-dodger")
+	tsrDodgerEntityID = encountercore.EntityID("char-tsr-dodger")
+	tsrBuddyPlayerID  = encountercore.PlayerID("tsr-buddy")
+	tsrBuddyEntityID  = encountercore.EntityID("char-tsr-buddy")
+	tsrBarbPlayerID   = encountercore.PlayerID("tsr-barb")
+	tsrBarbEntityID   = encountercore.EntityID("char-tsr-barb")
+	tsrDownedPlayerID = encountercore.PlayerID("tsr-downed")
+	tsrDownedEntityID = encountercore.EntityID("char-tsr-downed")
+)
+
+// TurnStartRevivalSuite exercises the revived TurnStartTopic publish end to
+// end on the real cascade-hydrated encounter bus.
+type TurnStartRevivalSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *tkenc.InMemoryTransport
+	broker    *tkenc.Broker
+}
+
+func TestTurnStartRevivalSuite(t *testing.T) {
+	suite.Run(t, new(TurnStartRevivalSuite))
+}
+
+func (s *TurnStartRevivalSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = tkenc.NewInMemoryTransport()
+	s.broker = tkenc.NewBroker(s.transport)
+}
+
+func (s *TurnStartRevivalSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// charDataJSON builds a minimal serialized dnd5e character.Data for a
+// combat-ready fighter (Dodge is a universal combat ability, wired onto every
+// character regardless of class), optionally carrying persisted conditions so
+// the LoadFromData cascade reconstitutes + Apply()s them onto the held bus.
+func (s *TurnStartRevivalSuite) charDataJSON(id, playerID string, conds ...json.RawMessage) json.RawMessage {
+	s.T().Helper()
+	data := &dnd5eCharacter.Data{
+		ID:               id,
+		PlayerID:         playerID,
+		Name:             id,
+		Level:            3,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Fighter,
+		RaceID:           races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14, abilities.DEX: 12, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 10, abilities.CHA: 10,
+		},
+		HitPoints:    20,
+		MaxHitPoints: 20,
+		ArmorClass:   15,
+		ActionEconomy: &dnd5eCharacter.ActionEconomyData{
+			TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+			ReactionsRemaining: 1, MovementRemaining: 30,
+		},
+		Conditions: conds,
+	}
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+	return raw
+}
+
+// loadEncounter builds a fresh encounter, adds the given players, then
+// round-trips through ToData/LoadFromData so the cascade hydrates each
+// player's character (and any persisted conditions) onto the held bus exactly
+// once — mirroring hydration_test.go's loadEncounterWithRogue pattern.
+func (s *TurnStartRevivalSuite) loadEncounter(players ...tkenc.PlayerInput) *tkenc.Encounter {
+	s.T().Helper()
+	enc := tkenc.New(s.ctx, "enc-turnstart-revival", s.broker)
+	for _, p := range players {
+		s.Require().NoError(enc.AddPlayer(p))
+	}
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data tkenc.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := tkenc.LoadFromData(s.ctx, &data, s.broker)
+	s.Require().NoError(err)
+	return loaded
+}
+
+// advanceUntilActive cycles EndTurn (whoever is currently active) until the
+// target entity becomes the active actor.
+func (s *TurnStartRevivalSuite) advanceUntilActive(enc *tkenc.Encounter, target encountercore.EntityID) {
+	s.T().Helper()
+	for i := 0; i < 8; i++ {
+		if enc.ActiveActor() == target {
+			return
+		}
+		active := enc.ActiveActor()
+		_, _, err := enc.EndTurn(s.ctx, active)
+		s.Require().NoError(err)
+	}
+	s.FailNow("never reached target's turn", "target=%s", target)
+}
+
+// attackHasDisadvantageFromDodging publishes a synthetic AttackChainEvent
+// targeting the given entity and reports whether Dodging's disadvantage
+// modifier is present on the resolved chain — the same publish/execute
+// pattern conditions/dodging_test.go uses, run here on the encounter-held bus.
+func (s *TurnStartRevivalSuite) attackHasDisadvantageFromDodging(
+	bus dnd5events.EventBus, targetID encountercore.EntityID,
+) bool {
+	s.T().Helper()
+	evt := dnd5eEvents.AttackChainEvent{
+		AttackerID: "attacker-x",
+		TargetID:   string(targetID),
+		IsMelee:    true,
+	}
+	chain := dnd5events.NewStagedChain[dnd5eEvents.AttackChainEvent](dnd5eCombat.ModifierStages)
+	modified, err := dnd5eEvents.AttackChain.On(bus).PublishWithChain(s.ctx, evt, chain)
+	s.Require().NoError(err)
+	final, err := modified.Execute(s.ctx, evt)
+	s.Require().NoError(err)
+	for _, src := range final.DisadvantageSources {
+		if src.SourceRef != nil && src.SourceRef.String() == refs.Conditions.Dodging().String() {
+			return true
+		}
+	}
+	return false
+}
+
+// attackHasRecklessAdvantage publishes a synthetic AttackChainEvent targeting
+// the barbarian and reports whether Reckless Attack's "target is reckless"
+// advantage modifier is present.
+func (s *TurnStartRevivalSuite) attackHasRecklessAdvantage(
+	bus dnd5events.EventBus, targetID encountercore.EntityID,
+) bool {
+	s.T().Helper()
+	evt := dnd5eEvents.AttackChainEvent{
+		AttackerID: "attacker-x",
+		TargetID:   string(targetID),
+		IsMelee:    true,
+	}
+	chain := dnd5events.NewStagedChain[dnd5eEvents.AttackChainEvent](dnd5eCombat.ModifierStages)
+	modified, err := dnd5eEvents.AttackChain.On(bus).PublishWithChain(s.ctx, evt, chain)
+	s.Require().NoError(err)
+	final, err := modified.Execute(s.ctx, evt)
+	s.Require().NoError(err)
+	for _, src := range final.AdvantageSources {
+		if src.SourceRef != nil && src.SourceRef.String() == refs.Conditions.RecklessAttack().String() {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDodge_LiveActivation_ExpiresAtOwnersNextTurnStart_NotAtBuddysTurnStart
+// is the goal-behavior proof: Dodge, activated live through TakeAction on the
+// real encounter, grants disadvantage immediately, survives another actor's
+// turn start, and is removed exactly at the dodger's own next turn start.
+func (s *TurnStartRevivalSuite) TestDodge_LiveActivation_ExpiresAtOwnersNextTurnStart_NotAtBuddysTurnStart() {
+	dodgerData := s.charDataJSON(string(tsrDodgerEntityID), string(tsrDodgerPlayerID))
+	buddyData := s.charDataJSON(string(tsrBuddyEntityID), string(tsrBuddyPlayerID))
+
+	enc := s.loadEncounter(
+		tkenc.PlayerInput{
+			PlayerID: tsrDodgerPlayerID, EntityID: tsrDodgerEntityID,
+			Position: encountercore.Hex{}, SightRange: 10,
+			HP: 20, MaxHP: 20, AC: 15, DataJSON: dodgerData,
+		},
+		tkenc.PlayerInput{
+			PlayerID: tsrBuddyPlayerID, EntityID: tsrBuddyEntityID,
+			Position: encountercore.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+			HP: 20, MaxHP: 20, AC: 15, DataJSON: buddyData,
+		},
+	)
+	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	s.advanceUntilActive(enc, tsrDodgerEntityID)
+
+	dodgeRef := refs.CombatAbilities.Dodge()
+	err := enc.TakeAction(tsrDodgerPlayerID,
+		tkenc.ActionRef{Module: dodgeRef.Module, Type: dodgeRef.Type, ID: dodgeRef.ID},
+		tkenc.ActionTarget{})
+	s.Require().NoError(err)
+
+	bus := enc.EventBus()
+	s.Require().NotNil(bus)
+	s.True(s.attackHasDisadvantageFromDodging(bus, tsrDodgerEntityID),
+		"attack against the dodger should carry disadvantage right after Dodge")
+
+	var removed *dnd5eEvents.ConditionRemovedEvent
+	_, err = dnd5eEvents.ConditionRemovedTopic.On(bus).Subscribe(s.ctx,
+		func(_ context.Context, e dnd5eEvents.ConditionRemovedEvent) error {
+			if e.CharacterID == string(tsrDodgerEntityID) {
+				removed = &e
+			}
+			return nil
+		})
+	s.Require().NoError(err)
+
+	// Buddy's turn starts next — Dodging must NOT be removed.
+	_, _, err = enc.EndTurn(s.ctx, tsrDodgerEntityID)
+	s.Require().NoError(err)
+	s.Equal(tsrBuddyEntityID, enc.ActiveActor())
+	s.Nil(removed, "dodging must not be removed at another actor's turn start")
+	s.True(s.attackHasDisadvantageFromDodging(bus, tsrDodgerEntityID),
+		"dodging must still be active during buddy's turn")
+
+	// The dodger's own next turn starts — Dodging must be removed.
+	_, _, err = enc.EndTurn(s.ctx, tsrBuddyEntityID)
+	s.Require().NoError(err)
+	s.Equal(tsrDodgerEntityID, enc.ActiveActor())
+	s.Require().NotNil(removed, "dodging must be removed at the dodger's own next turn start")
+	s.Equal(refs.Conditions.Dodging().String(), removed.ConditionRef)
+	s.False(s.attackHasDisadvantageFromDodging(bus, tsrDodgerEntityID),
+		"dodging should no longer impose disadvantage")
+}
+
+// TestRecklessAttack_RegressionRemovedAtOwnersNextTurnStart_NotAtBuddysTurnStart
+// is the R2-required regression check: Reckless Attack's own code is
+// untouched by this wave, but its self-removal now actually fires once
+// turn-start is live. A persisted RecklessAttackCondition (simulating "used on
+// a prior turn") must survive another actor's turn start and be removed
+// exactly at the barbarian's own next turn start.
+func (s *TurnStartRevivalSuite) TestRecklessAttack_RegressionRemovedAtOwnersNextTurnStart_NotAtBuddysTurnStart() {
+	recklessCond := dnd5eConditions.NewRecklessAttackCondition(string(tsrBarbEntityID))
+	recklessJSON, err := recklessCond.ToJSON()
+	s.Require().NoError(err)
+
+	barbData := s.charDataJSON(string(tsrBarbEntityID), string(tsrBarbPlayerID), recklessJSON)
+	buddyData := s.charDataJSON(string(tsrBuddyEntityID), string(tsrBuddyPlayerID))
+
+	enc := s.loadEncounter(
+		tkenc.PlayerInput{
+			PlayerID: tsrBarbPlayerID, EntityID: tsrBarbEntityID,
+			Position: encountercore.Hex{}, SightRange: 10,
+			HP: 20, MaxHP: 20, AC: 15, DataJSON: barbData,
+		},
+		tkenc.PlayerInput{
+			PlayerID: tsrBuddyPlayerID, EntityID: tsrBuddyEntityID,
+			Position: encountercore.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+			HP: 20, MaxHP: 20, AC: 15, DataJSON: buddyData,
+		},
+	)
+
+	bus := enc.EventBus()
+	s.Require().NotNil(bus)
+
+	var removed *dnd5eEvents.ConditionRemovedEvent
+	_, err = dnd5eEvents.ConditionRemovedTopic.On(bus).Subscribe(s.ctx,
+		func(_ context.Context, e dnd5eEvents.ConditionRemovedEvent) error {
+			if e.CharacterID == string(tsrBarbEntityID) {
+				removed = &e
+			}
+			return nil
+		})
+	s.Require().NoError(err)
+
+	// SetMode seeds the first actor's turn — which one rolled first is
+	// non-deterministic, so branch rather than assume an order.
+	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+
+	if enc.ActiveActor() == tsrBarbEntityID {
+		// The barbarian rolled first: SetMode's own seed IS the barbarian's own
+		// turn start, so the persisted condition is correctly removed immediately.
+		s.Require().NotNil(removed, "reckless attack must be removed at the barbarian's own turn start")
+		s.Equal(refs.Conditions.RecklessAttack().String(), removed.ConditionRef)
+		s.False(s.attackHasRecklessAdvantage(bus, tsrBarbEntityID))
+		return
+	}
+
+	// Buddy rolled first: the persisted condition must survive buddy's turn start.
+	s.Nil(removed, "reckless attack must not be removed at another actor's turn start")
+	s.True(s.attackHasRecklessAdvantage(bus, tsrBarbEntityID),
+		"reckless attack advantage should still be active during buddy's turn")
+
+	_, _, err = enc.EndTurn(s.ctx, tsrBuddyEntityID)
+	s.Require().NoError(err)
+	s.Equal(tsrBarbEntityID, enc.ActiveActor())
+	s.Require().NotNil(removed, "reckless attack must be removed at the barbarian's own next turn start")
+	s.Equal(refs.Conditions.RecklessAttack().String(), removed.ConditionRef)
+	s.False(s.attackHasRecklessAdvantage(bus, tsrBarbEntityID))
+}
+
+// TestUnconscious_RegressionAutoDeathSaveAtOwnersNextTurnStart_NotAtBuddysTurnStart
+// proves the R2-named connection to rpg-api#612: an unconscious character's
+// death save now actually auto-rolls at the start of their own turn on the
+// live encounter path, and does not roll on another actor's turn start.
+func (s *TurnStartRevivalSuite) TestUnconscious_RegressionAutoDeathSaveAtOwnersNextTurnStart_NotAtBuddysTurnStart() {
+	unconsciousCond := &dnd5eConditions.UnconsciousCondition{CharacterID: string(tsrDownedEntityID)}
+	unconsciousJSON, err := unconsciousCond.ToJSON()
+	s.Require().NoError(err)
+
+	downedData := s.charDataJSON(string(tsrDownedEntityID), string(tsrDownedPlayerID), unconsciousJSON)
+	buddyData := s.charDataJSON(string(tsrBuddyEntityID), string(tsrBuddyPlayerID))
+
+	enc := s.loadEncounter(
+		tkenc.PlayerInput{
+			PlayerID: tsrDownedPlayerID, EntityID: tsrDownedEntityID,
+			Position: encountercore.Hex{}, SightRange: 10,
+			HP: 0, MaxHP: 20, AC: 15, DataJSON: downedData,
+		},
+		tkenc.PlayerInput{
+			PlayerID: tsrBuddyPlayerID, EntityID: tsrBuddyEntityID,
+			Position: encountercore.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+			HP: 20, MaxHP: 20, AC: 15, DataJSON: buddyData,
+		},
+	)
+
+	bus := enc.EventBus()
+	s.Require().NotNil(bus)
+
+	var rolled []dnd5eEvents.DeathSaveRolledEvent
+	_, err = dnd5eEvents.DeathSaveRolledTopic.On(bus).Subscribe(s.ctx,
+		func(_ context.Context, e dnd5eEvents.DeathSaveRolledEvent) error {
+			rolled = append(rolled, e)
+			return nil
+		})
+	s.Require().NoError(err)
+
+	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+
+	if enc.ActiveActor() == tsrDownedEntityID {
+		// Downed rolled first: SetMode's own seed IS their own turn start.
+		s.Require().Len(rolled, 1, "a death save should auto-roll at the downed character's own turn start")
+		s.Equal(string(tsrDownedEntityID), rolled[0].CharacterID)
+		return
+	}
+
+	// Buddy rolled first: no death save should roll on buddy's turn start.
+	s.Empty(rolled, "no death save should auto-roll on another actor's turn start")
+
+	_, _, err = enc.EndTurn(s.ctx, tsrBuddyEntityID)
+	s.Require().NoError(err)
+	s.Equal(tsrDownedEntityID, enc.ActiveActor())
+	s.Require().Len(rolled, 1, "a death save should auto-roll at the downed character's own next turn start")
+	s.Equal(string(tsrDownedEntityID), rolled[0].CharacterID)
+}

--- a/rulebooks/dnd5e/combatabilities/dodge.go
+++ b/rulebooks/dnd5e/combatabilities/dodge.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
@@ -75,8 +76,12 @@ func (d *Dodge) CanActivate(ctx context.Context, owner core.Entity, input Combat
 	return nil
 }
 
-// Activate consumes 1 action and publishes a DodgeActivatedEvent.
-// Subscribers to the event can apply the Dodging condition.
+// Activate consumes 1 action, applies the Dodging condition, and publishes a
+// DodgeActivatedEvent (kept as a narration signal alongside the condition).
+// Mirrors Rage.Activate's ConditionAppliedTopic pattern verbatim: constructs
+// the condition here and publishes it with Condition set so the owning
+// character's onConditionApplied subscriber calls Condition.Apply, which is
+// what actually subscribes DodgingCondition's handlers onto the bus.
 func (d *Dodge) Activate(ctx context.Context, owner core.Entity, input CombatAbilityInput) error {
 	// Validate event bus before consuming action
 	if input.Bus == nil {
@@ -88,13 +93,25 @@ func (d *Dodge) Activate(ctx context.Context, owner core.Entity, input CombatAbi
 		return err
 	}
 
-	// Publish the dodge activated event
-	// A DodgingCondition (to be implemented in a future phase) will subscribe
-	// to this event and apply the actual mechanical effects
+	// Publish the dodge activated event (narration signal).
 	if err := dnd5eEvents.DodgeActivatedTopic.On(input.Bus).Publish(ctx, dnd5eEvents.DodgeActivatedEvent{
 		CharacterID: owner.GetID(),
 	}); err != nil {
 		return fmt.Errorf("failed to publish dodge activated event: %w", err)
+	}
+
+	// Construct and publish the DodgingCondition so it actually applies:
+	// disadvantage to attackers, advantage on DEX saves, self-removal at the
+	// owner's next turn start.
+	dodgingCondition := conditions.NewDodgingCondition(owner.GetID())
+	topic := dnd5eEvents.ConditionAppliedTopic.On(input.Bus)
+	if err := topic.Publish(ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    owner,
+		Type:      dnd5eEvents.ConditionDodging,
+		Source:    dnd5eEvents.ConditionSourceCombatAbility,
+		Condition: dodgingCondition,
+	}); err != nil {
+		return fmt.Errorf("failed to publish dodging condition: %w", err)
 	}
 
 	return nil

--- a/rulebooks/dnd5e/combatabilities/dodge_test.go
+++ b/rulebooks/dnd5e/combatabilities/dodge_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combatabilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/stretchr/testify/suite"
@@ -125,6 +126,40 @@ func (s *DodgeAbilityTestSuite) TestActivate_PublishesDodgeActivatedEvent() {
 	s.Require().NoError(err)
 	s.Assert().True(eventReceived, "DodgeActivatedEvent should be published")
 	s.Assert().Equal(s.owner.GetID(), receivedEvent.CharacterID)
+}
+
+// TestActivate_PublishesDodgingCondition mirrors Rage/RecklessAttack's
+// ConditionAppliedTopic pattern: Activate must construct a *conditions.
+// DodgingCondition for the owner and publish it via ConditionAppliedTopic, not
+// just the narration-only DodgeActivatedEvent above.
+func (s *DodgeAbilityTestSuite) TestActivate_PublishesDodgingCondition() {
+	// Arrange
+	var receivedEvent *dnd5eEvents.ConditionAppliedEvent
+	_, err := dnd5eEvents.ConditionAppliedTopic.On(s.bus).Subscribe(
+		s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionAppliedEvent) error {
+			receivedEvent = &event
+			return nil
+		},
+	)
+	s.Require().NoError(err)
+
+	// Act
+	err = s.dodge.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
+		ActionEconomy: s.actionEconomy,
+		Bus:           s.bus,
+	})
+
+	// Assert
+	s.Require().NoError(err)
+	s.Require().NotNil(receivedEvent, "ConditionAppliedEvent should be published")
+	s.Assert().Equal(s.owner, receivedEvent.Target)
+	s.Assert().Equal(dnd5eEvents.ConditionDodging, receivedEvent.Type)
+	s.Assert().Equal(dnd5eEvents.ConditionSourceCombatAbility, receivedEvent.Source)
+
+	dodgingCond, ok := receivedEvent.Condition.(*conditions.DodgingCondition)
+	s.Require().True(ok, "Event condition should be *DodgingCondition")
+	s.Assert().Equal(s.owner.GetID(), dodgingCond.CharacterID)
 }
 
 func (s *DodgeAbilityTestSuite) TestActivate_NoActionEconomy() {

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -68,6 +68,11 @@ const (
 
 	// ConditionFightingStyle represents an active fighting style
 	ConditionFightingStyle ConditionType = "fighting_style"
+
+	// ConditionDodging is applied when a character uses the Dodge combat ability.
+	// Attackers have disadvantage against the character and the character has
+	// advantage on DEX saves, until the start of the character's next turn.
+	ConditionDodging ConditionType = "dodging"
 )
 
 // ConditionSource identifies where a condition originated
@@ -78,6 +83,8 @@ const (
 	ConditionSourceClass ConditionSource = "class"
 	// ConditionSourceFeature indicates condition from feature activation (e.g., rage)
 	ConditionSourceFeature ConditionSource = "feature"
+	// ConditionSourceCombatAbility indicates condition from a combat ability activation (e.g., dodge)
+	ConditionSourceCombatAbility ConditionSource = "combat_ability"
 )
 
 // ConditionBehavior represents the behavior of an active condition.


### PR DESCRIPTION
## Summary

Root scope (per the last comment on #699, re-scoped by the wave's adversarial review):

- `Dodge.Activate()` now constructs `conditions.NewDodgingCondition(owner.GetID())` and publishes it via `ConditionAppliedTopic`, reusing the `Rage.Activate` pattern verbatim (`rulebooks/dnd5e/features/rage.go`). `DodgeActivatedEvent` stays as a narration signal; `ConditionAppliedEvent` is added alongside it.
- Two taxonomy additions to `rulebooks/dnd5e/events/events.go`: `ConditionDodging` (`ConditionType`) and `ConditionSourceCombatAbility` (`ConditionSource`) — the latter also independently added by the parallel Help/Hide PR (#727, already merged to main); resolved to a single shared declaration during the merge.
- Revived the dead `dnd5eEvents.TurnStartTopic` publish inside `encounter.seedActorTurn` (`encounter/turn_economy.go`), mirroring `EndTurn`'s existing `TurnEndTopic` publish exactly — same bus, same not-best-effort error handling. The publish is unconditional (fires for NPCs too, not just hydrated player characters), matching `EndTurn`'s own unconditional `TurnEndTopic` publish.

## What the turn-start revival wakes, and how each is tested

Reviving this publish lights up **three** live subscribers, not just Dodging — all three get end-to-end regression coverage in `encounter/turn_start_revival_test.go`, run on the real cascade-hydrated encounter bus (not bare condition-level unit tests):

1. **`DodgingCondition`'s self-removal** (this PR's own need). `TestDodge_LiveActivation_ExpiresAtOwnersNextTurnStart_NotAtBuddysTurnStart` drives Dodge live through `TakeAction`, confirms disadvantage is present immediately, survives another actor's turn start, and is removed exactly at the dodger's own next turn start.
2. **Barbarian `RecklessAttackCondition`'s self-removal** (R2-required regression check — this PR does not touch Reckless Attack's code, but its lifecycle now actually fires). `TestRecklessAttack_RegressionRemovedAtOwnersNextTurnStart_NotAtBuddysTurnStart` seeds a persisted condition and proves the same survive/remove behavior.
3. **`UnconsciousCondition`'s auto-death-save roll** — the mechanism behind the wave's own "player gets hit → death gate" playtest beat (rpg-api#612). `TestUnconscious_RegressionAutoDeathSaveAtOwnersNextTurnStart_NotAtBuddysTurnStart` proves a death save auto-rolls at the unconscious character's own next turn start and not on another actor's.

Also added `TestActivate_PublishesDodgingCondition` in `rulebooks/dnd5e/combatabilities/dodge_test.go`, mirroring Rage/RecklessAttack's own `ConditionAppliedEvent` unit test.

Initiative order is roll-dependent (per existing `hydration_test.go` precedent), so the three integration tests branch on which actor rolled first rather than assuming a fixed order — verified flake-free across 15+ repeated runs plus `-race`.

## Merge note

Origin/main advanced past this branch's base commit while this was in flight (#727, the parallel Help/Hide Beat 2 PR, which also touched `events.go`'s taxonomy const blocks). Per repo policy this branch was **merged** (not rebased) with origin/main; the only real conflict was the duplicate `ConditionSourceCombatAbility` addition, resolved to one declaration. `encounter/go.mod`'s `rulebooks/dnd5e` pseudo-version now points at the post-merge commit.

## Test plan

- [x] `go build ./...` clean in both `rulebooks/dnd5e` and `encounter` modules
- [x] `go test ./...` green in both modules (including full pre-existing suites, no regressions)
- [x] `go test -race ./...` green in both modules
- [x] `gofmt -l -s .`, `goimports -l .`, `go vet ./...` clean in both modules
- [x] `golangci-lint run ./...`: 0 issues in `rulebooks/dnd5e`; `encounter` has 39 pre-existing `goconst` findings, none in files this PR touches
- [x] New integration suite run 15+ times to confirm no initiative-order flakiness

Closes #699
Part of KirkDiggler/rpg-project#75

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01E2xgbzQbNgFvkhBkmB3xQE