### PR TITLE
fix(conditions): rage sustains on a missed attack — attempt counts, RAW

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-05
-confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05
+updated: 2026-07-12
+confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05; #755 rage-sustain-on-miss fix added 2026-07-12
 ---
 
 # rpg-toolkit: Where We Are
@@ -156,6 +156,18 @@ See "Paused / on hold" below.
 
 ## Recently landed (last 30 days, highlights)
 
+- **Rage sustains on a missed attack** — PR for issue #755 (2026-07-12), found
+  in the rage-sweep verification playtest. `RagingCondition.DidAttackThisTurn`
+  was only set inside `onDamageChain`, which fires only on a hit — a raging
+  character who attacked and missed lost rage at turn end
+  (`no_combat_activity`), even though RAW (PHB rage) sustains rage on any
+  attack attempt against a hostile creature, hit or miss. Fix: the sustain
+  flag now comes from a new `onPostAttackRoll` handler subscribed to
+  `PostAttackRollChain` — which fires once per attack roll regardless of
+  outcome (the same signal `ShieldSpellCondition` already reads for its
+  predicate) — instead of the hit-only damage chain. The damage chain
+  subscription is unchanged and still owns the rage damage bonus and B/P/S
+  resistance.
 - **Encounter-end condition sweep (rage no longer leaks across encounters)**
   — PR for issue #752 (2026-07-12). Rage (and any future combat-scoped
   condition) previously had no way to hear "the encounter is over" — it only

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -139,6 +139,18 @@ func (r *RagingCondition) Apply(ctx context.Context, bus events.EventBus) error 
 	}
 	r.subscriptionIDs = append(r.subscriptionIDs, subID8)
 
+	// Subscribe to the post-attack-roll chain to track attack attempts for
+	// the sustain flag. This fires once per attack roll, hit or miss --
+	// unlike the damage chain, which only fires on a hit (rpg-toolkit#755).
+	postRolls := dnd5eEvents.PostAttackRollChain.On(bus)
+	subID9, err := postRolls.SubscribeWithChain(ctx, r.onPostAttackRoll)
+	if err != nil {
+		// Rollback: unsubscribe from previous subscriptions
+		_ = r.Remove(ctx, bus)
+		return err
+	}
+	r.subscriptionIDs = append(r.subscriptionIDs, subID9)
+
 	return nil
 }
 
