### PR TITLE
feat(encounter): generic static obstacle instances in SpaceData + spatial room (#818)

### DIFF
--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -1,83 +1,28 @@
 {
-  "branch": "feat/814-n-region-dungeon",
-  "issues": ["#814"],
-  "goal": "Generalize encounter/two_chamber.go's fixed two-chamber generator into a single generic N-region linear-chain dungeon generator (InitDungeon), adding region archetypes (entrance|chamber|corridor|boss) and an opaque SpaceData.Theme, while preserving InitTwoChamberRoom's existing public behavior by delegating it to the new generator.",
-  "design_doc": "rpg-project/ideas/the-dungeon/wave2-design.md",
+  "branch": "feat/818-static-obstacles",
+  "issues": ["#818"],
+  "goal": "Generic, dependency-free infrastructure for static obstacle instances in encounter.SpaceData and the underlying spatial room truth: same category as a wall (blocking id/position), but instanced and content-agnostic, with a stable ID/Ref, full ToData/LoadFromData round-trip, and rebuild parity with walls/doors for movement and LoS.",
+  "depends_on": ["#821 (merged, e1f9840, generalizes two-chamber into InitDungeon N-region generator - base for this branch)"],
   "sessions": [
     {
       "id": "2026-07-22-001",
-      "task": "Baseline verification + worktree/artifact setup",
-      "status": "completed",
-      "artifacts": [".gitignore", ".claude/progress.json", ".claude/tests.json"],
-      "commit": null,
-      "notes": "Verified no existing branch/PR for #814. Added .worktrees/ to .gitignore (repo had no linked-worktree convention yet, unlike rpg-api/rpg-dnd5e-web). Baseline `go test ./...` in encounter/ green (55s) before any behavioral change."
-    },
-    {
-      "id": "2026-07-22-002",
-      "task": "TDD RegionArchetype vocabulary + SpaceData.Theme opaque field",
-      "status": "completed",
-      "artifacts": ["encounter/data.go", "encounter/dungeon_test.go"],
-      "commit": null,
-      "notes": "RED/GREEN: TestRegionArchetype_GenericVocabulary, TestSpaceData_ThemeIsOpaqueAndDistinctFromArchetype. Added RegionArchetype type + ArchetypeEntrance/Chamber/Corridor/Boss constants and RegionData.Archetype; added SpaceData.Theme (opaque, omitempty)."
-    },
-    {
-      "id": "2026-07-22-003",
-      "task": "TDD InitDungeon validation (region/connector count, dimensions, door IDs, boss scale invariant)",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go"],
-      "commit": null,
-      "notes": "RED/GREEN per assertion: TestInitDungeon_RejectsFewerThanTwoRegions, RejectsWrongConnectorCount, RejectsNarrowRegion, RejectsShortSharedHeight, RejectsEmptyDoorID, RejectsUndersizedBossRoom (axis==6 rejected), AcceptsBossRoomExceedingScaleInvariant (axis>6 accepted). validateDungeonParams called unconditionally at InitDungeon's entry."
-    },
-    {
-      "id": "2026-07-22-004",
-      "task": "TDD InitDungeon N-region linear-chain generation + retire two_chamber.go's duplicate geometry",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go", "encounter/two_chamber.go"],
-      "commit": null,
-      "notes": "RED (nil-Space panic) then GREEN: generalized generateTwoChamberLayout -> generateDungeonLayout for N regions (shared Height, per-region Width, required-path-by-construction connectivity: entrance->door for region 0, door->door for interior regions, door->center for the terminal region). Rewrote two_chamber.go as a thin validating wrapper delegating to e.InitDungeon (N=2, chamber-1=ArchetypeEntrance, chamber-2=ArchetypeChamber); retired the now-duplicate chamberCubes/chamberWallSegments/generateChamberWalls/hexesFromCubes/chamberPathWidth in favor of the shared regionCubes/regionWallSegments/generateRegionWalls/hexesFromCubes/dungeonPathWidth in dungeon.go. two_chamber_test.go untouched and green throughout (existing tests pass against the generalized entry point, per the done bar). DungeonSuite added (3-region entrance/corridor/boss fixture): closed-door block, open-door connectivity, region archetype/theme partition, seed determinism, crypt-shaped capability without ArchetypeChamber.",
-      "concerns": "Isolated and worked around (not fixed — different module, out of scope) a pre-existing tools/environments|tools/spatial pointy-top-hex-grid parity quirk: IsLineOfSightBlocked's short-range raycast across a 2-column gap gives a different (incorrect-looking) result depending on which column parity (even/odd) the door sits on, even though wall placement is byte-identical between the two parities and BFS movement reachability is unaffected in both. Fixture's corridor width nudged 4->5 so both connector doors land on the working parity. Documented in tests.json and will flag in the PR body for awareness; not an #814 regression (reproduced identically via a bare two-door layout unrelated to InitDungeon's own logic)."
-    },
-    {
-      "id": "2026-07-22-005",
-      "task": "Full verification + lint/scope self-review",
+      "task": "Preflight: verify #821 merged on origin/main, no existing #818 branch/PR, create isolated worktree, baseline tests",
       "status": "completed",
       "artifacts": [],
       "commit": null,
-      "notes": "go build ./..., go vet ./..., go test ./... (55s, all green), go test -race ./... (all green), gofmt -l . / goimports -l . (clean), go mod tidy (no diff), golangci-lint run ./... (66 goconst issues, identical to the pre-existing origin/main baseline count of 65+1 -- verified byte-identical baseline list except zero new hits from dungeon.go/dungeon_test.go after fixing the 2 lll + 3 goconst hits my own new test file introduced). Diff confined to encounter/data.go, encounter/two_chamber.go, encounter/dungeon.go (new), encounter/dungeon_test.go (new); no go.mod/go.sum/go.work changes; no crypt-specific props/monster-seeding/locked-door/API/proto/client code touched."
-    },
-    {
-      "id": "2026-07-22-006",
-      "task": "PR #821 review response: LoS coverage gap in closed-door dungeon test + InitDungeon partial-init atomicity",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go"],
-      "commit": null,
-      "notes": "Two independent review findings addressed. (1) TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors only checked movement/reachability, never IsLineOfSightBlocked, despite its name. DISCRIMINATION: temporarily mutated space.go's closed-door wall Properties.BlocksLoS from true to false (production code, reverted immediately after) and reran the two suites: TestTwoChamberSuite/TestClosedDoor_BlocksMovementAndLoS_BetweenChambers (which DOES check LoS) correctly failed; TestDungeonSuite/TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors still passed -- proving the exact gap. Added two IsLineOfSightBlocked(farEdge,nearEdge) assertions (one per connector, mirroring the two-chamber precedent's direct across-the-door check) to the dungeon test; reran with the same mutation still active -> both new assertions failed for the expected reason (RED); reverted the mutation -> GREEN, space.go diff empty (no unrelated change kept). (2) InitDungeon's original per-connector `for range layout.doors { e.AddDoor(...) }` loop could leave e.data.Space set and earlier connectors' doors added if a LATER connector's AddDoor failed, despite returning an error -- observable partial state. RED: new top-level test TestInitDungeon_FailedRoomRebuild_LeavesNoPartialState pre-seeds a decoy door at an out-of-bounds position (Space nil at that point, so AddDoor just records it; rebuildRoomFromData's PlaceEntity deterministically fails on out-of-bounds positions, since same-cell collisions are defensively skipped rather than errored) then calls InitDungeon and asserts Space/both connector doors are absent after the failure -- failed for the expected reason (Space non-nil leaked) against the original code. GREEN: rewrote InitDungeon to stage all connector DoorData entries directly into e.data.Doors and call rebuildRoomFromData exactly ONCE (instead of once per connector), snapshotting the pre-call Space and rolling both Space and the newly-staged door IDs back on any rebuild failure -- rebuildRoomFromData itself never calls registerRoom (swapping in e.room/e.roomOrchestrator) until every wall/door places successfully, so the room side was already atomic; the fix completes the Data-side half of that guarantee. Bonus: single rebuild instead of N-1 is also strictly cheaper. No changes to AddDoor or any other public API.",
-      "verification": "go build ./..., go vet ./..., go test -count=1 ./... (54s all green incl. new + full existing suites), go test -race -count=1 ./... (58s all green), gofmt/goimports clean, go mod tidy no diff, golangci-lint run ./... unchanged at 65 goconst issues (byte-identical to origin/main baseline, zero new findings). Diff confined to encounter/dungeon.go and encounter/dungeon_test.go only (space.go's mutation was fully reverted, confirmed via `git diff origin/main -- encounter/space.go` producing no output)."
-    },
-    {
-      "id": "2026-07-22-007",
-      "task": "File tracker issue for the pre-existing LoS parity quirk + board it",
-      "status": "completed",
-      "artifacts": [],
-      "commit": null,
-      "notes": "Checked for duplicates first (gh issue search: 'hex grid line of sight', 'IsLineOfSightBlocked parity', 'pointy-top hex grid', 'roundCube', 'door line of sight' -- found #763 'lerpCube truncation makes GetLineOfSight directionally asymmetric at distance >=22', read its full body: different symptom (direction-dependent A vs B disagreement at long range, already has proper cube rounding as the fix target) from ours (a single, direction-SYMMETRIC but wrong short-range answer at distance 2). Confirmed symmetry empirically with a throwaway repro test (both IsLineOfSightBlocked(far1,near2) and the reverse call agreed, both true, for the width-4-corridor/odd-door-column case that exposed the quirk) before concluding it's a distinct issue, not a duplicate of #763 -- repro test deleted after use, not committed. Filed https://github.com/KirkDiggler/rpg-toolkit/issues/822, signed '-- platform agent, on behalf of KirkDiggler'. Added to board #19 'The Dungeon Run' (item PVTI_lAHOAASbwc4Bcj4vzgzvPkM) with Feature=The Dungeon, Team=Platform, Status=Todo."
-    },
-    {
-      "id": "2026-07-22-008",
-      "task": "PR #821 Copilot re-review: 3 unresolved threads (region ID/archetype validation, duplicate DoorID validation, terminal-region path Purpose string)",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go"],
-      "commit": "a642c72",
-      "notes": "Fetched all 3 unresolved review threads via GraphQL (reviewThreads) before starting: PRRT_kwDOPB8ngM6TADW7 (comment 3632233153, region IDs/archetypes), PRRT_kwDOPB8ngM6TADXf (comment 3632233194, duplicate DoorIDs), PRRT_kwDOPB8ngM6TADXz (comment 3632233223, 'door-to-chamber' purpose string). Addressed all three: (1) validateDungeonParams now rejects empty region IDs, duplicate region IDs, and any Archetype outside the documented fixed vocabulary (entrance|chamber|corridor|boss) -- went slightly beyond the user's literal 'ID non-empty+unique' scope to also close the archetype half of the SAME Copilot comment, since it's a one-line closed-set switch consistent with data.go's own 'fixed vocabulary' documentation and costs nothing in flexibility (future archetypes would be new exported constants in this package, not arbitrary caller strings). RED: TestInitDungeon_RejectsEmptyRegionID, RejectsDuplicateRegionIDs, RejectsUnknownArchetype all failed 'want error, got nil' against prior code. (2) validateDungeonParams now also rejects duplicate connector DoorIDs (existing non-empty check preserved). Reproduced the silent-overwrite symptom with a throwaway test BEFORE the fix: duplicate DoorIDs across 2 connectors left err=nil and exactly 1 entry in e.data.Doors (the later connector's, at the later connector's position) -- the earlier boundary column got no door entity, confirming Copilot's exact 'permanently unblocked, closed-by-default contract broken' claim. RED: TestInitDungeon_RejectsDuplicateConnectorDoorIDs failed the same way; also asserts the rejected call leaves Space nil and Doors empty (consistent with the prior round's atomicity fix). (3) Renamed the terminal region's required-path Purpose from 'door-to-chamber' to 'door-to-region-center' -- accurate for any terminal archetype. Investigated whether to add a test: confirmed Purpose only surfaces via environments.validatePathSafety's 'required path blocked' error, which PathSafetyParams.EmergencyFallback: true (already set in generateRegionWalls) swallows by falling back to an empty layout before it can propagate -- deterministically forcing that exact error would need brittle setup fighting the fallback, so per the user's explicit guidance against manufacturing a brittle test for an internal/cosmetic string, made the string fix only, explained the reasoning in the reply instead.",
-      "verification": "go build ./..., go vet ./..., go test -count=1 ./... (54s all green incl. 4 new tests + all pre-existing suites), go test -race -count=1 ./... (54s all green), gofmt/goimports clean, go mod tidy no diff, golangci-lint run ./... unchanged at 65 goconst issues (byte-identical baseline, zero new). Diff confined to encounter/dungeon.go + encounter/dungeon_test.go (+121/-4 lines). Pushed as a642c72 before posting any reply or resolving any thread. Posted one reply per thread (each citing the commit and exact change) then resolved all 3 threads via GraphQL resolveReviewThread -- verified zero unresolved threads remain on the PR afterward.",
-      "comment_replies": [
-        {"comment_id": 3632233153, "reply_url": "https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632507283", "thread_id": "PRRT_kwDOPB8ngM6TADW7", "resolved": true},
-        {"comment_id": 3632233194, "reply_url": "https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632508545", "thread_id": "PRRT_kwDOPB8ngM6TADXf", "resolved": true},
-        {"comment_id": 3632233223, "reply_url": "https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632509808", "thread_id": "PRRT_kwDOPB8ngM6TADXz", "resolved": true}
-      ]
+      "notes": "Confirmed merge commit e1f98403ed7c92626e1e3fd69dea3383965febb3 is an ancestor of origin/main. No feat/818* branch or open PR found. Created linked worktree .worktrees/feat-818-static-obstacles from origin/main (not local main, which was 2 commits behind). Baseline `go test ./...` in encounter/ green (56s, 4 packages) before any change. .worktrees/ not in root .gitignore (pre-existing gap predating this branch, shared by 3 sibling worktrees already present) - left untouched per explicit instruction not to modify the shared checkout."
     }
   ],
   "next_steps": [
-    "None outstanding -- all 3 Copilot review threads resolved and replied to. Awaiting further review/merge decision on PR #821."
+    "Add ObstacleData shape + SpaceData.Obstacles field (data.go)",
+    "TDD: serialization round-trip (ToData/LoadFromData)",
+    "TDD: rebuildRoomFromData places obstacles into the same spatial.Room as walls/doors",
+    "TDD: movement blocking true/false",
+    "TDD: LoS blocking true/false",
+    "TDD: coexistence with walls/doors",
+    "TDD: validation - empty/duplicate obstacle IDs, out-of-bounds position, duplicate occupancy - atomic failure (no partial state)",
+    "TDD: backward compatibility - encounters with no obstacles round-trip unchanged",
+    "Full verification: build/vet/test/race/fmt/imports/tidy/lint for encounter module",
+    "Commit, push, open PR linked to #818"
   ]
 }

--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -34,10 +34,18 @@
       "status": "completed",
       "artifacts": [],
       "commit": null,
-      "notes": "go build ./... clean; go vet ./... clean; go test ./... green (4 packages, ~54s); go test -race ./... green (~58s); go mod tidy no diff; gofmt/goimports clean; golangci-lint v2.2.1 (repo-pinned via .github/workflows/ci-enhanced.yml GOLANGCI_VERSION, installed to an isolated temp bin rather than the globally-installed v2.12.2) run --config=../.golangci.yml: 0 issues. Diff scope confirmed via `git diff --stat origin/main...HEAD`: encounter/data.go, encounter/space.go, encounter/obstacle_test.go, .claude/*.json only - no unrelated module/refactor changes."
+      "notes": "go build ./... clean; go vet ./... clean; go test ./... green (4 packages, ~54s); go test -race ./... green (~58s); go mod tidy no diff; gofmt/goimports clean; golangci-lint v2.2.1 (repo-pinned via .github/workflows/ci-enhanced.yml GOLANGCI_VERSION, installed to an isolated temp bin rather than the globally-installed v2.12.2) run --config=../.golangci.yml: 0 issues. Diff scope confirmed via `git diff --stat origin/main...HEAD`: encounter/data.go, encounter/space.go, encounter/obstacle_test.go, .claude/*.json only - no unrelated module/refactor changes. Opened PR #823, requested Copilot review (matches repo convention observed on #821)."
+    },
+    {
+      "id": "2026-07-22-005",
+      "task": "Address Copilot automated review on PR #823",
+      "status": "completed",
+      "artifacts": ["encounter/space.go", "encounter/obstacle_test.go"],
+      "commit": null,
+      "notes": "Two Copilot comments, both verified correct against actual code (not accepted blindly): (1) spatial.BasicRoom.canPlaceEntityUnsafe only rejects placement when the EXISTING occupant BlocksMovement() - so two BlocksMovement=false obstacles sharing a hex would silently co-locate via room.PlaceEntity alone, contradicting this package's stated 'any collision is a data error' invariant. RED: added TestAddObstacle_RejectsDuplicateOccupancy_BothNonBlocking, confirmed it failed (Error asserted, got nil) before any fix. GREEN: rebuildRoomFromData now checks the obstacle's cube against the shared `placed` occupancy set explicitly (same set walls/doors already populate) and rejects ANY collision before calling PlaceEntity, regardless of blocking flags. (2) validateObstacles' doc comment claimed duplicate IDs would 'silently relocate' room occupancy via PlaceEntity's same-ID move semantics - verified against tools/environments/wall_entities.go: WallEntity.GetID() embeds position (`wall_<segment>_<x>_<y>`), so two obstacles with the same stated ID but different positions get DIFFERENT entity IDs and would NOT relocate each other. Rewrote the comment to state the real invariant: unique IDs are the package's contract for referencing the SAME obstacle across ticks/reloads, and a same-ID-SAME-position pair would collide to one entity via PlaceEntity's move-in-place semantics, silently swallowing a should-be-rejected duplicate. Full re-verification (build/vet/test/race/fmt/imports/tidy/lint v2.2.1) all green after the fix. Replied to both review comments individually with the signature footnote."
     }
   ],
   "next_steps": [
-    "Open PR linked to #818, address any immediate automated review comments"
+    "Monitor for further review activity; do not merge (coordinating session merges)"
   ]
 }

