### PR TITLE
fix(conditions): gate Rage damage bonus to STR melee, add STR check/save advantage

### DIFF
--- a/rulebooks/dnd5e/combat/attack_phases.go
+++ b/rulebooks/dnd5e/combat/attack_phases.go
@@ -85,6 +85,7 @@ type AttackContext struct {
 	AbilityMod      int
 	AbilityUsed     abilities.Ability
 	IsOffHandAttack bool
+	IsMelee         bool // True for melee attacks, false for ranged (from the attack chain's weapon check)
 }
 
 // ReactionModifier represents an AC or roll modification chosen by a player
@@ -396,6 +397,7 @@ func ResolveAttackHit(ctx context.Context, input *ResolveAttackHitInput) (*Attac
 		AbilityMod:          abilityMod,
 		AbilityUsed:         determineAbilityUsed(input.Weapon, attackerScores),
 		IsOffHandAttack:     isOffHandAttack,
+		IsMelee:             finalAttackEvent.IsMelee,
 	}, nil
 }
 
@@ -514,6 +516,7 @@ func ApplyAttackOutcome(ctx context.Context, input *ApplyAttackOutcomeInput) (*A
 		WeaponDamage:    ac.Weapon.Damage,
 		AbilityUsed:     ac.AbilityUsed,
 		WeaponRef:       weaponToRef(ac.Weapon),
+		IsMelee:         ac.IsMelee,
 	})
 	if err != nil {
 		return nil, err

--- a/rulebooks/dnd5e/combat/damage.go
+++ b/rulebooks/dnd5e/combat/damage.go
@@ -70,6 +70,17 @@ type DealDamageInput struct {
 	// HasAdvantage indicates if the attack had advantage (for sneak attack eligibility, etc.)
 	HasAdvantage bool
 
+	// AbilityUsed is which ability was used for the attack, if any (e.g. STR for a
+	// melee weapon attack). Used by modifiers like Rage that only apply to
+	// attacks using a specific ability. Leave empty for non-attack damage
+	// (spells, conditions, environment).
+	AbilityUsed abilities.Ability
+
+	// IsMelee indicates this damage came from a melee attack, as opposed to a
+	// ranged one. Used alongside AbilityUsed by modifiers like Rage that only
+	// apply to melee weapon attacks. Leave false for non-attack damage.
+	IsMelee bool
+
 	// EventBus is the event bus for publishing chain and notification events
 	EventBus events.EventBus
 }
@@ -154,6 +165,8 @@ func DealDamage(ctx context.Context, input *DealDamageInput) (*DealDamageOutput,
 		Components:   components,
 		IsCritical:   input.IsCritical,
 		HasAdvantage: input.HasAdvantage,
+		AbilityUsed:  input.AbilityUsed,
+		IsMelee:      input.IsMelee,
 		EventBus:     input.EventBus,
 	})
 	if err != nil {
@@ -236,6 +249,10 @@ type ResolveDamageInput struct {
 	// AbilityModifier is the ability modifier for this attack (STR or DEX mod).
 	// Used by Two-Weapon Fighting style to add modifier to off-hand damage.
 	AbilityModifier int
+
+	// IsMelee indicates this is a melee attack (mirrors AttackChainEvent.IsMelee).
+	// Used by modifiers like Rage that only apply to melee weapon attacks.
+	IsMelee bool
 }
 
 // ResolveDamageOutput contains the result of damage resolution (before HP application).
@@ -283,6 +300,7 @@ func ResolveDamage(ctx context.Context, input *ResolveDamageInput) (*ResolveDama
 		WeaponDamage: input.WeaponDamage,
 		AbilityUsed:  input.AbilityUsed,
 		WeaponRef:    input.WeaponRef,
+		IsMelee:      input.IsMelee,
 	}
 
 	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](ModifierStages)

