### PR TITLE
feat(encounter): administrative EndEncounter(reason) — abandon path

### DIFF
--- a/encounter/abandon_test.go
+++ b/encounter/abandon_test.go
@@ -1,0 +1,238 @@
+package encounter_test
+
+// rpg-toolkit#797 (rpg-api#663) — administrative Encounter.End(reason),
+// reusing checkEncounterEnd's terminal transition rather than a parallel
+// path. Coverage:
+//
+//  1. Mid-combat: End("abandoned") drives the same Mode -> ModeEnded /
+//     Initiative-cleared / EncounterEndedEvent transition a natural
+//     victory or TPK end does, the state persists as ended through
+//     ToData/LoadFromData, and post-load the encounter refuses further
+//     verbs (TakeAction/EndTurn/NPCAct) exactly like a naturally-ended one.
+//  2. FREE_ROAM: the actual reported bug shape (#483's movement deadlock)
+//     — an encounter that never entered combat, so checkEncounterEnd's
+//     victory/TPK predicates (only evaluated from killEntity/
+//     publishPlayerDied) can never fire. End must work anyway, since it is
+//     unconditional on Mode.
+//  3. Negative control: End against an already-ended encounter (whether
+//     ended by a prior End call or by a natural end) returns
+//     ErrEncounterEnded and does not re-publish EncounterEndedEvent.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// AbandonSuite covers the administrative End(reason) path.
+type AbandonSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestAbandonSuite(t *testing.T) {
+	suite.Run(t, new(AbandonSuite))
+}
+
+func (s *AbandonSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *AbandonSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// TestEnd_MidCombat_Abandoned_EndsEncounter_PersistsThroughReload_RejectsPostLoadVerbs
+// is the goal-behavior proof: a mid-combat encounter (player + monster in
+// mutual LoS, auto-entered TURN_BASED) is administratively ended via
+// End("abandoned"). Asserts the full observable contract: Mode flips,
+// Initiative/ActiveIdx/Round clear, EncounterEndedEvent carries Reason
+// "abandoned", the ended state round-trips through ToData -> JSON ->
+// LoadFromData, and — critically for the resume/liveness bug this closes —
+// the reloaded encounter rejects TakeAction/EndTurn/NPCAct with
+// ErrEncounterEnded exactly as a naturally-ended encounter does
+// (TestSlice_PostEndRoundTrips, death_test.go).
+func (s *AbandonSuite) TestEnd_MidCombat_Abandoned_EndsEncounter_PersistsThroughReload_RejectsPostLoadVerbs() {
+	encID := core.EncounterID("enc-abandon-midcombat")
+	enc := encounter.New(s.ctx, encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode(),
+		"alice is in LoS of the goblin — AddMonster must auto-enter combat")
+
+	sub, err := s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	endErr := enc.End(encounter.EncounterEndedReasonAbandoned)
+	s.Require().NoError(endErr)
+
+	s.Equal(core.ModeEnded, enc.Mode())
+	persisted := enc.ToData()
+	s.Empty(persisted.Initiative)
+	s.Equal(0, persisted.ActiveIdx)
+	s.Equal(0, persisted.Round)
+	// The monster is untouched by an abandon — nobody won or lost, so
+	// unlike a victory end there is no reason to have cleared Monsters.
+	s.Contains(persisted.Monsters, core.EntityID(gobEntityID))
+
+	ended := waitForEncounterEnded(s.T(), sub)
+	s.Require().NotNil(ended, "End must publish EncounterEndedEvent")
+	s.Equal(encounter.EncounterEndedReasonAbandoned, ended.Reason)
+
+	// Persistence: ended state survives a real JSON round-trip + LoadFromData,
+	// the same path rpg-api's per-RPC load/save cycle exercises.
+	raw, err := json.Marshal(persisted)
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	s.Equal(core.ModeEnded, data.Mode, "Mode=ENDED must be the persisted marker — no separate EndedAt field exists")
+
+	reloaded, err := encounter.LoadFromData(s.ctx, &data, s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(err)
+	s.Equal(core.ModeEnded, reloaded.Mode(), "ended state must survive LoadFromData")
+
+	// Post-load: the reloaded, abandoned encounter refuses every combat verb
+	// exactly like a naturally-ended one — this is the actual fix for the
+	// reported bug (resume/liveness re-imprisoning players in a stuck
+	// encounter with no escape).
+	err = reloaded.TakeAction("alice",
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+
+	_, _, err = reloaded.EndTurn(s.ctx, aliceEntityID)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+
+	err = reloaded.NPCAct(s.ctx, gobEntityID)
+	s.ErrorIs(err, encounter.ErrEncounterEnded)
+}
+
+// TestEnd_FreeRoam_Abandoned_EndsEncounter proves End works on the actual
+// shape of the reported bug: an encounter that never entered combat at all
+// (no monster ever added, Mode stays the New()-default ModeFreeRoam).
+// checkEncounterEnd's victory/TPK predicates are only ever evaluated from
+// killEntity/publishPlayerDied — a FREE_ROAM encounter with no combat
+// activity structurally never reaches either, so this proves End's "works
+// from ANY mode, not just TURN_BASED" doc claim rather than just asserting
+// it.
+func (s *AbandonSuite) TestEnd_FreeRoam_Abandoned_EndsEncounter() {
+	encID := core.EncounterID("enc-abandon-freeroam")
+	enc := encounter.New(s.ctx, encID, s.broker)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 10,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "setup sanity: no monster ever added, must stay FREE_ROAM")
+
+	sub, err := s.broker.Subscribe(encID, "alice")
+	s.Require().NoError(err)
+	defer func() { _ = sub.Close() }()
+
+	s.Require().NoError(enc.End(encounter.EncounterEndedReasonAbandoned))
+	s.Equal(core.ModeEnded, enc.Mode())
+
+	ended := waitForEncounterEnded(s.T(), sub)
+	s.Require().NotNil(ended, "End must publish EncounterEndedEvent even from FREE_ROAM")
+	s.Equal(encounter.EncounterEndedReasonAbandoned, ended.Reason)
+}
+
+// TestEnd_AlreadyEnded_ReturnsErrEncounterEnded_NegativeControl is the
+// negative control: End against an already-ended encounter — whether ended
+// by a prior End call or by reaching a natural conclusion — returns
+// ErrEncounterEnded rather than silently re-transitioning or double-
+// publishing EncounterEndedEvent.
+func (s *AbandonSuite) TestEnd_AlreadyEnded_ReturnsErrEncounterEnded_NegativeControl() {
+	s.Run("already ended by a prior End call", func() {
+		encID := core.EncounterID("enc-abandon-double-end")
+		enc := encounter.New(s.ctx, encID, s.broker)
+		s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+			PlayerID: "alice", EntityID: aliceEntityID,
+			Position: core.Hex{}, SightRange: 10,
+		}))
+
+		sub, err := s.broker.Subscribe(encID, "alice")
+		s.Require().NoError(err)
+		defer func() { _ = sub.Close() }()
+
+		s.Require().NoError(enc.End(encounter.EncounterEndedReasonAbandoned))
+		drainSub(sub, 100*time.Millisecond)
+
+		err = enc.End(encounter.EncounterEndedReasonAbandoned)
+		s.ErrorIs(err, encounter.ErrEncounterEnded)
+
+		// No second EncounterEndedEvent — the guard must short-circuit
+		// before endWithReason runs a second time, not merely error after
+		// re-publishing.
+		seen := collectTypes(sub, 300*time.Millisecond)
+		s.NotContains(seen, "*events.EncounterEndedEvent",
+			"a rejected second End must not re-publish the terminal event")
+	})
+
+	s.Run("already ended naturally (victory)", func() {
+		encID := core.EncounterID("enc-abandon-after-victory")
+		enc := encounter.New(s.ctx, encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
+			encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+		s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+			PlayerID: "alice", EntityID: aliceEntityID,
+			Position: core.Hex{}, SightRange: 10,
+			HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+			DamageDice: damage1d8plus2, DamageType: damageSlashing,
+		}))
+		s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+			ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+			HP: 1, MaxHP: 7, AC: 15, Speed: 6,
+			AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		}))
+
+		sub, err := s.broker.Subscribe(encID, "alice")
+		s.Require().NoError(err)
+		defer func() { _ = sub.Close() }()
+
+		s.Require().NoError(enc.TakeAction("alice",
+			encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+			encounter.ActionTarget{EntityID: gobEntityID},
+		))
+		s.Require().Equal(core.ModeEnded, enc.Mode(), "setup must reach a natural victory end")
+
+		original := waitForEncounterEnded(s.T(), sub)
+		s.Require().NotNil(original)
+		s.Equal(encounter.EncounterEndedReasonAllHostilesDefeated, original.Reason,
+			"setup sanity: must have ended as a victory, not by whatever this test is trying to reject")
+
+		endErr := enc.End(encounter.EncounterEndedReasonAbandoned)
+		s.ErrorIs(endErr, encounter.ErrEncounterEnded,
+			"abandoning an encounter that already ended naturally must reject the same way")
+		s.Equal(core.ModeEnded, enc.Mode())
+
+		// The rejected abandon attempt must not have published a second
+		// EncounterEndedEvent overwriting the original victory reason.
+		seen := collectTypes(sub, 300*time.Millisecond)
+		s.NotContains(seen, "*events.EncounterEndedEvent",
+			"a rejected End after a natural end must not re-publish the terminal event")
+	})
+}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -301,10 +301,12 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 		return errors.New("mode unspecified")
 	}
 	if mode == core.ModeEnded {
-		// Terminal state is gameplay-driven (Encounter.checkEncounterEnd
-		// fires when the last hostile dies), never set externally. Reject
-		// so callers don't accidentally bypass the kill chain.
-		return errors.New("ModeEnded is set internally by checkEncounterEnd, not via SetMode")
+		// Terminal state is driven internally — either gameplay
+		// (Encounter.checkEncounterEnd fires when the last hostile dies or
+		// a TPK is confirmed) or administrative (Encounter.End,
+		// rpg-toolkit#797) — never set externally via this verb. Reject so
+		// callers don't accidentally bypass either path.
+		return errors.New("ModeEnded is set internally by checkEncounterEnd or End, not via SetMode")
 	}
 	if e.data.Mode == core.ModeEnded {
 		return ErrEncounterEnded

--- a/encounter/core/mode.go
+++ b/encounter/core/mode.go
@@ -16,19 +16,21 @@ const (
 	ModeFreeRoam
 	// ModeTurnBased is initiative-locked combat. Verbs gate on the active actor.
 	ModeTurnBased
-	// ModeEnded is the terminal state for an encounter — entered when the
-	// encounter-end predicate first goes true (Wave 2.10: all hostiles
-	// defeated). Combat verbs (TakeAction, EndTurn, NPCAct) reject with
-	// ErrEncounterEnded; the orchestrator stops dispatching turns. The
+	// ModeEnded is the terminal state for an encounter — entered either when
+	// the encounter-end predicate first goes true (Wave 2.10: all hostiles
+	// defeated; #772/#782: TPK) or via an administrative Encounter.End call
+	// (rpg-toolkit#797). Combat verbs (TakeAction, EndTurn, NPCAct) reject
+	// with ErrEncounterEnded; the orchestrator stops dispatching turns. The
 	// encounter persists in storage with this mode so reconnects see the
 	// terminal state via snapshot replay.
 	//
 	// The transition to ModeEnded happens inside the kill chain
-	// (Encounter.checkEncounterEnd, in death.go), not via SetMode.
-	// SetMode does NOT accept ModeEnded as a target — terminal state is
-	// always orchestrator-driven through gameplay (last hostile dies),
-	// never through an explicit "set the mode to ended" call. The
-	// transition clears Initiative / ActiveIdx / Round.
+	// (Encounter.checkEncounterEnd, in death.go) or the administrative End
+	// path (also death.go) — both funnel through the same endWithReason
+	// helper — never via SetMode. SetMode does NOT accept ModeEnded as a
+	// target: terminal state is always driven through one of those two
+	// purpose-built entry points, never through an explicit "set the mode
+	// to ended" call. The transition clears Initiative / ActiveIdx / Round.
 	ModeEnded
 )
 

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -30,6 +30,17 @@ const EntityRemovedReasonDestroyed = "destroyed"
 // "time_out", etc.).
 const EncounterEndedReasonAllHostilesDefeated = "all_hostiles_defeated"
 
+// EncounterEndedReasonAbandoned is the Reason value on EncounterEndedEvent
+// when the encounter is administratively ended via End rather than reaching
+// a natural victory/TPK conclusion — rpg-toolkit#797 (rpg-api#663). The slot
+// was reserved by #783's reason-taxonomy comment on this same constant
+// block. Typical caller: rpg-api's abandon path, invoked by a lobby host (or
+// the liveness/resume check) on an encounter with no other way to end —
+// e.g. a FREE_ROAM encounter stuck by #483's movement deadlock, which never
+// reaches checkEncounterEnd's victory/TPK predicates because those only
+// evaluate from combat kill paths.
+const EncounterEndedReasonAbandoned = "abandoned"
+
 // EncounterEndedReasonTPK is the Reason value on EncounterEndedEvent when
 // every seated player has died within the encounter (a Total Party Kill) —
 // rpg-toolkit#772/#782. Symmetric with EncounterEndedReasonAllHostilesDefeated
@@ -571,6 +582,51 @@ func (e *Encounter) checkEncounterEnd() error {
 	default:
 		return nil
 	}
+	return e.endWithReason(reason)
+}
+
+// End administratively ends the encounter with the given reason, driving
+// the SAME terminal transition checkEncounterEnd uses for a natural
+// victory/TPK conclusion (Mode -> ModeEnded, Initiative/ActiveIdx/Round
+// cleared, combat-scoped conditions swept, ActionEconomy cleared via
+// ExitCombat, EncounterEndedEvent published) rather than a parallel path.
+// rpg-toolkit#797 (rpg-api#663).
+//
+// Unlike checkEncounterEnd, End does not evaluate the victory/TPK
+// predicates — it forces the transition unconditionally, regardless of the
+// encounter's current Mode. This is what makes it usable on a FREE_ROAM
+// encounter (checkEncounterEnd's predicates only ever get evaluated from
+// combat kill paths — killEntity, publishPlayerDied — so a stuck FREE_ROAM
+// encounter can never reach them) as well as a TURN_BASED one.
+//
+// Returns ErrEncounterEnded if the encounter has already ended — abandoning
+// an already-terminal encounter is a caller bug (the caller should have
+// seen ModeEnded and not tried again), surfaced rather than silently
+// swallowed. This mirrors the same sentinel every other post-end verb
+// (TakeAction, EndTurn, NPCAct, SetMode) already returns, so callers can
+// treat "encounter already over" identically everywhere.
+//
+// The caller supplies reason; rpg-api's abandon path passes
+// EncounterEndedReasonAbandoned. Any string is accepted with no validation
+// — EncounterEndedEvent.Reason is a bare passthrough string all the way to
+// the wire (see #783's "no proto or rpg-api change needed" note), so End
+// imposes no new constraint on that contract.
+func (e *Encounter) End(reason string) error {
+	if e.data.Mode == core.ModeEnded {
+		return ErrEncounterEnded
+	}
+	return e.endWithReason(reason)
+}
+
+// endWithReason performs the terminal-state transition shared by every
+// encounter-end path (natural, via checkEncounterEnd, and administrative,
+// via End): flips Mode -> ModeEnded, clears Initiative/ActiveIdx/Round,
+// sweeps combat-scoped conditions + ActionEconomy, and publishes
+// EncounterEndedEvent with the given reason. Callers are responsible for
+// the ModeEnded re-entrancy guard — this function assumes the caller
+// already confirmed e.data.Mode != core.ModeEnded, so it is not itself
+// idempotent.
+func (e *Encounter) endWithReason(reason string) error {
 	e.data.Mode = core.ModeEnded
 	e.data.Initiative = nil
 	e.data.ActiveIdx = 0

--- a/encounter/death_test.go
+++ b/encounter/death_test.go
@@ -493,7 +493,7 @@ func (s *DeathSuite) TestSlice_EncounterEndedReasonAllHostilesDefeated() {
 		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
 		encounter.ActionTarget{EntityID: gobEntityID},
 	))
