### PR TITLE
feat(dnd5e): skeleton captain crypt boss stat block (#816)

### DIFF
--- a/rulebooks/dnd5e/monster/monsters/skeleton_captain.go
+++ b/rulebooks/dnd5e/monster/monsters/skeleton_captain.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monsters
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// NewSkeletonCaptain creates a CR 2 skeleton captain boss with multiattack
+// (2x longsword), vulnerability to bludgeoning, and immunity to poison.
+//
+// This is a skeleton-shaped boss, not a wight: a wight's signature Life Drain
+// ability needs a max-HP-reducing attack effect that does not exist in the
+// toolkit today (monstertraits/loader.go only knows immunity, vulnerability,
+// pack_tactics, and undead_fortitude - and undead_fortitude itself is not
+// wired into any HP-clamp path yet). Shipping a wight without Life Drain
+// would just be this captain wearing a different name, so the boss stays a
+// stat-line upgrade of the existing Skeleton archetype instead.
+func NewSkeletonCaptain(id string) *monster.Monster {
+	m := monster.New(monster.Config{
+		ID:   id,
+		Name: "Skeleton Captain",
+		Ref:  refs.Monsters.SkeletonCaptain(),
+		HP:   45, // 6d8+18
+		AC:   16, // Chain shirt + shield
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, // +3
+			abilities.DEX: 14, // +2
+			abilities.CON: 16, // +3
+			abilities.INT: 6,  // -2
+			abilities.WIS: 8,  // -1
+			abilities.CHA: 5,  // -3
+		},
+	})
+
+	// Longsword attack (part of multiattack)
+	m.AddAction(actions.NewMeleeAction(actions.MeleeConfig{
+		Name:        "longsword",
+		AttackBonus: 5,       // +3 STR + 2 proficiency
+		DamageDice:  "1d8+3", // 1d8 + STR
+		Reach:       5,
+		DamageType:  damage.Slashing,
+	}))
+
+	// Multiattack - 2x longsword
+	m.AddAction(actions.NewMultiattackAction(actions.MultiattackConfig{
+		Attacks: []string{"longsword", "longsword"},
+	}))
+
+	// Set movement speed
+	m.SetSpeed(monster.SpeedData{Walk: 30})
+
+	// Add vulnerability to bludgeoning damage (skeleton archetype, D&D 5e SRD)
+	m.AddTraitData(monstertraits.MustVulnerabilityJSON(id, damage.Bludgeoning))
+
+	// Add immunity to poison damage (skeleton archetype, D&D 5e SRD)
+	m.AddTraitData(monstertraits.MustImmunityJSON(id, damage.Poison))
+
+	return m
+}

