### PR TITLE
fix(encounter): confine viewer memory to hexes that belong to the space

### DIFF
--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -93,6 +93,15 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 	}
 	edges := e.edgesByHex()
 	for h := range hexes {
+		// rpg-toolkit#859: hexes is frequently a raw perception.VisibleHexesAt
+		// disc (sight-range radius around a position), which has no notion of
+		// whether a hex is part of the space at all — it happily includes the
+		// void beyond the room's walls. Confine what gets remembered to hexes
+		// that are actually part of the space; see isSpaceHex's doc for why
+		// this can't be approximated with RegionAt.
+		if !e.isSpaceHex(h) {
+			continue
+		}
 		obs := perception.HexObservation{
 			Position: h,
 			State:    perception.KnowledgeStateVisible,
@@ -109,6 +118,49 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 		}
 		view.Observe(obs)
 	}
+}
+
+// isSpaceHex reports whether h is actually part of this encounter's space —
+// not merely within sight-range distance of some viewer position.
+// rpg-toolkit#859: three live encounters measured ~80% of a viewer's stored
+// Memory as hexes with no floor beneath them at all — perception.
+// VisibleHexesAt returns every hex within sightRange that isn't
+// wall-blocked, with no notion of whether a hex belongs to the space, so
+// refreshObservations was faithfully recording the void beyond the room's
+// walls right alongside real floor.
+//
+// RegionAt alone is NOT this test: a door's own cell deliberately belongs to
+// no region (RegionAt(door.Position) is always ("", false) by construction —
+// see doorPassageNeighbor's doc), and corridors may be similarly unregioned
+// in future generators. Filtering on "has a region" would silently drop
+// doorways from memory — a worse bug than the one being fixed, since the
+// player would lose the doorway they are standing in.
+//
+// The real test is the room's own grid bounds. rebuildRoomFromData builds
+// e.room's HexGrid from exactly SpaceData.Width/Height (spatial.HexGridConfig
+// {Width: sd.Width, Height: sd.Height}), and every generator this package
+// ships lays hexes out with NO gaps inside that rectangle:
+//   - InitRoom: a single implicit region spanning the whole grid — the
+//     entire rectangle IS the floor.
+//   - InitDungeon (InitTwoChamberRoom included, generalized to N=2):
+//     generateDungeonLayout places each region's columns contiguously
+//     (starts[i] = x; x += r.Width + 1) with the boundary/door column
+//     immediately after — the shared rectangle is exactly regions plus
+//     their connecting door columns, tiled with zero slack.
+//
+// So "within the room's grid bounds" IS "part of the space" for every shape
+// this package generates, doors included, with no per-generator
+// special-casing and no dependency on region tagging at all — precisely the
+// real membership answer the space itself already has, not an approximation.
+//
+// A nil e.room (InitRoom/LoadFromData-with-Space never ran) means there is
+// no room to be outside of: every hex is accepted, preserving this
+// package's pre-wave-1 unbounded-radius behavior for non-spatial encounters.
+func (e *Encounter) isSpaceHex(h core.Hex) bool {
+	if e.room == nil {
+		return true
+	}
+	return e.room.GetGrid().IsValidPosition(h.ToPosition())
 }
 
 // unionPlacement returns placements with a Placement for entityID appended

--- a/encounter/knowledge_test.go
+++ b/encounter/knowledge_test.go
@@ -7,6 +7,15 @@ package encounter_test
 // reconciliation. See encounter/knowledge.go's file doc for the
 // implementation this exercises, and perception/knowledge.go for the
 // HexObservation contract these tests assert against.
