### PR TITLE
fix(encounter): MoveEvent carries the mover's own post-move knowledge

### DIFF
--- a/encounter/broker_test.go
+++ b/encounter/broker_test.go
@@ -44,6 +44,7 @@ func (s *BrokerSuite) TestPublish_RoutesByAudience() {
 			"alice": {SeenSegments: []core.Hex{{Q: 0, R: 0, S: 0}}},
 			// bob absent — out of audience
 		},
+		"", nil,
 	)
 	s.Require().NoError(s.broker.Publish(move))
 
@@ -57,7 +58,7 @@ func (s *BrokerSuite) TestPublish_IsolatesEncounters() {
 	sub2, _ := s.broker.Subscribe("enc:2", "alice")
 
 	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x", core.Hex{},
-		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}})))
+		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}}, "", nil)))
 
 	s.assertReceivesType(sub1, "*events.MoveEvent")
 	s.assertNoReceive(sub2)
@@ -69,7 +70,7 @@ func (s *BrokerSuite) TestSubscribe_MultiSubsForSamePlayer() {
 	a2, _ := s.broker.Subscribe("enc:1", "alice")
 
 	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x", core.Hex{},
-		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}})))
+		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}}, "", nil)))
 
 	s.assertReceivesType(a1, "*events.MoveEvent")
 	s.assertReceivesType(a2, "*events.MoveEvent")
