### PR TITLE
fix(encounter): death-save resolution is now a first-class broker event stream

### DIFF
--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -261,6 +261,10 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "TurnEndedEvent"
 	case *events.EntityDiedEvent:
 		typeName = "EntityDiedEvent"
+	case *events.EntityStabilizedEvent:
+		typeName = "EntityStabilizedEvent"
+	case *events.DeathSaveRolledEvent:
+		typeName = "DeathSaveRolledEvent"
 	case *events.EntityRemovedEvent:
 		typeName = "EntityRemovedEvent"
 	case *events.EncounterEndedEvent:
@@ -377,6 +381,18 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "EntityDiedEvent":
 		var e events.EntityDiedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "EntityStabilizedEvent":
+		var e events.EntityStabilizedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "DeathSaveRolledEvent":
+		var e events.DeathSaveRolledEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -109,9 +109,13 @@ func (e *Encounter) killEntity(monsterID, killerID core.EntityID) error {
 // goblin" without committing to a dying-state model that hasn't shipped.
 //
 // Visibility: a viewer is in PerPlayer iff they have LoS to the dying
-// player OR the killing NPC. The dying player themselves are always
-// considered to perceive their own death (their position is, by
-// definition, in their own view).
+// player OR the killing NPC. The dying player themselves is ALWAYS included
+// unconditionally (rpg-toolkit#741 hardening) — a player learning of their
+// own death must never depend on a LoS/perception computation over their
+// own position; that dependency is real (CanSeeAt reads live position +
+// sight range) but conceptually unnecessary, and any future change to LoS
+// rules (multi-room, forced movement, senses) should not be able to hide a
+// player's own death from them.
 func (e *Encounter) publishPlayerDied(playerEntityID, killerID core.EntityID) error {
 	playerData := e.findPlayerByEntityID(playerEntityID)
 	if playerData == nil || playerData.View == nil {
@@ -121,7 +125,11 @@ func (e *Encounter) publishPlayerDied(playerEntityID, killerID core.EntityID) er
 	killerPos, killerHasPos := e.positionFor(killerID)
 
 	diedPerPlayer := make(map[core.PlayerID]events.EntityDiedSlice)
+	diedPerPlayer[playerData.ID] = events.EntityDiedSlice{Visible: true}
 	for viewerID, viewer := range e.data.Players {
+		if viewerID == playerData.ID {
+			continue
+		}
 		seesDying := perception.CanSeeAt(viewer.View, dyingPos)
 		seesKiller := killerHasPos && perception.CanSeeAt(viewer.View, killerPos)
 		if !seesDying && !seesKiller {
@@ -225,6 +233,147 @@ func (e *Encounter) subscribeCharacterDiedBridge(ctx context.Context) error {
 		return fmt.Errorf("subscribe character died bridge: %w", err)
 	}
 	return nil
+}
+
+// subscribeCharacterStabilizedBridge installs a PERMANENT subscription to
+// the rulebook's CharacterStabilizedTopic on e.bus, bridging "3 successful
+// death saves" to the broker-facing EntityStabilizedEvent (rpg-toolkit#741 —
+// previously this topic had zero production subscribers anywhere in
+// encounter/, so stabilization was completely wire-invisible). Same
+// lifetime shape as subscribeCharacterDiedBridge: CharacterStabilizedEvent
+// can fire from a turn-start auto-roll at any point in the encounter's
+// life, not just once per verb call, so this is installed once alongside
+// the other permanent bridges in both New and LoadFromData.
+//
+// A no-op (not an error) if the stabilized character doesn't resolve to a
+// seated player, mirroring subscribeCharacterDiedBridge's same fallback.
+func (e *Encounter) subscribeCharacterStabilizedBridge(ctx context.Context) error {
+	_, err := dnd5eEvents.CharacterStabilizedTopic.On(e.bus).Subscribe(ctx,
+		func(_ context.Context, event dnd5eEvents.CharacterStabilizedEvent) error {
+			return e.bridgeCharacterStabilized(core.EntityID(event.CharacterID))
+		})
+	if err != nil {
+		return fmt.Errorf("subscribe character stabilized bridge: %w", err)
+	}
+	return nil
+}
+
+// bridgeCharacterStabilized publishes an EntityStabilizedEvent for the
+// stabilized entity. Visibility policy mirrors publishPlayerDied's
+// EntityDied projection: the stabilized player is always included
+// unconditionally, and any other viewer with LoS to their position is added
+// alongside — same "own state is never LoS-gated" reasoning documented on
+// publishPlayerDied. No-op if the entity doesn't resolve to a seated player.
+func (e *Encounter) bridgeCharacterStabilized(entityID core.EntityID) error {
+	p := e.findPlayerByEntityID(entityID)
+	if p == nil {
+		return nil
+	}
+	perPlayer := e.deathSaveAudience(p)
+	if err := e.broker.Publish(events.NewEntityStabilizedEvent(
+		e.data.ID, e.nextSeq(), entityID, perPlayer,
+	)); err != nil {
+		return fmt.Errorf("publish entity stabilized: %w", err)
+	}
+	return nil
+}
+
+// subscribeDeathSaveRolledBridge installs a PERMANENT subscription to the
+// rulebook's DeathSaveRolledTopic on e.bus, bridging EVERY death save roll
+// (or automatic damage-while-unconscious failure) to the broker-facing
+// DeathSaveRolledEvent (rpg-toolkit#741 — previously zero production
+// subscribers, so individual rolls never reached the wire even though the
+// terminal Died/Stabilized outcomes now do). Same permanent-lifetime shape
+// as the other two death-save bridges: rolls happen at turn-start or on
+// damage, not confined to one verb call.
+//
+// A no-op (not an error) if the rolling character doesn't resolve to a
+// seated player.
+func (e *Encounter) subscribeDeathSaveRolledBridge(ctx context.Context) error {
+	_, err := dnd5eEvents.DeathSaveRolledTopic.On(e.bus).Subscribe(ctx,
+		func(_ context.Context, event dnd5eEvents.DeathSaveRolledEvent) error {
+			return e.bridgeDeathSaveRolled(event)
+		})
+	if err != nil {
+		return fmt.Errorf("subscribe death save rolled bridge: %w", err)
+	}
+	return nil
+}
+
+// bridgeDeathSaveRolled publishes a DeathSaveRolledEvent carrying the roll
+// detail (roll value, running successes/failures, crit flags, and the
+// nat-20-revival fields) for the rolling entity. Visibility policy mirrors
+// bridgeCharacterStabilized. No-op if the entity doesn't resolve to a
+// seated player.
+func (e *Encounter) bridgeDeathSaveRolled(event dnd5eEvents.DeathSaveRolledEvent) error {
+	entityID := core.EntityID(event.CharacterID)
+	p := e.findPlayerByEntityID(entityID)
+	if p == nil {
+		return nil
+	}
+	perPlayer := e.deathSaveRolledAudience(p)
+	if err := e.broker.Publish(events.NewDeathSaveRolledEvent(&events.NewDeathSaveRolledEventInput{
+		EncID:                 e.data.ID,
+		Seq:                   e.nextSeq(),
+		EntityID:              entityID,
+		Roll:                  event.Roll,
+		Successes:             event.Successes,
+		Failures:              event.Failures,
+		IsCriticalFail:        event.IsCriticalFail,
+		IsCriticalSuccess:     event.IsCriticalSuccess,
+		Stabilized:            event.Stabilized,
+		Dead:                  event.Dead,
+		RegainedConsciousness: event.RegainedConsciousness,
+		HPRestored:            event.HPRestored,
+		PerPlayer:             perPlayer,
+	})); err != nil {
+		return fmt.Errorf("publish death save rolled: %w", err)
+	}
+	return nil
+}
+
+// deathSaveAudience builds the per-viewer projection shared by the
+// Stabilized and (via deathSaveRolledAudience) DeathSaveRolled bridges: the
+// rolling/stabilizing player themselves is always included unconditionally
+// (same "own state is never LoS-gated" reasoning as publishPlayerDied),
+// plus any other viewer with LoS to their current position.
+func (e *Encounter) deathSaveAudience(p *PlayerData) map[core.PlayerID]events.EntityStabilizedSlice {
+	perPlayer := make(map[core.PlayerID]events.EntityStabilizedSlice)
+	perPlayer[p.ID] = events.EntityStabilizedSlice{Visible: true}
+	if p.View == nil {
+		return perPlayer
+	}
+	pos := p.View.Position
+	for viewerID, viewer := range e.data.Players {
+		if viewerID == p.ID {
+			continue
+		}
+		if perception.CanSeeAt(viewer.View, pos) {
+			perPlayer[viewerID] = events.EntityStabilizedSlice{Visible: true}
+		}
+	}
+	return perPlayer
+}
+
+// deathSaveRolledAudience is deathSaveAudience's DeathSaveRolledSlice
+// counterpart — identical projection, different slice type (the two events
+// are not structurally related beyond sharing this visibility policy).
+func (e *Encounter) deathSaveRolledAudience(p *PlayerData) map[core.PlayerID]events.DeathSaveRolledSlice {
+	perPlayer := make(map[core.PlayerID]events.DeathSaveRolledSlice)
+	perPlayer[p.ID] = events.DeathSaveRolledSlice{Visible: true}
+	if p.View == nil {
+		return perPlayer
+	}
+	pos := p.View.Position
+	for viewerID, viewer := range e.data.Players {
+		if viewerID == p.ID {
+			continue
+		}
+		if perception.CanSeeAt(viewer.View, pos) {
+			perPlayer[viewerID] = events.DeathSaveRolledSlice{Visible: true}
+		}
+	}
+	return perPlayer
 }
 
 // checkEncounterEnd evaluates the encounter-end predicate and, if true,

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -109,7 +109,7 @@ func (e *Encounter) killEntity(monsterID, killerID core.EntityID) error {
 // goblin" without committing to a dying-state model that hasn't shipped.
 //
 // Visibility: a viewer is in PerPlayer iff they have LoS to the dying
-// player OR the killing NPC. The dying player themselves is ALWAYS included
+// player OR the killing NPC. The dying player is ALWAYS included
 // unconditionally (rpg-toolkit#741 hardening) — a player learning of their
 // own death must never depend on a LoS/perception computation over their
 // own position; that dependency is real (CanSeeAt reads live position +

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -195,6 +195,12 @@ func New(ctx context.Context, id core.EncounterID, b *Broker, opts ...Option) *E
 	// returns no error, so this is deliberately swallowed rather than
 	// widening New's contract for something structurally infallible here.
 	_ = e.subscribeCharacterDiedBridge(ctx)
+	// #741: same permanent-bridge shape and same "cannot fail" reasoning as
+	// subscribeCharacterDiedBridge above — CharacterStabilizedTopic and
+	// DeathSaveRolledTopic previously had zero production subscribers
+	// anywhere in this package.
+	_ = e.subscribeCharacterStabilizedBridge(ctx)
+	_ = e.subscribeDeathSaveRolledBridge(ctx)
 	e.subscribeConditionRemovedBridge(ctx)
 	for _, o := range opts {
 		o(e)
@@ -253,6 +259,15 @@ func LoadFromData(ctx context.Context, data *Data, b *Broker, opts ...Option) (*
 	// returns an error, so failure here is propagated rather than swallowed.
 	if err := e.subscribeCharacterDiedBridge(ctx); err != nil {
 		return nil, fmt.Errorf("subscribe character died bridge: %w", err)
+	}
+	// #741: same permanent-bridge shape as subscribeCharacterDiedBridge —
+	// CharacterStabilizedTopic and DeathSaveRolledTopic previously had zero
+	// production subscribers anywhere in this package.
+	if err := e.subscribeCharacterStabilizedBridge(ctx); err != nil {
+		return nil, fmt.Errorf("subscribe character stabilized bridge: %w", err)
+	}
+	if err := e.subscribeDeathSaveRolledBridge(ctx); err != nil {
+		return nil, fmt.Errorf("subscribe death save rolled bridge: %w", err)
 	}
 	e.subscribeConditionRemovedBridge(ctx)
 	for _, o := range opts {

--- a/encounter/events/death_save_rolled.go
+++ b/encounter/events/death_save_rolled.go
@@ -1,0 +1,153 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// DeathSaveRolledEvent is the cause / narrative event published for every
+// death save roll (or automatic damage-while-unconscious failure) an
+// unconscious entity takes (rpg-toolkit#741). Unlike EntityDiedEvent /
+// EntityStabilizedEvent, which fire once at a terminal transition, this
+// fires on EVERY roll so a client (or playtest harness log) can show death
+// saves resolving in real time. Roll is 0 when the failure came from taking
+// damage while unconscious rather than an actual d20 roll (mirrors
+// rulebooks/dnd5e/events.DeathSaveRolledEvent's own Roll==0 convention).
+// Same per-viewer projection template as EntityDiedEvent (LoS to the
+// rolling entity) — no killer/causer concept. Maps to the proto
+// DeathSaveRolled wire shape.
+type DeathSaveRolledEvent struct {
+	eventMeta
+	encID                 core.EncounterID
+	seq                   uint64
+	EntityID              core.EntityID
+	Roll                  int
+	Successes             int
+	Failures              int
+	IsCriticalFail        bool
+	IsCriticalSuccess     bool
+	Stabilized            bool
+	Dead                  bool
+	RegainedConsciousness bool
+	HPRestored            int
+	PerPlayer             map[core.PlayerID]DeathSaveRolledSlice
+}
+
+// DeathSaveRolledSlice is each viewer's projection. Visible says whether
+// the player perceived the roll.
+type DeathSaveRolledSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewDeathSaveRolledEventInput bundles DeathSaveRolledEvent's fields —
+// enough distinct int/bool fields that a positional constructor would be
+// error-prone to call correctly at each bridge call site.
+type NewDeathSaveRolledEventInput struct {
+	EncID                 core.EncounterID
+	Seq                   uint64
+	EntityID              core.EntityID
+	Roll                  int
+	Successes             int
+	Failures              int
+	IsCriticalFail        bool
+	IsCriticalSuccess     bool
+	Stabilized            bool
+	Dead                  bool
+	RegainedConsciousness bool
+	HPRestored            int
+	PerPlayer             map[core.PlayerID]DeathSaveRolledSlice
+}
+
+// NewDeathSaveRolledEvent constructs a DeathSaveRolledEvent.
+func NewDeathSaveRolledEvent(in *NewDeathSaveRolledEventInput) *DeathSaveRolledEvent {
+	return &DeathSaveRolledEvent{
+		encID:                 in.EncID,
+		seq:                   in.Seq,
+		EntityID:              in.EntityID,
+		Roll:                  in.Roll,
+		Successes:             in.Successes,
+		Failures:              in.Failures,
+		IsCriticalFail:        in.IsCriticalFail,
+		IsCriticalSuccess:     in.IsCriticalSuccess,
+		Stabilized:            in.Stabilized,
+		Dead:                  in.Dead,
+		RegainedConsciousness: in.RegainedConsciousness,
+		HPRestored:            in.HPRestored,
+		PerPlayer:             in.PerPlayer,
+	}
+}
+
+func (*DeathSaveRolledEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *DeathSaveRolledEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *DeathSaveRolledEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who can perceive the roll, derived
+// from PerPlayer keys.
+func (e *DeathSaveRolledEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type deathSaveRolledWire struct {
+	metaWire
+	EncID                 core.EncounterID                       `json:"encounter_id"`
+	Seq                   uint64                                 `json:"sequence"`
+	EntityID              core.EntityID                          `json:"entity_id"`
+	Roll                  int                                    `json:"roll"`
+	Successes             int                                    `json:"successes"`
+	Failures              int                                    `json:"failures"`
+	IsCriticalFail        bool                                   `json:"is_critical_fail"`
+	IsCriticalSuccess     bool                                   `json:"is_critical_success"`
+	Stabilized            bool                                   `json:"stabilized"`
+	Dead                  bool                                   `json:"dead"`
+	RegainedConsciousness bool                                   `json:"regained_consciousness"`
+	HPRestored            int                                    `json:"hp_restored"`
+	PerPlayer             map[core.PlayerID]DeathSaveRolledSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *DeathSaveRolledEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(deathSaveRolledWire{
+		metaWire:              e.toWire(),
+		EncID:                 e.encID,
+		Seq:                   e.seq,
+		EntityID:              e.EntityID,
+		Roll:                  e.Roll,
+		Successes:             e.Successes,
+		Failures:              e.Failures,
+		IsCriticalFail:        e.IsCriticalFail,
+		IsCriticalSuccess:     e.IsCriticalSuccess,
+		Stabilized:            e.Stabilized,
+		Dead:                  e.Dead,
+		RegainedConsciousness: e.RegainedConsciousness,
+		HPRestored:            e.HPRestored,
+		PerPlayer:             e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *DeathSaveRolledEvent) UnmarshalJSON(b []byte) error {
+	var w deathSaveRolledWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.fromWire(w.metaWire)
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.EntityID = w.EntityID
+	e.Roll = w.Roll
+	e.Successes = w.Successes
+	e.Failures = w.Failures
+	e.IsCriticalFail = w.IsCriticalFail
+	e.IsCriticalSuccess = w.IsCriticalSuccess
+	e.Stabilized = w.Stabilized
+	e.Dead = w.Dead
+	e.RegainedConsciousness = w.RegainedConsciousness
+	e.HPRestored = w.HPRestored
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/death_save_test.go
+++ b/encounter/events/death_save_test.go
@@ -1,0 +1,162 @@
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testDSPlayerAlice = "p-alice"
+	testDSPlayerCarol = "p-carol"
+)
+
+// DeathSaveEventsSuite covers the two rpg-toolkit#741 event types:
+// EntityStabilizedEvent and DeathSaveRolledEvent.
+type DeathSaveEventsSuite struct {
+	suite.Suite
+}
+
+func TestDeathSaveEventsSuite(t *testing.T) {
+	suite.Run(t, new(DeathSaveEventsSuite))
+}
+
+// EntityStabilizedEvent satisfies EncounterEvent.
+func (s *DeathSaveEventsSuite) TestEntityStabilized_SatisfiesInterface() {
+	var _ events.EncounterEvent = (*events.EntityStabilizedEvent)(nil)
+}
+
+// DeathSaveRolledEvent satisfies EncounterEvent.
+func (s *DeathSaveEventsSuite) TestDeathSaveRolled_SatisfiesInterface() {
+	var _ events.EncounterEvent = (*events.DeathSaveRolledEvent)(nil)
+}
+
+// JSON round-trip preserves all fields including unexported encID/seq.
+func (s *DeathSaveEventsSuite) TestEntityStabilized_JSONRoundTrip() {
+	original := events.NewEntityStabilizedEvent(
+		"enc-1", 42, "char-bob",
+		map[core.PlayerID]events.EntityStabilizedSlice{
+			testDSPlayerAlice: {Visible: true},
+		},
+	)
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.EntityStabilizedEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(42), decoded.Sequence())
+	s.Equal(core.EntityID("char-bob"), decoded.EntityID)
+	s.True(decoded.PerPlayer[testDSPlayerAlice].Visible)
+}
+
+// Audience derives from PerPlayer keys.
+func (s *DeathSaveEventsSuite) TestEntityStabilized_Audience_DerivedFromPerPlayer() {
+	evt := events.NewEntityStabilizedEvent(
+		"enc-1", 1, "char-bob",
+		map[core.PlayerID]events.EntityStabilizedSlice{
+			testDSPlayerAlice: {Visible: true},
+			testDSPlayerCarol: {Visible: false},
+		},
+	)
+	s.ElementsMatch(
+		events.AudienceSet{testDSPlayerAlice, testDSPlayerCarol},
+		evt.Audience(),
+	)
+}
+
+// JSON round-trip preserves all fields including unexported encID/seq and
+// the full roll-detail field set (roll, running counters, crit flags,
+// nat-20-revival fields).
+func (s *DeathSaveEventsSuite) TestDeathSaveRolled_JSONRoundTrip() {
+	original := events.NewDeathSaveRolledEvent(&events.NewDeathSaveRolledEventInput{
+		EncID:                 "enc-1",
+		Seq:                   7,
+		EntityID:              "char-bob",
+		Roll:                  17,
+		Successes:             2,
+		Failures:              1,
+		IsCriticalFail:        false,
+		IsCriticalSuccess:     false,
+		Stabilized:            false,
+		Dead:                  false,
+		RegainedConsciousness: false,
+		HPRestored:            0,
+		PerPlayer: map[core.PlayerID]events.DeathSaveRolledSlice{
+			testDSPlayerAlice: {Visible: true},
+		},
+	})
+
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.DeathSaveRolledEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(7), decoded.Sequence())
+	s.Equal(core.EntityID("char-bob"), decoded.EntityID)
+	s.Equal(17, decoded.Roll)
+	s.Equal(2, decoded.Successes)
+	s.Equal(1, decoded.Failures)
+	s.False(decoded.IsCriticalFail)
+	s.False(decoded.IsCriticalSuccess)
+	s.False(decoded.Stabilized)
+	s.False(decoded.Dead)
+	s.False(decoded.RegainedConsciousness)
+	s.Equal(0, decoded.HPRestored)
+	s.True(decoded.PerPlayer[testDSPlayerAlice].Visible)
+}
+
+// Roll==0 (the damage-while-unconscious auto-fail convention) and the
+// nat-20-revival field set round-trip correctly too — a separate case since
+// zero values are the easiest place for a hand-rolled wire struct to
+// silently drop a field.
+func (s *DeathSaveEventsSuite) TestDeathSaveRolled_JSONRoundTrip_DamageDrivenAndRevival() {
+	damageDriven := events.NewDeathSaveRolledEvent(&events.NewDeathSaveRolledEventInput{
+		EncID: "enc-1", Seq: 1, EntityID: "char-bob",
+		Roll: 0, Successes: 0, Failures: 3, Dead: true,
+		PerPlayer: map[core.PlayerID]events.DeathSaveRolledSlice{testDSPlayerAlice: {Visible: true}},
+	})
+	payload, err := json.Marshal(damageDriven)
+	s.Require().NoError(err)
+	var decodedDamage events.DeathSaveRolledEvent
+	s.Require().NoError(json.Unmarshal(payload, &decodedDamage))
+	s.Equal(0, decodedDamage.Roll)
+	s.Equal(3, decodedDamage.Failures)
+	s.True(decodedDamage.Dead)
+
+	revival := events.NewDeathSaveRolledEvent(&events.NewDeathSaveRolledEventInput{
+		EncID: "enc-1", Seq: 2, EntityID: "char-bob",
+		Roll: 20, IsCriticalSuccess: true, RegainedConsciousness: true, HPRestored: 1,
+		PerPlayer: map[core.PlayerID]events.DeathSaveRolledSlice{testDSPlayerAlice: {Visible: true}},
+	})
+	payload, err = json.Marshal(revival)
+	s.Require().NoError(err)
+	var decodedRevival events.DeathSaveRolledEvent
+	s.Require().NoError(json.Unmarshal(payload, &decodedRevival))
+	s.Equal(20, decodedRevival.Roll)
+	s.True(decodedRevival.IsCriticalSuccess)
+	s.True(decodedRevival.RegainedConsciousness)
+	s.Equal(1, decodedRevival.HPRestored)
+}
+
+// Audience derives from PerPlayer keys.
+func (s *DeathSaveEventsSuite) TestDeathSaveRolled_Audience_DerivedFromPerPlayer() {
+	evt := events.NewDeathSaveRolledEvent(&events.NewDeathSaveRolledEventInput{
+		EncID: "enc-1", Seq: 1, EntityID: "char-bob", Roll: 12, Successes: 1,
+		PerPlayer: map[core.PlayerID]events.DeathSaveRolledSlice{
+			testDSPlayerAlice: {Visible: true},
+			testDSPlayerCarol: {Visible: false},
+		},
+	})
+	s.ElementsMatch(
+		events.AudienceSet{testDSPlayerAlice, testDSPlayerCarol},
+		evt.Audience(),
+	)
+}

--- a/encounter/events/entity_stabilized.go
+++ b/encounter/events/entity_stabilized.go
@@ -1,0 +1,89 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// EntityStabilizedEvent is the cause / narrative event published when an
+// unconscious entity accumulates 3 successful death saves (rpg-toolkit#741).
+// Mirrors EntityDiedEvent's shape — same per-viewer projection template, no
+// killer/causer concept since stabilization has no attacker. Maps to the
+// proto EntityStabilized wire shape.
+type EntityStabilizedEvent struct {
+	eventMeta
+	encID     core.EncounterID
+	seq       uint64
+	EntityID  core.EntityID
+	PerPlayer map[core.PlayerID]EntityStabilizedSlice
+}
+
+// EntityStabilizedSlice is each viewer's projection. Visible says whether
+// the player perceived the stabilization.
+type EntityStabilizedSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewEntityStabilizedEvent constructs an EntityStabilizedEvent.
+func NewEntityStabilizedEvent(
+	encID core.EncounterID,
+	seq uint64,
+	entityID core.EntityID,
+	perPlayer map[core.PlayerID]EntityStabilizedSlice,
+) *EntityStabilizedEvent {
+	return &EntityStabilizedEvent{
+		encID:     encID,
+		seq:       seq,
+		EntityID:  entityID,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*EntityStabilizedEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *EntityStabilizedEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *EntityStabilizedEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who can perceive the stabilization,
+// derived from PerPlayer keys.
+func (e *EntityStabilizedEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type entityStabilizedWire struct {
+	metaWire
+	EncID     core.EncounterID                        `json:"encounter_id"`
+	Seq       uint64                                  `json:"sequence"`
+	EntityID  core.EntityID                           `json:"entity_id"`
+	PerPlayer map[core.PlayerID]EntityStabilizedSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *EntityStabilizedEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(entityStabilizedWire{
+		metaWire:  e.toWire(),
+		EncID:     e.encID,
+		Seq:       e.seq,
+		EntityID:  e.EntityID,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *EntityStabilizedEvent) UnmarshalJSON(b []byte) error {
+	var w entityStabilizedWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.fromWire(w.metaWire)
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.EntityID = w.EntityID
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/events/turn_ended.go
+++ b/encounter/events/turn_ended.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
 package events
 
 import (

--- a/encounter/unconscious_zero_hp_test.go
+++ b/encounter/unconscious_zero_hp_test.go
@@ -32,8 +32,10 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	dnd5eConditions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -53,6 +55,27 @@ func (alwaysFailDeathSaveRoller) Roll(_ context.Context, size int) (int, error) 
 }
 
 func (alwaysFailDeathSaveRoller) RollN(_ context.Context, count, size int) ([]int, error) {
+	out := make([]int, count)
+	for i := range out {
+		out[i] = size
+	}
+	return out, nil
+}
+
+// alwaysSuccessDeathSaveRoller always rolls a 15 on a d20 (a plain death-save
+// success — not a natural 20, which would instead regain consciousness) so a
+// downed character's death saves succeed deterministically, three turn-starts
+// in a row, stabilizing rather than reviving or dying.
+type alwaysSuccessDeathSaveRoller struct{}
+
+func (alwaysSuccessDeathSaveRoller) Roll(_ context.Context, size int) (int, error) {
+	if size == 20 {
+		return 15, nil
+	}
+	return size, nil
+}
+
+func (alwaysSuccessDeathSaveRoller) RollN(_ context.Context, count, size int) ([]int, error) {
 	out := make([]int, count)
 	for i := range out {
 		out[i] = size
@@ -269,4 +292,305 @@ func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_BridgesToEntityDied()
 	persisted := enc.ToData()
 	s.Contains(persisted.Players, core.PlayerID(alicePlayerID))
 	s.NotEmpty(persisted.Initiative)
+}
+
+// reloadEncounter round-trips enc through ToData/LoadFromData with the given
+// opts, mirroring the real per-RPC production lifecycle: hydration.go's
+// package doc states the hydration cascade is "the only place conditions
+// Apply() to e.bus" and runs from a FRESH bus on every LoadFromData call —
+// which is what rpg-api actually does once per verb RPC (load, call the
+// verb, persist, discard). encounter.Option values (roller, resolver) are
+// NOT persisted, so callers must re-supply the same opts on every reload,
+// exactly as rpg-api's orchestrator does with its fixed construction.
+func (s *UnconsciousZeroHPSuite) reloadEncounter(
+	enc *encounter.Encounter, opts ...encounter.Option,
+) *encounter.Encounter {
+	s.T().Helper()
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker, opts...)
+	s.Require().NoError(err)
+	return loaded
+}
+
+// TestThreeFailedDeathSaves_AcrossPerRPCReloads_BridgesToEntityDied is the
+// rpg-toolkit#741 root-cause repro. TestThreeFailedDeathSaves_BridgesToEntityDied
+// above proves the CharacterDied bridge fires when the entire 3-failure
+// sequence runs against ONE long-lived in-memory *Encounter — but production
+// never holds an Encounter across RPCs; every verb call is its own
+// LoadFromData round-trip (see hydration.go's package doc and
+// hydration_test.go's reloadVia, which mirrors the same "per-RPC" lifecycle
+// for its own regression).
+//
+// Failures are driven via repeated damage while unconscious
+// (UnconsciousCondition.onDamageReceived — 1 automatic death-save failure
+// per hit, no dice roll involved: rpg-toolkit/rulebooks/dnd5e/saves.
+// TakeDamageWhileUnconscious), published directly on the encounter-held bus
+// rather than routed through NPCAct/monster AI. Two independent reasons a
+// turn-start-roll-driven, NPCAct-driven repro cannot give a deterministic
+// signal here: (1) buildPerception (encounter/npc.go) deliberately excludes
+// HP<=0 players from a monster's target list (rpg-toolkit#733's
+// closestPlayer fix — "don't keep attacking a downed player"), so NPCAct
+// against an already-downed alice is a silent no-op, not a failure source;
+// (2) onTurnStart's Roller is NOT restored by conditions.LoadJSON (documented
+// in unconscious.go's onTurnStart comment — reload survives CharacterID +
+// counters but not Roller, falling back to a fresh, un-injectable
+// dice.NewRoller() every time), so even a turn-start roll can't be forced
+// deterministic across reloads. Publishing DamageReceivedEvent directly
+// exercises the identical onDamageReceived -> CharacterDiedTopic code path
+// death saves ultimately use, without depending on either gap.
+func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_AcrossPerRPCReloads_BridgesToEntityDied() {
+	roller := encounter.WithRoller(fixedMaxRoller{})
+	resolver := encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing})
+	opts := []encounter.Option{roller, resolver}
+
+	enc := s.buildEncounter("enc-uzh-3", 1, roller)
+
+	aliceSub, err := s.broker.Subscribe("enc-uzh-3", alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = aliceSub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	enc = s.reloadEncounter(enc, opts...)
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(endErr)
+		enc = s.reloadEncounter(enc, opts...)
+	}
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	// Knockdown: 1 HP -> 0 applies UnconsciousCondition, 0 failures yet.
+	// Reload before the next verb call, matching one RPC per verb.
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+	enc = s.reloadEncounter(enc, opts...)
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	// 3 more automatic death-save failures via direct DamageReceivedEvent
+	// publishes on the freshly-reloaded bus, reloading again after each one.
+	// The 3rd pushes Failures to 3 -> Dead -> rulebook CharacterDiedTopic ->
+	// subscribeCharacterDiedBridge -> broker EntityDiedEvent. Reloading fresh
+	// before/after each publish exercises the exact per-RPC
+	// bridge-resubscription path #741 reports as broken.
+	for i := 0; i < 3; i++ {
+		bus := enc.EventBus()
+		s.Require().NotNil(bus)
+
+		var diedRulebook bool
+		_, subErr := dnd5eEvents.CharacterDiedTopic.On(bus).Subscribe(s.ctx,
+			func(_ context.Context, e dnd5eEvents.CharacterDiedEvent) error {
+				if e.CharacterID == string(aliceEntityID) {
+					diedRulebook = true
+				}
+				return nil
+			})
+		s.Require().NoError(subErr)
+
+		pubErr := dnd5eEvents.DamageReceivedTopic.On(bus).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+			TargetID: string(aliceEntityID), SourceID: string(gobEntityID),
+			Amount: 5, DamageType: damageSlashing,
+		})
+		s.Require().NoError(pubErr)
+
+		var successes, failures int
+		var dead, stabilized bool
+		for _, pd := range enc.ToData().Players {
+			if pd.EntityID != aliceEntityID {
+				continue
+			}
+			var charData dnd5eCharacter.Data
+			s.Require().NoError(json.Unmarshal(pd.DataJSON, &charData))
+			for _, raw := range charData.Conditions {
+				var uc dnd5eConditions.UnconsciousData
+				if jerr := json.Unmarshal(raw, &uc); jerr == nil && uc.Ref != nil && uc.Ref.ID == refs.Conditions.Unconscious().ID {
+					successes, failures, dead, stabilized = uc.Successes, uc.Failures, uc.Dead, uc.Stabilized
+				}
+			}
+		}
+		s.T().Logf(
+			"hit=%d diedRulebook=%v successes=%d failures=%d dead=%v stabilized=%v",
+			i, diedRulebook, successes, failures, dead, stabilized,
+		)
+
+		enc = s.reloadEncounter(enc, opts...)
+	}
+
+	seen := collectEventsTyped(aliceSub, 500*time.Millisecond)
+	var died *events.EntityDiedEvent
+	for _, e := range seen {
+		if d, ok := e.(*events.EntityDiedEvent); ok {
+			died = d
+		}
+	}
+	s.Require().NotNil(died,
+		"3 failed death saves across per-RPC reloads must bridge to a broker EntityDiedEvent")
+	s.Equal(core.EntityID(aliceEntityID), died.EntityID)
+	s.Empty(died.KillerID, "final death-save death has no specific killer")
+
+	persisted := enc.ToData()
+	for _, pd := range persisted.Players {
+		if pd.EntityID != aliceEntityID {
+			continue
+		}
+		var charData dnd5eCharacter.Data
+		s.Require().NoError(json.Unmarshal(pd.DataJSON, &charData))
+		var found bool
+		for _, raw := range charData.Conditions {
+			var uc dnd5eConditions.UnconsciousData
+			if jerr := json.Unmarshal(raw, &uc); jerr == nil && uc.Ref != nil && uc.Ref.ID == refs.Conditions.Unconscious().ID {
+				found = true
+				s.GreaterOrEqual(uc.Failures, 3)
+				s.True(uc.Dead)
+			}
+		}
+		s.True(found, "persisted state must carry the dead unconscious condition")
+	}
+}
+
+// TestDeathSaveRolledBridge_EveryRollBridgesToEvent is rpg-toolkit#741 part 3
+// regression coverage: before this fix, dnd5eEvents.DeathSaveRolledTopic had
+// zero production subscribers anywhere in encounter/*.go — every death save
+// roll (not just the terminal Dead/Stabilized outcome) was wire-invisible.
+// One turn-start roll is enough to prove the bridge: alice is knocked to 0 HP,
+// then her own next turn start rolls a single plain failure (roll=2, not a
+// crit) via alwaysFailDeathSaveRoller, and the broker DeathSaveRolledEvent
+// must carry the roll detail.
+func (s *UnconsciousZeroHPSuite) TestDeathSaveRolledBridge_EveryRollBridgesToEvent() {
+	enc := s.buildEncounter("enc-dsr-1", 1, encounter.WithRoller(alwaysFailDeathSaveRoller{}))
+
+	aliceSub, err := s.broker.Subscribe("enc-dsr-1", alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = aliceSub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	// Goblin's attack drops alice to 0 HP — Unconscious applied, not dead.
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	// Cycle to alice's own next turn start — her one auto-rolled death save.
+	active := enc.ActiveActor()
+	for active != aliceEntityID {
+		next, _, endErr := enc.EndTurn(s.ctx, active)
+		s.Require().NoError(endErr)
+		active = next
+	}
+
+	seen := collectEventsTyped(aliceSub, 500*time.Millisecond)
+	var rolled *events.DeathSaveRolledEvent
+	for _, e := range seen {
+		if d, ok := e.(*events.DeathSaveRolledEvent); ok {
+			rolled = d
+		}
+	}
+	s.Require().NotNil(rolled, "a death save roll must bridge to a broker DeathSaveRolledEvent")
+	s.Equal(core.EntityID(aliceEntityID), rolled.EntityID)
+	s.Equal(2, rolled.Roll)
+	s.Equal(0, rolled.Successes)
+	s.Equal(1, rolled.Failures)
+	s.False(rolled.IsCriticalFail)
+	s.False(rolled.IsCriticalSuccess)
+	s.False(rolled.Stabilized)
+	s.False(rolled.Dead)
+}
+
+// TestCharacterStabilizedBridge_ThreeSuccessfulDeathSaves_BridgesToEntityStabilized
+// is rpg-toolkit#741 part 2 regression coverage: before this fix,
+// dnd5eEvents.CharacterStabilizedTopic had zero production subscribers
+// anywhere in encounter/*.go — a character who stabilized (3 successful
+// death saves) never told any client. Mirrors
+// TestThreeFailedDeathSaves_BridgesToEntityDied's shape exactly but with
+// alwaysSuccessDeathSaveRoller instead of alwaysFailDeathSaveRoller, so all
+// three of alice's own turn-start rolls succeed instead of fail. Also
+// asserts a DeathSaveRolledEvent appeared for each of the three rolls (part
+// 3 coverage, complementing the single-roll proof above with the
+// multi-roll/no-double-count shape).
+func (s *UnconsciousZeroHPSuite) TestCharacterStabilizedBridge_ThreeSuccessfulDeathSaves_BridgesToEntityStabilized() {
+	enc := s.buildEncounter("enc-csb-1", 1, encounter.WithRoller(alwaysSuccessDeathSaveRoller{}))
+
+	aliceSub, err := s.broker.Subscribe("enc-csb-1", alicePlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = aliceSub.Close() }()
+
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != gobEntityID {
+		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	// Goblin's attack drops alice to 0 HP — Unconscious applied, not dead.
+	s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
+	drainSub(aliceSub, 100*time.Millisecond)
+
+	bus := enc.EventBus()
+	s.Require().NotNil(bus)
+	var stabilizedRulebook bool
+	_, err = dnd5eEvents.CharacterStabilizedTopic.On(bus).Subscribe(s.ctx,
+		func(_ context.Context, e dnd5eEvents.CharacterStabilizedEvent) error {
+			if e.CharacterID == string(aliceEntityID) {
+				stabilizedRulebook = true
+			}
+			return nil
+		})
+	s.Require().NoError(err)
+
+	// Cycle turns (goblin <-> alice) until alice's own turn-start has fired
+	// exactly 3 times — 3 consecutive plain death-save successes
+	// (alwaysSuccessDeathSaveRoller never rolls a failure/crit).
+	aliceTurnStarts := 0
+	active := enc.ActiveActor()
+	for i := 0; i < 20 && aliceTurnStarts < 3; i++ {
+		next, _, endErr := enc.EndTurn(s.ctx, active)
+		s.Require().NoError(endErr)
+		active = next
+		if active == aliceEntityID {
+			aliceTurnStarts++
+		}
+	}
+	s.Require().Equal(3, aliceTurnStarts, "must reach alice's own turn 3 times to accumulate 3 successes")
+	s.Require().True(stabilizedRulebook, "3 successful death saves must publish the rulebook CharacterStabilizedEvent")
+
+	seen := collectEventsTyped(aliceSub, 500*time.Millisecond)
+	var stabilized *events.EntityStabilizedEvent
+	rolledCount := 0
+	for _, e := range seen {
+		switch ev := e.(type) {
+		case *events.EntityStabilizedEvent:
+			stabilized = ev
+		case *events.DeathSaveRolledEvent:
+			if ev.EntityID == core.EntityID(aliceEntityID) {
+				rolledCount++
+			}
+		}
+	}
+	s.Require().NotNil(stabilized,
+		"3 successful death saves must bridge to a broker EntityStabilizedEvent")
+	s.Equal(core.EntityID(aliceEntityID), stabilized.EntityID)
+	s.Equal(3, rolledCount, "all 3 rolls must each bridge their own DeathSaveRolledEvent")
+
+	persisted := enc.ToData()
+	for _, pd := range persisted.Players {
+		if pd.EntityID != aliceEntityID {
+			continue
+		}
+		var charData dnd5eCharacter.Data
+		s.Require().NoError(json.Unmarshal(pd.DataJSON, &charData))
+		var found bool
+		for _, raw := range charData.Conditions {
+			var uc dnd5eConditions.UnconsciousData
+			if jerr := json.Unmarshal(raw, &uc); jerr == nil && uc.Ref != nil && uc.Ref.ID == refs.Conditions.Unconscious().ID {
+				found = true
+				s.GreaterOrEqual(uc.Successes, 3)
+				s.True(uc.Stabilized)
+			}
+		}
+		s.True(found, "persisted state must carry the stabilized unconscious condition")
+	}
 }

--- a/encounter/unconscious_zero_hp_test.go
+++ b/encounter/unconscious_zero_hp_test.go
@@ -65,7 +65,10 @@ func (alwaysFailDeathSaveRoller) RollN(_ context.Context, count, size int) ([]in
 // alwaysSuccessDeathSaveRoller always rolls a 15 on a d20 (a plain death-save
 // success — not a natural 20, which would instead regain consciousness) so a
 // downed character's death saves succeed deterministically, three turn-starts
-// in a row, stabilizing rather than reviving or dying.
+// in a row, stabilizing rather than reviving or dying. Non-d20 rolls (RollN,
+// or Roll for any other size) pass through at max face — irrelevant here
+// since nothing else in these fixtures rolls dice via RollN (same
+// convention as alwaysFailDeathSaveRoller above).
 type alwaysSuccessDeathSaveRoller struct{}
 
 func (alwaysSuccessDeathSaveRoller) Roll(_ context.Context, size int) (int, error) {
@@ -137,12 +140,15 @@ func (s *UnconsciousZeroHPSuite) charDataJSON(id, playerID string) json.RawMessa
 	return raw
 }
 
-// buildEncounter constructs a 1-hydrated-player (alice, HP=aliceHP) +
-// 1-scripted-monster (goblin, no DataJSON) encounter wired with roller, then
-// round-trips through ToData/LoadFromData so the cascade hydrates alice's
-// character (mirrors turn_start_revival_test.go's loadEncounter).
+// buildEncounter constructs a 1-hydrated-player (alice, HP=1 — always
+// guaranteed lethal via alwaysHitResolver's 999 damage) + 1-scripted-monster
+// (goblin, no DataJSON) encounter wired with roller, then round-trips
+// through ToData/LoadFromData so the cascade hydrates alice's character
+// (mirrors turn_start_revival_test.go's loadEncounter). alice's starting HP
+// is not a caller-varying concern across this file's tests — every one of
+// them needs the same guaranteed-knockdown setup.
 func (s *UnconsciousZeroHPSuite) buildEncounter(
-	encID core.EncounterID, aliceHP int, roller encounter.Option,
+	encID core.EncounterID, roller encounter.Option,
 ) *encounter.Encounter {
 	s.T().Helper()
 	enc := encounter.New(s.ctx, encID, s.broker, roller,
@@ -151,7 +157,7 @@ func (s *UnconsciousZeroHPSuite) buildEncounter(
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
-		HP: aliceHP, MaxHP: 12, AC: 10, AttackBonus: 4,
+		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
 		DamageDice: damage1d8plus2, DamageType: damageSlashing,
 		DataJSON: s.charDataJSON(string(aliceEntityID), string(alicePlayerID)),
 	}))
@@ -180,7 +186,7 @@ func (s *UnconsciousZeroHPSuite) buildEncounter(
 // same partial-death shape Wave 2.10 established, just gated behind death
 // saves now instead of firing instantly.
 func (s *UnconsciousZeroHPSuite) TestPlayerHitsZeroHP_AppliesUnconscious_NotImmediateEntityDied() {
-	enc := s.buildEncounter("enc-uzh-1", 1, encounter.WithRoller(fixedMaxRoller{}))
+	enc := s.buildEncounter("enc-uzh-1", encounter.WithRoller(fixedMaxRoller{}))
 
 	sub, err := s.broker.Subscribe("enc-uzh-1", alicePlayerID)
 	s.Require().NoError(err)
@@ -231,7 +237,7 @@ func (s *UnconsciousZeroHPSuite) TestPlayerHitsZeroHP_AppliesUnconscious_NotImme
 // New/LoadFromData (subscribeCharacterDiedBridge). KillerID is empty: there
 // is no specific final blow at 3-failed-saves death.
 func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_BridgesToEntityDied() {
-	enc := s.buildEncounter("enc-uzh-2", 1, encounter.WithRoller(alwaysFailDeathSaveRoller{}))
+	enc := s.buildEncounter("enc-uzh-2", encounter.WithRoller(alwaysFailDeathSaveRoller{}))
 
 	aliceSub, err := s.broker.Subscribe("enc-uzh-2", alicePlayerID)
 	s.Require().NoError(err)
@@ -346,7 +352,7 @@ func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_AcrossPerRPCReloads_B
 	resolver := encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing})
 	opts := []encounter.Option{roller, resolver}
 
-	enc := s.buildEncounter("enc-uzh-3", 1, roller)
+	enc := s.buildEncounter("enc-uzh-3", roller)
 
 	aliceSub, err := s.broker.Subscribe("enc-uzh-3", alicePlayerID)
 	s.Require().NoError(err)
@@ -457,7 +463,7 @@ func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_AcrossPerRPCReloads_B
 // crit) via alwaysFailDeathSaveRoller, and the broker DeathSaveRolledEvent
 // must carry the roll detail.
 func (s *UnconsciousZeroHPSuite) TestDeathSaveRolledBridge_EveryRollBridgesToEvent() {
-	enc := s.buildEncounter("enc-dsr-1", 1, encounter.WithRoller(alwaysFailDeathSaveRoller{}))
+	enc := s.buildEncounter("enc-dsr-1", encounter.WithRoller(alwaysFailDeathSaveRoller{}))
 
 	aliceSub, err := s.broker.Subscribe("enc-dsr-1", alicePlayerID)
 	s.Require().NoError(err)
@@ -512,7 +518,7 @@ func (s *UnconsciousZeroHPSuite) TestDeathSaveRolledBridge_EveryRollBridgesToEve
 // 3 coverage, complementing the single-roll proof above with the
 // multi-roll/no-double-count shape).
 func (s *UnconsciousZeroHPSuite) TestCharacterStabilizedBridge_ThreeSuccessfulDeathSaves_BridgesToEntityStabilized() {
-	enc := s.buildEncounter("enc-csb-1", 1, encounter.WithRoller(alwaysSuccessDeathSaveRoller{}))
+	enc := s.buildEncounter("enc-csb-1", encounter.WithRoller(alwaysSuccessDeathSaveRoller{}))
 
 	aliceSub, err := s.broker.Subscribe("enc-csb-1", alicePlayerID)
 	s.Require().NoError(err)


### PR DESCRIPTION
## Summary

Closes #741. Wave: KirkDiggler/rpg-project#75.

The death-save resolution arc (rolls → stabilization/death) was wire-invisible: `CharacterStabilizedTopic` and `DeathSaveRolledTopic` had zero production subscribers anywhere in `encounter/*.go`, and the merged `#739` `CharacterDied` bridge was reported as never delivering despite `dead:true` being reached in persisted state during the 2026-07-05 re-playtest.

### What changed

1. **Two new bridges** (`encounter/death.go`), following `#738`'s `ConditionRemoved` bridge pattern exactly:
   - `subscribeCharacterStabilizedBridge` → `dnd5eEvents.CharacterStabilizedTopic` → new broker `events.EntityStabilizedEvent`
   - `subscribeDeathSaveRolledBridge` → `dnd5eEvents.DeathSaveRolledTopic` → new broker `events.DeathSaveRolledEvent` (fires on *every* roll, including damage-while-unconscious auto-fails)
   - Both installed as permanent subscriptions in `New()` and `LoadFromData()`, same lifetime shape as the existing `CharacterDied` bridge.
   - New event types live in `encounter/events/entity_stabilized.go` and `encounter/events/death_save_rolled.go`, registered in `broker.go`'s encode/decode switch.

2. **Hardened `publishPlayerDied`** (the existing `#739` bridge): the dying player is now unconditionally included in the event's own audience, instead of relying on a LoS self-check (`perception.CanSeeAt` against their own position). A player learning of their own death should never depend on a perception computation staying in sync with their live position.

3. **Root-caused the reported "Died bridge never delivered" bug empirically.** I could not reproduce a toolkit-side defect despite extensive testing:
   - Built `TestThreeFailedDeathSaves_AcrossPerRPCReloads_BridgesToEntityDied`, which reloads the encounter fresh (new bus, new bridge subscription) before/after **every single verb call** — matching production's per-RPC lifecycle exactly (see `hydration.go`'s own doc: "a fresh Encounter is loaded per RPC"). It passes.
   - Also verified turn-start-driven death (not just damage-driven) survives a reload via a throwaway diagnostic (not committed — used only to isolate the mechanism).
   - My working theory: the reported break is downstream of the toolkit (rpg-api translator or client render), consistent with the wave retro's own note that "cross-repo event plumbing... each layer individually looked done." I'm flagging this explicitly rather than claiming a fix I can't demonstrate — the `publishPlayerDied` hardening above is a real, defensible improvement I found along the way, not a confirmed root cause.

### Tests

- `encounter/events/death_save_test.go` — JSON round-trip + `Audience()` derivation for both new event types (including `Roll==0` damage-driven and nat-20-revival field combinations).
- `encounter/unconscious_zero_hp_test.go`:
  - `TestDeathSaveRolledBridge_EveryRollBridgesToEvent` — red→green: the topic had zero subscribers before this PR.
  - `TestCharacterStabilizedBridge_ThreeSuccessfulDeathSaves_BridgesToEntityStabilized` — same, plus asserts all 3 rolls each bridge their own `DeathSaveRolledEvent` (no double-counting).
  - `TestThreeFailedDeathSaves_AcrossPerRPCReloads_BridgesToEntityDied` — the per-RPC-reload regression test described above.

Full suite + `-race` passing. `gofmt`/`go vet`/`golangci-lint` clean (no net-new lint debt — the only lint findings are pre-existing `goconst`/`unparam` noise in files I didn't touch, or in this exact test file matching its own established `"enc-1"`/`"char-bob"` literal convention).

No `rulebooks/dnd5e` changes were needed — `DeathSaveRolledTopic`/`CharacterStabilizedTopic`/their event types already existed there and are already covered by `encounter`'s current dependency version, so no cross-module version bump.

### Load-bearing

The death-save arc is now a first-class broker event stream: `DeathSaveRolled` / `EntityStabilized` / `EntityDied`-via-saves, all reachable from a real per-RPC-reloaded encounter, not just a long-lived in-process one.

### For rpg-api#622 (translator, part 2)

New broker event names to add translate cases for: **`EntityStabilizedEvent`** and **`DeathSaveRolledEvent`** (alongside the existing `EntityDiedEvent`). Field shapes are in `encounter/events/entity_stabilized.go` and `encounter/events/death_save_rolled.go`. `rpg-api#623`'s `ConditionRemoved` translate case (just merged) is a good pattern to follow for both.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test -race ./...` — all green
- [x] `golangci-lint run ./...` — no net-new issues
- [x] `go mod tidy` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)