### PR TITLE
feat(encounter): crypt dressing + light-anchor set pieces per region (#839)

### DIFF
--- a/encounter/crypt_dungeon.go
+++ b/encounter/crypt_dungeon.go
@@ -88,6 +88,35 @@ const (
 	CryptObstacleRefPillar = "dnd5e:props:pillar"
 )
 
+// Crypt dressing + light-anchor refs (rpg-toolkit#839, "the depth pass"):
+// the crypt renders correct-but-flat with zero light sources; these feed
+// the existing light pipeline (client mood-light derivation lights props
+// by ref, capped at 8 — rpg-dnd5e-web#585) and carry decay/dressing that
+// the art target wants instead of broken wall geometry (rpg-dnd5e-
+// web#469). Already promoted + client-registered (rpg-game-assets#22/#23,
+// rpg-dnd5e-web#567) — same "dnd5e:props:..." namespace and opaque-ref
+// convention as the #819 vocabulary above.
+const (
+	// CryptObstacleRefBrazier identifies a standing brazier — a warm
+	// light anchor, shared by the entrance and boss chambers.
+	CryptObstacleRefBrazier = "dnd5e:props:brazier"
+	// CryptObstacleRefBonePile identifies a scattered bone-pile floor
+	// dressing piece — entrance-chamber only.
+	CryptObstacleRefBonePile = "dnd5e:props:bone-pile"
+	// CryptObstacleRefTorchOrnate identifies a wall-mount ornate torch —
+	// the corridor's single light anchor (must stay easily traversable).
+	CryptObstacleRefTorchOrnate = "dnd5e:props:torch-ornate"
+	// CryptObstacleRefCandles identifies a paired-candle floor dressing
+	// piece flanking the boss chamber's coffin.
+	CryptObstacleRefCandles = "dnd5e:props:candles"
+	// CryptObstacleRefChain identifies a hanging-chain dressing piece —
+	// boss-chamber only.
+	CryptObstacleRefChain = "dnd5e:props:chain"
+	// CryptObstacleRefSkeletonRemains identifies a skeletal-remains floor
+	// dressing piece — boss-chamber only.
+	CryptObstacleRefSkeletonRemains = "dnd5e:props:skeleton-remains"
+)
+
 // Crypt set-piece blocking properties: the VERIFIED canonical shipped-
 // asset-contract table (independent finding, PR #826 review — supersedes
 // this file's earlier "low vs tall" design guess, which had altar wrong):
@@ -103,9 +132,31 @@ const (
 // Every approved piece blocks movement; only the coffin/tomb does not
 // also block line of sight.
 const (
-	cryptBlocksMovement  = true
-	cryptBlocksLoS       = true
-	cryptCoffinBlocksLoS = false
+	cryptBlocksMovement = true
+	cryptBlocksLoS      = true
+	// cryptSeeOverBlocksLoS is BlocksLoS for a piece that's a physical
+	// obstruction (BlocksMovement true) but never blocks sightline over
+	// or around it: the coffin/tomb (table above), and rpg-toolkit#839's
+	// light anchors (brazier, torch-ornate — "you can see over flame").
+	cryptSeeOverBlocksLoS = false
+)
+
+// Crypt floor-dressing blocking properties (rpg-toolkit#839): candles,
+// bone-pile, chain, and skeleton-remains are walkable-past floor
+// dressing, never a physical obstruction or sightline blocker — verified
+// against this package's placement (placeRegionObstacles: each instance
+// still consumes its own unique candidate cell regardless of blocking
+// flags — no collision risk), room-rebuild (rebuildRoomFromData places a
+// WallEntity per obstacle with these exact flags copied verbatim — a
+// BlocksMovement=false entity places but never blocks CanPlaceEntity),
+// and reveal (publishRevealedObstacles keys purely on hex-position
+// overlap with a viewer's newly revealed hexes, never on either blocking
+// flag) machinery — see obstacle_test.go's existing
+// TestObstacle_BlocksMovement_False for the end-to-end proof this
+// already holds. No fallback to blocking=true needed.
+const (
+	cryptDressingBlocksMovement = false
+	cryptDressingBlocksLoS      = false
 )
 
 // The first crypt dungeon's fixed shape: entrance -> corridor -> boss,
@@ -124,40 +175,69 @@ const (
 	cryptRegionIDBoss     = "boss"
 )
 
-// cryptEntranceObstacles: an obelisk plus flanking pillars — the
-// entrance chamber's archetype-appropriate set pieces (#819 scope).
+// cryptEntranceObstacles: an obelisk plus flanking pillars (#819), now
+// joined by rpg-toolkit#839's depth-pass dressing — 2 braziers as the
+// warm light anchors, plus 2 bone-piles as floor dressing. Judgment call
+// on the issue's "1-2x bone-pile": chose 2, matching the fuller "gives
+// the room a depth" composition target rather than the sparser end of
+// the range — flagged in the PR body, easy to dial back to 1 if it reads
+// too busy once rendered.
 func cryptEntranceObstacles() []ObstacleSpec {
 	return []ObstacleSpec{
 		{Ref: CryptObstacleRefObelisk, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
 		{Ref: CryptObstacleRefPillar, Count: 2, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
+		{Ref: CryptObstacleRefBrazier, Count: 2, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS},
+		{
+			Ref: CryptObstacleRefBonePile, Count: 2,
+			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
+		},
 	}
 }
 
-// cryptCorridorObstacles: a single sparse pillar — the corridor must
-// stay monster-free and easily traversable (#819 scope), so this is
-// deliberately the lightest set-piece load of the three regions.
+// cryptCorridorObstacles: a single sparse pillar (#819), plus
+// rpg-toolkit#839's one light anchor — the corridor must stay
+// monster-free and easily traversable, so this stays deliberately the
+// lightest set-piece load of the three regions; a single torch is enough
+// to carry a light pool through it without competing for floor space.
 func cryptCorridorObstacles() []ObstacleSpec {
 	return []ObstacleSpec{
 		{Ref: CryptObstacleRefPillar, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
+		{
+			Ref: CryptObstacleRefTorchOrnate, Count: 1,
+			BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS,
+		},
 	}
 }
 
 // cryptBossObstacles: a coffin/tomb, an altar, and one of each of the
-// two promoted exact statue variants (a fixed reaper+hooded-knight
-// pairing, not a random-variant policy) — the boss chamber's archetype-
-// appropriate set pieces (#819 scope: "boss chamber with an altar and
-// flanking statues that don't block the path to it"). Keeping coffin as
-// coffin only — no tomb/sarcophagus variant is added here; see the PR
-// body for why (#818 v1's single-anchor-per-instance limitation and
-// rpg-dnd5e-web#577's rendering/composition ownership).
+// two promoted exact statue variants (#819's fixed reaper+hooded-knight
+// pairing, not a random-variant policy), now joined by rpg-toolkit#839's
+// depth-pass dressing: 2 candles flanking the coffin, 2 braziers as
+// light anchors, 1 hanging chain, and 1 skeleton-remains pile. Keeping
+// coffin as coffin only — no tomb/sarcophagus variant is added here; see
+// the PR body for why (#818 v1's single-anchor-per-instance limitation
+// and rpg-dnd5e-web#577's rendering/composition ownership).
 func cryptBossObstacles() []ObstacleSpec {
 	return []ObstacleSpec{
-		{Ref: CryptObstacleRefCoffin, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptCoffinBlocksLoS},
+		{Ref: CryptObstacleRefCoffin, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS},
 		{Ref: CryptObstacleRefAltar, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
 		{Ref: CryptObstacleRefStatueReaper, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
 		{
 			Ref: CryptObstacleRefStatueKnightHooded, Count: 1,
 			BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS,
+		},
+		{
+			Ref: CryptObstacleRefCandles, Count: 2,
+			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
+		},
+		{Ref: CryptObstacleRefBrazier, Count: 2, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS},
+		{
+			Ref: CryptObstacleRefChain, Count: 1,
+			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
+		},
+		{
+			Ref: CryptObstacleRefSkeletonRemains, Count: 1,
+			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
 		},
 	}
 }

--- a/encounter/crypt_dungeon.go
+++ b/encounter/crypt_dungeon.go
@@ -119,18 +119,30 @@ const (
 
 // Crypt set-piece blocking properties: the VERIFIED canonical shipped-
 // asset-contract table (independent finding, PR #826 review — supersedes
-// this file's earlier "low vs tall" design guess, which had altar wrong):
+// this file's earlier "low vs tall" design guess, which had altar wrong),
+// now spanning three flag classes across #819's structural vocabulary and
+// rpg-toolkit#839's depth-pass dressing/light-anchor additions:
 //
 //	ref                    BlocksMovement  BlocksLoS
-//	coffin/tomb            true            false  (walk around, see over)
 //	altar                  true            true   (measured 2.057m, role "obstacle")
 //	statue-reaper          true            true
 //	statue-knight-hooded   true            true
 //	obelisk                true            true
 //	pillar                 true            true
+//	coffin/tomb            true            false  (walk around, see over)
+//	brazier                true            false  (physical, but see over the flame)
+//	torch-ornate           true            false  (same shape as brazier)
+//	candles                false           false  (walkable-past floor dressing)
+//	bone-pile              false           false  (walkable-past floor dressing)
+//	chain                  false           false  (walkable-past floor dressing)
+//	skeleton-remains       false           false  (walkable-past floor dressing)
 //
-// Every approved piece blocks movement; only the coffin/tomb does not
-// also block line of sight.
+// Three flag shapes, not one: structural pieces (obelisk/pillar/altar/
+// statues) block both movement and LoS; a see-over class (coffin/tomb,
+// brazier, torch-ornate) is a physical obstruction that never blocks
+// sightline over or around it (coffin: low enough to see over; brazier/
+// torch-ornate: see over the flame); dressing (candles/bone-pile/chain/
+// skeleton-remains) blocks neither.
 const (
 	cryptBlocksMovement = true
 	cryptBlocksLoS      = true
@@ -186,9 +198,12 @@ func cryptEntranceObstacles() []ObstacleSpec {
 	return []ObstacleSpec{
 		{Ref: CryptObstacleRefObelisk, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
 		{Ref: CryptObstacleRefPillar, Count: 2, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
-		{Ref: CryptObstacleRefBrazier, Count: 2, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS},
 		{
-			Ref: CryptObstacleRefBonePile, Count: 2,
+			Ref: CryptObstacleRefBrazier, Count: 2, PreferBorder: true,
+			BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS,
+		},
+		{
+			Ref: CryptObstacleRefBonePile, Count: 2, PreferBorder: true,
 			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
 		},
 	}
@@ -203,7 +218,7 @@ func cryptCorridorObstacles() []ObstacleSpec {
 	return []ObstacleSpec{
 		{Ref: CryptObstacleRefPillar, Count: 1, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS},
 		{
-			Ref: CryptObstacleRefTorchOrnate, Count: 1,
+			Ref: CryptObstacleRefTorchOrnate, Count: 1, PreferBorder: true,
 			BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS,
 		},
 	}
@@ -227,16 +242,19 @@ func cryptBossObstacles() []ObstacleSpec {
 			BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptBlocksLoS,
 		},
 		{
-			Ref: CryptObstacleRefCandles, Count: 2,
-			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
-		},
-		{Ref: CryptObstacleRefBrazier, Count: 2, BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS},
-		{
-			Ref: CryptObstacleRefChain, Count: 1,
+			Ref: CryptObstacleRefCandles, Count: 2, PreferBorder: true,
 			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
 		},
 		{
-			Ref: CryptObstacleRefSkeletonRemains, Count: 1,
+			Ref: CryptObstacleRefBrazier, Count: 2, PreferBorder: true,
+			BlocksMovement: cryptBlocksMovement, BlocksLoS: cryptSeeOverBlocksLoS,
+		},
+		{
+			Ref: CryptObstacleRefChain, Count: 1, PreferBorder: true,
+			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
+		},
+		{
+			Ref: CryptObstacleRefSkeletonRemains, Count: 1, PreferBorder: true,
 			BlocksMovement: cryptDressingBlocksMovement, BlocksLoS: cryptDressingBlocksLoS,
 		},
 	}

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -168,34 +168,59 @@ func TestCryptDungeonParams_RegionArchetypeComposition(t *testing.T) {
 	entranceRefs := refsOf(byArchetype[encounter.ArchetypeEntrance].Obstacles)
 	require.Contains(t, entranceRefs, encounter.CryptObstacleRefObelisk)
 	require.Contains(t, entranceRefs, encounter.CryptObstacleRefPillar)
+	require.Contains(t, entranceRefs, encounter.CryptObstacleRefBrazier, "rpg-toolkit#839 depth-pass light anchor")
+	require.Contains(t, entranceRefs, encounter.CryptObstacleRefBonePile, "rpg-toolkit#839 depth-pass dressing")
 	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefCoffin)
 	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefAltar)
 	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefStatueReaper)
 	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefStatueKnightHooded)
+	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefTorchOrnate, "corridor-only light anchor")
+	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefCandles, "boss-only dressing")
+	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefChain, "boss-only dressing")
+	require.NotContains(t, entranceRefs, encounter.CryptObstacleRefSkeletonRemains, "boss-only dressing")
+	require.Equal(t, 2, entranceRefs[encounter.CryptObstacleRefBrazier].Count)
+	require.Equal(t, 2, entranceRefs[encounter.CryptObstacleRefBonePile].Count)
 
 	corridorRefs := refsOf(byArchetype[encounter.ArchetypeCorridor].Obstacles)
 	require.Contains(t, corridorRefs, encounter.CryptObstacleRefPillar)
+	require.Contains(t, corridorRefs, encounter.CryptObstacleRefTorchOrnate, "rpg-toolkit#839 depth-pass light anchor")
 	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefObelisk)
 	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefCoffin)
 	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefAltar)
 	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefStatueReaper)
 	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefStatueKnightHooded)
+	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefBrazier, "entrance/boss-only anchor")
+	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefBonePile, "entrance-only dressing")
+	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefCandles, "boss-only dressing")
+	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefChain, "boss-only dressing")
+	require.NotContains(t, corridorRefs, encounter.CryptObstacleRefSkeletonRemains, "boss-only dressing")
 	corridorTotal := 0
 	for _, s := range byArchetype[encounter.ArchetypeCorridor].Obstacles {
 		corridorTotal += s.Count
 	}
