### PR TITLE
feat(encounter): publish initiative roster as InitiativeRolledEvent

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -341,8 +341,8 @@ resolver's own "prevented at first step" semantics.
 at combat's *other* edge (death.go): when the encounter is `ModeFreeRoam`
 and any player has LoS (`perception.CanSeeAt`, wall-aware) to any monster,
 it calls `SetMode(ModeTurnBased)` — the exact same initiative-roll +
-`ModeChanged`/`TurnStarted` publish path `SetMode` always used for any other
-FreeRoam→TurnBased flip. Called inline at the mutation sites (`Move`,
+`ModeChanged`/`InitiativeRolled`/`TurnStarted` publish path `SetMode` always
+used for any other FreeRoam→TurnBased flip. Called inline at the mutation sites (`Move`,
 `AddMonster`) rather than as a kicked/deferred check — a forgotten kick call
 would silently mean combat never starts, a worse failure mode than a
 redundant inline check. The mode gate at the top makes repeated calls
@@ -463,6 +463,59 @@ is a genuine moving-entity problem needing the *player-sees-player* shape of
 `ProjectVisibilityTransition` (stationary viewers, a real moving entity) —
 different mechanics, already tracked separately, and folding it in here
 would have widened this fix past a single reviewable change.
+
+### Initiative roster event (rpg-toolkit#765)
+
+`SetMode`'s FreeRoam→TurnBased flip always rolled `data.Initiative`
+(`rollInitiative`) but published no event carrying it — only
+`ModeChangedEvent` (the transition itself) and `TurnStartedEvent` (the first
+actor's turn) hit the wire. Consumers that need the roster had to read it
+back from persisted state, which races the orchestrator's Save (the toolkit
+publishes synchronously inside the verb call, before the caller persists) —
+rpg-api's stream handler carried a bounded 15×10ms retry around exactly this
+(rpg-api#647), plus a synthesized envelope that reused `ModeChangedEvent`'s
+sequence number since the handler has no way to mint a real broker sequence.
+
+`SetMode` now publishes `events.InitiativeRolledEvent{Order
+[]core.EntityID}` between `ModeChanged` and `TurnStarted`. Design choice —
+**dedicated event, not fields on `ModeChangedEvent`**:
+
+- The wire proto already models this as its own message
+  (`InitiativeRolled{order}`, `EncounterEvent` oneof field 41, added ahead of
+  this toolkit seam and left unpopulated until now). A dedicated toolkit
+  event maps onto it 1:1, so rpg-api's translator drops the special-cased
+  `translateForStream` branch entirely (repo read, retry, shared-sequence
+  hack, and all) and treats `InitiativeRolledEvent` like every other event —
+  a plain `TranslateEvent` case. Growing `ModeChangedEvent` with roster
+  fields instead would still leave that branch in place (still splitting one
+  broker event into two wire envelopes by hand), just without the repo read.
+- `ModeChangedEvent` is generic — it fires for every mode pair, including
+  TurnBased→FreeRoam, where a roster field would have to be empty/absent.
+  Every other roster-adjacent fact in this taxonomy (`TurnStarted`,
+  `TurnEnded`, `EntityDied`, `EntityRemoved`) is already its own dedicated
+  event type; bundling roster data onto the mode-transition event breaks
+  that precedent for a shape that only makes sense on one specific
+  transition.
+
+**Ordering contract**: `ModeChangedEvent` → `InitiativeRolledEvent` →
+`TurnStartedEvent`. `ModeChanged` is the cause; both the roster and the
+first turn are effects of it, but the roster (STATE — "here is the full
+turn order") is placed before the turn announcement (an ACTION — "it's this
+actor's turn") since a client building a combat-order UI wants the full
+roster before being told who's first. Published only on the FreeRoam→
+TurnBased direction, and only once per transition — not re-sent on every
+later per-turn `TurnStartedEvent` from `EndTurn`, since the roster doesn't
+change turn to turn. Pinned by
+`TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted`,
+`TestEndTurn_DoesNotRepublishInitiativeRolled`, and
+`TestSetMode_FreeRoamTransition_NoInitiativeRolled`
+(`initiative_rolled_test.go`).
+
+The published `Order` is a defensive copy of `e.data.Initiative`, not the
+same backing slice — mirrors `applyAndPublishMove`'s
+`append([]core.Hex(nil), traveledPath...)` pattern, since `AddMonster`'s
+mid-combat reinforcement path (`e.data.Initiative = append(e.data.Initiative,
+input.ID)`, #757) can grow the roster after this event already published.
 
 ## Implementation notes worth keeping
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-07-15
-confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05; #755 rage-sustain-on-miss fix added 2026-07-12; #757 the walled room added 2026-07-13; #761 monster EntityAppeared/Disappeared added 2026-07-15; #764 AddMonster-side EntityAppeared added 2026-07-15
+updated: 2026-07-16
+confidence: medium — seeded from full repo read, test run, go.mod inspection, and PR history; #689 + Wave 2.11d updates verified against shipped code; #714 move-economy added 2026-07-02; #747/#748 Rage+Ki fixes and v0.65.0 tag added 2026-07-05; #755 rage-sustain-on-miss fix added 2026-07-12; #757 the walled room added 2026-07-13; #761 monster EntityAppeared/Disappeared added 2026-07-15; #764 AddMonster-side EntityAppeared added 2026-07-15; #765 InitiativeRolledEvent added 2026-07-16
 ---
 
 # rpg-toolkit: Where We Are
@@ -190,6 +190,23 @@ See "Paused / on hold" below.
 
 ## Recently landed (last 30 days, highlights)
 
+- **InitiativeRolledEvent — the roster on the wire (rpg-toolkit#765,
+  2026-07-16).** `SetMode` always rolled `data.Initiative` on the
+  FreeRoam→TurnBased flip but published no event carrying it, forcing
+  rpg-api to read it back from persisted state on a bounded 15×10ms retry
+  (racing the orchestrator's Save, which runs synchronously after the
+  toolkit's in-call publish — rpg-api#647) plus a synthesized wire envelope
+  that reused `ModeChangedEvent`'s sequence number. `SetMode` now publishes
+  `InitiativeRolledEvent{Order []EntityID}`, sequenced between
+  `ModeChangedEvent` and `TurnStartedEvent`, published once per transition
+  (not re-sent on later per-turn `TurnStartedEvent`s from `EndTurn`). Chose
+  a dedicated event over fields on `ModeChangedEvent`: the wire proto
+  already models `InitiativeRolled` as its own message, so a dedicated
+  toolkit event lets rpg-api delete its special-cased translator branch
+  entirely rather than just dropping the repo read from it; `ModeChanged` is
+  also generic across every mode pair, and a roster field would be
+  meaningless on the TurnBased→FreeRoam direction. See
+  [encounter.md](architecture/components/encounter.md#initiative-roster-event-rpg-toolkit765).
 - **AddMonster-side EntityAppeared (rpg-toolkit#764, 2026-07-15).** Found by
   the review gate on #762: a monster spawned via `AddMonster` directly into
   an already-visible position started combat (`checkCombatEntry` fired) but

--- a/encounter/broker.go
+++ b/encounter/broker.go
@@ -255,6 +255,8 @@ func encodeEvent(evt events.EncounterEvent) ([]byte, error) {
 		typeName = "ConditionRemovedEvent"
 	case *events.ModeChangedEvent:
 		typeName = "ModeChangedEvent"
+	case *events.InitiativeRolledEvent:
+		typeName = "InitiativeRolledEvent"
 	case *events.TurnStartedEvent:
 		typeName = "TurnStartedEvent"
 	case *events.TurnEndedEvent:
@@ -363,6 +365,12 @@ func decodeEvent(b []byte) (events.EncounterEvent, error) {
 		return &e, nil
 	case "ModeChangedEvent":
 		var e events.ModeChangedEvent
+		if err := json.Unmarshal(env.Payload, &e); err != nil {
+			return nil, err
+		}
+		return &e, nil
+	case "InitiativeRolledEvent":
+		var e events.InitiativeRolledEvent
 		if err := json.Unmarshal(env.Payload, &e); err != nil {
 			return nil, err
 		}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -278,7 +278,24 @@ type ActionTarget struct {
 // the round/active-idx are initialized.
 //
 // Publishes ModeChangedEvent in both directions; on the FreeRoam->TurnBased
-// flip also publishes a TurnStartedEvent for the first actor.
+// flip also publishes InitiativeRolledEvent (rpg-toolkit#765) and a
+// TurnStartedEvent for the first actor.
+//
+// Ordering contract for this transition: ModeChangedEvent ->
+// InitiativeRolledEvent -> TurnStartedEvent. ModeChanged is the cause (the
+// transition itself, matching the cause-before-effect ordering this SDK
+// applies everywhere else — e.g. Move/reveal published before the
+// combat-entry check that can trigger this very SetMode call);
+// InitiativeRolled and TurnStarted are both effects of that cause, but
+// InitiativeRolled comes first because it describes STATE the encounter is
+// now in (the full roster) while TurnStarted describes an ACTION the
+// encounter is now taking (announcing whose turn it is) — a client building
+// its combat-order UI wants the full roster in hand before it's told who's
+// first, not after. InitiativeRolled is published exactly once per
+// transition, not on every later per-turn TurnStartedEvent (EndTurn), since
+// the roster itself doesn't change turn to turn — pinned by
+// TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted and
+// TestEndTurn_DoesNotRepublishInitiativeRolled.
 func (e *Encounter) SetMode(mode core.EncounterMode) error {
 	if mode == core.ModeUnspecified {
 		return errors.New("mode unspecified")
@@ -316,6 +333,29 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 	}
 
 	if mode == core.ModeTurnBased && len(e.data.Initiative) > 0 {
+		// InitiativeRolledEvent (rpg-toolkit#765): published right after
+		// ModeChanged, before TurnStarted — see this method's doc comment for
+		// the full ordering rationale. Deletes the need for rpg-api's
+		// synthesized envelope + racy repo-read-back (rpg-api#647): the
+		// roster is now on the wire the moment SetMode rolls it, from the
+		// same in-memory e.data.Initiative rollInitiative just populated, no
+		// persistence round-trip involved.
+		//
+		// Copies the slice before handing it to the event (mirrors
+		// applyAndPublishMove's append([]core.Hex(nil), traveledPath...)
+		// pattern): e.data.Initiative can grow later via AddMonster's
+		// mid-combat reinforcement append, and while rollInitiative's
+		// make([]core.EntityID, len(seeds)) currently always leaves zero
+		// spare capacity (guaranteeing that append reallocates rather than
+		// mutating this event's backing array in place), the copy removes
+		// any dependency on that allocation detail staying true.
+		if err := e.broker.Publish(events.NewInitiativeRolledEvent(
+			e.data.ID, e.nextSeq(),
+			append([]core.EntityID(nil), e.data.Initiative...),
+			e.allViewersInitiativeRolled(),
+		)); err != nil {
+			return fmt.Errorf("publish initiative rolled: %w", err)
+		}
 		// Seed the first actor's economy before announcing their turn, so the
 		// menu/economy is ready when the TurnStartedEvent lands (Beat-1: the
 		// engine owns turn-start seeding, not the host).
@@ -726,6 +766,16 @@ func (e *Encounter) allViewersModeChanged() map[core.PlayerID]events.ModeChanged
 	out := make(map[core.PlayerID]events.ModeChangedSlice, len(e.data.Players))
 	for id := range e.data.Players {
 		out[id] = events.ModeChangedSlice{Visible: true}
+	}
+	return out
+}
+
+// allViewersInitiativeRolled builds a per-player slice marking every player
+// as a viewer of the rolled initiative roster (rpg-toolkit#765).
+func (e *Encounter) allViewersInitiativeRolled() map[core.PlayerID]events.InitiativeRolledSlice {
+	out := make(map[core.PlayerID]events.InitiativeRolledSlice, len(e.data.Players))
+	for id := range e.data.Players {
+		out[id] = events.InitiativeRolledSlice{Visible: true}
 	}
 	return out
 }

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -29,6 +29,7 @@ func (s *EventsSuite) TestConcretes_SatisfyInterface() {
 	var _ events.EncounterEvent = (*events.DamageDealtEvent)(nil)
 	var _ events.EncounterEvent = (*events.ConditionAppliedEvent)(nil)
 	var _ events.EncounterEvent = (*events.ModeChangedEvent)(nil)
+	var _ events.EncounterEvent = (*events.InitiativeRolledEvent)(nil)
 	var _ events.EncounterEvent = (*events.TurnStartedEvent)(nil)
 	var _ events.EncounterEvent = (*events.TurnEndedEvent)(nil)
 	var _ events.EncounterEvent = (*events.EntityDiedEvent)(nil)
@@ -422,6 +423,30 @@ func (s *EventsSuite) TestModeChangedEvent_JSONRoundTrip() {
 	s.Equal(core.ModeTurnBased, decoded.To)
 	s.Equal("ambush", decoded.Reason)
 	s.Len(decoded.PerPlayer, 2)
+}
+
+// InitiativeRolledEvent JSON round-trip — Order and PerPlayer survive
+// encoding, audience derives from PerPlayer keys.
+func (s *EventsSuite) TestInitiativeRolledEvent_JSONRoundTrip() {
+	original := events.NewInitiativeRolledEvent(
+		"enc-1", 15, []core.EntityID{"goblin-1", "char-alice", "char-bob"},
+		map[core.PlayerID]events.InitiativeRolledSlice{
+			"alice": {Visible: true},
+			"bob":   {Visible: true},
+		},
+	)
+	payload, err := json.Marshal(original)
+	s.Require().NoError(err)
+
+	var decoded events.InitiativeRolledEvent
+	s.Require().NoError(json.Unmarshal(payload, &decoded))
+
+	s.Equal(core.EncounterID("enc-1"), decoded.EncounterID())
+	s.Equal(uint64(15), decoded.Sequence())
+	s.Equal([]core.EntityID{"goblin-1", "char-alice", "char-bob"}, decoded.Order)
+	s.Len(decoded.PerPlayer, 2)
+	s.True(decoded.PerPlayer["alice"].Visible)
+	s.ElementsMatch(events.AudienceSet{"alice", "bob"}, decoded.Audience())
 }
 
 // EntityDiedEvent JSON round-trip — KillerID and PerPlayer survive encoding,

--- a/encounter/events/initiative_rolled.go
+++ b/encounter/events/initiative_rolled.go
@@ -1,0 +1,92 @@
+//nolint:dupl // Event scaffold intentionally mirrors other concretes in this package.
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// InitiativeRolledEvent is published once, immediately after ModeChangedEvent,
+// when SetMode rolls initiative on a FREE_ROAM->TURN_BASED transition
+// (rpg-toolkit#765). It carries the freshly-rolled turn order so consumers
+// never need to read it back from persisted state — see SetMode's doc
+// comment for the full ordering contract (ModeChanged -> InitiativeRolled ->
+// TurnStarted) and why InitiativeRolled is not re-published on later,
+// per-turn TurnStartedEvents. Audience is all players in the encounter — the
+// roster is shared knowledge among combatants, not fog-of-war-gated.
+type InitiativeRolledEvent struct {
+	eventMeta
+	encID     core.EncounterID
+	seq       uint64
+	Order     []core.EntityID
+	PerPlayer map[core.PlayerID]InitiativeRolledSlice
+}
+
+// InitiativeRolledSlice is each viewer's projection. Visible is always true —
+// every player in the encounter observes the rolled turn order.
+type InitiativeRolledSlice struct {
+	Visible bool `json:"visible"`
+}
+
+// NewInitiativeRolledEvent constructs an InitiativeRolledEvent.
+func NewInitiativeRolledEvent(
+	encID core.EncounterID,
+	seq uint64,
+	order []core.EntityID,
+	perPlayer map[core.PlayerID]InitiativeRolledSlice,
+) *InitiativeRolledEvent {
+	return &InitiativeRolledEvent{
+		encID:     encID,
+		seq:       seq,
+		Order:     order,
+		PerPlayer: perPlayer,
+	}
+}
+
+func (*InitiativeRolledEvent) isEncounterEvent() {}
+
+// EncounterID returns the encounter this event belongs to.
+func (e *InitiativeRolledEvent) EncounterID() core.EncounterID { return e.encID }
+
+// Sequence returns the encounter-monotonic sequence number stamped at publish time.
+func (e *InitiativeRolledEvent) Sequence() uint64 { return e.seq }
+
+// Audience returns the set of players who can perceive the rolled roster,
+// derived from PerPlayer keys.
+func (e *InitiativeRolledEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer) }
+
+type initiativeRolledWire struct {
+	metaWire
+	EncID     core.EncounterID                        `json:"encounter_id"`
+	Seq       uint64                                  `json:"sequence"`
+	Order     []core.EntityID                         `json:"order"`
+	PerPlayer map[core.PlayerID]InitiativeRolledSlice `json:"per_player"`
+}
+
+// MarshalJSON exposes encID and seq under stable JSON field names.
+// Implements encoding/json.Marshaler.
+func (e *InitiativeRolledEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(initiativeRolledWire{
+		metaWire:  e.toWire(),
+		EncID:     e.encID,
+		Seq:       e.seq,
+		Order:     e.Order,
+		PerPlayer: e.PerPlayer,
+	})
+}
+
+// UnmarshalJSON populates the unexported fields from JSON.
+// Implements encoding/json.Unmarshaler.
+func (e *InitiativeRolledEvent) UnmarshalJSON(b []byte) error {
+	var w initiativeRolledWire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	e.fromWire(w.metaWire)
+	e.encID = w.EncID
+	e.seq = w.Seq
+	e.Order = w.Order
+	e.PerPlayer = w.PerPlayer
+	return nil
+}

--- a/encounter/initiative_rolled_test.go
+++ b/encounter/initiative_rolled_test.go
@@ -32,7 +32,14 @@ func TestInitiativeRolledSuite(t *testing.T) {
 func (s *InitiativeRolledSuite) SetupTest() {
 	s.transport = encounter.NewInMemoryTransport()
 	s.broker = encounter.NewBroker(s.transport)
-	s.enc = encounter.New(context.Background(), "enc-initiative-rolled", s.broker)
+	// fixedMaxRoller (death_test.go) makes every d20 roll 20, so initiative
+	// ties are broken deterministically by rollInitiative's ascending-id
+	// tiebreak ("char-alice" < "goblin-1") — alice always acts first. Without
+	// this, a real roll can put the goblin first, and TestEndTurn's EndTurn
+	// call would need a wired CombatResolver to run NPCAct on it; determinism
+	// here is simpler and correct than exercising both branches.
+	s.enc = encounter.New(context.Background(), "enc-initiative-rolled", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}))
 
 	var err error
 	s.aliceSub, err = s.broker.Subscribe("enc-initiative-rolled", "alice")
@@ -46,10 +53,12 @@ func (s *InitiativeRolledSuite) TearDownTest() {
 }
 
 // TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted
-// pins the ordering contract stated in SetMode's doc comment: ModeChanged ->
-// InitiativeRolled -> TurnStarted, all three from the same FREE_ROAM ->
-// TURN_BASED transition (triggered here via AddMonster's checkCombatEntry
-// call, the same combat-entry path #764 exercises).
+// pins the FULL ordering contract this AddMonster call produces: the
+// goblin's EntityAppearedEvent (#764) -> ModeChanged -> InitiativeRolled ->
+// TurnStarted, all from the same FREE_ROAM -> TURN_BASED transition
+// (triggered here via AddMonster's checkCombatEntry call, the same
+// combat-entry path #764 exercises). Consumers bind to this order, so all
+// four are pinned together in one place rather than split across tests.
 func (s *InitiativeRolledSuite) TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted() {
 	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: "char-alice",
@@ -62,10 +71,14 @@ func (s *InitiativeRolledSuite) TestSetMode_InitiativeRolled_SequencedBetweenMod
 
 	aliceEvts := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
 
-	modeChangedIdx, rolledIdx, turnStartedIdx := -1, -1, -1
+	appearedIdx, modeChangedIdx, rolledIdx, turnStartedIdx := -1, -1, -1, -1
 	var rolled *events.InitiativeRolledEvent
 	for i, evt := range aliceEvts {
 		switch e := evt.(type) {
+		case *events.EntityAppearedEvent:
+			if e.Entity == core.EntityID("goblin-1") {
+				appearedIdx = i
+			}
 		case *events.ModeChangedEvent:
 			modeChangedIdx = i
 		case *events.InitiativeRolledEvent:
@@ -75,9 +88,11 @@ func (s *InitiativeRolledSuite) TestSetMode_InitiativeRolled_SequencedBetweenMod
 			turnStartedIdx = i
 		}
 	}
+	s.Require().GreaterOrEqual(appearedIdx, 0, "goblin-1's EntityAppearedEvent must have fired")
 	s.Require().GreaterOrEqual(modeChangedIdx, 0, "ModeChangedEvent must have fired")
 	s.Require().GreaterOrEqual(rolledIdx, 0, "InitiativeRolledEvent must have fired")
 	s.Require().GreaterOrEqual(turnStartedIdx, 0, "TurnStartedEvent must have fired")
+	s.Less(appearedIdx, modeChangedIdx, "the goblin's appearance must precede the ModeChanged it caused")
 	s.Less(modeChangedIdx, rolledIdx, "InitiativeRolled must come after ModeChanged")
 	s.Less(rolledIdx, turnStartedIdx, "InitiativeRolled must come before TurnStarted")
 
@@ -93,6 +108,9 @@ func (s *InitiativeRolledSuite) TestSetMode_InitiativeRolled_SequencedBetweenMod
 // TestEndTurn_DoesNotRepublishInitiativeRolled: the roster doesn't change
 // turn to turn, so InitiativeRolledEvent must fire exactly once at the
 // FREE_ROAM->TURN_BASED transition, never again on later EndTurn advances.
+// The suite's fixedMaxRoller makes alice deterministically win the initiative
+// tiebreak (ascending entity id), so EndTurn always runs the player path
+// here — no NPCAct / CombatResolver dependency.
 func (s *InitiativeRolledSuite) TestEndTurn_DoesNotRepublishInitiativeRolled() {
 	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: "char-alice",
@@ -102,15 +120,11 @@ func (s *InitiativeRolledSuite) TestEndTurn_DoesNotRepublishInitiativeRolled() {
 		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
 	}))
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
+	s.Require().Equal(core.EntityID("char-alice"), s.enc.ActiveActor(),
+		"fixedMaxRoller's ascending-id tiebreak must put alice first")
 	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond) // drain the entry transition's events
 
-	active := s.enc.ActiveActor()
-	if active == "goblin-1" {
-		// Deterministic tie-break in rollInitiative is by entity id; whichever
-		// combatant is active, end their turn once to exercise EndTurn.
-		s.Require().NoError(s.enc.NPCAct(context.Background(), "goblin-1"))
-	}
-	_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
+	_, _, err := s.enc.EndTurn(context.Background(), "char-alice")
 	s.Require().NoError(err)
 
 	aliceEvts := collectEventsTyped(s.aliceSub, 300*time.Millisecond)

--- a/encounter/initiative_rolled_test.go
+++ b/encounter/initiative_rolled_test.go
@@ -1,0 +1,146 @@
+package encounter_test
+
+// initiative_rolled_test.go covers rpg-toolkit#765: SetMode publishes
+// InitiativeRolledEvent{Order} on the FREE_ROAM->TURN_BASED transition, so
+// consumers get the rolled roster on the wire instead of synthesizing it via
+// a racy repo read-back (rpg-api#647).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+)
+
+type InitiativeRolledSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	enc       *encounter.Encounter
+	aliceSub  *encounter.Subscription
+}
+
+func TestInitiativeRolledSuite(t *testing.T) {
+	suite.Run(t, new(InitiativeRolledSuite))
+}
+
+func (s *InitiativeRolledSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	s.enc = encounter.New(context.Background(), "enc-initiative-rolled", s.broker)
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe("enc-initiative-rolled", "alice")
+	s.Require().NoError(err)
+}
+
+func (s *InitiativeRolledSuite) TearDownTest() {
+	_ = s.aliceSub.Close()
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted
+// pins the ordering contract stated in SetMode's doc comment: ModeChanged ->
+// InitiativeRolled -> TurnStarted, all three from the same FREE_ROAM ->
+// TURN_BASED transition (triggered here via AddMonster's checkCombatEntry
+// call, the same combat-entry path #764 exercises).
+func (s *InitiativeRolledSuite) TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
+
+	aliceEvts := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
+
+	modeChangedIdx, rolledIdx, turnStartedIdx := -1, -1, -1
+	var rolled *events.InitiativeRolledEvent
+	for i, evt := range aliceEvts {
+		switch e := evt.(type) {
+		case *events.ModeChangedEvent:
+			modeChangedIdx = i
+		case *events.InitiativeRolledEvent:
+			rolledIdx = i
+			rolled = e
+		case *events.TurnStartedEvent:
+			turnStartedIdx = i
+		}
+	}
+	s.Require().GreaterOrEqual(modeChangedIdx, 0, "ModeChangedEvent must have fired")
+	s.Require().GreaterOrEqual(rolledIdx, 0, "InitiativeRolledEvent must have fired")
+	s.Require().GreaterOrEqual(turnStartedIdx, 0, "TurnStartedEvent must have fired")
+	s.Less(modeChangedIdx, rolledIdx, "InitiativeRolled must come after ModeChanged")
+	s.Less(rolledIdx, turnStartedIdx, "InitiativeRolled must come before TurnStarted")
+
+	// The roster must match the encounter's actual rolled initiative and
+	// contain both combatants.
+	s.Require().NotNil(rolled)
+	s.ElementsMatch([]core.EntityID{"char-alice", "goblin-1"}, rolled.Order)
+	s.Equal(s.enc.ToData().Initiative, rolled.Order)
+	s.Contains(rolled.PerPlayer, core.PlayerID("alice"))
+	s.True(rolled.PerPlayer["alice"].Visible)
+}
+
+// TestEndTurn_DoesNotRepublishInitiativeRolled: the roster doesn't change
+// turn to turn, so InitiativeRolledEvent must fire exactly once at the
+// FREE_ROAM->TURN_BASED transition, never again on later EndTurn advances.
+func (s *InitiativeRolledSuite) TestEndTurn_DoesNotRepublishInitiativeRolled() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
+	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond) // drain the entry transition's events
+
+	active := s.enc.ActiveActor()
+	if active == "goblin-1" {
+		// Deterministic tie-break in rollInitiative is by entity id; whichever
+		// combatant is active, end their turn once to exercise EndTurn.
+		s.Require().NoError(s.enc.NPCAct(context.Background(), "goblin-1"))
+	}
+	_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
+	s.Require().NoError(err)
+
+	aliceEvts := collectEventsTyped(s.aliceSub, 300*time.Millisecond)
+	for _, evt := range aliceEvts {
+		if _, ok := evt.(*events.InitiativeRolledEvent); ok {
+			s.Fail("InitiativeRolledEvent must not republish on a later EndTurn advance")
+		}
+	}
+}
+
+// TestSetMode_FreeRoamTransition_NoInitiativeRolled: the reverse transition
+// (TURN_BASED -> FREE_ROAM, e.g. combat ending) clears Initiative and must
+// not publish InitiativeRolledEvent — there is no roster to report.
+func (s *InitiativeRolledSuite) TestSetMode_FreeRoamTransition_NoInitiativeRolled() {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 4,
+	}))
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
+	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond) // drain the entry transition's events
+
+	s.Require().NoError(s.enc.SetMode(core.ModeFreeRoam))
+
+	aliceEvts := collectEventsTyped(s.aliceSub, 300*time.Millisecond)
+	for _, evt := range aliceEvts {
+		if _, ok := evt.(*events.InitiativeRolledEvent); ok {
+			s.Fail("InitiativeRolledEvent must not fire on TURN_BASED->FREE_ROAM (Initiative is cleared, not rolled)")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #765

`SetMode` always rolled `data.Initiative` on the FreeRoam→TurnBased flip but published no event carrying it. rpg-api's stream handler had to read the roster back from persisted state on a bounded 15×10ms retry — racing the orchestrator's Save, which the toolkit's synchronous in-call publish always precedes (rpg-api#647) — and synthesize a wire envelope that reused `ModeChangedEvent`'s sequence number (two wire events sharing one sequence).

## What changed

- New `events.InitiativeRolledEvent{Order []core.EntityID}` (encounter/events/initiative_rolled.go), mirroring the existing `ModeChangedEvent`/`TurnStartedEvent` shape (all-viewers audience, standard wire envelope + round-trip).
- `SetMode` (encounter/combat.go) publishes it on the FreeRoam→TurnBased transition, sequenced between `ModeChangedEvent` and `TurnStartedEvent`, exactly once per transition.
- Registered the new type in the broker's `encode`/`decode` codec (encounter/broker.go) — every test that exercises `SetMode` goes through this path, so this was load-bearing, not optional.
- New `encounter/initiative_rolled_test.go` (3 tests, see below).

## Load-bearing

- **Dedicated event, not fields on `ModeChangedEvent`** — the issue asked for a stated rationale. The wire proto already models this as its own message (`InitiativeRolled{order}`, `EncounterEvent` oneof field 41, sitting unpopulated). A dedicated toolkit event maps onto it 1:1, so rpg-api's translator can delete its whole special-cased `translateForStream` branch (repo read + retry + shared-sequence hack) and treat this like every other event via `TranslateEvent` — not just drop the repo read from an existing branch. `ModeChangedEvent` is also generic across every mode pair (including TurnBased→FreeRoam, where a roster field would be meaningless); every other roster-adjacent fact in this event taxonomy (`TurnStarted`, `TurnEnded`, `EntityDied`, `EntityRemoved`) is already its own dedicated type, and bundling roster data onto the transition event would break that precedent for a shape that only applies to one specific transition.
- **Ordering contract**: `ModeChangedEvent` → `InitiativeRolledEvent` → `TurnStartedEvent`. `ModeChanged` is the cause; roster (STATE) is placed before the turn announcement (an ACTION) since a client building a combat-order UI wants the full roster in hand before being told who's first. Published once per transition, not re-sent on later per-turn `TurnStartedEvent`s from `EndTurn` (the roster doesn't change turn to turn).
- **Defensive slice copy**: `Order` is `append([]core.EntityID(nil), e.data.Initiative...)`, not the same backing slice — mirrors `applyAndPublishMove`'s existing `append([]core.Hex(nil), traveledPath...)` pattern, since `AddMonster`'s mid-combat reinforcement path (#764) can grow `e.data.Initiative` after this event already published.
- **Codec registration was the actual hard part**: forgetting `encoder`/`decodeEvent` entries in broker.go silently broke *every* test in the package that triggers `SetMode` (`publish initiative rolled: encode event: unknown event type`) — caught immediately by the full suite, not by the new tests in isolation.

## Test plan

- [x] New `encounter/initiative_rolled_test.go`, `InitiativeRolledSuite` (3 tests):
  - `TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted` — pins the ordering contract + verifies `Order` matches `ToData().Initiative` and contains both combatants.
  - `TestEndTurn_DoesNotRepublishInitiativeRolled` — roster fires once, not on later turn advances.
  - `TestSetMode_FreeRoamTransition_NoInitiativeRolled` — the reverse transition (combat ending) must not fire it.
- [x] New `TestInitiativeRolledEvent_JSONRoundTrip` in `events/events_test.go` + added to the sealed-interface satisfaction check.
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `gofmt -s -l` / `goimports -l` on changed files — clean
- [x] `go mod tidy` (encounter module) — no diff
- [x] `golangci-lint run --no-config` (encounter module) — 0 issues
- [x] `go test ./... -count=1` (encounter module, full suite incl. new + existing) — all green (~46s + core/events/perception subpackages)
- [x] `make pre-commit` at repo root — fails on the already-filed, pre-existing, unrelated `core` module coverage-check bug (#769); this PR touches neither `core/` nor `events/` (root module), and `git status` after the run showed zero incidental changes.

## Docs

- `docs/status.md` — new "Recently landed" entry for #765 + frontmatter bump
- `docs/architecture/components/encounter.md` — new "Initiative roster event" section with the design rationale; updated the combat-entry section's stale "ModeChanged/TurnStarted" publish-path description to include the new event

## rpg-api follow-up (not this PR)

rpg-api can now delete `loadRolledInitiative` + its retry constants, the `translateInitiativeRolledEvent` shared-sequence synthesis, and the special-cased branch in `translateForStream` (handler.go/translate.go), replacing it with a plain `InitiativeRolledEvent` case in its normal translator dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9