### PR TITLE
feat(encounter): generator emits a locked boss door (Locked + LockDC through AddDoor) (#815)

### DIFF
--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -24,7 +24,7 @@
       "task": "TDD: DungeonConnectorParams lock fields, generation, validation, persistence, full unlock-flow integration",
       "status": "completed",
       "artifacts": ["encounter/dungeon.go", "encounter/locked_connector_test.go"],
-      "commit": null,
+      "commit": "a5c38cb",
       "notes": "RED: wrote encounter/locked_connector_test.go referencing DungeonConnectorParams.Locked/LockDC/LockAbility/LockTool (did not exist yet) -- go test failed to build with exactly the expected 'undefined field' errors on those 4 fields (9 occurrences across the file), zero other build errors once a pre-existing core.HexSet map-index-as-bool test bug was fixed (View.RevealedHexes is core.HexSet i.e. map[Hex]struct{}, not map[Hex]bool -- switched two assertions to .Has()). GREEN: added Locked/LockDC/LockAbility/LockTool to DungeonConnectorParams (doc'd per CI public-API rules); InitDungeon's door-staging loop copies them onto the generated DoorData when Locked; validateDungeonParams gained a new pre-mutation loop rejecting Locked && LockDC<=0 or Locked && LockAbility==\"\" (mirrors the file's existing duplicate-ID/unknown-archetype gates -- runs before any Space/Doors mutation, so atomicity falls out for free, no rollback logic needed for this new check). All 8 new tests pass; zero other test in the module touched or modified.",
       "tests_added": [
         "TestInitDungeon_RejectsLockedConnectorWithoutDC",
@@ -42,11 +42,22 @@
       "task": "Full verification sweep",
       "status": "completed",
       "artifacts": [],
-      "commit": null,
+      "commit": "0a6f089",
       "notes": "go build ./... clean; go vet ./... clean; go test -count=1 ./... all green (55s, full module incl. new tests); go test -race -count=1 ./... all green (56s); gofmt -s -l . empty; goimports -l -local github.com/KirkDiggler . flags 13 PRE-EXISTING files (none touched by this change) -- confirmed byte-identical list against a throwaway origin/main worktree, so zero new drift introduced; go mod tidy produces no go.mod/go.sum diff. golangci-lint pinned to the repo's CI version (v2.2.1, per .github/workflows/ci-enhanced.yml GOLANGCI_VERSION, installed standalone to /tmp/opencode/toolbin since the ambient global install was v2.12.2) run against --config=../.golangci.yml: 0 issues. Diff confined to encounter/dungeon.go (extended) and encounter/locked_connector_test.go (new) -- no other module, no go.mod/go.work changes, no proto/API/client/monster/obstacle/HP code touched."
+    },
+    {
+      "id": "2026-07-22-004",
+      "task": "Open PR #824, verify CI + automated review",
+      "status": "completed",
+      "artifacts": [],
+      "commit": null,
+      "notes": "Pushed feat/815-locked-boss-door; opened PR #824 (ready, not draft), body includes dependency proof, scope, out-of-scope list, test roster, and full verification evidence, signed '-- platform agent, on behalf of KirkDiggler'. Confirmed via GraphQL closingIssuesReferences that PR #824 closes #815. Polled gh pr checks until settled: ci-status=pass, test-changed(encounter,1.25.x)=pass, changes=pass; the other jobs (detect-modules/lint/mod-tidy/test-all/build/test/all-checks-passed) report 'skipping' -- expected, this repo's CI fans out per-module and skips modules the changed-files filter didn't select (only encounter/ changed) while ci-status is the actual required gate. Copilot's automated PR review (copilot-pull-request-reviewer) completed: summary body explicitly states 'Copilot reviewed 4 out of 4 changed files ... and generated no comments.' Confirmed zero inline review threads via GraphQL reviewThreads (nodes: []) and zero PR-level comments (gh pr view --json comments empty) -- nothing to reply to or resolve.",
+      "pr": "https://github.com/KirkDiggler/rpg-toolkit/pull/824",
+      "ci_status": "pass",
+      "copilot_review": "completed, zero comments, zero review threads"
     }
   ],
   "next_steps": [
-    "None outstanding for #815's toolkit scope. Open PR, address any automated review comments, do not merge."
+    "None outstanding. PR #824 open, ready-not-draft, CI green, zero automated review comments to address. Awaiting human merge decision -- not merging per instructions."
   ]
 }

