### PR TITLE
feat(dnd5e): equip rules for the wire — two-handed occupancy + stat_line/AC-note projection (#811)

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -18,6 +18,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combatabilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/languages"
@@ -917,13 +918,20 @@ func (c *Character) GetEquippedSlot(slot InventorySlot) *EquippedItem {
 	return nil
 }
 
-// EquipItem equips an inventory item to the specified slot.
-// Returns error if the item is not in inventory.
+// EquipItem equips an inventory item to the specified slot, enforcing
+// two-handed weapon occupancy (rpg-toolkit#811): a two-handed weapon
+// always claims main hand and clears the off hand; equipping into the off
+// hand while a two-handed weapon is held frees the main hand for the new
+// item. Equipping into an occupied slot overwrites the slot mapping — the
+// previous occupant remains in inventory, simply no longer equipped.
+// Returns error if the item is not in inventory or cannot occupy the slot.
 func (c *Character) EquipItem(slot InventorySlot, itemID string) error {
 	// Verify item exists in inventory
+	var item equipment.Equipment
 	found := false
 	for _, invItem := range c.inventory {
 		if invItem.Equipment.EquipmentID() == itemID {
+			item = invItem.Equipment
 			found = true
 			break
 		}
@@ -933,10 +941,41 @@ func (c *Character) EquipItem(slot InventorySlot, itemID string) error {
 		return rpgerr.New(rpgerr.CodeNotFound, "item not found in inventory")
 	}
 
+	if !equipmentFitsSlot(item, slot) {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "item cannot be equipped in that slot",
+			rpgerr.WithMeta("item_id", itemID),
+			rpgerr.WithMeta("slot", slot))
+	}
+
 	// Initialize map if nil
 	if c.equipmentSlots == nil {
 		c.equipmentSlots = make(EquipmentSlots)
 	}
+
+	// A two-handed weapon claims main hand and forces the off hand empty.
+	// equipmentFitsSlot above already limits two-handed weapons to main
+	// hand, so slot == SlotMainHand whenever this branch runs.
+	if isTwoHanded(item) {
+		c.equipmentSlots.Clear(SlotOffHand)
+		c.equipmentSlots.Set(SlotMainHand, itemID)
+		return nil
+	}
+
+	// Moving an equipped item into a new slot vacates its old slot.
+	for s, id := range c.equipmentSlots {
+		if id == itemID {
+			c.equipmentSlots.Clear(s)
+		}
+	}
+
+	// Main hand holding a two-handed weapon blocks the off hand until
+	// something is equipped there, which frees the main hand.
+	if slot == SlotOffHand {
+		if mainHand := c.GetEquippedSlot(SlotMainHand); mainHand != nil && isTwoHanded(mainHand.Item) {
+			c.equipmentSlots.Clear(SlotMainHand)
+		}
+	}
+
 	c.equipmentSlots.Set(slot, itemID)
 	return nil
 }
@@ -1304,7 +1343,7 @@ func (c *Character) EffectiveAC(ctx context.Context) *combat.ACBreakdown {
 		if dexMod != 0 {
 			breakdown.AddComponent(combat.ACComponent{
 				Type:   combat.ACSourceAbility,
-				Source: nil, // Ability modifiers don't have specific refs
+				Source: refs.Abilities.Dexterity(),
 				Value:  dexMod,
 			})
 		}
@@ -1320,7 +1359,7 @@ func (c *Character) EffectiveAC(ctx context.Context) *combat.ACBreakdown {
 		if dexMod != 0 {
 			breakdown.AddComponent(combat.ACComponent{
 				Type:   combat.ACSourceAbility,
-				Source: nil,
+				Source: refs.Abilities.Dexterity(),
 				Value:  dexMod,
 			})
 		}

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -31,11 +31,6 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
 )
 
-const (
-	// shieldCategory is the category value for shield items
-	shieldCategory = "shield"
-)
-
 // Compile-time check that Character implements ActionHolder and CombatAbilityHolder
 var _ actions.ActionHolder = (*Character)(nil)
 var _ combatabilities.CombatAbilityHolder = (*Character)(nil)
@@ -952,6 +947,20 @@ func (c *Character) EquipItem(slot InventorySlot, itemID string) error {
 		c.equipmentSlots = make(EquipmentSlots)
 	}
 
+	// Moving an equipped item into a new slot vacates its old slot(s).
+	// Runs before either occupancy branch below: EquipItem alone can
+	// never leave itemID mapped under more than one slot (a two-handed
+	// weapon's only compatible slot is main hand, so it can never already
+	// sit elsewhere when this runs), but corrupted/legacy persisted state
+	// could (LoadFromData copies EquipmentSlots verbatim, unvalidated) —
+	// running this first keeps that invariant regardless of how state
+	// arrived, instead of only guarding the non-two-handed path.
+	for s, id := range c.equipmentSlots {
+		if id == itemID {
+			c.equipmentSlots.Clear(s)
+		}
+	}
+
 	// A two-handed weapon claims main hand and forces the off hand empty.
 	// equipmentFitsSlot above already limits two-handed weapons to main
 	// hand, so slot == SlotMainHand whenever this branch runs.
@@ -959,13 +968,6 @@ func (c *Character) EquipItem(slot InventorySlot, itemID string) error {
 		c.equipmentSlots.Clear(SlotOffHand)
 		c.equipmentSlots.Set(SlotMainHand, itemID)
 		return nil
-	}
-
-	// Moving an equipped item into a new slot vacates its old slot.
-	for s, id := range c.equipmentSlots {
-		if id == itemID {
-			c.equipmentSlots.Clear(s)
-		}
 	}
 
 	// Main hand holding a two-handed weapon blocks the off hand until
@@ -1366,7 +1368,7 @@ func (c *Character) EffectiveAC(ctx context.Context) *combat.ACBreakdown {
 	}
 
 	// Add shield bonus if equipped
-	if shieldItem != nil && shieldItem.Category == shieldCategory {
+	if shieldItem != nil && shieldItem.Category == armor.CategoryShield {
 		breakdown.AddComponent(calculateShieldAC(shieldItem))
 	}
 
@@ -1375,7 +1377,7 @@ func (c *Character) EffectiveAC(ctx context.Context) *combat.ACBreakdown {
 		CharacterID: c.id,
 		Breakdown:   breakdown,
 		HasArmor:    armorItem != nil,
-		HasShield:   shieldItem != nil && shieldItem.Category == shieldCategory,
+		HasShield:   shieldItem != nil && shieldItem.Category == armor.CategoryShield,
 	}
 
 	// Create and publish through AC chain

--- a/rulebooks/dnd5e/character/equip_occupancy_test.go
+++ b/rulebooks/dnd5e/character/equip_occupancy_test.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// EquipOccupancyTestSuite ports the two-handed occupancy behaviors from
+// rpg-dnd5e-web#557 src/concepts/equipment/fixtures.test.ts — the fixture
+// reducer's applyIntent semantics are the acceptance spec for this rule
+// (rpg-toolkit#811). The fixture file's other describe block
+// (targetSlotFor) covers client-side click-targeting, a UI convenience
+// with no state-mutating equivalent here — see the PR's scope-decisions.
+type EquipOccupancyTestSuite struct {
+	suite.Suite
+	char *Character
+}
+
+func (s *EquipOccupancyTestSuite) SetupTest() {
+	longsword := weapons.All[weapons.Longsword]
+	greatsword := weapons.All[weapons.Greatsword]
+	handaxe := weapons.All[weapons.Handaxe]
+	shield := armor.All[armor.Shield]
+	chainMail := armor.All[armor.ChainMail]
+
+	s.char = &Character{
+		inventory: []InventoryItem{
+			{Equipment: &longsword, Quantity: 1},
+			{Equipment: &greatsword, Quantity: 1},
+			{Equipment: &handaxe, Quantity: 1},
+			{Equipment: &shield, Quantity: 1},
+			{Equipment: &chainMail, Quantity: 1},
+		},
+		equipmentSlots: make(EquipmentSlots),
+	}
+}
+
+func TestEquipOccupancySuite(t *testing.T) {
+	suite.Run(t, new(EquipOccupancyTestSuite))
+}
+
+// equips a carried item into an empty compatible slot
+func (s *EquipOccupancyTestSuite) TestEquipsIntoEmptyCompatibleSlot() {
+	err := s.char.EquipItem(SlotMainHand, weapons.Longsword)
+	s.Require().NoError(err)
+	s.Assert().Equal(weapons.Longsword, s.char.equipmentSlots[SlotMainHand])
+}
+
+// two-handed equip clears the off hand
+func (s *EquipOccupancyTestSuite) TestTwoHandedEquipClearsOffHand() {
+	s.Require().NoError(s.char.EquipItem(SlotMainHand, weapons.Longsword))
+	s.Require().NoError(s.char.EquipItem(SlotOffHand, armor.Shield))
+
+	err := s.char.EquipItem(SlotMainHand, weapons.Greatsword)
+	s.Require().NoError(err)
+
+	s.Assert().Equal(weapons.Greatsword, s.char.equipmentSlots[SlotMainHand])
+	_, offHandOccupied := s.char.equipmentSlots[SlotOffHand]
+	s.Assert().False(offHandOccupied)
+}
+
+// equipping the off hand while a two-hander is held frees the main hand
+func (s *EquipOccupancyTestSuite) TestEquippingOffHandFreesMainHandFromTwoHander() {
+	s.Require().NoError(s.char.EquipItem(SlotMainHand, weapons.Greatsword))
+
+	err := s.char.EquipItem(SlotOffHand, armor.Shield)
+	s.Require().NoError(err)
+
+	s.Assert().Equal(armor.Shield, s.char.equipmentSlots[SlotOffHand])
+	_, mainHandOccupied := s.char.equipmentSlots[SlotMainHand]
+	s.Assert().False(mainHandOccupied)
+}
+
+// unequip empties only the named slot
+func (s *EquipOccupancyTestSuite) TestUnequipEmptiesOnlyNamedSlot() {
+	s.Require().NoError(s.char.EquipItem(SlotMainHand, weapons.Longsword))
+	s.Require().NoError(s.char.EquipItem(SlotArmor, armor.ChainMail))
+
+	s.char.UnequipItem(SlotMainHand)
+
+	_, mainHandOccupied := s.char.equipmentSlots[SlotMainHand]
+	s.Assert().False(mainHandOccupied)
+	s.Assert().Equal(armor.ChainMail, s.char.equipmentSlots[SlotArmor])
+}
+
+// rejects an incompatible slot (no state change)
+func (s *EquipOccupancyTestSuite) TestRejectsIncompatibleSlot() {
+	s.Require().NoError(s.char.EquipItem(SlotArmor, armor.ChainMail))
+
+	err := s.char.EquipItem(SlotMainHand, armor.ChainMail)
+
+	s.Require().Error(err)
+	s.Assert().Equal(armor.ChainMail, s.char.equipmentSlots[SlotArmor])
+	_, mainHandOccupied := s.char.equipmentSlots[SlotMainHand]
+	s.Assert().False(mainHandOccupied)
+}
+
+// moving an equipped item between slots vacates its old slot
+func (s *EquipOccupancyTestSuite) TestMovingEquippedItemVacatesOldSlot() {
+	s.Require().NoError(s.char.EquipItem(SlotMainHand, weapons.Longsword))
+
+	err := s.char.EquipItem(SlotOffHand, weapons.Longsword)
+	s.Require().NoError(err)
+
+	s.Assert().Equal(weapons.Longsword, s.char.equipmentSlots[SlotOffHand])
+	_, mainHandOccupied := s.char.equipmentSlots[SlotMainHand]
+	s.Assert().False(mainHandOccupied)
+}
+
+// equipping into an occupied slot returns the previous occupant to
+// inventory (i.e. it's simply no longer equipped anywhere; it stays in
+// the character's inventory list)
+func (s *EquipOccupancyTestSuite) TestEquippingOccupiedSlotSwapsOccupant() {
+	s.Require().NoError(s.char.EquipItem(SlotMainHand, weapons.Longsword))
+
+	err := s.char.EquipItem(SlotMainHand, weapons.Handaxe)
+	s.Require().NoError(err)
+
+	s.Assert().Equal(weapons.Handaxe, s.char.equipmentSlots[SlotMainHand])
+	// longsword is no longer equipped anywhere, but remains in inventory
+	for _, id := range s.char.equipmentSlots {
+		s.Assert().NotEqual(weapons.Longsword, id)
+	}
+	found := false
+	for _, invItem := range s.char.inventory {
+		if invItem.Equipment.EquipmentID() == weapons.Longsword {
+			found = true
+		}
+	}
+	s.Assert().True(found, "unequipped item should remain in inventory")
+}

--- a/rulebooks/dnd5e/character/equip_occupancy_test.go
+++ b/rulebooks/dnd5e/character/equip_occupancy_test.go
@@ -136,3 +136,30 @@ func (s *EquipOccupancyTestSuite) TestEquippingOccupiedSlotSwapsOccupant() {
 	}
 	s.Assert().True(found, "unequipped item should remain in inventory")
 }
+
+// TestTwoHandedEquipVacatesStaleSlot is a regression test for a Copilot
+// finding on #812: the two-handed branch's early return used to run
+// before the vacate-old-slot loop, so if EquipmentSlots ever held the
+// same itemID under a stale key OTHER than off_hand (unreachable through
+// EquipItem alone — equipmentFitsSlot only ever lets a two-handed weapon
+// occupy main hand — but possible via corrupted/legacy persisted state,
+// since LoadFromData copies EquipmentSlots verbatim with no validation),
+// that stale mapping would survive equipping the two-hander into main
+// hand, leaving the same item nominally equipped in two slots at once.
+// (A stale off_hand entry specifically doesn't exercise this: the
+// two-handed branch already unconditionally clears off_hand as its own
+// occupancy rule, incidentally masking that case — this uses armor,
+// which nothing in the two-handed branch touches, to isolate the bug.)
+func (s *EquipOccupancyTestSuite) TestTwoHandedEquipVacatesStaleSlot() {
+	// Simulate corrupted/legacy state directly — greatsword already
+	// (invalidly) mapped under armor, as no legitimate EquipItem call
+	// could produce.
+	s.char.equipmentSlots[SlotArmor] = weapons.Greatsword
+
+	err := s.char.EquipItem(SlotMainHand, weapons.Greatsword)
+	s.Require().NoError(err)
+
+	s.Assert().Equal(weapons.Greatsword, s.char.equipmentSlots[SlotMainHand])
+	_, armorSlotStillHoldsIt := s.char.equipmentSlots[SlotArmor]
+	s.Assert().False(armorSlotStillHoldsIt, "stale armor-slot mapping must be vacated, not left duplicated")
+}

--- a/rulebooks/dnd5e/character/equipment_display.go
+++ b/rulebooks/dnd5e/character/equipment_display.go
@@ -1,0 +1,181 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// EquippedItemView is the display projection of one inventory item: its
+// identity, the slot it currently occupies (empty if merely carried), and
+// the server-composed stat_line the web renders verbatim.
+type EquippedItemView struct {
+	ItemID   string
+	Slot     InventorySlot
+	StatLine string
+}
+
+// EquipmentView is the display projection rpg-api needs to serve
+// equipped/inventory items and armor class (rpg-toolkit#811) — every item
+// the character owns, the composed AC total and note. rpg-api passes
+// these through verbatim; it never assembles them from rules data.
+type EquipmentView struct {
+	Items   []EquippedItemView
+	ACTotal int
+	ACNote  string
+}
+
+// EquipmentView composes the display projection for this character's
+// inventory and effective AC: a stat_line per owned item (equipped or
+// carried) plus AC total + note. Consumable by rpg-api with zero rules
+// knowledge.
+func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
+	items := make([]EquippedItemView, 0, len(c.inventory))
+	for _, invItem := range c.inventory {
+		id := invItem.Equipment.EquipmentID()
+		items = append(items, EquippedItemView{
+			ItemID:   id,
+			Slot:     c.equipmentSlots.slotFor(id),
+			StatLine: StatLine(equipment.ResolveEquipmentDetail(id)),
+		})
+	}
+
+	breakdown := c.EffectiveAC(ctx)
+	return &EquipmentView{
+		Items:   items,
+		ACTotal: breakdown.Total,
+		ACNote:  ACNote(breakdown),
+	}
+}
+
+// slotFor returns the slot itemID is equipped in, or "" if it's carried
+// but not equipped.
+func (e EquipmentSlots) slotFor(itemID string) InventorySlot {
+	for slot, id := range e {
+		if id == itemID {
+			return slot
+		}
+	}
+	return ""
+}
+
+// StatLine composes the display line rpg-api passes through and the web
+// renders verbatim (rpg-toolkit#811), e.g. "1d8 slashing · versatile" or
+// "AC 16 · heavy". detail is typically equipment.ResolveEquipmentDetail's
+// output. Returns "" for nil detail or gear with no combat stats (tools,
+// packs, ammunition, misc items) — those have no wire-relevant line today.
+func StatLine(detail *equipment.EquipmentDetail) string {
+	switch {
+	case detail == nil:
+		return ""
+	case detail.Weapon != nil:
+		return weaponStatLine(detail.Weapon)
+	case detail.Armor != nil:
+		return armorStatLine(detail.Armor)
+	default:
+		return ""
+	}
+}
+
+// weaponStatLine composes "{damage} {damage type} · {properties}", e.g.
+// "1d8 slashing · versatile". Thrown weapons carry their range inline
+// ("thrown 20/60"); every other property already reads as its display
+// word (weapons.WeaponProperty values are lowercase, hyphenated where
+// needed — "two-handed", "finesse", etc).
+func weaponStatLine(w *equipment.WeaponDetail) string {
+	line := fmt.Sprintf("%s %s", w.Damage, w.DamageType)
+	if len(w.Properties) == 0 {
+		return line
+	}
+
+	fragments := make([]string, len(w.Properties))
+	for i, prop := range w.Properties {
+		if prop == weapons.PropertyThrown && w.Range != nil {
+			fragments[i] = fmt.Sprintf("thrown %d/%d", w.Range.Normal, w.Range.Long)
+			continue
+		}
+		fragments[i] = string(prop)
+	}
+	return line + " · " + strings.Join(fragments, ", ")
+}
+
+// armorStatLine composes "AC {value} · {category}" for worn armor, or
+// "+{value} AC" for shields (a shield's AC is a bonus, not a base).
+func armorStatLine(a *equipment.ArmorDetail) string {
+	if a.Category == armor.CategoryShield {
+		return fmt.Sprintf("+%d AC", a.BaseAC)
+	}
+	return fmt.Sprintf("AC %d · %s", a.BaseAC, a.Category)
+}
+
+// ACNote composes a human-readable summary of an AC breakdown, e.g.
+// "16 chain mail + 2 shield" or "10 + 2 DEX + 3 (Unarmored Defense)". The
+// breakdown stays the source of truth (rpg-toolkit#811 keeps this a
+// projection over it, not a second source of AC math); this is display
+// only. Returns "" for a nil or empty breakdown.
+func ACNote(breakdown *combat.ACBreakdown) string {
+	if breakdown == nil || len(breakdown.Components) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for i, comp := range breakdown.Components {
+		label := acComponentLabel(comp)
+		switch {
+		case i == 0:
+			fmt.Fprintf(&b, "%d", comp.Value)
+		case comp.Value < 0:
+			fmt.Fprintf(&b, " - %d", -comp.Value)
+		default:
+			fmt.Fprintf(&b, " + %d", comp.Value)
+		}
+		if label != "" {
+			b.WriteString(" " + label)
+		}
+	}
+	return b.String()
+}
+
+// acComponentLabel derives a display label for one AC component from its
+// source ref, so the note reads naturally regardless of what feature,
+// condition, or spell contributed it — no per-source hardcoding needed as
+// new AC sources are added.
+func acComponentLabel(comp combat.ACComponent) string {
+	if comp.Source == nil {
+		return ""
+	}
+	switch comp.Type {
+	case combat.ACSourceArmor, combat.ACSourceShield:
+		return spaceify(comp.Source.ID)
+	case combat.ACSourceAbility:
+		return strings.ToUpper(comp.Source.ID)
+	default:
+		// Feature/spell/item/condition sources: value + a readable label,
+		// e.g. "unarmored_defense" -> "(Unarmored Defense)".
+		return "(" + titleCase(spaceify(comp.Source.ID)) + ")"
+	}
+}
+
+// spaceify turns a ref ID like "chain-mail" or "unarmored_defense" into
+// space-separated words.
+func spaceify(id string) string {
+	id = strings.ReplaceAll(id, "-", " ")
+	return strings.ReplaceAll(id, "_", " ")
+}
+
+// titleCase capitalizes the first letter of each word.
+func titleCase(s string) string {
+	words := strings.Fields(s)
+	for i, w := range words {
+		words[i] = strings.ToUpper(w[:1]) + w[1:]
+	}
+	return strings.Join(words, " ")
+}

--- a/rulebooks/dnd5e/character/equipment_display.go
+++ b/rulebooks/dnd5e/character/equipment_display.go
@@ -6,6 +6,7 @@ package character
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
@@ -25,18 +26,20 @@ type EquippedItemView struct {
 
 // EquipmentView is the display projection rpg-api needs to serve
 // equipped/inventory items and armor class (rpg-toolkit#811) — every item
-// the character owns, the composed AC total and note. rpg-api passes
-// these through verbatim; it never assembles them from rules data.
+// the character owns, the composed AC total and note, and the resolved
+// main-hand damage display (contract §5). rpg-api passes these through
+// verbatim; it never assembles them from rules data.
 type EquipmentView struct {
-	Items   []EquippedItemView
-	ACTotal int
-	ACNote  string
+	Items          []EquippedItemView
+	ACTotal        int
+	ACNote         string
+	MainHandDamage string
 }
 
 // EquipmentView composes the display projection for this character's
 // inventory and effective AC: a stat_line per owned item (equipped or
-// carried) plus AC total + note. Consumable by rpg-api with zero rules
-// knowledge.
+// carried), AC total + note, and the resolved main-hand damage display.
+// Consumable by rpg-api with zero rules knowledge.
 func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
 	items := make([]EquippedItemView, 0, len(c.inventory))
 	for _, invItem := range c.inventory {
@@ -49,11 +52,66 @@ func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
 	}
 
 	breakdown := c.EffectiveAC(ctx)
+	mainHand := c.GetEquippedSlot(SlotMainHand)
 	return &EquipmentView{
-		Items:   items,
-		ACTotal: breakdown.Total,
-		ACNote:  ACNote(breakdown),
+		Items:          items,
+		ACTotal:        breakdown.Total,
+		ACNote:         ACNote(breakdown),
+		MainHandDamage: MainHandDamage(mainHand.AsWeapon(), c.GetEquippedSlot(SlotOffHand)),
 	}
+}
+
+// MainHandDamage composes the resolved main-hand damage display for the
+// given equipped state (rpg-toolkit#811, contract §5): occupancy changes
+// the die. A versatile weapon grips two-handed — its die steps up one
+// notch (e.g. "1d8" -> "1d10") — only when offHand is nil (the off hand
+// is completely empty, not merely holding a shield). Whenever offHand
+// holds a weapon, its damage folds in as a dual-wield fragment, e.g.
+// "1d4 piercing · off-hand 1d4". Returns "" if mainWeapon is nil.
+func MainHandDamage(mainWeapon *weapons.Weapon, offHand *EquippedItem) string {
+	if mainWeapon == nil {
+		return ""
+	}
+
+	damage := mainWeapon.Damage
+	if mainWeapon.HasProperty(weapons.PropertyVersatile) && offHand == nil {
+		damage = versatileTwoHandedDamage(damage)
+	}
+
+	line := fmt.Sprintf("%s %s", damage, mainWeapon.DamageType)
+	if offWeapon := offHand.AsWeapon(); offWeapon != nil {
+		line += fmt.Sprintf(" · off-hand %s", offWeapon.Damage)
+	}
+	return line
+}
+
+// versatileStepUp is the standard 5e versatile-weapon die progression: a
+// versatile weapon's two-handed die is always exactly one step up from
+// its one-handed die on this table (longsword 1d8 -> 1d10, spear 1d6 ->
+// 1d8, etc — no versatile weapon in the ruleset skips a step).
+var versatileStepUp = map[int]int{4: 6, 6: 8, 8: 10, 10: 12}
+
+// versatileTwoHandedDamage steps a "NdM" damage notation's die size up
+// one notch per versatileStepUp, e.g. "1d8" -> "1d10". Returns damage
+// unchanged if it doesn't parse as "NdM" or the size isn't in the table.
+func versatileTwoHandedDamage(damage string) string {
+	parts := strings.SplitN(damage, "d", 2)
+	if len(parts) != 2 {
+		return damage
+	}
+	count, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return damage
+	}
+	size, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return damage
+	}
+	next, ok := versatileStepUp[size]
+	if !ok {
+		return damage
+	}
+	return fmt.Sprintf("%dd%d", count, next)
 }
 
 // slotFor returns the slot itemID is equipped in, or "" if it's carried

