### PR TITLE
feat(encounter): dungeonspec M1 — YAML dungeon specs with static placement, registry, placement path, workbench (#842)

### DIFF
--- a/encounter/cmd/dungeonspec-workbench/main.go
+++ b/encounter/cmd/dungeonspec-workbench/main.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Command dungeonspec-workbench is the fast dungeon-authoring loop
+// (design.md's observability addendum, rpg-toolkit#842): edit a spec YAML
+// file, run this against it, and see the compiled layout -- verdict,
+// regions, spawn plan, placed props, and an ASCII floor plan -- in
+// seconds, with no server, no rpg-api, no Discord activity involved. All
+// the actual work happens in dungeonspec.WorkbenchReport; this file is
+// just flag parsing and printing.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+)
+
+func main() {
+	file := flag.String("file", "", "path to a dungeon spec YAML file (required)")
+	seed := flag.Int64("seed", 1, "seed to compile the layout at")
+	n := flag.Int("n", 1, "sweep this many consecutive seeds starting at -seed, printing one report per seed")
+	flag.Parse()
+
+	if *file == "" {
+		fmt.Fprintln(os.Stderr, "usage: dungeonspec-workbench -file <spec.yaml> [-seed N] [-n SWEEP]")
+		os.Exit(2)
+	}
+	if *n < 1 {
+		fmt.Fprintln(os.Stderr, "-n must be at least 1")
+		os.Exit(2)
+	}
+
+	raw, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", *file, err)
+		os.Exit(1)
+	}
+
+	// A -n sweep prints every seed's report regardless of individual
+	// failures (an author sweeping seeds wants to see ALL of them, not
+	// have the run abort partway through) -- the exit code just reflects
+	// whether ANY seed in the sweep came back INVALID.
+	sawInvalid := false
+	for i := 0; i < *n; i++ {
+		report, err := dungeonspec.WorkbenchReport(raw, *seed+int64(i))
+		fmt.Println(report)
+		if err != nil {
+			sawInvalid = true
+		}
+	}
+	if sawInvalid {
+		os.Exit(1)
+	}
+}

--- a/encounter/cmd/dungeonspec-workbench/main.go
+++ b/encounter/cmd/dungeonspec-workbench/main.go
@@ -39,10 +39,24 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Decode/Validate never look at seed, so a spec that fails to Load is
+	// INVALID identically at every seed in a sweep -- check that ONCE up
+	// front and print the (single) resulting report rather than n
+	// identical copies of it.
+	if _, err := dungeonspec.Load(raw); err != nil {
+		report, _ := dungeonspec.WorkbenchReport(raw, *seed)
+		fmt.Println(report)
+		os.Exit(1)
+	}
+
 	// A -n sweep prints every seed's report regardless of individual
 	// failures (an author sweeping seeds wants to see ALL of them, not
 	// have the run abort partway through) -- the exit code just reflects
