### PR TITLE
fix(encounter): sweep encounter-scoped conditions at encounter end

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -167,6 +167,18 @@ The single SDK call site is unchanged from the orchestrator's perspective: rpg-a
 
 PvP and monster-vs-monster directions return `ErrUnsupportedAttackDirection` (maps to gRPC `Unimplemented`). A future wave that wants either direction would add the corresponding `applyAndPublish*` helper to the dispatch switch; the SDK surface stays the same.
 
+### Encounter-end condition sweep (rpg-toolkit#752)
+
+`checkEncounterEnd` (death.go) is the single chokepoint every encounter-end predicate feeds through (today: all hostiles defeated). Before it publishes the terminal `EncounterEndedEvent`, it calls `endCombatForPlayers`, which publishes `dnd5eEvents.CombatEndEvent` (via `character.Character.EndCombat`) for every held player character.
+
+This exists because combat-scoped conditions (rage being the motivating case) previously had no way to hear "the encounter is over" — `RagingCondition` only self-removed on no-combat-activity-this-turn, duration expiry, unconsciousness, or rest. A raging character whose *own killing blow* ended the fight skipped all of those triggers, so the condition rode all the way to `ToData()` still present in the persisted `character.Data.Conditions`, and the next encounter's `LoadFromData` cascade silently re-`Apply`'d it — granting the rage damage bonus to a character who never activated rage in that encounter and had no charges left.
+
+**Lifetime model: opt-in per condition, not a taxonomy on Encounter.** `CombatEndTopic` is just another self-termination trigger a condition can subscribe to in its own `Apply`, the same shape `RestTopic` already established (`RagingCondition.onRest` / `onCombatEnd` sit side by side). A condition that should outlive combat (a curse, say) simply never subscribes — the encounter package has no allowlist or type-switch over condition kinds, and doesn't need one to add the next combat-scoped condition.
+
+Flat stat-snapshot seats (no hydrated `*character.Character`) have nothing to sweep and are skipped. Ordering: the sweep runs *before* `EncounterEndedEvent` publishes, so any `StatusRemoved` a condition emits is sequenced ahead of the terminal event on the broker stream.
+
+**Known gap (not fixed here):** encounter snapshots don't carry active statuses — a client that (re)connects mid-encounter only ever learns about a condition from the live `StatusApplied`/`StatusRemoved` stream, never from state. A condition that was hydrated in via `LoadFromData` (as opposed to activated live) is invisible to any viewer who wasn't already connected, even though it's mechanically active. Tracked as a follow-up, not part of this fix.
+
 ## MovementResolver (Wave 2.11e)
 
 `MovementResolver` is the second instance of the resolver-per-verb pattern that `PhasedCombatResolver` established. It lets the encounter SDK delegate per-step movement mechanics (MovementChain execution, OA triggering) to a rulebook implementation without importing rulebook packages.

--- a/docs/status.md
+++ b/docs/status.md
@@ -156,6 +156,25 @@ See "Paused / on hold" below.
 
 ## Recently landed (last 30 days, highlights)
 