--- a/rulebooks/dnd5e/character/equipment_display.go
+++ b/rulebooks/dnd5e/character/equipment_display.go
@@ -41,12 +41,26 @@ type SlotDefView struct {
 	Accepts      []string
 }
 
-// equipSlotTaxonomy is the static slot taxonomy EquipmentView.Slots
-// returns. See SlotDefView's doc for why it's static today.
+// equipSlotTaxonomy is the static slot taxonomy EquipmentView.Slots is
+// cloned from. See SlotDefView's doc for why it's static today.
 var equipSlotTaxonomy = []SlotDefView{
 	{Key: string(SlotMainHand), DisplayLabel: "Main hand", Accepts: []string{"weapon"}},
 	{Key: string(SlotOffHand), DisplayLabel: "Off hand", Accepts: []string{"weapon", "shield"}},
 	{Key: string(SlotArmor), DisplayLabel: "Armor", Accepts: []string{"armor"}},
+}
+
+// cloneSlotTaxonomy deep-copies equipSlotTaxonomy — including each
+// SlotDefView's Accepts slice — so a caller mutating one EquipmentView's
+// Slots can never affect the shared package-level taxonomy (or a
+// concurrent/later EquipmentView call).
+func cloneSlotTaxonomy() []SlotDefView {
+	view := make([]SlotDefView, len(equipSlotTaxonomy))
+	for i, def := range equipSlotTaxonomy {
+		accepts := make([]string, len(def.Accepts))
+		copy(accepts, def.Accepts)
+		view[i] = SlotDefView{Key: def.Key, DisplayLabel: def.DisplayLabel, Accepts: accepts}
+	}
+	return view
 }
 
 // EquipmentView is the display projection rpg-api needs to serve
