### PR TITLE
fix(encounter): extend boundary-edge walls to connector columns (#848)

### DIFF
--- a/encounter/connector_column_walls_test.go
+++ b/encounter/connector_column_walls_test.go
@@ -1,0 +1,173 @@
+package encounter_test
+
+// connector_column_walls_test.go is the TDD gate for rpg-toolkit#848:
+// InitDungeon no longer emits a degenerate (Start == End) WallSegmentData
+// entry per connector boundary column's flanking (non-door) cell — doing
+// so made each flanking cell an independently-classified wall hex
+// client-side (rpg-dnd5e-web's buildDungeonWallSegments/collectWallHexes),
+// and a hex column's flanking cells expose 4 of their 6 sides to the two
+// adjacent regions (not 2, the way a square-grid column would — a hex has
+// 6 neighbors, and a north/south column only ever shares 2 of them with
+// its own same-column neighbors), rendering as an isolated "chunky rubble
+// box" per cell that visually drowned the door immediately beside it
+// (rpg-dnd5e-web#562). Every flanking cell is now the End of one or more
+// boundary-edge segments (Start != End, exactly one hex step apart) whose
+// Start is a real region floor hex — the same technique
+// perimeter_edge_walls_test.go already proves for rpg-toolkit#834's
+// outer-perimeter case, extended to these interior boundary columns.
+//
+// The door cell itself never carried a wall entry before this fix and
+// still doesn't (TestPerimeterEdgeWalls_NeverAtConnectorDoorCells,
+// unchanged) — but this file adds an explicit walkability check anyway
+// (TestConnectorColumnWalls_DoorCellStaysWalkable) since this fix also
+// touches the room-rebuild blocking path (rebuildRoomFromData) the door
+// cell's own passability depends on, not just wall-segment emission.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// TestConnectorColumnWalls_NoLongerDegenerate proves every connector's
+// flanking cell has been converted away from the old degenerate
+// (Start == End) representation, across the same seed sweep
+// perimeter_edge_walls_test.go uses.
+func TestConnectorColumnWalls_NoLongerDegenerate(t *testing.T) {
+	for _, seed := range perimeterEdgeSeeds {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
+		data := enc.ToData()
+		flanking := connectorFlankingCubes(data, []core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
+		require.NotEmpty(t, flanking, "seed %d: fixture must actually have connector flanking cells", seed)
+
+		degenerate := blockedCubesFromDegenerateWalls(data.Space.Walls)
+		for cube := range flanking {
+			require.False(t, degenerate[cube],
+				"seed %d: flanking cell %v must no longer be a degenerate wall entry", seed, cube)
+		}
+	}
+}
+
+// assertConnectorBoundaryCompleteness re-derives, from first principles
+// against public data only (RegionData.Hexes + Data.Doors, never
+// dungeon.go's own unexported connectorBoundaryEdgeWalls), every
+// {Start, End} boundary-edge pair a connector's flanking cells imply — a
+// real region floor hex is any cube inside some region's Hexes that isn't
+// itself blocked by a degenerate (interior obstacle) wall entry — then
+// proves data.Space.Walls' connector-facing (flanking End) entries match
+// that set exactly: no extras, no missing edges, no duplicates. Mirrors
+// perimeter_edge_walls_test.go's assertPerimeterCompletenessAndNoDuplicates,
+// scoped to the complementary (interior, not outer) boundary-edge category.
+func assertConnectorBoundaryCompleteness(t *testing.T, label string, data *encounter.Data, doorIDs []core.EntityID) {
+	t.Helper()
+	flanking := connectorFlankingCubes(data, doorIDs)
+	degenerate := blockedCubesFromDegenerateWalls(data.Space.Walls)
+
+	inAnyRegion := make(map[spatial.CubeCoordinate]bool)
+	for _, r := range data.Space.Regions {
+		for _, h := range r.Hexes.Slice() {
+			inAnyRegion[h.ToCube()] = true
+		}
+	}
+
+	gotEdges := make(map[[2]spatial.CubeCoordinate]int)
+	for _, w := range data.Space.Walls {
+		if w.Start == w.End {
+			continue
+		}
+		if !flanking[w.End] {
+			continue // an outer-perimeter edge (#834) -- not this test's concern
+		}
+		gotEdges[[2]spatial.CubeCoordinate{w.Start, w.End}]++
+	}
+	for pair, count := range gotEdges {
+		require.Equal(t, 1, count, "%s: duplicate connector boundary edge %v", label, pair)
+	}
+
+	expected := make(map[[2]spatial.CubeCoordinate]bool)
+	for cube := range inAnyRegion {
+		if degenerate[cube] {
+			continue // an interior obstacle, not real floor
+		}
+		for _, n := range cube.GetNeighbors() {
+			if !flanking[n] {
+				continue
+			}
+			expected[[2]spatial.CubeCoordinate{cube, n}] = true
+		}
+	}
+
+	require.Len(t, gotEdges, len(expected), "%s: connector boundary edge count mismatch", label)
+	for pair := range expected {
+		require.Contains(t, gotEdges, pair, "%s: missing connector boundary edge %v", label, pair)
+	}
+}
+
+// TestConnectorColumnWalls_BoundaryEdgeCompleteness sweeps the same seeds
+// perimeter_edge_walls_test.go uses to prove the connector-facing boundary
+// edges are complete and duplicate-free across varying interior-wall
+// layouts, not just one lucky seed.
+func TestConnectorColumnWalls_BoundaryEdgeCompleteness(t *testing.T) {
+	for _, seed := range perimeterEdgeSeeds {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
+		data := enc.ToData()
+		assertConnectorBoundaryCompleteness(t, fmt.Sprintf("seed %d", seed), data,
+			[]core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
+	}
+}
+
+// TestConnectorColumnWalls_FlankingCellsRemainBlocked proves rpg-toolkit#848
+// didn't quietly turn off movement/LOS blocking for a connector's flanking
+// cells now that they're no longer their own degenerate wall entry —
+// rebuildRoomFromData's companion change must still place a blocker at
+// each one (see space.go's Start != End / in-grid-End branch).
+func TestConnectorColumnWalls_FlankingCellsRemainBlocked(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
+	data := enc.ToData()
+	flanking := connectorFlankingCubes(data, []core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
+	require.NotEmpty(t, flanking, "fixture must actually have connector flanking cells")
+
+	room := enc.Room()
+	for cube := range flanking {
+		pos := cube.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		require.False(t, room.CanPlaceEntity(probeEntity{}, pos),
+			"flanking cell %v must still block movement/LOS", cube)
+	}
+}
+
+// TestConnectorColumnWalls_DoorCellStaysWalkable is the explicit
+// door-walkability coverage rpg-toolkit#848 calls for: with a connector's
+// door OPEN, its own cell must remain enterable. connectorBoundaryEdgeWalls
+// never emits an edge whose End is a door cube (flanking excludes doors by
+// construction), so rebuildRoomFromData's new Start != End / in-grid-End
+// blocking branch never reaches a door cell — this proves that holds
+// end-to-end through the actual room rebuild, not just as a claim about
+// wall-segment shape.
+func TestConnectorColumnWalls_DoorCellStaysWalkable(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
+	data := enc.ToData()
+
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: data.Space.Entrance, SightRange: 30,
+	}))
+	require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+	require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor1ID))
+
+	room := enc.Room()
+	for _, doorID := range []core.EntityID{dungeonDoor0ID, dungeonDoor1ID} {
+		door := enc.ToData().Doors[doorID]
+		pos := door.Position.ToPosition()
+		require.True(t, room.CanPlaceEntity(probeEntity{}, pos),
+			"open door %q's own cell must remain walkable", doorID)
+	}
+}