--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -9,20 +9,35 @@
       "task": "Preflight: verify #821 merged on origin/main, no existing #818 branch/PR, create isolated worktree, baseline tests",
       "status": "completed",
       "artifacts": [],
-      "commit": null,
+      "commit": "1cb306c",
       "notes": "Confirmed merge commit e1f98403ed7c92626e1e3fd69dea3383965febb3 is an ancestor of origin/main. No feat/818* branch or open PR found. Created linked worktree .worktrees/feat-818-static-obstacles from origin/main (not local main, which was 2 commits behind). Baseline `go test ./...` in encounter/ green (56s, 4 packages) before any change. .worktrees/ not in root .gitignore (pre-existing gap predating this branch, shared by 3 sibling worktrees already present) - left untouched per explicit instruction not to modify the shared checkout."
+    },
+    {
+      "id": "2026-07-22-002",
+      "task": "TDD: ObstacleData shape + SpaceData.Obstacles + serialization round-trip",
+      "status": "completed",
+      "artifacts": ["encounter/data.go", "encounter/space.go", "encounter/obstacle_test.go"],
+      "commit": "dda6488",
+      "notes": "RED: TestObstacle_ToData_LoadFromData_RoundTrip failed to compile (AddObstacle/ObstacleData/SpaceData.Obstacles undefined). GREEN: added ObstacleData{ID,Ref,Position,BlocksMovement,BlocksLoS} on SpaceData (Ref is a plain opaque string, mirroring MonsterData.MonsterRef's existing convention in this file); Encounter.AddObstacle mirrors AddDoor's atomicity (append, rebuild, rollback on failure); rebuildRoomFromData places every obstacle into the same spatial.Room walls/doors use via environments.WallEntity (no new entity type); validateObstacles rejects empty/duplicate IDs before touching the room (load-bearing: Obstacles is an order-preserving slice, so an unchecked duplicate ID would silently relocate an earlier obstacle's room occupancy via PlaceEntity's same-ID move semantics)."
+    },
+    {
+      "id": "2026-07-22-003",
+      "task": "TDD: LoS, coexistence, validation boundary, backward compatibility",
+      "status": "completed",
+      "artifacts": ["encounter/obstacle_test.go"],
+      "commit": "1b1615f",
+      "notes": "10 additional tests: BlocksLoS true/false, CoexistsWithWallsAndDoors (wall+door+obstacle at distinct hexes), AddObstacle rejects empty ID/duplicate ID/out-of-bounds/duplicate-occupancy (each asserting no partial Data.Space.Obstacles/room state survives), BackwardCompatible_NoObstacles (nil/empty Obstacles omitted from wire, round-trips unchanged). Most passed immediately since the prior session's implementation was already comprehensive; verified non-vacuous by mutation-testing AddObstacle's empty-ID/duplicate-ID pre-checks (temporarily removed, reran RejectsEmptyID/RejectsDuplicateID - still caught by validateObstacles inside rebuildRoomFromData as defense-in-depth, restored). Out-of-bounds/duplicate-occupancy tests rely on tools/spatial's own pre-existing, independently-tested PlaceEntity/grid.IsValidPosition semantics (same mechanism walls/doors already depend on)."
+    },
+    {
+      "id": "2026-07-22-004",
+      "task": "Full verification + PR",
+      "status": "completed",
+      "artifacts": [],
+      "commit": null,
+      "notes": "go build ./... clean; go vet ./... clean; go test ./... green (4 packages, ~54s); go test -race ./... green (~58s); go mod tidy no diff; gofmt/goimports clean; golangci-lint v2.2.1 (repo-pinned via .github/workflows/ci-enhanced.yml GOLANGCI_VERSION, installed to an isolated temp bin rather than the globally-installed v2.12.2) run --config=../.golangci.yml: 0 issues. Diff scope confirmed via `git diff --stat origin/main...HEAD`: encounter/data.go, encounter/space.go, encounter/obstacle_test.go, .claude/*.json only - no unrelated module/refactor changes."
     }
   ],
   "next_steps": [
-    "Add ObstacleData shape + SpaceData.Obstacles field (data.go)",
-    "TDD: serialization round-trip (ToData/LoadFromData)",
-    "TDD: rebuildRoomFromData places obstacles into the same spatial.Room as walls/doors",
-    "TDD: movement blocking true/false",
-    "TDD: LoS blocking true/false",
-    "TDD: coexistence with walls/doors",
-    "TDD: validation - empty/duplicate obstacle IDs, out-of-bounds position, duplicate occupancy - atomic failure (no partial state)",
-    "TDD: backward compatibility - encounters with no obstacles round-trip unchanged",
-    "Full verification: build/vet/test/race/fmt/imports/tidy/lint for encounter module",
-    "Commit, push, open PR linked to #818"
+    "Open PR linked to #818, address any immediate automated review comments"
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -95,6 +95,14 @@
       "passes": true,
       "last_checked": "2026-07-22",
       "notes": "TestObstacle_BackwardCompatible_NoObstacles"
+    },
+    {
+      "id": "obstacle-rejects-duplicate-occupancy-both-nonblocking",
+      "feature": "obstacle-validation",
+      "prompt": "Two obstacles with BlocksMovement=false sharing the same hex are rejected as a data error, not silently co-located (Copilot review gap on PR #823: spatial.BasicRoom's occupancy check only rejects when the EXISTING occupant blocks movement).",
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestAddObstacle_RejectsDuplicateOccupancy_BothNonBlocking. RED confirmed (Error expected, got nil) before the placed-map explicit check was added to rebuildRoomFromData."
     }
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -4,85 +4,97 @@
       "id": "obstacle-serialization-roundtrip",
       "feature": "obstacle-data",
       "prompt": "A SpaceData carrying obstacle instances (ID, Ref, Position, BlocksMovement, BlocksLoS) round-trips exactly through Encounter.ToData()/encounter.LoadFromData - every field on every instance preserved.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestObstacle_ToData_LoadFromData_RoundTrip"
     },
     {
       "id": "obstacle-rebuild-into-canonical-room",
       "feature": "obstacle-room-truth",
       "prompt": "After LoadFromData (or AddObstacle), the obstacle is present in the same spatial.Room the encounter uses for walls - not a parallel/separate representation.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "Implicit in every blocking test below (room.CanPlaceEntity/IsLineOfSightBlocked queried against enc.Room(), the same instance walls/doors use) - not a separate assertion, folded into the movement/LoS tests."
     },
     {
       "id": "obstacle-blocks-movement-true",
       "feature": "obstacle-movement",
       "prompt": "An obstacle with BlocksMovement=true truncates a player's Move path at its hex, exactly like a wall.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestObstacle_BlocksMovement_True"
     },
     {
       "id": "obstacle-blocks-movement-false",
       "feature": "obstacle-movement",
       "prompt": "An obstacle with BlocksMovement=false does not block movement through its hex.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestObstacle_BlocksMovement_False"
     },
     {
       "id": "obstacle-blocks-los-true",
       "feature": "obstacle-los",
       "prompt": "An obstacle with BlocksLoS=true blocks room.IsLineOfSightBlocked between two hexes on either side of it.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestObstacle_BlocksLoS_True"
     },
     {
       "id": "obstacle-blocks-los-false",
       "feature": "obstacle-los",
       "prompt": "An obstacle with BlocksLoS=false does not block line of sight through its hex.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestObstacle_BlocksLoS_False"
     },
     {
       "id": "obstacle-coexists-with-walls-and-doors",
       "feature": "obstacle-coexistence",
       "prompt": "A Space with walls, a door, and an obstacle at distinct hexes all block/unblock independently and correctly after rebuild.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestObstacle_CoexistsWithWallsAndDoors"
     },
     {
       "id": "obstacle-rejects-empty-id",
       "feature": "obstacle-validation",
       "prompt": "AddObstacle with an empty ID is rejected with a contextual error and leaves Data.Space/room state unchanged.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestAddObstacle_RejectsEmptyID (mutation-verified: still caught by validateObstacles when AddObstacle's own pre-check was temporarily removed)"
     },
     {
       "id": "obstacle-rejects-duplicate-id",
       "feature": "obstacle-validation",
       "prompt": "AddObstacle with an ID that already exists among the Space's obstacles is rejected with a contextual error and leaves Data.Space/room state unchanged.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestAddObstacle_RejectsDuplicateID (mutation-verified, same as above)"
     },
     {
       "id": "obstacle-rejects-out-of-bounds-position",
       "feature": "obstacle-validation",
       "prompt": "AddObstacle at a position outside the room's grid bounds is rejected with a contextual error, and the failed add does not leave a partial obstacle entry in Data.Space.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestAddObstacle_RejectsOutOfBoundsPosition"
     },
     {
       "id": "obstacle-rejects-duplicate-occupancy",
       "feature": "obstacle-validation",
       "prompt": "AddObstacle at a hex already occupied by a movement-blocking wall/door is rejected with a contextual error, atomically (no partial Data.Space/room state).",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestAddObstacle_RejectsDuplicateOccupancy"
     },
     {
       "id": "obstacle-backward-compatible-no-obstacles",
       "feature": "obstacle-compat",
       "prompt": "An encounter/SpaceData with no Obstacles field (nil/empty, e.g. pre-#818 snapshots) loads and round-trips exactly as before - Obstacles omitted from the wire, no room-side change.",
-      "passes": false,
-      "last_checked": null
+      "passes": true,
+      "last_checked": "2026-07-22",
+      "notes": "TestObstacle_BackwardCompatible_NoObstacles"
     }
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -1,116 +1,88 @@
 {
   "tests": [
     {
-      "id": "region-archetype-vocabulary",
-      "feature": "region-archetype",
-      "prompt": "RegionData gains an Archetype field of a generic RegionArchetype type with exactly the values entrance | chamber | corridor | boss.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "TestRegionArchetype_GenericVocabulary (dungeon_test.go)."
+      "id": "obstacle-serialization-roundtrip",
+      "feature": "obstacle-data",
+      "prompt": "A SpaceData carrying obstacle instances (ID, Ref, Position, BlocksMovement, BlocksLoS) round-trips exactly through Encounter.ToData()/encounter.LoadFromData - every field on every instance preserved.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "space-theme-opaque-passthrough",
-      "feature": "space-theme",
-      "prompt": "SpaceData gains a Theme string field, distinct from RegionData.Archetype, that InitDungeon copies verbatim from DungeonParams.Theme without branching on its value anywhere in the generator.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "TestSpaceData_ThemeIsOpaqueAndDistinctFromArchetype + DungeonSuite/TestRegions_ArchetypesThemeAndPartition (Theme='crypt' round-trip). Grepped dungeon.go/two_chamber.go for any `Theme ==`/switch-on-Theme branching: none exists."
+      "id": "obstacle-rebuild-into-canonical-room",
+      "feature": "obstacle-room-truth",
+      "prompt": "After LoadFromData (or AddObstacle), the obstacle is present in the same spatial.Room the encounter uses for walls - not a parallel/separate representation.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-validates-region-count",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects fewer than 2 regions (a dungeon needs at least an entrance and one connected region).",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsFewerThanTwoRegions."
+      "id": "obstacle-blocks-movement-true",
+      "feature": "obstacle-movement",
+      "prompt": "An obstacle with BlocksMovement=true truncates a player's Move path at its hex, exactly like a wall.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-validates-connector-count",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects a Connectors slice whose length is not exactly len(Regions)-1.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsWrongConnectorCount."
+      "id": "obstacle-blocks-movement-false",
+      "feature": "obstacle-movement",
+      "prompt": "An obstacle with BlocksMovement=false does not block movement through its hex.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-validates-dimensions-and-door-ids",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects any region narrower than 4, a shared Height under 4, and any connector with an empty DoorID.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsNarrowRegion, TestInitDungeon_RejectsShortSharedHeight, TestInitDungeon_RejectsEmptyDoorID."
+      "id": "obstacle-blocks-los-true",
+      "feature": "obstacle-los",
+      "prompt": "An obstacle with BlocksLoS=true blocks room.IsLineOfSightBlocked between two hexes on either side of it.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-boss-scale-invariant",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects (generation-time assertion, not eyeballing) any boss-archetype region whose primary playable axis (min(width, shared height)) does not exceed 6 hex steps.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsUndersizedBossRoom (axis==6 rejected), TestInitDungeon_AcceptsBossRoomExceedingScaleInvariant (axis>6 accepted). Enforced in validateDungeonParams, called unconditionally at the top of InitDungeon."
+      "id": "obstacle-blocks-los-false",
+      "feature": "obstacle-los",
+      "prompt": "An obstacle with BlocksLoS=false does not block line of sight through its hex.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-n-region-linear-chain",
-      "feature": "init-dungeon",
-      "prompt": "A 3-region linear dungeon (entrance chamber -> corridor -> boss chamber, 2 doors) generates with a reproducible seed; every region is reachable from the entrance once its door opens; RegionAt returns the right archetype for each hex; a closed connector door blocks movement+LoS across it, matching the two-chamber behavior generalized to N.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "DungeonSuite (dungeon_test.go): TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors (now asserts IsLineOfSightBlocked for BOTH connectors, not just movement/reachability -- see closed-door-los-coverage below for the discrimination evidence), TestOpeningBothDoors_ConnectsEntranceThroughToBoss, TestRegions_ArchetypesThemeAndPartition, TestLayout_DeterministicSeedVsEntropyDefault. NOTE (concern, not a regression): the fixture's corridor width had to be nudged from 4 to 5 hexes to sidestep a pre-existing tools/environments|tools/spatial pointy-top-hex-grid parity quirk in IsLineOfSightBlocked's short-range raycast across a door column of certain column parity relative to its flanking columns — reproduced and isolated to that dependency, unrelated to InitDungeon's own geometry math (identical wall placement on both doors; only LOS raycast result differed by door-column parity). Movement/BFS reachability was unaffected in both parities. Confirmed direction-SYMMETRIC (not the #763 asymmetry bug) via a throwaway repro test before filing https://github.com/KirkDiggler/rpg-toolkit/issues/822 (boarded #19 The Dungeon Run, Feature=The Dungeon, Team=Platform, Status=Todo) to track it. Out of scope for #814 to fix (different module)."
+      "id": "obstacle-coexists-with-walls-and-doors",
+      "feature": "obstacle-coexistence",
+      "prompt": "A Space with walls, a door, and an obstacle at distinct hexes all block/unblock independently and correctly after rebuild.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "closed-door-los-coverage",
-      "feature": "init-dungeon",
-      "prompt": "TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors must actually assert IsLineOfSightBlocked for both connectors (not just movement/reachability), following the two-chamber precedent (TestClosedDoor_BlocksMovementAndLoS_BetweenChambers).",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Review finding: the test name promised LoS coverage it didn't have. DISCRIMINATION (before the test fix): temporarily set space.go's closed-door wall Properties.BlocksLoS from true to false (production mutation, reverted immediately) and reran both suites -- TestTwoChamberSuite/TestClosedDoor_BlocksMovementAndLoS_BetweenChambers (which DOES check LoS) correctly FAILED; TestDungeonSuite/TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors (lacking the LoS assertion) still PASSED, proving the exact gap. FIX: added IsLineOfSightBlocked(farEdge(i), nearEdge(i+1)) assertions for both connector 0 and connector 1, mirroring the two-chamber precedent's direct across-the-door check. RED (with the same production mutation still active): both new assertions failed with the expected messages ('closed door 0/1 must block LoS...'). GREEN (mutation reverted): all DungeonSuite + TwoChamberSuite tests pass; `git diff origin/main -- encounter/space.go` is empty, confirming no unrelated production change was kept."
+      "id": "obstacle-rejects-empty-id",
+      "feature": "obstacle-validation",
+      "prompt": "AddObstacle with an empty ID is rejected with a contextual error and leaves Data.Space/room state unchanged.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-atomic-on-door-failure",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon's per-connector door placement must be atomic: if the room rebuild fails for any reason, the encounter must be left exactly as it was before the call (no partially-set Space, no leaked connector doors, no partially-rebuilt room) rather than returning an error while leaving observable partial state.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Review finding: the original `for range layout.doors { e.AddDoor(...) }` loop could leave e.data.Space set and earlier connectors' doors added if a LATER connector's AddDoor failed, despite InitDungeon returning an error. RED: TestInitDungeon_FailedRoomRebuild_LeavesNoPartialState pre-seeds a decoy door at an out-of-bounds position (deterministically fails spatial.BasicRoom.PlaceEntity's grid.IsValidPosition check once InitDungeon sets Space and rebuilds -- same-cell door/wall collisions are defensively skipped rather than erroring, so this is the only reliable failure-injection technique against this code), then asserts Space/both connector doors are absent and enc.Room() is nil after the failed call -- failed for the expected reason (Space non-nil leaked) against the original code. GREEN: InitDungeon now stages both connector doors directly into e.data.Doors, calls rebuildRoomFromData exactly ONCE for the whole batch (instead of once per connector), and on failure restores the pre-call Space and deletes the staged door IDs. rebuildRoomFromData itself only calls registerRoom (swapping in e.room/e.roomOrchestrator) after every wall/door places successfully, so the room side was already atomic; this completes the Data-side half. No changes to AddDoor or any other public API; bonus: 1 rebuild instead of N-1."
+      "id": "obstacle-rejects-duplicate-id",
+      "feature": "obstacle-validation",
+      "prompt": "AddObstacle with an ID that already exists among the Space's obstacles is rejected with a contextual error and leaves Data.Space/room state unchanged.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-crypt-shaped-capability",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon's generic parameters are flexible enough to express the first crypt's entrance/corridor/boss shape (Theme='crypt' passthrough only, no crypt-specific branching in the generator) without emitting a chamber archetype.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "DungeonSuite/TestFirstCryptTemplate_EntranceCorridorBossWithoutChamberArchetype."
+      "id": "obstacle-rejects-out-of-bounds-position",
+      "feature": "obstacle-validation",
+      "prompt": "AddObstacle at a position outside the room's grid bounds is rejected with a contextual error, and the failed add does not leave a partial obstacle entry in Data.Space.",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "two-chamber-compat-via-generalized-entry-point",
-      "feature": "two-chamber-compat",
-      "prompt": "InitTwoChamberRoom delegates to the generalized InitDungeon entry point internally (retiring the duplicate wall-generation implementation) while every existing encounter/two_chamber_test.go assertion (region IDs, entrance, door blocking/LoS, determinism-vs-entropy) continues to pass unchanged.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "two_chamber.go rewritten as a thin validating wrapper calling e.InitDungeon(...); two_chamber_test.go untouched and green (TestTwoChamberSuite, TestRegionAt_NilReceiver). Retired duplicate helpers: chamberCubes, chamberWallSegments, generateChamberWalls, hexesFromCubes, chamberPathWidth (now regionCubes/regionWallSegments/generateRegionWalls/hexesFromCubes/dungeonPathWidth in dungeon.go, shared by both entry points)."
+      "id": "obstacle-rejects-duplicate-occupancy",
+      "feature": "obstacle-validation",
+      "prompt": "AddObstacle at a hex already occupied by a movement-blocking wall/door is rejected with a contextual error, atomically (no partial Data.Space/room state).",
+      "passes": false,
+      "last_checked": null
     },
     {
-      "id": "init-dungeon-region-id-and-archetype-validation",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects an empty region ID, a duplicate region ID across the chain, and any region Archetype outside the documented fixed vocabulary (entrance | chamber | corridor | boss) -- errors must identify the offending region by index.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Copilot review thread (comment 3632233153, resolved): empty/duplicate region IDs make SpaceData.RegionAt ambiguous (returns the first matching region); an open-ended Archetype string undermines the documented 'fixed vocabulary' contract. RED: TestInitDungeon_RejectsEmptyRegionID, TestInitDungeon_RejectsDuplicateRegionIDs, TestInitDungeon_RejectsUnknownArchetype all failed 'want error, got nil' against the prior code. GREEN: validateDungeonParams now tracks seen region IDs in a map (rejecting empty and duplicate) and switches on Archetype against the 4 known constants (rejecting anything else). Errors follow the existing 'region %d (%q): ...' style and name the offending index. Reply: https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632507283."
-    },
-    {
-      "id": "init-dungeon-duplicate-connector-door-id",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects a duplicate connector DoorID before generation mutates encounter data -- reusing a DoorID across connectors must not silently overwrite an earlier door in e.data.Doors.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Copilot review thread (comment 3632233194, resolved): AddDoor keys e.data.Doors by DoorID, so two connectors sharing an ID silently overwrite each other, leaving the earlier boundary column permanently unblocked (no closed door entity) -- breaks the closed-by-default connectivity contract with no error. Reproduced the symptom directly with a throwaway (uncommitted) test before the fix: duplicate DoorIDs across 2 connectors left err=nil and exactly 1 entry in e.data.Doors (the later connector's door, at the later connector's position). RED: TestInitDungeon_RejectsDuplicateConnectorDoorIDs failed 'want error, got nil' against the prior code (also asserts the rejected call leaves Space nil and Doors empty). GREEN: validateDungeonParams now tracks seen connector DoorIDs in a map alongside the existing non-empty check, rejecting duplicates before InitDungeon ever calls generateDungeonLayout or mutates e.data. Reply: https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632508545."
-    },
-    {
-      "id": "terminal-region-path-purpose-string",
-      "feature": "init-dungeon",
-      "prompt": "The terminal region's required-path Purpose string must not claim 'chamber' when the terminal region can be any archetype (e.g. boss) -- use an accurate, generic description.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Copilot review thread (comment 3632233223, resolved): 'door-to-chamber' is misleading once the terminal region isn't a chamber. FIX: renamed to 'door-to-region-center', accurate for any archetype, smallest possible change (one string literal). NOT added a new test: confirmed (by reading tools/environments/wall_patterns.go) this string only surfaces via validatePathSafety's 'required path blocked' error, and generateRegionWalls always sets Safety.EmergencyFallback: true, which swallows that error by falling back to an empty layout before it can propagate -- deterministically forcing that exact error would require brittle setup fighting the fallback. Per explicit instruction not to manufacture a brittle test for an internal/cosmetic string, this was left as a documented reasoning in the reply rather than a new assertion. Reply: https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632509808."
+      "id": "obstacle-backward-compatible-no-obstacles",
+      "feature": "obstacle-compat",
+      "prompt": "An encounter/SpaceData with no Obstacles field (nil/empty, e.g. pre-#818 snapshots) loads and round-trips exactly as before - Obstacles omitted from the wire, no room-side change.",
+      "passes": false,
+      "last_checked": null
     }
   ]
 }

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -114,6 +114,62 @@ type SpaceData struct {
 	// vocabulary), not cosmetic theme. Empty for InitRoom/InitTwoChamberRoom
 	// spaces and any InitDungeon call that doesn't set it.
 	Theme string `json:"theme,omitempty"`
+
+	// Obstacles are generic, content-agnostic static obstacle instances —
+	// rpg-toolkit#818. Same category as a Wall (a static blocker the room
+	// must agree with on BlocksMovement/BlocksLoS) but an INSTANCE at one
+	// hex, not a boundary-edge segment, and with a stable ID/Ref a host or
+	// client can key off across ticks/reloads — a set-piece (crypt
+	// sarcophagus, altar, pillar, ...) rather than room geometry. The
+	// toolkit never interprets Ref or branches on it; placement policy
+	// (WHERE obstacles go for a given theme/archetype) is out of scope for
+	// #818 — see the crypt-placement issue that depends on it. Order-
+	// preserving slice, not a map: AddObstacle enforces unique, non-empty
+	// IDs itself (see validateObstacles) rather than relying on map-key
+	// overwrite semantics the way Doors does. Empty for every space
+	// predating #818 — omitted from the wire when empty so old snapshots
+	// round-trip byte-for-byte.
+	Obstacles []ObstacleData `json:"obstacles,omitempty"`
+}
+
+// ObstacleData persists one static obstacle instance: a generic,
+// content-agnostic blocker at a single hex — rpg-toolkit#818. Distinct
+// from a Wall (a boundary-edge segment discretized per-hex, generator-
+// owned) and from a Door (a connector with open/locked state): an
+// obstacle is an INSTANCE a host places (e.g. via AddObstacle) at a
+// specific position, with no notion of "edge" or "connects two regions".
+type ObstacleData struct {
+	// ID is this obstacle's stable identifier — unique within its
+	// SpaceData's Obstacles — so a host or client can reference the SAME
+	// obstacle across ticks/reloads (e.g. to target it with an interaction
+	// verb in a later issue). Required; enforced non-empty and unique by
+	// AddObstacle/validateObstacles, never auto-generated.
+	ID core.EntityID `json:"id"`
+
+	// Ref is an opaque content identifier for this obstacle (e.g.
+	// "dnd5e:obstacles:sarcophagus") — mirrors MonsterData.MonsterRef's
+	// plain-opaque-string convention. The encounter SDK never interprets
+	// Ref; it exists so a host/client can look up dressing, interaction
+	// verbs, or other content-specific behavior keyed off it downstream,
+	// without the toolkit needing to know what a "sarcophagus" is.
+	Ref string `json:"ref"`
+
+	// Position is this obstacle's absolute cube-coordinate-backed hex in
+	// the encounter's Space — the same coordinate space Walls/Doors/
+	// Regions already use (core.Hex, ->ToCube()/->ToPosition() convert to
+	// the spatial package's types rebuildRoomFromData places into).
+	Position core.Hex `json:"position"`
+
+	// BlocksMovement mirrors environments.WallProperties.BlocksMovement —
+	// when true, the reconstructed spatial.Room rejects placing/moving a
+	// blocking entity onto this obstacle's hex, exactly like a wall.
+	BlocksMovement bool `json:"blocks_movement"`
+
+	// BlocksLoS mirrors environments.WallProperties.BlocksLoS — when
+	// true, the reconstructed spatial.Room's IsLineOfSightBlocked reports
+	// true for any line of sight passing through this obstacle's hex,
+	// exactly like a wall.
+	BlocksLoS bool `json:"blocks_los"`
 }
 
 // RegionData tags a named set of hexes as one chamber/region within a

