### PR TITLE
feat(encounter): the walled room — space, wall-aware LOS, inline combat entry, spawn engine unblocked

### DIFF
--- a/docs/adr/0034-where-encounter-logic-lives.md
+++ b/docs/adr/0034-where-encounter-logic-lives.md
@@ -277,3 +277,22 @@ composable foundation.
 - rpg-toolkit#699 (merged as PR #729, 2026-07-04) — the turn-start revival that
   fully orphaned the fossil.
 - rpg-project#75 — the chapter ledger tracking this decision.
+
+### Amendment (2026-07-13): #757 executes part of this ADR's intent early, without the module split
+
+"The walled room" (rpg-toolkit#757) gives `encounter` a real dependency on
+`tools/spatial` + `tools/environments` (`Data.Space`, wall-aware LoS,
+wall-blocked movement — see
+[encounter.md](architecture/components/encounter.md#walled-rooms-wall-aware-los-and-inline-combat-entry-rpg-toolkit757)).
+This is directionally what "Primitives out: ... fold `encounter/core` hex
+into `tools/spatial`" describes above, but it is **not** that migration:
+`encounter/core.Hex` still exists as its own type (bridged to
+`spatial.CubeCoordinate`/`spatial.Position` via new converter methods, not
+replaced by them), `encounter/go.mod` is untouched as a module boundary, and
+none of the migration sketch's other steps (rulebook-coupled files moving to
+`rulebooks/dnd5e/encounter`, `broker`/`eventspine`/`tools/perception`
+extraction, rpg-api import rewrite) happened. The timing gate above ("starts
+only after Beat 2's playtest + retro close... never mid-wave") still governs
+the actual split — this PR only adds a new downward dependency edge the
+split will eventually have to account for, it doesn't pull the split
+forward.

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,8 +1,8 @@
 ---
 name: encounter module
-description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, combatant hydration cascade, discrete-phase combat orchestration, MovementResolver seam (both movement directions)
-updated: 2026-06-01
-confidence: high — #689 made LoadFromData own combatant hydration (the #684 double-subscribe cure); Wave 2.11d shipped discrete-phase combat; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement in BOTH directions; #697 (TakeAction wave, ADR-0032) deleted the attack-only gate — non-attack refs delegate to the held character's economy/menu, turn-start seeding moved into the engine, ActorTurnState exposes the menu as data
+description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, combatant hydration cascade, discrete-phase combat orchestration, MovementResolver seam (both movement directions), walled-room space + wall-aware LoS + inline combat entry
+updated: 2026-07-13
+confidence: high — #689 made LoadFromData own combatant hydration (the #684 double-subscribe cure); Wave 2.11d shipped discrete-phase combat; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement in BOTH directions; #697 (TakeAction wave, ADR-0032) deleted the attack-only gate — non-attack refs delegate to the held character's economy/menu, turn-start seeding moved into the engine, ActorTurnState exposes the menu as data; #757 (the walled room) added SpaceData, wall-aware VisibleHexesAt/CanSeeAt, wall-blocked movement, and inline combat-entry self-transition
 ---
 
 # encounter module
@@ -22,10 +22,10 @@ back via `ToData`, and save. Player-facing events flow through a process-scoped
 
 One Go module with three subpackages forming a linear DAG (`core ← events ← perception ← encounter`):
 
-- `encounter/core` — identity primitives (`EncounterID`, `PlayerID`, `EntityID`) and spatial primitives (`Hex`, `HexSet`). Exists to break the encounter↔events package import cycle. `HexSet` has custom `MarshalJSON`/`UnmarshalJSON` (struct map keys can't serialize via the default codec). `Hex`/`HexSet` may move to `tools/spatial` in a future slice once the encounter SDK is ready to depend on the spatial module directly.
+- `encounter/core` — identity primitives (`EncounterID`, `PlayerID`, `EntityID`) and spatial primitives (`Hex`, `HexSet`). Exists to break the encounter↔events package import cycle. `HexSet` has custom `MarshalJSON`/`UnmarshalJSON` (struct map keys can't serialize via the default codec). Since #757, `core` also depends on `tools/spatial`: `Hex.ToCube`/`HexFromCube` (field-rename bridge to `spatial.CubeCoordinate`) and `Hex.ToPosition`/`HexFromPosition` (offset-coordinate bridge to `spatial.Position`, pointy-top orientation) — see "Walled rooms" below.
 - `encounter/events` — sealed `EncounterEvent` interface, three concrete events (`MoveEvent`, `HexRevealedEvent`, `DoorOpenedEvent`), and `AudienceSet` (event-routing concept; lives with events).
 - `encounter/events` — sealed `EncounterEvent` interface (AWS v2 SDK marker pattern: unexported `isEncounterEvent()` makes the interface externally unsatisfiable). Concrete events implemented in slice 1: `MoveEvent`, `HexRevealedEvent`, `DoorOpenedEvent`. Each has its own `MarshalJSON`/`UnmarshalJSON` so unexported `encID`/`seq` fields round-trip without leaking construction-only state.
-- `encounter/perception` — pure projection functions (`ProjectMove`, `ProjectDoorOpen`) and `View` value type. Stub LoS today (Manhattan radius); real LoS is a future slice.
+- `encounter/perception` — pure projection functions (`ProjectMove`, `ProjectDoorOpen`) and `View` value type. `VisibleHexesAt`/`CanSeeAt` take a `room spatial.Room` parameter since #757 — nil room is the original pure-radius stub (unchanged for encounters with no `SpaceData`); a non-nil room additionally excludes hexes `room.IsLineOfSightBlocked` reports as wall-blocked. SightRange always caps distance first, regardless of room.
 - `encounter` (top-level) — `Encounter` aggregate, `Broker`, `Transport`, `InMemoryTransport`, JSON codec. The `Broker` is process-scoped — one per game-server process — and uses `sync.WaitGroup` to ensure listener goroutines exit before subscription channels close on shutdown (no double-close races).
 
 ## Key types
@@ -262,6 +262,123 @@ Tests cover the production path explicitly (`TestNPCAct_MovementOA_AppliesDamage
 
 When a player-bearer reaction becomes a goal-shaped feature (Sentinel feat, Shield/Counterspell, etc.), the per-step iteration loop gains a second branch: partition triggers by reactor type, persist `PendingReactionPrompt` for player-bearer triggers, publish a sentinel `errPlayerPausedForReactionDuringMove`, and resume via the existing `SubmitCheck{take_reaction}` path. The design sketch lives on #665; the structural seam is already in place (the per-step iteration + buffer drain are the load-bearing infrastructure).
 
+## Walled rooms, wall-aware LoS, and inline combat entry (rpg-toolkit#757)
+
+Wave 1 of "the walled room" bridges the encounter SDK to `tools/spatial` +
+`tools/environments` — the heavy machinery (wall LoS, movement blocking,
+serialization, spawn engine) already existed in those modules; this wave
+connects it. Design doc: `rpg-project/ideas/the-dungeon/design.md`.
+
+### SpaceData: snapshot, not seed-regeneration
+
+`Data.Space *SpaceData` (`Walls []environments.WallSegmentData`, `Width`,
+`Height`) persists a room as a **snapshot**, not a regeneration seed —
+`environments.QuickRoom`'s wall generator (`RandomPattern`) is only
+deterministic because `QuickRoom`'s 3-arg convenience wrapper never sets
+`RandomSeed` (defaults to 0); nothing else about the design intends to
+replay a seed. `DoorData` already persists mutable state directly, and
+destroyed walls / opened doors (wave 2+) can't replay from a seed either —
+picking the snapshot representation now avoids a representation split
+later.
+
+`Encounter.InitRoom(width, height, pattern)` builds a room via
+`environments.QuickRoom`, and `LoadFromData` rebuilds one from `Data.Space`
+on every call (`rebuildRoomFromData`, transient — reconstructed each load,
+like `e.bus`/`e.combatants`, never serialized). Both are nil-safe: an
+encounter that never calls `InitRoom` (every pre-#757 fixture) has
+`e.room == nil`, and every room-aware call site in this package checks for
+that — LoS falls back to pure radius, movement is unblocked.
+
+**Position precision gotcha (why InitRoom doesn't use QuickRoom's room
+directly):** `environments`' wall generator (`generateRandomWall`,
+`wall_patterns.go`) places walls at **continuous** float positions (e.g.
+`X=3.7`) — it was not built assuming hex-cell-snapped placement. Every
+LoS/movement check in this package queries at the **integer** positions
+`core.Hex.ToPosition()` produces. Those two essentially never collide in a
+`spatial.Room`'s position-keyed occupancy map, which would make most
+generated walls silently non-blocking. `InitRoom` avoids this by never
+registering `QuickRoom`'s own room as `e.room` — it snapshots the walls
+(rounding each wall entity's position to the nearest integer hex cell:
+`space.go`'s `snapshotWalls`) and calls the same `rebuildRoomFromData` path
+`LoadFromData` uses, so `e.room`'s walls always sit at exact integer hex
+positions. One degenerate (`Start == End`) `WallSegmentData` entry per
+discretized wall hex — wave 1 needs per-hex blocking, not polyline
+geometry; per-viewer wall reveal (which would want real geometry) is a
+wave-2+ concern.
+
+### Hex ↔ CubeCoordinate ↔ Position bridge
+
+`encounter/core`'s `Hex{Q,R,S}` and `spatial.CubeCoordinate{X,Y,Z}` are the
+same cube math with different field names — `Hex.ToCube`/`HexFromCube` is a
+pure rename, no computation. `spatial.Position{X,Y float64}` is a
+**different** representation (hex-grid offset coordinates, not cube) that
+`spatial.Room`'s LoS/movement methods actually take; `Hex.ToPosition`/
+`HexFromPosition` compose the cube bridge with `spatial`'s existing
+`ToOffsetCoordinateWithOrientation`/`OffsetCoordinateToCubeWithOrientation`,
+hardcoded to `HexOrientationPointyTop` (the only orientation
+`environments.QuickRoom`'s room builder constructs — D&D 5e standard).
+`npc.go`'s three pre-existing inline `spatial.CubeCoordinate{X: h.Q, ...}`
+conversions were refactored onto `Hex.ToCube`/`HexFromCube` in the same
+change — one bridge, not four copies of the same field mapping.
+
+### Wall-blocked movement
+
+`Encounter.truncateAtWall(path)` (space.go) returns the prefix of a
+requested path up to (not including) the first hex `room.CanPlaceEntity`
+rejects — checked via a throwaway `wallCheckEntity` (players/monsters are
+never themselves placed into the spatial room; only walls occupy it, so
+`CanPlaceEntity`'s occupancy check only ever finds walls). Applied at the
+top of both `Move` (player direction) and `applyNPCMovementSteps` (NPC
+direction, shared by `NPCAct` and the `MoveNPCSteps` test seam) — before
+any movement-budget/resolver logic sees the path, mirroring how a
+resolver's chain-prevented truncation already works. A fully-blocked first
+hex is a no-op (nil error, no state change, no events), matching the
+resolver's own "prevented at first step" semantics.
+
+### Inline combat-entry self-transition
+
+`checkCombatEntry` (combat.go) mirrors `checkEncounterEnd`'s self-transition
+at combat's *other* edge (death.go): when the encounter is `ModeFreeRoam`
+and any player has LoS (`perception.CanSeeAt`, wall-aware) to any monster,
+it calls `SetMode(ModeTurnBased)` — the exact same initiative-roll +
+`ModeChanged`/`TurnStarted` publish path `SetMode` always used for any other
+FreeRoam→TurnBased flip. Called inline at the mutation sites (`Move`,
+`AddMonster`) rather than as a kicked/deferred check — a forgotten kick call
+would silently mean combat never starts, a worse failure mode than a
+redundant inline check. The mode gate at the top makes repeated calls
+idempotent (no re-roll, no "already TURN_BASED" error) once combat has
+started.
+
+"Hostile" == "is a monster" for wave 1 — no faction model exists yet, so
+player-player visibility never triggers this, and every monster is a valid
+trigger for every player. `AddMonster` checks visibility against existing
+players (a monster's visibility to anyone is inherently "newly formed" the
+moment it's added — there's no "before" state for an entity that didn't
+exist); `Move` checks after the mover's `View` has updated, so a player
+walking around a corner into a goblin's hex triggers combat the moment the
+wall no longer blocks LoS between them.
+
+**Pre-hydration entry + the turn-seed catch-up.** Combat entry can now fire
+on an **un-hydrated** encounter: the production creation flow is
+`New()`+`AddPlayer`+`AddMonster` (rpg-api's `StartEncounter`), and `New`
+never hydrates — only a `LoadFromData` round-trip does. `SetMode`'s
+`seedActorTurn` finds no held character at that moment and correctly skips,
+but `SetMode` and `EndTurn` were the only two seeding sites — so the first
+active player's action economy would never be seeded, and every `TakeAction`
+would fail `"not in combat"` (a latent gap that predates #757 for any host
+calling `SetMode` on a fresh encounter — devseed's `--inject-combat` shape —
+which combat entry turned into the default path; surfaced as a ~50%-flaky
+`TestResolver_ReceivesHeldEntity` during #757's test run, the flake being
+initiative order). The fix: `LoadFromData` ends with
+`seedActiveActorIfUnseeded` (turn_economy.go) — if the mode is TURN_BASED
+and the active actor's held character reports `!InCombat()` (economy nil,
+i.e. never seeded; the economy persists through `ToData`/`LoadFromData`, so
+a mid-turn reload sees `InCombat() == true` and is never re-seeded), it runs
+the missed `seedActorTurn` and pushes a fresh `TurnStateChangedEvent`
+(Invariant 12 — the flip-time push snapshotted an un-hydrated empty menu).
+No `TurnStartedEvent` re-publish: the turn already started and was announced
+at the flip; the catch-up completes its seeding, it doesn't restart it.
+
 ## Implementation notes worth keeping
 
 Three lessons surfaced while building slice 1 that are likely to bite future toolkit work:
@@ -297,7 +414,9 @@ handling. Wave 2.11d shipped the combat slice of that list:
   `SubmitCheck` (lives on rpg-api today; the SDK only sees the resumed
   attack flow via `CompleteTakeAction`), `EndTurn` (lives on rpg-api),
   action economy beyond what `combatabilities` ships, conditions beyond
-  the dnd5e rulebook's set, senses, real LoS (still Manhattan stub),
+  the dnd5e rulebook's set, senses, per-viewer wall reveal (wave 1 ships
+  whole-room wall visibility — see "Walled rooms" below), faction model
+  (combat-entry's "hostile" == "is a monster" is a wave-1 stand-in),
   Redis transport, gRPC handler. Entity-visibility accumulation is
   reserved in the type shapes (`HexRevealedSlice.Entities`,
   `View.KnownEntities`) but not emitted yet — future slice.

--- a/docs/architecture/components/tools-environments.md
+++ b/docs/architecture/components/tools-environments.md
@@ -94,6 +94,21 @@ Clean. Published versions, no replace directives.
 - `graph_generator.go` is load-bearing but untested in isolation.
 - No test for `SelectablesTable` integration within environment generation (mentioned as "missing" in `quality.md`).
 - Large environments (100+ rooms) are not load-tested. Performance is extrapolated from small (4-8 room) tests.
+- **Wall placement is not hex-cell-snapped (found by rpg-toolkit#757, tracked as rpg-toolkit#758).**
+  `wall_patterns.go`'s `generateRandomWall`/`calculateWallPositions` place
+  `WallEntity` instances at continuous float positions (e.g. `X=3.7`) — the
+  generator was built assuming a continuous coordinate space, not discrete
+  hex cells, even when `QuickRoom` builds the room on a `spatial.HexGrid`.
+  A consumer that queries `room.CanPlaceEntity`/`IsLineOfSightBlocked` at
+  integer hex positions (as `encounter/core.Hex.ToPosition()` always does)
+  will essentially never collide with those fractional-position walls in the
+  room's position-keyed occupancy map — most generated walls would be
+  silently non-blocking for a hex-grid consumer. `encounter#757` works
+  around this at the call site (rounds wall positions to the nearest hex
+  cell before building the room it actually queries — see
+  [encounter.md](encounter.md#walled-rooms-wall-aware-los-and-inline-combat-entry-rpg-toolkit757));
+  the real fix belongs here, snapping wall placement to the grid's cells
+  when the room is hex-shaped.
 
 ## Verification
 

--- a/docs/architecture/components/tools-spawn.md
+++ b/docs/architecture/components/tools-spawn.md
@@ -1,7 +1,7 @@
 ---
 name: tools/spawn module
 description: 4-phase entity spawn engine — selection, patterns, constraints, environment integration (toolkit-internal; not directly imported by rpg-api)
-updated: 2026-05-04
+updated: 2026-07-13
 confidence: medium-high — verified by reading go.mod and test file names; logic verified through quality.md first-pass; consumer view per audit 049
 ---
 
@@ -55,11 +55,33 @@ basic engine integration tests. This is the primary quality gap.
 - Room scaling based on actual entity count
 - Split-room recommendations when capacity is exceeded
 
+## Spatial wiring (rpg-toolkit#757)
+
+`getRoomFromSpatial` and `placeEntityInRoom` were both literal Phase-1 stubs:
+the first unconditionally returned `"spatial integration not implemented"`,
+the second silently discarded the entity without ever calling
+`room.PlaceEntity` — so even a caller that worked around the first stub would
+get a `SpawnResult` reporting success with nothing actually placed in the
+room. Both are now real: `BasicSpawnEngineConfig.RoomOrchestrator` resolves
+room IDs via `RoomOrchestrator.GetRoom`, and `placeEntityInRoom` calls
+`room.PlaceEntity`. `PopulateRoom`'s existing patterns (scattered, formation,
+team-based, player-choice, clustered) now actually occupy a registered room
+end to end — see `room_wiring_test.go`.
+
+`findValidPosition` (the no-constraints position-picking path) remains a
+Phase-1 stub: it returns a uniform-random `Position` within a hardcoded
+0–10 range, ignoring the room's actual dimensions and never checking for
+walls/occupancy. `findValidPositionWithConstraints` (used whenever
+`SpatialRules` are non-empty) is the real, room-aware path via
+`ConstraintSolver.FindValidPositions`. A caller that needs correct placement
+against non-trivial room geometry should supply `SpatialRules`, not rely on
+the constraint-free scattered default.
+
 ## go.mod status
 
 Clean. Uses published versions:
-- `tools/spatial v0.2.1`
-- `tools/environments v0.1.2`
+- `tools/spatial v0.5.0`
+- `tools/environments v0.4.2`
 
 No replace directives. This is the cleanest dependency chain in the tools layer.
 
@@ -67,6 +89,7 @@ No replace directives. This is the cleanest dependency chain in the tools layer.
 
 - `spawning_patterns.go` and `capacity_analysis.go` have no standalone tests. A bug in formation logic would not be caught until it manifests in the encounter.
 - No documented behavior for spawning in gridless rooms — the spawn engine was designed with hex/square rooms in mind.
+- `findValidPosition`'s hardcoded-random-range stub (see above) — a real fix is unseeded scope, not part of #757.
 
 ## Verification
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-toolkit quality scorecard
 description: Per-module grade with rationale — graded from code read, test run, and go.mod inspection 2026-05-02
-updated: 2026-05-14
-confidence: medium — first-pass grades from read-through and live test run; Wave 2.11d grades from shipped-code verification; no coverage tooling run
+updated: 2026-07-13
+confidence: medium — first-pass grades from read-through and live test run; Wave 2.11d grades from shipped-code verification; rpg-toolkit#757 (encounter, tools/spawn) verified against shipped code 2026-07-13; no coverage tooling run
 ---
 
 # Quality scorecard
@@ -63,14 +63,17 @@ Subpackages (unchanged from slice 1):
 
 - `encounter/core` — identity primitives (EncounterID, PlayerID, EntityID)
   + spatial primitives (Hex, HexSet) with custom `HexSet` JSON (struct map
-  keys can't serialize via the default codec). Hex/HexSet may move to
-  `tools/spatial` in a future slice.
+  keys can't serialize via the default codec). Since rpg-toolkit#757, `core`
+  depends on `tools/spatial` for the `Hex.ToCube`/`ToPosition` bridge
+  (field-rename to `CubeCoordinate`; offset-coordinate bridge to `Position`).
 - `encounter/events` — concrete events (Move, HexRevealed, DoorOpened,
   Wave 2.11d adds `InputRequiredDelivered`), each with
   `MarshalJSON`/`UnmarshalJSON` so unexported `encID`/`seq` round-trip
   cleanly. Also holds `AudienceSet` (event-routing concept).
-- `encounter/perception` — pure `ProjectMove`/`ProjectDoorOpen` over
-  Manhattan-radius stub LoS.
+- `encounter/perception` — pure `ProjectMove`/`ProjectDoorOpen`. Since
+  rpg-toolkit#757, `VisibleHexesAt`/`CanSeeAt` take a `room spatial.Room` and
+  are wall-aware when one is supplied (nil room = the original Manhattan-radius
+  stub, unchanged — the fallback for every encounter with no `Data.Space`).
 - `encounter` (top-level) — Encounter aggregate, Broker (with `sync.WaitGroup`
   for clean shutdown — no double-close races), Transport, InMemoryTransport,
   JSON codec, **Wave 2.11d** combat orchestration (combat.go,
@@ -86,6 +89,19 @@ meaningful architectural surface addition that lifts the module above
 on `PendingReactionPrompt.AttackContextJSON` (issue #657 — SDK trusts
 host to populate the bytes; resolver-supplied serializer would close it)
 and by no coverage tooling run yet.
+
+**rpg-toolkit#757 (the walled room, 2026-07-13) adds `Data.Space`, wall-aware
+LoS/movement, and inline combat-entry self-transition** — see
+[encounter.md](architecture/components/encounter.md#walled-rooms-wall-aware-los-and-inline-combat-entry-rpg-toolkit757).
+Caught and fixed during implementation: `environments`' wall generator places
+walls at continuous (non-hex-snapped) positions, which would have made most
+`environments.QuickRoom`-generated walls silently non-blocking against this
+package's integer-hex LoS/movement checks — worth flagging here since it's
+exactly the kind of cross-module assumption mismatch that doesn't show up
+until two modules are actually wired together, not from reading either one
+in isolation. Grade unchanged (B+) — the new surface is well-tested
+(`space_test.go`, `combat_entry_test.go`, `perception/room_los_test.go`,
+`core/core_test.go`) but doesn't change what's holding the module back from A.
 
 ### events — B+
 
@@ -213,12 +229,20 @@ distribution (all zero, single item, overflow).
 ### tools/spawn — B
 
 All four spawn phases (basic engine, advanced patterns, constraints, environment
-integration) are tested. `basic_engine_test.go`, `constraints_test.go`, and
-`environment_integration_test.go` all pass. The module depends on
-`tools/spatial v0.2.1` and `tools/environments v0.1.2` — these are published
-versions with no replace directives. Clean go.mod. Grade held at B because
+integration) are tested. `basic_engine_test.go`, `constraints_test.go`,
+`environment_integration_test.go`, and (new, rpg-toolkit#757) `room_wiring_test.go`
+all pass. The module depends on `tools/spatial v0.5.0` and
+`tools/environments v0.4.2` — these are published versions with no replace
+directives. Clean go.mod. Grade held at B: `getRoomFromSpatial` and
+`placeEntityInRoom` were both literal stubs — the second silently discarded
+every entity without calling `room.PlaceEntity`, so a caller could get
+`SpawnResult.Success == true` with nothing actually placed — fixed in #757 via
+a new `BasicSpawnEngineConfig.RoomOrchestrator` field, but
 `spawning_patterns.go` (formation, team, clustered) and `capacity_analysis.go`
-have no standalone tests; they are exercised through the engine.
+still have no standalone tests, and `findValidPosition` (the no-constraints
+position-picking path) is still a stub that returns a hardcoded 0–10 random
+range ignoring the room's actual dimensions — see
+[tools-spawn.md](architecture/components/tools-spawn.md#spatial-wiring-rpg-toolkit757).
 
 ---
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-12
-confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05; #755 rage-sustain-on-miss fix added 2026-07-12
+updated: 2026-07-13
+confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05; #755 rage-sustain-on-miss fix added 2026-07-12; #757 the walled room added 2026-07-13
 ---
 
 # rpg-toolkit: Where We Are
@@ -10,6 +10,37 @@ confidence: medium — seeded from full repo read, test run, go.mod inspection, 
 This is a living doc. Edit it in the same PR that invalidates a line. Don't let it rot.
 
 ## Active work
+
+**#757 — the walled room: SpaceData, wall-aware LoS, wall-blocked movement,
+inline combat entry, spawn engine unblocked (2026-07-13).** Toolkit half of
+"The Dungeon" wave 1 (design: `rpg-project/ideas/the-dungeon/design.md`).
+Encounters gain a real room: `Data.Space *SpaceData` snapshots wall geometry
+(built via `environments.QuickRoom` at `Encounter.InitRoom`, reconstructed on
+every `LoadFromData` — a replay, not a re-roll). `perception.VisibleHexesAt`/
+`CanSeeAt` take a `room spatial.Room` and exclude wall-blocked hexes via
+`room.IsLineOfSightBlocked` (nil room = unchanged pure-radius behavior).
+`Move`/`applyNPCMovementSteps` truncate a requested path at the first
+`room.CanPlaceEntity`-rejected hex. `checkCombatEntry` (combat.go) mirrors
+`checkEncounterEnd`'s self-transition at combat's other edge: a
+player-monster visibility pair forming while `ModeFreeRoam` flips the
+encounter to `ModeTurnBased` inline at the `Move`/`AddMonster` mutation
+sites, reusing `SetMode` rather than duplicating its initiative-roll +
+event-publish logic. `tools/spawn`'s `getRoomFromSpatial` and
+`placeEntityInRoom` — both literal Phase-1 stubs (the second silently
+discarded every entity without ever calling `room.PlaceEntity`, so
+`PopulateRoom` could report success while placing nothing) — are now real via
+a new `BasicSpawnEngineConfig.RoomOrchestrator` field. Found and fixed along
+the way: `environments`' wall generator places walls at continuous
+(non-hex-snapped) positions, which would have made most `QuickRoom`-generated
+walls silently non-blocking against this package's integer-hex LoS/movement
+checks — `InitRoom` rounds wall positions to the nearest hex cell before
+building the room encounters actually query, rather than using
+`QuickRoom`'s room object directly. See
+[encounter.md](architecture/components/encounter.md#walled-rooms-wall-aware-los-and-inline-combat-entry-rpg-toolkit757)
+and [tools-spawn.md](architecture/components/tools-spawn.md#spatial-wiring-rpg-toolkit757).
+Zero proto/contract changes — rpg-api (Space.Walls projection, spawn-engine
+wiring at StartEncounter) and web (wall rendering) wave-1 steps follow in
+separate PRs/repos.
 
 **#750 — isPlayerCombatant honors hydration, not just the flat AC/DamageDice
 snapshot (2026-07-11, branch fix/combat-gate-hydration).** `isPlayerCombatant`
@@ -147,7 +178,10 @@ landed earlier. New top-level `encounter/` module with subpackages `core`
 `Encounter` aggregate with `Move` and `OpenDoor` verbs,
 `ToData`/`LoadFromData` persistence, `SnapshotFor` for stream snapshots.
 Stub Manhattan-radius LoS in `encounter/perception/`; real LoS is a
-future slice.
+future slice. **Superseded 2026-07-13 by #757** — see the Active work entry
+below: `VisibleHexesAt`/`CanSeeAt` now take a `room spatial.Room` and are
+wall-aware when one is supplied; the pure-radius behavior remains the
+fallback for a nil room (every encounter with no `Data.Space`).
 
 Earlier active state: no open PRs as of 2026-05-02; last merge was PR #609.
 A large number of stale remote branches remain (40+) from earlier

--- a/encounter/action_resolved_test.go
+++ b/encounter/action_resolved_test.go
@@ -69,8 +69,10 @@ func (s *ActionResolvedSuite) TearDownTest() {
 // A real TakeAction attack emits ActionResolved + AttackResolved + DamageDealt;
 // all three share one correlation id, the ActionResolved carries action_ref +
 // economy_consumed, and every event is stamped with the fixed clock time.
+// alice and the goblin start in mutual LoS, so SetupTest's AddMonster
+// already auto-transitioned the encounter to TURN_BASED; an explicit
+// SetMode here would be redundant and error.
 func (s *ActionResolvedSuite) TestTakeAction_EmitsCorrelatedResolvedAction() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	for s.enc.ActiveActor() != aliceEntityID {
 		_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
 		s.Require().NoError(err)

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -338,6 +338,42 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 	return nil
 }
 
+// checkCombatEntry evaluates whether any player currently has line of sight
+// to any monster and, if so and the encounter is still FREE_ROAM,
+// self-transitions to TURN_BASED by calling SetMode — the exact same
+// initiative-roll + ModeChanged/TurnStarted publish path SetMode already
+// runs for any other FreeRoam->TurnBased flip. This mirrors
+// checkEncounterEnd's self-transition at combat's other edge (death.go): the
+// toolkit owns both entry and exit of combat, not just exit.
+//
+// Called inline at the mutation sites (Move, AddMonster) — not a kicked
+// method — per Kirk's fork-1 call on the design doc: a forgotten kick call
+// silently never starts combat, which is a worse failure mode than a
+// redundant inline check.
+//
+// "Hostile" == "is a monster" for wave 1 — no faction model exists yet, so
+// every monster is a valid combat-entry trigger for every player.
+//
+// The mode gate at the top makes this idempotent: once TURN_BASED, repeated
+// Move/AddMonster calls short-circuit here without re-checking visibility or
+// re-rolling initiative.
+func (e *Encounter) checkCombatEntry() error {
+	if e.data.Mode != core.ModeFreeRoam {
+		return nil
+	}
+	if len(e.data.Players) == 0 || len(e.data.Monsters) == 0 {
+		return nil
+	}
+	for _, p := range e.data.Players {
+		for _, m := range e.data.Monsters {
+			if perception.CanSeeAt(p.View, m.Position, e.room) {
+				return e.SetMode(core.ModeTurnBased)
+			}
+		}
+	}
+	return nil
+}
+
 // EndTurn ends the active actor's turn and advances initiative. Returns
 // the new active actor's id and whether it is an NPC, so the orchestrator
 // can decide whether to call NPCAct next.
@@ -530,8 +566,8 @@ func (e *Encounter) publishAttackOutcome(
 	attackPerPlayer := make(map[core.PlayerID]events.AttackResolvedSlice)
 	damagePerPlayer := make(map[core.PlayerID]events.DamageDealtSlice)
 	for viewerID, viewer := range e.data.Players {
-		if !perception.CanSeeAt(viewer.View, attackerPos) &&
-			!perception.CanSeeAt(viewer.View, targetPos) {
+		if !perception.CanSeeAt(viewer.View, attackerPos, e.room) &&
+			!perception.CanSeeAt(viewer.View, targetPos, e.room) {
 			continue
 		}
 		actionPerPlayer[viewerID] = events.ActionResolvedSlice{Visible: true}

--- a/encounter/combat_entry_test.go
+++ b/encounter/combat_entry_test.go
@@ -103,11 +103,16 @@ func (s *CombatEntrySuite) TestIdempotent_AddMonsterAndMoveAfterCombatStarted() 
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
 
 	// A second monster, also visible, must not error even though the
-	// encounter is already TURN_BASED.
+	// encounter is already TURN_BASED — and it must JOIN the running
+	// initiative (appended, acts last): rollInitiative only saw the
+	// combatants present at the flip, so without the append a sequentially
+	// seeded second goblin would never get a turn (Copilot review, PR #759).
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-2", Position: core.Hex{Q: 2, R: -2, S: 0}, HP: 7, MaxHP: 7,
 	}))
 	s.Equal(core.ModeTurnBased, s.enc.Mode())
+	s.Contains(s.enc.ToData().Initiative, core.EntityID("goblin-2"),
+		"late-added monster must be appended to the running initiative")
 
 	// A further move by the same player must not error either.
 	s.Require().NoError(s.enc.Move("alice", []core.Hex{{Q: 0, R: 1, S: -1}}))

--- a/encounter/combat_entry_test.go
+++ b/encounter/combat_entry_test.go
@@ -1,0 +1,115 @@
+package encounter_test
+
+// combat_entry_test.go covers rpg-toolkit#757's inline combat-entry
+// self-transition: a player-monster visibility pair forming while FREE_ROAM
+// flips the encounter to TURN_BASED by itself, mirroring checkEncounterEnd's
+// self-transition at combat's other edge. See death.go / visibility_transition_test.go
+// for the analogous pattern at combat end.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+type CombatEntrySuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	enc       *encounter.Encounter
+}
+
+func TestCombatEntrySuite(t *testing.T) {
+	suite.Run(t, new(CombatEntrySuite))
+}
+
+func (s *CombatEntrySuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	s.enc = encounter.New(context.Background(), "enc-combat-entry", s.broker)
+}
+
+// A player added within sight of an already-present monster: AddMonster
+// itself is the mutation site that must notice the pair (the monster didn't
+// exist a moment ago, so its visibility to any player is inherently "newly
+// formed").
+func (s *CombatEntrySuite) TestAddMonster_VisibleToExistingPlayer_EntersCombat() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 5,
+	}))
+	s.Equal(core.ModeFreeRoam, s.enc.Mode())
+
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 2, R: -2, S: 0}, HP: 7, MaxHP: 7,
+	}))
+
+	s.Equal(core.ModeTurnBased, s.enc.Mode())
+	s.NotEmpty(s.enc.ToData().Initiative, "SetMode's initiative roll must have run")
+}
+
+// A player who moves into an already-present monster's LoS: Move is the
+// mutation site.
+func (s *CombatEntrySuite) TestMove_IntoMonsterLOS_EntersCombat() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: -10, R: 10, S: 0}, SightRange: 5, // far from the goblin
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Equal(core.ModeFreeRoam, s.enc.Mode(), "goblin out of LoS at add time — must not have entered combat yet")
+
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{
+		{Q: -5, R: 5, S: 0}, {Q: 0, R: 0, S: 0},
+	}))
+
+	s.Equal(core.ModeTurnBased, s.enc.Mode())
+}
+
+// Player-player visibility must never trigger combat entry — "hostile" ==
+// "is a monster" for wave 1.
+func (s *CombatEntrySuite) TestPlayerPlayerVisibility_NeverEntersCombat() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 5,
+	}))
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 1, R: -1, S: 0}, SightRange: 5,
+	}))
+
+	s.Equal(core.ModeFreeRoam, s.enc.Mode())
+
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{{Q: 1, R: 0, S: -1}}))
+	s.Equal(core.ModeFreeRoam, s.enc.Mode(), "no monster in the encounter — must stay FREE_ROAM")
+}
+
+// Once combat has started, further mutation-site calls must not re-fire
+// SetMode (which would error "mode is already TURN_BASED") — the mode gate
+// at the top of checkCombatEntry makes it idempotent.
+func (s *CombatEntrySuite) TestIdempotent_AddMonsterAndMoveAfterCombatStarted() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 5,
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 1, R: -1, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
+
+	// A second monster, also visible, must not error even though the
+	// encounter is already TURN_BASED.
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-2", Position: core.Hex{Q: 2, R: -2, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Equal(core.ModeTurnBased, s.enc.Mode())
+
+	// A further move by the same player must not error either.
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{{Q: 0, R: 1, S: -1}}))
+	s.Equal(core.ModeTurnBased, s.enc.Mode())
+}