@@ -87,7 +101,7 @@ func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
 	mainHand := c.GetEquippedSlot(SlotMainHand)
 	return &EquipmentView{
 		Items:          items,
-		Slots:          equipSlotTaxonomy,
+		Slots:          cloneSlotTaxonomy(),
 		ACTotal:        breakdown.Total,
 		ACNote:         ACNote(breakdown),
 		MainHandDamage: MainHandDamage(mainHand.AsWeapon(), c.GetEquippedSlot(SlotOffHand)),

--- a/rulebooks/dnd5e/character/equipment_display.go
+++ b/rulebooks/dnd5e/character/equipment_display.go
@@ -16,36 +16,68 @@ import (
 )
 
 // EquippedItemView is the display projection of one inventory item: its
-// identity, the slot it currently occupies (empty if merely carried), and
-// the server-composed stat_line the web renders verbatim.
+// identity (Name, Kind — "weapon" | "shield" | "armor" | "gear"), the
+// slots it MAY occupy (SlotKeys, from CompatibleSlots), the slot it
+// currently occupies (Slot — empty if merely carried), and the
+// server-composed stat_line the web renders verbatim.
 type EquippedItemView struct {
 	ItemID   string
+	Name     string
+	Kind     string
+	SlotKeys []string
 	Slot     InventorySlot
 	StatLine string
 }
 
+// SlotDefView is one entry in the character's equip-slot taxonomy: which
+// slots exist, their display label, and which item Kinds each accepts.
+// Static for now (main hand / off hand / armor, mirroring
+// rpg-dnd5e-web#557 fixtures.ts's MARTIAL_SLOTS) — a future class- or
+// module-driven taxonomy plugs in here without changing the shape rpg-api
+// consumes.
+type SlotDefView struct {
+	Key          string
+	DisplayLabel string
+	Accepts      []string
+}
+
+// equipSlotTaxonomy is the static slot taxonomy EquipmentView.Slots
+// returns. See SlotDefView's doc for why it's static today.
+var equipSlotTaxonomy = []SlotDefView{
+	{Key: string(SlotMainHand), DisplayLabel: "Main hand", Accepts: []string{"weapon"}},
+	{Key: string(SlotOffHand), DisplayLabel: "Off hand", Accepts: []string{"weapon", "shield"}},
+	{Key: string(SlotArmor), DisplayLabel: "Armor", Accepts: []string{"armor"}},
+}
+
 // EquipmentView is the display projection rpg-api needs to serve
 // equipped/inventory items and armor class (rpg-toolkit#811) — every item
-// the character owns, the composed AC total and note, and the resolved
-// main-hand damage display (contract §5). rpg-api passes these through
-// verbatim; it never assembles them from rules data.
+// the character owns, the slot taxonomy, the composed AC total and note,
+// and the resolved main-hand damage display (contract §5). This is THE
+// single projection rpg-api maps to the wire CharacterData: every display
+// field comes from here, composed with zero rules knowledge required
+// upstream.
 type EquipmentView struct {
 	Items          []EquippedItemView
+	Slots          []SlotDefView
 	ACTotal        int
 	ACNote         string
 	MainHandDamage string
 }
 
 // EquipmentView composes the display projection for this character's
-// inventory and effective AC: a stat_line per owned item (equipped or
-// carried), AC total + note, and the resolved main-hand damage display.
-// Consumable by rpg-api with zero rules knowledge.
+// inventory and effective AC: identity + SlotKeys + stat_line per owned
+// item (equipped or carried), the slot taxonomy, AC total + note, and the
+// resolved main-hand damage display. Consumable by rpg-api with zero
+// rules knowledge.
 func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
 	items := make([]EquippedItemView, 0, len(c.inventory))
 	for _, invItem := range c.inventory {
 		id := invItem.Equipment.EquipmentID()
 		items = append(items, EquippedItemView{
 			ItemID:   id,
+			Name:     invItem.Equipment.EquipmentName(),
+			Kind:     itemKind(invItem.Equipment),
+			SlotKeys: slotKeys(CompatibleSlots(invItem.Equipment)),
 			Slot:     c.equipmentSlots.slotFor(id),
 			StatLine: StatLine(equipment.ResolveEquipmentDetail(id)),
 		})
@@ -55,10 +87,25 @@ func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
 	mainHand := c.GetEquippedSlot(SlotMainHand)
 	return &EquipmentView{
 		Items:          items,
+		Slots:          equipSlotTaxonomy,
 		ACTotal:        breakdown.Total,
 		ACNote:         ACNote(breakdown),
 		MainHandDamage: MainHandDamage(mainHand.AsWeapon(), c.GetEquippedSlot(SlotOffHand)),
 	}
+}
+
+// slotKeys converts CompatibleSlots' typed InventorySlots into the plain
+// strings EquippedItemView.SlotKeys carries. Returns nil for no
+// compatible slots (slotless gear).
+func slotKeys(slots []InventorySlot) []string {
+	if len(slots) == 0 {
+		return nil
+	}
+	keys := make([]string, len(slots))
+	for i, s := range slots {
+		keys[i] = string(s)
+	}
+	return keys
 }
 
 // MainHandDamage composes the resolved main-hand damage display for the

--- a/rulebooks/dnd5e/character/equipment_display_test.go
+++ b/rulebooks/dnd5e/character/equipment_display_test.go
@@ -178,6 +178,9 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView() {
 	s.Require().NotNil(view)
 	s.Assert().Equal(18, view.ACTotal)
 	s.Assert().Equal("16 chain mail + 2 shield", view.ACNote)
+	// shield occupies off hand, so the versatile longsword is gripped
+	// one-handed: its base die, not the versatile two-handed upgrade.
+	s.Assert().Equal("1d8 slashing", view.MainHandDamage)
 	s.Require().Len(view.Items, 3)
 
 	byID := make(map[string]EquippedItemView, len(view.Items))
@@ -212,4 +215,80 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView_CarriedItemHasNoSlot() {
 	s.Require().Len(view.Items, 1)
 	s.Assert().Equal(InventorySlot(""), view.Items[0].Slot)
 	s.Assert().Equal("1d6 slashing · light, thrown 20/60", view.Items[0].StatLine)
+}
+
+// TestEquipmentView_VersatileFreeOffHand proves a versatile weapon grips
+// two-handed (upgraded die) when the off hand is completely empty — the
+// occupancy-dependent half of contract §5's main_hand_damage.
+func (s *EquipmentDisplayTestSuite) TestEquipmentView_VersatileFreeOffHand() {
+	longsword := weapons.All[weapons.Longsword]
+
+	char := &Character{
+		id:            "char-3",
+		bus:           s.bus,
+		abilityScores: shared.AbilityScores{abilities.DEX: 10},
+		inventory:     []InventoryItem{{Equipment: &longsword, Quantity: 1}},
+		equipmentSlots: EquipmentSlots{
+			SlotMainHand: "longsword",
+		},
+	}
+
+	view := char.EquipmentView(s.ctx)
+	s.Assert().Equal("1d10 slashing", view.MainHandDamage)
+}
+
+// TestEquipmentView_DualWield proves dual-wielding folds the off-hand
+// weapon's die into the display, e.g. "1d4 piercing · off-hand 1d4".
+func (s *EquipmentDisplayTestSuite) TestEquipmentView_DualWield() {
+	// Two distinct inventory entries of the same weapon type need distinct
+	// IDs (EquipmentID() would otherwise collide and both slots would
+	// resolve to the same inventory item). weapons.All returns copies, so
+	// mutating the ID on each copy is safe — the registry is untouched.
+	daggerMain := weapons.All[weapons.Dagger]
+	daggerMain.ID = "dagger-main"
+	daggerOff := weapons.All[weapons.Dagger]
+	daggerOff.ID = "dagger-off"
+
+	char := &Character{
+		id:            "char-4",
+		bus:           s.bus,
+		abilityScores: shared.AbilityScores{abilities.DEX: 10},
+		inventory: []InventoryItem{
+			{Equipment: &daggerMain, Quantity: 1},
+			{Equipment: &daggerOff, Quantity: 1},
+		},
+		equipmentSlots: EquipmentSlots{
+			SlotMainHand: "dagger-main",
+			SlotOffHand:  "dagger-off",
+		},
+	}
+
+	view := char.EquipmentView(s.ctx)
+	s.Assert().Equal("1d4 piercing · off-hand 1d4", view.MainHandDamage)
+}
+
+func (s *EquipmentDisplayTestSuite) TestMainHandDamage() {
+	longsword := weapons.All[weapons.Longsword]
+	greatsword := weapons.All[weapons.Greatsword]
+	dagger := weapons.All[weapons.Dagger]
+	shield := armor.All[armor.Shield]
+
+	testCases := []struct {
+		name       string
+		mainWeapon *weapons.Weapon
+		offHand    *EquippedItem
+		expected   string
+	}{
+		{"no main-hand weapon", nil, nil, ""},
+		{"versatile, off hand free", &longsword, nil, "1d10 slashing"},
+		{"versatile, shield in off hand", &longsword, &EquippedItem{Item: &shield}, "1d8 slashing"},
+		{"two-handed weapon, off hand free", &greatsword, nil, "2d6 slashing"},
+		{"dual-wield, non-versatile", &dagger, &EquippedItem{Item: &dagger}, "1d4 piercing · off-hand 1d4"},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.Assert().Equal(tc.expected, MainHandDamage(tc.mainWeapon, tc.offHand))
+		})
+	}
 }

