### PR TITLE
fix(encounter): stop recording a mover on every hex a viewer saw them cross

### DIFF
--- a/encounter/death.go
+++ b/encounter/death.go
@@ -132,7 +132,7 @@ func (e *Encounter) killEntity(monsterID, killerID core.EntityID) error {
 	// no refresh here — they never had authorized knowledge of that hex's
 	// contents to correct.
 	for _, viewerID := range witnesses {
-		e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(dyingPos), "")
+		e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(dyingPos))
 	}
 
 	// Broadcast removal — every player must drop the entity from local

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -348,11 +348,8 @@ func (e *Encounter) AddPlayer(input PlayerInput) error {
 	// e.data.Players so refreshObservations' placementsAt scan finds this
 	// seat's own entity on its own starting hex (and any other
 	// already-seated entity that happens to share it), the same way any
-	// other viewer's own-position observation works. No entityID union
-	// needed here (unlike the pass-through-move case elsewhere in this
-	// file): the new seat's stored position and its starting hex are the
-	// same value by construction.
-	e.refreshObservations(view, perception.VisibleHexesAt(input.Position, input.SightRange, e.room), "")
+	// other viewer's own-position observation works.
+	e.refreshObservations(view, perception.VisibleHexesAt(input.Position, input.SightRange, e.room))
 
 	// Seed default OA readiness for combatants. Free-cost reactions default
 	// on so players do not need to opt in every fight.
@@ -520,11 +517,11 @@ func (e *Encounter) addMonsterNoCombatCheck(input MonsterInput) error {
 		// rpg-toolkit#851: refresh each such viewer's memory at the
 		// monster's own hex — first-sight if that hex was never known to
 		// them, or a content-only refresh if it was (a hex they already
-		// knew now has a new occupant). No entityID union needed:
-		// placementsAt's own scan already finds the monster, since it's
-		// stationary and just-stored at mon.Position.
+		// knew now has a new occupant). placementsAt's own scan already
+		// finds the monster, since it's stationary and just-stored at
+		// mon.Position.
 		for viewerID := range viewers {
-			e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(mon.Position), "")
+			e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(mon.Position))
 		}
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), mon.ID, mon.Position, viewers,
@@ -1096,7 +1093,7 @@ func (e *Encounter) applyAndPublishMove(
 	//    is what makes re-sight (a hex the mover once knew, lost, and is
 	//    now back in range of) atomically correct (rpg-toolkit#851).
 	p.View.Position = end
-	e.refreshObservations(p.View, newVisible, "")
+	e.refreshObservations(p.View, newVisible)
 
 	// 3. Per-player projection.
 	movePerPlayer := make(map[core.PlayerID]events.MovePlayerSlice)
@@ -1132,7 +1129,7 @@ func (e *Encounter) applyAndPublishMove(
 		}
 		if revealSlice != nil {
 			if revealSlice.Hexes != nil {
-				e.refreshObservations(other.View, revealSlice.Hexes, "")
+				e.refreshObservations(other.View, revealSlice.Hexes)
 			}
 			revealPerPlayer[otherID] = *revealSlice
 		}
@@ -1142,17 +1139,29 @@ func (e *Encounter) applyAndPublishMove(
 		if moveSlice != nil {
 			seenSegments = moveSlice.SeenSegments
 		}
-		// rpg-toolkit#851: refresh other's memory for exactly the hexes the
-		// mover was actually seen crossing — the mover's presence there is
-		// new content on an otherwise-unchanged hex (other's own vision
-		// didn't move), so this is a targeted content refresh, not a
-		// visibility change of other's own. p.EntityID is unioned in rather
-		// than left to placementsAt's own current-position scan because a
-		// pass-through mover can be observed at an INTERMEDIATE hex their
-		// final resting position (what placementsAt would find) no longer
-		// reflects — see ProjectVisibilityTransition's doc.
+		// rpg-toolkit#851/#858: refresh other's memory for exactly the hexes
+		// the mover was actually seen crossing — the mover's presence (or
+		// absence) there is new content on an otherwise-unchanged hex
+		// (other's own vision didn't move), so this is a targeted content
+		// refresh, not a visibility change of other's own.
+		//
+		// rpg-toolkit#858: this used to also force-union p.EntityID into
+		// EVERY segment hex's Contents, which recorded the mover as present
+		// on every hex this viewer watched them cross, not just the one
+		// they stopped on — a stale, fabricated placement on every earlier
+		// hex the mover had since left. No forcing is needed at all:
+		// p.View.Position was already mutated to end (the mover's true
+		// final hex) in step 2 above, BEFORE this loop runs, so
+		// refreshObservations' own placementsAt scan already gets every
+		// segment hex right on its own — present at end (if end is one of
+		// these segment hexes), absent from every other one, and absent
+		// from all of them for a pass-through mover whose true final hex
+		// isn't among the hexes this viewer actually saw (their sight
+		// simply lost them before they arrived — see
+		// ProjectVisibilityTransition's doc for that disappearance case,
+		// handled separately below).
 		if len(seenSegments) > 0 {
-			e.refreshObservations(other.View, core.NewHexSet(seenSegments...), p.EntityID)
+			e.refreshObservations(other.View, core.NewHexSet(seenSegments...))
 		}
 		appearedAt, disappearedAt := perception.ProjectVisibilityTransition(
 			moverStart, traveledPath, seenSegments, other.View, visible,
@@ -1225,7 +1234,7 @@ func (e *Encounter) applyAndPublishMove(
 	// identical player-sees-player transition just above, so the monster
 	// case is wired in right alongside it, sharing the same machinery.
 	// rpg-toolkit#851: no separate memory refresh is needed here for
-	// monsterAppeared — step 2's e.refreshObservations(p.View, newVisible, "")
+	// monsterAppeared — step 2's e.refreshObservations(p.View, newVisible)
 	// already wrote a full observation (via placementsAt) for every hex in
 	// the mover's post-move visible set, and a monster only ever appears
 	// here because its position IS in that set (monsterVisibilityTransitions'
@@ -1312,7 +1321,7 @@ func (e *Encounter) OpenDoor(playerID core.PlayerID, doorID core.EntityID) error
 			// new ones. Bounded by this viewer's own sight range, same cost
 			// class as their own move's reveal.
 			visible := perception.VisibleHexesAt(viewer.View.Position, viewer.View.SightRange, e.room)
-			e.refreshObservations(viewer.View, visible, "")
+			e.refreshObservations(viewer.View, visible)
 		}
 		if revealSlice != nil {
 			revealPerPlayer[viewerID] = *revealSlice

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -69,25 +69,32 @@ func (e *Encounter) KnownHexes(playerID core.PlayerID) map[core.Hex]perception.H
 // must derive hexes from a real VisibleHexesAt/ProjectMove/ProjectDoorOpen
 // result, never invent one.
 //
-// entityID, if non-empty, is guaranteed present in every written hex's
-// Contents even when e.data's CURRENT stored position for that entity
-// differs from the hex being observed — the pass-through-move case: a
-// mover can be OBSERVED (per ProjectVisibilityTransition) at an
-// intermediate hex of their path that is not where they end up, so a plain
-// placementsAt(h) scan (which reads CURRENT position) would miss them
-// there. Leave entityID empty for refreshes that aren't about placing one
-// specific entity (e.g. the mover's own reveal, or a door-open re-sight) —
-// those should reflect purely current world truth, already keyed by
-// position via placementsAt.
-//
 // A hex's Edges/Contents are rebuilt from CURRENT e.data every call, never
 // patched — the same "Visible is TOTAL, replace wholesale" rule
 // HexObservation's doc states for the wire applies identically to memory:
+// Contents comes ENTIRELY from placementsAt's current-world scan, which
+// finds every player/monster/obstacle actually AT that hex right now — so
 // if something else is already standing on a hex being refreshed here (a
-// second monster the caller doesn't know about), placementsAt still finds
-// it, because it scans ALL of e.data, not just the caller's one entity of
+// second monster the caller doesn't know about), it's included, because
+// placementsAt scans ALL of e.data, not just the caller's one entity of
 // interest.
-func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet, entityID core.EntityID) {
+//
+// rpg-toolkit#858: this used to also take an entityID parameter, unioned
+// into every written hex's Contents regardless of whether placementsAt
+// already found that entity there — meant for the pass-through-move case,
+// but its one caller (applyAndPublishMove's per-viewer crossing refresh)
+// passed the SAME entity id for every hex in a multi-hex crossing, so a
+// mover watched crossing several hexes ended up recorded as present on ALL
+// of them, not just the one they actually stopped on — a stale, fabricated
+// placement on every hex they'd since left. The fix is that this function
+// needs no entity-forcing at all: applyAndPublishMove mutates the mover's
+// stored position to their final hex BEFORE calling this, so
+// placementsAt's own current-position scan already gets it exactly right —
+// present at the hex they actually ended on (if that hex is one this
+// viewer refreshes), absent from every other hex, and absent everywhere
+// for a pass-through mover whose final hex isn't a hex this viewer saw at
+// all. See applyAndPublishMove's call site for the full reasoning.
+func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet) {
 	if view == nil || len(hexes) == 0 {
 		return
 	}
@@ -104,23 +111,8 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 				obs.ZoneID = zoneID
 			}
 		}
-		if entityID != "" {
-			obs.Contents = unionPlacement(obs.Contents, entityID)
-		}
 		view.Observe(obs)
 	}
-}
-
-// unionPlacement returns placements with a Placement for entityID appended
-// unless one already names it. See refreshObservations' doc for why this
-// is needed (the pass-through-observed-at-an-intermediate-hex case).
-func unionPlacement(placements []perception.Placement, entityID core.EntityID) []perception.Placement {
-	for _, p := range placements {
-		if p.EntityID == entityID {
-			return placements
-		}
-	}
-	return append(placements, perception.Placement{EntityID: entityID})
 }
 
 // placementsAt returns a Placement for every player, monster, and static

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -93,6 +93,15 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 	}
 	edges := e.edgesByHex()
 	for h := range hexes {
+		// rpg-toolkit#859: hexes is frequently a raw perception.VisibleHexesAt
+		// disc (sight-range radius around a position), which has no notion of
+		// whether a hex is part of the space at all — it happily includes the
+		// void beyond the room's walls. Confine what gets remembered to hexes
+		// that are actually part of the space; see isSpaceHex's doc for why
+		// this can't be approximated with RegionAt.
+		if !e.isSpaceHex(h) {
+			continue
+		}
 		obs := perception.HexObservation{
 			Position: h,
 			State:    perception.KnowledgeStateVisible,
@@ -109,6 +118,49 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 		}
 		view.Observe(obs)
 	}
