### PR TITLE
feat(encounter): boundary-edge perimeter walls — rooms ship real walls on the wire (#834)

### DIFF
--- a/encounter/boss_primary_axis_test.go
+++ b/encounter/boss_primary_axis_test.go
@@ -94,6 +94,17 @@ func TestInitDungeon_BossPrimaryAxis_NeverBlockedByGeneratedWalls(t *testing.T) 
 		data := enc.ToData()
 
 		for _, w := range data.Space.Walls {
+			// rpg-toolkit#834: a boundary-edge segment (Start != End) is a
+			// non-blocking render-contract entry for a REAL floor hex on
+			// the space's outer perimeter, not a generated interior wall —
+			// the boss region's far (rightmost) column sits on the whole
+			// dungeon's own right edge, so it legitimately gets one of
+			// these on its primary-axis cell too. This test's invariant is
+			// about GENERATED (blocking) walls only; only degenerate
+			// (Start == End) entries are ever candidates.
+			if w.Start != w.End {
+				continue
+			}
 			pos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
 			localX := int(pos.X) - bossStart
 			if localX < 0 || localX >= dungeonBossWidth {

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -484,6 +484,18 @@ func TestCryptDungeon_EntranceAndBossPatternEmpty_NoInteriorWallsAcrossSeeds(t *
 		require.NotEmpty(t, bossHexes, "seed %d: boss region must have hexes", seed)
 
 		for _, w := range data.Space.Walls {
+			// rpg-toolkit#834: a boundary-edge segment (Start != End) is a
+			// non-blocking render-contract entry for a REAL floor hex on
+			// the space's outer perimeter, not a generated interior
+			// wall -- the entrance's west edge and the boss region's own
+			// outer edge legitimately carry one of these even under
+			// PatternEmpty. This test's invariant is about GENERATED
+			// (blocking) interior walls only; only degenerate
+			// (Start == End) entries are ever candidates (same fix as
+			// boss_primary_axis_test.go's analogous filter).
+			if w.Start != w.End {
+				continue
+			}
 			h := core.HexFromCube(w.Start)
 			require.False(t, entranceHexes[h],
 				"seed %d: entrance region must roll zero interior walls with PatternEmpty; found one at %v", seed, h)

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -78,10 +78,24 @@ type Data struct {
 // rather than a toolkit-local type — same shape environments.EnvironmentData
 // already persists, no reason to duplicate it.
 type SpaceData struct {
-	// Walls are the room's wall segments in absolute cube coordinates. Wave 1
-	// stores one degenerate (Start == End) segment per discretized wall hex —
-	// geometry fidelity beyond per-hex blocking isn't needed until per-viewer
-	// wall reveal (wave 2+).
+	// Walls are the room's wall segments in absolute cube coordinates, in
+	// one of two shapes:
+	//
+	//   - Degenerate (Start == End): one blocked interior hex — interior
+	//     pattern walls (RandomPattern etc.) and InitDungeon's connector
+	//     boundary columns between regions. This is the ONLY shape wave 1
+	//     stored, and the only one rebuildRoomFromData turns into an
+	//     actual spatial.Room blocker (see its Start != End skip) —
+	//     geometry fidelity beyond per-hex blocking isn't needed for these.
+	//
+	//   - Boundary-edge (Start != End, exactly one hex step apart): Start
+	//     is a real walkable floor hex, End is the adjacent hex just
+	//     outside the room's grid bounds — InitDungeon's outer-perimeter
+	//     segments (rpg-toolkit#834), one per room-facing edge. Purely a
+	//     render contract (rpg-dnd5e-web#566's client-side hexDistance==1
+	//     branch draws one clean full-width slab on that edge) — never a
+	//     spatial.Room blocker; walkability there already comes from the
+	//     grid's own bounds, not from this entry.
 	Walls []environments.WallSegmentData `json:"walls"`
 
 	// Width and Height are the room's grid dimensions (offset-coordinate

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -553,8 +553,9 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 // x=0/x=width-1/y=0/y=height-1 edges either (validateDungeonParams' >=4
 // height/width floor keeps doorRow strictly interior) -- so this function
 // needs no separate door-passage exclusion; the geometry already keeps
-// every connector passage off the outer perimeter (see dungeon_test.go's
-// TestPerimeterEdgeWalls_NeverOnConnectorDoorCells for the assertion).
+// every connector passage off the outer perimeter (see
+// perimeter_edge_walls_test.go's TestPerimeterEdgeWalls_NeverAtConnectorDoorCells
+// for the assertion).
 //
 // A single floor hex can and does emit MORE than one segment (e.g. a true
 // corner-of-the-map hex, whose skewed odd-q offset neighbor geometry can

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -507,6 +507,15 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 		}
 	}
 
+	// rpg-toolkit#834: one boundary-edge segment (Start != End) per
+	// room-facing perimeter edge of the WHOLE combined space, appended
+	// after every region's interior walls and every connector's boundary
+	// column above -- see perimeterEdgeWalls' doc for why this never
+	// touches interior wall emission or the connector columns, and is a
+	// pure, seed-independent function of the floor/wall layout already
+	// built above.
+	segs = append(segs, perimeterEdgeWalls(segs, totalWidth, params.Height)...)
+
 	entrance := spatial.OffsetCoordinateToCubeWithOrientation(
 		spatial.Position{X: 0, Y: float64(doorRow)}, spatial.HexOrientationPointyTop)
 
@@ -518,6 +527,78 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 		doors:     doors,
 		obstacles: obstacles,
 	}, nil
+}
+
+// perimeterEdgeWalls computes one boundary-edge WallSegmentData (Start !=
+// End, exactly one hex step apart) per room-facing edge of the combined
+// dungeon space's outer perimeter (rpg-toolkit#834) -- rooms shipped ZERO
+// perimeter wall data before this; blocking came only from grid bounds,
+// and the client's wall renderer had nothing to draw a room's outer walls
+// with. For every FLOOR hex in [0,width) x [0,height) (i.e. not already a
+// blocked cell in walls -- interior pattern walls and connector boundary
+// columns alike, both always degenerate Start==End entries at this point)
+// and every one of its 6 hex-grid neighbor directions that lands OUTSIDE
+// those bounds, one segment {Start: the floor hex, End: the out-of-bounds
+// neighbor} is emitted.
+//
+// Deliberately excludes cells already IN walls, not just those failing an
+// IsValidPosition check on the OUTER rectangle: a connector's boundary
+// column sits at an interior x (strictly between two regions, never the
+// space's x=0 or x=width-1 edge) but spans every y INCLUDING the true
+// edge rows y=0/y=height-1 -- by "floor hex" exclusion those cells never
+// get a NEW edge segment here, keeping them exactly the "interior
+// structure" they already were (this function only ever ADDS segments,
+// never touches walls' existing entries). Doors sit at a boundary
+// column's doorRow cell specifically, which is never on the space's own
+// x=0/x=width-1/y=0/y=height-1 edges either (validateDungeonParams' >=4
+// height/width floor keeps doorRow strictly interior) -- so this function
+// needs no separate door-passage exclusion; the geometry already keeps
+// every connector passage off the outer perimeter (see dungeon_test.go's
+// TestPerimeterEdgeWalls_NeverOnConnectorDoorCells for the assertion).
+//
+// A single floor hex can and does emit MORE than one segment (e.g. a true
+// corner-of-the-map hex, whose skewed odd-q offset neighbor geometry can
+// put several of its 6 sides outside the rectangle) -- "one segment per
+// room-facing edge," not per hex, is exactly what rpg-dnd5e-web#566's
+// client-side hexDistance==1 renderer wants: each exposed edge draws its
+// own clean slab.
+//
+// Purely a function of walls/width/height, already fully determined by
+// the (possibly seeded) region generation above -- no RNG here, so
+// perimeter emission is itself deterministic and seed-independent, unlike
+// the per-region interior pattern it follows.
+//
+// These segments never become a spatial.Room blocker (see
+// rebuildRoomFromData's Start != End skip): Start is real walkable floor
+// and End is entirely outside the grid, already unreachable by
+// construction (every LOS/movement check already runs through
+// spatial.HexGrid.IsValidPosition) -- this is the render contract
+// (rpg-dnd5e-web#566) catching up to the room's actual shape, not a new
+// blocking mechanism, so walkability outcomes are unchanged by this
+// function's output.
+func perimeterEdgeWalls(walls []environments.WallSegmentData, width, height int) []environments.WallSegmentData {
+	blocked := wallCubeSet(walls)
+	var out []environments.WallSegmentData
+	fw, fh := float64(width), float64(height)
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(
+				spatial.Position{X: float64(x), Y: float64(y)}, spatial.HexOrientationPointyTop)
+			if _, isWall := blocked[cube]; isWall {
+				continue
+			}
+			for _, n := range cube.GetNeighbors() {
+				npos := n.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+				if npos.X >= 0 && npos.X < fw && npos.Y >= 0 && npos.Y < fh {
+					continue // neighbor is inside the space -- not a perimeter edge
+				}
+				out = append(out, environments.WallSegmentData{
+					Start: cube, End: n, BlocksMovement: true, BlocksLoS: true,
+				})
+			}
+		}
+	}
+	return out
 }
 
 // generateRegionWalls generates one region's interior wall pattern,

--- a/encounter/perimeter_edge_walls_test.go
+++ b/encounter/perimeter_edge_walls_test.go
@@ -1,0 +1,214 @@
+package encounter_test
+
+// perimeter_edge_walls_test.go is the TDD gate for rpg-toolkit#834:
+// InitDungeon now emits one boundary-edge WallSegmentData (Start != End,
+// exactly one hex step apart) per room-facing edge of the combined
+// dungeon space's outer perimeter, in addition to the existing degenerate
+// (Start == End) interior/connector wall entries, which are left
+// untouched. Reuses dungeon_test.go's shared threeRegionDungeonParams /
+// dungeonHeight / dungeonRegionIDs fixture and dungeon_completion_test.go's
+// dcDungeonParams (all-PatternEmpty) fixture — both already establish this
+// package's shared conventions (newTestEncounter, dungeonDoor0ID/1ID) —
+// rather than inventing a third one.
+//
+// Every check here is derived independently of dungeon.go's own unexported
+// perimeterEdgeWalls/wallCubeSet: "floor" is reconstructed from the public
+// Data.Space.Walls shape (a degenerate entry marks a blocked cell), and
+// "outside the room" is queried against the LIVE room's own
+// GetGrid().IsValidPosition — the exact same grid movement/LoS already use
+// — rather than a hand-rolled bounds recheck that could share a bug with
+// the generator.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// perimeterEdgeSeeds sweeps a handful of seeds across the shared
+// three-region dungeon fixture (entrance/boss PatternRandom, corridor
+// PatternEmpty) so perimeter-edge behavior is proven across varying
+// interior-wall layouts, not just one lucky seed.
+var perimeterEdgeSeeds = []int64{dungeonSeed, 1, 2, 3, 4, 5, 100, 909091}
+
+// blockedCubesFromDegenerateWalls returns every cube coordinate marked
+// blocked by a degenerate (Start == End) wall entry — interior pattern
+// walls and connector boundary columns alike. Boundary-edge entries
+// (Start != End) never mark a cube blocked; a real floor hex is exactly
+// the complement of this set within the space's bounds.
+func blockedCubesFromDegenerateWalls(walls []environments.WallSegmentData) map[spatial.CubeCoordinate]bool {
+	out := make(map[spatial.CubeCoordinate]bool, len(walls))
+	for _, w := range walls {
+		if w.Start == w.End {
+			out[w.Start] = true
+		}
+	}
+	return out
+}
+
+// TestPerimeterEdgeWalls_Completeness proves, independently of dungeon.go's
+// own perimeterEdgeWalls, that every non-wall (floor) hex in the combined
+// space whose neighbor lies outside the room's ACTUAL grid bounds (queried
+// via the live room's own GetGrid().IsValidPosition, not a hand-rolled
+// recheck) has exactly one matching Start != End boundary-edge segment in
+// Data.Space.Walls — no extras, no duplicates, across a spread of seeds.
+func TestPerimeterEdgeWalls_Completeness(t *testing.T) {
+	for _, seed := range perimeterEdgeSeeds {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
+		data := enc.ToData()
+		grid := enc.Room().GetGrid()
+
+		blocked := blockedCubesFromDegenerateWalls(data.Space.Walls)
+		gotEdges := make(map[[2]spatial.CubeCoordinate]int)
+		for _, w := range data.Space.Walls {
+			if w.Start == w.End {
+				continue
+			}
+			gotEdges[[2]spatial.CubeCoordinate{w.Start, w.End}]++
+		}
+		for pair, count := range gotEdges {
+			require.Equal(t, 1, count, "seed %d: duplicate perimeter edge segment %v", seed, pair)
+		}
+
+		expected := make(map[[2]spatial.CubeCoordinate]bool)
+		for x := 0; x < data.Space.Width; x++ {
+			for y := 0; y < data.Space.Height; y++ {
+				pos := spatial.Position{X: float64(x), Y: float64(y)}
+				cube := spatial.OffsetCoordinateToCubeWithOrientation(pos, spatial.HexOrientationPointyTop)
+				if blocked[cube] {
+					continue
+				}
+				for _, n := range cube.GetNeighbors() {
+					npos := n.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+					if grid.IsValidPosition(npos) {
+						continue // neighbor is inside the room -- not a perimeter edge
+					}
+					expected[[2]spatial.CubeCoordinate{cube, n}] = true
+				}
+			}
+		}
+
+		require.Len(t, gotEdges, len(expected), "seed %d: perimeter edge segment count mismatch", seed)
+		for pair := range expected {
+			require.Contains(t, gotEdges, pair, "seed %d: missing perimeter edge %v", seed, pair)
+		}
+	}
+}
+
+// TestPerimeterEdgeWalls_StartInsideEndOutsideDistanceOne pins the shape
+// contract every boundary-edge segment must satisfy: Start and End are
+// exactly one hex step apart, Start is a real position inside the live
+// room's grid, and End is outside it — plus the BlocksMovement/BlocksLoS
+// semantics match existing (degenerate) walls, per the issue's ask.
+func TestPerimeterEdgeWalls_StartInsideEndOutsideDistanceOne(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
+	data := enc.ToData()
+	grid := enc.Room().GetGrid()
+
+	found := false
+	for _, w := range data.Space.Walls {
+		if w.Start == w.End {
+			continue
+		}
+		found = true
+		require.Equal(t, 1, w.Start.Distance(w.End),
+			"boundary-edge segment %+v must be exactly one hex step apart", w)
+
+		startPos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		endPos := w.End.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		require.True(t, grid.IsValidPosition(startPos),
+			"boundary-edge segment %+v: Start must be inside the room", w)
+		require.False(t, grid.IsValidPosition(endPos),
+			"boundary-edge segment %+v: End must be outside the room", w)
+
+		require.True(t, w.BlocksMovement, "boundary-edge segment %+v must carry BlocksMovement like existing walls", w)
+		require.True(t, w.BlocksLoS, "boundary-edge segment %+v must carry BlocksLoS like existing walls", w)
+	}
+	require.True(t, found, "fixture must actually produce at least one boundary-edge segment")
+}
+
+// TestPerimeterEdgeWalls_EntranceHexHasWestFacingEdge is a concrete,
+// human-checkable pin alongside the from-first-principles completeness
+// test above: the entrance hex sits on the required entrance-to-door
+// path, so it is guaranteed floor regardless of seed, and it sits at the
+// space's own column 0 -- its westward neighbor is always outside the
+// room. It must therefore always carry a west-facing boundary-edge
+// segment, for every seed.
+func TestPerimeterEdgeWalls_EntranceHexHasWestFacingEdge(t *testing.T) {
+	for _, seed := range perimeterEdgeSeeds {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
+		data := enc.ToData()
+		entranceCube := data.Space.Entrance.ToCube()
+
+		found := false
+		for _, w := range data.Space.Walls {
+			if w.Start != entranceCube || w.Start == w.End {
+				continue
+			}
+			endPos := w.End.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+			if endPos.X < 0 {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "seed %d: the entrance hex must carry a west-facing boundary-edge segment", seed)
+	}
+}
+
+// TestPerimeterEdgeWalls_NeverAtConnectorDoorCells pins a geometric fact
+// dungeon.go's perimeterEdgeWalls doc explains rather than works around: a
+// connector's door always sits at doorRow within an INTERIOR boundary
+// column (never the space's own x=0/x=width-1 edge), and doorRow=height/2
+// is itself never y=0/y=height-1 given validateDungeonParams' >=4 height
+// floor -- so a door cell can never be the Start of a boundary-edge
+// segment. The door-passage exclusion the issue anticipated turns out to
+// be geometrically moot; this test proves that fact directly rather than
+// just trusting the reasoning.
+func TestPerimeterEdgeWalls_NeverAtConnectorDoorCells(t *testing.T) {
+	for _, seed := range perimeterEdgeSeeds {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
+		data := enc.ToData()
+
+		doorCubes := map[spatial.CubeCoordinate]bool{
+			data.Doors[dungeonDoor0ID].Position.ToCube(): true,
+			data.Doors[dungeonDoor1ID].Position.ToCube(): true,
+		}
+		for _, w := range data.Space.Walls {
+			if w.Start == w.End {
+				continue
+			}
+			require.False(t, doorCubes[w.Start],
+				"seed %d: a connector door cell must never be the Start of a boundary-edge perimeter segment", seed)
+		}
+	}
+}
+
+// TestPerimeterEdgeWalls_DeterministicAcrossSeeds proves perimeter-edge
+// emission is a pure function of the floor set, not of the seed itself.
+// dungeon_completion_test.go's dcDungeonParams fixture uses PatternEmpty
+// for every region, so its floor set is entirely seed-independent — under
+// it, Data.Space.Walls (connector boundary columns AND the new perimeter
+// edges alike) must be byte-for-byte identical across every seed tried,
+// not merely "the same shape."
+func TestPerimeterEdgeWalls_DeterministicAcrossSeeds(t *testing.T) {
+	var first []environments.WallSegmentData
+	for i, seed := range []int64{1, 2, 3, 42, 909090, 123456789} {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(dcDungeonParams(seed)), "seed %d", seed)
+		walls := enc.ToData().Space.Walls
+		if i == 0 {
+			first = walls
+			continue
+		}
+		require.Equal(t, first, walls,
+			"seed %d: an all-PatternEmpty fixture's wall layout (including perimeter edges) must be "+
+				"identical across seeds", seed)
+	}
+}

--- a/encounter/perimeter_edge_walls_test.go
+++ b/encounter/perimeter_edge_walls_test.go
@@ -20,10 +20,13 @@ package encounter_test
 // the generator.
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -49,6 +52,71 @@ func blockedCubesFromDegenerateWalls(walls []environments.WallSegmentData) map[s
 	return out
 }
 
+// assertPerimeterCompletenessAndNoDuplicates re-derives, from first
+// principles against public spatial primitives only (never dungeon.go's
+// own unexported perimeterEdgeWalls/wallCubeSet), every {Start, End}
+// boundary-edge pair a SpaceData's floor/wall layout implies, then proves
+// data.Space.Walls' non-degenerate entries match that set exactly: no
+// extras, no missing edges, no duplicates. Shared by every test in this
+// file that builds a dungeon (varying seed or shape) and checks the same
+// invariant, rather than duplicating the derivation per call site.
+func assertPerimeterCompletenessAndNoDuplicates(t *testing.T, label string, data *encounter.Data, grid spatial.Grid) {
+	t.Helper()
+	blocked := blockedCubesFromDegenerateWalls(data.Space.Walls)
+	gotEdges := make(map[[2]spatial.CubeCoordinate]int)
+	for _, w := range data.Space.Walls {
+		if w.Start == w.End {
+			continue
+		}
+		gotEdges[[2]spatial.CubeCoordinate{w.Start, w.End}]++
+	}
+	for pair, count := range gotEdges {
+		require.Equal(t, 1, count, "%s: duplicate perimeter edge segment %v", label, pair)
+	}
+
+	expected := make(map[[2]spatial.CubeCoordinate]bool)
+	for x := 0; x < data.Space.Width; x++ {
+		for y := 0; y < data.Space.Height; y++ {
+			pos := spatial.Position{X: float64(x), Y: float64(y)}
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(pos, spatial.HexOrientationPointyTop)
+			if blocked[cube] {
+				continue
+			}
+			for _, n := range cube.GetNeighbors() {
+				npos := n.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+				if grid.IsValidPosition(npos) {
+					continue // neighbor is inside the room -- not a perimeter edge
+				}
+				expected[[2]spatial.CubeCoordinate{cube, n}] = true
+			}
+		}
+	}
+
+	require.Len(t, gotEdges, len(expected), "%s: perimeter edge segment count mismatch", label)
+	for pair := range expected {
+		require.Contains(t, gotEdges, pair, "%s: missing perimeter edge %v", label, pair)
+	}
+}
+
+// assertNoDoorCellIsPerimeterStart proves a connector door's cell is never
+// the Start of a boundary-edge segment, for the given door entity IDs.
+// Shared by every test in this file that checks the door-passage-
+// exclusion invariant across a seed or shape sweep.
+func assertNoDoorCellIsPerimeterStart(t *testing.T, label string, data *encounter.Data, doorIDs []core.EntityID) {
+	t.Helper()
+	doorCubes := make(map[spatial.CubeCoordinate]bool, len(doorIDs))
+	for _, id := range doorIDs {
+		doorCubes[data.Doors[id].Position.ToCube()] = true
+	}
+	for _, w := range data.Space.Walls {
+		if w.Start == w.End {
+			continue
+		}
+		require.False(t, doorCubes[w.Start],
+			"%s: a connector door cell must never be the Start of a boundary-edge perimeter segment", label)
+	}
+}
+
 // TestPerimeterEdgeWalls_Completeness proves, independently of dungeon.go's
 // own perimeterEdgeWalls, that every non-wall (floor) hex in the combined
 // space whose neighbor lies outside the room's ACTUAL grid bounds (queried
@@ -60,42 +128,7 @@ func TestPerimeterEdgeWalls_Completeness(t *testing.T) {
 		enc := newTestEncounter(t)
 		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
 		data := enc.ToData()
-		grid := enc.Room().GetGrid()
-
-		blocked := blockedCubesFromDegenerateWalls(data.Space.Walls)
-		gotEdges := make(map[[2]spatial.CubeCoordinate]int)
-		for _, w := range data.Space.Walls {
-			if w.Start == w.End {
-				continue
-			}
-			gotEdges[[2]spatial.CubeCoordinate{w.Start, w.End}]++
-		}
-		for pair, count := range gotEdges {
-			require.Equal(t, 1, count, "seed %d: duplicate perimeter edge segment %v", seed, pair)
-		}
-
-		expected := make(map[[2]spatial.CubeCoordinate]bool)
-		for x := 0; x < data.Space.Width; x++ {
-			for y := 0; y < data.Space.Height; y++ {
-				pos := spatial.Position{X: float64(x), Y: float64(y)}
-				cube := spatial.OffsetCoordinateToCubeWithOrientation(pos, spatial.HexOrientationPointyTop)
-				if blocked[cube] {
-					continue
-				}
-				for _, n := range cube.GetNeighbors() {
-					npos := n.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
-					if grid.IsValidPosition(npos) {
-						continue // neighbor is inside the room -- not a perimeter edge
-					}
-					expected[[2]spatial.CubeCoordinate{cube, n}] = true
-				}
-			}
-		}
-
-		require.Len(t, gotEdges, len(expected), "seed %d: perimeter edge segment count mismatch", seed)
-		for pair := range expected {
-			require.Contains(t, gotEdges, pair, "seed %d: missing perimeter edge %v", seed, pair)
-		}
+		assertPerimeterCompletenessAndNoDuplicates(t, fmt.Sprintf("seed %d", seed), data, enc.Room().GetGrid())
 	}
 }
 