-	// whether ANY seed in the sweep came back INVALID.
+	// whether ANY seed in the sweep came back INVALID. Unlike the Load
+	// check above, a failure here (InitDungeon, after Load already
+	// succeeded) CAN be seed-dependent -- e.g. a scattered pattern that
+	// occasionally rolls a required path blocked at a particular seed --
+	// so every seed genuinely needs its own attempt.
 	sawInvalid := false
 	for i := 0; i < *n; i++ {
 		report, err := dungeonspec.WorkbenchReport(raw, *seed+int64(i))

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -154,6 +154,13 @@ type ObstacleSpec struct {
 // frame regionObstacleCandidates already scans (see that function's doc).
 type LocalHex struct{ Col, Row int }
 
+// String implements fmt.Stringer so error messages print "col=6 row=4"
+// instead of Go's default struct format ("{6 4}"), which doesn't name
+// which number is which.
+func (h LocalHex) String() string {
+	return fmt.Sprintf("col=%d row=%d", h.Col, h.Row)
+}
+
 // PlacedObstacleSpec pins one obstacle instance to an exact room-local cell
 // — verbatim placement, not a candidate-pool roll (design.md §Design delta).
 // encounter never interprets Ref, mirroring ObstacleSpec's existing
@@ -163,10 +170,11 @@ type PlacedObstacleSpec struct {
 	// opaque-content-identifier contract as ObstacleSpec.Ref.
 	Ref string
 
-	// At is this instance's room-local cell. InitDungeon rejects At.Row
-	// == doorRow, a cell already claimed by another PlacedObstacleSpec in
-	// the same region, or a wall cell — placed entries are guarantees,
-	// not best-effort (design.md §Validation).
+	// At is this instance's room-local cell. InitDungeon rejects At out of
+	// [0,width)x[0,height) bounds, At.Row == doorRow, a cell already
+	// claimed by another PlacedObstacleSpec in the same region, or a wall
+	// cell — placed entries are guarantees, not best-effort (design.md
+	// §Validation).
 	At LocalHex
 
 	// BlocksMovement/BlocksLoS are copied verbatim into the placed
@@ -964,19 +972,28 @@ func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[s
 	placedCubes := make(map[spatial.CubeCoordinate]struct{}, len(p.placed))
 	out := make([]ObstacleData, 0, len(p.placed))
 	for i, spec := range p.placed {
+		// Bounds first: an out-of-bounds cell can still coincidentally
+		// pass the doorRow/collision/wall checks below (or land in an
+		// adjacent region's own span, or the boundary/door column), which
+		// would report the wrong problem — same defense-in-depth
+		// rationale as the doorRow check below (InitDungeon is a public
+		// entry point; a caller other than dungeonspec's own load-time
+		// Validate could reach an out-of-bounds At directly).
+		if spec.At.Col < 0 || spec.At.Col >= p.width || spec.At.Row < 0 || spec.At.Row >= p.height {
+			return nil, nil, fmt.Errorf("placed obstacle %q at %v is out of bounds (width=%d, height=%d)",
+				spec.Ref, spec.At, p.width, p.height)
+		}
 		if spec.At.Row == p.doorRow {
-			return nil, nil, fmt.Errorf("region %q: placed obstacle %q at %v is on the reserved row (doorRow=%d)",
-				p.regionID, spec.Ref, spec.At, p.doorRow)
+			return nil, nil, fmt.Errorf("placed obstacle %q at %v is on the reserved row (doorRow=%d)",
+				spec.Ref, spec.At, p.doorRow)
 		}
 		hex := core.HexFromPosition(spatial.Position{X: float64(p.offsetX + spec.At.Col), Y: float64(spec.At.Row)})
 		cube := hex.ToCube()
 		if _, dup := placedCubes[cube]; dup {
-			return nil, nil, fmt.Errorf("region %q: placed obstacle %q at %v is already placed",
-				p.regionID, spec.Ref, spec.At)
+			return nil, nil, fmt.Errorf("placed obstacle %q at %v is already placed", spec.Ref, spec.At)
 		}
 		if _, wall := p.wallCubes[cube]; wall {
-			return nil, nil, fmt.Errorf("region %q: placed obstacle %q at %v is a wall cell",
-				p.regionID, spec.Ref, spec.At)
+			return nil, nil, fmt.Errorf("placed obstacle %q at %v is a wall cell", spec.Ref, spec.At)
 		}
 		placedCubes[cube] = struct{}{}
 		out = append(out, ObstacleData{

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -96,6 +96,24 @@ type DungeonRegionParams struct {
 	// Placed cells are excluded from Obstacles' rolled candidate pool, so
 	// the two mechanisms coexist in the same region without collision.
 	PlacedObstacles []PlacedObstacleSpec
+
+	// ReservedCells are cells excluded from rolled-obstacle placement
+	// WITHOUT emitting any obstacle data for them (the compiler reserves
+	// placed-monster/boss cells here) — rpg-toolkit#842 gate finding: a
+	// place: monster entry (or a pinned boss.at) compiles to a
+	// SpawnInstruction, never a PlacedObstacleSpec, so without this field
+	// the rolled-obstacle draw below has no idea that cell is already
+	// spoken for and can roll a count-based obstacle directly onto it —
+	// surfacing much later and far more confusingly as
+	// Encounter.SeedMonsters failing to place the monster into a cell an
+	// obstacle already occupies, on some fraction of seeds rather than
+	// deterministically. Validated the same way as PlacedObstacles (bounds,
+	// doorRow, wall cell, collision with a PlacedObstacles entry) — see
+	// reserveCubes — but a reserved cell is otherwise inert: nothing is
+	// added to SpaceData.Obstacles for it, since whatever occupies it is
+	// the caller's responsibility to place (dungeonspec's SeedMonsters
+	// call, for the case this field exists to fix).
+	ReservedCells []LocalHex
 }
 
 // ObstacleSpec describes one kind of physical set-piece instance a caller
@@ -554,6 +572,7 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 			regionID:  r.ID,
 			specs:     r.Obstacles,
 			placed:    r.PlacedObstacles,
+			reserved:  r.ReservedCells,
 			width:     r.Width,
 			height:    params.Height,
 			offsetX:   starts[i],
@@ -803,6 +822,7 @@ type placeRegionObstaclesParams struct {
 	regionID  string
 	specs     []ObstacleSpec
 	placed    []PlacedObstacleSpec
+	reserved  []LocalHex
 	width     int
 	height    int
 	offsetX   int
@@ -869,12 +889,37 @@ type placeRegionObstaclesParams struct {
 // numbered first, and rolled instances continue that same region's ID
 // sequence via idOffset, so a region with zero PlacedObstacles produces
 // byte-identical rolled output to before this field existed.
+//
+// p.reserved (DungeonRegionParams.ReservedCells) is validated the same way
+// as p.placed (see reserveCubes) and excluded from the SAME rolled
+// candidate pool, but never emits any ObstacleData of its own — it exists
+// purely to keep the rolled draw off a cell something else (a compiled
+// place: monster, or a pinned boss.at) already occupies.
 func placeRegionObstacles(p placeRegionObstaclesParams) ([]ObstacleData, error) {
 	placedData, placedCubes, err := placeVerbatimObstacles(p)
 	if err != nil {
 		return nil, err
 	}
 	idOffset := len(placedData)
+
+	reservedCubes, err := reserveCubes(p, placedCubes)
+	if err != nil {
+		return nil, err
+	}
+	// excluded is the union of placedCubes and reservedCubes: every cube
+	// EITHER rolled draw-order branch below must skip. Built even when
+	// p.specs is empty (the early-return just below), since reserveCubes'
+	// validation above must run regardless of whether there's anything to
+	// roll -- a caller can set ReservedCells with no Obstacles at all.
+	excluded := make(map[spatial.CubeCoordinate]string, len(placedCubes)+len(reservedCubes))
+	for cube, ref := range placedCubes {
+		excluded[cube] = ref
+	}
+	for cube := range reservedCubes {
+		if _, already := excluded[cube]; !already {
+			excluded[cube] = "" // reserved, not placed -- no obstacle name to report
+		}
+	}
 
 	if len(p.specs) == 0 {
 		return placedData, nil
@@ -892,7 +937,7 @@ func placeRegionObstacles(p placeRegionObstaclesParams) ([]ObstacleData, error) 
 	rng := rand.New(rand.NewSource(p.seed))
 
 	if !anyPrefersBorder {
-		candidates := regionObstacleCandidates(p, placedCubes)
+		candidates := regionObstacleCandidates(p, excluded)
 		rng.Shuffle(len(candidates), func(i, j int) {
 			candidates[i], candidates[j] = candidates[j], candidates[i]
 		})
@@ -910,7 +955,7 @@ func placeRegionObstacles(p placeRegionObstaclesParams) ([]ObstacleData, error) 
 			if _, blocked := p.wallCubes[cube]; blocked {
 				continue
 			}
-			if _, taken := placedCubes[cube]; taken {
+			if _, taken := excluded[cube]; taken {
 				continue
 			}
 			if x == 0 || x == p.width-1 || y == 0 || y == p.height-1 {
@@ -1014,17 +1059,65 @@ func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[s
 	return out, placedCubes, nil
 }
 
+// reserveCubes validates and positions one region's ReservedCells
+// (DungeonRegionParams.ReservedCells) — cells excluded from the rolled-
+// obstacle draw without any ObstacleData ever emitted for them, because
+// something OUTSIDE this obstacle mechanism already occupies the cell (a
+// compiled place: monster or a pinned boss.at — dungeonspec's own use of
+// this field, compile.go). Validated the same way as
+// placeVerbatimObstacles' PlacedObstacleSpecs — bounds, doorRow, wall
+// cell, and collision with an already-placed obstacle — for the same
+// defense-in-depth reason: InitDungeon is a public entry point a caller
+// other than dungeonspec's load-time Validate could reach directly with a
+// bad cell. Two ReservedCells landing on the SAME cell is not itself
+// rejected (harmless — both just mean "this cell is spoken for"), unlike
+// two PlacedObstacleSpecs at the same cell (which would silently drop one
+// obstacle's data if not rejected).
+//
+// This function exists to close a real cross-task seam bug (rpg-toolkit#842
+// gate finding): compileRoom routes a place: monster (or the boss's pinned
+// boss.at) to a SpawnInstruction, never to PlacedObstacles — so without
+// this reservation, the rolled-obstacle draw below has no idea that cell
+// is spoken for, and can roll a count-based obstacle directly onto it. The
+// collision then surfaces much later and far more confusingly, as
+// Encounter.SeedMonsters failing to place the monster into a cell an
+// obstacle already occupies — on some fraction of seeds, not all,
+// depending on whether the shuffle happens to draw that cell.
+func reserveCubes(
+	p placeRegionObstaclesParams, placedCubes map[spatial.CubeCoordinate]string,
+) (map[spatial.CubeCoordinate]struct{}, error) {
+	reserved := make(map[spatial.CubeCoordinate]struct{}, len(p.reserved))
+	for _, cell := range p.reserved {
+		if cell.Col < 0 || cell.Col >= p.width || cell.Row < 0 || cell.Row >= p.height {
+			return nil, fmt.Errorf("reserved cell %v is out of bounds (width=%d, height=%d)", cell, p.width, p.height)
+		}
+		if cell.Row == p.doorRow {
+			return nil, fmt.Errorf("reserved cell %v is on the reserved row (doorRow=%d)", cell, p.doorRow)
+		}
+		cube := spatial.OffsetCoordinateToCubeWithOrientation(
+			spatial.Position{X: float64(p.offsetX + cell.Col), Y: float64(cell.Row)}, spatial.HexOrientationPointyTop)
+		if _, wall := p.wallCubes[cube]; wall {
+			return nil, fmt.Errorf("reserved cell %v is on a wall cell", cell)
+		}
+		if prevRef, dup := placedCubes[cube]; dup {
+			return nil, fmt.Errorf("reserved cell %v collides with placed obstacle %q", cell, prevRef)
+		}
+		reserved[cube] = struct{}{}
+	}
+	return reserved, nil
+}
+
 // regionObstacleCandidates enumerates every LOCAL floor cell (x in
 // [0,width), y in [0,height)) that is NOT a wall cell, NOT on doorRow, and
-// NOT already consumed by a PlacedObstacleSpec (placedCubes, absolute
+// NOT already excluded (placed obstacle OR reserved cell, absolute
 // coordinates) — the same reservation placeRegionObstacles' doc explains
 // (a superset of every required path, and sufficient for the boss
 // primary-axis invariant too), in natural (x,y) scan order, unshuffled.
 // Extracted so the no-PreferBorder path (placeRegionObstacles) can build
 // the exact same candidate list the pre-#839 mechanism always built, now
-// also excluding placed cells.
+// also excluding placed and reserved cells.
 func regionObstacleCandidates(
-	p placeRegionObstaclesParams, placedCubes map[spatial.CubeCoordinate]string,
+	p placeRegionObstaclesParams, excluded map[spatial.CubeCoordinate]string,
 ) []spatial.CubeCoordinate {
 	candidates := make([]spatial.CubeCoordinate, 0, p.width*p.height)
 	for x := 0; x < p.width; x++ {
@@ -1037,7 +1130,7 @@ func regionObstacleCandidates(
 			if _, blocked := p.wallCubes[cube]; blocked {
 				continue
 			}
-			if _, taken := placedCubes[cube]; taken {
+			if _, taken := excluded[cube]; taken {
 				continue
 			}
 			candidates = append(candidates, cube)

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -85,6 +85,17 @@ type DungeonRegionParams struct {
 	// package only places it safely. See placeRegionObstacles for the
 	// placement algorithm and its safety invariants.
 	Obstacles []ObstacleSpec
+
+	// PlacedObstacles pin specific obstacle instances to exact room-local
+	// cells — verbatim placement, not a candidate-pool roll (design.md
+	// §Design delta). Unlike Obstacles (best-effort: a region whose safe
+	// floor can't fit every requested instance places as many as fit),
+	// a PlacedObstacleSpec is a hard guarantee: InitDungeon fails outright
+	// if any entry lands on the reserved doorRow, collides with another
+	// placed entry, or lands on a wall cell — see placeRegionObstacles.
+	// Placed cells are excluded from Obstacles' rolled candidate pool, so
+	// the two mechanisms coexist in the same region without collision.
+	PlacedObstacles []PlacedObstacleSpec
 }
 
 // ObstacleSpec describes one kind of physical set-piece instance a caller
@@ -136,6 +147,32 @@ type ObstacleSpec struct {
 	// go in the center," a claim placeRegionObstacles has no way to
 	// verify structurally.
 	PreferBorder bool
+}
+
+// LocalHex is a region-local (pre-offsetX) grid cell: Col in [0,width),
+// Row in [0,height) (the dungeon-shared height) — exactly the local (x,y)
+// frame regionObstacleCandidates already scans (see that function's doc).
+type LocalHex struct{ Col, Row int }
+
+// PlacedObstacleSpec pins one obstacle instance to an exact room-local cell
+// — verbatim placement, not a candidate-pool roll (design.md §Design delta).
+// encounter never interprets Ref, mirroring ObstacleSpec's existing
+// content-agnostic contract.
+type PlacedObstacleSpec struct {
+	// Ref is copied verbatim into the placed ObstacleData.Ref — same
+	// opaque-content-identifier contract as ObstacleSpec.Ref.
+	Ref string
+
+	// At is this instance's room-local cell. InitDungeon rejects At.Row
+	// == doorRow, a cell already claimed by another PlacedObstacleSpec in
+	// the same region, or a wall cell — placed entries are guarantees,
+	// not best-effort (design.md §Validation).
+	At LocalHex
+
+	// BlocksMovement/BlocksLoS are copied verbatim into the placed
+	// ObstacleData, same as ObstacleSpec's fields of the same name.
+	BlocksMovement bool
+	BlocksLoS      bool
 }
 
 // DungeonConnectorParams configures the door joining two consecutive
@@ -505,16 +542,21 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 			Archetype: r.Archetype,
 			Hexes:     core.NewHexSet(hexesFromCubes(regionCubes(r.Width, params.Height, starts[i]))...),
 		}
-		obstacles = append(obstacles, placeRegionObstacles(placeRegionObstaclesParams{
+		regionObstacles, err := placeRegionObstacles(placeRegionObstaclesParams{
 			regionID:  r.ID,
 			specs:     r.Obstacles,
+			placed:    r.PlacedObstacles,
 			width:     r.Width,
 			height:    params.Height,
 			offsetX:   starts[i],
 			doorRow:   doorRow,
 			wallCubes: wallCubeSet(regionWalls),
 			seed:      obstacleSeeds[i],
-		})...)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("place region %d (%q) obstacles: %w", i, r.ID, err)
+		}
+		obstacles = append(obstacles, regionObstacles...)
 
 		if i < n-1 {
 			doorX := starts[i] + r.Width
@@ -752,6 +794,7 @@ func stripReservedAxisWalls(
 type placeRegionObstaclesParams struct {
 	regionID  string
 	specs     []ObstacleSpec
+	placed    []PlacedObstacleSpec
 	width     int
 	height    int
 	offsetX   int
@@ -806,11 +849,27 @@ type placeRegionObstaclesParams struct {
 // consuming one candidate so no two specs (or two instances of the same
 // spec) can ever collide — a spec whose Count exceeds its pool's
 // capacity naturally places as many as fit and drops the rest — #819's
-// "skip rather than invalidate the dungeon" requirement — this function
-// never errors regardless of which path runs.
-func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
+// "skip rather than invalidate the dungeon" requirement — the ROLLED path
+// never errors regardless of which draw-order branch runs.
+//
+// p.placed (PlacedObstacleSpec, design.md §Design delta) is handled FIRST,
+// verbatim — see placeVerbatimObstacles — and is NOT best-effort: any
+// violation (reserved row, collision with another placed entry, a wall
+// cell) fails this call outright. Placed cells are then excluded from the
+// rolled candidate pool (both draw-order branches below), so the two
+// mechanisms never collide with each other; placed obstacle IDs are
+// numbered first, and rolled instances continue that same region's ID
+// sequence via idOffset, so a region with zero PlacedObstacles produces
+// byte-identical rolled output to before this field existed.
+func placeRegionObstacles(p placeRegionObstaclesParams) ([]ObstacleData, error) {
+	placedData, placedCubes, err := placeVerbatimObstacles(p)
+	if err != nil {
+		return nil, err
+	}
+	idOffset := len(placedData)
+
 	if len(p.specs) == 0 {
-		return nil
+		return placedData, nil
 	}
 
 	anyPrefersBorder := false
@@ -825,11 +884,11 @@ func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 	rng := rand.New(rand.NewSource(p.seed))
 
 	if !anyPrefersBorder {
-		candidates := regionObstacleCandidates(p)
+		candidates := regionObstacleCandidates(p, placedCubes)
 		rng.Shuffle(len(candidates), func(i, j int) {
 			candidates[i], candidates[j] = candidates[j], candidates[i]
 		})
-		return drawObstacles(p.regionID, p.specs, candidates)
+		return append(placedData, drawObstaclesFrom(p.regionID, p.specs, candidates, idOffset)...), nil
 	}
 
 	var border, interior []spatial.CubeCoordinate
@@ -841,6 +900,9 @@ func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 			cube := spatial.OffsetCoordinateToCubeWithOrientation(
 				spatial.Position{X: float64(x + p.offsetX), Y: float64(y)}, spatial.HexOrientationPointyTop)
 			if _, blocked := p.wallCubes[cube]; blocked {
+				continue
+			}
+			if _, taken := placedCubes[cube]; taken {
 				continue
 			}
 			if x == 0 || x == p.width-1 || y == 0 || y == p.height-1 {
@@ -869,7 +931,7 @@ func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 		}
 	}
 
-	out := drawObstacles(p.regionID, preferSpecs, preferPool)
+	out := drawObstaclesFrom(p.regionID, preferSpecs, preferPool, idOffset)
 
 	consumed := 0
 	for _, spec := range preferSpecs {
@@ -883,18 +945,63 @@ func placeRegionObstacles(p placeRegionObstaclesParams) []ObstacleData {
 		remainder[i], remainder[j] = remainder[j], remainder[i]
 	})
 
-	out = append(out, drawObstaclesFrom(p.regionID, normalSpecs, remainder, len(out))...)
-	return out
+	out = append(out, drawObstaclesFrom(p.regionID, normalSpecs, remainder, idOffset+len(out))...)
+	return append(placedData, out...), nil
+}
+
+// placeVerbatimObstacles validates and positions one region's
+// PlacedObstacleSpecs (design.md §Design delta) — verbatim placement, not
+// a candidate-pool roll. Unlike rolled ObstacleSpecs (best-effort: skip
+// whatever doesn't fit), a placed entry is a hard guarantee: any violation
+// fails region generation outright rather than silently dropping the
+// entry, mirroring InitDungeon's "either the whole dungeon commits, or a
+// failure leaves the encounter exactly as it was before the call"
+// contract. Returns the placed ObstacleData — IDs 0..len(p.placed)-1 in
+// p.regionID's numbering, so rolled instances continue from len(placed)
+// via idOffset — and the set of absolute cube coordinates consumed, so
+// the rolled candidate pool can exclude them too.
+func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[spatial.CubeCoordinate]struct{}, error) {
+	placedCubes := make(map[spatial.CubeCoordinate]struct{}, len(p.placed))
+	out := make([]ObstacleData, 0, len(p.placed))
+	for i, spec := range p.placed {
+		if spec.At.Row == p.doorRow {
+			return nil, nil, fmt.Errorf("region %q: placed obstacle %q at %v is on the reserved row (doorRow=%d)",
+				p.regionID, spec.Ref, spec.At, p.doorRow)
+		}
+		hex := core.HexFromPosition(spatial.Position{X: float64(p.offsetX + spec.At.Col), Y: float64(spec.At.Row)})
+		cube := hex.ToCube()
+		if _, dup := placedCubes[cube]; dup {
+			return nil, nil, fmt.Errorf("region %q: placed obstacle %q at %v is already placed",
+				p.regionID, spec.Ref, spec.At)
+		}
+		if _, wall := p.wallCubes[cube]; wall {
+			return nil, nil, fmt.Errorf("region %q: placed obstacle %q at %v is a wall cell",
+				p.regionID, spec.Ref, spec.At)
+		}
+		placedCubes[cube] = struct{}{}
+		out = append(out, ObstacleData{
+			ID:             core.EntityID(fmt.Sprintf("obstacle-%s-%d", p.regionID, i)),
+			Ref:            spec.Ref,
+			Position:       hex,
+			BlocksMovement: spec.BlocksMovement,
+			BlocksLoS:      spec.BlocksLoS,
+		})
+	}
+	return out, placedCubes, nil
 }
 
 // regionObstacleCandidates enumerates every LOCAL floor cell (x in
-// [0,width), y in [0,height)) that is NOT a wall cell AND NOT on doorRow
-// — the same reservation placeRegionObstacles' doc explains (a superset
-// of every required path, and sufficient for the boss primary-axis
-// invariant too), in natural (x,y) scan order, unshuffled. Extracted so
-// the no-PreferBorder path (placeRegionObstacles) can build the exact
-// same candidate list the pre-#839 mechanism always built.
-func regionObstacleCandidates(p placeRegionObstaclesParams) []spatial.CubeCoordinate {
+// [0,width), y in [0,height)) that is NOT a wall cell, NOT on doorRow, and
+// NOT already consumed by a PlacedObstacleSpec (placedCubes, absolute
+// coordinates) — the same reservation placeRegionObstacles' doc explains
+// (a superset of every required path, and sufficient for the boss
+// primary-axis invariant too), in natural (x,y) scan order, unshuffled.
+// Extracted so the no-PreferBorder path (placeRegionObstacles) can build
+// the exact same candidate list the pre-#839 mechanism always built, now
+// also excluding placed cells.
+func regionObstacleCandidates(
+	p placeRegionObstaclesParams, placedCubes map[spatial.CubeCoordinate]struct{},
+) []spatial.CubeCoordinate {
 	candidates := make([]spatial.CubeCoordinate, 0, p.width*p.height)
 	for x := 0; x < p.width; x++ {
 		for y := 0; y < p.height; y++ {
@@ -906,16 +1013,13 @@ func regionObstacleCandidates(p placeRegionObstaclesParams) []spatial.CubeCoordi
 			if _, blocked := p.wallCubes[cube]; blocked {
 				continue
 			}
+			if _, taken := placedCubes[cube]; taken {
+				continue
+			}
 			candidates = append(candidates, cube)
 		}
 	}
 	return candidates
-}
-
-// drawObstacles places specs against an already-shuffled candidates pool,
-// starting IDs at 0 — the common case (a single pool, one pass).
-func drawObstacles(regionID string, specs []ObstacleSpec, candidates []spatial.CubeCoordinate) []ObstacleData {
-	return drawObstaclesFrom(regionID, specs, candidates, 0)
 }
 
 // drawObstaclesFrom places specs against an already-shuffled candidates

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -968,8 +968,11 @@ func placeRegionObstacles(p placeRegionObstaclesParams) ([]ObstacleData, error) 
 // p.regionID's numbering, so rolled instances continue from len(placed)
 // via idOffset — and the set of absolute cube coordinates consumed, so
 // the rolled candidate pool can exclude them too.
-func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[spatial.CubeCoordinate]struct{}, error) {
-	placedCubes := make(map[spatial.CubeCoordinate]struct{}, len(p.placed))
+func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[spatial.CubeCoordinate]string, error) {
+	// Keyed by the Ref of whichever PlacedObstacleSpec claimed that cell
+	// first, so a collision error can name BOTH obstacles involved, not
+	// just the later one.
+	placedCubes := make(map[spatial.CubeCoordinate]string, len(p.placed))
 	out := make([]ObstacleData, 0, len(p.placed))
 	for i, spec := range p.placed {
 		// Bounds first: an out-of-bounds cell can still coincidentally
@@ -987,19 +990,23 @@ func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[s
 			return nil, nil, fmt.Errorf("placed obstacle %q at %v is on the reserved row (doorRow=%d)",
 				spec.Ref, spec.At, p.doorRow)
 		}
-		hex := core.HexFromPosition(spatial.Position{X: float64(p.offsetX + spec.At.Col), Y: float64(spec.At.Row)})
-		cube := hex.ToCube()
-		if _, dup := placedCubes[cube]; dup {
-			return nil, nil, fmt.Errorf("placed obstacle %q at %v is already placed", spec.Ref, spec.At)
+		// Same conversion idiom as the sibling loops below (regionObstacleCandidates,
+		// the border/interior partition): OffsetCoordinateToCubeWithOrientation
+		// directly, rather than a HexFromPosition -> ToCube round trip.
+		cube := spatial.OffsetCoordinateToCubeWithOrientation(
+			spatial.Position{X: float64(p.offsetX + spec.At.Col), Y: float64(spec.At.Row)}, spatial.HexOrientationPointyTop)
+		if prevRef, dup := placedCubes[cube]; dup {
+			return nil, nil, fmt.Errorf("placed obstacle %q at %v collides with placed obstacle %q",
+				spec.Ref, spec.At, prevRef)
 		}
 		if _, wall := p.wallCubes[cube]; wall {
-			return nil, nil, fmt.Errorf("placed obstacle %q at %v is a wall cell", spec.Ref, spec.At)
+			return nil, nil, fmt.Errorf("placed obstacle %q at %v is on a wall cell", spec.Ref, spec.At)
 		}
-		placedCubes[cube] = struct{}{}
+		placedCubes[cube] = spec.Ref
 		out = append(out, ObstacleData{
 			ID:             core.EntityID(fmt.Sprintf("obstacle-%s-%d", p.regionID, i)),
 			Ref:            spec.Ref,
-			Position:       hex,
+			Position:       core.HexFromCube(cube),
 			BlocksMovement: spec.BlocksMovement,
 			BlocksLoS:      spec.BlocksLoS,
 		})
@@ -1017,7 +1024,7 @@ func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[s
 // the exact same candidate list the pre-#839 mechanism always built, now
 // also excluding placed cells.
 func regionObstacleCandidates(
-	p placeRegionObstaclesParams, placedCubes map[spatial.CubeCoordinate]struct{},
+	p placeRegionObstaclesParams, placedCubes map[spatial.CubeCoordinate]string,
 ) []spatial.CubeCoordinate {
 	candidates := make([]spatial.CubeCoordinate, 0, p.width*p.height)
 	for x := 0; x < p.width; x++ {

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+)
+
+// SpawnInstruction is encounter's OWN type (defined in Task N2's
+// encounter/seed_monsters.go, alongside SeedMonsters) -- dungeonspec
+// re-exports it via a plain type ALIAS, not a second struct, so
+// CompiledDungeon.Spawns can be passed directly to
+// enc.SeedMonsters(compiled.Spawns) with zero conversion.
+type SpawnInstruction = encounter.SpawnInstruction
+
+// CompiledDungeon is a dungeon spec compiled down to what the engine and
+// SeedMonsters actually consume: engine params ready for InitDungeon, and
+// a spawn plan ready for SeedMonsters.
+type CompiledDungeon struct {
+	Params encounter.DungeonParams
+	Spawns []SpawnInstruction // boss first, then entrance->boss chain order
+}
+
+// Load decodes, validates, and compiles a spec in one call -- the only
+// entry point callers use. Door entity ids are COMPILER-GENERATED from
+// content ("<key>-door-<from>-<to>" per connector), so callers supply
+// nothing but the bytes.
+func Load(raw []byte) (CompiledDungeon, error) {
+	spec, err := Decode(raw)
+	if err != nil {
+		return CompiledDungeon{}, err
+	}
+	if err := Validate(spec); err != nil {
+		return CompiledDungeon{}, err
+	}
+	return compile(spec)
+}
+
+// compile assumes spec has already passed Validate -- every ref shape,
+// cell bound, and boss-cardinality invariant it relies on is guaranteed by
+// that pass. It still returns an error rather than panicking, matching
+// this package's style elsewhere, in case that assumption is ever violated
+// by a future caller.
+func compile(spec *DungeonSpec) (CompiledDungeon, error) {
+	var bossRoom *RoomSpec
+	for i := range spec.Rooms {
+		if spec.Rooms[i].Boss != nil {
+			bossRoom = &spec.Rooms[i]
+		}
+	}
+	if bossRoom == nil {
+		return CompiledDungeon{}, fmt.Errorf("compile: no boss room (Validate should have rejected this spec)")
+	}
+
+	// Boss spawn goes first, regardless of the boss room's position in the
+	// chain (design.md, defense-in-depth ahead of Slice C's own invariant).
+	bossAt := encounter.LocalHex{Col: bossRoom.Boss.At[0], Row: bossRoom.Boss.At[1]}
+	spawns := []SpawnInstruction{{
+		RoomID:     bossRoom.ID,
+		MonsterRef: bossRoom.Boss.Ref,
+		Count:      1,
+		At:         &bossAt,
+	}}
+
+	regions := make([]encounter.DungeonRegionParams, len(spec.Rooms))
+	for i := range spec.Rooms {
+		room := &spec.Rooms[i]
+		region, roomSpawns, err := compileRoom(room)
+		if err != nil {
+			return CompiledDungeon{}, fmt.Errorf("room %q: %w", room.ID, err)
+		}
+		regions[i] = region
+		spawns = append(spawns, roomSpawns...)
+	}
+
+	connectors := make([]encounter.DungeonConnectorParams, len(spec.Connectors))
+	for i := range spec.Connectors {
+		connectors[i] = compileConnector(spec.Key, &spec.Connectors[i])
+	}
+
+	return CompiledDungeon{
+		Params: encounter.DungeonParams{
+			Regions:    regions,
+			Connectors: connectors,
+			Height:     spec.Height,
+			Theme:      spec.Theme,
+		},
+		Spawns: spawns,
+	}, nil
+}
+
+// compileRoom compiles one room's geometry/obstacles/place block. It
+// returns the room's placed monster spawns separately (never the boss
+// spawn, which compile builds directly from room.Boss) so compile can
+// prepend the boss spawn once, ahead of every room's placed spawns, rather
+// than every call site re-deriving "is this room the boss room."
+func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruction, error) {
+	region := encounter.DungeonRegionParams{
+		ID:        room.ID,
+		Archetype: encounter.RegionArchetype(room.Archetype),
+		Width:     room.Width,
+		Pattern:   compilePattern(room.Pattern),
+	}
+
+	for _, o := range room.Obstacles {
+		region.Obstacles = append(region.Obstacles, encounter.ObstacleSpec{
+			Ref:            o.Ref,
+			Count:          o.Count,
+			BlocksMovement: boolOrTrue(o.BlocksMovement),
+			BlocksLoS:      boolOrTrue(o.BlocksLoS),
+			PreferBorder:   o.PreferBorder,
+		})
+	}
+
+	var spawns []SpawnInstruction
+	for _, entry := range room.Place {
+		refType, err := refParts(entry.Ref)
+		if err != nil {
+			return encounter.DungeonRegionParams{}, nil, fmt.Errorf("place %q: %w", entry.Ref, err)
+		}
+		switch refType {
+		case refTypeProps:
+			region.PlacedObstacles = append(region.PlacedObstacles, encounter.PlacedObstacleSpec{
+				Ref:            entry.Ref,
+				At:             encounter.LocalHex{Col: entry.At[0], Row: entry.At[1]},
+				BlocksMovement: boolOrTrue(entry.BlocksMovement),
+				BlocksLoS:      boolOrTrue(entry.BlocksLoS),
+			})
+		case refTypeMonsters:
+			at := encounter.LocalHex{Col: entry.At[0], Row: entry.At[1]}
+			spawns = append(spawns, SpawnInstruction{
+				RoomID:     room.ID,
+				MonsterRef: entry.Ref,
+				Count:      1,
+				At:         &at,
+			})
+		default:
+			return encounter.DungeonRegionParams{}, nil, fmt.Errorf("place %q: ref type %q must be props or monsters",
+				entry.Ref, refType)
+		}
+	}
+
+	return region, spawns, nil
+}
+
+// compilePattern maps the spec's author-facing pattern vocabulary onto the
+// engine's own (design.md's PATTERN-DEFAULT TRAP: the engine treats an
+// empty DungeonRegionParams.Pattern as PatternRandom, but the spec's
+// default -- "" or "empty" -- means no interior walls at all, so the zero
+// value must never pass through unmapped).
+func compilePattern(pattern string) string {
+	if pattern == patternScattered {
+		return environments.PatternRandom
+	}
+	return environments.PatternEmpty
+}
+
+// compileConnector generates this connector's door id from content
+// ("<key>-door-<from>-<to>") and copies its lock config verbatim.
+func compileConnector(key string, c *ConnectorSpec) encounter.DungeonConnectorParams {
+	params := encounter.DungeonConnectorParams{
+		DoorID: core.EntityID(fmt.Sprintf("%s-door-%s-%s", key, c.From, c.To)),
+	}
+	if c.Locked != nil {
+		params.Locked = true
+		params.LockDC = c.Locked.DC
+		params.LockAbility = c.Locked.Ability
+	}
+	return params
+}
+
+// boolOrTrue returns *b, or true when b is nil -- the nil=>true blocking
+// default shared by ObstacleEntry and PlacedEntry's BlocksMovement/
+// BlocksLoS flags (design.md: an unflagged entry blocks both).
+func boolOrTrue(b *bool) bool {
+	if b == nil {
+		return true
+	}
+	return *b
+}

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -88,8 +88,9 @@ func compile(spec *DungeonSpec) (CompiledDungeon, error) {
 		at := encounter.LocalHex{Col: bossRoom.Boss.At[0], Row: bossRoom.Boss.At[1]}
 		bossAt = &at
 	}
-	// Capacity is a lower bound, not exact: the boss spawn plus at most one
-	// spawn per room's place list (rooms can also place zero monsters).
+	// Capacity is a lower bound, not exact: sized for the boss spawn plus
+	// one per room, but a room's place list can name several monster
+	// entries (or none), so appends can grow this well past the hint.
 	spawns := make([]SpawnInstruction, 0, len(spec.Rooms)+1)
 	spawns = append(spawns, SpawnInstruction{
 		RoomID:     bossRoom.ID,

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -59,12 +59,23 @@ func compile(spec *DungeonSpec) (CompiledDungeon, error) {
 
 	// Boss spawn goes first, regardless of the boss room's position in the
 	// chain (design.md, defense-in-depth ahead of Slice C's own invariant).
-	bossAt := encounter.LocalHex{Col: bossRoom.Boss.At[0], Row: bossRoom.Boss.At[1]}
+	//
+	// bossRoom.Boss.At is nil only for an unpinned boss -- Validate's M1-only
+	// restriction (Task B2) rejects that shape today, so Load can never
+	// reach this branch; it stays here so compile() never panics regardless
+	// (this function's own doc), and it's exactly where M2's Task C0 lands:
+	// an unpinned boss becomes a rolled (Count-based, no At) spawn candidate,
+	// which is precisely what Count:1, At:nil already expresses.
+	var bossAt *encounter.LocalHex
+	if bossRoom.Boss.At != nil {
+		at := encounter.LocalHex{Col: bossRoom.Boss.At[0], Row: bossRoom.Boss.At[1]}
+		bossAt = &at
+	}
 	spawns := []SpawnInstruction{{
 		RoomID:     bossRoom.ID,
 		MonsterRef: bossRoom.Boss.Ref,
 		Count:      1,
-		At:         &bossAt,
+		At:         bossAt,
 	}}
 
 	regions := make([]encounter.DungeonRegionParams, len(spec.Rooms))

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -11,17 +11,25 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
-// SpawnInstruction is encounter's OWN type (defined in Task N2's
-// encounter/seed_monsters.go, alongside SeedMonsters) -- dungeonspec
-// re-exports it via a plain type ALIAS, not a second struct, so
-// CompiledDungeon.Spawns can be passed directly to
+// SpawnInstruction is encounter's OWN type (defined in
+// encounter/seed_monsters.go, alongside SeedMonsters -- rpg-toolkit#842)
+// -- dungeonspec re-exports it via a plain type ALIAS, not a second
+// struct, so CompiledDungeon.Spawns can be passed directly to
 // enc.SeedMonsters(compiled.Spawns) with zero conversion.
 type SpawnInstruction = encounter.SpawnInstruction
 
 // CompiledDungeon is a dungeon spec compiled down to what the engine and
 // SeedMonsters actually consume: engine params ready for InitDungeon, and
-// a spawn plan ready for SeedMonsters.
+// a spawn plan ready for SeedMonsters. It is a plain value (no internal
+// state, no mutable shared pointers into the source spec) -- safe to
+// cache and share across concurrent requests, since the engine only ever
+// reads Params/Spawns off of it.
 type CompiledDungeon struct {
+	// Params feeds Encounter.InitDungeon directly. Params.RandomSeed is
+	// deliberately left at its zero value -- Load has no opinion on
+	// reproducibility, so the caller MUST set it before calling
+	// InitDungeon, or repeated encounters compiled from the same spec
+	// bytes won't roll the same layout.
 	Params encounter.DungeonParams
 	Spawns []SpawnInstruction // boss first, then entrance->boss chain order
 }
@@ -30,6 +38,14 @@ type CompiledDungeon struct {
 // entry point callers use. Door entity ids are COMPILER-GENERATED from
 // content ("<key>-door-<from>-<to>" per connector), so callers supply
 // nothing but the bytes.
+//
+// Expected call sequence once Load returns: enc.InitDungeon(compiled.Params)
+// (after setting Params.RandomSeed, see CompiledDungeon.Params), then
+// enc.AddPlayer for each player, then enc.SeedMonsters(compiled.Spawns) --
+// in that order. SeedMonsters' combat-entry check only evaluates players
+// already added; calling it before every AddPlayer silently skips combat
+// entry for that seeding pass rather than erroring, so an author-placed
+// monster in a party's starting sightline needs the party added first.
 func Load(raw []byte) (CompiledDungeon, error) {
 	spec, err := Decode(raw)
 	if err != nil {
@@ -51,10 +67,11 @@ func compile(spec *DungeonSpec) (CompiledDungeon, error) {
 	for i := range spec.Rooms {
 		if spec.Rooms[i].Boss != nil {
 			bossRoom = &spec.Rooms[i]
+			break // validateBossCardinality already guarantees exactly one
 		}
 	}
 	if bossRoom == nil {
-		return CompiledDungeon{}, fmt.Errorf("compile: no boss room (Validate should have rejected this spec)")
+		return CompiledDungeon{}, fmt.Errorf("dungeon %q: no boss room (Validate should have rejected this spec)", spec.Key)
 	}
 
 	// Boss spawn goes first, regardless of the boss room's position in the
@@ -71,12 +88,15 @@ func compile(spec *DungeonSpec) (CompiledDungeon, error) {
 		at := encounter.LocalHex{Col: bossRoom.Boss.At[0], Row: bossRoom.Boss.At[1]}
 		bossAt = &at
 	}
-	spawns := []SpawnInstruction{{
+	// Capacity is a lower bound, not exact: the boss spawn plus at most one
+	// spawn per room's place list (rooms can also place zero monsters).
+	spawns := make([]SpawnInstruction, 0, len(spec.Rooms)+1)
+	spawns = append(spawns, SpawnInstruction{
 		RoomID:     bossRoom.ID,
 		MonsterRef: bossRoom.Boss.Ref,
 		Count:      1,
 		At:         bossAt,
-	}}
+	})
 
 	regions := make([]encounter.DungeonRegionParams, len(spec.Rooms))
 	for i := range spec.Rooms {
@@ -111,6 +131,18 @@ func compile(spec *DungeonSpec) (CompiledDungeon, error) {
 // prepend the boss spawn once, ahead of every room's placed spawns, rather
 // than every call site re-deriving "is this room the boss room."
 func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruction, error) {
+	// room.Monsters is unreachable via Load today -- Validate's M1-only
+	// restriction (validateM1Restrictions) rejects any non-empty
+	// room.Monsters -- but compileRoom does not yet know how to compile
+	// count-based rolled monsters (M2's Task C0), so it errors loudly
+	// rather than silently dropping them if that assumption is ever
+	// violated by a future caller, mirroring compile()'s own nil-boss.At
+	// guard.
+	if len(room.Monsters) > 0 {
+		return encounter.DungeonRegionParams{}, nil,
+			fmt.Errorf("rolled monsters not compiled yet (Validate should have rejected this spec)")
+	}
+
 	region := encounter.DungeonRegionParams{
 		ID:        room.ID,
 		Archetype: encounter.RegionArchetype(room.Archetype),
@@ -118,6 +150,9 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 		Pattern:   compilePattern(room.Pattern),
 	}
 
+	if len(room.Obstacles) > 0 {
+		region.Obstacles = make([]encounter.ObstacleSpec, 0, len(room.Obstacles))
+	}
 	for _, o := range room.Obstacles {
 		region.Obstacles = append(region.Obstacles, encounter.ObstacleSpec{
 			Ref:            o.Ref,
@@ -128,6 +163,13 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 		})
 	}
 
+	if len(room.Place) > 0 {
+		// Capacity is an upper bound, not exact: place entries split between
+		// props (appended below to PlacedObstacles) and monsters (appended
+		// to spawns), so a place block that's all monsters never grows
+		// PlacedObstacles at all.
+		region.PlacedObstacles = make([]encounter.PlacedObstacleSpec, 0, len(room.Place))
+	}
 	var spawns []SpawnInstruction
 	for _, entry := range room.Place {
 		refType, err := refParts(entry.Ref)
@@ -151,7 +193,11 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 				At:         &at,
 			})
 		default:
-			return encounter.DungeonRegionParams{}, nil, fmt.Errorf("place %q: ref type %q must be props or monsters",
+			// Phrasing matches validatePlaceBlock's "must be props or
+			// monsters" message (validate.go) -- this branch is unreachable
+			// via Load (Validate already rejects it), but the two should
+			// read as the same rule stated twice, not two different ones.
+			return encounter.DungeonRegionParams{}, nil, fmt.Errorf("place ref %q must be props or monsters, got type %q",
 				entry.Ref, refType)
 		}
 	}
@@ -159,16 +205,22 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 	return region, spawns, nil
 }
 
-// compilePattern maps the spec's author-facing pattern vocabulary onto the
-// engine's own (design.md's PATTERN-DEFAULT TRAP: the engine treats an
-// empty DungeonRegionParams.Pattern as PatternRandom, but the spec's
-// default -- "" or "empty" -- means no interior walls at all, so the zero
-// value must never pass through unmapped).
+// compilePattern maps the spec's author-facing pattern vocabulary
+// (patternEmpty/patternScattered, validate.go) onto the engine's own.
+//
+// PATTERN-DEFAULT TRAP: the engine treats an empty DungeonRegionParams.
+// Pattern as PatternRandom, but the spec's default -- "" or patternEmpty
+// -- means no interior walls at all, so the zero value must never pass
+// through unmapped. This is the one place that mapping happens; anything
+// that wants to reason about it again should point back here rather than
+// re-deriving it.
 func compilePattern(pattern string) string {
-	if pattern == patternScattered {
+	switch pattern {
+	case patternScattered:
 		return environments.PatternRandom
+	default: // "", patternEmpty, and (Validate having already run) nothing else
+		return environments.PatternEmpty
 	}
-	return environments.PatternEmpty
 }
 
 // compileConnector generates this connector's door id from content

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -88,9 +88,10 @@ func compile(spec *DungeonSpec) (CompiledDungeon, error) {
 		at := encounter.LocalHex{Col: bossRoom.Boss.At[0], Row: bossRoom.Boss.At[1]}
 		bossAt = &at
 	}
-	// Capacity is a lower bound, not exact: sized for the boss spawn plus
-	// one per room, but a room's place list can name several monster
-	// entries (or none), so appends can grow this well past the hint.
+	// Capacity is a hint, not a bound: sized for the boss spawn plus one
+	// per room, but a room's place list can name several monster entries
+	// (growing past the hint) or none at all (falling short of it) --
+	// neither direction is guaranteed.
 	spawns := make([]SpawnInstruction, 0, len(spec.Rooms)+1)
 	spawns = append(spawns, SpawnInstruction{
 		RoomID:     bossRoom.ID,

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -136,10 +136,10 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 	// room.Monsters is unreachable via Load today -- Validate's M1-only
 	// restriction (validateM1Restrictions) rejects any non-empty
 	// room.Monsters -- but compileRoom does not yet know how to compile
-	// count-based rolled monsters (M2's Task C0), so it errors loudly
-	// rather than silently dropping them if that assumption is ever
-	// violated by a future caller, mirroring compile()'s own nil-boss.At
-	// guard.
+	// count-based rolled monsters (M2's Slice C, count-based compiling --
+	// see plan), so it errors loudly rather than silently dropping them if
+	// that assumption is ever violated by a future caller, mirroring
+	// compile()'s own nil-boss.At guard.
 	if len(room.Monsters) > 0 {
 		return encounter.DungeonRegionParams{}, nil,
 			fmt.Errorf("rolled monsters not compiled yet (Validate should have rejected this spec)")
@@ -150,6 +150,17 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 		Archetype: encounter.RegionArchetype(room.Archetype),
 		Width:     room.Width,
 		Pattern:   compilePattern(room.Pattern),
+	}
+
+	// The boss room's own pinned boss.at cell is a MONSTER placement exactly
+	// like a place: monster entry below -- compile() builds its
+	// SpawnInstruction directly from room.Boss, never through this room's
+	// Place loop, so without reserving it here separately, InitDungeon's
+	// rolled-obstacle draw has no idea that cell is spoken for (rpg-toolkit#842
+	// gate finding: see encounter.DungeonRegionParams.ReservedCells' doc).
+	if room.Boss != nil && room.Boss.At != nil {
+		region.ReservedCells = append(region.ReservedCells,
+			encounter.LocalHex{Col: room.Boss.At[0], Row: room.Boss.At[1]})
 	}
 
 	if len(room.Obstacles) > 0 {
@@ -188,6 +199,12 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 			})
 		case refTypeMonsters:
 			at := encounter.LocalHex{Col: entry.At[0], Row: entry.At[1]}
+			// Reserve this cell the same way as the boss's own pinned
+			// boss.at above -- a placed monster never becomes a
+			// PlacedObstacleSpec, so without this InitDungeon's
+			// rolled-obstacle draw would have no idea the cell is taken
+			// (rpg-toolkit#842 gate finding: see ReservedCells' doc).
+			region.ReservedCells = append(region.ReservedCells, at)
 			spawns = append(spawns, SpawnInstruction{
 				RoomID:     room.ID,
 				MonsterRef: entry.Ref,

--- a/encounter/dungeonspec/compile_internal_test.go
+++ b/encounter/dungeonspec/compile_internal_test.go
@@ -14,6 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Room ids shared by both hand-built specs below (goconst) -- kept
+// distinct from the archetypeEntrance/archetypeBoss vocabulary constants
+// (validate.go) even though entranceRoomID happens to share a string value
+// with archetypeEntrance: one names an arbitrary room id, the other the
+// fixed archetype vocabulary, and conflating them (reusing one constant
+// for both fields) is the exact mistake this split avoids.
+const (
+	entranceRoomID = "entrance"
+	bossRoomID     = "boss-room"
+)
+
 // TestCompile_NilBossAtProducesRolledSpawn calls compile() on a hand-built
 // spec with Boss.At == nil -- a shape Validate currently rejects in M1
 // (the temporary at-pinning restriction, Task B2), so Load itself can
@@ -26,20 +37,19 @@ import (
 // so the assertion below (Count: 1, At: nil) is the permanent contract,
 // not a placeholder.
 func TestCompile_NilBossAtProducesRolledSpawn(t *testing.T) {
-	const entranceRoomID = "entrance"
 	spec := &DungeonSpec{
 		Version: 1,
 		Key:     "nil-boss-at-check",
 		Name:    "Nil Boss At Check",
 		Height:  8,
 		Rooms: []RoomSpec{
-			{ID: entranceRoomID, Archetype: entranceRoomID, Width: 6},
+			{ID: entranceRoomID, Archetype: archetypeEntrance, Width: 6},
 			{
-				ID: "boss-room", Archetype: "boss", Width: 7,
+				ID: bossRoomID, Archetype: archetypeBoss, Width: 7,
 				Boss: &BossEntry{Ref: "dnd5e:monsters:skeleton-captain"}, // At: nil
 			},
 		},
-		Connectors: []ConnectorSpec{{From: entranceRoomID, To: "boss-room"}},
+		Connectors: []ConnectorSpec{{From: entranceRoomID, To: bossRoomID}},
 	}
 
 	compiled, err := compile(spec)
@@ -49,4 +59,42 @@ func TestCompile_NilBossAtProducesRolledSpawn(t *testing.T) {
 	assert.Equal(t, "dnd5e:monsters:skeleton-captain", boss.MonsterRef)
 	assert.Equal(t, 1, boss.Count)
 	assert.Nil(t, boss.At)
+}
+
+// TestCompile_RoomMonstersGuardedAgainstSilentDrop mirrors
+// TestCompile_NilBossAtProducesRolledSpawn's shape: compileRoom does not
+// yet know how to compile count-based room.Monsters entries into rolled
+// SpawnInstructions (that's M2's Task C0), so it must error loudly rather
+// than silently drop them -- a compiler that just ignored room.Monsters
+// would still produce a CompiledDungeon with zero error, quietly losing
+// every rolled monster in the process. Constructed directly at the
+// compile layer (bypassing Validate, which rejects this shape in M1 via
+// validateM1Restrictions) for the same reason as the nil-boss.At test
+// above: this is the guard's whole point, independent of whether
+// Validate currently makes it unreachable. This test is also the
+// forcing function for M2's Task C0: deleting validateM1Restrictions
+// alone, without teaching compileRoom to actually compile room.Monsters,
+// fails THIS test instead of silently vanishing monsters at runtime.
+func TestCompile_RoomMonstersGuardedAgainstSilentDrop(t *testing.T) {
+	spec := &DungeonSpec{
+		Version: 1,
+		Key:     "room-monsters-guard-check",
+		Name:    "Room Monsters Guard Check",
+		Height:  8,
+		Rooms: []RoomSpec{
+			{
+				ID: entranceRoomID, Archetype: archetypeEntrance, Width: 6,
+				Monsters: []MonsterEntry{{Ref: "dnd5e:monsters:skeleton", Count: 2}},
+			},
+			{
+				ID: bossRoomID, Archetype: archetypeBoss, Width: 7,
+				Boss: &BossEntry{Ref: "dnd5e:monsters:skeleton-captain", At: &[2]int{3, 5}},
+			},
+		},
+		Connectors: []ConnectorSpec{{From: entranceRoomID, To: bossRoomID}},
+	}
+
+	_, err := compile(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rolled monsters not compiled yet")
 }

--- a/encounter/dungeonspec/compile_internal_test.go
+++ b/encounter/dungeonspec/compile_internal_test.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// package dungeonspec (not dungeonspec_test): this file calls the
+// unexported compile() directly, bypassing Load's Validate call, to test
+// compile()'s own nil-boss.At guard independently of whether Validate
+// currently forbids that shape (M1 does; M2's Task C0 lifts it).
+package dungeonspec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompile_NilBossAtProducesRolledSpawn calls compile() on a hand-built
+// spec with Boss.At == nil -- a shape Validate currently rejects in M1
+// (the temporary at-pinning restriction, Task B2), so Load itself can
+// never reach this path today. compile()'s own doc says it "still returns
+// an error rather than panicking... in case that assumption is ever
+// violated by a future caller" -- this test is that violation, constructed
+// directly at the compile layer since Load's Validate call would otherwise
+// make it unreachable. This is also exactly the shape M2's Task C0 lands:
+// an unpinned boss becomes a rolled (Count-based, no At) spawn candidate,
+// so the assertion below (Count: 1, At: nil) is the permanent contract,
+// not a placeholder.
+func TestCompile_NilBossAtProducesRolledSpawn(t *testing.T) {
+	const entranceRoomID = "entrance"
+	spec := &DungeonSpec{
+		Version: 1,
+		Key:     "nil-boss-at-check",
+		Name:    "Nil Boss At Check",
+		Height:  8,
+		Rooms: []RoomSpec{
+			{ID: entranceRoomID, Archetype: entranceRoomID, Width: 6},
+			{
+				ID: "boss-room", Archetype: "boss", Width: 7,
+				Boss: &BossEntry{Ref: "dnd5e:monsters:skeleton-captain"}, // At: nil
+			},
+		},
+		Connectors: []ConnectorSpec{{From: entranceRoomID, To: "boss-room"}},
+	}
+
+	compiled, err := compile(spec)
+	require.NoError(t, err)
+	require.NotEmpty(t, compiled.Spawns)
+	boss := compiled.Spawns[0]
+	assert.Equal(t, "dnd5e:monsters:skeleton-captain", boss.MonsterRef)
+	assert.Equal(t, 1, boss.Count)
+	assert.Nil(t, boss.At)
+}

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -1,0 +1,145 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_GeneratesDeterministicDoorIDs(t *testing.T) {
+	// placedTombYAML: key "reference-tomb", 2 rooms (entrance, tomb), 1 connector —
+	// the M1-valid fixture (referenceYAML's own count-based monsters fail Validate
+	// in M1; see Task B2's fixture consequence). N-connector coverage (3+ doors in
+	// one file) resumes in M2 once referenceYAML/cryptYAML are loadable again.
+	compiled, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	require.Len(t, compiled.Params.Connectors, 1)
+	assert.Equal(t, core.EntityID("reference-tomb-door-entrance-tomb"),
+		compiled.Params.Connectors[0].DoorID)
+}
+
+// PATTERN-DEFAULT TRAP (advisory made explicit): the engine treats an
+// empty DungeonRegionParams.Pattern as PatternRandom. The SPEC's default
+// is empty (design.md). The compiler must therefore map "" and "empty" ->
+// environments.PatternEmpty and "scattered" -> environments.PatternRandom
+// EXPLICITLY -- never pass the zero value through. placedTombYAML's own
+// rooms are both empty-pattern (no room in it is scattered -- Task B2's
+// scattered-rejection rows exercise scattered ONLY in combination with
+// place/boss.at, never the plain mapping), so the scattered->PatternRandom
+// direction needs its OWN small fixture, inline here, decoupled from
+// placedTombYAML/validM1YAML entirely.
+func TestLoad_ScatteredPatternMapsToPatternRandom(t *testing.T) {
+	// Throwaway 2-room fixture threading all three interacting rules
+	// correctly (a fixture missing any one of them fails Validate for an
+	// UNRELATED reason before this test's actual assertion ever runs):
+	// exactly one boss-archetype room is required (v1's own rule) with a
+	// non-nil boss: entry (M1's permanent boss-required rule, Task B2) and
+	// a pinned at: (M1's temporary at-pinning rule, lifted in M2's Task
+	// C0) -- so the boss room carries `pattern` empty/default (NOT
+	// scattered; the scattered-rejection rule only fires on a room that
+	// HAS place/pinned boss.at, and this room does), width 7 (height 8,
+	// boss primary axis needs min(width,height) > 6). The entrance room
+	// is the one under test: pattern: scattered, no place/boss.at, so
+	// none of the pinning rules apply to it at all.
+	const scatteredYAML = `
+version: 1
+key: pattern-mapping-check
+name: Pattern Mapping Check
+height: 8
+rooms:
+  - {id: entrance, archetype: entrance, width: 6, pattern: scattered}
+  - {id: boss-room, archetype: boss, width: 7, boss: {ref: "dnd5e:monsters:skeleton-captain", at: [3, 5]}}
+connectors:
+  - {from: entrance, to: boss-room}
+`
+	// scattered is legal on its own -- design.md's clarification.
+	compiled, err := dungeonspec.Load([]byte(scatteredYAML))
+	require.NoError(t, err)
+	// entrance: scattered -> PatternRandom.
+	assert.Equal(t, environments.PatternRandom, compiled.Params.Regions[0].Pattern)
+	// boss-room: default -> PatternEmpty, same test.
+	assert.Equal(t, environments.PatternEmpty, compiled.Params.Regions[1].Pattern)
+}
+
+// regionByID finds a compiled region by id, failing the test loudly if
+// absent, so callers don't have to repeat a linear scan + nil check.
+func regionByID(t *testing.T, regions []encounter.DungeonRegionParams, id string) *encounter.DungeonRegionParams {
+	t.Helper()
+	for i := range regions {
+		if regions[i].ID == id {
+			return &regions[i]
+		}
+	}
+	t.Fatalf("no region %q in compiled regions", id)
+	return nil
+}
+
+func TestLoad_PlaceRoutesByRefType(t *testing.T) {
+	compiled, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	tombRegion := regionByID(t, compiled.Params.Regions, "tomb")
+	require.Len(t, tombRegion.PlacedObstacles, 5) // coffin, altar, statue-reaper, brazier x2
+	assert.Equal(t, "dnd5e:props:coffin", tombRegion.PlacedObstacles[0].Ref)
+	assert.Equal(t, encounter.LocalHex{Col: 6, Row: 3}, tombRegion.PlacedObstacles[0].At)
+	assert.False(t, tombRegion.PlacedObstacles[0].BlocksLoS)
+
+	// BLOCKING-DEFAULT TRAP (advisory made explicit, same class as the
+	// PATTERN-DEFAULT TRAP above): PlacedEntry.BlocksMovement/BlocksLoS are
+	// *bool with nil => true (design.md: "same defaults/semantics as
+	// ObstacleEntry"), but PlacedObstacleSpec.BlocksMovement/BlocksLoS
+	// (engine-side, Task N1) are plain bool, whose Go zero value is FALSE.
+	// A compiler that just dereferences a nil *bool panics; one that
+	// silently treats nil as the zero value inverts the default (an
+	// unflagged placed prop would compile to "blocks nothing," backwards
+	// from the design's intent). The altar entry in placedTombYAML sets
+	// NEITHER flag, so it's the direct test of this: it must compile to
+	// BlocksMovement: true, BlocksLoS: true (matching the existing
+	// crypt_dungeon.go precedent: altar is a structural piece, blocks both).
+	altar := tombRegion.PlacedObstacles[1]
+	assert.Equal(t, "dnd5e:props:altar", altar.Ref)
+	assert.True(t, altar.BlocksMovement)
+	assert.True(t, altar.BlocksLoS)
+
+	var skeletonSpawn *dungeonspec.SpawnInstruction
+	for i := range compiled.Spawns {
+		if compiled.Spawns[i].MonsterRef == "dnd5e:monsters:skeleton" {
+			skeletonSpawn = &compiled.Spawns[i]
+		}
+	}
+	require.NotNil(t, skeletonSpawn)
+	require.NotNil(t, skeletonSpawn.At)
+	assert.Equal(t, encounter.LocalHex{Col: 4, Row: 2}, *skeletonSpawn.At)
+	assert.Equal(t, 1, skeletonSpawn.Count)
+}
+
+func TestLoad_BossAtCompilesToSpawnPosition(t *testing.T) {
+	compiled, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	require.NotEmpty(t, compiled.Spawns)
+	boss := compiled.Spawns[0] // boss-first ordering unchanged
+	assert.Equal(t, "dnd5e:monsters:skeleton-captain", boss.MonsterRef)
+	require.NotNil(t, boss.At)
+	assert.Equal(t, encounter.LocalHex{Col: 7, Row: 5}, *boss.At)
+}
+
+// TestLoad_SameBytesProduceIdenticalCompiledDungeon: Load has no source of
+// randomness of its own (RandomSeed is left at its zero value -- entropy
+// seeding happens later, at InitDungeon time, never inside the compiler) --
+// calling it twice on the same bytes must yield byte-for-byte identical
+// output, including the placed obstacles and positioned spawns from the
+// place block, not just the top-level scalars.
+func TestLoad_SameBytesProduceIdenticalCompiledDungeon(t *testing.T) {
+	first, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	second, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -143,3 +143,127 @@ func TestLoad_SameBytesProduceIdenticalCompiledDungeon(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, first, second)
 }
+
+// TestLoad_PropagatesValidateErrors pins Load's Decode -> Validate ->
+// compile wiring: a Load that skipped the Validate call (calling compile
+// directly on whatever Decode returned) would still pass every other test
+// in this file, since none of their fixtures are M1-invalid. referenceYAML
+// (decode_test.go) IS M1-invalid on two counts at once (count-based
+// monsters: on its entrance/gallery rooms, Task B2's validateM1Restrictions)
+// -- so Load must surface that error, not a CompiledDungeon.
+func TestLoad_PropagatesValidateErrors(t *testing.T) {
+	_, err := dungeonspec.Load([]byte(referenceYAML))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rolled monster placement lands in M2")
+}
+
+// obstacleDefaultsYAML exercises the count-based obstacle loop's
+// nil->true blocking defaults AND explicit-false/PreferBorder carry-
+// through, independent of placedTombYAML (which only has an unflagged
+// place entry, never a count-based obstacle with flags set).
+const obstacleDefaultsYAML = `
+version: 1
+key: obstacle-defaults-check
+name: Obstacle Defaults Check
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 6
+    obstacles:
+      - { ref: "dnd5e:props:pillar", count: 2, blocks_movement: false, prefer_border: true }
+      - { ref: "dnd5e:props:obelisk", count: 1 }
+  - id: boss-room
+    archetype: boss
+    width: 7
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [3, 5] }
+connectors:
+  - { from: entrance, to: boss-room }
+`
+
+func TestLoad_CountBasedObstaclesCompileWithDefaultsAndPreferBorder(t *testing.T) {
+	compiled, err := dungeonspec.Load([]byte(obstacleDefaultsYAML))
+	require.NoError(t, err)
+	entrance := regionByID(t, compiled.Params.Regions, "entrance")
+	require.Len(t, entrance.Obstacles, 2)
+
+	pillar := entrance.Obstacles[0]
+	assert.Equal(t, "dnd5e:props:pillar", pillar.Ref)
+	assert.Equal(t, 2, pillar.Count)
+	assert.False(t, pillar.BlocksMovement) // explicit false carried through, not defaulted
+	assert.True(t, pillar.BlocksLoS)       // unset -> nil -> true
+	assert.True(t, pillar.PreferBorder)
+
+	obelisk := entrance.Obstacles[1]
+	assert.Equal(t, "dnd5e:props:obelisk", obelisk.Ref)
+	assert.True(t, obelisk.BlocksMovement) // unset -> nil -> true
+	assert.True(t, obelisk.BlocksLoS)      // unset -> nil -> true
+	assert.False(t, obelisk.PreferBorder)  // unset, no flip-to-true default for this field
+}
+
+// lockedConnectorYAML exercises locked-connector compilation independent
+// of placedTombYAML (which has no lock at all) -- Locked/LockDC/LockAbility
+// must all copy through from the spec's locked: block.
+const lockedConnectorYAML = `
+version: 1
+key: locked-connector-check
+name: Locked Connector Check
+height: 8
+rooms:
+  - {id: entrance, archetype: entrance, width: 6}
+  - {id: boss-room, archetype: boss, width: 7, boss: {ref: "dnd5e:monsters:skeleton-captain", at: [3, 5]}}
+connectors:
+  - {from: entrance, to: boss-room, locked: {dc: 15, ability: str}}
+`
+
+func TestLoad_LockedConnectorCompilesLockFields(t *testing.T) {
+	compiled, err := dungeonspec.Load([]byte(lockedConnectorYAML))
+	require.NoError(t, err)
+	require.Len(t, compiled.Params.Connectors, 1)
+	conn := compiled.Params.Connectors[0]
+	assert.True(t, conn.Locked)
+	assert.Equal(t, 15, conn.LockDC)
+	assert.Equal(t, "str", conn.LockAbility)
+}
+
+// TestLoad_DoorIDsComposeHyphenatedRoomIDs pins the door-id rule's
+// composition against a room id that itself contains a hyphen
+// ("trap-crossing") -- plain concatenation must not get confused by it.
+// validM1YAML (validate_test.go): key "sunken-crypt", chain entrance ->
+// gallery -> trap-crossing -> tomb.
+func TestLoad_DoorIDsComposeHyphenatedRoomIDs(t *testing.T) {
+	compiled, err := dungeonspec.Load([]byte(validM1YAML))
+	require.NoError(t, err)
+	require.Len(t, compiled.Params.Connectors, 3)
+	assert.Equal(t, core.EntityID("sunken-crypt-door-trap-crossing-tomb"),
+		compiled.Params.Connectors[2].DoorID)
+}
+
+// TestLoad_CryptKeyDoorIDsMatchAPIConstants pins the M2 parity requirement
+// the Door-ID rule exists for: once the crypt migrates to content under
+// key: crypt, the compiler must reproduce rpg-api's own hardcoded test
+// constants byte-for-byte -- cryptEntranceDoorID =
+// "crypt-door-entrance-corridor" and cryptBossDoorID =
+// "crypt-door-corridor-boss" (internal/integration/dungeon_crypt_test.go,
+// internal/handlers/dnd5e/v2/encounter/project_test.go on rpg-api
+// origin/main) -- with zero special-casing in the compiler.
+func TestLoad_CryptKeyDoorIDsMatchAPIConstants(t *testing.T) {
+	const cryptKeyYAML = `
+version: 1
+key: crypt
+name: Crypt Key Door ID Check
+height: 8
+rooms:
+  - {id: entrance, archetype: entrance, width: 6}
+  - {id: corridor, archetype: corridor, width: 6}
+  - {id: boss, archetype: boss, width: 7, boss: {ref: "dnd5e:monsters:skeleton-captain", at: [3, 5]}}
+connectors:
+  - {from: entrance, to: corridor}
+  - {from: corridor, to: boss}
+`
+	compiled, err := dungeonspec.Load([]byte(cryptKeyYAML))
+	require.NoError(t, err)
+	require.Len(t, compiled.Params.Connectors, 2)
+	assert.Equal(t, core.EntityID("crypt-door-entrance-corridor"), compiled.Params.Connectors[0].DoorID)
+	assert.Equal(t, core.EntityID("crypt-door-corridor-boss"), compiled.Params.Connectors[1].DoorID)
+}

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -4,6 +4,7 @@
 package dungeonspec_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
@@ -280,4 +281,71 @@ connectors:
 	require.Len(t, compiled.Params.Connectors, 2)
 	assert.Equal(t, core.EntityID("crypt-door-entrance-corridor"), compiled.Params.Connectors[0].DoorID)
 	assert.Equal(t, core.EntityID("crypt-door-corridor-boss"), compiled.Params.Connectors[1].DoorID)
+}
+
+// TestLoad_PlacedMonsterCellsReservedFromRolledObstacles is the regression
+// test for rpg-toolkit#842's gate-blocking cross-task seam bug: a placed
+// monster -- a place: monster entry, or the boss's own pinned boss.at --
+// compiles to a SpawnInstruction, never a PlacedObstacleSpec, so
+// InitDungeon's rolled-obstacle draw had no idea that cell was already
+// spoken for and could roll a count-based obstacle directly onto it. The
+// bug never showed up at compile time (compile()/compileRoom's own output
+// was correct in isolation) -- it only surfaced later, and only on SOME
+// seeds, as Encounter.SeedMonsters failing to place the monster into a
+// cell an obstacle already occupies. Exercising the FULL pipeline (Load ->
+// InitDungeon -> SeedMonsters), not just the compiler or the engine in
+// isolation, is the point: the seam between two independently-correct
+// pieces is exactly what broke.
+//
+// reservedCellRegressionYAML is single-use and deliberately NOT
+// placedTombYAML/validM1YAML: this fixture's tomb room needs BOTH a
+// count-based obstacles: block (to create rollable candidates) and a
+// place: monster entry alongside its boss.at (to create reserved cells to
+// collide with) in the SAME room -- a combination the shared fixtures
+// don't have, and adding one to them would perturb OTHER tests' exact
+// obstacle-position/floor-plan assertions (compile_test.go's own
+// TestLoad_GeneratesDeterministicDoorIDs and workbench_test.go's floor-plan
+// row pins, in particular).
+//
+// Count: 40 count-based obstacles crammed into the tomb room's ~84
+// non-doorRow cells (12x8, minus the shared doorRow row) makes a missing
+// reservation collide on a large fraction of seeds -- the gate's own
+// empirical finding was roughly a third of seeds at a comparable
+// room/count ratio -- so a 50-seed sweep is well past enough to catch a
+// fix that only closes PART of the gap (e.g. the boss.at half but not the
+// place: monster half, or vice versa).
+func TestLoad_PlacedMonsterCellsReservedFromRolledObstacles(t *testing.T) {
+	const reservedCellRegressionYAML = `
+version: 1
+key: reserved-cell-regression
+name: Reserved Cell Regression Check
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+    obstacles:
+      - { ref: "dnd5e:props:pillar", count: 40 }
+    place:
+      - { ref: "dnd5e:monsters:skeleton", at: [4, 2] }
+connectors:
+  - { from: entrance, to: tomb }
+`
+	compiled, err := dungeonspec.Load([]byte(reservedCellRegressionYAML))
+	require.NoError(t, err)
+
+	for seed := int64(1); seed <= 50; seed++ {
+		params := compiled.Params
+		params.RandomSeed = seed
+
+		transport := encounter.NewInMemoryTransport()
+		broker := encounter.NewBroker(transport)
+		enc := encounter.New(context.Background(), "reserved-cell-regression-test", broker)
+		require.NoError(t, enc.InitDungeon(params), "seed %d: InitDungeon", seed)
+		require.NoError(t, enc.SeedMonsters(compiled.Spawns), "seed %d: SeedMonsters", seed)
+	}
 }

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -24,18 +24,21 @@ func TestLoad_GeneratesDeterministicDoorIDs(t *testing.T) {
 	require.Len(t, compiled.Params.Connectors, 1)
 	assert.Equal(t, core.EntityID("reference-tomb-door-entrance-tomb"),
 		compiled.Params.Connectors[0].DoorID)
+
+	// Plain scalar carry-throughs -- currently swappable with the suite
+	// green if compile() dropped or mis-wired either field.
+	assert.Equal(t, 8, compiled.Params.Height)
+	assert.Equal(t, "crypt", compiled.Params.Theme)
 }
 
-// PATTERN-DEFAULT TRAP (advisory made explicit): the engine treats an
-// empty DungeonRegionParams.Pattern as PatternRandom. The SPEC's default
-// is empty (design.md). The compiler must therefore map "" and "empty" ->
-// environments.PatternEmpty and "scattered" -> environments.PatternRandom
-// EXPLICITLY -- never pass the zero value through. placedTombYAML's own
-// rooms are both empty-pattern (no room in it is scattered -- Task B2's
-// scattered-rejection rows exercise scattered ONLY in combination with
-// place/boss.at, never the plain mapping), so the scattered->PatternRandom
-// direction needs its OWN small fixture, inline here, decoupled from
-// placedTombYAML/validM1YAML entirely.
+// TestLoad_ScatteredPatternMapsToPatternRandom exercises the
+// scattered->PatternRandom half of the PATTERN-DEFAULT TRAP (see
+// compilePattern's doc, compile.go, for what the trap is and why it
+// matters). placedTombYAML's own rooms are both empty-pattern (no room
+// in it is scattered -- Task B2's scattered-rejection rows exercise
+// scattered ONLY in combination with place/boss.at, never the plain
+// mapping), so this direction needs its own small fixture, decoupled
+// from placedTombYAML/validM1YAML entirely.
 func TestLoad_ScatteredPatternMapsToPatternRandom(t *testing.T) {
 	// Throwaway 2-room fixture threading all three interacting rules
 	// correctly (a fixture missing any one of them fails Validate for an
@@ -86,6 +89,12 @@ func TestLoad_PlaceRoutesByRefType(t *testing.T) {
 	compiled, err := dungeonspec.Load([]byte(placedTombYAML))
 	require.NoError(t, err)
 	tombRegion := regionByID(t, compiled.Params.Regions, "tomb")
+
+	// Plain scalar carry-throughs -- currently swappable with the suite
+	// green if compileRoom dropped or mis-wired either field.
+	assert.Equal(t, 12, tombRegion.Width)
+	assert.Equal(t, encounter.ArchetypeBoss, tombRegion.Archetype)
+
 	require.Len(t, tombRegion.PlacedObstacles, 5) // coffin, altar, statue-reaper, brazier x2
 	assert.Equal(t, "dnd5e:props:coffin", tombRegion.PlacedObstacles[0].Ref)
 	assert.Equal(t, encounter.LocalHex{Col: 6, Row: 3}, tombRegion.PlacedObstacles[0].At)
@@ -118,6 +127,7 @@ func TestLoad_PlaceRoutesByRefType(t *testing.T) {
 	require.NotNil(t, skeletonSpawn.At)
 	assert.Equal(t, encounter.LocalHex{Col: 4, Row: 2}, *skeletonSpawn.At)
 	assert.Equal(t, 1, skeletonSpawn.Count)
+	assert.Equal(t, "tomb", skeletonSpawn.RoomID)
 }
 
 func TestLoad_BossAtCompilesToSpawnPosition(t *testing.T) {
@@ -157,11 +167,12 @@ func TestLoad_PropagatesValidateErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "rolled monster placement lands in M2")
 }
 
-// obstacleDefaultsYAML exercises the count-based obstacle loop's
-// nil->true blocking defaults AND explicit-false/PreferBorder carry-
-// through, independent of placedTombYAML (which only has an unflagged
-// place entry, never a count-based obstacle with flags set).
-const obstacleDefaultsYAML = `
+func TestLoad_CountBasedObstaclesCompileWithDefaultsAndPreferBorder(t *testing.T) {
+	// obstacleDefaultsYAML exercises the count-based obstacle loop's
+	// nil->true blocking defaults AND explicit-false/PreferBorder carry-
+	// through, independent of placedTombYAML (which only has an unflagged
+	// place entry, never a count-based obstacle with flags set).
+	const obstacleDefaultsYAML = `
 version: 1
 key: obstacle-defaults-check
 name: Obstacle Defaults Check
@@ -180,8 +191,6 @@ rooms:
 connectors:
   - { from: entrance, to: boss-room }
 `
-
-func TestLoad_CountBasedObstaclesCompileWithDefaultsAndPreferBorder(t *testing.T) {
 	compiled, err := dungeonspec.Load([]byte(obstacleDefaultsYAML))
 	require.NoError(t, err)
 	entrance := regionByID(t, compiled.Params.Regions, "entrance")
@@ -201,10 +210,11 @@ func TestLoad_CountBasedObstaclesCompileWithDefaultsAndPreferBorder(t *testing.T
 	assert.False(t, obelisk.PreferBorder)  // unset, no flip-to-true default for this field
 }
 
-// lockedConnectorYAML exercises locked-connector compilation independent
-// of placedTombYAML (which has no lock at all) -- Locked/LockDC/LockAbility
-// must all copy through from the spec's locked: block.
-const lockedConnectorYAML = `
+func TestLoad_LockedConnectorCompilesLockFields(t *testing.T) {
+	// lockedConnectorYAML exercises locked-connector compilation independent
+	// of placedTombYAML (which has no lock at all) -- Locked/LockDC/
+	// LockAbility must all copy through from the spec's locked: block.
+	const lockedConnectorYAML = `
 version: 1
 key: locked-connector-check
 name: Locked Connector Check
@@ -215,8 +225,6 @@ rooms:
 connectors:
   - {from: entrance, to: boss-room, locked: {dc: 15, ability: str}}
 `
-
-func TestLoad_LockedConnectorCompilesLockFields(t *testing.T) {
 	compiled, err := dungeonspec.Load([]byte(lockedConnectorYAML))
 	require.NoError(t, err)
 	require.Len(t, compiled.Params.Connectors, 1)
@@ -248,6 +256,12 @@ func TestLoad_DoorIDsComposeHyphenatedRoomIDs(t *testing.T) {
 // internal/handlers/dnd5e/v2/encounter/project_test.go on rpg-api
 // origin/main) -- with zero special-casing in the compiler.
 func TestLoad_CryptKeyDoorIDsMatchAPIConstants(t *testing.T) {
+	// cryptKeyYAML is the fourth minimal entrance+boss-room-plus-one-more,
+	// single-linear-chain throwaway fixture in this file (after
+	// scatteredYAML, obstacleDefaultsYAML, lockedConnectorYAML) built just
+	// to isolate one compile rule. If a test needs a fifth, that's the
+	// signal to extract a shared minimal-dungeon builder helper instead of
+	// copy-pasting another one.
 	const cryptKeyYAML = `
 version: 1
 key: crypt

--- a/encounter/dungeonspec/decode.go
+++ b/encounter/dungeonspec/decode.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Decode strictly decodes a dungeon spec from YAML bytes. Unknown fields
+// (typos, stale keys) fail loudly instead of being silently dropped — this
+// is why yaml.NewDecoder with KnownFields(true) is used instead of the
+// plain yaml.Unmarshal, which would drop them silently.
+func Decode(raw []byte) (*DungeonSpec, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+
+	var spec DungeonSpec
+	if err := dec.Decode(&spec); err != nil {
+		return nil, fmt.Errorf("decode dungeon spec: %w", err)
+	}
+	return &spec, nil
+}

--- a/encounter/dungeonspec/decode.go
+++ b/encounter/dungeonspec/decode.go
@@ -5,7 +5,9 @@ package dungeonspec
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 
 	"gopkg.in/yaml.v3"
 )
@@ -13,14 +15,31 @@ import (
 // Decode strictly decodes a dungeon spec from YAML bytes. Unknown fields
 // (typos, stale keys) fail loudly instead of being silently dropped — this
 // is why yaml.NewDecoder with KnownFields(true) is used instead of the
-// plain yaml.Unmarshal, which would drop them silently.
+// plain yaml.Unmarshal, which would drop them silently. A dungeon spec is
+// exactly one YAML document: empty input and a stray second `---` document
+// both fail loudly here rather than silently decoding to a zero-value spec
+// or silently dropping everything after the first document.
 func Decode(raw []byte) (*DungeonSpec, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(raw))
 	dec.KnownFields(true)
 
 	var spec DungeonSpec
 	if err := dec.Decode(&spec); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("empty dungeon spec")
+		}
 		return nil, fmt.Errorf("decode dungeon spec: %w", err)
 	}
+
+	// A second call to Decode reads the next YAML document in the stream,
+	// if any. yaml.v3 otherwise accepts multi-document input and silently
+	// discards everything past the first document — the same silent-drop
+	// class KnownFields already closes for unknown fields, closed here for
+	// stray `---` documents.
+	var extra DungeonSpec
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		return nil, errors.New("multi-document YAML not supported: a dungeon spec is one document")
+	}
+
 	return &spec, nil
 }

--- a/encounter/dungeonspec/decode_test.go
+++ b/encounter/dungeonspec/decode_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// referenceYAML is design.md's §Schema v1 reference example, copied
+// verbatim (ideas/dungeon-authoring/design.md, "Schema v1 — reference
+// example").
+const referenceYAML = `
+version: 1
+key: sunken-crypt
+name: The Sunken Crypt
+theme: crypt
+height: 8                      # shared by every room — the generator's real shape
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 10
+    monsters:
+      - { ref: "dnd5e:monsters:skeleton", count: 2 }
+    obstacles:
+      - { ref: "dnd5e:props:obelisk", count: 1 }
+      - { ref: "dnd5e:props:pillar", count: 2 }
+  - id: gallery
+    archetype: chamber
+    width: 8
+    monsters:
+      - { ref: "dnd5e:monsters:ghoul", count: 1 }
+  - id: trap-crossing            # v1: an empty corridor; trap content lands in the
+    archetype: corridor          # reserved ` + "`interactions`" + ` seat (see Deferred)
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain" }
+    obstacles:
+      - { ref: "dnd5e:props:coffin", count: 1, blocks_los: false }
+      - { ref: "dnd5e:props:altar", count: 1 }
+connectors:
+  - { from: entrance, to: gallery }
+  - { from: gallery, to: trap-crossing }
+  - { from: trap-crossing, to: tomb, locked: { dc: 12, ability: dex } }
+`
+
+func TestDecode_RoundTripsTheReferenceSpec(t *testing.T) {
+	spec, err := dungeonspec.Decode([]byte(referenceYAML))
+	require.NoError(t, err)
+	assert.Equal(t, 1, spec.Version)
+	assert.Equal(t, "sunken-crypt", spec.Key)
+	assert.Equal(t, 8, spec.Height)
+	require.Len(t, spec.Rooms, 4)
+	assert.Equal(t, "entrance", spec.Rooms[0].ID)
+	require.Len(t, spec.Connectors, 3)
+	require.NotNil(t, spec.Connectors[2].Locked)
+	assert.Equal(t, 12, spec.Connectors[2].Locked.DC)
+}
+
+func TestDecode_UnknownFieldFailsLoudly(t *testing.T) {
+	_, err := dungeonspec.Decode([]byte("version: 1\nmosnters: []\n"))
+	require.Error(t, err) // the typo class the design promises dies at load
+	assert.Contains(t, err.Error(), "mosnter")
+}

--- a/encounter/dungeonspec/decode_test.go
+++ b/encounter/dungeonspec/decode_test.go
@@ -11,44 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// referenceYAML is the dungeon-authoring design's §Schema v1 reference
-// example, copied verbatim (rpg-toolkit#842).
-const referenceYAML = `
-version: 1
-key: sunken-crypt
-name: The Sunken Crypt
-theme: crypt
-height: 8                      # shared by every room — the generator's real shape
-rooms:
-  - id: entrance
-    archetype: entrance
-    width: 10
-    monsters:
-      - { ref: "dnd5e:monsters:skeleton", count: 2 }
-    obstacles:
-      - { ref: "dnd5e:props:obelisk", count: 1 }
-      - { ref: "dnd5e:props:pillar", count: 2 }
-  - id: gallery
-    archetype: chamber
-    width: 8
-    monsters:
-      - { ref: "dnd5e:monsters:ghoul", count: 1 }
-  - id: trap-crossing            # v1: an empty corridor; trap content lands in the
-    archetype: corridor          # reserved ` + "`interactions`" + ` seat (see Deferred)
-    width: 6
-  - id: tomb
-    archetype: boss
-    width: 12
-    boss: { ref: "dnd5e:monsters:skeleton-captain" }
-    obstacles:
-      - { ref: "dnd5e:props:coffin", count: 1, blocks_los: false }
-      - { ref: "dnd5e:props:altar", count: 1 }
-connectors:
-  - { from: entrance, to: gallery }
-  - { from: gallery, to: trap-crossing }
-  - { from: trap-crossing, to: tomb, locked: { dc: 12, ability: dex } }
-`
-
 func TestDecode_RoundTripsTheReferenceSpec(t *testing.T) {
 	spec, err := dungeonspec.Decode([]byte(referenceYAML))
 	require.NoError(t, err)
@@ -62,14 +24,13 @@ func TestDecode_RoundTripsTheReferenceSpec(t *testing.T) {
 	assert.Equal(t, 12, spec.Connectors[2].Locked.DC)
 }
 
-// Deliberate typos below — the test is that this exact typo class dies at
-// decode, so misspell must not flag (or "fix") either string.
-const (
-	typoYAML  = "version: 1\nmosnters: []\n" //nolint:misspell
-	typoField = "mosnter"                    //nolint:misspell
-)
-
 func TestDecode_UnknownFieldFailsLoudly(t *testing.T) {
+	// Deliberate typos below — the test is that this exact typo class dies
+	// at decode, so misspell must not flag (or "fix") either string.
+	const (
+		typoYAML  = "version: 1\nmosnters: []\n" //nolint:misspell
+		typoField = "mosnter"                    //nolint:misspell
+	)
 	_, err := dungeonspec.Decode([]byte(typoYAML))
 	require.Error(t, err) // the typo class the design promises dies at load
 	assert.Contains(t, err.Error(), typoField)
@@ -92,38 +53,6 @@ func TestDecode_EmptyInputReturnsFriendlyError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty dungeon spec")
 }
-
-// placedTombYAML is the dungeon-authoring design's "Schema: the place
-// block" tomb fragment (rpg-toolkit#842), wrapped in a complete, valid
-// two-room file — this IS content/dungeons/reference-tomb.yaml's content,
-// not a separate lookalike. height: 8 is load-bearing: the tomb room's
-// placements use rows 1, 2, 3, 5, and 6 (boss at row 5; coffin/altar at
-// row 3; statue/skeleton/braziers at rows 1/1/2/6), so height: 8 puts
-// doorRow (height/2) at row 4, clear of all of them.
-const placedTombYAML = `
-version: 1
-key: reference-tomb
-name: The Reference Tomb
-theme: crypt
-height: 8
-rooms:
-  - id: entrance
-    archetype: entrance
-    width: 6
-  - id: tomb
-    archetype: boss
-    width: 12
-    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
-    place:
-      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
-      - { ref: "dnd5e:props:altar",         at: [9, 3] }
-      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
-      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
-      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
-      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
-connectors:
-  - { from: entrance, to: tomb }
-`
 
 func TestDecode_PlaceBlockRoundTrips(t *testing.T) {
 	spec, err := dungeonspec.Decode([]byte(placedTombYAML))

--- a/encounter/dungeonspec/decode_test.go
+++ b/encounter/dungeonspec/decode_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// referenceYAML is design.md's §Schema v1 reference example, copied
-// verbatim (ideas/dungeon-authoring/design.md, "Schema v1 — reference
-// example").
+// referenceYAML is the dungeon-authoring design's §Schema v1 reference
+// example, copied verbatim (rpg-toolkit#842).
 const referenceYAML = `
 version: 1
 key: sunken-crypt
@@ -63,14 +62,39 @@ func TestDecode_RoundTripsTheReferenceSpec(t *testing.T) {
 	assert.Equal(t, 12, spec.Connectors[2].Locked.DC)
 }
 
+// Deliberate typos below — the test is that this exact typo class dies at
+// decode, so misspell must not flag (or "fix") either string.
+const (
+	typoYAML  = "version: 1\nmosnters: []\n" //nolint:misspell
+	typoField = "mosnter"                    //nolint:misspell
+)
+
 func TestDecode_UnknownFieldFailsLoudly(t *testing.T) {
-	_, err := dungeonspec.Decode([]byte("version: 1\nmosnters: []\n"))
+	_, err := dungeonspec.Decode([]byte(typoYAML))
 	require.Error(t, err) // the typo class the design promises dies at load
-	assert.Contains(t, err.Error(), "mosnter")
+	assert.Contains(t, err.Error(), typoField)
+	assert.Contains(t, err.Error(), "line 2") // the field+line promise: names both
 }
 
-// placedTombYAML is design.md's "Schema: the place block" tomb fragment
-// (ideas/dungeon-authoring/design.md), wrapped in a complete, valid
+func TestDecode_MultiDocumentYAMLRejected(t *testing.T) {
+	// A stray `---` second document after a valid first one. yaml.v3
+	// otherwise decodes the first document and silently discards the rest —
+	// the same silent-drop class KnownFields already closes for unknown
+	// fields, closed here deliberately for multi-document input.
+	multiDoc := referenceYAML + "\n---\nversion: 1\n"
+	_, err := dungeonspec.Decode([]byte(multiDoc))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multi-document YAML not supported")
+}
+
+func TestDecode_EmptyInputReturnsFriendlyError(t *testing.T) {
+	_, err := dungeonspec.Decode([]byte(""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty dungeon spec")
+}
+
+// placedTombYAML is the dungeon-authoring design's "Schema: the place
+// block" tomb fragment (rpg-toolkit#842), wrapped in a complete, valid
 // two-room file — this IS content/dungeons/reference-tomb.yaml's content,
 // not a separate lookalike. height: 8 is load-bearing: the tomb room's
 // placements use rows 1, 2, 3, 5, and 6 (boss at row 5; coffin/altar at
@@ -104,7 +128,7 @@ connectors:
 func TestDecode_PlaceBlockRoundTrips(t *testing.T) {
 	spec, err := dungeonspec.Decode([]byte(placedTombYAML))
 	require.NoError(t, err)
-	tomb := spec.Rooms[len(spec.Rooms)-1]
+	tomb := spec.Rooms[1]
 	require.Len(t, tomb.Place, 6) // coffin, altar, statue-reaper, brazier x2, skeleton
 	assert.Equal(t, "dnd5e:props:coffin", tomb.Place[0].Ref)
 	assert.Equal(t, [2]int{6, 3}, tomb.Place[0].At)

--- a/encounter/dungeonspec/decode_test.go
+++ b/encounter/dungeonspec/decode_test.go
@@ -68,3 +68,49 @@ func TestDecode_UnknownFieldFailsLoudly(t *testing.T) {
 	require.Error(t, err) // the typo class the design promises dies at load
 	assert.Contains(t, err.Error(), "mosnter")
 }
+
+// placedTombYAML is design.md's "Schema: the place block" tomb fragment
+// (ideas/dungeon-authoring/design.md), wrapped in a complete, valid
+// two-room file — this IS content/dungeons/reference-tomb.yaml's content,
+// not a separate lookalike. height: 8 is load-bearing: the tomb room's
+// placements use rows 1, 2, 3, 5, and 6 (boss at row 5; coffin/altar at
+// row 3; statue/skeleton/braziers at rows 1/1/2/6), so height: 8 puts
+// doorRow (height/2) at row 4, clear of all of them.
+const placedTombYAML = `
+version: 1
+key: reference-tomb
+name: The Reference Tomb
+theme: crypt
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+    place:
+      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
+      - { ref: "dnd5e:props:altar",         at: [9, 3] }
+      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
+      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
+connectors:
+  - { from: entrance, to: tomb }
+`
+
+func TestDecode_PlaceBlockRoundTrips(t *testing.T) {
+	spec, err := dungeonspec.Decode([]byte(placedTombYAML))
+	require.NoError(t, err)
+	tomb := spec.Rooms[len(spec.Rooms)-1]
+	require.Len(t, tomb.Place, 6) // coffin, altar, statue-reaper, brazier x2, skeleton
+	assert.Equal(t, "dnd5e:props:coffin", tomb.Place[0].Ref)
+	assert.Equal(t, [2]int{6, 3}, tomb.Place[0].At)
+	require.NotNil(t, tomb.Place[0].BlocksLoS)
+	assert.False(t, *tomb.Place[0].BlocksLoS)
+	assert.Equal(t, "dnd5e:monsters:skeleton", tomb.Place[5].Ref)
+	require.NotNil(t, tomb.Boss.At)
+	assert.Equal(t, [2]int{7, 5}, *tomb.Boss.At)
+}

--- a/encounter/dungeonspec/fixtures_test.go
+++ b/encounter/dungeonspec/fixtures_test.go
@@ -1,0 +1,123 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec_test
+
+// This file holds the fixtures shared across more than one test file
+// (decode_test.go, validate_test.go, compile_test.go). A fixture used by
+// only one test function belongs function-local in that file instead --
+// see e.g. compile_test.go's scatteredYAML/cryptKeyYAML.
+
+// referenceYAML is the dungeon-authoring design's §Schema v1 reference
+// example, copied verbatim (rpg-toolkit#842).
+const referenceYAML = `
+version: 1
+key: sunken-crypt
+name: The Sunken Crypt
+theme: crypt
+height: 8                      # shared by every room — the generator's real shape
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 10
+    monsters:
+      - { ref: "dnd5e:monsters:skeleton", count: 2 }
+    obstacles:
+      - { ref: "dnd5e:props:obelisk", count: 1 }
+      - { ref: "dnd5e:props:pillar", count: 2 }
+  - id: gallery
+    archetype: chamber
+    width: 8
+    monsters:
+      - { ref: "dnd5e:monsters:ghoul", count: 1 }
+  - id: trap-crossing            # v1: an empty corridor; trap content lands in the
+    archetype: corridor          # reserved ` + "`interactions`" + ` seat (see Deferred)
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain" }
+    obstacles:
+      - { ref: "dnd5e:props:coffin", count: 1, blocks_los: false }
+      - { ref: "dnd5e:props:altar", count: 1 }
+connectors:
+  - { from: entrance, to: gallery }
+  - { from: gallery, to: trap-crossing }
+  - { from: trap-crossing, to: tomb, locked: { dc: 12, ability: dex } }
+`
+
+// placedTombYAML is the dungeon-authoring design's "Schema: the place
+// block" tomb fragment (rpg-toolkit#842), wrapped in a complete, valid
+// two-room file — this IS content/dungeons/reference-tomb.yaml's content,
+// not a separate lookalike. height: 8 is load-bearing: the tomb room's
+// placements use rows 1, 2, 3, 5, and 6 (boss at row 5; coffin/altar at
+// row 3; statue/skeleton/braziers at rows 1/1/2/6), so height: 8 puts
+// doorRow (height/2) at row 4, clear of all of them.
+const placedTombYAML = `
+version: 1
+key: reference-tomb
+name: The Reference Tomb
+theme: crypt
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+    place:
+      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
+      - { ref: "dnd5e:props:altar",         at: [9, 3] }
+      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
+      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
+connectors:
+  - { from: entrance, to: tomb }
+`
+
+// validM1YAML is the M1-valid variant of referenceYAML's shape (rpg-toolkit#842):
+// same 4-room/3-connector chain (entrance -> gallery -> trap-crossing -> tomb,
+// same ids/widths/archetypes/connectors/lock DC 12), but M1-valid: entrance/
+// gallery drop their count-based monsters: blocks (their count-based
+// obstacles: stay, unaffected by the M1 restriction); the tomb room's boss:
+// gains at: [7, 5] and its obstacles: are replaced by the design delta's full
+// place: list (coffin/altar/statue-reaper/brazier x2/skeleton), occupying
+// rows 1, 2, 3, 5, and 6 — clear of doorRow (row 4, height/2).
+const validM1YAML = `
+version: 1
+key: sunken-crypt
+name: The Sunken Crypt
+theme: crypt
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 10
+    obstacles:
+      - { ref: "dnd5e:props:obelisk", count: 1 }
+      - { ref: "dnd5e:props:pillar", count: 2 }
+  - id: gallery
+    archetype: chamber
+    width: 8
+  - id: trap-crossing
+    archetype: corridor
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+    place:
+      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
+      - { ref: "dnd5e:props:altar",         at: [9, 3] }
+      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
+      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
+connectors:
+  - { from: entrance, to: gallery }
+  - { from: gallery, to: trap-crossing }
+  - { from: trap-crossing, to: tomb, locked: { dc: 12, ability: dex } }
+`

--- a/encounter/dungeonspec/spec.go
+++ b/encounter/dungeonspec/spec.go
@@ -25,7 +25,7 @@ type RoomSpec struct {
 	Monsters  []MonsterEntry  `yaml:"monsters,omitempty"`
 	Boss      *BossEntry      `yaml:"boss,omitempty"`
 	Obstacles []ObstacleEntry `yaml:"obstacles,omitempty"`
-	Place     []PlacedEntry   `yaml:"place,omitempty"` // design delta — see PlacedEntry
+	Place     []PlacedEntry   `yaml:"place,omitempty"` // static placement — see PlacedEntry
 }
 
 // MonsterEntry is a count-based monster roll for a room.
@@ -49,13 +49,13 @@ type ObstacleEntry struct {
 	PreferBorder   bool   `yaml:"prefer_border,omitempty"`   // post-design delta: toolkit#840
 }
 
-// PlacedEntry is one static placement (design.md §Design delta) — routed by
-// Ref's `module:type:id` type segment at VALIDATE time (props → obstacle,
-// monsters → spawn; see Validate), not at decode time, so a bad ref type
-// fails validation with a clear message instead of a decode error.
+// PlacedEntry is one static placement (static-placement delta, rpg-toolkit#842)
+// — routed by Ref's `module:type:id` type segment at VALIDATE time (props →
+// obstacle, monsters → spawn; see Validate), not at decode time, so a bad
+// ref type fails validation with a clear message instead of a decode error.
 type PlacedEntry struct {
 	Ref            string `yaml:"ref"`
-	At             [2]int `yaml:"at"` // [col, row], room-local — see design.md §Design delta
+	At             [2]int `yaml:"at"` // [col, row], room-local — static-placement delta, rpg-toolkit#842
 	BlocksMovement *bool  `yaml:"blocks_movement,omitempty"`
 	BlocksLoS      *bool  `yaml:"blocks_los,omitempty"`
 }

--- a/encounter/dungeonspec/spec.go
+++ b/encounter/dungeonspec/spec.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package dungeonspec decodes, validates, and compiles versioned YAML
+// dungeon specs into the engine's DungeonParams + spawn plan (rpg-toolkit#842).
+package dungeonspec
+
+// DungeonSpec is the top-level decoded shape of a dungeon spec file.
+type DungeonSpec struct {
+	Version    int             `yaml:"version"`
+	Key        string          `yaml:"key"`
+	Name       string          `yaml:"name"`
+	Theme      string          `yaml:"theme"`
+	Height     int             `yaml:"height"`
+	Rooms      []RoomSpec      `yaml:"rooms"`
+	Connectors []ConnectorSpec `yaml:"connectors"`
+}
+
+// RoomSpec is one room in a dungeon spec.
+type RoomSpec struct {
+	ID        string          `yaml:"id"`
+	Archetype string          `yaml:"archetype"` // entrance|chamber|corridor|boss
+	Width     int             `yaml:"width"`
+	Pattern   string          `yaml:"pattern,omitempty"` // ""(=empty)|empty|scattered
+	Monsters  []MonsterEntry  `yaml:"monsters,omitempty"`
+	Boss      *BossEntry      `yaml:"boss,omitempty"`
+	Obstacles []ObstacleEntry `yaml:"obstacles,omitempty"`
+	Place     []PlacedEntry   `yaml:"place,omitempty"` // design delta — see PlacedEntry
+}
+
+// MonsterEntry is a count-based monster roll for a room.
+type MonsterEntry struct {
+	Ref   string `yaml:"ref"`
+	Count int    `yaml:"count"`
+}
+
+// BossEntry designates a room's boss monster.
+type BossEntry struct {
+	Ref string  `yaml:"ref"`
+	At  *[2]int `yaml:"at,omitempty"` // design delta: nil = unpinned (v1 behavior)
+}
+
+// ObstacleEntry is a count-based rolled obstacle for a room.
+type ObstacleEntry struct {
+	Ref            string `yaml:"ref"`
+	Count          int    `yaml:"count"`
+	BlocksMovement *bool  `yaml:"blocks_movement,omitempty"` // nil => true
+	BlocksLoS      *bool  `yaml:"blocks_los,omitempty"`      // nil => true
+	PreferBorder   bool   `yaml:"prefer_border,omitempty"`   // post-design delta: toolkit#840
+}
+
+// PlacedEntry is one static placement (design.md §Design delta) — routed by
+// Ref's `module:type:id` type segment at VALIDATE time (props → obstacle,
+// monsters → spawn; see Validate), not at decode time, so a bad ref type
+// fails validation with a clear message instead of a decode error.
+type PlacedEntry struct {
+	Ref            string `yaml:"ref"`
+	At             [2]int `yaml:"at"` // [col, row], room-local — see design.md §Design delta
+	BlocksMovement *bool  `yaml:"blocks_movement,omitempty"`
+	BlocksLoS      *bool  `yaml:"blocks_los,omitempty"`
+}
+
+// ConnectorSpec joins two rooms, optionally behind a locked check.
+type ConnectorSpec struct {
+	From   string      `yaml:"from"`
+	To     string      `yaml:"to"`
+	Locked *LockedSpec `yaml:"locked,omitempty"`
+}
+
+// LockedSpec describes an ability check gating a connector.
+type LockedSpec struct {
+	DC      int    `yaml:"dc"`
+	Ability string `yaml:"ability"`
+}

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -26,6 +26,13 @@ const (
 	refTypeMonsters = "monsters"
 )
 
+// patternScattered is the one pattern value with special handling on both
+// sides of this package: Validate rejects it in combination with place/
+// pinned boss.at (validatePlaceBlock), and the compiler maps it onto
+// environments.PatternRandom (compile.go's compilePattern) -- shared here
+// so both sides name it the same way instead of repeating the literal.
+const patternScattered = "scattered"
+
 // Validate checks a decoded DungeonSpec against every generator constraint
 // the engine assumes, mirroring design.md's §Validation rules so a spec
 // that loads is a spec that plays. Checks run in a fixed order chosen so an
@@ -166,10 +173,10 @@ func validateChain(spec *DungeonSpec) error {
 
 func validatePattern(pattern string) error {
 	switch pattern {
-	case "", "empty", "scattered":
+	case "", "empty", patternScattered:
 		return nil
 	default:
-		return fmt.Errorf(`invalid pattern %q (must be "", "empty", or "scattered")`, pattern)
+		return fmt.Errorf("invalid pattern %q (must be %q, %q, or %q)", pattern, "", "empty", patternScattered)
 	}
 }
 
@@ -228,7 +235,7 @@ func validateBossRef(bossRoom *RoomSpec) error {
 // pinned boss.at, which share one collision domain.
 func validatePlaceBlock(room *RoomSpec, height int) error {
 	hasPinned := len(room.Place) > 0 || (room.Boss != nil && room.Boss.At != nil)
-	if room.Pattern == "scattered" && hasPinned {
+	if room.Pattern == patternScattered && hasPinned {
 		// Scattered interior walls are seed-rolled — no at cell can be
 		// guaranteed clear or non-wall at author time (design.md §Design
 		// delta), so the load-time contract can't hold for this combination.

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -26,12 +26,27 @@ const (
 	refTypeMonsters = "monsters"
 )
 
-// patternScattered is the one pattern value with special handling on both
-// sides of this package: Validate rejects it in combination with place/
-// pinned boss.at (validatePlaceBlock), and the compiler maps it onto
-// environments.PatternRandom (compile.go's compilePattern) -- shared here
-// so both sides name it the same way instead of repeating the literal.
-const patternScattered = "scattered"
+// The spec's author-facing pattern vocabulary, shared between
+// validatePattern/validatePlaceBlock (this file) and compile.go's
+// compilePattern, which maps patternEmpty (and "") onto
+// environments.PatternEmpty and patternScattered onto
+// environments.PatternRandom -- named once here so both sides agree.
+const (
+	patternEmpty     = "empty"
+	patternScattered = "scattered"
+)
+
+// The fixed room-archetype vocabulary, matching encounter's own
+// RegionArchetype constants (encounter/data.go) exactly -- shared between
+// validateArchetype (this file) and validateBossCardinality's "boss" check
+// below, so both name the vocabulary the same way instead of repeating the
+// literals.
+const (
+	archetypeEntrance = "entrance"
+	archetypeChamber  = "chamber"
+	archetypeCorridor = "corridor"
+	archetypeBoss     = "boss"
+)
 
 // Validate checks a decoded DungeonSpec against every generator constraint
 // the engine assumes, mirroring design.md's §Validation rules so a spec
@@ -68,6 +83,9 @@ func Validate(spec *DungeonSpec) error {
 		room := &spec.Rooms[i]
 		if room.Width < minWidth {
 			return fmt.Errorf("room %q: width must be at least %d, got %d", room.ID, minWidth, room.Width)
+		}
+		if err := validateArchetype(room.Archetype); err != nil {
+			return fmt.Errorf("room %q: %w", room.ID, err)
 		}
 		if err := validatePattern(room.Pattern); err != nil {
 			return fmt.Errorf("room %q: %w", room.ID, err)
@@ -171,12 +189,32 @@ func validateChain(spec *DungeonSpec) error {
 	return nil
 }
 
-func validatePattern(pattern string) error {
-	switch pattern {
-	case "", "empty", patternScattered:
+// validateArchetype checks a room's archetype against the fixed vocabulary
+// the engine's own RegionArchetype accepts (encounter/data.go). Without
+// this check, an author typo like "chambre" decodes and validates cleanly
+// today, and only surfaces much later as an Internal error at
+// StartEncounter (another repo) once InitDungeon's own archetype switch
+// rejects it -- exactly the failure class this package's load-time
+// contract exists to close, the same way validatePattern already does for
+// the pattern vocabulary.
+//
+//nolint:misspell // "chambre" above is the deliberate typo example, not a real misspelling
+func validateArchetype(archetype string) error {
+	switch archetype {
+	case archetypeEntrance, archetypeChamber, archetypeCorridor, archetypeBoss:
 		return nil
 	default:
-		return fmt.Errorf("invalid pattern %q (must be %q, %q, or %q)", pattern, "", "empty", patternScattered)
+		return fmt.Errorf("invalid archetype %q (must be %q, %q, %q, or %q)",
+			archetype, archetypeEntrance, archetypeChamber, archetypeCorridor, archetypeBoss)
+	}
+}
+
+func validatePattern(pattern string) error {
+	switch pattern {
+	case "", patternEmpty, patternScattered:
+		return nil
+	default:
+		return fmt.Errorf("invalid pattern %q (must be %q, %q, or %q)", pattern, "", patternEmpty, patternScattered)
 	}
 }
 
@@ -189,7 +227,7 @@ func validateBossCardinality(rooms []RoomSpec) (*RoomSpec, error) {
 	bossCount := 0
 	for i := range rooms {
 		room := &rooms[i]
-		if room.Archetype == "boss" {
+		if room.Archetype == archetypeBoss {
 			bossCount++
 			if room.Boss == nil {
 				return nil, fmt.Errorf("room %q: boss room must declare boss", room.ID)

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -1,0 +1,315 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+)
+
+const (
+	minRooms    = 2
+	minHeight   = 4
+	minWidth    = 4
+	minCount    = 1
+	minLockDC   = 1
+	maxLockDC   = 30
+	bossAxisMin = 6 // primary axis (min(boss room width, height)) must exceed this
+)
+
+const (
+	refTypeProps    = "props"
+	refTypeMonsters = "monsters"
+)
+
+// Validate checks a decoded DungeonSpec against every generator constraint
+// the engine assumes, mirroring design.md's §Validation rules so a spec
+// that loads is a spec that plays. Checks run in a fixed order chosen so an
+// author always sees the most useful error first — e.g. a too-small boss
+// room reports "primary axis" rather than an incidental out-of-bounds error
+// on one of its placed props, because the boss-axis check runs before any
+// per-cell place-block check.
+func Validate(spec *DungeonSpec) error {
+	if spec.Version != 1 {
+		return fmt.Errorf("unsupported spec version %d (must be 1)", spec.Version)
+	}
+	if strings.TrimSpace(spec.Key) == "" {
+		return fmt.Errorf("key must not be empty")
+	}
+	if strings.TrimSpace(spec.Name) == "" {
+		return fmt.Errorf("name must not be empty")
+	}
+	if spec.Height < minHeight {
+		return fmt.Errorf("height must be at least %d, got %d", minHeight, spec.Height)
+	}
+	if len(spec.Rooms) < minRooms {
+		return fmt.Errorf("must have at least %d rooms, got %d", minRooms, len(spec.Rooms))
+	}
+
+	if err := validateUniqueRoomIDs(spec.Rooms); err != nil {
+		return err
+	}
+	if err := validateChain(spec); err != nil {
+		return err
+	}
+
+	for i := range spec.Rooms {
+		room := &spec.Rooms[i]
+		if room.Width < minWidth {
+			return fmt.Errorf("room %q: width must be at least %d, got %d", room.ID, minWidth, room.Width)
+		}
+		if err := validatePattern(room.Pattern); err != nil {
+			return fmt.Errorf("room %q: %w", room.ID, err)
+		}
+	}
+
+	bossRoom, err := validateBossCardinality(spec.Rooms)
+	if err != nil {
+		return err
+	}
+
+	if err := validateBossAxis(bossRoom, spec.Height); err != nil {
+		return err
+	}
+
+	for i := range spec.Rooms {
+		room := &spec.Rooms[i]
+		if len(room.Monsters) > 0 {
+			// M1-only restriction (lifted in M2's Task C0): SeedMonsters can't
+			// yet roll count-based spawns, so a spec using them would compile
+			// but fail at runtime — the exact gap the load-time contract exists
+			// to prevent.
+			return fmt.Errorf("room %q: rolled monster placement lands in M2", room.ID)
+		}
+		for _, o := range room.Obstacles {
+			if _, err := refParts(o.Ref); err != nil {
+				return fmt.Errorf("room %q: obstacle %w", room.ID, err)
+			}
+			if o.Count < minCount {
+				return fmt.Errorf("room %q: obstacle %q count must be at least %d, got %d",
+					room.ID, o.Ref, minCount, o.Count)
+			}
+		}
+	}
+
+	if err := validateBossRef(bossRoom); err != nil {
+		return err
+	}
+	if bossRoom.Boss.At == nil {
+		// M1-only restriction, same class as the count-based-monsters check
+		// above: SeedMonsters only handles At-bearing spawns until M2.
+		return fmt.Errorf("room %q: rolled monster placement lands in M2", bossRoom.ID)
+	}
+
+	for i := range spec.Rooms {
+		if err := validatePlaceBlock(&spec.Rooms[i], spec.Height); err != nil {
+			return err
+		}
+	}
+
+	for _, c := range spec.Connectors {
+		if c.Locked != nil {
+			if err := validateLocked(c.Locked); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateUniqueRoomIDs(rooms []RoomSpec) error {
+	seen := make(map[string]bool, len(rooms))
+	for _, room := range rooms {
+		if seen[room.ID] {
+			return fmt.Errorf("duplicate room id %q", room.ID)
+		}
+		seen[room.ID] = true
+	}
+	return nil
+}
+
+// validateChain enforces the v1 generator constraint: connectors join rooms
+// in a single linear chain, in room order (rooms[i] -> rooms[i+1]).
+func validateChain(spec *DungeonSpec) error {
+	if len(spec.Connectors) != len(spec.Rooms)-1 {
+		return fmt.Errorf("connectors must form a linear chain: expected %d connectors for %d rooms, got %d",
+			len(spec.Rooms)-1, len(spec.Rooms), len(spec.Connectors))
+	}
+	for i, c := range spec.Connectors {
+		if c.From != spec.Rooms[i].ID || c.To != spec.Rooms[i+1].ID {
+			return fmt.Errorf("connectors must form a linear chain: connector %d (%s -> %s) must join room %q to room %q",
+				i, c.From, c.To, spec.Rooms[i].ID, spec.Rooms[i+1].ID)
+		}
+	}
+	return nil
+}
+
+func validatePattern(pattern string) error {
+	switch pattern {
+	case "", "empty", "scattered":
+		return nil
+	default:
+		return fmt.Errorf("invalid pattern %q (must be empty or scattered)", pattern)
+	}
+}
+
+// validateBossCardinality confirms exactly one room is the boss room (boss
+// archetype with a non-nil Boss entry) and that no other room declares one.
+// The boss-required half is permanent (never lifted by M2's Task C0); it is
+// distinct from the at-pinning check in Validate, which is M1-only.
+func validateBossCardinality(rooms []RoomSpec) (*RoomSpec, error) {
+	var bossRoom *RoomSpec
+	bossCount := 0
+	for i := range rooms {
+		room := &rooms[i]
+		if room.Archetype == "boss" {
+			bossCount++
+			if room.Boss == nil {
+				return nil, fmt.Errorf("room %q: boss room must declare boss", room.ID)
+			}
+			bossRoom = room
+		} else if room.Boss != nil {
+			return nil, fmt.Errorf("room %q: boss entry only on the boss room", room.ID)
+		}
+	}
+	if bossCount != 1 {
+		return nil, fmt.Errorf("dungeon must have exactly one boss room, found %d", bossCount)
+	}
+	return bossRoom, nil
+}
+
+func validateBossAxis(bossRoom *RoomSpec, height int) error {
+	axis := bossRoom.Width
+	if height < axis {
+		axis = height
+	}
+	if axis <= bossAxisMin {
+		return fmt.Errorf("room %q: boss room primary axis (min(width, height)=%d) must exceed %d",
+			bossRoom.ID, axis, bossAxisMin)
+	}
+	return nil
+}
+
+// validateBossRef checks the boss room's monster ref: shape, that it names
+// a monster (not a prop), and that it resolves via the registry.
+func validateBossRef(bossRoom *RoomSpec) error {
+	refType, err := refParts(bossRoom.Boss.Ref)
+	if err != nil {
+		return fmt.Errorf("room %q: boss %w", bossRoom.ID, err)
+	}
+	if refType != refTypeMonsters {
+		return fmt.Errorf("room %q: boss ref %q must be a monster ref, got type %q", bossRoom.ID, bossRoom.Boss.Ref, refType)
+	}
+	if _, ok := monsters.ByRef(bossRoom.Boss.Ref); !ok {
+		return fmt.Errorf("room %q: boss ref %q: unknown monster ref (known: %s)",
+			bossRoom.ID, bossRoom.Boss.Ref, strings.Join(monsters.Refs(), ", "))
+	}
+	return nil
+}
+
+// validatePlaceBlock validates one room's place block plus its (optional)
+// pinned boss.at, which share one collision domain.
+func validatePlaceBlock(room *RoomSpec, height int) error {
+	hasPinned := len(room.Place) > 0 || (room.Boss != nil && room.Boss.At != nil)
+	if room.Pattern == "scattered" && hasPinned {
+		// Scattered interior walls are seed-rolled — no at cell can be
+		// guaranteed clear or non-wall at author time (design.md §Design
+		// delta), so the load-time contract can't hold for this combination.
+		return fmt.Errorf("room %q: place/boss.at not allowed with pattern: scattered", room.ID)
+	}
+
+	doorRow := height / 2
+	occupied := make(map[[2]int]string, len(room.Place)+1)
+
+	if room.Boss != nil && room.Boss.At != nil {
+		at := *room.Boss.At
+		if err := checkCellBounds(room, height, at); err != nil {
+			return fmt.Errorf("room %q: boss.at %w", room.ID, err)
+		}
+		if at[1] == doorRow {
+			return fmt.Errorf("room %q: boss.at %v is on the reserved row (height/2=%d)", room.ID, at, doorRow)
+		}
+		occupied[at] = room.Boss.Ref
+	}
+
+	for _, entry := range room.Place {
+		if err := checkCellBounds(room, height, entry.At); err != nil {
+			return fmt.Errorf("room %q: place %q %w", room.ID, entry.Ref, err)
+		}
+		if entry.At[1] == doorRow {
+			return fmt.Errorf("room %q: place %q at %v is on the reserved row (height/2=%d)",
+				room.ID, entry.Ref, entry.At, doorRow)
+		}
+		if occupant, ok := occupied[entry.At]; ok {
+			return fmt.Errorf("room %q: place %q at %v is already placed (occupied by %q)",
+				room.ID, entry.Ref, entry.At, occupant)
+		}
+		occupied[entry.At] = entry.Ref
+
+		refType, err := refParts(entry.Ref)
+		if err != nil {
+			return fmt.Errorf("room %q: place %w", room.ID, err)
+		}
+		// Ref-type routing must be checked before the flags-only-on-props
+		// check below: an entry with an unrecognized ref type should always
+		// report that error, not whichever check happens to run first.
+		if refType != refTypeProps && refType != refTypeMonsters {
+			return fmt.Errorf("room %q: place ref %q must be props or monsters, got type %q",
+				room.ID, entry.Ref, refType)
+		}
+
+		if room.Boss != nil && entry.Ref == room.Boss.Ref {
+			return fmt.Errorf("room %q: boss ref may not also appear in place (ref %q)", room.ID, entry.Ref)
+		}
+
+		if refType == refTypeMonsters {
+			if _, ok := monsters.ByRef(entry.Ref); !ok {
+				return fmt.Errorf("room %q: place %q: unknown monster ref (known: %s)",
+					room.ID, entry.Ref, strings.Join(monsters.Refs(), ", "))
+			}
+			if entry.BlocksMovement != nil {
+				return fmt.Errorf("room %q: place %q: blocks_movement only valid on props", room.ID, entry.Ref)
+			}
+			if entry.BlocksLoS != nil {
+				return fmt.Errorf("room %q: place %q: blocks_los only valid on props", room.ID, entry.Ref)
+			}
+		}
+	}
+
+	return nil
+}
+
+func checkCellBounds(room *RoomSpec, height int, at [2]int) error {
+	if at[0] < 0 || at[0] >= room.Width {
+		return fmt.Errorf("out of bounds: col %d not in [0,%d)", at[0], room.Width)
+	}
+	if at[1] < 0 || at[1] >= height {
+		return fmt.Errorf("out of bounds: row %d not in [0,%d)", at[1], height)
+	}
+	return nil
+}
+
+func validateLocked(locked *LockedSpec) error {
+	if locked.DC < minLockDC || locked.DC > maxLockDC {
+		return fmt.Errorf("lock dc must be between %d and %d, got %d", minLockDC, maxLockDC, locked.DC)
+	}
+	if _, err := abilities.GetByID(locked.Ability); err != nil {
+		return fmt.Errorf("lock ability: %w", err)
+	}
+	return nil
+}
+
+// refParts returns a ref's type segment, erroring if the shape isn't
+// module:type:id with all three segments non-empty.
+func refParts(ref string) (refType string, err error) {
+	parts := strings.Split(ref, ":")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", fmt.Errorf("ref %q must be shaped like module:type:id", ref)
+	}
+	return parts[1], nil
+}

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -76,15 +76,12 @@ func Validate(spec *DungeonSpec) error {
 		return err
 	}
 
+	if err := validateM1Restrictions(spec, bossRoom); err != nil {
+		return err
+	}
+
 	for i := range spec.Rooms {
 		room := &spec.Rooms[i]
-		if len(room.Monsters) > 0 {
-			// M1-only restriction (lifted in M2's Task C0): SeedMonsters can't
-			// yet roll count-based spawns, so a spec using them would compile
-			// but fail at runtime — the exact gap the load-time contract exists
-			// to prevent.
-			return fmt.Errorf("room %q: rolled monster placement lands in M2", room.ID)
-		}
 		for _, o := range room.Obstacles {
 			if _, err := refParts(o.Ref); err != nil {
 				return fmt.Errorf("room %q: obstacle %w", room.ID, err)
@@ -99,11 +96,6 @@ func Validate(spec *DungeonSpec) error {
 	if err := validateBossRef(bossRoom); err != nil {
 		return err
 	}
-	if bossRoom.Boss.At == nil {
-		// M1-only restriction, same class as the count-based-monsters check
-		// above: SeedMonsters only handles At-bearing spawns until M2.
-		return fmt.Errorf("room %q: rolled monster placement lands in M2", bossRoom.ID)
-	}
 
 	for i := range spec.Rooms {
 		if err := validatePlaceBlock(&spec.Rooms[i], spec.Height); err != nil {
@@ -111,14 +103,37 @@ func Validate(spec *DungeonSpec) error {
 		}
 	}
 
-	for _, c := range spec.Connectors {
+	for i := range spec.Connectors {
+		c := &spec.Connectors[i]
 		if c.Locked != nil {
-			if err := validateLocked(c.Locked); err != nil {
+			if err := validateLocked(c); err != nil {
 				return err
 			}
 		}
 	}
 
+	return nil
+}
+
+// validateM1Restrictions enforces the M1-only monster/boss.at pinning
+// restriction (design.md, Task B2's "M1-only monster-pinning restriction"):
+// SeedMonsters only handles At-bearing spawns until M2's Task C0 lands
+// count-based rolling, so a spec using count-based monsters: or an unpinned
+// boss.at would compile but fail at runtime — the exact gap the load-time
+// contract exists to prevent. Both checks live in this one function so
+// C0 can lift the restriction as a pure deletion of this function and its
+// one call site in Validate (the boss-required non-nil check in
+// validateBossCardinality is a separate, permanent check C0 never touches).
+func validateM1Restrictions(spec *DungeonSpec, bossRoom *RoomSpec) error {
+	for i := range spec.Rooms {
+		room := &spec.Rooms[i]
+		if len(room.Monsters) > 0 {
+			return fmt.Errorf("room %q: monsters: rolled monster placement lands in M2", room.ID)
+		}
+	}
+	if bossRoom.Boss.At == nil {
+		return fmt.Errorf("room %q: boss.at: rolled monster placement lands in M2", bossRoom.ID)
+	}
 	return nil
 }
 
@@ -154,7 +169,7 @@ func validatePattern(pattern string) error {
 	case "", "empty", "scattered":
 		return nil
 	default:
-		return fmt.Errorf("invalid pattern %q (must be empty or scattered)", pattern)
+		return fmt.Errorf(`invalid pattern %q (must be "", "empty", or "scattered")`, pattern)
 	}
 }
 
@@ -184,10 +199,7 @@ func validateBossCardinality(rooms []RoomSpec) (*RoomSpec, error) {
 }
 
 func validateBossAxis(bossRoom *RoomSpec, height int) error {
-	axis := bossRoom.Width
-	if height < axis {
-		axis = height
-	}
+	axis := min(bossRoom.Width, height)
 	if axis <= bossAxisMin {
 		return fmt.Errorf("room %q: boss room primary axis (min(width, height)=%d) must exceed %d",
 			bossRoom.ID, axis, bossAxisMin)
@@ -294,12 +306,25 @@ func checkCellBounds(room *RoomSpec, height int, at [2]int) error {
 	return nil
 }
 
-func validateLocked(locked *LockedSpec) error {
+// validateLocked checks a connector's lock, prefixing errors with the
+// connector's location (from -> to) since a spec can have several.
+func validateLocked(c *ConnectorSpec) error {
+	locked := c.Locked
 	if locked.DC < minLockDC || locked.DC > maxLockDC {
-		return fmt.Errorf("lock dc must be between %d and %d, got %d", minLockDC, maxLockDC, locked.DC)
+		return fmt.Errorf("connector %q -> %q: lock dc must be between %d and %d, got %d",
+			c.From, c.To, minLockDC, maxLockDC, locked.DC)
 	}
 	if _, err := abilities.GetByID(locked.Ability); err != nil {
-		return fmt.Errorf("lock ability: %w", err)
+		// abilities.GetByID's error (verified empirically) renders as just
+		// "invalid ability" — its valid_options live only in structured
+		// metadata callers don't see via Error(). Build the known-abilities
+		// list ourselves, parallel to the monster known-refs treatment.
+		known := make([]string, 0, len(abilities.List()))
+		for _, a := range abilities.List() {
+			known = append(known, string(a))
+		}
+		return fmt.Errorf("connector %q -> %q: lock ability %q: %w (known: %s)",
+			c.From, c.To, locked.Ability, err, strings.Join(known, ", "))
 	}
 	return nil
 }

--- a/encounter/dungeonspec/validate_test.go
+++ b/encounter/dungeonspec/validate_test.go
@@ -1,0 +1,211 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validM1YAML is the M1-valid variant of referenceYAML's shape (rpg-toolkit#842):
+// same 4-room/3-connector chain (entrance -> gallery -> trap-crossing -> tomb,
+// same ids/widths/archetypes/connectors/lock DC 12), but M1-valid: entrance/
+// gallery drop their count-based monsters: blocks (their count-based
+// obstacles: stay, unaffected by the M1 restriction); the tomb room's boss:
+// gains at: [7, 5] and its obstacles: are replaced by the design delta's full
+// place: list (coffin/altar/statue-reaper/brazier x2/skeleton), occupying
+// rows 1, 2, 3, 5, and 6 — clear of doorRow (row 4, height/2).
+const validM1YAML = `
+version: 1
+key: sunken-crypt
+name: The Sunken Crypt
+theme: crypt
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 10
+    obstacles:
+      - { ref: "dnd5e:props:obelisk", count: 1 }
+      - { ref: "dnd5e:props:pillar", count: 2 }
+  - id: gallery
+    archetype: chamber
+    width: 8
+  - id: trap-crossing
+    archetype: corridor
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+    place:
+      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
+      - { ref: "dnd5e:props:altar",         at: [9, 3] }
+      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
+      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
+connectors:
+  - { from: entrance, to: gallery }
+  - { from: gallery, to: trap-crossing }
+  - { from: trap-crossing, to: tomb, locked: { dc: 12, ability: dex } }
+`
+
+// tomb returns validM1YAML's boss room (the last room), so mutate funcs
+// don't repeat magic indices as the fixture grows.
+func tomb(s *dungeonspec.DungeonSpec) *dungeonspec.RoomSpec {
+	return &s.Rooms[len(s.Rooms)-1]
+}
+
+// Shared substrings used by more than one table row below (goconst).
+const (
+	errRefShape = "must be shaped like module:type:id"
+	errM1Rolled = "rolled monster placement lands in M2"
+)
+
+func TestValidate_Table(t *testing.T) {
+	cases := []struct {
+		name    string
+		base    string // defaults to validM1YAML when empty
+		mutate  func(*dungeonspec.DungeonSpec)
+		wantErr string // substring; "" = valid
+	}{
+		// --- v1 core rules ---
+		{"valid reference spec", "", func(_ *dungeonspec.DungeonSpec) {}, ""},
+		{"version 2 rejected", "", func(s *dungeonspec.DungeonSpec) { s.Version = 2 }, "unsupported spec version"},
+		{"key empty rejected", "", func(s *dungeonspec.DungeonSpec) { s.Key = "" }, "key must not be empty"},
+		{"name empty rejected", "", func(s *dungeonspec.DungeonSpec) { s.Name = "" }, "name must not be empty"},
+		{"height below minimum rejected", "", func(s *dungeonspec.DungeonSpec) { s.Height = 3 },
+			"height must be at least"},
+		{"fewer than two rooms rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms = s.Rooms[:1] },
+			"must have at least"},
+		{"duplicate room id rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[1].ID = s.Rooms[0].ID },
+			"duplicate room id"},
+		{"broken chain", "", func(s *dungeonspec.DungeonSpec) { s.Connectors[1].To = "tomb" }, "linear chain"},
+		{"room width below minimum rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[0].Width = 3 },
+			"width must be at least"},
+		{"invalid pattern rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[0].Pattern = "bogus" },
+			"invalid pattern"},
+		{"boss width 5 fails axis rule", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[3].Width = 5 }, "primary axis"},
+		{"zero boss rooms rejected", "", func(s *dungeonspec.DungeonSpec) {
+			s.Rooms[3].Archetype = "chamber"
+			s.Rooms[3].Boss = nil
+		}, "exactly one boss room"},
+		{"two boss rooms rejected", "", func(s *dungeonspec.DungeonSpec) {
+			at := [2]int{2, 1}
+			s.Rooms[2].Archetype = "boss"
+			s.Rooms[2].Boss = &dungeonspec.BossEntry{Ref: "dnd5e:monsters:skeleton-captain", At: &at}
+		}, "exactly one boss room"},
+		{"boss entry only on the boss room", "", func(s *dungeonspec.DungeonSpec) {
+			at := [2]int{2, 2}
+			s.Rooms[0].Boss = &dungeonspec.BossEntry{Ref: "dnd5e:monsters:skeleton-captain", At: &at}
+		}, "boss entry only on the boss room"},
+		{"obstacle count below minimum rejected", "", func(s *dungeonspec.DungeonSpec) {
+			s.Rooms[0].Obstacles[0].Count = 0
+		}, "count must be at least"},
+		{"obstacle ref bad shape rejected", "", func(s *dungeonspec.DungeonSpec) {
+			s.Rooms[0].Obstacles[0].Ref = "bad-ref"
+		}, errRefShape},
+		{"boss ref bad shape rejected", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Boss.Ref = "not-a-real-ref"
+		}, errRefShape},
+		{"boss ref unresolvable rejected", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Boss.Ref = "dnd5e:monsters:beholder"
+		}, "unknown monster"},
+		{"lock dc out of range rejected", "", func(s *dungeonspec.DungeonSpec) {
+			s.Connectors[2].Locked.DC = 31
+		}, "dc must be between"},
+		{"lock ability unknown rejected", "", func(s *dungeonspec.DungeonSpec) {
+			s.Connectors[2].Locked.Ability = "luck"
+		}, "invalid ability"},
+
+		// --- design delta: place / boss.at ---
+		{"place at out of bounds (col)", "", func(s *dungeonspec.DungeonSpec) {
+			// row 3 deliberately, NOT the entry's real row 4 — height/2
+			// (doorRow) is ALSO row 4 (height:8), so col-99 at row 4 would
+			// double-break (col OOB + reserved row) and this row wouldn't
+			// isolate which check actually fired.
+			tomb(s).Place[0].At = [2]int{99, 3}
+		}, "out of bounds"},
+		{"place at out of bounds (row)", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Place[0].At = [2]int{6, 99}
+		}, "out of bounds"},
+		{"place ref bad shape rejected", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Place[0].Ref = "no-colons-here"
+		}, errRefShape},
+		{"place collides with another placed entry", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Place[1].At = tomb(s).Place[0].At
+		}, "already placed"},
+		{"place collides with boss.at", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Place[0].At = *tomb(s).Boss.At
+		}, "already placed"},
+		{"place on reserved row (height/2) rejected", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Place[0].At = [2]int{6, s.Height / 2}
+		}, "reserved row"},
+		{"place ref of unknown type rejected", "", func(s *dungeonspec.DungeonSpec) {
+			// Place[2] (statue-reaper) deliberately, NOT Place[0] (coffin,
+			// which sets blocks_los): this row must isolate the ref-type
+			// rule alone, not also trip "blocks_los only valid on props" on
+			// the same mutated entry.
+			tomb(s).Place[2].Ref = "dnd5e:traps:pit"
+		}, "must be props or monsters"},
+		{"blocks_los set on a monster place entry is rejected", "", func(s *dungeonspec.DungeonSpec) {
+			f := false
+			tomb(s).Place[5].BlocksLoS = &f // Place[5] is the skeleton (monster) entry
+		}, "blocks_los only valid on props"},
+		{"boss ref duplicated in place is rejected", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Place = append(tomb(s).Place, dungeonspec.PlacedEntry{Ref: tomb(s).Boss.Ref, At: [2]int{0, 0}})
+		}, "boss ref may not also appear in place"},
+		{"place monster ref unresolvable", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Place[5].Ref = "dnd5e:monsters:beholder"
+		}, "unknown monster"},
+		{"place rejected when room pattern is scattered", "", func(s *dungeonspec.DungeonSpec) {
+			// tomb has both place entries AND a pinned boss.at — either
+			// alone triggers this rule; Validate's OR condition is
+			// exercised either way.
+			tomb(s).Pattern = "scattered"
+		}, "place/boss.at not allowed with pattern: scattered"},
+		{"count-based monsters: entry rejected in M1", "", func(s *dungeonspec.DungeonSpec) {
+			s.Rooms[0].Monsters = append(s.Rooms[0].Monsters,
+				dungeonspec.MonsterEntry{Ref: "dnd5e:monsters:skeleton", Count: 2})
+		}, errM1Rolled},
+		{"unpinned boss (no at) rejected in M1", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Boss.At = nil
+		}, errM1Rolled},
+		{"boss-archetype room with no boss: entry rejected — permanent, not M1-only", "",
+			func(s *dungeonspec.DungeonSpec) { tomb(s).Boss = nil }, "boss room must declare boss"},
+
+		// --- fixture consequence: referenceYAML's own count-based monsters
+		// are M1-invalid (Task B2's documented fixture consequence). Uses
+		// referenceYAML (Task B1's decode-only fixture) instead of
+		// validM1YAML for this one row only. Removed (not flipped to ""),
+		// not kept, once M2's Task C0 lifts the M1 restriction.
+		{"referenceYAML's own count-based monsters are M1-invalid", referenceYAML,
+			func(_ *dungeonspec.DungeonSpec) {}, errM1Rolled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := tc.base
+			if base == "" {
+				base = validM1YAML
+			}
+			spec, err := dungeonspec.Decode([]byte(base))
+			require.NoError(t, err)
+
+			tc.mutate(spec)
+
+			err = dungeonspec.Validate(spec)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/encounter/dungeonspec/validate_test.go
+++ b/encounter/dungeonspec/validate_test.go
@@ -146,6 +146,10 @@ func TestValidate_Table(t *testing.T) {
 		{"place on reserved row (height/2) rejected", "", func(s *dungeonspec.DungeonSpec) {
 			tomb(s).Place[0].At = [2]int{6, s.Height / 2}
 		}, "reserved row"},
+		{"boss.at on reserved row (height/2) rejected", "", func(s *dungeonspec.DungeonSpec) {
+			at := [2]int{7, s.Height / 2}
+			tomb(s).Boss.At = &at
+		}, "reserved row"},
 		{"place ref of unknown type rejected", "", func(s *dungeonspec.DungeonSpec) {
 			// Place[2] (statue-reaper) deliberately, NOT Place[0] (coffin,
 			// which sets blocks_los): this row must isolate the ref-type
@@ -157,6 +161,10 @@ func TestValidate_Table(t *testing.T) {
 			f := false
 			tomb(s).Place[5].BlocksLoS = &f // Place[5] is the skeleton (monster) entry
 		}, "blocks_los only valid on props"},
+		{"blocks_movement set on a monster place entry is rejected", "", func(s *dungeonspec.DungeonSpec) {
+			b := true
+			tomb(s).Place[5].BlocksMovement = &b // Place[5] is the skeleton (monster) entry
+		}, "blocks_movement only valid on props"},
 		{"boss ref duplicated in place is rejected", "", func(s *dungeonspec.DungeonSpec) {
 			tomb(s).Place = append(tomb(s).Place, dungeonspec.PlacedEntry{Ref: tomb(s).Boss.Ref, At: [2]int{0, 0}})
 		}, "boss ref may not also appear in place"},

--- a/encounter/dungeonspec/validate_test.go
+++ b/encounter/dungeonspec/validate_test.go
@@ -11,50 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// validM1YAML is the M1-valid variant of referenceYAML's shape (rpg-toolkit#842):
-// same 4-room/3-connector chain (entrance -> gallery -> trap-crossing -> tomb,
-// same ids/widths/archetypes/connectors/lock DC 12), but M1-valid: entrance/
-// gallery drop their count-based monsters: blocks (their count-based
-// obstacles: stay, unaffected by the M1 restriction); the tomb room's boss:
-// gains at: [7, 5] and its obstacles: are replaced by the design delta's full
-// place: list (coffin/altar/statue-reaper/brazier x2/skeleton), occupying
-// rows 1, 2, 3, 5, and 6 — clear of doorRow (row 4, height/2).
-const validM1YAML = `
-version: 1
-key: sunken-crypt
-name: The Sunken Crypt
-theme: crypt
-height: 8
-rooms:
-  - id: entrance
-    archetype: entrance
-    width: 10
-    obstacles:
-      - { ref: "dnd5e:props:obelisk", count: 1 }
-      - { ref: "dnd5e:props:pillar", count: 2 }
-  - id: gallery
-    archetype: chamber
-    width: 8
-  - id: trap-crossing
-    archetype: corridor
-    width: 6
-  - id: tomb
-    archetype: boss
-    width: 12
-    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
-    place:
-      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
-      - { ref: "dnd5e:props:altar",         at: [9, 3] }
-      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
-      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
-      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
-      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2] }
-connectors:
-  - { from: entrance, to: gallery }
-  - { from: gallery, to: trap-crossing }
-  - { from: trap-crossing, to: tomb, locked: { dc: 12, ability: dex } }
-`
-
 // tomb returns validM1YAML's boss room (the last room), so mutate funcs
 // don't repeat magic indices as the fixture grows.
 func tomb(s *dungeonspec.DungeonSpec) *dungeonspec.RoomSpec {
@@ -91,6 +47,19 @@ func TestValidate_Table(t *testing.T) {
 			"linear chain"}, // distinct branch from "broken chain": the count check, not the per-connector match
 		{"room width below minimum rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[0].Width = 3 },
 			"width must be at least"},
+		{"invalid archetype rejected", "",
+			func(s *dungeonspec.DungeonSpec) { s.Rooms[1].Archetype = "chambre" }, //nolint:misspell
+			"invalid archetype"},
+		// gallery (rooms[1]) is a plain chamber room today; neither of these
+		// mutations trips any OTHER invariant (only "boss" is special-cased
+		// elsewhere in Validate) — chamber and boss themselves are already
+		// exercised, as-is, by every row that doesn't touch rooms[1]/[3].
+		{"archetype entrance accepted on a non-entrance room", "", func(s *dungeonspec.DungeonSpec) {
+			s.Rooms[1].Archetype = "entrance"
+		}, ""},
+		{"archetype corridor accepted on a non-corridor room", "", func(s *dungeonspec.DungeonSpec) {
+			s.Rooms[1].Archetype = "corridor"
+		}, ""},
 		{"invalid pattern rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[0].Pattern = "bogus" },
 			"invalid pattern"},
 		// Ordering guard: boss-axis must run before any per-cell place-bounds

--- a/encounter/dungeonspec/validate_test.go
+++ b/encounter/dungeonspec/validate_test.go
@@ -63,8 +63,9 @@ func tomb(s *dungeonspec.DungeonSpec) *dungeonspec.RoomSpec {
 
 // Shared substrings used by more than one table row below (goconst).
 const (
-	errRefShape = "must be shaped like module:type:id"
-	errM1Rolled = "rolled monster placement lands in M2"
+	errRefShape    = "must be shaped like module:type:id"
+	errM1Rolled    = "rolled monster placement lands in M2"
+	errOutOfBounds = "out of bounds"
 )
 
 func TestValidate_Table(t *testing.T) {
@@ -86,10 +87,16 @@ func TestValidate_Table(t *testing.T) {
 		{"duplicate room id rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[1].ID = s.Rooms[0].ID },
 			"duplicate room id"},
 		{"broken chain", "", func(s *dungeonspec.DungeonSpec) { s.Connectors[1].To = "tomb" }, "linear chain"},
+		{"connector count mismatch rejected", "", func(s *dungeonspec.DungeonSpec) { s.Connectors = s.Connectors[:1] },
+			"linear chain"}, // distinct branch from "broken chain": the count check, not the per-connector match
 		{"room width below minimum rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[0].Width = 3 },
 			"width must be at least"},
 		{"invalid pattern rejected", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[0].Pattern = "bogus" },
 			"invalid pattern"},
+		// Ordering guard: boss-axis must run before any per-cell place-bounds
+		// check, so shrinking the boss room reports "primary axis" and not an
+		// incidental "out of bounds" on one of its now-too-far-out place
+		// entries (the tomb room's place list uses col 9 for the altar).
 		{"boss width 5 fails axis rule", "", func(s *dungeonspec.DungeonSpec) { s.Rooms[3].Width = 5 }, "primary axis"},
 		{"zero boss rooms rejected", "", func(s *dungeonspec.DungeonSpec) {
 			s.Rooms[3].Archetype = "chamber"
@@ -116,6 +123,9 @@ func TestValidate_Table(t *testing.T) {
 		{"boss ref unresolvable rejected", "", func(s *dungeonspec.DungeonSpec) {
 			tomb(s).Boss.Ref = "dnd5e:monsters:beholder"
 		}, "unknown monster"},
+		{"boss ref must be a monster ref rejected", "", func(s *dungeonspec.DungeonSpec) {
+			tomb(s).Boss.Ref = "dnd5e:props:coffin"
+		}, "must be a monster ref"},
 		{"lock dc out of range rejected", "", func(s *dungeonspec.DungeonSpec) {
 			s.Connectors[2].Locked.DC = 31
 		}, "dc must be between"},
@@ -130,10 +140,10 @@ func TestValidate_Table(t *testing.T) {
 			// double-break (col OOB + reserved row) and this row wouldn't
 			// isolate which check actually fired.
 			tomb(s).Place[0].At = [2]int{99, 3}
-		}, "out of bounds"},
+		}, errOutOfBounds},
 		{"place at out of bounds (row)", "", func(s *dungeonspec.DungeonSpec) {
 			tomb(s).Place[0].At = [2]int{6, 99}
-		}, "out of bounds"},
+		}, errOutOfBounds},
 		{"place ref bad shape rejected", "", func(s *dungeonspec.DungeonSpec) {
 			tomb(s).Place[0].Ref = "no-colons-here"
 		}, errRefShape},
@@ -150,6 +160,10 @@ func TestValidate_Table(t *testing.T) {
 			at := [2]int{7, s.Height / 2}
 			tomb(s).Boss.At = &at
 		}, "reserved row"},
+		{"boss.at out of bounds rejected", "", func(s *dungeonspec.DungeonSpec) {
+			at := [2]int{99, 5}
+			tomb(s).Boss.At = &at
+		}, errOutOfBounds},
 		{"place ref of unknown type rejected", "", func(s *dungeonspec.DungeonSpec) {
 			// Place[2] (statue-reaper) deliberately, NOT Place[0] (coffin,
 			// which sets blocks_los): this row must isolate the ref-type
@@ -184,6 +198,10 @@ func TestValidate_Table(t *testing.T) {
 		{"unpinned boss (no at) rejected in M1", "", func(s *dungeonspec.DungeonSpec) {
 			tomb(s).Boss.At = nil
 		}, errM1Rolled},
+		// Ordering guard: boss-required (non-nil Boss) must be checked in
+		// validateBossCardinality before anything downstream dereferences
+		// bossRoom.Boss (axis, ref resolution, M1 at-pinning, place-block) —
+		// this row proves the guard fires first instead of a nil dereference.
 		{"boss-archetype room with no boss: entry rejected — permanent, not M1-only", "",
 			func(s *dungeonspec.DungeonSpec) { tomb(s).Boss = nil }, "boss room must declare boss"},
 

--- a/encounter/dungeonspec/workbench.go
+++ b/encounter/dungeonspec/workbench.go
@@ -104,6 +104,16 @@ func writeSpawnPlan(b *strings.Builder, spawns []SpawnInstruction) {
 // Space coordinates, since LocalHex is already the same room-local frame
 // the author's own place: block used.
 func writePlacedObstacles(b *strings.Builder, regions []encounter.DungeonRegionParams) {
+	hasPlaced := false
+	for _, r := range regions {
+		if len(r.PlacedObstacles) > 0 {
+			hasPlaced = true
+			break
+		}
+	}
+	if !hasPlaced {
+		return // nothing placed in this spec -- an empty header/section would just be noise
+	}
 	fmt.Fprintln(b, "placed props (exact coordinates):")
 	for _, r := range regions {
 		for _, p := range r.PlacedObstacles {
@@ -115,25 +125,29 @@ func writePlacedObstacles(b *strings.Builder, regions []encounter.DungeonRegionP
 
 // floorPlanLegend documents the ASCII floor plan's marker vocabulary,
 // printed once ahead of the grid so the symbols are self-describing.
-const floorPlanLegend = "floor plan (. floor, # wall/perimeter, D door, o obstacle):"
+const floorPlanLegend = "floor plan (. floor, # wall, D door, o obstacle, @ entrance):"
 
-// writeFloorPlan renders the encounter's committed Space (plus its Doors,
-// which live on Data, not SpaceData) as an ASCII grid: '.' floor, '#'
-// every wall cell, 'D' a door, 'o' an obstacle (rolled or placed alike --
-// writePlacedObstacles already calls out placed ones by name and exact
-// coordinate separately, so the map doesn't need a second, distinct
-// marker to carry that distinction too).
+// writeFloorPlan renders the encounter's committed Space (plus its Doors
+// and Entrance, which live on Data/SpaceData respectively) as an ASCII
+// grid: '.' floor, '#' an actual wall cell, 'D' a door, 'o' an obstacle
+// (rolled or placed alike -- writePlacedObstacles already calls out
+// placed ones by name and exact coordinate separately, so the map doesn't
+// need a second, distinct marker to carry that distinction too), '@' the
+// designated entrance cell (SpaceData.Entrance).
 //
-// PERIMETER-EDGE FOLDING: SpaceData.Walls carries two shapes (see that
-// field's doc) -- degenerate (Start == End, one blocked interior hex) and
-// boundary-edge (Start != End, a render-only outer-perimeter marker whose
-// End lies outside the grid). This renderer only ever looks at Start, so
-// both shapes land on the SAME '#' marker -- a boundary-edge segment's
-// Start is real floor that also happens to sit on the room's outer edge,
-// and this coarse a grid has no sub-cell resolution to draw a distinct
-// edge glyph there. That's the "fold into whatever's cheap" call this
-// package's doc comments elsewhere point authors back to this function
-// for.
+// DEGENERATE WALLS ONLY -- a decision, not a shortcut: SpaceData.Walls
+// carries two shapes (see that field's doc). Degenerate (Start == End) is
+// an actual blocked interior hex; boundary-edge (Start != End) is a
+// render-only outer-perimeter marker added for rpg-dnd5e-web's client
+// (rpg-toolkit#834) whose Start is real WALKABLE floor -- never a
+// spatial.Room blocker. An earlier version of this renderer folded both
+// shapes into the same '#' marker for simplicity; that was wrong, not
+// merely imprecise, because most of a dungeon's outer edge is
+// boundary-edge-only, INCLUDING the entrance region's own spawn column
+// (SpaceData.Entrance sits at the room's far edge, design.md/dungeon.go's
+// "just inside the entrance, not center") -- folding rendered the party's
+// own spawn point as a wall. This renderer skips boundary-edge segments
+// outright instead.
 func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
 	fmt.Fprintln(b, floorPlanLegend)
 	sd := data.Space
@@ -149,16 +163,24 @@ func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
 			grid[row][col] = '.'
 		}
 	}
+	// set is defensive, not load-bearing: every coordinate passed to it
+	// below is already guaranteed in-bounds -- walls/doors/obstacles by
+	// InitDungeon's own validation, Entrance by construction. The bounds
+	// check exists so a violation of that assumption drops the mark
+	// silently instead of panicking the whole report on a slice index.
 	set := func(h core.Hex, r rune) {
 		pos := h.ToPosition()
 		col, row := int(pos.X), int(pos.Y)
 		if row < 0 || row >= sd.Height || col < 0 || col >= sd.Width {
-			return // out-of-bounds perimeter endpoint (boundary-edge End) -- nothing to mark
+			return
 		}
 		grid[row][col] = r
 	}
 
 	for _, w := range sd.Walls {
+		if w.Start != w.End {
+			continue // boundary-edge: render-only perimeter marker, not a real wall -- see doc above
+		}
 		set(core.HexFromCube(w.Start), '#')
 	}
 	for _, door := range data.Doors {
@@ -167,6 +189,7 @@ func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
 	for _, o := range sd.Obstacles {
 		set(o.Position, 'o')
 	}
+	set(sd.Entrance, '@')
 
 	rows := make([]string, sd.Height)
 	for row := range grid {

--- a/encounter/dungeonspec/workbench.go
+++ b/encounter/dungeonspec/workbench.go
@@ -1,0 +1,177 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// WorkbenchReport is the fast-authoring-loop entry point (design.md's
+// observability addendum, rpg-toolkit#842): compile raw spec bytes at a
+// given seed and describe the result as human-readable text, without a
+// server. An author edits a YAML file, runs the workbench CLI
+// (encounter/cmd/dungeonspec-workbench), and sees the layout in seconds.
+//
+// A spec that fails to Load (Decode or Validate) still returns a non-empty
+// report -- naming the verdict INVALID and the error -- alongside the
+// error itself, so a caller (the CLI) always has something to print. A
+// spec that Loads successfully is then run through a throwaway
+// Encounter.InitDungeon at seed so the report's floor plan reflects the
+// SAME wall/door/obstacle generation a real encounter would produce at
+// that seed -- not a re-derivation of the compiler's own output.
+//
+// seed 0 is entropy-seeded (matches DungeonParams.RandomSeed's own zero-
+// value contract) -- pass a non-zero seed for a reproducible report.
+func WorkbenchReport(raw []byte, seed int64) (string, error) {
+	compiled, err := Load(raw)
+	if err != nil {
+		return fmt.Sprintf("verdict: INVALID\nseed: %d\nerror: %s\n", seed, err), err
+	}
+	compiled.Params.RandomSeed = seed
+
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	enc := encounter.New(context.Background(), "workbench", broker)
+	if err := enc.InitDungeon(compiled.Params); err != nil {
+		return fmt.Sprintf("verdict: INVALID\nseed: %d\nerror: init dungeon: %s\n", seed, err), err
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "verdict: VALID\nseed %d\n\n", seed)
+	writeRegions(&b, compiled.Params.Regions)
+	writeConnectors(&b, compiled.Params.Connectors)
+	writeSpawnPlan(&b, compiled.Spawns)
+	writePlacedObstacles(&b, compiled.Params.Regions)
+	writeFloorPlan(&b, enc.ToData())
+	return b.String(), nil
+}
+
+// writeRegions lists every region's id/archetype/width -- the "region ids
+// as a legend" the floor plan itself doesn't spell out per-cell.
+func writeRegions(b *strings.Builder, regions []encounter.DungeonRegionParams) {
+	fmt.Fprintln(b, "regions:")
+	for _, r := range regions {
+		fmt.Fprintf(b, "  %s [%s] width=%d\n", r.ID, r.Archetype, r.Width)
+	}
+	fmt.Fprintln(b)
+}
+
+// writeConnectors names each door in chain order, including lock state --
+// an author checking "is this door supposed to be locked" shouldn't have
+// to cross-reference the source YAML.
+func writeConnectors(b *strings.Builder, connectors []encounter.DungeonConnectorParams) {
+	fmt.Fprintln(b, "connectors:")
+	for i, c := range connectors {
+		lock := ""
+		if c.Locked {
+			lock = fmt.Sprintf(" locked dc=%d ability=%s", c.LockDC, c.LockAbility)
+		}
+		fmt.Fprintf(b, "  connector %d: door %s%s\n", i, c.DoorID, lock)
+	}
+	fmt.Fprintln(b)
+}
+
+// writeSpawnPlan renders the compiled spawn plan boss-first (compile()'s
+// own ordering contract) -- rolled (At == nil, M2's Task C0) spawns print
+// "rolled" in place of a coordinate rather than a misleading col=0 row=0.
+func writeSpawnPlan(b *strings.Builder, spawns []SpawnInstruction) {
+	fmt.Fprintln(b, "spawn plan (boss first):")
+	for i, s := range spawns {
+		role := ""
+		if i == 0 {
+			role = " (boss)"
+		}
+		at := "rolled"
+		if s.At != nil {
+			at = s.At.String()
+		}
+		fmt.Fprintf(b, "  %d. %s%s in %s at %s\n", i+1, s.MonsterRef, role, s.RoomID, at)
+	}
+	fmt.Fprintln(b)
+}
+
+// writePlacedObstacles lists every PlacedObstacleSpec at its exact
+// room-local coordinate -- the delta addition's own requirement (design.md
+// §Design delta): a placed prop must be nameable at its exact compiled
+// cell, not just "somewhere in the room." Read directly off
+// compiled.Params rather than re-derived from the encounter's absolute
+// Space coordinates, since LocalHex is already the same room-local frame
+// the author's own place: block used.
+func writePlacedObstacles(b *strings.Builder, regions []encounter.DungeonRegionParams) {
+	fmt.Fprintln(b, "placed props (exact coordinates):")
+	for _, r := range regions {
+		for _, p := range r.PlacedObstacles {
+			fmt.Fprintf(b, "  %s: %s at %s\n", r.ID, p.Ref, p.At.String())
+		}
+	}
+	fmt.Fprintln(b)
+}
+
+// floorPlanLegend documents the ASCII floor plan's marker vocabulary,
+// printed once ahead of the grid so the symbols are self-describing.
+const floorPlanLegend = "floor plan (. floor, # wall/perimeter, D door, o obstacle):"
+
+// writeFloorPlan renders the encounter's committed Space (plus its Doors,
+// which live on Data, not SpaceData) as an ASCII grid: '.' floor, '#'
+// every wall cell, 'D' a door, 'o' an obstacle (rolled or placed alike --
+// writePlacedObstacles already calls out placed ones by name and exact
+// coordinate separately, so the map doesn't need a second, distinct
+// marker to carry that distinction too).
+//
+// PERIMETER-EDGE FOLDING: SpaceData.Walls carries two shapes (see that
+// field's doc) -- degenerate (Start == End, one blocked interior hex) and
+// boundary-edge (Start != End, a render-only outer-perimeter marker whose
+// End lies outside the grid). This renderer only ever looks at Start, so
+// both shapes land on the SAME '#' marker -- a boundary-edge segment's
+// Start is real floor that also happens to sit on the room's outer edge,
+// and this coarse a grid has no sub-cell resolution to draw a distinct
+// edge glyph there. That's the "fold into whatever's cheap" call this
+// package's doc comments elsewhere point authors back to this function
+// for.
+func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
+	fmt.Fprintln(b, floorPlanLegend)
+	sd := data.Space
+	if sd == nil {
+		fmt.Fprintln(b, "(no space)")
+		return
+	}
+
+	grid := make([][]rune, sd.Height)
+	for row := range grid {
+		grid[row] = make([]rune, sd.Width)
+		for col := range grid[row] {
+			grid[row][col] = '.'
+		}
+	}
+	set := func(h core.Hex, r rune) {
+		pos := h.ToPosition()
+		col, row := int(pos.X), int(pos.Y)
+		if row < 0 || row >= sd.Height || col < 0 || col >= sd.Width {
+			return // out-of-bounds perimeter endpoint (boundary-edge End) -- nothing to mark
+		}
+		grid[row][col] = r
+	}
+
+	for _, w := range sd.Walls {
+		set(core.HexFromCube(w.Start), '#')
+	}
+	for _, door := range data.Doors {
+		set(door.Position, 'D')
+	}
+	for _, o := range sd.Obstacles {
+		set(o.Position, 'o')
+	}
+
+	rows := make([]string, sd.Height)
+	for row := range grid {
+		rows[row] = string(grid[row])
+	}
+	fmt.Fprintln(b, strings.Join(rows, "\n"))
+	fmt.Fprintln(b)
+}

--- a/encounter/dungeonspec/workbench.go
+++ b/encounter/dungeonspec/workbench.go
@@ -24,7 +24,18 @@ import (
 // spec that Loads successfully is then run through a throwaway
 // Encounter.InitDungeon at seed so the report's floor plan reflects the
 // SAME wall/door/obstacle generation a real encounter would produce at
-// that seed -- not a re-derivation of the compiler's own output.
+// that seed -- not a re-derivation of the compiler's own output -- and
+// then through SeedMonsters (no AddPlayer call first: this is a
+// throwaway single-report encounter, not a live one, and SeedMonsters'
+// combat-entry check is harmless with zero players seated), the third leg
+// of the same pipeline Load's own doc names (InitDungeon -> AddPlayer ->
+// SeedMonsters). Running it here is not optional: rpg-toolkit#842's gate
+// finding was a spec that Loaded and InitDungeon'd cleanly could still
+// fail at THIS step, on some fraction of seeds, because a placed
+// monster's cell hadn't been reserved from the rolled-obstacle draw --
+// without this call, the workbench would report VALID on a spec that
+// SeedMonsters actually rejects, exactly the failure mode this tool
+// exists to catch before an author ships a spec.
 //
 // seed 0 is entropy-seeded (matches DungeonParams.RandomSeed's own zero-
 // value contract) -- pass a non-zero seed for a reproducible report.
@@ -41,6 +52,9 @@ func WorkbenchReport(raw []byte, seed int64) (string, error) {
 	if err := enc.InitDungeon(compiled.Params); err != nil {
 		return fmt.Sprintf("verdict: INVALID\nseed: %d\nerror: init dungeon: %s\n", seed, err), err
 	}
+	if err := enc.SeedMonsters(compiled.Spawns); err != nil {
+		return fmt.Sprintf("verdict: INVALID\nseed: %d\nerror: seed monsters: %s\n", seed, err), err
+	}
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "verdict: VALID\nseed %d\n\n", seed)
@@ -48,6 +62,7 @@ func WorkbenchReport(raw []byte, seed int64) (string, error) {
 	writeConnectors(&b, compiled.Params.Connectors)
 	writeSpawnPlan(&b, compiled.Spawns)
 	writePlacedObstacles(&b, compiled.Params.Regions)
+	fmt.Fprintf(&b, "seeded %d monster(s)\n\n", len(enc.ToData().Monsters))
 	writeFloorPlan(&b, enc.ToData())
 	return b.String(), nil
 }

--- a/encounter/dungeonspec/workbench_test.go
+++ b/encounter/dungeonspec/workbench_test.go
@@ -35,11 +35,14 @@ func TestWorkbenchReport_ValidSpec(t *testing.T) {
 	assert.Contains(t, report, "verdict: VALID")
 	assert.Contains(t, report, "seed 42")
 	assert.Contains(t, report, "dnd5e:monsters:skeleton-captain (boss)") // spawn plan: actual boss spawn
-	// entrance (width 6) + a real wall at the region-boundary column (col
-	// 6) + tomb (width 12, no obstacle on this particular row): a mutant
-	// that draws no walls, or shifts any coordinate by even one column,
-	// cannot produce this exact string.
-	assert.Contains(t, report, "......#............")
+	// Row 3: entrance (width 6) floor, the real wall at the region-boundary
+	// column (col 6), then tomb-local row 3's own two placed obstacles --
+	// the coffin (tomb-local col 6 -> absolute col 13) and the altar
+	// (tomb-local col 9 -> absolute col 16). placedTombYAML has no
+	// count-based (randomly rolled) obstacles, so this row is stable across
+	// seeds. A mutant that draws no walls, drops an obstacle, or shifts any
+	// coordinate by even one column cannot produce this exact string.
+	assert.Contains(t, report, "......#......o..o..")
 }
 
 // TestWorkbenchReport_InvalidSpecShowsVerdict pins the other half of the

--- a/encounter/dungeonspec/workbench_test.go
+++ b/encounter/dungeonspec/workbench_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkbenchReport_ValidSpec pins the fast-authoring-loop contract
+// (design.md's observability addendum, rpg-toolkit#842): a valid spec
+// produces a VALID verdict naming the seed, the boss-first spawn plan,
+// and an ASCII floor plan (walls render as '#') -- everything an author
+// needs to eyeball a layout without standing up a server.
+//
+// placedTombYAML, not referenceYAML/a crypt fixture: referenceYAML's own
+// count-based monsters fail Validate in M1 (Task B2's fixture
+// consequence, same reason compile_test.go/validate_test.go avoid it for
+// their own M1-valid assertions).
+func TestWorkbenchReport_ValidSpec(t *testing.T) {
+	report, err := dungeonspec.WorkbenchReport([]byte(placedTombYAML), 42)
+	require.NoError(t, err)
+	assert.Contains(t, report, "VALID")
+	assert.Contains(t, report, "seed 42")
+	assert.Contains(t, report, "boss") // spawn plan section
+	assert.Contains(t, report, "#")    // ASCII map: walls
+}
+
+// TestWorkbenchReport_InvalidSpecShowsVerdict pins the other half of the
+// contract: an invalid spec still returns a report (not just an error) so
+// the CLI has something to print, and that report says INVALID rather
+// than silently looking like a truncated valid one.
+func TestWorkbenchReport_InvalidSpecShowsVerdict(t *testing.T) {
+	report, err := dungeonspec.WorkbenchReport([]byte("version: 1\n"), 1)
+	require.Error(t, err)
+	assert.Contains(t, report, "INVALID")
+}
+
+// TestWorkbenchReport_PlacedEntriesAtExactCoordinates pins the delta
+// addition (design.md §Design delta): a placed prop must show up in the
+// report at its exact compiled coordinate, not just "an obstacle
+// somewhere in the room" -- placedTombYAML's tomb room places a coffin at
+// [6, 3].
+func TestWorkbenchReport_PlacedEntriesAtExactCoordinates(t *testing.T) {
+	report, err := dungeonspec.WorkbenchReport([]byte(placedTombYAML), 7)
+	require.NoError(t, err)
+	assert.Contains(t, report, "coffin")
+	assert.Contains(t, report, "col=6 row=3")
+}

--- a/encounter/dungeonspec/workbench_test.go
+++ b/encounter/dungeonspec/workbench_test.go
@@ -14,8 +14,16 @@ import (
 // TestWorkbenchReport_ValidSpec pins the fast-authoring-loop contract
 // (design.md's observability addendum, rpg-toolkit#842): a valid spec
 // produces a VALID verdict naming the seed, the boss-first spawn plan,
-// and an ASCII floor plan (walls render as '#') -- everything an author
-// needs to eyeball a layout without standing up a server.
+// and an ASCII floor plan -- everything an author needs to eyeball a
+// layout without standing up a server.
+//
+// Assertions target generated CONTENT, not static header/legend text a
+// report could satisfy while broken: "verdict: VALID" (not bare "VALID",
+// which "verdict: INVALID" also contains -- an always-INVALID mutant must
+// fail this), the boss spawn's actual monster ref (not just the word
+// "boss", which the region legend/section headers also contain
+// regardless of whether any spawn printed), and a specific floor-plan
+// row -- see the comment on that assertion below.
 //
 // placedTombYAML, not referenceYAML/a crypt fixture: referenceYAML's own
 // count-based monsters fail Validate in M1 (Task B2's fixture
@@ -24,10 +32,14 @@ import (
 func TestWorkbenchReport_ValidSpec(t *testing.T) {
 	report, err := dungeonspec.WorkbenchReport([]byte(placedTombYAML), 42)
 	require.NoError(t, err)
-	assert.Contains(t, report, "VALID")
+	assert.Contains(t, report, "verdict: VALID")
 	assert.Contains(t, report, "seed 42")
-	assert.Contains(t, report, "boss") // spawn plan section
-	assert.Contains(t, report, "#")    // ASCII map: walls
+	assert.Contains(t, report, "dnd5e:monsters:skeleton-captain (boss)") // spawn plan: actual boss spawn
+	// entrance (width 6) + a real wall at the region-boundary column (col
+	// 6) + tomb (width 12, no obstacle on this particular row): a mutant
+	// that draws no walls, or shifts any coordinate by even one column,
+	// cannot produce this exact string.
+	assert.Contains(t, report, "......#............")
 }
 
 // TestWorkbenchReport_InvalidSpecShowsVerdict pins the other half of the
@@ -44,10 +56,34 @@ func TestWorkbenchReport_InvalidSpecShowsVerdict(t *testing.T) {
 // addition (design.md §Design delta): a placed prop must show up in the
 // report at its exact compiled coordinate, not just "an obstacle
 // somewhere in the room" -- placedTombYAML's tomb room places a coffin at
-// [6, 3].
+// [6, 3]. Asserted as ONE paired string (ref and coordinate together, not
+// two separate Contains checks) so a mutant that prints the right refs
+// and the right coordinates but MIS-PAIRS them (e.g. coffin's ref next to
+// altar's coordinate) still fails this test.
 func TestWorkbenchReport_PlacedEntriesAtExactCoordinates(t *testing.T) {
 	report, err := dungeonspec.WorkbenchReport([]byte(placedTombYAML), 7)
 	require.NoError(t, err)
-	assert.Contains(t, report, "coffin")
-	assert.Contains(t, report, "col=6 row=3")
+	assert.Contains(t, report, "dnd5e:props:coffin at col=6 row=3")
+}
+
+// TestWorkbenchReport_FloorPlanRendersEntranceAndWalkablePerimeter pins
+// the floor plan's honesty contract: SpaceData.Walls carries a
+// render-only "boundary-edge" shape (rpg-toolkit#834) whose Start is real
+// WALKABLE floor, distinct from an actual blocking wall (see
+// writeFloorPlan's doc) -- the floor plan must not draw those as '#'.
+func TestWorkbenchReport_FloorPlanRendersEntranceAndWalkablePerimeter(t *testing.T) {
+	report, err := dungeonspec.WorkbenchReport([]byte(placedTombYAML), 42)
+	require.NoError(t, err)
+	// The entrance sits at the room's far edge, on the SAME row as the
+	// door joining entrance->tomb (design.md/dungeon.go: "just inside the
+	// entrance, not center") -- '@' at col 0, 'D' at col 6, floor between
+	// and after. A renderer that folds boundary-edge segments into '#'
+	// (as an earlier version of this one did) draws the party's own spawn
+	// cell as a wall instead.
+	assert.Contains(t, report, "@.....D............")
+	// A door-free row elsewhere in the entrance region: its own left edge
+	// (col 0) is a walkable PERIMETER cell -- under the old (incorrect)
+	// boundary-edge-folding renderer this rendered as a wall too, even
+	// though nothing ever blocks movement there.
+	assert.Contains(t, report, "......#............")
 }

--- a/encounter/dungeonspec/workbench_test.go
+++ b/encounter/dungeonspec/workbench_test.go
@@ -14,27 +14,36 @@ import (
 // TestWorkbenchReport_ValidSpec pins the fast-authoring-loop contract
 // (design.md's observability addendum, rpg-toolkit#842): a valid spec
 // produces a VALID verdict naming the seed, the boss-first spawn plan,
-// and an ASCII floor plan -- everything an author needs to eyeball a
-// layout without standing up a server.
+// confirmation that SeedMonsters actually ran, and an ASCII floor plan --
+// everything an author needs to eyeball a layout without standing up a
+// server.
 //
 // Assertions target generated CONTENT, not static header/legend text a
 // report could satisfy while broken: "verdict: VALID" (not bare "VALID",
 // which "verdict: INVALID" also contains -- an always-INVALID mutant must
 // fail this), the boss spawn's actual monster ref (not just the word
 // "boss", which the region legend/section headers also contain
-// regardless of whether any spawn printed), and a specific floor-plan
-// row -- see the comment on that assertion below.
+// regardless of whether any spawn printed), the seeded-monster COUNT (not
+// just that SeedMonsters was called -- a mutant that calls it but ignores
+// its error, or a stray extra/dropped monster, still fails this), and a
+// specific floor-plan row -- see the comment on that assertion below.
 //
 // placedTombYAML, not referenceYAML/a crypt fixture: referenceYAML's own
 // count-based monsters fail Validate in M1 (Task B2's fixture
 // consequence, same reason compile_test.go/validate_test.go avoid it for
-// their own M1-valid assertions).
+// their own M1-valid assertions). placedTombYAML has no count-based
+// (rolled) obstacles at all, so the SeedMonsters step this test also pins
+// (rpg-toolkit#842's gate finding: SeedMonsters can fail even after a
+// clean Load+InitDungeon) can never fail for THIS fixture -- see
+// TestLoad_PlacedMonsterCellsReservedFromRolledObstacles (compile_test.go)
+// for the regression test that actually exercises the failure mode.
 func TestWorkbenchReport_ValidSpec(t *testing.T) {
 	report, err := dungeonspec.WorkbenchReport([]byte(placedTombYAML), 42)
 	require.NoError(t, err)
 	assert.Contains(t, report, "verdict: VALID")
 	assert.Contains(t, report, "seed 42")
 	assert.Contains(t, report, "dnd5e:monsters:skeleton-captain (boss)") // spawn plan: actual boss spawn
+	assert.Contains(t, report, "seeded 2 monster(s)")                    // boss + the tomb's one placed skeleton
 	// Row 3: entrance (width 6) floor, the real wall at the region-boundary
 	// column (col 6), then tomb-local row 3's own two placed obstacles --
 	// the coffin (tomb-local col 6 -> absolute col 13) and the altar
@@ -89,4 +98,47 @@ func TestWorkbenchReport_FloorPlanRendersEntranceAndWalkablePerimeter(t *testing
 	// boundary-edge-folding renderer this rendered as a wall too, even
 	// though nothing ever blocks movement there.
 	assert.Contains(t, report, "......#............")
+}
+
+// TestWorkbenchReport_SeedMonstersRunsAndCanFailTheVerdict proves the
+// workbench actually runs SeedMonsters as the third leg of the pipeline
+// (Load -> InitDungeon -> SeedMonsters), not just the first two --
+// rpg-toolkit#842's gate finding was a spec that Loaded and InitDungeon'd
+// cleanly could still fail at SeedMonsters, on some fraction of seeds,
+// because a placed monster's cell hadn't been reserved from the
+// rolled-obstacle draw. An earlier version of WorkbenchReport never called
+// SeedMonsters at all, so it reported VALID regardless -- this test's
+// fixture mixes count-based obstacles with a placed monster in the SAME
+// room (mirrors compile_test.go's
+// TestLoad_PlacedMonsterCellsReservedFromRolledObstacles, which
+// regression-tests the same fixture shape directly against the encounter
+// package) and sweeps seeds through the actual public WorkbenchReport
+// surface an author/the CLI uses, not just the lower-level API.
+func TestWorkbenchReport_SeedMonstersRunsAndCanFailTheVerdict(t *testing.T) {
+	const mixedYAML = `
+version: 1
+key: workbench-seedmonsters-check
+name: Workbench SeedMonsters Check
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5] }
+    obstacles:
+      - { ref: "dnd5e:props:pillar", count: 40 }
+    place:
+      - { ref: "dnd5e:monsters:skeleton", at: [4, 2] }
+connectors:
+  - { from: entrance, to: tomb }
+`
+	for seed := int64(1); seed <= 20; seed++ {
+		report, err := dungeonspec.WorkbenchReport([]byte(mixedYAML), seed)
+		require.NoError(t, err, "seed %d", seed)
+		assert.Contains(t, report, "verdict: VALID", "seed %d", seed)
+		assert.Contains(t, report, "seeded 2 monster(s)", "seed %d", seed)
+	}
 }

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -442,6 +442,28 @@ func (e *Encounter) AddDoor(id core.EntityID, position core.Hex, open bool) erro
 // melee capability auto-fire their OA reaction — no prompt needed for NPC
 // reactors per the wave's architectural call.
 func (e *Encounter) AddMonster(input MonsterInput) error {
+	if err := e.addMonsterNoCombatCheck(input); err != nil {
+		return err
+	}
+	// Combat-entry check (rpg-toolkit#757): a newly-added monster may already
+	// be visible to an existing player (e.g. spawned inside an already-open
+	// LoS), so this mutation site needs the same check as Move.
+	return e.checkCombatEntry()
+}
+
+// addMonsterNoCombatCheck does everything AddMonster does except the
+// final combat-entry check. SeedMonsters (#842) uses this to stage every
+// spawn in a batch before running exactly ONE checkCombatEntry pass at
+// the end — so a partial roster mid-batch (e.g. a not-yet-visible boss
+// added before an already-visible entrance monster) can never trigger a
+// premature, incomplete initiative roll the way a naive per-spawn
+// AddMonster loop would (see combat_entry_test.go's
+// TestIdempotent_AddMonsterAndMoveAfterCombatStarted: once combat has
+// started, EVERY subsequent AddMonster joins initiative unconditionally,
+// regardless of that monster's own visibility). AddMonster itself is
+// unchanged for every other caller — this is a pure extraction, not a
+// behavior change.
+func (e *Encounter) addMonsterNoCombatCheck(input MonsterInput) error {
 	if input.ID == "" {
 		return errors.New("monster ID required")
 	}
@@ -493,11 +515,7 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 			return fmt.Errorf("publish monster appeared on add: %w", err)
 		}
 	}
-
-	// Combat-entry check (rpg-toolkit#757): a newly-added monster may already
-	// be visible to an existing player (e.g. spawned inside an already-open
-	// LoS), so this mutation site needs the same check as Move.
-	return e.checkCombatEntry()
+	return nil
 }
 
 // seedOAReadiness initialises an entity's readiness map (if needed) and

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -20,5 +21,4 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.5-0.20260720004354-a89a5e000bd7
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.1-0.20260725014520-a740d9672fb6
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.0
 	github.com/stretchr/testify v1.11.1

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.5-0.20260720004354-a89a5e000bd7 h1:8Rup8p3kuo8RE9mAzpw4MZx4P66N7caJSdRqT27pTRI=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.65.5-0.20260720004354-a89a5e000bd7/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.1-0.20260725014520-a740d9672fb6 h1:89XgwyHH0mxvTAeicPzIpsIdu2gKos/5Bvma6F2+x+c=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.68.1-0.20260725014520-a740d9672fb6/go.mod h1:vx1sByl/MceFEzfdmi+HP5hGotGJ8u5uR5T1RVQMqn4=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3 h1:MIfL0WWHeeVJIDHntEDlzN+mXphq7HGYuadxa/I6pEc=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -515,20 +515,9 @@ func TestInitDungeon_ObstaclePlacement_PreferBorderSpecsDrawBeforeNormalSpecs(t 
 func opTwoRegionParamsWithPlaced(
 	seed int64, placed []encounter.PlacedObstacleSpec, specs []encounter.ObstacleSpec,
 ) encounter.DungeonParams {
-	return encounter.DungeonParams{
-		Height:     opChamberHeight,
-		RandomSeed: seed,
-		Regions: []encounter.DungeonRegionParams{
-			{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
-			{
-				ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: opChamberWidth,
-				Pattern:         environments.PatternEmpty,
-				PlacedObstacles: placed,
-				Obstacles:       specs,
-			},
-		},
-		Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
-	}
+	params := opTwoRegionParams(seed, specs)
+	params.Regions[1].PlacedObstacles = placed
+	return params
 }
 
 // TestInitDungeon_PlacedObstaclesLandVerbatim proves a PlacedObstacleSpec
@@ -612,7 +601,10 @@ func TestInitDungeon_PlacedObstacleCollisionRejected(t *testing.T) {
 		}
 		err := enc.InitDungeon(opTwoRegionParamsWithPlaced(1, placed, nil))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "already placed")
+		require.Contains(t, err.Error(), "collides with placed obstacle")
+		// Names BOTH obstacles involved, not just the later (colliding) one.
+		require.Contains(t, err.Error(), opSpecRefA)
+		require.Contains(t, err.Error(), opSpecRefB)
 	})
 
 	t.Run("placed obstacle on a wall cell is rejected", func(t *testing.T) {
@@ -627,15 +619,8 @@ func TestInitDungeon_PlacedObstacleCollisionRejected(t *testing.T) {
 		var seedUsed int64
 		found := false
 		for seed := int64(1); seed <= 50 && !found; seed++ {
-			probeParams := encounter.DungeonParams{
-				Height:     opChamberHeight,
-				RandomSeed: seed,
-				Regions: []encounter.DungeonRegionParams{
-					{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
-					{ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: opChamberWidth, Pattern: environments.PatternRandom},
-				},
-				Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
-			}
+			probeParams := opTwoRegionParams(seed, nil)
+			probeParams.Regions[1].Pattern = environments.PatternRandom
 			probe := opNewEncounter(t)
 			require.NoError(t, probe.InitDungeon(probeParams), "seed %d", seed)
 			for _, w := range probe.ToData().Space.Walls {
@@ -656,19 +641,9 @@ func TestInitDungeon_PlacedObstacleCollisionRejected(t *testing.T) {
 		require.True(t, found, "expected at least one seed in [1,50] to produce an interior wall cell in the chamber")
 
 		enc := opNewEncounter(t)
-		params := encounter.DungeonParams{
-			Height:     opChamberHeight,
-			RandomSeed: seedUsed,
-			Regions: []encounter.DungeonRegionParams{
-				{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
-				{
-					ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: opChamberWidth,
-					Pattern:         environments.PatternRandom,
-					PlacedObstacles: []encounter.PlacedObstacleSpec{{Ref: opSpecRefA, At: wallCell}},
-				},
-			},
-			Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
-		}
+		placed := []encounter.PlacedObstacleSpec{{Ref: opSpecRefA, At: wallCell}}
+		params := opTwoRegionParamsWithPlaced(seedUsed, placed, nil)
+		params.Regions[1].Pattern = environments.PatternRandom
 		err := enc.InitDungeon(params)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "wall cell")

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -813,3 +813,179 @@ func TestInitDungeon_PreferBorderRemainderPathExcludesPlacedCells(t *testing.T) 
 		require.Equal(t, len(placed), nPlaced, "seed %d", seed)
 	}
 }
+
+// opTwoRegionParamsWithReserved mirrors opTwoRegionParamsWithPlaced but
+// attaches ReservedCells to the chamber region instead of PlacedObstacles
+// -- proving the rolled-obstacle draw excludes reserved cells the same way
+// it excludes placed ones, even though a reserved cell emits no
+// ObstacleData of its own (rpg-toolkit#842 gate finding: see
+// DungeonRegionParams.ReservedCells' doc).
+func opTwoRegionParamsWithReserved(
+	seed int64, reserved []encounter.LocalHex, specs []encounter.ObstacleSpec,
+) encounter.DungeonParams {
+	params := opTwoRegionParams(seed, specs)
+	params.Regions[1].ReservedCells = reserved
+	return params
+}
+
+// TestInitDungeon_ReservedCellsExcludedFromRolledPool mirrors
+// TestInitDungeon_RolledObstaclesNeverUsePlacedCells, for cells that emit
+// no obstacle data of their own -- the exact shape dungeonspec's compiler
+// uses for a placed monster or a pinned boss.at (rpg-toolkit#842 gate
+// finding). Across a seed sweep, no rolled ObstacleData ever lands on a
+// reserved cell's cube coordinate.
+func TestInitDungeon_ReservedCellsExcludedFromRolledPool(t *testing.T) {
+	reserved := []encounter.LocalHex{{Col: 6, Row: 3}, {Col: 2, Row: 2}, {Col: 8, Row: 6}}
+	rolled := []encounter.ObstacleSpec{{Ref: opSpecRefB, Count: 20, BlocksMovement: true}}
+
+	reservedCells := make(map[core.Hex]bool, len(reserved))
+	for _, r := range reserved {
+		reservedCells[core.HexFromPosition(spatial.Position{
+			X: float64(opChamberOffsetX + r.Col), Y: float64(r.Row),
+		})] = true
+	}
+
+	for seed := int64(1); seed <= 50; seed++ {
+		enc := opNewEncounter(t)
+		require.NoError(t, enc.InitDungeon(opTwoRegionParamsWithReserved(seed, reserved, rolled)), "seed %d", seed)
+		for _, o := range enc.ToData().Space.Obstacles {
+			require.False(t, reservedCells[o.Position],
+				"seed %d: rolled obstacle %q landed on a reserved cell %v", seed, o.ID, o.Position)
+		}
+	}
+}
+
+// TestInitDungeon_ReservedCellsExcludedFromPreferBorderPool mirrors
+// TestInitDungeon_PreferBorderExcludesPlacedBorderCell: the PreferBorder
+// border/interior partition (dungeon.go's second draw-order branch,
+// distinct from the flat pool TestInitDungeon_ReservedCellsExcludedFromRolledPool
+// exercises) must ALSO exclude reserved cells. A reserved cell sits ON a
+// border cell, with a PreferBorder rolled spec sized to exactly saturate
+// the unreduced border pool: if the partition's reserved-cell exclusion
+// were missing, the border-preferring spec's shuffle would eventually
+// draw the reserved cell too.
+func TestInitDungeon_ReservedCellsExcludedFromPreferBorderPool(t *testing.T) {
+	cases := []encounter.LocalHex{
+		{Col: 0, Row: 0}, // corner
+		{Col: opChamberWidth - 1, Row: opChamberHeight - 1}, // opposite corner
+		{Col: 5, Row: 0}, // top edge
+		{Col: 0, Row: 3}, // left edge, adjacent to doorRow
+	}
+	for _, at := range cases {
+		for seed := int64(1); seed <= 30; seed++ {
+			reserved := []encounter.LocalHex{at}
+			// Same 30-count saturation as
+			// TestInitDungeon_PreferBorderExcludesPlacedBorderCell: a 10x8
+			// region's border pool is 32 cells minus 2 doorRow border cells
+			// = 30, exactly saturating the unreduced pool.
+			rolled := []encounter.ObstacleSpec{{Ref: opSpecRefB, Count: 30, PreferBorder: true}}
+
+			enc := opNewEncounter(t)
+			require.NoError(t, enc.InitDungeon(opTwoRegionParamsWithReserved(seed, reserved, rolled)),
+				"at=%v seed=%d", at, seed)
+
+			want := core.HexFromPosition(spatial.Position{X: float64(opChamberOffsetX + at.Col), Y: float64(at.Row)})
+			for _, o := range enc.ToData().Space.Obstacles {
+				require.NotEqual(t, want, o.Position,
+					"at=%v seed=%d: rolled obstacle %q must never land on the reserved cell", at, seed, o.ID)
+			}
+		}
+	}
+}
+
+// TestInitDungeon_ReservedCellOutOfBoundsRejected mirrors
+// TestInitDungeon_PlacedObstacleOutOfBoundsRejected: InitDungeon rejects a
+// ReservedCells entry falling outside [0,width)x[0,height) -- same
+// defense-in-depth rationale (InitDungeon is a public toolkit entry point
+// other callers besides dungeonspec's own load-time Validate could reach
+// directly).
+func TestInitDungeon_ReservedCellOutOfBoundsRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		at   encounter.LocalHex
+	}{
+		{"col at the door/boundary column (one past the right edge)", encounter.LocalHex{Col: opChamberWidth, Row: 2}},
+		{"col before the left edge", encounter.LocalHex{Col: -1, Row: 2}},
+		{"row below the floor", encounter.LocalHex{Col: 2, Row: opChamberHeight}},
+		{"row above the floor", encounter.LocalHex{Col: 2, Row: -1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := opNewEncounter(t)
+			err := enc.InitDungeon(opTwoRegionParamsWithReserved(7, []encounter.LocalHex{tc.at}, nil))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "out of bounds")
+		})
+	}
+}
+
+// TestInitDungeon_ReservedCellOnReservedRowRejected mirrors
+// TestInitDungeon_PlacedObstacleOnReservedRowRejected: InitDungeon rejects
+// a ReservedCells entry whose Row == height/2.
+func TestInitDungeon_ReservedCellOnReservedRowRejected(t *testing.T) {
+	enc := opNewEncounter(t)
+	reserved := []encounter.LocalHex{{Col: 5, Row: opChamberHeight / 2}}
+	err := enc.InitDungeon(opTwoRegionParamsWithReserved(1, reserved, nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved row")
+}
+
+// TestInitDungeon_ReservedCellCollisionRejected mirrors
+// TestInitDungeon_PlacedObstacleCollisionRejected: a ReservedCells entry
+// landing on a wall cell (PatternRandom region), or on a cell an existing
+// PlacedObstacleSpec already claims, is a hard InitDungeon error -- the
+// same defense-in-depth treatment placeVerbatimObstacles gives
+// PlacedObstacles, extended to reserveCubes.
+func TestInitDungeon_ReservedCellCollisionRejected(t *testing.T) {
+	t.Run("reserved cell on a wall cell is rejected", func(t *testing.T) {
+		// Discover an actual wall cell for some seed first (a plain probe
+		// run, no reserved cells), then re-run WITH a ReservedCells entry at
+		// that exact cell using the SAME seed -- mirrors
+		// TestInitDungeon_PlacedObstacleCollisionRejected's own wall-cell
+		// sub-test: wall layout depends only on RandomSeed + region shape,
+		// never on ReservedCells content.
+		var wallCell encounter.LocalHex
+		var seedUsed int64
+		found := false
+		for seed := int64(1); seed <= 50 && !found; seed++ {
+			probeParams := opTwoRegionParams(seed, nil)
+			probeParams.Regions[1].Pattern = environments.PatternRandom
+			probe := opNewEncounter(t)
+			require.NoError(t, probe.InitDungeon(probeParams), "seed %d", seed)
+			for _, w := range probe.ToData().Space.Walls {
+				if w.Start != w.End {
+					continue // boundary-edge perimeter segment, not an interior wall cell
+				}
+				pos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+				localCol := int(pos.X) - opChamberOffsetX
+				localRow := int(pos.Y)
+				if localCol >= 0 && localCol < opChamberWidth && localRow != opChamberHeight/2 {
+					wallCell = encounter.LocalHex{Col: localCol, Row: localRow}
+					seedUsed = seed
+					found = true
+					break
+				}
+			}
+		}
+		require.True(t, found, "expected at least one seed in [1,50] to produce an interior wall cell in the chamber")
+
+		enc := opNewEncounter(t)
+		params := opTwoRegionParamsWithReserved(seedUsed, []encounter.LocalHex{wallCell}, nil)
+		params.Regions[1].Pattern = environments.PatternRandom
+		err := enc.InitDungeon(params)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wall cell")
+	})
+
+	t.Run("reserved cell colliding with a placed obstacle is rejected", func(t *testing.T) {
+		enc := opNewEncounter(t)
+		params := opTwoRegionParamsWithReserved(1, []encounter.LocalHex{{Col: 6, Row: 3}}, nil)
+		params.Regions[1].PlacedObstacles = []encounter.PlacedObstacleSpec{
+			{Ref: opSpecRefA, At: encounter.LocalHex{Col: 6, Row: 3}},
+		}
+		err := enc.InitDungeon(params)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "collides with placed obstacle")
+		require.Contains(t, err.Error(), opSpecRefA)
+	})
+}

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 const (
@@ -503,4 +504,195 @@ func TestInitDungeon_ObstaclePlacement_PreferBorderSpecsDrawBeforeNormalSpecs(t 
 					"pool on its own) was declared first", seed, o.ID, localX, localY)
 		}
 	}
+}
+
+// opTwoRegionParamsWithPlaced mirrors opTwoRegionParams but also attaches
+// PlacedObstacleSpecs to the chamber region alongside its rolled specs —
+// proving the two placement mechanisms coexist in the same region
+// (design.md §Design delta: "place coexists with the count-based
+// obstacles... list in the same room; placed entries are honored first,
+// then count-based entries roll into the remaining safe cells").
+func opTwoRegionParamsWithPlaced(
+	seed int64, placed []encounter.PlacedObstacleSpec, specs []encounter.ObstacleSpec,
+) encounter.DungeonParams {
+	return encounter.DungeonParams{
+		Height:     opChamberHeight,
+		RandomSeed: seed,
+		Regions: []encounter.DungeonRegionParams{
+			{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
+			{
+				ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: opChamberWidth,
+				Pattern:         environments.PatternEmpty,
+				PlacedObstacles: placed,
+				Obstacles:       specs,
+			},
+		},
+		Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
+	}
+}
+
+// TestInitDungeon_PlacedObstaclesLandVerbatim proves a PlacedObstacleSpec
+// lands at EXACTLY its declared room-local cell, translated by the
+// region's offsetX — not just "an obstacle with this ref exists somewhere
+// in the region" (design.md §Design delta).
+func TestInitDungeon_PlacedObstaclesLandVerbatim(t *testing.T) {
+	enc := opNewEncounter(t)
+	placed := []encounter.PlacedObstacleSpec{
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 6, Row: 3}, BlocksMovement: true, BlocksLoS: false},
+	}
+	require.NoError(t, enc.InitDungeon(opTwoRegionParamsWithPlaced(1, placed, nil)))
+
+	data := enc.ToData()
+	require.Len(t, data.Space.Obstacles, 1)
+
+	want := core.HexFromPosition(spatial.Position{X: float64(opChamberOffsetX + 6), Y: float64(3)})
+	got := data.Space.Obstacles[0]
+	require.Equal(t, opSpecRefA, got.Ref)
+	require.Equal(t, want, got.Position, "placed obstacle must land at exactly its declared cell, translated by offsetX")
+	require.True(t, got.BlocksMovement)
+	require.False(t, got.BlocksLoS)
+}
+
+// TestInitDungeon_RolledObstaclesNeverUsePlacedCells proves placed cells
+// are excluded from the rolled candidate pool: across a seed sweep, no
+// rolled ObstacleData ever lands on a placed cell's cube coordinate.
+func TestInitDungeon_RolledObstaclesNeverUsePlacedCells(t *testing.T) {
+	placed := []encounter.PlacedObstacleSpec{
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 6, Row: 3}},
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 2, Row: 2}},
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 8, Row: 6}},
+	}
+	rolled := []encounter.ObstacleSpec{{Ref: opSpecRefB, Count: 20, BlocksMovement: true}}
+
+	placedCells := make(map[core.Hex]bool, len(placed))
+	for _, p := range placed {
+		placedCells[core.HexFromPosition(spatial.Position{
+			X: float64(opChamberOffsetX + p.At.Col), Y: float64(p.At.Row),
+		})] = true
+	}
+
+	for seed := int64(1); seed <= 20; seed++ {
+		enc := opNewEncounter(t)
+		require.NoError(t, enc.InitDungeon(opTwoRegionParamsWithPlaced(seed, placed, rolled)), "seed %d", seed)
+		for _, o := range enc.ToData().Space.Obstacles {
+			if o.Ref != opSpecRefB {
+				continue // only the rolled spec's instances are under test here
+			}
+			require.False(t, placedCells[o.Position],
+				"seed %d: rolled obstacle %q landed on a placed cell %v", seed, o.ID, o.Position)
+		}
+	}
+}
+
+// TestInitDungeon_PlacedObstacleOnReservedRowRejected: InitDungeon rejects
+// a PlacedObstacleSpec whose At.Row == height/2 — belt-and-suspenders with
+// dungeonspec's own load-time check (Task B2), since InitDungeon is a
+// public toolkit entry point other callers besides dungeonspec could reach
+// directly.
+func TestInitDungeon_PlacedObstacleOnReservedRowRejected(t *testing.T) {
+	enc := opNewEncounter(t)
+	placed := []encounter.PlacedObstacleSpec{
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 5, Row: opChamberHeight / 2}},
+	}
+	err := enc.InitDungeon(opTwoRegionParamsWithPlaced(1, placed, nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved row")
+}
+
+// TestInitDungeon_PlacedObstacleCollisionRejected: two PlacedObstacleSpecs
+// at the same At, or one at a wall cell (PatternRandom region), is a hard
+// InitDungeon error — placed entries are guarantees, not best-effort
+// (design.md §Validation).
+func TestInitDungeon_PlacedObstacleCollisionRejected(t *testing.T) {
+	t.Run("two placed obstacles at the same cell", func(t *testing.T) {
+		enc := opNewEncounter(t)
+		placed := []encounter.PlacedObstacleSpec{
+			{Ref: opSpecRefA, At: encounter.LocalHex{Col: 6, Row: 3}},
+			{Ref: opSpecRefB, At: encounter.LocalHex{Col: 6, Row: 3}},
+		}
+		err := enc.InitDungeon(opTwoRegionParamsWithPlaced(1, placed, nil))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already placed")
+	})
+
+	t.Run("placed obstacle on a wall cell is rejected", func(t *testing.T) {
+		// PatternRandom's interior walls are seed-dependent -- discover an
+		// actual wall cell for some seed first (a plain probe run, no
+		// placed obstacles), then re-run WITH a PlacedObstacleSpec at that
+		// exact cell using the SAME seed, expecting rejection. Wall layout
+		// depends only on RandomSeed + region shape, never on
+		// PlacedObstacles content, so the discovered cell is still a real
+		// wall cell in the second run.
+		var wallCell encounter.LocalHex
+		var seedUsed int64
+		found := false
+		for seed := int64(1); seed <= 50 && !found; seed++ {
+			probeParams := encounter.DungeonParams{
+				Height:     opChamberHeight,
+				RandomSeed: seed,
+				Regions: []encounter.DungeonRegionParams{
+					{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
+					{ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: opChamberWidth, Pattern: environments.PatternRandom},
+				},
+				Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
+			}
+			probe := opNewEncounter(t)
+			require.NoError(t, probe.InitDungeon(probeParams), "seed %d", seed)
+			for _, w := range probe.ToData().Space.Walls {
+				if w.Start != w.End {
+					continue // boundary-edge perimeter segment, not an interior wall cell
+				}
+				pos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+				localCol := int(pos.X) - opChamberOffsetX
+				localRow := int(pos.Y)
+				if localCol >= 0 && localCol < opChamberWidth && localRow != opChamberHeight/2 {
+					wallCell = encounter.LocalHex{Col: localCol, Row: localRow}
+					seedUsed = seed
+					found = true
+					break
+				}
+			}
+		}
+		require.True(t, found, "expected at least one seed in [1,50] to produce an interior wall cell in the chamber")
+
+		enc := opNewEncounter(t)
+		params := encounter.DungeonParams{
+			Height:     opChamberHeight,
+			RandomSeed: seedUsed,
+			Regions: []encounter.DungeonRegionParams{
+				{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
+				{
+					ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: opChamberWidth,
+					Pattern:         environments.PatternRandom,
+					PlacedObstacles: []encounter.PlacedObstacleSpec{{Ref: opSpecRefA, At: wallCell}},
+				},
+			},
+			Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
+		}
+		err := enc.InitDungeon(params)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wall cell")
+	})
+}
+
+// TestInitDungeon_PlacedObstaclesDeterministicSameSeed: the same seed
+// reproduces byte-identical placement (placed AND rolled obstacles
+// together) across independent Encounters — mirrors
+// TestInitDungeon_ObstaclePlacement_DeterministicSameSeed's rolled-only
+// gate; determinism must hold with placements present too.
+func TestInitDungeon_PlacedObstaclesDeterministicSameSeed(t *testing.T) {
+	placed := []encounter.PlacedObstacleSpec{
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 6, Row: 3}, BlocksMovement: true},
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 2, Row: 2}, BlocksMovement: true},
+	}
+	rolled := []encounter.ObstacleSpec{{Ref: opSpecRefB, Count: 5, BlocksMovement: true, BlocksLoS: true}}
+	build := func() *encounter.Data {
+		enc := opNewEncounter(t)
+		require.NoError(t, enc.InitDungeon(opTwoRegionParamsWithPlaced(909, placed, rolled)))
+		return enc.ToData()
+	}
+	a := build()
+	b := build()
+	require.Equal(t, a.Space.Obstacles, b.Space.Obstacles,
+		"identical seed must reproduce identical placement, placed and rolled together")
 }

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -696,3 +696,137 @@ func TestInitDungeon_PlacedObstaclesDeterministicSameSeed(t *testing.T) {
 	require.Equal(t, a.Space.Obstacles, b.Space.Obstacles,
 		"identical seed must reproduce identical placement, placed and rolled together")
 }
+
+// TestInitDungeon_PlacedObstacleOutOfBoundsRejected: InitDungeon rejects a
+// PlacedObstacleSpec whose At falls outside [0,width)x[0,height) — the
+// same defense-in-depth rationale as the reserved-row check, since
+// InitDungeon is a public toolkit entry point other callers besides
+// dungeonspec's own load-time Validate could reach directly. Without this
+// check, an out-of-bounds col lands in the connector's boundary/door
+// column or an adjacent region's own span (failing downstream in
+// rebuildRoomFromData with a message naming neither region nor local
+// cell), and an out-of-bounds row degrades to a bare "hex already
+// occupied" the moment it happens to collide with something.
+func TestInitDungeon_PlacedObstacleOutOfBoundsRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		at   encounter.LocalHex
+	}{
+		{"col at the door/boundary column (one past the right edge)", encounter.LocalHex{Col: opChamberWidth, Row: 2}},
+		{"col inside the next region's span", encounter.LocalHex{Col: opChamberWidth + 3, Row: 2}},
+		{"col before the left edge", encounter.LocalHex{Col: -1, Row: 2}},
+		{"row below the floor", encounter.LocalHex{Col: 2, Row: opChamberHeight}},
+		{"row above the floor", encounter.LocalHex{Col: 2, Row: -1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := opNewEncounter(t)
+			placed := []encounter.PlacedObstacleSpec{{Ref: opSpecRefA, At: tc.at}}
+			err := enc.InitDungeon(opTwoRegionParamsWithPlaced(7, placed, nil))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "out of bounds")
+		})
+	}
+}
+
+// TestInitDungeon_PreferBorderExcludesPlacedBorderCell proves the
+// PreferBorder border/interior partition (dungeon.go's second draw-order
+// branch, distinct from the flat pool
+// TestInitDungeon_RolledObstaclesNeverUsePlacedCells already exercises)
+// ALSO excludes placed cells. A placed obstacle sits ON a border cell,
+// with a PreferBorder rolled spec sized to exactly saturate the
+// unreduced border pool: if the partition's placed-cell exclusion were
+// missing, the border-preferring spec's shuffle would eventually draw
+// the placed cell too, since border+placed together exceed the pool by
+// exactly one — a deterministic collision, not a rare one, so a single
+// seed sweep per cell is enough to catch a missing exclusion.
+func TestInitDungeon_PreferBorderExcludesPlacedBorderCell(t *testing.T) {
+	cases := []encounter.LocalHex{
+		{Col: 0, Row: 0}, // corner
+		{Col: opChamberWidth - 1, Row: opChamberHeight - 1}, // opposite corner
+		{Col: 5, Row: 0}, // top edge
+		{Col: 0, Row: 3}, // left edge, adjacent to doorRow
+		{Col: 4, Row: 2}, // interior (control)
+	}
+	for _, at := range cases {
+		for seed := int64(1); seed <= 30; seed++ {
+			placed := []encounter.PlacedObstacleSpec{{Ref: opSpecRefA, At: at, BlocksMovement: true}}
+			// Border pool for a 10x8 region: perimeter 2*10+2*8-4=32 cells,
+			// minus the two doorRow (y=4) border cells = 30. Count=30
+			// exactly saturates the unreduced pool, so a missing
+			// exclusion forces a deterministic collision with the placed
+			// cell whenever it sits on the border.
+			rolled := []encounter.ObstacleSpec{{Ref: opSpecRefB, Count: 30, PreferBorder: true}}
+
+			enc := opNewEncounter(t)
+			require.NoError(t, enc.InitDungeon(opTwoRegionParamsWithPlaced(seed, placed, rolled)),
+				"at=%v seed=%d", at, seed)
+
+			want := core.HexFromPosition(spatial.Position{X: float64(opChamberOffsetX + at.Col), Y: float64(at.Row)})
+			sawPlaced := false
+			for _, o := range enc.ToData().Space.Obstacles {
+				switch o.Ref {
+				case opSpecRefA:
+					sawPlaced = true
+					require.Equal(t, want, o.Position,
+						"at=%v seed=%d: placed obstacle must land at its declared cell", at, seed)
+				case opSpecRefB:
+					require.NotEqual(t, want, o.Position,
+						"at=%v seed=%d: rolled obstacle %q must never land on the placed cell", at, seed, o.ID)
+				}
+			}
+			require.True(t, sawPlaced, "at=%v seed=%d: placed obstacle missing", at, seed)
+		}
+	}
+}
+
+// TestInitDungeon_PreferBorderRemainderPathExcludesPlacedCells proves the
+// remainder-reshuffle path — normalSpecs drawing from whatever the
+// PreferBorder specs left over, via drawObstaclesFrom's idOffset+len(out)
+// ID continuation — still produces unique IDs, no cell collisions, and
+// never draws a placed cell, across a mix of PreferBorder and normal
+// specs and several placed entries at once (mirrors rpg-toolkit#840's own
+// PreferBorder-vs-normal-spec gate, extended to placed cells).
+func TestInitDungeon_PreferBorderRemainderPathExcludesPlacedCells(t *testing.T) {
+	placed := []encounter.PlacedObstacleSpec{
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 0, Row: 0}},
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: opChamberWidth - 1, Row: opChamberHeight - 1}},
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 3, Row: 5}},
+		{Ref: opSpecRefA, At: encounter.LocalHex{Col: 6, Row: 1}},
+	}
+	rolled := []encounter.ObstacleSpec{
+		{Ref: opSpecRefB, Count: 20, PreferBorder: true},
+		{Ref: opSpecRefB, Count: 25},
+		{Ref: opSpecRefB, Count: 15, PreferBorder: true},
+	}
+	placedCells := make(map[core.Hex]bool, len(placed))
+	for _, p := range placed {
+		placedCells[core.HexFromPosition(spatial.Position{
+			X: float64(opChamberOffsetX + p.At.Col), Y: float64(p.At.Row),
+		})] = true
+	}
+
+	for seed := int64(1); seed <= 40; seed++ {
+		enc := opNewEncounter(t)
+		require.NoError(t, enc.InitDungeon(opTwoRegionParamsWithPlaced(seed, placed, rolled)), "seed %d", seed)
+
+		ids := make(map[core.EntityID]bool)
+		cells := make(map[core.Hex]core.EntityID)
+		nPlaced := 0
+		for _, o := range enc.ToData().Space.Obstacles {
+			require.False(t, ids[o.ID], "seed %d: duplicate obstacle ID %q", seed, o.ID)
+			ids[o.ID] = true
+			if prev, dup := cells[o.Position]; dup {
+				t.Fatalf("seed %d: obstacles %q and %q collide at %v", seed, prev, o.ID, o.Position)
+			}
+			cells[o.Position] = o.ID
+			if o.Ref == opSpecRefA {
+				nPlaced++
+				continue
+			}
+			require.False(t, placedCells[o.Position],
+				"seed %d: rolled obstacle %q landed on a placed cell %v", seed, o.ID, o.Position)
+		}
+		require.Equal(t, len(placed), nPlaced, "seed %d", seed)
+	}
+}

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -30,6 +30,14 @@ import (
 const (
 	opSpecRefA = "test:obstacles:blocker-a"
 	opSpecRefB = "test:obstacles:blocker-b"
+
+	// dungeonRegionIDChamber and doorID0/doorID1 are this file's own
+	// repeated region-id/door-id literals (goconst) -- dungeonRegionIDEntrance
+	// and dungeonRegionIDBoss already exist package-wide (dungeon_test.go),
+	// so those are reused directly instead of duplicated here.
+	dungeonRegionIDChamber = "chamber"
+	doorID0                = "door-0"
+	doorID1                = "door-1"
 )
 
 // opTwoRegionParams builds a minimal, otherwise-valid 2-region DungeonParams
@@ -42,13 +50,13 @@ func opTwoRegionParams(seed int64, specs []encounter.ObstacleSpec) encounter.Dun
 		Height:     8,
 		RandomSeed: seed,
 		Regions: []encounter.DungeonRegionParams{
-			{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
+			{ID: dungeonRegionIDEntrance, Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
 			{
-				ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: 10, Pattern: environments.PatternEmpty,
+				ID: dungeonRegionIDChamber, Archetype: encounter.ArchetypeChamber, Width: 10, Pattern: environments.PatternEmpty,
 				Obstacles: specs,
 			},
 		},
-		Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
+		Connectors: []encounter.DungeonConnectorParams{{DoorID: doorID0}},
 	}
 }
 
@@ -203,13 +211,13 @@ func TestInitDungeon_ObstaclePlacement_NeverOnReservedRow(t *testing.T) {
 		Height:     8,
 		RandomSeed: 7,
 		Regions: []encounter.DungeonRegionParams{
-			{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 10, Pattern: environments.PatternEmpty},
+			{ID: dungeonRegionIDEntrance, Archetype: encounter.ArchetypeEntrance, Width: 10, Pattern: environments.PatternEmpty},
 			{
-				ID: "boss", Archetype: encounter.ArchetypeBoss, Width: 10, Pattern: environments.PatternRandom,
+				ID: dungeonRegionIDBoss, Archetype: encounter.ArchetypeBoss, Width: 10, Pattern: environments.PatternRandom,
 				Obstacles: []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 40, BlocksMovement: true, BlocksLoS: true}},
 			},
 		},
-		Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
+		Connectors: []encounter.DungeonConnectorParams{{DoorID: doorID0}},
 	}
 	require.NoError(t, enc.InitDungeon(params))
 	data := enc.ToData()
@@ -236,7 +244,7 @@ func TestInitDungeon_ObstaclePlacement_PreservesEntranceToBossConnectivity(t *te
 		RandomSeed: 77,
 		Regions: []encounter.DungeonRegionParams{
 			{
-				ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 10, Pattern: environments.PatternEmpty,
+				ID: dungeonRegionIDEntrance, Archetype: encounter.ArchetypeEntrance, Width: 10, Pattern: environments.PatternEmpty,
 				Obstacles: []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 20, BlocksMovement: true, BlocksLoS: true}},
 			},
 			{
@@ -244,11 +252,11 @@ func TestInitDungeon_ObstaclePlacement_PreservesEntranceToBossConnectivity(t *te
 				Obstacles: []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 10, BlocksMovement: true, BlocksLoS: true}},
 			},
 			{
-				ID: "boss", Archetype: encounter.ArchetypeBoss, Width: 10, Pattern: environments.PatternEmpty,
+				ID: dungeonRegionIDBoss, Archetype: encounter.ArchetypeBoss, Width: 10, Pattern: environments.PatternEmpty,
 				Obstacles: []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 20, BlocksMovement: true, BlocksLoS: true}},
 			},
 		},
-		Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}, {DoorID: "door-1"}},
+		Connectors: []encounter.DungeonConnectorParams{{DoorID: doorID0}, {DoorID: doorID1}},
 	}
 	require.NoError(t, enc.InitDungeon(params))
 
@@ -257,11 +265,11 @@ func TestInitDungeon_ObstaclePlacement_PreservesEntranceToBossConnectivity(t *te
 	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: entrance, SightRange: 30,
 	}))
-	require.NoError(t, enc.OpenDoor(alicePlayerID, "door-0"))
-	require.NoError(t, enc.OpenDoor(alicePlayerID, "door-1"))
+	require.NoError(t, enc.OpenDoor(alicePlayerID, doorID0))
+	require.NoError(t, enc.OpenDoor(alicePlayerID, doorID1))
 
 	reachable := reachableFrom(enc.Room(), entrance)
-	boss := regionHexSet(enc.ToData().Space, "boss")
+	boss := regionHexSet(enc.ToData().Space, dungeonRegionIDBoss)
 	require.NotEmpty(t, boss)
 	reachedBoss := false
 	for h := range reachable {
@@ -287,13 +295,13 @@ func TestInitDungeon_ObstaclePlacement_SkipsWhenNoSafeHexRemains(t *testing.T) {
 		Height:     4,
 		RandomSeed: 3,
 		Regions: []encounter.DungeonRegionParams{
-			{ID: "entrance", Archetype: encounter.ArchetypeEntrance, Width: 4, Pattern: environments.PatternEmpty},
+			{ID: dungeonRegionIDEntrance, Archetype: encounter.ArchetypeEntrance, Width: 4, Pattern: environments.PatternEmpty},
 			{
-				ID: "chamber", Archetype: encounter.ArchetypeChamber, Width: 4, Pattern: environments.PatternEmpty,
+				ID: dungeonRegionIDChamber, Archetype: encounter.ArchetypeChamber, Width: 4, Pattern: environments.PatternEmpty,
 				Obstacles: []encounter.ObstacleSpec{{Ref: opSpecRefA, Count: 1000, BlocksMovement: true}},
 			},
 		},
-		Connectors: []encounter.DungeonConnectorParams{{DoorID: "door-0"}},
+		Connectors: []encounter.DungeonConnectorParams{{DoorID: doorID0}},
 	}
 	err := enc.InitDungeon(params)
 	require.NoError(t, err, "InitDungeon must never fail because an obstacle spec could not fully fit")

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -43,35 +43,110 @@ type SpawnInstruction struct {
 }
 
 // resolvedSpawn is one SpawnInstruction after it has passed every
-// validation check in SeedMonsters' first pass — everything the commit
-// pass needs, so committing never has to re-derive or re-check anything
-// the validation pass already established.
+// validation check AND had its full MonsterInput derived — everything
+// the commit pass needs to call addMonsterNoCombatCheck directly, with
+// no remaining derivation or fallible step (monster construction,
+// DataJSON marshaling, attack-snapshot extraction) left for commit time.
 type resolvedSpawn struct {
-	id         core.EntityID
-	roomID     string
-	monsterRef string
-	position   core.Hex
-	ctor       monsters.Constructor
+	roomID string
+	input  MonsterInput
+}
+
+// spawnBatch holds one SeedMonsters call's shared validation state: the
+// room geometry (doorRow, wallCubes) and the evolving collision domain
+// (claimed) that every instruction in the batch is checked against, in
+// order. Kept as its own type (rather than local variables in
+// validateSpawnBatch) so M2's Slice C count-based safe-cell roller has
+// the same seam to extend — it needs this exact geometry/claimed shape
+// to pick safe cells for At == nil instructions, not just to reject bad
+// At-bearing ones.
+type spawnBatch struct {
+	doorRow   int
+	wallCubes map[spatial.CubeCoordinate]struct{}
+	claimed   map[core.Hex]string
+}
+
+// newSpawnBatch seeds a spawnBatch's collision domain from the
+// encounter's CURRENT players, monsters, and blocking obstacles, so a
+// spawn can't land on any existing occupant either — not just on another
+// spawn within this same batch. Non-blocking obstacles (candles,
+// bone-pile, chain — data.go's ObstacleData.BlocksMovement doc) are
+// walkable-past floor dressing, so they don't reserve a cell here,
+// matching room-rebuild's own walkability semantics (rebuildRoomFromData
+// only ever rejects a BlocksMovement entity's cell as occupied).
+func newSpawnBatch(e *Encounter, spawnCountHint int) *spawnBatch {
+	b := &spawnBatch{
+		doorRow:   e.data.Space.Height / 2,
+		wallCubes: make(map[spatial.CubeCoordinate]struct{}, len(e.data.Space.Walls)),
+		claimed: make(map[core.Hex]string,
+			spawnCountHint+len(e.data.Players)+len(e.data.Monsters)+len(e.data.Space.Obstacles)),
+	}
+	for _, w := range e.data.Space.Walls {
+		if w.Start != w.End {
+			continue // boundary-edge perimeter segment (rpg-toolkit#834), not a blocking wall cell
+		}
+		b.wallCubes[w.Start] = struct{}{}
+	}
+	for id, p := range e.data.Players {
+		if p.View == nil {
+			continue // no persisted position to check against (shouldn't happen for a real seat, but be defensive)
+		}
+		b.claimed[p.View.Position] = fmt.Sprintf("player %q", id)
+	}
+	for id, m := range e.data.Monsters {
+		b.claimed[m.Position] = fmt.Sprintf("monster %q", id)
+	}
+	for _, o := range e.data.Space.Obstacles {
+		if !o.BlocksMovement {
+			continue
+		}
+		b.claimed[o.Position] = fmt.Sprintf("obstacle %q", o.ID)
+	}
+	return b
+}
+
+// isWall reports whether position is a blocking wall cell.
+func (b *spawnBatch) isWall(position core.Hex) bool {
+	_, wall := b.wallCubes[position.ToCube()]
+	return wall
+}
+
+// claim reports the existing occupant's descriptor if position is
+// already taken; otherwise it reserves position for descriptor and
+// reports ("", false).
+func (b *spawnBatch) claim(position core.Hex, descriptor string) (occupant string, alreadyTaken bool) {
+	if occ, taken := b.claimed[position]; taken {
+		return occ, true
+	}
+	b.claimed[position] = descriptor
+	return "", false
 }
 
 // SeedMonsters places a compiled spawn plan (e.g.
 // dungeonspec.CompiledDungeon.Spawns) into an already-InitDungeon'd
 // encounter under two invariants:
 //
-//  1. All-or-nothing batch validation: EVERY instruction is validated
-//     (At non-nil, Count==1, MonsterRef resolves, RoomID names a real
+//  1. All-or-nothing batch validation: EVERY instruction is validated —
+//     At non-nil, Count==1, MonsterRef resolves, RoomID names a real
 //     region, the cell is in-bounds/not-doorRow/not-a-wall-cell/not
-//     already claimed by this batch or an existing occupant) BEFORE any
-//     monster is added. A single bad instruction anywhere in the batch
-//     leaves the encounter exactly as it was before the call — no
-//     partial commit, no monsters added, mode unchanged — mirroring
-//     placeVerbatimObstacles' own contract one file over (dungeon.go)
-//     and closing the class of bug where an early instruction commits
-//     and only a LATER one fails.
+//     already claimed by this batch or an existing player/monster/
+//     blocking obstacle, and its minted ID isn't already in the
+//     encounter — and has its full MonsterInput derived (monster
+//     construction, DataJSON, attack snapshot), BEFORE any monster is
+//     added. The ONE honest exception to "no partial commit": once
+//     validation passes, the only way a commit-phase call can still fail
+//     is addMonsterNoCombatCheck's own EntityAppearedEvent broker
+//     publish (an I/O-shaped failure, not a spec error) — every
+//     REALISTIC failure mode (bad ref, bad room, OOB, collision, wrong
+//     Count, duplicate ID) is caught in validation and can never reach
+//     commit. This mirrors placeVerbatimObstacles' own contract one file
+//     over (dungeon.go).
 //  2. Atomic combat-entry evaluation: every validated spawn is staged
 //     with combat-entry evaluation suppressed (addMonsterNoCombatCheck),
 //     and exactly ONE checkCombatEntry pass runs after the whole batch
-//     commits. This matters because AddMonster's own per-call
+//     commits (including when spawns is empty — SeedMonsters(nil) still
+//     runs this pass; harmless and intended, not worth special-casing
+//     away). This matters because AddMonster's own per-call
 //     checkCombatEntry would otherwise let a monster added mid-batch
 //     while combat is already running (triggered by an EARLIER spawn's
 //     own visibility) join initiative unconditionally, regardless of
@@ -80,6 +155,11 @@ type resolvedSpawn struct {
 //     partial-roster bug this invariant exists to prevent for spawn
 //     orders (boss-first, per the compiler) where a monster is added
 //     AFTER an earlier one's own visibility already flipped the mode.
+//
+// Caller ordering (Slice E and any other host): players must be added
+// (AddPlayer) BEFORE calling SeedMonsters — combat-entry evaluation only
+// ever sees whoever is already in e.data.Players at call time, the same
+// as any other checkCombatEntry-driven check in this package.
 //
 // M1 scope (this plan's Task N2 scoping call): only At-bearing (placed)
 // instructions are supported — an At == nil (rolled, count-based)
@@ -95,8 +175,9 @@ type resolvedSpawn struct {
 // initial dungeon setup), so this is never an issue today. A second call
 // against the SAME encounter (M2 territory, e.g. re-seeding after a
 // pocket clears) would restart each room's counter at 0 and collide with
-// IDs this call already assigned — M2's Slice C, whichever caller ends
-// up needing repeat calls, must carry the counters forward or use a
+// IDs this call already assigned — validated and rejected outright
+// rather than silently colliding, but M2's Slice C, whichever caller
+// ends up needing repeat calls, must carry the counters forward or use a
 // different scheme; not needed for M1's single-call acceptance path.
 func (e *Encounter) SeedMonsters(spawns []SpawnInstruction) error {
 	if e.data.Space == nil {
@@ -109,66 +190,21 @@ func (e *Encounter) SeedMonsters(spawns []SpawnInstruction) error {
 	}
 
 	for _, r := range resolved {
-		mon := r.ctor(string(r.id))
-		dataJSON, err := json.Marshal(mon.ToData())
-		if err != nil {
-			return fmt.Errorf("room %q: monster %q: marshal monster data: %w", r.roomID, r.monsterRef, err)
-		}
-		attackBonus, damageDice, damageType := primaryAttackSnapshot(mon)
-
-		if err := e.addMonsterNoCombatCheck(MonsterInput{
-			ID:          r.id,
-			Position:    r.position,
-			HP:          mon.HP(),
-			MaxHP:       mon.MaxHP(),
-			AC:          mon.AC(),
-			Speed:       mon.Speed().Walk / 5, // feet -> hexes (npc.go/action.go consume Speed in hexes)
-			MonsterRef:  r.monsterRef,
-			DataJSON:    dataJSON,
-			AttackBonus: attackBonus,
-			DamageDice:  damageDice,
-			DamageType:  damageType,
-		}); err != nil {
-			return fmt.Errorf("room %q: monster %q: %w", r.roomID, r.monsterRef, err)
+		if err := e.addMonsterNoCombatCheck(r.input); err != nil {
+			return fmt.Errorf("room %q: monster %q: %w", r.roomID, r.input.MonsterRef, err)
 		}
 	}
 	return e.checkCombatEntry()
 }
 
 // validateSpawnBatch checks every instruction in spawns and resolves it
-// to a resolvedSpawn, WITHOUT mutating the encounter — SeedMonsters only
-// starts committing once every instruction has passed here, so a single
-// bad instruction anywhere in the batch never leaves an earlier one
-// committed.
+// to a resolvedSpawn — including constructing the monster, marshaling
+// its DataJSON, and extracting its attack snapshot — WITHOUT mutating
+// the encounter. SeedMonsters only starts committing once every
+// instruction has passed here, so a single bad instruction anywhere in
+// the batch never leaves an earlier one committed.
 func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpawn, error) {
-	doorRow := e.data.Space.Height / 2
-	wallCubes := make(map[spatial.CubeCoordinate]struct{}, len(e.data.Space.Walls))
-	for _, w := range e.data.Space.Walls {
-		if w.Start != w.End {
-			continue // boundary-edge perimeter segment (rpg-toolkit#834), not a blocking wall cell
-		}
-		wallCubes[w.Start] = struct{}{}
-	}
-
-	// Seeded from any monster or BLOCKING obstacle already in the
-	// encounter, so a spawn can't land on an existing occupant either —
-	// not just on another spawn within this same batch. Non-blocking
-	// obstacles (candles, bone-pile, chain — data.go's ObstacleData.
-	// BlocksMovement doc) are walkable-past floor dressing, so they don't
-	// reserve a cell here, matching room-rebuild's own walkability
-	// semantics (rebuildRoomFromData only ever rejects a BlocksMovement
-	// entity's cell as occupied). occupant is a human-readable descriptor
-	// (kind + ID/ref) for the collision error, not just a bool.
-	claimed := make(map[core.Hex]string, len(spawns)+len(e.data.Monsters)+len(e.data.Space.Obstacles))
-	for id, m := range e.data.Monsters {
-		claimed[m.Position] = fmt.Sprintf("monster %q", id)
-	}
-	for _, o := range e.data.Space.Obstacles {
-		if !o.BlocksMovement {
-			continue
-		}
-		claimed[o.Position] = fmt.Sprintf("obstacle %q", o.ID)
-	}
+	batch := newSpawnBatch(e, len(spawns))
 
 	roomCounts := make(map[string]int, len(spawns))
 	resolved := make([]resolvedSpawn, 0, len(spawns))
@@ -183,31 +219,27 @@ func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpa
 		}
 		ctor, ok := monsters.ByRef(spawn.MonsterRef)
 		if !ok {
-			return nil, fmt.Errorf("room %q: unknown monster ref %q", spawn.RoomID, spawn.MonsterRef)
+			return nil, fmt.Errorf("room %q: monster %q: unknown monster ref", spawn.RoomID, spawn.MonsterRef)
 		}
 		region, err := e.regionByID(spawn.RoomID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("room %q: monster %q: %w", spawn.RoomID, spawn.MonsterRef, err)
 		}
 		offsetX := regionOffsetX(region.Hexes)
 		position := core.HexFromPosition(spatial.Position{
 			X: float64(offsetX + spawn.At.Col), Y: float64(spawn.At.Row),
 		})
 		if !region.Hexes.Has(position) {
-			return nil, fmt.Errorf("room %q: monster %q: at %v is out of bounds for this region",
-				spawn.RoomID, spawn.MonsterRef, spawn.At)
+			return nil, fmt.Errorf("room %q: monster %q: at %v is out of bounds for this region (width=%d, height=%d)",
+				spawn.RoomID, spawn.MonsterRef, spawn.At, regionWidth(region.Hexes), e.data.Space.Height)
 		}
-		if spawn.At.Row == doorRow {
+		if spawn.At.Row == batch.doorRow {
 			return nil, fmt.Errorf("room %q: monster %q: at %v is on the reserved row (doorRow=%d)",
-				spawn.RoomID, spawn.MonsterRef, spawn.At, doorRow)
+				spawn.RoomID, spawn.MonsterRef, spawn.At, batch.doorRow)
 		}
-		if _, wall := wallCubes[position.ToCube()]; wall {
+		if batch.isWall(position) {
 			return nil, fmt.Errorf("room %q: monster %q: at %v is on a wall cell",
 				spawn.RoomID, spawn.MonsterRef, spawn.At)
-		}
-		if occupant, taken := claimed[position]; taken {
-			return nil, fmt.Errorf("room %q: monster %q: at %v collides with %s",
-				spawn.RoomID, spawn.MonsterRef, spawn.At, occupant)
 		}
 
 		// Minted here, not just at commit time: the whole point of
@@ -225,9 +257,33 @@ func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpa
 				spawn.RoomID, spawn.MonsterRef, id)
 		}
 
-		claimed[position] = fmt.Sprintf("monster %q", id)
+		if occupant, taken := batch.claim(position, fmt.Sprintf("monster %q", id)); taken {
+			return nil, fmt.Errorf("room %q: monster %q: at %v collides with %s",
+				spawn.RoomID, spawn.MonsterRef, spawn.At, occupant)
+		}
+
+		mon := ctor(string(id))
+		dataJSON, err := json.Marshal(mon.ToData())
+		if err != nil {
+			return nil, fmt.Errorf("room %q: monster %q: marshal monster data: %w", spawn.RoomID, spawn.MonsterRef, err)
+		}
+		attackBonus, damageDice, damageType := primaryAttackSnapshot(mon)
+
 		resolved = append(resolved, resolvedSpawn{
-			id: id, roomID: spawn.RoomID, monsterRef: spawn.MonsterRef, position: position, ctor: ctor,
+			roomID: spawn.RoomID,
+			input: MonsterInput{
+				ID:          id,
+				Position:    position,
+				HP:          mon.HP(),
+				MaxHP:       mon.MaxHP(),
+				AC:          mon.AC(),
+				Speed:       mon.Speed().Walk / 5, // feet -> hexes (npc.go/action.go consume Speed in hexes)
+				MonsterRef:  spawn.MonsterRef,
+				DataJSON:    dataJSON,
+				AttackBonus: attackBonus,
+				DamageDice:  damageDice,
+				DamageType:  damageType,
+			},
 		})
 	}
 	return resolved, nil
@@ -236,16 +292,17 @@ func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpa
 // regionByID finds a region by its ID (RegionData.ID) in the encounter's
 // current Space — the lookup direction SpaceData.RegionAt doesn't
 // provide (that's hex -> region id; this is region id -> RegionData).
+// Its only caller (validateSpawnBatch, via SeedMonsters) already checked
+// e.data.Space != nil before this can ever be reached, so there's no
+// nil-Space branch here; callers wrap the returned error with their own
+// room/monster context.
 func (e *Encounter) regionByID(id string) (*RegionData, error) {
-	if e.data.Space == nil {
-		return nil, fmt.Errorf("room %q: no space initialized (call InitDungeon first)", id)
-	}
 	for i := range e.data.Space.Regions {
 		if e.data.Space.Regions[i].ID == id {
 			return &e.data.Space.Regions[i], nil
 		}
 	}
-	return nil, fmt.Errorf("room %q: no such region", id)
+	return nil, errors.New("no such region")
 }
 
 // regionOffsetX recovers a region's generateDungeonLayout offsetX
@@ -265,6 +322,27 @@ func regionOffsetX(hexes core.HexSet) int {
 		}
 	}
 	return minX
+}
+
+// regionWidth recovers a region's Width the same way regionOffsetX
+// recovers its offsetX: RegionData carries no Width field, but Hexes is
+// the region's full local rectangle (regionCubes), so max absolute X -
+// min absolute X + 1 IS the width. Used only for an author-facing
+// out-of-bounds error detail — not on any hot path.
+func regionWidth(hexes core.HexSet) int {
+	minX, maxX := 0, 0
+	first := true
+	for h := range hexes {
+		x := int(math.Round(h.ToPosition().X))
+		if first || x < minX {
+			minX = x
+		}
+		if first || x > maxX {
+			maxX = x
+		}
+		first = false
+	}
+	return maxX - minX + 1
 }
 
 // attackSnapshot mirrors the JSON shape shared by every damage-dealing

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -150,12 +150,24 @@ func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpa
 		wallCubes[w.Start] = struct{}{}
 	}
 
-	// Seeded from any monsters already in the encounter, so a spawn can't
-	// land on an existing occupant either — not just on another spawn
-	// within this same batch.
-	claimed := make(map[core.Hex]bool, len(spawns)+len(e.data.Monsters))
-	for _, m := range e.data.Monsters {
-		claimed[m.Position] = true
+	// Seeded from any monster or BLOCKING obstacle already in the
+	// encounter, so a spawn can't land on an existing occupant either —
+	// not just on another spawn within this same batch. Non-blocking
+	// obstacles (candles, bone-pile, chain — data.go's ObstacleData.
+	// BlocksMovement doc) are walkable-past floor dressing, so they don't
+	// reserve a cell here, matching room-rebuild's own walkability
+	// semantics (rebuildRoomFromData only ever rejects a BlocksMovement
+	// entity's cell as occupied). occupant is a human-readable descriptor
+	// (kind + ID/ref) for the collision error, not just a bool.
+	claimed := make(map[core.Hex]string, len(spawns)+len(e.data.Monsters)+len(e.data.Space.Obstacles))
+	for id, m := range e.data.Monsters {
+		claimed[m.Position] = fmt.Sprintf("monster %q", id)
+	}
+	for _, o := range e.data.Space.Obstacles {
+		if !o.BlocksMovement {
+			continue
+		}
+		claimed[o.Position] = fmt.Sprintf("obstacle %q", o.ID)
 	}
 
 	roomCounts := make(map[string]int, len(spawns))
@@ -193,15 +205,27 @@ func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpa
 			return nil, fmt.Errorf("room %q: monster %q: at %v is on a wall cell",
 				spawn.RoomID, spawn.MonsterRef, spawn.At)
 		}
-		if claimed[position] {
-			return nil, fmt.Errorf("room %q: monster %q: at %v collides with another monster",
-				spawn.RoomID, spawn.MonsterRef, spawn.At)
+		if occupant, taken := claimed[position]; taken {
+			return nil, fmt.Errorf("room %q: monster %q: at %v collides with %s",
+				spawn.RoomID, spawn.MonsterRef, spawn.At, occupant)
 		}
-		claimed[position] = true
 
+		// Minted here, not just at commit time: the whole point of
+		// validating the ENTIRE batch before committing any of it is that
+		// an ID collision — e.g. a second SeedMonsters call re-minting
+		// "monster-entrance-0" against an encounter that already has one
+		// from a prior call — must be caught here too, not discovered
+		// mid-commit by addMonsterNoCombatCheck's own "already in
+		// encounter" check after earlier spawns in THIS batch already
+		// committed.
 		id := core.EntityID(fmt.Sprintf("monster-%s-%d", spawn.RoomID, roomCounts[spawn.RoomID]))
 		roomCounts[spawn.RoomID]++
+		if _, exists := e.data.Monsters[id]; exists {
+			return nil, fmt.Errorf("room %q: monster %q: minted id %q already in encounter",
+				spawn.RoomID, spawn.MonsterRef, id)
+		}
 
+		claimed[position] = fmt.Sprintf("monster %q", id)
 		resolved = append(resolved, resolvedSpawn{
 			id: id, roomID: spawn.RoomID, monsterRef: spawn.MonsterRef, position: position, ctor: ctor,
 		})

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// SpawnInstruction describes one monster spawn compiled from a dungeon
+// spec — encounter-owned (not dungeonspec-owned; dungeonspec re-exports
+// it via a plain type alias) so a host can call
+// enc.SeedMonsters(compiled.Spawns) directly, with zero conversion.
+type SpawnInstruction struct {
+	// RoomID names the region (DungeonRegionParams.ID / RegionData.ID)
+	// this spawn targets.
+	RoomID string
+
+	// MonsterRef is the canonical monster ref (e.g.
+	// "dnd5e:monsters:skeleton") resolved via monsters.ByRef.
+	MonsterRef string
+
+	// Count is how many instances to spawn. M1 only supports At-bearing
+	// instructions, which are always exactly one instance at a fixed
+	// cell — see At's doc.
+	Count int
+
+	// At is this spawn's room-local cell: nil means rolled (count-based,
+	// safe-cell selection — M2 only, SeedMonsters rejects it in M1);
+	// non-nil means placed (M1) at this exact cell, translated by the
+	// target region's offsetX exactly like Task N1's PlacedObstacleSpec.
+	At *LocalHex
+}
+
+// SeedMonsters places a compiled spawn plan (e.g.
+// dungeonspec.CompiledDungeon.Spawns) into an already-InitDungeon'd
+// encounter, under the atomic combat-entry invariant: every spawn in the
+// batch is staged with combat-entry evaluation suppressed
+// (addMonsterNoCombatCheck), and exactly ONE checkCombatEntry pass runs
+// after the whole batch commits. This matters because AddMonster's own
+// per-call checkCombatEntry would otherwise let a monster added mid-batch
+// while combat is already running (triggered by an EARLIER spawn's own
+// visibility) join initiative unconditionally, regardless of that later
+// monster's own visibility (see combat_entry_test.go's
+// TestIdempotent_AddMonsterAndMoveAfterCombatStarted) — exactly the
+// partial-roster bug class the invariant exists to prevent, for spawn
+// orders (boss-first, per the compiler) where the boss is seeded before
+// an already-visible entrance monster.
+//
+// M1 scope (this plan's Task N2 scoping call): only At-bearing (placed)
+// instructions are supported — an At == nil (rolled, count-based)
+// instruction returns the scope-boundary error below regardless of
+// Count. M2's Slice C extends this same function with safe-cell rolling
+// for At == nil instructions. dungeonspec's own Validate (Task B2)
+// already rejects any M1 spec that would produce one, so this is
+// unreachable via the content-hosting path today — this check is
+// defense-in-depth for SeedMonsters' other, non-dungeonspec callers.
+func (e *Encounter) SeedMonsters(spawns []SpawnInstruction) error {
+	roomCounts := make(map[string]int, len(spawns))
+	for _, spawn := range spawns {
+		if spawn.At == nil {
+			return fmt.Errorf("room %q: monster %q: rolled (count-based) monster placement lands in M2",
+				spawn.RoomID, spawn.MonsterRef)
+		}
+		ctor, ok := monsters.ByRef(spawn.MonsterRef)
+		if !ok {
+			return fmt.Errorf("room %q: unknown monster ref %q", spawn.RoomID, spawn.MonsterRef)
+		}
+		region, err := e.regionByID(spawn.RoomID)
+		if err != nil {
+			return err
+		}
+		offsetX := regionOffsetX(region.Hexes)
+		position := core.HexFromPosition(spatial.Position{
+			X: float64(offsetX + spawn.At.Col), Y: float64(spawn.At.Row),
+		})
+
+		id := core.EntityID(fmt.Sprintf("monster-%s-%d", spawn.RoomID, roomCounts[spawn.RoomID]))
+		roomCounts[spawn.RoomID]++
+
+		mon := ctor(string(id))
+		dataJSON, err := json.Marshal(mon.ToData())
+		if err != nil {
+			return fmt.Errorf("room %q: monster %q: marshal monster data: %w", spawn.RoomID, spawn.MonsterRef, err)
+		}
+
+		if err := e.addMonsterNoCombatCheck(MonsterInput{
+			ID:         id,
+			Position:   position,
+			HP:         mon.HP(),
+			MaxHP:      mon.MaxHP(),
+			AC:         mon.AC(),
+			Speed:      mon.Speed().Walk,
+			MonsterRef: spawn.MonsterRef,
+			DataJSON:   dataJSON,
+		}); err != nil {
+			return fmt.Errorf("room %q: monster %q: %w", spawn.RoomID, spawn.MonsterRef, err)
+		}
+	}
+	return e.checkCombatEntry()
+}
+
+// regionByID finds a region by its ID (RegionData.ID) in the encounter's
+// current Space — the lookup direction SpaceData.RegionAt doesn't
+// provide (that's hex -> region id; this is region id -> RegionData).
+func (e *Encounter) regionByID(id string) (*RegionData, error) {
+	if e.data.Space == nil {
+		return nil, fmt.Errorf("room %q: no space initialized (call InitDungeon first)", id)
+	}
+	for i := range e.data.Space.Regions {
+		if e.data.Space.Regions[i].ID == id {
+			return &e.data.Space.Regions[i], nil
+		}
+	}
+	return nil, fmt.Errorf("room %q: no such region", id)
+}
+
+// regionOffsetX recovers a region's generateDungeonLayout offsetX
+// (starts[i]) from its persisted RegionData.Hexes — InitDungeon discards
+// DungeonParams once the layout is built, and RegionData carries no
+// offset field (data.go), so this is the only source left. Every
+// region's local x=0 column is a member of Hexes for every row (see
+// regionCubes), so the minimum absolute X across the set IS offsetX.
+func regionOffsetX(hexes core.HexSet) int {
+	minX := 0
+	first := true
+	for h := range hexes {
+		x := int(math.Round(h.ToPosition().X))
+		if first || x < minX {
+			minX = x
+			first = false
+		}
+	}
+	return minX
+}

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -379,7 +379,10 @@ type attackSnapshot struct {
 // (monster/scimitar_action.go, predating the generic actions.MeleeAction)
 // never serializes a damage type at all (damage_bonus instead) — its
 // DamageType comes back empty here; AttackBonus/DamageDice still populate
-// correctly, which is what OA readiness actually needs.
+// correctly, which is what OA readiness actually needs. A broader gap —
+// a ranged-only monster's OA readiness assumes a melee-shaped attack —
+// is tracked separately as rpg-toolkit#844 (a typed attack-snapshot
+// accessor belongs in rulebooks/dnd5e, not patched here).
 func primaryAttackSnapshot(mon *monster.Monster) (attackBonus int, damageDice, damageType string) {
 	for _, action := range mon.Actions() {
 		var snap attackSnapshot

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -5,10 +5,12 @@ package encounter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -27,8 +29,10 @@ type SpawnInstruction struct {
 	MonsterRef string
 
 	// Count is how many instances to spawn. M1 only supports At-bearing
-	// instructions, which are always exactly one instance at a fixed
-	// cell — see At's doc.
+	// instructions, which SeedMonsters requires to have Count exactly 1
+	// (a placed instruction pins ONE instance to ONE cell — Count>1 with
+	// At set is rejected outright, never silently truncated) — see At's
+	// doc.
 	Count int
 
 	// At is this spawn's room-local cell: nil means rolled (count-based,
@@ -38,20 +42,44 @@ type SpawnInstruction struct {
 	At *LocalHex
 }
 
+// resolvedSpawn is one SpawnInstruction after it has passed every
+// validation check in SeedMonsters' first pass — everything the commit
+// pass needs, so committing never has to re-derive or re-check anything
+// the validation pass already established.
+type resolvedSpawn struct {
+	id         core.EntityID
+	roomID     string
+	monsterRef string
+	position   core.Hex
+	ctor       monsters.Constructor
+}
+
 // SeedMonsters places a compiled spawn plan (e.g.
 // dungeonspec.CompiledDungeon.Spawns) into an already-InitDungeon'd
-// encounter, under the atomic combat-entry invariant: every spawn in the
-// batch is staged with combat-entry evaluation suppressed
-// (addMonsterNoCombatCheck), and exactly ONE checkCombatEntry pass runs
-// after the whole batch commits. This matters because AddMonster's own
-// per-call checkCombatEntry would otherwise let a monster added mid-batch
-// while combat is already running (triggered by an EARLIER spawn's own
-// visibility) join initiative unconditionally, regardless of that later
-// monster's own visibility (see combat_entry_test.go's
-// TestIdempotent_AddMonsterAndMoveAfterCombatStarted) — exactly the
-// partial-roster bug class the invariant exists to prevent, for spawn
-// orders (boss-first, per the compiler) where the boss is seeded before
-// an already-visible entrance monster.
+// encounter under two invariants:
+//
+//  1. All-or-nothing batch validation: EVERY instruction is validated
+//     (At non-nil, Count==1, MonsterRef resolves, RoomID names a real
+//     region, the cell is in-bounds/not-doorRow/not-a-wall-cell/not
+//     already claimed by this batch or an existing occupant) BEFORE any
+//     monster is added. A single bad instruction anywhere in the batch
+//     leaves the encounter exactly as it was before the call — no
+//     partial commit, no monsters added, mode unchanged — mirroring
+//     placeVerbatimObstacles' own contract one file over (dungeon.go)
+//     and closing the class of bug where an early instruction commits
+//     and only a LATER one fails.
+//  2. Atomic combat-entry evaluation: every validated spawn is staged
+//     with combat-entry evaluation suppressed (addMonsterNoCombatCheck),
+//     and exactly ONE checkCombatEntry pass runs after the whole batch
+//     commits. This matters because AddMonster's own per-call
+//     checkCombatEntry would otherwise let a monster added mid-batch
+//     while combat is already running (triggered by an EARLIER spawn's
+//     own visibility) join initiative unconditionally, regardless of
+//     that later monster's own visibility (see combat_entry_test.go's
+//     TestIdempotent_AddMonsterAndMoveAfterCombatStarted) — the
+//     partial-roster bug this invariant exists to prevent for spawn
+//     orders (boss-first, per the compiler) where a monster is added
+//     AFTER an earlier one's own visibility already flipped the mode.
 //
 // M1 scope (this plan's Task N2 scoping call): only At-bearing (placed)
 // instructions are supported — an At == nil (rolled, count-based)
@@ -61,49 +89,124 @@ type SpawnInstruction struct {
 // already rejects any M1 spec that would produce one, so this is
 // unreachable via the content-hosting path today — this check is
 // defense-in-depth for SeedMonsters' other, non-dungeonspec callers.
+//
+// ID numbering ("monster-<roomID>-<n>", per-room, 0-based) is scoped to
+// ONE SeedMonsters call: M1 only ever calls this once per encounter (at
+// initial dungeon setup), so this is never an issue today. A second call
+// against the SAME encounter (M2 territory, e.g. re-seeding after a
+// pocket clears) would restart each room's counter at 0 and collide with
+// IDs this call already assigned — M2's Slice C, whichever caller ends
+// up needing repeat calls, must carry the counters forward or use a
+// different scheme; not needed for M1's single-call acceptance path.
 func (e *Encounter) SeedMonsters(spawns []SpawnInstruction) error {
+	if e.data.Space == nil {
+		return errors.New("seed monsters: no space initialized (call InitDungeon first)")
+	}
+
+	resolved, err := e.validateSpawnBatch(spawns)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range resolved {
+		mon := r.ctor(string(r.id))
+		dataJSON, err := json.Marshal(mon.ToData())
+		if err != nil {
+			return fmt.Errorf("room %q: monster %q: marshal monster data: %w", r.roomID, r.monsterRef, err)
+		}
+		attackBonus, damageDice, damageType := primaryAttackSnapshot(mon)
+
+		if err := e.addMonsterNoCombatCheck(MonsterInput{
+			ID:          r.id,
+			Position:    r.position,
+			HP:          mon.HP(),
+			MaxHP:       mon.MaxHP(),
+			AC:          mon.AC(),
+			Speed:       mon.Speed().Walk / 5, // feet -> hexes (npc.go/action.go consume Speed in hexes)
+			MonsterRef:  r.monsterRef,
+			DataJSON:    dataJSON,
+			AttackBonus: attackBonus,
+			DamageDice:  damageDice,
+			DamageType:  damageType,
+		}); err != nil {
+			return fmt.Errorf("room %q: monster %q: %w", r.roomID, r.monsterRef, err)
+		}
+	}
+	return e.checkCombatEntry()
+}
+
+// validateSpawnBatch checks every instruction in spawns and resolves it
+// to a resolvedSpawn, WITHOUT mutating the encounter — SeedMonsters only
+// starts committing once every instruction has passed here, so a single
+// bad instruction anywhere in the batch never leaves an earlier one
+// committed.
+func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpawn, error) {
+	doorRow := e.data.Space.Height / 2
+	wallCubes := make(map[spatial.CubeCoordinate]struct{}, len(e.data.Space.Walls))
+	for _, w := range e.data.Space.Walls {
+		if w.Start != w.End {
+			continue // boundary-edge perimeter segment (rpg-toolkit#834), not a blocking wall cell
+		}
+		wallCubes[w.Start] = struct{}{}
+	}
+
+	// Seeded from any monsters already in the encounter, so a spawn can't
+	// land on an existing occupant either — not just on another spawn
+	// within this same batch.
+	claimed := make(map[core.Hex]bool, len(spawns)+len(e.data.Monsters))
+	for _, m := range e.data.Monsters {
+		claimed[m.Position] = true
+	}
+
 	roomCounts := make(map[string]int, len(spawns))
+	resolved := make([]resolvedSpawn, 0, len(spawns))
 	for _, spawn := range spawns {
 		if spawn.At == nil {
-			return fmt.Errorf("room %q: monster %q: rolled (count-based) monster placement lands in M2",
+			return nil, fmt.Errorf("room %q: monster %q: rolled (count-based) monster placement lands in M2",
 				spawn.RoomID, spawn.MonsterRef)
+		}
+		if spawn.Count != 1 {
+			return nil, fmt.Errorf("room %q: monster %q: placed (At-bearing) instructions must have Count 1, got %d",
+				spawn.RoomID, spawn.MonsterRef, spawn.Count)
 		}
 		ctor, ok := monsters.ByRef(spawn.MonsterRef)
 		if !ok {
-			return fmt.Errorf("room %q: unknown monster ref %q", spawn.RoomID, spawn.MonsterRef)
+			return nil, fmt.Errorf("room %q: unknown monster ref %q", spawn.RoomID, spawn.MonsterRef)
 		}
 		region, err := e.regionByID(spawn.RoomID)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		offsetX := regionOffsetX(region.Hexes)
 		position := core.HexFromPosition(spatial.Position{
 			X: float64(offsetX + spawn.At.Col), Y: float64(spawn.At.Row),
 		})
+		if !region.Hexes.Has(position) {
+			return nil, fmt.Errorf("room %q: monster %q: at %v is out of bounds for this region",
+				spawn.RoomID, spawn.MonsterRef, spawn.At)
+		}
+		if spawn.At.Row == doorRow {
+			return nil, fmt.Errorf("room %q: monster %q: at %v is on the reserved row (doorRow=%d)",
+				spawn.RoomID, spawn.MonsterRef, spawn.At, doorRow)
+		}
+		if _, wall := wallCubes[position.ToCube()]; wall {
+			return nil, fmt.Errorf("room %q: monster %q: at %v is on a wall cell",
+				spawn.RoomID, spawn.MonsterRef, spawn.At)
+		}
+		if claimed[position] {
+			return nil, fmt.Errorf("room %q: monster %q: at %v collides with another monster",
+				spawn.RoomID, spawn.MonsterRef, spawn.At)
+		}
+		claimed[position] = true
 
 		id := core.EntityID(fmt.Sprintf("monster-%s-%d", spawn.RoomID, roomCounts[spawn.RoomID]))
 		roomCounts[spawn.RoomID]++
 
-		mon := ctor(string(id))
-		dataJSON, err := json.Marshal(mon.ToData())
-		if err != nil {
-			return fmt.Errorf("room %q: monster %q: marshal monster data: %w", spawn.RoomID, spawn.MonsterRef, err)
-		}
-
-		if err := e.addMonsterNoCombatCheck(MonsterInput{
-			ID:         id,
-			Position:   position,
-			HP:         mon.HP(),
-			MaxHP:      mon.MaxHP(),
-			AC:         mon.AC(),
-			Speed:      mon.Speed().Walk,
-			MonsterRef: spawn.MonsterRef,
-			DataJSON:   dataJSON,
-		}); err != nil {
-			return fmt.Errorf("room %q: monster %q: %w", spawn.RoomID, spawn.MonsterRef, err)
-		}
+		resolved = append(resolved, resolvedSpawn{
+			id: id, roomID: spawn.RoomID, monsterRef: spawn.MonsterRef, position: position, ctor: ctor,
+		})
 	}
-	return e.checkCombatEntry()
+	return resolved, nil
 }
 
 // regionByID finds a region by its ID (RegionData.ID) in the encounter's
@@ -138,4 +241,53 @@ func regionOffsetX(hexes core.HexSet) int {
 		}
 	}
 	return minX
+}
+
+// attackSnapshot mirrors the JSON shape shared by every damage-dealing
+// MonsterAction's Config (MeleeConfig, RangedConfig, BiteConfig —
+// monster/actions/*.go): attack_bonus/damage_dice/damage_type. Decoding
+// into this one small struct rather than each action's own concrete
+// Config type means no type switch on the action's Ref is needed —
+// Multiattack (whose Config only ever carries an Attacks []string) and
+// any non-damage action (e.g. Nimble Escape) simply decode to zero
+// values here and get skipped by primaryAttackSnapshot below.
+type attackSnapshot struct {
+	AttackBonus int    `json:"attack_bonus"`
+	DamageDice  string `json:"damage_dice"`
+	DamageType  string `json:"damage_type"`
+}
+
+// primaryAttackSnapshot extracts a flat combat-snapshot (AttackBonus,
+// DamageDice, DamageType) from the first of a monster's actions that
+// actually carries one — MonsterInput's own flat-field shape,
+// combat_resolver.go's documented "stat-snapshot stand-in path" for
+// callers with no rehydratable DataJSON.
+//
+// This is NOT redundant with DataJSON. Real combat resolution runs
+// through the resolved monster's DataJSON-hydrated Attacker/Defender
+// regardless of these fields (combat_resolver.go's own doc) — but
+// encounter.go's Opportunity Attack readiness seeding
+// (addMonsterNoCombatCheck: "if input.DamageDice != \"\" { seedOAReadiness }")
+// gates ONLY on this flat DamageDice field, and never consults DataJSON.
+// Leaving it empty (an earlier version of this function did, reasoning
+// DataJSON alone was sufficient) silently starves every dungeon-seeded
+// monster's OA reaction of readiness forever.
+//
+// One known, accepted gap: the goblin's hardcoded ScimitarConfig
+// (monster/scimitar_action.go, predating the generic actions.MeleeAction)
+// never serializes a damage type at all (damage_bonus instead) — its
+// DamageType comes back empty here; AttackBonus/DamageDice still populate
+// correctly, which is what OA readiness actually needs.
+func primaryAttackSnapshot(mon *monster.Monster) (attackBonus int, damageDice, damageType string) {
+	for _, action := range mon.Actions() {
+		var snap attackSnapshot
+		if err := json.Unmarshal(action.ToData().Config, &snap); err != nil {
+			continue
+		}
+		if snap.DamageDice == "" {
+			continue
+		}
+		return snap.AttackBonus, snap.DamageDice, snap.DamageType
+	}
+	return 0, "", ""
 }

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -19,6 +19,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -36,7 +40,13 @@ const (
 	smRefSkeleton        = "dnd5e:monsters:skeleton"
 	smRefZombie          = "dnd5e:monsters:zombie"
 
-	smObstacleRefCrate = "test:obstacles:crate"
+	smObstacleRefCrate  = "test:obstacles:crate"
+	smObstacleRefCandle = "test:obstacles:candle"
+
+	smAlicePlayerID = "alice"
+	smAliceEntityID = "char-alice"
+
+	smLongswordActionName = "longsword"
 )
 
 // smDungeonParams builds a minimal 2-region (entrance -> boss) dungeon,
@@ -160,7 +170,7 @@ func TestSeedMonsters_CombatEntryNeverSeesPartialRoster(t *testing.T) {
 
 	entrance := enc.ToData().Space.Entrance
 	require.NoError(t, enc.AddPlayer(PlayerInput{
-		PlayerID: "alice", EntityID: "char-alice", Position: entrance, SightRange: 30,
+		PlayerID: smAlicePlayerID, EntityID: smAliceEntityID, Position: entrance, SightRange: 30,
 	}))
 	require.Equal(t, core.ModeFreeRoam, enc.Mode())
 
@@ -225,7 +235,7 @@ func TestSeedMonsters_SpawnVisibleStillStartsCombat(t *testing.T) {
 
 	entrance := enc.ToData().Space.Entrance
 	require.NoError(t, enc.AddPlayer(PlayerInput{
-		PlayerID: "alice", EntityID: "char-alice", Position: entrance, SightRange: 30,
+		PlayerID: smAlicePlayerID, EntityID: smAliceEntityID, Position: entrance, SightRange: 30,
 	}))
 	require.Equal(t, core.ModeFreeRoam, enc.Mode())
 
@@ -560,4 +570,126 @@ func TestSeedMonsters_WallCellRejected(t *testing.T) {
 	require.NoError(t, enc.SeedMonsters([]SpawnInstruction{
 		{RoomID: smRoomIDEntrance, MonsterRef: smRefZombie, Count: 1, At: &perimeterAt},
 	}), "a perimeter floor cell (boundary-edge segment only, no interior wall) must be accepted")
+}
+
+// TestSeedMonsters_PlayerCollisionRejected: a player already occupying a
+// cell joins the collision domain, the same as a monster or blocking
+// obstacle — without this, a spawn could silently co-locate with a party
+// member.
+func TestSeedMonsters_PlayerCollisionRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	at := LocalHex{Col: 1, Row: 2}
+	pos := core.HexFromPosition(spatial.Position{X: float64(at.Col), Y: float64(at.Row)}) // entrance offsetX=0
+	require.NoError(t, enc.AddPlayer(PlayerInput{
+		PlayerID: smAlicePlayerID, EntityID: smAliceEntityID, Position: pos, SightRange: 5,
+	}))
+
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "collides with player")
+	require.Empty(t, enc.ToData().Monsters)
+}
+
+// TestSeedMonsters_ExistingMonsterCollisionRejected: a monster already in
+// the encounter (added directly via AddMonster, not SeedMonsters — so no
+// minted-ID collision is possible here, isolating the position-collision
+// check specifically) joins the collision domain the same as a player or
+// blocking obstacle.
+func TestSeedMonsters_ExistingMonsterCollisionRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	at := LocalHex{Col: 1, Row: 2}
+	pos := core.HexFromPosition(spatial.Position{X: float64(at.Col), Y: float64(at.Row)})
+	require.NoError(t, enc.AddMonster(MonsterInput{ID: "hand-placed-goblin", Position: pos, HP: 7, MaxHP: 7}))
+
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "collides with monster")
+	require.Len(t, enc.ToData().Monsters, 1,
+		"only the hand-placed monster must remain -- SeedMonsters must not have committed anything")
+}
+
+// TestSeedMonsters_UnknownRoomIDRejected: a RoomID that names no real
+// region is rejected before any commit.
+func TestSeedMonsters_UnknownRoomIDRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	at := LocalHex{Col: 1, Row: 2}
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: "nonexistent-room", MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no such region")
+	require.Empty(t, enc.ToData().Monsters)
+}
+
+// TestSeedMonsters_BeforeInitDungeonRejected: SeedMonsters on a fresh
+// encounter with no Space initialized yet is rejected outright, not a
+// panic or a nil-pointer crash deeper in validateSpawnBatch.
+func TestSeedMonsters_BeforeInitDungeonRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	at := LocalHex{Col: 1, Row: 2}
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no space initialized")
+}
+
+// TestSeedMonsters_NonBlockingObstacleDoesNotReserveCell: a non-blocking
+// obstacle (BlocksMovement false — candles, bone-pile, chain in the real
+// crypt content) does NOT reserve its cell; a monster may be pinned
+// there. Rolls a spread of non-blocking obstacles and targets one back.
+func TestSeedMonsters_NonBlockingObstacleDoesNotReserveCell(t *testing.T) {
+	enc := smNewEncounter(t)
+	params := smDungeonParams()
+	params.Regions[0].Obstacles = []ObstacleSpec{
+		{Ref: smObstacleRefCandle, Count: 6, BlocksMovement: false, BlocksLoS: false},
+	}
+	require.NoError(t, enc.InitDungeon(params))
+
+	obstacles := enc.ToData().Space.Obstacles
+	require.NotEmpty(t, obstacles, "fixture must actually roll obstacles for this to be a real proof")
+	target := obstacles[0]
+	pos := target.Position.ToPosition()
+	at := LocalHex{Col: int(pos.X), Row: int(pos.Y)} // entrance offsetX=0
+
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.NoError(t, err, "a non-blocking obstacle must not reserve its cell")
+	require.Len(t, enc.ToData().Monsters, 1)
+}
+
+// TestPrimaryAttackSnapshot_SkipsMultiattackAction proves the Multiattack
+// skip directly: every real 11-constructor monster with a Multiattack
+// action happens to register its individual attack action(s) FIRST
+// (skeleton-captain: longsword, then multiattack), so primaryAttackSnapshot
+// never actually needs to skip past one in practice — that ordering
+// coincidence would let a bug (e.g. accidentally treating Multiattack as
+// if it had its own damage_dice) hide. Building a monster with Multiattack
+// registered FIRST isolates the skip from that coincidence.
+func TestPrimaryAttackSnapshot_SkipsMultiattackAction(t *testing.T) {
+	mon := monster.New(monster.Config{
+		ID: "test-multiattack-first", Name: "Test", Ref: refs.Monsters.SkeletonCaptain(), HP: 10, AC: 10,
+	})
+	mon.AddAction(actions.NewMultiattackAction(actions.MultiattackConfig{
+		Attacks: []string{smLongswordActionName, smLongswordActionName},
+	}))
+	mon.AddAction(actions.NewMeleeAction(actions.MeleeConfig{
+		Name: smLongswordActionName, AttackBonus: 5, DamageDice: "1d8+3", Reach: 1, DamageType: damage.Slashing,
+	}))
+
+	attackBonus, damageDice, damageType := primaryAttackSnapshot(mon)
+	require.Equal(t, 5, attackBonus)
+	require.Equal(t, "1d8+3", damageDice)
+	require.Equal(t, string(damage.Slashing), damageType)
 }

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -13,6 +13,7 @@ package encounter
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,8 @@ const (
 	smRefSkeletonCaptain = "dnd5e:monsters:skeleton-captain"
 	smRefSkeleton        = "dnd5e:monsters:skeleton"
 	smRefZombie          = "dnd5e:monsters:zombie"
+
+	smObstacleRefCrate = "test:obstacles:crate"
 )
 
 // smDungeonParams builds a minimal 2-region (entrance -> boss) dungeon,
@@ -65,6 +68,19 @@ func smNewEncounter(t *testing.T) *Encounter {
 		_ = transport.Close()
 	})
 	return New(context.Background(), "enc-seed-monsters-test", broker)
+}
+
+// marshalData snapshots enc's current state as JSON bytes. ToData()
+// returns e.data directly (the SAME pointer every call, never a copy) —
+// require.Equal on two ToData() results compares a pointer to itself and
+// can never fail regardless of what happened in between. Marshaling to
+// bytes at each call site captures a genuine point-in-time snapshot, so
+// comparing before/after actually proves nothing changed.
+func marshalData(t *testing.T, enc *Encounter) []byte {
+	t.Helper()
+	b, err := json.Marshal(enc.ToData())
+	require.NoError(t, err)
+	return b
 }
 
 // TestSeedMonsters_PlacedMonstersSpawnAtTheirCells: an At-bearing
@@ -319,7 +335,7 @@ func TestSeedMonsters_OpportunityAttackReadySeeded(t *testing.T) {
 func TestSeedMonsters_MidBatchInvalidInstructionLeavesEncounterUnchanged(t *testing.T) {
 	enc := smNewEncounter(t)
 	require.NoError(t, enc.InitDungeon(smDungeonParams()))
-	before := enc.ToData()
+	before := marshalData(t, enc)
 
 	validAt := LocalHex{Col: 1, Row: 2}
 	badAt := LocalHex{Col: 2, Row: 2}
@@ -330,10 +346,10 @@ func TestSeedMonsters_MidBatchInvalidInstructionLeavesEncounterUnchanged(t *test
 	err := enc.SeedMonsters(spawns)
 	require.Error(t, err)
 
-	after := enc.ToData()
-	require.Empty(t, after.Monsters, "a bad instruction anywhere in the batch must commit NOTHING, "+
+	require.Empty(t, enc.ToData().Monsters, "a bad instruction anywhere in the batch must commit NOTHING, "+
 		"not just skip the failing one")
 	require.Equal(t, core.ModeFreeRoam, enc.Mode())
+	after := marshalData(t, enc)
 	require.Equal(t, before, after, "encounter must be byte-identical to before the call")
 }
 
@@ -386,5 +402,143 @@ func TestSeedMonsters_CountGreaterThanOneWithAtRejected(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Count")
+	require.Empty(t, enc.ToData().Monsters)
+}
+
+// TestSeedMonsters_ObstacleCollisionRejected: a BLOCKING obstacle already
+// in the encounter's Space joins the collision domain — a monster pinned
+// onto its exact cell is rejected before any commit, the same as
+// colliding with another monster. Non-blocking obstacles (candles,
+// bone-pile, chain — data.go's ObstacleData.BlocksMovement doc) do NOT
+// reserve a cell here, matching room-rebuild's own walkability semantics.
+// Rolls a full spread of blocking obstacles (rolled placement is
+// seed-dependent, so the exact cell can't be hardcoded) and reads one
+// back to target directly.
+func TestSeedMonsters_ObstacleCollisionRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	params := smDungeonParams()
+	params.Regions[0].Obstacles = []ObstacleSpec{
+		{Ref: smObstacleRefCrate, Count: 6, BlocksMovement: true, BlocksLoS: false},
+	}
+	require.NoError(t, enc.InitDungeon(params))
+
+	obstacles := enc.ToData().Space.Obstacles
+	require.NotEmpty(t, obstacles, "fixture must actually roll obstacles for this to be a real proof")
+	target := obstacles[0]
+
+	// Entrance is region 0 (offsetX 0), so absolute position IS local
+	// position directly — no offsetX translation needed.
+	pos := target.Position.ToPosition()
+	at := LocalHex{Col: int(pos.X), Row: int(pos.Y)}
+
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "collides with obstacle")
+	require.Empty(t, enc.ToData().Monsters)
+}
+
+// TestSeedMonsters_SecondCallMintedIDCollisionRejectsNothingCommitted:
+// SeedMonsters mints "monster-<roomID>-<n>" IDs starting at 0 for each
+// room on every call — a second call touching a room an earlier call
+// already seeded would re-mint an ID already in the encounter. This is
+// caught in the VALIDATION pass (not deferred to commit-time, where it
+// would only be caught mid-commit by addMonsterNoCombatCheck's own
+// "already in encounter" check, after any earlier-in-THIS-batch spawns
+// already committed) — a batch mixing a fresh room and a colliding room
+// must commit NOTHING from the second call, including the fresh room's
+// otherwise-valid spawn.
+func TestSeedMonsters_SecondCallMintedIDCollisionRejectsNothingCommitted(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	firstAt := LocalHex{Col: 1, Row: 2}
+	require.NoError(t, enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &firstAt},
+	}))
+	before := marshalData(t, enc)
+
+	// Second call: a fresh room (boss, untouched by the first call) plus
+	// a spawn back in entrance -- which would re-mint "monster-entrance-0",
+	// colliding with the first call's monster.
+	bossAt := LocalHex{Col: 7, Row: 5}
+	secondEntranceAt := LocalHex{Col: 3, Row: 1}
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDBoss, MonsterRef: smRefSkeletonCaptain, Count: 1, At: &bossAt},
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefZombie, Count: 1, At: &secondEntranceAt},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already in encounter")
+
+	after := marshalData(t, enc)
+	require.Equal(t, before, after,
+		"the second call's failure must commit NOTHING -- not even the boss spawn that would have succeeded alone")
+}
+
+// TestSeedMonsters_DoorRowRejected: a cell on the shared doorRow
+// (height/2) is rejected before any commit — belt-and-suspenders with
+// dungeonspec's own load-time check, since SeedMonsters is reachable by
+// callers other than the content-hosting path. Verified by temporarily
+// deleting the check: confirmed this test fails (no error) before
+// restoring it — same discipline as N1's mutation testing.
+func TestSeedMonsters_DoorRowRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	at := LocalHex{Col: 1, Row: smHeight / 2}
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved row")
+	require.Empty(t, enc.ToData().Monsters)
+}
+
+// TestSeedMonsters_WallCellRejected guards the non-obvious Start != End
+// skip in validateSpawnBatch's wallCubes build: SpaceData.Walls also
+// carries boundary-edge perimeter segments (rpg-toolkit#834, Start !=
+// End) that are NOT blocking wall cells — a naive "every Walls entry
+// blocks" reading would wrongly reject cells that are actually walkable
+// floor. PatternRandom's interior walls are seed-dependent, so this
+// discovers an actual wall cell for some seed first (a probe run), then
+// targets that exact cell with the same seed.
+func TestSeedMonsters_WallCellRejected(t *testing.T) {
+	var wallCell LocalHex
+	var seedUsed int64
+	found := false
+	for seed := int64(1); seed <= 50 && !found; seed++ {
+		probe := smNewEncounter(t)
+		params := smDungeonParams()
+		params.RandomSeed = seed
+		params.Regions[0].Pattern = environments.PatternRandom
+		require.NoError(t, probe.InitDungeon(params), "seed %d", seed)
+		for _, w := range probe.ToData().Space.Walls {
+			if w.Start != w.End {
+				continue // boundary-edge perimeter segment, not an interior wall cell
+			}
+			pos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+			col, row := int(pos.X), int(pos.Y) // entrance is region 0, offsetX 0
+			if col >= 0 && col < smEntranceWidth && row != smHeight/2 {
+				wallCell = LocalHex{Col: col, Row: row}
+				seedUsed = seed
+				found = true
+				break
+			}
+		}
+	}
+	require.True(t, found, "expected at least one seed in [1,50] to produce an interior wall cell in the entrance")
+
+	enc := smNewEncounter(t)
+	params := smDungeonParams()
+	params.RandomSeed = seedUsed
+	params.Regions[0].Pattern = environments.PatternRandom
+	require.NoError(t, enc.InitDungeon(params))
+
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &wallCell},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wall cell")
 	require.Empty(t, enc.ToData().Monsters)
 }

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -376,6 +376,7 @@ func TestSeedMonsters_OutOfBoundsAtRejected(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "out of bounds")
+	require.Contains(t, err.Error(), "width=8") // pins the region's own width in the detail, not just "out of bounds"
 	require.Empty(t, enc.ToData().Monsters)
 }
 

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -252,3 +252,139 @@ func TestSeedMonsters_UnpinnedInstructionReturnsNotYetSupported(t *testing.T) {
 		})
 	}
 }
+
+// smSeedOneSkeleton spawns a single skeleton at a fixed, valid entrance
+// cell and returns its entity ID.
+func smSeedOneSkeleton(t *testing.T, enc *Encounter) core.EntityID {
+	t.Helper()
+	at := LocalHex{Col: 1, Row: 2}
+	require.NoError(t, enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	}))
+	data := enc.ToData()
+	require.Len(t, data.Monsters, 1)
+	var id core.EntityID
+	for mid := range data.Monsters {
+		id = mid
+	}
+	return id
+}
+
+// TestSeedMonsters_SpeedConvertedFromFeetToHexes: monster.Monster.Speed()
+// reports Walk in FEET (e.g. 30 for a skeleton); npc.go/action.go consume
+// MonsterData.Speed as HEXES directly (movement remaining for the turn).
+// Storing the raw feet value gives a seeded skeleton 30 hexes (150ft) of
+// movement per turn instead of 6 (30ft) — the same feet->hexes conversion
+// devseed/main.go and rpg-api's crypt_monster_seed.go both apply
+// (cryptMinionSpeed = 6 // 30ft / 5ft per hex) must happen here too.
+func TestSeedMonsters_SpeedConvertedFromFeetToHexes(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	id := smSeedOneSkeleton(t, enc)
+	m := enc.ToData().Monsters[id]
+	require.Equal(t, 6, m.Speed, "skeleton's 30ft walk speed must convert to 6 hexes (30/5), not store raw feet")
+}
+
+// TestSeedMonsters_OpportunityAttackReadySeeded: encounter.go only seeds
+// OA readiness when MonsterInput.DamageDice is non-empty, and never
+// derives readiness from DataJSON — rpg-api's gamectx readiness map is
+// built straight from data.ReactionReadiness. A SeedMonsters caller that
+// leaves the flat AttackBonus/DamageDice/DamageType fields empty
+// (reasoning DataJSON alone carries the monster's real stats) silently
+// starves every seeded monster's OA reaction of readiness forever.
+func TestSeedMonsters_OpportunityAttackReadySeeded(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	id := smSeedOneSkeleton(t, enc)
+	require.True(t, enc.IsReactionReady(id, OAReactionRef),
+		"a seeded monster with a real attack action must have its Opportunity Attack reaction seeded ready")
+
+	m := enc.ToData().Monsters[id]
+	require.NotZero(t, m.AttackBonus,
+		"the flat combat-snapshot AttackBonus must be populated from the monster's own attack action")
+	require.NotEmpty(t, m.DamageDice, "the flat combat-snapshot DamageDice must be populated")
+	require.NotEmpty(t, m.DamageType, "the flat combat-snapshot DamageType must be populated")
+}
+
+// TestSeedMonsters_MidBatchInvalidInstructionLeavesEncounterUnchanged:
+// an invalid instruction ANYWHERE in the batch (here: the second of two)
+// must commit NOTHING — no monsters added, mode unchanged, encounter
+// byte-identical to before the call. This is the all-or-nothing batch
+// validation contract (mirrors placeVerbatimObstacles' own contract one
+// file over, dungeon.go): SeedMonsters validates the ENTIRE batch before
+// committing any of it, rather than committing earlier instructions and
+// only failing on a later one.
+func TestSeedMonsters_MidBatchInvalidInstructionLeavesEncounterUnchanged(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+	before := enc.ToData()
+
+	validAt := LocalHex{Col: 1, Row: 2}
+	badAt := LocalHex{Col: 2, Row: 2}
+	spawns := []SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &validAt},
+		{RoomID: smRoomIDEntrance, MonsterRef: "dnd5e:monsters:beholder", Count: 1, At: &badAt}, // unresolvable ref
+	}
+	err := enc.SeedMonsters(spawns)
+	require.Error(t, err)
+
+	after := enc.ToData()
+	require.Empty(t, after.Monsters, "a bad instruction anywhere in the batch must commit NOTHING, "+
+		"not just skip the failing one")
+	require.Equal(t, core.ModeFreeRoam, enc.Mode())
+	require.Equal(t, before, after, "encounter must be byte-identical to before the call")
+}
+
+// TestSeedMonsters_OutOfBoundsAtRejected: a cell outside the target
+// region's own extent (here: one column past its right edge, landing in
+// the connector's boundary/door column) is rejected before any commit.
+func TestSeedMonsters_OutOfBoundsAtRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	at := LocalHex{Col: smEntranceWidth, Row: 2}
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of bounds")
+	require.Empty(t, enc.ToData().Monsters)
+}
+
+// TestSeedMonsters_TwoInstructionsOnOneCellRejected: two instructions
+// targeting the exact same cell (whether in the same room or not) is
+// rejected before any commit — the batch-internal collision half of the
+// "not already claimed by this batch or existing occupant" check.
+func TestSeedMonsters_TwoInstructionsOnOneCellRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	at := LocalHex{Col: 1, Row: 2}
+	spawns := []SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefZombie, Count: 1, At: &at},
+	}
+	err := enc.SeedMonsters(spawns)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "collides")
+	require.Empty(t, enc.ToData().Monsters)
+}
+
+// TestSeedMonsters_CountGreaterThanOneWithAtRejected: a placed
+// (At-bearing) instruction must have Count exactly 1 — a caller asking
+// for 5 placed instances at one cell is rejected outright, never
+// silently truncated to 1.
+func TestSeedMonsters_CountGreaterThanOneWithAtRejected(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	at := LocalHex{Col: 1, Row: 2}
+	err := enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 5, At: &at},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Count")
+	require.Empty(t, enc.ToData().Monsters)
+}

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -498,11 +498,17 @@ func TestSeedMonsters_DoorRowRejected(t *testing.T) {
 // TestSeedMonsters_WallCellRejected guards the non-obvious Start != End
 // skip in validateSpawnBatch's wallCubes build: SpaceData.Walls also
 // carries boundary-edge perimeter segments (rpg-toolkit#834, Start !=
-// End) that are NOT blocking wall cells — a naive "every Walls entry
-// blocks" reading would wrongly reject cells that are actually walkable
-// floor. PatternRandom's interior walls are seed-dependent, so this
-// discovers an actual wall cell for some seed first (a probe run), then
-// targets that exact cell with the same seed.
+// End) that are NOT blocking wall cells — Start is real walkable floor,
+// End is the adjacent hex outside the grid. A naive "every Walls entry
+// blocks" reading would wrongly reject a perimeter floor cell (a boss
+// pinned against the back wall is ordinary content, not a rejected
+// placement). This test proves BOTH directions on the SAME seed: a real
+// interior wall cell (Start == End) is rejected, AND a perimeter floor
+// cell (which also appears in Walls, but only via its Start != End
+// boundary segment) is accepted — only the acceptance half actually
+// depends on the skip; deleting it leaves the rejection half green on
+// its own (verified: the skip's removal doesn't touch Start == End
+// entries at all, so the interior-wall assertion alone can't catch it).
 func TestSeedMonsters_WallCellRejected(t *testing.T) {
 	var wallCell LocalHex
 	var seedUsed int64
@@ -541,4 +547,17 @@ func TestSeedMonsters_WallCellRejected(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "wall cell")
 	require.Empty(t, enc.ToData().Monsters)
+
+	// Perimeter acceptance: Col 0 sits on the whole space's own left edge,
+	// so this cell ALSO appears in Space.Walls — but only via a Start !=
+	// End boundary-edge segment (its west-facing side lands outside the
+	// grid); it is real walkable floor. This is what the Start != End
+	// skip actually guards: without it, this cell would wrongly land in
+	// wallCubes too and get rejected, even though it's ordinary content.
+	perimeterAt := LocalHex{Col: 0, Row: 1}
+	require.NotEqual(t, wallCell, perimeterAt,
+		"the discovered interior wall and the perimeter probe must be distinct cells")
+	require.NoError(t, enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefZombie, Count: 1, At: &perimeterAt},
+	}), "a perimeter floor cell (boundary-edge segment only, no interior wall) must be accepted")
 }

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -1,0 +1,254 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+// seed_monsters_test.go is package encounter (not encounter_test): the
+// regionOffsetX helper it tests in isolation is unexported, and this
+// codebase's convention otherwise (every other _test.go file here is
+// package encounter_test) is to test through the public API — this file
+// is the one deliberate exception, needed for the same reason
+// checkCombatEntry's own tests never need one (that logic is entirely
+// reachable through AddMonster/AddPlayer/Move).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+const (
+	smHeight        = 8
+	smEntranceWidth = 8
+	smBossWidth     = 10
+	smSeed          = 1
+
+	smRoomIDEntrance = "entrance"
+	smRoomIDBoss     = "boss"
+
+	smRefSkeletonCaptain = "dnd5e:monsters:skeleton-captain"
+	smRefSkeleton        = "dnd5e:monsters:skeleton"
+	smRefZombie          = "dnd5e:monsters:zombie"
+)
+
+// smDungeonParams builds a minimal 2-region (entrance -> boss) dungeon,
+// fixed at smSeed (no test in this file needs a different one — only the
+// wiring/logic these tests exercise, not seed-dependent RNG behavior):
+// the entrance holds the player's spawn, the boss region sits behind a
+// closed connector door — closed doors block LoS the same as a solid
+// wall (rebuildRoomFromData), so a monster placed there is guaranteed NOT
+// visible from the entrance regardless of SightRange, no distance tuning
+// needed.
+func smDungeonParams() DungeonParams {
+	return DungeonParams{
+		Height:     smHeight,
+		RandomSeed: smSeed,
+		Regions: []DungeonRegionParams{
+			{ID: smRoomIDEntrance, Archetype: ArchetypeEntrance, Width: smEntranceWidth, Pattern: environments.PatternEmpty},
+			{ID: smRoomIDBoss, Archetype: ArchetypeBoss, Width: smBossWidth, Pattern: environments.PatternEmpty},
+		},
+		Connectors: []DungeonConnectorParams{{DoorID: "door-0"}},
+	}
+}
+
+func smNewEncounter(t *testing.T) *Encounter {
+	t.Helper()
+	transport := NewInMemoryTransport()
+	broker := NewBroker(transport)
+	t.Cleanup(func() {
+		_ = broker.Close()
+		_ = transport.Close()
+	})
+	return New(context.Background(), "enc-seed-monsters-test", broker)
+}
+
+// TestSeedMonsters_PlacedMonstersSpawnAtTheirCells: an At-bearing
+// SpawnInstruction resolves its MonsterRef via monsters.ByRef and lands
+// at exactly its declared region-local cell, translated by
+// regionOffsetX — same conversion as Task N1's placed obstacles, minus
+// the shortcut N1 gets from already being inside generateDungeonLayout.
+func TestSeedMonsters_PlacedMonstersSpawnAtTheirCells(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	bossAt := LocalHex{Col: 7, Row: 5}
+	entranceAt := LocalHex{Col: 4, Row: 2}
+	spawns := []SpawnInstruction{
+		{RoomID: smRoomIDBoss, MonsterRef: smRefSkeletonCaptain, Count: 1, At: &bossAt},
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &entranceAt},
+	}
+	require.NoError(t, enc.SeedMonsters(spawns))
+
+	data := enc.ToData()
+	require.Len(t, data.Monsters, 2)
+
+	bossOffsetX := smEntranceWidth + 1 // generateDungeonLayout's "+1 reserves the boundary/door column"
+	wantBoss := core.HexFromPosition(spatial.Position{X: float64(bossOffsetX + bossAt.Col), Y: float64(bossAt.Row)})
+	wantEntrance := core.HexFromPosition(spatial.Position{X: float64(entranceAt.Col), Y: float64(entranceAt.Row)})
+
+	var sawBoss, sawEntrance bool
+	for _, m := range data.Monsters {
+		switch m.MonsterRef {
+		case smRefSkeletonCaptain:
+			sawBoss = true
+			require.Equal(t, wantBoss, m.Position, "boss must land at exactly its declared cell")
+			require.NotEmpty(t, m.DataJSON, "a resolved monster must carry rehydratable DataJSON")
+			require.Positive(t, m.HP, "a resolved monster must carry its real stat block, not zero values")
+		case smRefSkeleton:
+			sawEntrance = true
+			require.Equal(t, wantEntrance, m.Position, "entrance monster must land at exactly its declared cell")
+		}
+	}
+	require.True(t, sawBoss, "boss spawn missing")
+	require.True(t, sawEntrance, "entrance spawn missing")
+}
+
+// TestRegionOffsetX_RecoversStartsIFromPersistedHexes tests the helper in
+// isolation from SeedMonsters' other machinery: build a 2-region
+// InitDungeon, read back e.data.Space.Regions, assert regionOffsetX
+// recovers the SAME offsetX generateDungeonLayout used internally
+// (region[0].Width + 1, per its own doc).
+func TestRegionOffsetX_RecoversStartsIFromPersistedHexes(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	data := enc.ToData()
+	require.Len(t, data.Space.Regions, 2)
+	require.Equal(t, smRoomIDEntrance, data.Space.Regions[0].ID)
+	require.Equal(t, smRoomIDBoss, data.Space.Regions[1].ID)
+
+	require.Equal(t, 0, regionOffsetX(data.Space.Regions[0].Hexes), "the first region always starts at column 0")
+	require.Equal(t, smEntranceWidth+1, regionOffsetX(data.Space.Regions[1].Hexes))
+}
+
+// TestSeedMonsters_CombatEntryNeverSeesPartialRoster: boss placed at a
+// cell NOT visible from the party's spawn (behind the closed connector
+// door), entrance monster placed at a cell that IS. SeedMonsters must add
+// both under suppressed combat-entry evaluation, then run ONE
+// checkCombatEntry pass — initiative must never contain the boss if only
+// the entrance monster was actually visible when the batch committed. A
+// naive per-spawn AddMonster loop would NOT guarantee this: see
+// combat_entry_test.go's TestIdempotent_AddMonsterAndMoveAfterCombatStarted,
+// which proves a monster added AFTER combat has already started (from an
+// earlier add's own visibility) gets appended to initiative unconditionally,
+// regardless of its own visibility — exactly the bug this batch exists to
+// prevent for boss-first spawn ordering.
+func TestSeedMonsters_CombatEntryNeverSeesPartialRoster(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	entrance := enc.ToData().Space.Entrance
+	require.NoError(t, enc.AddPlayer(PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice", Position: entrance, SightRange: 30,
+	}))
+	require.Equal(t, core.ModeFreeRoam, enc.Mode())
+
+	bossAt := LocalHex{Col: 7, Row: 5}
+	entranceAt := LocalHex{Col: 1, Row: 2}
+	bossMinionAt := LocalHex{Col: 3, Row: 1}
+	// Order matters, and a boss+entrance-only fixture would NOT catch a
+	// missing batch here: the entrance monster's add is the only one
+	// that can trigger the FreeRoam->TurnBased flip, and by then the
+	// boss is already resident in e.data.Monsters, so rollInitiative's
+	// own per-monster visibility check already excludes it correctly
+	// either way — verified empirically (a 2-monster version of this
+	// test still passed with SeedMonsters calling plain AddMonster
+	// instead of the suppressed addMonsterNoCombatCheck). The bug
+	// AddMonster's "mode already TURN_BASED -> append unconditionally"
+	// branch introduces (combat_entry_test.go's
+	// TestIdempotent_AddMonsterAndMoveAfterCombatStarted) only bites a
+	// monster added AFTER the triggering add — bossMinion, spawned
+	// THIRD (after the entrance monster flips the mode), is that
+	// monster, and is what actually isolates the invariant.
+	spawns := []SpawnInstruction{
+		{RoomID: smRoomIDBoss, MonsterRef: smRefSkeletonCaptain, Count: 1, At: &bossAt},
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &entranceAt},
+		{RoomID: smRoomIDBoss, MonsterRef: smRefZombie, Count: 1, At: &bossMinionAt},
+	}
+	require.NoError(t, enc.SeedMonsters(spawns))
+
+	require.Equal(t, core.ModeTurnBased, enc.Mode(), "the visible entrance monster must have started combat")
+
+	data := enc.ToData()
+	var bossID, entranceID, minionID core.EntityID
+	for id, m := range data.Monsters {
+		switch m.MonsterRef {
+		case smRefSkeletonCaptain:
+			bossID = id
+		case smRefSkeleton:
+			entranceID = id
+		case smRefZombie:
+			minionID = id
+		}
+	}
+	require.NotEmpty(t, entranceID)
+	require.NotEmpty(t, bossID)
+	require.NotEmpty(t, minionID)
+	require.Contains(t, data.Initiative, entranceID, "the actually-visible entrance monster must be in the roster")
+	require.NotContains(t, data.Initiative, bossID,
+		"the boss (not visible, spawned before the flip) must NOT be in initiative")
+	require.NotContains(t, data.Initiative, minionID,
+		"the boss-room minion (not visible, spawned AFTER the flip-triggering entrance monster) must NOT be "+
+			"in initiative — this is the case a naive per-spawn AddMonster loop gets wrong: once combat has "+
+			"already started, AddMonster appends every subsequent add to initiative unconditionally, "+
+			"regardless of that monster's own visibility")
+}
+
+// TestSeedMonsters_SpawnVisibleStillStartsCombat: the AddPlayer-doesn't-
+// check trap, reverified on today's origin/main (encounter.go's AddPlayer
+// never calls checkCombatEntry; only AddMonster/Move do) — batching must
+// not lose "combat starts immediately if you spawn already visible."
+func TestSeedMonsters_SpawnVisibleStillStartsCombat(t *testing.T) {
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+	entrance := enc.ToData().Space.Entrance
+	require.NoError(t, enc.AddPlayer(PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice", Position: entrance, SightRange: 30,
+	}))
+	require.Equal(t, core.ModeFreeRoam, enc.Mode())
+
+	at := LocalHex{Col: 1, Row: 2}
+	spawns := []SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},
+	}
+	require.NoError(t, enc.SeedMonsters(spawns))
+
+	require.Equal(t, core.ModeTurnBased, enc.Mode(),
+		"a monster placed already visible must start combat, exactly like a direct AddMonster would — "+
+			"batching/suppression must not swallow this")
+	require.NotEmpty(t, enc.ToData().Initiative)
+}
+
+// TestSeedMonsters_UnpinnedInstructionReturnsNotYetSupported: At == nil,
+// REGARDLESS of Count (including Count == 1 — an unpinned single-monster
+// room is just as unimplemented in M1 as a Count > 1 room; there's no
+// safe-cell-rolling machinery for either yet). M2's Slice C replaces this
+// error path with real safe-cell rolling for every At == nil instruction.
+func TestSeedMonsters_UnpinnedInstructionReturnsNotYetSupported(t *testing.T) {
+	cases := []struct {
+		name  string
+		count int
+	}{
+		{"count 1", 1},
+		{"count 3", 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := smNewEncounter(t)
+			require.NoError(t, enc.InitDungeon(smDungeonParams()))
+
+			spawns := []SpawnInstruction{
+				{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: tc.count, At: nil},
+			}
+			err := enc.SeedMonsters(spawns)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "M2")
+		})
+	}
+}

--- a/rulebooks/dnd5e/monster/monsters/registry.go
+++ b/rulebooks/dnd5e/monster/monsters/registry.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monsters
+
+import (
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// Constructor builds a monster's full stat bundle. It matches the signature
+// shared by the existing NewSkeleton/NewGhoul/... constructors.
+type Constructor = func(id string) *monster.Monster
+
+// byRef maps each canonical monster ref string (refs.Monsters.*.String(),
+// full "dnd5e:monsters:<id>" form) to its existing constructor. This is a
+// lookup table over constructors that already exist — no new stat
+// interpretation lives here (rpg-toolkit#842).
+//
+// Four canonical refs have no constructor today and are deliberately absent:
+// skeleton-archer, giant-spider, giant-wolf-spider, bandit-captain.
+var byRef = map[string]Constructor{
+	refs.Monsters.Skeleton().String():        NewSkeleton,
+	refs.Monsters.Zombie().String():          NewZombie,
+	refs.Monsters.SkeletonCaptain().String(): NewSkeletonCaptain,
+	refs.Monsters.Ghoul().String():           NewGhoul,
+	refs.Monsters.GiantRat().String():        NewGiantRat,
+	refs.Monsters.Wolf().String():            NewWolf,
+	refs.Monsters.BrownBear().String():       NewBrownBear,
+	refs.Monsters.Bandit().String():          NewBanditMelee,
+	refs.Monsters.BanditArcher().String():    NewBanditRanged,
+	refs.Monsters.Thug().String():            NewThug,
+	refs.Monsters.Goblin().String(): func(id string) *monster.Monster {
+		return monster.NewGoblin(id)
+	},
+}
+
+// ByRef resolves a canonical monster ref to its constructor. The bool
+// reports whether the ref is known — callers validate at author/load
+// time so a bad ref fails a file, never a spawn.
+func ByRef(ref string) (Constructor, bool) {
+	c, ok := byRef[ref]
+	return c, ok
+}
+
+// Refs returns every ref known to the registry, sorted. Callers (e.g.
+// dungeonspec's validation) can use this to name the known set in an
+// "unknown monster ref" error message.
+func Refs() []string {
+	known := make([]string, 0, len(byRef))
+	for ref := range byRef {
+		known = append(known, ref)
+	}
+	sort.Strings(known)
+	return known
+}

--- a/rulebooks/dnd5e/monster/monsters/registry_test.go
+++ b/rulebooks/dnd5e/monster/monsters/registry_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monsters_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestByRef_EveryCanonicalMonsterResolves(t *testing.T) {
+	// The 11 refs verified to have a real constructor today (see the
+	// inventory comment on the byRef map in registry.go) — bandit/
+	// bandit-archer resolve via NewBanditMelee/NewBanditRanged despite the
+	// name mismatch; the other 4 canonical refs (skeleton-archer,
+	// giant-spider, giant-wolf-spider, bandit-captain) have no constructor
+	// and are deliberately absent.
+	want := []string{
+		refs.Monsters.Skeleton().String(),
+		refs.Monsters.Zombie().String(),
+		refs.Monsters.SkeletonCaptain().String(),
+		refs.Monsters.Ghoul().String(),
+		refs.Monsters.GiantRat().String(),
+		refs.Monsters.Wolf().String(),
+		refs.Monsters.BrownBear().String(),
+		refs.Monsters.Bandit().String(),
+		refs.Monsters.BanditArcher().String(),
+		refs.Monsters.Thug().String(),
+		refs.Monsters.Goblin().String(),
+	}
+
+	// Closes the "12th entry never gets mapping-checked" drift window: a
+	// future addition to byRef that isn't also added to this list would
+	// otherwise go untested by the loop below.
+	assert.ElementsMatch(t, want, monsters.Refs())
+
+	for _, ref := range want {
+		ctor, ok := monsters.ByRef(ref)
+		require.True(t, ok, "ref %q must resolve", ref)
+		require.NotNil(t, ctor, "ref %q must have a constructor", ref)
+
+		// Mapping-correctness: the constructor registered under this ref
+		// must actually build a monster carrying that same ref. Without
+		// this, swapping e.g. NewBanditMelee/NewBanditRanged between the
+		// bandit/bandit-archer map entries would still pass every other
+		// assertion in this test.
+		require.Equal(t, ref, ctor("test-id").Ref().String(),
+			"constructor registered under %q must build a monster with that ref", ref)
+	}
+}
+
+func TestByRef_UnconstructedCanonicalRefReturnsFalse(t *testing.T) {
+	// bandit-captain IS a canonical ref (refs.Monsters.BanditCaptain()) but
+	// has no constructor today — distinct from an entirely fictional ref,
+	// and worth its own case so a future constructor addition here doesn't
+	// silently get missed by only testing a made-up name.
+	ctor, ok := monsters.ByRef(refs.Monsters.BanditCaptain().String())
+	assert.False(t, ok)
+	assert.Nil(t, ctor)
+}
+
+func TestByRef_UnknownRefReturnsFalse(t *testing.T) {
+	ctor, ok := monsters.ByRef("dnd5e:monsters:beholder")
+	assert.False(t, ok)
+	assert.Nil(t, ctor)
+}


### PR DESCRIPTION
Closes #842.

Spec: rpg-project#121's `design.md`/`plan.md` (approved 2026-07-25). Part of the dungeon-authoring M1 milestone — the api-side content-hosting slice (rpg-api#709) is blocked on this PR's release.

## What this ships (M1: A, B, N, D)

- **Slice A — registry**: `rulebooks/dnd5e/monster/monsters.ByRef`/`Refs()`, a lookup table over existing monster constructors. Inventory: 11 of 15 canonical monster refs resolve today; `skeleton-archer`, `giant-spider`, `giant-wolf-spider`, and `bandit-captain` have no constructor yet and are deliberately absent (documented in `registry.go`).
- **Slice B — schema**: `encounter/dungeonspec` strictly decodes a versioned YAML dungeon spec (unknown fields fail loudly) and validates it against the generator's full constraint set — around 38 distinct rejection rules, table-tested red/green — before compiling to `encounter.DungeonParams` plus an ordered spawn plan. Covers the static-placement delta (`place:` blocks pinning exact props/monsters, not just count-based rolling).
- **New M1 slice — engine placement path**: `encounter/dungeon.go` places `place:` entries verbatim into the room, excluded from the rolled-obstacle candidate pool; a new `Encounter.SeedMonsters` (`encounter/seed_monsters.go`) executes the spawn plan under the atomic combat-entry invariant — either the whole batch of monster seeds commits, or none do, so a partial failure never leaves combat half-entered.
- **Slice D — workbench CLI**: `encounter/cmd/dungeonspec-workbench` + testable `dungeonspec.WorkbenchReport` — compile a spec at a seed and see the verdict, spawn plan, placed props, and an ASCII floor plan in seconds, no server required.

M2 (count-based multi-monster rolling, the crypt's migration to YAML) is out of scope for this PR — the M1-only monster-pinning restriction (`validateM1Restrictions`) is a documented, deliberately temporary gate lifted by a later task.

## Review process

Every task in this slice went through independent spec-compliance and code-quality review, with mutation-verified test coverage (assertions checked to actually fail when the behavior they claim to pin is broken, not just satisfied by static text). Notable catches fixed before this PR: a feet-vs-hexes speed unit mismatch, opportunity-attack readiness seeding for ranged-only monsters, spawn-batch atomicity, and obstacle/wall/door collision-domain gaps.

Tracked follow-ups, not blocking this PR:
- toolkit#843 — `.golangci.yml` declares config version 2 but uses v1 flat `linters-settings`, so settings are silently ignored.
- toolkit#844 — `rulebooks/dnd5e` needs a monster attack-snapshot accessor; `encounter` currently hardcodes action JSON tags, and ranged-only monsters seed opportunity-attack readiness incorrectly.

## Cross-module note

This PR touches both `rulebooks/dnd5e` (the registry) and `encounter` (everything else) — per toolkit#805, it must be **merge-commit, not squash**, when merged, since squashing would orphan `encounter/go.mod`'s pinned pseudo-version of `rulebooks/dnd5e` from a real, reachable commit. `encounter/go.mod` currently pins a branch pseudo-version of `rulebooks/dnd5e`; the post-merge release cut supersedes it with a tagged version.

## Verification

- `go test -count=1 -race ./...` green in both touched modules (`encounter` and `rulebooks/dnd5e`).
- `golangci-lint run` clean, package-scoped, on every package this PR touches.
- `gofmt`/`go vet` clean in both modules.

— implementer (asset-pipeline), on behalf of KirkDiggler