@@ -82,7 +83,7 @@ func (s *BrokerSuite) TestClose_RemovesOnlyClosedSub() {
 	s.Require().NoError(a1.Close())
 
 	s.Require().NoError(s.broker.Publish(events.NewMoveEvent("enc:1", 1, "x", core.Hex{},
-		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}})))
+		nil, map[core.PlayerID]events.MovePlayerSlice{"alice": {}}, "", nil)))
 
 	// a2 still receives — the meaningful assertion.
 	s.assertReceivesType(a2, "*events.MoveEvent")

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -132,7 +132,7 @@ func (e *Encounter) killEntity(monsterID, killerID core.EntityID) error {
 	// no refresh here — they never had authorized knowledge of that hex's
 	// contents to correct.
 	for _, viewerID := range witnesses {
-		e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(dyingPos), "")
+		e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(dyingPos))
 	}
 
 	// Broadcast removal — every player must drop the entity from local

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -348,11 +348,8 @@ func (e *Encounter) AddPlayer(input PlayerInput) error {
 	// e.data.Players so refreshObservations' placementsAt scan finds this
 	// seat's own entity on its own starting hex (and any other
 	// already-seated entity that happens to share it), the same way any
-	// other viewer's own-position observation works. No entityID union
-	// needed here (unlike the pass-through-move case elsewhere in this
-	// file): the new seat's stored position and its starting hex are the
-	// same value by construction.
-	e.refreshObservations(view, perception.VisibleHexesAt(input.Position, input.SightRange, e.room), "")
+	// other viewer's own-position observation works.
+	e.refreshObservations(view, perception.VisibleHexesAt(input.Position, input.SightRange, e.room))
 
 	// Seed default OA readiness for combatants. Free-cost reactions default
 	// on so players do not need to opt in every fight.
@@ -520,11 +517,11 @@ func (e *Encounter) addMonsterNoCombatCheck(input MonsterInput) error {
 		// rpg-toolkit#851: refresh each such viewer's memory at the
 		// monster's own hex — first-sight if that hex was never known to
 		// them, or a content-only refresh if it was (a hex they already
-		// knew now has a new occupant). No entityID union needed:
-		// placementsAt's own scan already finds the monster, since it's
-		// stationary and just-stored at mon.Position.
+		// knew now has a new occupant). placementsAt's own scan already
+		// finds the monster, since it's stationary and just-stored at
+		// mon.Position.
 		for viewerID := range viewers {
-			e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(mon.Position), "")
+			e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(mon.Position))
 		}
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), mon.ID, mon.Position, viewers,
@@ -1096,7 +1093,7 @@ func (e *Encounter) applyAndPublishMove(
 	//    is what makes re-sight (a hex the mover once knew, lost, and is
 	//    now back in range of) atomically correct (rpg-toolkit#851).
 	p.View.Position = end
-	e.refreshObservations(p.View, newVisible, "")
+	e.refreshObservations(p.View, newVisible)
 
 	// 3. Per-player projection.
 	movePerPlayer := make(map[core.PlayerID]events.MovePlayerSlice)
@@ -1132,7 +1129,7 @@ func (e *Encounter) applyAndPublishMove(
 		}
 		if revealSlice != nil {
 			if revealSlice.Hexes != nil {
-				e.refreshObservations(other.View, revealSlice.Hexes, "")
+				e.refreshObservations(other.View, revealSlice.Hexes)
 			}
 			revealPerPlayer[otherID] = *revealSlice
 		}
@@ -1142,17 +1139,29 @@ func (e *Encounter) applyAndPublishMove(
 		if moveSlice != nil {
 			seenSegments = moveSlice.SeenSegments
 		}
-		// rpg-toolkit#851: refresh other's memory for exactly the hexes the
-		// mover was actually seen crossing — the mover's presence there is
-		// new content on an otherwise-unchanged hex (other's own vision
-		// didn't move), so this is a targeted content refresh, not a
-		// visibility change of other's own. p.EntityID is unioned in rather
-		// than left to placementsAt's own current-position scan because a
-		// pass-through mover can be observed at an INTERMEDIATE hex their
-		// final resting position (what placementsAt would find) no longer
-		// reflects — see ProjectVisibilityTransition's doc.
+		// rpg-toolkit#851/#858: refresh other's memory for exactly the hexes
+		// the mover was actually seen crossing — the mover's presence (or
+		// absence) there is new content on an otherwise-unchanged hex
+		// (other's own vision didn't move), so this is a targeted content
+		// refresh, not a visibility change of other's own.
+		//
+		// rpg-toolkit#858: this used to also force-union p.EntityID into
+		// EVERY segment hex's Contents, which recorded the mover as present
+		// on every hex this viewer watched them cross, not just the one
+		// they stopped on — a stale, fabricated placement on every earlier
+		// hex the mover had since left. No forcing is needed at all:
+		// p.View.Position was already mutated to end (the mover's true
+		// final hex) in step 2 above, BEFORE this loop runs, so
+		// refreshObservations' own placementsAt scan already gets every
+		// segment hex right on its own — present at end (if end is one of
+		// these segment hexes), absent from every other one, and absent
+		// from all of them for a pass-through mover whose true final hex
+		// isn't among the hexes this viewer actually saw (their sight
+		// simply lost them before they arrived — see
+		// ProjectVisibilityTransition's doc for that disappearance case,
+		// handled separately below).
 		if len(seenSegments) > 0 {
-			e.refreshObservations(other.View, core.NewHexSet(seenSegments...), p.EntityID)
+			e.refreshObservations(other.View, core.NewHexSet(seenSegments...))
 		}
 		appearedAt, disappearedAt := perception.ProjectVisibilityTransition(
 			moverStart, traveledPath, seenSegments, other.View, visible,
@@ -1225,7 +1234,7 @@ func (e *Encounter) applyAndPublishMove(
 	// identical player-sees-player transition just above, so the monster
 	// case is wired in right alongside it, sharing the same machinery.
 	// rpg-toolkit#851: no separate memory refresh is needed here for
-	// monsterAppeared — step 2's e.refreshObservations(p.View, newVisible, "")
+	// monsterAppeared — step 2's e.refreshObservations(p.View, newVisible)
 	// already wrote a full observation (via placementsAt) for every hex in
 	// the mover's post-move visible set, and a monster only ever appears
 	// here because its position IS in that set (monsterVisibilityTransitions'
@@ -1312,7 +1321,7 @@ func (e *Encounter) OpenDoor(playerID core.PlayerID, doorID core.EntityID) error
 			// new ones. Bounded by this viewer's own sight range, same cost
 			// class as their own move's reveal.
 			visible := perception.VisibleHexesAt(viewer.View.Position, viewer.View.SightRange, e.room)
-			e.refreshObservations(viewer.View, visible, "")
+			e.refreshObservations(viewer.View, visible)
 		}
 		if revealSlice != nil {
 			revealPerPlayer[viewerID] = *revealSlice

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -1170,10 +1170,23 @@ func (e *Encounter) applyAndPublishMove(
 
 	// 4. Publish — cause event always; effect event only when someone's
 	//    vision changed. The two events get sequential sequence numbers.
+	//
+	// rpg-toolkit#862: moverKnownHexes is computed HERE, from THIS in-memory
+	// e.data, immediately after step 2's mutation (p.View.Position / the
+	// refreshObservations call above) and before anything else — including
+	// this same method's own caller persisting the result — can act. This
+	// is the only moment provably free of the stale-repository-read race a
+	// downstream consumer's own out-of-band KnownHexes(playerID) re-load
+	// was exposed to (it could run before the caller's persist landed,
+	// reading pre-move state — e.g. reporting the mover's just-vacated hex
+	// as still VISIBLE with them on it). See events.MoveEvent's
+	// MoverKnownHexes doc for the full contract.
+	moverKnownHexes := knownHexesToEvents(e.KnownHexes(playerID))
+
 	moveSeq := e.nextSeq()
 	corrID := e.correlationFor(moveSeq)
 	if err := e.broker.Publish(events.NewMoveEvent(
-		e.data.ID, moveSeq, p.EntityID, moverStart, traveledPath, movePerPlayer,
+		e.data.ID, moveSeq, p.EntityID, moverStart, traveledPath, movePerPlayer, playerID, moverKnownHexes,
 	)); err != nil {
 		return "", fmt.Errorf("publish move: %w", err)
 	}

--- a/encounter/encounter_test.go
+++ b/encounter/encounter_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -133,6 +135,77 @@ func (s *EncounterSuite) TestMove_PublishesHexRevealedEventForMover() {
 	seen := collectTypes(aliceSub, 500*time.Millisecond)
 	s.Contains(seen, "*events.MoveEvent")
 	s.Contains(seen, "*events.HexRevealedEvent")
+}
+
+// rpg-toolkit#862 (companion fix for KirkDiggler/rpg-api#737): the mover's
+// own MoveEvent.MoverKnownHexes must place them at the NEW hex, and must
+// NOT still report the just-vacated origin hex as VISIBLE with them on it.
+// This is the toolkit-side half of a real bug: a downstream consumer
+// (rpg-api's stream translator) that instead re-derives this via its own
+// out-of-band repository read raced against the SAME move's not-yet-executed
+// persist, and read pre-move truth — the origin
+// hex, still VISIBLE, still listing the mover. MoverKnownHexes exists so a
+// consumer never needs that separate, racy read: this asserts the event's
+// OWN payload is correct at the moment of publish.
+func (s *EncounterSuite) TestMove_MoverKnownHexesReflectsPostMoveTruth() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice",
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 2,
+	}))
+	aliceSub, _ := s.broker.Subscribe("enc-1", "alice")
+
+	// Straight-line move of hex-distance 3 — strictly farther than
+	// SightRange 2, so the origin hex (0,0,0) unambiguously drops out of
+	// sight this move, the same shape as "stepping behind a pillar" or
+	// backing out of a room far enough to lose the doorway.
+	path := []core.Hex{
+		{Q: 1, R: -1, S: 0},
+		{Q: 2, R: -2, S: 0},
+		{Q: 3, R: -3, S: 0},
+	}
+	s.Require().NoError(e.Move("alice", path))
+
+	var moveEvt *events.MoveEvent
+	select {
+	case evt, ok := <-aliceSub.Events():
+		s.Require().True(ok)
+		var isMove bool
+		moveEvt, isMove = evt.(*events.MoveEvent)
+		s.Require().True(isMove, "expected *events.MoveEvent, got %T", evt)
+	case <-time.After(time.Second):
+		s.FailNow("did not receive MoveEvent in 1s")
+	}
+
+	byPos := make(map[core.Hex]events.KnownHex, len(moveEvt.MoverKnownHexes))
+	for _, kh := range moveEvt.MoverKnownHexes {
+		byPos[kh.Position] = kh
+	}
+
+	// This is the actual bug: rpg-api's own out-of-band re-read reported the
+	// origin hex as STILL VISIBLE with alice on it, because it raced ahead
+	// of the persist for this exact move. State REMEMBERED (not VISIBLE) is
+	// the one assertion that pins the fix — a remembered record's Contents
+	// legitimately still names alice (she WAS there the last time this hex
+	// was actually observed as visible, which for the starting hex is true
+	// by construction); "nothing is ever deleted" from a memory without a
+	// fresh VISIBLE re-observation is the documented HexRecord contract,
+	// not a bug this test should assert against.
+	origin, ok := byPos[core.Hex{Q: 0, R: 0, S: 0}]
+	s.Require().True(ok, "origin hex must still be present (remembered), not dropped")
+	s.Equal(int(perception.KnowledgeStateRemembered), origin.State,
+		"origin hex must be REMEMBERED, not still VISIBLE, now that alice has moved out of range")
+
+	dest, ok := byPos[core.Hex{Q: 3, R: -3, S: 0}]
+	s.Require().True(ok, "destination hex must be present")
+	s.Equal(int(perception.KnowledgeStateVisible), dest.State, "destination hex must be VISIBLE")
+	foundMoverAtDest := false
+	for _, c := range dest.Contents {
+		if c.EntityID == "char-alice" {
+			foundMoverAtDest = true
+		}
+	}
+	s.True(foundMoverAtDest, "destination hex's contents must place alice there")
 }
 
 func (s *EncounterSuite) TestMove_Validations() {

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -107,7 +107,7 @@ func (s *EventsSuite) TestSpineMeta_StampAndAccessors() {
 	corr := core.CorrelationID("corr-enc-1-7")
 
 	samples := []events.EncounterEvent{
-		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil),
+		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil, "", nil),
 		events.NewAttackResolvedEvent("enc-1", 2, "a", "b", true, false, 1, 1, 1, false, false, nil, nil, nil),
 		events.NewDamageDealtEvent("enc-1", 3, "a", "b", 1, "slashing", 1, 1, nil),
 		events.NewActionResolvedEvent("enc-1", 4, "a", "dnd5e:action:attack", "b",
@@ -192,6 +192,7 @@ func (s *EventsSuite) TestMoveEvent_AudienceFromPerPlayer() {
 			"alice": {SeenSegments: []core.Hex{{Q: 0, R: 0, S: 0}}},
 			"carol": {SeenSegments: []core.Hex{}},
 		},
+		"bob", nil,
 	)
 
 	s.Equal(core.EncounterID("enc-1"), e.EncounterID())
@@ -209,6 +210,25 @@ func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
 		map[core.PlayerID]events.MovePlayerSlice{
 			"alice": {SeenSegments: []core.Hex{{Q: 1, R: -1, S: 0}}},
 		},
+		"bob-player",
+		// rpg-toolkit#862: a REMEMBERED entry (state 2) alongside a VISIBLE one
+		// (state 1) exercises exactly the shape the stale-read race
+		// corrupted — the round-trip must keep them distinguishable.
+		[]events.KnownHex{
+			{
+				Position: core.Hex{Q: 0, R: 0, S: 0},
+				State:    2,
+				Contents: []events.KnownHexPlacement{{EntityID: "bob", Facing: 3}},
+			},
+			{
+				Position: core.Hex{Q: 1, R: -1, S: 0},
+				State:    1,
+				ZoneID:   "entrance",
+				Edges: []events.KnownHexEdge{
+					{From: core.Hex{Q: 1, R: -1, S: 0}, To: core.Hex{Q: 2, R: -1, S: -1}, BlocksMovement: true, BlocksLoS: true},
+				},
+			},
+		},
 	)
 
 	payload, err := json.Marshal(original)
@@ -225,6 +245,19 @@ func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
 	s.Equal(original.Path, decoded.Path)
 	s.Require().Contains(decoded.PerPlayer, core.PlayerID("alice"))
 	s.Equal(original.PerPlayer["alice"].SeenSegments, decoded.PerPlayer["alice"].SeenSegments)
+	s.Equal(core.PlayerID("bob-player"), decoded.MoverPlayerID)
+	s.Equal(original.MoverKnownHexes, decoded.MoverKnownHexes)
+}
+
+// A nil moverKnownHexes normalizes to an empty (never nil) slice — the NPC
+// mover path (encounter/npc.go) always passes nil, and a consumer ranging
+// over MoverKnownHexes unconditionally must never nil-panic or need its own
+// nil guard. moverPlayerID is likewise empty for that same NPC path.
+func (s *EventsSuite) TestMoveEvent_NilMoverKnownHexesNormalizesToEmpty() {
+	e := events.NewMoveEvent("enc-1", 1, "goblin-1", core.Hex{}, nil, nil, "", nil)
+	s.Empty(e.MoverPlayerID)
+	s.NotNil(e.MoverKnownHexes)
+	s.Empty(e.MoverKnownHexes)
 }
 
 // HexRevealedEvent JSON round-trip — load-bearing because PerceptionView
