### PR TITLE
fix(encounter): bridge ConditionRemovedTopic to broker StatusRemoved

### DIFF
--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -251,6 +251,8 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "DamageDealtEvent"
 	case *events.ConditionAppliedEvent:
 		typeName = "ConditionAppliedEvent"
+	case *events.ConditionRemovedEvent:
+		typeName = "ConditionRemovedEvent"
 	case *events.ModeChangedEvent:
 		typeName = "ModeChangedEvent"
 	case *events.TurnStartedEvent:
@@ -345,6 +347,12 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "ConditionAppliedEvent":
 		var e events.ConditionAppliedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "ConditionRemovedEvent":
+		var e events.ConditionRemovedEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/condition_removed_bridge.go
+++ b/encounter/condition_removed_bridge.go
@@ -1,0 +1,98 @@
+package encounter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// subscribeConditionRemovedBridge installs the encounter's ONE permanent
+// subscription to the rulebook-level dnd5eEvents.ConditionRemovedTopic on
+// e.bus (rpg-toolkit#734).
+//
+// Unlike every other bridge in this package (subscribeAttacks,
+// subscribeConditions in npc.go; installTriggerBuffer in combat_phased.go;
+// the capture-window applyActivatedConditions itself relies on), those are
+// all TRANSIENT capture windows: install a temporary subscriber right before
+// one specific verb call, collect whatever fires synchronously during that
+// call, then unsubscribe. That pattern does not work here — a condition can
+// self-remove at ANY future turn start (seedActorTurn, unrelated to whoever
+// originally applied it), or on a healing action targeting a downed ally (a
+// completely different verb call, possibly turns later). There is no single
+// verb call to wrap a transient subscriber around, so this subscription must
+// outlive any one verb call. It is installed once, right after e.bus is
+// constructed, and lives for the Encounter's lifetime — called from both New
+// and LoadFromData so there is exactly one implementation of the
+// subscribe+handler logic. This is the first permanent (non-transient-capture)
+// bus subscription in the encounter package.
+//
+// Subscribe on a freshly constructed dnd5e EventBus never errors (see
+// events/bus.go's simpleEventBus.Subscribe, which unconditionally returns a
+// nil error) — the error is intentionally discarded here because New() has
+// no error return to propagate it through, and LoadFromData already fails a
+// caller on the (unrelated) hydration error path, not this one.
+func (e *Encounter) subscribeConditionRemovedBridge(ctx context.Context) {
+	_, _ = dnd5eEvents.ConditionRemovedTopic.On(e.bus).Subscribe(ctx,
+		func(_ context.Context, evt dnd5eEvents.ConditionRemovedEvent) error {
+			return e.bridgeConditionRemoved(evt)
+		})
+}
+
+// bridgeConditionRemoved translates one rulebook-level
+// dnd5eEvents.ConditionRemovedEvent into a broker-facing
+// events.ConditionRemovedEvent (StatusRemoved), mirroring
+// applyActivatedConditions' audience-projection template
+// (activate_feature.go) exactly: LoS from each viewer's position to the
+// TARGET's position — never the causer's, since removal (like application)
+// is something that happens TO the target.
+//
+// Format consistency (rpg-toolkit#734): the rulebook event's ConditionRef
+// arrives as a fully namespaced ref string (e.g. "dnd5e:conditions:dodging"
+// — see conditions/dodging.go's onTurnStart), but the broker
+// ConditionAppliedEvent this pairs with on the wire carries the short
+// ConditionType keyword ("dodging" — activate_feature.go's
+// `condRef := string(cond.Type)`). Without normalizing, StatusApplied and
+// StatusRemoved for the SAME condition would carry the ref in two different
+// string formats and a client matching them up by ref would silently fail to
+// correlate a removal with its earlier applied event.
+// normalizeConditionRef parses the full ref and keeps just the ID segment so
+// both sides match.
+func (e *Encounter) bridgeConditionRemoved(evt dnd5eEvents.ConditionRemovedEvent) error {
+	targetID := encountercore.EntityID(evt.CharacterID)
+	condRef := normalizeConditionRef(evt.ConditionRef)
+
+	targetPos, haveTargetPos := e.findEntityPosition(targetID)
+
+	perPlayer := make(map[encountercore.PlayerID]events.ConditionRemovedSlice)
+	for viewerID, viewer := range e.data.Players {
+		if !haveTargetPos || !e.viewerCanSee(viewer, targetPos) {
+			continue
+		}
+		perPlayer[viewerID] = events.ConditionRemovedSlice{Visible: true}
+	}
+
+	if err := e.broker.Publish(events.NewConditionRemovedEvent(
+		e.data.ID, e.nextSeq(), targetID, condRef, evt.Reason, perPlayer,
+	)); err != nil {
+		return fmt.Errorf("publish condition removed: %w", err)
+	}
+	return nil
+}
+
+// normalizeConditionRef reduces a fully namespaced condition ref string
+// (e.g. "dnd5e:conditions:dodging") to just its ID segment ("dodging") — the
+// same short keyword form ConditionAppliedEvent.ConditionRef already carries
+// on the wire (see activate_feature.go's applyActivatedConditions). Falls
+// back to the raw input if it does not parse as a namespaced ref, so an
+// already-short or unexpected value is still published rather than dropped.
+func normalizeConditionRef(ref string) string {
+	parsed, err := core.ParseString(ref)
+	if err != nil {
+		return ref
+	}
+	return parsed.ID
+}

