### PR TITLE
fix(encounter): tear down combat economy on pocket-clear free-roam exit

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -492,7 +492,49 @@ func (e *Encounter) checkPocketCleared() error {
 	// the case where e.data.Monsters is now empty entirely — reaching here
 	// with Mode still ModeTurnBased means monsters exist, just not in this
 	// pocket's initiative.
+	if err := e.exitCombatForHeldPlayers(); err != nil {
+		return err
+	}
 	return e.SetMode(core.ModeFreeRoam)
+}
+
+// exitCombatForHeldPlayers clears ActionEconomy (character.Character
+// .ExitCombat, rpg-toolkit#767) for every held player as the current
+// combat pocket clears back to FREE_ROAM (rpg-toolkit#808).
+//
+// Before this, checkPocketCleared flipped Mode to FREE_ROAM but left every
+// held player's ActionEconomy exactly as the fight left it — so
+// char.InCombat() (actionEconomy != nil) stayed true, and Move's budget
+// gate (encounter.go's tracksMovement, keyed on InCombat(), not Mode)
+// wrongly kept enforcing whatever MovementRemaining the player had left,
+// rejecting free-roam movement that is meant to be unmetered.
+//
+// Deliberately ExitCombat-ONLY, NOT the terminal path's fuller
+// endCombatForPlayers (death.go): this exit is non-terminal — the pocket
+// cleared, not the whole encounter — so it does not call
+// char.EndCombat / publish CombatEndEvent, and combat-scoped conditions
+// (e.g. Raging, which subscribes to CombatEndTopic) correctly PERSIST
+// across the breather instead of being swept. Only the movement-gating
+// side effect of an in-combat economy needs tearing down here; re-entering
+// the next pocket re-seeds a fresh economy via SetMode(TurnBased)'s
+// existing seedActorTurn->StartTurn call. Making the condition sweep on
+// this path configurable is a separate, deferred issue.
+//
+// Flat stat-snapshot seats (no hydrated *character.Character —
+// heldCharacter returns nil) have nothing to tear down and are skipped,
+// mirroring endCombatForPlayers.
+func (e *Encounter) exitCombatForHeldPlayers() error {
+	ctx := context.Background()
+	for _, pd := range e.data.Players {
+		char := e.heldCharacter(pd.EntityID)
+		if char == nil {
+			continue
+		}
+		if _, err := char.ExitCombat(ctx, &dnd5eCharacter.ExitCombatInput{}); err != nil {
+			return fmt.Errorf("exit combat for %q: %w", pd.EntityID, err)
+		}
+	}
+	return nil
 }
 
 // playersWhoCanSee returns the set of players who currently have LoS to m,

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -749,8 +749,15 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 		return nil
 	}
 
+	// rpg-toolkit#808: movement budgeting is structurally a turn-based-only
+	// concept, gated on Mode as well as InCombat(). InCombat() alone isn't
+	// enough — checkPocketCleared (combat.go) now tears down the held
+	// player's economy on a non-terminal pocket exit (the primary #808
+	// fix), but this Mode check is defense-in-depth: any FUTURE path that
+	// leaves a stale in-combat economy behind in FREE_ROAM must still not
+	// gate movement, rather than resurrecting this exact bug.
 	char := e.heldCharacter(p.EntityID)