@@ -300,7 +333,7 @@ func (s *EventsSuite) TestEntityDisappearedEvent_JSONRoundTrip() {
 // Type switch returns the concrete type.
 func (s *EventsSuite) TestTypeSwitch_RecoversConcrete() {
 	evts := []events.EncounterEvent{
-		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil),
+		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil, "", nil),
 		events.NewHexRevealedEvent("enc-1", 2, nil),
 		events.NewDoorOpenedEvent("enc-1", 3, "door-1", "bob", nil),
 		events.NewEntityAppearedEvent("enc-1", 4, "bob", core.Hex{}, nil),

--- a/encounter/events/known_hex.go
+++ b/encounter/events/known_hex.go
@@ -1,0 +1,51 @@
+package events
+
+import "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+
+// KnownHex is one hex's complete authorized knowledge for a viewer, as
+// carried by MoveEvent.MoverKnownHexes.
+//
+// It flatly mirrors encounter/perception.HexObservation (and that package's
+// Edge/Placement) rather than importing it directly: encounter/perception
+// already imports this events package (perception.ProjectMove builds
+// MovePlayerSlice/HexRevealedSlice values), so events importing perception
+// back would cycle. This follows the SAME "events owns the minimal wire
+// shape; a richer package projects down into it" split
+// MovePlayerSlice/HexRevealedSlice already establish for this exact event —
+// encounter.go's applyAndPublishMove (the one place with both packages
+// in scope) is what builds a KnownHex from a real
+// perception.HexObservation, immediately after mutating the mover's view,
+// so this is never at risk of the stale-read race MoverKnownHexes exists to
+// close (see MoveEvent's own doc).
+type KnownHex struct {
+	Position core.Hex
+	// State mirrors perception.KnowledgeState's int values (0 = unspecified,
+	// 1 = visible, 2 = remembered) without importing that package.
+	State int
+	// Terrain mirrors perception.TerrainKind's int values.
+	Terrain  int
+	ZoneID   string
+	Edges    []KnownHexEdge
+	Contents []KnownHexPlacement
+}
+
+// KnownHexEdge mirrors encounter/perception.Edge.
+type KnownHexEdge struct {
+	From core.Hex
+	To   core.Hex
+
+	BlocksMovement bool
+	BlocksLoS      bool
+
+	// DoorID is the door's entity id, empty when this edge is not a door.
+	DoorID     string
+	DoorOpen   bool
+	DoorLocked bool
+}
+
+// KnownHexPlacement mirrors encounter/perception.Placement.
+type KnownHexPlacement struct {
+	EntityID core.EntityID
+	// Facing is a hex-direction index 0-5.
+	Facing int
+}

--- a/encounter/events/move.go
+++ b/encounter/events/move.go
@@ -26,6 +26,41 @@ type MoveEvent struct {
 	From      core.Hex
 	Path      []core.Hex
 	PerPlayer map[core.PlayerID]MovePlayerSlice
+	// MoverPlayerID is the player who controls Mover, when Mover is
+	// player-controlled — empty for an NPC/monster mover. Set directly from
+	// the same playerID the encounter's own Move(playerID, ...) call
+	// already has in hand, so a consumer deciding "is THIS viewer the
+	// mover's own viewer" (to attach MoverKnownHexes) never needs its own
+	// entity-id -> player-id repository lookup either — the same
+	// stale-read class MoverKnownHexes itself exists to close, just for a
+	// smaller, easier-to-miss piece of data.
+	MoverPlayerID core.PlayerID
+	// MoverKnownHexes is the MOVER's OWN complete current knowledge
+	// (KnownHexes(Mover)'s wire projection — see KnownHex's doc), computed
+	// at the exact moment this event is published, i.e. immediately after
+	// the mover's position/view mutation above and before anything else can
+	// observe or persist this encounter.
+	//
+	// This exists because HexRevealedEvent — the toolkit's only other
+	// vision-change signal — fires exclusively on vision GAIN
+	// (perception.ProjectMove never reports a LOSS). A move that purely
+	// loses sight of a hex (stepping behind a pillar, backing out of a
+	// room) publishes no HexRevealedEvent at all, so a consumer with no
+	// other signal never learns that hex demoted to remembered.
+	//
+	// A consumer that needs the mover's current knowledge (e.g. to restate
+	// it to the mover's own client) MUST read this field rather than doing
+	// its own out-of-band re-load-and-KnownHexes(Mover) call: this
+	// encounter's in-memory state at publish time is the ONLY moment
+	// guaranteed to reflect this exact move — a caller's own repository
+	// read racing against the SAME move's not-yet-executed persist would
+	// see pre-move state (KirkDiggler/rpg-api#737: exactly this race, caught live —
+	// the restatement reported the mover's old hex as still VISIBLE with
+	// them on it, in the very event meant to correct that).
+	//
+	// Empty (not nil) when Mover has no view (e.g. a non-player-controlled
+	// mover) — never nil, so a consumer can range over it unconditionally.
+	MoverKnownHexes []KnownHex
 }
 
 // MovePlayerSlice is each viewer's projection of the move — which hexes
@@ -38,8 +73,12 @@ type MovePlayerSlice struct {
 }
 
 // NewMoveEvent constructs a MoveEvent. The encounter is responsible for
-// stamping the encounter ID and sequence number; PerPlayer is computed
-// by perception.ProjectMove.
+// stamping the encounter ID and sequence number; PerPlayer is computed by
+// perception.ProjectMove. moverPlayerID is empty for a non-player-controlled
+// mover (an NPC/monster). moverKnownHexes is the mover's own
+// KnownHexes(mover), projected to KnownHex by the caller — see
+// MoverKnownHexes' doc for why this must be read at publish time, not
+// re-derived later. A nil moverKnownHexes is normalized to an empty slice.
 func NewMoveEvent(
 	encID core.EncounterID,
 	seq uint64,
@@ -47,14 +86,21 @@ func NewMoveEvent(
 	from core.Hex,
 	path []core.Hex,
 	perPlayer map[core.PlayerID]MovePlayerSlice,
+	moverPlayerID core.PlayerID,
+	moverKnownHexes []KnownHex,
 ) *MoveEvent {
+	if moverKnownHexes == nil {
+		moverKnownHexes = []KnownHex{}
+	}
 	return &MoveEvent{
-		encID:     encID,
-		seq:       seq,
-		Mover:     mover,
-		From:      from,
-		Path:      path,
-		PerPlayer: perPlayer,
+		encID:           encID,
+		seq:             seq,
+		Mover:           mover,
+		From:            from,
+		Path:            path,
+		PerPlayer:       perPlayer,
+		MoverPlayerID:   moverPlayerID,
+		MoverKnownHexes: moverKnownHexes,
 	}
 }
 
@@ -76,25 +122,29 @@ func (e *MoveEvent) Audience() AudienceSet { return audienceFromMap(e.PerPlayer)
 // the encounter ID and sequence number.
 type moveEventWire struct {
 	metaWire
-	EncID     core.EncounterID                  `json:"encounter_id"`
-	Seq       uint64                            `json:"sequence"`
-	Mover     core.EntityID                     `json:"mover"`
-	From      core.Hex                          `json:"from"`
-	Path      []core.Hex                        `json:"path"`
-	PerPlayer map[core.PlayerID]MovePlayerSlice `json:"per_player"`
+	EncID           core.EncounterID                  `json:"encounter_id"`
+	Seq             uint64                            `json:"sequence"`
+	Mover           core.EntityID                     `json:"mover"`
+	From            core.Hex                          `json:"from"`
+	Path            []core.Hex                        `json:"path"`
+	PerPlayer       map[core.PlayerID]MovePlayerSlice `json:"per_player"`
+	MoverPlayerID   core.PlayerID                     `json:"mover_player_id,omitempty"`
+	MoverKnownHexes []KnownHex                        `json:"mover_known_hexes,omitempty"`
 }
 
 // MarshalJSON exposes encID and seq under stable JSON field names without
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *MoveEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(moveEventWire{
-		metaWire:  e.toWire(),
-		EncID:     e.encID,
-		Seq:       e.seq,
-		Mover:     e.Mover,
-		From:      e.From,
-		Path:      e.Path,
-		PerPlayer: e.PerPlayer,
+		metaWire:        e.toWire(),
+		EncID:           e.encID,
+		Seq:             e.seq,
+		Mover:           e.Mover,
+		From:            e.From,
+		Path:            e.Path,
+		PerPlayer:       e.PerPlayer,
+		MoverPlayerID:   e.MoverPlayerID,
+		MoverKnownHexes: e.MoverKnownHexes,
 	})
 }
 
@@ -112,5 +162,10 @@ func (e *MoveEvent) UnmarshalJSON(b []byte) error {
 	e.From = w.From
 	e.Path = w.Path
 	e.PerPlayer = w.PerPlayer
+	e.MoverPlayerID = w.MoverPlayerID
+	e.MoverKnownHexes = w.MoverKnownHexes
+	if e.MoverKnownHexes == nil {
+		e.MoverKnownHexes = []KnownHex{}
+	}
 	return nil
 }

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -69,25 +69,32 @@ func (e *Encounter) KnownHexes(playerID core.PlayerID) map[core.Hex]perception.H
 // must derive hexes from a real VisibleHexesAt/ProjectMove/ProjectDoorOpen
 // result, never invent one.
 //
-// entityID, if non-empty, is guaranteed present in every written hex's
-// Contents even when e.data's CURRENT stored position for that entity
-// differs from the hex being observed — the pass-through-move case: a
-// mover can be OBSERVED (per ProjectVisibilityTransition) at an
-// intermediate hex of their path that is not where they end up, so a plain
-// placementsAt(h) scan (which reads CURRENT position) would miss them
-// there. Leave entityID empty for refreshes that aren't about placing one
-// specific entity (e.g. the mover's own reveal, or a door-open re-sight) —
-// those should reflect purely current world truth, already keyed by
-// position via placementsAt.
-//
 // A hex's Edges/Contents are rebuilt from CURRENT e.data every call, never
 // patched — the same "Visible is TOTAL, replace wholesale" rule
 // HexObservation's doc states for the wire applies identically to memory:
+// Contents comes ENTIRELY from placementsAt's current-world scan, which
+// finds every player/monster/obstacle actually AT that hex right now — so
 // if something else is already standing on a hex being refreshed here (a
-// second monster the caller doesn't know about), placementsAt still finds
-// it, because it scans ALL of e.data, not just the caller's one entity of
+// second monster the caller doesn't know about), it's included, because
+// placementsAt scans ALL of e.data, not just the caller's one entity of
 // interest.
-func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet, entityID core.EntityID) {
+//
+// rpg-toolkit#858: this used to also take an entityID parameter, unioned
+// into every written hex's Contents regardless of whether placementsAt
+// already found that entity there — meant for the pass-through-move case,
+// but its one caller (applyAndPublishMove's per-viewer crossing refresh)
+// passed the SAME entity id for every hex in a multi-hex crossing, so a
+// mover watched crossing several hexes ended up recorded as present on ALL
+// of them, not just the one they actually stopped on — a stale, fabricated
+// placement on every hex they'd since left. The fix is that this function
+// needs no entity-forcing at all: applyAndPublishMove mutates the mover's
+// stored position to their final hex BEFORE calling this, so
+// placementsAt's own current-position scan already gets it exactly right —
+// present at the hex they actually ended on (if that hex is one this
+// viewer refreshes), absent from every other hex, and absent everywhere
+// for a pass-through mover whose final hex isn't a hex this viewer saw at
+// all. See applyAndPublishMove's call site for the full reasoning.
+func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet) {
 	if view == nil || len(hexes) == 0 {
 		return
 	}
@@ -104,23 +111,8 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 				obs.ZoneID = zoneID
 			}
 		}