+}
+
+// isSpaceHex reports whether h is actually part of this encounter's space —
+// not merely within sight-range distance of some viewer position.
+// rpg-toolkit#859: three live encounters measured ~80% of a viewer's stored
+// Memory as hexes with no floor beneath them at all — perception.
+// VisibleHexesAt returns every hex within sightRange that isn't
+// wall-blocked, with no notion of whether a hex belongs to the space, so
+// refreshObservations was faithfully recording the void beyond the room's
+// walls right alongside real floor.
+//
+// RegionAt alone is NOT this test: a door's own cell deliberately belongs to
+// no region (RegionAt(door.Position) is always ("", false) by construction —
+// see doorPassageNeighbor's doc), and corridors may be similarly unregioned
+// in future generators. Filtering on "has a region" would silently drop
+// doorways from memory — a worse bug than the one being fixed, since the
+// player would lose the doorway they are standing in.
+//
+// The real test is the room's own grid bounds. rebuildRoomFromData builds
+// e.room's HexGrid from exactly SpaceData.Width/Height (spatial.HexGridConfig
+// {Width: sd.Width, Height: sd.Height}), and every generator this package
+// ships lays hexes out with NO gaps inside that rectangle:
+//   - InitRoom: a single implicit region spanning the whole grid — the
+//     entire rectangle IS the floor.
+//   - InitDungeon (InitTwoChamberRoom included, generalized to N=2):
+//     generateDungeonLayout places each region's columns contiguously
+//     (starts[i] = x; x += r.Width + 1) with the boundary/door column
+//     immediately after — the shared rectangle is exactly regions plus
+//     their connecting door columns, tiled with zero slack.
+//
+// So "within the room's grid bounds" IS "part of the space" for every shape
+// this package generates, doors included, with no per-generator
+// special-casing and no dependency on region tagging at all — precisely the
+// real membership answer the space itself already has, not an approximation.
+//
+// A nil e.room (InitRoom/LoadFromData-with-Space never ran) means there is
+// no room to be outside of: every hex is accepted, preserving this
+// package's pre-wave-1 unbounded-radius behavior for non-spatial encounters.
+func (e *Encounter) isSpaceHex(h core.Hex) bool {
+	if e.room == nil {
+		return true
+	}
+	return e.room.GetGrid().IsValidPosition(h.ToPosition())
 }
 
 // unionPlacement returns placements with a Placement for entityID appended