--- a/encounter/obstacle_test.go
+++ b/encounter/obstacle_test.go
@@ -268,6 +268,28 @@ func (s *ObstacleSuite) TestAddObstacle_RejectsDuplicateOccupancy() {
 	s.Require().NotNil(enc.Room(), "the room itself must remain intact after the rejected add")
 }
 
+// TestAddObstacle_RejectsDuplicateOccupancy_BothNonBlocking covers the
+// Copilot review gap on PR #823: spatial.BasicRoom's own occupancy check
+// (canPlaceEntityUnsafe) only rejects a placement when the EXISTING
+// occupant BlocksMovement() — so two obstacles that both have
+// BlocksMovement=false (e.g. LoS-only set pieces) sharing a hex would
+// silently co-locate via room.PlaceEntity alone, contradicting this
+// package's stated invariant that ANY hex collision among host-authored
+// obstacles is a data error, regardless of blocking flags. rebuildRoomFromData
+// must reject this explicitly (via the shared `placed` occupancy set),
+// not rely on PlaceEntity's blocks-movement-only check.
+func (s *ObstacleSuite) TestAddObstacle_RejectsDuplicateOccupancy_BothNonBlocking() {
+	enc := encounter.New(context.Background(), "enc-obstacle-dup-occupancy-nonblocking", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+	s.Require().NoError(enc.AddObstacle("haze-1", "dnd5e:obstacles:haze", obstacleTestHex, false, true))
+
+	addErr := enc.AddObstacle("haze-2", "dnd5e:obstacles:haze", obstacleTestHex, false, true)
+	s.Require().Error(addErr,
+		"two non-movement-blocking obstacles sharing a hex must still be rejected as a data error")
+	s.Require().Len(enc.ToData().Space.Obstacles, 1,
+		"a rejected duplicate-occupancy add must not leave a second entry")
+}
+
 // TestObstacle_BackwardCompatible_NoObstacles covers the #818 done bar's
 // backward-compatibility requirement: an encounter/SpaceData predating
 // #818 (nil/empty Obstacles) must load and round-trip exactly as before —

--- a/encounter/obstacle_test.go
+++ b/encounter/obstacle_test.go
@@ -1,0 +1,65 @@
+package encounter_test
+
+// obstacle_test.go covers rpg-toolkit#818's generic static-obstacle
+// infrastructure: a persisted ObstacleData shape on SpaceData (stable
+// ID/Ref, absolute position, BlocksMovement/BlocksLoS), full
+// ToData/LoadFromData round-trip, and rebuild parity with walls/doors —
+// obstacles are placed into the exact same spatial.Room truth so
+// movement and line-of-sight consult them identically. Infrastructure
+// only: no crypt-specific placement (#819), no cover math, no
+// interaction verbs.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+)
+
+type ObstacleSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestObstacleSuite(t *testing.T) {
+	suite.Run(t, new(ObstacleSuite))
+}
+
+func (s *ObstacleSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+// TestObstacle_ToData_LoadFromData_RoundTrip covers the #818 done bar's
+// core requirement: every field on every obstacle instance survives a
+// ToData/LoadFromData round-trip exactly.
+func (s *ObstacleSuite) TestObstacle_ToData_LoadFromData_RoundTrip() {
+	enc := encounter.New(context.Background(), "enc-obstacle-rt", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+
+	pos := core.Hex{Q: 2, R: -3, S: 1}
+	s.Require().NoError(enc.AddObstacle("sarcophagus-1", "dnd5e:obstacles:sarcophagus", pos, true, true))
+
+	original := enc.ToData()
+	s.Require().NotNil(original.Space)
+	s.Require().Len(original.Space.Obstacles, 1)
+	got := original.Space.Obstacles[0]
+	s.Equal(core.EntityID("sarcophagus-1"), got.ID)
+	s.Equal("dnd5e:obstacles:sarcophagus", got.Ref)
+	s.Equal(pos, got.Position)
+	s.True(got.BlocksMovement)
+	s.True(got.BlocksLoS)
+
+	reloaded, err := encounter.LoadFromData(context.Background(), original, s.broker)
+	s.Require().NoError(err)
+
+	again := reloaded.ToData()
+	s.Require().NotNil(again.Space)
+	s.Require().Len(again.Space.Obstacles, 1)
+	s.Equal(got, again.Space.Obstacles[0], "obstacle must round-trip exactly through LoadFromData")
+}

--- a/encounter/obstacle_test.go
+++ b/encounter/obstacle_test.go
@@ -11,12 +11,14 @@ package encounter_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
@@ -34,6 +36,13 @@ func (s *ObstacleSuite) SetupTest() {
 	s.transport = encounter.NewInMemoryTransport()
 	s.broker = encounter.NewBroker(s.transport)
 }
+
+// obstacleTestHex is a fixed, verified-in-bounds hex (offset (3,3) under
+// pointy-top orientation) inside every 10x10 room this file builds — the
+// same cell space_test.go's TestLoadFromData_DuplicateWallEntries_Tolerated
+// pins for the identical reason: a known cell with all neighbors in-bounds
+// too, so a single-hex approach-and-move always lands cleanly.
+var obstacleTestHex = core.Hex{Q: 3, R: -5, S: 2}
 
 // TestObstacle_ToData_LoadFromData_RoundTrip covers the #818 done bar's
 // core requirement: every field on every obstacle instance survives a
@@ -62,4 +71,221 @@ func (s *ObstacleSuite) TestObstacle_ToData_LoadFromData_RoundTrip() {
 	s.Require().NotNil(again.Space)
 	s.Require().Len(again.Space.Obstacles, 1)
 	s.Equal(got, again.Space.Obstacles[0], "obstacle must round-trip exactly through LoadFromData")
+}
+
+// TestObstacle_BlocksMovement_True covers the #818 done bar's movement
+// invariant: the rebuilt spatial.Room agrees with an obstacle's
+// BlocksMovement=true exactly as it does for a wall — Move truncates at
+// the obstacle's hex rather than passing through it.
+func (s *ObstacleSuite) TestObstacle_BlocksMovement_True() {
+	enc := encounter.New(context.Background(), "enc-obstacle-move-block", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+	s.Require().NoError(enc.AddObstacle("pillar-1", "dnd5e:obstacles:pillar", obstacleTestHex, true, false))
+
+	start := perception.HexNeighbors(obstacleTestHex)[0]
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: start, SightRange: 10,
+	}))
+
+	s.Require().NoError(enc.Move("alice", []core.Hex{obstacleTestHex}))
+
+	after := enc.ToData().Players["alice"].View.Position
+	s.Equal(start, after, "player must not have moved onto the obstacle's hex")
+}
+
+// TestObstacle_BlocksMovement_False covers the complement: an obstacle
+// that only blocks line of sight (BlocksMovement=false) must NOT impede
+// movement through its hex.
+func (s *ObstacleSuite) TestObstacle_BlocksMovement_False() {
+	enc := encounter.New(context.Background(), "enc-obstacle-move-pass", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+	s.Require().NoError(enc.AddObstacle("haze-1", "dnd5e:obstacles:haze", obstacleTestHex, false, true))
+
+	start := perception.HexNeighbors(obstacleTestHex)[0]
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: start, SightRange: 10,
+	}))
+
+	s.Require().NoError(enc.Move("alice", []core.Hex{obstacleTestHex}))
+
+	after := enc.ToData().Players["alice"].View.Position
+	s.Equal(obstacleTestHex, after, "a non-movement-blocking obstacle must not impede movement")
+}
+
+// TestObstacle_BlocksLoS_True covers the LoS half of the #818 done bar:
+// an obstacle with BlocksLoS=true must block room.IsLineOfSightBlocked
+// between two hexes on opposite sides of it, exactly like a wall.
+// HexNeighbors(h)[0] and [3] are diametrically opposite directions (their
+// deltas negate each other), so the obstacle sits exactly on the line
+// between them.
+func (s *ObstacleSuite) TestObstacle_BlocksLoS_True() {
+	enc := encounter.New(context.Background(), "enc-obstacle-los-block", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+	s.Require().NoError(enc.AddObstacle("statue-1", "dnd5e:obstacles:statue", obstacleTestHex, false, true))
+
+	neighbors := perception.HexNeighbors(obstacleTestHex)
+	from, to := neighbors[0], neighbors[3]
+
+	s.Require().NotNil(enc.Room())
+	s.True(enc.Room().IsLineOfSightBlocked(from.ToPosition(), to.ToPosition()),
+		"an obstacle with BlocksLoS=true must block LoS across its hex")
+}
+
+// TestObstacle_BlocksLoS_False covers the complement: an obstacle that
+// only blocks movement (BlocksLoS=false) must NOT block line of sight
+// through its hex.
+func (s *ObstacleSuite) TestObstacle_BlocksLoS_False() {
+	enc := encounter.New(context.Background(), "enc-obstacle-los-pass", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+	s.Require().NoError(enc.AddObstacle("rubble-1", "dnd5e:obstacles:rubble", obstacleTestHex, true, false))
+
+	neighbors := perception.HexNeighbors(obstacleTestHex)
+	from, to := neighbors[0], neighbors[3]
+
+	s.Require().NotNil(enc.Room())
+	s.False(enc.Room().IsLineOfSightBlocked(from.ToPosition(), to.ToPosition()),
+		"an obstacle with BlocksLoS=false must not block LoS across its hex")
+}
+
+// TestObstacle_CoexistsWithWallsAndDoors covers the #818 done bar's
+// coexistence requirement: a Space carrying a wall, a closed door, and an
+// obstacle at three DISTINCT hexes must have all three block/unblock
+// independently and correctly after rebuild — the obstacle is additive,
+// not a replacement for the existing wall/door machinery.
+func (s *ObstacleSuite) TestObstacle_CoexistsWithWallsAndDoors() {
+	wallHex := core.Hex{Q: 3, R: -5, S: 2}     // offset (3,3)
+	doorHex := core.Hex{Q: 4, R: -6, S: 2}     // offset (4,3)
+	obstacleHex := core.Hex{Q: 5, R: -7, S: 2} // offset (5,3)
+
+	data := encounter.NewData("enc-obstacle-coexist")
+	data.Doors["door-1"] = &encounter.DoorData{ID: "door-1", Position: doorHex, Open: false}
+	data.Space = &encounter.SpaceData{
+		Walls: []environments.WallSegmentData{
+			{Start: wallHex.ToCube(), End: wallHex.ToCube(), BlocksMovement: true, BlocksLoS: true},
+		},
+		Width:  10,
+		Height: 10,
+		Obstacles: []encounter.ObstacleData{
+			{ID: "crate-1", Ref: "dnd5e:obstacles:crate", Position: obstacleHex, BlocksMovement: true, BlocksLoS: false},
+		},
+	}
+
+	enc, err := encounter.LoadFromData(context.Background(), data, s.broker)
+	s.Require().NoError(err)
+	s.Require().NotNil(enc.Room())
+
+	// Wall still blocks movement.
+	wallStart := perception.HexNeighbors(wallHex)[0]
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice", Position: wallStart, SightRange: 10,
+	}))
+	s.Require().NoError(enc.Move("alice", []core.Hex{wallHex}))
+	s.Equal(wallStart, enc.ToData().Players["alice"].View.Position, "wall must still block movement")
+
+	// Closed door still blocks movement.
+	doorStart := perception.HexNeighbors(doorHex)[0]
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "bob", EntityID: "char-bob", Position: doorStart, SightRange: 10,
+	}))
+	s.Require().NoError(enc.Move("bob", []core.Hex{doorHex}))
+	s.Equal(doorStart, enc.ToData().Players["bob"].View.Position, "closed door must still block movement")
+
+	// Obstacle blocks movement too, independently.
+	obstacleStart := perception.HexNeighbors(obstacleHex)[0]
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "carol", EntityID: "char-carol", Position: obstacleStart, SightRange: 10,
+	}))
+	s.Require().NoError(enc.Move("carol", []core.Hex{obstacleHex}))
+	s.Equal(obstacleStart, enc.ToData().Players["carol"].View.Position, "obstacle must block movement")
+}
+
+// TestAddObstacle_RejectsEmptyID covers the #818 validation boundary:
+// AddObstacle with an empty ID must fail with a contextual error and
+// leave Data.Space.Obstacles unchanged (no partial state).
+func (s *ObstacleSuite) TestAddObstacle_RejectsEmptyID() {
+	enc := encounter.New(context.Background(), "enc-obstacle-empty-id", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+
+	err := enc.AddObstacle("", "dnd5e:obstacles:crate", obstacleTestHex, true, true)
+	s.Require().Error(err)
+	s.Empty(enc.ToData().Space.Obstacles, "a rejected AddObstacle must not leave a partial entry")
+}
+
+// TestAddObstacle_RejectsDuplicateID covers the #818 validation boundary:
+// AddObstacle with an ID that already exists among the Space's obstacles
+// must fail with a contextual error and leave Data.Space.Obstacles
+// unchanged — this is load-bearing (not just tidiness): Obstacles is an
+// order-preserving slice, and room.PlaceEntity keys placement by
+// entity.GetID(), so an UNCHECKED duplicate ID would silently relocate
+// the first obstacle's room occupancy rather than erroring.
+func (s *ObstacleSuite) TestAddObstacle_RejectsDuplicateID() {
+	enc := encounter.New(context.Background(), "enc-obstacle-dup-id", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+	s.Require().NoError(enc.AddObstacle("crate-1", "dnd5e:obstacles:crate", obstacleTestHex, true, true))
+
+	otherHex := perception.HexNeighbors(obstacleTestHex)[2]
+	err := enc.AddObstacle("crate-1", "dnd5e:obstacles:crate", otherHex, true, true)
+	s.Require().Error(err)
+	s.Require().Len(enc.ToData().Space.Obstacles, 1, "a rejected duplicate-ID add must not leave a second entry")
+}
+
+// TestAddObstacle_RejectsOutOfBoundsPosition covers the #818 validation
+// boundary: AddObstacle at a position outside the room's grid bounds must
+// fail with a contextual error, and the failed add must not leave a
+// partial obstacle entry in Data.Space (atomicity mirrors AddDoor).
+func (s *ObstacleSuite) TestAddObstacle_RejectsOutOfBoundsPosition() {
+	enc := encounter.New(context.Background(), "enc-obstacle-oob", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))
+
+	outOfBounds := core.Hex{Q: 100, R: -150, S: 50}
+	err := enc.AddObstacle("crate-1", "dnd5e:obstacles:crate", outOfBounds, true, true)
+	s.Require().Error(err)
+	s.Empty(enc.ToData().Space.Obstacles, "a rejected out-of-bounds add must not leave a partial entry")
+}
+
+// TestAddObstacle_RejectsDuplicateOccupancy covers the #818 validation
+// boundary: AddObstacle at a hex already occupied by a movement-blocking
+// wall must fail with a contextual error, atomically — no partial
+// Data.Space/room state survives the failed call.
+func (s *ObstacleSuite) TestAddObstacle_RejectsDuplicateOccupancy() {
+	wallHex := core.Hex{Q: 3, R: -5, S: 2} // offset (3,3)
+	data := encounter.NewData("enc-obstacle-dup-occupancy")
+	data.Space = &encounter.SpaceData{
+		Walls: []environments.WallSegmentData{
+			{Start: wallHex.ToCube(), End: wallHex.ToCube(), BlocksMovement: true, BlocksLoS: true},
+		},
+		Width:  10,
+		Height: 10,
+	}
+	enc, err := encounter.LoadFromData(context.Background(), data, s.broker)
+	s.Require().NoError(err)
+
+	addErr := enc.AddObstacle("crate-1", "dnd5e:obstacles:crate", wallHex, true, true)
+	s.Require().Error(addErr, "an obstacle placed on an already-wall-occupied hex must be rejected")
+	s.Empty(enc.ToData().Space.Obstacles, "a rejected duplicate-occupancy add must not leave a partial entry")
+	s.Require().NotNil(enc.Room(), "the room itself must remain intact after the rejected add")
+}
+
+// TestObstacle_BackwardCompatible_NoObstacles covers the #818 done bar's
+// backward-compatibility requirement: an encounter/SpaceData predating
+// #818 (nil/empty Obstacles) must load and round-trip exactly as before —
+// Obstacles omitted from the wire, no room-side change.
+func (s *ObstacleSuite) TestObstacle_BackwardCompatible_NoObstacles() {
+	enc := encounter.New(context.Background(), "enc-obstacle-compat", s.broker)
+	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternRandom, spaceTestSeed))
+
+	original := enc.ToData()
+	s.Require().NotNil(original.Space)
+	s.Empty(original.Space.Obstacles, "a space with no obstacles must have an empty Obstacles slice")
+
+	raw, err := json.Marshal(original)
+	s.Require().NoError(err)
+	s.NotContains(string(raw), `"obstacles"`, "Obstacles must be omitted from the wire when empty")
+
+	reloaded, err := encounter.LoadFromData(context.Background(), original, s.broker)
+	s.Require().NoError(err)
+	s.Require().NotNil(reloaded.Room())
+	s.Empty(reloaded.ToData().Space.Obstacles)
 }

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -1,6 +1,7 @@
 package encounter
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -205,7 +206,103 @@ func (e *Encounter) rebuildRoomFromData() error {
 			return fmt.Errorf("place door wall %s: %w", id, err)
 		}
 	}
