### PR TITLE
fix(dnd5e+encounter): players go unconscious at 0 HP instead of dying outright

### DIFF
--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -381,7 +381,11 @@ func (e *Encounter) applyAndPublishNPCOutcome(monster *MonsterData, player *Play
 		return err
 	}
 	if outcome.Hit && hpBefore > 0 && player.HP == 0 {
-		if err := e.publishPlayerDied(player.EntityID, monster.ID); err != nil {
+		// #733: apply Unconscious (death saves) instead of dying outright.
+		// ctx: not threaded through this call chain today; context.Background()
+		// is an established precedent in this exact file (see the
+		// topic.Subscribe(context.Background(), ...) call below).
+		if err := e.applyUnconsciousOnZeroHP(context.Background(), player, monster.ID); err != nil {
 			return err
 		}
 	}

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -1,12 +1,15 @@
 package encounter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
 
 // ErrEncounterEnded is returned by combat verbs (TakeAction, EndTurn,
@@ -130,6 +133,96 @@ func (e *Encounter) publishPlayerDied(playerEntityID, killerID core.EntityID) er
 		e.data.ID, e.nextSeq(), playerEntityID, killerID, diedPerPlayer,
 	)); err != nil {
 		return fmt.Errorf("publish entity died (player): %w", err)
+	}
+	return nil
+}
+
+// applyUnconsciousOnZeroHP replaces the old "player hits 0 HP -> immediately
+// dead" behavior (#733). Instead of calling publishPlayerDied directly, a
+// player whose HP just transitioned >0 -> 0 has the Unconscious condition
+// applied, which engages the death-save mechanism (auto-roll at their own
+// next turn start, auto-fail on further damage, wake on healing — all
+// already implemented in conditions.UnconsciousCondition and wired live by
+// rpg-toolkit#729's turn-start revival). EntityDiedEvent for the player now
+// only fires via the CharacterDied bridge (subscribeCharacterDiedBridge)
+// after 3 failed death saves.
+//
+// Falls back to the pre-#733 publishPlayerDied behavior when the target has
+// no hydrated *character.Character (a flat stat-snapshot seat) — there is no
+// rulebook object to carry death-save state onto, so this is a deliberate,
+// narrow scope call rather than building unconscious-tracking for
+// non-hydrated seats.
+//
+// Monster HP-zero handling (killEntity) is completely untouched by this —
+// this helper is player-only, called from the three sites that used to call
+// publishPlayerDied for the player branch of their isMonster check.
+func (e *Encounter) applyUnconsciousOnZeroHP(ctx context.Context, target *PlayerData, sourceID core.EntityID) error {
+	char := e.heldCharacter(target.EntityID)
+	if char == nil {
+		return e.publishPlayerDied(target.EntityID, sourceID)
+	}
+
+	uc := conditions.NewUnconsciousCondition(string(target.EntityID), e.roller)
+	evt := dnd5eEvents.ConditionAppliedEvent{
+		Target:    char,
+		Type:      dnd5eEvents.ConditionUnconscious,
+		Source:    dnd5eEvents.ConditionSourceDamage,
+		Condition: uc,
+	}
+	// Publishing on ConditionAppliedTopic is what actually applies the
+	// condition: character.Character.onConditionApplied is permanently
+	// subscribed to this topic and calls evt.Condition.Apply(ctx, c.bus)
+	// itself (the Dodge/Rage pattern — see combatabilities/dodge.go).
+	if err := dnd5eEvents.ConditionAppliedTopic.On(e.bus).Publish(ctx, evt); err != nil {
+		return fmt.Errorf("publish unconscious condition: %w", err)
+	}
+
+	// Bridge the same event to the broker-facing ConditionAppliedEvent so
+	// live clients see the status, reusing applyActivatedConditions (which
+	// already resolves target/audience from cond.Target — the R1 fix from
+	// #716) rather than writing new broker-bridging code. sourceID as the
+	// actorID arg gives correct "who did this" narration; audience
+	// resolution is unaffected by it since cond.Target is always set here.
+	if err := e.applyActivatedConditions(nil, sourceID, []dnd5eEvents.ConditionAppliedEvent{evt}); err != nil {
+		return fmt.Errorf("bridge unconscious condition: %w", err)
+	}
+	return nil
+}
+
+// subscribeCharacterDiedBridge installs a PERMANENT subscription to the
+// rulebook's CharacterDiedTopic on e.bus, bridging final death-save-death (3
+// failed death saves) to the broker-facing EntityDiedEvent. Unlike the
+// transient capture-buffers used elsewhere in this package (subscribeAttacks,
+// subscribeConditions, installTriggerBuffer), CharacterDiedEvent can fire
+// from multiple, unrelated call sites over the encounter's lifetime — a
+// turn-start auto-roll (UnconsciousCondition.onTurnStart) or getting hit
+// again while already down (UnconsciousCondition.onDamageReceived) — not
+// just once per verb call. So this is installed once, immediately after e.bus
+// is constructed, and lives for the encounter's lifetime; both New and
+// LoadFromData call this right after building a fresh bus.
+//
+// Handler: resolves the dying character to a seated player; if found,
+// publishes EntityDiedEvent via publishPlayerDied with an empty killer id —
+// there is no specific final blow at 3-failed-saves death.
+// publishPlayerDied/positionFor already handle an empty id gracefully (it
+// simply contributes nothing to the per-viewer LoS projection beyond the
+// dying player's own position). Does NOT call killEntity, remove the player
+// from initiative, or trigger checkEncounterEnd — Wave 2.10's "player is NOT
+// removed from initiative, dying-state/TPK is future work" call still stands;
+// this only wires the missing broker event. A no-op (not an error) if the
+// dead character doesn't resolve to a seated player — e.g. a future monster
+// with an Unconscious condition would simply not match here.
+func (e *Encounter) subscribeCharacterDiedBridge(ctx context.Context) error {
+	_, err := dnd5eEvents.CharacterDiedTopic.On(e.bus).Subscribe(ctx,
+		func(_ context.Context, event dnd5eEvents.CharacterDiedEvent) error {
+			p := e.findPlayerByEntityID(core.EntityID(event.CharacterID))
+			if p == nil {
+				return nil
+			}
+			return e.publishPlayerDied(p.EntityID, "")
+		})
+	if err != nil {
+		return fmt.Errorf("subscribe character died bridge: %w", err)
 	}
 	return nil
 }

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -177,7 +177,7 @@ type MonsterInput struct {
 // AddPlayer/AddMonster carrying DataJSON is therefore not hydrated until its
 // next round-trip through LoadFromData, matching the production lifecycle of
 // create → persist → load-per-RPC.
-func New(_ context.Context, id core.EncounterID, b *Broker, opts ...Option) *Encounter {
+func New(ctx context.Context, id core.EncounterID, b *Broker, opts ...Option) *Encounter {
 	e := &Encounter{
 		data:       NewData(id),
 		broker:     b,
@@ -185,6 +185,16 @@ func New(_ context.Context, id core.EncounterID, b *Broker, opts ...Option) *Enc
 		bus:        dnd5events.NewEventBus(),
 		combatants: make(map[core.EntityID]combat.Combatant),
 	}
+	// #733: permanent bridge from the rulebook's CharacterDiedTopic (3 failed
+	// death saves) to the broker EntityDiedEvent — installed once, right after
+	// the fresh bus is constructed, for the encounter's lifetime (see
+	// subscribeCharacterDiedBridge's doc for why this can't be a transient
+	// per-verb capture buffer like the rest of this package's subscriptions).
+	// Subscribing against a just-constructed simpleEventBus cannot fail (its
+	// Subscribe implementation only ever returns nil) — New's signature
+	// returns no error, so this is deliberately swallowed rather than
+	// widening New's contract for something structurally infallible here.
+	_ = e.subscribeCharacterDiedBridge(ctx)
 	for _, o := range opts {
 		o(e)
 	}
@@ -236,6 +246,12 @@ func LoadFromData(ctx context.Context, data *Data, b *Broker, opts ...Option) (*
 		roller:     dice.NewRoller(),
 		bus:        dnd5events.NewEventBus(),
 		combatants: make(map[core.EntityID]combat.Combatant),
+	}
+	// #733: same permanent CharacterDied -> EntityDied bridge as New — see
+	// subscribeCharacterDiedBridge's doc. Unlike New, LoadFromData already
+	// returns an error, so failure here is propagated rather than swallowed.
+	if err := e.subscribeCharacterDiedBridge(ctx); err != nil {
+		return nil, fmt.Errorf("subscribe character died bridge: %w", err)
 	}
 	for _, o := range opts {
 		o(e)
@@ -759,8 +775,15 @@ func (e *Encounter) iterateMovementStepsForEntity(
 		// before the Prevented check because OAs fire whether or not the
 		// chain ends up preventing the step — the attack (and any damage)
 		// applies either way.
+		//
+		// context.Background(): iterateMovementStepsForEntity and Move (its
+		// only caller) don't thread a ctx through this call chain today,
+		// mirroring the ctx := context.Background() already used a few
+		// lines up in this same function's per-step closure (#733: needed
+		// by applyMoveAttackOutcomes -> applyMoveDamage -> the new
+		// applyUnconsciousOnZeroHP helper's ConditionAppliedTopic publish).
 		if len(capture.rolls) > 0 || len(capture.dmg) > 0 {
-			if err := e.applyMoveAttackOutcomes(capture.rolls, capture.dmg); err != nil {
+			if err := e.applyMoveAttackOutcomes(context.Background(), capture.rolls, capture.dmg); err != nil {
 				return traveled, fmt.Errorf("apply move attack outcomes: %w", err)
 			}
 		}

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,6 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81 h1:zpTdUnwxZyFxXVN76J7yTxehNK5ZLNmOOespt9kKJBs=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1 h1://KFXuoUfR2G8KxHcNPbfgj2WFL2vPAbrZs4/AcPjBM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -12,6 +12,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81 h1:zpTdUnwxZyFxXVN76J7yTxehNK5ZLNmOOespt9kKJBs=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.63.1-0.20260704072501-c424adfbfc81/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1 h1://KFXuoUfR2G8KxHcNPbfgj2WFL2vPAbrZs4/AcPjBM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/encounter/hydration_test.go
+++ b/encounter/hydration_test.go
@@ -84,7 +84,17 @@ func (s *HydrationCascadeSuite) rogueCharDataJSON() json.RawMessage {
 		Name:             "Rogue",
 		Level:            3,
 		ProficiencyBonus: 2,
-		Conditions:       []json.RawMessage{sneakJSON},
+		// HitPoints/MaxHitPoints must match the PlayerInput{HP: 24, MaxHP: 24}
+		// the two call sites below construct this blob for. Before #733,
+		// seedActorTurn's downed check read the encounter's PlayerData.HP
+		// snapshot, so this held character's own (previously zero-value)
+		// HitPoints never mattered. It now gates turn-start economy seeding
+		// directly (char.GetHitPoints() <= 0 — see turn_economy.go), so a
+		// live rogue's held character must actually carry a positive HP or
+		// her own turn-start spuriously treats her as downed.
+		HitPoints:    24,
+		MaxHitPoints: 24,
+		Conditions:   []json.RawMessage{sneakJSON},
 	}
 	raw, err := json.Marshal(data)
 	s.Require().NoError(err)

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -151,7 +151,7 @@ func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) er
 	// from capturedDmg (#684). Any remaining events are from non-attack damage
 	// sources (e.g., a future breath-weapon monster action using DealDamage
 	// directly) and must still be processed here.
-	if err := e.applyCapturedDamage(mon, *capturedDmg); err != nil {
+	if err := e.applyCapturedDamage(ctx, mon, *capturedDmg); err != nil {
 		return err
 	}
 	if err := e.applyCapturedConditions(mon, *capturedCond); err != nil {
@@ -637,7 +637,9 @@ func (e *Encounter) PendingPhasedAttackContext(reactorPlayerID encountercore.Pla
 // player-death per Wave 2.10 architectural call). Re-applying damage to
 // an already-zero target does NOT re-fire death events — death is gated
 // on the >0 → 0 transition.
-func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.DamageReceivedEvent) error {
+func (e *Encounter) applyCapturedDamage(
+	ctx context.Context, mon *MonsterData, damages []dnd5eEvents.DamageReceivedEvent,
+) error {
 	for _, dmg := range damages {
 		targetID := encountercore.EntityID(dmg.TargetID)
 		sourceID := encountercore.EntityID(dmg.SourceID)
@@ -673,7 +675,10 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 					return err
 				}
 			} else {
-				if err := e.publishPlayerDied(targetID, sourceID); err != nil {
+				// #733: apply Unconscious (death saves) instead of dying
+				// outright. See applyUnconsciousOnZeroHP (death.go).
+				target := e.findPlayerByEntityID(targetID)
+				if err := e.applyUnconsciousOnZeroHP(ctx, target, sourceID); err != nil {
 					return err
 				}
 			}
@@ -718,7 +723,7 @@ func (e *Encounter) applyCapturedDamage(mon *MonsterData, damages []dnd5eEvents.
 // from). HP correctness takes priority over the attackResolved-shape
 // guarantee when the two signals disagree.
 func (e *Encounter) applyMoveAttackOutcomes(
-	rolls []dnd5eEvents.PostAttackRollEvent, damages []dnd5eEvents.DamageReceivedEvent,
+	ctx context.Context, rolls []dnd5eEvents.PostAttackRollEvent, damages []dnd5eEvents.DamageReceivedEvent,
 ) error {
 	dmgIdx := 0
 	for _, roll := range rolls {
@@ -736,7 +741,7 @@ func (e *Encounter) applyMoveAttackOutcomes(
 		if dmg == nil {
 			continue
 		}
-		if err := e.applyMoveDamage(*dmg, corrID); err != nil {
+		if err := e.applyMoveDamage(ctx, *dmg, corrID); err != nil {
 			return err
 		}
 	}
@@ -744,7 +749,7 @@ func (e *Encounter) applyMoveAttackOutcomes(
 	// derived correlation id) to publish alongside it — apply HP +
 	// DamageDealtEvent on their own, uncorrelated.
 	for _, dmg := range damages[dmgIdx:] {
-		if err := e.applyMoveDamage(dmg, ""); err != nil {
+		if err := e.applyMoveDamage(ctx, dmg, ""); err != nil {
 			return err
 		}
 	}
@@ -833,7 +838,9 @@ func (e *Encounter) publishMoveAttackResolved(
 // visibility — viewers who can see the target see the event, viewers
 // who can't, don't. The same skip rule as applyCapturedDamage applies
 // for unknown targets (we can't mutate HP on something we can't find).
-func (e *Encounter) applyMoveDamage(dmg dnd5eEvents.DamageReceivedEvent, corrID encountercore.CorrelationID) error {
+func (e *Encounter) applyMoveDamage(
+	ctx context.Context, dmg dnd5eEvents.DamageReceivedEvent, corrID encountercore.CorrelationID,
+) error {
 	targetID := encountercore.EntityID(dmg.TargetID)
 	sourceID := encountercore.EntityID(dmg.SourceID)
 
@@ -874,7 +881,10 @@ func (e *Encounter) applyMoveDamage(dmg dnd5eEvents.DamageReceivedEvent, corrID 
 				return err
 			}
 		} else {
-			if err := e.publishPlayerDied(targetID, sourceID); err != nil {
+			// #733: apply Unconscious (death saves) instead of dying
+			// outright. See applyUnconsciousOnZeroHP (death.go).
+			target := e.findPlayerByEntityID(targetID)
+			if err := e.applyUnconsciousOnZeroHP(ctx, target, sourceID); err != nil {
 				return err
 			}
 		}
@@ -1011,12 +1021,21 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 // buildPerception assembles the PerceptionData a monster needs to choose
 // and target an action. Wave 2.8 treats every player as an enemy and
 // computes distances directly from hex coordinates — no walls or cover.
+//
+// #733: a player at HP<=0 (dead or unconscious) is never perceived as an
+// enemy — this is the fix for the observed soft-lock where a goblin kept
+// attacking a downed player round after round. D&D RAW's auto-crit-on-
+// unconscious-target is deliberately NOT implemented here; the issue only
+// asks to skip dead/unconscious targets, not add that rule.
 func (e *Encounter) buildPerception(mon *MonsterData) *monster.PerceptionData {
 	pos := spatial.CubeCoordinate{X: mon.Position.Q, Y: mon.Position.R, Z: mon.Position.S}
 	pd := &monster.PerceptionData{
 		MyPosition: pos,
 	}
 	for _, p := range e.data.Players {
+		if p.HP <= 0 {
+			continue
+		}
 		dist := hexDistance(mon.Position, p.View.Position)
 		pd.Enemies = append(pd.Enemies, monster.PerceivedEntity{
 			Entity:   &playerEntity{id: string(p.EntityID), name: string(p.ID)},
@@ -1045,12 +1064,19 @@ func (p *playerEntity) GetID() string            { return p.id }
 func (p *playerEntity) GetType() core.EntityType { return "character" }
 func (p *playerEntity) GetName() string          { return p.name }
 
-// closestPlayer returns the player nearest the given hex, or nil if the
-// encounter has no players.
+// closestPlayer returns the LIVE player (HP>0) nearest the given hex, or nil
+// if the encounter has no live players. #733: a downed player (HP<=0) is
+// never returned — before this fix, npcActScripted (the caller) would keep
+// targeting/attacking a downed player round after round, since nothing
+// filtered by HP. The existing "no players" nil-return path already covers
+// the all-downed case correctly (the caller treats nil as "nothing to do").
 func (e *Encounter) closestPlayer(from encountercore.Hex) *PlayerData {
 	var best *PlayerData
 	bestDist := -1
 	for _, p := range e.data.Players {
+		if p.HP <= 0 {
+			continue
+		}
 		d := hexDistance(from, p.View.Position)
 		if best == nil || d < bestDist {
 			best = p

--- a/encounter/npc_targeting_downed_test.go
+++ b/encounter/npc_targeting_downed_test.go
@@ -1,0 +1,192 @@
+package encounter_test
+
+// rpg-toolkit#733 — playtest evidence: a goblin kept attacking a corpse
+// round after round because nothing filtered NPC targeting by player HP.
+// Two call sites feed a monster's targeting:
+//   - closestPlayer (scripted path, no monster DataJSON) — exercised here via
+//     npcActScripted / NPCAct directly.
+//   - buildPerception (full monster.TakeTurn path, DataJSON present) — feeds
+//     monster.PerceptionData.Enemies, which ClosestEnemy()/TargetLowestHP/
+//     TargetLowestAC all read from.
+//
+// Both must skip any player at HP<=0 (dead or unconscious) — this file
+// proves both never target the downed player, across multiple turns.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+)
+
+const (
+	ntdAlivePlayerID = core.PlayerID("ntd-alive")
+	ntdAliveEntityID = core.EntityID("char-ntd-alive")
+	ntdDownEntityID  = core.EntityID("char-ntd-down")
+)
+
+// NPCTargetingDownedSuite covers the #733 targeting-skip fix.
+type NPCTargetingDownedSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestNPCTargetingDownedSuite(t *testing.T) {
+	suite.Run(t, new(NPCTargetingDownedSuite))
+}
+
+func (s *NPCTargetingDownedSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *NPCTargetingDownedSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer is the closestPlayer
+// regression proof, reproducing the exact reported soft-lock: a downed player
+// positioned CLOSER to the goblin than the alive player. npcActScripted has
+// no adjacency gate (unlike the DataJSON/Scimitar path), so pre-fix this
+// deterministically attacks the corpse every single turn. Across 3 goblin
+// turns, the fix must make the goblin attack ONLY the live player, never the
+// downed one.
+func (s *NPCTargetingDownedSuite) TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer() {
+	encID := core.EncounterID("enc-ntd-scripted")
+	enc := encounter.New(s.ctx, encID, s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 1, damageType: damageSlashing}),
+	)
+	// Downed player is adjacent (distance 1) — strictly closer than alive.
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "ntd-down", EntityID: ntdDownEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 0, MaxHP: 12, AC: 10,
+	}))
+	// Alive player is farther away (distance 3).
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: ntdAlivePlayerID, EntityID: ntdAliveEntityID,
+		Position: core.Hex{Q: 3, R: 0, S: -3}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 10,
+	}))
+	// No DataJSON — triggers the scripted (closestPlayer) path.
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	aliceSub, err := s.broker.Subscribe(encID, ntdAlivePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = aliceSub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+
+	for turn := 0; turn < 3; turn++ {
+		for enc.ActiveActor() != gobEntityID {
+			_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+			s.Require().NoError(endErr)
+		}
+		drainSub(aliceSub, 50*time.Millisecond)
+
+		s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+
+		seen := collectEventsTyped(aliceSub, 300*time.Millisecond)
+		var attack *events.AttackResolvedEvent
+		for _, e := range seen {
+			if a, ok := e.(*events.AttackResolvedEvent); ok {
+				attack = a
+			}
+		}
+		s.Require().NotNil(attack, "turn %d: goblin must attack someone", turn)
+		s.Equal(ntdAliveEntityID, attack.TargetID,
+			"turn %d: goblin must target the live player, never the downed one (closestPlayer HP filter)", turn)
+
+		_, _, endErr := enc.EndTurn(s.ctx, gobEntityID)
+		s.Require().NoError(endErr)
+	}
+}
+
+// TestFullAIPath_BuildPerception_NeverTargetsDownedPlayer is the
+// buildPerception regression proof, using the full monster.TakeTurn AI path
+// (DataJSON goblin, ClosestEnemy() targeting via ScimitarAction) rather than
+// the scripted stand-in. The downed player is adjacent (would be
+// ClosestEnemy() and in melee range pre-fix); the alive player is farther
+// and non-adjacent. This asserts the negative: across the goblin's turn(s),
+// it never attacks or damages the downed player. (It does not assert the
+// goblin successfully chases down the alive player — that depends on
+// movement/pathfinding mechanics unrelated to this fix; only that the downed
+// player is structurally excluded from being perceived as a target at all.)
+func (s *NPCTargetingDownedSuite) TestFullAIPath_BuildPerception_NeverTargetsDownedPlayer() {
+	encID := core.EncounterID("enc-ntd-full-ai")
+	enc := encounter.New(s.ctx, encID, s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 1, damageType: damageSlashing}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "ntd-down", EntityID: ntdDownEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 0, MaxHP: 12, AC: 10,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: ntdAlivePlayerID, EntityID: ntdAliveEntityID,
+		Position: core.Hex{Q: 2, R: 0, S: -2}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 10,
+	}))
+
+	gob := monster.NewGoblin(gobEntityID)
+	gobData := gob.ToData()
+	dataJSON, err := json.Marshal(gobData)
+	s.Require().NoError(err)
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: core.Hex{},
+		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
+		MonsterRef:  monsterRefGoblin,
+		DataJSON:    dataJSON,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	aliceSub, err := s.broker.Subscribe(encID, ntdAlivePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = aliceSub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+
+	for turn := 0; turn < 2; turn++ {
+		for enc.ActiveActor() != gobEntityID {
+			_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+			s.Require().NoError(endErr)
+		}
+		drainSub(aliceSub, 50*time.Millisecond)
+
+		s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+
+		seen := collectEventsTyped(aliceSub, 300*time.Millisecond)
+		for _, e := range seen {
+			switch ev := e.(type) {
+			case *events.AttackResolvedEvent:
+				s.NotEqual(ntdDownEntityID, ev.TargetID,
+					"turn %d: goblin must never attack the downed player (buildPerception HP filter)", turn)
+			case *events.DamageDealtEvent:
+				s.NotEqual(ntdDownEntityID, ev.TargetID,
+					"turn %d: goblin must never damage the downed player (buildPerception HP filter)", turn)
+			}
+		}
+
+		_, _, endErr := enc.EndTurn(s.ctx, gobEntityID)
+		s.Require().NoError(endErr)
+	}
+
+	// The downed player's HP must be completely untouched.
+	s.Equal(0, enc.ToData().Players["ntd-down"].HP)
+}

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -78,7 +78,17 @@ func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) er
 	// inventing new zeroing logic. Design intent: "ActionEconomy for an
 	// unconscious actor should not offer actions" (rpg-project#75 Beat 2
 	// mechanical-effects design doc, "Turn-start is dead code").
-	if p := e.findPlayerByEntityID(actorID); p != nil && p.HP <= 0 {
+	//
+	// Gated on char.GetHitPoints() — the held character's LIVE HP — not the
+	// encounter's PlayerData.HP snapshot. The TurnStartTopic publish above is
+	// synchronous and can itself change the held character's HP before this
+	// check runs: UnconsciousCondition's nat-20 death-save path publishes
+	// HealingReceivedEvent, which character.onHealingReceived applies to
+	// c.hitPoints directly. PlayerData.HP is only refreshed from the held
+	// character at ToData() time, so reading the snapshot here would still see
+	// the pre-revival value and zero the economy of an actor who just came
+	// back to 1 HP (Copilot review, PR #739).
+	if char.GetHitPoints() <= 0 {
 		if _, err := char.EndTurn(ctx, &character.EndTurnInput{}); err != nil {
 			return fmt.Errorf("zero turn economy for downed actor %q: %w", actorID, err)
 		}

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -70,6 +70,21 @@ func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) er
 		return nil // NPC or stat-snapshot seat — no character economy to seed.
 	}
 
+	// #733: an unconscious/downed player (HP<=0) gets no seeded action economy
+	// — the TurnStartTopic publish above still drives their auto-death-save
+	// roll, but they cannot act. char.EndTurn is a pure local mutation
+	// (zeroes actions/bonus/reaction/movement remaining, resets Granted, no
+	// event side effects — see action_economy.go) reused here instead of
+	// inventing new zeroing logic. Design intent: "ActionEconomy for an
+	// unconscious actor should not offer actions" (rpg-project#75 Beat 2
+	// mechanical-effects design doc, "Turn-start is dead code").
+	if p := e.findPlayerByEntityID(actorID); p != nil && p.HP <= 0 {
+		if _, err := char.EndTurn(ctx, &character.EndTurnInput{}); err != nil {
+			return fmt.Errorf("zero turn economy for downed actor %q: %w", actorID, err)
+		}
+		return nil
+	}
+
 	if _, err := char.StartTurn(ctx, &character.StartTurnInput{
 		Speed:      char.GetSpeed(),
 		TurnNumber: e.data.Round,

--- a/encounter/turn_economy_downed_test.go
+++ b/encounter/turn_economy_downed_test.go
@@ -1,0 +1,215 @@
+package encounter_test
+
+// rpg-toolkit#733 — design intent (rpg-project#75 Beat 2 mechanical-effects
+// design doc, "Turn-start is dead code"): "ActionEconomy for an unconscious
+// actor should not offer actions." seedActorTurn (turn_economy.go) used to
+// unconditionally call char.StartTurn on any player whose turn began,
+// including a downed one — reseeding a fresh 1/1/1/30 economy for a player
+// who cannot act. This file proves the fix: a downed player's own turn-start
+// zeroes the economy (via char.EndTurn) instead of reseeding it, and the
+// pushed TurnStateChangedEvent reflects that.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	tedDownedPlayerID = core.PlayerID("ted-downed")
+	tedDownedEntityID = core.EntityID("char-ted-downed")
+	tedBuddyPlayerID  = core.PlayerID("ted-buddy")
+	tedBuddyEntityID  = core.EntityID("char-ted-buddy")
+)
+
+// TurnEconomyDownedSuite proves the seedActorTurn fix.
+type TurnEconomyDownedSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestTurnEconomyDownedSuite(t *testing.T) {
+	suite.Run(t, new(TurnEconomyDownedSuite))
+}
+
+func (s *TurnEconomyDownedSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *TurnEconomyDownedSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// charDataJSONWithSeededEconomy builds a hydratable dnd5e character.Data blob
+// carrying a PRE-SEEDED ActionEconomy (1/1/1/30, TurnNumber 1) — simulating a
+// character already mid-combat (a real StartTurn already ran) before going
+// down. This makes the regression meaningful: pre-fix, seedActorTurn would
+// call char.StartTurn and RESEED 1/1/1/30 (visibly nonzero) at the downed
+// player's next turn start; post-fix, char.EndTurn zeroes it instead.
+func (s *TurnEconomyDownedSuite) charDataJSONWithSeededEconomy(id, playerID string) json.RawMessage {
+	s.T().Helper()
+	data := &dnd5eCharacter.Data{
+		ID:               id,
+		PlayerID:         playerID,
+		Name:             id,
+		Level:            3,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Fighter,
+		RaceID:           races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14, abilities.DEX: 12, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 10, abilities.CHA: 10,
+		},
+		HitPoints:    0,
+		MaxHitPoints: 20,
+		ArmorClass:   15,
+		ActionEconomy: &dnd5eCharacter.ActionEconomyData{
+			TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+			ReactionsRemaining: 1, MovementRemaining: 30,
+		},
+	}
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+	return raw
+}
+
+// buddyCharDataJSON builds a plain hydratable Fighter with no special state —
+// just needs to be a valid seat so the encounter has >1 combatant to cycle
+// through.
+func (s *TurnEconomyDownedSuite) buddyCharDataJSON(id, playerID string) json.RawMessage {
+	s.T().Helper()
+	data := &dnd5eCharacter.Data{
+		ID:               id,
+		PlayerID:         playerID,
+		Name:             id,
+		Level:            3,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Fighter,
+		RaceID:           races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14, abilities.DEX: 12, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 10, abilities.CHA: 10,
+		},
+		HitPoints:    20,
+		MaxHitPoints: 20,
+		ArmorClass:   15,
+	}
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+	return raw
+}
+
+// TestDownedPlayerTurnStart_ZeroesEconomy_NotReseeds is the goal-behavior
+// proof: at the downed player's own turn start, the pushed
+// TurnStateChangedEvent shows ZERO actions/bonus/reactions/movement — not
+// the normal freshly-seeded 1/1/1/30 values.
+func (s *TurnEconomyDownedSuite) TestDownedPlayerTurnStart_ZeroesEconomy_NotReseeds() {
+	downedData := s.charDataJSONWithSeededEconomy(string(tedDownedEntityID), string(tedDownedPlayerID))
+	buddyData := s.buddyCharDataJSON(string(tedBuddyEntityID), string(tedBuddyPlayerID))
+
+	encID := core.EncounterID("enc-ted-1")
+	enc := encounter.New(s.ctx, encID, s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: tedDownedPlayerID, EntityID: tedDownedEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 0, MaxHP: 20, AC: 15, DataJSON: downedData,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: tedBuddyPlayerID, EntityID: tedBuddyEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 20, MaxHP: 20, AC: 15, DataJSON: buddyData,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker)
+	s.Require().NoError(err)
+
+	sub, err := s.broker.Subscribe(encID, tedDownedPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	// Subscribe before flipping to TURN_BASED so we catch the push
+	// regardless of whether the downed player rolls first (SetMode itself
+	// seeds the first actor) or second (via one EndTurn cycle).
+	s.Require().NoError(loaded.SetMode(core.ModeTurnBased))
+	for loaded.ActiveActor() != tedDownedEntityID {
+		_, _, endErr := loaded.EndTurn(s.ctx, loaded.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	seen := collectEventsTyped(sub, 500*time.Millisecond)
+	var ts *events.TurnStateChangedEvent
+	for _, e := range seen {
+		if t, ok := e.(*events.TurnStateChangedEvent); ok {
+			ts = t
+		}
+	}
+	s.Require().NotNil(ts, "the downed player's turn start must still push a TurnStateChangedEvent")
+	s.Equal(tedDownedEntityID, ts.ActorID)
+	s.Equal(0, ts.State.ActionsRemaining, "a downed player's turn start must NOT reseed the standard action")
+	s.Equal(0, ts.State.BonusActionsRemaining, "a downed player's turn start must NOT reseed the bonus action")
+	s.Equal(0, ts.State.ReactionsRemaining, "a downed player's turn start must NOT reseed the reaction")
+	s.Equal(0, ts.State.MovementRemaining, "a downed player's turn start must NOT reseed movement")
+}
+
+// TestAlivePlayerTurnStart_StillSeedsNormalEconomy is the negative control:
+// an ALIVE player's turn start is completely unaffected by this fix — still
+// gets the normal freshly-seeded 1/1/1/30 economy.
+func (s *TurnEconomyDownedSuite) TestAlivePlayerTurnStart_StillSeedsNormalEconomy() {
+	aliveData := s.buddyCharDataJSON(string(tedBuddyEntityID), string(tedBuddyPlayerID))
+
+	encID := core.EncounterID("enc-ted-2")
+	enc := encounter.New(s.ctx, encID, s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: tedBuddyPlayerID, EntityID: tedBuddyEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 20, MaxHP: 20, AC: 15, DataJSON: aliveData,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker)
+	s.Require().NoError(err)
+
+	sub, err := s.broker.Subscribe(encID, tedBuddyPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(loaded.SetMode(core.ModeTurnBased))
+	s.Require().Equal(tedBuddyEntityID, loaded.ActiveActor())
+
+	seen := collectEventsTyped(sub, 500*time.Millisecond)
+	var ts *events.TurnStateChangedEvent
+	for _, e := range seen {
+		if t, ok := e.(*events.TurnStateChangedEvent); ok {
+			ts = t
+		}
+	}
+	s.Require().NotNil(ts)
+	s.Equal(1, ts.State.ActionsRemaining)
+	s.Equal(1, ts.State.BonusActionsRemaining)
+	s.Equal(1, ts.State.ReactionsRemaining)
+	s.Positive(ts.State.MovementRemaining)
+}

--- a/encounter/turn_economy_downed_test.go
+++ b/encounter/turn_economy_downed_test.go
@@ -172,6 +172,118 @@ func (s *TurnEconomyDownedSuite) TestDownedPlayerTurnStart_ZeroesEconomy_NotRese
 	s.Equal(0, ts.State.MovementRemaining, "a downed player's turn start must NOT reseed movement")
 }
 
+// aliceAliveSeededCharDataJSON builds a hydratable Fighter at 1 HP (alive,
+// about to be knocked down) with a pre-seeded ActionEconomy — same shape as
+// unconscious_zero_hp_test.go's charDataJSON, duplicated here so this file
+// stays self-contained (no cross-suite coupling to UnconsciousZeroHPSuite).
+func (s *TurnEconomyDownedSuite) aliceAliveSeededCharDataJSON() json.RawMessage {
+	s.T().Helper()
+	data := &dnd5eCharacter.Data{
+		ID:               string(aliceEntityID),
+		PlayerID:         string(alicePlayerID),
+		Name:             string(aliceEntityID),
+		Level:            3,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Fighter,
+		RaceID:           races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14, abilities.DEX: 12, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 10, abilities.CHA: 10,
+		},
+		HitPoints:    1,
+		MaxHitPoints: 12,
+		ArmorClass:   10,
+		ActionEconomy: &dnd5eCharacter.ActionEconomyData{
+			TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+			ReactionsRemaining: 1, MovementRemaining: 30,
+		},
+	}
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+	return raw
+}
+
+// TestDownedPlayerRevivedByNat20MidTurnStart_ReseedsEconomy is the regression
+// proof for the Copilot review on PR #739 (turn_economy.go): seedActorTurn
+// used to gate the downed/unconscious check on the encounter's PlayerData.HP
+// snapshot. That snapshot is written once — when a hit first drops a player
+// to 0 (combat_phased.go / npc.go) — and is never refreshed afterward; it does
+// NOT track the held character's live HP. But the TurnStartTopic publish
+// immediately above the check is synchronous, and can itself revive the
+// actor: a natural-20 death save (UnconsciousCondition.onTurnStart) publishes
+// HealingReceivedEvent, which character.onHealingReceived applies straight to
+// the held character's live hitPoints. Gating on the stale PlayerData.HP
+// snapshot would still read 0 and zero the just-revived actor's action
+// economy for a turn they can now fully act in. This proves the fix — reading
+// char.GetHitPoints() instead — reseeds a full economy for the revived actor.
+func (s *TurnEconomyDownedSuite) TestDownedPlayerRevivedByNat20MidTurnStart_ReseedsEconomy() {
+	encID := core.EncounterID("enc-ted-nat20")
+	roller := encounter.WithRoller(fixedMaxRoller{})
+	resolver := encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing})
+
+	enc := encounter.New(s.ctx, encID, s.broker, roller, resolver)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+		DataJSON: s.aliceAliveSeededCharDataJSON(),
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker, roller, resolver)
+	s.Require().NoError(err)
+
+	sub, err := s.broker.Subscribe(encID, alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(loaded.SetMode(core.ModeTurnBased))
+	for loaded.ActiveActor() != gobEntityID {
+		_, _, endErr := loaded.EndTurn(s.ctx, loaded.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(sub, 100*time.Millisecond)
+
+	// Goblin's attack drops alice (1 HP) to 0 — applies UnconsciousCondition
+	// (constructed with e.roller == fixedMaxRoller, per applyUnconsciousOnZeroHP).
+	s.Require().NoError(loaded.NPCAct(s.ctx, gobEntityID))
+	drainSub(sub, 100*time.Millisecond)
+
+	// Cycle back to alice's own turn start. Her turn-start publish drives
+	// UnconsciousCondition's auto-death-save roll; fixedMaxRoller guarantees a
+	// nat 20, reviving her to 1 HP via HealingReceivedEvent synchronously,
+	// before seedActorTurn's downed check runs.
+	active := loaded.ActiveActor()
+	for active != aliceEntityID {
+		next, _, endErr := loaded.EndTurn(s.ctx, active)
+		s.Require().NoError(endErr)
+		active = next
+	}
+
+	seen := collectEventsTyped(sub, 500*time.Millisecond)
+	var ts *events.TurnStateChangedEvent
+	for _, e := range seen {
+		if t, ok := e.(*events.TurnStateChangedEvent); ok && t.ActorID == aliceEntityID {
+			ts = t
+		}
+	}
+	s.Require().NotNil(ts, "alice's revived turn-start must still push a TurnStateChangedEvent")
+	s.Equal(1, ts.State.ActionsRemaining,
+		"a nat-20-revived player must get a fresh action, not a zeroed economy carried over from the stale HP snapshot")
+	s.Equal(1, ts.State.BonusActionsRemaining)
+	s.Equal(1, ts.State.ReactionsRemaining)
+	s.Positive(ts.State.MovementRemaining)
+}
+
 // TestAlivePlayerTurnStart_StillSeedsNormalEconomy is the negative control:
 // an ALIVE player's turn start is completely unaffected by this fix — still
 // gets the normal freshly-seeded 1/1/1/30 economy.

--- a/encounter/unconscious_zero_hp_test.go
+++ b/encounter/unconscious_zero_hp_test.go
@@ -1,0 +1,272 @@
+package encounter_test
+
+// rpg-toolkit#733 — players die outright at 0 HP instead of going
+// unconscious and rolling death saves. This file covers the two encounter-
+// level behaviors from the fix:
+//
+//  1. A player whose HP transitions >0 -> 0 now has UnconsciousCondition
+//     applied (broker ConditionAppliedEvent, type "unconscious") instead of
+//     firing EntityDiedEvent immediately — death saves gate death now.
+//  2. Three failed death saves (the rulebook's own CharacterDiedTopic) are
+//     bridged to the broker EntityDiedEvent via the new PERMANENT
+//     subscription installed in New/LoadFromData (subscribeCharacterDiedBridge,
+//     death.go), with an empty KillerID (no specific final blow).
+//
+// The pre-existing DeathSuite tests (death_test.go) already cover the
+// fallback path unchanged: those fixtures use encounter.New with no
+// PlayerInput.DataJSON, so e.heldCharacter returns nil and
+// applyUnconsciousOnZeroHP falls back to the old publishPlayerDied behavior
+// verbatim — proven by those tests passing unmodified against this change.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// alwaysFailDeathSaveRoller always rolls a 2 on a d20 (a plain death-save
+// failure — not a natural 1 or 20) so a downed character's death saves fail
+// deterministically, three turn-starts in a row, without depending on real
+// randomness. Non-d20 rolls (RollN, or Roll for any other size) pass through
+// at max face — irrelevant here since nothing else in these fixtures rolls
+// dice (alwaysHitResolver is a canned CombatResolver stub).
+type alwaysFailDeathSaveRoller struct{}
+
+func (alwaysFailDeathSaveRoller) Roll(_ context.Context, size int) (int, error) {
+	if size == 20 {
+		return 2, nil
+	}
+	return size, nil
+}
+
+func (alwaysFailDeathSaveRoller) RollN(_ context.Context, count, size int) ([]int, error) {
+	out := make([]int, count)
+	for i := range out {
+		out[i] = size
+	}
+	return out, nil
+}
+
+// UnconsciousZeroHPSuite drives the real cascade-hydrated encounter path
+// (LoadFromData -> held *character.Character), same house style as
+// turn_start_revival_test.go.
+type UnconsciousZeroHPSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestUnconsciousZeroHPSuite(t *testing.T) {
+	suite.Run(t, new(UnconsciousZeroHPSuite))
+}
+
+func (s *UnconsciousZeroHPSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *UnconsciousZeroHPSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// charDataJSON builds a minimal hydratable dnd5e character.Data blob for a
+// combat-ready Fighter, mirroring turn_start_revival_test.go's helper.
+func (s *UnconsciousZeroHPSuite) charDataJSON(id, playerID string) json.RawMessage {
+	s.T().Helper()
+	data := &dnd5eCharacter.Data{
+		ID:               id,
+		PlayerID:         playerID,
+		Name:             id,
+		Level:            3,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Fighter,
+		RaceID:           races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 14, abilities.DEX: 12, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 10, abilities.CHA: 10,
+		},
+		HitPoints:    1,
+		MaxHitPoints: 12,
+		ArmorClass:   10,
+		ActionEconomy: &dnd5eCharacter.ActionEconomyData{
+			TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+			ReactionsRemaining: 1, MovementRemaining: 30,
+		},
+	}
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+	return raw
+}
+
+// buildEncounter constructs a 1-hydrated-player (alice, HP=aliceHP) +
+// 1-scripted-monster (goblin, no DataJSON) encounter wired with roller, then
+// round-trips through ToData/LoadFromData so the cascade hydrates alice's
+// character (mirrors turn_start_revival_test.go's loadEncounter).
+func (s *UnconsciousZeroHPSuite) buildEncounter(
+	encID core.EncounterID, aliceHP int, roller encounter.Option,
+) *encounter.Encounter {
+	s.T().Helper()
+	enc := encounter.New(s.ctx, encID, s.broker, roller,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: aliceHP, MaxHP: 12, AC: 10, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+		DataJSON: s.charDataJSON(string(aliceEntityID), string(alicePlayerID)),
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker, roller,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}),
+	)
+	s.Require().NoError(err)
+	return loaded
+}
+
+// TestPlayerHitsZeroHP_AppliesUnconscious_NotImmediateEntityDied is the goal-
+// behavior proof for the fix's core change: a player hit to 0 HP by an NPC
+// gets the Unconscious condition applied (broker ConditionAppliedEvent,
+// ConditionRef="unconscious", labeled with the KILLER as source) instead of
+// an immediate EntityDiedEvent. The player stays seated and in initiative —
+// same partial-death shape Wave 2.10 established, just gated behind death
+// saves now instead of firing instantly.
+func (s *UnconsciousZeroHPSuite) TestPlayerHitsZeroHP_AppliesUnconscious_NotImmediateEntityDied() {
+	enc := s.buildEncounter("enc-uzh-1", 1, encounter.WithRoller(fixedMaxRoller{}))
+
+	sub, err := s.broker.Subscribe("enc-uzh-1", alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(sub, 100*time.Millisecond)
+
+	// Goblin's attack drops alice (1 HP) to 0 — guaranteed lethal via
+	// alwaysHitResolver's 999 damage.
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+
+	seen := collectEventsTyped(sub, 500*time.Millisecond)
+	var (
+		condApplied *events.ConditionAppliedEvent
+		died        *events.EntityDiedEvent
+	)
+	for _, e := range seen {
+		switch ev := e.(type) {
+		case *events.ConditionAppliedEvent:
+			condApplied = ev
+		case *events.EntityDiedEvent:
+			died = ev
+		}
+	}
+	s.Require().NotNil(condApplied, "hitting 0 HP must apply the Unconscious condition")
+	s.Equal(string(dnd5eEvents.ConditionUnconscious), condApplied.ConditionRef)
+	s.Equal(core.EntityID(aliceEntityID), condApplied.TargetID,
+		"condition must be labeled with the downed player, not the killer")
+	s.Equal(core.EntityID(gobEntityID), condApplied.SourceID, "narration source is the killer")
+	s.Nil(died, "player hitting 0 HP must NOT immediately fire EntityDiedEvent — death saves gate it now")
+
+	persisted := enc.ToData()
+	s.Contains(persisted.Players, core.PlayerID(alicePlayerID),
+		"player must remain seated (Wave 2.10 partial-death shape)")
+	s.Contains(persisted.Initiative, core.EntityID(aliceEntityID), "player must remain in initiative even at HP=0")
+}
+
+// TestThreeFailedDeathSaves_BridgesToEntityDied proves the missing half of
+// the death-save loop: once UnconsciousCondition's own death-save state
+// reaches Dead (3 failures), the rulebook's CharacterDiedTopic — which
+// nothing in encounter/*.go subscribed to before this fix — now bridges to
+// the broker EntityDiedEvent via the permanent subscription installed in
+// New/LoadFromData (subscribeCharacterDiedBridge). KillerID is empty: there
+// is no specific final blow at 3-failed-saves death.
+func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_BridgesToEntityDied() {
+	enc := s.buildEncounter("enc-uzh-2", 1, encounter.WithRoller(alwaysFailDeathSaveRoller{}))
+
+	aliceSub, err := s.broker.Subscribe("enc-uzh-2", alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = aliceSub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	// Goblin's attack drops alice to 0 HP — Unconscious applied, not dead.
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	bus := enc.EventBus()
+	s.Require().NotNil(bus)
+	var diedRulebook bool
+	_, err = dnd5eEvents.CharacterDiedTopic.On(bus).Subscribe(s.ctx,
+		func(_ context.Context, e dnd5eEvents.CharacterDiedEvent) error {
+			if e.CharacterID == string(aliceEntityID) {
+				diedRulebook = true
+			}
+			return nil
+		})
+	s.Require().NoError(err)
+
+	// Cycle turns (goblin <-> alice) until alice's own turn-start has fired
+	// exactly 3 times — 3 consecutive plain death-save failures
+	// (alwaysFailDeathSaveRoller never rolls a success/crit).
+	aliceTurnStarts := 0
+	active := enc.ActiveActor()
+	for i := 0; i < 20 && aliceTurnStarts < 3; i++ {
+		next, _, endErr := enc.EndTurn(s.ctx, active)
+		s.Require().NoError(endErr)
+		active = next
+		if active == aliceEntityID {
+			aliceTurnStarts++
+		}
+	}
+	s.Require().Equal(3, aliceTurnStarts, "must reach alice's own turn 3 times to accumulate 3 failures")
+	s.Require().True(diedRulebook, "3 failed death saves must publish the rulebook CharacterDiedEvent")
+
+	seen := collectEventsTyped(aliceSub, 500*time.Millisecond)
+	var died *events.EntityDiedEvent
+	for _, e := range seen {
+		if d, ok := e.(*events.EntityDiedEvent); ok {
+			died = d
+		}
+	}
+	s.Require().NotNil(died, "3 failed death saves must bridge to a broker EntityDiedEvent")
+	s.Equal(core.EntityID(aliceEntityID), died.EntityID)
+	s.Empty(died.KillerID, "final death-save death has no specific killer")
+
+	// Wave 2.10's "player is NOT removed from initiative" call still stands —
+	// this fix only wires the missing event, not removal/TPK semantics.
+	persisted := enc.ToData()
+	s.Contains(persisted.Players, core.PlayerID(alicePlayerID))
+	s.NotEmpty(persisted.Initiative)
+}

--- a/rulebooks/dnd5e/conditions/unconscious.go
+++ b/rulebooks/dnd5e/conditions/unconscious.go
@@ -40,6 +40,17 @@ type UnconsciousCondition struct {
 // Ensure UnconsciousCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*UnconsciousCondition)(nil)
 
+// NewUnconsciousCondition creates a new Unconscious condition for the
+// specified character, using roller for its auto-rolled death saves.
+// Mirrors NewDodgingCondition's constructor pattern; Unconscious additionally
+// needs a dice.Roller since (unlike Dodging) it rolls dice on its own.
+func NewUnconsciousCondition(characterID string, roller dice.Roller) *UnconsciousCondition {
+	return &UnconsciousCondition{
+		CharacterID: characterID,
+		Roller:      roller,
+	}
+}
+
 // IsApplied returns true if this condition is currently applied
 func (c *UnconsciousCondition) IsApplied() bool {
 	return c.bus != nil
@@ -151,8 +162,20 @@ func (c *UnconsciousCondition) onTurnStart(ctx context.Context, event dnd5eEvent
 		return nil
 	}
 
+	// Reload survives CharacterID + death-save counters (loadJSON) but NOT
+	// Roller — every RPC reconstructs the encounter/character fresh from
+	// persisted JSON, so a character that went unconscious on a prior RPC
+	// has Roller == nil here on the next one. Lazy-fallback at point-of-use,
+	// mirroring BrutalCriticalCondition.onDamageChain / SneakAttackCondition.
+	// onDamageChain, rather than depending on construction-time injection
+	// surviving a reload (rpg-toolkit#733).
+	roller := c.Roller
+	if roller == nil {
+		roller = dice.NewRoller()
+	}
+
 	result, err := saves.MakeDeathSave(ctx, &saves.DeathSaveInput{
-		Roller: c.Roller,
+		Roller: roller,
 		State:  c.deathSaveState,
 	})
 	if err != nil {

--- a/rulebooks/dnd5e/conditions/unconscious_test.go
+++ b/rulebooks/dnd5e/conditions/unconscious_test.go
@@ -478,6 +478,60 @@ func (s *UnconsciousConditionTestSuite) TestOnDamageReceived_StabilizedCreature_
 	s.False(uc.deathSaveState.Stabilized, "stabilization should be reset")
 }
 
+// TestReload_NoRollerAfterReload_StillRollsRealDeathSave is the rpg-toolkit#733
+// regression test: loadJSON restores CharacterID + death-save counters but
+// NEVER Roller (it isn't part of UnconsciousData — nothing to unmarshal it
+// from). In production, Encounter/Character are reconstructed fresh on every
+// RPC: a player goes unconscious this RPC (Roller injected via
+// NewUnconsciousCondition, fine), the encounter persists, the next RPC
+// reloads via conditions.LoadJSON — a BRAND NEW instance with Roller == nil —
+// and Apply()s it onto a fresh bus. This proves that reload-then-fire-again
+// shape actually works: no panic, no nil dereference, a real death save still
+// rolls (onTurnStart's lazy dice.NewRoller() fallback, mirroring
+// BrutalCriticalCondition/SneakAttackCondition's onDamageChain).
+func (s *UnconsciousConditionTestSuite) TestReload_NoRollerAfterReload_StillRollsRealDeathSave() {
+	original := NewUnconsciousCondition("char-reload", s.mockRoller)
+	err := original.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	data, err := original.ToJSON()
+	s.Require().NoError(err)
+
+	// Simulate the next RPC's reload: a fresh instance via the same
+	// registration path unconscious_test's sibling loader.go uses.
+	reloadedAny, err := LoadJSON(data)
+	s.Require().NoError(err)
+	reloaded, ok := reloadedAny.(*UnconsciousCondition)
+	s.Require().True(ok)
+	s.Nil(reloaded.Roller, "reload must not carry over the original Roller — this is the bug's precondition")
+
+	// Apply to a fresh bus, mirroring LoadFromData reconstructing e.bus fresh
+	// every RPC.
+	freshBus := events.NewEventBus()
+	s.Require().NoError(reloaded.Apply(s.ctx, freshBus))
+
+	var rolled *dnd5eEvents.DeathSaveRolledEvent
+	_, err = dnd5eEvents.DeathSaveRolledTopic.On(freshBus).Subscribe(s.ctx,
+		func(_ context.Context, e dnd5eEvents.DeathSaveRolledEvent) error {
+			rolled = &e
+			return nil
+		})
+	s.Require().NoError(err)
+
+	s.Require().NotPanics(func() {
+		err = dnd5eEvents.TurnStartTopic.On(freshBus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
+			CharacterID: "char-reload",
+			Round:       1,
+		})
+	}, "a nil Roller after reload must not panic")
+	s.Require().NoError(err)
+
+	s.Require().NotNil(rolled, "a real death save must still roll after reload with a nil Roller")
+	s.Equal("char-reload", rolled.CharacterID)
+	s.GreaterOrEqual(rolled.Roll, 1, "roll must be a real d20 result, not a zero-value stand-in")
+	s.LessOrEqual(rolled.Roll, 20)
+}
+
 func (s *UnconsciousConditionTestSuite) TestIsApplied_ReflectsBusState() {
 	uc := s.newCondition("char-1")
 

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -96,6 +96,10 @@ const (
 	// ConditionSourceCombatAbility indicates condition from a universal combat
 	// ability activation (e.g., Dodge, Hide, Help)
 	ConditionSourceCombatAbility ConditionSource = "combat_ability"
+	// ConditionSourceDamage indicates a condition applied as a direct
+	// consequence of taking damage (e.g., Unconscious at 0 HP) rather than
+	// an actor's own ability activation.
+	ConditionSourceDamage ConditionSource = "damage"
 )
 
 // ConditionBehavior represents the behavior of an active condition.


### PR DESCRIPTION
## Problem (from #733)

> Players die outright at 0 HP instead of going unconscious and rolling death saves. Observed **twice, independently**, in the 2026-07-04 Beat 2 MCP playtest (wave KirkDiggler/rpg-project#75): an `EntityDamaged` event with `hp_after=0/10` is immediately followed by `EntityDied` for the player — the exact same event sequence as a monster kill.

> Minimum dead/unconscious handling required for this to be playable, not just theoretically correct:
> - An unconscious player's turn must auto-advance through the death-save flow (no stuck turn waiting on input from a player who can't act).
> - NPC closest-player targeting must skip dead/unconscious targets. Observed soft-lock in the same playtest: a goblin kept attacking a corpse round after round — active turn stayed pinned on the dead player with a fully enabled action menu.

## Root cause

`killEntity`'s player path was explicitly deferred when death detection was built (#642: "player dying-state is Wave 2.11+"). Since then, #729 wired `UnconsciousCondition`'s auto-death-save roll to fire live on `TurnStartTopic` — the death-save *mechanism* existed and worked — but nothing ever applied `UnconsciousCondition` to a player in the first place. Three call sites (NPC-attacker outcome in `combat_phased.go`, captured NPC damage + move/OA damage in `npc.go`) dropped a player to 0 HP and called `publishPlayerDied` directly, which only fires a broker `EntityDiedEvent` with no state mutation — death saves never got a chance to engage.

## Fix

**rulebooks/dnd5e:**
- Add `NewUnconsciousCondition(characterID, roller)` constructor (previously had no constructor and was never applied anywhere), mirroring `NewDodgingCondition`.
- Add `ConditionSourceDamage` to the `ConditionSource` taxonomy.
- `onTurnStart` now lazily falls back to `dice.NewRoller()` when `Roller` is nil, mirroring `BrutalCriticalCondition`/`SneakAttackCondition` — defense-in-depth for the reload path (see Pushback below).

**encounter:**
- New `applyUnconsciousOnZeroHP` helper (death.go): applies `UnconsciousCondition` via the Dodge/Rage `ConditionAppliedTopic` pattern and bridges it to the broker via the existing `applyActivatedConditions`, for any player whose held `*character.Character` is hydrated. Falls back to the old `publishPlayerDied` behavior for non-hydrated (stat-snapshot) seats. Replaces all three `publishPlayerDied` call sites for the player branch — monster branches (`killEntity`) are completely untouched.
- New `subscribeCharacterDiedBridge` (death.go): a **permanent** subscription (installed once in both `New` and `LoadFromData`, right after the bus is constructed) bridging the rulebook's `CharacterDiedTopic` (3 failed death saves) to the broker `EntityDiedEvent`, with an empty killer id. Nothing subscribed to this topic before.
- `seedActorTurn`: a downed player's (HP<=0) own turn-start now calls `char.EndTurn` (zeroes the economy) instead of `char.StartTurn` (which would reseed a fresh usable economy for an actor who cannot act). The `TurnStartTopic` publish stays unconditional — it still drives the auto-death-save roll.
- `closestPlayer` + `buildPerception` (npc.go): both now skip any player at HP<=0 when choosing an NPC's target — fixes the observed soft-lock.

## Tests

- `rulebooks/dnd5e/conditions/unconscious_test.go`: round-trip regression — apply → `ToJSON` → `LoadJSON` (fresh instance, simulating an RPC reload) → `Apply` → fire `TurnStartTopic` → assert a real death-save roll happens with no panic.
- `encounter/unconscious_zero_hp_test.go`: hitting 0 HP applies `UnconsciousCondition` (not immediate `EntityDied`); 3 failed death saves bridge to a broker `EntityDiedEvent` with an empty killer.
- `encounter/npc_targeting_downed_test.go`: both the scripted (`closestPlayer`) and full `monster.TakeTurn` (`buildPerception`) AI paths never target a downed player across multiple turns.
- `encounter/turn_economy_downed_test.go`: a downed player's turn-start push shows a zeroed economy; an alive player's is unaffected.

All four behavior changes were verified red-then-green by temporarily reverting each fix in isolation and confirming the corresponding test fails, then restoring it.

## Load-bearing changes

- **Players at 0 HP now enter Unconscious and roll death saves** — `EntityDied` for players now fires **only** via 3 failed death saves, never immediately at 0 HP.
- **NPC targeting now skips any player at HP<=0** (closestPlayer + buildPerception).
- **A downed player's own turn-start no longer reseeds action economy** — it's zeroed instead, so the action menu can't offer actions to an actor who can't act.
- `encounter.New`'s previously-unused `ctx` parameter is now used (installs the permanent `CharacterDied` bridge subscription) — no signature change, but the parameter is no longer a no-op.

## Cross-module dependency

`encounter/go.mod`'s `rulebooks/dnd5e` pseudo-version is bumped to this branch's rulebooks/dnd5e commit (no local `replace` committed — verified clean, `grep -c replace go.mod` = 0).

Closes #733
Part of KirkDiggler/rpg-project#75

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>