--- a/rulebooks/dnd5e/combat/integration_test.go
+++ b/rulebooks/dnd5e/combat/integration_test.go
@@ -763,7 +763,11 @@ func (s *CombatIntegrationSuite) TestDealDamageWithRageBonus() {
 			Instances: []combat.DamageInstanceInput{
 				{Amount: baseDamage, Type: "slashing"},
 			},
-			EventBus: s.bus,
+			// Grog's swing is a STR-based melee attack, so the rage damage
+			// bonus applies (RAW gates rage damage to STR melee weapon attacks).
+			AbilityUsed: abilities.STR,
+			IsMelee:     true,
+			EventBus:    s.bus,
 		})
 
 		s.Require().NoError(err)

--- a/rulebooks/dnd5e/conditions/loader_test.go
+++ b/rulebooks/dnd5e/conditions/loader_test.go
@@ -57,6 +57,7 @@ func (s *LoaderTestSuite) executeDamageChain(
 		DamageType:   damage.Slashing,
 		WeaponDamage: "1d8",
 		AbilityUsed:  abilities.STR,
+		IsMelee:      true, // Simulates a STR-based melee attack (rage bonus applies)
 	}
 
 	ch := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -13,9 +13,11 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
 )
 
 // RagingData is the JSON structure for persisting raging condition state
@@ -106,6 +108,26 @@ func (r *RagingCondition) Apply(ctx context.Context, bus events.EventBus) error 
 		return err
 	}
 	r.subscriptionIDs = append(r.subscriptionIDs, subID5)
+
+	// Subscribe to saving throw chain to grant advantage on STR saves
+	saveChain := dnd5eEvents.SavingThrowChain.On(bus)
+	subID6, err := saveChain.SubscribeWithChain(ctx, r.onSavingThrowChain)
+	if err != nil {
+		// Rollback: unsubscribe from previous subscriptions
+		_ = r.Remove(ctx, bus)
+		return err
+	}
+	r.subscriptionIDs = append(r.subscriptionIDs, subID6)
+
+	// Subscribe to ability check chain to grant advantage on STR checks
+	checkChain := dnd5eEvents.AbilityCheckChain.On(bus)
+	subID7, err := checkChain.SubscribeWithChain(ctx, r.onAbilityCheckChain)
+	if err != nil {
+		// Rollback: unsubscribe from previous subscriptions
+		_ = r.Remove(ctx, bus)
+		return err
+	}
+	r.subscriptionIDs = append(r.subscriptionIDs, subID7)
 
 	return nil
 }
