### PR TITLE
feat(encounter): AddMonster into a player's LoS emits EntityAppeared

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -379,7 +379,7 @@ the missed `seedActorTurn` and pushes a fresh `TurnStateChangedEvent`
 No `TurnStartedEvent` re-publish: the turn already started and was announced
 at the flip; the catch-up completes its seeding, it doesn't restart it.
 
-### Monster visibility events (rpg-toolkit#761)
+### Monster visibility events (rpg-toolkit#761, #764)
 
 `checkCombatEntry` flips the encounter mode on a newly-formed player-monster
 sightline, but flipping the mode alone doesn't tell a client which monster it
@@ -430,8 +430,39 @@ hex lives on the *player's* path (where the player crossed into or out of
 range) and is meaningless for where to draw an entity that never moved.
 
 Scope: player-move side only. `npc.go`'s simpler NPC-move visibility model
-and populated `View.KnownEntities` remain future work, unchanged by this
-issue.
+(tracked separately, #637) and populated `View.KnownEntities` remain future
+work, unchanged by this issue.
+
+**The spawn-side gap (#764).** #761/#762 only wired detection into
+`applyAndPublishMove` (the player-Move path), so a monster added via
+`AddMonster` directly into an already-visible position started combat
+(`checkCombatEntry` fired) but never told the client which monster it was —
+found by the review gate on PR #762. `AddMonster` now also publishes
+`EntityAppearedEvent` for every player who can already see the newly-added
+monster (`Encounter.playersWhoCanSee`, combat.go), published *before*
+`checkCombatEntry` so the appearance precedes the `ModeChangedEvent` it
+causes, same ordering contract as the Move path. Unlike
+`monsterVisibilityTransitions`, this needs no `ProjectVisibilityTransition`
+machinery: a freshly-added monster has no "before" state to diff against —
+its visibility to any existing player is inherently newly formed the moment
+it exists (the same reasoning `checkCombatEntry`'s own doc comment already
+gives) — so a plain per-player `CanSeeAt` scan is sufficient. Deliberately
+NOT gated on encounter mode: a reinforcement or door-triggered spawn added
+mid-combat must still appear even though `checkCombatEntry`'s
+`ModeFreeRoam` gate makes the mode-change half of the check a no-op at that
+point. When more than one player can already see the new monster (only
+possible via `AddMonster` — a single player `Move` can only ever change
+that one player's own visibility), all of them are grouped into one
+`EntityAppearedEvent`'s `PerPlayer` set, since the monster's `Position` is
+the same fixed hex for every viewer.
+
+Considered folding `npc.go`'s NPC-move-side gap (#637) into the same change
+since the issue named it as "same family" — decided against it: `AddMonster`
+needs no transition machinery at all (see above), while the NPC-move case
+is a genuine moving-entity problem needing the *player-sees-player* shape of
+`ProjectVisibilityTransition` (stationary viewers, a real moving entity) —
+different mechanics, already tracked separately, and folding it in here
+would have widened this fix past a single reviewable change.
 
 ## Implementation notes worth keeping
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,7 +2,7 @@
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
 updated: 2026-07-15
-confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05; #755 rage-sustain-on-miss fix added 2026-07-12; #757 the walled room added 2026-07-13; #761 monster EntityAppeared/Disappeared added 2026-07-15
+confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05; #755 rage-sustain-on-miss fix added 2026-07-12; #757 the walled room added 2026-07-13; #761 monster EntityAppeared/Disappeared added 2026-07-15; #764 AddMonster-side EntityAppeared added 2026-07-15
 ---
 
 # rpg-toolkit: Where We Are
@@ -190,6 +190,23 @@ See "Paused / on hold" below.
 
 ## Recently landed (last 30 days, highlights)
 
+- **AddMonster-side EntityAppeared (rpg-toolkit#764, 2026-07-15).** Found by
+  the review gate on #762: a monster spawned via `AddMonster` directly into
+  an already-visible position started combat (`checkCombatEntry` fired) but
+  emitted no `EntityAppearedEvent` — #761/#762 only wired detection into the
+  player-Move path. `AddMonster` now publishes `EntityAppearedEvent` for
+  every player who can already see the new monster
+  (`Encounter.playersWhoCanSee`, combat.go), sequenced before the
+  `ModeChangedEvent` it may trigger — same ordering contract as #762. No
+  `ProjectVisibilityTransition` machinery needed here (a brand-new monster
+  has no "before" state to diff against); not gated on encounter mode, so a
+  mid-combat reinforcement/door-spawn still appears even when
+  `checkCombatEntry`'s entry-only gate no-ops. Considered folding in
+  `npc.go`'s NPC-move-side gap (#637, "same family" per the issue) —
+  decided against it: that's a genuine moving-entity problem needing the
+  player-sees-player shape of the transition machinery, different mechanics,
+  already tracked separately. See
+  [encounter.md](architecture/components/encounter.md#monster-visibility-events-rpg-toolkit761-764).
 - **Monster EntityAppeared/EntityDisappeared on player moves (rpg-toolkit#761,
   2026-07-15).** Found in The Dungeon wave 1's closing playtest (rpg-api
   #645): `checkCombatEntry` correctly detected a player-monster sightline and

--- a/encounter/addmonster_visibility_test.go
+++ b/encounter/addmonster_visibility_test.go
@@ -1,0 +1,207 @@
+package encounter_test
+
+// addmonster_visibility_test.go covers rpg-toolkit#764: AddMonster into a
+// player's existing LoS starts combat but previously emitted no
+// EntityAppearedEvent, leaving the client to enter combat against an entity
+// it was never told exists. Companion to monster_visibility_test.go (#761),
+// which covers the player-Move-triggered direction.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+)
+
+type AddMonsterVisibilitySuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	enc       *encounter.Encounter
+	aliceSub  *encounter.Subscription
+	bobSub    *encounter.Subscription
+}
+
+func TestAddMonsterVisibilitySuite(t *testing.T) {
+	suite.Run(t, new(AddMonsterVisibilitySuite))
+}
+
+func (s *AddMonsterVisibilitySuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	s.enc = encounter.New(context.Background(), "enc-addmonster-vis", s.broker)
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe("enc-addmonster-vis", "alice")
+	s.Require().NoError(err)
+	s.bobSub, err = s.broker.Subscribe("enc-addmonster-vis", "bob")
+	s.Require().NoError(err)
+}
+
+func (s *AddMonsterVisibilitySuite) TearDownTest() {
+	_ = s.aliceSub.Close()
+	_ = s.bobSub.Close()
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// TestAddMonster_IntoVisibleRange_AppearsBeforeModeChanged pins the issue's
+// core scenario: a monster spawned into a player's existing LoS fires
+// EntityAppearedEvent, sequenced strictly before the ModeChangedEvent that
+// same AddMonster call triggers — matching #762's ordering contract.
+func (s *AddMonsterVisibilitySuite) TestAddMonster_IntoVisibleRange_AppearsBeforeModeChanged() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, s.enc.Mode())
+
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 2, R: 0, S: -2}, HP: 7, MaxHP: 7,
+	}))
+	s.Equal(core.ModeTurnBased, s.enc.Mode(), "goblin visible at add time — combat must start")
+
+	aliceEvts := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
+
+	appearedIdx := -1
+	modeChangedIdx := -1
+	for i, evt := range aliceEvts {
+		switch e := evt.(type) {
+		case *events.EntityAppearedEvent:
+			if e.Entity == core.EntityID("goblin-1") {
+				appearedIdx = i
+				s.Equal(core.Hex{Q: 2, R: 0, S: -2}, e.Position,
+					"appeared Position must be the monster's own fixed hex")
+				s.Contains(e.PerPlayer, core.PlayerID("alice"))
+			}
+		case *events.ModeChangedEvent:
+			modeChangedIdx = i
+		}
+	}
+	s.Require().GreaterOrEqual(appearedIdx, 0, "goblin-1 must have appeared to alice")
+	s.Require().GreaterOrEqual(modeChangedIdx, 0, "AddMonster must have triggered combat entry")
+	s.Less(appearedIdx, modeChangedIdx,
+		"EntityAppearedEvent must precede ModeChangedEvent (appearance before the mode change it caused)")
+}
+
+// TestAddMonster_OutOfRange_NoAppearedEvent is the regression guard: a
+// monster added outside every player's LoS must not fire
+// EntityAppearedEvent (and, unchanged from before #764, must not trigger
+// combat entry either).
+func (s *AddMonsterVisibilitySuite) TestAddMonster_OutOfRange_NoAppearedEvent() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 20, R: 0, S: -20}, HP: 7, MaxHP: 7,
+	}))
+	s.Equal(core.ModeFreeRoam, s.enc.Mode(), "goblin out of range — must not start combat")
+
+	aliceEvts := collectEventsTyped(s.aliceSub, 300*time.Millisecond)
+	for _, evt := range aliceEvts {
+		if _, ok := evt.(*events.EntityAppearedEvent); ok {
+			s.Fail("goblin is out of alice's LoS — EntityAppearedEvent must not fire")
+		}
+	}
+}
+
+// TestAddMonster_MidCombatReinforcement_AppearsWithNoModeChange covers the
+// wave-2 case the issue calls out directly: a monster added while the
+// encounter is ALREADY TURN_BASED (a reinforcement, or a door opening onto
+// an occupied room) must still fire EntityAppearedEvent for any player who
+// can already see it, even though checkCombatEntry's ModeFreeRoam gate makes
+// the mode-change part a no-op (no second ModeChangedEvent should fire).
+func (s *AddMonsterVisibilitySuite) TestAddMonster_MidCombatReinforcement_AppearsWithNoModeChange() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeTurnBased, s.enc.Mode(), "first goblin starts combat")
+	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond) // drain the first goblin's appear + mode change
+
+	// A second goblin, also within alice's sight range, added mid-combat.
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-2", Position: core.Hex{Q: 2, R: 0, S: -2}, HP: 7, MaxHP: 7,
+	}))
+	s.Equal(core.ModeTurnBased, s.enc.Mode(), "still turn-based — no re-flip")
+
+	aliceEvts := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
+
+	var found *events.EntityAppearedEvent
+	for _, evt := range aliceEvts {
+		switch e := evt.(type) {
+		case *events.EntityAppearedEvent:
+			if e.Entity == core.EntityID("goblin-2") {
+				found = e
+			}
+		case *events.ModeChangedEvent:
+			s.Fail("checkCombatEntry's mode gate must no-op mid-combat — no second ModeChangedEvent")
+		}
+	}
+	s.Require().NotNil(found, "goblin-2 must have appeared to alice even though the mode gate no-ops")
+	s.Equal(core.Hex{Q: 2, R: 0, S: -2}, found.Position)
+	s.Contains(found.PerPlayer, core.PlayerID("alice"))
+}
+
+// TestAddMonster_VisibleToMultiplePlayers_GroupsIntoOneEvent: when a new
+// monster is visible to more than one player at once (only possible via
+// AddMonster — a single player Move can only ever change that ONE player's
+// own visibility), all seeing players are grouped into a single
+// EntityAppearedEvent's PerPlayer set, since the monster's Position is the
+// same fixed hex for every viewer (mirroring the hex-grouping the
+// player-sees-player path already does for its appearedByHex map).
+func (s *AddMonsterVisibilitySuite) TestAddMonster_VisibleToMultiplePlayers_GroupsIntoOneEvent() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: -1, R: 0, S: 1}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob",
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 4,
+	}))
+
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+	}))
+
+	aliceEvts := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
+	bobEvts := collectEventsTyped(s.bobSub, 500*time.Millisecond)
+
+	aliceAppeared := s.assertHasType(aliceEvts, "*events.EntityAppearedEvent").(*events.EntityAppearedEvent)
+	bobAppeared := s.assertHasType(bobEvts, "*events.EntityAppearedEvent").(*events.EntityAppearedEvent)
+
+	// Both subscriptions observe the SAME underlying event (same sequence,
+	// same PerPlayer set) — the broker fans one publish out to every
+	// audience member rather than the SDK publishing per-viewer duplicates.
+	s.Equal(aliceAppeared.Sequence(), bobAppeared.Sequence())
+	s.Contains(aliceAppeared.PerPlayer, core.PlayerID("alice"))
+	s.Contains(aliceAppeared.PerPlayer, core.PlayerID("bob"))
+	s.Len(aliceAppeared.PerPlayer, 2)
+}
+
+// assertHasType returns the first event of the given type name, or fails.
+// Mirrors visibility_transition_test.go's helper of the same shape (that one
+// is a *VisibilityTransitionSuite method; this suite needs its own).
+func (s *AddMonsterVisibilitySuite) assertHasType(evts []events.EncounterEvent, typeName string) events.EncounterEvent {
+	s.T().Helper()
+	for _, e := range evts {
+		if typeNameOf(e) == typeName {
+			return e
+		}
+	}
+	names := make([]string, 0, len(evts))
+	for _, e := range evts {
+		names = append(names, typeNameOf(e))
+	}
+	s.FailNowf("event not found", "want %s, got %v", typeName, names)
+	return nil
+}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -396,9 +396,12 @@ func (e *Encounter) checkCombatEntry() error {
 // occupied room — the wave-2 case this issue calls out) must still emit
 // EntityAppearedEvent even though checkCombatEntry itself will no-op.
 func (e *Encounter) playersWhoCanSee(m *MonsterData) map[core.PlayerID]struct{} {
-	viewers := make(map[core.PlayerID]struct{})
+	var viewers map[core.PlayerID]struct{}
 	for playerID, p := range e.data.Players {
 		if perception.CanSeeAt(p.View, m.Position, e.room) {
+			if viewers == nil {
+				viewers = make(map[core.PlayerID]struct{})
+			}
 			viewers[playerID] = struct{}{}
 		}
 	}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -374,6 +374,37 @@ func (e *Encounter) checkCombatEntry() error {
 	return nil
 }
 
+// playersWhoCanSee returns the set of players who currently have LoS to m,
+// via the same perception.CanSeeAt predicate checkCombatEntry uses. Used by
+// AddMonster (rpg-toolkit#764) to publish EntityAppearedEvent for a
+// brand-new monster.
+//
+// Unlike monsterVisibilityTransitions (which diffs a MOVING player's
+// before/after visibility against STATIONARY monsters, since a move can
+// enter, leave, or pass through a monster's range), a freshly-added monster
+// has no "before" state to diff against — its visibility to any existing
+// player is inherently newly formed the moment it's added (the same
+// reasoning checkCombatEntry's own doc comment already gives for why
+// AddMonster needs the combat-entry check at all). A plain per-player
+// CanSeeAt scan is therefore sufficient; no ProjectVisibilityTransition or
+// synthetic-View machinery is needed here.
+//
+// Deliberately NOT gated on e.data.Mode: checkCombatEntry's ModeFreeRoam
+// gate exists to make repeated Move/AddMonster calls idempotent for the
+// *entry* transition only. A monster added mid-combat (a reinforcement
+// spawned into an already-visible position, or a door opening onto an
+// occupied room — the wave-2 case this issue calls out) must still emit
+// EntityAppearedEvent even though checkCombatEntry itself will no-op.
+func (e *Encounter) playersWhoCanSee(m *MonsterData) map[core.PlayerID]struct{} {
+	viewers := make(map[core.PlayerID]struct{})
+	for playerID, p := range e.data.Players {
+		if perception.CanSeeAt(p.View, m.Position, e.room) {
+			viewers[playerID] = struct{}{}
+		}
+	}
+	return viewers
+}
+
 // monsterVisibilityTransitions detects which monsters newly entered or left
 // a single moving player's line of sight during a move (rpg-toolkit#761),
 // reusing the exact machinery applyAndPublishMove already uses to detect

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -387,6 +387,23 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 	if e.data.Mode == core.ModeTurnBased {
 		e.data.Initiative = append(e.data.Initiative, input.ID)
 	}
+
+	// EntityAppearedEvent for any player who can already see the newly-added
+	// monster (rpg-toolkit#764) — published BEFORE checkCombatEntry so a
+	// triggering add's ModeChangedEvent is preceded by the appearance that
+	// caused it, matching #762's ordering contract (appearance before mode
+	// change on the triggering action). Not gated on mode — see
+	// playersWhoCanSee's doc comment for why a mid-combat reinforcement must
+	// still appear even when checkCombatEntry itself is a no-op.
+	mon := e.data.Monsters[input.ID]
+	if viewers := e.playersWhoCanSee(mon); len(viewers) > 0 {
+		if err := e.broker.Publish(events.NewEntityAppearedEvent(
+			e.data.ID, e.nextSeq(), mon.ID, mon.Position, viewers,
+		)); err != nil {
+			return fmt.Errorf("publish monster appeared on add: %w", err)
+		}
+	}
+
 	// Combat-entry check (rpg-toolkit#757): a newly-added monster may already
 	// be visible to an existing player (e.g. spawned inside an already-open
 	// LoS), so this mutation site needs the same check as Move.

--- a/encounter/monster_visibility_test.go
+++ b/encounter/monster_visibility_test.go
@@ -93,12 +93,14 @@ func (s *MonsterVisibilitySuite) TestMoveIntoMonsterLOS_AppearsOnTheSameMoveThat
 }
 
 // TestMoveOutOfMonsterLOS_Disappears covers the mid-combat case: a monster
-// the player has actually SEEN appear (not merely one that happened to be in
-// range when added — AddMonster flips the mode but does not itself publish
-// an EntityAppearedEvent) must fire EntityDisappearedEvent when a later move
-// takes the player out of range. This exercises the path OUTSIDE
-// checkCombatEntry's FREE_ROAM gate, proving detection isn't tied to the
-// entry transition.
+// the player has actually SEEN appear must fire EntityDisappearedEvent when
+// a later move takes the player out of range. This exercises the path
+// OUTSIDE checkCombatEntry's FREE_ROAM gate, proving detection isn't tied to
+// the entry transition. The setup deliberately keeps the goblin out of
+// alice's range at AddMonster time (see rpg-toolkit#764: AddMonster DOES
+// publish EntityAppearedEvent for a monster that's already visible when
+// added) so the appearance under test is unambiguously the one caused by
+// alice's own move below, not the add.
 func (s *MonsterVisibilitySuite) TestMoveOutOfMonsterLOS_Disappears() {
 	// Alice starts out of the goblin's sight range (distance 10 > sight 4),
 	// so no combat entry and no appearance fire at setup time.
@@ -157,9 +159,9 @@ func (s *MonsterVisibilitySuite) TestStaysVisible_NoAppearDisappearEvents() {
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
 	}))