-	require.LessOrEqual(t, corridorTotal, 1, "corridor set pieces must stay sparse")
+	require.LessOrEqual(t, corridorTotal, 2,
+		"corridor set pieces must stay sparse (1 pillar + 1 torch, rpg-toolkit#839)")
 
 	bossRefs := refsOf(byArchetype[encounter.ArchetypeBoss].Obstacles)
 	require.Contains(t, bossRefs, encounter.CryptObstacleRefCoffin)
 	require.Contains(t, bossRefs, encounter.CryptObstacleRefAltar)
 	require.Contains(t, bossRefs, encounter.CryptObstacleRefStatueReaper)
 	require.Contains(t, bossRefs, encounter.CryptObstacleRefStatueKnightHooded)
+	require.Contains(t, bossRefs, encounter.CryptObstacleRefCandles, "rpg-toolkit#839 depth-pass dressing")
+	require.Contains(t, bossRefs, encounter.CryptObstacleRefBrazier, "rpg-toolkit#839 depth-pass light anchor")
+	require.Contains(t, bossRefs, encounter.CryptObstacleRefChain, "rpg-toolkit#839 depth-pass dressing")
+	require.Contains(t, bossRefs, encounter.CryptObstacleRefSkeletonRemains, "rpg-toolkit#839 depth-pass dressing")
 	require.NotContains(t, bossRefs, encounter.CryptObstacleRefObelisk)