--- a/rulebooks/dnd5e/character/equipment_display_test.go
+++ b/rulebooks/dnd5e/character/equipment_display_test.go
@@ -1,0 +1,215 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/items"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// EquipmentDisplayTestSuite covers the display projection (rpg-toolkit#811):
+// StatLine composed from equipment.ResolveEquipmentDetail, ACNote composed
+// from combat.ACBreakdown, and the EquipmentView accessor that gives
+// rpg-api both with zero rules knowledge.
+type EquipmentDisplayTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	bus events.EventBus
+}
+
+func (s *EquipmentDisplayTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+func TestEquipmentDisplaySuite(t *testing.T) {
+	suite.Run(t, new(EquipmentDisplayTestSuite))
+}
+
+func (s *EquipmentDisplayTestSuite) TestStatLine() {
+	testCases := []struct {
+		name     string
+		id       shared.EquipmentID
+		expected string
+	}{
+		{"versatile weapon", weapons.Longsword, "1d8 slashing · versatile"},
+		{"two-handed weapon", weapons.Greatsword, "2d6 slashing · heavy, two-handed"},
+		{"thrown weapon with range", weapons.Handaxe, "1d6 slashing · light, thrown 20/60"},
+		{"finesse light thrown weapon", weapons.Dagger, "1d4 piercing · finesse, light, thrown 20/60"},
+		{"heavy armor, no dex bonus", armor.ChainMail, "AC 16 · heavy"},
+		{"light armor", armor.Leather, "AC 11 · light"},
+		{"shield", armor.Shield, "+2 AC"},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			detail := equipment.ResolveEquipmentDetail(tc.id)
+			s.Require().NotNil(detail)
+			s.Assert().Equal(tc.expected, StatLine(detail))
+		})
+	}
+}
+
+func (s *EquipmentDisplayTestSuite) TestStatLine_Nil() {
+	s.Assert().Equal("", StatLine(nil))
+}
+
+func (s *EquipmentDisplayTestSuite) TestStatLine_GearHasNoCombatStatLine() {
+	detail := equipment.ResolveEquipmentDetail(items.ComponentPouch)
+	s.Require().NotNil(detail)
+	s.Assert().Equal("", StatLine(detail))
+}
+
+func (s *EquipmentDisplayTestSuite) TestACNote() {
+	dexRef := refs.Abilities.Dexterity()
+	unarmoredDefenseRef := refs.Conditions.UnarmoredDefense()
+	armorRef := func(id shared.EquipmentID) *core.Ref {
+		return &core.Ref{Module: refs.Module, Type: "armor", ID: id}
+	}
+
+	testCases := []struct {
+		name       string
+		components []combat.ACComponent
+		expected   string
+	}{
+		{
+			name: "armor plus shield, no dex bonus",
+			components: []combat.ACComponent{
+				{Type: combat.ACSourceArmor, Source: armorRef(armor.ChainMail), Value: 16},
+				{Type: combat.ACSourceShield, Source: armorRef(armor.Shield), Value: 2},
+			},
+			expected: "16 chain mail + 2 shield",
+		},
+		{
+			name: "light armor plus dex",
+			components: []combat.ACComponent{
+				{Type: combat.ACSourceArmor, Source: armorRef(armor.Leather), Value: 11},
+				{Type: combat.ACSourceAbility, Source: dexRef, Value: 3},
+			},
+			expected: "11 leather + 3 DEX",
+		},
+		{
+			name: "unarmored, no dex bonus",
+			components: []combat.ACComponent{
+				{Type: combat.ACSourceBase, Source: nil, Value: 10},
+			},
+			expected: "10",
+		},
+		{
+			name: "unarmored with dex",
+			components: []combat.ACComponent{
+				{Type: combat.ACSourceBase, Source: nil, Value: 10},
+				{Type: combat.ACSourceAbility, Source: dexRef, Value: 2},
+			},
+			expected: "10 + 2 DEX",
+		},
+		{
+			name: "negative dex modifier",
+			components: []combat.ACComponent{
+				{Type: combat.ACSourceArmor, Source: armorRef(armor.Leather), Value: 11},
+				{Type: combat.ACSourceAbility, Source: dexRef, Value: -1},
+			},
+			expected: "11 leather - 1 DEX",
+		},
+		{
+			name: "unarmored defense feature component",
+			components: []combat.ACComponent{
+				{Type: combat.ACSourceBase, Source: nil, Value: 10},
+				{Type: combat.ACSourceAbility, Source: dexRef, Value: 2},
+				{Type: combat.ACSourceFeature, Source: unarmoredDefenseRef, Value: 3},
+			},
+			expected: "10 + 2 DEX + 3 (Unarmored Defense)",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			breakdown := &combat.ACBreakdown{Components: tc.components}
+			s.Assert().Equal(tc.expected, ACNote(breakdown))
+		})
+	}
+}
+
+func (s *EquipmentDisplayTestSuite) TestACNote_NilOrEmpty() {
+	s.Assert().Equal("", ACNote(nil))
+	s.Assert().Equal("", ACNote(&combat.ACBreakdown{}))
+}
+
+// TestEquipmentView proves the full wiring: a real character's equipped
+// gear projects into items with composed stat_line, plus AC total + note
+// derived from EffectiveAC — the shape rpg-api consumes with zero rules
+// knowledge.
+func (s *EquipmentDisplayTestSuite) TestEquipmentView() {
+	chainMail := armor.All[armor.ChainMail]
+	shield := armor.All[armor.Shield]
+	longsword := weapons.All[weapons.Longsword]
+
+	char := &Character{
+		id:            "char-1",
+		bus:           s.bus,
+		abilityScores: shared.AbilityScores{abilities.DEX: 10}, // +0 mod
+		inventory: []InventoryItem{
+			{Equipment: &chainMail, Quantity: 1},
+			{Equipment: &shield, Quantity: 1},
+			{Equipment: &longsword, Quantity: 1},
+		},
+		equipmentSlots: EquipmentSlots{
+			SlotArmor:    armor.ChainMail,
+			SlotOffHand:  armor.Shield,
+			SlotMainHand: "longsword",
+		},
+	}
+
+	view := char.EquipmentView(s.ctx)
+	s.Require().NotNil(view)
+	s.Assert().Equal(18, view.ACTotal)
+	s.Assert().Equal("16 chain mail + 2 shield", view.ACNote)
+	s.Require().Len(view.Items, 3)
+
+	byID := make(map[string]EquippedItemView, len(view.Items))
+	for _, it := range view.Items {
+		byID[it.ItemID] = it
+	}
+
+	s.Assert().Equal(SlotArmor, byID[armor.ChainMail].Slot)
+	s.Assert().Equal("AC 16 · heavy", byID[armor.ChainMail].StatLine)
+
+	s.Assert().Equal(SlotOffHand, byID[armor.Shield].Slot)
+	s.Assert().Equal("+2 AC", byID[armor.Shield].StatLine)
+
+	s.Assert().Equal(InventorySlot(SlotMainHand), byID["longsword"].Slot)
+	s.Assert().Equal("1d8 slashing · versatile", byID["longsword"].StatLine)
+}
+
+// TestEquipmentView_CarriedItemHasNoSlot proves inventory items that
+// aren't equipped are still listed, just with an empty Slot.
+func (s *EquipmentDisplayTestSuite) TestEquipmentView_CarriedItemHasNoSlot() {
+	handaxe := weapons.All[weapons.Handaxe]
+
+	char := &Character{
+		id:             "char-2",
+		bus:            s.bus,
+		abilityScores:  shared.AbilityScores{abilities.DEX: 10},
+		inventory:      []InventoryItem{{Equipment: &handaxe, Quantity: 1}},
+		equipmentSlots: make(EquipmentSlots),
+	}
+
+	view := char.EquipmentView(s.ctx)
+	s.Require().Len(view.Items, 1)
+	s.Assert().Equal(InventorySlot(""), view.Items[0].Slot)
+	s.Assert().Equal("1d6 slashing · light, thrown 20/60", view.Items[0].StatLine)
+}