+- **Encounter-end condition sweep (rage no longer leaks across encounters)**
+  — PR for issue #752 (2026-07-12). Rage (and any future combat-scoped
+  condition) previously had no way to hear "the encounter is over" — it only
+  self-removed on no-combat-activity-this-turn, duration expiry,
+  unconsciousness, or rest. A raging character whose own killing blow ended
+  the fight skipped all of those, so the condition survived into
+  `ToData()`'s persisted `character.Data.Conditions` and silently
+  re-`Apply`'d in the character's next encounter via `LoadFromData`,
+  granting the rage damage bonus with zero rage charges spent. Fix: a new
+  `dnd5eEvents.CombatEndEvent`/`CombatEndTopic`, published per held player
+  by `checkEncounterEnd` (death.go) before the terminal
+  `EncounterEndedEvent`; `RagingCondition` subscribes to it in `Apply` and
+  self-removes the same way it already does for `RestEvent` — opt-in per
+  condition, not a lifetime taxonomy on `Encounter`. See
+  [encounter.md](architecture/components/encounter.md#encounter-end-condition-sweep-rpg-toolkit752).
+  Known follow-up gap (not fixed here): encounter snapshots don't carry
+  active statuses, so a condition that rode in via `LoadFromData` is
+  invisible to a client that (re)connects mid-encounter — see Known rough
+  edges below.
 - **Rage RAW fixes: STR-melee damage gate + STR check/save advantage** — PR
   #747 (2026-07-05), tagged `rulebooks/dnd5e/v0.65.0`. Rage's damage bonus had
   no ability/range check at all — it applied to *any* hit landed by the
@@ -292,6 +311,20 @@ See "Paused / on hold" below.
   order rather than a declared priority. SneakAttack has the same latent
   shape. Irrelevant at level 1 single-class (today's only playtest shape) —
   revisit if multiclass ordering is ever exercised.
+
+### Encounter SDK
+
+- **Snapshots don't carry active statuses (rpg-toolkit#752 follow-up).** The
+  broker only streams `StatusApplied`/`StatusRemoved` live; `Encounter.Data`
+  has no field projecting a held character's currently-active conditions. A
+  condition hydrated in via `LoadFromData` (as opposed to activated while a
+  client is connected and watching) is mechanically active but invisible to
+  any viewer who wasn't already connected when it was applied — including a
+  client that reconnects mid-encounter. Not a data-loss bug (the condition
+  still functions correctly server-side), but a client-rendering gap. Not
+  addressed by the encounter-end condition sweep (which prevents conditions
+  from surviving *past* their encounter, not this in-encounter visibility
+  gap) — tracked as a separate follow-up.
 
 ### Events
 

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -409,9 +409,15 @@ func (e *Encounter) checkEncounterEnd() (bool, error) {
 	// rpg-toolkit#752: without this, a raging character survives to
 	// ToData() with the condition still in Conditions, and it silently
 	// re-hydrates into the character's NEXT encounter.
-	if err := e.endCombatForPlayers(); err != nil {
-		return true, err
-	}
+	//
+	// Best-effort: a sweep failure must NOT skip the terminal publish below.
+	// Mode is already flipped to ModeEnded above — if we returned here
+	// without publishing, the encounter would be stuck ended with no client
+	// ever told so (every subsequent verb fails ErrEncounterEnded with no
+	// recovery path), which is strictly worse than a condition failing to
+	// sweep. Capture the error and surface it after the publish instead
+	// (Copilot review, PR #753).
+	sweepErr := e.endCombatForPlayers()
 
 	if err := e.broker.Publish(events.NewEncounterEndedEvent(
 		e.data.ID, e.nextSeq(),
@@ -419,6 +425,9 @@ func (e *Encounter) checkEncounterEnd() (bool, error) {
 		e.allViewersEncounterEnded(),
 	)); err != nil {
 		return true, fmt.Errorf("publish encounter ended: %w", err)
+	}
+	if sweepErr != nil {
+		return true, fmt.Errorf("end combat for players: %w", sweepErr)
 	}
 	return true, nil
 }

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -402,6 +402,17 @@ func (e *Encounter) checkEncounterEnd() (bool, error) {
 	e.data.ActiveIdx = 0
 	e.data.Round = 0
 
+	// Sweep combat-scoped conditions (rage, etc.) BEFORE publishing the
+	// terminal event, so any StatusRemoved a condition emits lands ahead of
+	// EncounterEndedEvent in sequence — clients see the drop, then the
+	// terminal transition, rather than a stale status surviving past "over."
+	// rpg-toolkit#752: without this, a raging character survives to
+	// ToData() with the condition still in Conditions, and it silently
+	// re-hydrates into the character's NEXT encounter.
+	if err := e.endCombatForPlayers(); err != nil {
+		return true, err
+	}
+
 	if err := e.broker.Publish(events.NewEncounterEndedEvent(
 		e.data.ID, e.nextSeq(),
 		EncounterEndedReasonAllHostilesDefeated,
@@ -410,6 +421,35 @@ func (e *Encounter) checkEncounterEnd() (bool, error) {
 		return true, fmt.Errorf("publish encounter ended: %w", err)
 	}
 	return true, nil
+}
+
+// endCombatForPlayers publishes CombatEnd for every hydrated player
+// character, giving combat-scoped conditions (e.g. raging) the same
+// self-terminating opportunity LongRest/ShortRest already give them via
+// RestEvent (see character.Character.EndCombat, conditions.RagingCondition
+// .onCombatEnd). Conditions with no reason to end at combat's close (a
+// curse, say) simply never subscribed to CombatEndTopic, so they are
+// untouched — this sweeps by opt-in, not by an encounter-side allowlist of
+// condition types.
+//
+// Flat stat-snapshot seats (no hydrated *character.Character — heldCharacter
+// returns nil) have nothing to sweep and are skipped.
+//
+// ctx: not threaded through checkEncounterEnd's callers today — killEntity
+// is invoked from both ctx-having and ctx-less call sites. context.Background()
+// per the existing precedent (applyUnconsciousOnZeroHP, combat_phased.go).
+func (e *Encounter) endCombatForPlayers() error {
+	ctx := context.Background()
+	for _, pd := range e.data.Players {
+		char := e.heldCharacter(pd.EntityID)
+		if char == nil {
+			continue
+		}
+		if err := char.EndCombat(ctx); err != nil {
+			return fmt.Errorf("end combat for %q: %w", pd.EntityID, err)
+		}
+	}
+	return nil
 }
 
 // spliceFromInitiative removes id from Initiative (if present) and adjusts

--- a/encounter/encounter_end_condition_sweep_test.go
+++ b/encounter/encounter_end_condition_sweep_test.go
@@ -1,0 +1,286 @@
+package encounter_test
+
+// rpg-toolkit#752 regression coverage.
+//
+// Before this fix, checkEncounterEnd (death.go) transitioned the encounter
+// to ModeEnded and published EncounterEndedEvent without touching any held
+// player's conditions. A raging character whose encounter ended via the
+// killing blow itself (rather than "no combat activity this turn") carried
+// RagingCondition all the way to ToData() with the condition still present
+// in the persisted character.Data.Conditions — and the next encounter's
+// LoadFromData cascade silently re-Applied it, granting the rage damage
+// bonus to a character who never activated rage and had no charges left.
+//
+// These tests exercise the fix on the real cascade-hydrated encounter bus
+// (LoadFromData), not a bare condition-level unit test (that lives in
+// conditions/raging_test.go): a barbarian enters the encounter already
+// raging (DataJSON carries the condition, as it would mid-encounter after
+// an earlier ActivateFeature call), lands the killing blow that ends the
+// encounter, and the fix must (a) emit a broker StatusRemoved for raging
+// before EncounterEndedEvent and (b) leave the persisted character data
+// clean so a second, independent encounter never re-applies it.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	tkevents "github.com/KirkDiggler/rpg-toolkit/events"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	encountercore "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+const (
+	ecsEncounterID = encountercore.EncounterID("enc-condition-sweep")
+	ecsDamageDice  = "1d12"
+)
+
+// EncounterEndConditionSweepSuite exercises the checkEncounterEnd condition
+// sweep end to end (rpg-toolkit#752).
+type EncounterEndConditionSweepSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestEncounterEndConditionSweepSuite(t *testing.T) {
+	suite.Run(t, new(EncounterEndConditionSweepSuite))
+}
+
+func (s *EncounterEndConditionSweepSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *EncounterEndConditionSweepSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// ecsRagingBarbDataJSON builds a serialized dnd5e character.Data for a
+// barbarian who is ALREADY raging — Conditions carries the raging condition
+// blob, matching what an earlier in-encounter ActivateFeature("rage") call
+// would have produced and rpg-api would have fed back into this seat's
+// DataJSON.
+func ecsRagingBarbDataJSON(t *testing.T, id, playerID string) json.RawMessage {
+	t.Helper()
+
+	ragingJSON, err := json.Marshal(conditions.RagingData{
+		Ref:         refs.Conditions.Raging(),
+		CharacterID: id,
+		DamageBonus: 2,
+		Level:       3,
+		Source:      "dnd5e:features:rage",
+	})
+	require.NoError(t, err)
+
+	data := &dnd5eCharacter.Data{
+		ID:               id,
+		PlayerID:         playerID,
+		Name:             id,
+		Level:            3,
+		ProficiencyBonus: 2,
+		ClassID:          classes.Barbarian,
+		RaceID:           races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 12, abilities.CON: 15,
+			abilities.INT: 8, abilities.WIS: 10, abilities.CHA: 10,
+		},
+		HitPoints:    16,
+		MaxHitPoints: 16,
+		ArmorClass:   14,
+		Conditions:   []json.RawMessage{ragingJSON},
+		ActionEconomy: &dnd5eCharacter.ActionEconomyData{
+			TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+			ReactionsRemaining: 1, MovementRemaining: 30,
+		},
+	}
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	return raw
+}
+
+// loadRagingBarbVsGoblin builds a fresh encounter with one already-raging
+// barbarian seat and one 1-HP goblin, then round-trips through
+// ToData/LoadFromData so the cascade hydrates the barbarian's character
+// (and its raging condition) onto the held bus exactly once — mirroring
+// condition_removed_bridge_test.go's loadEncounter pattern. The goblin's 1
+// HP guarantees the fixedMaxRoller-driven attack lands the killing blow that
+// ends the encounter.
+func (s *EncounterEndConditionSweepSuite) loadRagingBarbVsGoblin(charJSON json.RawMessage) *encounter.Encounter {
+	s.T().Helper()
+	enc := encounter.New(s.ctx, ecsEncounterID, s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: encountercore.Hex{}, SightRange: 10,
+		HP: 16, MaxHP: 16, AC: 14, AttackBonus: 5,
+		DamageDice: ecsDamageDice, DamageType: damageSlashing,
+		DataJSON: charJSON,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID:       gobEntityID,
+		Position: encountercore.Hex{Q: 1, R: 0, S: -1},
+		HP:       1, MaxHP: 7, AC: 5, Speed: 6,
+		MonsterRef:  monsterRefGoblin,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(err)
+
+	s.Require().NoError(loaded.SetMode(encountercore.ModeTurnBased))
+	for i := 0; loaded.ActiveActor() != encountercore.EntityID(bobEntityID) && i < 4; i++ {
+		_, _, err := loaded.EndTurn(s.ctx, loaded.ActiveActor())
+		s.Require().NoError(err)
+	}
+	s.Require().Equal(encountercore.EntityID(bobEntityID), loaded.ActiveActor(), "setup must land on the barbarian's turn")
+	return loaded
+}
+
+// TestKillingBlow_SweepsRagingCondition_BeforeEncounterEnded is the primary
+// goal-behavior proof: a barbarian who is raging when their own attack ends
+// the encounter (last hostile defeated) must have rage swept — a broker
+// StatusRemoved (ConditionRemovedEvent) fires for "raging" with reason
+// "combat_ended", sequenced BEFORE EncounterEndedEvent, and the persisted
+// character data (ToData) no longer carries the condition.
+func (s *EncounterEndConditionSweepSuite) TestKillingBlow_SweepsRagingCondition_BeforeEncounterEnded() {
+	charJSON := ecsRagingBarbDataJSON(s.T(), bobEntityID, string(bobPlayerID))
+	enc := s.loadRagingBarbVsGoblin(charJSON)
+
+	sub, err := s.broker.Subscribe(ecsEncounterID, bobPlayerID)
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.TakeAction(bobPlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+
+	evts := drainEvents(sub, time.Second)
+
+	removed := findConditionRemoved(evts, encountercore.EntityID(bobEntityID))
+	s.Require().NotNil(removed, "raging must be swept (StatusRemoved) when the killing blow ends the encounter")
+	s.Equal("raging", removed.ConditionRef)
+	s.Equal("combat_ended", removed.Reason)
+
+	var ended *events.EncounterEndedEvent
+	for _, evt := range evts {
+		if e, ok := evt.(*events.EncounterEndedEvent); ok {
+			ended = e
+		}
+	}
+	s.Require().NotNil(ended, "encounter must end once the lone goblin dies")
+	s.Less(removed.Sequence(), ended.Sequence(),
+		"the StatusRemoved for raging must be sequenced before the terminal EncounterEndedEvent")
+
+	// The persisted write-back (ToData) must no longer carry raging — this
+	// is the actual leak vector: rpg-api reads PlayerData.DataJSON here and
+	// persists it as the character's post-encounter state.
+	persisted := enc.ToData()
+	playerData := persisted.Players[bobPlayerID]
+	s.Require().NotNil(playerData)
+	var charData dnd5eCharacter.Data
+	s.Require().NoError(json.Unmarshal(playerData.DataJSON, &charData))
+	s.Empty(charData.Conditions, "raging must not survive into the persisted character data")
+}
+
+// TestTwoEncounterLeak_CleanedCharacterNeverReappliesRaging reproduces the
+// rpg-toolkit#752 playtest evidence directly: take the character data that
+// survives Encounter A's end (post-fix, clean), hydrate it fresh into an
+// unrelated Encounter B, and prove the damage chain cannot include raging —
+// because nothing Applied a RagingCondition onto Encounter B's bus, the same
+// way the playtest's Encounter B fight would have.
+func (s *EncounterEndConditionSweepSuite) TestTwoEncounterLeak_CleanedCharacterNeverReappliesRaging() {
+	// --- Encounter A: rage active, killing blow ends the encounter ---
+	charJSON := ecsRagingBarbDataJSON(s.T(), bobEntityID, string(bobPlayerID))
+	encA := s.loadRagingBarbVsGoblin(charJSON)
+	s.Require().NoError(encA.TakeAction(bobPlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	cleanedCharJSON := encA.ToData().Players[bobPlayerID].DataJSON
+	s.Require().NotEmpty(cleanedCharJSON)
+
+	// --- Encounter B: a brand new encounter, seeded with the SAME character
+	// data rpg-api would have persisted from Encounter A's end. Bob never
+	// activated rage here and has no rage charges left, matching the
+	// playtest's "no rage uses remaining ... yet his hit resolves
+	// [... raging:2]" evidence. ---
+	encB := encounter.New(s.ctx, "enc-condition-sweep-b", s.broker)
+	s.Require().NoError(encB.AddPlayer(encounter.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: encountercore.Hex{}, SightRange: 10,
+		HP: 16, MaxHP: 16, AC: 14, AttackBonus: 5,
+		DamageDice: ecsDamageDice, DamageType: damageSlashing,
+		DataJSON: cleanedCharJSON,
+	}))
+	raw, err := json.Marshal(encB.ToData())
+	s.Require().NoError(err)
+	var dataB encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &dataB))
+	loadedB, err := encounter.LoadFromData(s.ctx, &dataB, s.broker)
+	s.Require().NoError(err)
+
+	// Publish a raw DamageChainEvent for bob's attack directly on Encounter
+	// B's live bus, mirroring conditions/raging_test.go's own
+	// executeDamageChain technique — this is the actual mechanism the
+	// playtest's damage breakdown surfaced the leak through. If raging had
+	// re-hydrated (the bug), RagingCondition.onDamageChain would append a
+	// DamageSourceCondition component with SourceRef raging.
+	weaponComp := dnd5eEvents.DamageComponent{
+		Source: dnd5eEvents.DamageSourceWeapon, FlatBonus: 7,
+		DamageType: damage.Slashing,
+	}
+	abilityComp := dnd5eEvents.DamageComponent{
+		Source: dnd5eEvents.DamageSourceAbility, FlatBonus: 3,
+		DamageType: damage.Slashing,
+	}
+	damageEvent := &dnd5eEvents.DamageChainEvent{
+		AttackerID:   bobEntityID,
+		TargetID:     "some-other-goblin",
+		Components:   []dnd5eEvents.DamageComponent{weaponComp, abilityComp},
+		DamageType:   damage.Slashing,
+		WeaponDamage: ecsDamageDice,
+		AbilityUsed:  abilities.STR,
+		IsMelee:      true,
+	}
+	chain := tkevents.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damageTopic := dnd5eEvents.DamageChain.On(loadedB.EventBus())
+	modifiedChain, err := damageTopic.PublishWithChain(s.ctx, damageEvent, chain)
+	s.Require().NoError(err)
+	final, err := modifiedChain.Execute(s.ctx, damageEvent)
+	s.Require().NoError(err)
+
+	s.Len(final.Components, 2,
+		"damage chain must NOT include a raging component — bob never activated rage in this encounter")
+	for _, comp := range final.Components {
+		s.NotEqual(dnd5eEvents.DamageSourceCondition, comp.Source,
+			"no condition-sourced damage component should exist without an active condition")
+	}
+}

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1-0.20260712152207-1db8a6639e64
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1 h1://KFXuoUfR2G8KxHcNPbfgj2WFL2vPAbrZs4/AcPjBM=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.64.1-0.20260704232541-acd0ab0081d1/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1-0.20260712152207-1db8a6639e64 h1:9XH1QLrUPCYhgwiuHtnf/VgG2mAJ5WGvan2gpOFg4kM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1-0.20260712152207-1db8a6639e64/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -503,6 +503,31 @@ func (c *Character) ShortRest(ctx context.Context) error {
 	return nil
 }
 
+// EndCombat publishes CombatEndEvent so combat-scoped conditions can remove
+// themselves (RAW: rage ends when combat ends) — mirrors LongRest/ShortRest's
+// RestEvent publish. A condition opts into combat-scoped lifetime by
+// subscribing to CombatEndTopic in its own Apply (see
+// RagingCondition.onCombatEnd); a condition that should outlive combat (e.g.
+// a curse) simply does not subscribe, so this is not a lifetime taxonomy on
+// Character — each condition decides its own scope. Unlike LongRest/ShortRest,
+// EndCombat does not touch HP or resources: the encounter-end lifecycle is
+// orthogonal to resting.
+func (c *Character) EndCombat(ctx context.Context) error {
+	if c.bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "character has no event bus")
+	}
+
+	combatEndTopic := dnd5eEvents.CombatEndTopic.On(c.bus)
+	err := combatEndTopic.Publish(ctx, dnd5eEvents.CombatEndEvent{
+		CharacterID: c.id,
+	})
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to publish combat end event")
+	}
+
+	return nil
+}
+
 // GetFeatures returns all character features
 func (c *Character) GetFeatures() []features.Feature {
 	return c.features

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -129,6 +129,16 @@ func (r *RagingCondition) Apply(ctx context.Context, bus events.EventBus) error 
 	}
 	r.subscriptionIDs = append(r.subscriptionIDs, subID7)
 
+	// Subscribe to combat-end events - RAW: rage ends when combat ends
+	combatEnds := dnd5eEvents.CombatEndTopic.On(bus)
+	subID8, err := combatEnds.Subscribe(ctx, r.onCombatEnd)
+	if err != nil {
+		// Rollback: unsubscribe from previous subscriptions
+		_ = r.Remove(ctx, bus)
+		return err
+	}
+	r.subscriptionIDs = append(r.subscriptionIDs, subID8)
+
 	return nil
 }
 