--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -1,83 +1,52 @@
 {
-  "branch": "feat/814-n-region-dungeon",
-  "issues": ["#814"],
-  "goal": "Generalize encounter/two_chamber.go's fixed two-chamber generator into a single generic N-region linear-chain dungeon generator (InitDungeon), adding region archetypes (entrance|chamber|corridor|boss) and an opaque SpaceData.Theme, while preserving InitTwoChamberRoom's existing public behavior by delegating it to the new generator.",
-  "design_doc": "rpg-project/ideas/the-dungeon/wave2-design.md",
+  "branch": "feat/815-locked-boss-door",
+  "issues": ["#815"],
+  "goal": "Extend InitDungeon's connector spec so a connector can declare its generated door Locked (+ LockDC/LockAbility/LockTool), reusing DoorData's existing Wave 2.9 lock-state fields verbatim. Generated boss door is closed+locked, round-trips through ToData/LoadFromData, and the existing AttemptUnlock/SubmitCheck/OpenDoor loop works against it end to end. Plain connectors and the InitTwoChamberRoom compatibility wrapper stay unlocked.",
+  "design_doc": "rpg-project/ideas/the-dungeon/wave2-design.md (Slice 3: locked boss door + boss chamber)",
+  "dependency": {
+    "issue": "#814 (N-region InitDungeon generator)",
+    "pr": "#821",
+    "verified_merged": true,
+    "merge_commit": "e1f98403ed7c92626e1e3fd69dea3383965febb3",
+    "verified_head_of_origin_main": true
+  },
   "sessions": [
     {
       "id": "2026-07-22-001",
-      "task": "Baseline verification + worktree/artifact setup",
+      "task": "Dependency verification + duplicate check + worktree/artifact setup + clean baseline",
       "status": "completed",
-      "artifacts": [".gitignore", ".claude/progress.json", ".claude/tests.json"],
+      "artifacts": [".claude/progress.json", ".claude/tests.json"],
       "commit": null,
-      "notes": "Verified no existing branch/PR for #814. Added .worktrees/ to .gitignore (repo had no linked-worktree convention yet, unlike rpg-api/rpg-dnd5e-web). Baseline `go test ./...` in encounter/ green (55s) before any behavioral change."
+      "notes": "Confirmed PR #821 state=MERGED, mergeCommit e1f9840 == origin/main HEAD (git log origin/main --oneline -1). Read #815 body + comments (zero comments) via gh issue view. Searched for duplicate branches/PRs referencing 815 (gh pr list --search 815: none; git ls-remote --heads: only an unrelated worktree-agent-* bootstrap branch). Created worktree .worktrees/feat-815-locked-boss-door on branch feat/815-locked-boss-door from origin/main (matches the repo's existing per-issue worktree convention). Baseline go build/vet/test all green (encounter module, 55s) before any change."
     },
     {
       "id": "2026-07-22-002",
-      "task": "TDD RegionArchetype vocabulary + SpaceData.Theme opaque field",
+      "task": "TDD: DungeonConnectorParams lock fields, generation, validation, persistence, full unlock-flow integration",
       "status": "completed",
-      "artifacts": ["encounter/data.go", "encounter/dungeon_test.go"],
+      "artifacts": ["encounter/dungeon.go", "encounter/locked_connector_test.go"],
       "commit": null,
-      "notes": "RED/GREEN: TestRegionArchetype_GenericVocabulary, TestSpaceData_ThemeIsOpaqueAndDistinctFromArchetype. Added RegionArchetype type + ArchetypeEntrance/Chamber/Corridor/Boss constants and RegionData.Archetype; added SpaceData.Theme (opaque, omitempty)."
+      "notes": "RED: wrote encounter/locked_connector_test.go referencing DungeonConnectorParams.Locked/LockDC/LockAbility/LockTool (did not exist yet) -- go test failed to build with exactly the expected 'undefined field' errors on those 4 fields (9 occurrences across the file), zero other build errors once a pre-existing core.HexSet map-index-as-bool test bug was fixed (View.RevealedHexes is core.HexSet i.e. map[Hex]struct{}, not map[Hex]bool -- switched two assertions to .Has()). GREEN: added Locked/LockDC/LockAbility/LockTool to DungeonConnectorParams (doc'd per CI public-API rules); InitDungeon's door-staging loop copies them onto the generated DoorData when Locked; validateDungeonParams gained a new pre-mutation loop rejecting Locked && LockDC<=0 or Locked && LockAbility==\"\" (mirrors the file's existing duplicate-ID/unknown-archetype gates -- runs before any Space/Doors mutation, so atomicity falls out for free, no rollback logic needed for this new check). All 8 new tests pass; zero other test in the module touched or modified.",
+      "tests_added": [
+        "TestInitDungeon_RejectsLockedConnectorWithoutDC",
+        "TestInitDungeon_RejectsLockedConnectorWithoutAbility",
+        "TestInitDungeon_RejectsInvalidLockedConnector_LeavesNoPartialState",
+        "TestInitDungeon_GeneratesLockedBossDoor_ClosedAndLocked",
+        "TestInitTwoChamberRoom_GeneratedDoor_RemainsUnlocked",
+        "TestInitDungeon_LockedBossDoor_RoundTripsThroughToDataLoadFromData",
+        "TestLockedBossDoorSuite/TestFailedCheck_LeavesDoorLockedRecoverableAndBlocking",
+        "TestLockedBossDoorSuite/TestSuccessfulCheck_UnlocksOpensAndRevealsBossRegion"
+      ]
     },
     {
       "id": "2026-07-22-003",
-      "task": "TDD InitDungeon validation (region/connector count, dimensions, door IDs, boss scale invariant)",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go"],
-      "commit": null,
-      "notes": "RED/GREEN per assertion: TestInitDungeon_RejectsFewerThanTwoRegions, RejectsWrongConnectorCount, RejectsNarrowRegion, RejectsShortSharedHeight, RejectsEmptyDoorID, RejectsUndersizedBossRoom (axis==6 rejected), AcceptsBossRoomExceedingScaleInvariant (axis>6 accepted). validateDungeonParams called unconditionally at InitDungeon's entry."
-    },
-    {
-      "id": "2026-07-22-004",
-      "task": "TDD InitDungeon N-region linear-chain generation + retire two_chamber.go's duplicate geometry",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go", "encounter/two_chamber.go"],
-      "commit": null,
-      "notes": "RED (nil-Space panic) then GREEN: generalized generateTwoChamberLayout -> generateDungeonLayout for N regions (shared Height, per-region Width, required-path-by-construction connectivity: entrance->door for region 0, door->door for interior regions, door->center for the terminal region). Rewrote two_chamber.go as a thin validating wrapper delegating to e.InitDungeon (N=2, chamber-1=ArchetypeEntrance, chamber-2=ArchetypeChamber); retired the now-duplicate chamberCubes/chamberWallSegments/generateChamberWalls/hexesFromCubes/chamberPathWidth in favor of the shared regionCubes/regionWallSegments/generateRegionWalls/hexesFromCubes/dungeonPathWidth in dungeon.go. two_chamber_test.go untouched and green throughout (existing tests pass against the generalized entry point, per the done bar). DungeonSuite added (3-region entrance/corridor/boss fixture): closed-door block, open-door connectivity, region archetype/theme partition, seed determinism, crypt-shaped capability without ArchetypeChamber.",
-      "concerns": "Isolated and worked around (not fixed — different module, out of scope) a pre-existing tools/environments|tools/spatial pointy-top-hex-grid parity quirk: IsLineOfSightBlocked's short-range raycast across a 2-column gap gives a different (incorrect-looking) result depending on which column parity (even/odd) the door sits on, even though wall placement is byte-identical between the two parities and BFS movement reachability is unaffected in both. Fixture's corridor width nudged 4->5 so both connector doors land on the working parity. Documented in tests.json and will flag in the PR body for awareness; not an #814 regression (reproduced identically via a bare two-door layout unrelated to InitDungeon's own logic)."
-    },
-    {
-      "id": "2026-07-22-005",
-      "task": "Full verification + lint/scope self-review",
+      "task": "Full verification sweep",
       "status": "completed",
       "artifacts": [],
       "commit": null,
-      "notes": "go build ./..., go vet ./..., go test ./... (55s, all green), go test -race ./... (all green), gofmt -l . / goimports -l . (clean), go mod tidy (no diff), golangci-lint run ./... (66 goconst issues, identical to the pre-existing origin/main baseline count of 65+1 -- verified byte-identical baseline list except zero new hits from dungeon.go/dungeon_test.go after fixing the 2 lll + 3 goconst hits my own new test file introduced). Diff confined to encounter/data.go, encounter/two_chamber.go, encounter/dungeon.go (new), encounter/dungeon_test.go (new); no go.mod/go.sum/go.work changes; no crypt-specific props/monster-seeding/locked-door/API/proto/client code touched."
-    },
-    {
-      "id": "2026-07-22-006",
-      "task": "PR #821 review response: LoS coverage gap in closed-door dungeon test + InitDungeon partial-init atomicity",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go"],
-      "commit": null,
-      "notes": "Two independent review findings addressed. (1) TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors only checked movement/reachability, never IsLineOfSightBlocked, despite its name. DISCRIMINATION: temporarily mutated space.go's closed-door wall Properties.BlocksLoS from true to false (production code, reverted immediately after) and reran the two suites: TestTwoChamberSuite/TestClosedDoor_BlocksMovementAndLoS_BetweenChambers (which DOES check LoS) correctly failed; TestDungeonSuite/TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors still passed -- proving the exact gap. Added two IsLineOfSightBlocked(farEdge,nearEdge) assertions (one per connector, mirroring the two-chamber precedent's direct across-the-door check) to the dungeon test; reran with the same mutation still active -> both new assertions failed for the expected reason (RED); reverted the mutation -> GREEN, space.go diff empty (no unrelated change kept). (2) InitDungeon's original per-connector `for range layout.doors { e.AddDoor(...) }` loop could leave e.data.Space set and earlier connectors' doors added if a LATER connector's AddDoor failed, despite returning an error -- observable partial state. RED: new top-level test TestInitDungeon_FailedRoomRebuild_LeavesNoPartialState pre-seeds a decoy door at an out-of-bounds position (Space nil at that point, so AddDoor just records it; rebuildRoomFromData's PlaceEntity deterministically fails on out-of-bounds positions, since same-cell collisions are defensively skipped rather than errored) then calls InitDungeon and asserts Space/both connector doors are absent after the failure -- failed for the expected reason (Space non-nil leaked) against the original code. GREEN: rewrote InitDungeon to stage all connector DoorData entries directly into e.data.Doors and call rebuildRoomFromData exactly ONCE (instead of once per connector), snapshotting the pre-call Space and rolling both Space and the newly-staged door IDs back on any rebuild failure -- rebuildRoomFromData itself never calls registerRoom (swapping in e.room/e.roomOrchestrator) until every wall/door places successfully, so the room side was already atomic; the fix completes the Data-side half of that guarantee. Bonus: single rebuild instead of N-1 is also strictly cheaper. No changes to AddDoor or any other public API.",
-      "verification": "go build ./..., go vet ./..., go test -count=1 ./... (54s all green incl. new + full existing suites), go test -race -count=1 ./... (58s all green), gofmt/goimports clean, go mod tidy no diff, golangci-lint run ./... unchanged at 65 goconst issues (byte-identical to origin/main baseline, zero new findings). Diff confined to encounter/dungeon.go and encounter/dungeon_test.go only (space.go's mutation was fully reverted, confirmed via `git diff origin/main -- encounter/space.go` producing no output)."
-    },
-    {
-      "id": "2026-07-22-007",
-      "task": "File tracker issue for the pre-existing LoS parity quirk + board it",
-      "status": "completed",
-      "artifacts": [],
-      "commit": null,
-      "notes": "Checked for duplicates first (gh issue search: 'hex grid line of sight', 'IsLineOfSightBlocked parity', 'pointy-top hex grid', 'roundCube', 'door line of sight' -- found #763 'lerpCube truncation makes GetLineOfSight directionally asymmetric at distance >=22', read its full body: different symptom (direction-dependent A vs B disagreement at long range, already has proper cube rounding as the fix target) from ours (a single, direction-SYMMETRIC but wrong short-range answer at distance 2). Confirmed symmetry empirically with a throwaway repro test (both IsLineOfSightBlocked(far1,near2) and the reverse call agreed, both true, for the width-4-corridor/odd-door-column case that exposed the quirk) before concluding it's a distinct issue, not a duplicate of #763 -- repro test deleted after use, not committed. Filed https://github.com/KirkDiggler/rpg-toolkit/issues/822, signed '-- platform agent, on behalf of KirkDiggler'. Added to board #19 'The Dungeon Run' (item PVTI_lAHOAASbwc4Bcj4vzgzvPkM) with Feature=The Dungeon, Team=Platform, Status=Todo."
-    },
-    {
-      "id": "2026-07-22-008",
-      "task": "PR #821 Copilot re-review: 3 unresolved threads (region ID/archetype validation, duplicate DoorID validation, terminal-region path Purpose string)",
-      "status": "completed",
-      "artifacts": ["encounter/dungeon.go", "encounter/dungeon_test.go"],
-      "commit": "a642c72",
-      "notes": "Fetched all 3 unresolved review threads via GraphQL (reviewThreads) before starting: PRRT_kwDOPB8ngM6TADW7 (comment 3632233153, region IDs/archetypes), PRRT_kwDOPB8ngM6TADXf (comment 3632233194, duplicate DoorIDs), PRRT_kwDOPB8ngM6TADXz (comment 3632233223, 'door-to-chamber' purpose string). Addressed all three: (1) validateDungeonParams now rejects empty region IDs, duplicate region IDs, and any Archetype outside the documented fixed vocabulary (entrance|chamber|corridor|boss) -- went slightly beyond the user's literal 'ID non-empty+unique' scope to also close the archetype half of the SAME Copilot comment, since it's a one-line closed-set switch consistent with data.go's own 'fixed vocabulary' documentation and costs nothing in flexibility (future archetypes would be new exported constants in this package, not arbitrary caller strings). RED: TestInitDungeon_RejectsEmptyRegionID, RejectsDuplicateRegionIDs, RejectsUnknownArchetype all failed 'want error, got nil' against prior code. (2) validateDungeonParams now also rejects duplicate connector DoorIDs (existing non-empty check preserved). Reproduced the silent-overwrite symptom with a throwaway test BEFORE the fix: duplicate DoorIDs across 2 connectors left err=nil and exactly 1 entry in e.data.Doors (the later connector's, at the later connector's position) -- the earlier boundary column got no door entity, confirming Copilot's exact 'permanently unblocked, closed-by-default contract broken' claim. RED: TestInitDungeon_RejectsDuplicateConnectorDoorIDs failed the same way; also asserts the rejected call leaves Space nil and Doors empty (consistent with the prior round's atomicity fix). (3) Renamed the terminal region's required-path Purpose from 'door-to-chamber' to 'door-to-region-center' -- accurate for any terminal archetype. Investigated whether to add a test: confirmed Purpose only surfaces via environments.validatePathSafety's 'required path blocked' error, which PathSafetyParams.EmergencyFallback: true (already set in generateRegionWalls) swallows by falling back to an empty layout before it can propagate -- deterministically forcing that exact error would need brittle setup fighting the fallback, so per the user's explicit guidance against manufacturing a brittle test for an internal/cosmetic string, made the string fix only, explained the reasoning in the reply instead.",
-      "verification": "go build ./..., go vet ./..., go test -count=1 ./... (54s all green incl. 4 new tests + all pre-existing suites), go test -race -count=1 ./... (54s all green), gofmt/goimports clean, go mod tidy no diff, golangci-lint run ./... unchanged at 65 goconst issues (byte-identical baseline, zero new). Diff confined to encounter/dungeon.go + encounter/dungeon_test.go (+121/-4 lines). Pushed as a642c72 before posting any reply or resolving any thread. Posted one reply per thread (each citing the commit and exact change) then resolved all 3 threads via GraphQL resolveReviewThread -- verified zero unresolved threads remain on the PR afterward.",
-      "comment_replies": [
-        {"comment_id": 3632233153, "reply_url": "https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632507283", "thread_id": "PRRT_kwDOPB8ngM6TADW7", "resolved": true},
-        {"comment_id": 3632233194, "reply_url": "https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632508545", "thread_id": "PRRT_kwDOPB8ngM6TADXf", "resolved": true},
-        {"comment_id": 3632233223, "reply_url": "https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632509808", "thread_id": "PRRT_kwDOPB8ngM6TADXz", "resolved": true}
-      ]
+      "notes": "go build ./... clean; go vet ./... clean; go test -count=1 ./... all green (55s, full module incl. new tests); go test -race -count=1 ./... all green (56s); gofmt -s -l . empty; goimports -l -local github.com/KirkDiggler . flags 13 PRE-EXISTING files (none touched by this change) -- confirmed byte-identical list against a throwaway origin/main worktree, so zero new drift introduced; go mod tidy produces no go.mod/go.sum diff. golangci-lint pinned to the repo's CI version (v2.2.1, per .github/workflows/ci-enhanced.yml GOLANGCI_VERSION, installed standalone to /tmp/opencode/toolbin since the ambient global install was v2.12.2) run against --config=../.golangci.yml: 0 issues. Diff confined to encounter/dungeon.go (extended) and encounter/locked_connector_test.go (new) -- no other module, no go.mod/go.work changes, no proto/API/client/monster/obstacle/HP code touched."
     }
   ],
   "next_steps": [
-    "None outstanding -- all 3 Copilot review threads resolved and replied to. Awaiting further review/merge decision on PR #821."
+    "None outstanding for #815's toolkit scope. Open PR, address any automated review comments, do not merge."
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -1,116 +1,68 @@
 {
   "tests": [
     {
-      "id": "region-archetype-vocabulary",
-      "feature": "region-archetype",
-      "prompt": "RegionData gains an Archetype field of a generic RegionArchetype type with exactly the values entrance | chamber | corridor | boss.",
+      "id": "locked-connector-rejects-missing-dc",
+      "feature": "locked-boss-door",
+      "prompt": "Call InitDungeon with a connector marked Locked but LockDC<=0. Verify InitDungeon returns an error identifying the offending connector by index, and mutates no encounter data.",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "TestRegionArchetype_GenericVocabulary (dungeon_test.go)."
+      "test_name": "TestInitDungeon_RejectsLockedConnectorWithoutDC"
     },
     {
-      "id": "space-theme-opaque-passthrough",
-      "feature": "space-theme",
-      "prompt": "SpaceData gains a Theme string field, distinct from RegionData.Archetype, that InitDungeon copies verbatim from DungeonParams.Theme without branching on its value anywhere in the generator.",
+      "id": "locked-connector-rejects-missing-ability",
+      "feature": "locked-boss-door",
+      "prompt": "Call InitDungeon with a connector marked Locked, LockDC set, but LockAbility empty. Verify InitDungeon returns an error identifying the offending connector by index.",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "TestSpaceData_ThemeIsOpaqueAndDistinctFromArchetype + DungeonSuite/TestRegions_ArchetypesThemeAndPartition (Theme='crypt' round-trip). Grepped dungeon.go/two_chamber.go for any `Theme ==`/switch-on-Theme branching: none exists."
+      "test_name": "TestInitDungeon_RejectsLockedConnectorWithoutAbility"
     },
     {
-      "id": "init-dungeon-validates-region-count",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects fewer than 2 regions (a dungeon needs at least an entrance and one connected region).",
+      "id": "locked-connector-invalid-leaves-no-partial-state",
+      "feature": "locked-boss-door",
+      "prompt": "Call InitDungeon on a 3-region dungeon where connector 1 is Locked but invalid. Verify the rejected call leaves Space nil and Doors empty -- the invariant InitDungeon's atomicity contract already guarantees for its other pre-mutation validation gates.",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsFewerThanTwoRegions."
+      "test_name": "TestInitDungeon_RejectsInvalidLockedConnector_LeavesNoPartialState"
     },
     {
-      "id": "init-dungeon-validates-connector-count",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects a Connectors slice whose length is not exactly len(Regions)-1.",
+      "id": "locked-connector-generates-closed-locked-door",
+      "feature": "locked-boss-door",
+      "prompt": "Build a 3-region dungeon (entrance/corridor/boss) where connector 0 is plain and connector 1 is Locked with a DC/Ability/Tool. Verify connector 1's generated DoorData is Locked=true, Open=false, and carries the exact LockDC/LockAbility/LockTool configured; verify connector 0's generated door stays entirely unlocked (Locked=false, LockDC=0, LockAbility/LockTool empty).",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsWrongConnectorCount."
+      "test_name": "TestInitDungeon_GeneratesLockedBossDoor_ClosedAndLocked"
     },
     {
-      "id": "init-dungeon-validates-dimensions-and-door-ids",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects any region narrower than 4, a shared Height under 4, and any connector with an empty DoorID.",
+      "id": "two-chamber-wrapper-stays-unlocked",
+      "feature": "locked-boss-door",
+      "prompt": "Call InitTwoChamberRoom (the compatibility wrapper over InitDungeon). Verify its generated door is never locked -- the wrapper must not gain locked-door behavior as a side effect of #815.",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsNarrowRegion, TestInitDungeon_RejectsShortSharedHeight, TestInitDungeon_RejectsEmptyDoorID."
+      "test_name": "TestInitTwoChamberRoom_GeneratedDoor_RemainsUnlocked"
     },
     {
-      "id": "init-dungeon-boss-scale-invariant",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects (generation-time assertion, not eyeballing) any boss-archetype region whose primary playable axis (min(width, shared height)) does not exceed 6 hex steps.",
+      "id": "locked-door-persists-through-todata-loadfromdata",
+      "feature": "locked-boss-door",
+      "prompt": "Build a dungeon with a generated locked boss connector, marshal ToData() to JSON, unmarshal, and LoadFromData. Verify the reloaded door's Locked/LockDC/LockAbility/LockTool are intact and it still blocks LoS into the boss region.",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "TestInitDungeon_RejectsUndersizedBossRoom (axis==6 rejected), TestInitDungeon_AcceptsBossRoomExceedingScaleInvariant (axis>6 accepted). Enforced in validateDungeonParams, called unconditionally at the top of InitDungeon."
+      "test_name": "TestInitDungeon_LockedBossDoor_RoundTripsThroughToDataLoadFromData"
     },
     {
-      "id": "init-dungeon-n-region-linear-chain",
-      "feature": "init-dungeon",
-      "prompt": "A 3-region linear dungeon (entrance chamber -> corridor -> boss chamber, 2 doors) generates with a reproducible seed; every region is reachable from the entrance once its door opens; RegionAt returns the right archetype for each hex; a closed connector door blocks movement+LoS across it, matching the two-chamber behavior generalized to N.",
+      "id": "locked-door-failed-check-stays-locked-and-recoverable",
+      "feature": "locked-boss-door",
+      "prompt": "Against a generated locked boss door: AttemptUnlock, then SubmitCheck with a roll that fails the DC. Verify the door remains Locked=true, Open=false, still blocks movement/LoS into the boss region, and is recoverable (a second AttemptUnlock succeeds).",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "DungeonSuite (dungeon_test.go): TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors (now asserts IsLineOfSightBlocked for BOTH connectors, not just movement/reachability -- see closed-door-los-coverage below for the discrimination evidence), TestOpeningBothDoors_ConnectsEntranceThroughToBoss, TestRegions_ArchetypesThemeAndPartition, TestLayout_DeterministicSeedVsEntropyDefault. NOTE (concern, not a regression): the fixture's corridor width had to be nudged from 4 to 5 hexes to sidestep a pre-existing tools/environments|tools/spatial pointy-top-hex-grid parity quirk in IsLineOfSightBlocked's short-range raycast across a door column of certain column parity relative to its flanking columns — reproduced and isolated to that dependency, unrelated to InitDungeon's own geometry math (identical wall placement on both doors; only LOS raycast result differed by door-column parity). Movement/BFS reachability was unaffected in both parities. Confirmed direction-SYMMETRIC (not the #763 asymmetry bug) via a throwaway repro test before filing https://github.com/KirkDiggler/rpg-toolkit/issues/822 (boarded #19 The Dungeon Run, Feature=The Dungeon, Team=Platform, Status=Todo) to track it. Out of scope for #814 to fix (different module)."
+      "test_name": "TestLockedBossDoorSuite/TestFailedCheck_LeavesDoorLockedRecoverableAndBlocking"
     },
     {
-      "id": "closed-door-los-coverage",
-      "feature": "init-dungeon",
-      "prompt": "TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors must actually assert IsLineOfSightBlocked for both connectors (not just movement/reachability), following the two-chamber precedent (TestClosedDoor_BlocksMovementAndLoS_BetweenChambers).",
+      "id": "locked-door-successful-check-unlocks-opens-reveals",
+      "feature": "locked-boss-door",
+      "prompt": "Against a generated locked boss door: AttemptUnlock, then SubmitCheck with a roll that passes the DC. Verify Locked clears, Open becomes true (via the existing dispatchPromptAction -> OpenDoor path, no new verb), the entrance becomes reachable through to the boss region, LoS across the doorway clears, and the player's View reveals into the boss chamber through the doorway.",
       "passes": true,
       "last_checked": "2026-07-22",
-      "notes": "Review finding: the test name promised LoS coverage it didn't have. DISCRIMINATION (before the test fix): temporarily set space.go's closed-door wall Properties.BlocksLoS from true to false (production mutation, reverted immediately) and reran both suites -- TestTwoChamberSuite/TestClosedDoor_BlocksMovementAndLoS_BetweenChambers (which DOES check LoS) correctly FAILED; TestDungeonSuite/TestClosedDoors_BlockMovementAndLoS_AcrossBothConnectors (lacking the LoS assertion) still PASSED, proving the exact gap. FIX: added IsLineOfSightBlocked(farEdge(i), nearEdge(i+1)) assertions for both connector 0 and connector 1, mirroring the two-chamber precedent's direct across-the-door check. RED (with the same production mutation still active): both new assertions failed with the expected messages ('closed door 0/1 must block LoS...'). GREEN (mutation reverted): all DungeonSuite + TwoChamberSuite tests pass; `git diff origin/main -- encounter/space.go` is empty, confirming no unrelated production change was kept."
-    },
-    {
-      "id": "init-dungeon-atomic-on-door-failure",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon's per-connector door placement must be atomic: if the room rebuild fails for any reason, the encounter must be left exactly as it was before the call (no partially-set Space, no leaked connector doors, no partially-rebuilt room) rather than returning an error while leaving observable partial state.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Review finding: the original `for range layout.doors { e.AddDoor(...) }` loop could leave e.data.Space set and earlier connectors' doors added if a LATER connector's AddDoor failed, despite InitDungeon returning an error. RED: TestInitDungeon_FailedRoomRebuild_LeavesNoPartialState pre-seeds a decoy door at an out-of-bounds position (deterministically fails spatial.BasicRoom.PlaceEntity's grid.IsValidPosition check once InitDungeon sets Space and rebuilds -- same-cell door/wall collisions are defensively skipped rather than erroring, so this is the only reliable failure-injection technique against this code), then asserts Space/both connector doors are absent and enc.Room() is nil after the failed call -- failed for the expected reason (Space non-nil leaked) against the original code. GREEN: InitDungeon now stages both connector doors directly into e.data.Doors, calls rebuildRoomFromData exactly ONCE for the whole batch (instead of once per connector), and on failure restores the pre-call Space and deletes the staged door IDs. rebuildRoomFromData itself only calls registerRoom (swapping in e.room/e.roomOrchestrator) after every wall/door places successfully, so the room side was already atomic; this completes the Data-side half. No changes to AddDoor or any other public API; bonus: 1 rebuild instead of N-1."
-    },
-    {
-      "id": "init-dungeon-crypt-shaped-capability",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon's generic parameters are flexible enough to express the first crypt's entrance/corridor/boss shape (Theme='crypt' passthrough only, no crypt-specific branching in the generator) without emitting a chamber archetype.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "DungeonSuite/TestFirstCryptTemplate_EntranceCorridorBossWithoutChamberArchetype."
-    },
-    {
-      "id": "two-chamber-compat-via-generalized-entry-point",
-      "feature": "two-chamber-compat",
-      "prompt": "InitTwoChamberRoom delegates to the generalized InitDungeon entry point internally (retiring the duplicate wall-generation implementation) while every existing encounter/two_chamber_test.go assertion (region IDs, entrance, door blocking/LoS, determinism-vs-entropy) continues to pass unchanged.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "two_chamber.go rewritten as a thin validating wrapper calling e.InitDungeon(...); two_chamber_test.go untouched and green (TestTwoChamberSuite, TestRegionAt_NilReceiver). Retired duplicate helpers: chamberCubes, chamberWallSegments, generateChamberWalls, hexesFromCubes, chamberPathWidth (now regionCubes/regionWallSegments/generateRegionWalls/hexesFromCubes/dungeonPathWidth in dungeon.go, shared by both entry points)."
-    },
-    {
-      "id": "init-dungeon-region-id-and-archetype-validation",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects an empty region ID, a duplicate region ID across the chain, and any region Archetype outside the documented fixed vocabulary (entrance | chamber | corridor | boss) -- errors must identify the offending region by index.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Copilot review thread (comment 3632233153, resolved): empty/duplicate region IDs make SpaceData.RegionAt ambiguous (returns the first matching region); an open-ended Archetype string undermines the documented 'fixed vocabulary' contract. RED: TestInitDungeon_RejectsEmptyRegionID, TestInitDungeon_RejectsDuplicateRegionIDs, TestInitDungeon_RejectsUnknownArchetype all failed 'want error, got nil' against the prior code. GREEN: validateDungeonParams now tracks seen region IDs in a map (rejecting empty and duplicate) and switches on Archetype against the 4 known constants (rejecting anything else). Errors follow the existing 'region %d (%q): ...' style and name the offending index. Reply: https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632507283."
-    },
-    {
-      "id": "init-dungeon-duplicate-connector-door-id",
-      "feature": "init-dungeon",
-      "prompt": "InitDungeon rejects a duplicate connector DoorID before generation mutates encounter data -- reusing a DoorID across connectors must not silently overwrite an earlier door in e.data.Doors.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Copilot review thread (comment 3632233194, resolved): AddDoor keys e.data.Doors by DoorID, so two connectors sharing an ID silently overwrite each other, leaving the earlier boundary column permanently unblocked (no closed door entity) -- breaks the closed-by-default connectivity contract with no error. Reproduced the symptom directly with a throwaway (uncommitted) test before the fix: duplicate DoorIDs across 2 connectors left err=nil and exactly 1 entry in e.data.Doors (the later connector's door, at the later connector's position). RED: TestInitDungeon_RejectsDuplicateConnectorDoorIDs failed 'want error, got nil' against the prior code (also asserts the rejected call leaves Space nil and Doors empty). GREEN: validateDungeonParams now tracks seen connector DoorIDs in a map alongside the existing non-empty check, rejecting duplicates before InitDungeon ever calls generateDungeonLayout or mutates e.data. Reply: https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632508545."
-    },
-    {
-      "id": "terminal-region-path-purpose-string",
-      "feature": "init-dungeon",
-      "prompt": "The terminal region's required-path Purpose string must not claim 'chamber' when the terminal region can be any archetype (e.g. boss) -- use an accurate, generic description.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Copilot review thread (comment 3632233223, resolved): 'door-to-chamber' is misleading once the terminal region isn't a chamber. FIX: renamed to 'door-to-region-center', accurate for any archetype, smallest possible change (one string literal). NOT added a new test: confirmed (by reading tools/environments/wall_patterns.go) this string only surfaces via validatePathSafety's 'required path blocked' error, and generateRegionWalls always sets Safety.EmergencyFallback: true, which swallows that error by falling back to an empty layout before it can propagate -- deterministically forcing that exact error would require brittle setup fighting the fallback. Per explicit instruction not to manufacture a brittle test for an internal/cosmetic string, this was left as a documented reasoning in the reply rather than a new assertion. Reply: https://github.com/KirkDiggler/rpg-toolkit/pull/821#discussion_r3632509808."
+      "test_name": "TestLockedBossDoorSuite/TestSuccessfulCheck_UnlocksOpensAndRevealsBossRegion"
     }
   ]
 }

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -79,10 +79,41 @@ type DungeonRegionParams struct {
 // DungeonConnectorParams configures the door joining two consecutive
 // regions in an InitDungeon chain.
 type DungeonConnectorParams struct {
-	// DoorID is the entity id for the plain door generated at this
-	// connector. Required — mirrors AddDoor, which InitDungeon composes
-	// with internally.
+	// DoorID is the entity id for the door generated at this connector.
+	// Required — mirrors AddDoor, which InitDungeon composes with
+	// internally.
 	DoorID core.EntityID
+
+	// Locked marks this connector's generated door as closed AND locked
+	// (rpg-toolkit#815), reusing DoorData's existing Wave 2.9 lock-state
+	// fields verbatim: AttemptUnlock/SubmitCheck become the path through
+	// it (issuing and resolving a skill-check prompt) until a player
+	// passes the configured check; OpenDoor alone does not gate on it —
+	// see DoorData.Locked's doc for the full contract. Zero value
+	// (false) generates a plain closed door, same as every connector
+	// before #815 and the InitTwoChamberRoom compatibility wrapper,
+	// which never sets this field.
+	Locked bool
+
+	// LockDC is the skill-check DC AttemptUnlock issues when Locked is
+	// true, copied verbatim onto the generated door's DoorData.LockDC.
+	// Required (> 0) when Locked is true — validateDungeonParams rejects
+	// a locked connector with LockDC<=0 before any generation runs.
+	// Ignored when Locked is false.
+	LockDC int
+
+	// LockAbility is the 3-letter ability code (e.g. "DEX") the check
+	// rolls against, copied verbatim onto DoorData.LockAbility. Required
+	// (non-empty) when Locked is true — validateDungeonParams rejects a
+	// locked connector with an empty LockAbility. Ignored when Locked is
+	// false.
+	LockAbility string
+
+	// LockTool is an optional toolkit ref (e.g.
+	// "dnd5e:item:thieves-tools") granting a tool-proficiency bonus on
+	// the check, copied verbatim onto DoorData.LockTool. Empty means no
+	// tool bonus applies; never required. Ignored when Locked is false.
+	LockTool string
 }
 
 // InitDungeon builds an N-region linear-chain dungeon: an ordered list of
@@ -127,8 +158,16 @@ func (e *Encounter) InitDungeon(params DungeonParams) error {
 
 	stagedDoorIDs := make([]core.EntityID, 0, len(layout.doors))
 	for i, door := range layout.doors {
-		doorID := params.Connectors[i].DoorID
-		e.data.Doors[doorID] = &DoorData{ID: doorID, Position: core.HexFromCube(door), Open: false}
+		connector := params.Connectors[i]
+		doorID := connector.DoorID
+		dd := &DoorData{ID: doorID, Position: core.HexFromCube(door), Open: false}
+		if connector.Locked {
+			dd.Locked = true
+			dd.LockDC = connector.LockDC
+			dd.LockAbility = connector.LockAbility
+			dd.LockTool = connector.LockTool
+		}
+		e.data.Doors[doorID] = dd
 		stagedDoorIDs = append(stagedDoorIDs, doorID)
 	}
 
@@ -197,6 +236,25 @@ func validateDungeonParams(params DungeonParams) error {
 			return fmt.Errorf("connector %d (%q): duplicate door id (already used by connector %d)", i, c.DoorID, first)
 		}
 		seenDoorIDs[c.DoorID] = i
+	}
+	// A locked connector's check config is validated contextually, before
+	// InitDungeon mutates any encounter data: LockDC/LockAbility only mean
+	// anything when Locked is true, and AttemptUnlock/SubmitCheck depend
+	// on both being present (a zero DC is never a meaningful skill-check
+	// target; an empty ability leaves the CharacterResolver nothing to
+	// resolve a modifier against). Rejecting here — rather than letting a
+	// half-configured locked door generate — mirrors the file's other
+	// pre-mutation validation gates (duplicate IDs, unknown archetypes).
+	for i, c := range params.Connectors {
+		if !c.Locked {
+			continue
+		}
+		if c.LockDC <= 0 {
+			return fmt.Errorf("connector %d (%q): locked connector requires LockDC > 0 (got %d)", i, c.DoorID, c.LockDC)
+		}
+		if c.LockAbility == "" {
+			return fmt.Errorf("connector %d (%q): locked connector requires LockAbility", i, c.DoorID)
+		}
 	}
 	for i, r := range params.Regions {
 		if r.Archetype != ArchetypeBoss {

--- a/encounter/locked_connector_test.go
+++ b/encounter/locked_connector_test.go
@@ -1,0 +1,319 @@
+package encounter_test
+
+// locked_connector_test.go is the TDD gate for rpg-toolkit#815: extending
+// InitDungeon's connector spec so a connector can declare its generated
+// door Locked (+ LockDC/LockAbility/LockTool), reusing DoorData's existing
+// Wave 2.9 lock-state fields verbatim rather than inventing a parallel
+// representation. Scope is generation + validation + persistence + the
+// existing AttemptUnlock/SubmitCheck/OpenDoor round-trip against a
+// GENERATED locked door — no new verb/RPC (see prompts_test.go for the
+// hand-mutated-DoorData half of that machinery's own gate).
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+)
+
+// dungeonBossDoorLockDC is the fixture DC used by every locked-connector
+// test in this file — an arbitrary but fixed value distinct from
+// prompts_test.go's own fixture DCs (15, 17) only by coincidence; reusing
+// abilityDEX/thievesTool from prompts_test.go (same package) keeps the
+// lock-check vocabulary identical across both files.
+const dungeonBossDoorLockDC = 15
+
+// threeRegionDungeonParamsWithLockedBossDoor mirrors dungeon_test.go's
+// threeRegionDungeonParams (entrance/corridor/boss, same widths/height/
+// seed/theme/door IDs) but marks connector 1 (corridor -> boss) as a
+// locked connector — the shape #815's done bar describes: one plain
+// connector, one locked connector guarding the boss region.
+func threeRegionDungeonParamsWithLockedBossDoor(seed int64) encounter.DungeonParams {
+	params := threeRegionDungeonParams(seed)
+	params.Connectors[1].Locked = true
+	params.Connectors[1].LockDC = dungeonBossDoorLockDC
+	params.Connectors[1].LockAbility = abilityDEX
+	params.Connectors[1].LockTool = thievesTool
+	return params
+}
+
+// --- Validation: locked connector config is checked contextually, before
+// any mutation of encounter data (mirrors the file's other
+// validate-then-reject gates, e.g. TestInitDungeon_RejectsDuplicateConnectorDoorIDs). ---
+
+// TestInitDungeon_RejectsLockedConnectorWithoutDC: a locked connector with
+// LockDC<=0 has no meaningful skill-check DC — AttemptUnlock would issue a
+// prompt no roll could ever succeed against sensibly. Reject at generation
+// time rather than producing an unwinnable door.
+func TestInitDungeon_RejectsLockedConnectorWithoutDC(t *testing.T) {
+	enc := newTestEncounter(t)
+	params := validTwoRegionParams()
+	params.Connectors[0].Locked = true
+	params.Connectors[0].LockAbility = abilityDEX
+	err := enc.InitDungeon(params)
+	if err == nil {
+		t.Fatal("InitDungeon with a locked connector and no LockDC: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "connector 0") {
+		t.Errorf("error must identify the offending connector by index; got %q", err.Error())
+	}
+}
+
+// TestInitDungeon_RejectsLockedConnectorWithoutAbility: a locked connector
+// with no LockAbility has no ability for SubmitCheck's CharacterResolver to
+// resolve a modifier against — reject at generation time.
+func TestInitDungeon_RejectsLockedConnectorWithoutAbility(t *testing.T) {
+	enc := newTestEncounter(t)
+	params := validTwoRegionParams()
+	params.Connectors[0].Locked = true
+	params.Connectors[0].LockDC = dungeonBossDoorLockDC
+	err := enc.InitDungeon(params)
+	if err == nil {
+		t.Fatal("InitDungeon with a locked connector and no LockAbility: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "connector 0") {
+		t.Errorf("error must identify the offending connector by index; got %q", err.Error())
+	}
+}
+
+// TestInitDungeon_RejectsInvalidLockedConnector_LeavesNoPartialState: an
+// invalid locked-connector config must be caught by validateDungeonParams
+// (called before any generation) and must not leave a partially-built
+// Space or any staged doors behind — same atomicity contract
+// TestInitDungeon_RejectsDuplicateConnectorDoorIDs pins for the other
+// pre-mutation validation gate.
+func TestInitDungeon_RejectsInvalidLockedConnector_LeavesNoPartialState(t *testing.T) {
+	enc := newTestEncounter(t)
+	params := threeRegionDungeonParams(dungeonSeed)
+	params.Connectors[1].Locked = true // LockDC/LockAbility left zero-value: invalid
+
+	err := enc.InitDungeon(params)
+	if err == nil {
+		t.Fatal("InitDungeon with an invalid locked connector: want error, got nil")
+	}
+
+	data := enc.ToData()
+	if data.Space != nil {
+		t.Error("a rejected InitDungeon call must not mutate encounter data (Space)")
+	}
+	if len(data.Doors) != 0 {
+		t.Errorf("a rejected InitDungeon call must not stage any doors; got %d", len(data.Doors))
+	}
+}
+
+// --- Generation: a locked connector produces a closed+locked door;
+// plain connectors (and the two-chamber compatibility wrapper) stay
+// unlocked. ---
+
+// TestInitDungeon_GeneratesLockedBossDoor_ClosedAndLocked: connector 1's
+// lock config must land on the generated DoorData verbatim (Locked,
+// LockDC, LockAbility, LockTool), the door must start closed (mirrors
+// every other generated door), and connector 0's plain door must remain
+// entirely unlocked — a locked connector must not leak lock state onto
+// its sibling.
+func TestInitDungeon_GeneratesLockedBossDoor_ClosedAndLocked(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitDungeon(threeRegionDungeonParamsWithLockedBossDoor(dungeonSeed)))
+
+	data := enc.ToData()
+	door0 := data.Doors[dungeonDoor0ID]
+	door1 := data.Doors[dungeonDoor1ID]
+
+	require.False(t, door0.Locked, "connector 0 (plain) must generate an unlocked door")
+	require.Equal(t, 0, door0.LockDC)
+	require.Empty(t, door0.LockAbility)
+	require.Empty(t, door0.LockTool)
+
+	require.True(t, door1.Locked, "connector 1 (locked) must generate a locked door")
+	require.False(t, door1.Open, "a generated locked door must start closed, same as a plain door")
+	require.Equal(t, dungeonBossDoorLockDC, door1.LockDC)
+	require.Equal(t, abilityDEX, door1.LockAbility)
+	require.Equal(t, thievesTool, door1.LockTool)
+}
+
+// TestInitTwoChamberRoom_GeneratedDoor_RemainsUnlocked: the
+// InitTwoChamberRoom compatibility wrapper never sets DungeonConnectorParams'
+// new lock fields, so its zero-value Connectors entry must keep generating
+// a plain unlocked door — a regression guard distinct from
+// TestInitDungeon_GeneratesLockedBossDoor_ClosedAndLocked's "connector 0
+// stays unlocked" assertion because this exercises the actual public
+// entry point rpg-api still calls, not InitDungeon directly.
+func TestInitTwoChamberRoom_GeneratedDoor_RemainsUnlocked(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitTwoChamberRoom(encounter.TwoChamberRoomParams{
+		ChamberWidth: 8, ChamberHeight: 8, Pattern: environments.PatternEmpty, DoorID: "door-compat",
+	}))
+	door := enc.ToData().Doors["door-compat"]
+	require.False(t, door.Locked, "InitTwoChamberRoom's compatibility wrapper must never generate a locked door")
+}
+
+// --- Persistence: a generated locked door round-trips through
+// ToData/JSON/LoadFromData and still blocks afterward. ---
+
+// TestInitDungeon_LockedBossDoor_RoundTripsThroughToDataLoadFromData
+// rebuilds an Encounter from its own ToData() JSON snapshot (the
+// LoadFromData path a host's Redis round-trip exercises on every call,
+// mirroring reload_door_blocking_test.go's TestClosedDoor_StillBlocksAfterReload)
+// and asserts a GENERATED locked door's lock state survives intact and
+// still blocks movement/LoS on the reloaded instance.
+func TestInitDungeon_LockedBossDoor_RoundTripsThroughToDataLoadFromData(t *testing.T) {
+	transport := encounter.NewInMemoryTransport()
+	defer func() { _ = transport.Close() }()
+	broker := encounter.NewBroker(transport)
+	defer func() { _ = broker.Close() }()
+
+	enc := encounter.New(context.Background(), "enc-locked-persist", broker)
+	require.NoError(t, enc.InitDungeon(threeRegionDungeonParamsWithLockedBossDoor(dungeonSeed)))
+
+	payload, err := json.Marshal(enc.ToData())
+	require.NoError(t, err)
+	var data encounter.Data
+	require.NoError(t, json.Unmarshal(payload, &data))
+
+	reloaded, err := encounter.LoadFromData(context.Background(), &data, broker)
+	require.NoError(t, err)
+
+	door := reloaded.ToData().Doors[dungeonDoor1ID]
+	require.True(t, door.Locked, "lock state must survive a ToData/JSON/LoadFromData round-trip")
+	require.False(t, door.Open)
+	require.Equal(t, dungeonBossDoorLockDC, door.LockDC)
+	require.Equal(t, abilityDEX, door.LockAbility)
+	require.Equal(t, thievesTool, door.LockTool)
+
+	require.True(t,
+		reloaded.Room().IsLineOfSightBlocked(
+			dungeonRegionFarEdgeHex(1).ToPosition(), dungeonRegionNearEdgeHex(2).ToPosition()),
+		"a generated locked door persisted via ToData must still block LoS after LoadFromData",
+	)
+}
+
+// --- Integration: the full AttemptUnlock -> SubmitCheck -> OpenDoor loop
+// against a GENERATED locked door (#815 done bar). ---
+
+// LockedBossDoorSuite builds a fresh 3-region dungeon (entrance/corridor/
+// boss) with connector 1 locked, one player at the entrance with a wired
+// CharacterResolver, per test — mirrors DungeonSuite's fixture shape plus
+// prompts_test.go's PromptsSuite resolver wiring.
+type LockedBossDoorSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	resolver  *fakeResolver
+	enc       *encounter.Encounter
+}
+
+func TestLockedBossDoorSuite(t *testing.T) {
+	suite.Run(t, new(LockedBossDoorSuite))
+}
+
+func (s *LockedBossDoorSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	// abilityMod=3, toolBonus=2: roll=1 totals 6 (fails DC 15), roll=20
+	// totals 25 (succeeds) — the same fixed-resolver-plus-chosen-roll
+	// determinism pattern prompts_test.go's PromptsSuite uses.
+	s.resolver = &fakeResolver{abilityMod: 3, abilityOK: true, toolBonus: 2, toolOK: true}
+	s.enc = encounter.New(
+		context.Background(), "enc-locked-boss-door", s.broker, encounter.WithCharacterResolver(s.resolver),
+	)
+	s.Require().NoError(s.enc.InitDungeon(threeRegionDungeonParamsWithLockedBossDoor(dungeonSeed)))
+}
+
+func (s *LockedBossDoorSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+// TestFailedCheck_LeavesDoorLockedRecoverableAndBlocking: a failed
+// SubmitCheck against a generated locked door must clear the pending
+// prompt (existing SubmitCheck contract) but must NOT open or unlock the
+// door — it must remain locked, closed, still blocking movement/LoS into
+// the boss region, and recoverable (a second AttemptUnlock must succeed).
+func (s *LockedBossDoorSuite) TestFailedCheck_LeavesDoorLockedRecoverableAndBlocking() {
+	data := s.enc.ToData()
+	entrance := data.Space.Entrance
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: entrance, SightRange: 30,
+	}))
+	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+
+	_, err := s.enc.AttemptUnlock(alicePlayerID, dungeonDoor1ID)
+	s.Require().NoError(err)
+	result, err := s.enc.SubmitCheck(alicePlayerID, 1) // total 6 < DC 15
+	s.Require().NoError(err)
+	s.False(result.Success)
+
+	door1 := s.enc.ToData().Doors[dungeonDoor1ID]
+	s.True(door1.Locked, "a failed check must leave the door locked")
+	s.False(door1.Open, "a failed check must leave the door closed")
+
+	reachable := reachableFrom(s.enc.Room(), entrance)
+	boss := regionHexSet(data.Space, dungeonRegionIDBoss)
+	for h := range reachable {
+		s.False(boss[h], "a failed check must not open door 1; the boss region must remain unreachable")
+	}
+	s.True(
+		s.enc.Room().IsLineOfSightBlocked(
+			dungeonRegionFarEdgeHex(1).ToPosition(), dungeonRegionNearEdgeHex(2).ToPosition()),
+		"a failed check must leave door 1 blocking LoS into the boss region",
+	)
+
+	_, err = s.enc.AttemptUnlock(alicePlayerID, dungeonDoor1ID)
+	s.Require().NoError(err, "the door must remain recoverable for another AttemptUnlock after a failed check")
+}
+
+// TestSuccessfulCheck_UnlocksOpensAndRevealsBossRegion: a successful
+// SubmitCheck against a generated locked door must clear Locked, open the
+// door (reusing the existing dispatchPromptAction -> OpenDoor path), connect
+// the entrance through to the boss region, clear LoS across the doorway,
+// and reveal into the boss region through it — the full #815 done-bar loop.
+func (s *LockedBossDoorSuite) TestSuccessfulCheck_UnlocksOpensAndRevealsBossRegion() {
+	data := s.enc.ToData()
+	entrance := data.Space.Entrance
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: entrance, SightRange: 30,
+	}))
+	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+
+	boss := regionHexSet(data.Space, dungeonRegionIDBoss)
+	before := s.enc.ToData().Players[alicePlayerID].View.RevealedHexes
+	s.False(before.Has(dungeonRegionNearEdgeHex(2)), "the boss chamber must not be revealed before unlocking door 1")
+
+	_, err := s.enc.AttemptUnlock(alicePlayerID, dungeonDoor1ID)
+	s.Require().NoError(err)
+	result, err := s.enc.SubmitCheck(alicePlayerID, 20) // total 25 >= DC 15
+	s.Require().NoError(err)
+	s.True(result.Success)
+
+	door1 := s.enc.ToData().Doors[dungeonDoor1ID]
+	s.False(door1.Locked, "a successful check must clear Locked")
+	s.True(door1.Open, "a successful check must open the door")
+
+	reachable := reachableFrom(s.enc.Room(), entrance)
+	reachedBoss := false
+	for h := range reachable {
+		if boss[h] {
+			reachedBoss = true
+			break
+		}
+	}
+	s.True(reachedBoss, "a successful check must open door 1 and connect the entrance to the boss region")
+
+	s.False(
+		s.enc.Room().IsLineOfSightBlocked(
+			dungeonRegionFarEdgeHex(1).ToPosition(), dungeonRegionNearEdgeHex(2).ToPosition()),
+		"a successful check must clear LoS blocking into the boss region",
+	)
+
+	after := s.enc.ToData().Players[alicePlayerID].View.RevealedHexes
+	s.True(after.Has(dungeonRegionNearEdgeHex(2)),
+		"opening the boss door via a successful check must reveal the boss chamber through the doorway")
+}