+	require.NotContains(t, bossRefs, encounter.CryptObstacleRefBonePile, "entrance-only dressing")
+	require.NotContains(t, bossRefs, encounter.CryptObstacleRefTorchOrnate, "corridor-only light anchor")
 	require.Equal(t, 1, bossRefs[encounter.CryptObstacleRefStatueReaper].Count,
 		"exactly one reaper statue -- the promoted default pairing, not a random-variant policy")
 	require.Equal(t, 1, bossRefs[encounter.CryptObstacleRefStatueKnightHooded].Count,
 		"exactly one hooded-knight statue -- the promoted default pairing, not a random-variant policy")
+	require.Equal(t, 2, bossRefs[encounter.CryptObstacleRefCandles].Count, "2 candles flanking the coffin")
+	require.Equal(t, 2, bossRefs[encounter.CryptObstacleRefBrazier].Count)
+	require.Equal(t, 1, bossRefs[encounter.CryptObstacleRefChain].Count)
+	require.Equal(t, 1, bossRefs[encounter.CryptObstacleRefSkeletonRemains].Count)
 }
 
 // TestCryptDungeonParams_NoGenericStatueRefExists: the generic,
@@ -226,6 +251,9 @@ func TestCryptDungeonParams_NoObstacleUsesModelFilenamesOrSyntyPaths(t *testing.
 		encounter.CryptObstacleRefCoffin, encounter.CryptObstacleRefAltar,
 		encounter.CryptObstacleRefStatueReaper, encounter.CryptObstacleRefStatueKnightHooded,
 		encounter.CryptObstacleRefObelisk, encounter.CryptObstacleRefPillar,
+		encounter.CryptObstacleRefBrazier, encounter.CryptObstacleRefBonePile,
+		encounter.CryptObstacleRefTorchOrnate, encounter.CryptObstacleRefCandles,
+		encounter.CryptObstacleRefChain, encounter.CryptObstacleRefSkeletonRemains,
 	} {
 		require.Regexp(t, `^dnd5e:props:[a-z-]+$`, ref)
 	}
@@ -245,6 +273,14 @@ var cryptCanonicalAssetManifestKeys = map[string]string{
 	"CryptObstacleRefStatueKnightHooded": "dnd5e:props:statue-knight-hooded",
 	"CryptObstacleRefObelisk":            "dnd5e:props:obelisk",
 	"CryptObstacleRefPillar":             "dnd5e:props:pillar",
+	// rpg-toolkit#839 depth-pass dressing + light anchors -- already
+	// promoted + client-registered (rpg-game-assets#22/#23, web#567).
+	"CryptObstacleRefBrazier":         "dnd5e:props:brazier",
+	"CryptObstacleRefBonePile":        "dnd5e:props:bone-pile",
+	"CryptObstacleRefTorchOrnate":     "dnd5e:props:torch-ornate",
+	"CryptObstacleRefCandles":         "dnd5e:props:candles",
+	"CryptObstacleRefChain":           "dnd5e:props:chain",
+	"CryptObstacleRefSkeletonRemains": "dnd5e:props:skeleton-remains",
 }
 
 // TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly: each
@@ -264,6 +300,12 @@ func TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly(t *testing.T) 
 		"CryptObstacleRefStatueKnightHooded": encounter.CryptObstacleRefStatueKnightHooded,
 		"CryptObstacleRefObelisk":            encounter.CryptObstacleRefObelisk,
 		"CryptObstacleRefPillar":             encounter.CryptObstacleRefPillar,