-	// AddMonster flips the mode (goblin is visible at add time) but does not
-	// itself publish an EntityAppearedEvent — drain the mode-change events
-	// only, so the assertions below are scoped to the move under test.
+	// AddMonster flips the mode AND publishes EntityAppearedEvent (the goblin
+	// is visible at add time — rpg-toolkit#764) — drain both so the
+	// assertions below are scoped to the move under test.
 	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
 
 	// Alice moves from Q=1 to Q=2, staying well inside sight range of the


### PR DESCRIPTION
## Summary

Closes #764

A monster spawned via `AddMonster` directly into an already-visible position started combat (`checkCombatEntry` fired, mode flipped to TURN_BASED) but emitted no `EntityAppearedEvent` — found by the review gate on PR #762 (https://github.com/KirkDiggler/rpg-toolkit/pull/762), since #761/#762 only wired detection into the player-`Move` path.

## What changed

- `Encounter.playersWhoCanSee` (encounter/combat.go) computes which players currently have LoS to a given monster, via the same `perception.CanSeeAt` predicate `checkCombatEntry` already uses.
- `AddMonster` (encounter/encounter.go) now publishes `EntityAppearedEvent` for every player who can already see the new monster, grouped into a single event (the monster's `Position` is the same fixed hex for every viewer). Published **before** `checkCombatEntry`, so the appearance precedes any `ModeChangedEvent` it triggers.
- Fixed two now-stale comments in `monster_visibility_test.go` that asserted "AddMonster does not itself publish an EntityAppearedEvent" — that claim was true before this PR and is false after it.
- New `encounter/addmonster_visibility_test.go` covering the scenarios below.

## Load-bearing

- **No transition machinery needed here, unlike #761/#762**: a freshly-added monster has no "before" state to diff against — its visibility to any existing player is inherently newly formed the moment it exists (the same reasoning `checkCombatEntry`'s own doc comment already gives for why `AddMonster` needs the combat-entry check at all). A plain per-player `CanSeeAt` scan is sufficient; `perception.ProjectVisibilityTransition` / the synthetic-View trick from #762 is not used.
- **Deliberately NOT gated on encounter mode**: `checkCombatEntry`'s `ModeFreeRoam` gate exists to make repeated `Move`/`AddMonster` calls idempotent for the *entry* transition only. A monster added mid-combat (a reinforcement, or a door opening onto an occupied room — the wave-2 case the issue calls out) must still fire `EntityAppearedEvent` even though `checkCombatEntry` itself is a no-op once combat has started. Covered by `TestAddMonster_MidCombatReinforcement_AppearsWithNoModeChange`.
- **NPC-move-side gap NOT folded in, on purpose**: the issue names it "same family" and floats folding it in if the seam is shared. It isn't: `AddMonster` needs zero transition machinery (see above), while NPC-move visibility is a genuine moving-entity problem needing the *player-sees-player* shape of `ProjectVisibilityTransition` (stationary viewers, a real moving entity) — different mechanics entirely. It's already tracked as issue #637 (filed back in Wave 2.8, predates this work). Folding it in here would have widened a small, reviewable fix into two unrelated changes.
- **Grouping**: when multiple players can already see the new monster at once (only possible via `AddMonster` — a single player `Move` can only ever change that one player's own visibility), they're grouped into one `EntityAppearedEvent`'s `PerPlayer` set rather than one event per viewer.

## Test plan

- [x] New `encounter/addmonster_visibility_test.go`, `AddMonsterVisibilitySuite` (4 tests):
  - `TestAddMonster_IntoVisibleRange_AppearsBeforeModeChanged` — pins the issue's core scenario + ordering (appeared before mode-changed).
  - `TestAddMonster_OutOfRange_NoAppearedEvent` — regression guard.
  - `TestAddMonster_MidCombatReinforcement_AppearsWithNoModeChange` — the wave-2 reinforcement case; also asserts no spurious second `ModeChangedEvent`.
  - `TestAddMonster_VisibleToMultiplePlayers_GroupsIntoOneEvent` — grouping behavior, same sequence number observed by both viewers.
- [x] Updated `monster_visibility_test.go` comments that the new behavior made stale; existing suite still green.
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `gofmt -s -l` / `goimports -l` on changed files — clean
- [x] `go mod tidy` (encounter module) — no diff
- [x] `golangci-lint run --no-config` (encounter module) — 0 issues
- [x] `go test ./...` (encounter module, full suite incl. new + existing suites) — all green (~44s + core/events/perception subpackages)
- [x] `make pre-commit` at repo root — ran it; it fails on a **pre-existing, unrelated** `core` module coverage-check bug (a duplicated `go test` invocation's stdout leaks into the `bc` arithmetic, producing a syntax error and bogus "76.5%" reading). This PR never touches `core/` or `events/`; `git status` after the run showed zero incidental changes from the `go fmt`/`go mod tidy` steps. The target only ever exercises `core`/`events`, never `encounter` — the module this PR actually changes was independently verified via the checks above.

## Docs

- `docs/status.md` — new "Recently landed" entry for #764 + frontmatter bump
- `docs/architecture/components/encounter.md` — extended the "Monster visibility events" section (retitled to cover #761 + #764) with the `AddMonster` fix and the fold-in-vs-#637 rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9