-	ended := waitForEncounterEnded(s.T(), s.aliceSub, time.Second)
+	ended := waitForEncounterEnded(s.T(), s.aliceSub)
 	s.Require().NotNil(ended)
 	s.Equal(encounter.EncounterEndedReasonAllHostilesDefeated, ended.Reason)
 }
@@ -652,10 +652,10 @@ func waitForEntityRemoved(
 }
 
 func waitForEncounterEnded(
-	t *testing.T, sub *encounter.Subscription, timeout time.Duration,
+	t *testing.T, sub *encounter.Subscription,
 ) *events.EncounterEndedEvent {
 	t.Helper()
-	deadline := time.After(timeout)
+	deadline := time.After(time.Second)
 	for {
 		select {
 		case evt, ok := <-sub.Events():


### PR DESCRIPTION
## Summary

Adds `Encounter.End(reason string) error` — an administrative, unconditional encounter-end that reuses `checkEncounterEnd`'s exact terminal transition rather than building a parallel path. Closes #797, refs rpg-api#663 (https://github.com/KirkDiggler/rpg-api/issues/663).

**The bug this unblocks:** Kirk got re-imprisoned tonight in a FREE_ROAM encounter stuck by #483's movement deadlock — the resume/liveness check faithfully resumes players into it on every reload, with no escape but manual Redis surgery. There was no way to administratively end an encounter that isn't naturally reaching a victory (#772) or TPK (#772/#782) conclusion.

## What changed

- `death.go`: extracted `checkEncounterEnd`'s transition body (Mode → ModeEnded, Initiative/ActiveIdx/Round clear, condition sweep + ExitCombat via `endCombatForPlayers`, `EncounterEndedEvent` publish) into a shared unexported `endWithReason(reason string) error`. `checkEncounterEnd` now calls it for the two existing predicate-driven reasons; the new `End(reason string) error` calls it directly, forcing the transition unconditionally regardless of the encounter's current Mode.
- New constant `EncounterEndedReasonAbandoned = "abandoned"` — fills the slot #783's reason-taxonomy comment reserved.
- `End` returns `ErrEncounterEnded` (the same sentinel every other post-end verb already returns) if called against an already-ended encounter, rather than silently no-op'ing or re-transitioning.
- Doc updates on `core/mode.go`'s `ModeEnded` and `combat.go`'s `SetMode` rejection comment — both previously said checkEncounterEnd was the *sole* internal entry point to `ModeEnded`; now note there are two (checkEncounterEnd, End), both funneling through `endWithReason`.

## Why unconditional-on-Mode matters

`checkEncounterEnd`'s victory/TPK predicates are only ever evaluated from combat kill paths (`killEntity`, `publishPlayerDied`). A FREE_ROAM encounter that never entered combat — the actual shape of the reported bug — structurally can never reach either predicate. `End` doesn't evaluate predicates at all; it forces the same transition from any Mode. Covered explicitly by `TestEnd_FreeRoam_Abandoned_EndsEncounter`.

## Test plan

New `abandon_test.go`, `AbandonSuite`:
- [x] `TestEnd_MidCombat_Abandoned_EndsEncounter_PersistsThroughReload_RejectsPostLoadVerbs` — mid-combat `End("abandoned")` → Mode/Initiative/ActiveIdx/Round transition observed, `EncounterEndedEvent{Reason:"abandoned"}` published, state round-trips through `ToData`/JSON/`LoadFromData`, and the reloaded encounter rejects `TakeAction`/`EndTurn`/`NPCAct` with `ErrEncounterEnded` exactly like a naturally-ended encounter.
- [x] `TestEnd_FreeRoam_Abandoned_EndsEncounter` — proves `End` works from FREE_ROAM (no combat ever entered), the actual bug shape.
- [x] `TestEnd_AlreadyEnded_ReturnsErrEncounterEnded_NegativeControl` — two subtests: already ended by a prior `End` call, and already ended naturally (victory). Both reject with `ErrEncounterEnded` and neither re-publishes `EncounterEndedEvent`.

Also fixed a pre-existing `unparam` lint finding on `waitForEncounterEnded` (death_test.go) that tipped over once this PR's new call sites made every call site agree on `timeout=time.Second` — dropped the now-redundant parameter.

## Scope decisions

- **rpg-api orchestrator + resume/liveness wiring is NOT in this PR** — tracked separately as rpg-api#663. This PR is toolkit-only: the exported verb and its terminal-transition guarantee.
- **Web's Leave-button UX is NOT in this PR** — separate dispatch per the umbrella issue.
- **No new `EndedAt` timestamp field** — `Data.Mode == ModeEnded` is already the sole persisted terminal marker (no separate field exists for victory/TPK either), so `End` doesn't introduce one just for this path.

## Verification

- `go build ./...`, `go vet ./...` clean (encounter module).
- `go test -race -covermode=atomic ./...` — all packages green (encounter 80.4%, core 72.5%, events 78.6%, perception 86.8% coverage).
- `go mod tidy` — no diff.
- `golangci-lint run --config=../.golangci.yml ./...` with the CI-pinned v2.2.1 (matched exactly — my local default install is v2.12.2 and produces different, misleading `goconst`/exclude-rule behavior on this repo's `_test.go` exclusions) — **0 issues**.
- Ran the module-scoped equivalent of `make pre-commit` rather than the repo-wide `make pre-commit`/`lint-all`/`test-all` targets, since those sweep every module including other agents' active worktrees under `.claude/worktrees/` — out of scope and unsafe to touch per this repo's own module-isolation rule.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9