--- a/rulebooks/dnd5e/monster/monsters/skeleton_captain_test.go
+++ b/rulebooks/dnd5e/monster/monsters/skeleton_captain_test.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monsters
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/stretchr/testify/suite"
+)
+
+type SkeletonCaptainTestSuite struct {
+	suite.Suite
+}
+
+func TestSkeletonCaptainSuite(t *testing.T) {
+	suite.Run(t, new(SkeletonCaptainTestSuite))
+}
+
+func (s *SkeletonCaptainTestSuite) TestNewSkeletonCaptain() {
+	captain := NewSkeletonCaptain("skeleton-captain-1")
+
+	s.Require().NotNil(captain)
+	s.Assert().Equal("skeleton-captain-1", captain.GetID())
+	s.Assert().Equal("Skeleton Captain", captain.Name())
+	s.Assert().Equal(refs.Monsters.SkeletonCaptain(), captain.Ref())
+
+	// Check stats (CR 2 crypt boss)
+	s.Assert().Equal(45, captain.HP())
+	s.Assert().Equal(45, captain.MaxHP())
+	s.Assert().Equal(16, captain.AC())
+
+	// Check ability scores
+	scores := captain.AbilityScores()
+	s.Assert().Equal(16, scores[abilities.STR])
+	s.Assert().Equal(14, scores[abilities.DEX])
+	s.Assert().Equal(16, scores[abilities.CON])
+	s.Assert().Equal(6, scores[abilities.INT])
+	s.Assert().Equal(8, scores[abilities.WIS])
+	s.Assert().Equal(5, scores[abilities.CHA])
+
+	// Check speed
+	speed := captain.Speed()
+	s.Assert().Equal(30, speed.Walk)
+
+	// Check actions - should have longsword and multiattack
+	actions := captain.Actions()
+	s.Require().Len(actions, 2)
+
+	var hasLongsword, hasMultiattack bool
+	for _, action := range actions {
+		switch action.GetID() {
+		case "longsword":
+			hasLongsword = true
+		case "multiattack":
+			hasMultiattack = true
+		}
+	}
+	s.Assert().True(hasLongsword, "should have longsword action")
+	s.Assert().True(hasMultiattack, "should have multiattack action")
+}
+
+func (s *SkeletonCaptainTestSuite) TestSkeletonCaptainTraitsIncludedInData() {
+	captain := NewSkeletonCaptain("skeleton-captain-1")
+	s.Require().NotNil(captain)
+
+	data := captain.ToData()
+	s.Require().NotNil(data)
+
+	// Should have 2 conditions: vulnerability to bludgeoning, immunity to poison
+	// (same undead traits as a rank-and-file skeleton - no Life Drain, no
+	// Undead Fortitude, no paralysis: none of those are wired in the toolkit today)
+	s.Require().Len(data.Conditions, 2, "skeleton captain should have 2 trait conditions")
+
+	var hasVulnerability, hasImmunity bool
+	for _, condJSON := range data.Conditions {
+		var peek struct {
+			Ref        string      `json:"ref"`
+			DamageType damage.Type `json:"damage_type"`
+		}
+		err := json.Unmarshal(condJSON, &peek)
+		s.Require().NoError(err)
+
+		if peek.Ref == refs.MonsterTraits.Vulnerability().String() {
+			hasVulnerability = true
+			s.Assert().Equal(damage.Bludgeoning, peek.DamageType, "vulnerability should be to bludgeoning")
+		}
+		if peek.Ref == refs.MonsterTraits.Immunity().String() {
+			hasImmunity = true
+			s.Assert().Equal(damage.Poison, peek.DamageType, "immunity should be to poison")
+		}
+	}
+
+	s.Assert().True(hasVulnerability, "skeleton captain should have vulnerability trait")
+	s.Assert().True(hasImmunity, "skeleton captain should have immunity trait")
+}
+
+func (s *SkeletonCaptainTestSuite) TestSkeletonCaptainTraitsLoadedFromData() {
+	ctx := context.Background()
+
+	captain := NewSkeletonCaptain("skeleton-captain-1")
+	data := captain.ToData()
+
+	bus := events.NewEventBus()
+	loaded, err := monster.LoadFromData(ctx, data, bus)
+	s.Require().NoError(err)
+	s.Require().NotNil(loaded)
+	defer func() { _ = loaded.Cleanup(ctx) }()
+
+	err = monstertraits.LoadMonsterConditions(ctx, loaded, data.Conditions, bus, nil)
+	s.Require().NoError(err)
+
+	conditions := loaded.GetConditions()
+	s.Assert().Len(conditions, 2, "loaded skeleton captain should have 2 conditions applied")
+
+	for _, cond := range conditions {
+		s.Assert().True(cond.IsApplied(), "condition should be applied to bus")
+	}
+}


### PR DESCRIPTION
Closes #816.

## Why this is not a wight

A wight's signature ability is **Life Drain** — necrotic damage that reduces the target's *maximum* HP. There is no primitive for that in the toolkit today: `monstertraits/loader.go` hard-switches on exactly four traits (`immunity`, `vulnerability`, `pack_tactics`, `undead_fortitude`), and nothing modifies max HP from an attack effect. `undead_fortitude` itself is declared but not wired to any HP-clamp path (no existing monster factory even calls it).

Shipping a wight without Life Drain would repeat the pattern the issue calls out twice already: the ghoul's paralyzing touch is stubbed (`monsters/ghoul.go` — "would be implemented as a condition effect in the full combat system"), and undead fortitude's HP-clamp is unwired. A wight that just swings for necrotic damage is this captain with a different name.

So this boss stays a **stat-line upgrade of the existing Skeleton archetype** — same shape, higher CR — exactly as the issue's "skeleton-captain-shaped undead boss" scope calls for. Life Drain, if wanted, is its own issue once the toolkit has a max-HP-reduction primitive to hang it on.

## Stats / ref (exact, per issue scope)