-		if entityID != "" {
-			obs.Contents = unionPlacement(obs.Contents, entityID)
-		}
 		view.Observe(obs)
 	}
-}
-
-// unionPlacement returns placements with a Placement for entityID appended
-// unless one already names it. See refreshObservations' doc for why this
-// is needed (the pass-through-observed-at-an-intermediate-hex case).
-func unionPlacement(placements []perception.Placement, entityID core.EntityID) []perception.Placement {
-	for _, p := range placements {
-		if p.EntityID == entityID {
-			return placements
-		}
-	}
-	return append(placements, perception.Placement{EntityID: entityID})
 }
 
 // placementsAt returns a Placement for every player, monster, and static

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
 )
 
@@ -53,6 +54,61 @@ func (e *Encounter) KnownHexes(playerID core.PlayerID) map[core.Hex]perception.H
 		}
 		out[h] = obs
 	}
+	return out
+}
+
+// knownHexesToEvents projects KnownHexes' result into events.KnownHex — the
+// events package's own wire-shape mirror of perception.HexObservation (see
+// events.KnownHex's doc for why events cannot import perception directly).
+// This is the ONE place a perception.HexObservation crosses into that
+// mirror, keeping the projection logic in one spot rather than duplicated
+// at every MoveEvent publish call site.
+//
+// Sorted by (Q, R, S) for deterministic output — Go randomizes map
+// iteration, so without this two calls against unchanged data could
+// disagree on order (matches KnownHexes' own callers' existing
+// determinism convention, e.g. rpg-api's sortObservations).
+func knownHexesToEvents(known map[core.Hex]perception.HexObservation) []events.KnownHex {
+	out := make([]events.KnownHex, 0, len(known))
+	for _, o := range known {
+		edges := make([]events.KnownHexEdge, 0, len(o.Edges))
+		for _, e := range o.Edges {
+			edges = append(edges, events.KnownHexEdge{
+				From:           e.From,
+				To:             e.To,
+				BlocksMovement: e.BlocksMovement,
+				BlocksLoS:      e.BlocksLoS,
+				DoorID:         e.DoorID,
+				DoorOpen:       e.DoorOpen,
+				DoorLocked:     e.DoorLocked,
+			})
+		}
+		contents := make([]events.KnownHexPlacement, 0, len(o.Contents))
+		for _, c := range o.Contents {
+			contents = append(contents, events.KnownHexPlacement{
+				EntityID: c.EntityID,
+				Facing:   c.Facing,
+			})
+		}
+		out = append(out, events.KnownHex{
+			Position: o.Position,
+			State:    int(o.State),
+			Terrain:  int(o.Terrain),
+			ZoneID:   o.ZoneID,
+			Edges:    edges,
+			Contents: contents,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i].Position, out[j].Position
+		if a.Q != b.Q {
+			return a.Q < b.Q
+		}
+		if a.R != b.R {
+			return a.R < b.R
+		}
+		return a.S < b.S
+	})
 	return out
 }
 

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -93,6 +93,15 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 	}
 	edges := e.edgesByHex()
 	for h := range hexes {
+		// rpg-toolkit#859: hexes is frequently a raw perception.VisibleHexesAt
+		// disc (sight-range radius around a position), which has no notion of
+		// whether a hex is part of the space at all — it happily includes the
+		// void beyond the room's walls. Confine what gets remembered to hexes
+		// that are actually part of the space; see isSpaceHex's doc for why
+		// this can't be approximated with RegionAt.
+		if !e.isSpaceHex(h) {
+			continue
+		}
 		obs := perception.HexObservation{
 			Position: h,
 			State:    perception.KnowledgeStateVisible,
@@ -109,6 +118,49 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 		}
 		view.Observe(obs)
 	}