--- a/encounter/knowledge_test.go
+++ b/encounter/knowledge_test.go
@@ -332,3 +332,75 @@ func (s *KnowledgeSuite) TestKnownHexes_DuplicateReconciliation_Idempotent() {
 
 	s.Equal(first, second, "reconciling unchanged visibility twice must leave KnownHexes identical")
 }
+
+// TestKnownHexes_StationaryViewer_MoverCrossingSeveralHexes_EndsInExactlyOne
+// is rpg-toolkit#858's core acceptance bar: bob is stationary with sight
+// range 5 (never moves, never refreshes his own position), and watches
+// alice cross FOUR of his visible hexes in one move, stopping on the last
+// one (still within his sight — not a pass-through). Bob's memory of
+// alice's crossing must show her in exactly the hex she stopped on, not
+// smeared across every hex he watched her traverse.
+func (s *KnowledgeSuite) TestKnownHexes_StationaryViewer_MoverCrossingSeveralHexes_EndsInExactlyOne() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 5,
+	}))
+	// alice starts well outside bob's sight (distance 6) and crosses four
+	// hexes all within it (distances 5,4,3,2), stopping on the last —
+	// crossedHex1/2/3 must end up empty of her; finalHex must hold her.
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 6, R: -6, S: 0}, SightRange: 1,
+	}))
+	crossedHex1 := core.Hex{Q: 5, R: -5, S: 0}
+	crossedHex2 := core.Hex{Q: 4, R: -4, S: 0}
+	crossedHex3 := core.Hex{Q: 3, R: -3, S: 0}
+	finalHex := core.Hex{Q: 2, R: -2, S: 0}
+
+	s.Require().NoError(e.Move(alicePlayerID, []core.Hex{crossedHex1, crossedHex2, crossedHex3, finalHex}))
+
+	bobKnown := e.KnownHexes(bobPlayerID)
+	s.Require().Contains(bobKnown, finalHex)
+	s.Equal([]core.EntityID{aliceEntityID}, contentIDs(bobKnown[finalHex]),
+		"alice must be recorded on the hex she actually stopped on")
+
+	for _, h := range []core.Hex{crossedHex1, crossedHex2, crossedHex3} {
+		s.Require().Contains(bobKnown, h, "bob watched alice cross this hex, so it must be known to him")
+		s.Empty(contentIDs(bobKnown[h]),
+			"alice must NOT be recorded on a hex she has since left, even though bob watched her cross it")
+	}
+}
+
+// TestKnownHexes_PassThrough_MoverCrossesAndExits_LeavesNoVisibleTrace is
+// rpg-toolkit#858's pass-through acceptance bar: bob is stationary with
+// sight range 2, and alice moves in one path from far outside his sight,
+// briefly through two hexes he CAN see, and out the far side back beyond
+// his sight — neither her start nor her true final position is ever within
+// bob's sight. Bob must end with alice in NO hex's contents at all: not
+// pinned at the last hex he saw her in (that would fabricate a visible
+// placement the contract reserves for REMEMBERED state, never VISIBLE).
+func (s *KnowledgeSuite) TestKnownHexes_PassThrough_MoverCrossesAndExits_LeavesNoVisibleTrace() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 2,
+	}))
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 20, R: -20, S: 0}, SightRange: 1,
+	}))
+	seenHex1 := core.Hex{Q: 1, R: -1, S: 0}
+	seenHex2 := core.Hex{Q: 2, R: -2, S: 0}
+	farExit := core.Hex{Q: 30, R: -30, S: 0}
+
+	s.Require().NoError(e.Move(alicePlayerID, []core.Hex{seenHex1, seenHex2, farExit}))
+
+	bobKnown := e.KnownHexes(bobPlayerID)
+	for _, h := range []core.Hex{seenHex1, seenHex2} {
+		s.Require().Contains(bobKnown, h, "bob watched alice cross this hex, so it must be known to him")
+		s.Empty(contentIDs(bobKnown[h]),
+			"alice has moved on past bob's sight entirely — she must not be pinned at the last hex he saw her in")
+	}
+	s.NotContains(bobKnown, farExit, "alice's true final hex was never within bob's sight at all")
+}