--- a/encounter/combat_phased_test.go
+++ b/encounter/combat_phased_test.go
@@ -133,8 +133,10 @@ func (s *PhasedTakeActionSuite) SetupTest() {
 		HP: 10, MaxHP: 10, AC: 13, Speed: 30, AttackBonus: 4,
 		DamageDice: damage1d6plus1, DamageType: damageSlashing,
 	}))
-	// Initiative is random per-roll; tests cycle EndTurn until alice is active.
-	s.Require().NoError(s.enc.SetMode(encountercore.ModeTurnBased))
+	// alice/bob are in mutual LoS of the goblin, so AddMonster (above)
+	// already auto-transitioned to TURN_BASED; an explicit SetMode here
+	// would be redundant and error. Initiative is random per-roll; tests
+	// cycle EndTurn until alice is active.
 }
 
 // makeAliceActive cycles EndTurn until alice is the active actor.
@@ -269,7 +271,8 @@ func (s *PhasedTakeActionSuite) TestLegacyResolverFallback() {
 		HP: 10, MaxHP: 10, AC: 13, Speed: 30, AttackBonus: 4,
 		DamageDice: damage1d6plus1, DamageType: damageSlashing,
 	}))
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// alice is in LoS of the goblin, so AddMonster already auto-transitioned
+	// to TURN_BASED; an explicit SetMode here would be redundant and error.
 	for i := 0; i < 5; i++ {
 		if enc.ActiveActor() == aliceEntityID {
 			break

--- a/encounter/combat_resolver_test.go
+++ b/encounter/combat_resolver_test.go
@@ -84,7 +84,9 @@ func (s *CombatResolverWiringSuite) TestTakeAction_ErrNoCombatResolver() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, err := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(err)
@@ -113,7 +115,9 @@ func (s *CombatResolverWiringSuite) TestTakeAction_UsesResolverOutcome() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, err := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(err)

--- a/encounter/combat_test.go
+++ b/encounter/combat_test.go
@@ -92,37 +92,68 @@ func (s *CombatSuite) TearDownTest() {
 
 // SetMode flip to TURN_BASED rolls initiative, fires ModeChangedEvent +
 // TurnStartedEvent, and gates verbs on mode.
+// The shared s.enc fixture (SetupTest) has alice/bob/goblin in mutual LoS,
+// so AddMonster auto-transitions it to TURN_BASED before any test body runs.
+// This test verifies the FreeRoam->TurnBased flip itself, so it needs its
+// own encounter with no monster (checkCombatEntry no-ops with zero monsters)
+// to observe the actual FreeRoam starting state.
 func (s *CombatSuite) TestSetMode_FlipsAndPublishes() {
-	s.Equal(core.ModeFreeRoam, s.enc.Mode())
-	s.Equal(core.EntityID(""), s.enc.ActiveActor())
+	enc := encounter.New(context.Background(), "enc-mode-flip", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: "1d8+2", DamageType: damageSlashing,
+	}))
+	sub, err := s.broker.Subscribe(enc.ID(), "alice")
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
 
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
-	s.Equal(core.ModeTurnBased, s.enc.Mode())
-	s.NotEqual(core.EntityID(""), s.enc.ActiveActor())
+	s.Equal(core.ModeFreeRoam, enc.Mode())
+	s.Equal(core.EntityID(""), enc.ActiveActor())
 
-	seen := collectTypes(s.aliceSub, 500*time.Millisecond)
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Equal(core.ModeTurnBased, enc.Mode())
+	s.NotEqual(core.EntityID(""), enc.ActiveActor())
+
+	seen := collectTypes(sub, 500*time.Millisecond)
 	s.Contains(seen, "*events.ModeChangedEvent")
 	s.Contains(seen, "*events.TurnStartedEvent")
 }
 
-// SetMode rejects redundant flips.
+// SetMode rejects redundant flips. Own monster-less encounter for the same
+// reason as TestSetMode_FlipsAndPublishes: the shared fixture is already
+// TURN_BASED by the time this test body runs.
 func (s *CombatSuite) TestSetMode_RejectsRedundant() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
-	s.Error(s.enc.SetMode(core.ModeTurnBased))
+	enc := encounter.New(context.Background(), "enc-mode-redundant", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+	}))
+	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	s.Error(enc.SetMode(core.ModeTurnBased))
 }
 