@@ -239,6 +249,19 @@ func (r *RagingCondition) onRest(ctx context.Context, event dnd5eEvents.RestEven
 		return nil
 	}
 	return r.endRage(ctx, "rest")
+}
+
+// onCombatEnd handles combat-end events - RAW: rage ends when combat ends.
+// Without this, a raging character whose encounter ends via a route other
+// than "no combat activity this turn" (e.g. the killing blow itself ends the
+// encounter) would carry the condition into persisted character data and
+// silently re-apply it in the next encounter (rpg-toolkit#752).
+func (r *RagingCondition) onCombatEnd(ctx context.Context, event dnd5eEvents.CombatEndEvent) error {
+	// Only end rage if this is our character
+	if event.CharacterID != r.CharacterID {
+		return nil
+	}
+	return r.endRage(ctx, "combat_ended")
 }
 
 // endRage publishes the removal event and unsubscribes from all events

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -572,6 +572,93 @@ func (s *RagingConditionTestSuite) TestRagingConditionIgnoresOtherCharacterRest(
 	s.True(raging.IsApplied(), "rage should still be applied")
 }
 
+// TestRagingConditionEndsOnCombatEnd is the regression test for
+// rpg-toolkit#752: rage must end when combat ends, the same way it already
+// ends on a rest, so it can never survive into a persisted character's next
+// encounter.
+func (s *RagingConditionTestSuite) TestRagingConditionEndsOnCombatEnd() {
+	// Create a raging condition
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       5,
+		Source:      "dnd5e:features:rage",
+	})
+
+	// Apply it to subscribe to events
+	err := raging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(raging.IsApplied(), "rage should be applied")
+
+	// Track if condition removed event is published
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	removalTopic := dnd5eEvents.ConditionRemovedTopic.On(s.bus)
+	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+		removedEvent = &event
+		return nil
+	})
+	s.Require().NoError(err)
+
+	// Publish a combat-end event for this character (no attack, no hit,
+	// no rest — just the encounter ending, e.g. the killing blow that ended
+	// the fight).
+	combatEndTopic := dnd5eEvents.CombatEndTopic.On(s.bus)
+	err = combatEndTopic.Publish(s.ctx, dnd5eEvents.CombatEndEvent{
+		CharacterID: "barbarian-1",
+	})
+	s.Require().NoError(err)
+
+	// Verify condition published removal event
+	s.Require().NotNil(removedEvent, "rage should be removed when combat ends")
+	s.Equal("barbarian-1", removedEvent.CharacterID)
+	s.Equal("dnd5e:conditions:raging", removedEvent.ConditionRef)
+	s.Equal("combat_ended", removedEvent.Reason)
+
+	// Verify condition is no longer applied
+	s.False(raging.IsApplied(), "rage should no longer be applied after combat ends")
+}
+
+// TestRagingConditionIgnoresOtherCharacterCombatEnd mirrors
+// TestRagingConditionIgnoresOtherCharacterRest: CombatEndEvent is published
+// per-character (the encounter sweeps every held player), so one character's
+// combat-end must not remove another's rage.
+func (s *RagingConditionTestSuite) TestRagingConditionIgnoresOtherCharacterCombatEnd() {
+	// Create a raging condition for barbarian-1
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       5,
+		Source:      "dnd5e:features:rage",
+	})
+
+	// Apply it to subscribe to events
+	err := raging.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	s.True(raging.IsApplied(), "rage should be applied")
+
+	// Track if condition removed event is published
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	removalTopic := dnd5eEvents.ConditionRemovedTopic.On(s.bus)
+	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+		removedEvent = &event
+		return nil
+	})
+	s.Require().NoError(err)
+
+	// Publish a combat-end event for a DIFFERENT character
+	combatEndTopic := dnd5eEvents.CombatEndTopic.On(s.bus)
+	err = combatEndTopic.Publish(s.ctx, dnd5eEvents.CombatEndEvent{
+		CharacterID: "barbarian-2", // Different character
+	})
+	s.Require().NoError(err)
+
+	// Verify condition did NOT publish removal event
+	s.Nil(removedEvent, "rage should NOT be removed when another character's combat ends")
+
+	// Verify condition is still applied
+	s.True(raging.IsApplied(), "rage should still be applied")
+}
+
 // executeDamageChainAgainstTarget creates a damage chain event where a specific target is hit
 // and executes it through the damage chain topic. Used to test resistance.
 func (s *RagingConditionTestSuite) executeDamageChainAgainstTarget(
@@ -706,8 +793,9 @@ func (s *RagingConditionTestSuite) TestRagingConditionResistanceOnlyAffectsOwnCh
 }
 
 func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