--- a/encounter/knowledge_test.go
+++ b/encounter/knowledge_test.go
@@ -7,6 +7,15 @@ package encounter_test
 // reconciliation. See encounter/knowledge.go's file doc for the
 // implementation this exercises, and perception/knowledge.go for the
 // HexObservation contract these tests assert against.
+//
+// rpg-toolkit#859 added TestKnownHexes_MemoryHexes_AllBelongToTheSpace and
+// TestKnownHexes_DoorwayCell_IsStillRemembered: every test above this point
+// predates that fix and uses encounter.New with no InitRoom/InitDungeon call
+// at all (e.room stays nil), so they never previously exercised — and still
+// don't exercise — the space-membership filter; they keep passing precisely
+// because a nil room means "nothing to be outside of," preserving this
+// package's pre-wave-1 unbounded behavior for non-spatial encounters. The
+// two new tests are the ones that actually build a spatial room.
 
 import (
 	"context"
@@ -18,6 +27,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
 type KnowledgeSuite struct {
@@ -331,4 +341,69 @@ func (s *KnowledgeSuite) TestKnownHexes_DuplicateReconciliation_Idempotent() {
 	second := e.KnownHexes(alicePlayerID)
 
 	s.Equal(first, second, "reconciling unchanged visibility twice must leave KnownHexes identical")
+}
+
+// TestKnownHexes_MemoryHexes_AllBelongToTheSpace is rpg-toolkit#859's core
+// acceptance bar: perception.VisibleHexesAt returns every hex within
+// sightRange that isn't wall-blocked, with no notion of whether a hex is
+// part of the space at all — measured from live Redis, ~80% of a viewer's
+// stored Memory was hexes with no floor beneath them, well outside the
+// room. A tiny 6x6 room with sight range 10 (the measured scenario's own
+// sight range) reproduces the shape of the bug directly: an unfiltered
+// radius-10 disc is up to 331 hexes, vastly more than the room's own 36.
+func (s *KnowledgeSuite) TestKnownHexes_MemoryHexes_AllBelongToTheSpace() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.InitRoom(6, 6, environments.PatternEmpty))
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+
+	known := e.KnownHexes(alicePlayerID)
+	s.Require().NotEmpty(known)
+
+	room := e.Room()
+	s.Require().NotNil(room)
+	for h := range known {
+		s.True(room.GetGrid().IsValidPosition(h.ToPosition()),
+			"every stored hex must belong to the room's grid bounds; %v does not", h)
+	}
+
+	// Memory size must equal the room's own footprint (6x6=36) exactly, not
+	// the sight-range disc (radius 10 reaches the whole tiny room from this
+	// corner, so pre-fix this would instead have been the full unfiltered
+	// disc size — up to 331 hexes for radius 10).
+	s.Equal(36, len(known),
+		"memory must be proportional to the room's footprint, not the sight-range area")
+}
+
+// TestKnownHexes_DoorwayCell_IsStillRemembered is rpg-toolkit#859's
+// trap-avoidance bar: RegionAt alone is NOT a valid space-membership test —
+// a door's own cell deliberately belongs to no region (doorPassageNeighbor's
+// documented trap) — so a fix that filtered purely on "has a region" would
+// silently drop doorways from memory, losing the exact cell the player is
+// standing in front of. Proves the real fix does not make that mistake.
+func (s *KnowledgeSuite) TestKnownHexes_DoorwayCell_IsStillRemembered() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.InitTwoChamberRoom(encounter.TwoChamberRoomParams{
+		ChamberWidth: 4, ChamberHeight: 4, Pattern: environments.PatternEmpty,
+		DoorID: twoChamberDoorID,
+	}))
+	entrance := e.ToData().Space.Entrance
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: entrance, SightRange: 10,
+	}))
+
+	doorHex := e.ToData().Doors[twoChamberDoorID].Position
+
+	// Precondition pinning the documented trap itself: the door's own cell
+	// belongs to no region.
+	_, hasRegion := e.ToData().Space.RegionAt(doorHex)
+	s.Require().False(hasRegion,
+		"precondition: the door's own cell belongs to no region (doorPassageNeighbor's documented trap)")
+
+	known := e.KnownHexes(alicePlayerID)
+	s.Require().Contains(known, doorHex,
+		"the doorway must still be remembered even though RegionAt reports it belongs to no region")
 }