-// TakeAction in FreeRoam mode returns ErrNotTurnBased.
+// TakeAction in FreeRoam mode returns ErrNotTurnBased. Own monster-less
+// encounter so the fixture stays FreeRoam (the shared s.enc is already
+// TURN_BASED by setup time); TakeAction's mode gate fires before any target
+// lookup, so no monster needs to exist for this assertion.
 func (s *CombatSuite) TestTakeAction_RejectedOutsideTurnBased() {
-	err := s.enc.TakeAction("alice",
+	enc := encounter.New(context.Background(), "enc-mode-notb", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+	}))
+	err := enc.TakeAction("alice",
 		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
 		encounter.ActionTarget{EntityID: gobEntityID},
 	)
 	s.ErrorIs(err, encounter.ErrNotTurnBased)
 }
 
-// TakeAction by a non-active player returns ErrNotYourTurn.
+// TakeAction by a non-active player returns ErrNotYourTurn. s.enc is
+// already TURN_BASED by SetupTest (alice/bob/goblin start in mutual LoS).
 func (s *CombatSuite) TestTakeAction_RejectedWhenNotYourTurn() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	active := s.enc.ActiveActor()
 	// Find the OTHER player and try to act.
 	var attackerID core.PlayerID
@@ -139,8 +170,8 @@ func (s *CombatSuite) TestTakeAction_RejectedWhenNotYourTurn() {
 }
 
 // TakeAction with an unknown action ref returns ErrUnsupportedAction.
+// s.enc is already TURN_BASED by SetupTest.
 func (s *CombatSuite) TestTakeAction_RejectsUnknownAction() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	active := s.enc.ActiveActor()
 	playerID := s.playerIDFor(active)
 	if playerID == "" {
@@ -162,8 +193,9 @@ func (s *CombatSuite) TestTakeAction_RejectsUnknownAction() {
 
 // TakeAction publishes AttackResolvedEvent (always); on hit a
 // DamageDealtEvent rides alongside.
+// s.enc is already TURN_BASED by SetupTest (alice/bob/goblin start in
+// mutual LoS, auto-triggering combat entry at AddMonster time).
 func (s *CombatSuite) TestTakeAction_PublishesAttackOutcome() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	for s.enc.ActiveActor() != aliceEntityID {
 		_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
 		s.Require().NoError(err)
@@ -206,7 +238,9 @@ func (s *CombatSuite) TestTakeAction_PublishesAdvantageDisadvantageOnAttackResol
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, err := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(err)
@@ -261,7 +295,9 @@ func (s *CombatSuite) TestTakeAction_RejectsNonCombatant() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, err := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(err)
@@ -318,7 +354,10 @@ func (s *CombatSuite) TestTakeAction_HydratedPlayerBypassesFlatSnapshotGate() {
 	)
 	s.Require().NoError(err)
 
-	s.Require().NoError(loaded.SetMode(core.ModeTurnBased))
+	// AddMonster auto-transitioned to TURN_BASED (mutual LoS, #757) back on
+	// the pre-round-trip encounter; LoadFromData's catch-up seeded the active
+	// actor's economy (the seed was structurally impossible at the flip —
+	// nothing was hydrated yet).
 	for loaded.ActiveActor() != aliceEntityID {
 		_, _, endErr := loaded.EndTurn(context.Background(), loaded.ActiveActor())
 		s.Require().NoError(endErr)
@@ -360,7 +399,9 @@ func (s *CombatSuite) TestTakeAction_DataJSONWithoutLoadFromData_StillRejected()
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -373,9 +414,9 @@ func (s *CombatSuite) TestTakeAction_DataJSONWithoutLoadFromData_StillRejected()
 	s.ErrorIs(err, encounter.ErrNonCombatant, "DataJSON alone (no LoadFromData round-trip) must not satisfy the gate")
 }
 
-// EndTurn publishes TurnEnded + TurnStarted; rotates Initiative.
+// EndTurn publishes TurnEnded + TurnStarted; rotates Initiative. s.enc is
+// already TURN_BASED by SetupTest.
 func (s *CombatSuite) TestEndTurn_AdvancesInitiative() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	first := s.enc.ActiveActor()
 	drainSub(s.aliceSub, 100*time.Millisecond)
 	drainSub(s.bobSub, 100*time.Millisecond)
@@ -390,9 +431,9 @@ func (s *CombatSuite) TestEndTurn_AdvancesInitiative() {
 	s.Contains(seen, "*events.TurnStartedEvent")
 }
 
-// EndTurn called by a non-active actor errors with ErrNotYourTurn.
+// EndTurn called by a non-active actor errors with ErrNotYourTurn. s.enc is
+// already TURN_BASED by SetupTest.
 func (s *CombatSuite) TestEndTurn_RejectsWrongActor() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	active := s.enc.ActiveActor()
 	other := core.EntityID(aliceEntityID)
 	if active == aliceEntityID {
@@ -402,9 +443,16 @@ func (s *CombatSuite) TestEndTurn_RejectsWrongActor() {
 	s.ErrorIs(err, encounter.ErrNotYourTurn)
 }
 
-// EndTurn outside TURN_BASED returns ErrNotTurnBased.
+// EndTurn outside TURN_BASED returns ErrNotTurnBased. Own monster-less
+// encounter so the fixture stays FreeRoam (the shared s.enc is already
+// TURN_BASED by setup time).
 func (s *CombatSuite) TestEndTurn_RequiresTurnBased() {
-	_, _, err := s.enc.EndTurn(context.Background(), aliceEntityID)
+	enc := encounter.New(context.Background(), "enc-mode-endturn-notb", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+	}))
+	_, _, err := enc.EndTurn(context.Background(), aliceEntityID)
 	s.ErrorIs(err, encounter.ErrNotTurnBased)
 }
 
@@ -424,8 +472,8 @@ func (s *CombatSuite) TestEndTurn_GuardsEmptyInitiative() {
 
 // NPCAct (scripted path — no DataJSON) emits an attack event when a
 // player is reachable.
+// s.enc is already TURN_BASED by SetupTest.
 func (s *CombatSuite) TestNPCAct_ScriptedAttackPublishes() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	for s.enc.ActiveActor() != gobEntityID {
 		_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
 		s.Require().NoError(err)
@@ -470,7 +518,9 @@ func (s *CombatSuite) TestTakeAction_OmitsNonViewersFromAudience() {
 	s.Require().NoError(err)
 	defer func() { _ = farBobSub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice is in LoS of gob2 (bob is far away and out of range), so
+	// AddMonster already auto-transitioned to TURN_BASED; an explicit
+	// SetMode here would be redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -498,9 +548,9 @@ func (s *CombatSuite) TestTakeAction_OmitsNonViewersFromAudience() {
 	s.Nil(bobEvent, "bob is out of LoS; no AttackResolvedEvent should be delivered")
 }
 
-// MonsterData round-trips through ToData / LoadFromData.
+// MonsterData round-trips through ToData / LoadFromData. s.enc is already
+// TURN_BASED by SetupTest.
 func (s *CombatSuite) TestMonsterData_RoundTrips() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	persisted := s.enc.ToData()
 	s.Require().Contains(persisted.Monsters, core.EntityID(gobEntityID))
 

--- a/encounter/core/core_test.go
+++ b/encounter/core/core_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -56,4 +57,35 @@ func (s *CoreSuite) TestHexSet_EmptyRoundTrip() {
 	s.Require().NoError(json.Unmarshal([]byte("null"), &fromNull))
 	s.NotNil(fromNull)
 	s.Empty(fromNull)
+}
+
+// ToCube/HexFromCube round-trip: same cube math, different field names
+// (rpg-toolkit#757). Negative coordinates exercise the field mapping, not
+// just zero-value passthrough.
+func (s *CoreSuite) TestHex_CubeRoundTrip() {
+	h := core.Hex{Q: 3, R: -5, S: 2}
+
+	cube := h.ToCube()
+	s.Equal(spatial.CubeCoordinate{X: 3, Y: -5, Z: 2}, cube)
+
+	back := core.HexFromCube(cube)
+	s.Equal(h, back)
+}
+
+// ToPosition/HexFromPosition round-trip through spatial's offset-coordinate
+// bridge (pointy-top orientation — the only orientation environments.QuickRoom
+// builds). Distinct from the cube round-trip: Position is NOT cube
+// coordinates, it's the offset representation spatial.Room's LoS/movement
+// methods actually take.
+func (s *CoreSuite) TestHex_PositionRoundTrip() {
+	for _, h := range []core.Hex{
+		{Q: 0, R: 0, S: 0},
+		{Q: 4, R: -2, S: -2},
+		{Q: -3, R: 1, S: 2},
+		{Q: 5, R: -5, S: 0},
+	} {
+		pos := h.ToPosition()
+		back := core.HexFromPosition(pos)
+		s.Equal(h, back, "round-trip mismatch for %+v via %+v", h, pos)
+	}
 }

--- a/encounter/core/spatial.go
+++ b/encounter/core/spatial.go
@@ -1,0 +1,28 @@
+package core
+
+import "github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+// ToCube converts a Hex to spatial's CubeCoordinate. Both are cube
+// coordinates under the hood — this is a field rename, not a projection.
+func (h Hex) ToCube() spatial.CubeCoordinate {
+	return spatial.CubeCoordinate{X: h.Q, Y: h.R, Z: h.S}
+}
+
+// HexFromCube converts a spatial CubeCoordinate back to a Hex.
+func HexFromCube(c spatial.CubeCoordinate) Hex {
+	return Hex{Q: c.X, R: c.Y, S: c.Z}
+}
+
+// ToPosition converts a Hex to a spatial.Position (offset coordinates).
+// Pointy-top orientation — the only orientation environments.QuickRoom
+// builds (D&D 5e standard) — so wave 1 hardcodes it here rather than
+// threading an orientation parameter through every call site.
+func (h Hex) ToPosition() spatial.Position {
+	return h.ToCube().ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+}
+
+// HexFromPosition converts a spatial.Position (offset coordinates,
+// pointy-top orientation) back to a Hex.
+func HexFromPosition(pos spatial.Position) Hex {
+	return HexFromCube(spatial.OffsetCoordinateToCubeWithOrientation(pos, spatial.HexOrientationPointyTop))
+}

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
 // Data is the persisted shape of an Encounter. The orchestrator
@@ -58,6 +59,37 @@ type Data struct {
 	//
 	// Cleared when the reactor's SubmitCheck resolves (take or skip).
 	PendingReactionPrompts map[core.PlayerID]*PendingReactionPrompt `json:"pending_reaction_prompts,omitempty"`
+
+	// Space is the encounter's room snapshot (walls + dimensions), populated
+	// once from environments.QuickRoom at encounter creation (see
+	// Encounter.InitRoom). Nil for encounters with no spatial room —
+	// pre-wave-1 fixtures and non-spatial (social/free-form) encounters —
+	// which fall back to the pure-radius LoS and unblocked movement that
+	// predates this field. Persists as a snapshot, not a regeneration seed:
+	// wave 2+ wall destruction / door state would otherwise be unable to
+	// replay from a pattern.
+	Space *SpaceData `json:"space,omitempty"`
+}
+
+// SpaceData is the persisted snapshot of an encounter's room: the wall
+// layout and grid dimensions needed to reconstruct the spatial.Room (and
+// its wall entities) on every LoadFromData, without re-running the
+// (non-deterministic) room generator. Walls reuse environments.WallSegmentData
+// rather than a toolkit-local type — same shape environments.EnvironmentData
+// already persists, no reason to duplicate it.
+type SpaceData struct {
+	// Walls are the room's wall segments in absolute cube coordinates. Wave 1
+	// stores one degenerate (Start == End) segment per discretized wall hex —
+	// geometry fidelity beyond per-hex blocking isn't needed until per-viewer
+	// wall reveal (wave 2+).
+	Walls []environments.WallSegmentData `json:"walls"`
+
+	// Width and Height are the room's grid dimensions (offset-coordinate
+	// bounds), needed to reconstruct a HexGrid that agrees with the original
+	// on IsValidPosition — without these, a reconstructed room would need a
+	// guessed bound, silently accepting or rejecting edge positions wrong.
+	Width  int `json:"width"`
+	Height int `json:"height"`
 }
 
 // PendingReactionPrompt is the persisted shape of a reaction prompt waiting

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -67,8 +67,8 @@ func (e *Encounter) killEntity(monsterID, killerID core.EntityID) error {
 
 	diedPerPlayer := make(map[core.PlayerID]events.EntityDiedSlice)
 	for viewerID, viewer := range e.data.Players {
-		seesDying := perception.CanSeeAt(viewer.View, dyingPos)
-		seesKiller := killerHasPos && perception.CanSeeAt(viewer.View, killerPos)
+		seesDying := perception.CanSeeAt(viewer.View, dyingPos, e.room)
+		seesKiller := killerHasPos && perception.CanSeeAt(viewer.View, killerPos, e.room)
 		if !seesDying && !seesKiller {
 			continue
 		}
@@ -130,8 +130,8 @@ func (e *Encounter) publishPlayerDied(playerEntityID, killerID core.EntityID) er
 		if viewerID == playerData.ID {
 			continue
 		}
-		seesDying := perception.CanSeeAt(viewer.View, dyingPos)
-		seesKiller := killerHasPos && perception.CanSeeAt(viewer.View, killerPos)
+		seesDying := perception.CanSeeAt(viewer.View, dyingPos, e.room)
+		seesKiller := killerHasPos && perception.CanSeeAt(viewer.View, killerPos, e.room)
 		if !seesDying && !seesKiller {
 			continue
 		}
@@ -348,7 +348,7 @@ func (e *Encounter) deathSaveAudience(p *PlayerData) map[core.PlayerID]events.En
 		if viewerID == p.ID {
 			continue
 		}
-		if perception.CanSeeAt(viewer.View, pos) {
+		if perception.CanSeeAt(viewer.View, pos, e.room) {
 			perPlayer[viewerID] = events.EntityStabilizedSlice{Visible: true}
 		}
 	}
@@ -369,7 +369,7 @@ func (e *Encounter) deathSaveRolledAudience(p *PlayerData) map[core.PlayerID]eve
 		if viewerID == p.ID {
 			continue
 		}
-		if perception.CanSeeAt(viewer.View, pos) {
+		if perception.CanSeeAt(viewer.View, pos, e.room) {
 			perPlayer[viewerID] = events.DeathSaveRolledSlice{Visible: true}
 		}
 	}

--- a/encounter/death_test.go
+++ b/encounter/death_test.go
@@ -180,26 +180,15 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 	encID := core.EncounterID("enc-death-3")
 	enc := encounter.New(context.Background(), encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
-	// Both monsters are added BEFORE any player: AddMonster's combat-entry
-	// check no-ops while Players is empty, and AddPlayer never triggers the
-	// check itself. This keeps the encounter FreeRoam through setup so the
-	// explicit SetMode below rolls initiative with all four combatants
-	// present — adding a player before the second goblin would auto-enter
-	// combat on the first AddMonster call and silently drop goblin-2 from
-	// Initiative (rollInitiative only sees combatants present at that
-	// moment).
-	//
-	// Two goblins; goblin-1 has 1 HP (instakill target), goblin-2 has 7.
-	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
-		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-	}))
-	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
-		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-	}))
+	// Players first (original order — this is the realistic shape: players
+	// join the lobby, then StartEncounter seeds monsters one AddMonster call
+	// at a time). Two goblins; goblin-1 has 1 HP (instakill target), goblin-2
+	// has 7. goblin-1 shares bob's hex, so AddMonster(goblin-1) auto-enters
+	// combat (checkCombatEntry) with only 3 combatants present; goblin-2 is
+	// then added WHILE already TURN_BASED — this is the exact shape of the
+	// should-fix bug (PR #759 gate): rollInitiative only sees combatants
+	// present at the mode flip, so a late-joining monster must be appended to
+	// the running Initiative rather than silently stranded outside it.
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
@@ -211,6 +200,20 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
 		HP: 10, MaxHP: 10, AC: 13,
 	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode(),
+		"goblin-1 shares bob's hex — AddMonster must auto-enter combat")
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().Contains(enc.ToData().Initiative, core.EntityID(gob2EntityID),
+		"goblin-2 was added after the auto-transition and must still join initiative")
 
 	var err error
 	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
@@ -218,7 +221,6 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 	s.bobSub, err = s.broker.Subscribe(encID, "bob")
 	s.Require().NoError(err)
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -255,34 +257,37 @@ func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 	encID := core.EncounterID("enc-death-4")
 	enc := encounter.New(context.Background(), encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
-	// Both monsters added BEFORE the player, same reasoning as
-	// TestSlice_OneOfTwoMonstersDies_EncounterContinues: this test needs
-	// goblin-2 in Initiative to prove EndTurn skips the dead goblin rather
-	// than landing on it, and adding alice before goblin-2 would auto-enter
-	// combat on the first AddMonster call, dropping goblin-2 from the
-	// initiative roll entirely.
-	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
-		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-	}))
-	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
-		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-	}))
+	// Player first (original order), same reasoning as
+	// TestSlice_OneOfTwoMonstersDies_EncounterContinues: goblin-1 shares
+	// alice's line of sight, so AddMonster(goblin-1) auto-enters combat;
+	// goblin-2 is then added WHILE already TURN_BASED, exercising the
+	// should-fix bug (PR #759 gate) — a late-joining monster must be
+	// appended to the running Initiative, not stranded outside it.
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: aliceEntityID,
 		Position: core.Hex{}, SightRange: 10,
 		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
 		DamageDice: damage1d8plus2, DamageType: damageSlashing,
 	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode(),