+//
+// rpg-toolkit#859 added TestKnownHexes_MemoryHexes_AllBelongToTheSpace and
+// TestKnownHexes_DoorwayCell_IsStillRemembered: every test above this point
+// predates that fix and uses encounter.New with no InitRoom/InitDungeon call
+// at all (e.room stays nil), so they never previously exercised — and still
+// don't exercise — the space-membership filter; they keep passing precisely
+// because a nil room means "nothing to be outside of," preserving this
+// package's pre-wave-1 unbounded behavior for non-spatial encounters. The
+// two new tests are the ones that actually build a spatial room.
 
 import (
 	"context"
@@ -18,6 +27,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
 type KnowledgeSuite struct {
@@ -331,4 +341,69 @@ func (s *KnowledgeSuite) TestKnownHexes_DuplicateReconciliation_Idempotent() {
 	second := e.KnownHexes(alicePlayerID)
 
 	s.Equal(first, second, "reconciling unchanged visibility twice must leave KnownHexes identical")
+}
+
+// TestKnownHexes_MemoryHexes_AllBelongToTheSpace is rpg-toolkit#859's core
+// acceptance bar: perception.VisibleHexesAt returns every hex within
+// sightRange that isn't wall-blocked, with no notion of whether a hex is
+// part of the space at all — measured from live Redis, ~80% of a viewer's
+// stored Memory was hexes with no floor beneath them, well outside the
+// room. A tiny 6x6 room with sight range 10 (the measured scenario's own
+// sight range) reproduces the shape of the bug directly: an unfiltered
+// radius-10 disc is up to 331 hexes, vastly more than the room's own 36.
+func (s *KnowledgeSuite) TestKnownHexes_MemoryHexes_AllBelongToTheSpace() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.InitRoom(6, 6, environments.PatternEmpty))
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+
+	known := e.KnownHexes(alicePlayerID)
+	s.Require().NotEmpty(known)
+
+	room := e.Room()
+	s.Require().NotNil(room)
+	for h := range known {
+		s.True(room.GetGrid().IsValidPosition(h.ToPosition()),
+			"every stored hex must belong to the room's grid bounds; %v does not", h)
+	}
+
+	// Memory size must equal the room's own footprint (6x6=36) exactly, not
+	// the sight-range disc (radius 10 reaches the whole tiny room from this
+	// corner, so pre-fix this would instead have been the full unfiltered
+	// disc size — up to 331 hexes for radius 10).
+	s.Equal(36, len(known),
+		"memory must be proportional to the room's footprint, not the sight-range area")
+}
+
+// TestKnownHexes_DoorwayCell_IsStillRemembered is rpg-toolkit#859's
+// trap-avoidance bar: RegionAt alone is NOT a valid space-membership test —
+// a door's own cell deliberately belongs to no region (doorPassageNeighbor's
+// documented trap) — so a fix that filtered purely on "has a region" would
+// silently drop doorways from memory, losing the exact cell the player is
+// standing in front of. Proves the real fix does not make that mistake.
+func (s *KnowledgeSuite) TestKnownHexes_DoorwayCell_IsStillRemembered() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.InitTwoChamberRoom(encounter.TwoChamberRoomParams{
+		ChamberWidth: 4, ChamberHeight: 4, Pattern: environments.PatternEmpty,
+		DoorID: twoChamberDoorID,
+	}))
+	entrance := e.ToData().Space.Entrance
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: entrance, SightRange: 10,
+	}))
+
+	doorHex := e.ToData().Doors[twoChamberDoorID].Position
+
+	// Precondition pinning the documented trap itself: the door's own cell
+	// belongs to no region.
+	_, hasRegion := e.ToData().Space.RegionAt(doorHex)
+	s.Require().False(hasRegion,
+		"precondition: the door's own cell belongs to no region (doorPassageNeighbor's documented trap)")
+
+	known := e.KnownHexes(alicePlayerID)
+	s.Require().Contains(known, doorHex,
+		"the doorway must still be remembered even though RegionAt reports it belongs to no region")
 }


### PR DESCRIPTION
## Summary

Fixes #859: `perception.VisibleHexesAt` returns every hex within `sightRange` that isn't wall-blocked, with no notion of whether a hex is part of the space at all — `refreshObservations` faithfully stored an observation for each one, including the void well beyond the room's own walls.

Measured from three live encounters (sight range 10): 483/494/392 stored memory hexes against 200 actual room floor hexes — **76-80% of every viewer's persisted Memory was hexes with no floor beneath them.** That memory is per-player, per-encounter, only grows, and rides the wire on every full knowledge restatement (rpg-api#732).

## How space membership is determined (and how doorways survive it)

Adds `Encounter.isSpaceHex` — the real "is this part of the floor" answer the issue asked for, not an approximation:

