### PR TITLE
fix(encounter): isPlayerCombatant passes for hydrated seats

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -63,6 +63,14 @@ per turn-boundary, each re-`Apply`'ing conditions to the same bus.
   `MovementStepInput.Mover` are `combat.Combatant`; resolvers use them and MUST
   NOT re-load. Nil when a seat carried no rehydratable data → resolver falls back
   to its stat-snapshot stand-in.
+- **Hydration alone satisfies the combatant gate (#750).** `isPlayerCombatant`
+  (`combat.go`) treats a seat as combat-ready when `DataJSON` is present, not just
+  when the flat `AC`/`DamageDice` snapshot is set — a hydrated resolver ignores
+  the flat snapshot entirely (per the bullet above), so requiring it too would
+  strand any host that hydrates real characters but has no honest value to offer
+  for a precomputed attack-bonus/damage-dice field (e.g. rpg-api's lobby
+  `StartEncounter`, which seeds real HP/AC but leaves those three fields
+  zero-value on purpose).
 - **`EndTurn(ctx, ...)` emits the turn-boundary** (`dnd5eEvents.TurnEndTopic`)
   directly on the bus for the ending actor, so held conditions reset per-turn
   state (`SneakAttack.UsedThisTurn`) in place with no re-load.

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -64,13 +64,17 @@ per turn-boundary, each re-`Apply`'ing conditions to the same bus.
   NOT re-load. Nil when a seat carried no rehydratable data → resolver falls back
   to its stat-snapshot stand-in.
 - **Hydration alone satisfies the combatant gate (#750).** `isPlayerCombatant`
-  (`combat.go`) treats a seat as combat-ready when `DataJSON` is present, not just
-  when the flat `AC`/`DamageDice` snapshot is set — a hydrated resolver ignores
-  the flat snapshot entirely (per the bullet above), so requiring it too would
-  strand any host that hydrates real characters but has no honest value to offer
-  for a precomputed attack-bonus/damage-dice field (e.g. rpg-api's lobby
+  (now an `*Encounter` method, `combat.go`) treats a seat as combat-ready when
+  it is ACTUALLY HELD (`e.heldCharacter(...) != nil`), not just when the flat
+  `AC`/`DamageDice` snapshot is set — a hydrated resolver ignores the flat
+  snapshot entirely (per the bullet above), so requiring it too would strand
+  any host that hydrates real characters but has no honest value to offer for
+  a precomputed attack-bonus/damage-dice field (e.g. rpg-api's lobby
   `StartEncounter`, which seeds real HP/AC but leaves those three fields
-  zero-value on purpose).
+  zero-value on purpose). Deliberately checks the held-character map, not
+  `len(DataJSON) > 0` on the input: DataJSON being set means a seat carries
+  rehydratable data, not that hydration happened — `New()`+`AddPlayer` never
+  hydrate, only a `LoadFromData` round-trip's cascade does.
 - **`EndTurn(ctx, ...)` emits the turn-boundary** (`dnd5eEvents.TurnEndTopic`)
   directly on the bus for the ending actor, so held conditions reset per-turn
   state (`SneakAttack.UsedThisTurn`) in place with no re-load.

--- a/docs/status.md
+++ b/docs/status.md
@@ -23,10 +23,14 @@ host that hydrates real characters but has no honest value to offer for a
 precomputed attack-bonus/damage-dice field — rpg-api's lobby `StartEncounter`
 seeds real HP/AC from the stored character but has no rules-legitimate way to
 also invent AttackBonus/DamageDice/DamageType (not stored fields; derived at
-attack time). `isPlayerCombatant` now treats `len(DataJSON) > 0` as
-sufficient on its own; the flat-snapshot check remains the gate for
-un-hydrated seats (devseed-style fixtures, tests without a character store).
-Consumer-side proof: rpg-api#635.
+attack time). `isPlayerCombatant` (now an `*Encounter` method) treats an
+ACTUALLY HELD seat (`e.heldCharacter(...) != nil`) as sufficient on its own —
+deliberately NOT `len(DataJSON) > 0`, since DataJSON being set on a
+`PlayerInput` means a seat carries rehydratable data, not that it has been
+hydrated: `New()`+`AddPlayer` never hydrate, only a `LoadFromData` round-trip
+does (Copilot review catch on #751). The flat-snapshot check remains the gate
+for un-hydrated seats (devseed-style fixtures, tests without a character
+store). Consumer-side proof: rpg-api#635.
 
 **#714 — encounter Move verb enforces + spends the movement budget
 (2026-07-02, PR #720).** `Encounter.Move` had no economy accounting at all (its

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,6 +11,23 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
+**#750 — isPlayerCombatant honors hydration, not just the flat AC/DamageDice
+snapshot (2026-07-11, branch fix/combat-gate-hydration).** `isPlayerCombatant`
+(`encounter/combat.go`) gated TakeAction on `MaxHP > 0 && AC > 0 && DamageDice
+!= ""` regardless of whether the seat was hydrated — but the real
+`Dnd5eCombatResolver` (rpg-api) ignores that flat snapshot entirely once a seat
+carries `DataJSON`, driving damage off the held `*character.Character`'s real
+equipped weapon instead (`Character.WeaponForActionRef`). The flat snapshot
+only feeds the stand-in fallback for an un-hydrated seat. This stranded any
+host that hydrates real characters but has no honest value to offer for a
+precomputed attack-bonus/damage-dice field — rpg-api's lobby `StartEncounter`
+seeds real HP/AC from the stored character but has no rules-legitimate way to
+also invent AttackBonus/DamageDice/DamageType (not stored fields; derived at
+attack time). `isPlayerCombatant` now treats `len(DataJSON) > 0` as
+sufficient on its own; the flat-snapshot check remains the gate for
+un-hydrated seats (devseed-style fixtures, tests without a character store).
+Consumer-side proof: rpg-api#635.
+
 **#714 — encounter Move verb enforces + spends the movement budget
 (2026-07-02, PR #720).** `Encounter.Move` had no economy accounting at all (its
 own doc said "Slice scope: no action economy") — `movement_remaining` never

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -222,27 +222,38 @@ func (e *Encounter) spendStrikeEconomy(
 // the gate that contract enforces. AttackBonus may legitimately be 0
 // (no proficiency bonus), so it is NOT required.
 //
-// A hydrated seat (DataJSON present) is always combat-ready regardless of
-// the flat AC/DamageDice snapshot: Dnd5eCombatResolver routes a held
-// attacker through the real rules chain (character.WeaponForActionRef +
-// combat.ResolveAttack), which reads the held character's actual equipped
-// weapon and ability scores and never consults the flat snapshot fields —
-// see the resolver's doc comment ("Stand-in fallback"). Those fields are
-// load-bearing ONLY for a seat with no held character (the stat-snapshot
-// stand-in path), so a host that hydrates every seat (e.g. via a
-// character-store cascade keyed by EntityID) has no honest way to also
-// populate a real AttackBonus/DamageDice/DamageType without duplicating
-// rules math the resolver already owns — see rpg-api#634 (lobby
-// StartEncounter seeds real characters but has no honest attack-bonus/
-// damage-dice snapshot to offer).
-func isPlayerCombatant(p *PlayerData) bool {
+// An ACTUALLY HELD seat (e.heldCharacter returns non-nil) is always
+// combat-ready regardless of the flat AC/DamageDice snapshot:
+// Dnd5eCombatResolver routes a held attacker through the real rules chain
+// (character.WeaponForActionRef + combat.ResolveAttack), which reads the
+// held character's actual equipped weapon and ability scores and never
+// consults the flat snapshot fields — see the resolver's doc comment
+// ("Stand-in fallback"). Those fields are load-bearing ONLY for a seat
+// with no held character (the stat-snapshot stand-in path), so a host
+// that hydrates every seat (e.g. via a character-store cascade keyed by
+// EntityID) has no honest way to also populate a real AttackBonus/
+// DamageDice/DamageType without duplicating rules math the resolver
+// already owns — see rpg-api#634 (lobby StartEncounter seeds real
+// characters but has no honest attack-bonus/damage-dice snapshot to
+// offer).
+//
+// Deliberately checks e.heldCharacter, NOT len(p.DataJSON) > 0: DataJSON
+// presence on PlayerData means a seat CARRIES rehydratable data, not that
+// it HAS BEEN hydrated — New()+AddPlayer never hydrates (only
+// LoadFromData's cascade does), so a seat built via New() with DataJSON
+// set but never round-tripped through LoadFromData would report
+// combat-ready here while e.combatants holds nothing for it, and the
+// resolver would silently fall through to the (likely underpopulated)
+// stand-in path instead of the real rules chain this check is meant to
+// vouch for.
+func (e *Encounter) isPlayerCombatant(p *PlayerData) bool {
 	if p == nil {
 		return false
 	}
 	if p.MaxHP <= 0 {
 		return false
 	}
-	if len(p.DataJSON) > 0 {
+	if e.heldCharacter(p.EntityID) != nil {
 		return true
 	}
 	return p.AC > 0 && p.DamageDice != ""

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -221,11 +221,31 @@ func (e *Encounter) spendStrikeEconomy(
 // zero combat snapshot opts a seat out of combat verbs; this helper is
 // the gate that contract enforces. AttackBonus may legitimately be 0
 // (no proficiency bonus), so it is NOT required.
+//
+// A hydrated seat (DataJSON present) is always combat-ready regardless of
+// the flat AC/DamageDice snapshot: Dnd5eCombatResolver routes a held
+// attacker through the real rules chain (character.WeaponForActionRef +
+// combat.ResolveAttack), which reads the held character's actual equipped
+// weapon and ability scores and never consults the flat snapshot fields —
+// see the resolver's doc comment ("Stand-in fallback"). Those fields are
+// load-bearing ONLY for a seat with no held character (the stat-snapshot
+// stand-in path), so a host that hydrates every seat (e.g. via a
+// character-store cascade keyed by EntityID) has no honest way to also
+// populate a real AttackBonus/DamageDice/DamageType without duplicating
+// rules math the resolver already owns — see rpg-api#634 (lobby
+// StartEncounter seeds real characters but has no honest attack-bonus/
+// damage-dice snapshot to offer).
 func isPlayerCombatant(p *PlayerData) bool {
 	if p == nil {
 		return false
 	}
-	return p.MaxHP > 0 && p.AC > 0 && p.DamageDice != ""
+	if p.MaxHP <= 0 {
+		return false
+	}
+	if len(p.DataJSON) > 0 {
+		return true
+	}
+	return p.AC > 0 && p.DamageDice != ""
 }
 
 // ActionRef identifies an action via the toolkit's three-part ref shape

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -76,7 +76,7 @@ func (e *Encounter) TakeActionPhased(
 		return e.takeCharacterAction(context.Background(), player, ref, target)
 	}
 
-	if !isPlayerCombatant(player) {
+	if !e.isPlayerCombatant(player) {
 		return nil, fmt.Errorf("%w: player %q missing HP/AC/DamageDice", ErrNonCombatant, playerID)
 	}
 	if target.EntityID == "" {

--- a/encounter/combat_test.go
+++ b/encounter/combat_test.go
@@ -2,6 +2,7 @@ package encounter_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 )
 
 // Test-package fixture identifiers (extracted to satisfy goconst).
@@ -269,6 +271,64 @@ func (s *CombatSuite) TestTakeAction_RejectsNonCombatant() {
 		encounter.ActionTarget{EntityID: gobEntityID},
 	)
 	s.ErrorIs(err, encounter.ErrNonCombatant)
+}
+
+// TestTakeAction_HydratedPlayerBypassesFlatSnapshotGate is the #634 gate
+// relaxation: a player seat carrying NO flat AC/DamageDice snapshot — the
+// honest state a host lands in when it hydrates real characters but has no
+// rules-legitimate way to also invent an attack-bonus/damage-dice snapshot
+// (rpg-api's lobby StartEncounter, see rpg-api#634) — still passes
+// isPlayerCombatant once hydrated via DataJSON. alwaysHitResolver is a stub
+// that ignores its input, so this proves the GATE specifically, mirroring
+// TestTakeAction_RejectsNonCombatant's scope for the un-hydrated case.
+func (s *CombatSuite) TestTakeAction_HydratedPlayerBypassesFlatSnapshotGate() {
+	charData := &dnd5eCharacter.Data{
+		ID:               aliceEntityID,
+		Name:             "Alice",
+		Level:            1,
+		ProficiencyBonus: 2,
+		HitPoints:        12,
+		MaxHitPoints:     12,
+	}
+	charJSON, err := json.Marshal(charData)
+	s.Require().NoError(err)
+
+	enc := encounter.New(context.Background(), "enc-hydrated-gate", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, // No AC, no DamageDice — the honest StartEncounter snapshot.
+		DataJSON: charJSON,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+
+	// Round-trip through Data so the hydration cascade runs — New/AddPlayer
+	// never hydrate; only LoadFromData does (mirrors hydration_test.go).
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(context.Background(), &data, s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	s.Require().NoError(err)
+
+	s.Require().NoError(loaded.SetMode(core.ModeTurnBased))
+	for loaded.ActiveActor() != aliceEntityID {
+		_, _, endErr := loaded.EndTurn(context.Background(), loaded.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	err = loaded.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.Require().NoError(err, "hydrated seat must pass the combatant gate without a flat AC/DamageDice snapshot")
 }
 
 // EndTurn publishes TurnEnded + TurnStarted; rotates Initiative.

--- a/encounter/combat_test.go
+++ b/encounter/combat_test.go
@@ -331,6 +331,48 @@ func (s *CombatSuite) TestTakeAction_HydratedPlayerBypassesFlatSnapshotGate() {
 	s.Require().NoError(err, "hydrated seat must pass the combatant gate without a flat AC/DamageDice snapshot")
 }
 
+// TestTakeAction_DataJSONWithoutLoadFromData_StillRejected is the regression
+// guard for Copilot review on rpg-toolkit#751: DataJSON being SET on a
+// PlayerInput is not the same as a seat being HYDRATED — New()+AddPlayer
+// never hydrate; only a LoadFromData round-trip's hydrateCombatants cascade
+// does (see hydration.go). A seat built via New()+AddPlayer(DataJSON: ...)
+// and used directly, with no LoadFromData round-trip, must still be
+// rejected — e.heldCharacter returns nil for it, and it carries no flat
+// AC/DamageDice snapshot either.
+func (s *CombatSuite) TestTakeAction_DataJSONWithoutLoadFromData_StillRejected() {
+	charData := &dnd5eCharacter.Data{
+		ID: aliceEntityID, Name: "Alice", Level: 1,
+		HitPoints: 12, MaxHitPoints: 12,
+	}
+	charJSON, err := json.Marshal(charData)
+	s.Require().NoError(err)
+
+	enc := encounter.New(context.Background(), "enc-unhydrated-datajson", s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, // No AC, no DamageDice.
+		DataJSON: charJSON, // Set, but never round-tripped through LoadFromData — not actually hydrated.
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	for enc.ActiveActor() != aliceEntityID {
+		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
+		s.Require().NoError(endErr)
+	}
+
+	err = enc.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.ErrorIs(err, encounter.ErrNonCombatant, "DataJSON alone (no LoadFromData round-trip) must not satisfy the gate")
+}
+
 // EndTurn publishes TurnEnded + TurnStarted; rotates Initiative.
 func (s *CombatSuite) TestEndTurn_AdvancesInitiative() {
 	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -122,11 +122,14 @@ func WithMovementResolver(r MovementResolver) Option {
 // PlayerInput populates a player seat at construction / AddPlayer time.
 //
 // Combat fields are optional. A seat is treated as a combatant for
-// TakeAction iff MaxHP > 0, AC > 0, and DamageDice is non-empty (see
-// isPlayerCombatant in combat.go). AttackBonus may be 0 (no proficiency)
-// and DamageType defaults to "untyped" when empty. Seats added without
-// these fields cannot call combat verbs and TakeAction returns
-// ErrNonCombatant for them.
+// TakeAction iff MaxHP > 0 AND EITHER the seat carries DataJSON (a hydrated
+// character resolves attacks through the real rules chain, which never
+// reads the flat AC/DamageDice snapshot — see isPlayerCombatant in
+// combat.go) OR AC > 0 and DamageDice is non-empty (the stat-snapshot
+// stand-in path). AttackBonus may be 0 (no proficiency) and DamageType
+// defaults to "untyped" when empty. Seats added without MaxHP and one of
+// the two combat-readiness paths cannot call combat verbs and TakeAction
+// returns ErrNonCombatant for them.
 type PlayerInput struct {
 	PlayerID   core.PlayerID
 	EntityID   core.EntityID

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -122,14 +122,17 @@ func WithMovementResolver(r MovementResolver) Option {
 // PlayerInput populates a player seat at construction / AddPlayer time.
 //
 // Combat fields are optional. A seat is treated as a combatant for
-// TakeAction iff MaxHP > 0 AND EITHER the seat carries DataJSON (a hydrated
-// character resolves attacks through the real rules chain, which never
-// reads the flat AC/DamageDice snapshot — see isPlayerCombatant in
-// combat.go) OR AC > 0 and DamageDice is non-empty (the stat-snapshot
-// stand-in path). AttackBonus may be 0 (no proficiency) and DamageType
-// defaults to "untyped" when empty. Seats added without MaxHP and one of
-// the two combat-readiness paths cannot call combat verbs and TakeAction
-// returns ErrNonCombatant for them.
+// TakeAction iff MaxHP > 0 AND EITHER the seat is actually HELD — hydrated
+// via the LoadFromData cascade, which happens when DataJSON was present at
+// load time, NOT merely when DataJSON is set on this input (New()+AddPlayer
+// never hydrates; only a LoadFromData round-trip does) — OR AC > 0 and
+// DamageDice is non-empty (the stat-snapshot stand-in path). A held
+// character resolves attacks through the real rules chain, which never reads
+// the flat AC/DamageDice snapshot — see isPlayerCombatant in combat.go.
+// AttackBonus may be 0 (no proficiency) and DamageType defaults to "untyped"
+// when empty. Seats added without MaxHP and one of the two combat-readiness
+// paths cannot call combat verbs and TakeAction returns ErrNonCombatant for
+// them.
 type PlayerInput struct {
 	PlayerID   core.PlayerID
 	EntityID   core.EntityID


### PR DESCRIPTION
Closes #750

## What this does

`isPlayerCombatant` (`encounter/combat.go`) gated `TakeAction` on `MaxHP > 0 && AC > 0 && DamageDice != ""` — the flat combat snapshot on `PlayerData` — regardless of whether the seat was hydrated. It now also passes when the seat carries `DataJSON` (hydrated), independent of the flat snapshot. The flat-snapshot check remains the gate for un-hydrated seats.

## Load-bearing

The real `Dnd5eCombatResolver` (rpg-api's `internal/handlers/dnd5e/v2/encounter/dnd5e_combat_resolver.go`) completely ignores `AttackBonus`/`DamageDice`/`DamageType` on the flat snapshot once a player seat is hydrated — it drives damage off the held `*character.Character`'s real equipped weapon via `Character.WeaponForActionRef` and the real ability-score/proficiency chain. Those flat fields only feed the `StandInCombatResolver` fallback used when a seat carries no held character. So the old gate had a real gap: a host that hydrates every seat (real characters, `DataJSON` present) but has no honest value to offer for a precomputed attack-bonus/damage-dice field could never pass `TakeAction`'s gate, even though the resolver would have handled that seat correctly.

This isn't hypothetical — it's rpg-api's actual situation. Lobby-created players (`StartEncounter`) get real HP/AC seeded from the stored character, but `character.Data` has no stored field for AttackBonus/DamageDice/DamageType (they're derived at attack time from equipped weapon + ability scores + proficiency bonus — real rules math the game server must not duplicate). Faking those three fields to satisfy the old gate would have been theater: numbers that pass the gate but never touch the actual damage chain once hydrated.

Consumer-side proof this actually closes the gap end-to-end: **rpg-api#635** (open, not draft). Its committed `go.mod` still points at the published toolkit (no replace directive shipped) — CI there is green because the one assertion that needs this fix is `t.Skip()`'d until this PR lands and rpg-api's `go.mod` bumps past the release containing it. Its integration test (`TestPartyAssembles_FourPlayers_ThenCombatEntry_AttackResolves`) drives a real lobby-created player through `TakeAction` against an injected goblin — verified locally (via a temporary replace directive pointing at this branch) that the assertion passes with this fix and fails with the exact `ErrNonCombatant: missing HP/AC/DamageDice` against the currently published `v0.24.3`.

## Tests

Added `TestTakeAction_HydratedPlayerBypassesFlatSnapshotGate` in `encounter/combat_test.go`: a player seat with HP but no AC/DamageDice, hydrated via `DataJSON`, round-tripped through `LoadFromData` (mirrors the existing hydration-cascade test pattern in `hydration_test.go`), must pass `TakeAction`'s combatant gate. Existing `TestTakeAction_RejectsNonCombatant` (an un-hydrated seat with nothing set) is unchanged and still passes — proving the un-hydrated path's rejection is untouched.

## Docs

`docs/status.md` gets a new entry; `docs/architecture/components/encounter.md`'s combatant-hydration-cascade section gets a bullet documenting that hydration alone now satisfies the gate.

## Verification

- `cd encounter && go build ./... && go vet ./... && gofmt -l .` clean
- `cd encounter && go test -race ./...` green (all 4 sub-packages)
- `cd encounter && golangci-lint run ./...`: 42 pre-existing `goconst` issues (test-fixture string literals across many files), none in `combat.go`/`encounter.go`/the new test in `combat_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
