### PR TITLE
fix(character): gate Monk Ki resource creation to level 2+

### DIFF
--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -1554,14 +1554,19 @@ func (d *Draft) initializeClassResources(char *Character) {
 		}
 
 	case classes.Monk:
-		// Ki points - equal to monk level, recovered on short or long rest
-		kiResource := combat.NewRecoverableResource(combat.RecoverableResourceConfig{
-			ID:          string(resources.Ki),
-			Maximum:     level,
-			CharacterID: char.id,
-			ResetType:   coreResources.ResetShortRest,
-		})
-		char.resources[resources.Ki] = kiResource
+		// Ki points - equal to monk level, recovered on short or long rest.
+		// SRD: Ki starts at Monk level 2 (Flurry of Blows, Patient Defense, and
+		// Step of the Wind -- the features that spend Ki -- are all level-2
+		// features), so a level 1 Monk gets no Ki resource at all.
+		if level >= 2 {
+			kiResource := combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+				ID:          string(resources.Ki),
+				Maximum:     level,
+				CharacterID: char.id,
+				ResetType:   coreResources.ResetShortRest,
+			})
+			char.resources[resources.Ki] = kiResource
+		}
 	}
 
 	// Hit dice - all classes get hit dice for short rest healing

--- a/rulebooks/dnd5e/character/monk_resources_test.go
+++ b/rulebooks/dnd5e/character/monk_resources_test.go
@@ -1,0 +1,57 @@
+package character
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+)
+
+// MonkResourcesTestSuite tests Monk-specific class resource initialization,
+// in particular the Ki resource's level-2 gate (rpg-toolkit#746).
+type MonkResourcesTestSuite struct {
+	suite.Suite
+}
+
+func TestMonkResourcesSuite(t *testing.T) {
+	suite.Run(t, new(MonkResourcesTestSuite))
+}
+
+// newTestMonkDraftAndCharacter builds a bare Draft/Character pair for
+// exercising initializeClassResources directly at a given level. The public
+// SetRace/SetClass/SetBackground/ToCharacter flow always produces a level 1
+// character (leveling up isn't implemented yet), so this is the only way to
+// exercise the level-2 Ki gate today.
+func newTestMonkDraftAndCharacter(level int) (*Draft, *Character) {
+	draft := &Draft{class: classes.Monk}
+	char := &Character{
+		id:        "test-monk",
+		level:     level,
+		resources: make(map[coreResources.ResourceKey]*combat.RecoverableResource),
+	}
+	return draft, char
+}
+
+func (s *MonkResourcesTestSuite) TestLevel1MonkHasNoKiResource() {
+	draft, char := newTestMonkDraftAndCharacter(1)
+
+	draft.initializeClassResources(char)
+
+	_, ok := char.resources[resources.Ki]
+	s.False(ok, "Level 1 Monk should not have a Ki resource (Ki starts at Monk level 2)")
+}
+
+func (s *MonkResourcesTestSuite) TestLevel2MonkHasKiResource() {
+	draft, char := newTestMonkDraftAndCharacter(2)
+
+	draft.initializeClassResources(char)
+
+	kiResource, ok := char.resources[resources.Ki]
+	s.Require().True(ok, "Level 2 Monk should have a Ki resource")
+	s.Equal(2, kiResource.Maximum(), "Level 2 Monk should have 2 max Ki points")
+	s.Equal(2, kiResource.Current(), "Ki should start at maximum")
+}


### PR DESCRIPTION
Closes #746

## Summary
`initializeClassResources` in `character/draft.go` seeded a Ki resource for Monk unconditionally at any level ≥ 1. Per SRD, Ki starts at Monk level 2 (Flurry of Blows, Patient Defense, and Step of the Wind — the only features that spend Ki — are all level-2 features). Gated Ki resource creation on `level >= 2`.

**Note on test approach:** the public `SetRace`/`SetClass`/`SetBackground`/`ToCharacter` flow currently hardcodes `level: 1` for every finalized character (leveling up isn't implemented yet — see the character package's own docs). So there's no way to reach a level-2 Monk through the public API today. The new tests call `initializeClassResources` directly at level 1 and level 2 (same-package unit test, mirrors how `conditions` package tests construct runtime structs directly) rather than going through the full draft/finalize flow.

## Load-bearing
None — this is a scoped bug fix gating an existing resource's creation to the correct level; no new invariant introduced.

## Test plan
- `go build ./...` (rulebooks/dnd5e module) — clean
- `go test ./...` (rulebooks/dnd5e module) — all packages pass
- `golangci-lint run ./...` (rulebooks/dnd5e module) — 0 issues
- `go vet ./...`, `gofmt -l`, `go mod tidy` (no diff) — clean
- New tests: `TestLevel1MonkHasNoKiResource` (no Ki resource key present), `TestLevel2MonkHasKiResource` (Ki resource present, Maximum/Current == 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpYTxv1QkBQx98n34AL9w2