+		"goblin-1 is in alice's LoS — AddMonster must auto-enter combat")
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().Contains(enc.ToData().Initiative, core.EntityID(gob2EntityID),
+		"goblin-2 was added after the auto-transition and must still join initiative")
 
 	var err error
 	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
 	s.Require().NoError(err)
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -293,9 +298,12 @@ func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 		encounter.ActionTarget{EntityID: gobEntityID},
 	))
 
-	// Initiative must no longer contain the dead goblin.
+	// Initiative must no longer contain the dead goblin, but must still
+	// contain goblin-2 (proving the earlier late-join wasn't a fluke that a
+	// subsequent splice could mask).
 	persisted := enc.ToData()
 	s.NotContains(persisted.Initiative, core.EntityID(gobEntityID))
+	s.Contains(persisted.Initiative, core.EntityID(gob2EntityID))
 
 	// alice ends her turn; the next active actor must be a live entity
 	// (alice or goblin-2), never the dead goblin.

--- a/encounter/death_test.go
+++ b/encounter/death_test.go
@@ -103,7 +103,9 @@ func (s *DeathSuite) newSingleMonsterEnc(encID core.EncounterID) *encounter.Enco
 	s.bobSub, err = s.broker.Subscribe(encID, "bob")
 	s.Require().NoError(err)
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice/bob are in mutual LoS of the goblin, so AddMonster (above)
+	// already auto-transitioned to TURN_BASED; an explicit SetMode here
+	// would be redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -178,17 +180,15 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 	encID := core.EncounterID("enc-death-3")
 	enc := encounter.New(context.Background(), encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
-	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: "alice", EntityID: aliceEntityID,
-		Position: core.Hex{}, SightRange: 10,
-		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
-		DamageDice: damage1d8plus2, DamageType: damageSlashing,
-	}))
-	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: "bob", EntityID: bobEntityID,
-		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
-		HP: 10, MaxHP: 10, AC: 13,
-	}))
+	// Both monsters are added BEFORE any player: AddMonster's combat-entry
+	// check no-ops while Players is empty, and AddPlayer never triggers the
+	// check itself. This keeps the encounter FreeRoam through setup so the
+	// explicit SetMode below rolls initiative with all four combatants
+	// present — adding a player before the second goblin would auto-enter
+	// combat on the first AddMonster call and silently drop goblin-2 from
+	// Initiative (rollInitiative only sees combatants present at that
+	// moment).
+	//
 	// Two goblins; goblin-1 has 1 HP (instakill target), goblin-2 has 7.
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
@@ -199,6 +199,17 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: bobEntityID,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		HP: 10, MaxHP: 10, AC: 13,
 	}))
 
 	var err error
@@ -244,12 +255,12 @@ func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 	encID := core.EncounterID("enc-death-4")
 	enc := encounter.New(context.Background(), encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
-	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: "alice", EntityID: aliceEntityID,
-		Position: core.Hex{}, SightRange: 10,
-		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
-		DamageDice: damage1d8plus2, DamageType: damageSlashing,
-	}))
+	// Both monsters added BEFORE the player, same reasoning as
+	// TestSlice_OneOfTwoMonstersDies_EncounterContinues: this test needs
+	// goblin-2 in Initiative to prove EndTurn skips the dead goblin rather
+	// than landing on it, and adding alice before goblin-2 would auto-enter
+	// combat on the first AddMonster call, dropping goblin-2 from the
+	// initiative roll entirely.
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
@@ -259,6 +270,12 @@ func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
 	}))
 
 	var err error
