### PR TITLE
feat(encounter): crypt interiors PatternEmpty — set pieces carry the cover role (#835)

### DIFF
--- a/encounter/crypt_dungeon.go
+++ b/encounter/crypt_dungeon.go
@@ -179,7 +179,18 @@ func CryptDungeonParams(seed int64, entranceDoorID, bossDoorID core.EntityID) Du
 		Regions: []DungeonRegionParams{
 			{
 				ID: cryptRegionIDEntrance, Archetype: ArchetypeEntrance,
-				Width: cryptEntranceWidth, Pattern: environments.PatternRandom, Obstacles: cryptEntranceObstacles(),
+				// PatternEmpty (rpg-toolkit#835): PatternRandom's scattered
+				// wall cells were designed as tactical cover before the
+				// obstacle layer existed (#819) and now double-book that
+				// role — the entrance's obelisk+pillar set pieces (#819)
+				// already provide cover, and each isolated scattered wall
+				// cell renders client-side as 3-5 crisscrossed slabs (one
+				// per exposed face), reading as rubble rather than the
+				// approved crypt art target of intact walls with decay
+				// carried by dressing, not broken geometry (rpg-dnd5e-
+				// web#469, rpg-dnd5e-web#562). Cover now comes from set
+				// pieces; interior walls stay empty.
+				Width: cryptEntranceWidth, Pattern: environments.PatternEmpty, Obstacles: cryptEntranceObstacles(),
 			},
 			{
 				ID: cryptRegionIDCorridor, Archetype: ArchetypeCorridor,
@@ -190,7 +201,15 @@ func CryptDungeonParams(seed int64, entranceDoorID, bossDoorID core.EntityID) Du
 			},
 			{
 				ID: cryptRegionIDBoss, Archetype: ArchetypeBoss,
-				Width: cryptBossWidth, Pattern: environments.PatternRandom, Obstacles: cryptBossObstacles(),
+				// PatternEmpty (rpg-toolkit#835): same reasoning as the
+				// entrance region above — the boss chamber's coffin,
+				// altar, and paired statues (#819) already carry the cover
+				// role, so PatternRandom's scattered wall cells are now
+				// redundant rubble-rendering noise rather than needed
+				// tactical cover. Side benefit: shrinks this region's
+				// exposure to the doorRow-collision bug class (#826,
+				// #833) since fewer interior walls get rolled at all.
+				Width: cryptBossWidth, Pattern: environments.PatternEmpty, Obstacles: cryptBossObstacles(),
 			},
 		},
 		Connectors: []DungeonConnectorParams{

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 const (
@@ -408,4 +409,97 @@ func TestCryptDungeon_DeterministicSameSeed(t *testing.T) {
 	b := build()
 	require.Equal(t, a.Space.Obstacles, b.Space.Obstacles)
 	require.Equal(t, a.Space.Walls, b.Space.Walls)
+}
+
+// cdHeight/cdEntranceWidth/cdCorridorWidth/cdBossWidth duplicate
+// crypt_dungeon.go's own unexported cryptHeight/cryptEntranceWidth/
+// cryptCorridorWidth/cryptBossWidth dimensions (this file lives in
+// package encounter_test and can't see those directly) — the same
+// "assert the generator's construction guarantee actually holds"
+// convention dungeon_test.go's dungeonRegionStarts and
+// two_chamber_test.go's doorAdjacentChamber2Hex already use, not a public
+// API this package exports.
+const (
+	cdHeight        = 8
+	cdEntranceWidth = 10
+	cdCorridorWidth = 5
+	cdBossWidth     = 10
+	cryptDoorRow    = cdHeight / 2
+)
+
+var cryptRegionWidths = []int{cdEntranceWidth, cdCorridorWidth, cdBossWidth}
+
+func cryptRegionStarts() []int {
+	starts := make([]int, len(cryptRegionWidths))
+	x := 0
+	for i, w := range cryptRegionWidths {
+		starts[i] = x
+		x += w + 1 // +1 reserves the boundary/door column after this region
+	}
+	return starts
+}
+
+// cryptBoundaryColumnHexes returns every hex the connector boundary column
+// between region connectorIdx and connectorIdx+1 must carry a blocked wall
+// segment at — every row except cryptDoorRow (that cell is the connector's
+// door), mirroring generateDungeonLayout's own boundary-column construction
+// (dungeon.go). Unaffected by rpg-toolkit#835's Pattern change: this column
+// is emitted unconditionally, independent of either neighboring region's
+// interior wall pattern.
+func cryptBoundaryColumnHexes(connectorIdx int) []core.Hex {
+	starts := cryptRegionStarts()
+	x := starts[connectorIdx] + cryptRegionWidths[connectorIdx]
+	out := make([]core.Hex, 0, cdHeight-1)
+	for y := 0; y < cdHeight; y++ {
+		if y == cryptDoorRow {
+			continue
+		}
+		out = append(out, core.HexFromPosition(spatial.Position{X: float64(x), Y: float64(y)}))
+	}
+	return out
+}
+
+// TestCryptDungeon_EntranceAndBossPatternEmpty_NoInteriorWallsAcrossSeeds
+// pins rpg-toolkit#835: the entrance and boss regions now use
+// environments.PatternEmpty instead of PatternRandom (set pieces carry the
+// cover role per #819; PatternRandom's scattered wall cells rendered as
+// rubble client-side, rpg-dnd5e-web#562), so building the crypt across a
+// spread of seeds must roll ZERO interior wall cells in either region.
+// PatternEmpty never generates interior walls by construction (see
+// environments.EmptyPattern), but this proves that holds for the crypt's
+// actual dimensions/archetypes/obstacle placement, not just in isolation —
+// while the connector boundary columns between regions (always emitted
+// regardless of either neighbor's interior pattern) must still be present,
+// completely unaffected by this change.
+func TestCryptDungeon_EntranceAndBossPatternEmpty_NoInteriorWallsAcrossSeeds(t *testing.T) {
+	for seed := int64(1); seed <= 50; seed++ {
+		enc := cdNewEncounter(t)
+		require.NoError(t, enc.InitDungeon(encounter.CryptDungeonParams(seed, cdEntranceDoorID, cdBossDoorID)),
+			"seed %d", seed)
+
+		data := enc.ToData()
+		entranceHexes := regionHexSet(data.Space, "entrance")
+		bossHexes := regionHexSet(data.Space, "boss")
+		require.NotEmpty(t, entranceHexes, "seed %d: entrance region must have hexes", seed)
+		require.NotEmpty(t, bossHexes, "seed %d: boss region must have hexes", seed)
+
+		for _, w := range data.Space.Walls {
+			h := core.HexFromCube(w.Start)
+			require.False(t, entranceHexes[h],
+				"seed %d: entrance region must roll zero interior walls with PatternEmpty; found one at %v", seed, h)
+			require.False(t, bossHexes[h],
+				"seed %d: boss region must roll zero interior walls with PatternEmpty; found one at %v", seed, h)
+		}
+
+		wallSet := make(map[core.Hex]bool, len(data.Space.Walls))
+		for _, w := range data.Space.Walls {
+			wallSet[core.HexFromCube(w.Start)] = true
+		}
+		for connectorIdx := 0; connectorIdx < 2; connectorIdx++ {
+			for _, h := range cryptBoundaryColumnHexes(connectorIdx) {
+				require.True(t, wallSet[h],
+					"seed %d: connector %d boundary column must still carry a wall at %v", seed, connectorIdx, h)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

`CryptDungeonParams` (`encounter/crypt_dungeon.go`) gave the entrance and boss regions `Pattern: environments.PatternRandom` — density-0.4 scattered interior wall cells, 70% destructible, designed as tactical cover before the obstacle layer (#819) existed. This switches both regions to `environments.PatternEmpty`, matching the corridor.

## Why

Two problems `PatternRandom` created once #819 shipped set pieces:

1. **It reads as rubble, structurally.** Each scattered blocked cell renders client-side as 3-5 crisscrossed slabs (one per exposed face — rpg-dnd5e-web#562). This is the dominant visual noise in Kirk's July-23 prod walk; even with #834's perimeter walls, interiors would stay littered.
2. **It duplicates the cover role.** The same regions place real set pieces (obelisk/pillars in the entrance; coffin/altar/statues in the boss chamber — #819) that already block movement and LoS. The approved crypt art target (rpg-dnd5e-web#469) is intact walls with decay carried by dressing, never broken geometry.

Side benefit: shrinks the crypt's exposure to the doorRow-collision bug class (#826, #833) since fewer interior walls get rolled at all.

## Client-side rubble mechanism this removes

Per rpg-dnd5e-web#562, an isolated degenerate `WallSegmentData{Start == End}` blocked cell has no shared edge with any neighboring wall, so the client's wall renderer draws a slab on every exposed face of that single hex — 3-5 slabs per scattered cell, reading as debris/rubble rather than a wall. `PatternEmpty` never generates these cells, so the entrance and boss regions no longer produce any.

## Test evidence

Added `TestCryptDungeon_EntranceAndBossPatternEmpty_NoInteriorWallsAcrossSeeds` (`encounter/crypt_dungeon_test.go`): builds the crypt across 50 seeds (1-50) and asserts, for every seed:
- Zero wall segments land inside either the entrance or boss region's hex set (PatternEmpty is deterministic-empty by construction — `environments.EmptyPattern` — but this proves it holds for the crypt's actual dimensions/archetypes/obstacle placement, not just in isolation).
- Both connector boundary columns (between entrance/corridor and corridor/boss — always emitted regardless of either neighbor's interior pattern) still carry their full set of blocked wall cells, unaffected by this change.

Full suite:
```
go test -race ./...
ok  	github.com/KirkDiggler/rpg-toolkit/encounter	64.983s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/core	1.018s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/events	1.030s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/perception	1.023s
```
`golangci-lint run ./...` reports the same 79 pre-existing `goconst` issues as `origin/main` (none in the changed files); `gofmt`/`goimports` clean on both changed files.

Refs: #819, #833, #834, rpg-dnd5e-web#562.

Closes #835

— asset-pipeline agent, on behalf of KirkDiggler