- **Ref**: `refs.Monsters.SkeletonCaptain()` — `dnd5e:monsters:skeleton-captain` (already declared in `refs/monsters.go`, referenced by the retired rpg-api `ThemeCrypt.BossPool` at `CR: 2`; this PR adds the missing factory that constructs it — no other ref/registration change needed).
- **CR 2**, factory pattern: `monster.Config{ID, Name, Ref, HP, AC, AbilityScores}` + `AddAction` + `SetSpeed` + damage immunity/vulnerability JSON — the same shape as `NewSkeleton`/`NewThug`, not a new pattern.
- HP 45 (6d8+18), AC 16 (chain shirt + shield).
- Ability scores: STR 16 (+3), DEX 14 (+2), CON 16 (+3), INT 6 (-2), WIS 8 (-1), CHA 5 (-3).
- Speed: Walk 30.
- Actions: `longsword` melee (+5 = +3 STR + 2 proficiency, `1d8+3` slashing, reach 5) + `multiattack` (2x longsword) — same multiattack shape as `NewThug`'s 2x mace / `NewGhoul`'s bite+claw.
- Traits: vulnerability to bludgeoning + immunity to poison — the same two `monstertraits` the base Skeleton carries (skeleton archetype, D&D 5e SRD). No `undead_fortitude` (unwired toolkit-wide, per issue's "Why not a wight" rationale — applying it here would be no more real than skipping it), no paralysis, no Life Drain.

## Out of scope (per issue)

- No boss-specific AI/legendary actions — same attack/move AI as any monster.
- No HP-scaling/variant system — HP is a literal in this factory, tuned here if it needs to change for playability.
- No dungeon-generation/spawn wiring, no rpg-api/protos/web changes — model/visual mapping and spawn-by-ref into the generated boss chamber are separate work.

## RED → GREEN

RED (before implementation — factory doesn't exist):
```
cd rulebooks/dnd5e && go test ./monster/monsters/... -run TestSkeletonCaptainSuite -v
# monster/monsters/skeleton_captain_test.go:29:13: undefined: NewSkeletonCaptain
# monster/monsters/skeleton_captain_test.go:72:13: undefined: NewSkeletonCaptain
# monster/monsters/skeleton_captain_test.go:109:13: undefined: NewSkeletonCaptain
# FAIL	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters [build failed]
```

GREEN (after implementation):
```
cd rulebooks/dnd5e && go test ./monster/monsters/... -run TestSkeletonCaptainSuite -v
# --- PASS: TestSkeletonCaptainSuite (0.00s)
#     --- PASS: TestSkeletonCaptainSuite/TestNewSkeletonCaptain (0.00s)
#     --- PASS: TestSkeletonCaptainSuite/TestSkeletonCaptainTraitsIncludedInData (0.00s)
#     --- PASS: TestSkeletonCaptainSuite/TestSkeletonCaptainTraitsLoadedFromData (0.00s)
# PASS
```

## Full verification

```
cd rulebooks/dnd5e
go build ./...                              # clean
go vet ./...                                # clean
go test ./...                               # all packages ok (monster/monsters included)
gofmt -l . ; goimports -l .                 # no diffs
go mod tidy && git diff --stat go.mod go.sum  # no diff
golangci-lint run ./monster/...             # 0 issues
```

## Self-review against #816's done bar

- ✅ Factory follows the existing `monster.Config`/`AddAction`/`SetSpeed`/trait-JSON pattern exactly (mirrors `NewSkeleton`, `NewThug`).
- ✅ Ref registered/selectable by key (`refs.Monsters.SkeletonCaptain()` — pre-existing declaration, now backed by a constructor).
- ✅ No `NewGoblin`/`NewGoblinBoss` fallback anywhere in this change — this is the concrete skeleton-captain boss the issue asks for.
- ✅ No wight, no stubbed Life Drain/Undead Fortitude/paralysis shipped.
- ✅ No dungeon-generation, API, protos, or web changes.
- ✅ No HP-scaling/variant machinery added — HP is a literal in this factory only.
- Boss spawn-by-ref into a generated boss chamber is explicitly out of scope here (model/visual mapping and dungeon wiring are separate PRs) — this PR delivers the data-only stat block the rest of that work depends on.

## Files

- `rulebooks/dnd5e/monster/monsters/skeleton_captain.go` (new)
- `rulebooks/dnd5e/monster/monsters/skeleton_captain_test.go` (new)

— platform agent, on behalf of KirkDiggler
