### PR TITLE
feat(encounter): extend crypt prop vocabulary with 9 wave-1 promotion refs

### DIFF
--- a/encounter/crypt_dungeon.go
+++ b/encounter/crypt_dungeon.go
@@ -117,11 +117,51 @@ const (
 	CryptObstacleRefSkeletonRemains = "dnd5e:props:skeleton-remains"
 )
 
+// Wave-1 promotion refs (rpg-toolkit#854, part of rpg-project#132's
+// look-and-feel wave): 9 of a 16-ref promotion batch — asset-w is
+// promoting matching meshes for these exact names in parallel (the name
+// IS the contract; do not rename without coordinating). Vocabulary only —
+// not yet wired into cryptEntranceObstacles/cryptCorridorObstacles/
+// cryptBossObstacles' fixed room composition, which room gets which of
+// these is a separate, later authoring/composition decision.
+const (
+	// CryptObstacleRefRug identifies a floor rug — walkable-past dressing.
+	CryptObstacleRefRug = "dnd5e:props:rug"
+	// CryptObstacleRefWallBanner identifies a hanging wall banner —
+	// walkable-past dressing.
+	CryptObstacleRefWallBanner = "dnd5e:props:wall-banner"
+	// CryptObstacleRefCandleStand identifies a small candle stand —
+	// walkable-past dressing (distinct from CryptObstacleRefStoneLantern's
+	// physical stone pedestal).
+	CryptObstacleRefCandleStand = "dnd5e:props:candle-stand"
+	// CryptObstacleRefLantern identifies a hanging/table lantern —
+	// walkable-past dressing.
+	CryptObstacleRefLantern = "dnd5e:props:lantern"
+	// CryptObstacleRefStoneLantern identifies a stone pedestal lantern — a
+	// physical light anchor, same flag shape as CryptObstacleRefBrazier/
+	// CryptObstacleRefTorchOrnate (blocks movement, see over/around it).
+	CryptObstacleRefStoneLantern = "dnd5e:props:stone-lantern"
+	// CryptObstacleRefTortureTable identifies a torture table set piece —
+	// a physical obstruction, same flag shape as CryptObstacleRefCoffin
+	// (blocks movement, see over/around it).
+	CryptObstacleRefTortureTable = "dnd5e:props:torture-table"
+	// CryptObstacleRefRibcage identifies a ribcage floor dressing piece —
+	// walkable-past dressing.
+	CryptObstacleRefRibcage = "dnd5e:props:ribcage"
+	// CryptObstacleRefBoneScatter identifies a scattered-bones floor
+	// dressing piece — walkable-past dressing.
+	CryptObstacleRefBoneScatter = "dnd5e:props:bone-scatter"
+	// CryptObstacleRefRubbleScatter identifies a scattered-rubble floor
+	// dressing piece — walkable-past dressing.
+	CryptObstacleRefRubbleScatter = "dnd5e:props:rubble-scatter"
+)
+
 // Crypt set-piece blocking properties: the VERIFIED canonical shipped-
 // asset-contract table (independent finding, PR #826 review — supersedes
 // this file's earlier "low vs tall" design guess, which had altar wrong),
-// now spanning three flag classes across #819's structural vocabulary and
-// rpg-toolkit#839's depth-pass dressing/light-anchor additions:
+// now spanning three flag classes across #819's structural vocabulary,
+// rpg-toolkit#839's depth-pass dressing/light-anchor additions, and
+// rpg-toolkit#854's wave-1 promotion refs:
 //
 //	ref                    BlocksMovement  BlocksLoS
 //	altar                  true            true   (measured 2.057m, role "obstacle")