+		"CryptObstacleRefBrazier":            encounter.CryptObstacleRefBrazier,
+		"CryptObstacleRefBonePile":           encounter.CryptObstacleRefBonePile,
+		"CryptObstacleRefTorchOrnate":        encounter.CryptObstacleRefTorchOrnate,
+		"CryptObstacleRefCandles":            encounter.CryptObstacleRefCandles,
+		"CryptObstacleRefChain":              encounter.CryptObstacleRefChain,
+		"CryptObstacleRefSkeletonRemains":    encounter.CryptObstacleRefSkeletonRemains,
 	}
 	for name, want := range cryptCanonicalAssetManifestKeys {
 		require.Equal(t, want, actual[name], "%s must equal the exact canonical asset-manifest key", name)
@@ -274,7 +316,12 @@ func TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly(t *testing.T) 
 // contract blocking table (independent finding, not this file's own
 // design guess): coffin/tomb movement=true LoS=false; altar movement=
 // true LoS=true (measured 2.057m, role "obstacle"); statues movement=
-// true LoS=true; obelisk/pillar movement=true LoS=true.
+// true LoS=true; obelisk/pillar movement=true LoS=true. rpg-toolkit#839's
+// depth-pass additions per the issue's flag table: braziers/torch-ornate
+// are physical light anchors (movement=true) you can still see over
+// (LoS=false, "you can see over flame"); candles/bone-pile/chain/
+// skeleton-remains are walkable-past floor dressing (movement=false,
+// LoS=false).
 var cryptBlockingContractTable = []struct {
 	ref            string
 	blocksMovement bool
@@ -286,6 +333,12 @@ var cryptBlockingContractTable = []struct {
 	{encounter.CryptObstacleRefStatueKnightHooded, true, true},
 	{encounter.CryptObstacleRefObelisk, true, true},
 	{encounter.CryptObstacleRefPillar, true, true},
+	{encounter.CryptObstacleRefBrazier, true, false},
+	{encounter.CryptObstacleRefTorchOrnate, true, false},
+	{encounter.CryptObstacleRefBonePile, false, false},
+	{encounter.CryptObstacleRefCandles, false, false},
+	{encounter.CryptObstacleRefChain, false, false},
+	{encounter.CryptObstacleRefSkeletonRemains, false, false},
 }
 
 // TestCryptDungeonParams_BlockingFlagsMatchVerifiedAssetContract: every
@@ -358,6 +411,13 @@ func TestCryptDungeon_GeneratesPlaceableDungeon_WithSetPieces(t *testing.T) {
 		encounter.CryptObstacleRefStatueKnightHooded: true,
 		encounter.CryptObstacleRefObelisk:            true,
 		encounter.CryptObstacleRefPillar:             true,
+		// rpg-toolkit#839 depth-pass dressing + light anchors.
+		encounter.CryptObstacleRefBrazier:         true,
+		encounter.CryptObstacleRefBonePile:        true,
+		encounter.CryptObstacleRefTorchOrnate:     true,
+		encounter.CryptObstacleRefCandles:         true,
+		encounter.CryptObstacleRefChain:           true,
+		encounter.CryptObstacleRefSkeletonRemains: true,
 	}
 	for _, o := range data.Space.Obstacles {
 		require.True(t, approved[o.Ref], "obstacle ref %q is outside the approved crypt vocabulary", o.Ref)
@@ -393,6 +453,89 @@ func TestCryptDungeon_EntranceToBossConnectivity_SurvivesSetPieces(t *testing.T)
 		}
 	}
 	require.True(t, reachedBoss, "the crypt template's real set pieces must never sever entrance->boss connectivity")
+}
+
+// cryptDressingSweepSeeds sweeps a spread of seeds for the rpg-toolkit#839
+// depth-pass tests below — the same "prove it across seeds, not just one
+// lucky roll" convention #835's own seed-sweep test established.
+var cryptDressingSweepSeeds = []int64{
+	cdSeed, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 42, 100, 909091, 123456789,
+}
+
+// TestCryptDungeon_DressingSpecCounts_PlaceFullyAcrossSeeds pins
+// rpg-toolkit#839's done bar ("fresh crypt via InitDungeon carries the
+// new specs, counts asserted across seeds"): unlike the generic
+// ObstacleSpec mechanism's best-effort contract (a region whose safe
+// floor can't fit every requested instance places as many as fit, never
+// failing generation), THIS specific composition never actually contests
+// capacity — every region's floor area comfortably exceeds its total
+// requested instance count (entrance: 7 new/70 candidate cells; corridor:
+// 1 new/35; boss: 6 new/70) — so every new dressing/light-anchor spec
+// must place its FULL requested count in every region, every seed, not
+// merely "at least one." A region that silently shrank below its full
+// count here would mean placeRegionObstacles' candidate pool had
+// unexpectedly shrunk (e.g. a doorRow/wall change eating into the shared
+// floor budget), which this test exists to catch.
+func TestCryptDungeon_DressingSpecCounts_PlaceFullyAcrossSeeds(t *testing.T) {
+	wantCounts := map[string]int{
+		encounter.CryptObstacleRefBrazier:         2 + 2, // entrance (2) + boss (2)
+		encounter.CryptObstacleRefBonePile:        2,     // entrance only
+		encounter.CryptObstacleRefTorchOrnate:     1,     // corridor only
+		encounter.CryptObstacleRefCandles:         2,     // boss only
+		encounter.CryptObstacleRefChain:           1,     // boss only
+		encounter.CryptObstacleRefSkeletonRemains: 1,     // boss only
+	}
+
+	for _, seed := range cryptDressingSweepSeeds {
+		enc := cdNewEncounter(t)
+		require.NoError(t, enc.InitDungeon(encounter.CryptDungeonParams(seed, cdEntranceDoorID, cdBossDoorID)),
+			"seed %d", seed)
+
+		gotCounts := make(map[string]int, len(wantCounts))
+		for _, o := range enc.ToData().Space.Obstacles {
+			gotCounts[o.Ref]++
+		}
+		for ref, want := range wantCounts {
+			require.Equal(t, want, gotCounts[ref],
+				"seed %d: ref %q must place its full requested count (ample floor capacity, never contested)",
+				seed, ref)
+		}
+	}
+}
+
+// TestCryptDungeon_EntranceToBossConnectivity_SurvivesDressingAcrossSeeds
+// generalizes TestCryptDungeon_EntranceToBossConnectivity_SurvivesSetPieces
+// (single fixture seed) to a spread of seeds, now that #839 has roughly
+// doubled the crypt's total set-piece load — the depth-pass dressing must
+// never sever entrance->boss connectivity at ANY seed, not just the one
+// the pre-existing fixture happens to use.
+func TestCryptDungeon_EntranceToBossConnectivity_SurvivesDressingAcrossSeeds(t *testing.T) {
+	for _, seed := range cryptDressingSweepSeeds {
+		enc := cdNewEncounter(t)
+		require.NoError(t, enc.InitDungeon(encounter.CryptDungeonParams(seed, cdEntranceDoorID, cdBossDoorID)),
+			"seed %d", seed)
+
+		data := enc.ToData()
+		entrance := data.Space.Entrance
+		require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+			PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: entrance, SightRange: 30,
+		}), "seed %d", seed)
+		require.NoError(t, enc.OpenDoor(alicePlayerID, cdEntranceDoorID), "seed %d", seed)
+		require.NoError(t, enc.OpenDoor(alicePlayerID, cdBossDoorID), "seed %d", seed)
+
+		reachable := reachableFrom(enc.Room(), entrance)
+		boss := regionHexSet(enc.ToData().Space, "boss")
+		require.NotEmpty(t, boss, "seed %d", seed)
+		reachedBoss := false
+		for h := range reachable {
+			if boss[h] {
+				reachedBoss = true
+				break
+			}
+		}
+		require.True(t, reachedBoss,
+			"seed %d: the depth-pass dressing must never sever entrance->boss connectivity", seed)
+	}
 }
 
 // TestCryptDungeon_DeterministicSameSeed: same seed reproduces the

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -111,6 +111,31 @@ type ObstacleSpec struct {
 	// ObstacleData.
 	BlocksMovement bool
 	BlocksLoS      bool
+
+	// PreferBorder opts this spec into placeRegionObstacles' border-
+	// hugging draw-order bias (rpg-toolkit#839's composition ask,
+	// rpg-dnd5e-web#469: "dressing hugs walls/corners; floor centers
+	// stay clear; focal pieces centered") — false by default, matching
+	// every pre-#839 caller/fixture's original uniform-random placement
+	// exactly (see placeRegionObstacles' doc: the zero-value case is a
+	// byte-identical code path to the mechanism before #839, not merely
+	// an equivalent one).
+	//
+	// This is PER-SPEC, not per-region (rpg-toolkit#840 gate finding):
+	// an earlier revision applied the bias to every spec in a region
+	// regardless of intent, which forced FOCAL pieces (a region's own
+	// obelisk/coffin/altar/statues, always listed first) onto the
+	// border before dressing ever got a turn — inverting the art
+	// target instead of achieving it. Set true only on dressing/light-
+	// anchor specs (e.g. CryptDungeonParams' brazier/torch-ornate/
+	// candles/bone-pile/chain/skeleton-remains); leave false on focal/
+	// structural specs so they draw uniformly from whatever the
+	// border-preferring specs left over, which in practice biases them
+	// toward the interior/center precisely because the borders filled
+	// up first — without this package ever hard-coding "focal pieces
+	// go in the center," a claim placeRegionObstacles has no way to
+	// verify structurally.
+	PreferBorder bool
 }
 
 // DungeonConnectorParams configures the door joining two consecutive
@@ -753,24 +778,60 @@ type placeRegionObstaclesParams struct {
 // size floor already enforces at construction time. One rule, no
 // archetype-specific branching, provably sufficient for both invariants.
 //
-// The candidate pool is PARTITIONED into border cells (local x==0,
-// x==width-1, y==0, or y==height-1 — hugging the region's own four
-// walls/corners) and interior cells, each independently shuffled with a
-// seeded Fisher-Yates (deterministic per seed, varies across seeds), then
-// concatenated border-first (rpg-toolkit#839's composition ask: "dressing
-// hugs walls/corners; floor centers stay clear" — rpg-dnd5e-web#469).
-// Specs draw from the combined pool in order, each instance consuming
-// one candidate so no two specs (or two instances of the same spec) can
-// collide — a spec whose Count exceeds the border pool naturally spills
-// into interior cells, so this is a DRAW-ORDER preference, not a hard
-// requirement; it changes nothing about which cells are eligible; a spec
-// that asks for more instances than the remaining pool has places as
-// many as fit and drops the rest — #819's "skip rather than invalidate
-// the dungeon" requirement — this function never errors.
+// The candidate pool's draw order depends on whether ANY spec in this
+// region sets PreferBorder (rpg-toolkit#839/#840):
+//
+//   - No spec prefers the border (every pre-#839 caller/fixture): ONE
+//     flat candidate list in natural (x,y) scan order, ONE seeded
+//     Fisher-Yates shuffle — the exact, byte-identical code path this
+//     function used before #839 ever existed. Zero behavior change for
+//     any caller that never sets PreferBorder.
+//   - At least one spec prefers the border: the pool is PARTITIONED into
+//     border cells (local x==0, x==width-1, y==0, or y==height-1 —
+//     hugging the region's own four walls/corners) and interior cells,
+//     each independently shuffled. PreferBorder specs draw border-first
+//     (falling back to interior on overflow) in TWO PASSES: every
+//     PreferBorder=true spec draws before any PreferBorder=false spec,
+//     regardless of each spec's position in p.specs — rpg-toolkit#840's
+//     gate finding was that applying the border bias to ALL specs in
+//     list order forced focal pieces (always listed first: obelisk;
+//     coffin→altar→statues) onto the border ahead of the dressing that
+//     actually wanted it, inverting the composition target instead of
+//     achieving it. Once every border-preferring spec has drawn, the
+//     UNCONSUMED remainder (border leftovers + all interior, mixed) is
+//     reshuffled once more so PreferBorder=false specs still draw
+//     uniformly over what's left, not a residual border-first order.
+//
+// Either way, specs draw from their pool in order, each instance
+// consuming one candidate so no two specs (or two instances of the same
+// spec) can ever collide — a spec whose Count exceeds its pool's
+// capacity naturally places as many as fit and drops the rest — #819's
+// "skip rather than invalidate the dungeon" requirement — this function
+// never errors regardless of which path runs.
 func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 	if len(p.specs) == 0 {
 		return nil
 	}
+
+	anyPrefersBorder := false
+	for _, spec := range p.specs {
+		if spec.PreferBorder {
+			anyPrefersBorder = true
+			break
+		}
+	}
+
+	//nolint:gosec // G404: deterministic per-region obstacle seed, not cryptographic
+	rng := rand.New(rand.NewSource(p.seed))
+
+	if !anyPrefersBorder {
+		candidates := regionObstacleCandidates(p)
+		rng.Shuffle(len(candidates), func(i, j int) {
+			candidates[i], candidates[j] = candidates[j], candidates[i]
+		})
+		return drawObstacles(p.regionID, p.specs, candidates)
+	}
+
 	var border, interior []spatial.CubeCoordinate
 	for x := 0; x < p.width; x++ {
 		for y := 0; y < p.height; y++ {
@@ -789,24 +850,89 @@ func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 			}
 		}
 	}