### PR DESCRIPTION
Closes #815.

## Dependency

Verified before branching: PR #821 (issue #814, N-region `InitDungeon` generator) is `MERGED`, merge commit `e1f98403ed7c92626e1e3fd69dea3383965febb3` == `origin/main` HEAD at branch time (`git log origin/main --oneline -1`).

## Scope

`encounter/dungeon.go` only (+ its test file):

- `DungeonConnectorParams` gains `Locked bool`, `LockDC int`, `LockAbility string`, `LockTool string` — copied verbatim onto the generated door's existing `DoorData` lock-state fields (Wave 2.9). No new persisted representation.
- `InitDungeon`'s door-staging loop sets these on the `DoorData` it builds when `Locked` is true. A generated locked door starts closed (`Open: false`), same as every other generated door.
- `validateDungeonParams` gets a new pre-mutation check: a `Locked` connector with `LockDC<=0` or empty `LockAbility` is rejected before any `Space`/`Doors` mutation runs — `InitDungeon`'s existing atomicity contract (validate-before-mutate) covers this gate for free, no rollback logic needed.
- Zero-value `Connectors` (every plain connector, and every connector `InitTwoChamberRoom`'s compatibility wrapper builds) keep generating entirely unlocked doors.

**No new verb/RPC.** The existing `AttemptUnlock`/`SubmitCheck`/`OpenDoor` loop (Wave 2.9, `prompts.go`) already round-trips a *generated* locked door end to end — this PR proves that with a generated door rather than only a hand-mutated `DoorData` (which `prompts_test.go` already covered).

## Out of scope (per #815 and the design doc)

No locked proto enum (`WALL_KIND_DOOR_LOCKED`, #194 territory), no API projection (#690), no web prompt/render (#573), no monsters, no obstacles/crypt composition, no generic HP work.

## Tests (`encounter/locked_connector_test.go`, 8 new tests)

- `TestInitDungeon_RejectsLockedConnectorWithoutDC`
- `TestInitDungeon_RejectsLockedConnectorWithoutAbility`
- `TestInitDungeon_RejectsInvalidLockedConnector_LeavesNoPartialState`
- `TestInitDungeon_GeneratesLockedBossDoor_ClosedAndLocked`
- `TestInitTwoChamberRoom_GeneratedDoor_RemainsUnlocked` (regression: compatibility wrapper never locks)
- `TestInitDungeon_LockedBossDoor_RoundTripsThroughToDataLoadFromData`
- `TestLockedBossDoorSuite/TestFailedCheck_LeavesDoorLockedRecoverableAndBlocking`
- `TestLockedBossDoorSuite/TestSuccessfulCheck_UnlocksOpensAndRevealsBossRegion` (full loop: closed+locked blocks LoS/movement → `AttemptUnlock` issues prompt → `SubmitCheck` success clears `Locked`, opens via the existing `dispatchPromptAction`→`OpenDoor` path, connects the entrance to the boss region, clears LoS, and reveals into the boss chamber through the doorway)

## Verification

- **RED**: `go test` failed to *build*, referencing the undefined `DungeonConnectorParams.Locked`/`LockDC`/`LockAbility`/`LockTool` fields — confirmed before any production change.
- **GREEN**: all 8 new tests + full existing suite pass.
- `go build ./...`, `go vet ./...` clean.
- `go test -count=1 ./...` — all green (encounter, core, events, perception).
- `go test -race -count=1 ./...` — all green.
- `gofmt -s -l .` clean; `goimports -l -local github.com/KirkDiggler .` flags 13 pre-existing files, none touched by this change (confirmed byte-identical against a throwaway `origin/main` worktree — zero new drift).
- `go mod tidy` — no `go.mod`/`go.sum` diff.
- `golangci-lint` pinned to the repo's CI version (`v2.2.1`, per `.github/workflows/ci-enhanced.yml`) against `.golangci.yml` — **0 issues**.
- Diff confined to `encounter/dungeon.go` and `encounter/locked_connector_test.go`; no other module, no `go.work`/replace directives, no proto/API/client/monster/obstacle/HP code touched.

`.claude/progress.json` / `.claude/tests.json` updated with the session log and discriminating-test roster.

— platform agent, on behalf of KirkDiggler