-	tracksMovement := char != nil && char.InCombat()
+	tracksMovement := char != nil && char.InCombat() && e.data.Mode == core.ModeTurnBased
 	if tracksMovement {
 		requestedCost := pathCostFeet(moverStart, path)
 		remaining := char.GetActionEconomy().MovementRemaining

--- a/encounter/pocket_clear_move_teardown_test.go
+++ b/encounter/pocket_clear_move_teardown_test.go
@@ -1,0 +1,310 @@
+package encounter_test
+
+// pocket_clear_move_teardown_test.go is the regression gate for
+// rpg-toolkit#808: FREE_ROAM movement was wrongly rejected with
+// ErrInsufficientMovement after a combat pocket cleared.
+//
+// Root cause: checkPocketCleared (combat.go, rpg-toolkit#794) exits a
+// cleared pocket back to FREE_ROAM via SetMode(ModeFreeRoam), but never
+// tore down the held players' combat economy the way the TERMINAL
+// encounter-end path already does (endCombatForPlayers's ExitCombat call,
+// death.go, rpg-toolkit#767). Move's budget gate (encounter.go) keys off
+// char.InCombat() (actionEconomy != nil), not the encounter's mode, so a
+// player who was mid-fight when their pocket cleared kept InCombat()==true
+// with whatever MovementRemaining they had left, and the next Move was
+// wrongly gated even though free-roam movement is meant to be unmetered.
+//
+// combat_pockets_test.go (#794's own gate) never caught this: its player
+// (alice) is a flat stat-snapshot seat with no hydrated
+// *character.Character, so InCombat() is never true for her regardless.
+// These tests use a HYDRATED, round-tripped-through-LoadFromData player
+// (loadRagingBarbVsGoblin's technique, encounter_end_condition_sweep_test.go)
+// so the movement gate has real economy state to misbehave with.
+//
+// Geometry: reuses doors_slice1_test.go's lineHex(k) convention (k maps to
+// {X:0, Y:k}), with the door pushed out to k=10 (rather than #794's k=3) so
+// there is ample room (k=0..9) to spend movement freely without touching
+// the still-closed door — this suite only opens it in the re-entry test.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+)
+
+const (
+	pcmPlayerID = core.PlayerID("erin")
+	pcmEntityID = core.EntityID("char-erin")
+	pcmGobA     = core.EntityID("goblin-pcm-a")
+	pcmGobB     = core.EntityID("goblin-pcm-b")
+	pcmDoorID   = "door-pcm-1"
+)
+
+// spendHex is a single Move waypoint 5ft from erin's start (lineHex(0)) —
+// well clear of the closed door at k=10.
+var spendHex = lineHex(1)
+
+// PocketClearMoveTeardownSuite exercises rpg-toolkit#808's fix end to end.
+type PocketClearMoveTeardownSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestPocketClearMoveTeardownSuite(t *testing.T) {
+	suite.Run(t, new(PocketClearMoveTeardownSuite))
+}
+
+func (s *PocketClearMoveTeardownSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *PocketClearMoveTeardownSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// erinCharJSON builds a level-1 Human Fighter (30ft speed) with no
+// pre-seeded ActionEconomy — combat entry seeds it live via
+// seedActiveActorIfUnseeded's LoadFromData catch-up, matching
+// move_economy_test.go's charliCharJSON.
+func (s *PocketClearMoveTeardownSuite) erinCharJSON() json.RawMessage {
+	s.T().Helper()
+	charData := &dnd5eCharacter.Data{
+		ID: string(pcmEntityID), PlayerID: string(pcmPlayerID),
+		Name: "Erin the Fighter", Level: 1,
+		ClassID: classes.Fighter, RaceID: races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints: 12, MaxHitPoints: 12, ArmorClass: 16, ProficiencyBonus: 2,
+	}
+	raw, err := json.Marshal(charData)
+	s.Require().NoError(err)
+	return raw
+}
+
+// loadErinVsTwoPockets builds group A (visible immediately, k=1) and group
+// B (behind a closed door at k=10, monster at k=15) with erin's DataJSON
+// attached, then round-trips through ToData/LoadFromData
+// (loadRagingBarbVsGoblin's technique) so the cascade hydrates erin's
+// *character.Character onto the returned encounter's combatant map —
+// required for InCombat()/ExitCombat to mean anything. Group B is added
+// BEFORE group A (combat_pockets_test.go's ordering note): group A's own
+// AddMonster call must be what triggers checkCombatEntry, scoping
+// initiative to the engaged pocket only.
+func (s *PocketClearMoveTeardownSuite) loadErinVsTwoPockets() *encounter.Encounter {
+	s.T().Helper()
+	enc := encounter.New(s.ctx, "enc-pocket-clear-move-teardown", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(enc.InitRoom(20, 20, environments.PatternEmpty))
+	s.Require().NoError(enc.AddDoor(pcmDoorID, lineHex(10), false))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: pcmPlayerID, EntityID: pcmEntityID,
+		Position: lineHex(0), SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 16, AttackBonus: 5,
+		DamageDice: moveEconDamage, DamageType: damageSlashing,
+		DataJSON: s.erinCharJSON(),
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: pcmGobB, Position: lineHex(15),
+		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
+		MonsterRef: monsterRefGoblin,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: pcmGobA, Position: lineHex(1),
+		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
+		MonsterRef: monsterRefGoblin,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(err)
+	return loaded
+}
+
+// endTurnUntilErin cycles EndTurn until erin is the active actor, bounded
+// so a bug that never lands on erin fails the test instead of hanging.
+func (s *PocketClearMoveTeardownSuite) endTurnUntilErin(enc *encounter.Encounter) {
+	for i := 0; enc.ActiveActor() != pcmEntityID && i < 8; i++ {
+		_, _, err := enc.EndTurn(s.ctx, enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+	s.Require().Equal(pcmEntityID, enc.ActiveActor(), "setup must land on erin's turn")
+}
+
+// TestPocketClear_TearsDownEconomy_FreeRoamMoveSucceeds is the primary
+// goal-behavior proof: after group A (the whole current pocket) dies with
+// group B still alive elsewhere, and erin had FULLY spent her movement
+// budget landing the killing blow, a further FREE_ROAM move must succeed —
+// free-roam movement is unmetered, and this is the bug's own repro shape:
+// MovementRemaining==0 carried into FREE_ROAM.
+func (s *PocketClearMoveTeardownSuite) TestPocketClear_TearsDownEconomy_FreeRoamMoveSucceeds() {
+	enc := s.loadErinVsTwoPockets()
+	s.endTurnUntilErin(enc)
+
+	pre := enc.ActorTurnState(pcmEntityID)
+	s.Require().NotNil(pre.Economy, "erin must be seeded into the pocket A fight")
+	s.Equal(30, pre.Economy.MovementRemaining, "Human fighter seeds 30ft")
+
+	// Spend the ENTIRE budget before the killing blow (6 hexes, oscillating
+	// between lineHex(0) and lineHex(1) so the cumulative path distance is
+	// 30ft while ending back at the starting hex, well clear of the closed
+	// door at k=10) — the exact repro shape: MovementRemaining==0 the
+	// instant the pocket clears.
+	s.Require().NoError(enc.Move(pcmPlayerID,
+		[]core.Hex{spendHex, lineHex(0), spendHex, lineHex(0), spendHex, lineHex(0)}))
+	mid := enc.ActorTurnState(pcmEntityID)
+	s.Require().Equal(0, mid.Economy.MovementRemaining,
+		"test premise: movement fully spent before the killing blow")
+
+	s.Require().NoError(enc.TakeAction(pcmPlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: pcmGobA},
+	))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
+		"test premise: pocket A cleared to FREE_ROAM, group B alive elsewhere")
+
+	// The regression: with MovementRemaining still 0 from the pre-kill
+	// spend, the OLD gate (keyed on InCombat(), not Mode) rejected ANY
+	// further move in FREE_ROAM.
+	s.Require().NoError(enc.Move(pcmPlayerID, []core.Hex{spendHex}),
+		"a free-roam move must not be gated by the now-stale in-combat movement budget (rpg-toolkit#808)")
+}
+
+// TestWithinPocket_MovementStillEnforced_WhenGenuinelyExhausted proves the
+// fix does not loosen in-combat enforcement: while pocket A is STILL
+// active (group A alive), a move requested after the budget is fully spent
+// must still be rejected with ErrInsufficientMovement.
+func (s *PocketClearMoveTeardownSuite) TestWithinPocket_MovementStillEnforced_WhenGenuinelyExhausted() {
+	enc := s.loadErinVsTwoPockets()
+	s.endTurnUntilErin(enc)
+
+	s.Require().NoError(enc.Move(pcmPlayerID,
+		[]core.Hex{spendHex, lineHex(0), spendHex, lineHex(0), spendHex, lineHex(0)}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "test premise: pocket A still active, group A alive")
+
+	err := enc.Move(pcmPlayerID, []core.Hex{spendHex})
+	s.Require().Error(err, "a genuinely exhausted budget must still reject movement while in combat")
+	s.ErrorIs(err, encounter.ErrInsufficientMovement)
+}
+
+// TestPocketClear_ThenReEntry_ReseedsFullMovementBudget proves re-engaging
+// a fresh pocket restores a full movement budget for the actor's turn —
+// SetMode(TurnBased)'s existing seedActorTurn->StartTurn call, unaffected
+// by this fix's teardown.
+func (s *PocketClearMoveTeardownSuite) TestPocketClear_ThenReEntry_ReseedsFullMovementBudget() {
+	enc := s.loadErinVsTwoPockets()
+	s.endTurnUntilErin(enc)
+
+	s.Require().NoError(enc.TakeAction(pcmPlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: pcmGobA},
+	))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: pocket A cleared")
+
+	s.Require().NoError(enc.OpenDoor(pcmPlayerID, pcmDoorID))
+	// Move adjacent to group B (k=14, one hex from B at k=15) — gains LoS
+	// through the now-open door and re-triggers checkCombatEntry, exactly
+	// like combat_pockets_test.go's TestOpenDoorAndSightB_StartsFreshPocket.
+	path := make([]core.Hex, 0, 14)
+	for k := 1; k <= 14; k++ {
+		path = append(path, lineHex(k))
+	}
+	s.Require().NoError(enc.Move(pcmPlayerID, path))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting group B must start a fresh pocket")
+
+	s.endTurnUntilErin(enc)
+	post := enc.ActorTurnState(pcmEntityID)
+	s.Require().NotNil(post.Economy)
+	s.Equal(30, post.Economy.MovementRemaining,
+		"re-entering a fresh pocket must re-seed a full movement budget")
+}
+
+// TestPocketClear_CombatScopedConditionPersists_NoEndCombatSweep proves the
+// pocket exit's teardown is ExitCombat-ONLY, not the terminal path's fuller
+// endCombatForPlayers sweep (death.go): a combat-scoped condition (Raging,
+// which subscribes to CombatEndTopic and self-removes on EndCombat) must
+// SURVIVE a pocket clear — by design, the breather is not "combat over,"
+// just "this pocket's fight is." Configurable condition-sweep on this path
+// is deferred to a separate issue, not this fix.
+func (s *PocketClearMoveTeardownSuite) TestPocketClear_CombatScopedConditionPersists_NoEndCombatSweep() {
+	charJSON := ecsRagingBarbDataJSON(s.T(), string(bobEntityID), string(bobPlayerID), 16)
+
+	enc := encounter.New(s.ctx, "enc-pocket-clear-condition-persist", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(enc.InitRoom(20, 20, environments.PatternEmpty))
+	s.Require().NoError(enc.AddDoor(pcmDoorID, lineHex(10), false))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: lineHex(0), SightRange: 10,
+		HP: 16, MaxHP: 16, AC: 14, AttackBonus: 5,
+		DamageDice: ecsDamageDice, DamageType: damageSlashing,
+		DataJSON: charJSON,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: pcmGobB, Position: lineHex(15),
+		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
+		MonsterRef: monsterRefGoblin,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: pcmGobA, Position: lineHex(1),
+		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
+		MonsterRef: monsterRefGoblin,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
+	s.Require().NoError(err)
+
+	for i := 0; loaded.ActiveActor() != core.EntityID(bobEntityID) && i < 8; i++ {
+		_, _, err := loaded.EndTurn(s.ctx, loaded.ActiveActor())
+		s.Require().NoError(err)
+	}
+	s.Require().Equal(core.EntityID(bobEntityID), loaded.ActiveActor(), "setup must land on the barbarian's turn")
+
+	s.Require().NoError(loaded.TakeAction(bobPlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: pcmGobA},
+	))
+	s.Require().Equal(core.ModeFreeRoam, loaded.Mode(), "test premise: pocket A cleared, group B alive elsewhere")
+
+	persisted := loaded.ToData()
+	playerData := persisted.Players[bobPlayerID]
+	s.Require().NotNil(playerData)
+	var charData dnd5eCharacter.Data
+	s.Require().NoError(json.Unmarshal(playerData.DataJSON, &charData))
+	s.NotEmpty(charData.Conditions,
+		"raging must PERSIST across a non-terminal pocket clear (rpg-toolkit#808 scope decision) — "+
+			"only the terminal encounter-end path (death.go's endCombatForPlayers) sweeps conditions via EndCombat")
+
+	post := loaded.ActorTurnState(core.EntityID(bobEntityID))
+	s.Nil(post.Economy, "ActionEconomy must still be torn down (ExitCombat) even though conditions persist")
+}


### PR DESCRIPTION
## Load-bearing digest
- **Root cause**: `checkPocketCleared` (encounter/combat.go, rpg-toolkit#794) flips Mode to `FREE_ROAM` when a combat pocket clears but never tears down held players' combat economy — unlike the terminal encounter-end path (`endCombatForPlayers`, death.go, rpg-toolkit#767). `Move`'s budget gate keys off `char.InCombat()` (`actionEconomy != nil`), not Mode, so a player who was mid-fight when their pocket cleared kept `InCombat()==true` with whatever `MovementRemaining` they had left, and the next free-roam `Move` was wrongly rejected with `ErrInsufficientMovement`.
- **Fix**: `checkPocketCleared` now calls a new `exitCombatForHeldPlayers()` helper that runs `character.Character.ExitCombat` (the same call the terminal path uses) for every held player, clearing `ActionEconomy` back to `nil`. Re-entering the next pocket re-seeds a fresh economy via the existing `SetMode(TurnBased)`→`seedActorTurn`→`StartTurn` chain.
- **Hardening**: `Move`'s `tracksMovement` predicate (encounter.go) now also requires `e.data.Mode == core.ModeTurnBased`, making movement budgeting structurally a turn-based-only concept as defense-in-depth against any future path leaving a stale in-combat economy behind in `FREE_ROAM`.

Closes #808

## Scope decisions
- **Conditions PERSIST across a pocket clear, by design.** `exitCombatForHeldPlayers` calls `ExitCombat` **only** — it deliberately does **not** call `char.EndCombat` / publish `CombatEndEvent`. A pocket clearing is not the encounter ending; combat-scoped conditions (e.g. Raging, which subscribes to `CombatEndTopic` and self-removes on `EndCombat`) must survive the breather. This is proven directly by `TestPocketClear_CombatScopedConditionPersists_NoEndCombatSweep`.
- **Making the condition-sweep on this path configurable is deferred to a separate issue** — not part of this fix.

## Module scope
Single module: `encounter/`. No `go.mod`/`go.sum` change (confirmed via `go mod tidy`, no diff).

## Negative control
Temporarily reverted **both** the primary fix (`exitCombatForHeldPlayers` call) and the secondary hardening (`Mode == ModeTurnBased` check) — with either one alone, the test failed to reproduce (they're independently sufficient), so both had to be reverted together to see the original bug:

```
--- FAIL: TestPocketClearMoveTeardownSuite/TestPocketClear_TearsDownEconomy_FreeRoamMoveSucceeds
    Error: Received unexpected error:
           insufficient movement remaining: path costs 5ft, 0ft remaining
```

This is the exact bug symptom from the issue. Restored both changes and reran — all tests pass, full `go test -race ./...` for the module is green.

## Tests (all in `encounter/pocket_clear_move_teardown_test.go`)
1. `TestPocketClear_TearsDownEconomy_FreeRoamMoveSucceeds` — primary regression proof: erin spends her entire 30ft budget before landing the killing blow that clears pocket A (group B alive elsewhere); pocket clears to `FREE_ROAM`; a further `Move` (which would have failed against the stale 0ft budget) now succeeds.
2. `TestWithinPocket_MovementStillEnforced_WhenGenuinelyExhausted` — proves in-combat enforcement is unregressed: while pocket A is still active, an exhausted budget still rejects `Move` with `ErrInsufficientMovement`.
3. `TestPocketClear_ThenReEntry_ReseedsFullMovementBudget` — proves re-engaging a fresh pocket (group B, after opening the door) re-seeds a full 30ft budget for the new turn.
4. `TestPocketClear_CombatScopedConditionPersists_NoEndCombatSweep` — proves the Scope-decisions claim: a Raging condition present before the pocket clears is still present after (via `ToData()`/`DataJSON`), while `ActionEconomy` is still torn down (`nil`).

## CI / verification
- `go build ./...`, `go vet ./...`, `go test -race ./...` — all green for the `encounter` module (55s, no regressions).
- `gofmt -l` — clean.
- `go mod tidy` — no diff.
- `golangci-lint run ./...` — zero new issues attributable to this diff. (The module currently carries ~66 pre-existing `goconst`/`dupl` issues across unrelated test files, predating this branch — out of scope for this focused bugfix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybty7BT4V1mzQgPXUfUs1U