@@ -175,18 +208,8 @@ func TestPerimeterEdgeWalls_NeverAtConnectorDoorCells(t *testing.T) {
 		enc := newTestEncounter(t)
 		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
 		data := enc.ToData()
-
-		doorCubes := map[spatial.CubeCoordinate]bool{
-			data.Doors[dungeonDoor0ID].Position.ToCube(): true,
-			data.Doors[dungeonDoor1ID].Position.ToCube(): true,
-		}
-		for _, w := range data.Space.Walls {
-			if w.Start == w.End {
-				continue
-			}
-			require.False(t, doorCubes[w.Start],
-				"seed %d: a connector door cell must never be the Start of a boundary-edge perimeter segment", seed)
-		}
+		assertNoDoorCellIsPerimeterStart(t, fmt.Sprintf("seed %d", seed), data,
+			[]core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
 	}
 }
 
@@ -210,5 +233,83 @@ func TestPerimeterEdgeWalls_DeterministicAcrossSeeds(t *testing.T) {
 		require.Equal(t, first, walls,
 			"seed %d: an all-PatternEmpty fixture's wall layout (including perimeter edges) must be "+
 				"identical across seeds", seed)
+	}
+}
+
+// perimeterEdgeShape is one SHAPE (region count, height, widths, pattern
+// mix) to sweep TestPerimeterEdgeWalls_VariedShapes over.
+type perimeterEdgeShape struct {
+	name    string
+	params  encounter.DungeonParams
+	doorIDs []core.EntityID
+}
+
+// perimeterEdgeShapeCases sweeps DungeonParams SHAPE (region count, the
+// validateDungeonParams height floor, and varied per-region widths) rather
+// than just seed. Every other test in this file pins the perimeter-edge
+// geometry (completeness, no duplicates, door-passage exclusion) across
+// randomness at ONE fixed shape (the 3-region entrance/corridor/boss
+// fixture, Height=8, widths 10/5/10) — this proves the same invariants
+// hold at shapes that fixture never exercises: a 2-region dungeon at the
+// minimum allowed height (4), and a 5-region dungeon with unequal widths
+// ending in a boss archetype (exercising the boss room's >6-hex-step
+// scale invariant at a non-default height too).
+func perimeterEdgeShapeCases() []perimeterEdgeShape {
+	twoRegionDoor := core.EntityID("shape-2region-door")
+	fiveRegionDoors := []core.EntityID{
+		"shape-5region-door-0", "shape-5region-door-1", "shape-5region-door-2", "shape-5region-door-3",
+	}
+	return []perimeterEdgeShape{
+		{
+			name: "2-region at the minimum allowed height",
+			params: encounter.DungeonParams{
+				Height: 4, RandomSeed: 7,
+				Regions: []encounter.DungeonRegionParams{
+					{ID: "a", Archetype: encounter.ArchetypeEntrance, Width: 5, Pattern: environments.PatternRandom},
+					{ID: "b", Archetype: encounter.ArchetypeChamber, Width: 6, Pattern: environments.PatternEmpty},
+				},
+				Connectors: []encounter.DungeonConnectorParams{{DoorID: twoRegionDoor}},
+			},
+			doorIDs: []core.EntityID{twoRegionDoor},
+		},
+		{
+			name: "5-region with varied widths ending in boss",
+			params: encounter.DungeonParams{
+				Height: 8, RandomSeed: 13,
+				Regions: []encounter.DungeonRegionParams{
+					{ID: "r0", Archetype: encounter.ArchetypeEntrance, Width: 4, Pattern: environments.PatternRandom},
+					{ID: "r1", Archetype: encounter.ArchetypeCorridor, Width: 9, Pattern: environments.PatternEmpty},
+					{ID: "r2", Archetype: encounter.ArchetypeChamber, Width: 5, Pattern: environments.PatternRandom},
+					{ID: "r3", Archetype: encounter.ArchetypeCorridor, Width: 4, Pattern: environments.PatternEmpty},
+					{ID: "r4", Archetype: encounter.ArchetypeBoss, Width: 11, Pattern: environments.PatternRandom},
+				},
+				Connectors: []encounter.DungeonConnectorParams{
+					{DoorID: fiveRegionDoors[0]}, {DoorID: fiveRegionDoors[1]},
+					{DoorID: fiveRegionDoors[2]}, {DoorID: fiveRegionDoors[3]},
+				},
+			},
+			doorIDs: fiveRegionDoors,
+		},
+	}
+}
+
+// TestPerimeterEdgeWalls_VariedShapes is the gate review's minor finding
+// (PR #838): every other test in this file sweeps SEED at one fixed
+// 3-region shape, which pins the geometry across randomness but never
+// across the shapes the reasoning in dungeon.go's perimeterEdgeWalls doc
+// actually depends on (an interior boundary column is never at the
+// space's x=0/x=width-1 edge; doorRow is never y=0/y=height-1). This pins
+// completeness, no-duplicates, and door-passage exclusion as DATA at a
+// 2-region minimum-height shape and a 5-region varied-width shape, not
+// just as argument.
+func TestPerimeterEdgeWalls_VariedShapes(t *testing.T) {
+	for _, tc := range perimeterEdgeShapeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := newTestEncounter(t)
+			require.NoError(t, enc.InitDungeon(tc.params))
+			data := enc.ToData()
+			assertPerimeterCompletenessAndNoDuplicates(t, tc.name, data, enc.Room().GetGrid())
+			assertNoDoorCellIsPerimeterStart(t, tc.name, data, tc.doorIDs)
+		})
 	}
 }

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -153,6 +153,20 @@ func (e *Encounter) rebuildRoomFromData() error {
 	})
 	placed := make(map[spatial.CubeCoordinate]struct{}, len(sd.Walls)+len(e.data.Doors))
 	for i, w := range sd.Walls {
+		// rpg-toolkit#834: a boundary-edge perimeter segment (Start != End)
+		// is purely the render contract (rpg-dnd5e-web#566's
+		// hexDistance==1 client branch) catching up to the room's actual
+		// shape, never a spatial.Room blocker in its own right — Start is
+		// real walkable floor (placing a WallEntity there would wrongly
+		// block legitimate floor) and End lies entirely outside this
+		// room's grid bounds (PlaceEntity would reject it, or worse,
+		// silently collide with an unrelated in-bounds cube on a
+		// differently-sized room). Every degenerate (Start == End) entry
+		// below — interior pattern walls, connector boundary columns —
+		// keeps placing exactly as before; this only skips the new shape.
+		if w.Start != w.End {
+			continue
+		}
 		// snapshotWalls dedupes on write; this read-side skip additionally
 		// tolerates a hand-built or legacy snapshot carrying duplicates —
 		// PlaceEntity rejects stacking a blocking entity on an occupied hex,


### PR DESCRIPTION
## Summary

`generateDungeonLayout`/`InitDungeon` (`encounter/dungeon.go`) previously emitted only degenerate `WallSegmentData{Start == End}` blocked cells for interior pattern walls and connector boundary columns — room perimeters shipped NO wall data at all; blocking came purely from grid bounds. This adds one boundary-edge segment (`Start != End`, exactly one hex step apart) per room-facing edge of the combined dungeon space's outer perimeter, so rooms now ship real perimeter wall data on the wire.

## Mechanism

For every floor hex (any hex in `[0,width) x [0,height)` that isn't already a blocked cell — interior pattern walls and connector boundary columns are untouched) and every one of its 6 hex-grid neighbor directions that lands outside those bounds, `perimeterEdgeWalls` (`dungeon.go`) emits `WallSegmentData{Start: floorHex, End: outsideNeighbor, BlocksMovement: true, BlocksLoS: true}`. This is appended once, after every region's interior walls and every connector's boundary column, as a pure function of the already-built floor/wall layout — no RNG, so it's deterministic and seed-independent by construction.

A single floor hex can legitimately get more than one segment: a true corner-of-the-map hex's skewed odd-q offset neighbor geometry puts several of its 6 sides outside the rectangle, and each exposed edge gets its own segment — exactly what the client's `hexDistance==1` renderer (rpg-dnd5e-web#566) wants, one clean slab per edge.

## Critical fix required: `rebuildRoomFromData`

`encounter/space.go`'s `rebuildRoomFromData` previously placed a blocking `WallEntity` at `w.Start` for **every** `Walls` entry, without checking `End`. Left unfixed, a perimeter segment (`Start` = real walkable floor) would have wrongly blocked that floor hex — a serious walkability regression. Fixed by skipping room-placement entirely for any `Start != End` entry: these segments are purely the render contract (rpg-dnd5e-web#566), never a `spatial.Room` blocker. `End` is already unreachable by construction (outside `spatial.HexGrid.IsValidPosition`), so no new blocking mechanism is needed — walkability outcomes are unchanged.

## Constraints honored

- Interior wall emission (degenerate cells) is untouched — same as before.
- Connector boundary columns are excluded by construction: a column sits at an interior x (never the space's own `x=0`/`x=width-1` edge), so its cells are never "floor" and never get a new segment; the doc explains why this is deliberate, not accidental.
- **Door-passage exclusion turned out to be geometrically moot** — see "Surprises" below.
- Determinism: pure function of the floor set, no RNG (`TestPerimeterEdgeWalls_DeterministicAcrossSeeds`).
- `SpaceData.Walls`' doc comment (`data.go`) now documents both shapes (degenerate vs. boundary-edge) instead of the stale wave-1-only comment.

## Surprise worth flagging: the door-passage exclusion is moot, not just "handled"

The issue anticipated needing explicit logic to avoid emitting perimeter edges across a connector's door passage. In practice, this never arises: a connector's door always sits at `doorRow` within an **interior** boundary column — never the space's own `x=0`/`x=width-1` edge — and `doorRow = height/2` is itself never `y=0`/`y=height-1` given `validateDungeonParams`' `height >= 4` floor. So a door cell can geometrically never be the `Start` of a boundary-edge segment; no special-case code was needed. `TestPerimeterEdgeWalls_NeverAtConnectorDoorCells` pins this as an explicit assertion rather than leaving it as an unverified assumption.

## Test evidence

`encounter/perimeter_edge_walls_test.go` (6 tests), each deriving expectations independently of `dungeon.go`'s own unexported `perimeterEdgeWalls`/`wallCubeSet` — "floor" is reconstructed from the public `Data.Space.Walls` shape, and "outside the room" is queried against the *live room's own* `GetGrid().IsValidPosition` (the same grid movement/LoS already use), not a hand-rolled recheck that could share a bug with the generator:

- `TestPerimeterEdgeWalls_Completeness` — across 8 seeds: every expected edge present, no extras, no duplicates.
- `TestPerimeterEdgeWalls_StartInsideEndOutsideDistanceOne` — every segment is `hexDistance(Start,End) == 1`, `Start` inside the room, `End` outside, `BlocksMovement`/`BlocksLoS` both true.
- `TestPerimeterEdgeWalls_EntranceHexHasWestFacingEdge` — concrete pin: the entrance hex always carries a west-facing edge, across seeds.
- `TestPerimeterEdgeWalls_NeverAtConnectorDoorCells` — the door-passage-exclusion-is-moot claim above, asserted directly.
- `TestPerimeterEdgeWalls_DeterministicAcrossSeeds` — an all-`PatternEmpty` fixture's full wall layout is byte-for-byte identical across 6 seeds.
- `TestPerimeterEdgeWalls_VariedShapes` — added post-gate-review (see below): completeness/no-duplicates/door-exclusion pinned at a 2-region dungeon at the minimum allowed height (4) and a 5-region dungeon with varied widths ending in a boss archetype, not just at the fixed 3-region fixture the other tests share.

Also updated `boss_primary_axis_test.go`: its existing invariant ("no *generated* wall on the boss primary axis") was checking `w.Start` without filtering to degenerate entries, so it started failing once the boss region's own far/right edge (legitimately on the whole space's outer perimeter) got its own boundary-edge segment. Fixed by skipping non-degenerate entries in that check — the test's intent (no *blocking* interior wall on the primary axis) is unchanged and still enforced.

Full suite:
```
go test -race ./...
ok  	github.com/KirkDiggler/rpg-toolkit/encounter	65.234s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/core	1.018s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/events	1.030s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/perception	1.021s
```
`golangci-lint run ./...` reports the same pre-existing `goconst`/`dupl` background noise as `origin/main` (none in changed files); `gofmt`/`goimports` clean on all changed files.

## Follow-up (not in this PR)

**Correction (post-gate-review):** an earlier version of this section wrongly claimed rpg-api's `wallsToProto` (`project.go`) collapses `From = To`. It does not — it already reads `Start`/`End` separately and passes them through as distinct `From`/`To` (verified directly against `origin/main`, since rpg-api#645). So **no rpg-api code change is needed** for these new segments to reach the client once rpg-api bumps its toolkit dependency to include this PR. The real remaining follow-up work is: (a) tag a toolkit release and bump rpg-api's dependency, and (b) add an rpg-api projection test built from an actual `InitDungeon`-generated fixture — rpg-api's existing wall-projection tests hand-build `data.Space` with degenerate (`Start == End`) fixtures only, so there's currently no automatic red-test safety net there for this new `Start != End` shape at bump time. **Part of #834** (not closing it here).

Refs: #814, rpg-dnd5e-web#562, rpg-dnd5e-web#566, rpg-dnd5e-web#540, rpg-dnd5e-web#560.

— asset-pipeline agent, on behalf of KirkDiggler