--- a/encounter/connector_column_walls_test.go
+++ b/encounter/connector_column_walls_test.go
@@ -37,7 +37,14 @@ import (
 // TestConnectorColumnWalls_NoLongerDegenerate proves every connector's
 // flanking cell has been converted away from the old degenerate
 // (Start == End) representation, across the same seed sweep
-// perimeter_edge_walls_test.go uses.
+// perimeter_edge_walls_test.go uses. connectorBoundaryEdgeWalls keeps a
+// degenerate fallback for the fringe case where a flanking cell's every
+// region-facing neighbor is itself interior-obstacle-blocked
+// (rpg-toolkit#849 gate review finding 1) -- this test's fixture never
+// reaches that density, so the fallback is never observed to fire here;
+// see TestConnectorColumnWalls_FlankingCellsRemainBlocked for the
+// invariant that matters regardless of which shape actually blocks a
+// given cell.
 func TestConnectorColumnWalls_NoLongerDegenerate(t *testing.T) {
 	for _, seed := range perimeterEdgeSeeds {
 		enc := newTestEncounter(t)
@@ -124,23 +131,93 @@ func TestConnectorColumnWalls_BoundaryEdgeCompleteness(t *testing.T) {
 }
 
 // TestConnectorColumnWalls_FlankingCellsRemainBlocked proves rpg-toolkit#848
-// didn't quietly turn off movement/LOS blocking for a connector's flanking
+// didn't quietly turn off movement blocking for a connector's flanking
 // cells now that they're no longer their own degenerate wall entry —
 // rebuildRoomFromData's companion change must still place a blocker at
-// each one (see space.go's Start != End / in-grid-End branch).
+// each one (see space.go's Start != End / in-grid-End branch), whether
+// that blocker comes from a region-facing edge or connectorBoundaryEdgeWalls'
+// degenerate fallback for an unreachable cell (rpg-toolkit#849 gate review
+// finding 1). Swept across perimeterEdgeSeeds (gate review finding 3) —
+// this is the one test that actually proves the movement invariant rather
+// than just the wire shape, so it's worth exercising varying interior-wall
+// layouts, not just dungeonSeed alone. See
+// TestConnectorColumnWalls_FlankingCellBlocksLineOfSight for the
+// companion LOS check.
 func TestConnectorColumnWalls_FlankingCellsRemainBlocked(t *testing.T) {
+	for _, seed := range perimeterEdgeSeeds {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
+		data := enc.ToData()
+		flanking := connectorFlankingCubes(data, []core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
+		require.NotEmpty(t, flanking, "seed %d: fixture must actually have connector flanking cells", seed)
+
+		room := enc.Room()
+		for cube := range flanking {
+			pos := cube.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+			require.False(t, room.CanPlaceEntity(probeEntity{}, pos),
+				"seed %d: flanking cell %v must still block movement/LOS", seed, cube)
+		}
+	}
+}
+
+// TestConnectorColumnWalls_FlankingCellBlocksLineOfSight is the explicit
+// LOS coverage rpg-toolkit#849's gate review asked for (finding 4):
+// FlankingCellsRemainBlocked above only ever asserted movement
+// (room.CanPlaceEntity); LOS was verified indirectly (by the reviewer,
+// separately) but never asserted here. Picks one flanking cell and finds
+// TWO of its real region-floor neighbors on genuinely OPPOSITE sides —
+// one with a smaller offset X, one with a larger offset X — via
+// GetNeighbors() rather than hand-derived offset arithmetic, since this
+// hex grid's odd-q parity makes same-row column stepping unsafe to
+// assume (a neighbor toward the adjacent column can land at a DIFFERENT
+// row depending on column parity). Asserts LOS between those two
+// neighbors is blocked — a straight line between genuinely opposite
+// neighbors of a single hex necessarily passes through that hex, so this
+// is a real "blocked straight through the flanking cell" check, not two
+// neighbors that might see each other around it.
+func TestConnectorColumnWalls_FlankingCellBlocksLineOfSight(t *testing.T) {
 	enc := newTestEncounter(t)
 	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
 	data := enc.ToData()
 	flanking := connectorFlankingCubes(data, []core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
-	require.NotEmpty(t, flanking, "fixture must actually have connector flanking cells")
-
+	degenerate := blockedCubesFromDegenerateWalls(data.Space.Walls)
 	room := enc.Room()
+	grid := room.GetGrid()
+
+	found := false
 	for cube := range flanking {
-		pos := cube.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
-		require.False(t, room.CanPlaceEntity(probeEntity{}, pos),
-			"flanking cell %v must still block movement/LOS", cube)
+		var left, right *spatial.CubeCoordinate
+		for _, n := range cube.GetNeighbors() {
+			npos := n.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+			if !grid.IsValidPosition(npos) {
+				continue // outside the room entirely -- a true-edge-row flanking cell's outward
+				// neighbor, not a candidate floor cell at all
+			}
+			if flanking[n] || degenerate[n] {
+				continue // not real floor -- either another flanking/door cell or an interior obstacle
+			}
+			switch {
+			case n.X < cube.X && left == nil:
+				nCopy := n
+				left = &nCopy
+			case n.X > cube.X && right == nil:
+				nCopy := n
+				right = &nCopy
+			}
+		}
+		if left == nil || right == nil {
+			continue
+		}
+		leftPos := left.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		rightPos := right.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		require.True(t, room.IsLineOfSightBlocked(leftPos, rightPos),
+			"flanking cell %v must block LOS between its opposite real-floor neighbors %v and %v",
+			cube, leftPos, rightPos)
+		found = true
+		break
 	}
+	require.True(t, found,
+		"fixture must have at least one flanking cell with real-floor neighbors on both sides to check LOS through")
 }
 
 // TestConnectorColumnWalls_DoorCellStaysWalkable is the explicit

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -652,12 +652,19 @@ func TestCryptDungeon_EntranceAndBossPatternEmpty_NoInteriorWallsAcrossSeeds(t *
 		// no longer degenerate (Start == End) entries of their own — they
 		// are the End of a boundary-edge segment whose Start is a real
 		// region floor hex (see connectorBoundaryEdgeWalls). wallSet must
-		// therefore include End too, or every flanking hex would wrongly
-		// look unreferenced.
-		wallSet := make(map[core.Hex]bool, len(data.Space.Walls)*2)
+		// therefore key on End for those, not Start — a boundary-edge
+		// Start is always real WALKABLE floor (rpg-toolkit#849 gate review
+		// finding 6), never a blocked cell in its own right, so folding it
+		// in unconditionally would let this set silently start meaning
+		// "cell referenced by a wall entry" rather than "cell carrying a
+		// blocked wall reference".
+		wallSet := make(map[core.Hex]bool, len(data.Space.Walls))
 		for _, w := range data.Space.Walls {
-			wallSet[core.HexFromCube(w.Start)] = true
-			wallSet[core.HexFromCube(w.End)] = true
+			if w.Start == w.End {
+				wallSet[core.HexFromCube(w.Start)] = true
+			} else {
+				wallSet[core.HexFromCube(w.End)] = true
+			}
 		}
 		for connectorIdx := 0; connectorIdx < 2; connectorIdx++ {
 			for _, h := range cryptBoundaryColumnHexes(connectorIdx) {

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -584,11 +584,13 @@ func cryptRegionStarts() []int {
 
 // cryptBoundaryColumnHexes returns every hex the connector boundary column
 // between region connectorIdx and connectorIdx+1 must carry a blocked wall
-// segment at — every row except cryptDoorRow (that cell is the connector's
-// door), mirroring generateDungeonLayout's own boundary-column construction
-// (dungeon.go). Unaffected by rpg-toolkit#835's Pattern change: this column
-// is emitted unconditionally, independent of either neighboring region's
-// interior wall pattern.
+// reference at — every row except cryptDoorRow (that cell is the
+// connector's door), mirroring generateDungeonLayout's own boundary-column
+// construction (dungeon.go). Unaffected by rpg-toolkit#835's Pattern
+// change: this column is emitted unconditionally, independent of either
+// neighboring region's interior wall pattern. As of rpg-toolkit#848 these
+// hexes are referenced as the End of a boundary-edge segment rather than
+// the Start of a degenerate one — see this function's caller.
 func cryptBoundaryColumnHexes(connectorIdx int) []core.Hex {
 	starts := cryptRegionStarts()
 	x := starts[connectorIdx] + cryptRegionWidths[connectorIdx]
@@ -646,9 +648,16 @@ func TestCryptDungeon_EntranceAndBossPatternEmpty_NoInteriorWallsAcrossSeeds(t *
 				"seed %d: boss region must roll zero interior walls with PatternEmpty; found one at %v", seed, h)
 		}
 
-		wallSet := make(map[core.Hex]bool, len(data.Space.Walls))
+		// rpg-toolkit#848: a connector boundary column's flanking cells are
+		// no longer degenerate (Start == End) entries of their own — they
+		// are the End of a boundary-edge segment whose Start is a real
+		// region floor hex (see connectorBoundaryEdgeWalls). wallSet must
+		// therefore include End too, or every flanking hex would wrongly
+		// look unreferenced.
+		wallSet := make(map[core.Hex]bool, len(data.Space.Walls)*2)
 		for _, w := range data.Space.Walls {
 			wallSet[core.HexFromCube(w.Start)] = true
+			wallSet[core.HexFromCube(w.End)] = true
 		}
 		for connectorIdx := 0; connectorIdx < 2; connectorIdx++ {
 			for _, h := range cryptBoundaryColumnHexes(connectorIdx) {

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -82,20 +82,26 @@ type SpaceData struct {
 	// one of two shapes:
 	//
 	//   - Degenerate (Start == End): one blocked interior hex — interior
-	//     pattern walls (RandomPattern etc.) and InitDungeon's connector
-	//     boundary columns between regions. This is the ONLY shape wave 1
-	//     stored, and the only one rebuildRoomFromData turns into an
-	//     actual spatial.Room blocker (see its Start != End skip) —
-	//     geometry fidelity beyond per-hex blocking isn't needed for these.
+	//     pattern walls (RandomPattern etc.) only, as of rpg-toolkit#848
+	//     (InitDungeon's connector boundary columns used to be degenerate
+	//     entries too; they're boundary-edge segments now, below).
+	//     rebuildRoomFromData always turns these into an actual
+	//     spatial.Room blocker — geometry fidelity beyond per-hex blocking
+	//     isn't needed for these.
 	//
 	//   - Boundary-edge (Start != End, exactly one hex step apart): Start
-	//     is a real walkable floor hex, End is the adjacent hex just
-	//     outside the room's grid bounds — InitDungeon's outer-perimeter
-	//     segments (rpg-toolkit#834), one per room-facing edge. Purely a
-	//     render contract (rpg-dnd5e-web#566's client-side hexDistance==1
-	//     branch draws one clean full-width slab on that edge) — never a
-	//     spatial.Room blocker; walkability there already comes from the
-	//     grid's own bounds, not from this entry.
+	//     is always a real walkable floor hex; End is either (a) the
+	//     adjacent hex just outside the room's grid bounds — InitDungeon's
+	//     outer-perimeter segments (rpg-toolkit#834), one per room-facing
+	//     edge, purely a render contract with no gameplay effect of its
+	//     own (walkability there already comes from the grid's own
+	//     bounds) — or (b) a connector column's flanking cell, still
+	//     inside the grid (rpg-toolkit#848): a real, in-bounds cell that
+	//     must keep blocking movement/LOS even though it's no longer its
+	//     own degenerate entry. rebuildRoomFromData distinguishes the two
+	//     purely by grid validity: it places a blocker at End whenever End
+	//     is itself a valid in-grid position (case b), and no-ops when it
+	//     isn't (case a, unreachable by construction regardless).
 	Walls []environments.WallSegmentData `json:"walls"`
 
 	// Width and Height are the room's grid dimensions (offset-coordinate

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -773,12 +773,16 @@ func perimeterEdgeWalls(blocked map[spatial.CubeCoordinate]struct{}, width, heig
 // Start here either, matching TestPerimeterEdgeWalls_NeverAtConnectorDoorCells'
 // invariant) and every one of its 6 neighbor directions; whenever that
 // neighbor is one of THIS dungeon's connector flanking cells, emit one
-// {Start: the floor hex, End: the flanking cell} segment. Two regions
-// share a single flanking cell as a neighbor (one on each side), so most
-// flanking cells end up boxed in by exactly two segments -- one contributed
-// by each region's own boundary column -- which is what "the corridor's
-// side walls" (the issue's phrasing) actually looks like once rendered:
-// two clean edges per row, not a floating block.
+// {Start: the floor hex, End: the flanking cell} segment. A flanking cell
+// has up to 4 "region-facing" neighbor candidates (2 toward each adjacent
+// region, matching the "4 exposed sides" diagnosis above) -- one on the
+// space's own true edge row (y=0 or y=height-1) has 2 of those candidates
+// land outside the whole grid rather than in a region, so it receives
+// only 2 edges; every other flanking cell receives all 4. Either way,
+// both of a flanking cell's neighboring regions still contribute at
+// least one edge, which is what "the corridor's side walls" (the issue's
+// phrasing) actually looks like once rendered: clean edges on both
+// sides, not a floating block.
 //
 // Unlike perimeterEdgeWalls' segments, a flanking cell IS a valid in-grid
 // position (an interior column, not the space's true edge) -- these
@@ -787,12 +791,30 @@ func perimeterEdgeWalls(blocked map[spatial.CubeCoordinate]struct{}, width, heig
 // change: it places a blocker at the End of any Start != End segment that
 // is itself a valid in-grid position, leaving the true out-of-grid
 // perimeter case (#834) an unaffected no-op.
+//
+// rpg-toolkit#849 gate review finding 1: without the fallback below, a
+// flanking cell's blocking would be EMERGENT rather than structural --
+// it's only blocked if at least one of its region-facing neighbors is
+// itself real, unblocked floor that emits an edge to it. If every one of
+// a flanking cell's region-facing neighbors happened to already be an
+// interior obstacle-blocked cell, the main loop would emit no edge to it
+// at all, and rebuildRoomFromData would place nothing there -- silently
+// making that cell both walkable and see-through, a real regression
+// versus the old unconditional degenerate block. Never observed across
+// hundreds of seeds of the 3-region fixture (interior density has never
+// been high enough to surround a flanking cell on every side), but the
+// guarantee shouldn't rest on interior density: any flanking cell the
+// main loop never covers falls back to the pre-fix degenerate
+// (Start == End) shape, so it renders as the old "rubble box" only in
+// this fringe case -- never in the common case the main loop already
+// covers.
 func connectorBoundaryEdgeWalls(
 	blocked map[spatial.CubeCoordinate]struct{},
 	flanking map[spatial.CubeCoordinate]struct{},
 	width, height int,
 ) []environments.WallSegmentData {
 	var out []environments.WallSegmentData
+	covered := make(map[spatial.CubeCoordinate]struct{}, len(flanking))
 	for x := 0; x < width; x++ {
 		for y := 0; y < height; y++ {
 			cube := spatial.OffsetCoordinateToCubeWithOrientation(
@@ -804,11 +826,20 @@ func connectorBoundaryEdgeWalls(
 				if _, isFlanking := flanking[n]; !isFlanking {
 					continue
 				}
+				covered[n] = struct{}{}
 				out = append(out, environments.WallSegmentData{
 					Start: cube, End: n, BlocksMovement: true, BlocksLoS: true,
 				})
 			}
 		}
+	}
+	for cube := range flanking {
+		if _, ok := covered[cube]; ok {
+			continue
+		}
+		out = append(out, environments.WallSegmentData{
+			Start: cube, End: cube, BlocksMovement: true, BlocksLoS: true,
+		})
 	}
 	return out
 }
@@ -891,8 +922,15 @@ func regionWallSegments(walls []environments.WallSegment, offsetX, offsetY int) 
 // wallCubeSet builds a lookup set of every absolute cube coordinate a
 // region's wall segments occupy — used by placeRegionObstacles to reject
 // wall cells as obstacle candidates. walls is already in absolute
-// coordinates (the caller's regionWallSegments output); Start == End for
-// every entry (see WallSegmentData's doc), so only Start is read.
+// coordinates (the caller's regionWallSegments output); only Start is
+// read, which is correct as long as every entry passed in is degenerate
+// (Start == End) — true of both current call sites (regionWalls at :590,
+// always degenerate; segs at :631, called BEFORE perimeterEdgeWalls/
+// connectorBoundaryEdgeWalls append any boundary-edge entries to it) but
+// no longer a property of WallSegmentData in general since rpg-toolkit#834/
+// #848 (rpg-toolkit#849 gate review finding 7) — calling this on a wall
+// list that already contains boundary-edge entries would silently fold
+// their real-floor Start cubes into the result as if they were blocked.
 func wallCubeSet(walls []environments.WallSegmentData) map[spatial.CubeCoordinate]struct{} {
 	set := make(map[spatial.CubeCoordinate]struct{}, len(walls))
 	for _, w := range walls {

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -480,6 +480,16 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 	regions := make([]RegionData, n)
 	doors := make([]spatial.CubeCoordinate, n-1)
 	var obstacles []ObstacleData
+	// connectorColumnCubes is every connector's FULL boundary column (door
+	// cell included); connectorFlankingCubes is the same columns minus
+	// their door cells -- rpg-toolkit#848. Both are populated as the
+	// connector loop below runs and consumed once, after every region's
+	// walls are known, by the perimeterEdgeWalls/connectorBoundaryEdgeWalls
+	// calls at the bottom of this function. See connectorBoundaryEdgeWalls'
+	// doc for why these can no longer be plain degenerate (Start == End)
+	// entries in segs itself.
+	connectorColumnCubes := make(map[spatial.CubeCoordinate]struct{})
+	connectorFlankingCubes := make(map[spatial.CubeCoordinate]struct{})
 
 	for i, r := range params.Regions {
 		local := spatial.Position{X: 0, Y: float64(doorRow)}
@@ -587,18 +597,40 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 
 		if i < n-1 {
 			doorX := starts[i] + r.Width
+			// rpg-toolkit#848: no longer appends a degenerate (Start == End)
+			// entry per non-door cell here -- that made each flanking cell
+			// an independently-classified wall hex client-side, and a hex
+			// column's flanking cells expose 4 of their 6 sides to the two
+			// adjacent regions (not 2, the way a square-grid column would),
+			// rendering as an isolated "chunky rubble box" per cell instead
+			// of a clean wall. Every column cell (door included) is instead
+			// recorded here and converted into boundary-edge segments by
+			// connectorBoundaryEdgeWalls below, once every region's own
+			// walls are known.
 			for y := 0; y < params.Height; y++ {
+				cube := spatial.OffsetCoordinateToCubeWithOrientation(
+					spatial.Position{X: float64(doorX), Y: float64(y)}, spatial.HexOrientationPointyTop)
+				connectorColumnCubes[cube] = struct{}{}
 				if y == doorRow {
 					continue
 				}
-				cube := spatial.OffsetCoordinateToCubeWithOrientation(
-					spatial.Position{X: float64(doorX), Y: float64(y)}, spatial.HexOrientationPointyTop)
-				segs = append(segs,
-					environments.WallSegmentData{Start: cube, End: cube, BlocksMovement: true, BlocksLoS: true})
+				connectorFlankingCubes[cube] = struct{}{}
 			}
 			doors[i] = spatial.OffsetCoordinateToCubeWithOrientation(
 				spatial.Position{X: float64(doorX), Y: float64(doorRow)}, spatial.HexOrientationPointyTop)
 		}
+	}
+
+	// blocked is every cell that is NOT real floor for boundary-edge
+	// purposes: interior pattern-wall/obstacle cells (degenerate Start==End
+	// entries already in segs) UNION every connector column cell, door
+	// cells included (rpg-toolkit#848) -- a connector's own door cell must
+	// never be treated as floor eligible to grow an outward-facing
+	// perimeter edge of its own (TestPerimeterEdgeWalls_NeverAtConnectorDoorCells),
+	// even though it carries no wall entry in segs itself.
+	blocked := wallCubeSet(segs)
+	for cube := range connectorColumnCubes {
+		blocked[cube] = struct{}{}
 	}
 
 	// rpg-toolkit#834: one boundary-edge segment (Start != End) per
@@ -608,7 +640,13 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 	// touches interior wall emission or the connector columns, and is a
 	// pure, seed-independent function of the floor/wall layout already
 	// built above.
-	segs = append(segs, perimeterEdgeWalls(segs, totalWidth, params.Height)...)
+	segs = append(segs, perimeterEdgeWalls(blocked, totalWidth, params.Height)...)
+
+	// rpg-toolkit#848: the same boundary-edge technique, extended to every
+	// connector's interior boundary column -- see connectorBoundaryEdgeWalls'
+	// doc for why the column's flanking (non-door) cells can no longer be
+	// left as degenerate Start==End entries.
+	segs = append(segs, connectorBoundaryEdgeWalls(blocked, connectorFlankingCubes, totalWidth, params.Height)...)
 
 	entrance := spatial.OffsetCoordinateToCubeWithOrientation(
 		spatial.Position{X: 0, Y: float64(doorRow)}, spatial.HexOrientationPointyTop)
@@ -628,26 +666,36 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 // dungeon space's outer perimeter (rpg-toolkit#834) -- rooms shipped ZERO
 // perimeter wall data before this; blocking came only from grid bounds,
 // and the client's wall renderer had nothing to draw a room's outer walls
-// with. For every FLOOR hex in [0,width) x [0,height) (i.e. not already a
-// blocked cell in walls -- interior pattern walls and connector boundary
-// columns alike, both always degenerate Start==End entries at this point)
-// and every one of its 6 hex-grid neighbor directions that lands OUTSIDE
-// those bounds, one segment {Start: the floor hex, End: the out-of-bounds
-// neighbor} is emitted.
+// with. For every FLOOR hex in [0,width) x [0,height) (i.e. not already in
+// blocked -- interior pattern/obstacle walls and every connector column
+// cell alike, rpg-toolkit#848) and every one of its 6 hex-grid neighbor
+// directions that lands OUTSIDE those bounds, one segment {Start: the
+// floor hex, End: the out-of-bounds neighbor} is emitted.
 //
-// Deliberately excludes cells already IN walls, not just those failing an
-// IsValidPosition check on the OUTER rectangle: a connector's boundary
-// column sits at an interior x (strictly between two regions, never the
-// space's x=0 or x=width-1 edge) but spans every y INCLUDING the true
-// edge rows y=0/y=height-1 -- by "floor hex" exclusion those cells never
-// get a NEW edge segment here, keeping them exactly the "interior
-// structure" they already were (this function only ever ADDS segments,
-// never touches walls' existing entries). Doors sit at a boundary
-// column's doorRow cell specifically, which is never on the space's own
-// x=0/x=width-1/y=0/y=height-1 edges either (validateDungeonParams' >=4
-// height/width floor keeps doorRow strictly interior) -- so this function
-// needs no separate door-passage exclusion; the geometry already keeps
-// every connector passage off the outer perimeter (see
+// blocked is caller-supplied (generateDungeonLayout unions wallCubeSet(segs)
+// with every connector column cube, doors included) rather than derived
+// here from a raw wall list, specifically so a connector column's flanking
+// cells -- no longer degenerate Start==End entries in segs themselves,
+// see connectorBoundaryEdgeWalls -- still count as "not floor" for THIS
+// function's purposes. Without that, a flanking cell sitting at the
+// space's own y=0/y=height-1 row (common: validateDungeonParams' >=4
+// height floor guarantees a connector column always has flanking rows at
+// both true edge rows, only doorRow is ever excluded) would be
+// misidentified as real floor and grow a bogus outward-facing perimeter
+// edge of its own.
+//
+// A connector's boundary column sits at an interior x (strictly between
+// two regions, never the space's x=0 or x=width-1 edge) but spans every y
+// INCLUDING the true edge rows y=0/y=height-1 -- by "floor hex" exclusion
+// those cells never get a NEW edge segment here, keeping them exactly the
+// "interior structure" they already were (this function only ever ADDS
+// segments, never touches walls' existing entries). Doors sit at a
+// boundary column's doorRow cell specifically, which is never on the
+// space's own x=0/x=width-1/y=0/y=height-1 edges either
+// (validateDungeonParams' >=4 height/width floor keeps doorRow strictly
+// interior) -- so this function needs no separate door-passage exclusion;
+// the geometry already keeps every connector passage off the outer
+// perimeter (see
 // perimeter_edge_walls_test.go's TestPerimeterEdgeWalls_NeverAtConnectorDoorCells
 // for the assertion).
 //
@@ -658,21 +706,22 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 // client-side hexDistance==1 renderer wants: each exposed edge draws its
 // own clean slab.
 //
-// Purely a function of walls/width/height, already fully determined by
+// Purely a function of blocked/width/height, already fully determined by
 // the (possibly seeded) region generation above -- no RNG here, so
 // perimeter emission is itself deterministic and seed-independent, unlike
 // the per-region interior pattern it follows.
 //
-// These segments never become a spatial.Room blocker (see
-// rebuildRoomFromData's Start != End skip): Start is real walkable floor
-// and End is entirely outside the grid, already unreachable by
-// construction (every LOS/movement check already runs through
-// spatial.HexGrid.IsValidPosition) -- this is the render contract
+// These segments never become a spatial.Room blocker in their own right
+// when End is genuinely outside the grid (see rebuildRoomFromData): Start
+// is real walkable floor and End is entirely outside the grid, already
+// unreachable by construction (every LOS/movement check already runs
+// through spatial.HexGrid.IsValidPosition) -- this is the render contract
 // (rpg-dnd5e-web#566) catching up to the room's actual shape, not a new
 // blocking mechanism, so walkability outcomes are unchanged by this
-// function's output.
-func perimeterEdgeWalls(walls []environments.WallSegmentData, width, height int) []environments.WallSegmentData {
-	blocked := wallCubeSet(walls)
+// function's output. (connectorBoundaryEdgeWalls' segments differ here --
+// their End IS a valid in-grid position, and rebuildRoomFromData places a
+// blocker there specifically because of that.)
+func perimeterEdgeWalls(blocked map[spatial.CubeCoordinate]struct{}, width, height int) []environments.WallSegmentData {
 	var out []environments.WallSegmentData
 	fw, fh := float64(width), float64(height)
 	for x := 0; x < width; x++ {
@@ -686,6 +735,74 @@ func perimeterEdgeWalls(walls []environments.WallSegmentData, width, height int)
 				npos := n.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
 				if npos.X >= 0 && npos.X < fw && npos.Y >= 0 && npos.Y < fh {
 					continue // neighbor is inside the space -- not a perimeter edge
+				}
+				out = append(out, environments.WallSegmentData{
+					Start: cube, End: n, BlocksMovement: true, BlocksLoS: true,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// connectorBoundaryEdgeWalls computes one boundary-edge WallSegmentData
+// (Start != End, exactly one hex step apart) per room-facing edge where a
+// REAL floor hex sits adjacent to a connector column's flanking (non-door)
+// cell -- extending #834's boundary-edge technique from the space's outer
+// perimeter (perimeterEdgeWalls, above) to these INTERIOR boundary columns
+// (rpg-toolkit#848).
+//
+// Root cause this replaces: a connector column's flanking cells used to be
+// individual degenerate (Start == End) WallSegmentData entries. Client-side
+// (rpg-dnd5e-web's buildDungeonWallSegments/collectWallHexes), any such
+// entry is classified as an independent wall hex and rendered by drawing
+// one edge piece per exposed side. Unlike a square grid, a straight
+// single-file line of hex cells does NOT collapse to "2 exposed sides": a
+// hex has 6 neighbors, and a north/south column only ever shares 2 of them
+// with its own same-column neighbors -- the other 4 face diagonally into
+// the two ADJACENT REGIONS (at rows skewed by the odd-q offset scheme,
+// tools/spatial's OffsetCoordinateToCubeWithOrientation). So even a
+// flanking cell in the middle of a long run exposes 4 sides, not 2,
+// rendering as an isolated "chunky rubble box" that visually drowns the
+// (correctly rendered) door immediately beside it.
+//
+// The fix mirrors perimeterEdgeWalls exactly, just facing inward instead
+// of outward: iterate every REAL floor hex in [0,width) x [0,height) (not
+// in blocked, which the caller has already unioned with every connector
+// column cell -- door cells included, so a door is never treated as a
+// Start here either, matching TestPerimeterEdgeWalls_NeverAtConnectorDoorCells'
+// invariant) and every one of its 6 neighbor directions; whenever that
+// neighbor is one of THIS dungeon's connector flanking cells, emit one
+// {Start: the floor hex, End: the flanking cell} segment. Two regions
+// share a single flanking cell as a neighbor (one on each side), so most
+// flanking cells end up boxed in by exactly two segments -- one contributed
+// by each region's own boundary column -- which is what "the corridor's
+// side walls" (the issue's phrasing) actually looks like once rendered:
+// two clean edges per row, not a floating block.
+//
+// Unlike perimeterEdgeWalls' segments, a flanking cell IS a valid in-grid
+// position (an interior column, not the space's true edge) -- these
+// segments DO need to keep blocking movement/LOS even though they're no
+// longer a degenerate entry in segs. See rebuildRoomFromData's companion
+// change: it places a blocker at the End of any Start != End segment that
+// is itself a valid in-grid position, leaving the true out-of-grid
+// perimeter case (#834) an unaffected no-op.
+func connectorBoundaryEdgeWalls(
+	blocked map[spatial.CubeCoordinate]struct{},
+	flanking map[spatial.CubeCoordinate]struct{},
+	width, height int,
+) []environments.WallSegmentData {
+	var out []environments.WallSegmentData
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(
+				spatial.Position{X: float64(x), Y: float64(y)}, spatial.HexOrientationPointyTop)
+			if _, isBlocked := blocked[cube]; isBlocked {
+				continue
+			}
+			for _, n := range cube.GetNeighbors() {
+				if _, isFlanking := flanking[n]; !isFlanking {
+					continue
 				}
 				out = append(out, environments.WallSegmentData{
 					Start: cube, End: n, BlocksMovement: true, BlocksLoS: true,

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -813,7 +813,10 @@ func connectorBoundaryEdgeWalls(
 	flanking map[spatial.CubeCoordinate]struct{},
 	width, height int,
 ) []environments.WallSegmentData {
-	var out []environments.WallSegmentData
+	// Capacity hint only, not exact: each flanking cell has at most 4
+	// region-facing edges (see doc above), plus at most one fallback
+	// entry apiece.
+	out := make([]environments.WallSegmentData, 0, len(flanking)*4)
 	covered := make(map[spatial.CubeCoordinate]struct{}, len(flanking))
 	for x := 0; x < width; x++ {
 		for y := 0; y < height; y++ {

--- a/encounter/dungeonspec/workbench.go
+++ b/encounter/dungeonspec/workbench.go
@@ -150,19 +150,19 @@ const floorPlanLegend = "floor plan (. floor, # wall, D door, o obstacle, @ entr
 // need a second, distinct marker to carry that distinction too), '@' the
 // designated entrance cell (SpaceData.Entrance).
 //
-// DEGENERATE WALLS ONLY -- a decision, not a shortcut: SpaceData.Walls
-// carries two shapes (see that field's doc). Degenerate (Start == End) is
-// an actual blocked interior hex; boundary-edge (Start != End) is a
-// render-only outer-perimeter marker added for rpg-dnd5e-web's client
-// (rpg-toolkit#834) whose Start is real WALKABLE floor -- never a
-// spatial.Room blocker. An earlier version of this renderer folded both
-// shapes into the same '#' marker for simplicity; that was wrong, not
-// merely imprecise, because most of a dungeon's outer edge is
-// boundary-edge-only, INCLUDING the entrance region's own spawn column
-// (SpaceData.Entrance sits at the room's far edge, design.md/dungeon.go's
-// "just inside the entrance, not center") -- folding rendered the party's
-// own spawn point as a wall. This renderer skips boundary-edge segments
-// outright instead.
+// SpaceData.Walls carries two shapes (see that field's doc): degenerate
+// (Start == End) is an actual blocked interior hex, marked at Start;
+// boundary-edge (Start != End) always has a real WALKABLE floor Start
+// (never marked '#' -- an earlier version of this renderer folded both
+// shapes into the same marker, which wrongly rendered the entrance
+// region's own spawn column, and SpaceData.Entrance itself, as a wall,
+// since most of a dungeon's outer edge is boundary-edge-only), but its End
+// is one of two cases: genuinely outside the room (the outer-perimeter
+// case, rpg-toolkit#834 -- nothing to mark, `set`'s own bounds check
+// silently no-ops) or a connector column's flanking cell, still inside
+// the room (rpg-toolkit#848) -- a real blocked interior cell, marked '#'
+// exactly like a degenerate entry, just discretized as an edge rather
+// than a hex.
 func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
 	fmt.Fprintln(b, floorPlanLegend)
 	sd := data.Space
@@ -193,10 +193,16 @@ func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
 	}
 
 	for _, w := range sd.Walls {
-		if w.Start != w.End {
-			continue // boundary-edge: render-only perimeter marker, not a real wall -- see doc above
+		if w.Start == w.End {
+			set(core.HexFromCube(w.Start), '#')
+			continue
 		}
-		set(core.HexFromCube(w.Start), '#')
+		// Boundary-edge: Start is real floor, never marked -- see doc
+		// above. End is marked when it's a real in-grid blocked cell
+		// (rpg-toolkit#848); `set`'s own bounds check silently no-ops for
+		// the outer-perimeter case, where End is genuinely outside the
+		// room.
+		set(core.HexFromCube(w.End), '#')
 	}
 	for _, door := range data.Doors {
 		set(door.Position, 'D')

--- a/encounter/dungeonspec/workbench.go
+++ b/encounter/dungeonspec/workbench.go
@@ -178,11 +178,15 @@ func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
 			grid[row][col] = '.'
 		}
 	}
-	// set is defensive, not load-bearing: every coordinate passed to it
-	// below is already guaranteed in-bounds -- walls/doors/obstacles by
-	// InitDungeon's own validation, Entrance by construction. The bounds
-	// check exists so a violation of that assumption drops the mark
-	// silently instead of panicking the whole report on a slice index.
+	// set's bounds check is load-bearing, not merely defensive
+	// (rpg-toolkit#848/#849 gate review finding 7): every wall/door/
+	// obstacle coordinate is in-bounds by InitDungeon's own validation,
+	// Entrance by construction -- EXCEPT a boundary-edge segment's End
+	// when it lands outside the room (the outer-perimeter case,
+	// rpg-toolkit#834). The loop below calls set(End, '#') unconditionally
+	// for every non-degenerate wall entry and deliberately relies on this
+	// check to silently no-op the out-of-grid ones rather than treat them
+	// as a real cell to mark.
 	set := func(h core.Hex, r rune) {
 		pos := h.ToPosition()
 		col, row := int(pos.X), int(pos.Y)

--- a/encounter/perimeter_edge_walls_test.go
+++ b/encounter/perimeter_edge_walls_test.go
@@ -39,9 +39,10 @@ var perimeterEdgeSeeds = []int64{dungeonSeed, 1, 2, 3, 4, 5, 100, 909091}
 
 // blockedCubesFromDegenerateWalls returns every cube coordinate marked
 // blocked by a degenerate (Start == End) wall entry — interior pattern
-// walls and connector boundary columns alike. Boundary-edge entries
-// (Start != End) never mark a cube blocked; a real floor hex is exactly
-// the complement of this set within the space's bounds.
+// walls only, as of rpg-toolkit#848 (connector boundary columns used to
+// be degenerate entries too; see connectorFlankingCubes below for their
+// replacement). Boundary-edge entries (Start != End) never mark a cube
+// blocked via THIS function.
 func blockedCubesFromDegenerateWalls(walls []environments.WallSegmentData) map[spatial.CubeCoordinate]bool {
 	out := make(map[spatial.CubeCoordinate]bool, len(walls))
 	for _, w := range walls {
@@ -52,21 +53,80 @@ func blockedCubesFromDegenerateWalls(walls []environments.WallSegmentData) map[s
 	return out
 }
 
+// connectorFlankingCubes reconstructs every connector's boundary-column
+// flanking (non-door) cube for a built dungeon, independently of
+// dungeon.go's own starts/width arithmetic (rpg-toolkit#848): a
+// RegionData.Hexes already covers a region's FULL local rectangle —
+// interior pattern walls/obstacles included (rpg-toolkit#814) — so any
+// cube within the combined space's [0,Width)x[0,Height) bounds that
+// belongs to NO region is exactly a connector's boundary column; the
+// door cells themselves (data.Doors, keyed by doorIDs) are excluded,
+// leaving only the flanking cells that must remain blocked without any
+// longer being their own degenerate wire entry.
+func connectorFlankingCubes(data *encounter.Data, doorIDs []core.EntityID) map[spatial.CubeCoordinate]bool {
+	doorCubes := make(map[spatial.CubeCoordinate]bool, len(doorIDs))
+	for _, id := range doorIDs {
+		doorCubes[data.Doors[id].Position.ToCube()] = true
+	}
+	flanking := make(map[spatial.CubeCoordinate]bool)
+	for x := 0; x < data.Space.Width; x++ {
+		for y := 0; y < data.Space.Height; y++ {
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(
+				spatial.Position{X: float64(x), Y: float64(y)}, spatial.HexOrientationPointyTop)
+			if doorCubes[cube] {
+				continue
+			}
+			hex := core.HexFromCube(cube)
+			inRegion := false
+			for _, r := range data.Space.Regions {
+				if r.Hexes.Has(hex) {
+					inRegion = true
+					break
+				}
+			}
+			if !inRegion {
+				flanking[cube] = true
+			}
+		}
+	}
+	return flanking
+}
+
 // assertPerimeterCompletenessAndNoDuplicates re-derives, from first
 // principles against public spatial primitives only (never dungeon.go's
 // own unexported perimeterEdgeWalls/wallCubeSet), every {Start, End}
-// boundary-edge pair a SpaceData's floor/wall layout implies, then proves
-// data.Space.Walls' non-degenerate entries match that set exactly: no
-// extras, no missing edges, no duplicates. Shared by every test in this
-// file that builds a dungeon (varying seed or shape) and checks the same
-// invariant, rather than duplicating the derivation per call site.
-func assertPerimeterCompletenessAndNoDuplicates(t *testing.T, label string, data *encounter.Data, grid spatial.Grid) {
+// OUTER-PERIMETER boundary-edge pair a SpaceData's floor/wall layout
+// implies, then proves data.Space.Walls' non-degenerate, out-of-grid-End
+// entries match that set exactly: no extras, no missing edges, no
+// duplicates. Shared by every test in this file that builds a dungeon
+// (varying seed or shape) and checks the same invariant, rather than
+// duplicating the derivation per call site.
+//
+// doorIDs feeds connectorFlankingCubes (rpg-toolkit#848): a connector's
+// flanking cells must count as "not real floor" here too, exactly like an
+// interior obstacle wall, even though they're no longer degenerate wire
+// entries themselves — otherwise a flanking cell sitting on the space's
+// own true y=0/y=height-1 edge row (which always happens: a connector
+// column always spans every row, only its doorRow cell is ever excluded)
+// would be misidentified as real floor and expected to grow a bogus
+// outward-facing perimeter edge of its own. Connector-to-region boundary
+// edges are a separate concern with their own completeness test — see
+// connector_column_walls_test.go — deliberately excluded from `expected`
+// and filtered out of `gotEdges` here by their in-grid End.
+func assertPerimeterCompletenessAndNoDuplicates(
+	t *testing.T, label string, data *encounter.Data, grid spatial.Grid, doorIDs []core.EntityID,
+) {
 	t.Helper()
 	blocked := blockedCubesFromDegenerateWalls(data.Space.Walls)
+	flanking := connectorFlankingCubes(data, doorIDs)
 	gotEdges := make(map[[2]spatial.CubeCoordinate]int)
 	for _, w := range data.Space.Walls {
 		if w.Start == w.End {
 			continue
+		}
+		endPos := w.End.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		if grid.IsValidPosition(endPos) {
+			continue // a connector boundary edge (#848) -- not this test's concern
 		}
 		gotEdges[[2]spatial.CubeCoordinate{w.Start, w.End}]++
 	}
@@ -79,7 +139,7 @@ func assertPerimeterCompletenessAndNoDuplicates(t *testing.T, label string, data
 		for y := 0; y < data.Space.Height; y++ {
 			pos := spatial.Position{X: float64(x), Y: float64(y)}
 			cube := spatial.OffsetCoordinateToCubeWithOrientation(pos, spatial.HexOrientationPointyTop)
-			if blocked[cube] {
+			if blocked[cube] || flanking[cube] {
 				continue
 			}
 			for _, n := range cube.GetNeighbors() {
@@ -128,27 +188,33 @@ func TestPerimeterEdgeWalls_Completeness(t *testing.T) {
 		enc := newTestEncounter(t)
 		require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(seed)), "seed %d", seed)
 		data := enc.ToData()
-		assertPerimeterCompletenessAndNoDuplicates(t, fmt.Sprintf("seed %d", seed), data, enc.Room().GetGrid())
+		assertPerimeterCompletenessAndNoDuplicates(t, fmt.Sprintf("seed %d", seed), data, enc.Room().GetGrid(),
+			[]core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
 	}
 }
 
 // TestPerimeterEdgeWalls_StartInsideEndOutsideDistanceOne pins the shape
 // contract every boundary-edge segment must satisfy: Start and End are
-// exactly one hex step apart, Start is a real position inside the live
-// room's grid, and End is outside it — plus the BlocksMovement/BlocksLoS
-// semantics match existing (degenerate) walls, per the issue's ask.
+// exactly one hex step apart, Start is always a real position inside the
+// live room's grid, and BlocksMovement/BlocksLoS match existing
+// (degenerate) walls, per the issue's ask. End is outside the room for
+// the outer-perimeter case (#834); rpg-toolkit#848 adds a second, EQUALLY
+// valid shape — End is itself a valid in-grid position that is exactly
+// one of this dungeon's connector flanking cells (never anything else,
+// e.g. never an interior obstacle cell or a door cell) — see
+// connector_column_walls_test.go for that shape's own dedicated coverage.
 func TestPerimeterEdgeWalls_StartInsideEndOutsideDistanceOne(t *testing.T) {
 	enc := newTestEncounter(t)
 	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
 	data := enc.ToData()
 	grid := enc.Room().GetGrid()
+	flanking := connectorFlankingCubes(data, []core.EntityID{dungeonDoor0ID, dungeonDoor1ID})
 
-	found := false
+	foundOuter, foundConnector := false, false
 	for _, w := range data.Space.Walls {
 		if w.Start == w.End {
 			continue
 		}
-		found = true
 		require.Equal(t, 1, w.Start.Distance(w.End),
 			"boundary-edge segment %+v must be exactly one hex step apart", w)
 
@@ -156,13 +222,20 @@ func TestPerimeterEdgeWalls_StartInsideEndOutsideDistanceOne(t *testing.T) {
 		endPos := w.End.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
 		require.True(t, grid.IsValidPosition(startPos),
 			"boundary-edge segment %+v: Start must be inside the room", w)
-		require.False(t, grid.IsValidPosition(endPos),
-			"boundary-edge segment %+v: End must be outside the room", w)
+
+		if grid.IsValidPosition(endPos) {
+			foundConnector = true
+			require.True(t, flanking[w.End],
+				"boundary-edge segment %+v: an in-grid End must be a connector flanking cell", w)
+		} else {
+			foundOuter = true
+		}
 
 		require.True(t, w.BlocksMovement, "boundary-edge segment %+v must carry BlocksMovement like existing walls", w)
 		require.True(t, w.BlocksLoS, "boundary-edge segment %+v must carry BlocksLoS like existing walls", w)
 	}
-	require.True(t, found, "fixture must actually produce at least one boundary-edge segment")
+	require.True(t, foundOuter, "fixture must actually produce at least one outer-perimeter boundary-edge segment")
+	require.True(t, foundConnector, "fixture must actually produce at least one connector boundary-edge segment")
 }
 
 // TestPerimeterEdgeWalls_EntranceHexHasWestFacingEdge is a concrete,
@@ -308,7 +381,7 @@ func TestPerimeterEdgeWalls_VariedShapes(t *testing.T) {
 			enc := newTestEncounter(t)
 			require.NoError(t, enc.InitDungeon(tc.params))
 			data := enc.ToData()
-			assertPerimeterCompletenessAndNoDuplicates(t, tc.name, data, enc.Room().GetGrid())
+			assertPerimeterCompletenessAndNoDuplicates(t, tc.name, data, enc.Room().GetGrid(), tc.doorIDs)
 			assertNoDoorCellIsPerimeterStart(t, tc.name, data, tc.doorIDs)
 		})
 	}

--- a/encounter/perimeter_edge_walls_test.go
+++ b/encounter/perimeter_edge_walls_test.go
@@ -35,7 +35,19 @@ import (
 // three-region dungeon fixture (entrance/boss PatternRandom, corridor
 // PatternEmpty) so perimeter-edge behavior is proven across varying
 // interior-wall layouts, not just one lucky seed.
-var perimeterEdgeSeeds = []int64{dungeonSeed, 1, 2, 3, 4, 5, 100, 909091}
+//
+// rpg-toolkit#849 gate review finding 2: the original 8-seed list here
+// (dungeonSeed, 1, 2, 3, 4, 5, 100, 909091) actually produced interior
+// wall cells on only 2 of those 8 seeds (4 and 100, 3 cells each) — the
+// other 6 rolled entirely empty entrance/boss interiors, so the sweep
+// exercised essentially one non-trivial layout, not "varying interior-wall
+// layouts" as the doc above claims. Measured directly (interior wall cell
+// counts per seed against this exact fixture): 4→3, 6→7, 17→9, 19→8,
+// 100→3, 101→10; dungeonSeed and 909091 stay at 0, kept deliberately for
+// the all-empty case (a PatternEmpty-heavy dungeon is itself a real,
+// legitimate shape worth covering, not just an accident of a bad seed
+// pick).
+var perimeterEdgeSeeds = []int64{dungeonSeed, 4, 6, 17, 19, 100, 101, 909091}
 
 // blockedCubesFromDegenerateWalls returns every cube coordinate marked
 // blocked by a degenerate (Start == End) wall entry — interior pattern

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -152,45 +152,65 @@ func (e *Encounter) rebuildRoomFromData() error {
 		Grid: grid,
 	})
 	placed := make(map[spatial.CubeCoordinate]struct{}, len(sd.Walls)+len(e.data.Doors))
-	for i, w := range sd.Walls {
-		// rpg-toolkit#834: a boundary-edge perimeter segment (Start != End)
-		// is purely the render contract (rpg-dnd5e-web#566's
-		// hexDistance==1 client branch) catching up to the room's actual
-		// shape, never a spatial.Room blocker in its own right — Start is
-		// real walkable floor (placing a WallEntity there would wrongly
-		// block legitimate floor) and End lies entirely outside this
-		// room's grid bounds (PlaceEntity would reject it, or worse,
-		// silently collide with an unrelated in-bounds cube on a
-		// differently-sized room). Every degenerate (Start == End) entry
-		// below — interior pattern walls, connector boundary columns —
-		// keeps placing exactly as before; this only skips the new shape.
-		if w.Start != w.End {
-			continue
+	// placeWallBlocker places (or, if cube is already occupied, no-ops) an
+	// indestructible blocking WallEntity at cube — shared by both the
+	// degenerate and boundary-edge branches below so they can't drift on
+	// WallType/dedup semantics.
+	placeWallBlocker := func(segmentID string, cube spatial.CubeCoordinate, blocksMovement, blocksLoS bool) error {
+		if _, dup := placed[cube]; dup {
+			return nil
 		}
-		// snapshotWalls dedupes on write; this read-side skip additionally
-		// tolerates a hand-built or legacy snapshot carrying duplicates —
-		// PlaceEntity rejects stacking a blocking entity on an occupied hex,
-		// which would otherwise fail the whole load.
-		if _, dup := placed[w.Start]; dup {
-			continue
-		}
-		placed[w.Start] = struct{}{}
-		pos := w.Start.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		placed[cube] = struct{}{}
+		pos := cube.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
 		entity := environments.NewWallEntity(environments.WallEntityConfig{
-			SegmentID: fmt.Sprintf("space-%d", i),
+			SegmentID: segmentID,
 			// Wave 1 doesn't persist WallType (no destruction model yet —
 			// see design doc Wave 2+); Indestructible is the correct default
 			// since BlocksMovement/BlocksLoS (the only behavior wave 1
 			// exercises) are preserved from the original snapshot regardless.
 			WallType: environments.WallTypeIndestructible,
 			Properties: environments.WallProperties{
-				BlocksMovement: w.BlocksMovement,
-				BlocksLoS:      w.BlocksLoS,
+				BlocksMovement: blocksMovement,
+				BlocksLoS:      blocksLoS,
 			},
 			Position: pos,
 		})
-		if err := room.PlaceEntity(entity, pos); err != nil {
-			return fmt.Errorf("place wall %d: %w", i, err)
+		return room.PlaceEntity(entity, pos)
+	}
+	for i, w := range sd.Walls {
+		if w.Start == w.End {
+			// snapshotWalls dedupes on write; this read-side skip
+			// additionally tolerates a hand-built or legacy snapshot
+			// carrying duplicates — PlaceEntity rejects stacking a
+			// blocking entity on an occupied hex, which would otherwise
+			// fail the whole load.
+			if err := placeWallBlocker(fmt.Sprintf("space-%d", i), w.Start, w.BlocksMovement, w.BlocksLoS); err != nil {
+				return fmt.Errorf("place wall %d: %w", i, err)
+			}
+			continue
+		}
+		// A boundary-edge segment (Start != End) is primarily the render
+		// contract (rpg-dnd5e-web#566's hexDistance==1 client branch)
+		// catching up to the room's actual shape — Start is always real
+		// walkable floor (placing a WallEntity there would wrongly block
+		// legitimate floor), so Start itself never becomes a blocker here.
+		// End is one of two cases:
+		//   - outer perimeter (rpg-toolkit#834): End lies entirely outside
+		//     this room's grid bounds — already unreachable by construction
+		//     (every LOS/movement check already runs through
+		//     spatial.HexGrid.IsValidPosition) — so placing anything there
+		//     would either error or collide with an unrelated in-bounds
+		//     cube on a differently-sized room. No-op, exactly as before.
+		//   - connector column flanking cell (rpg-toolkit#848): End IS a
+		//     valid in-grid position — a real, interior cell that must
+		//     keep blocking movement/LOS even though it's no longer its
+		//     own degenerate entry in sd.Walls. Gets its own blocker here.
+		endPos := w.End.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		if !grid.IsValidPosition(endPos) {
+			continue
+		}
+		if err := placeWallBlocker(fmt.Sprintf("space-%d-end", i), w.End, w.BlocksMovement, w.BlocksLoS); err != nil {
+			return fmt.Errorf("place wall %d end: %w", i, err)
 		}
 	}
 	for id, door := range e.data.Doors {


### PR DESCRIPTION
## Summary

Fixes #848: connector-column flanking cells still rendered as degenerate "rubble box" wall entries, drowning the door frame beside them (rpg-dnd5e-web#562), because #834's boundary-edge conversion deliberately excluded interior connector columns.

- `perimeterEdgeWalls` (#834) never touched a connector's boundary column — its non-door cells stayed degenerate (`Start == End`) entries. Client-side, an isolated wall hex like that renders as a "chunky box": a hex only shares 2 of its 6 sides with same-column neighbors, so even a cell mid-run exposes 4 sides toward the two adjacent regions (unlike a square grid, a hex column never collapses to "2 exposed sides"). Diagnosed live against the M1 build: 7 of these per connector, sandwiching every door.
- New `connectorBoundaryEdgeWalls` emits the same boundary-edge shape (`Start != End`, `Start` real region floor, `End` the flanking cell) `perimeterEdgeWalls` already uses for the outer perimeter, extended to each connector's flanking cells. The door cell itself is untouched — still carries no wall entry of any kind (`TestPerimeterEdgeWalls_NeverAtConnectorDoorCells`, unchanged).
- Since a flanking cell's `End` is a real in-grid position (unlike the outer-perimeter case, where `End` is always out-of-grid), `rebuildRoomFromData` can no longer rely on its existing "`Start != End` is never a room blocker" shortcut for it — that would silently open movement/LOS through the connector column anywhere except the door. `rebuildRoomFromData` now places a blocker at `End` whenever `End` is itself a valid in-grid position, and no-ops otherwise (the unaffected outer-perimeter case).
- Also fixes two other `Start == End`-only consumers this uncovered: `crypt_dungeon_test.go`'s boundary-column presence check, and `encounter/dungeonspec`'s new ASCII floor-plan workbench renderer (both assumed a connector column's blocked cells were always their own degenerate entry).

Single module (`encounter`) — normal squash-merge flow, no `go.mod` boundary crossed.

## Test plan

- [x] New `connector_column_walls_test.go`: no degenerate entries remain at flanking cells; boundary-edge completeness/no-duplicates derived **independently** of `dungeon.go` internals (via `RegionData.Hexes` + `Data.Doors`); flanking cells still block movement/LOS (`room.CanPlaceEntity`); **open doors remain walkable end-to-end** through the actual room rebuild (the movement/LOS-blocking-semantics risk this issue called out).
- [x] Updated `perimeter_edge_walls_test.go`'s shared completeness/shape assertions to account for the new connector-boundary-edge category (previously only knew about the outer-perimeter category).
- [x] `go test ./...` and `go test -race ./...` green across the whole `encounter` module (including `encounter/dungeonspec`, `encounter/core`, `encounter/events`, `encounter/perception`).
- [x] `golangci-lint` package-scoped — zero new findings in any touched file.
- [ ] Live visual verification against the running local stack (screenshots attached in a follow-up comment).

— implementer (asset-pipeline), on behalf of KirkDiggler