+}
+
+// isSpaceHex reports whether h is actually part of this encounter's space —
+// not merely within sight-range distance of some viewer position.
+// rpg-toolkit#859: three live encounters measured ~80% of a viewer's stored
+// Memory as hexes with no floor beneath them at all — perception.
+// VisibleHexesAt returns every hex within sightRange that isn't
+// wall-blocked, with no notion of whether a hex belongs to the space, so
+// refreshObservations was faithfully recording the void beyond the room's
+// walls right alongside real floor.
+//
+// RegionAt alone is NOT this test: a door's own cell deliberately belongs to
+// no region (RegionAt(door.Position) is always ("", false) by construction —
+// see doorPassageNeighbor's doc), and corridors may be similarly unregioned
+// in future generators. Filtering on "has a region" would silently drop
+// doorways from memory — a worse bug than the one being fixed, since the
+// player would lose the doorway they are standing in.
+//
+// The real test is the room's own grid bounds. rebuildRoomFromData builds
+// e.room's HexGrid from exactly SpaceData.Width/Height (spatial.HexGridConfig
+// {Width: sd.Width, Height: sd.Height}), and every generator this package
+// ships lays hexes out with NO gaps inside that rectangle:
+//   - InitRoom: a single implicit region spanning the whole grid — the
+//     entire rectangle IS the floor.
+//   - InitDungeon (InitTwoChamberRoom included, generalized to N=2):
+//     generateDungeonLayout places each region's columns contiguously
+//     (starts[i] = x; x += r.Width + 1) with the boundary/door column
+//     immediately after — the shared rectangle is exactly regions plus
+//     their connecting door columns, tiled with zero slack.
+//
+// So "within the room's grid bounds" IS "part of the space" for every shape
+// this package generates, doors included, with no per-generator
+// special-casing and no dependency on region tagging at all — precisely the
+// real membership answer the space itself already has, not an approximation.
+//
+// A nil e.room (InitRoom/LoadFromData-with-Space never ran) means there is
+// no room to be outside of: every hex is accepted, preserving this
+// package's pre-wave-1 unbounded-radius behavior for non-spatial encounters.
+func (e *Encounter) isSpaceHex(h core.Hex) bool {
+	if e.room == nil {
+		return true
+	}
+	return e.room.GetGrid().IsValidPosition(h.ToPosition())
 }
 
 // unionPlacement returns placements with a Placement for entityID appended