-	// Apply a raging condition (creates 7 subscriptions: damage received, turn end,
-	// condition applied, damage chain, rest, saving throw chain, ability check chain)
+	// Apply a raging condition (creates 8 subscriptions: damage received, turn end,
+	// condition applied, damage chain, rest, saving throw chain, ability check chain,
+	// combat end)
 	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
@@ -717,7 +805,7 @@ func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
 
 	err := raging.Apply(s.ctx, s.bus)
 	s.Require().NoError(err)
-	s.Require().Len(raging.subscriptionIDs, 7)
+	s.Require().Len(raging.subscriptionIDs, 8)
 
 	// Wrap the bus so that the first subscription ID fails on unsubscribe
 	failBus := &errorOnUnsubscribeBus{
@@ -728,7 +816,7 @@ func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
 	// Remove should return an error but still clean up all other subscriptions
 	err = raging.Remove(s.ctx, failBus)
 	s.Require().Error(err, "Remove should report the failed unsubscribe")
-	s.Contains(err.Error(), "1/7", "error should report count of failures vs total")
+	s.Contains(err.Error(), "1/8", "error should report count of failures vs total")
 
 	// Condition should be fully cleaned up despite the error
 	s.Nil(raging.subscriptionIDs, "subscriptionIDs should be nil after Remove")

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -536,6 +536,16 @@ type RestEvent struct {
 	CharacterID string              // ID of the character resting
 }
 
+// CombatEndEvent is published when the combat/encounter a character was
+// participating in has ended. Combat-scoped conditions (e.g. RagingCondition)
+// subscribe to CombatEndTopic in their Apply to remove themselves — RAW: rage
+// ends when combat ends. This is an opt-in, per-condition lifetime: a
+// condition that should outlive combat (e.g. a curse) simply does not
+// subscribe. Mirrors the RestEvent self-termination pattern.
+type CombatEndEvent struct {
+	CharacterID string // ID of the character whose combat just ended
+}
+
 // ResourceConsumedEvent is published when a character uses a resource
 type ResourceConsumedEvent struct {
 	CharacterID string                // ID of the character consuming the resource
@@ -878,6 +888,9 @@ var (
 
 	// RestTopic provides typed pub/sub for rest events
 	RestTopic = events.DefineTypedTopic[RestEvent]("dnd5e.rest")
+
+	// CombatEndTopic provides typed pub/sub for combat-end events
+	CombatEndTopic = events.DefineTypedTopic[CombatEndEvent]("dnd5e.combat.end")
 
 	// ResourceConsumedTopic provides typed pub/sub for resource consumption events
 	ResourceConsumedTopic = events.DefineTypedTopic[ResourceConsumedEvent]("dnd5e.resource.consumed")


### PR DESCRIPTION
## Summary

Fixes a two-encounter rage leak found in the 2026-07-12 slice-3 playtest (evidence in the issue): a barbarian's own killing blow ended Encounter A while raging (`EncounterEnded: all_hostiles_defeated` fired, no `StatusRemoved`). The condition survived into the persisted character data, and Encounter B's `LoadFromData` cascade silently re-`Apply`'d it — the character's next hit resolved `[..., dnd5e:conditions:raging:2]` despite never activating rage and having zero rage charges.

**Where the leak actually lived:** entirely in the toolkit's condition lifecycle, not rpg-api's write-back. `checkEncounterEnd` (`encounter/death.go`) is the one chokepoint every encounter-end predicate feeds through (today, only `all_hostiles_defeated`); it transitioned to `ModeEnded` and published `EncounterEndedEvent` without ever touching a held player's conditions. `RagingCondition` only self-removed on no-combat-activity-this-turn, duration expiry, unconsciousness, or rest — nothing fired for "the encounter itself just ended." rpg-api's write-back (`Encounter.ToData()` → `PlayerData.DataJSON`) is unconditional and faithful to whatever the held `*character.Character` holds — it was doing exactly what it should; there was just nothing telling the character rage was over.

**Fix shape:**
- `rulebooks/dnd5e/events`: new `CombatEndEvent`/`CombatEndTopic`, mirroring the existing `RestEvent`/`RestTopic` self-termination pattern.
- `rulebooks/dnd5e/conditions/raging.go`: `RagingCondition` subscribes to `CombatEndTopic` in `Apply` and ends itself with reason `"combat_ended"` — same shape as `onRest`.
- `rulebooks/dnd5e/character/character.go`: new `Character.EndCombat(ctx)`, mirroring `LongRest`/`ShortRest`'s `RestEvent` publish (no HP/resource touch — orthogonal to resting).
- `encounter/death.go`: `checkEncounterEnd` now calls `endCombatForPlayers` (new) before publishing the terminal event — publishes `CombatEndEvent` for every held player character. Flat stat-snapshot seats (no hydrated character) are skipped.

**Lifetime model:** opt-in per condition, not a taxonomy on `Encounter`. `CombatEndTopic` is just another self-termination trigger a condition can subscribe to, the same way `RestTopic` already works. A condition that should outlive combat (a curse, say) simply never subscribes — no allowlist or type-switch over condition kinds on the encounter side. Did not invent a full condition-lifetime taxonomy; noted as a possible future design if a second combat-scoped condition needs different semantics.

**Ordering:** the sweep runs before `EncounterEndedEvent` publishes, so any `StatusRemoved` a condition emits is sequenced ahead of the terminal event.

**Known gap, not fixed here:** encounter snapshots don't carry active statuses. A condition hydrated in via `LoadFromData` (rather than activated live while a client is watching) is mechanically active but invisible to a client that (re)connects mid-encounter, since the client only ever learns about conditions from the live `StatusApplied`/`StatusRemoved` stream. Documented in `docs/status.md` under Known rough edges / Encounter SDK as a follow-up.

Board: [#19 "The Dungeon Run"](https://github.com/users/KirkDiggler/projects/19), Class Kits leg (rage RAW family, sibling of rpg-toolkit#745 / #747).

Closes #752

## Load-bearing

- `checkEncounterEnd` is the single encounter-end chokepoint; the sweep lives there so it automatically covers every future end-condition (fled, negotiated, TPK, time-out) without new wiring.
- Condition lifetime is opt-in per condition (subscribe to `CombatEndTopic` or don't) — not an encounter-side registry of "which condition types are combat-scoped." Keeps the encounter package rulebook-agnostic about *which* conditions end at combat's close.
- The rpg-api write-back path was not the bug and was not touched — `ToData()`'s unconditional re-serialization is correct behavior; it just needed the condition itself to be gone by the time it ran.
- Snapshot-visibility (conditions invisible to reconnecting clients) is a real, separate gap — flagged for a follow-up issue, not folded into this fix.

## Test plan

- [x] `conditions/raging_test.go`: `TestRagingConditionEndsOnCombatEnd` + `TestRagingConditionIgnoresOtherCharacterCombatEnd` (unit-level, mirrors the existing Rest tests) — both pass.
- [x] `encounter/encounter_end_condition_sweep_test.go` (new): `TestKillingBlow_SweepsRagingCondition_BeforeEncounterEnded` — real cascade-hydrated encounter, killing blow ends combat, asserts `StatusRemoved` fires before `EncounterEndedEvent` and `ToData()`'s persisted character data is clean.
- [x] `encounter/encounter_end_condition_sweep_test.go` (new): `TestTwoEncounterLeak_CleanedCharacterNeverReappliesRaging` — reproduces the exact two-encounter shape: cleaned DataJSON from Encounter A hydrates into a brand new Encounter B, a raw damage-chain execution proves no rage component appears.
- [x] Verified both new encounter-level tests actually catch the regression: temporarily reverted the `checkEncounterEnd` sweep call and confirmed both fail, with test 2's failure output showing the literal leaked `{condition dnd5e:conditions:raging ... 2 slashing}` damage component — then restored the fix and re-confirmed green.
- [x] `go build`, `go vet`, `gofmt -l`, `go test -race ./...` clean on both `rulebooks/dnd5e` and `encounter` modules (make pre-commit is broken on main per #721, ran gates directly per repo convention).
- [x] `golangci-lint run ./...` clean on both modules (touched files only — pre-existing goconst debt elsewhere in `encounter` untouched).
- [x] `rulebooks/dnd5e` bumped in `encounter/go.mod` via a real pushed-commit pseudo-version (no local replace directive committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)