-	//nolint:gosec // G404: deterministic per-region obstacle seed, not cryptographic
-	rng := rand.New(rand.NewSource(p.seed))
 	rng.Shuffle(len(border), func(i, j int) {
 		border[i], border[j] = border[j], border[i]
 	})
 	rng.Shuffle(len(interior), func(i, j int) {
 		interior[i], interior[j] = interior[j], interior[i]
 	})
-	candidates := make([]spatial.CubeCoordinate, 0, len(border)+len(interior))
-	candidates = append(candidates, border...)
-	candidates = append(candidates, interior...)
+	preferPool := make([]spatial.CubeCoordinate, 0, len(border)+len(interior))
+	preferPool = append(preferPool, border...)
+	preferPool = append(preferPool, interior...)
 
+	var preferSpecs, normalSpecs []ObstacleSpec
+	for _, spec := range p.specs {
+		if spec.PreferBorder {
+			preferSpecs = append(preferSpecs, spec)
+		} else {
+			normalSpecs = append(normalSpecs, spec)
+		}
+	}
+
+	out := drawObstacles(p.regionID, preferSpecs, preferPool)
+
+	consumed := 0
+	for _, spec := range preferSpecs {
+		consumed += spec.Count
+	}
+	if consumed > len(preferPool) {
+		consumed = len(preferPool)
+	}
+	remainder := append([]spatial.CubeCoordinate(nil), preferPool[consumed:]...)
+	rng.Shuffle(len(remainder), func(i, j int) {
+		remainder[i], remainder[j] = remainder[j], remainder[i]
+	})
+
+	out = append(out, drawObstaclesFrom(p.regionID, normalSpecs, remainder, len(out))...)
+	return out
+}
+
+// regionObstacleCandidates enumerates every LOCAL floor cell (x in
+// [0,width), y in [0,height)) that is NOT a wall cell AND NOT on doorRow
+// — the same reservation placeRegionObstacles' doc explains (a superset
+// of every required path, and sufficient for the boss primary-axis
+// invariant too), in natural (x,y) scan order, unshuffled. Extracted so
+// the no-PreferBorder path (placeRegionObstacles) can build the exact
+// same candidate list the pre-#839 mechanism always built.
+func regionObstacleCandidates(p placeRegionObstaclesParams) []spatial.CubeCoordinate {
+	candidates := make([]spatial.CubeCoordinate, 0, p.width*p.height)
+	for x := 0; x < p.width; x++ {
+		for y := 0; y < p.height; y++ {
+			if y == p.doorRow {
+				continue
+			}
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(
+				spatial.Position{X: float64(x + p.offsetX), Y: float64(y)}, spatial.HexOrientationPointyTop)
+			if _, blocked := p.wallCubes[cube]; blocked {
+				continue
+			}
+			candidates = append(candidates, cube)
+		}
+	}
+	return candidates
+}
+
+// drawObstacles places specs against an already-shuffled candidates pool,
+// starting IDs at 0 — the common case (a single pool, one pass).
+func drawObstacles(regionID string, specs []ObstacleSpec, candidates []spatial.CubeCoordinate) []ObstacleData {
+	return drawObstaclesFrom(regionID, specs, candidates, 0)
+}
+
+// drawObstaclesFrom places specs against an already-shuffled candidates
+// pool, each instance consuming one candidate in order so no two specs
+// (or two instances of the same spec) can collide. idOffset lets a
+// second pass over a second pool continue this region's ID numbering
+// (obstacle-<regionID>-<n>) rather than restarting at 0 and colliding
+// with the first pass's IDs.
+func drawObstaclesFrom(
+	regionID string, specs []ObstacleSpec, candidates []spatial.CubeCoordinate, idOffset int,
+) []ObstacleData {
 	var out []ObstacleData
 	next := 0
-	for _, spec := range p.specs {
+	for _, spec := range specs {
 		for n := 0; n < spec.Count && next < len(candidates); n++ {
 			out = append(out, ObstacleData{
-				ID:             core.EntityID(fmt.Sprintf("obstacle-%s-%d", p.regionID, len(out))),
+				ID:             core.EntityID(fmt.Sprintf("obstacle-%s-%d", regionID, idOffset+len(out))),
 				Ref:            spec.Ref,
 				Position:       core.HexFromCube(candidates[next]),
 				BlocksMovement: spec.BlocksMovement,

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -753,18 +753,25 @@ type placeRegionObstaclesParams struct {
 // size floor already enforces at construction time. One rule, no
 // archetype-specific branching, provably sufficient for both invariants.
 //
-// The candidate pool is shuffled with a seeded Fisher-Yates (deterministic
-// per seed, varies across seeds) and specs draw from it in order, each
-// instance consuming one candidate so no two specs (or two instances of
-// the same spec) can collide. A spec that asks for more instances than
-// the remaining pool has places as many as fit and drops the rest —
-// #819's "skip rather than invalidate the dungeon" requirement — this
-// function never errors.
+// The candidate pool is PARTITIONED into border cells (local x==0,
+// x==width-1, y==0, or y==height-1 — hugging the region's own four
+// walls/corners) and interior cells, each independently shuffled with a
+// seeded Fisher-Yates (deterministic per seed, varies across seeds), then
+// concatenated border-first (rpg-toolkit#839's composition ask: "dressing
+// hugs walls/corners; floor centers stay clear" — rpg-dnd5e-web#469).
+// Specs draw from the combined pool in order, each instance consuming
+// one candidate so no two specs (or two instances of the same spec) can
+// collide — a spec whose Count exceeds the border pool naturally spills
+// into interior cells, so this is a DRAW-ORDER preference, not a hard
+// requirement; it changes nothing about which cells are eligible; a spec
+// that asks for more instances than the remaining pool has places as
+// many as fit and drops the rest — #819's "skip rather than invalidate
+// the dungeon" requirement — this function never errors.
 func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 	if len(p.specs) == 0 {
 		return nil
 	}
-	candidates := make([]spatial.CubeCoordinate, 0, p.width*p.height)
+	var border, interior []spatial.CubeCoordinate
 	for x := 0; x < p.width; x++ {
 		for y := 0; y < p.height; y++ {
 			if y == p.doorRow {
@@ -775,14 +782,24 @@ func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 			if _, blocked := p.wallCubes[cube]; blocked {
 				continue
 			}
-			candidates = append(candidates, cube)
+			if x == 0 || x == p.width-1 || y == 0 || y == p.height-1 {
+				border = append(border, cube)
+			} else {
+				interior = append(interior, cube)
+			}
 		}
 	}
 	//nolint:gosec // G404: deterministic per-region obstacle seed, not cryptographic
 	rng := rand.New(rand.NewSource(p.seed))
-	rng.Shuffle(len(candidates), func(i, j int) {
-		candidates[i], candidates[j] = candidates[j], candidates[i]
+	rng.Shuffle(len(border), func(i, j int) {
+		border[i], border[j] = border[j], border[i]
 	})
+	rng.Shuffle(len(interior), func(i, j int) {
+		interior[i], interior[j] = interior[j], interior[i]
+	})
+	candidates := make([]spatial.CubeCoordinate, 0, len(border)+len(interior))
+	candidates = append(candidates, border...)
+	candidates = append(candidates, interior...)
 
 	var out []ObstacleData
 	next := 0

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -355,16 +355,22 @@ func opIsBorderLocal(x, y int) bool {
 
 // TestInitDungeon_ObstaclePlacement_PrefersBorderCellsWhenTheyFit pins
 // rpg-toolkit#839's composition ask ("dressing hugs walls/corners; floor
-// centers stay clear") as implemented: a DRAW-ORDER preference in
-// placeRegionObstacles, where border candidates (local x==0, x==width-1,
-// y==0, y==height-1) are shuffled and drawn before interior candidates.
-// When a spec's Count comfortably fits within the region's border-cell
-// capacity, every placed instance must land on the border -- across a
-// spread of seeds, not just one lucky roll.
+// centers stay clear") as implemented: a PER-SPEC, opt-in (PreferBorder
+// bool) DRAW-ORDER preference in placeRegionObstacles, where border
+// candidates (local x==0, x==width-1, y==0, y==height-1) are shuffled
+// and drawn before interior candidates -- but ONLY for a spec that sets
+// PreferBorder (rpg-toolkit#840 gate finding: an earlier revision
+// applied this to every spec regardless of intent, which forced FOCAL
+// pieces onto the border ahead of the dressing that actually wanted it).
+// When a PreferBorder=true spec's Count comfortably fits within the
+// region's border-cell capacity, every placed instance must land on the
+// border -- across a spread of seeds, not just one lucky roll.
 func TestInitDungeon_ObstaclePlacement_PrefersBorderCellsWhenTheyFit(t *testing.T) {
 	for _, seed := range []int64{1, 2, 3, 4, 5, 42, 100, 909091} {
 		enc := opNewEncounter(t)
-		specs := []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 5, BlocksMovement: true, BlocksLoS: true}}
+		specs := []encounter.ObstacleSpec{
+			{Ref: opSpecRefA, Count: 5, BlocksMovement: true, BlocksLoS: true, PreferBorder: true},
+		}
 		require.NoError(t, enc.InitDungeon(opTwoRegionParams(seed, specs)), "seed %d", seed)
 
 		data := enc.ToData()
@@ -374,18 +380,51 @@ func TestInitDungeon_ObstaclePlacement_PrefersBorderCellsWhenTheyFit(t *testing.
 			localX := int(pos.X) - opChamberOffsetX
 			localY := int(pos.Y)
 			require.True(t, opIsBorderLocal(localX, localY),
-				"seed %d: obstacle %q at local (%d,%d) must be a border cell when the border pool "+
-					"comfortably fits the requested count", seed, o.ID, localX, localY)
+				"seed %d: obstacle %q at local (%d,%d) must be a border cell when a PreferBorder=true spec's "+
+					"Count comfortably fits the requested count", seed, o.ID, localX, localY)
 		}
 	}
 }
 
+// TestInitDungeon_ObstaclePlacement_DefaultDoesNotPreferBorder proves
+// PreferBorder's zero value (false) is genuinely UNBIASED, not merely
+// "less biased" -- rpg-toolkit#840's whole reason to make this per-spec
+// and opt-in. Requests the SAME Count (5) the biased test above proves
+// always lands on the border when PreferBorder=true -- but here every
+// spec leaves PreferBorder at its zero value. If this path were still
+// secretly border-biased, every seed would place all 5 on the border,
+// exactly like the test above. A genuine uniform draw must place at
+// least one instance on an interior cell somewhere across this seed
+// spread.
+func TestInitDungeon_ObstaclePlacement_DefaultDoesNotPreferBorder(t *testing.T) {
+	sawInterior := false
+	for _, seed := range []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 42, 100, 909091} {
+		enc := opNewEncounter(t)
+		specs := []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 5, BlocksMovement: true, BlocksLoS: true}}
+		require.NoError(t, enc.InitDungeon(opTwoRegionParams(seed, specs)), "seed %d", seed)
+		for _, o := range enc.ToData().Space.Obstacles {
+			pos := o.Position.ToPosition()
+			localX := int(pos.X) - opChamberOffsetX
+			localY := int(pos.Y)
+			if !opIsBorderLocal(localX, localY) {
+				sawInterior = true
+			}
+		}
+		if sawInterior {
+			break
+		}
+	}
+	require.True(t, sawInterior,
+		"PreferBorder's zero value must be genuinely unbiased -- at least one seed in this spread must place "+
+			"an instance on an interior cell when no spec opts into the border preference")
+}
+
 // TestInitDungeon_ObstaclePlacement_SpillsToInteriorWhenBorderPoolExhausted:
 // the border preference above is a DRAW-ORDER bias, not a hard
-// requirement on which cells are eligible -- a spec whose Count exceeds
-// the region's border-cell capacity must still place its full
-// best-effort count (never fail generation), with the overflow landing
-// on interior cells. The chamber's border pool is the full-grid
+// requirement on which cells are eligible -- a PreferBorder=true spec
+// whose Count exceeds the region's border-cell capacity must still place
+// its full best-effort count (never fail generation), with the overflow
+// landing on interior cells. The chamber's border pool is the full-grid
 // perimeter (2*10 + 2*8 - 4 corners = 32 cells) minus the two border
 // cells doorRow's exclusion removes (local (0,4) and (9,4), the only
 // border cells whose row is the reserved doorRow) = 30; total floor
@@ -394,7 +433,9 @@ func TestInitDungeon_ObstaclePlacement_PrefersBorderCellsWhenTheyFit(t *testing.
 // exactly 30 on the border and the remaining 10 spilling to interior.
 func TestInitDungeon_ObstaclePlacement_SpillsToInteriorWhenBorderPoolExhausted(t *testing.T) {
 	enc := opNewEncounter(t)
-	specs := []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 40, BlocksMovement: true, BlocksLoS: true}}
+	specs := []encounter.ObstacleSpec{
+		{Ref: opSpecRefA, Count: 40, BlocksMovement: true, BlocksLoS: true, PreferBorder: true},
+	}
 	require.NoError(t, enc.InitDungeon(opTwoRegionParams(7, specs)))
 
 	data := enc.ToData()
@@ -413,4 +454,53 @@ func TestInitDungeon_ObstaclePlacement_SpillsToInteriorWhenBorderPoolExhausted(t
 	}
 	require.Equal(t, 30, borderCount, "every border cell must be exhausted before any interior cell is used")
 	require.Equal(t, 10, interiorCount, "the remaining instances must spill to interior cells")
+}
+
+// TestInitDungeon_ObstaclePlacement_PreferBorderSpecsDrawBeforeNormalSpecs
+// pins rpg-toolkit#840's exact gate finding and fix: a region mixing a
+// PreferBorder=true spec with a PreferBorder=false spec (mirroring
+// CryptDungeonParams' own composition -- e.g. entrance's obelisk/pillar
+// left false, brazier/bone-pile set true) must place the border-
+// preferring spec's instances on the border regardless of which spec is
+// declared FIRST in p.specs -- the earlier revision's bug was that list
+// order (not PreferBorder) decided who got first crack at the border,
+// which put a region's always-first-listed FOCAL piece there instead of
+// its dressing. Declares the NON-preferring spec first (matching every
+// crypt region's own declaration order: focal piece first, dressing
+// after), with a Count (28) deliberately large enough to nearly exhaust
+// the 30-cell border pool on its own -- if list order still controlled
+// draw order (the bug), the non-preferring spec would claim almost all
+// of the border before the preferring spec ever got a turn, forcing most
+// of its 5 instances into the interior. A Count of 1 here would NOT
+// discriminate (confirmed: re-run against a temporarily-reintroduced
+// version of the bug with Count:1 and it stayed green by coincidence --
+// the border pool is large enough that one focal instance never
+// contests it. 28 does.).
+func TestInitDungeon_ObstaclePlacement_PreferBorderSpecsDrawBeforeNormalSpecs(t *testing.T) {
+	for _, seed := range []int64{1, 2, 3, 4, 5, 42} {
+		enc := opNewEncounter(t)
+		specs := []encounter.ObstacleSpec{
+			// Declared FIRST but PreferBorder=false -- mirrors a focal
+			// piece (e.g. crypt's obelisk) declared ahead of its dressing.
+			// Count=28 nearly exhausts the 30-cell border pool on its own.
+			{Ref: opSpecRefB, Count: 28, BlocksMovement: true, BlocksLoS: true},
+			// Declared SECOND but PreferBorder=true -- mirrors dressing
+			// declared after its region's focal piece.
+			{Ref: opSpecRefA, Count: 5, BlocksMovement: true, BlocksLoS: true, PreferBorder: true},
+		}
+		require.NoError(t, enc.InitDungeon(opTwoRegionParams(seed, specs)), "seed %d", seed)
+
+		for _, o := range enc.ToData().Space.Obstacles {
+			if o.Ref != opSpecRefA {
+				continue // only asserting the PreferBorder=true spec's placements
+			}
+			pos := o.Position.ToPosition()
+			localX := int(pos.X) - opChamberOffsetX
+			localY := int(pos.Y)
+			require.True(t, opIsBorderLocal(localX, localY),
+				"seed %d: obstacle %q at local (%d,%d) must be a border cell -- PreferBorder must win over "+
+					"list order, even though the non-preferring spec (Count=28, nearly exhausting the border "+
+					"pool on its own) was declared first", seed, o.ID, localX, localY)
+		}
+	}
 }

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -333,3 +333,84 @@ func TestInitDungeon_ObstaclePlacement_RoundTripsThroughToDataLoadFromData(t *te
 			"obstacle %q BlocksMovement=%v must match the reloaded room's actual movement block", o.ID, o.BlocksMovement)
 	}
 }
+
+// opChamberOffsetX is opTwoRegionParams' chamber region's global column
+// offset (entrance width 8 + 1 boundary column) -- needed to convert a
+// placed obstacle's global Position back to the chamber's own LOCAL
+// coordinates for the border-preference tests below. opChamberWidth/
+// opChamberHeight mirror that same fixture's chamber region dimensions.
+const (
+	opChamberOffsetX = 8 + 1
+	opChamberWidth   = 10
+	opChamberHeight  = 8
+)
+
+// opIsBorderLocal reports whether local (x,y) sits on the chamber
+// region's own four edges -- the "hugs walls/corners" preference
+// placeRegionObstacles now draws from first (rpg-toolkit#839, composition
+// ask from rpg-dnd5e-web#469).
+func opIsBorderLocal(x, y int) bool {
+	return x == 0 || x == opChamberWidth-1 || y == 0 || y == opChamberHeight-1
+}
+
+// TestInitDungeon_ObstaclePlacement_PrefersBorderCellsWhenTheyFit pins
+// rpg-toolkit#839's composition ask ("dressing hugs walls/corners; floor
+// centers stay clear") as implemented: a DRAW-ORDER preference in
+// placeRegionObstacles, where border candidates (local x==0, x==width-1,
+// y==0, y==height-1) are shuffled and drawn before interior candidates.
+// When a spec's Count comfortably fits within the region's border-cell
+// capacity, every placed instance must land on the border -- across a
+// spread of seeds, not just one lucky roll.
+func TestInitDungeon_ObstaclePlacement_PrefersBorderCellsWhenTheyFit(t *testing.T) {
+	for _, seed := range []int64{1, 2, 3, 4, 5, 42, 100, 909091} {
+		enc := opNewEncounter(t)
+		specs := []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 5, BlocksMovement: true, BlocksLoS: true}}
+		require.NoError(t, enc.InitDungeon(opTwoRegionParams(seed, specs)), "seed %d", seed)
+
+		data := enc.ToData()
+		require.Len(t, data.Space.Obstacles, 5, "seed %d", seed)
+		for _, o := range data.Space.Obstacles {
+			pos := o.Position.ToPosition()
+			localX := int(pos.X) - opChamberOffsetX
+			localY := int(pos.Y)
+			require.True(t, opIsBorderLocal(localX, localY),
+				"seed %d: obstacle %q at local (%d,%d) must be a border cell when the border pool "+
+					"comfortably fits the requested count", seed, o.ID, localX, localY)
+		}
+	}
+}
+
+// TestInitDungeon_ObstaclePlacement_SpillsToInteriorWhenBorderPoolExhausted:
+// the border preference above is a DRAW-ORDER bias, not a hard
+// requirement on which cells are eligible -- a spec whose Count exceeds
+// the region's border-cell capacity must still place its full
+// best-effort count (never fail generation), with the overflow landing
+// on interior cells. The chamber's border pool is the full-grid
+// perimeter (2*10 + 2*8 - 4 corners = 32 cells) minus the two border
+// cells doorRow's exclusion removes (local (0,4) and (9,4), the only
+// border cells whose row is the reserved doorRow) = 30; total floor
+// candidates are width*height minus one full doorRow (10*8 - 10 = 70).
+// Requesting 40 (comfortably under 70, over 30) must place all 40, with
+// exactly 30 on the border and the remaining 10 spilling to interior.
+func TestInitDungeon_ObstaclePlacement_SpillsToInteriorWhenBorderPoolExhausted(t *testing.T) {
+	enc := opNewEncounter(t)
+	specs := []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 40, BlocksMovement: true, BlocksLoS: true}}
+	require.NoError(t, enc.InitDungeon(opTwoRegionParams(7, specs)))
+
+	data := enc.ToData()
+	require.Len(t, data.Space.Obstacles, 40, "40 comfortably fits the region's 70 total floor candidates")
+
+	var borderCount, interiorCount int
+	for _, o := range data.Space.Obstacles {
+		pos := o.Position.ToPosition()
+		localX := int(pos.X) - opChamberOffsetX
+		localY := int(pos.Y)
+		if opIsBorderLocal(localX, localY) {
+			borderCount++
+		} else {
+			interiorCount++
+		}
+	}
+	require.Equal(t, 30, borderCount, "every border cell must be exhausted before any interior cell is used")
+	require.Equal(t, 10, interiorCount, "the remaining instances must spill to interior cells")
+}