@@ -132,30 +172,44 @@ const (
 //	coffin/tomb            true            false  (walk around, see over)
 //	brazier                true            false  (physical, but see over the flame)
 //	torch-ornate           true            false  (same shape as brazier)
+//	stone-lantern          true            false  (same shape as brazier, #854)
+//	torture-table          true            false  (same shape as coffin, #854)
 //	candles                false           false  (walkable-past floor dressing)
 //	bone-pile              false           false  (walkable-past floor dressing)
 //	chain                  false           false  (walkable-past floor dressing)
 //	skeleton-remains       false           false  (walkable-past floor dressing)
+//	rug                    false           false  (walkable-past floor dressing, #854)
+//	wall-banner            false           false  (walkable-past floor dressing, #854)
+//	candle-stand           false           false  (walkable-past floor dressing, #854)
+//	lantern                false           false  (walkable-past floor dressing, #854)
+//	ribcage                false           false  (walkable-past floor dressing, #854)
+//	bone-scatter           false           false  (walkable-past floor dressing, #854)
+//	rubble-scatter         false           false  (walkable-past floor dressing, #854)
 //
 // Three flag shapes, not one: structural pieces (obelisk/pillar/altar/
 // statues) block both movement and LoS; a see-over class (coffin/tomb,
-// brazier, torch-ornate) is a physical obstruction that never blocks
-// sightline over or around it (coffin: low enough to see over; brazier/
-// torch-ornate: see over the flame); dressing (candles/bone-pile/chain/
-// skeleton-remains) blocks neither.
+// brazier, torch-ornate, and #854's stone-lantern/torture-table) is a
+// physical obstruction that never blocks sightline over or around it
+// (coffin/torture-table: low enough to see over; brazier/torch-ornate/
+// stone-lantern: see over the flame); dressing (candles/bone-pile/chain/
+// skeleton-remains, and #854's rug/wall-banner/candle-stand/lantern/
+// ribcage/bone-scatter/rubble-scatter) blocks neither.
 const (
 	cryptBlocksMovement = true
 	cryptBlocksLoS      = true
 	// cryptSeeOverBlocksLoS is BlocksLoS for a piece that's a physical
 	// obstruction (BlocksMovement true) but never blocks sightline over
-	// or around it: the coffin/tomb (table above), and rpg-toolkit#839's
-	// light anchors (brazier, torch-ornate — "you can see over flame").
+	// or around it: the coffin/tomb (table above), rpg-toolkit#839's
+	// light anchors (brazier, torch-ornate — "you can see over flame"),
+	// and rpg-toolkit#854's stone-lantern/torture-table.
 	cryptSeeOverBlocksLoS = false
 )
 
 // Crypt floor-dressing blocking properties (rpg-toolkit#839): candles,
 // bone-pile, chain, and skeleton-remains are walkable-past floor
-// dressing, never a physical obstruction or sightline blocker — verified
+// dressing, never a physical obstruction or sightline blocker — same
+// shape rpg-toolkit#854's rug/wall-banner/candle-stand/lantern/ribcage/
+// bone-scatter/rubble-scatter reuse — verified
 // against this package's placement (placeRegionObstacles: each instance
 // still consumes its own unique candidate cell regardless of blocking
 // flags — no collision risk), room-rebuild (rebuildRoomFromData places a

--- a/encounter/crypt_dungeon.go
+++ b/encounter/crypt_dungeon.go
@@ -124,6 +124,14 @@ const (
 // not yet wired into cryptEntranceObstacles/cryptCorridorObstacles/
 // cryptBossObstacles' fixed room composition, which room gets which of
 // these is a separate, later authoring/composition decision.
+//
+// Resolved, no renames: asset-w reconciled the shipped manifest TO this
+// exact 16-ref contract (rpg-game-assets#36) rather than the other way
+// around — every key here matches the promoted asset names verbatim.
+// #36 ships real meshes for 15 of the 16; CryptObstacleRefRibcage below
+// is the one exception (still blocked on an asset defect, see its own
+// doc). See the blocking-properties table below for each ref's promotion
+// status relative to the pre-#854 verified shipped-asset contract.
 const (
 	// CryptObstacleRefRug identifies a floor rug — walkable-past dressing.
 	CryptObstacleRefRug = "dnd5e:props:rug"
@@ -132,7 +140,9 @@ const (
 	CryptObstacleRefWallBanner = "dnd5e:props:wall-banner"
 	// CryptObstacleRefCandleStand identifies a small candle stand —
 	// walkable-past dressing (distinct from CryptObstacleRefStoneLantern's
-	// physical stone pedestal).
+	// physical stone pedestal). rpg-game-assets#36 ships the base mesh;
+	// its flame companion is blocked by rpg-game-assets#35 — candle
+	// clusters (CryptObstacleRefCandles) carry the flames this wave.
 	CryptObstacleRefCandleStand = "dnd5e:props:candle-stand"
 	// CryptObstacleRefLantern identifies a hanging/table lantern —
 	// walkable-past dressing.
@@ -146,7 +156,11 @@ const (
 	// (blocks movement, see over/around it).
 	CryptObstacleRefTortureTable = "dnd5e:props:torture-table"
 	// CryptObstacleRefRibcage identifies a ribcage floor dressing piece —
-	// walkable-past dressing.
+	// walkable-past dressing. No shipped mesh yet as of rpg-game-assets#36
+	// — every pack candidate is scale-broken, blocked by
+	// rpg-game-assets#21. The ref/vocabulary entry stays regardless; a
+	// caller placing it will get correct blocking behavior once a mesh
+	// ships, this is purely an asset-availability gap.
 	CryptObstacleRefRibcage = "dnd5e:props:ribcage"
 	// CryptObstacleRefBoneScatter identifies a scattered-bones floor
 	// dressing piece — walkable-past dressing.
@@ -159,7 +173,8 @@ const (
 // Wave-1 promotion refs, addendum (rpg-toolkit#854): the asset
 // inventory's crypt reprioritization added 7 more candidates to the same
 // batch, bringing the total to 16 -- same vocabulary-only scope and
-// pattern as the const block above. Only 6 are new here:
+// pattern as the const block above; resolved without renames the same
+// way (see that block's doc). Only 6 are new here:
 // "dnd5e:props:skeleton-remains" (false/false, "lying/shackled skeleton
 // dressing") was also in this addendum's list, but it's byte-for-byte the
 // same ref string and flags as CryptObstacleRefSkeletonRemains above
@@ -193,9 +208,12 @@ const (
 // Crypt set-piece blocking properties: the VERIFIED canonical shipped-
 // asset-contract table (independent finding, PR #826 review — supersedes
 // this file's earlier "low vs tall" design guess, which had altar wrong),
-// now spanning three flag classes across #819's structural vocabulary,
-// rpg-toolkit#839's depth-pass dressing/light-anchor additions, and
-// rpg-toolkit#854's wave-1 promotion refs:
+// spanning #819's structural vocabulary and rpg-toolkit#839's depth-pass
+// dressing/light-anchor additions. Every ref below already has a shipped,
+// measured mesh in the asset manifest — see the SEPARATE table below this
+// one for rpg-toolkit#854's wave-1 promotion refs, which started pending
+// and are tracked distinctly until rpg-game-assets#36 (now merged, see
+// #854's own doc above) fully collapses that distinction:
 //
 //	ref                    BlocksMovement  BlocksLoS
 //	altar                  true            true   (measured 2.057m, role "obstacle")
@@ -203,40 +221,50 @@ const (
 //	statue-knight-hooded   true            true
 //	obelisk                true            true
 //	pillar                 true            true
-//	rune-pillar            true            true   (#854 addendum, same shape as pillar)
 //	coffin/tomb            true            false  (walk around, see over)
-//	tomb-open              true            false  (same shape as coffin, #854 addendum)
-//	pillar-broken          true            false  (stump, same shape as coffin, #854 addendum)
 //	brazier                true            false  (physical, but see over the flame)
 //	torch-ornate           true            false  (same shape as brazier)
-//	stone-lantern          true            false  (same shape as brazier, #854)
-//	torture-table          true            false  (same shape as coffin, #854)
 //	candles                false           false  (walkable-past floor dressing)
 //	bone-pile              false           false  (walkable-past floor dressing)
 //	chain                  false           false  (walkable-past floor dressing)
-//	chains                 false           false  (walkable-past floor dressing, #854 addendum)
 //	skeleton-remains       false           false  (walkable-past floor dressing)
+//
+// rpg-toolkit#854's wave-1 promotion refs (pending promotion —
+// rpg-game-assets#36 has now shipped meshes reconciled to this exact
+// 16-ref contract, resolving 15 of the 16; ribcage remains the one
+// exception, blocked by a separate asset defect — see its own doc
+// comment above):
+//
+//	ref                    BlocksMovement  BlocksLoS
+//	rune-pillar            true            true   (#854 addendum, same shape as pillar)
+//	tomb-open              true            false  (same shape as coffin, #854 addendum)
+//	pillar-broken          true            false  (stump, same shape as coffin, #854 addendum)
+//	stone-lantern          true            false  (same shape as brazier, #854)
+//	torture-table          true            false  (same shape as coffin, #854)
+//	chains                 false           false  (walkable-past floor dressing, #854 addendum)
 //	rug                    false           false  (walkable-past floor dressing, #854)
 //	wall-banner            false           false  (walkable-past floor dressing, #854)
-//	candle-stand           false           false  (walkable-past floor dressing, #854)
+//	candle-stand           false           false  (walkable-past floor dressing, #854; flame
+//	                                               companion pending, see its own doc comment)
 //	lantern                false           false  (walkable-past floor dressing, #854)
-//	ribcage                false           false  (walkable-past floor dressing, #854)
+//	ribcage                false           false  (walkable-past floor dressing, #854; no
+//	                                               shipped mesh yet, see its own doc comment)
 //	bone-scatter           false           false  (walkable-past floor dressing, #854)
 //	rubble-scatter         false           false  (walkable-past floor dressing, #854)
 //	glowing-orb            false           false  (walkable-past floor dressing, #854 addendum)
 //	rune-marker            false           false  (walkable-past floor dressing, #854 addendum)
 //
-// Three flag shapes, not one: structural pieces (obelisk/pillar/altar/
-// statues, and #854 addendum's rune-pillar) block both movement and LoS;
-// a see-over class (coffin/tomb, brazier, torch-ornate, #854's
-// stone-lantern/torture-table, and #854 addendum's tomb-open/
-// pillar-broken) is a physical obstruction that never blocks sightline
-// over or around it (coffin/torture-table/tomb-open/pillar-broken: low
-// enough or broken enough to see over; brazier/torch-ornate/
-// stone-lantern: see over the flame); dressing (candles/bone-pile/chain/
-// skeleton-remains, #854's rug/wall-banner/candle-stand/lantern/
-// ribcage/bone-scatter/rubble-scatter, and #854 addendum's chains/
-// glowing-orb/rune-marker) blocks neither.
+// Three flag shapes, not one, across BOTH tables: structural pieces
+// (obelisk/pillar/altar/statues, and #854 addendum's rune-pillar) block
+// both movement and LoS; a see-over class (coffin/tomb, brazier,
+// torch-ornate, #854's stone-lantern/torture-table, and #854 addendum's
+// tomb-open/pillar-broken) is a physical obstruction that never blocks
+// sightline over or around it (coffin/torture-table/tomb-open/
+// pillar-broken: low enough or broken enough to see over; brazier/
+// torch-ornate/stone-lantern: see over the flame); dressing (candles/
+// bone-pile/chain/skeleton-remains, #854's rug/wall-banner/candle-stand/
+// lantern/ribcage/bone-scatter/rubble-scatter, and #854 addendum's
+// chains/glowing-orb/rune-marker) blocks neither.
 const (
 	cryptBlocksMovement = true
 	cryptBlocksLoS      = true

--- a/encounter/crypt_dungeon.go
+++ b/encounter/crypt_dungeon.go
@@ -156,6 +156,40 @@ const (
 	CryptObstacleRefRubbleScatter = "dnd5e:props:rubble-scatter"
 )
 
+// Wave-1 promotion refs, addendum (rpg-toolkit#854): the asset
+// inventory's crypt reprioritization added 7 more candidates to the same
+// batch, bringing the total to 16 -- same vocabulary-only scope and
+// pattern as the const block above. Only 6 are new here:
+// "dnd5e:props:skeleton-remains" (false/false, "lying/shackled skeleton
+// dressing") was also in this addendum's list, but it's byte-for-byte the
+// same ref string and flags as CryptObstacleRefSkeletonRemains above
+// (rpg-toolkit#839) -- not re-added, to avoid a duplicate constant for
+// an identical value.
+const (
+	// CryptObstacleRefChains identifies a hanging-chains dressing piece —
+	// walkable-past dressing (distinct from CryptObstacleRefChain,
+	// singular, rpg-toolkit#839).
+	CryptObstacleRefChains = "dnd5e:props:chains"
+	// CryptObstacleRefGlowingOrb identifies a glowing-orb light/dressing
+	// piece — walkable-past dressing.
+	CryptObstacleRefGlowingOrb = "dnd5e:props:glowing-orb"
+	// CryptObstacleRefRuneMarker identifies a floor/small rune-marker
+	// dressing piece — walkable-past dressing.
+	CryptObstacleRefRuneMarker = "dnd5e:props:rune-marker"
+	// CryptObstacleRefRunePillar identifies a rune-carved pillar — a
+	// structural piece, same flag shape as CryptObstacleRefPillar (blocks
+	// both movement and LoS).
+	CryptObstacleRefRunePillar = "dnd5e:props:rune-pillar"
+	// CryptObstacleRefTombOpen identifies an opened sarcophagus/tomb — a
+	// physical obstruction, same flag shape as CryptObstacleRefCoffin
+	// (blocks movement, see over/around it).
+	CryptObstacleRefTombOpen = "dnd5e:props:tomb-open"
+	// CryptObstacleRefPillarBroken identifies a broken-pillar stump — a
+	// physical obstruction, same flag shape as CryptObstacleRefCoffin/
+	// CryptObstacleRefTombOpen (blocks movement, LoS clears over it).
+	CryptObstacleRefPillarBroken = "dnd5e:props:pillar-broken"
+)
+
 // Crypt set-piece blocking properties: the VERIFIED canonical shipped-
 // asset-contract table (independent finding, PR #826 review — supersedes
 // this file's earlier "low vs tall" design guess, which had altar wrong),
@@ -169,7 +203,10 @@ const (
 //	statue-knight-hooded   true            true
 //	obelisk                true            true
 //	pillar                 true            true
+//	rune-pillar            true            true   (#854 addendum, same shape as pillar)
 //	coffin/tomb            true            false  (walk around, see over)
+//	tomb-open              true            false  (same shape as coffin, #854 addendum)
+//	pillar-broken          true            false  (stump, same shape as coffin, #854 addendum)
 //	brazier                true            false  (physical, but see over the flame)
 //	torch-ornate           true            false  (same shape as brazier)
 //	stone-lantern          true            false  (same shape as brazier, #854)
@@ -177,6 +214,7 @@ const (
 //	candles                false           false  (walkable-past floor dressing)
 //	bone-pile              false           false  (walkable-past floor dressing)
 //	chain                  false           false  (walkable-past floor dressing)
+//	chains                 false           false  (walkable-past floor dressing, #854 addendum)
 //	skeleton-remains       false           false  (walkable-past floor dressing)
 //	rug                    false           false  (walkable-past floor dressing, #854)
 //	wall-banner            false           false  (walkable-past floor dressing, #854)
@@ -185,15 +223,20 @@ const (
 //	ribcage                false           false  (walkable-past floor dressing, #854)
 //	bone-scatter           false           false  (walkable-past floor dressing, #854)
 //	rubble-scatter         false           false  (walkable-past floor dressing, #854)
+//	glowing-orb            false           false  (walkable-past floor dressing, #854 addendum)
+//	rune-marker            false           false  (walkable-past floor dressing, #854 addendum)
 //
 // Three flag shapes, not one: structural pieces (obelisk/pillar/altar/
-// statues) block both movement and LoS; a see-over class (coffin/tomb,
-// brazier, torch-ornate, and #854's stone-lantern/torture-table) is a
-// physical obstruction that never blocks sightline over or around it
-// (coffin/torture-table: low enough to see over; brazier/torch-ornate/
+// statues, and #854 addendum's rune-pillar) block both movement and LoS;
+// a see-over class (coffin/tomb, brazier, torch-ornate, #854's
+// stone-lantern/torture-table, and #854 addendum's tomb-open/
+// pillar-broken) is a physical obstruction that never blocks sightline
+// over or around it (coffin/torture-table/tomb-open/pillar-broken: low
+// enough or broken enough to see over; brazier/torch-ornate/
 // stone-lantern: see over the flame); dressing (candles/bone-pile/chain/
-// skeleton-remains, and #854's rug/wall-banner/candle-stand/lantern/
-// ribcage/bone-scatter/rubble-scatter) blocks neither.
+// skeleton-remains, #854's rug/wall-banner/candle-stand/lantern/
+// ribcage/bone-scatter/rubble-scatter, and #854 addendum's chains/
+// glowing-orb/rune-marker) blocks neither.
 const (
 	cryptBlocksMovement = true
 	cryptBlocksLoS      = true
@@ -201,7 +244,8 @@ const (
 	// obstruction (BlocksMovement true) but never blocks sightline over
 	// or around it: the coffin/tomb (table above), rpg-toolkit#839's
 	// light anchors (brazier, torch-ornate — "you can see over flame"),
-	// and rpg-toolkit#854's stone-lantern/torture-table.
+	// rpg-toolkit#854's stone-lantern/torture-table, and #854's addendum
+	// tomb-open/pillar-broken.
 	cryptSeeOverBlocksLoS = false
 )
 
@@ -209,7 +253,8 @@ const (
 // bone-pile, chain, and skeleton-remains are walkable-past floor
 // dressing, never a physical obstruction or sightline blocker — same
 // shape rpg-toolkit#854's rug/wall-banner/candle-stand/lantern/ribcage/
-// bone-scatter/rubble-scatter reuse — verified
+// bone-scatter/rubble-scatter and #854's addendum chains/glowing-orb/
+// rune-marker reuse — verified
 // against this package's placement (placeRegionObstacles: each instance
 // still consumes its own unique candidate cell regardless of blocking
 // flags — no collision risk), room-rebuild (rebuildRoomFromData places a

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -12,13 +12,16 @@ package encounter_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
@@ -254,6 +257,12 @@ func TestCryptDungeonParams_NoObstacleUsesModelFilenamesOrSyntyPaths(t *testing.
 		encounter.CryptObstacleRefBrazier, encounter.CryptObstacleRefBonePile,
 		encounter.CryptObstacleRefTorchOrnate, encounter.CryptObstacleRefCandles,
 		encounter.CryptObstacleRefChain, encounter.CryptObstacleRefSkeletonRemains,
+		// rpg-toolkit#854 wave-1 promotion refs.
+		encounter.CryptObstacleRefRug, encounter.CryptObstacleRefWallBanner,
+		encounter.CryptObstacleRefCandleStand, encounter.CryptObstacleRefLantern,
+		encounter.CryptObstacleRefStoneLantern, encounter.CryptObstacleRefTortureTable,
+		encounter.CryptObstacleRefRibcage, encounter.CryptObstacleRefBoneScatter,
+		encounter.CryptObstacleRefRubbleScatter,
 	} {
 		require.Regexp(t, `^dnd5e:props:[a-z-]+$`, ref)
 	}
@@ -281,6 +290,17 @@ var cryptCanonicalAssetManifestKeys = map[string]string{
 	"CryptObstacleRefCandles":         "dnd5e:props:candles",
 	"CryptObstacleRefChain":           "dnd5e:props:chain",
 	"CryptObstacleRefSkeletonRemains": "dnd5e:props:skeleton-remains",
+	// rpg-toolkit#854 wave-1 promotion refs -- asset-w is promoting
+	// matching meshes for these exact names in parallel.
+	"CryptObstacleRefRug":           "dnd5e:props:rug",
+	"CryptObstacleRefWallBanner":    "dnd5e:props:wall-banner",
+	"CryptObstacleRefCandleStand":   "dnd5e:props:candle-stand",
+	"CryptObstacleRefLantern":       "dnd5e:props:lantern",
+	"CryptObstacleRefStoneLantern":  "dnd5e:props:stone-lantern",
+	"CryptObstacleRefTortureTable":  "dnd5e:props:torture-table",
+	"CryptObstacleRefRibcage":       "dnd5e:props:ribcage",
+	"CryptObstacleRefBoneScatter":   "dnd5e:props:bone-scatter",
+	"CryptObstacleRefRubbleScatter": "dnd5e:props:rubble-scatter",
 }
 
 // TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly: each
@@ -306,6 +326,15 @@ func TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly(t *testing.T) 
 		"CryptObstacleRefCandles":            encounter.CryptObstacleRefCandles,
 		"CryptObstacleRefChain":              encounter.CryptObstacleRefChain,
 		"CryptObstacleRefSkeletonRemains":    encounter.CryptObstacleRefSkeletonRemains,
+		"CryptObstacleRefRug":                encounter.CryptObstacleRefRug,
+		"CryptObstacleRefWallBanner":         encounter.CryptObstacleRefWallBanner,
+		"CryptObstacleRefCandleStand":        encounter.CryptObstacleRefCandleStand,
+		"CryptObstacleRefLantern":            encounter.CryptObstacleRefLantern,
+		"CryptObstacleRefStoneLantern":       encounter.CryptObstacleRefStoneLantern,
+		"CryptObstacleRefTortureTable":       encounter.CryptObstacleRefTortureTable,
+		"CryptObstacleRefRibcage":            encounter.CryptObstacleRefRibcage,
+		"CryptObstacleRefBoneScatter":        encounter.CryptObstacleRefBoneScatter,
+		"CryptObstacleRefRubbleScatter":      encounter.CryptObstacleRefRubbleScatter,
 	}
 	for name, want := range cryptCanonicalAssetManifestKeys {
 		require.Equal(t, want, actual[name], "%s must equal the exact canonical asset-manifest key", name)
@@ -360,6 +389,60 @@ func TestCryptDungeonParams_BlockingFlagsMatchVerifiedAssetContract(t *testing.T
 		require.True(t, ok, "ref %q must appear somewhere in CryptDungeonParams", tc.ref)
 		require.Equal(t, tc.blocksMovement, spec.BlocksMovement, "ref %q BlocksMovement mismatch", tc.ref)
 		require.Equal(t, tc.blocksLoS, spec.BlocksLoS, "ref %q BlocksLoS mismatch", tc.ref)
+	}
+}
+
+// cryptWaveOnePromotionRefs is rpg-toolkit#854's wave-1 promotion
+// vocabulary and its documented default blocking flags. Not yet wired
+// into cryptEntranceObstacles/cryptCorridorObstacles/cryptBossObstacles'
+// fixed room composition (a separate, later authoring/composition
+// decision), so these refs never "appear somewhere in CryptDungeonParams"
+// the way cryptBlockingContractTable's refs do -- see
+// TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom
+// below for how this table is actually verified instead.
+var cryptWaveOnePromotionRefs = []struct {
+	ref            string
+	blocksMovement bool
+	blocksLoS      bool
+}{
+	{encounter.CryptObstacleRefRug, false, false},
+	{encounter.CryptObstacleRefWallBanner, false, false},
+	{encounter.CryptObstacleRefCandleStand, false, false},
+	{encounter.CryptObstacleRefLantern, false, false},
+	{encounter.CryptObstacleRefStoneLantern, true, false},
+	{encounter.CryptObstacleRefTortureTable, true, false},
+	{encounter.CryptObstacleRefRibcage, false, false},
+	{encounter.CryptObstacleRefBoneScatter, false, false},
+	{encounter.CryptObstacleRefRubbleScatter, false, false},
+}
+
+// TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom
+// proves each rpg-toolkit#854 wave-1 ref's documented default blocking
+// flags actually produce the correct movement/LoS behavior through a
+// real room -- one instance per ref, each at its own hex (avoiding any
+// placement collision across the table), verified via room.CanPlaceEntity
+// (movement) and room.IsLineOfSightBlocked across two opposite neighbors
+// (LoS) -- mirrors obstacle_test.go's TestObstacle_BlocksMovement_False/
+// TestObstacle_BlocksLoS_True/_False pattern, the same generic mechanism
+// every other obstacle ref already goes through (AddObstacle/
+// rebuildRoomFromData don't know or care what the ref string is).
+func TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom(t *testing.T) {
+	enc := cdNewEncounter(t)
+	require.NoError(t, enc.InitRoom(20, 20, environments.PatternEmpty))
+
+	for i, tc := range cryptWaveOnePromotionRefs {
+		hex := core.HexFromPosition(spatial.Position{X: float64(2 + i*2), Y: 10})
+		id := core.EntityID(fmt.Sprintf("wave1-promotion-%d", i))
+		require.NoError(t, enc.AddObstacle(id, tc.ref, hex, tc.blocksMovement, tc.blocksLoS), "ref %q", tc.ref)
+
+		room := enc.Room()
+		require.Equal(t, !tc.blocksMovement, room.CanPlaceEntity(probeEntity{}, hex.ToPosition()),
+			"ref %q: CanPlaceEntity must match BlocksMovement=%v", tc.ref, tc.blocksMovement)
+
+		neighbors := perception.HexNeighbors(hex)
+		from, to := neighbors[0], neighbors[3]
+		require.Equal(t, tc.blocksLoS, room.IsLineOfSightBlocked(from.ToPosition(), to.ToPosition()),
+			"ref %q: IsLineOfSightBlocked must match BlocksLoS=%v", tc.ref, tc.blocksLoS)
 	}
 }
 

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -263,6 +263,10 @@ func TestCryptDungeonParams_NoObstacleUsesModelFilenamesOrSyntyPaths(t *testing.
 		encounter.CryptObstacleRefStoneLantern, encounter.CryptObstacleRefTortureTable,
 		encounter.CryptObstacleRefRibcage, encounter.CryptObstacleRefBoneScatter,
 		encounter.CryptObstacleRefRubbleScatter,
+		// rpg-toolkit#854 wave-1 promotion refs, addendum.
+		encounter.CryptObstacleRefChains, encounter.CryptObstacleRefGlowingOrb,
+		encounter.CryptObstacleRefRuneMarker, encounter.CryptObstacleRefRunePillar,
+		encounter.CryptObstacleRefTombOpen, encounter.CryptObstacleRefPillarBroken,
 	} {
 		require.Regexp(t, `^dnd5e:props:[a-z-]+$`, ref)
 	}
@@ -301,6 +305,15 @@ var cryptCanonicalAssetManifestKeys = map[string]string{
 	"CryptObstacleRefRibcage":       "dnd5e:props:ribcage",
 	"CryptObstacleRefBoneScatter":   "dnd5e:props:bone-scatter",
 	"CryptObstacleRefRubbleScatter": "dnd5e:props:rubble-scatter",
+	// rpg-toolkit#854 wave-1 promotion refs, addendum (skeleton-remains
+	// was also in the addendum's list but is byte-for-byte identical to
+	// CryptObstacleRefSkeletonRemains above -- not duplicated here).
+	"CryptObstacleRefChains":       "dnd5e:props:chains",
+	"CryptObstacleRefGlowingOrb":   "dnd5e:props:glowing-orb",
+	"CryptObstacleRefRuneMarker":   "dnd5e:props:rune-marker",
+	"CryptObstacleRefRunePillar":   "dnd5e:props:rune-pillar",
+	"CryptObstacleRefTombOpen":     "dnd5e:props:tomb-open",
+	"CryptObstacleRefPillarBroken": "dnd5e:props:pillar-broken",
 }
 
 // TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly: each
@@ -335,6 +348,12 @@ func TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly(t *testing.T) 
 		"CryptObstacleRefRibcage":            encounter.CryptObstacleRefRibcage,
 		"CryptObstacleRefBoneScatter":        encounter.CryptObstacleRefBoneScatter,
 		"CryptObstacleRefRubbleScatter":      encounter.CryptObstacleRefRubbleScatter,
+		"CryptObstacleRefChains":             encounter.CryptObstacleRefChains,
+		"CryptObstacleRefGlowingOrb":         encounter.CryptObstacleRefGlowingOrb,
+		"CryptObstacleRefRuneMarker":         encounter.CryptObstacleRefRuneMarker,
+		"CryptObstacleRefRunePillar":         encounter.CryptObstacleRefRunePillar,
+		"CryptObstacleRefTombOpen":           encounter.CryptObstacleRefTombOpen,
+		"CryptObstacleRefPillarBroken":       encounter.CryptObstacleRefPillarBroken,
 	}
 	for name, want := range cryptCanonicalAssetManifestKeys {
 		require.Equal(t, want, actual[name], "%s must equal the exact canonical asset-manifest key", name)
@@ -393,12 +412,15 @@ func TestCryptDungeonParams_BlockingFlagsMatchVerifiedAssetContract(t *testing.T
 }
 
 // cryptWaveOnePromotionRefs is rpg-toolkit#854's wave-1 promotion
-// vocabulary and its documented default blocking flags. Not yet wired
-// into cryptEntranceObstacles/cryptCorridorObstacles/cryptBossObstacles'
-// fixed room composition (a separate, later authoring/composition
-// decision), so these refs never "appear somewhere in CryptDungeonParams"
-// the way cryptBlockingContractTable's refs do -- see
-// TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom
+// vocabulary (15 refs: the original 9 plus 6 new from the addendum --
+// skeleton-remains was in the addendum's list too but is byte-for-byte
+// identical to the pre-existing CryptObstacleRefSkeletonRemains, so it's
+// not duplicated here) and its documented default blocking flags. Not
+// yet wired into cryptEntranceObstacles/cryptCorridorObstacles/
+// cryptBossObstacles' fixed room composition (a separate, later
+// authoring/composition decision), so these refs never "appear somewhere
+// in CryptDungeonParams" the way cryptBlockingContractTable's refs do --
+// see TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom
 // below for how this table is actually verified instead.
 var cryptWaveOnePromotionRefs = []struct {
 	ref            string
@@ -414,6 +436,13 @@ var cryptWaveOnePromotionRefs = []struct {
 	{encounter.CryptObstacleRefRibcage, false, false},
 	{encounter.CryptObstacleRefBoneScatter, false, false},
 	{encounter.CryptObstacleRefRubbleScatter, false, false},
+	// Addendum.
+	{encounter.CryptObstacleRefChains, false, false},
+	{encounter.CryptObstacleRefGlowingOrb, false, false},
+	{encounter.CryptObstacleRefRuneMarker, false, false},
+	{encounter.CryptObstacleRefRunePillar, true, true},
+	{encounter.CryptObstacleRefTombOpen, true, false},
+	{encounter.CryptObstacleRefPillarBroken, true, false},
 }
 
 // TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom
@@ -428,7 +457,9 @@ var cryptWaveOnePromotionRefs = []struct {
 // rebuildRoomFromData don't know or care what the ref string is).
 func TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom(t *testing.T) {
 	enc := cdNewEncounter(t)
-	require.NoError(t, enc.InitRoom(20, 20, environments.PatternEmpty))
+	// Width must clear 2 + len(cryptWaveOnePromotionRefs)*2 with margin to
+	// spare for each entry's neighbor-based LoS check.
+	require.NoError(t, enc.InitRoom(2*len(cryptWaveOnePromotionRefs)+10, 20, environments.PatternEmpty))
 
 	for i, tc := range cryptWaveOnePromotionRefs {
 		hex := core.HexFromPosition(spatial.Position{X: float64(2 + i*2), Y: 10})


### PR DESCRIPTION
## Summary

Closes #854 — part of rpg-project#132's look-and-feel wave (9 of a 16-ref promotion batch; asset-w is promoting matching meshes for these exact names in parallel).

Adds `rug`, `wall-banner`, `candle-stand`, `lantern`, `stone-lantern`, `torture-table`, `ribcage`, `bone-scatter`, `rubble-scatter` to `encounter/crypt_dungeon.go`'s `CryptObstacleRef*` vocabulary:

| Ref | BlocksMovement | BlocksLoS |
|---|---|---|
| `dnd5e:props:rug` | false | false |
| `dnd5e:props:wall-banner` | false | false |
| `dnd5e:props:candle-stand` | false | false |
| `dnd5e:props:lantern` | false | false |
| `dnd5e:props:stone-lantern` | true | false |
| `dnd5e:props:torture-table` | true | false |
| `dnd5e:props:ribcage` | false | false |
| `dnd5e:props:bone-scatter` | false | false |
| `dnd5e:props:rubble-scatter` | false | false |

Vocabulary/data only — no engine logic, no renderer, no API changes. All 9 reuse the existing `cryptBlocksMovement`/`cryptSeeOverBlocksLoS`/`cryptDressingBlocksMovement`/`cryptDressingBlocksLoS` flag constants (stone-lantern/torture-table are physical-but-see-over, same shape as brazier/coffin; the other 7 are walkable-past dressing, same shape as candles/bone-pile) — no new flag categories needed.

None of these are wired into `cryptEntranceObstacles`/`cryptCorridorObstacles`/`cryptBossObstacles`' fixed room composition — deciding which crypt room gets which of these is a separate, later authoring decision, out of scope here.

Single module (`encounter`) — normal squash-merge flow.

## Test plan

- [x] Extended the canonical-ref-string pinning map (`cryptCanonicalAssetManifestKeys`) and its exact-match test (`TestCryptObstacleRefs_MatchCanonicalAssetManifestKeysExactly`).
- [x] Extended the model-filename/Synty-path shape regex test (`TestCryptDungeonParams_NoObstacleUsesModelFilenamesOrSyntyPaths`).
- [x] New `TestCryptWaveOnePromotionRefs_BlockingFlagsRoundTripThroughRealRoom`: proves each ref's documented default flags produce correct movement (`room.CanPlaceEntity`) and LoS (`room.IsLineOfSightBlocked`) behavior through a real room — mirrors `obstacle_test.go`'s `TestObstacle_BlocksMovement_False`/`BlocksLoS_True`/`_False` pattern, since these refs don't appear in `CryptDungeonParams`' own output yet (so the existing `cryptBlockingContractTable`'s "must appear somewhere in CryptDungeonParams" shape doesn't apply).
- [x] `go test ./...` and `go test -race ./...` green across the whole `encounter` module.
- [x] `golangci-lint` — both a local run and the exact CI-pinned v2.3.1 — zero new findings.

— implementer (asset-pipeline), on behalf of KirkDiggler