### PR TITLE
docs(status): wave-1 rage/ki fixes + IsMelee signal, tag v0.65.0

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -135,20 +135,22 @@ See "Paused / on hold" below.
 
 ## Recently landed (last 30 days, highlights)
 
-- **Rage RAW fixes: STR-melee damage gate + STR check/save advantage** — PRs
-  #747 and #748 (2026-07-05), tagged `rulebooks/dnd5e/v0.65.0`. Rage's damage
-  bonus was applying to any Strength-ability damage, including ranged
-  (thrown Strength weapons); it now gates on `IsMelee` too, matching RAW. That
-  required threading a new `IsMelee` field through `DamageChainEvent` — a
-  general-purpose signal future damage-chain modifiers can read directly
-  instead of re-deriving melee-ness from weapon/ability data. Raging also
-  gained the STR check/save advantage the condition was missing (advantage on
-  Strength checks and saving throws while raging), subscribing to
-  `SavingThrowChain` the same way `DodgingCondition` does for DEX saves —
-  Rage is the second consumer of that pattern — plus a new `AbilityCheckChain`
-  subscription for the check side. Separately, `character/draft.go` now gates
-  Monk Ki resource creation to level 2+ (a level-1 Monk was getting a phantom
-  Ki resource).
+- **Rage RAW fixes: STR-melee damage gate + STR check/save advantage** — PR
+  #747 (2026-07-05), tagged `rulebooks/dnd5e/v0.65.0`. Rage's damage bonus had
+  no ability/range check at all — it applied to *any* hit landed by the
+  raging character, including DEX and ranged attacks; it now gates on
+  `AbilityUsed == STR` and `IsMelee`, matching RAW. That required threading a
+  new `IsMelee` field through `DamageChainEvent` — a general-purpose signal
+  future damage-chain modifiers can read directly instead of re-deriving
+  melee-ness from weapon/ability data. Raging also gained the STR check/save
+  advantage the condition was missing (advantage on Strength checks and
+  saving throws while raging), subscribing to `SavingThrowChain` the same way
+  `DodgingCondition` does for DEX saves — Rage is the second consumer of that
+  pattern — plus a new `AbilityCheckChain` subscription for the check side.
+- **Monk Ki resource gated to level 2+** — PR #748 (2026-07-05), tagged
+  `rulebooks/dnd5e/v0.65.0`. `character/draft.go` was creating a Ki resource
+  for level-1 Monks, who don't have Ki per RAW (it's a level-2 feature); draft
+  finalization now gates Ki resource creation on level >= 2.
 - **Move-iteration OA damage application** — PR for issue #675 (2026-05-24) — Wave 2.11e
   SDK seam: `iterateMovementStepsForEntity` now captures `DamageReceivedEvent` on the
   encounter bus per step (alongside the existing `ReactionTriggerTopic` buffer) and
@@ -263,8 +265,8 @@ See "Paused / on hold" below.
   `testdata/api/races/`). The provenance and freshness of this data is not
   documented. If the upstream API changes, tests silently test stale data.
 
-- **Same-stage `DamageChain` modifier execution order is registration-order-
-  dependent, not explicitly ordered.** Rage and Martial Arts both modify
+- **Same-stage `DamageChain` modifier execution order is
+  registration-order-dependent, not explicitly ordered.** Rage and Martial Arts both modify
   damage at the same chain stage; which one runs first depends on subscribe
   order rather than a declared priority. SneakAttack has the same latent
   shape. Irrelevant at level 1 single-class (today's only playtest shape) —

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-02
-confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02
+updated: 2026-07-05
+confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05
 ---
 
 # rpg-toolkit: Where We Are
@@ -135,6 +135,20 @@ See "Paused / on hold" below.
 
 ## Recently landed (last 30 days, highlights)
 
+- **Rage RAW fixes: STR-melee damage gate + STR check/save advantage** — PRs
+  #747 and #748 (2026-07-05), tagged `rulebooks/dnd5e/v0.65.0`. Rage's damage
+  bonus was applying to any Strength-ability damage, including ranged
+  (thrown Strength weapons); it now gates on `IsMelee` too, matching RAW. That
+  required threading a new `IsMelee` field through `DamageChainEvent` — a
+  general-purpose signal future damage-chain modifiers can read directly
+  instead of re-deriving melee-ness from weapon/ability data. Raging also
+  gained the STR check/save advantage the condition was missing (advantage on
+  Strength checks and saving throws while raging), subscribing to
+  `SavingThrowChain` the same way `DodgingCondition` does for DEX saves —
+  Rage is the second consumer of that pattern — plus a new `AbilityCheckChain`
+  subscription for the check side. Separately, `character/draft.go` now gates
+  Monk Ki resource creation to level 2+ (a level-1 Monk was getting a phantom
+  Ki resource).
 - **Move-iteration OA damage application** — PR for issue #675 (2026-05-24) — Wave 2.11e
   SDK seam: `iterateMovementStepsForEntity` now captures `DamageReceivedEvent` on the
   encounter bus per step (alongside the existing `ReactionTriggerTopic` buffer) and
@@ -248,6 +262,13 @@ See "Paused / on hold" below.
 - **`character/choices` has testdata from a DnD 5e API** (`testdata/api/classes/`,
   `testdata/api/races/`). The provenance and freshness of this data is not
   documented. If the upstream API changes, tests silently test stale data.
+
+- **Same-stage `DamageChain` modifier execution order is registration-order-
+  dependent, not explicitly ordered.** Rage and Martial Arts both modify
+  damage at the same chain stage; which one runs first depends on subscribe
+  order rather than a declared priority. SneakAttack has the same latent
+  shape. Irrelevant at level 1 single-class (today's only playtest shape) —
+  revisit if multiclass ordering is ever exercised.
 
 ### Events
 


### PR DESCRIPTION
## Summary
- Docs-only close-the-loop for the wave-1 Rage/Ki fixes merged on main (PR #747, #748) and the resulting `rulebooks/dnd5e/v0.65.0` tag.
- Adds a "Recently landed" entry: Rage's damage bonus now gates on `IsMelee` (RAW fix — ranged Strength damage no longer gets the bonus), Rage gained STR check/save advantage (second consumer of the `SavingThrowChain` advantage pattern `DodgingCondition` established), and Monk Ki resource creation is now gated to level 2+.
- Adds a known-rough-edge note: same-stage `DamageChain` modifier execution order between conditions (Rage vs. Martial Arts, and latently SneakAttack) is registration-order-dependent rather than explicitly ordered. Not exercised today (level-1 single-class playtests only); flagged for whenever multiclass ordering gets tested.
- Bumps the frontmatter `updated` date and appends to the `confidence` provenance line, matching the doc's existing convention.

No code changed — this is a docs-only PR. `make pre-commit` is known-broken in this repo (#721), so for this change I verified by reading the rendered diff rather than running pre-commit.

## Test plan
- [x] Read the diff and confirmed markdown renders sensibly (no broken tables/links, matches surrounding voice/format)
- [x] N/A — no code changes, no tests to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpYTxv1QkBQx98n34AL9w2