### PR DESCRIPTION
— implementer (asset-pipeline), on behalf of KirkDiggler

## Summary

The crypt renders correct-but-flat: real walls, tinted floor, 0.40 ambient — and zero light sources. This adds the CONTENT that feeds the existing light pipeline: light-anchor and dressing set pieces in `CryptDungeonParams` (`encounter/crypt_dungeon.go`), flowing through the proven `ObstacleSpec` → api#702 projection → client propManifest + mood-light derivation (capped at 8, web#585).

## Content added (per the issue's exact vocabulary)

- **entrance**: keep obelisk + 2 pillars; **+2× brazier** (light anchors) **+2× bone-pile** (floor dressing).
- **corridor**: keep 1 pillar; **+1× torch-ornate** (light anchor) — stays the lightest set-piece load of the three regions.
- **boss**: keep coffin/altar/2 statues; **+2× candles** flanking the coffin, **+2× brazier**, **+1× chain**, **+1× skeleton-remains**.

Flags per the issue: braziers/torch-ornate are physical (`BlocksMovement` true) but see-over (`BlocksLoS` false — "you can see over flame"); candles/bone-pile/chain/skeleton-remains are walkable-past floor dressing (`BlocksMovement` false, `BlocksLoS` false).

**Judgment call**: chose 2 bone-piles (the issue said "1-2×") for the fuller "gives the room depth" composition target — easy to dial back to 1 if it reads too busy once rendered.