### PR DESCRIPTION
## Summary

Fixes #858: `applyAndPublishMove`'s "other viewers see the mover" refresh unioned the mover's entity ID into **every** segment hex a stationary viewer witnessed them crossing, not just the one they stopped on:

```go
e.refreshObservations(other.View, core.NewHexSet(seenSegments...), p.EntityID)
```

`seenSegments` is correct as a *visibility* set (exactly the hexes this stationary viewer actually watched the mover cross), but forcing `entityID` into ALL of them meant a viewer watching someone walk past ended up with that entity recorded in several hexes' contents at once — violating the contract's central claim that a VISIBLE observation is TOTAL, a positive assertion about what occupies that hex **right now**, not a trace of where something recently was.

## Why the forcing was unnecessary entirely, not just too broad

`applyAndPublishMove` already mutates the mover's stored position to their true final hex (`end`) in step 2, **before** the per-viewer loop that computes `seenSegments` and calls `refreshObservations`. So by the time this call runs, `refreshObservations`' own `placementsAt(h)` scan — which reads CURRENT stored position — already gets every segment hex exactly right on its own:
- present at `end`, if `end` happens to be one of the hexes this viewer refreshes,
- absent from every other segment hex,
- absent from **all** of them for a pass-through mover whose true final hex isn't among the hexes this viewer actually saw (their sight lost the mover before they arrived).