@@ -319,7 +336,9 @@ func (s *DeathSuite) TestSlice_EncounterEndedBroadcastsToAll() {
 	s.bobSub, err = s.broker.Subscribe(encID, "bob")
 	s.Require().NoError(err)
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice is in LoS of the goblin (bob is far away and out of range), so
+	// AddMonster already auto-transitioned to TURN_BASED; an explicit
+	// SetMode here would be redundant and error.
 	for enc.ActiveActor() != aliceEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -366,7 +385,8 @@ func (s *DeathSuite) TestSlice_PlayerDies_PartialOnly() {
 	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
 	s.Require().NoError(err)
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice is in LoS of the goblin, so AddMonster already auto-transitioned
+	// to TURN_BASED; an explicit SetMode here would be redundant and error.
 	// Cycle to the goblin's turn.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
@@ -480,7 +500,8 @@ func (s *DeathSuite) TestSlice_PlayerDeath_NotRePublishedOnReHit() {
 	s.aliceSub, err = s.broker.Subscribe(encID, "alice")
 	s.Require().NoError(err)
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice is in LoS of the goblin, so AddMonster already auto-transitioned
+	// to TURN_BASED; an explicit SetMode here would be redundant and error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // OAReactionRef is the canonical reaction ref string for Opportunity Attack.
@@ -66,6 +67,15 @@ type Encounter struct {
 	// correctness loss (e.g. unsaved per-turn condition state). Nil when the
 	// last ToData synced cleanly. #689.
 	syncErr error
+
+	// room and roomOrchestrator are the encounter's spatial room, built by
+	// InitRoom (fresh encounter) or rebuildRoomFromData (LoadFromData) from
+	// data.Space. Transient — reconstructed on every New/LoadFromData call,
+	// exactly like bus and combatants, never serialized. Both remain nil for
+	// encounters with no room (data.Space == nil); every room-aware call
+	// site in this package nil-checks before using them.
+	room             spatial.Room
+	roomOrchestrator spatial.RoomOrchestrator
 }
 
 // Option configures an Encounter at construction.
@@ -282,6 +292,14 @@ func LoadFromData(ctx context.Context, data *Data, b *Broker, opts ...Option) (*
 	if err := e.hydrateCombatants(ctx); err != nil {
 		return nil, fmt.Errorf("hydrate combatants: %w", err)
 	}
+	if err := e.rebuildRoomFromData(); err != nil {
+		return nil, fmt.Errorf("rebuild room: %w", err)
+	}
+	// #757: catch up the active actor's turn seed when combat entry fired on
+	// an un-hydrated encounter (see seedActiveActorIfUnseeded's doc).
+	if err := e.seedActiveActorIfUnseeded(ctx); err != nil {
+		return nil, fmt.Errorf("seed active actor: %w", err)
+	}
 	return e, nil
 }
 
@@ -298,7 +316,7 @@ func (e *Encounter) AddPlayer(input PlayerInput) error {
 		return fmt.Errorf("player %q already in encounter", input.PlayerID)
 	}
 	view := perception.NewView(input.PlayerID, input.Position, input.SightRange)
-	view.ApplyReveal(perception.VisibleHexesAt(input.Position, input.SightRange))
+	view.ApplyReveal(perception.VisibleHexesAt(input.Position, input.SightRange, e.room))
 
 	e.data.Players[input.PlayerID] = &PlayerData{
 		ID:          input.PlayerID,
@@ -357,7 +375,10 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 	if input.DamageDice != "" {
 		e.seedOAReadiness(input.ID)
 	}
-	return nil
+	// Combat-entry check (rpg-toolkit#757): a newly-added monster may already
+	// be visible to an existing player (e.g. spawned inside an already-open
+	// LoS), so this mutation site needs the same check as Move.
+	return e.checkCombatEntry()
 }
 
 // seedOAReadiness initialises an entity's readiness map (if needed) and
@@ -598,6 +619,18 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 
 	moverStart := p.View.Position
 
+	// Wall-blocked movement (rpg-toolkit#757): truncate the requested path at
+	// the first wall-occupied hex before ANY downstream cost/resolver logic
+	// sees it, so a blocked path is never partially budgeted or chain-run.
+	// Nil room (no SpaceData) is a no-op — pre-wave-1 unblocked movement.
+	path = e.truncateAtWall(path)
+	if len(path) == 0 {
+		// Blocked at the very first requested hex. Nothing to publish —
+		// position unchanged, no events fire, nothing spent. Mirrors the
+		// movementResolver's own "prevented at first step" early return below.
+		return nil
+	}
+
 	char := e.heldCharacter(p.EntityID)
 	tracksMovement := char != nil && char.InCombat()
 	if tracksMovement {
@@ -678,6 +711,14 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		if err := e.publishTurnStateChanged(p.EntityID, corrID); err != nil {
 			return fmt.Errorf("publish turn-state changed: %w", err)
 		}
+	}
+
+	// Combat-entry check (rpg-toolkit#757): the mover's view just updated,
+	// so this is a mutation site where a player-monster visibility pair can
+	// newly form. Runs after the MoveEvent/reveal/economy publishes above so
+	// a client sees "you moved" before "combat starts" (cause before effect).
+	if err := e.checkCombatEntry(); err != nil {
+		return err
 	}
 
 	return nil
@@ -846,7 +887,7 @@ func (e *Encounter) applyAndPublishMove(
 	//    - The reveal delta = (visible-from-new-position) MINUS (already-revealed).
 	//      Critical: if we apply the reveal first, the diff is always empty.
 	end := traveledPath[len(traveledPath)-1]
-	newVisible := perception.VisibleHexesAt(end, p.View.SightRange)
+	newVisible := perception.VisibleHexesAt(end, p.View.SightRange, e.room)
 	moverNewHexes := diffHexes(p.View.RevealedHexes, newVisible)
 
 	// 2. Mutate state: position, then apply the reveal delta we just computed.
@@ -881,7 +922,7 @@ func (e *Encounter) applyAndPublishMove(
 		}
 		// ProjectMove returns the visible set so we can pass it directly to
 		// ProjectVisibilityTransition without recomputing VisibleHexesAt.
-		moveSlice, revealSlice, visible := perception.ProjectMove(p.EntityID, traveledPath, other.View)
+		moveSlice, revealSlice, visible := perception.ProjectMove(p.EntityID, traveledPath, other.View, e.room)
 		if moveSlice != nil {
 			movePerPlayer[otherID] = *moveSlice
 		}
@@ -977,7 +1018,7 @@ func (e *Encounter) OpenDoor(playerID core.PlayerID, doorID core.EntityID) error
 
 	for viewerID, viewer := range e.data.Players {
 		doorSlice, revealSlice := perception.ProjectDoorOpen(
-			doorID, door.Position, p.EntityID, viewer.View,
+			doorID, door.Position, p.EntityID, viewer.View, e.room,
 		)
 		if doorSlice != nil {
 			doorPerPlayer[viewerID] = *doorSlice

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -375,6 +375,18 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 	if input.DamageDice != "" {
 		e.seedOAReadiness(input.ID)
 	}
+	// A monster added while combat is already running joins the initiative
+	// order — appended to the end, acting last in the round (the common
+	// reinforcement house rule; a full mid-round initiative roll + insertion
+	// is a future refinement). Without this, sequential monster seeding
+	// (rpg-api's StartEncounter adds its goblins one AddMonster at a time)
+	// would strand every monster after the first visible one: checkCombatEntry
+	// below flips the mode on the FIRST visible add, and rollInitiative only
+	// includes combatants present at that moment (Copilot review, PR #759).
+	// Appending never disturbs ActiveIdx — existing turn order is untouched.
+	if e.data.Mode == core.ModeTurnBased {
+		e.data.Initiative = append(e.data.Initiative, input.ID)
+	}
 	// Combat-entry check (rpg-toolkit#757): a newly-added monster may already
 	// be visible to an existing player (e.g. spawned inside an already-open
 	// LoS), so this mutation site needs the same check as Move.

--- a/encounter/encounter_end_condition_sweep_test.go
+++ b/encounter/encounter_end_condition_sweep_test.go
@@ -154,7 +154,13 @@ func (s *EncounterEndConditionSweepSuite) loadRagingBarbVsGoblin(charJSON json.R
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 	s.Require().NoError(err)
 
-	s.Require().NoError(loaded.SetMode(encountercore.ModeTurnBased))
+	// bob and the goblin are in mutual LoS, so AddMonster (above, on enc)
+	// already auto-transitioned to TURN_BASED before the Data round-trip;
+	// loaded inherits that mode. An explicit SetMode here would be
+	// redundant and error. bob's DataJSON carries a pre-seeded
+	// ActionEconomy (simulating a barbarian already mid-encounter), so this
+	// fixture — unlike TestTakeAction_HydratedPlayerBypassesFlatSnapshotGate
+	// — doesn't depend on SetMode's seedActorTurn call to populate economy.
 	for i := 0; loaded.ActiveActor() != encountercore.EntityID(bobEntityID) && i < 4; i++ {
 		_, _, err := loaded.EndTurn(s.ctx, loaded.ActiveActor())
 		s.Require().NoError(err)

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1-0.20260712152207-1db8a6639e64
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0
+	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -15,6 +16,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 // indirect
 	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 // indirect
+	github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -12,8 +12,12 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1-0.20260712152207-1db8a6639e64 h1:9XH1QLrUPCYhgwiuHtnf/VgG2mAJ5WGvan2gpOFg4kM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.1-0.20260712152207-1db8a6639e64/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0 h1:vlraS3uAcQ5N2+UxZ0l61CoCe6LtZhLIlxuGUnA+2NE=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.4.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2 h1:kPc3FZSRAB/gIzTBvlOYxzqp9mdL0akkeRW/8EZcI9A=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
+github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=
+github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0 h1:weKsLlsRV9kgoD/y68VWy0lpsu5zhwCmbnr5MUkLpsA=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/encounter/hydration_test.go
+++ b/encounter/hydration_test.go
@@ -156,7 +156,9 @@ func (s *HydrationCascadeSuite) TestSneakAttack_SubscribesExactlyOnce_AcrossAtta
 // boundary with NO re-load (EndTurn emits the turn signal on the held bus).
 func (s *HydrationCascadeSuite) TestSneakAttack_UsedThisTurn_PersistsAndResets() {
 	enc := s.loadEncounterWithRogue()
-	s.Require().NoError(enc.SetMode(encountercore.ModeTurnBased))
+	// The rogue and the goblin are in mutual LoS, so loadEncounterWithRogue's
+	// AddMonster already auto-transitioned to TURN_BASED; an explicit
+	// SetMode here would be redundant and error.
 
 	// Fire the rogue's sneak attack once — sets UsedThisTurn=true on the held
 	// condition instance.
@@ -258,7 +260,10 @@ func (s *HydrationCascadeSuite) TestNPCAct_UsesHeldMonster_NoDoubleSubscribe() {
 	// Round-trip so the cascade hydrates the goblin onto the held bus.
 	spy := &spyCombatResolver{}
 	enc2 := s.reloadViaWithResolver(enc, spy)
-	s.Require().NoError(enc2.SetMode(encountercore.ModeTurnBased))
+	// The rogue and the goblin are in mutual LoS, so AddMonster (above, on
+	// enc) already auto-transitioned to TURN_BASED before the round-trip;
+	// enc2 inherits that mode. An explicit SetMode here would be redundant
+	// and error.
 
 	// Advance to the goblin's turn and run NPCAct. If NPCAct re-loaded the
 	// goblin onto the bus, the monster's conditions would double-subscribe.
@@ -309,7 +314,10 @@ func (s *HydrationCascadeSuite) TestResolver_ReceivesHeldEntity() {
 	}))
 
 	enc2 := s.reloadViaWithResolver(enc, spy)
-	s.Require().NoError(enc2.SetMode(encountercore.ModeTurnBased))
+	// AddMonster auto-transitioned to TURN_BASED (mutual LoS, #757), and the
+	// reload's LoadFromData catch-up seeded the active actor's economy —
+	// including the pre-hydration-entry case this test previously hit as a
+	// flaky "not in combat" failure.
 	s.driveAttackFromRogue(enc2)
 
 	s.Require().Positive(spy.calls, "resolver should have been called")
@@ -338,7 +346,10 @@ func (s *HydrationCascadeSuite) TestResolver_NoDataJSON_FallsBack() {
 	}))
 
 	enc2 := s.reloadViaWithResolver(enc, spy)
-	s.Require().NoError(enc2.SetMode(encountercore.ModeTurnBased))
+	// The rogue and the goblin are in mutual LoS, so AddMonster (above, on
+	// enc) already auto-transitioned to TURN_BASED before the round-trip;
+	// enc2 inherits that mode. An explicit SetMode here would be redundant
+	// and error.
 	s.driveAttackFromRogue(enc2)
 
 	s.Require().Positive(spy.calls)

--- a/encounter/integration_test.go
+++ b/encounter/integration_test.go
@@ -233,8 +233,9 @@ func (s *ConditionPersistenceSuite) TestSlice_ConditionStatePersistsAcrossAttack
 		DamageDice: dice1d6, DamageType: damagePiercing,
 	}))
 
-	// Start combat — alice must go first for the test to be deterministic.
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error. Cycle until alice is active for determinism.
 	for enc.ActiveActor() != "char-alice" {
 		_, _, err := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(err)

--- a/encounter/move_economy_test.go
+++ b/encounter/move_economy_test.go
@@ -95,7 +95,7 @@ func (s *MoveEconomySuite) charliCharJSON() json.RawMessage {
 func (s *MoveEconomySuite) loadedEncounter() *encounter.Encounter {
 	s.T().Helper()
 	view := perception.NewView(moveEconPlayerID, core.Hex{}, 10)
-	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10, nil))
 	data := encounter.NewData("enc-move-econ")
 	data.Players[moveEconPlayerID] = &encounter.PlayerData{
 		ID:         moveEconPlayerID,
@@ -211,7 +211,7 @@ func (s *MoveEconomySuite) TestMove_PublishesTurnStateChangedAfterSuccessfulMove
 // the fix must not regress non-combat movement.
 func (s *MoveEconomySuite) TestMove_NotInCombat_SkipsEconomyEnforcement() {
 	view := perception.NewView(moveEconPlayerID, core.Hex{}, 10)
-	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10, nil))
 	data := encounter.NewData("enc-move-econ-free")
 	data.Players[moveEconPlayerID] = &encounter.PlayerData{
 		ID:         moveEconPlayerID,

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -249,7 +249,7 @@ func (e *Encounter) applyNPCMovement(mon *MonsterData, movement []spatial.CubeCo
 	// encounter SDK's core.Hex path.
 	path := make([]encountercore.Hex, 0, len(movement))
 	for _, hop := range movement {
-		path = append(path, encountercore.Hex{Q: hop.X, R: hop.Y, S: hop.Z})
+		path = append(path, encountercore.HexFromCube(hop))
 	}
 	return e.applyNPCMovementSteps(mon, path)
 }
@@ -302,6 +302,13 @@ func (e *Encounter) applyNPCMovementSteps(mon *MonsterData, path []encountercore
 	}
 	if len(path) == 0 {
 		return nil // No real movement — moving to where you already are.
+	}
+
+	// Wall-blocked movement (rpg-toolkit#757): same truncation as the player
+	// path — an NPC cannot walk through a wall either. Nil room is a no-op.
+	path = e.truncateAtWall(path)
+	if len(path) == 0 {
+		return nil // Blocked at the very first hex.
 	}
 
 	traveledPath := path
@@ -1028,7 +1035,7 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 // unconscious-target is deliberately NOT implemented here; the issue only
 // asks to skip dead/unconscious targets, not add that rule.
 func (e *Encounter) buildPerception(mon *MonsterData) *monster.PerceptionData {
-	pos := spatial.CubeCoordinate{X: mon.Position.Q, Y: mon.Position.R, Z: mon.Position.S}
+	pos := mon.Position.ToCube()
 	pd := &monster.PerceptionData{
 		MyPosition: pos,
 	}
@@ -1039,7 +1046,7 @@ func (e *Encounter) buildPerception(mon *MonsterData) *monster.PerceptionData {
 		dist := hexDistance(mon.Position, p.View.Position)
 		pd.Enemies = append(pd.Enemies, monster.PerceivedEntity{
 			Entity:   &playerEntity{id: string(p.EntityID), name: string(p.ID)},
-			Position: spatial.CubeCoordinate{X: p.View.Position.Q, Y: p.View.Position.R, Z: p.View.Position.S},
+			Position: p.View.Position.ToCube(),
 			Distance: dist,
 			Adjacent: dist == 1,
 			HP:       p.HP,

--- a/encounter/npc_targeting_downed_test.go
+++ b/encounter/npc_targeting_downed_test.go
@@ -90,7 +90,9 @@ func (s *NPCTargetingDownedSuite) TestScriptedPath_ClosestPlayer_NeverTargetsDow
 	s.Require().NoError(err)
 	defer func() { _ = aliceSub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// The downed player is in LoS of the goblin, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 
 	for turn := 0; turn < 3; turn++ {
 		for enc.ActiveActor() != gobEntityID {
@@ -160,7 +162,9 @@ func (s *NPCTargetingDownedSuite) TestFullAIPath_BuildPerception_NeverTargetsDow
 	s.Require().NoError(err)
 	defer func() { _ = aliceSub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// Both players are in LoS of the goblin, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 
 	for turn := 0; turn < 2; turn++ {
 		for enc.ActiveActor() != gobEntityID {

--- a/encounter/npc_test.go
+++ b/encounter/npc_test.go
@@ -79,8 +79,10 @@ func (s *NPCSuite) TearDownTest() {
 // NPCAct via monster.TakeTurn captures the dnd5e AttackEvent the goblin's
 // scimitar action emits and re-publishes it as an encounter
 // AttackResolvedEvent.
+// alice and the goblin are in mutual LoS, so SetupTest's AddMonster already
+// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+// redundant and error.
 func (s *NPCSuite) TestNPCAct_GoblinTakeTurn_PublishesAttack() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	for s.enc.ActiveActor() != gobEntityID {
 		_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
 		s.Require().NoError(err)
@@ -94,16 +96,24 @@ func (s *NPCSuite) TestNPCAct_GoblinTakeTurn_PublishesAttack() {
 	s.Contains(seen, "*events.AttackResolvedEvent")
 }
 
-// NPCAct outside TURN_BASED returns ErrNotTurnBased.
+// NPCAct outside TURN_BASED returns ErrNotTurnBased. Own monster-less
+// encounter so the fixture stays FreeRoam (the shared s.enc is already
+// TURN_BASED by setup time — alice and the goblin start in mutual LoS).
 func (s *NPCSuite) TestNPCAct_RequiresTurnBased() {
-	err := s.enc.NPCAct(s.ctx, gobEntityID)
+	enc := encounter.New(context.Background(), "enc-npc-notb", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+	}))
+	err := enc.NPCAct(s.ctx, gobEntityID)
 	s.ErrorIs(err, encounter.ErrNotTurnBased)
 }
 
 // NPCAct against an unknown id returns ErrNotYourTurn (the active-actor
-// check fires before the existence check).
+// check fires before the existence check). alice and the goblin are in
+// mutual LoS, so SetupTest's AddMonster already auto-transitioned to
+// TURN_BASED; an explicit SetMode here would be redundant and error.
 func (s *NPCSuite) TestNPCAct_RejectsUnknownNPC() {
-	s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	// Cycle to goblin to satisfy the active-actor gate, then try to act
 	// for a non-existent npc — the test exercises ErrNotYourTurn (the
 	// active-actor check fires before the existence check).
@@ -137,7 +147,9 @@ func (s *NPCSuite) TestNPCAct_ErrNoCombatResolver() {
 		MonsterRef: monsterRefGoblin,
 		DataJSON:   dataJSON,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -163,7 +175,9 @@ func (s *NPCSuite) TestNPCAct_Scripted_ErrNoCombatResolver() {
 		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -232,7 +246,9 @@ func (s *NPCSuite) TestNPCAct_MovementOA_AppliesDamageOnce() {
 		DataJSON:    dataJSON,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
 	}))
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice (distance 10) is within the goblin's mutual LoS (sight 12), so
+	// AddMonster already auto-transitioned to TURN_BASED; an explicit
+	// SetMode here would be redundant and error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -294,7 +310,9 @@ func (s *NPCSuite) TestNPCAct_RegularAttack_DamageSharesAttackCorrelationID() {
 	s.Require().NoError(subErr)
 	defer func() { _ = sub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -400,7 +418,9 @@ func (s *NPCSuite) TestNPCAct_SingleDamageDealtEvent_PerAttack() {
 	s.Require().NoError(subErr)
 	defer func() { _ = sub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster already
+	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
+	// redundant and error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
 		s.Require().NoError(endErr)

--- a/encounter/perception/los_stub.go
+++ b/encounter/perception/los_stub.go
@@ -1,6 +1,9 @@
 package perception
 
-import "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+import (
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
 
 // HexDistance is the cube-coordinate hex distance between two hexes.
 // Exported for use by the encounter package's verbs.
@@ -20,12 +23,17 @@ func HexDistance(a, b core.Hex) int {
 	return ds
 }
 
-// VisibleHexesAt returns the hexes within sightRange of from, including from.
+// VisibleHexesAt returns the hexes within sightRange of from, including from,
+// that are not wall-blocked from from.
 //
-// STUB: ignores walls, lighting, conditions. Replaced with real LoS in a
-// future slice.
-func VisibleHexesAt(from core.Hex, sightRange int) core.HexSet {
+// room is wall-aware LoS (Wave 1, rpg-toolkit#757): a hex within range is
+// excluded when room.IsLineOfSightBlocked reports a wall between from and
+// that hex. room may be nil — encounters with no SpaceData (pre-wave-1
+// fixtures, non-spatial encounters) get the original pure-radius behavior.
+// SightRange always caps distance regardless of room.
+func VisibleHexesAt(from core.Hex, sightRange int, room spatial.Room) core.HexSet {
 	out := make(core.HexSet)
+	fromPos := from.ToPosition()
 	for dq := -sightRange; dq <= sightRange; dq++ {
 		for dr := -sightRange; dr <= sightRange; dr++ {
 			ds := -dq - dr
@@ -34,20 +42,30 @@ func VisibleHexesAt(from core.Hex, sightRange int) core.HexSet {
 				continue
 			}
 			h := core.Hex{Q: from.Q + dq, R: from.R + dr, S: from.S + ds}
+			if room != nil && room.IsLineOfSightBlocked(fromPos, h.ToPosition()) {
+				continue
+			}
 			out[h] = struct{}{}
 		}
 	}
 	return out
 }
 
-// CanSeeAt reports whether a viewer can currently see the given hex,
-// using the stub LoS rules: a hex is visible iff it is within the
-// viewer's SightRange (cube distance). Returns false for a nil viewer.
-func CanSeeAt(viewer *View, target core.Hex) bool {
+// CanSeeAt reports whether a viewer can currently see the given hex: within
+// the viewer's SightRange (cube distance) AND, when room is non-nil, not
+// wall-blocked (room.IsLineOfSightBlocked). Returns false for a nil viewer.
+// room may be nil for the pre-wave-1 pure-radius behavior.
+func CanSeeAt(viewer *View, target core.Hex, room spatial.Room) bool {
 	if viewer == nil {
 		return false
 	}
-	return HexDistance(viewer.Position, target) <= viewer.SightRange
+	if HexDistance(viewer.Position, target) > viewer.SightRange {
+		return false
+	}
+	if room != nil && room.IsLineOfSightBlocked(viewer.Position.ToPosition(), target.ToPosition()) {
+		return false
+	}
+	return true
 }
 
 // HexNeighbors returns the six adjacent hexes (cube coords).

--- a/encounter/perception/project.go
+++ b/encounter/perception/project.go
@@ -3,6 +3,7 @@ package perception
 import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // ProjectVisibilityTransition determines whether the mover entered or left the
@@ -98,11 +99,12 @@ func ProjectMove(
 	_ core.EntityID, // mover — reserved for future-slice entity-visibility
 	path []core.Hex,
 	viewer *View,
+	room spatial.Room,
 ) (moveSlice *events.MovePlayerSlice, revealSlice *events.HexRevealedSlice, visible core.HexSet) {
 	if viewer == nil || len(path) == 0 {
 		return nil, nil, make(core.HexSet)
 	}
-	visible = VisibleHexesAt(viewer.Position, viewer.SightRange)
+	visible = VisibleHexesAt(viewer.Position, viewer.SightRange, room)
 
 	var seen []core.Hex
 	for _, hex := range path {
@@ -135,11 +137,12 @@ func ProjectDoorOpen(
 	doorPos core.Hex,
 	_ core.EntityID, // openedBy — reserved for future-slice entity-visibility
 	viewer *View,
+	room spatial.Room,
 ) (doorSlice *events.DoorOpenedPlayerSlice, revealSlice *events.HexRevealedSlice) {
 	if viewer == nil {
 		return nil, nil
 	}
-	visible := VisibleHexesAt(viewer.Position, viewer.SightRange)
+	visible := VisibleHexesAt(viewer.Position, viewer.SightRange, room)
 	if !visible.Has(doorPos) {
 		return nil, nil
 	}

--- a/encounter/perception/project_test.go
+++ b/encounter/perception/project_test.go
@@ -24,7 +24,7 @@ func (s *ProjectSuite) TestProjectMove_ViewerInRange() {
 		{Q: 2, R: 0, S: -2},
 		{Q: 3, R: 0, S: -3},
 	}
-	moveSlice, _, _ := perception.ProjectMove("bob", path, viewer)
+	moveSlice, _, _ := perception.ProjectMove("bob", path, viewer, nil)
 
 	s.Require().NotNil(moveSlice)
 	s.Equal(path, moveSlice.SeenSegments)
@@ -37,7 +37,7 @@ func (s *ProjectSuite) TestProjectMove_ViewerOutOfRange() {
 		{Q: 5, R: -2, S: -3},
 		{Q: 6, R: -2, S: -4},
 	}
-	moveSlice, revealSlice, _ := perception.ProjectMove("bob", path, viewer)
+	moveSlice, revealSlice, _ := perception.ProjectMove("bob", path, viewer, nil)
 
 	s.Nil(moveSlice)
 	s.Nil(revealSlice)
@@ -47,7 +47,7 @@ func (s *ProjectSuite) TestProjectDoorOpen_ViewerNearDoor() {
 	viewer := perception.NewView("alice", core.Hex{}, 3)
 
 	doorPos := core.Hex{Q: 2, R: 0, S: -2}
-	doorSlice, revealSlice := perception.ProjectDoorOpen("door-1", doorPos, "bob", viewer)
+	doorSlice, revealSlice := perception.ProjectDoorOpen("door-1", doorPos, "bob", viewer, nil)
 
 	s.Require().NotNil(doorSlice)
 	s.True(doorSlice.Visible)
@@ -59,7 +59,7 @@ func (s *ProjectSuite) TestProjectDoorOpen_ViewerOutOfRange() {
 	viewer := perception.NewView("alice", core.Hex{}, 1)
 
 	doorPos := core.Hex{Q: 5, R: -2, S: -3}
-	doorSlice, revealSlice := perception.ProjectDoorOpen("door-1", doorPos, "bob", viewer)
+	doorSlice, revealSlice := perception.ProjectDoorOpen("door-1", doorPos, "bob", viewer, nil)
 
 	s.Nil(doorSlice)
 	s.Nil(revealSlice)
@@ -77,7 +77,7 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_EnterLoS() {
 	path := []core.Hex{pathEnd}
 
 	// Use ProjectMove to get both seenSegments and the precomputed visible set.
-	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer, nil)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
@@ -99,7 +99,7 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_LeaveLoS() {
 		{Q: 10, R: 0, S: -10}, // outside
 	}
 
-	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer, nil)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
@@ -123,7 +123,7 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_PassThrough() {
 		{Q: 10, R: 0, S: -10}, // outside
 	}
 
-	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer, nil)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
@@ -142,7 +142,7 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_StaysVisible() {
 	moverStart := core.Hex{Q: 1, R: 0, S: -1} // inside
 	path := []core.Hex{{Q: 2, R: 0, S: -2}}   // inside
 
-	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer)
+	moveSlice, _, visible := perception.ProjectMove("alice", path, viewer, nil)
 	s.Require().NotNil(moveSlice)
 	seenSegments := moveSlice.SeenSegments
 
@@ -159,7 +159,7 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_NeverVisible() {
 	moverStart := core.Hex{Q: 10, R: 0, S: -10}
 	path := []core.Hex{{Q: 15, R: 0, S: -15}}
 
-	_, _, visible := perception.ProjectMove("alice", path, viewer)
+	_, _, visible := perception.ProjectMove("alice", path, viewer, nil)
 
 	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, nil, viewer, visible)
 
@@ -176,7 +176,7 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_LeaveLoS_EmptySeenSegment
 	moverStart := core.Hex{Q: 2, R: 0, S: -2}
 	path := []core.Hex{{Q: 10, R: 0, S: -10}} // single destination, outside
 
-	_, _, visible := perception.ProjectMove("alice", path, viewer)
+	_, _, visible := perception.ProjectMove("alice", path, viewer, nil)
 
 	// seenSegments will be empty because the single path hex is out of range.
 	appearedAt, disappearedAt := perception.ProjectVisibilityTransition(moverStart, path, nil, viewer, visible)

--- a/encounter/perception/room_los_test.go
+++ b/encounter/perception/room_los_test.go
@@ -1,0 +1,106 @@
+package perception_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// RoomLOSSuite covers rpg-toolkit#757's wall-aware VisibleHexesAt/CanSeeAt:
+// a wall between viewer and target blocks LoS through a real spatial.Room
+// (not a stub), the same hex is open when the room has no wall, SightRange
+// still caps distance regardless of walls, and a nil room preserves the
+// pre-wave-1 pure-radius behavior for encounters with no SpaceData.
+type RoomLOSSuite struct {
+	suite.Suite
+	viewer core.Hex
+	target core.Hex
+}
+
+func TestRoomLOSSuite(t *testing.T) {
+	suite.Run(t, new(RoomLOSSuite))
+}
+
+func (s *RoomLOSSuite) SetupTest() {
+	s.viewer = core.Hex{Q: 0, R: 0, S: 0}
+	s.target = core.Hex{Q: 4, R: -4, S: 0} // distance 4
+}
+
+func newTestRoom(id string) *spatial.BasicRoom {
+	grid := spatial.NewHexGrid(spatial.HexGridConfig{
+		Width:       20,
+		Height:      20,
+		Orientation: spatial.HexOrientationPointyTop,
+	})
+	return spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: id, Type: "test", Grid: grid})
+}
+
+// midpointWallPosition finds a hex strictly between from and to on the
+// room's line of sight, so a wall placed there is guaranteed to sit on the
+// path IsLineOfSightBlocked actually walks (rather than a hand-picked
+// coordinate that may not land on the lerped hex line).
+func midpointWallPosition(s *suite.Suite, room spatial.Room, from, to core.Hex) spatial.Position {
+	los := room.GetLineOfSight(from.ToPosition(), to.ToPosition())
+	s.Require().GreaterOrEqual(len(los), 3, "need an intermediate hex to place a wall on")
+	return los[len(los)/2]
+}
+
+func (s *RoomLOSSuite) TestCanSeeAt_BlockedByWall() {
+	room := newTestRoom("blocked")
+	wallPos := midpointWallPosition(&s.Suite, room, s.viewer, s.target)
+	wall := environments.NewWallEntity(environments.WallEntityConfig{
+		SegmentID: "wall-1",
+		WallType:  environments.WallTypeIndestructible,
+		Properties: environments.WallProperties{
+			BlocksMovement: true,
+			BlocksLoS:      true,
+		},
+		Position: wallPos,
+	})
+	s.Require().NoError(room.PlaceEntity(wall, wallPos))
+
+	view := perception.NewView("p1", s.viewer, 10)
+	s.False(perception.CanSeeAt(view, s.target, room), "wall between viewer and target must block LoS")
+}
+
+func (s *RoomLOSSuite) TestCanSeeAt_OpenRoom_NoWall() {
+	room := newTestRoom("open")
+	view := perception.NewView("p1", s.viewer, 10)
+	s.True(perception.CanSeeAt(view, s.target, room), "no wall on the path — same room type, must be visible")
+}
+
+func (s *RoomLOSSuite) TestCanSeeAt_NilRoom_PureRadius() {
+	view := perception.NewView("p1", s.viewer, 10)
+	s.True(perception.CanSeeAt(view, s.target, nil), "nil room must fall back to pure-radius behavior")
+}
+
+func (s *RoomLOSSuite) TestCanSeeAt_SightRangeStillCapsDistance() {
+	// Room has no wall at all — only distance should reject this.
+	room := newTestRoom("far")
+	view := perception.NewView("p1", s.viewer, 2) // target is distance 4, out of range
+	s.False(perception.CanSeeAt(view, s.target, room))
+	s.False(perception.CanSeeAt(view, s.target, nil), "distance cap applies with or without a room")
+}
+
+func (s *RoomLOSSuite) TestVisibleHexesAt_ExcludesWallBlockedHex() {
+	room := newTestRoom("blocked-set")
+	wallPos := midpointWallPosition(&s.Suite, room, s.viewer, s.target)
+	wall := environments.NewWallEntity(environments.WallEntityConfig{
+		SegmentID:  "wall-1",
+		WallType:   environments.WallTypeIndestructible,
+		Properties: environments.WallProperties{BlocksMovement: true, BlocksLoS: true},
+		Position:   wallPos,
+	})
+	s.Require().NoError(room.PlaceEntity(wall, wallPos))
+
+	visible := perception.VisibleHexesAt(s.viewer, 10, room)
+	s.False(visible.Has(s.target), "target beyond the wall must be excluded from the visible set")
+
+	nilRoomVisible := perception.VisibleHexesAt(s.viewer, 10, nil)
+	s.True(nilRoomVisible.Has(s.target), "nil room must not filter by walls")
+}

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -58,17 +58,29 @@ func (e *Encounter) RoomOrchestrator() spatial.RoomOrchestrator { return e.roomO
 // discretized wall hex — see SpaceData.Walls doc. Positions are rounded to
 // the nearest integer hex cell before converting to cube coordinates — see
 // InitRoom's doc for why this matters (environments' wall generator doesn't
-// snap to hex cells on its own). Adjacent discretized wall entities from the
-// same original segment may round to the same cell; duplicate WallSegmentData
-// entries are harmless (rebuildRoomFromData just places two wall entities on
-// one hex), not deduplicated for wave 1's simplicity.
+// snap to hex cells on its own).
+//
+// Adjacent discretized wall entities from the same original segment can
+// round to the SAME cell, so entries are deduplicated by cube coordinate,
+// OR-merging the blocking flags. This is load-bearing, not tidiness:
+// rebuildRoomFromData places each entry via room.PlaceEntity, which rejects
+// placing a blocking entity onto an already-occupied hex — a duplicate entry
+// would make every InitRoom/LoadFromData of that snapshot fail (Copilot
+// review, PR #759).
 func snapshotWalls(room spatial.Room) []environments.WallSegmentData {
 	entities := environments.GetWallEntitiesInRoom(room)
 	walls := make([]environments.WallSegmentData, 0, len(entities))
+	seen := make(map[spatial.CubeCoordinate]int, len(entities))
 	for _, w := range entities {
 		pos := w.GetPosition()
 		rounded := spatial.Position{X: math.Round(pos.X), Y: math.Round(pos.Y)}
 		cube := spatial.OffsetCoordinateToCubeWithOrientation(rounded, spatial.HexOrientationPointyTop)
+		if i, dup := seen[cube]; dup {
+			walls[i].BlocksMovement = walls[i].BlocksMovement || w.BlocksMovement()
+			walls[i].BlocksLoS = walls[i].BlocksLoS || w.BlocksLineOfSight()
+			continue
+		}
+		seen[cube] = len(walls)
 		walls = append(walls, environments.WallSegmentData{
 			Start:          cube,
 			End:            cube,
@@ -114,7 +126,16 @@ func (e *Encounter) rebuildRoomFromData() error {
 		Type: "encounter_room",
 		Grid: grid,
 	})
+	placed := make(map[spatial.CubeCoordinate]struct{}, len(sd.Walls))
 	for i, w := range sd.Walls {
+		// snapshotWalls dedupes on write; this read-side skip additionally
+		// tolerates a hand-built or legacy snapshot carrying duplicates —
+		// PlaceEntity rejects stacking a blocking entity on an occupied hex,
+		// which would otherwise fail the whole load.
+		if _, dup := placed[w.Start]; dup {
+			continue
+		}
+		placed[w.Start] = struct{}{}
 		pos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
 		entity := environments.NewWallEntity(environments.WallEntityConfig{
 			SegmentID: fmt.Sprintf("space-%d", i),

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -1,0 +1,165 @@
+package encounter
+
+import (
+	"fmt"
+	"math"
+
+	rpgcore "github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// InitRoom builds a walled room for this encounter via environments.QuickRoom,
+// snapshots its walls into Data.Space for persistence, and registers a
+// reconstructed room (see rebuildRoomFromData) with a fresh RoomOrchestrator
+// for the encounter's lifetime. Call once, right after New, before any
+// Move/AddMonster/LOS query relies on wall geometry.
+//
+// Deliberately does NOT register QuickRoom's own *spatial.Room as e.room:
+// environments' wall generator places walls at continuous positions (e.g.
+// X=3.7), not hex-cell-snapped ones, while every LOS/movement check in this
+// package queries at the INTEGER positions core.Hex.ToPosition() produces —
+// those two would essentially never collide in the room's position-keyed
+// occupancy map, making most generated walls silently non-blocking. Routing
+// through the same snapshot -> rebuildRoomFromData path New/LoadFromData use
+// guarantees e.room's walls always sit at the exact integer hex positions
+// this package's checks query.
+//
+// An encounter with no room (InitRoom never called) falls back to the
+// pre-wave-1 radius-only LoS and unblocked movement throughout this package —
+// every room-aware call site is nil-checked.
+func (e *Encounter) InitRoom(width, height int, pattern string) error {
+	room, err := environments.QuickRoom(width, height, pattern)
+	if err != nil {
+		return fmt.Errorf("build room: %w", err)
+	}
+	e.data.Space = &SpaceData{
+		Walls:  snapshotWalls(room),
+		Width:  width,
+		Height: height,
+	}
+	return e.rebuildRoomFromData()
+}
+
+// Room returns the encounter's spatial room, or nil if InitRoom was never
+// called (or LoadFromData found no persisted Space).
+func (e *Encounter) Room() spatial.Room { return e.room }
+
+// RoomOrchestrator returns the orchestrator the encounter's room is
+// registered with, or nil under the same conditions as Room. Exposed so a
+// host (e.g. rpg-api's spawn-engine wiring) can share the exact same room
+// instance the encounter uses for LoS/movement, rather than reconstructing
+// its own from Data.Space.
+func (e *Encounter) RoomOrchestrator() spatial.RoomOrchestrator { return e.roomOrchestrator }
+
+// snapshotWalls converts a built room's wall entities into the persisted
+// WallSegmentData snapshot. One degenerate (Start == End) segment per
+// discretized wall hex — see SpaceData.Walls doc. Positions are rounded to
+// the nearest integer hex cell before converting to cube coordinates — see
+// InitRoom's doc for why this matters (environments' wall generator doesn't
+// snap to hex cells on its own). Adjacent discretized wall entities from the
+// same original segment may round to the same cell; duplicate WallSegmentData
+// entries are harmless (rebuildRoomFromData just places two wall entities on
+// one hex), not deduplicated for wave 1's simplicity.
+func snapshotWalls(room spatial.Room) []environments.WallSegmentData {
+	entities := environments.GetWallEntitiesInRoom(room)
+	walls := make([]environments.WallSegmentData, 0, len(entities))
+	for _, w := range entities {
+		pos := w.GetPosition()
+		rounded := spatial.Position{X: math.Round(pos.X), Y: math.Round(pos.Y)}
+		cube := spatial.OffsetCoordinateToCubeWithOrientation(rounded, spatial.HexOrientationPointyTop)
+		walls = append(walls, environments.WallSegmentData{
+			Start:          cube,
+			End:            cube,
+			BlocksMovement: w.BlocksMovement(),
+			BlocksLoS:      w.BlocksLineOfSight(),
+		})
+	}
+	return walls
+}
+
+// registerRoom wires room into a fresh orchestrator for this Encounter
+// instance. Both are transient — reconstructed at New/LoadFromData exactly
+// like e.bus and e.combatants, never serialized.
+func (e *Encounter) registerRoom(room spatial.Room) error {
+	orch := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
+		ID: spatial.OrchestratorID(e.data.ID),
+	})
+	if err := orch.AddRoom(room); err != nil {
+		return fmt.Errorf("register room: %w", err)
+	}
+	e.room = room
+	e.roomOrchestrator = orch
+	return nil
+}
+
+// rebuildRoomFromData reconstructs the spatial room + orchestrator from a
+// persisted Data.Space snapshot (the LoadFromData path). Walls are placed
+// exactly as persisted, not regenerated from a pattern — the snapshot
+// decision (SpaceData doc) exists precisely so this is a replay, not a
+// re-roll. No-op when data.Space is nil (no room to rebuild).
+func (e *Encounter) rebuildRoomFromData() error {
+	sd := e.data.Space
+	if sd == nil {
+		return nil
+	}
+	grid := spatial.NewHexGrid(spatial.HexGridConfig{
+		Width:       float64(sd.Width),
+		Height:      float64(sd.Height),
+		Orientation: spatial.HexOrientationPointyTop,
+	})
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   string(e.data.ID),
+		Type: "encounter_room",
+		Grid: grid,
+	})
+	for i, w := range sd.Walls {
+		pos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		entity := environments.NewWallEntity(environments.WallEntityConfig{
+			SegmentID: fmt.Sprintf("space-%d", i),
+			// Wave 1 doesn't persist WallType (no destruction model yet —
+			// see design doc Wave 2+); Indestructible is the correct default
+			// since BlocksMovement/BlocksLoS (the only behavior wave 1
+			// exercises) are preserved from the original snapshot regardless.
+			WallType: environments.WallTypeIndestructible,
+			Properties: environments.WallProperties{
+				BlocksMovement: w.BlocksMovement,
+				BlocksLoS:      w.BlocksLoS,
+			},
+			Position: pos,
+		})
+		if err := room.PlaceEntity(entity, pos); err != nil {
+			return fmt.Errorf("place wall %d: %w", i, err)
+		}
+	}
+	return e.registerRoom(room)
+}
+
+// truncateAtWall returns the prefix of path up to (not including) the first
+// wall-blocked hex, checked via room.CanPlaceEntity (which also rejects
+// out-of-bounds hexes via the grid's IsValidPosition). Nil room (no
+// SpaceData) returns path unchanged — the pre-wave-1 unblocked-movement
+// behavior. Used by both the player (Move) and NPC (applyNPCMovementSteps)
+// movement paths so neither can walk through a wall.
+func (e *Encounter) truncateAtWall(path []core.Hex) []core.Hex {
+	if e.room == nil {
+		return path
+	}
+	for i, hex := range path {
+		if !e.room.CanPlaceEntity(wallCheckEntity{}, hex.ToPosition()) {
+			return path[:i]
+		}
+	}
+	return path
+}
+
+// wallCheckEntity is a throwaway core.Entity used to query room.CanPlaceEntity
+// for wall-blocking purposes. Players and monsters are never themselves
+// placed into the spatial room (wave 1 doesn't track their positions there —
+// only walls occupy it), so this identity is never compared against a real
+// occupant; it exists only to satisfy the core.Entity parameter.
+type wallCheckEntity struct{}
+
+func (wallCheckEntity) GetID() string               { return "wall-check" }
+func (wallCheckEntity) GetType() rpgcore.EntityType { return "wall-check" }

--- a/encounter/space_test.go
+++ b/encounter/space_test.go
@@ -115,6 +115,41 @@ func (s *SpaceSuite) TestMove_BlockedByWall_TruncatesAtFirstBlockedHex() {
 	s.Equal(start, after, "player must not have moved onto the wall hex")
 }
 
+// TestLoadFromData_DuplicateWallEntries_Tolerated covers the Copilot catch on
+// PR #759: room.PlaceEntity rejects stacking a blocking entity on an occupied
+// hex, so a snapshot carrying two wall entries on the same cube coordinate
+// (hand-built, or written before snapshotWalls deduped) must not fail the
+// whole LoadFromData — the rebuild skips the duplicate and the wall still
+// blocks.
+func (s *SpaceSuite) TestLoadFromData_DuplicateWallEntries_Tolerated() {
+	// Hex{3,-5,2} = offset position (3,3) under pointy-top — safely inside
+	// the 10x10 grid with all its neighbors in-bounds too.
+	wallCube := core.Hex{Q: 3, R: -5, S: 2}.ToCube()
+	dupWall := environments.WallSegmentData{
+		Start: wallCube, End: wallCube, BlocksMovement: true, BlocksLoS: true,
+	}
+	data := encounter.NewData("enc-space-dup")
+	data.Space = &encounter.SpaceData{
+		Walls:  []environments.WallSegmentData{dupWall, dupWall},
+		Width:  10,
+		Height: 10,
+	}
+
+	reloaded, err := encounter.LoadFromData(context.Background(), data, s.broker)
+	s.Require().NoError(err, "duplicate wall entries must be skipped, not fail the load")
+	s.Require().NotNil(reloaded.Room())
+
+	wallHex := core.HexFromCube(wallCube)
+	start := perception.HexNeighbors(wallHex)[0]
+	s.Require().NoError(reloaded.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: start, SightRange: 10,
+	}))
+	s.Require().NoError(reloaded.Move("alice", []core.Hex{wallHex}))
+	s.Equal(start, reloaded.ToData().Players["alice"].View.Position,
+		"the deduplicated wall must still block movement")
+}
+
 func (s *SpaceSuite) TestMove_NilRoom_Unblocked() {
 	enc := encounter.New(context.Background(), "enc-space-nil-move", s.broker)
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{

--- a/encounter/space_test.go
+++ b/encounter/space_test.go
@@ -1,0 +1,131 @@
+package encounter_test
+
+// space_test.go covers rpg-toolkit#757's SpaceData snapshot: InitRoom's
+// ToData()/LoadFromData round-trip, and wall-blocked movement via a real
+// room built through environments.QuickRoom (not a hand-rolled stub).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+)
+
+type SpaceSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestSpaceSuite(t *testing.T) {
+	suite.Run(t, new(SpaceSuite))
+}
+
+func (s *SpaceSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+// firstBlockingWall returns the hex of the first wall segment that blocks
+// movement, from an encounter's persisted Space snapshot. Fails the test if
+// none exists — environments.QuickRoom with PatternRandom is deterministic
+// (unseeded => RandomSeed 0), so a 10x10 room reliably generates walls.
+func (s *SpaceSuite) firstBlockingWall(enc *encounter.Encounter) core.Hex {
+	space := enc.ToData().Space
+	s.Require().NotNil(space)
+	for _, w := range space.Walls {
+		if w.BlocksMovement {
+			return core.HexFromCube(w.Start)
+		}
+	}
+	s.FailNow("no movement-blocking wall found in generated room")
+	return core.Hex{}
+}
+
+func (s *SpaceSuite) TestInitRoom_ToData_LoadFromData_RoundTrip() {
+	enc := encounter.New(context.Background(), "enc-space-rt", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternRandom))
+	s.Require().NotNil(enc.Room())
+	s.Require().NotNil(enc.RoomOrchestrator())
+
+	original := enc.ToData()
+	s.Require().NotNil(original.Space)
+	s.NotEmpty(original.Space.Walls)
+	s.Equal(10, original.Space.Width)
+	s.Equal(10, original.Space.Height)
+
+	reloaded, err := encounter.LoadFromData(context.Background(), original, s.broker)
+	s.Require().NoError(err)
+	s.Require().NotNil(reloaded.Room(), "LoadFromData must rebuild the room from the Space snapshot")
+	s.Require().NotNil(reloaded.RoomOrchestrator())
+
+	// The reloaded room's wall count must match the snapshot exactly — a
+	// replay, not a re-roll (SpaceData's whole reason to exist).
+	roomFromOrch, ok := reloaded.RoomOrchestrator().GetRoom(string(reloaded.ID()))
+	s.Require().True(ok)
+	wallEntities := environments.GetWallEntitiesInRoom(roomFromOrch)
+	s.Len(wallEntities, len(original.Space.Walls))
+
+	// A second ToData() after the round-trip must reproduce the same
+	// wall snapshot (not drift/regenerate).
+	again := reloaded.ToData()
+	s.Require().NotNil(again.Space)
+	s.Equal(len(original.Space.Walls), len(again.Space.Walls))
+}
+
+func (s *SpaceSuite) TestLoadFromData_NilSpace_NoRoom() {
+	enc := encounter.New(context.Background(), "enc-space-nil", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 5,
+	}))
+	s.Nil(enc.Room(), "InitRoom never called — pre-wave-1 fixture shape")
+
+	data := enc.ToData()
+	s.Nil(data.Space)
+
+	reloaded, err := encounter.LoadFromData(context.Background(), data, s.broker)
+	s.Require().NoError(err)
+	s.Nil(reloaded.Room(), "nil Space must round-trip to nil Room, not panic or fabricate one")
+}
+
+func (s *SpaceSuite) TestMove_BlockedByWall_TruncatesAtFirstBlockedHex() {
+	enc := encounter.New(context.Background(), "enc-space-move", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternRandom))
+
+	wallHex := s.firstBlockingWall(enc)
+	// Approach the wall from one of its neighbors so a single-hex move lands
+	// exactly on it.
+	start := perception.HexNeighbors(wallHex)[0]
+
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: start, SightRange: 10,
+	}))
+
+	err := enc.Move("alice", []core.Hex{wallHex})
+	s.Require().NoError(err, "blocked-at-first-hex is a no-op, not an error (mirrors resolver-prevented semantics)")
+
+	after := enc.ToData().Players["alice"].View.Position
+	s.Equal(start, after, "player must not have moved onto the wall hex")
+}
+
+func (s *SpaceSuite) TestMove_NilRoom_Unblocked() {
+	enc := encounter.New(context.Background(), "enc-space-nil-move", s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+
+	// No InitRoom call — nil room must not block anything, matching the
+	// pre-wave-1 behavior every other test in this package already relies on.
+	s.Require().NoError(enc.Move("alice", []core.Hex{{Q: 1, R: 0, S: -1}, {Q: 2, R: 0, S: -2}}))
+
+	after := enc.ToData().Players["alice"].View.Position
+	s.Equal(core.Hex{Q: 2, R: 0, S: -2}, after)
+}

--- a/encounter/space_test.go
+++ b/encounter/space_test.go
@@ -6,6 +6,7 @@ package encounter_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -113,6 +114,25 @@ func (s *SpaceSuite) TestMove_BlockedByWall_TruncatesAtFirstBlockedHex() {
 
 	after := enc.ToData().Players["alice"].View.Position
 	s.Equal(start, after, "player must not have moved onto the wall hex")
+}
+
+// TestInitRoom_DimensionsThatPreviouslyCollided covers the actual reported
+// blocker directly (not just a hand-built proxy): before snapshotWalls
+// deduped by rounded cube coordinate, environments.QuickRoom's own wall
+// generator produced discretized wall hexes that rounded to the same cell at
+// several width/height combinations — gate review on PR #759 deterministically
+// reproduced failures at 5x20, 7x15, and 20x15 (22 of 512 dimension pairs
+// probed failed); 10x10, used by every other test in this file, happens not
+// to collide. InitRoom must succeed at dimension pairs that DID collide
+// pre-fix.
+func (s *SpaceSuite) TestInitRoom_DimensionsThatPreviouslyCollided() {
+	for _, dims := range [][2]int{{5, 20}, {7, 15}, {20, 15}} {
+		id := core.EncounterID(fmt.Sprintf("enc-space-collide-%dx%d", dims[0], dims[1]))
+		enc := encounter.New(context.Background(), id, s.broker)
+		err := enc.InitRoom(dims[0], dims[1], environments.PatternRandom)
+		s.Require().NoError(err, "InitRoom(%d,%d) must not fail on duplicate rounded wall cells", dims[0], dims[1])
+		s.Require().NotNil(enc.Room())
+	}
 }
 
 // TestLoadFromData_DuplicateWallEntries_Tolerated covers the Copilot catch on

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -107,6 +107,55 @@ func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) er
 	return nil
 }
 
+// seedActiveActorIfUnseeded is LoadFromData's catch-up for a turn seed that
+// was structurally impossible at the moment the turn started (rpg-toolkit#757).
+//
+// The gap: SetMode's flip to ModeTurnBased can now fire on an UN-hydrated
+// encounter — checkCombatEntry runs inline at AddMonster, and the production
+// creation flow is New()+AddPlayer+AddMonster, where nothing is hydrated (New
+// never hydrates; only a LoadFromData round-trip does). seedActorTurn at that
+// moment finds no held character for the first active player and correctly
+// skips — but SetMode and EndTurn are the only two turn-start seeding sites,
+// so without this catch-up that player's economy would never be seeded for
+// their first turn: every TakeAction fails "not in combat". The same latent
+// gap predates #757 for any host that called SetMode on a fresh encounter
+// (devseed's --inject-combat shape); combat entry just made it the default
+// production path.
+//
+// Detection is the held character's own persisted combat state: InCombat()
+// (== actionEconomy != nil) survives ToData/LoadFromData round-trips, so a
+// mid-turn reload (economy seeded, partially spent) sees InCombat() == true
+// and skips — this catch-up cannot re-seed (and thereby refill) a live
+// turn's economy. It fires exactly once: the first load after the missed
+// seed, after which the seeded economy persists.
+//
+// The refreshed turn state is push-published after seeding (Invariant 12):
+// the TurnStateChangedEvent the client got at the SetMode flip snapshotted an
+// un-hydrated (empty) menu/economy; without a fresh push the real menu would
+// be silently stale until the actor's next action. No TurnStartedEvent —
+// the turn already started and was announced at the flip; this completes its
+// seeding, it doesn't restart it.
+func (e *Encounter) seedActiveActorIfUnseeded(ctx context.Context) error {
+	if e.data.Mode != core.ModeTurnBased || len(e.data.Initiative) == 0 {
+		return nil
+	}
+	if e.data.ActiveIdx < 0 || e.data.ActiveIdx >= len(e.data.Initiative) {
+		return nil
+	}
+	actorID := e.data.Initiative[e.data.ActiveIdx]
+	char := e.heldCharacter(actorID)
+	if char == nil || char.InCombat() {
+		return nil // NPC / stat-snapshot seat, or already seeded — nothing missed.
+	}
+	if err := e.seedActorTurn(ctx, actorID); err != nil {
+		return err
+	}
+	if err := e.publishTurnStateChanged(actorID, ""); err != nil {
+		return fmt.Errorf("publish caught-up turn state: %w", err)
+	}
+	return nil
+}
+
 // heldCharacter returns the hydrated *character.Character for the given entity
 // id, or nil if the id is not a player seat or carries no hydrated character
 // (no DataJSON at load time). It reads the LoadFromData-cascade-held combatant

--- a/encounter/turn_economy_downed_test.go
+++ b/encounter/turn_economy_downed_test.go
@@ -246,7 +246,12 @@ func (s *TurnEconomyDownedSuite) TestDownedPlayerRevivedByNat20MidTurnStart_Rese
 	s.Require().NoError(err)
 	defer func() { _ = sub.Close() }()
 
-	s.Require().NoError(loaded.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so AddMonster (above, on enc)
+	// already auto-transitioned to TURN_BASED before the Data round-trip;
+	// loaded inherits that mode. An explicit SetMode here would be
+	// redundant and error. alice's DataJSON carries a pre-seeded
+	// ActionEconomy (aliceAliveSeededCharDataJSON), so this fixture doesn't
+	// depend on SetMode's seedActorTurn call to populate her economy.
 	for loaded.ActiveActor() != gobEntityID {
 		_, _, endErr := loaded.EndTurn(s.ctx, loaded.ActiveActor())
 		s.Require().NoError(endErr)

--- a/encounter/turn_state_test.go
+++ b/encounter/turn_state_test.go
@@ -93,7 +93,7 @@ func (s *TurnStateSuite) monkCharJSON() json.RawMessage {
 func (s *TurnStateSuite) loadedMonkEncounter() *encounter.Encounter {
 	s.T().Helper()
 	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
-	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10, nil))
 	data := encounter.NewData("enc-ts")
 	data.Players[monkPlayerID] = &encounter.PlayerData{
 		ID:         monkPlayerID,
@@ -337,7 +337,7 @@ func (s *TurnStateSuite) TestSetMode_PushesTurnStateChangedAtTurnStart() {
 func (s *TurnStateSuite) combatMonkEncounter() *encounter.Encounter {
 	s.T().Helper()
 	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
-	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10, nil))
 	data := encounter.NewData("enc-ts")
 	data.Players[monkPlayerID] = &encounter.PlayerData{
 		ID:          monkPlayerID,
@@ -439,7 +439,7 @@ func (r *recordingResolver) ResolveAttack(input encounter.AttackInput) (*encount
 func (s *TurnStateSuite) TestTakeAction_GrantedStrikeResolvesAttack() {
 	resolver := &recordingResolver{alwaysHitResolver: alwaysHitResolver{damage: 3, damageType: "bludgeoning"}}
 	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
-	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10, nil))
 	data := encounter.NewData("enc-ts")
 	data.Players[monkPlayerID] = &encounter.PlayerData{
 		ID:         monkPlayerID,
@@ -771,19 +771,19 @@ func (s *TurnStateSuite) helpTargetingEncounter() (
 	s.T().Helper()
 
 	monkView := perception.NewView(monkPlayerID, core.Hex{}, 5)
-	monkView.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 5))
+	monkView.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 5, nil))
 
 	fighterPos := core.Hex{Q: 20, R: 0, S: -20}
 	fighterEntityID := core.EntityID("char-fighter")
 	fighterPlayerID := core.PlayerID("finn")
 	fighterView := perception.NewView(fighterPlayerID, fighterPos, 5)
-	fighterView.ApplyReveal(perception.VisibleHexesAt(fighterPos, 5))
+	fighterView.ApplyReveal(perception.VisibleHexesAt(fighterPos, 5, nil))
 
 	roguePos := core.Hex{Q: 21, R: 0, S: -21} // adjacent to the fighter, far from the monk
 	rogueEntityID := core.EntityID("char-rogue")
 	roguePlID := core.PlayerID("remy")
 	rogueView := perception.NewView(roguePlID, roguePos, 5)
-	rogueView.ApplyReveal(perception.VisibleHexesAt(roguePos, 5))
+	rogueView.ApplyReveal(perception.VisibleHexesAt(roguePos, 5, nil))
 
 	data := encounter.NewData("enc-help")
 	data.Players[monkPlayerID] = &encounter.PlayerData{
@@ -896,7 +896,7 @@ func (s *TurnStateSuite) TestTakeAction_Help_ViewerWhoSeesNeitherPartyGetsNothin
 // applying HiddenCondition end-to-end through the unified TakeAction verb.
 func (s *TurnStateSuite) TestTakeAction_Hide_AppliesHiddenConditionAgainstLowObserverPerception() {
 	view := perception.NewView(monkPlayerID, core.Hex{}, 10)
-	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10))
+	view.ApplyReveal(perception.VisibleHexesAt(core.Hex{}, 10, nil))
 
 	data := encounter.NewData("enc-hide")
 	data.Players[monkPlayerID] = &encounter.PlayerData{

--- a/encounter/unconscious_zero_hp_test.go
+++ b/encounter/unconscious_zero_hp_test.go
@@ -192,7 +192,11 @@ func (s *UnconsciousZeroHPSuite) TestPlayerHitsZeroHP_AppliesUnconscious_NotImme
 	s.Require().NoError(err)
 	defer func() { _ = sub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so buildEncounter's AddMonster
+	// already auto-transitioned to TURN_BASED (alice's DataJSON carries a
+	// pre-seeded ActionEconomy, so this doesn't depend on SetMode's
+	// seedActorTurn call); an explicit SetMode here would be redundant and
+	// error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -243,7 +247,11 @@ func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_BridgesToEntityDied()
 	s.Require().NoError(err)
 	defer func() { _ = aliceSub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so buildEncounter's AddMonster
+	// already auto-transitioned to TURN_BASED (alice's DataJSON carries a
+	// pre-seeded ActionEconomy, so this doesn't depend on SetMode's
+	// seedActorTurn call); an explicit SetMode here would be redundant and
+	// error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -358,7 +366,11 @@ func (s *UnconsciousZeroHPSuite) TestThreeFailedDeathSaves_AcrossPerRPCReloads_B
 	s.Require().NoError(err)
 	defer func() { _ = aliceSub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so buildEncounter's AddMonster
+	// already auto-transitioned to TURN_BASED (alice's DataJSON carries a
+	// pre-seeded ActionEconomy, so this doesn't depend on SetMode's
+	// seedActorTurn call); an explicit SetMode here would be redundant and
+	// error.
 	enc = s.reloadEncounter(enc, opts...)
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
@@ -469,7 +481,11 @@ func (s *UnconsciousZeroHPSuite) TestDeathSaveRolledBridge_EveryRollBridgesToEve
 	s.Require().NoError(err)
 	defer func() { _ = aliceSub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so buildEncounter's AddMonster
+	// already auto-transitioned to TURN_BASED (alice's DataJSON carries a
+	// pre-seeded ActionEconomy, so this doesn't depend on SetMode's
+	// seedActorTurn call); an explicit SetMode here would be redundant and
+	// error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
 		s.Require().NoError(endErr)
@@ -524,7 +540,11 @@ func (s *UnconsciousZeroHPSuite) TestCharacterStabilizedBridge_ThreeSuccessfulDe
 	s.Require().NoError(err)
 	defer func() { _ = aliceSub.Close() }()
 
-	s.Require().NoError(enc.SetMode(core.ModeTurnBased))
+	// alice and the goblin are in mutual LoS, so buildEncounter's AddMonster
+	// already auto-transitioned to TURN_BASED (alice's DataJSON carries a
+	// pre-seeded ActionEconomy, so this doesn't depend on SetMode's
+	// seedActorTurn call); an explicit SetMode here would be redundant and
+	// error.
 	for enc.ActiveActor() != gobEntityID {
 		_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
 		s.Require().NoError(endErr)

--- a/tools/spawn/basic_engine.go
+++ b/tools/spawn/basic_engine.go
@@ -19,6 +19,7 @@ type BasicSpawnEngine struct {
 	spatialHandler     spatial.QueryHandler
 	environmentHandler *environments.BasicQueryHandler
 	selectablesReg     SelectablesRegistry
+	roomOrchestrator   spatial.RoomOrchestrator
 	// Type-safe event publishers (replaces eventBus events.EventBus)
 	entitySpawned    events.TypedTopic[EntitySpawnedEvent]
 	enableEvents     bool
@@ -34,6 +35,10 @@ type BasicSpawnEngineConfig struct {
 	SpatialHandler     spatial.QueryHandler
 	EnvironmentHandler *environments.BasicQueryHandler
 	SelectablesReg     SelectablesRegistry
+	// RoomOrchestrator resolves room IDs to spatial.Room for getRoomFromSpatial
+	// (rpg-toolkit#757). Required for PopulateRoom/PopulateSpace/PopulateSplitRooms
+	// to place entities — without it, getRoomFromSpatial returns an error.
+	RoomOrchestrator spatial.RoomOrchestrator
 	// EventBus removed - use ConnectToEventBus() method after creation
 	EnableEvents bool
 	MaxAttempts  int
@@ -54,6 +59,7 @@ func NewBasicSpawnEngine(config BasicSpawnEngineConfig) *BasicSpawnEngine {
 		spatialHandler:     config.SpatialHandler,
 		environmentHandler: config.EnvironmentHandler,
 		selectablesReg:     config.SelectablesReg,
+		roomOrchestrator:   config.RoomOrchestrator,
 		// Event topics will be connected via ConnectToEventBus()
 		enableEvents:     config.EnableEvents,
 		maxAttempts:      config.MaxAttempts,
@@ -196,11 +202,18 @@ func (e *BasicSpawnEngine) selectEntitiesForGroup(group EntityGroup) ([]core.Ent
 	return entities, nil
 }
 
-// getRoomFromSpatial gets room from spatial module (Phase 1: not implemented)
-func (e *BasicSpawnEngine) getRoomFromSpatial(_ string) (spatial.Room, error) {
-	// Phase 1: Spatial integration not yet implemented
-	// Real implementation would query e.spatialHandler.GetRoom(roomID)
-	return nil, fmt.Errorf("spatial integration not implemented in Phase 1")
+// getRoomFromSpatial resolves roomID to a spatial.Room via the configured
+// RoomOrchestrator (rpg-toolkit#757). Returns an error if no orchestrator was
+// configured, or if roomID isn't registered with it.
+func (e *BasicSpawnEngine) getRoomFromSpatial(roomID string) (spatial.Room, error) {
+	if e.roomOrchestrator == nil {
+		return nil, fmt.Errorf("spawn engine has no RoomOrchestrator configured")
+	}
+	room, ok := e.roomOrchestrator.GetRoom(roomID)
+	if !ok {
+		return nil, fmt.Errorf("room %q not found in orchestrator", roomID)
+	}
+	return room, nil
 }
 
 // findValidPosition finds a valid position for an entity (simplified for Phase 1)
@@ -289,10 +302,13 @@ func (e *BasicSpawnEngine) hasValidConstraints(constraints SpatialConstraints) b
 		constraints.PathingRules.MaintainExitAccess
 }
 
-// placeEntityInRoom places entity in the spatial room
-func (e *BasicSpawnEngine) placeEntityInRoom(_ spatial.Room, _ core.Entity, _ spatial.Position) error {
-	// Phase 1: This would call room.PlaceEntity(entity, position)
-	// For now, just validate the basic operation
+// placeEntityInRoom places entity in the spatial room (rpg-toolkit#757: this
+// was a no-op stub — PopulateRoom reported spawned entities without ever
+// actually occupying the room).
+func (e *BasicSpawnEngine) placeEntityInRoom(room spatial.Room, entity core.Entity, position spatial.Position) error {
+	if err := room.PlaceEntity(entity, position); err != nil {
+		return fmt.Errorf("place entity %s: %w", entity.GetID(), err)
+	}
 	return nil
 }
 

--- a/tools/spawn/go.mod
+++ b/tools/spawn/go.mod
@@ -7,8 +7,8 @@ toolchain go1.24.5
 require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.9.6
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.2.1
+	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/tools/spawn/go.sum
+++ b/tools/spawn/go.sum
@@ -6,12 +6,12 @@ github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0/go.mod h1:6k+SKiGEAjeI4JRaQtVKOcsUsp3O/sDDee4GH9rl+WM=
-github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2 h1:warO6dvk/Ymyc3lnVU7x1xIM0T6dw7h6DQ8Clz4z/PI=
-github.com/KirkDiggler/rpg-toolkit/tools/environments v0.1.2/go.mod h1:IwhSpU197TgOvI/ZjnJMJabykFnivhCywj5gFENQV9c=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2 h1:kPc3FZSRAB/gIzTBvlOYxzqp9mdL0akkeRW/8EZcI9A=
+github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.2/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.2.1 h1:gN+TL6PiZHSckyvy/rhHCJQsoXnb+lZYqjOJeqo8FV0=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.2.1/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0 h1:weKsLlsRV9kgoD/y68VWy0lpsu5zhwCmbnr5MUkLpsA=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/tools/spawn/room_wiring_test.go
+++ b/tools/spawn/room_wiring_test.go
@@ -1,0 +1,110 @@
+package spawn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// RoomWiringSuite covers rpg-toolkit#757: getRoomFromSpatial and
+// placeEntityInRoom were both literal stubs (the first always errored, the
+// second silently discarded the entity without ever calling
+// room.PlaceEntity). This suite proves PopulateRoom's happy path now
+// actually occupies a registered room, not just that it stops erroring.
+type RoomWiringSuite struct {
+	suite.Suite
+	room     *spatial.BasicRoom
+	orch     spatial.RoomOrchestrator
+	engine   *BasicSpawnEngine
+	registry *BasicSelectablesRegistry
+}
+
+func (s *RoomWiringSuite) SetupTest() {
+	grid := spatial.NewHexGrid(spatial.HexGridConfig{
+		Width:       10,
+		Height:      10,
+		Orientation: spatial.HexOrientationPointyTop,
+	})
+	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   "test-room",
+		Type: "test",
+		Grid: grid,
+	})
+
+	s.orch = spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{ID: "test-orch"})
+	s.Require().NoError(s.orch.AddRoom(s.room))
+
+	s.registry = NewBasicSelectablesRegistry()
+	s.Require().NoError(s.registry.RegisterTable("goblins", []core.Entity{
+		&MockEntity{id: "goblin-1", entityType: "monster"},
+	}))
+
+	s.engine = NewBasicSpawnEngine(BasicSpawnEngineConfig{
+		ID:               "test-engine",
+		SelectablesReg:   s.registry,
+		RoomOrchestrator: s.orch,
+		MaxAttempts:      10,
+	})
+}
+
+// TestGetRoomFromSpatial_NoOrchestrator: an engine with no RoomOrchestrator
+// configured still fails clearly, rather than panicking on a nil dereference.
+func (s *RoomWiringSuite) TestGetRoomFromSpatial_NoOrchestrator() {
+	bare := NewBasicSpawnEngine(BasicSpawnEngineConfig{SelectablesReg: s.registry})
+	_, err := bare.getRoomFromSpatial("test-room")
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "no RoomOrchestrator")
+}
+
+// TestGetRoomFromSpatial_UnknownRoom: a configured orchestrator that simply
+// doesn't have the requested room ID still errors clearly.
+func (s *RoomWiringSuite) TestGetRoomFromSpatial_UnknownRoom() {
+	_, err := s.engine.getRoomFromSpatial("no-such-room")
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "not found")
+}
+
+// TestPopulateRoom_HappyPath_PlacesEntityInRegisteredRoom is the regression
+// test for #757's spawn-stub fix: PopulateRoom against a registered room
+// must both report success AND leave the entity actually occupying the
+// spatial room — before this fix, placeEntityInRoom silently no-op'd, so
+// result.Success could be true while the room stayed empty.
+func (s *RoomWiringSuite) TestPopulateRoom_HappyPath_PlacesEntityInRegisteredRoom() {
+	one := 1
+	config := SpawnConfig{
+		EntityGroups: []EntityGroup{
+			{
+				ID:             "goblins",
+				Type:           "monster",
+				SelectionTable: "goblins",
+				Quantity:       QuantitySpec{Fixed: &one},
+			},
+		},
+		Pattern: PatternScattered,
+	}
+
+	result, err := s.engine.PopulateRoom(context.Background(), "test-room", config)
+	s.Require().NoError(err)
+	s.Assert().True(result.Success)
+	s.Require().Len(result.SpawnedEntities, 1)
+	s.Assert().Empty(result.Failures)
+
+	spawned := result.SpawnedEntities[0]
+	s.Assert().Equal("goblin-1", spawned.Entity.GetID())
+
+	// The regression check: the entity is actually IN the room, not just
+	// reported as spawned.
+	roomEntities := s.room.GetAllEntities()
+	s.Require().Contains(roomEntities, "goblin-1")
+	placedAt, ok := s.room.GetEntityPosition("goblin-1")
+	s.Require().True(ok)
+	s.Assert().Equal(spawned.Position, placedAt)
+}
+
+func TestRoomWiringSuite(t *testing.T) {
+	suite.Run(t, new(RoomWiringSuite))
+}


### PR DESCRIPTION
Closes #757

Toolkit half of **The Dungeon wave 1** — steps 1–6 of the merged design ([ideas/the-dungeon/design.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/the-dungeon/design.md), board [#19 The Dungeon Run](https://github.com/users/KirkDiggler/projects/19)). Both design forks were resolved by Kirk (inline combat-entry check; fixed 2-goblin seeding — the seeding itself rides the rpg-api PR).

## What's here

**Space (step 1).** `SpaceData{Walls, Width, Height}` on `encounter.Data` — the room persists as a **snapshot**, not a regeneration seed (decided in design). `Encounter.InitRoom(w, h, pattern)` builds via `environments.QuickRoom`, snapshots walls, and registers the room with a `spatial.RoomOrchestrator`; `LoadFromData` rebuilds the same room from the snapshot on every call (transient, like `e.bus`). Nil-safe throughout: encounters without `Space` (all existing fixtures) keep the exact pre-wave-1 behavior.

**Converter (step 2).** `Hex.ToCube`/`HexFromCube` (same cube math, different field names) + `Hex.ToPosition`/`HexFromPosition` (offset-coordinate bridge `spatial.Room` methods actually take; pointy-top). `npc.go`'s three inline conversions refactored onto them.

**Wall-aware LOS (step 3).** `VisibleHexesAt`/`CanSeeAt` gain a `room spatial.Room` param and consult `room.IsLineOfSightBlocked`; SightRange still caps distance; nil room = old radius behavior.

**Wall-blocked movement (step 4).** `Move` and `applyNPCMovementSteps` truncate the requested path at the first `room.CanPlaceEntity`-rejected hex, before any budget/resolver logic.

**Inline combat entry (step 5).** `checkCombatEntry` runs at the `Move`/`AddMonster` mutation sites, mirroring `checkEncounterEnd` (death.go): FREE_ROAM + a player↔monster visibility pair (wall-aware) → `SetMode(TURN_BASED)` — reusing SetMode's initiative roll + ModeChanged/TurnStarted publishes, not duplicating them. "Hostile" == "is a monster" (wave 1; the predicate names the seam where factions land). Idempotent via the mode gate. Composes with the existing #638 NPC-first kick — the toolkit flips + publishes; the api kicks.

**Spawn engine unblocked (step 6).** `tools/spawn.getRoomFromSpatial` stub → real `RoomOrchestrator.GetRoom` lookup via new `BasicSpawnEngineConfig.RoomOrchestrator`; also fixed `placeEntityInRoom`, which silently never called `room.PlaceEntity` (success reported, nothing placed).

## Found & fixed along the way

- **Pre-hydration turn-seed gap.** Combat entry can fire on a `New()`-built (un-hydrated) encounter — rpg-api's exact `StartEncounter` shape. `seedActorTurn` finds no held character, and nothing ever re-seeds → first active player's `TakeAction` fails `"not in combat"` (~50% flaky by initiative order; latent for any pre-hydration `SetMode`, e.g. devseed inject). Fixed with `seedActiveActorIfUnseeded` at the end of `LoadFromData`, keyed off the held character's persisted `InCombat()` so a mid-turn reload can never re-fill spent economy.
- **environments walls aren't hex-snapped** (`X=3.7`-style positions never collide with integer-hex queries → walls silently non-blocking). Worked around in `InitRoom` (snapshot rounds to the nearest hex cell); upstream fix filed as #758.

## Tests

New: `space_test.go` (round-trip, nil-space, wall-blocked move, nil-room move), `combat_entry_test.go` (entry via AddMonster + via Move, player↔player never, idempotency), `perception/room_los_test.go` (blocked/open/nil-room/range-cap through a real `spatial.BasicRoom`), `core` converter round-trips, `tools/spawn/room_wiring_test.go` (PopulateRoom happy path proves occupancy). Existing suites updated: fixtures that manually forced TURN_BASED after adding a visible monster drop the now-redundant `SetMode` (13 files); two death fixtures reorder adds so both goblins make the initiative roll. Full `go test ./... -race` green on both modules; flaky-prone suites stress-run ≥15×.

## Load-bearing

- The room the encounter queries is always **rebuilt from the snapshot** — `QuickRoom`'s own room object is never registered (hex-snapping, replay-not-reroll).
- Combat entry and combat end are now symmetric self-transitions; `SetMode` remains the single mode-flip authority.
- `LoadFromData` gained a turn-seed catch-up that is a no-op unless a TURN_BASED flip happened while un-hydrated — detection is the character's own persisted economy, so it can't double-seed.
- Zero proto/contract changes. rpg-api (steps 7–8) and web (step 9) follow in separate PRs.
- ADR-0034 amended: this adds the encounter→tools/spatial+environments edge without executing the module split; the post-Beat-2 timing gate still governs the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9