--- a/rulebooks/dnd5e/character/equipment_display_test.go
+++ b/rulebooks/dnd5e/character/equipment_display_test.go
@@ -214,6 +214,34 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView() {
 	}, view.Slots)
 }
 
+// TestEquipmentView_SlotsIsDefensiveCopy proves Slots (and each
+// SlotDefView.Accepts) is a copy, not a reference into the shared
+// package-level taxonomy — mutating one view's Slots must not leak into
+// a later EquipmentView call (Copilot finding on #812: returning the
+// shared slice/nested slices directly risked exactly this).
+func (s *EquipmentDisplayTestSuite) TestEquipmentView_SlotsIsDefensiveCopy() {
+	char := &Character{
+		id:             "char-6",
+		bus:            s.bus,
+		abilityScores:  shared.AbilityScores{abilities.DEX: 10},
+		inventory:      []InventoryItem{},
+		equipmentSlots: make(EquipmentSlots),
+	}
+
+	first := char.EquipmentView(s.ctx)
+	first.Slots[0].Accepts[0] = "MUTATED"
+	first.Slots = append(first.Slots, SlotDefView{Key: "mutated_slot"})
+
+	second := char.EquipmentView(s.ctx)
+	s.Require().Len(second.Slots, 3)
+	s.Assert().Equal("weapon", second.Slots[0].Accepts[0])
+	s.Assert().Equal([]SlotDefView{
+		{Key: "main_hand", DisplayLabel: "Main hand", Accepts: []string{"weapon"}},
+		{Key: "off_hand", DisplayLabel: "Off hand", Accepts: []string{"weapon", "shield"}},
+		{Key: "armor", DisplayLabel: "Armor", Accepts: []string{"armor"}},
+	}, second.Slots)
+}
+
 // TestEquipmentView_CarriedItemHasNoSlot proves inventory items that
 // aren't equipped are still listed, just with an empty Slot.
 func (s *EquipmentDisplayTestSuite) TestEquipmentView_CarriedItemHasNoSlot() {

--- a/rulebooks/dnd5e/character/equipment_display_test.go
+++ b/rulebooks/dnd5e/character/equipment_display_test.go
@@ -190,12 +190,28 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView() {
 
 	s.Assert().Equal(SlotArmor, byID[armor.ChainMail].Slot)
 	s.Assert().Equal("AC 16 · heavy", byID[armor.ChainMail].StatLine)
+	s.Assert().Equal("Chain Mail", byID[armor.ChainMail].Name)
+	s.Assert().Equal("armor", byID[armor.ChainMail].Kind)
+	s.Assert().Equal([]string{"armor"}, byID[armor.ChainMail].SlotKeys)
 
 	s.Assert().Equal(SlotOffHand, byID[armor.Shield].Slot)
 	s.Assert().Equal("+2 AC", byID[armor.Shield].StatLine)
+	s.Assert().Equal("Shield", byID[armor.Shield].Name)
+	s.Assert().Equal("shield", byID[armor.Shield].Kind)
+	s.Assert().Equal([]string{"off_hand"}, byID[armor.Shield].SlotKeys)
 
 	s.Assert().Equal(InventorySlot(SlotMainHand), byID["longsword"].Slot)
 	s.Assert().Equal("1d8 slashing · versatile", byID["longsword"].StatLine)
+	s.Assert().Equal("Longsword", byID["longsword"].Name)
+	s.Assert().Equal("weapon", byID["longsword"].Kind)
+	s.Assert().Equal([]string{"main_hand", "off_hand"}, byID["longsword"].SlotKeys)
+
+	s.Require().Len(view.Slots, 3)
+	s.Assert().Equal([]SlotDefView{
+		{Key: "main_hand", DisplayLabel: "Main hand", Accepts: []string{"weapon"}},
+		{Key: "off_hand", DisplayLabel: "Off hand", Accepts: []string{"weapon", "shield"}},
+		{Key: "armor", DisplayLabel: "Armor", Accepts: []string{"armor"}},
+	}, view.Slots)
 }
 
 // TestEquipmentView_CarriedItemHasNoSlot proves inventory items that
@@ -215,6 +231,29 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView_CarriedItemHasNoSlot() {
 	s.Require().Len(view.Items, 1)
 	s.Assert().Equal(InventorySlot(""), view.Items[0].Slot)
 	s.Assert().Equal("1d6 slashing · light, thrown 20/60", view.Items[0].StatLine)
+	s.Assert().Equal("Handaxe", view.Items[0].Name)
+	s.Assert().Equal("weapon", view.Items[0].Kind)
+	s.Assert().Equal([]string{"main_hand", "off_hand"}, view.Items[0].SlotKeys)
+}
+
+// TestEquipmentView_SlotlessGear proves gear with no combat-relevant slot
+// projects with an empty SlotKeys and Kind "gear".
+func (s *EquipmentDisplayTestSuite) TestEquipmentView_SlotlessGear() {
+	pouch := items.All[items.ComponentPouch]
+
+	char := &Character{
+		id:             "char-5",
+		bus:            s.bus,
+		abilityScores:  shared.AbilityScores{abilities.DEX: 10},
+		inventory:      []InventoryItem{{Equipment: &pouch, Quantity: 1}},
+		equipmentSlots: make(EquipmentSlots),
+	}
+
+	view := char.EquipmentView(s.ctx)
+	s.Require().Len(view.Items, 1)
+	s.Assert().Equal("gear", view.Items[0].Kind)
+	s.Assert().Nil(view.Items[0].SlotKeys)
+	s.Assert().Equal("", view.Items[0].StatLine)
 }
 
 // TestEquipmentView_VersatileFreeOffHand proves a versatile weapon grips

--- a/rulebooks/dnd5e/character/equipment_slots.go
+++ b/rulebooks/dnd5e/character/equipment_slots.go
@@ -76,7 +76,7 @@ func CompatibleSlots(item equipment.Equipment) []InventorySlot {
 		}
 		return []InventorySlot{SlotMainHand, SlotOffHand}
 	case *armor.Armor:
-		if it.Category == shieldCategory {
+		if it.Category == armor.CategoryShield {
 			return []InventorySlot{SlotOffHand}
 		}
 		return []InventorySlot{SlotArmor}
@@ -110,7 +110,7 @@ func itemKind(item equipment.Equipment) string {
 	case *weapons.Weapon:
 		return "weapon"
 	case *armor.Armor:
-		if it.Category == shieldCategory {
+		if it.Category == armor.CategoryShield {
 			return "shield"
 		}
 		return "armor"

--- a/rulebooks/dnd5e/character/equipment_slots.go
+++ b/rulebooks/dnd5e/character/equipment_slots.go
@@ -59,31 +59,62 @@ func (e *EquippedItem) AsWeapon() *weapons.Weapon {
 	return w
 }
 
-// equipmentFitsSlot reports whether item may be equipped into slot. Ported
-// from the occupancy semantics in rpg-dnd5e-web#557
+// CompatibleSlots returns every InventorySlot item may be equipped into —
+// the single source of truth for slot compatibility, ported from the
+// occupancy semantics in rpg-dnd5e-web#557
 // src/concepts/equipment/fixtures.ts (applyIntent/targetSlotFor): weapons
 // fit main or off hand, two-handed weapons fit main hand only, shields fit
 // off hand, other armor fits the armor slot, and everything else (tools,
 // packs, ammunition, misc gear) has no combat-relevant slot today.
-func equipmentFitsSlot(item equipment.Equipment, slot InventorySlot) bool {
+// EquipItem validates against this, and EquipmentView projects it as each
+// item's SlotKeys — rpg-api must not reconstruct this rule itself.
+func CompatibleSlots(item equipment.Equipment) []InventorySlot {
 	switch it := item.(type) {
 	case *weapons.Weapon:
 		if it.HasProperty(weapons.PropertyTwoHanded) {
-			return slot == SlotMainHand
+			return []InventorySlot{SlotMainHand}
 		}
-		return slot == SlotMainHand || slot == SlotOffHand
+		return []InventorySlot{SlotMainHand, SlotOffHand}
 	case *armor.Armor:
 		if it.Category == shieldCategory {
-			return slot == SlotOffHand
+			return []InventorySlot{SlotOffHand}
 		}
-		return slot == SlotArmor
+		return []InventorySlot{SlotArmor}
 	default:
-		return false
+		return nil
 	}
+}
+
+// equipmentFitsSlot reports whether item may be equipped into slot —
+// membership in CompatibleSlots(item).
+func equipmentFitsSlot(item equipment.Equipment, slot InventorySlot) bool {
+	for _, s := range CompatibleSlots(item) {
+		if s == slot {
+			return true
+		}
+	}
+	return false
 }
 
 // isTwoHanded reports whether item is a weapon with the two-handed property.
 func isTwoHanded(item equipment.Equipment) bool {
 	w, ok := item.(*weapons.Weapon)
 	return ok && w.HasProperty(weapons.PropertyTwoHanded)
+}
+
+// itemKind classifies item into the display vocabulary EquippedItemView
+// uses ("weapon" | "shield" | "armor" | "gear"), mirroring
+// rpg-dnd5e-web#557 fixtures.ts's ItemFixture.kind.
+func itemKind(item equipment.Equipment) string {
+	switch it := item.(type) {
+	case *weapons.Weapon:
+		return "weapon"
+	case *armor.Armor:
+		if it.Category == shieldCategory {
+			return "shield"
+		}
+		return "armor"
+	default:
+		return "gear"
+	}
 }

--- a/rulebooks/dnd5e/character/equipment_slots.go
+++ b/rulebooks/dnd5e/character/equipment_slots.go
@@ -58,3 +58,32 @@ func (e *EquippedItem) AsWeapon() *weapons.Weapon {
 	w, _ := e.Item.(*weapons.Weapon)
 	return w
 }
+
+// equipmentFitsSlot reports whether item may be equipped into slot. Ported
+// from the occupancy semantics in rpg-dnd5e-web#557
+// src/concepts/equipment/fixtures.ts (applyIntent/targetSlotFor): weapons
+// fit main or off hand, two-handed weapons fit main hand only, shields fit
+// off hand, other armor fits the armor slot, and everything else (tools,
+// packs, ammunition, misc gear) has no combat-relevant slot today.
+func equipmentFitsSlot(item equipment.Equipment, slot InventorySlot) bool {
+	switch it := item.(type) {
+	case *weapons.Weapon:
+		if it.HasProperty(weapons.PropertyTwoHanded) {
+			return slot == SlotMainHand
+		}
+		return slot == SlotMainHand || slot == SlotOffHand
+	case *armor.Armor:
+		if it.Category == shieldCategory {
+			return slot == SlotOffHand
+		}
+		return slot == SlotArmor
+	default:
+		return false
+	}
+}
+
+// isTwoHanded reports whether item is a weapon with the two-handed property.
+func isTwoHanded(item equipment.Equipment) bool {
+	w, ok := item.(*weapons.Weapon)
+	return ok && w.HasProperty(weapons.PropertyTwoHanded)
+}

--- a/rulebooks/dnd5e/character/equipment_slots_display_test.go
+++ b/rulebooks/dnd5e/character/equipment_slots_display_test.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/items"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// CompatibleSlotsTestSuite covers CompatibleSlots — the exported, single
+// source of truth for slot compatibility that EquipItem validates against
+// and EquipmentView projects as each item's SlotKeys (rpg-toolkit#811).
+type CompatibleSlotsTestSuite struct {
+	suite.Suite
+}
+
+func TestCompatibleSlotsSuite(t *testing.T) {
+	suite.Run(t, new(CompatibleSlotsTestSuite))
+}
+
+func (s *CompatibleSlotsTestSuite) TestCompatibleSlots() {
+	greatsword := weapons.All[weapons.Greatsword]
+	dagger := weapons.All[weapons.Dagger]
+	shield := armor.All[armor.Shield]
+	chainMail := armor.All[armor.ChainMail]
+	componentPouch := items.All[items.ComponentPouch]
+
+	testCases := []struct {
+		name     string
+		item     equipment.Equipment
+		expected []InventorySlot
+	}{
+		{"two-handed weapon", &greatsword, []InventorySlot{SlotMainHand}},
+		{"one-handed weapon", &dagger, []InventorySlot{SlotMainHand, SlotOffHand}},
+		{"shield", &shield, []InventorySlot{SlotOffHand}},
+		{"armor", &chainMail, []InventorySlot{SlotArmor}},
+		{"slotless gear", &componentPouch, nil},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.Assert().Equal(tc.expected, CompatibleSlots(tc.item))
+		})
+	}
+}
+
+func (s *CompatibleSlotsTestSuite) TestItemKind() {
+	greatsword := weapons.All[weapons.Greatsword]
+	shield := armor.All[armor.Shield]
+	chainMail := armor.All[armor.ChainMail]
+	componentPouch := items.All[items.ComponentPouch]
+
+	testCases := []struct {
+		name     string
+		item     equipment.Equipment
+		expected string
+	}{
+		{"weapon", &greatsword, "weapon"},
+		{"shield", &shield, "shield"},
+		{"armor", &chainMail, "armor"},
+		{"gear", &componentPouch, "gear"},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.Assert().Equal(tc.expected, itemKind(tc.item))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Toolkit half of the "equipment on the wire" slice (rpg-project#94). Two things had no home
before this PR — both now compose in the toolkit, per the boundary this slice draws
(rules compose here, rpg-api passes through, web renders verbatim):

1. **Two-handed occupancy in `Character.EquipItem`** — was a bare `equipmentSlots.Set` with no
   hand-occupancy enforcement. Now: a two-handed weapon claims main hand and clears off hand;
   equipping into off hand while a two-hander is held frees main hand; equipping an incompatible
   slot errors instead of silently corrupting state; moving an equipped item vacates its old slot.
   Ported (TDD, red before green) from rpg-dnd5e-web#557 `fixtures.test.ts`'s `applyIntent`
   describe block — the fixture reducer's semantics are the acceptance spec.

2. **A display projection** (new `equipment_display.go`):
   - `StatLine(*equipment.EquipmentDetail) string` — e.g. `"1d8 slashing · versatile"`,
     `"AC 16 · heavy"`, `"+2 AC"` for shields.
   - `ACNote(*combat.ACBreakdown) string` — e.g. `"16 chain mail + 2 shield"`,
     `"10 + 2 DEX + 3 (Unarmored Defense)"`. Generic over component `Type`/`Source`/`Value`, so
     new AC sources label themselves automatically — no per-feature hardcoding. Gave
     `EffectiveAC`'s DEX components a real `Source` ref (`refs.Abilities.Dexterity()`) instead of
     `nil` so the note can label them (verified no existing test asserted the old `nil`).
   - `(*Character).EquipmentView(ctx) *EquipmentView` — the single accessor rpg-api needs: every
     owned item with its slot + `stat_line`, AC total + note, and the resolved main-hand damage
     display. Zero rules knowledge required upstream.

3. **Resolved main-hand damage** (`MainHandDamage`, added after the protos gate flagged
   rpg-api-protos#187 §5 / CONTRACT §5 as unhomed): occupancy-dependent rules output, so it
   composes here too, not as a static stat_line. `MainHandDamage(mainWeapon, offHand) string` —
   one-handed die by default; a versatile weapon steps its die up one notch
   (`versatileStepUp`: 4→6→8→10→12) only when the off hand is completely empty (a shield or
   another weapon there forces the one-handed grip); a weapon in the off hand folds in as
   `" · off-hand {die}"`. Wired into `EquipmentView.MainHandDamage`.

4. **`EquipmentView` as the single wire projection** (a second gap from the api integration gate):
   exported the occupancy rule as `CompatibleSlots(item) []InventorySlot` — the single source of
   truth `EquipItem` validates against AND `EquipmentView` projects as each item's `SlotKeys`
   (`equipmentFitsSlot` is now defined in terms of it, not a second copy of the type switch). Added
   `itemKind(item) string` (`"weapon"|"shield"|"armor"|"gear"`, matching fixtures.ts's
   `ItemFixture.kind`). `EquippedItemView` gained `Name` and `Kind` per item; `EquipmentView`
   gained `Slots []SlotDefView` — a static slot taxonomy (`main_hand`/`off_hand`/`armor` with
   `DisplayLabel` + `Accepts`) mirroring fixtures.ts's `MARTIAL_SLOTS`. `EquipmentView` is now a
   1:1 source for every wire display field on `CharacterData`.

## Scope-decisions

- Ported the 6 `EquipItem`-relevant behaviors from `fixtures.test.ts`. The file's other 3 tests
  (`targetSlotFor` describe block) cover client-side click-targeting — deciding which `slot_key`
  an equip click should send, computed from wire data (`Item.slot_keys ∩ SlotDef.accepts`, no
  rules knowledge) — not a state-mutating rule. No toolkit equivalent added; **settled** with the
  wave lead: `targetSlotFor` stays web-side, the approved concept's intent log already sends an
  explicit `slot` (`EquipItem { ref, slot: "main_hand" }`), and `EquipItem` enforces
  occupancy/swap once that slot arrives. 6 ported (state-mutating) + 3 not-ported (client
  convenience) is the intended split, not a gap.
- `StatLine` lists every weapon property from the real weapons registry (not a curated subset),
  so it diverges cosmetically in a couple of spots from web#557's hand-authored fixture strings
  (e.g. greatsword shows `"heavy, two-handed"` not just `"two-handed"`; handaxe shows
  `"light, thrown 20/60"` not just `"thrown 20/60"`) — happy to curate further if design wants a
  shorter list.
- Encumbrance, quantity/stacking, proficiency effects on equip, creation-time loadout, and
  in-combat action-economy cost of equipping are all explicitly out of scope, per rpg-project#94.
- `versatileStepUp`'s 4→6→8→10→12 table is a hardcoded standard-5e-rule constant (same pattern as
  `conditions/martial_arts.go`'s monk-level dice table), not derived from weapon data — there's no
  per-weapon "two-handed die" field in the registry today. Checked first: confirmed nothing
  existing (weapon_selection.go, actions/, combat/) already resolves this.
- `CompatibleSlots`/`SlotDefView.Key`/`EquippedItemView.SlotKeys` use plain `string`/`[]string`
  (not `InventorySlot`) per the wave lead's spec — these are new fields meant to mirror the wire
  shape 1:1. The existing `EquippedItemView.Slot` field (already integrated by rpg-api) keeps its
  original `InventorySlot` type; changing it now would break an existing consumer.
- The slot taxonomy (`Slots`) is a static var today (main_hand/off_hand/armor), not
  class/module-derived — matches the wave lead's explicit "static default is fine for now."

## Load-bearing digest

- AC note lives in `equipment_display.go`'s `ACNote(*combat.ACBreakdown) string`, generic over
  component `Type`/`Source` — extend by giving new AC sources a real `*core.Ref`, not by touching
  this function.
- `stat_line` composer is `equipment_display.go`'s `StatLine(*equipment.EquipmentDetail) string`.
- Main-hand damage composer is `equipment_display.go`'s
  `MainHandDamage(*weapons.Weapon, *EquippedItem) string`.
- Slot-compatibility source of truth is `equipment_slots.go`'s
  `CompatibleSlots(item equipment.Equipment) []InventorySlot` — extend by editing its type switch,
  not by touching `EquipItem` or `EquipmentView` separately.
- rpg-api's accessor: `(*Character).EquipmentView(ctx) *EquipmentView`, giving
  `[]EquippedItemView{ItemID, Name, Kind, SlotKeys, Slot, StatLine}` + `Slots []SlotDefView{Key,
  DisplayLabel, Accepts}` + `ACTotal` + `ACNote` + `MainHandDamage`.

## Test plan

- [x] TDD throughout: wrote the 6 occupancy tests, display-projection tests, `MainHandDamage`'s 5
      table-driven cases, and `CompatibleSlots`/`itemKind` table tests first, watched each set
      fail against current behavior, then implemented.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean for `rulebooks/dnd5e`
- [x] `golangci-lint run ./character/...` — 0 issues
- [x] `go test -race ./character/... ./combat/... ./conditions/... ./equipment/... ./weapons/...` — all green
- [x] `go test ./...` (full `rulebooks/dnd5e` module) — all green
- [x] `go mod tidy` — no diff
- [ ] Copilot review
- [ ] Kirk review/merge

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHGGBCWA47czyYBHy6UTuG
