### PR TITLE
fix(environments): retry RandomPattern with fresh seeds before empty fallback

### DIFF
--- a/tools/environments/wall_patterns.go
+++ b/tools/environments/wall_patterns.go
@@ -3,6 +3,7 @@ package environments
 import (
 	"context"
 	"fmt"
+	"log"
 	"math"
 	"math/rand"
 
@@ -120,13 +121,68 @@ func EmptyPattern(
 	return walls, nil
 }
 
-// RandomPattern generates random wall segments based on density parameter
+// maxGenerationAttempts bounds RandomPattern's retry loop before it
+// surrenders to PathSafetyParams.EmergencyFallback (rpg-toolkit#792).
+// Validation rejects a single random layout often enough at typical game
+// sizes (20x20) that a rejection is not evidence the room is unbuildable --
+// a fresh layout from a different seed usually passes.
+const maxGenerationAttempts = 10
+
+// RandomPattern generates random wall segments based on density parameter.
+//
+// A single generated layout frequently fails validateAndFixPathfinding's
+// path-safety checks, especially at larger room sizes -- see
+// rpg-toolkit#792. Rather than surrendering to the emergency-empty fallback
+// on the first miss, generation retries up to maxGenerationAttempts times
+// with fresh layouts before giving up. Retry seeds are derived
+// deterministically from params.RandomSeed via a dedicated RNG (never the
+// global entropy source), so the same input seed always retries through the
+// same sequence of attempts and explicit-seed callers stay fully
+// reproducible -- including the first attempt, which uses params.RandomSeed
+// directly and is therefore identical to pre-#792 behavior whenever it
+// already passes validation.
 func RandomPattern(
 	ctx context.Context, shape *RoomShape, size spatial.Dimensions, params PatternParams,
 ) ([]WallSegment, error) {
+	// #nosec G404 - deterministic seed derivation from params.RandomSeed, not cryptographic
+	retrySeeds := rand.New(rand.NewSource(params.RandomSeed))
+
+	var lastErr error
+	for attempt := 0; attempt < maxGenerationAttempts; attempt++ {
+		seed := params.RandomSeed
+		if attempt > 0 {
+			seed = retrySeeds.Int63()
+		}
+
+		walls, err := generateAndValidateWalls(ctx, shape, size, params, seed)
+		if err == nil {
+			return walls, nil
+		}
+		lastErr = err
+	}
+
+	if params.Safety.EmergencyFallback {
+		log.Printf(
+			"environments: RandomPattern emergency fallback to empty room after %d attempts "+
+				"(seed=%d, size=%.0fx%.0f): %v",
+			maxGenerationAttempts, params.RandomSeed, size.Width, size.Height, lastErr,
+		)
+		return []WallSegment{}, nil
+	}
+
+	return nil, fmt.Errorf("random pattern failed validation after %d attempts: %w", maxGenerationAttempts, lastErr)
+}
+
+// generateAndValidateWalls generates one candidate wall layout from seed and
+// runs it through path-safety validation/fixup. It does not apply the
+// emergency-empty fallback -- that decision belongs to RandomPattern, which
+// knows whether more retry attempts remain.
+func generateAndValidateWalls(
+	ctx context.Context, shape *RoomShape, size spatial.Dimensions, params PatternParams, seed int64,
+) ([]WallSegment, error) {
 	// #nosec G404 - Using math/rand for seeded, reproducible wall pattern generation
-	// Same RandomSeed must produce identical wall layouts for consistent gameplay
-	random := rand.New(rand.NewSource(params.RandomSeed))
+	// Same seed must produce identical wall layouts for consistent gameplay
+	random := rand.New(rand.NewSource(seed))
 	var walls []WallSegment
 
 	// Calculate number of walls based on density
@@ -151,12 +207,7 @@ func RandomPattern(
 	walls = applyDestructibleRatio(walls, params.DestructibleRatio, random)
 
 	// Validate and fix pathfinding
-	validatedWalls, err := validateAndFixPathfinding(ctx, walls, shape, size, params.Safety, params)
-	if err != nil {
-		return nil, fmt.Errorf("random pattern failed validation: %w", err)
-	}
-
-	return validatedWalls, nil
+	return validateAndFixPathfinding(ctx, walls, shape, size, params.Safety)
 }
 
 // Helper functions for wall generation
@@ -245,9 +296,14 @@ func validatePathSafety(walls []WallSegment, shape *RoomShape, size spatial.Dime
 	return nil
 }
 
+// validateAndFixPathfinding validates a candidate wall layout, attempting a
+// handful of local fixes (clearing required paths, connection access,
+// trimming for open space) before giving up. It returns an error -- never
+// the emergency-empty fallback -- when the layout can't be salvaged; the
+// caller (RandomPattern) owns the retry-then-fallback decision.
 func validateAndFixPathfinding(
 	_ context.Context, walls []WallSegment, shape *RoomShape, size spatial.Dimensions,
-	safety PathSafetyParams, _ PatternParams,
+	safety PathSafetyParams,
 ) ([]WallSegment, error) {
 	// First, try to validate as-is
 	if err := validatePathSafety(walls, shape, size, safety); err == nil {
@@ -278,11 +334,6 @@ func validateAndFixPathfinding(
 
 	// Final validation
 	if err := validatePathSafety(fixedWalls, shape, size, safety); err != nil {
-		if safety.EmergencyFallback {
-			// Emergency fallback: return empty room
-			// TODO: Consider how to notify callers about fallback usage
-			return []WallSegment{}, nil
-		}
 		return nil, fmt.Errorf("could not fix pathfinding issues: %w", err)
 	}
 

--- a/tools/environments/wall_patterns_sweep_test.go
+++ b/tools/environments/wall_patterns_sweep_test.go
@@ -1,0 +1,84 @@
+package environments
+
+import (
+	"fmt"
+	"testing"
+)
+
+// sweepSeedCount is the number of distinct explicit seeds swept for the
+// empty-room-rate measurement below. Matches the acceptance criteria in
+// rpg-toolkit#792: a 100-seed sweep at 20x20 PatternRandom.
+const sweepSeedCount = 100
+
+// TestRandomPattern_EmptyRoomRate_20x20 sweeps sweepSeedCount explicit seeds
+// through the real BasicRoomBuilder path (the same path StartEncounter
+// drives in rpg-api) at 20x20 with PatternRandom and PatternParams'
+// defaults, and reports the fraction of resulting rooms with zero walls.
+//
+// This is rpg-toolkit#792's acceptance test: at 20x20 PatternRandom, walls
+// must appear in >=95% of rooms across the sweep. Before the bounded-retry
+// fix, this sat around ~15-20% non-empty (5/6 empty matches the rate
+// rpg-api#669 observed against the real StartEncounter path); see the PR
+// body for the exact measured before/after numbers.
+func TestRandomPattern_EmptyRoomRate_20x20(t *testing.T) {
+	emptyCount := 0
+
+	for seed := int64(1); seed <= sweepSeedCount; seed++ {
+		builder := NewBasicRoomBuilder(BasicRoomBuilderConfig{}).
+			WithSize(20, 20).
+			WithWallPattern(PatternRandom).
+			WithRandomSeed(seed)
+
+		room, err := builder.Build()
+		if err != nil {
+			t.Fatalf("seed %d: Build failed: %v", seed, err)
+		}
+
+		if len(GetWallEntitiesInRoom(room)) == 0 {
+			emptyCount++
+		}
+	}
+
+	nonEmptyRate := float64(sweepSeedCount-emptyCount) / float64(sweepSeedCount)
+	t.Logf(
+		"20x20 PatternRandom sweep: %d/%d empty (%.1f%% non-empty)",
+		emptyCount, sweepSeedCount, nonEmptyRate*100,
+	)
+
+	if nonEmptyRate < 0.95 {
+		t.Errorf(
+			"non-empty rate %.1f%% is below the 95%% acceptance bar (rpg-toolkit#792): %d/%d seeds fell back to empty",
+			nonEmptyRate*100, emptyCount, sweepSeedCount,
+		)
+	}
+}
+
+// TestRandomPattern_EmptyRoomRate_Determinism proves the sweep above (and
+// the retry mechanism it exercises) doesn't disturb explicit-seed
+// reproducibility: the same seed must still produce the same wall layout
+// across repeated builds.
+func TestRandomPattern_EmptyRoomRate_Determinism(t *testing.T) {
+	build := func(seed int64) []string {
+		builder := NewBasicRoomBuilder(BasicRoomBuilderConfig{}).
+			WithSize(20, 20).
+			WithWallPattern(PatternRandom).
+			WithRandomSeed(seed)
+
+		room, err := builder.Build()
+		if err != nil {
+			t.Fatalf("seed %d: Build failed: %v", seed, err)
+		}
+		return wallSignature(room)
+	}
+
+	for _, seed := range []int64{1, 2, 3, 17, 99} {
+		first := build(seed)
+		second := build(seed)
+		if fmt.Sprint(first) != fmt.Sprint(second) {
+			t.Errorf(
+				"seed %d: layout not reproducible across repeated Build() calls\nfirst:  %v\nsecond: %v",
+				seed, first, second,
+			)
+		}
+	}
+}

--- a/tools/environments/wall_patterns_sweep_test.go
+++ b/tools/environments/wall_patterns_sweep_test.go
@@ -1,7 +1,7 @@
 package environments
 
 import (
-	"fmt"
+	"slices"
 	"testing"
 )
 
@@ -74,7 +74,7 @@ func TestRandomPattern_EmptyRoomRate_Determinism(t *testing.T) {
 	for _, seed := range []int64{1, 2, 3, 17, 99} {
 		first := build(seed)
 		second := build(seed)
-		if fmt.Sprint(first) != fmt.Sprint(second) {
+		if !slices.Equal(first, second) {
 			t.Errorf(
 				"seed %d: layout not reproducible across repeated Build() calls\nfirst:  %v\nsecond: %v",
 				seed, first, second,


### PR DESCRIPTION
## Summary

RandomPattern's generated wall layout frequently failed its own path-safety
validation at typical game sizes (20x20 PatternRandom), and the emergency
fallback silently surrendered to an empty room on the very first miss —
before rpg-toolkit#787's entropy-seeding fix, this was invisible because
the hardcoded seed 0 happened to be one of the layouts that passes
validation.

## Mechanism

`RandomPattern` generates one candidate wall layout, then
`validateAndFixPathfinding` tries a few local fixes (clear required paths,
ensure connection accessibility, trim for open space). If it still doesn't
validate, it used to give up immediately and return an empty room whenever
`PathSafetyParams.EmergencyFallback` was set — a single rejected layout was
treated as proof the room couldn't be built, when in practice most other
seeds at the same size succeed fine.

## Fix

`RandomPattern` now retries up to 10 times with fresh candidate layouts
before falling back to empty. Retry seeds are derived deterministically
from `params.RandomSeed` via a dedicated RNG (never the global entropy
source), so the same input seed always retries through the same sequence —
explicit-seed callers (`WithRandomSeed`, `QuickRoom`) stay fully
reproducible. The first attempt uses `params.RandomSeed` directly and is
therefore bit-identical to prior behavior whenever it already passes
validation (this is why the seed-4/seed-10 pinned determinism tests in
`room_builder_test.go` needed no changes).

`validateAndFixPathfinding` no longer owns the emergency-empty decision —
it just returns an error when a layout can't be salvaged; `RandomPattern`
decides whether to retry or surrender based on remaining attempts. When the
fallback does still fire (a genuinely difficult room, e.g. `MinOpenSpace`
near 1.0), it now logs the seed, room size, attempt count, and last
validation error instead of returning silently — closing the `// TODO:
Consider how to notify callers about fallback usage` that was sitting in
this exact code path.

## Before / after (100-seed sweep, 20x20, PatternRandom, default
`BasicRoomBuilder` params)

| | Empty rooms | Non-empty rate |
|---|---|---|
| Before | 70/100 | 30.0% |
| After | 4/100 | **96.0%** |

Sweep + a dedicated determinism check (`build(seed) == build(seed)` across
5 seeds, run twice each) live in
`tools/environments/wall_patterns_sweep_test.go` as a permanent regression
test enforcing the ≥95% acceptance bar from rpg-toolkit#792.

## Checks

- `go build ./...`, `go vet ./...`, `go test -race ./...` — all green in
  `tools/environments`
- `gofmt -l` / `goimports -l` — clean
- `golangci-lint run ./...` scoped to `tools/environments` — no new
  findings from the changed files (two pre-existing `goconst` hits on
  untouched lines in `room_builder.go`/`wall_patterns.go`)
- Full existing `wall_patterns_test.go` / `room_builder_test.go` suites
  pass unchanged, including the pinned seed-4/seed-10 reproducibility
  assertions

## Scope decisions

- **No cross-module version bump in this PR.** `tools/environments` is a
  leaf module; the delivery bump into `rpg-api` rides `rpg-api`'s next
  toolkit bump rather than a standalone chore here.
- **Retry-only fix, no generation-math tuning.** The 96% non-empty rate
  clears the 95% acceptance bar without touching wall density / path-safety
  parameter defaults. If a future size/density combination pushes the
  non-empty rate back down, that's density/safety tuning — a separate,
  narrower change from this bounded-retry mechanism.
- **Observability is a log line, not a wired event.** `tools/environments`
  already defines an unused `EmergencyFallbackTopic`/`EmergencyFallbackEvent`
  pair in `topics.go` that no code path publishes. Wiring that through
  `BasicRoomBuilder`'s event bus (including a nil-bus guard, since most
  current callers/tests never call `ConnectToEventBus`) is a reasonable
  follow-up but is more surface area than this bug needs; a `log.Printf` at
  the fallback site satisfies the issue's "make it loggable" ask with much
  less churn.

Closes #792
Refs rpg-api#669, #789, rpg-api#648