## Non-blocking-obstacle verification (issue's explicit ask)

Confirmed all three concerned machineries already tolerate `BlocksMovement=false` obstacles, so no fallback to `blocking=true` is needed:
- **Placement**: each instance still consumes its own unique candidate cell regardless of blocking flags (`placeRegionObstacles`) — no collision risk.
- **Room-rebuild**: `rebuildRoomFromData` copies `BlocksMovement`/`BlocksLoS` verbatim per obstacle into the placed `WallEntity` — a non-blocking obstacle places but never blocks `CanPlaceEntity`.
- **Reveal**: `publishRevealedObstacles` keys purely on hex-position overlap with a viewer's newly revealed hexes, never on either blocking flag.
- `obstacle_test.go`'s existing `TestObstacle_BlocksMovement_False` is the end-to-end proof this already holds.

## Composition preference (rpg-dnd5e-web#469 art target) — PER-SPEC opt-in

"Dressing hugs walls/corners; floor centers stay clear; focal pieces centered." Implemented as a **per-spec, opt-in** draw-order preference: `ObstacleSpec` gained a `PreferBorder bool` field (zero value `false`), and `placeRegionObstacles` only applies the border-hugging bias to specs that set it.

**Post-gate-review correction**: an earlier revision of this PR applied the border bias to *every* spec in a region regardless of intent. Since each region lists its focal piece(s) first (entrance: obelisk→…; boss: coffin→altar→statues→…), that meant the *focal* centerpieces got border-biased *before* the dressing — the exact opposite of the composition target (Copilot + gate review both caught this). Fixed: `PreferBorder=true` is now set only on the dressing/light-anchor specs (brazier, torch-ornate, candles, bone-pile, chain, skeleton-remains); focal/structural specs (obelisk, pillars, coffin, altar, statues) stay `false`. Mechanically, `placeRegionObstacles` now runs two passes — every `PreferBorder=true` spec draws from the border-then-interior pool *first*, regardless of its position in the spec list; the *unconsumed remainder* is reshuffled once more so `PreferBorder=false` specs still draw uniformly over whatever's left (which in practice pushes focal pieces toward the interior/center, since the borders fill up first — without this package ever hard-coding "focal pieces go in the center," a claim it has no way to verify structurally). When **no** spec in a region sets `PreferBorder`, the code takes the exact byte-identical path this mechanism used before #839 ever existed — zero behavior change for any non-opted-in caller.

