### PR TITLE
fix(encounter): SetMode's ModeEnded rejection message no longer names an internal function

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -305,8 +305,13 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 		// (Encounter.checkEncounterEnd fires when the last hostile dies or
 		// a TPK is confirmed) or administrative (Encounter.End,
 		// rpg-toolkit#797) — never set externally via this verb. Reject so
-		// callers don't accidentally bypass either path.
-		return errors.New("ModeEnded is set internally by checkEncounterEnd or End, not via SetMode")
+		// callers don't accidentally bypass either path. The error message
+		// stays action-oriented rather than naming the private
+		// checkEncounterEnd function: this error is user-facing all the way
+		// through rpg-api, and "checkEncounterEnd" means nothing to an API
+		// consumer (Copilot review, PR #798).
+		return errors.New("cannot set mode to ended directly — the encounter ends automatically on victory or TPK, " +
+			"or call End(reason) for an administrative end")
 	}
 	if e.data.Mode == core.ModeEnded {
 		return ErrEncounterEnded


### PR DESCRIPTION
## Summary

Tiny follow-up to #798, addressing Copilot's one review comment (which landed after #798 had already merged): `SetMode`'s rejection message for `mode == core.ModeEnded` named the private `checkEncounterEnd` function — meaningless to an API consumer, even though this error is user-facing all the way through rpg-api. Closes #802.

```
- "ModeEnded is set internally by checkEncounterEnd or End, not via SetMode"
+ "cannot set mode to ended directly — the encounter ends automatically on victory or TPK, or call End(reason) for an administrative end"
```

## Verification

- No test asserted the old exact string (grep confirmed).
- `go build`/`go test ./...` — clean, encounter module fully green.
- `golangci-lint run --config=../.golangci.yml` with the CI-pinned v2.2.1 — 0 issues.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9