@@ -251,27 +273,33 @@ func (r *RagingCondition) onDamageChain(
 	// Handle attacker side: add rage damage bonus
 	if event.AttackerID == r.CharacterID {
 		// Track that we successfully hit an enemy this turn
-		// (damage chain only fires when an attack hits)
+		// (damage chain only fires when an attack hits). Any successful attack
+		// counts as combat activity for keeping rage active, regardless of
+		// whether it qualifies for the rage damage bonus below.
 		r.DidAttackThisTurn = true
 
-		// Add rage damage modifier in the StageFeatures stage
-		modifyDamage := func(_ context.Context, e *dnd5eEvents.DamageChainEvent) (*dnd5eEvents.DamageChainEvent, error) {
-			// Append rage damage component
-			e.Components = append(e.Components, dnd5eEvents.DamageComponent{
-				Source:            dnd5eEvents.DamageSourceCondition,
-				SourceRef:         refs.Conditions.Raging(),
-				OriginalDiceRolls: nil, // No dice
-				FinalDiceRolls:    nil,
-				Rerolls:           nil,
-				FlatBonus:         r.DamageBonus,
-				DamageType:        e.DamageType, // Same as weapon damage type
-				IsCritical:        e.IsCritical,
-			})
-			return e, nil
-		}
-		err := c.Add(combat.StageFeatures, "rage", modifyDamage)
-		if err != nil {
-			return c, rpgerr.Wrapf(err, "error applying rage damage bonus for character id %s", r.CharacterID)
+		// RAW: the rage damage bonus only applies to melee weapon attacks that
+		// use Strength (including unarmed strikes) -- not ranged or DEX-based attacks.
+		if event.AbilityUsed == abilities.STR && event.IsMelee {
+			// Add rage damage modifier in the StageFeatures stage
+			modifyDamage := func(_ context.Context, e *dnd5eEvents.DamageChainEvent) (*dnd5eEvents.DamageChainEvent, error) {
+				// Append rage damage component
+				e.Components = append(e.Components, dnd5eEvents.DamageComponent{
+					Source:            dnd5eEvents.DamageSourceCondition,
+					SourceRef:         refs.Conditions.Raging(),
+					OriginalDiceRolls: nil, // No dice
+					FinalDiceRolls:    nil,
+					Rerolls:           nil,
+					FlatBonus:         r.DamageBonus,
+					DamageType:        e.DamageType, // Same as weapon damage type
+					IsCritical:        e.IsCritical,
+				})
+				return e, nil
+			}
+			err := c.Add(combat.StageFeatures, "rage", modifyDamage)
+			if err != nil {
+				return c, rpgerr.Wrapf(err, "error applying rage damage bonus for character id %s", r.CharacterID)
+			}
 		}
 	}
 
@@ -291,6 +319,74 @@ func (r *RagingCondition) onDamageChain(
 		if err != nil {
 			return c, rpgerr.Wrapf(err, "error applying rage resistance for character id %s", r.CharacterID)
 		}
+	}
+
+	return c, nil
+}
+
+// onSavingThrowChain grants advantage on Strength saving throws while raging (PHB rage benefits).
+func (r *RagingCondition) onSavingThrowChain(
+	_ context.Context,
+	event *dnd5eEvents.SavingThrowChainEvent,
+	c chain.Chain[*dnd5eEvents.SavingThrowChainEvent],
+) (chain.Chain[*dnd5eEvents.SavingThrowChainEvent], error) {
+	// Only apply to this character's saves
+	if event.SaverID != r.CharacterID {
+		return c, nil
+	}
+
+	// Only apply to STR saves
+	if event.Ability != abilities.STR {
+		return c, nil
+	}
+
+	// Add advantage at the conditions stage
+	modifySave := func(_ context.Context, e *dnd5eEvents.SavingThrowChainEvent) (*dnd5eEvents.SavingThrowChainEvent, error) {
+		e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.SaveModifierSource{
+			Name:       "Raging",
+			SourceType: "condition",
+			SourceRef:  refs.Conditions.Raging(),
+			EntityID:   r.CharacterID,
+		})
+		return e, nil
+	}
+
+	if err := c.Add(combat.StageConditions, "raging_str_advantage", modifySave); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add raging STR advantage modifier for character %s", r.CharacterID)
+	}
+
+	return c, nil
+}
+
+// onAbilityCheckChain grants advantage on Strength checks while raging (PHB rage benefits).
+func (r *RagingCondition) onAbilityCheckChain(
+	_ context.Context,
+	event *dnd5eEvents.AbilityCheckChainEvent,
+	c chain.Chain[*dnd5eEvents.AbilityCheckChainEvent],
+) (chain.Chain[*dnd5eEvents.AbilityCheckChainEvent], error) {
+	// Only apply to this character's checks
+	if event.CheckerID != r.CharacterID {
+		return c, nil
+	}
+
+	// Only apply to Strength-based skill checks (e.g., Athletics)
+	if skills.Ability(event.Skill) != abilities.STR {
+		return c, nil
+	}
+
+	// Add advantage at the conditions stage
+	modifyCheck := func(_ context.Context, e *dnd5eEvents.AbilityCheckChainEvent) (*dnd5eEvents.AbilityCheckChainEvent, error) {
+		e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.CheckModifierSource{
+			Name:       "Raging",
+			SourceType: "condition",
+			SourceRef:  refs.Conditions.Raging(),
+			EntityID:   r.CharacterID,
+		})
+		return e, nil
+	}
+
+	if err := c.Add(combat.StageConditions, "raging_str_check_advantage", modifyCheck); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add raging STR check advantage modifier for character %s", r.CharacterID)
 	}
 
 	return c, nil

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -278,28 +278,36 @@ func (r *RagingCondition) onDamageChain(
 		// whether it qualifies for the rage damage bonus below.
 		r.DidAttackThisTurn = true
 
-		// RAW: the rage damage bonus only applies to melee weapon attacks that
-		// use Strength (including unarmed strikes) -- not ranged or DEX-based attacks.
-		if event.AbilityUsed == abilities.STR && event.IsMelee {
-			// Add rage damage modifier in the StageFeatures stage
-			modifyDamage := func(_ context.Context, e *dnd5eEvents.DamageChainEvent) (*dnd5eEvents.DamageChainEvent, error) {
-				// Append rage damage component
-				e.Components = append(e.Components, dnd5eEvents.DamageComponent{
-					Source:            dnd5eEvents.DamageSourceCondition,
-					SourceRef:         refs.Conditions.Raging(),
-					OriginalDiceRolls: nil, // No dice
-					FinalDiceRolls:    nil,
-					Rerolls:           nil,
-					FlatBonus:         r.DamageBonus,
-					DamageType:        e.DamageType, // Same as weapon damage type
-					IsCritical:        e.IsCritical,
-				})
+		// Add rage damage modifier in the StageFeatures stage. Gated inside the
+		// modifier (on the live e.AbilityUsed/e.IsMelee) rather than on the
+		// publish-time event above, since other StageFeatures modifiers (e.g.
+		// Martial Arts) can change AbilityUsed while the chain executes --
+		// checking the pre-chain snapshot would let Rage's bonus survive a
+		// swap away from STR.
+		modifyDamage := func(_ context.Context, e *dnd5eEvents.DamageChainEvent) (*dnd5eEvents.DamageChainEvent, error) {
+			// RAW: the rage damage bonus only applies to melee weapon attacks
+			// that use Strength (including unarmed strikes) -- not ranged or
+			// DEX-based attacks.
+			if e.AbilityUsed != abilities.STR || !e.IsMelee {
 				return e, nil
 			}
-			err := c.Add(combat.StageFeatures, "rage", modifyDamage)
-			if err != nil {
-				return c, rpgerr.Wrapf(err, "error applying rage damage bonus for character id %s", r.CharacterID)
-			}
+
+			// Append rage damage component
+			e.Components = append(e.Components, dnd5eEvents.DamageComponent{
+				Source:            dnd5eEvents.DamageSourceCondition,
+				SourceRef:         refs.Conditions.Raging(),
+				OriginalDiceRolls: nil, // No dice
+				FinalDiceRolls:    nil,
+				Rerolls:           nil,
+				FlatBonus:         r.DamageBonus,
+				DamageType:        e.DamageType, // Same as weapon damage type
+				IsCritical:        e.IsCritical,
+			})
+			return e, nil
+		}
+		err := c.Add(combat.StageFeatures, "rage", modifyDamage)
+		if err != nil {
+			return c, rpgerr.Wrapf(err, "error applying rage damage bonus for character id %s", r.CharacterID)
 		}
 	}
 

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
 )
 
 // errorOnUnsubscribeBus wraps an EventBus to return errors for specific subscription IDs.
@@ -292,6 +294,7 @@ func (s *RagingConditionTestSuite) executeDamageChain(
 		IsCritical:   false,
 		WeaponDamage: "1d8",
 		AbilityUsed:  abilities.STR,
+		IsMelee:      true, // Simulates a STR-based melee attack (rage bonus applies)
 	}
 
 	chain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
@@ -303,6 +306,96 @@ func (s *RagingConditionTestSuite) executeDamageChain(
 	}
 
 	return modifiedChain.Execute(s.ctx, damageEvent)
+}
+
+// executeDamageChainWithAbility creates and executes a damage chain event with an
+// explicit ability/melee combination, for testing the rage damage bonus gate.
+func (s *RagingConditionTestSuite) executeDamageChainWithAbility(
+	attackerID string,
+	abilityUsed abilities.Ability,
+	isMelee bool,
+) (*dnd5eEvents.DamageChainEvent, error) {
+	weaponComp := dnd5eEvents.DamageComponent{
+		Source:            dnd5eEvents.DamageSourceWeapon,
+		OriginalDiceRolls: []int{5},
+		FinalDiceRolls:    []int{5},
+		DamageType:        damage.Slashing,
+	}
+
+	abilityComp := dnd5eEvents.DamageComponent{
+		Source:     dnd5eEvents.DamageSourceAbility,
+		FlatBonus:  3,
+		DamageType: damage.Slashing,
+	}
+
+	damageEvent := &dnd5eEvents.DamageChainEvent{
+		AttackerID:   attackerID,
+		TargetID:     "goblin-1",
+		Components:   []dnd5eEvents.DamageComponent{weaponComp, abilityComp},
+		DamageType:   damage.Slashing,
+		WeaponDamage: "1d8",
+		AbilityUsed:  abilityUsed,
+		IsMelee:      isMelee,
+	}
+
+	chain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damageTopic := dnd5eEvents.DamageChain.On(s.bus)
+
+	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
+	if err != nil {
+		return nil, err
+	}
+
+	return modifiedChain.Execute(s.ctx, damageEvent)
+}
+
+func (s *RagingConditionTestSuite) TestRagingConditionDamageBonusRequiresSTRMelee() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       3,
+		Source:      "dnd5e:features:rage",
+	})
+
+	err := raging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name        string
+		abilityUsed abilities.Ability
+		isMelee     bool
+	}{
+		{"DEX melee attack (finesse weapon)", abilities.DEX, true},
+		{"STR ranged attack (thrown weapon)", abilities.STR, false},
+		{"DEX ranged attack", abilities.DEX, false},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			finalEvent, err := s.executeDamageChainWithAbility("barbarian-1", tc.abilityUsed, tc.isMelee)
+			s.Require().NoError(err)
+			s.Require().Len(finalEvent.Components, 2, "no rage damage bonus should be added")
+		})
+	}
+}
+
+func (s *RagingConditionTestSuite) TestRagingConditionDamageBonusAppliesToSTRMelee() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       3,
+		Source:      "dnd5e:features:rage",
+	})
+
+	err := raging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	finalEvent, err := s.executeDamageChainWithAbility("barbarian-1", abilities.STR, true)
+	s.Require().NoError(err)
+
+	s.Require().Len(finalEvent.Components, 3, "rage damage bonus should be added for STR melee attacks")
+	s.Equal(dnd5eEvents.DamageSourceCondition, finalEvent.Components[2].Source)
+	s.Equal(2, finalEvent.Components[2].FlatBonus)
 }
 
 func (s *RagingConditionTestSuite) TestRagingConditionAddsDamageBonus() {
@@ -613,7 +706,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionResistanceOnlyAffectsOwnCh
 }
 
 func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