- **`RegionAt` alone is NOT valid here.** A door's own cell deliberately belongs to no region — the documented trap in `doorPassageNeighbor`'s comment (`RegionAt(door.Position)` is always `("", false)` by construction). Filtering on "has a region" would silently drop doorways from memory — a worse bug than the one being fixed, since the player would lose the doorway they're standing in.
- **The actual test is the room's own grid bounds.** `rebuildRoomFromData` builds `e.room`'s `HexGrid` from exactly `SpaceData.Width`/`Height`, and every generator this package ships (`InitRoom`'s single implicit region, `InitDungeon`'s N-region chain — `InitTwoChamberRoom` included, since it's a thin wrapper over `InitDungeon`) lays hexes out with **zero gaps** inside that rectangle: `generateDungeonLayout` places each region's columns contiguously (`starts[i] = x; x += r.Width + 1`) with the boundary/door column immediately after. So "within the room's grid bounds" already **is** "part of the space" — doors included — for every shape this package generates, with no per-generator special-casing and no new state to add.
- A nil `e.room` (no spatial room at all) accepts every hex, preserving the existing behavior for non-spatial encounters — confirmed by the full existing suite passing unchanged (none of it builds a room at all, which is exactly why it was never exercising this path).

## Where it's wired

`refreshObservations` — the single write path into `View.Memory` (death.go's witnessed-removal refresh, `AddPlayer`'s initial reveal, `AddMonster`'s appearance refresh, and every branch of `applyAndPublishMove`). `VisibleHexesAt` itself is untouched — it stays the widely-used raw-disc primitive its other callers (movement, targeting) legitimately want, per the issue's own "narrower fix at the observation-write site is likely safer" guidance.

## Before/after numbers

6x6 room, sight range 10 (the issue's own measured sight range), player at one corner:

| | stored memory hexes |
|---|---|
| Before | **331** (the exact radius-10 disc size: `1+3*10*11`) |
| After | **36** (the room's exact footprint, `6×6`) |

Measured directly (temporarily reverted the fix, re-ran the same scenario, confirmed 331, restored the fix, confirmed 36 again) — not estimated.

## Tests added

- `TestKnownHexes_MemoryHexes_AllBelongToTheSpace`: every stored hex passes `room.GetGrid().IsValidPosition`, and memory size equals the room's exact footprint (36) rather than the sight-range disc.
- `TestKnownHexes_DoorwayCell_IsStillRemembered`: a door's own cell — proven via a `RegionAt` precondition to belong to no region — is still present in `KnownHexes`. This is the trap-avoidance the issue specifically called out.

## Acceptance checklist (from the issue)

- [x] A viewer's memory contains only hexes belonging to the space.
- [x] Doorway cells — which belong to no region — are still remembered.
- [x] Memory size is proportional to explored floor, not to sight-range area.
- [x] Multi-viewer isolation and persist/reload coverage still pass (full existing suite, unchanged, `go test -race ./...`).

## A follow-up worth knowing about, not fixed here (out of this issue's scope)

The WIRE reveal-delta (`HexRevealedEvent`, computed via `diffHexes` against `View.KnownHexSet()`, upstream of `refreshObservations` in `applyAndPublishMove`) can now re-report the same void hex on every move that brings it back into range, since Memory no longer retains it to exclude from future diffs — previously each void hex was reported once then permanently suppressed (since it stayed in Memory forever). This affects only the small per-move incremental reveal, not the full-restatement payload rpg-api#732 sends (which reads Memory directly and shrinks correctly with this fix) — the concern this issue measured and its acceptance criteria are all about. Flagging it rather than silently expanding scope to also touch `applyAndPublishMove`/`perception.ProjectMove`, per the issue's own explicit "prefer the narrower fix" guidance.

## Verification (real output, this session)

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean (module: `encounter`)
- `go mod tidy` — zero diff
- `golangci-lint run ./...` — one issue from my own change (a line-length violation in the new test), fixed; zero remaining in touched files (pre-existing `goconst` issues in unrelated test files, unchanged)
- `go test -race ./...` (all encounter module packages) — all `ok`

## Deployment

Per the task brief: proved this with toolkit tests alone (the quantitative before/after above), so **Kirk's primary `rpg-api` container was never touched** — still running the fog-lab lighting build, `RPG_DUNGEON_KEY=fog-lab`, healthy, exactly as it was before this task started. This fix does not need to reach rpg-api today; it can be picked up later via publish + version bump, or via the local override (`scripts/toolkit-local-override.sh` in rpg-api, added in #735) when actually wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdG4UCKmpJCDgh9ipiqXF
