### PR TITLE
feat(spawn): room-aware position search, fixed/oracle placement, seeded spawns

### DIFF
--- a/tools/spawn/README.md
+++ b/tools/spawn/README.md
@@ -407,6 +407,11 @@ type SpawnConfig struct {
     // Player spawn zones and choices
     PlayerSpawnZones []SpawnZone         `json:"player_spawn_zones,omitempty"`
     PlayerChoices    []PlayerSpawnChoice `json:"player_choices,omitempty"`
+
+    // Seed makes this call's position search reproducible (both the
+    // unconstrained and constraint-aware paths). Nil uses a non-deterministic
+    // source.
+    Seed *int64 `json:"seed,omitempty"`
 }
 ```
 
@@ -420,6 +425,15 @@ type EntityGroup struct {
     Type           string       `json:"type"`            // Entity category
     SelectionTable string       `json:"selection_table"` // Selectables table ID
     Quantity       QuantitySpec `json:"quantity"`        // How many to spawn
+
+    // FixedPositions supplies exact positions for this group's entities, in
+    // order, bypassing search (still validated against the real room).
+    FixedPositions []spatial.Position `json:"fixed_positions,omitempty"`
+
+    // PositionOracle is a caller predicate ANDed into the search alongside
+    // room validity and SpatialRules — e.g. "not visible to any viewer,"
+    // for placement requirements the constraint vocabulary doesn't cover.
+    PositionOracle PositionOracle `json:"-"`
 }
 
 type QuantitySpec struct {

--- a/tools/spawn/basic_engine.go
+++ b/tools/spawn/basic_engine.go
@@ -123,18 +123,26 @@ func (e *BasicSpawnEngine) PopulateRoom(
 		return result, fmt.Errorf("capacity analysis failed: %w", err)
 	}
 
+	// A seeded config gets its own rng for this call so results are
+	// reproducible; otherwise every position-search call in this call tree
+	// shares the engine's own (non-deterministic) source.
+	rng := e.random
+	if config.Seed != nil {
+		rng = rand.New(rand.NewSource(*config.Seed)) // #nosec G404
+	}
+
 	// Route to appropriate spawning method based on pattern
 	switch config.Pattern {
 	case PatternScattered:
-		return e.applyScatteredSpawning(ctx, roomID, config, result)
+		return e.applyScatteredSpawning(ctx, roomID, config, result, rng)
 	case PatternFormation:
-		return e.applyFormationSpawning(ctx, roomID, config, result)
+		return e.applyFormationSpawning(ctx, roomID, config, result, rng)
 	case PatternTeamBased:
-		return e.applyTeamBasedSpawning(ctx, roomID, config, result)
+		return e.applyTeamBasedSpawning(ctx, roomID, config, result, rng)
 	case PatternPlayerChoice:
-		return e.applyPlayerChoiceSpawning(ctx, roomID, config, result)
+		return e.applyPlayerChoiceSpawning(ctx, roomID, config, result, rng)
 	case PatternClustered:
-		return e.applyClusteredSpawning(ctx, roomID, config, result)
+		return e.applyClusteredSpawning(ctx, roomID, config, result, rng)
 	default:
 		return result, fmt.Errorf("unsupported spawn pattern: %s", config.Pattern)
 	}
@@ -216,35 +224,38 @@ func (e *BasicSpawnEngine) getRoomFromSpatial(roomID string) (spatial.Room, erro
 	return room, nil
 }
 
-// findValidPosition finds a valid position for an entity (simplified for Phase 1)
-func (e *BasicSpawnEngine) findValidPosition(_ spatial.Room, _ core.Entity) spatial.Position {
-	// Phase 1: Simple random position within reasonable bounds
-	// Real implementation would query the spatial room for valid positions
-	x := e.random.Float64() * 10.0
-	y := e.random.Float64() * 10.0
-
-	return spatial.Position{X: x, Y: y}
+// findValidPosition finds a valid position for an entity using the real
+// room's dimensions and Room.CanPlaceEntity (bounds + wall/occupancy),
+// delegating to the constraint solver with an empty SpatialConstraints —
+// "unconstrained" still means "actually in the room and not on a wall,"
+// not "anywhere." rng nil uses the engine's own default source.
+func (e *BasicSpawnEngine) findValidPosition(
+	room spatial.Room, entity core.Entity, oracle PositionOracle, rng *rand.Rand,
+) (spatial.Position, error) {
+	return e.findValidPositionWithConstraints(room, entity, SpatialConstraints{}, nil, oracle, rng)
 }
 
-// findValidPositionWithConstraints finds a position that satisfies spatial constraints.
+// findValidPositionWithConstraints finds a position that satisfies
+// room-derived validity (bounds, walls/occupancy), an optional caller
+// PositionOracle, and the given spatial constraints.
 // Purpose: Phase 3 constraint-aware position finding.
 func (e *BasicSpawnEngine) findValidPositionWithConstraints(
 	room spatial.Room, entity core.Entity, constraints SpatialConstraints,
-	existingEntities []SpawnedEntity,
+	existingEntities []SpawnedEntity, oracle PositionOracle, rng *rand.Rand,
 ) (spatial.Position, error) {
+	if rng == nil {
+		rng = e.random
+	}
+
 	validPositions, err := e.constraintSolver.FindValidPositions(
-		room, entity, constraints, existingEntities, 10,
+		room, entity, constraints, existingEntities, 10, oracle, rng,
 	)
 	if err != nil {
 		return spatial.Position{}, err
 	}
 
-	if len(validPositions) == 0 {
-		return spatial.Position{}, fmt.Errorf("no valid positions found for entity %s", entity.GetType())
-	}
-
 	// Select random position from valid options
-	selectedIndex := e.random.Intn(len(validPositions))
+	selectedIndex := rng.Intn(len(validPositions))
 	return validPositions[selectedIndex], nil
 }
 

--- a/tools/spawn/constraints.go
+++ b/tools/spawn/constraints.go
@@ -85,18 +85,22 @@ func (cs *ConstraintSolver) FindValidPositions(
 
 	var validPositions []spatial.Position
 	dims := grid.GetDimensions()
-	for _, position := range allGridPositions(room) {
-		if len(validPositions) >= maxPositions {
-			break
-		}
-		if !room.CanPlaceEntity(entity, position) {
-			continue // wall-occupied or otherwise blocked
-		}
-		if oracle != nil && !oracle(position) {
-			continue
-		}
-		if cs.ValidatePosition(room, position, entity, constraints, existingEntities) == nil {
-			validPositions = append(validPositions, position)
+	minX, minY := gridOrigin(grid, dims)
+	for x := minX; x < minX+dims.Width && len(validPositions) < maxPositions; x++ {
+		for y := minY; y < minY+dims.Height && len(validPositions) < maxPositions; y++ {
+			position := spatial.Position{X: x, Y: y}
+			if !grid.IsValidPosition(position) {
+				continue // defensive: today's grids are rectangular, but the interface doesn't promise it
+			}
+			if !room.CanPlaceEntity(entity, position) {
+				continue // wall-occupied or otherwise blocked
+			}
+			if oracle != nil && !oracle(position) {
+				continue
+			}
+			if cs.ValidatePosition(room, position, entity, constraints, existingEntities) == nil {
+				validPositions = append(validPositions, position)
+			}
 		}
 	}
 
@@ -110,20 +114,23 @@ func (cs *ConstraintSolver) FindValidPositions(
 	return validPositions, nil
 }
 
-// allGridPositions enumerates every position the room's grid considers
-// valid, via Grid.GetPositionsInRange with a generously oversized radius
-// anchored at the bounding box's midpoint. Using each grid implementation's
-// own range query (rather than re-deriving a coordinate sweep here) keeps
-// this correct regardless of the grid's coordinate origin — 0-based offset
-// grids (SquareGrid, HexGrid) and grids centered on zero (AxialHexGrid)
-// alike — since GetPositionsInRange always filters through the grid's own
-// IsValidPosition.
-func allGridPositions(room spatial.Room) []spatial.Position {
-	grid := room.GetGrid()
-	dims := grid.GetDimensions()
-	center := spatial.Position{X: dims.Width / 2, Y: dims.Height / 2}
-	radius := dims.Width + dims.Height
-	return grid.GetPositionsInRange(center, radius)
+// gridOrigin returns the lower bound (minX, minY) of grid's valid
+// coordinate range, so callers can sweep exactly [minX, minX+dims.Width) x
+// [minY, minY+dims.Height) instead of guessing. Grids in this package use
+// one of two conventions: 0-based offset (SquareGrid, HexGrid — valid range
+// starts at (0,0)) or axial, centered on zero (AxialHexGrid — valid range
+// starts at (-dims.Width/2, -dims.Height/2)). (0,0) is a valid position
+// under both conventions, so this probes with IsValidPosition instead of
+// assuming one — a linear sweep anchored at the wrong origin would silently
+// skip an entire grid's worth of valid cells.
+func gridOrigin(grid spatial.Grid, dims spatial.Dimensions) (minX, minY float64) {
+	if grid.IsValidPosition(spatial.Position{X: -dims.Width / 2, Y: 0}) {
+		minX = -dims.Width / 2
+	}
+	if grid.IsValidPosition(spatial.Position{X: 0, Y: -dims.Height / 2}) {
+		minY = -dims.Height / 2
+	}
+	return minX, minY
 }
 
 // validateMinDistance checks minimum distance requirements between entity types.
@@ -167,11 +174,27 @@ func (cs *ConstraintSolver) validateWallProximity(
 		return nil // No wall proximity constraint
 	}
 
-	dims := room.GetGrid().GetDimensions()
-	if position.X < minWallDistance || position.Y < minWallDistance ||
-		position.X > dims.Width-minWallDistance || position.Y > dims.Height-minWallDistance {
-		return fmt.Errorf("position too close to room boundary: (%.2f, %.2f), minimum distance %.2f",
-			position.X, position.Y, minWallDistance)
+	// Probe minWallDistance out from position in each cardinal direction:
+	// if any probe falls outside the grid's valid range, position is too
+	// close to the boundary. This works regardless of the grid's coordinate
+	// origin — 0-based offset grids (SquareGrid, HexGrid) and axial grids
+	// centered on zero (AxialHexGrid) alike — since it only relies on the
+	// grid's own IsValidPosition, never an assumed 0..Width/Height range
+	// (a room.GetGrid() of nil, which the Room interface doesn't forbid,
+	// skips the boundary probe rather than panicking).
+	if grid := room.GetGrid(); grid != nil {
+		probes := []spatial.Position{
+			{X: position.X - minWallDistance, Y: position.Y},
+			{X: position.X + minWallDistance, Y: position.Y},
+			{X: position.X, Y: position.Y - minWallDistance},
+			{X: position.X, Y: position.Y + minWallDistance},
+		}
+		for _, probe := range probes {
+			if !grid.IsValidPosition(probe) {
+				return fmt.Errorf("position too close to room boundary: (%.2f, %.2f), minimum distance %.2f",
+					position.X, position.Y, minWallDistance)
+			}
+		}
 	}
 
 	for _, nearby := range room.GetEntitiesInRange(position, minWallDistance) {
@@ -376,7 +399,13 @@ func (cs *ConstraintSolver) findValidPositionsGridless(
 
 	var validPositions []spatial.Position
 
-	roomDimensions := room.GetGrid().GetDimensions()
+	// A nil grid routes here via isGridlessRoom, and the Room interface
+	// doesn't forbid GetGrid() returning nil — fall back to a reasonable
+	// default span instead of panicking on GetDimensions().
+	roomDimensions := spatial.Dimensions{Width: 10.0, Height: 10.0}
+	if grid := room.GetGrid(); grid != nil {
+		roomDimensions = grid.GetDimensions()
+	}
 	attempts := 0
 	maxAttempts := cs.maxAttempts * 2 // More attempts for gridless
 

--- a/tools/spawn/constraints.go
+++ b/tools/spawn/constraints.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"time"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
@@ -21,12 +22,18 @@ type ConstraintSolver struct {
 func NewConstraintSolver() *ConstraintSolver {
 	return &ConstraintSolver{
 		maxAttempts: 100,
-		random:      rand.New(rand.NewSource(42)), //nolint:gosec // Fixed seed for consistent testing
+		// Default source when a caller doesn't pass an explicit rng (e.g. via
+		// SpawnConfig.Seed) to FindValidPositions. Real randomness by
+		// default; callers that want reproducible spawns pass their own
+		// seeded *rand.Rand instead.
+		random: rand.New(rand.NewSource(time.Now().UnixNano())), // #nosec G404
 	}
 }
 
 // ValidatePosition checks if a position satisfies all spatial constraints.
-// Purpose: Core constraint validation for entity placement.
+// Purpose: Core constraint validation for entity placement. Does NOT check
+// room-derived validity (bounds, walls, occupancy) — callers must also
+// check Room.CanPlaceEntity; FindValidPositions does both.
 func (cs *ConstraintSolver) ValidatePosition(
 	room spatial.Room, position spatial.Position, entity core.Entity,
 	constraints SpatialConstraints, existingEntities []SpawnedEntity,
@@ -54,37 +61,69 @@ func (cs *ConstraintSolver) ValidatePosition(
 	return nil
 }
 
-// FindValidPositions finds all positions that satisfy constraints.
+// FindValidPositions finds positions that satisfy room-derived validity
+// (bounds, walls/occupancy via Room.CanPlaceEntity), an optional
+// caller-supplied PositionOracle, and the given spatial constraints.
 // Purpose: Generate valid placement options for constraint-aware spawning.
+//
+// rng controls candidate ordering for gridless sampling; pass nil to use
+// the solver's own default (real, non-reproducible) source — see
+// SpawnConfig.Seed for how callers opt into reproducible spawns.
 func (cs *ConstraintSolver) FindValidPositions(
 	room spatial.Room, entity core.Entity, constraints SpatialConstraints,
-	existingEntities []SpawnedEntity, maxPositions int,
+	existingEntities []SpawnedEntity, maxPositions int, oracle PositionOracle, rng *rand.Rand,
 ) ([]spatial.Position, error) {
-	var validPositions []spatial.Position
-
-	// Check if room uses gridless positioning
-	roomGrid := room.GetGrid()
-	if cs.isGridlessRoom(roomGrid) {
-		// For gridless rooms: use finer sampling for smooth positioning
-		return cs.findValidPositionsGridless(room, entity, constraints, existingEntities, maxPositions)
+	if rng == nil {
+		rng = cs.random
 	}
 
-	// For grid-based rooms: align to grid positions
-	for x := 1.0; x < 10.0 && len(validPositions) < maxPositions; x += 0.5 {
-		for y := 1.0; y < 10.0 && len(validPositions) < maxPositions; y += 0.5 {
-			position := spatial.Position{X: x, Y: y}
+	grid := room.GetGrid()
+	if cs.isGridlessRoom(grid) {
+		// For gridless rooms: use finer sampling for smooth positioning
+		return cs.findValidPositionsGridless(room, entity, constraints, existingEntities, maxPositions, oracle, rng)
+	}
 
-			if cs.ValidatePosition(room, position, entity, constraints, existingEntities) == nil {
-				validPositions = append(validPositions, position)
-			}
+	var validPositions []spatial.Position
+	dims := grid.GetDimensions()
+	for _, position := range allGridPositions(room) {
+		if len(validPositions) >= maxPositions {
+			break
+		}
+		if !room.CanPlaceEntity(entity, position) {
+			continue // wall-occupied or otherwise blocked
+		}
+		if oracle != nil && !oracle(position) {
+			continue
+		}
+		if cs.ValidatePosition(room, position, entity, constraints, existingEntities) == nil {
+			validPositions = append(validPositions, position)
 		}
 	}
 
 	if len(validPositions) == 0 {
-		return nil, fmt.Errorf("no valid positions found for entity %s with given constraints", entity.GetType())
+		return nil, fmt.Errorf(
+			"no valid positions found for entity %s with given constraints in a %s room",
+			entity.GetType(), dims,
+		)
 	}
 
 	return validPositions, nil
+}
+
+// allGridPositions enumerates every position the room's grid considers
+// valid, via Grid.GetPositionsInRange with a generously oversized radius
+// anchored at the bounding box's midpoint. Using each grid implementation's
+// own range query (rather than re-deriving a coordinate sweep here) keeps
+// this correct regardless of the grid's coordinate origin — 0-based offset
+// grids (SquareGrid, HexGrid) and grids centered on zero (AxialHexGrid)
+// alike — since GetPositionsInRange always filters through the grid's own
+// IsValidPosition.
+func allGridPositions(room spatial.Room) []spatial.Position {
+	grid := room.GetGrid()
+	dims := grid.GetDimensions()
+	center := spatial.Position{X: dims.Width / 2, Y: dims.Height / 2}
+	radius := dims.Width + dims.Height
+	return grid.GetPositionsInRange(center, radius)
 }
 
 // validateMinDistance checks minimum distance requirements between entity types.
@@ -119,33 +158,37 @@ func (cs *ConstraintSolver) validateMinDistance(
 	return nil
 }
 
-// validateWallProximity ensures entities maintain minimum distance from walls.
+// validateWallProximity ensures entities maintain minimum distance from both
+// the room boundary and any nearby wall/blocking entity.
 func (cs *ConstraintSolver) validateWallProximity(
-	_ spatial.Room, position spatial.Position, minWallDistance float64,
+	room spatial.Room, position spatial.Position, minWallDistance float64,
 ) error {
 	if minWallDistance <= 0 {
 		return nil // No wall proximity constraint
 	}
 
-	// Phase 3: Simple boundary check
-	// Real implementation would query spatial room for wall positions
-	if position.X < minWallDistance || position.Y < minWallDistance {
-		return fmt.Errorf("position too close to wall: (%.2f, %.2f), minimum distance %.2f",
+	dims := room.GetGrid().GetDimensions()
+	if position.X < minWallDistance || position.Y < minWallDistance ||
+		position.X > dims.Width-minWallDistance || position.Y > dims.Height-minWallDistance {
+		return fmt.Errorf("position too close to room boundary: (%.2f, %.2f), minimum distance %.2f",
 			position.X, position.Y, minWallDistance)
 	}
 
-	// Check distance from right and top walls (assuming 10x10 room)
-	if position.X > (10.0-minWallDistance) || position.Y > (10.0-minWallDistance) {
-		return fmt.Errorf("position too close to wall: (%.2f, %.2f), minimum distance %.2f",
-			position.X, position.Y, minWallDistance)
+	for _, nearby := range room.GetEntitiesInRange(position, minWallDistance) {
+		if placeable, ok := nearby.(spatial.Placeable); ok && placeable.BlocksMovement() {
+			return fmt.Errorf("position too close to a wall (%s): (%.2f, %.2f), minimum distance %.2f",
+				nearby.GetID(), position.X, position.Y, minWallDistance)
+		}
 	}
 
 	return nil
 }
 
-// validateLineOfSight ensures line of sight requirements are met.
+// validateLineOfSight ensures line of sight requirements are met, using the
+// real room's wall-aware Room.IsLineOfSightBlocked rather than a distance
+// heuristic.
 func (cs *ConstraintSolver) validateLineOfSight(
-	_ spatial.Room, position spatial.Position, entity core.Entity,
+	room spatial.Room, position spatial.Position, entity core.Entity,
 	losRules LineOfSightRules, existingEntities []SpawnedEntity,
 ) error {
 	entityType := string(entity.GetType()) // Convert to string for comparisons
@@ -154,13 +197,13 @@ func (cs *ConstraintSolver) validateLineOfSight(
 	for _, pair := range losRules.RequiredSight {
 		if pair.From == entityType {
 			// This entity must see entities of pair.To type
-			if err := cs.checkRequiredSight(position, pair.To, existingEntities); err != nil {
+			if err := cs.checkRequiredSight(room, position, pair.To, existingEntities); err != nil {
 				return fmt.Errorf("required sight from %s to %s: %w", pair.From, pair.To, err)
 			}
 		}
 		if pair.To == entityType {
 			// Entities of pair.From type must see this entity
-			if err := cs.checkCanBeSeen(position, pair.From, existingEntities); err != nil {
+			if err := cs.checkCanBeSeen(room, position, pair.From, existingEntities); err != nil {
 				return fmt.Errorf("required sight from %s to %s: %w", pair.From, pair.To, err)
 			}
 		}
@@ -170,13 +213,13 @@ func (cs *ConstraintSolver) validateLineOfSight(
 	for _, pair := range losRules.BlockedSight {
 		if pair.From == entityType {
 			// This entity must NOT see entities of pair.To type
-			if err := cs.checkBlockedSight(position, pair.To, existingEntities); err != nil {
+			if err := cs.checkBlockedSight(room, position, pair.To, existingEntities); err != nil {
 				return fmt.Errorf("blocked sight from %s to %s: %w", pair.From, pair.To, err)
 			}
 		}
 		if pair.To == entityType {
 			// Entities of pair.From type must NOT see this entity
-			if err := cs.checkCannotBeSeen(position, pair.From, existingEntities); err != nil {
+			if err := cs.checkCannotBeSeen(room, position, pair.From, existingEntities); err != nil {
 				return fmt.Errorf("blocked sight from %s to %s: %w", pair.From, pair.To, err)
 			}
 		}
@@ -220,7 +263,7 @@ func (cs *ConstraintSolver) validateAreaOfEffect(
 
 // checkRequiredSight verifies that position has line of sight to required entity types.
 func (cs *ConstraintSolver) checkRequiredSight(
-	position spatial.Position, targetType string, existingEntities []SpawnedEntity,
+	room spatial.Room, position spatial.Position, targetType string, existingEntities []SpawnedEntity,
 ) error {
 	// Find entities of target type
 	targetEntities := cs.getEntitiesByType(existingEntities, targetType)
@@ -230,7 +273,7 @@ func (cs *ConstraintSolver) checkRequiredSight(
 
 	// Check if we can see at least one target entity
 	for _, target := range targetEntities {
-		if cs.hasLineOfSight(position, target.Position) {
+		if cs.hasLineOfSight(room, position, target.Position) {
 			return nil // Found at least one visible target
 		}
 	}
@@ -240,7 +283,7 @@ func (cs *ConstraintSolver) checkRequiredSight(
 
 // checkCanBeSeen verifies that entities of fromType can see this position.
 func (cs *ConstraintSolver) checkCanBeSeen(
-	position spatial.Position, fromType string, existingEntities []SpawnedEntity,
+	room spatial.Room, position spatial.Position, fromType string, existingEntities []SpawnedEntity,
 ) error {
 	// Find entities of fromType
 	fromEntities := cs.getEntitiesByType(existingEntities, fromType)
@@ -250,7 +293,7 @@ func (cs *ConstraintSolver) checkCanBeSeen(
 
 	// Check if at least one fromType entity can see this position
 	for _, fromEntity := range fromEntities {
-		if cs.hasLineOfSight(fromEntity.Position, position) {
+		if cs.hasLineOfSight(room, fromEntity.Position, position) {
 			return nil // At least one entity can see this position
 		}
 	}
@@ -260,14 +303,14 @@ func (cs *ConstraintSolver) checkCanBeSeen(
 
 // checkBlockedSight verifies that position does NOT have line of sight to blocked entity types.
 func (cs *ConstraintSolver) checkBlockedSight(
-	position spatial.Position, targetType string, existingEntities []SpawnedEntity,
+	room spatial.Room, position spatial.Position, targetType string, existingEntities []SpawnedEntity,
 ) error {
 	// Find entities of target type
 	targetEntities := cs.getEntitiesByType(existingEntities, targetType)
 
 	// Check that we cannot see any target entity
 	for _, target := range targetEntities {
-		if cs.hasLineOfSight(position, target.Position) {
+		if cs.hasLineOfSight(room, position, target.Position) {
 			return fmt.Errorf("has line of sight to %s at (%.2f, %.2f)",
 				targetType, target.Position.X, target.Position.Y)
 		}
@@ -278,14 +321,14 @@ func (cs *ConstraintSolver) checkBlockedSight(
 
 // checkCannotBeSeen verifies that entities of fromType cannot see this position.
 func (cs *ConstraintSolver) checkCannotBeSeen(
-	position spatial.Position, fromType string, existingEntities []SpawnedEntity,
+	room spatial.Room, position spatial.Position, fromType string, existingEntities []SpawnedEntity,
 ) error {
 	// Find entities of fromType
 	fromEntities := cs.getEntitiesByType(existingEntities, fromType)
 
 	// Check that no fromType entity can see this position
 	for _, fromEntity := range fromEntities {
-		if cs.hasLineOfSight(fromEntity.Position, position) {
+		if cs.hasLineOfSight(room, fromEntity.Position, position) {
 			return fmt.Errorf("%s at (%.2f, %.2f) can see this position",
 				fromType, fromEntity.Position.X, fromEntity.Position.Y)
 		}
@@ -294,12 +337,12 @@ func (cs *ConstraintSolver) checkCannotBeSeen(
 	return nil // No entity can see this position
 }
 
-// hasLineOfSight checks if there's a clear line of sight between two positions.
-func (cs *ConstraintSolver) hasLineOfSight(from, to spatial.Position) bool {
-	// Phase 3: Simple line of sight calculation
-	// Real implementation would use spatial room queries for wall intersections
-	distance := cs.calculateDistance(from, to)
-	return distance <= 8.0 // Assume 8-unit line of sight range
+// hasLineOfSight checks if there's a clear line of sight between two
+// positions, using the real room's wall-aware IsLineOfSightBlocked (backed
+// by Placeable.BlocksLineOfSight on occupying entities) rather than a
+// distance heuristic.
+func (cs *ConstraintSolver) hasLineOfSight(room spatial.Room, from, to spatial.Position) bool {
+	return !room.IsLineOfSightBlocked(from, to)
 }
 
 // calculateDistance computes Euclidean distance between two positions.
@@ -309,48 +352,51 @@ func (cs *ConstraintSolver) calculateDistance(pos1, pos2 spatial.Position) float
 	return math.Sqrt(dx*dx + dy*dy)
 }
 
-// isGridlessRoom checks if the room uses gridless positioning.
+// isGridlessRoom checks if the room's grid is gridless (theater-of-mind:
+// continuous positioning rather than discrete cells). GridlessRoom is
+// itself a Grid implementation (GetShape() == GridShapeGridless), so this
+// is a shape check, not a nil check — a nil grid is treated as gridless
+// too, defensively, since there are no discrete cells to sweep.
 func (cs *ConstraintSolver) isGridlessRoom(grid spatial.Grid) bool {
-	// Check if grid is nil (indicates gridless) or if it's specifically a gridless type
-	if grid == nil {
-		return true
-	}
-	// Could also check grid type, but nil check covers most cases
-	return false
+	return grid == nil || grid.GetShape() == spatial.GridShapeGridless
 }
 
-// findValidPositionsGridless finds valid positions for gridless rooms.
+// findValidPositionsGridless finds valid positions for gridless rooms via
+// random continuous sampling within the room's real dimensions, checking
+// room-derived validity (Room.CanPlaceEntity), the optional oracle, and the
+// given constraints.
 // Purpose: Optimized position finding for continuous/smooth positioning systems.
 func (cs *ConstraintSolver) findValidPositionsGridless(
 	room spatial.Room, entity core.Entity, constraints SpatialConstraints,
-	existingEntities []SpawnedEntity, maxPositions int,
+	existingEntities []SpawnedEntity, maxPositions int, oracle PositionOracle, rng *rand.Rand,
 ) ([]spatial.Position, error) {
+	if rng == nil {
+		rng = cs.random
+	}
+
 	var validPositions []spatial.Position
 
-	// For gridless rooms: use finer resolution sampling for smooth positioning
-	// Also use random sampling to avoid predictable patterns
-	roomGrid := room.GetGrid()
-	var roomDimensions spatial.Dimensions
-	if roomGrid != nil {
-		roomDimensions = roomGrid.GetDimensions()
-	} else {
-		// Default dimensions for gridless rooms
-		roomDimensions = spatial.Dimensions{Width: 10.0, Height: 10.0}
-	}
+	roomDimensions := room.GetGrid().GetDimensions()
 	attempts := 0
 	maxAttempts := cs.maxAttempts * 2 // More attempts for gridless
 
 	for len(validPositions) < maxPositions && attempts < maxAttempts {
 		// Generate random position within room bounds with some margin
 		margin := 1.0
-		x := margin + (roomDimensions.Width-2*margin)*cs.random.Float64()
-		y := margin + (roomDimensions.Height-2*margin)*cs.random.Float64()
+		x := margin + (roomDimensions.Width-2*margin)*rng.Float64()
+		y := margin + (roomDimensions.Height-2*margin)*rng.Float64()
 		position := spatial.Position{X: x, Y: y}
+		attempts++
 
+		if !room.CanPlaceEntity(entity, position) {
+			continue // wall-occupied or otherwise blocked
+		}
+		if oracle != nil && !oracle(position) {
+			continue
+		}
 		if cs.ValidatePosition(room, position, entity, constraints, existingEntities) == nil {
 			validPositions = append(validPositions, position)
 		}
-		attempts++
 	}
 
 	if len(validPositions) == 0 {

--- a/tools/spawn/constraints_test.go
+++ b/tools/spawn/constraints_test.go
@@ -112,7 +112,7 @@ func (s *ConstraintSolverTestSuite) TestFindValidPositions() {
 			WallProximity: 1.0,
 		}
 
-		positions, err := s.solver.FindValidPositions(s.room, s.mockEntity, constraints, []SpawnedEntity{}, 3)
+		positions, err := s.solver.FindValidPositions(s.room, s.mockEntity, constraints, []SpawnedEntity{}, 3, nil, nil)
 		s.Assert().NoError(err)
 		s.Assert().NotEmpty(positions)
 		s.Assert().LessOrEqual(len(positions), 3)
@@ -130,7 +130,7 @@ func (s *ConstraintSolverTestSuite) TestFindValidPositions() {
 			WallProximity: 15.0, // Impossible in 10x10 room
 		}
 
-		positions, err := s.solver.FindValidPositions(s.room, s.mockEntity, constraints, []SpawnedEntity{}, 3)
+		positions, err := s.solver.FindValidPositions(s.room, s.mockEntity, constraints, []SpawnedEntity{}, 3, nil, nil)
 		s.Assert().Error(err)
 		s.Assert().Empty(positions)
 	})

--- a/tools/spawn/room_aware_test.go
+++ b/tools/spawn/room_aware_test.go
@@ -1,0 +1,299 @@
+package spawn
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// blockingEntity is a minimal core.Entity + spatial.Placeable used to plant
+// walls in a real spatial.Room. Room-awareness only means something against
+// actual occupying entities that block movement/sight — spawn has no
+// separate "wall" concept of its own.
+type blockingEntity struct {
+	id                string
+	blocksMovement    bool
+	blocksLineOfSight bool
+}
+
+func (b *blockingEntity) GetID() string            { return b.id }
+func (b *blockingEntity) GetType() core.EntityType { return "wall" }
+func (b *blockingEntity) GetSize() int             { return 1 }
+func (b *blockingEntity) BlocksMovement() bool     { return b.blocksMovement }
+func (b *blockingEntity) BlocksLineOfSight() bool  { return b.blocksLineOfSight }
+
+// RoomAwareSuite covers rpg-toolkit#760: position search now queries the
+// real spatial.Room instead of a hardcoded [0,10) sweep / distance stub.
+type RoomAwareSuite struct {
+	suite.Suite
+}
+
+func (s *RoomAwareSuite) newRoom(id string, width, height float64) *spatial.BasicRoom {
+	grid := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: width, Height: height})
+	return spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: id, Type: "test", Grid: grid})
+}
+
+// TestFindValidPositions_BoundsAndWalls pins the core #760 ask: every
+// candidate FindValidPositions returns is (a) within the room's real
+// dimensions and (b) never on a cell a wall occupies. Requesting every free
+// cell in a small room with a few walls planted and checking the result is
+// exactly "all cells minus the walls" also proves the search doesn't
+// overshoot or undershoot the real room.
+func (s *RoomAwareSuite) TestFindValidPositions_BoundsAndWalls() {
+	room := s.newRoom("bounded-room", 5, 5) // 25 cells total
+	wallPositions := []spatial.Position{{X: 0, Y: 0}, {X: 4, Y: 4}, {X: 2, Y: 2}}
+	for i, pos := range wallPositions {
+		wall := &blockingEntity{id: fmt.Sprintf("wall-%d", i), blocksMovement: true}
+		s.Require().NoError(room.PlaceEntity(wall, pos))
+	}
+
+	solver := NewConstraintSolver()
+	entity := &MockEntity{id: "goblin", entityType: "monster"}
+
+	positions, err := solver.FindValidPositions(room, entity, SpatialConstraints{}, nil, 100, nil, nil)
+	s.Require().NoError(err)
+
+	// 25 cells - 3 walls = 22 free cells; maxPositions=100 asks for more
+	// than exist, so this also proves the search doesn't overshoot.
+	s.Assert().Len(positions, 22)
+
+	seen := make(map[spatial.Position]bool)
+	for _, pos := range positions {
+		s.Assert().GreaterOrEqual(pos.X, 0.0)
+		s.Assert().Less(pos.X, 5.0)
+		s.Assert().GreaterOrEqual(pos.Y, 0.0)
+		s.Assert().Less(pos.Y, 5.0)
+		for _, wallPos := range wallPositions {
+			s.Assert().NotEqual(wallPos, pos, "position must not land on a wall cell")
+		}
+		s.Assert().False(seen[pos], "position returned twice")
+		seen[pos] = true
+	}
+}
+
+// TestLineOfSight_WallAware pins the #760 ask that LineOfSight constraints
+// use the room's actual wall-aware Room.IsLineOfSightBlocked instead of the
+// old Euclidean-distance stub (distance <= 8.0 == "visible", walls not
+// considered at all). Two candidates sit at the SAME distance (8 units)
+// from a viewer: one straight line crosses a sight-blocking wall, the other
+// doesn't come near it. The old stub could not tell them apart — both were
+// "visible" at distance 8. The wall-aware check must.
+func (s *RoomAwareSuite) TestLineOfSight_WallAware() {
+	room := s.newRoom("los-room", 10, 10)
+	wall := &blockingEntity{id: "wall", blocksLineOfSight: true}
+	s.Require().NoError(room.PlaceEntity(wall, spatial.Position{X: 5, Y: 1}))
+
+	solver := NewConstraintSolver()
+	goblin := &MockEntity{id: "goblin", entityType: "monster"}
+	viewer := SpawnedEntity{
+		Entity:   &MockEntity{id: "player-1", entityType: "player"},
+		Position: spatial.Position{X: 1, Y: 1},
+	}
+	constraints := SpatialConstraints{
+		LineOfSight: LineOfSightRules{
+			BlockedSight: []EntityPair{{From: "monster", To: "player"}},
+		},
+	}
+
+	// Straight line from the viewer along y=1 crosses the wall at (5,1):
+	// hidden, distance from viewer is exactly 8.
+	behindWall := spatial.Position{X: 9, Y: 1}
+	s.Assert().NoError(
+		solver.ValidatePosition(room, behindWall, goblin, constraints, []SpawnedEntity{viewer}),
+		"position behind the wall must be accepted as hidden",
+	)
+
+	// Straight line from the viewer along x=1 never approaches the wall:
+	// visible, also at distance exactly 8 from the viewer.
+	clearView := spatial.Position{X: 1, Y: 9}
+	err := solver.ValidatePosition(room, clearView, goblin, constraints, []SpawnedEntity{viewer})
+	s.Require().Error(err, "position with a clear line to the viewer must be rejected")
+	s.Assert().Contains(err.Error(), "line of sight")
+}
+
+// TestPositionOracle_ComposesWithSearch pins the rpg-api#644 use case
+// #760 exists for: a caller expresses a placement requirement the
+// constraint vocabulary doesn't cover (e.g. "not visible to any viewer") as
+// a PositionOracle instead of discarding the search's chosen position and
+// recomputing placement itself. The oracle must AND with room-derived
+// validity, not replace it.
+func (s *RoomAwareSuite) TestPositionOracle_ComposesWithSearch() {
+	room := s.newRoom("oracle-room", 4, 1) // a thin corridor: x in [0,4), y=0
+	solver := NewConstraintSolver()
+	entity := &MockEntity{id: "goblin", entityType: "monster"}
+
+	// Oracle rejects everything except x == 3.
+	oracle := PositionOracle(func(pos spatial.Position) bool {
+		return pos.X == 3
+	})
+
+	positions, err := solver.FindValidPositions(room, entity, SpatialConstraints{}, nil, 10, oracle, nil)
+	s.Require().NoError(err)
+	s.Require().Len(positions, 1)
+	s.Assert().Equal(spatial.Position{X: 3, Y: 0}, positions[0])
+}
+
+func TestRoomAwareSuite(t *testing.T) {
+	suite.Run(t, new(RoomAwareSuite))
+}
+
+// FixedPositionSuite covers rpg-toolkit#760's fixed-position injection: a
+// caller that already knows where an entity belongs (e.g. rpg-api's
+// safeGoblinHexes workaround) can hand SpawnConfig the exact positions
+// instead of taking whatever the search would have chosen and discarding
+// it (rpg-api PR #645's KNOWN TOOLKIT GAP).
+type FixedPositionSuite struct {
+	suite.Suite
+	room     *spatial.BasicRoom
+	engine   *BasicSpawnEngine
+	registry *BasicSelectablesRegistry
+}
+
+func (s *FixedPositionSuite) SetupTest() {
+	grid := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10})
+	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: "fixed-room", Type: "test", Grid: grid})
+
+	orch := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{ID: "orch"})
+	s.Require().NoError(orch.AddRoom(s.room))
+
+	s.registry = NewBasicSelectablesRegistry()
+	s.Require().NoError(s.registry.RegisterTable("goblins", []core.Entity{
+		&MockEntity{id: "goblin-1", entityType: "monster"},
+		&MockEntity{id: "goblin-2", entityType: "monster"},
+		&MockEntity{id: "goblin-3", entityType: "monster"},
+	}))
+	// Separate single-entity tables so a 1-per-group selection can never
+	// sample the same underlying entity twice (BasicSelectablesRegistry
+	// samples with replacement) — this test cares about each entity landing
+	// at its own fixed position, and Room keys occupancy by entity ID, so a
+	// duplicate-entity selection would collapse to one occupant.
+	for _, id := range []string{"solo-1", "solo-2", "solo-3"} {
+		s.Require().NoError(s.registry.RegisterTable(id, []core.Entity{
+			&MockEntity{id: id, entityType: "monster"},
+		}))
+	}
+
+	s.engine = NewBasicSpawnEngine(BasicSpawnEngineConfig{
+		ID:               "fixed-position-engine",
+		SelectablesReg:   s.registry,
+		RoomOrchestrator: orch,
+		MaxAttempts:      10,
+	})
+}
+
+// TestFixedPositions_UsedVerbatim proves fixed positions bypass search
+// entirely and land the entity exactly where the caller specified, in the
+// real spatial room.
+func (s *FixedPositionSuite) TestFixedPositions_UsedVerbatim() {
+	one := 1
+	fixed := []spatial.Position{{X: 2, Y: 2}, {X: 7, Y: 3}, {X: 4, Y: 8}}
+	tables := []string{"solo-1", "solo-2", "solo-3"}
+	groups := make([]EntityGroup, len(fixed))
+	for i, table := range tables {
+		groups[i] = EntityGroup{
+			ID:             table,
+			Type:           "monster",
+			SelectionTable: table,
+			Quantity:       QuantitySpec{Fixed: &one},
+			FixedPositions: []spatial.Position{fixed[i]},
+		}
+	}
+	config := SpawnConfig{
+		EntityGroups: groups,
+		Pattern:      PatternScattered,
+	}
+
+	result, err := s.engine.PopulateRoom(context.Background(), "fixed-room", config)
+	s.Require().NoError(err)
+	s.Assert().Empty(result.Failures)
+	s.Require().Len(result.SpawnedEntities, 3)
+
+	for i, spawned := range result.SpawnedEntities {
+		s.Assert().Equal(fixed[i], spawned.Position)
+		placedAt, ok := s.room.GetEntityPosition(spawned.Entity.GetID())
+		s.Require().True(ok)
+		s.Assert().Equal(fixed[i], placedAt)
+	}
+}
+
+// TestFixedPositions_InvalidOneReportsFailureNotCrash proves an
+// out-of-bounds fixed position is caught against the real room and
+// reported as a SpawnFailure, not trusted blindly.
+func (s *FixedPositionSuite) TestFixedPositions_InvalidOneReportsFailureNotCrash() {
+	quantity := 1
+	fixed := []spatial.Position{{X: 99, Y: 99}} // out of bounds for a 10x10 room
+	config := SpawnConfig{
+		EntityGroups: []EntityGroup{{
+			ID:             "goblins",
+			Type:           "monster",
+			SelectionTable: "goblins",
+			Quantity:       QuantitySpec{Fixed: &quantity},
+			FixedPositions: fixed,
+		}},
+		Pattern: PatternScattered,
+	}
+
+	result, err := s.engine.PopulateRoom(context.Background(), "fixed-room", config)
+	s.Require().NoError(err)
+	s.Assert().Empty(result.SpawnedEntities)
+	s.Require().Len(result.Failures, 1)
+	s.Assert().Contains(result.Failures[0].Reason, "not placeable")
+}
+
+func TestFixedPositionSuite(t *testing.T) {
+	suite.Run(t, new(FixedPositionSuite))
+}
+
+// TestSeed_ReproducesPositions pins SpawnConfig.Seed: two PopulateRoom
+// calls against identically-shaped fresh rooms with the same Seed produce
+// identical positions. Uses two separate rooms because PopulateRoom
+// mutates room occupancy, so a second call against the SAME room would see
+// different (already-occupied) state, not prove reproducibility.
+func TestSeed_ReproducesPositions(t *testing.T) {
+	newEngine := func(roomID string) *BasicSpawnEngine {
+		grid := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10})
+		room := spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: roomID, Type: "test", Grid: grid})
+		orchID := spatial.OrchestratorID(roomID + "-orch")
+		orch := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{ID: orchID})
+		require.NoError(t, orch.AddRoom(room))
+		registry := NewBasicSelectablesRegistry()
+		require.NoError(t, registry.RegisterTable("goblins", []core.Entity{
+			&MockEntity{id: "goblin-1", entityType: "monster"},
+			&MockEntity{id: "goblin-2", entityType: "monster"},
+		}))
+		return NewBasicSpawnEngine(BasicSpawnEngineConfig{
+			ID: roomID + "-engine", SelectablesReg: registry, RoomOrchestrator: orch, MaxAttempts: 10,
+		})
+	}
+
+	seed := int64(12345)
+	quantity := 2
+	config := SpawnConfig{
+		EntityGroups: []EntityGroup{{
+			ID: "goblins", Type: "monster", SelectionTable: "goblins",
+			Quantity: QuantitySpec{Fixed: &quantity},
+		}},
+		Pattern: PatternScattered,
+		Seed:    &seed,
+	}
+
+	resultA, err := newEngine("room-a").PopulateRoom(context.Background(), "room-a", config)
+	require.NoError(t, err)
+
+	resultB, err := newEngine("room-b").PopulateRoom(context.Background(), "room-b", config)
+	require.NoError(t, err)
+
+	require.Len(t, resultA.SpawnedEntities, 2)
+	require.Len(t, resultB.SpawnedEntities, 2)
+	for i := range resultA.SpawnedEntities {
+		assert.Equal(t, resultA.SpawnedEntities[i].Position, resultB.SpawnedEntities[i].Position,
+			"same Seed must reproduce the same searched position")
+	}
+}

--- a/tools/spawn/room_aware_test.go
+++ b/tools/spawn/room_aware_test.go
@@ -123,21 +123,83 @@ func (s *RoomAwareSuite) TestLineOfSight_WallAware() {
 // constraint vocabulary doesn't cover (e.g. "not visible to any viewer") as
 // a PositionOracle instead of discarding the search's chosen position and
 // recomputing placement itself. The oracle must AND with room-derived
-// validity, not replace it.
+// validity, not replace it — proven here by planting a wall on a cell the
+// oracle accepts: if the oracle replaced room validity instead of composing
+// with it, that walled cell would still come back.
 func (s *RoomAwareSuite) TestPositionOracle_ComposesWithSearch() {
 	room := s.newRoom("oracle-room", 4, 1) // a thin corridor: x in [0,4), y=0
+	wall := &blockingEntity{id: "wall", blocksMovement: true}
+	s.Require().NoError(room.PlaceEntity(wall, spatial.Position{X: 1, Y: 0}))
+
 	solver := NewConstraintSolver()
 	entity := &MockEntity{id: "goblin", entityType: "monster"}
 
-	// Oracle rejects everything except x == 3.
+	// Oracle accepts both x==1 (walled) and x==3 (free).
 	oracle := PositionOracle(func(pos spatial.Position) bool {
-		return pos.X == 3
+		return pos.X == 1 || pos.X == 3
 	})
 
 	positions, err := solver.FindValidPositions(room, entity, SpatialConstraints{}, nil, 10, oracle, nil)
 	s.Require().NoError(err)
-	s.Require().Len(positions, 1)
+	s.Require().Len(positions, 1, "the walled cell must be excluded even though the oracle accepts it")
 	s.Assert().Equal(spatial.Position{X: 3, Y: 0}, positions[0])
+}
+
+// TestFindValidPositions_AxialGrid pins the #770 review fix: enumeration
+// must work correctly on grids centered on zero (AxialHexGrid, valid range
+// [-span/2, span/2) on both axes), not just 0-based offset grids — the
+// search must find every valid negative-coordinate cell, not silently skip
+// half the grid because it assumed a 0-based origin.
+func (s *RoomAwareSuite) TestFindValidPositions_AxialGrid() {
+	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 4, SpanHeight: 4}) // Q,R in [-2,2)
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: "axial-room", Type: "test", Grid: grid})
+
+	solver := NewConstraintSolver()
+	entity := &MockEntity{id: "goblin", entityType: "monster"}
+
+	positions, err := solver.FindValidPositions(room, entity, SpatialConstraints{}, nil, 100, nil, nil)
+	s.Require().NoError(err)
+
+	seen := make(map[spatial.Position]bool)
+	for _, pos := range positions {
+		s.Assert().GreaterOrEqual(pos.X, -2.0)
+		s.Assert().Less(pos.X, 2.0)
+		s.Assert().GreaterOrEqual(pos.Y, -2.0)
+		s.Assert().Less(pos.Y, 2.0)
+		seen[pos] = true
+	}
+	s.Assert().Len(seen, 16, "every one of the 4x4 axial cells must be found, including negative coordinates")
+}
+
+// TestWallProximity_AxialGridNegativeCoordinates pins the real #770 review
+// bug: validateWallProximity used to assume the room boundary sits at
+// 0..Width/Height, so any negative coordinate on an AxialHexGrid (valid
+// range centered on zero) always failed the boundary check regardless of
+// its actual distance from a wall.
+func (s *RoomAwareSuite) TestWallProximity_AxialGridNegativeCoordinates() {
+	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 10, SpanHeight: 10}) // Q,R in [-5,5)
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: "axial-room", Type: "test", Grid: grid})
+
+	solver := NewConstraintSolver()
+	entity := &MockEntity{id: "goblin", entityType: "monster"}
+	constraints := SpatialConstraints{WallProximity: 1.0}
+
+	// Well inside the valid [-5,5) range on both axes — must NOT be
+	// rejected just because its coordinates are negative.
+	interior := spatial.Position{X: -3, Y: -3}
+	s.Assert().NoError(
+		solver.ValidatePosition(room, interior, entity, constraints, nil),
+		"a negative-coordinate position well inside an axial grid must pass wall-proximity",
+	)
+
+	// Within 1.0 of the real boundary at X=-5 — must be rejected, proving
+	// the check uses the grid's actual bound, not just "always pass
+	// negative coordinates."
+	tooClose := spatial.Position{X: -4.5, Y: -3}
+	s.Assert().Error(
+		solver.ValidatePosition(room, tooClose, entity, constraints, nil),
+		"a position within minWallDistance of the axial grid's real boundary must be rejected",
+	)
 }
 
 func TestRoomAwareSuite(t *testing.T) {

--- a/tools/spawn/spawning_patterns.go
+++ b/tools/spawn/spawning_patterns.go
@@ -3,14 +3,42 @@ package spawn
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
+// findGroupPosition resolves the position for the i-th entity in group:
+// group.FixedPositions[i] if supplied (validated against the real room, not
+// just trusted), otherwise a search seeded with group.PositionOracle and
+// config.SpatialRules.
+func (e *BasicSpawnEngine) findGroupPosition(
+	room spatial.Room, entity core.Entity, group EntityGroup, i int,
+	config SpawnConfig, existingEntities []SpawnedEntity, rng *rand.Rand,
+) (spatial.Position, error) {
+	if i < len(group.FixedPositions) {
+		position := group.FixedPositions[i]
+		if !room.CanPlaceEntity(entity, position) {
+			return spatial.Position{}, fmt.Errorf(
+				"fixed position (%.2f, %.2f) is not placeable", position.X, position.Y,
+			)
+		}
+		return position, nil
+	}
+
+	if e.hasValidConstraints(config.SpatialRules) || group.PositionOracle != nil {
+		return e.findValidPositionWithConstraints(
+			room, entity, config.SpatialRules, existingEntities, group.PositionOracle, rng,
+		)
+	}
+
+	return e.findValidPosition(room, entity, nil, rng)
+}
+
 // applyScatteredSpawning implements scattered spawning pattern
 func (e *BasicSpawnEngine) applyScatteredSpawning(
-	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult,
+	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult, rng *rand.Rand,
 ) (SpawnResult, error) {
 	// Get room from spatial handler
 	room, err := e.getRoomFromSpatial(roomID)
@@ -30,22 +58,14 @@ func (e *BasicSpawnEngine) applyScatteredSpawning(
 		}
 
 		// Place entities using scattered pattern
-		for _, entity := range entities {
-			// Phase 3: Use constraint-aware positioning if spatial rules provided
-			var position spatial.Position
-			var err error
-
-			if e.hasValidConstraints(config.SpatialRules) {
-				position, err = e.findValidPositionWithConstraints(room, entity, config.SpatialRules, result.SpawnedEntities)
-				if err != nil {
-					result.Failures = append(result.Failures, SpawnFailure{
-						EntityType: string(entity.GetType()), // Convert core.EntityType to string
-						Reason:     fmt.Sprintf("constraint validation failed: %v", err),
-					})
-					continue
-				}
-			} else {
-				position = e.findValidPosition(room, entity)
+		for i, entity := range entities {
+			position, err := e.findGroupPosition(room, entity, group, i, config, result.SpawnedEntities, rng)
+			if err != nil {
+				result.Failures = append(result.Failures, SpawnFailure{
+					EntityType: string(entity.GetType()), // Convert core.EntityType to string
+					Reason:     fmt.Sprintf("position search failed: %v", err),
+				})
+				continue
 			}
 
 			// Place entity in room
@@ -73,16 +93,16 @@ func (e *BasicSpawnEngine) applyScatteredSpawning(
 
 // applyFormationSpawning implements formation-based spawning pattern
 func (e *BasicSpawnEngine) applyFormationSpawning(
-	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult,
+	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult, rng *rand.Rand,
 ) (SpawnResult, error) {
 	// Phase 2: Simple implementation - delegate to scattered for now
 	// TODO: Implement actual formation logic
-	return e.applyScatteredSpawning(ctx, roomID, config, result)
+	return e.applyScatteredSpawning(ctx, roomID, config, result, rng)
 }
 
 // applyTeamBasedSpawning implements team-based spawning pattern
 func (e *BasicSpawnEngine) applyTeamBasedSpawning(
-	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult,
+	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult, rng *rand.Rand,
 ) (SpawnResult, error) {
 	// Phase 2: Basic implementation
 	if config.TeamConfiguration == nil {
@@ -91,12 +111,12 @@ func (e *BasicSpawnEngine) applyTeamBasedSpawning(
 
 	// For now, delegate to scattered spawning
 	// TODO: Implement actual team separation logic
-	return e.applyScatteredSpawning(ctx, roomID, config, result)
+	return e.applyScatteredSpawning(ctx, roomID, config, result, rng)
 }
 
 // applyPlayerChoiceSpawning implements player choice spawning pattern
 func (e *BasicSpawnEngine) applyPlayerChoiceSpawning(
-	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult,
+	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult, rng *rand.Rand,
 ) (SpawnResult, error) {
 	// Phase 2: Basic implementation
 	if len(config.PlayerSpawnZones) == 0 {
@@ -121,7 +141,7 @@ func (e *BasicSpawnEngine) applyPlayerChoiceSpawning(
 		}
 
 		// For player entities, use zones; for others, use scattered
-		for _, entity := range entities {
+		for i, entity := range entities {
 			if e.isPlayerEntity(entity) {
 				position, err := e.findPlayerSpawnPosition(entity, config.PlayerSpawnZones, config.PlayerChoices)
 				if err != nil {
@@ -139,20 +159,13 @@ func (e *BasicSpawnEngine) applyPlayerChoiceSpawning(
 				})
 			} else {
 				// Non-player entities use scattered placement
-				var position spatial.Position
-				var err error
-
-				if e.hasValidConstraints(config.SpatialRules) {
-					position, err = e.findValidPositionWithConstraints(room, entity, config.SpatialRules, result.SpawnedEntities)
-					if err != nil {
-						result.Failures = append(result.Failures, SpawnFailure{
-							EntityType: string(entity.GetType()), // Convert core.EntityType to string
-							Reason:     fmt.Sprintf("constraint validation failed: %v", err),
-						})
-						continue
-					}
-				} else {
-					position = e.findValidPosition(room, entity)
+				position, err := e.findGroupPosition(room, entity, group, i, config, result.SpawnedEntities, rng)
+				if err != nil {
+					result.Failures = append(result.Failures, SpawnFailure{
+						EntityType: string(entity.GetType()), // Convert core.EntityType to string
+						Reason:     fmt.Sprintf("position search failed: %v", err),
+					})
+					continue
 				}
 
 				result.SpawnedEntities = append(result.SpawnedEntities, SpawnedEntity{
@@ -172,11 +185,11 @@ func (e *BasicSpawnEngine) applyPlayerChoiceSpawning(
 
 // applyClusteredSpawning implements clustered spawning pattern
 func (e *BasicSpawnEngine) applyClusteredSpawning(
-	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult,
+	ctx context.Context, roomID string, config SpawnConfig, result SpawnResult, rng *rand.Rand,
 ) (SpawnResult, error) {
 	// Phase 2: Simple implementation - delegate to scattered for now
 	// TODO: Implement actual clustering logic
-	return e.applyScatteredSpawning(ctx, roomID, config, result)
+	return e.applyScatteredSpawning(ctx, roomID, config, result, rng)
 }
 
 // isPlayerEntity determines if an entity is a player

--- a/tools/spawn/types.go
+++ b/tools/spawn/types.go
@@ -1,5 +1,7 @@
 package spawn
 
+import "github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
 // SpawnConfig specifies how to spawn entities in a room.
 // Purpose: Complete configuration for entity placement following ADR-0013 patterns.
 //
@@ -23,6 +25,15 @@ type SpawnConfig struct {
 	// Player spawn zones and choices
 	PlayerSpawnZones []SpawnZone         `json:"player_spawn_zones,omitempty"`
 	PlayerChoices    []PlayerSpawnChoice `json:"player_choices,omitempty"`
+
+	// Seed makes this call's position search reproducible: the same room
+	// state plus the same Seed always yields the same searched positions
+	// (both the unconstrained and constraint-aware paths, including
+	// gridless sampling). Nil (default) uses the engine's own
+	// non-deterministic random source. Does not affect SelectablesRegistry
+	// entity-selection order, which is a separate random source
+	// (rpg-toolkit#760).
+	Seed *int64 `json:"seed,omitempty"`
 }
 
 // EntityGroup represents a group of entities to spawn.
@@ -32,7 +43,34 @@ type EntityGroup struct {
 	Type           string       `json:"type"`
 	SelectionTable string       `json:"selection_table"`
 	Quantity       QuantitySpec `json:"quantity"`
+
+	// FixedPositions optionally supplies exact positions to use for this
+	// group's entities, in order, bypassing the search entirely. A fixed
+	// position is still checked against the real room (Room.CanPlaceEntity)
+	// before use; an invalid one is reported as a SpawnFailure rather than
+	// silently placing the entity on a wall or out of bounds. If shorter
+	// than the group's quantity, the remaining entities fall through to the
+	// normal search (respecting PositionOracle and SpatialRules as usual).
+	FixedPositions []spatial.Position `json:"fixed_positions,omitempty"`
+
+	// PositionOracle optionally supplies a caller-defined predicate that a
+	// searched candidate position must satisfy, in addition to room-derived
+	// validity (bounds and walls/occupancy via Room.CanPlaceEntity) and any
+	// SpatialRules. This lets a caller express a placement requirement the
+	// constraint vocabulary doesn't cover yet — e.g. "outside these specific
+	// viewers' sight" — directly in the search, instead of discarding the
+	// engine's chosen position and recomputing placement itself
+	// (rpg-toolkit#760). Not serializable to JSON; nil means no extra
+	// filter. Applies only to entities in this group that fall through to
+	// search (i.e. beyond len(FixedPositions)).
+	PositionOracle PositionOracle `json:"-"`
 }
+
+// PositionOracle is a caller-supplied predicate for accepting or rejecting a
+// candidate position during search. It is ANDed with room-derived validity
+// (Room.CanPlaceEntity) and any SpatialRules — it composes with them, it
+// does not replace them.
+type PositionOracle func(pos spatial.Position) bool
 
 // QuantitySpec specifies how many entities to spawn.
 // Purpose: Supports fixed quantities, dice expressions, and ranges for flexible spawning.


### PR DESCRIPTION
## Summary

`tools/spawn`'s position search ignored the real `spatial.Room` entirely, and `SpawnConfig` had no way for a caller to inject a known-good position or a placement predicate. This closes rpg-toolkit#760, found while implementing rpg-api#644 (goblins needed to spawn outside the party's initial line of sight — rpg-api PR #645 worked around the gap by discarding the spawn engine's chosen position and recomputing placement itself via `perception.CanSeeAt`).

- `BasicSpawnEngine.findValidPosition` was a raw random X,Y in `[0,10)`. It (and `findValidPositionWithConstraints`) now delegate to `ConstraintSolver.FindValidPositions`, which enumerates the room's actual grid cells via `Grid.GetPositionsInRange` (correct regardless of coordinate origin — 0-based offset grids and axial grids centered on zero alike) and filters through `Room.CanPlaceEntity` for real bounds and wall/occupancy checks.
- `ConstraintSolver.FindValidPositions`'s grid-based path was a hardcoded `1.0-10.0` sweep; `LineOfSight` was a Euclidean-distance stub (`distance <= 8.0`, walls never considered). Both now use the real room: positions come from the grid enumeration above, and `hasLineOfSight` now calls `Room.IsLineOfSightBlocked`.
- `WallProximity` used to assume a fixed 10x10 room boundary. It now checks the room's real dimensions plus any actually-blocking entity (`Placeable.BlocksMovement`) within range via `Room.GetEntitiesInRange`.
- Fixed a latent bug in `isGridlessRoom`: it checked `grid == nil`, but `GridlessRoom` is itself a `Grid` implementation (`GetShape() == GridShapeGridless`), so a real gridless room's grid is never nil — the check now looks at shape.

### New SpawnConfig/EntityGroup fields

- `EntityGroup.FixedPositions []spatial.Position` — exact positions for this group's entities, in order, bypassing search. Still validated against the real room (`Room.CanPlaceEntity`) — an invalid one reports a `SpawnFailure`, not a silent wall-placement.
- `EntityGroup.PositionOracle func(spatial.Position) bool` — a caller predicate ANDed into the search alongside room validity and `SpatialRules`. This is the seam rpg-api's `seedGoblins`/`safeGoblinHexes` workaround needed: "not visible to any viewer" can now be expressed directly instead of discarding the engine's position and recomputing placement in the caller.
- `SpawnConfig.Seed *int64` — makes a call's position search reproducible (both search paths, including gridless sampling), threaded as a per-call `*rand.Rand`. This also fixes `ConstraintSolver`'s previous hardcoded seed-42 default, which had silently made every *constrained* spawn deterministic in production regardless of caller intent.

## Load-bearing

- Position search (unconstrained and constraint-aware) now always goes through `Room.CanPlaceEntity`, so "in bounds and not on a wall" is a real, room-derived guarantee, not a hope.
- `PositionOracle` composes with (does not replace) room validity and `SpatialRules` — it's the extension seam for placement policy the constraint vocabulary doesn't cover yet.
- `SpawnConfig.Seed` only makes *position search* reproducible, not `SelectablesRegistry` entity-selection order (a separate, already-fixed-seed-42 random source) — documented on the field, not a silent partial promise.
- `tools/spawn` has no dependency on `encounter/` and none was added; this PR does not touch `encounter/`.

## Test plan

- [x] `go test -race ./...` in `tools/spawn` — all existing tests pass, no signature regressions elsewhere in the package.
- [x] New `TestFindValidPositions_BoundsAndWalls` — requests every free cell in a 5x5 room with 3 walls planted; asserts the result is exactly the 22 free cells (bounds + no-wall-cells, pinned exactly).
- [x] New `TestLineOfSight_WallAware` — two candidates at the *same* Euclidean distance from a viewer (one behind a sight-blocking wall, one with a clear line); only the wall-aware check can tell them apart — the old stub would have treated both identically.
- [x] New `TestPositionOracle_ComposesWithSearch` — an oracle that accepts only one cell in a 4-cell corridor; proves it ANDs with room validity rather than replacing it.
- [x] New `FixedPositionSuite` — fixed positions land verbatim in the real room; an out-of-bounds fixed position reports a `SpawnFailure` instead of crashing or silently placing on a wall.
- [x] New `TestSeed_ReproducesPositions` — same `Seed` across two fresh identically-shaped rooms produces identical searched positions.
- [x] `gofmt`, `goimports -local github.com/KirkDiggler`, `go vet`, and `golangci-lint run` clean on `tools/spawn` (pre-existing `goconst` findings in untouched test files, and one line in `spawning_patterns.go`'s untouched `isPlayerEntity`, are baseline noise — confirmed via diff against `origin/main`, not introduced here).
- [x] `make pre-commit` at repo root run per project convention — it only scopes to `core`/`events` (not `tools/spawn`) and is currently failing there on a pre-existing, unrelated `core/mock` coverage-threshold script error, not touched by this PR.

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9