-	// Apply a raging condition (creates 5 subscriptions)
+	// Apply a raging condition (creates 7 subscriptions: damage received, turn end,
+	// condition applied, damage chain, rest, saving throw chain, ability check chain)
 	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
@@ -623,7 +717,7 @@ func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
 
 	err := raging.Apply(s.ctx, s.bus)
 	s.Require().NoError(err)
-	s.Require().Len(raging.subscriptionIDs, 5)
+	s.Require().Len(raging.subscriptionIDs, 7)
 
 	// Wrap the bus so that the first subscription ID fails on unsubscribe
 	failBus := &errorOnUnsubscribeBus{
@@ -634,10 +728,138 @@ func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
 	// Remove should return an error but still clean up all other subscriptions
 	err = raging.Remove(s.ctx, failBus)
 	s.Require().Error(err, "Remove should report the failed unsubscribe")
-	s.Contains(err.Error(), "1/5", "error should report count of failures vs total")
+	s.Contains(err.Error(), "1/7", "error should report count of failures vs total")
 
 	// Condition should be fully cleaned up despite the error
 	s.Nil(raging.subscriptionIDs, "subscriptionIDs should be nil after Remove")
 	s.Nil(raging.bus, "bus should be nil after Remove")
 	s.False(raging.IsApplied(), "condition should no longer be applied")
+}
+
+func (s *RagingConditionTestSuite) TestRagingConditionGrantsAdvantageOnSTRSaves() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       5,
+		Source:      "dnd5e:features:rage",
+	})
+	err := raging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	s.Run("adds advantage on STR saves for this character", func() {
+		saveEvent := &dnd5eEvents.SavingThrowChainEvent{
+			SaverID: "barbarian-1",
+			Ability: abilities.STR,
+			DC:      15,
+		}
+
+		saveChain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+		saves := dnd5eEvents.SavingThrowChain.On(s.bus)
+		modifiedChain, err := saves.PublishWithChain(s.ctx, saveEvent, saveChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, saveEvent)
+		s.Require().NoError(err)
+		s.Require().Len(finalEvent.AdvantageSources, 1)
+		s.Equal(refs.Conditions.Raging(), finalEvent.AdvantageSources[0].SourceRef)
+		s.Equal("Raging", finalEvent.AdvantageSources[0].Name)
+	})
+
+	s.Run("does not add advantage on non-STR saves", func() {
+		saveEvent := &dnd5eEvents.SavingThrowChainEvent{
+			SaverID: "barbarian-1",
+			Ability: abilities.CON,
+			DC:      15,
+		}
+
+		saveChain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+		saves := dnd5eEvents.SavingThrowChain.On(s.bus)
+		modifiedChain, err := saves.PublishWithChain(s.ctx, saveEvent, saveChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, saveEvent)
+		s.Require().NoError(err)
+		s.Empty(finalEvent.AdvantageSources)
+	})
+
+	s.Run("does not add advantage for other characters", func() {
+		saveEvent := &dnd5eEvents.SavingThrowChainEvent{
+			SaverID: "other-character",
+			Ability: abilities.STR,
+			DC:      15,
+		}
+
+		saveChain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+		saves := dnd5eEvents.SavingThrowChain.On(s.bus)
+		modifiedChain, err := saves.PublishWithChain(s.ctx, saveEvent, saveChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, saveEvent)
+		s.Require().NoError(err)
+		s.Empty(finalEvent.AdvantageSources)
+	})
+}
+
+func (s *RagingConditionTestSuite) TestRagingConditionGrantsAdvantageOnSTRChecks() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       5,
+		Source:      "dnd5e:features:rage",
+	})
+	err := raging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+
+	s.Run("adds advantage on Athletics (STR) checks for this character", func() {
+		checkEvent := &dnd5eEvents.AbilityCheckChainEvent{
+			CheckerID: "barbarian-1",
+			Skill:     skills.Athletics,
+			DC:        15,
+		}
+
+		checkChain := events.NewStagedChain[*dnd5eEvents.AbilityCheckChainEvent](combat.ModifierStages)
+		checks := dnd5eEvents.AbilityCheckChain.On(s.bus)
+		modifiedChain, err := checks.PublishWithChain(s.ctx, checkEvent, checkChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, checkEvent)
+		s.Require().NoError(err)
+		s.Require().Len(finalEvent.AdvantageSources, 1)
+		s.Equal(refs.Conditions.Raging(), finalEvent.AdvantageSources[0].SourceRef)
+		s.Equal("Raging", finalEvent.AdvantageSources[0].Name)
+	})
+
+	s.Run("does not add advantage on non-STR checks", func() {
+		checkEvent := &dnd5eEvents.AbilityCheckChainEvent{
+			CheckerID: "barbarian-1",
+			Skill:     skills.Stealth,
+			DC:        15,
+		}
+
+		checkChain := events.NewStagedChain[*dnd5eEvents.AbilityCheckChainEvent](combat.ModifierStages)
+		checks := dnd5eEvents.AbilityCheckChain.On(s.bus)
+		modifiedChain, err := checks.PublishWithChain(s.ctx, checkEvent, checkChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, checkEvent)
+		s.Require().NoError(err)
+		s.Empty(finalEvent.AdvantageSources)
+	})
+
+	s.Run("does not add advantage for other characters", func() {
+		checkEvent := &dnd5eEvents.AbilityCheckChainEvent{
+			CheckerID: "other-character",
+			Skill:     skills.Athletics,
+			DC:        15,
+		}
+
+		checkChain := events.NewStagedChain[*dnd5eEvents.AbilityCheckChainEvent](combat.ModifierStages)
+		checks := dnd5eEvents.AbilityCheckChain.On(s.bus)
+		modifiedChain, err := checks.PublishWithChain(s.ctx, checkEvent, checkChain)
+		s.Require().NoError(err)
+
+		finalEvent, err := modifiedChain.Execute(s.ctx, checkEvent)
+		s.Require().NoError(err)
+		s.Empty(finalEvent.AdvantageSources)
+	})
 }

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -274,6 +274,7 @@ type DamageChainEvent struct {
 	WeaponRef       *core.Ref         // Reference to the weapon used (for off-hand detection, etc.)
 	IsOffHandAttack bool              // True for bonus action off-hand attacks (two-weapon fighting)
 	AbilityModifier int               // The ability modifier (STR/DEX) for this attack
+	IsMelee         bool              // True for melee attacks, false for ranged (mirrors AttackChainEvent.IsMelee)
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #745

## Summary
Two RAW gaps in `conditions/raging.go`:
- `onDamageChain` added the rage damage component to every hit by the raging character, with no gate on ability used or melee/ranged. A DEX attack or a thrown STR attack incorrectly got the bonus. Now gated on `event.AbilityUsed == abilities.STR && event.IsMelee`.
- Rage granted no advantage on Strength checks/saves. `RagingCondition` now subscribes to `SavingThrowChain` (STR-gated, mirrors `DodgingCondition`'s DEX-save subscriber) and `AbilityCheckChain` (gated via `skills.Ability(event.Skill) == abilities.STR`, e.g. Athletics).

**Scope note:** `DamageChainEvent` had no melee/ranged signal at all (unlike `AttackChainEvent.IsMelee`), so gating on melee required threading a new `IsMelee` field through `AttackContext` → `ResolveDamageInput` → `DamageChainEvent`, and through `DealDamageInput` for the non-attack-pipeline entry point (needed to keep an existing rage integration test meaningful). This touches `combat/attack_phases.go`, `combat/damage.go`, and `events/events.go` in addition to the conditions package.

## Load-bearing
`DamageChainEvent` (and `ResolveDamageInput`/`DealDamageInput`) now carry `IsMelee`, matching `AttackChainEvent`. Any future damage-chain modifier that needs to distinguish melee from ranged (not just ability used) can rely on this instead of re-deriving it.

## Test plan
- `go build ./...` (rulebooks/dnd5e module) — clean
- `go test ./...` (rulebooks/dnd5e module) — all packages pass, including the pre-existing `combat` integration suite (updated `TestDealDamageWithRageBonus` to pass `AbilityUsed`/`IsMelee` since it exercises the lower-level `DealDamage` entry point directly)
- `golangci-lint run ./...` (rulebooks/dnd5e module) — 0 issues
- `go vet ./...`, `gofmt -l`, `go mod tidy` (no diff) — clean
- New tests: `TestRagingConditionDamageBonusRequiresSTRMelee` (DEX melee / STR ranged / DEX ranged all get no bonus), `TestRagingConditionDamageBonusAppliesToSTRMelee` (positive case), `TestRagingConditionGrantsAdvantageOnSTRSaves` (STR save / non-STR save / other-character), `TestRagingConditionGrantsAdvantageOnSTRChecks` (Athletics / Stealth / other-character). Updated `TestRemoveContinuesOnStaleSubscription` for the new subscription count (5 → 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpYTxv1QkBQx98n34AL9w2