--- a/encounter/knowledge_test.go
+++ b/encounter/knowledge_test.go
@@ -332,3 +332,75 @@ func (s *KnowledgeSuite) TestKnownHexes_DuplicateReconciliation_Idempotent() {
 
 	s.Equal(first, second, "reconciling unchanged visibility twice must leave KnownHexes identical")
 }
+
+// TestKnownHexes_StationaryViewer_MoverCrossingSeveralHexes_EndsInExactlyOne
+// is rpg-toolkit#858's core acceptance bar: bob is stationary with sight
+// range 5 (never moves, never refreshes his own position), and watches
+// alice cross FOUR of his visible hexes in one move, stopping on the last
+// one (still within his sight — not a pass-through). Bob's memory of
+// alice's crossing must show her in exactly the hex she stopped on, not
+// smeared across every hex he watched her traverse.
+func (s *KnowledgeSuite) TestKnownHexes_StationaryViewer_MoverCrossingSeveralHexes_EndsInExactlyOne() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 5,
+	}))
+	// alice starts well outside bob's sight (distance 6) and crosses four
+	// hexes all within it (distances 5,4,3,2), stopping on the last —
+	// crossedHex1/2/3 must end up empty of her; finalHex must hold her.
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 6, R: -6, S: 0}, SightRange: 1,
+	}))
+	crossedHex1 := core.Hex{Q: 5, R: -5, S: 0}
+	crossedHex2 := core.Hex{Q: 4, R: -4, S: 0}
+	crossedHex3 := core.Hex{Q: 3, R: -3, S: 0}
+	finalHex := core.Hex{Q: 2, R: -2, S: 0}
+
+	s.Require().NoError(e.Move(alicePlayerID, []core.Hex{crossedHex1, crossedHex2, crossedHex3, finalHex}))
+
+	bobKnown := e.KnownHexes(bobPlayerID)
+	s.Require().Contains(bobKnown, finalHex)
+	s.Equal([]core.EntityID{aliceEntityID}, contentIDs(bobKnown[finalHex]),
+		"alice must be recorded on the hex she actually stopped on")
+
+	for _, h := range []core.Hex{crossedHex1, crossedHex2, crossedHex3} {
+		s.Require().Contains(bobKnown, h, "bob watched alice cross this hex, so it must be known to him")
+		s.Empty(contentIDs(bobKnown[h]),
+			"alice must NOT be recorded on a hex she has since left, even though bob watched her cross it")
+	}
+}
+
+// TestKnownHexes_PassThrough_MoverCrossesAndExits_LeavesNoVisibleTrace is
+// rpg-toolkit#858's pass-through acceptance bar: bob is stationary with
+// sight range 2, and alice moves in one path from far outside his sight,
+// briefly through two hexes he CAN see, and out the far side back beyond
+// his sight — neither her start nor her true final position is ever within
+// bob's sight. Bob must end with alice in NO hex's contents at all: not
+// pinned at the last hex he saw her in (that would fabricate a visible
+// placement the contract reserves for REMEMBERED state, never VISIBLE).
+func (s *KnowledgeSuite) TestKnownHexes_PassThrough_MoverCrossesAndExits_LeavesNoVisibleTrace() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: bobPlayerID, EntityID: bobEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 2,
+	}))
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 20, R: -20, S: 0}, SightRange: 1,
+	}))
+	seenHex1 := core.Hex{Q: 1, R: -1, S: 0}
+	seenHex2 := core.Hex{Q: 2, R: -2, S: 0}
+	farExit := core.Hex{Q: 30, R: -30, S: 0}
+
+	s.Require().NoError(e.Move(alicePlayerID, []core.Hex{seenHex1, seenHex2, farExit}))
+
+	bobKnown := e.KnownHexes(bobPlayerID)
+	for _, h := range []core.Hex{seenHex1, seenHex2} {
+		s.Require().Contains(bobKnown, h, "bob watched alice cross this hex, so it must be known to him")
+		s.Empty(contentIDs(bobKnown[h]),
+			"alice has moved on past bob's sight entirely — she must not be pinned at the last hex he saw her in")
+	}
+	s.NotContains(bobKnown, farExit, "alice's true final hex was never within bob's sight at all")
+}