+	if err := validateObstacles(sd.Obstacles); err != nil {
+		return fmt.Errorf("validate obstacles: %w", err)
+	}
+	for _, o := range sd.Obstacles {
+		// Unlike walls/doors, an obstacle's occupancy conflict is NOT
+		// silently tolerated — obstacles are host-authored (via
+		// AddObstacle), not generator output with rounding artifacts, so a
+		// hex collision with an existing wall/door/obstacle is a genuine
+		// data error the caller must see (rpg-toolkit#818 done bar), not a
+		// dedup candidate. room.PlaceEntity itself rejects placing a
+		// blocking entity onto a hex an existing blocker occupies, which
+		// naturally surfaces that error here.
+		pos := o.Position.ToPosition()
+		entity := environments.NewWallEntity(environments.WallEntityConfig{
+			SegmentID: fmt.Sprintf("obstacle-%s", o.ID),
+			WallType:  environments.WallTypeIndestructible,
+			Properties: environments.WallProperties{
+				BlocksMovement: o.BlocksMovement,
+				BlocksLoS:      o.BlocksLoS,
+			},
+			Position: pos,
+		})
+		if err := room.PlaceEntity(entity, pos); err != nil {
+			return fmt.Errorf("place obstacle %q: %w", o.ID, err)
+		}
+	}
 	return e.registerRoom(room)