--- a/encounter/condition_removed_bridge_test.go
+++ b/encounter/condition_removed_bridge_test.go
@@ -1,0 +1,253 @@
+package encounter_test
+
+// rpg-toolkit#734 (rpg-project#75, Beat 2) regression coverage.
+//
+// Before this fix, dnd5eEvents.ConditionRemovedTopic had zero subscribers
+// anywhere in encounter/*.go: a condition's self-removal (e.g. Dodge at the
+// dodger's own next turn start) was only ever observable by forcing a fresh
+// reconnect and reading it off a snapshot. A client watching the live event
+// stream saw the condition get applied (ConditionAppliedTopic was already
+// bridged) but never saw it removed.
+//
+// These tests exercise the fix on the real cascade-hydrated encounter bus
+// (LoadFromData), not a bare condition-level unit test: a player activates
+// Dodge live via TakeAction, the broker's StatusApplied (ConditionAppliedEvent)
+// is observed, turns advance to the dodger's own next turn start, and the
+// broker's StatusRemoved (ConditionRemovedEvent) must appear — carrying a
+// ConditionRef in the SAME format as the earlier StatusApplied, so a client
+// can correlate the pair — and only to viewers with LoS to the dodger.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	tkenc "github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	crbEncounterID    = encountercore.EncounterID("enc-cond-removed-bridge")
+	crbDodgerPlayerID = encountercore.PlayerID("crb-dodger")
+	crbDodgerEntityID = encountercore.EntityID("char-crb-dodger")
+	crbBuddyPlayerID  = encountercore.PlayerID("crb-buddy")
+	crbBuddyEntityID  = encountercore.EntityID("char-crb-buddy")
+	crbFarPlayerID    = encountercore.PlayerID("crb-far")
+	crbFarEntityID    = encountercore.EntityID("char-crb-far")
+)
+
+// ConditionRemovedBridgeSuite exercises the ConditionRemovedTopic -> broker
+// ConditionRemovedEvent (StatusRemoved) bridge end to end.
+type ConditionRemovedBridgeSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *tkenc.InMemoryTransport
+	broker    *tkenc.Broker
+}
+
+func TestConditionRemovedBridgeSuite(t *testing.T) {
+	suite.Run(t, new(ConditionRemovedBridgeSuite))
+}
+
+func (s *ConditionRemovedBridgeSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = tkenc.NewInMemoryTransport()
+	s.broker = tkenc.NewBroker(s.transport)
+}
+
+func (s *ConditionRemovedBridgeSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// crbCharDataJSON builds a minimal serialized dnd5e character.Data for a
+// combat-ready fighter (Dodge is a universal combat ability, wired onto
+// every character regardless of class).
+func crbCharDataJSON(t *testing.T, id, playerID string) json.RawMessage {
+	t.Helper()
+	data := &dnd5eCharacter.Data{
+		ID:               id,
+		PlayerID:         playerID,
+		Name:             id,
+		Level:            3,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Fighter,
+		RaceID:           races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14, abilities.DEX: 12, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 10, abilities.CHA: 10,
+		},
+		HitPoints:    20,
+		MaxHitPoints: 20,
+		ArmorClass:   15,
+		ActionEconomy: &dnd5eCharacter.ActionEconomyData{
+			TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+			ReactionsRemaining: 1, MovementRemaining: 30,
+		},
+	}
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	return raw
+}
+
+// loadEncounter builds a fresh encounter, adds the given players, then
+// round-trips through ToData/LoadFromData so the cascade hydrates each
+// player's character onto the held bus exactly once — mirroring
+// turn_start_revival_test.go's loadEncounter pattern.
+func (s *ConditionRemovedBridgeSuite) loadEncounter(players ...tkenc.PlayerInput) *tkenc.Encounter {
+	s.T().Helper()
+	enc := tkenc.New(s.ctx, crbEncounterID, s.broker)
+	for _, p := range players {
+		s.Require().NoError(enc.AddPlayer(p))
+	}
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data tkenc.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := tkenc.LoadFromData(s.ctx, &data, s.broker)
+	s.Require().NoError(err)
+	return loaded
+}
+
+// advanceUntilActive cycles EndTurn (whoever is currently active) until the
+// target entity becomes the active actor.
+func (s *ConditionRemovedBridgeSuite) advanceUntilActive(enc *tkenc.Encounter, target encountercore.EntityID) {
+	s.T().Helper()
+	for i := 0; i < 8; i++ {
+		if enc.ActiveActor() == target {
+			return
+		}
+		active := enc.ActiveActor()
+		_, _, err := enc.EndTurn(s.ctx, active)
+		s.Require().NoError(err)
+	}
+	s.FailNow("never reached target's turn", "target=%s", target)
+}
+
+// advanceToOwnersNextTurn assumes target is currently active, ends its turn,
+// then keeps ending whoever is active until control cycles all the way back
+// to target — i.e. target's OWN next turn start, regardless of how many
+// other actors sit between them in initiative order.
+func (s *ConditionRemovedBridgeSuite) advanceToOwnersNextTurn(enc *tkenc.Encounter, target encountercore.EntityID) {
+	s.T().Helper()
+	s.Require().Equal(target, enc.ActiveActor(), "must be target's turn before advancing to their own NEXT turn")
+	for i := 0; i < 8; i++ {
+		active := enc.ActiveActor()
+		_, _, err := enc.EndTurn(s.ctx, active)
+		s.Require().NoError(err)
+		if enc.ActiveActor() == target {
+			return
+		}
+	}
+	s.FailNow("never returned to target's own next turn", "target=%s", target)
+}
+
+// findConditionApplied returns the first *events.ConditionAppliedEvent in
+// evts targeting targetID, or nil.
+func findConditionApplied(
+	evts []events.EncounterEvent, targetID encountercore.EntityID,
+) *events.ConditionAppliedEvent {
+	for _, evt := range evts {
+		if ca, ok := evt.(*events.ConditionAppliedEvent); ok && ca.TargetID == targetID {
+			return ca
+		}
+	}
+	return nil
+}
+
+// findConditionRemoved returns the first *events.ConditionRemovedEvent in
+// evts targeting targetID, or nil.
+func findConditionRemoved(
+	evts []events.EncounterEvent, targetID encountercore.EntityID,
+) *events.ConditionRemovedEvent {
+	for _, evt := range evts {
+		if cr, ok := evt.(*events.ConditionRemovedEvent); ok && cr.TargetID == targetID {
+			return cr
+		}
+	}
+	return nil
+}
+
+// TestDodgeRemoval_BridgesToBroker_RefMatchesAppliedEvent_AndAudienceRespectsLoS
+// is the goal-behavior proof for rpg-toolkit#734: Dodge activated live through
+// TakeAction produces a broker StatusApplied event a buddy with LoS observes;
+// advancing to the dodger's own next turn start then produces a broker
+// StatusRemoved event on the SAME live stream, with a ConditionRef that
+// matches the earlier StatusApplied's format (proving the applied/removed
+// pair correlates) — and a viewer with no LoS to the dodger never receives
+// either event.
+func (s *ConditionRemovedBridgeSuite) TestDodgeRemoval_BridgesToBroker_RefMatchesAppliedEvent_AndAudienceRespectsLoS() {
+	dodgerData := crbCharDataJSON(s.T(), string(crbDodgerEntityID), string(crbDodgerPlayerID))
+
+	enc := s.loadEncounter(
+		tkenc.PlayerInput{
+			PlayerID: crbDodgerPlayerID, EntityID: crbDodgerEntityID,
+			Position: encountercore.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+			HP: 20, MaxHP: 20, AC: 15, DataJSON: dodgerData,
+		},
+		tkenc.PlayerInput{
+			// Adjacent to the dodger — has LoS.
+			PlayerID: crbBuddyPlayerID, EntityID: crbBuddyEntityID,
+			Position: encountercore.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+			HP: 20, MaxHP: 20, AC: 15,
+		},
+		tkenc.PlayerInput{
+			// Far away with a short sight range — no LoS to the dodger.
+			PlayerID: crbFarPlayerID, EntityID: crbFarEntityID,
+			Position: encountercore.Hex{Q: 20, R: 0, S: -20}, SightRange: 1,
+			HP: 20, MaxHP: 20, AC: 15,
+		},
+	)
+	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	s.advanceUntilActive(enc, crbDodgerEntityID)
+
+	buddySub, err := s.broker.Subscribe(crbEncounterID, crbBuddyPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = buddySub.Close() }()
+
+	farSub, err := s.broker.Subscribe(crbEncounterID, crbFarPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = farSub.Close() }()
+
+	dodgeRef := refs.CombatAbilities.Dodge()
+	err = enc.TakeAction(crbDodgerPlayerID,
+		tkenc.ActionRef{Module: dodgeRef.Module, Type: dodgeRef.Type, ID: dodgeRef.ID},
+		tkenc.ActionTarget{})
+	s.Require().NoError(err)
+
+	// StatusApplied: buddy (LoS) must observe it; far (no LoS) must not.
+	buddyAppliedEvts := drainEvents(buddySub, time.Second)
+	applied := findConditionApplied(buddyAppliedEvts, crbDodgerEntityID)
+	s.Require().NotNil(applied, "buddy (LoS to dodger) must observe the StatusApplied event for dodge")
+	s.Equal("dodging", applied.ConditionRef, "StatusApplied carries the short ConditionType keyword form")
+
+	farAppliedEvts := drainEvents(farSub, 200*time.Millisecond)
+	s.Nil(findConditionApplied(farAppliedEvts, crbDodgerEntityID),
+		"far viewer (no LoS to dodger) must not observe the StatusApplied event")
+
+	// Advance to the dodger's own next turn start — Dodging self-removes.
+	s.advanceToOwnersNextTurn(enc, crbDodgerEntityID)
+
+	buddyRemovedEvts := drainEvents(buddySub, time.Second)
+	removed := findConditionRemoved(buddyRemovedEvts, crbDodgerEntityID)
+	s.Require().NotNil(removed, "buddy (LoS to dodger) must observe the StatusRemoved event on the live broker stream")
+	s.Equal(crbDodgerEntityID, removed.TargetID)
+	s.Equal(applied.ConditionRef, removed.ConditionRef,
+		"StatusRemoved's ConditionRef must match StatusApplied's format so a client can correlate the pair")
+	s.Equal("turn_start", removed.Reason)
+
+	farRemovedEvts := drainEvents(farSub, 200*time.Millisecond)
+	s.Nil(findConditionRemoved(farRemovedEvts, crbDodgerEntityID),
+		"far viewer (no LoS to dodger) must not observe the StatusRemoved event")
+}

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -177,7 +177,7 @@ type MonsterInput struct {
 // AddPlayer/AddMonster carrying DataJSON is therefore not hydrated until its
 // next round-trip through LoadFromData, matching the production lifecycle of
 // create → persist → load-per-RPC.
-func New(_ context.Context, id core.EncounterID, b *Broker, opts ...Option) *Encounter {
+func New(ctx context.Context, id core.EncounterID, b *Broker, opts ...Option) *Encounter {
 	e := &Encounter{
 		data:       NewData(id),
 		broker:     b,
@@ -185,6 +185,7 @@ func New(_ context.Context, id core.EncounterID, b *Broker, opts ...Option) *Enc
 		bus:        dnd5events.NewEventBus(),
 		combatants: make(map[core.EntityID]combat.Combatant),
 	}
+	e.subscribeConditionRemovedBridge(ctx)
 	for _, o := range opts {
 		o(e)
 	}
@@ -237,6 +238,7 @@ func LoadFromData(ctx context.Context, data *Data, b *Broker, opts ...Option) (*
 		bus:        dnd5events.NewEventBus(),
 		combatants: make(map[core.EntityID]combat.Combatant),
 	}
+	e.subscribeConditionRemovedBridge(ctx)
 	for _, o := range opts {
 		o(e)
 	}

--- a/encounter/events/condition_removed.go
+++ b/encounter/events/condition_removed.go
@@ -1,0 +1,98 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// ConditionRemovedEvent is the effect event published when a condition is
+// removed from an entity. Maps to the proto StatusRemoved wire shape.
+// Mirrors ConditionAppliedEvent's structure exactly — see condition_applied.go.
+type ConditionRemovedEvent struct {
+	eventMeta
+	encID        core.EncounterID
+	seq          uint64
+	TargetID     core.EntityID
+	ConditionRef string
+	Reason       string
+	PerPlayer    map[core.PlayerID]ConditionRemovedSlice
+}
+
+// ConditionRemovedSlice is each viewer's projection. Visible says whether
+// the player perceived the condition removal.
+type ConditionRemovedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewConditionRemovedEvent constructs a ConditionRemovedEvent.
+func NewConditionRemovedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	targetID core.EntityID,
+	conditionRef string,
+	reason string,
+	perPlayer map[core.PlayerID]ConditionRemovedSlice,
+) *ConditionRemovedEvent {
+	return &ConditionRemovedEvent{
+		encID:        encID,
+		seq:          seq,
+		TargetID:     targetID,
+		ConditionRef: conditionRef,
+		Reason:       reason,
+		PerPlayer:    perPlayer,
+	}
+}
+
+func (*ConditionRemovedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *ConditionRemovedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *ConditionRemovedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who can perceive the condition removal,
+// derived from PerPlayer keys.
+func (e *ConditionRemovedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type conditionRemovedWire struct {
+	metaWire
+	EncID        core.EncounterID                        `json:"encounter_id"`
+	Seq          uint64                                  `json:"sequence"`
+	TargetID     core.EntityID                           `json:"target_id"`
+	ConditionRef string                                  `json:"condition_ref"`
+	Reason       string                                  `json:"reason"`
+	PerPlayer    map[core.PlayerID]ConditionRemovedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *ConditionRemovedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(conditionRemovedWire{
+		metaWire:     e.toWire(),
+		EncID:        e.encID,
+		Seq:          e.seq,
+		TargetID:     e.TargetID,
+		ConditionRef: e.ConditionRef,
+		Reason:       e.Reason,
+		PerPlayer:    e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *ConditionRemovedEvent) UnmarshalJSON(b []byte) error {
+	var w conditionRemovedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.fromWire(w.metaWire)
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.TargetID = w.TargetID
+	e.ConditionRef = w.ConditionRef
+	e.Reason = w.Reason
+	e.PerPlayer = w.PerPlayer
+	return nil
+}


### PR DESCRIPTION
## Problem

When a condition expires (e.g. Dodge at the dodger's next turn start, via #729's turn-start revival), no live client ever finds out. The `StatusRemoved` broker event exists on the proto side, but `ConditionRemovedTopic` had **zero subscribers** anywhere in `encounter/*.go`.

### Playtest evidence (from #734, 2026-07-04 Beat 2 MCP playtest)

> Confirmed in the 2026-07-04 Beat 2 MCP playtest: Dodge's expiry was only ever observable by forcing a fresh reconnect and reading it off the resulting snapshot. A client watching the live event stream sees the condition applied (`ConditionAppliedTopic` is bridged) but never sees it removed — the status just silently goes stale in the client's own state until the next full snapshot.

Part of KirkDiggler/rpg-project#75 (Beat 2) — in-wave.

## Root cause

`encounter` bridges `dnd5eEvents.ConditionAppliedTopic` → broker `ConditionAppliedEvent` (StatusApplied) in a couple of places (`activate_feature.go`'s `applyActivatedConditions`, `take_character_action.go`), but no equivalent bridge existed for `dnd5eEvents.ConditionRemovedTopic` — the rulebook-level "a condition just ended" event that conditions like Dodge (`rulebooks/dnd5e/conditions/dodging.go`), Reckless Attack, Hidden, Helped, etc. publish on self-removal.

## Fix

1. **New broker event**: `encounter/events/condition_removed.go` adds `ConditionRemovedEvent` (`TargetID`, `ConditionRef`, `Reason`, `PerPlayer`), mirroring `ConditionAppliedEvent`'s structure/wire-envelope pattern exactly. Wired into `broker.go`'s `encodeEvent`/`decodeEvent` dispatcher.

2. **Permanent bridge subscription**: `encounter/condition_removed_bridge.go` adds `subscribeConditionRemovedBridge`, called from both `encounter.New` and `encounter.LoadFromData` right after `e.bus` is constructed. Unlike every existing bridge in this package (`subscribeAttacks`/`subscribeConditions` in npc.go, `installTriggerBuffer` in combat_phased.go — all transient capture windows installed right before one verb call and torn down after), condition removal can fire from **any future, unrelated call site**: a self-removal at the owner's own next turn start (`seedActorTurn`), or a removal triggered by a heal/death-save recovery on a completely different verb call, possibly turns later. There's no single verb call to wrap a transient subscriber around, so this is installed once and lives for the Encounter's lifetime.

3. **Ref format normalization**: the rulebook `ConditionRemovedEvent.ConditionRef` arrives as a fully-namespaced ref string (e.g. `"dnd5e:conditions:dodging"` — see `dodging.go`'s `onTurnStart`), but the broker `ConditionAppliedEvent` it pairs with on the wire carries the short `ConditionType` keyword (`"dodging"` — `activate_feature.go`'s `condRef := string(cond.Type)`). `normalizeConditionRef` parses the full ref and keeps just the `ID` segment so StatusApplied and StatusRemoved carry the SAME format for the same condition — otherwise a client matching them up by ref would silently fail to correlate a removal with its earlier applied event.

## Load-bearing changes

- Condition removal now bridges to broker `ConditionRemovedEvent`/StatusRemoved with the same audience projection (LoS to the condition's **target**, never the causer) and ref format as StatusApplied.
- This is the **first permanent (non-transient-capture) bus subscription** in the `encounter` package — every prior bridge in this package installs a temporary subscriber around one verb call; this one is installed once at construction and lives for the Encounter's lifetime, because removal can fire from any future turn-start or heal, unrelated to any single verb call.

## Test

`encounter/condition_removed_bridge_test.go` — `ConditionRemovedBridgeSuite`, real cascade-hydrated encounter bus via `LoadFromData` (not a bare condition-level unit test):

- `TestDodgeRemoval_BridgesToBroker_RefMatchesAppliedEvent_AndAudienceRespectsLoS`:
  - A player activates Dodge live via `TakeAction`; a buddy with LoS observes the broker `ConditionAppliedEvent` (`ConditionRef == "dodging"`).
  - A far-away viewer with no LoS does **not** observe the applied event.
  - Turns advance to the dodger's own next turn start (`EndTurn`/`seedActorTurn` cycling through all seated players); the buddy observes a broker `ConditionRemovedEvent` for the dodger.
  - **Asserts the removed event's `ConditionRef` matches the earlier applied event's `ConditionRef` exactly** — proving the applied/removed pair correlates, not just that some event fired.
  - Asserts `Reason == "turn_start"` (free narration value carried through from the rulebook event).
  - Asserts the far-away viewer never observes the removed event either.

### Red → Green evidence

Red (bridge subscription calls temporarily removed from `New`/`LoadFromData`):
```
--- FAIL: TestConditionRemovedBridgeSuite (2.21s)
    --- FAIL: TestConditionRemovedBridgeSuite/TestDodgeRemoval_BridgesToBroker_RefMatchesAppliedEvent_AndAudienceRespectsLoS (2.21s)
    condition_removed_bridge_test.go:244: Expected value not to be nil.
    Messages: buddy (LoS to dodger) must observe the StatusRemoved event on the live broker stream
```

Green (fix restored):
```
--- PASS: TestConditionRemovedBridgeSuite (2.41s)
    --- PASS: TestConditionRemovedBridgeSuite/TestDodgeRemoval_BridgesToBroker_RefMatchesAppliedEvent_AndAudienceRespectsLoS (2.41s)
PASS
ok  	github.com/KirkDiggler/rpg-toolkit/encounter	2.417s
```

Full module suite (`go test -race ./...`) green:
```
ok  	github.com/KirkDiggler/rpg-toolkit/encounter	32.137s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/core	1.024s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/events	1.036s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/perception	1.025s
```

`gofmt -s`, `goimports`, `go vet`, and `golangci-lint run ./...` are clean for the touched files (`golangci-lint` reports only pre-existing `goconst` findings in unrelated test files, none in the new/changed code).

Closes #734

Related: KirkDiggler/rpg-project#75 (Beat 2)