--- a/encounter/knowledge_test.go
+++ b/encounter/knowledge_test.go
@@ -7,6 +7,15 @@ package encounter_test
 // reconciliation. See encounter/knowledge.go's file doc for the
 // implementation this exercises, and perception/knowledge.go for the
 // HexObservation contract these tests assert against.
+//
+// rpg-toolkit#859 added TestKnownHexes_MemoryHexes_AllBelongToTheSpace and
+// TestKnownHexes_DoorwayCell_IsStillRemembered: every test above this point
+// predates that fix and uses encounter.New with no InitRoom/InitDungeon call
+// at all (e.room stays nil), so they never previously exercised — and still
+// don't exercise — the space-membership filter; they keep passing precisely
+// because a nil room means "nothing to be outside of," preserving this
+// package's pre-wave-1 unbounded behavior for non-spatial encounters. The
+// two new tests are the ones that actually build a spatial room.
 
 import (
 	"context"
@@ -18,6 +27,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
 type KnowledgeSuite struct {
@@ -331,4 +341,69 @@ func (s *KnowledgeSuite) TestKnownHexes_DuplicateReconciliation_Idempotent() {
 	second := e.KnownHexes(alicePlayerID)
 
 	s.Equal(first, second, "reconciling unchanged visibility twice must leave KnownHexes identical")
+}
+
+// TestKnownHexes_MemoryHexes_AllBelongToTheSpace is rpg-toolkit#859's core
+// acceptance bar: perception.VisibleHexesAt returns every hex within
+// sightRange that isn't wall-blocked, with no notion of whether a hex is
+// part of the space at all — measured from live Redis, ~80% of a viewer's
+// stored Memory was hexes with no floor beneath them, well outside the
+// room. A tiny 6x6 room with sight range 10 (the measured scenario's own
+// sight range) reproduces the shape of the bug directly: an unfiltered
+// radius-10 disc is up to 331 hexes, vastly more than the room's own 36.
+func (s *KnowledgeSuite) TestKnownHexes_MemoryHexes_AllBelongToTheSpace() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.InitRoom(6, 6, environments.PatternEmpty))
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
+	}))
+
+	known := e.KnownHexes(alicePlayerID)
+	s.Require().NotEmpty(known)
+
+	room := e.Room()
+	s.Require().NotNil(room)
+	for h := range known {
+		s.True(room.GetGrid().IsValidPosition(h.ToPosition()),
+			"every stored hex must belong to the room's grid bounds; %v does not", h)
+	}
+
+	// Memory size must equal the room's own footprint (6x6=36) exactly, not
+	// the sight-range disc (radius 10 reaches the whole tiny room from this
+	// corner, so pre-fix this would instead have been the full unfiltered
+	// disc size — up to 331 hexes for radius 10).
+	s.Equal(36, len(known),
+		"memory must be proportional to the room's footprint, not the sight-range area")
+}
+
+// TestKnownHexes_DoorwayCell_IsStillRemembered is rpg-toolkit#859's
+// trap-avoidance bar: RegionAt alone is NOT a valid space-membership test —
+// a door's own cell deliberately belongs to no region (doorPassageNeighbor's
+// documented trap) — so a fix that filtered purely on "has a region" would
+// silently drop doorways from memory, losing the exact cell the player is
+// standing in front of. Proves the real fix does not make that mistake.
+func (s *KnowledgeSuite) TestKnownHexes_DoorwayCell_IsStillRemembered() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	s.Require().NoError(e.InitTwoChamberRoom(encounter.TwoChamberRoomParams{
+		ChamberWidth: 4, ChamberHeight: 4, Pattern: environments.PatternEmpty,
+		DoorID: twoChamberDoorID,
+	}))
+	entrance := e.ToData().Space.Entrance
+	s.Require().NoError(e.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: entrance, SightRange: 10,
+	}))
+
+	doorHex := e.ToData().Doors[twoChamberDoorID].Position
+
+	// Precondition pinning the documented trap itself: the door's own cell
+	// belongs to no region.
+	_, hasRegion := e.ToData().Space.RegionAt(doorHex)
+	s.Require().False(hasRegion,
+		"precondition: the door's own cell belongs to no region (doorPassageNeighbor's documented trap)")
+
+	known := e.KnownHexes(alicePlayerID)
+	s.Require().Contains(known, doorHex,
+		"the doorway must still be remembered even though RegionAt reports it belongs to no region")
 }

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -348,8 +348,13 @@ func (e *Encounter) applyNPCMovementSteps(mon *MonsterData, path []encountercore
 	if len(movePerPlayer) == 0 {
 		return nil
 	}
+	// Empty moverPlayerID / nil moverKnownHexes: an NPC/monster mover has no
+	// Players entry / View, so there is no KnownHexes(mover) to restate —
+	// MoverKnownHexes exists only to fix the PLAYER mover's own-knowledge
+	// restatement race (see its doc comment); NewMoveEvent normalizes nil
+	// to an empty slice.
 	if err := e.broker.Publish(events.NewMoveEvent(
-		e.data.ID, e.nextSeq(), mon.ID, moverStart, traveledPath, movePerPlayer,
+		e.data.ID, e.nextSeq(), mon.ID, moverStart, traveledPath, movePerPlayer, "", nil,
 	)); err != nil {
 		return fmt.Errorf("publish npc move: %w", err)
 	}


### PR DESCRIPTION
## What

rpg-api's stream-handler restatement of the mover's own hex knowledge (rpg-api#733, "remembered transitions") reacted to `MoveEvent` by re-reading the encounter from its own repository. That read races the orchestrator's persist of the *same* move: `Move()` publishes `MoveEvent` synchronously, from inside its own call stack, before returning — the orchestrator only persists *after* `Move()` returns. So the downstream read observed the pre-persist snapshot every time, not occasionally. Caught live in a Kirk playtest: after a move, the restatement still reported the mover's old hex as `VISIBLE` with them standing on it, in the very event meant to correct that.

This is a concrete instance of the general race class tracked in KirkDiggler/rpg-api#647 ("event-then-load races the orchestrator's Save"), resolved the way #647 itself proposes and the same pattern already used for the initiative roster (#765): have the event carry what the wire needs.

## Fix

`MoveEvent` gains two fields, computed by `applyAndPublishMove` immediately after the mover's own position/view mutation — the one moment guaranteed to reflect this exact move:

- `MoverPlayerID core.PlayerID` — the player who controls the mover (empty for NPCs).
- `MoverKnownHexes []events.KnownHex` — the mover's own `KnownHexes(mover)`, projected into a new flat mirror type in the `events` package. `events` can't import `perception` directly (`perception` already imports `events` for `ProjectMove`), so `KnownHex`/`KnownHexEdge`/`KnownHexPlacement` mirror `perception.HexObservation`/`Edge`/`Placement` field-for-field.

A companion rpg-api PR (KirkDiggler/rpg-api#737) rewrites `translateMoveEventWithData` to trust this payload directly instead of doing its own repo read.

## Tests

- `TestMove_MoverKnownHexesReflectsPostMoveTruth` (encounter_test.go) — proves the payload reflects post-move truth: origin hex demoted to REMEMBERED, destination hex VISIBLE with the mover placed on it.
- `TestMoveEvent_JSONRoundTrip` extended with realistic mixed REMEMBERED/VISIBLE `MoverKnownHexes` fixture data.
- `TestMoveEvent_NilMoverKnownHexesNormalizesToEmpty` — nil never leaks to a consumer expecting to range unconditionally.
- All existing `NewMoveEvent` call sites (broker_test.go, events_test.go) updated for the two new constructor params.

## Bar

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- `golangci-lint run` — 68 pre-existing `goconst` issues, confirmed identical to a fresh `origin/main` baseline (zero new issues)
- `go test ./...` — all green

Fixes #862.

— asset-pipeline agent, on behalf of KirkDiggler