Judged the whole mechanism cheap and safe before touching it: grepped every test in the repo for a hardcoded exact obstacle position tied to a specific seed (none exist — only determinism/round-trip equality checks, which hold regardless of internal draw order) before making the change, and again after adding the per-spec split.

## Test evidence

Updated 5 pre-existing crypt vocabulary/composition/contract tests to cover the new refs/flags/counts (`TestCryptDungeonParams_RegionArchetypeComposition`, `TestCryptDungeon_GeneratesPlaceableDungeon_WithSetPieces`, `TestCryptDungeonParams_BlockingFlagsMatchVerifiedAssetContract`, `TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly`, `TestCryptDungeonParams_NoObstacleUsesModelFilenamesOrSyntyPaths`).

New:
- `TestCryptDungeon_DressingSpecCounts_PlaceFullyAcrossSeeds` + `TestCryptDungeon_EntranceToBossConnectivity_SurvivesDressingAcrossSeeds` (15-seed sweep): every new spec's full requested count places in every region at every seed (floor capacity is never actually contested at these counts — entrance 7 new/70 candidates, corridor 1/35, boss 6/70), and entrance→boss connectivity survives the roughly-doubled total set-piece load at every seed.
- `TestInitDungeon_ObstaclePlacement_PrefersBorderCellsWhenTheyFit`: a `PreferBorder=true` spec's Count comfortably within border capacity always lands on the border, across 8 seeds.
- `TestInitDungeon_ObstaclePlacement_DefaultDoesNotPreferBorder` (post-gate-review addition): the SAME Count that always lands on the border when `PreferBorder=true` must, at its zero value, place at least one instance on an interior cell somewhere across a 13-seed spread — proving the default is genuinely unbiased, not merely less biased.
- `TestInitDungeon_ObstaclePlacement_SpillsToInteriorWhenBorderPoolExhausted`: a `PreferBorder=true` spec whose Count exceeds the 30-cell border pool still places its full best-effort count, split exactly 30 border / 10 interior at `Count=40` in the fixture's 70-candidate region.
- `TestInitDungeon_ObstaclePlacement_PreferBorderSpecsDrawBeforeNormalSpecs` (post-gate-review addition, pins the exact bug the gate found): a `PreferBorder=false` spec declared *first* with `Count=28` (nearly exhausting the 30-cell border pool on its own) must NOT starve a `PreferBorder=true` spec declared *second* — the preferring spec's instances must all land on the border regardless of list order. Verified this test itself discriminates: a `Count=1` version of the same scenario passed even under a reintroduced version of the bug (not enough capacity contested to expose it) — only `Count=28` genuinely proves the fix, confirmed by temporarily reintroducing the "border bias applies in list order" bug and watching this exact test go RED, then GREEN once restored.

Every new/updated border-related test verified to discriminate: reverted the relevant code locally, confirmed RED, restored, confirmed GREEN.

Full suite:
```
go test -count=1 -race ./...
ok  	github.com/KirkDiggler/rpg-toolkit/encounter	65.918s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/core	1.018s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/events	1.031s
ok  	github.com/KirkDiggler/rpg-toolkit/encounter/perception	1.022s
```
`golangci-lint run ./...` reports the identical 85 pre-existing issues (6 dupl + 79 goconst) on this branch and on `origin/main` — delta is zero. Correction from the gate review: the pre-existing `goconst` findings in `obstacle_placement_test.go` DO sit in a file this PR changed (just not on lines this PR added or touched) — the earlier "none in changed files" phrasing was imprecise; the accurate claim is "zero new issues, delta zero." `gofmt`/`goimports` clean.

## Follow-up chain after merge

Same pattern as #834/#838 → api#704/#705: this repo's auto-tag workflow cuts an `encounter/vX.Y.Z` release tag on merge automatically; a small separate rpg-api go.mod bump PR (+ ideally a real-fixture projection regression test, mirroring api#705) is needed to get these specs onto the wire. Client light-color mapping for brazier/torch (web#569) and wall trim caps are explicitly out of scope here.

Closes #839

Refs: #819 (mechanism), rpg-dnd5e-web#569 (client half + umbrella), rpg-dnd5e-web#469 (art target).