+}
+
+// validateObstacles checks the structural invariant AddObstacle-authored
+// obstacle data depends on: every obstacle must have a non-empty, unique
+// ID. Obstacles is an order-preserving SLICE (unlike the map-keyed
+// Doors), so a duplicate ID is not rejected implicitly by key-overwrite —
+// room.PlaceEntity keys placement by entity.GetID(), so two obstacles
+// sharing an ID would silently relocate one another's room occupancy
+// (PlaceEntity's own doc: "Remove entity from old position if it exists")
+// rather than erroring, corrupting the room without this check. Run from
+// rebuildRoomFromData so both AddObstacle and a direct LoadFromData of
+// hand-built/legacy Data get the same guarantee.
+func validateObstacles(obstacles []ObstacleData) error {
+	seen := make(map[core.EntityID]int, len(obstacles))
+	for i, o := range obstacles {
+		if o.ID == "" {
+			return fmt.Errorf("obstacle %d: id required", i)
+		}
+		if first, dup := seen[o.ID]; dup {
+			return fmt.Errorf("obstacle %d (%q): duplicate obstacle id (already used by obstacle %d)", i, o.ID, first)
+		}
+		seen[o.ID] = i
+	}
+	return nil
+}
+
+// AddObstacle registers a static obstacle instance into the encounter's
+// SpaceData (rpg-toolkit#818): a generic, content-agnostic blocker at a
+// hex, distinct from a Wall (a boundary-edge segment) or a Door (a
+// connector with open/locked state). Mirrors AddDoor's atomicity: on
+// rebuild failure the newly-appended obstacle is rolled back so a failed
+// AddObstacle leaves Data.Space/e.room exactly as they were before the
+// call — no partial state (rpg-toolkit#818 done bar).
+//
+// Unlike AddDoor, which is a no-op on the room side when there's no room
+// yet (Data.Doors persists regardless), an obstacle's ONLY representation
+// is a SpaceData.Obstacles entry — there is nowhere to persist it without
+// a Space to attach to, so AddObstacle requires InitRoom/InitDungeon to
+// have already run.
+//
+// id must be non-empty and not already used by another obstacle in this
+// Space (see validateObstacles for why a duplicate ID is unsafe, not just
+// unwanted). position, blocksMovement, and blocksLoS are stored verbatim
+// and drive the entity rebuildRoomFromData places into the room.
+func (e *Encounter) AddObstacle(
+	id core.EntityID, ref string, position core.Hex, blocksMovement, blocksLoS bool,
+) error {
+	if e.data.Space == nil {
+		return errors.New("add obstacle: no room initialized (call InitRoom/InitDungeon first)")
+	}
+	if id == "" {
+		return errors.New("add obstacle: id required")
+	}
+	for _, existing := range e.data.Space.Obstacles {
+		if existing.ID == id {
+			return fmt.Errorf("add obstacle: obstacle %q already exists", id)
+		}
+	}
+	e.data.Space.Obstacles = append(e.data.Space.Obstacles, ObstacleData{
+		ID:             id,
+		Ref:            ref,
+		Position:       position,
+		BlocksMovement: blocksMovement,
+		BlocksLoS:      blocksLoS,
+	})
+	if err := e.rebuildRoomFromData(); err != nil {
+		e.data.Space.Obstacles = e.data.Space.Obstacles[:len(e.data.Space.Obstacles)-1]
+		return fmt.Errorf("add obstacle %q: rebuild room: %w", id, err)
+	}
+	return nil
 }
 
 // truncateAtWall returns the prefix of path up to (not including) the first

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -210,14 +210,24 @@ func (e *Encounter) rebuildRoomFromData() error {
 		return fmt.Errorf("validate obstacles: %w", err)
 	}
 	for _, o := range sd.Obstacles {
+		cube := o.Position.ToCube()
 		// Unlike walls/doors, an obstacle's occupancy conflict is NOT
-		// silently tolerated — obstacles are host-authored (via
-		// AddObstacle), not generator output with rounding artifacts, so a
-		// hex collision with an existing wall/door/obstacle is a genuine
-		// data error the caller must see (rpg-toolkit#818 done bar), not a
-		// dedup candidate. room.PlaceEntity itself rejects placing a
-		// blocking entity onto a hex an existing blocker occupies, which
-		// naturally surfaces that error here.
+		// tolerated at all — obstacles are host-authored (via
+		// AddObstacle), not generator output with rounding artifacts, so
+		// ANY hex collision with an existing wall/door/obstacle is a
+		// genuine data error the caller must see (rpg-toolkit#818 done
+		// bar), regardless of whether the colliding entities block
+		// movement. room.PlaceEntity's own occupancy check
+		// (canPlaceEntityUnsafe) only rejects placement when the EXISTING
+		// occupant BlocksMovement() — so two BlocksMovement=false
+		// obstacles (or an obstacle and a non-blocking wall) sharing a hex
+		// would otherwise silently co-locate rather than erroring. Checked
+		// explicitly against the shared `placed` occupancy set instead
+		// (Copilot review, PR #823) — not delegated to PlaceEntity.
+		if _, dup := placed[cube]; dup {
+			return fmt.Errorf("place obstacle %q: hex %v already occupied", o.ID, cube)
+		}
+		placed[cube] = struct{}{}
 		pos := o.Position.ToPosition()
 		entity := environments.NewWallEntity(environments.WallEntityConfig{
 			SegmentID: fmt.Sprintf("obstacle-%s", o.ID),
@@ -238,13 +248,16 @@ func (e *Encounter) rebuildRoomFromData() error {
 // validateObstacles checks the structural invariant AddObstacle-authored
 // obstacle data depends on: every obstacle must have a non-empty, unique
 // ID. Obstacles is an order-preserving SLICE (unlike the map-keyed
-// Doors), so a duplicate ID is not rejected implicitly by key-overwrite —
-// room.PlaceEntity keys placement by entity.GetID(), so two obstacles
-// sharing an ID would silently relocate one another's room occupancy
-// (PlaceEntity's own doc: "Remove entity from old position if it exists")
-// rather than erroring, corrupting the room without this check. Run from
-// rebuildRoomFromData so both AddObstacle and a direct LoadFromData of
-// hand-built/legacy Data get the same guarantee.
+// Doors), so a duplicate ID is not rejected implicitly by key-overwrite.
+// Uniqueness matters even though environments.WallEntity's derived
+// entity ID embeds position (making a same-ID-different-position pair
+// placement-safe on its own) — a stable ID is this package's contract for
+// referencing the SAME obstacle across ticks/reloads (a host or client
+// keying a future interaction verb off it), and a same-ID-SAME-position
+// pair would collide to one entity via PlaceEntity's move-in-place
+// semantics, silently swallowing what should be a rejected duplicate.
+// Run from rebuildRoomFromData so both AddObstacle and a direct
+// LoadFromData of hand-built/legacy Data get the same guarantee.
 func validateObstacles(obstacles []ObstacleData) error {
 	seen := make(map[core.EntityID]int, len(obstacles))
 	for i, o := range obstacles {


### PR DESCRIPTION
## Summary

Generic, dependency-free infrastructure for **static obstacle instances** in `encounter.SpaceData` and the underlying spatial room truth — closes #818.

Depends on #821 (merged, `e1f9840`), which generalized `two_chamber.go` into `InitDungeon`. This branch is based directly on `origin/main` at that commit.

## Data shape

```go
// encounter/data.go
type ObstacleData struct {
    ID             core.EntityID `json:"id"`
    Ref            string        `json:"ref"`
    Position       core.Hex      `json:"position"`
    BlocksMovement bool          `json:"blocks_movement"`
    BlocksLoS      bool          `json:"blocks_los"`
}
```

`SpaceData` gains `Obstacles []ObstacleData` (`json:"obstacles,omitempty"`). `Ref` is a plain opaque string — mirrors `MonsterData.MonsterRef`'s existing convention in this same file (e.g. `"dnd5e:obstacles:sarcophagus"`); the encounter SDK never interprets it. Obstacles are the same *category* of object as a wall (a static blocker the room truth agrees with) but are **instanced** (one hex, stable ID) rather than a generator-owned boundary-edge segment.

`Encounter.AddObstacle(id, ref, position, blocksMovement, blocksLoS) error` registers one instance, mirroring `AddDoor`'s shape and atomicity.

## Canonical-room flow

`rebuildRoomFromData` — the single function `InitRoom`, `AddDoor`, `AddObstacle`, and `LoadFromData` all funnel through — now also places every `SpaceData.Obstacles` entry into the *same* `spatial.Room` walls and doors use, reusing `environments.WallEntity` (the existing generic blocker abstraction walls and doors already share — no new entity type introduced). Movement (`Move`/`truncateAtWall` via `room.CanPlaceEntity`) and LoS (`room.IsLineOfSightBlocked`) consult obstacles exactly as they already do walls, because they're all the same room.

`validateObstacles` rejects empty/duplicate obstacle IDs before any placement happens. This is load-bearing, not just tidiness: `Obstacles` is an order-preserving **slice** (unlike the map-keyed `Doors`), so an unchecked duplicate ID would let `room.PlaceEntity` silently *relocate* an earlier obstacle's room occupancy (its own documented same-ID-move semantics) rather than erroring — corrupting the room without this check.

## TDD discrimination

12 tests in `encounter/obstacle_test.go`, each proving a distinct behavior:

| Test | Discriminates |
|---|---|
| `TestObstacle_ToData_LoadFromData_RoundTrip` | every field survives ToData/LoadFromData exactly (RED: compile failure on undefined `AddObstacle`/`ObstacleData`/`SpaceData.Obstacles` → GREEN) |
| `TestObstacle_BlocksMovement_True` / `_False` | movement truncates at a blocking obstacle, passes through a non-blocking one |
| `TestObstacle_BlocksLoS_True` / `_False` | `room.IsLineOfSightBlocked` agrees with `BlocksLoS` |
| `TestObstacle_CoexistsWithWallsAndDoors` | a wall + closed door + obstacle at three distinct hexes all block independently after one rebuild |
| `TestAddObstacle_RejectsEmptyID` / `RejectsDuplicateID` | rejected atomically — mutation-verified (temporarily removed `AddObstacle`'s own pre-checks; still caught by `validateObstacles` inside `rebuildRoomFromData` as defense-in-depth, then restored) |
| `TestAddObstacle_RejectsOutOfBoundsPosition` / `RejectsDuplicateOccupancy` | rejected atomically via `spatial`'s own pre-existing `PlaceEntity`/grid validation (the same mechanism walls/doors already depend on) |
| `TestAddObstacle_RejectsDuplicateOccupancy_BothNonBlocking` | two `BlocksMovement=false` obstacles sharing a hex are still rejected as a data error, not silently co-located — closes a Copilot review gap (`spatial.BasicRoom`'s own occupancy check only rejects when the *existing* occupant blocks movement); RED confirmed (expected `Error`, got `nil`) before `rebuildRoomFromData` was changed to check the shared `placed` occupancy set explicitly, ahead of calling `PlaceEntity` |
| `TestObstacle_BackwardCompatible_NoObstacles` | nil/empty `Obstacles` omitted from the wire; pre-#818 snapshots round-trip unchanged |

Every "Rejects*" test asserts the failed call leaves `Data.Space.Obstacles`/`e.room` **unchanged** — no partial state.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` (encounter, 4 packages) — green, ~54s
- `go test -race ./...` — green, ~58s
- `gofmt -l` / `goimports -l` — clean
- `go mod tidy` — no diff
- `golangci-lint run --config=../.golangci.yml` at the repo-pinned `v2.2.1` (from `.github/workflows/ci-enhanced.yml`'s `GOLANGCI_VERSION`, installed to an isolated path since the ambient install was a newer v2.12.2) — **0 issues**
- Diff scope confirmed via `git diff --stat origin/main...HEAD`: `encounter/data.go`, `encounter/space.go`, `encounter/obstacle_test.go`, `.claude/progress.json`, `.claude/tests.json` only — no unrelated module/refactor changes.

## Explicitly out of scope (per issue #818)

- Crypt-specific placement (deferred to #819, which depends on this)
- Cosmetic decor / rendering
- Interaction verbs (click/search/disarm)
- Cover calculations / partial-LoS math beyond the existing boolean model
- Monster seeding
- Any `rpg-api`/proto/web change

## Compatibility notes

- `Obstacles` is `omitempty`; every existing encounter/`SpaceData` with no obstacles round-trips byte-for-byte unchanged.
- No change to `Walls`, `Doors`, `Regions`, or any existing generator (`InitRoom`, `InitTwoChamberRoom`, `InitDungeon`).
- `AddObstacle` requires `Data.Space != nil` (an obstacle's only representation is a `SpaceData.Obstacles` entry — there's nowhere to persist it without a Space), unlike `AddDoor` which tolerates a nil Space.

— platform agent, on behalf of KirkDiggler