@@ -295,12 +307,6 @@ func (r *RagingCondition) onDamageChain(
 ) (chain.Chain[*dnd5eEvents.DamageChainEvent], error) {
 	// Handle attacker side: add rage damage bonus
 	if event.AttackerID == r.CharacterID {
-		// Track that we successfully hit an enemy this turn
-		// (damage chain only fires when an attack hits). Any successful attack
-		// counts as combat activity for keeping rage active, regardless of
-		// whether it qualifies for the rage damage bonus below.
-		r.DidAttackThisTurn = true
-
 		// Add rage damage modifier in the StageFeatures stage. Gated inside the
 		// modifier (on the live e.AbilityUsed/e.IsMelee) rather than on the
 		// publish-time event above, since other StageFeatures modifiers (e.g.
@@ -420,5 +426,23 @@ func (r *RagingCondition) onAbilityCheckChain(
 		return c, rpgerr.Wrapf(err, "failed to add raging STR check advantage modifier for character %s", r.CharacterID)
 	}
 
+	return c, nil
+}
+
+// onPostAttackRoll tracks that this character attempted an attack this turn,
+// regardless of whether it hits. RAW (PHB rage): rage continues if you've
+// "attacked a hostile creature since your last turn" -- an attempt counts,
+// hit or miss. PostAttackRollChain fires once per attack roll (after the d20
+// is rolled, before the hit/miss outcome is applied), unlike the damage
+// chain below, which only fires on a hit and was silently dropping rage on a
+// miss (rpg-toolkit#755). The chain itself is not modified.
+func (r *RagingCondition) onPostAttackRoll(
+	_ context.Context,
+	event *dnd5eEvents.PostAttackRollEvent,
+	c chain.Chain[*dnd5eEvents.PostAttackRollEvent],
+) (chain.Chain[*dnd5eEvents.PostAttackRollEvent], error) {
+	if event.AttackerID == r.CharacterID {
+		r.DidAttackThisTurn = true
+	}
 	return c, nil
 }

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -433,9 +433,9 @@ func (r *RagingCondition) onAbilityCheckChain(
 // regardless of whether it hits. RAW (PHB rage): rage continues if you've
 // "attacked a hostile creature since your last turn" -- an attempt counts,
 // hit or miss. PostAttackRollChain fires once per attack roll (after the d20
-// is rolled, before the hit/miss outcome is applied), unlike the damage
-// chain below, which only fires on a hit and was silently dropping rage on a
-// miss (rpg-toolkit#755). The chain itself is not modified.
+// is rolled, before the hit/miss outcome is applied), unlike onDamageChain
+// above, which only fires on a hit and was silently dropping rage on a miss
+// (rpg-toolkit#755). The chain itself is not modified.
 func (r *RagingCondition) onPostAttackRoll(
 	_ context.Context,
 	event *dnd5eEvents.PostAttackRollEvent,

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -91,21 +91,21 @@ func (s *RagingConditionTestSuite) TestRagingConditionTracksAttackAttempts() {
 
 	s.Run("hit sets DidAttackThisTurn", func() {
 		raging.DidAttackThisTurn = false
-		_, err := s.executePostAttackRoll("barbarian-1", "goblin-1", true)
+		err := s.executePostAttackRoll("barbarian-1", "goblin-1", true)
 		s.Require().NoError(err)
 		s.True(raging.DidAttackThisTurn)
 	})
 
 	s.Run("miss also sets DidAttackThisTurn -- RAW: an attempt counts", func() {
 		raging.DidAttackThisTurn = false
-		_, err := s.executePostAttackRoll("barbarian-1", "goblin-1", false)
+		err := s.executePostAttackRoll("barbarian-1", "goblin-1", false)
 		s.Require().NoError(err)
 		s.True(raging.DidAttackThisTurn, "a missed attack attempt should still count as combat activity")
 	})
 
 	s.Run("other character's attack does not set DidAttackThisTurn", func() {
 		raging.DidAttackThisTurn = false
-		_, err := s.executePostAttackRoll("barbarian-2", "goblin-1", true)
+		err := s.executePostAttackRoll("barbarian-2", "goblin-1", true)
 		s.Require().NoError(err)
 		s.False(raging.DidAttackThisTurn)
 	})
@@ -141,7 +141,7 @@ func (s *RagingConditionTestSuite) TestRagingConditionSustainsOnMissedAttack() {
 
 	// Barbarian attacks goblin-1 and MISSES (mirrors the playtest log: "MISS
 	// (6+5 vs AC 15)").
-	_, err = s.executePostAttackRoll("barbarian-1", "goblin-1", false)
+	err = s.executePostAttackRoll("barbarian-1", "goblin-1", false)
 	s.Require().NoError(err)
 
 	// End the barbarian's turn.
@@ -248,7 +248,7 @@ func (s *RagingConditionTestSuite) TestRagingConditionContinuesWithCombatActivit
 
 	// Execute a post-attack-roll chain event (simulates an attack attempt --
 	// combat activity, regardless of hit or miss)
-	_, err = s.executePostAttackRoll("barbarian-1", "goblin-1", true)
+	err = s.executePostAttackRoll("barbarian-1", "goblin-1", true)
 	s.Require().NoError(err)
 
 	// Publish turn end event
@@ -296,7 +296,7 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 	for round := 1; round <= 10; round++ {
 		// Execute a post-attack-roll chain event each round to keep rage active
 		// (simulates an attack attempt, regardless of hit or miss)
-		_, err = s.executePostAttackRoll("barbarian-1", "goblin-1", true)
+		err = s.executePostAttackRoll("barbarian-1", "goblin-1", true)
 		s.Require().NoError(err)
 
 		// End turn
@@ -319,13 +319,18 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 	s.Equal("duration_expired", removedEvent.Reason)
 }
 
-// executePostAttackRoll creates a PostAttackRollEvent and executes it through
+// executePostAttackRoll publishes a PostAttackRollEvent through
 // PostAttackRollChain, simulating an attack roll (hit or miss) for the
-// sustain-flag tests.
+// sustain-flag tests. Matches ResolveAttackHit's real usage of the topic
+// (attack_phases.go): it calls PublishWithChain and discards the returned
+// chain -- it never calls Execute. Subscribers that only inspect the event
+// and don't call c.Add (like onPostAttackRoll here and Shield's handler) run
+// their side effects during the publish itself, so Execute is unnecessary
+// and would exercise a codepath production never runs.
 func (s *RagingConditionTestSuite) executePostAttackRoll(
 	attackerID, targetID string,
 	wouldHit bool,
-) (*dnd5eEvents.PostAttackRollEvent, error) {
+) error {
 	postRollEvent := &dnd5eEvents.PostAttackRollEvent{
 		AttackerID: attackerID,
 		TargetID:   targetID,
@@ -335,12 +340,8 @@ func (s *RagingConditionTestSuite) executePostAttackRoll(
 	chain := events.NewStagedChain[*dnd5eEvents.PostAttackRollEvent](combat.ModifierStages)
 	postRolls := dnd5eEvents.PostAttackRollChain.On(s.bus)
 
-	modifiedChain, err := postRolls.PublishWithChain(s.ctx, postRollEvent, chain)
-	if err != nil {
-		return nil, err
-	}
-
-	return modifiedChain.Execute(s.ctx, postRollEvent)
+	_, err := postRolls.PublishWithChain(s.ctx, postRollEvent, chain)
+	return err
 }
 
 // executeDamageChain creates a damage chain event and executes it through the damage chain topic.

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -69,7 +69,11 @@ func TestRagingConditionTestSuite(t *testing.T) {
 	suite.Run(t, new(RagingConditionTestSuite))
 }
 
-func (s *RagingConditionTestSuite) TestRagingConditionTracksHits() {
+// TestRagingConditionTracksAttackAttempts is the regression test for
+// rpg-toolkit#755: DidAttackThisTurn must be set from the post-attack-roll
+// chain, which fires on both a hit and a miss -- not from the damage chain,
+// which only fires on a hit and was silently dropping rage on a miss.
+func (s *RagingConditionTestSuite) TestRagingConditionTracksAttackAttempts() {
 	// Create a raging condition
 	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
@@ -85,13 +89,72 @@ func (s *RagingConditionTestSuite) TestRagingConditionTracksHits() {
 	// Verify initial state
 	s.False(raging.DidAttackThisTurn)
 
-	// Execute damage chain (simulates a successful hit)
-	// Note: DamageChain only fires when an attack hits
-	_, err = s.executeDamageChain("barbarian-1", 5, 3)
+	s.Run("hit sets DidAttackThisTurn", func() {
+		raging.DidAttackThisTurn = false
+		_, err := s.executePostAttackRoll("barbarian-1", "goblin-1", true)
+		s.Require().NoError(err)
+		s.True(raging.DidAttackThisTurn)
+	})
+
+	s.Run("miss also sets DidAttackThisTurn -- RAW: an attempt counts", func() {
+		raging.DidAttackThisTurn = false
+		_, err := s.executePostAttackRoll("barbarian-1", "goblin-1", false)
+		s.Require().NoError(err)
+		s.True(raging.DidAttackThisTurn, "a missed attack attempt should still count as combat activity")
+	})
+
+	s.Run("other character's attack does not set DidAttackThisTurn", func() {
+		raging.DidAttackThisTurn = false
+		_, err := s.executePostAttackRoll("barbarian-2", "goblin-1", true)
+		s.Require().NoError(err)
+		s.False(raging.DidAttackThisTurn)
+	})
+}
+
+// TestRagingConditionSustainsOnMissedAttack is the end-to-end regression test
+// for rpg-toolkit#755, mirroring the rage-sweep playtest log exactly: a
+// barbarian rages, attacks, MISSES, and ends their turn. RAW (PHB rage):
+// rage ends early only if the character hasn't "attacked a hostile creature
+// since your last turn or taken damage" -- a missed attack attempt still
+// counts, so rage must sustain here.
+func (s *RagingConditionTestSuite) TestRagingConditionSustainsOnMissedAttack() {
+	// Create a raging condition
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       5,
+		Source:      "dnd5e:features:rage",
+	})
+
+	// Apply it to subscribe to events
+	err := raging.Apply(s.ctx, s.bus)
 	s.Require().NoError(err)
 
-	// Check that the condition tracked the successful hit
-	s.True(raging.DidAttackThisTurn)
+	// Track if condition removed event is published
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	removalTopic := dnd5eEvents.ConditionRemovedTopic.On(s.bus)
+	_, err = removalTopic.Subscribe(s.ctx, func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+		removedEvent = &event
+		return nil
+	})
+	s.Require().NoError(err)
+
+	// Barbarian attacks goblin-1 and MISSES (mirrors the playtest log: "MISS
+	// (6+5 vs AC 15)").
+	_, err = s.executePostAttackRoll("barbarian-1", "goblin-1", false)
+	s.Require().NoError(err)
+
+	// End the barbarian's turn.
+	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
+	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		CharacterID: "barbarian-1",
+		Round:       1,
+	})
+	s.Require().NoError(err)
+
+	// Rage must still be active -- a miss is still an attack attempt.
+	s.Nil(removedEvent, "rage should sustain after a missed attack attempt")
+	s.True(raging.IsApplied(), "rage should still be applied after a missed attack")
 }
 
 func (s *RagingConditionTestSuite) TestRagingConditionTracksDamage() {
@@ -183,9 +246,9 @@ func (s *RagingConditionTestSuite) TestRagingConditionContinuesWithCombatActivit
 	})
 	s.Require().NoError(err)
 
-	// Execute damage chain (simulates a successful hit - combat activity)
-	// Note: DamageChain only fires when an attack hits
-	_, err = s.executeDamageChain("barbarian-1", 5, 3)
+	// Execute a post-attack-roll chain event (simulates an attack attempt --
+	// combat activity, regardless of hit or miss)
+	_, err = s.executePostAttackRoll("barbarian-1", "goblin-1", true)
 	s.Require().NoError(err)
 
 	// Publish turn end event
@@ -229,10 +292,11 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 
-	// Simulate 10 rounds of combat with successful hits
+	// Simulate 10 rounds of combat with attack attempts
 	for round := 1; round <= 10; round++ {
-		// Execute damage chain each round to keep rage active (simulates successful hit)
-		_, err = s.executeDamageChain("barbarian-1", 5, 3)
+		// Execute a post-attack-roll chain event each round to keep rage active
+		// (simulates an attack attempt, regardless of hit or miss)
+		_, err = s.executePostAttackRoll("barbarian-1", "goblin-1", true)
 		s.Require().NoError(err)
 
 		// End turn
@@ -253,6 +317,30 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 	s.Equal("barbarian-1", removedEvent.CharacterID)
 	s.Equal("dnd5e:conditions:raging", removedEvent.ConditionRef)
 	s.Equal("duration_expired", removedEvent.Reason)
+}
+
+// executePostAttackRoll creates a PostAttackRollEvent and executes it through
+// PostAttackRollChain, simulating an attack roll (hit or miss) for the
+// sustain-flag tests.
+func (s *RagingConditionTestSuite) executePostAttackRoll(
+	attackerID, targetID string,
+	wouldHit bool,
+) (*dnd5eEvents.PostAttackRollEvent, error) {
+	postRollEvent := &dnd5eEvents.PostAttackRollEvent{
+		AttackerID: attackerID,
+		TargetID:   targetID,
+		WouldHit:   wouldHit,
+	}
+
+	chain := events.NewStagedChain[*dnd5eEvents.PostAttackRollEvent](combat.ModifierStages)
+	postRolls := dnd5eEvents.PostAttackRollChain.On(s.bus)
+
+	modifiedChain, err := postRolls.PublishWithChain(s.ctx, postRollEvent, chain)
+	if err != nil {
+		return nil, err
+	}
+
+	return modifiedChain.Execute(s.ctx, postRollEvent)
 }
 
 // executeDamageChain creates a damage chain event and executes it through the damage chain topic.
@@ -793,9 +881,9 @@ func (s *RagingConditionTestSuite) TestRagingConditionResistanceOnlyAffectsOwnCh
 }
 
 func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
-	// Apply a raging condition (creates 8 subscriptions: damage received, turn end,
+	// Apply a raging condition (creates 9 subscriptions: damage received, turn end,
 	// condition applied, damage chain, rest, saving throw chain, ability check chain,
-	// combat end)
+	// combat end, post-attack-roll chain)
 	raging := newRagingCondition(ragingConditionInput{
 		CharacterID: "barbarian-1",
 		DamageBonus: 2,
@@ -805,7 +893,7 @@ func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
 
 	err := raging.Apply(s.ctx, s.bus)
 	s.Require().NoError(err)
-	s.Require().Len(raging.subscriptionIDs, 8)
+	s.Require().Len(raging.subscriptionIDs, 9)
 
 	// Wrap the bus so that the first subscription ID fails on unsubscribe
 	failBus := &errorOnUnsubscribeBus{
@@ -816,7 +904,7 @@ func (s *RagingConditionTestSuite) TestRemoveContinuesOnStaleSubscription() {
 	// Remove should return an error but still clean up all other subscriptions
 	err = raging.Remove(s.ctx, failBus)
 	s.Require().Error(err, "Remove should report the failed unsubscribe")
-	s.Contains(err.Error(), "1/8", "error should report count of failures vs total")
+	s.Contains(err.Error(), "1/9", "error should report count of failures vs total")
 
 	// Condition should be fully cleaned up despite the error
 	s.Nil(raging.subscriptionIDs, "subscriptionIDs should be nil after Remove")


### PR DESCRIPTION
## Summary

`RagingCondition.DidAttackThisTurn` was only set inside `onDamageChain` (rulebooks/dnd5e/conditions/raging.go), which fires only on a **hit**. A raging character who attacked and missed lost rage at turn end (`no_combat_activity`) — found in the rage-sweep verification playtest (2026-07-12):

```
char-bob rages → attacks goblin-1 → MISS (6+5 vs AC 15) → ends turn → char-bob is no longer Raging (reason no_combat_activity)
```

RAW (PHB rage): rage ends early only if you haven't "attacked a hostile creature since your last turn or taken damage" — a missed attack attempt still counts.

Closes #755

## Fix

The sustain flag now comes from a new `onPostAttackRoll` handler subscribed to `PostAttackRollChain` (`rulebooks/dnd5e/events/events.go:991`), which fires once per attack roll — hit or miss — from `ResolveAttackHit` (`rulebooks/dnd5e/combat/attack_phases.go:358-377`), before the reaction window. It's the same post-roll signal `ShieldSpellCondition` already reads (`rulebooks/dnd5e/conditions/shield_spell.go:102-103`), so this reuses an established pattern rather than introducing a new event.

The damage-chain subscription (`onDamageChain`) is unchanged — it still owns the rage damage bonus (STR-melee gate) and the B/P/S resistance. Only the sustain-flag responsibility moved.

## Load-bearing

- `PostAttackRollEvent` fires unconditionally in phase 1 of attack resolution (before hit/miss is even applied), so it's a reliable "attempted an attack" signal independent of the damage chain, which only runs on a hit.
- No hostility/target validation was added — this matches the existing (pre-fix) level of abstraction in `onDamageChain`, which also didn't validate target hostility. Out of scope for this fix.

## Tests

- `TestRagingConditionSustainsOnMissedAttack` — end-to-end regression mirroring the exact playtest failure: rage → attack → MISS → end turn → still raging.
- `TestRagingConditionTracksAttackAttempts` — unit-level coverage for hit/miss/other-character on the new handler (replaces the old damage-chain-only `TestRagingConditionTracksHits`).
- Existing sustain/drop tests updated to source combat activity from the post-attack-roll chain instead of the damage chain (`TestRagingConditionContinuesWithCombatActivity`, `TestRagingConditionEndsAfter10Rounds`) — no-activity-turn-drops-rage and rest/combat-end removal paths are untouched and stay green.
- `go test -race ./...` green across all of `rulebooks/dnd5e`.

Docs: `docs/status.md` updated in this PR (Recently landed).

Board: [#19 The Dungeon Run](https://github.com/users/KirkDiggler/projects/19), rage RAW family: #745, #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)