### PR TITLE
feat(encounter): lock crypt boss connector (#831)

### DIFF
--- a/encounter/crypt_dungeon.go
+++ b/encounter/crypt_dungeon.go
@@ -34,6 +34,7 @@ package encounter
 
 import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
@@ -194,7 +195,10 @@ func CryptDungeonParams(seed int64, entranceDoorID, bossDoorID core.EntityID) Du
 		},
 		Connectors: []DungeonConnectorParams{
 			{DoorID: entranceDoorID},
-			{DoorID: bossDoorID},
+			{
+				DoorID: bossDoorID, Locked: true, LockDC: 12,
+				LockAbility: string(abilities.DEX),
+			},
 		},
 	}
 }

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -11,12 +11,14 @@ package encounter_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 )
 
 const (
@@ -34,6 +36,105 @@ func cdNewEncounter(t *testing.T) *encounter.Encounter {
 		_ = transport.Close()
 	})
 	return encounter.New(context.Background(), "enc-crypt-dungeon-test", broker)
+}
+
+// TestCryptDungeonParams_BossConnectorUsesApprovedLockConfig pins the first
+// crypt's approved door contract: its entrance stays a plain connector while
+// the boss connector requires a DC 12 Dexterity check without a tool.
+func TestCryptDungeonParams_BossConnectorUsesApprovedLockConfig(t *testing.T) {
+	params := encounter.CryptDungeonParams(cdSeed, cdEntranceDoorID, cdBossDoorID)
+	require.Len(t, params.Connectors, 2)
+
+	entrance := params.Connectors[0]
+	require.Equal(t, cdEntranceDoorID, entrance.DoorID)
+	require.False(t, entrance.Locked)
+	require.Zero(t, entrance.LockDC)
+	require.Empty(t, entrance.LockAbility)
+	require.Empty(t, entrance.LockTool)
+
+	boss := params.Connectors[1]
+	require.Equal(t, cdBossDoorID, boss.DoorID)
+	require.True(t, boss.Locked)
+	require.Equal(t, 12, boss.LockDC)
+	require.Equal(t, string(abilities.DEX), boss.LockAbility)
+	require.Empty(t, boss.LockTool)
+}
+
+// cryptDexResolver accepts only the canonical D&D Dexterity identifier. It
+// proves the crypt's generated prompt reaches the existing unlock rules with
+// no tool contribution.
+type cryptDexResolver struct {
+	ability string
+}
+
+func (r *cryptDexResolver) AbilityModifier(_ core.PlayerID, ability string) (int, bool) {
+	r.ability = ability
+	return 0, ability == string(abilities.DEX)
+}
+
+func (*cryptDexResolver) ToolProficiencyBonus(_ core.PlayerID, _ string) (int, bool) {
+	return 0, false
+}
+
+// TestCryptDungeon_BossDoorLockPersistsAndUnlocks verifies the crypt preset
+// config drives the existing generated-door state, persistence, and
+// AttemptUnlock/SubmitCheck recovery contract without introducing a new verb.
+func TestCryptDungeon_BossDoorLockPersistsAndUnlocks(t *testing.T) {
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() {
+		_ = broker.Close()
+		_ = transport.Close()
+	})
+	resolver := &cryptDexResolver{}
+	enc := encounter.New(
+		context.Background(), "enc-crypt-locked-door", broker, encounter.WithCharacterResolver(resolver),
+	)
+	require.NoError(t, enc.InitDungeon(encounter.CryptDungeonParams(cdSeed, cdEntranceDoorID, cdBossDoorID)))
+
+	data := enc.ToData()
+	require.False(t, data.Doors[cdEntranceDoorID].Open)
+	require.False(t, data.Doors[cdEntranceDoorID].Locked)
+	require.True(t, data.Doors[cdBossDoorID].Locked)
+	require.False(t, data.Doors[cdBossDoorID].Open)
+	require.Equal(t, 12, data.Doors[cdBossDoorID].LockDC)
+	require.Equal(t, string(abilities.DEX), data.Doors[cdBossDoorID].LockAbility)
+	require.Empty(t, data.Doors[cdBossDoorID].LockTool)
+
+	payload, err := json.Marshal(data)
+	require.NoError(t, err)
+	var loaded encounter.Data
+	require.NoError(t, json.Unmarshal(payload, &loaded))
+	reloaded, err := encounter.LoadFromData(
+		context.Background(), &loaded, broker, encounter.WithCharacterResolver(resolver),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, reloaded.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: reloaded.ToData().Space.Entrance, SightRange: 30,
+	}))
+	require.NoError(t, reloaded.OpenDoor(alicePlayerID, cdEntranceDoorID))
+
+	issued, err := reloaded.AttemptUnlock(alicePlayerID, cdBossDoorID)
+	require.NoError(t, err)
+	require.Equal(t, 12, issued.DC)
+	require.Equal(t, string(abilities.DEX), issued.Ability)
+	require.Empty(t, issued.Tool)
+	failed, err := reloaded.SubmitCheck(alicePlayerID, 11)
+	require.NoError(t, err)
+	require.False(t, failed.Success)
+	require.True(t, reloaded.ToData().Doors[cdBossDoorID].Locked)
+	require.False(t, reloaded.ToData().Doors[cdBossDoorID].Open)
+
+	_, err = reloaded.AttemptUnlock(alicePlayerID, cdBossDoorID)
+	require.NoError(t, err, "a failed lock check must remain recoverable")
+	succeeded, err := reloaded.SubmitCheck(alicePlayerID, 12)
+	require.NoError(t, err)
+	require.True(t, succeeded.Success)
+	require.Equal(t, string(abilities.DEX), resolver.ability)
+	require.False(t, reloaded.ToData().Doors[cdBossDoorID].Locked)
+	require.True(t, reloaded.ToData().Doors[cdBossDoorID].Open)
 }
 
 // TestCryptDungeonParams_RegionArchetypeComposition: entrance gets

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -390,9 +390,10 @@ type DoorData struct {
 	// Locked-door state (Wave 2.9). Locked must be true for AttemptUnlock
 	// to issue a prompt (returns ErrDoorNotLocked otherwise). LockDC,
 	// LockAbility, and LockTool feed the SkillCheck prompt that resolution
-	// runs through. LockAbility uses 3-letter codes ("DEX", "STR"). LockTool
-	// is a toolkit ref (e.g. "dnd5e:item:thieves-tools"); empty means no
-	// tool proficiency applies.
+	// runs through. LockAbility is an opaque host/rulebook-owned ability
+	// identifier; for D&D 5e, the canonical value is lowercase abilities.DEX
+	// ("dex"). LockTool is a toolkit ref (e.g. "dnd5e:item:thieves-tools");
+	// empty means no tool proficiency applies.
 	Locked      bool   `json:"locked,omitempty"`
 	LockDC      int    `json:"lock_dc,omitempty"`
 	LockAbility string `json:"lock_ability,omitempty"`

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -139,11 +139,11 @@ type DungeonConnectorParams struct {
 	// Ignored when Locked is false.
 	LockDC int
 
-	// LockAbility is the 3-letter ability code (e.g. "DEX") the check
-	// rolls against, copied verbatim onto DoorData.LockAbility. Required
-	// (non-empty) when Locked is true — validateDungeonParams rejects a
-	// locked connector with an empty LockAbility. Ignored when Locked is
-	// false.
+	// LockAbility is an opaque ability identifier owned by the host/rulebook,
+	// copied verbatim onto DoorData.LockAbility. For D&D 5e, use the canonical
+	// lowercase abilities.DEX identifier ("dex"). Required (non-empty) when
+	// Locked is true — validateDungeonParams rejects a locked connector with
+	// an empty LockAbility. Ignored when Locked is false.
 	LockAbility string
 
 	// LockTool is an optional toolkit ref (e.g.

--- a/encounter/prompts.go
+++ b/encounter/prompts.go
@@ -84,13 +84,14 @@ type PendingPrompt struct {
 // outside the toolkit (rpg-api wires it against the character store; tests
 // supply a stub) so the encounter package stays ruleset-agnostic.
 //
-// AbilityModifier returns the modifier for the named ability ("DEX",
-// "STR", ...). ToolProficiencyBonus returns the proficiency bonus to add
-// when the player is proficient with the given tool ref (empty tool means
-// no tool bonus). Both return ok=false to signal the player or modifier
-// is unknown; SubmitCheck treats unknowns as zero rather than erroring,
-// since a missing proficiency is normal play (you may attempt a check
-// without proficiency).
+// AbilityModifier returns the modifier for the supplied opaque ability
+// identifier. The host/rulebook owns its format; for D&D 5e the canonical
+// value is lowercase abilities.DEX ("dex"). ToolProficiencyBonus returns
+// the proficiency bonus to add when the player is proficient with the given
+// tool ref (empty tool means no tool bonus). Both return ok=false to signal
+// the player or modifier is unknown; SubmitCheck treats unknowns as zero
+// rather than erroring, since a missing proficiency is normal play (you may
+// attempt a check without proficiency).
 type CharacterResolver interface {
 	AbilityModifier(playerID core.PlayerID, ability string) (mod int, ok bool)
 	ToolProficiencyBonus(playerID core.PlayerID, tool string) (bonus int, ok bool)


### PR DESCRIPTION
Closes #831

## Summary
- Keeps the crypt entrance connector as the plain zero-value door.
- Configures the boss connector as closed and locked: `Locked: true`, `LockDC: 12`, `LockAbility: string(abilities.DEX)` (`"dex"`), and empty `LockTool`.
- Covers exact preset config, generated/persisted `DoorData`, and the existing failed/recoverable/successful `AttemptUnlock` + `SubmitCheck` path.

## Evidence
- Verified #815 and #819 are merged on latest `origin/main`.
- TDD: focused tests failed before the config change and passed after it. A temporary `LockDC: 13` mutation failed both new tests, then the approved `12` was restored.
- `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./...` pass in `encounter/`.
- `gofmt`, `goimports`, `go mod tidy`, and `git diff --check` pass.
- Pinned `golangci-lint` v2.2.1 reports `0 issues`.

No API, proto, web, generic connector, geometry, monster, or obstacle changes.

— platform agent, on behalf of KirkDiggler