No forcing needed at all — the bug was in the forcing itself, not in its scope.

## Cleanup

Simplifies `refreshObservations` to drop the `entityID` parameter. I grepped every call site in the package to confirm: this one buggy call site was the **only** one ever passing a non-empty value — all seven others were already passing `""`. So the parameter existed for exactly one caller, and that caller was wrong. Deletes `unionPlacement`, now unreachable, and updates every call site (`encounter.go` ×6, `death.go` ×1) to the 2-arg signature.

## Known downstream impact

rpg-api (#730) carries a `disclosedEntities` workaround in `translateEntityAppearedEventWithData` / `translateEntityDisappearedEventWithData` specifically because `KnownHexes(...).Contents` couldn't be trusted for this reason — both functions' doc comments explain why. That workaround can now be revisited (a separate rpg-api issue — **not changed here**, per the brief).

## Tests added

- `TestKnownHexes_StationaryViewer_MoverCrossingSeveralHexes_EndsInExactlyOne`: a stationary viewer watches a mover cross four visible hexes and stop on the last; the mover ends up recorded in exactly that one hex's contents, absent from the three she's since left.
- `TestKnownHexes_PassThrough_MoverCrossesAndExits_LeavesNoVisibleTrace`: a mover crosses two hexes within a stationary viewer's sight and exits back beyond it on both ends (neither her start nor her true final position was ever visible to this viewer) — the viewer ends with the mover in **no** hex's contents, not fabricated/pinned at the last hex she was seen in.

Both verified to fail against the pre-fix code (temporarily reverted the fix via `git stash`, confirmed both tests fail exactly as the bug predicts — alice appears in every crossed hex's contents — restored the fix, confirmed both pass again).

## Acceptance checklist (from the issue)

- [x] A stationary viewer watching a mover cross several visible hexes ends with the mover in exactly one hex's contents — the one they finished on.
- [x] Pass-through: a mover who crosses and exits the viewer's sight leaves the mover in no visible hex's contents.
- [x] Existing multi-viewer isolation coverage still passes (full existing suite, unchanged, `go test -race ./...`).
- [x] rpg-api's `disclosedEntities` workaround can be removed — separate rpg-api issue, not done here.

## Verified live against the running system

Same measurement discipline as #859/#860: read straight out of Redis, before and after, identical two-player scenario and move path, on `rpg-api` (Kirk's `RPG_DUNGEON_KEY=fog-lab` playtest instance, deployed via the local toolkit override built in rpg-api#735).

Setup: two real players in the same fog-lab lobby — `wave1a` (mover) at (0,-4,4), `wave1b` (stationary watcher, never moves) at (1,-4,3), both sight range 10. Moved `wave1a` through a single 4-hex path: (0,-4,4)→(0,-3,3)→(0,-2,2)→(0,-1,1)→(0,0,0), ending at (0,0,0), well within `wave1b`'s sight throughout.

**Before** (the deployed build that had #859 but not yet #858): `wave1b`'s persisted `view.memory` listed `wave1a`'s entity id in `contents` on **all 5** hexes of the crossing — the starting hex plus all 4 traversed hexes, including the 4 she'd since left.

**After** (identical scenario replayed on a fresh encounter with #858 deployed on top): `wave1b`'s memory shows `wave1a` in `contents` on **exactly 1** hex — (0,0,0), her true final position. The other 4 crossed hexes are still known (present in memory, correctly `visible`/`remembered`) but now have empty `contents`, matching the fix's guarantee precisely — read straight from the raw JSON, not summarized.

## Verification (real output, this session)

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean (module: `encounter`)
- `go mod tidy` — zero diff
- `golangci-lint run ./...` — zero issues in touched files (68 pre-existing `goconst` issues elsewhere, unchanged)
- `go test -race ./...` (all encounter module packages) — all `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdG4UCKmpJCDgh9ipiqXF
