### PR TITLE
fix(encounter): force combat-entry trigger into initiative slot 0

### DIFF
--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -296,7 +296,41 @@ type ActionTarget struct {
 // the roster itself doesn't change turn to turn — pinned by
 // TestSetMode_InitiativeRolled_SequencedBetweenModeChangedAndTurnStarted and
 // TestEndTurn_DoesNotRepublishInitiativeRolled.
+//
+// This public verb carries no combat-entry trigger — an administrative or
+// host-driven mode flip (devseed --inject-combat, a test calling SetMode
+// directly) has no single acting entity to privilege, so initiative rolls
+// purely by d20 as it always has. checkCombatEntry (rpg-toolkit#865) is the
+// one caller that DOES have a trigger (the mover whose LoS check fired) and
+// calls setMode directly to supply it.
 func (e *Encounter) SetMode(mode core.EncounterMode) error {
+	return e.setMode(mode, "", 0)
+}
+
+// setMode is SetMode's implementation, extended with the rpg-toolkit#865
+// combat-entry trigger.
+//
+// triggerID is the entity whose action caused a FreeRoam->TurnBased
+// transition — the mover in Move's checkCombatEntry call. Empty when the
+// transition has no single acting entity (SetMode's public wrapper, or a
+// monster becoming visible via AddMonster/SeedMonsters — nobody "acted" to
+// cause that). When non-empty, rollInitiative forces that entity into
+// initiative slot 0 regardless of its own roll (Kirk's creative-director
+// ruling on #865: "the entity that triggers combat is ALWAYS initiative
+// slot 1 [0-indexed: slot 0] — their action was already underway").
+//
+// triggerPreSpentFeet is how much of the trigger's movement budget it
+// already spent THIS turn before the transition (e.g. the free-roam move
+// that walked it into a monster's LoS — free-roam movement is unmetered, so
+// nothing gated it, but it still happened). Only applied when triggerID
+// actually lands in slot 0 (rollInitiative's own scoping — engagedMonsters
+// vs all monsters — can in principle leave a caller-supplied triggerID out
+// of the roster entirely, though Move's call site never does this: the
+// mover is always a player, and rollInitiative always seeds every player).
+// seedActorTurn subtracts it from the fresh StartTurn speed rather than
+// letting a free-roam approach stack with a full fresh combat turn's
+// movement.
+func (e *Encounter) setMode(mode core.EncounterMode, triggerID core.EntityID, triggerPreSpentFeet int) error {
 	if mode == core.ModeUnspecified {
 		return errors.New("mode unspecified")
 	}
@@ -324,7 +358,7 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 	e.data.Mode = mode
 	switch mode {
 	case core.ModeTurnBased:
-		e.rollInitiative()
+		e.rollInitiative(triggerID)
 		e.data.ActiveIdx = 0
 		e.data.Round = 1
 	case core.ModeFreeRoam:
@@ -377,7 +411,15 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 		// e.data.Initiative to nil on that transition. Re-indexing
 		// e.data.Initiative[0] after the seed call would panic in that case.
 		firstActive := e.data.Initiative[0]
-		if err := e.seedActorTurn(context.Background(), firstActive); err != nil {
+		// rpg-toolkit#865: the pre-spent budget only applies to the actual
+		// trigger, and only when it landed in slot 0 (rollInitiative always
+		// places a non-empty triggerID first when present in the roster —
+		// see setMode's doc comment for the one theoretical exception).
+		var preSpent int
+		if triggerID != "" && firstActive == triggerID {
+			preSpent = triggerPreSpentFeet
+		}
+		if err := e.seedActorTurn(context.Background(), firstActive, preSpent); err != nil {
 			return err
 		}
 		// See EndTurn's identical guard for the fuller rationale: once the
@@ -405,16 +447,22 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 
 // checkCombatEntry evaluates whether any player currently has line of sight
 // to any monster and, if so and the encounter is still FREE_ROAM,
-// self-transitions to TURN_BASED by calling SetMode — the exact same
+// self-transitions to TURN_BASED by calling setMode — the exact same
 // initiative-roll + ModeChanged/TurnStarted publish path SetMode already
 // runs for any other FreeRoam->TurnBased flip. This mirrors
 // checkEncounterEnd's self-transition at combat's other edge (death.go): the
 // toolkit owns both entry and exit of combat, not just exit.
 //
-// Called inline at the mutation sites (Move, AddMonster) — not a kicked
-// method — per Kirk's fork-1 call on the design doc: a forgotten kick call
-// silently never starts combat, which is a worse failure mode than a
-// redundant inline check.
+// Called inline at the mutation sites (Move, AddMonster, SeedMonsters) — not
+// a kicked method — per Kirk's fork-1 call on the design doc: a forgotten
+// kick call silently never starts combat, which is a worse failure mode than
+// a redundant inline check.
+//
+// triggerID/triggerPreSpentFeet (rpg-toolkit#865) name the acting entity that
+// caused THIS particular call — Move passes the mover and how many feet it
+// already traveled this call (unmetered free-roam movement); AddMonster and
+// SeedMonsters pass ("", 0) since a monster becoming visible has no acting
+// player to privilege. See setMode's doc comment for how these are used.
 //
 // "Hostile" == "is a monster" for wave 1 — no faction model exists yet, so
 // every monster is a valid combat-entry trigger for every player.
@@ -422,7 +470,7 @@ func (e *Encounter) SetMode(mode core.EncounterMode) error {
 // The mode gate at the top makes this idempotent: once TURN_BASED, repeated
 // Move/AddMonster calls short-circuit here without re-checking visibility or
 // re-rolling initiative.
-func (e *Encounter) checkCombatEntry() error {
+func (e *Encounter) checkCombatEntry(triggerID core.EntityID, triggerPreSpentFeet int) error {
 	if e.data.Mode != core.ModeFreeRoam {
 		return nil
 	}
@@ -432,7 +480,7 @@ func (e *Encounter) checkCombatEntry() error {
 	for _, p := range e.data.Players {
 		for _, m := range e.data.Monsters {
 			if perception.CanSeeAt(p.View, m.Position, e.room) {
-				return e.SetMode(core.ModeTurnBased)
+				return e.setMode(core.ModeTurnBased, triggerID, triggerPreSpentFeet)
 			}
 		}
 	}
@@ -692,7 +740,7 @@ func (e *Encounter) EndTurn(
 
 	// Seed the new actor's economy before announcing their turn (Beat-1: the
 	// engine owns turn-start seeding). No-op for NPCs and stat-snapshot seats.
-	if seedErr := e.seedActorTurn(ctx, newActive); seedErr != nil {
+	if seedErr := e.seedActorTurn(ctx, newActive, 0); seedErr != nil {
 		return "", false, seedErr
 	}
 
@@ -763,8 +811,16 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 }
 
 // rollInitiative seeds Initiative with every player plus the ENGAGED
-// monster pocket (rpg-toolkit#794) in d20-roll-desc order. Ties broken by
-// entity id for determinism.
+// monster pocket (rpg-toolkit#794) in d20-roll-desc order, EXCEPT for
+// triggerID (rpg-toolkit#865): when non-empty, that entity is forced into
+// slot 0 regardless of its own roll, per Kirk's creative-director ruling
+// that the entity whose action triggered combat (walked into sight, opened
+// the door) was already mid-action and does not "wait its turn" behind a
+// lucky monster roll. triggerID still rolls a d20 like everyone else (kept
+// so roller consumption/ordering stays identical to the no-trigger path —
+// simpler to reason about and to test) — the roll is just discarded for
+// placement. Ties among the REMAINING seeds are broken by entity id for
+// determinism, same as before this issue.
 //
 // Combat pockets: before this, every seeded monster anywhere in the space
 // joined initiative on the first sighting, so a locked-away boss (behind a
@@ -777,7 +833,7 @@ func (e *Encounter) TakeAction(playerID core.PlayerID, ref ActionRef, target Act
 // player already has a seat regardless of which pocket engages — a player
 // elsewhere in the dungeon simply takes an uneventful turn, not something
 // this slice changes.
-func (e *Encounter) rollInitiative() {
+func (e *Encounter) rollInitiative(triggerID core.EntityID) {
 	type seed struct {
 		id   core.EntityID
 		roll int
@@ -813,9 +869,25 @@ func (e *Encounter) rollInitiative() {
 		}
 		return seeds[i].id < seeds[j].id
 	})
-	out := make([]core.EntityID, len(seeds))
-	for i, s := range seeds {
-		out[i] = s.id
+
+	out := make([]core.EntityID, 0, len(seeds))
+	// rpg-toolkit#865: pull the trigger out of the rolled order and place it
+	// first, ahead of everyone else regardless of roll. A triggerID that
+	// isn't present among seeds (e.g. empty, or a caller-supplied id this
+	// pocket never engaged) leaves seeds untouched and out empty here, so
+	// the loop below reproduces the plain roll order exactly as before this
+	// issue.
+	if triggerID != "" {
+		for i, s := range seeds {
+			if s.id == triggerID {
+				out = append(out, s.id)
+				seeds = append(seeds[:i], seeds[i+1:]...)
+				break
+			}
+		}
+	}
+	for _, s := range seeds {
+		out = append(out, s.id)
 	}
 	e.data.Initiative = out
 }

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -365,6 +365,12 @@ func (e *Encounter) setMode(mode core.EncounterMode, triggerID core.EntityID, tr
 		e.data.Initiative = nil
 		e.data.ActiveIdx = 0
 		e.data.Round = 0
+		// PR #867 gate re-check: a pending trigger-seed stash from the pocket
+		// that just ended is stale the instant combat exits back to
+		// FREE_ROAM — clear it defensively (belt-and-suspenders alongside the
+		// unconditional resolve in the ModeTurnBased branch below) so it can
+		// never survive to be misapplied to a later, unrelated transition.
+		e.data.PendingTriggerSeed = nil
 	}
 
 	if err := e.broker.Publish(events.NewModeChangedEvent(
@@ -425,13 +431,28 @@ func (e *Encounter) setMode(mode core.EncounterMode, triggerID core.EntityID, tr
 		// below no-ops (heldCharacter returns nil) and preSpent would
 		// otherwise be lost as a Go-only local by the time the encounter is
 		// eventually loaded. Persist it so seedActiveActorIfUnseeded's later
-		// catch-up can still apply it. Skipped when preSpent is zero — the
-		// common no-deduction case needs nothing pending.
+		// catch-up can still apply it.
+		//
+		// Resolved UNCONDITIONALLY on every TurnBased transition (gate
+		// re-check finding, staleness): the same actor can legitimately be
+		// forced trigger across two SEPARATE FreeRoam->TurnBased flips —
+		// once with a real pre-spent deduction while still unhydrated, once
+		// later with none (e.g. it's still the only entity with LoS once
+		// combat re-enters) — and seedActiveActorIfUnseeded's ActorID-match
+		// guard can't tell those two events apart on its own, since it's the
+		// same actor both times. A prior version only WROTE this field when
+		// preSpent > 0 and never cleared it otherwise, so a stale stash from
+		// an earlier transition survived to be misapplied to a later one for
+		// the same actor with nothing pending. Always assigning here — nil
+		// when there's nothing to stash — guarantees the field only ever
+		// reflects the MOST RECENT transition.
 		if preSpent > 0 && e.heldCharacter(firstActive) == nil {
 			e.data.PendingTriggerSeed = &PendingTriggerSeedData{
 				ActorID:              firstActive,
 				PreSpentMovementFeet: preSpent,
 			}
+		} else {
+			e.data.PendingTriggerSeed = nil
 		}
 		if err := e.seedActorTurn(context.Background(), firstActive, preSpent); err != nil {
 			return err
@@ -547,19 +568,30 @@ func (e *Encounter) playerEntityHasMonsterLoS(entityID core.EntityID) bool {
 	return false
 }
 
-// firstEngagedPlayerEntityID returns the entity id of the first player
-// (by ascending PlayerID, for determinism — e.data.Players is a map) who
+// firstEngagedPlayerEntityID returns the entity id of the first player (by
+// ascending EntityID, for determinism — e.data.Players is a map) who
 // currently has LoS to any monster, and whether one was found. Used by
 // checkCombatEntry to attribute the actual trigger when the caller's own
 // candidate isn't the one whose LoS fired the transition.
+//
+// Sorts by EntityID, not PlayerID (PR #867 gate re-check nit): rollInitiative
+// itself sorts its player seeds by ascending EntityID, and "first" should
+// mean the same thing everywhere a tie-break like this runs in this file —
+// sorting by a different key here would let this fallback and rollInitiative
+// disagree on which of two simultaneously-engaged players counts as "first"
+// in the (today theoretical) case where more than one already has LoS.
 func (e *Encounter) firstEngagedPlayerEntityID() (core.EntityID, bool) {
-	playerIDs := make([]core.PlayerID, 0, len(e.data.Players))
-	for id := range e.data.Players {
-		playerIDs = append(playerIDs, id)
+	candidates := make([]*PlayerData, 0, len(e.data.Players))
+	for _, p := range e.data.Players {
+		candidates = append(candidates, p)
 	}
-	sort.Slice(playerIDs, func(i, j int) bool { return playerIDs[i] < playerIDs[j] })
-	for _, id := range playerIDs {
-		p := e.data.Players[id]
+	// Sorted by EntityID directly (not via a map keyed on it): two player
+	// seats sharing an EntityID isn't structurally enforced against
+	// elsewhere in this package (see CompleteTakeAction's doc comment on
+	// cross-map id collisions), so this avoids introducing a new place that
+	// would silently collapse such a collision.
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].EntityID < candidates[j].EntityID })
+	for _, p := range candidates {
 		for _, m := range e.data.Monsters {
 			if perception.CanSeeAt(p.View, m.Position, e.room) {
 				return p.EntityID, true

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -419,6 +419,20 @@ func (e *Encounter) setMode(mode core.EncounterMode, triggerID core.EntityID, tr
 		if triggerID != "" && firstActive == triggerID {
 			preSpent = triggerPreSpentFeet
 		}
+		// PR #867 gate finding 2: if firstActive has no held character yet
+		// (production's New()+AddPlayer+AddMonster flow — nothing is
+		// hydrated until a LoadFromData round-trip), the seedActorTurn call
+		// below no-ops (heldCharacter returns nil) and preSpent would
+		// otherwise be lost as a Go-only local by the time the encounter is
+		// eventually loaded. Persist it so seedActiveActorIfUnseeded's later
+		// catch-up can still apply it. Skipped when preSpent is zero — the
+		// common no-deduction case needs nothing pending.
+		if preSpent > 0 && e.heldCharacter(firstActive) == nil {
+			e.data.PendingTriggerSeed = &PendingTriggerSeedData{
+				ActorID:              firstActive,
+				PreSpentMovementFeet: preSpent,
+			}
+		}
 		if err := e.seedActorTurn(context.Background(), firstActive, preSpent); err != nil {
 			return err
 		}
@@ -458,11 +472,26 @@ func (e *Encounter) setMode(mode core.EncounterMode, triggerID core.EntityID, tr
 // kick call silently never starts combat, which is a worse failure mode than
 // a redundant inline check.
 //
-// triggerID/triggerPreSpentFeet (rpg-toolkit#865) name the acting entity that
-// caused THIS particular call — Move passes the mover and how many feet it
-// already traveled this call (unmetered free-roam movement); AddMonster and
-// SeedMonsters pass ("", 0) since a monster becoming visible has no acting
-// player to privilege. See setMode's doc comment for how these are used.
+// triggerID/triggerPreSpentFeet (rpg-toolkit#865) name the CALLER's candidate
+// acting entity — Move passes its own mover and how many feet it already
+// traveled this call (unmetered free-roam movement). But this check itself is
+// global (any player x monster pair, not just the caller's own view), so the
+// caller's candidate is not automatically the entity whose LoS actually made
+// this fire: a player-monster LoS pair can already exist, unclaimed, from an
+// earlier event that didn't itself call this check (OpenDoor doesn't —
+// see OpenDoor's own doc — so a player already lined up on a monster through
+// a freshly-opened door sits unflagged until SOMEONE's next Move call
+// re-evaluates this), and a completely unrelated player's own unrelated move
+// would otherwise be misattributed as the trigger (rpg-toolkit#865 follow-up
+// review on PR #867: a "wanderer" with zero LoS to anything, moving anywhere,
+// wrongly seized initiative slot 0 — and its own pre-spent budget — away from
+// the actually-exposed player). So: if the caller's own candidate has LoS to a
+// monster, it's unambiguously the trigger and keeps its own pre-spent budget;
+// otherwise fall back to whichever OTHER player is actually LoS-engaged (with
+// NO pre-spent budget attributed — the caller had nothing to do with
+// revealing that pair). triggerID == "" (AddMonster/SeedMonsters — no acting
+// player at all) skips trigger attribution entirely and keeps the plain
+// existence check this had before #865.
 //
 // "Hostile" == "is a monster" for wave 1 — no faction model exists yet, so
 // every monster is a valid combat-entry trigger for every player.
@@ -477,14 +506,67 @@ func (e *Encounter) checkCombatEntry(triggerID core.EntityID, triggerPreSpentFee
 	if len(e.data.Players) == 0 || len(e.data.Monsters) == 0 {
 		return nil
 	}
-	for _, p := range e.data.Players {
+
+	if triggerID == "" {
+		for _, p := range e.data.Players {
+			for _, m := range e.data.Monsters {
+				if perception.CanSeeAt(p.View, m.Position, e.room) {
+					return e.setMode(core.ModeTurnBased, "", 0)
+				}
+			}
+		}
+		return nil
+	}
+
+	if e.playerEntityHasMonsterLoS(triggerID) {
+		return e.setMode(core.ModeTurnBased, triggerID, triggerPreSpentFeet)
+	}
+	if actualTrigger, ok := e.firstEngagedPlayerEntityID(); ok {
+		return e.setMode(core.ModeTurnBased, actualTrigger, 0)
+	}
+	return nil
+}
+
+// playerEntityHasMonsterLoS reports whether the player entity identified by
+// entityID currently has LoS to any monster, via the same perception.CanSeeAt
+// predicate checkCombatEntry's own existence check uses. Returns false for an
+// unknown entity id (e.g. a monster's own EntityID, or one that has left the
+// encounter) — checkCombatEntry's caller-candidate check treats "not a
+// player, or not visible" identically: fall through to the actual-trigger
+// search.
+func (e *Encounter) playerEntityHasMonsterLoS(entityID core.EntityID) bool {
+	p := e.findPlayerByEntityID(entityID)
+	if p == nil {
+		return false
+	}
+	for _, m := range e.data.Monsters {
+		if perception.CanSeeAt(p.View, m.Position, e.room) {
+			return true
+		}
+	}
+	return false
+}
+
+// firstEngagedPlayerEntityID returns the entity id of the first player
+// (by ascending PlayerID, for determinism — e.data.Players is a map) who
+// currently has LoS to any monster, and whether one was found. Used by
+// checkCombatEntry to attribute the actual trigger when the caller's own
+// candidate isn't the one whose LoS fired the transition.
+func (e *Encounter) firstEngagedPlayerEntityID() (core.EntityID, bool) {
+	playerIDs := make([]core.PlayerID, 0, len(e.data.Players))
+	for id := range e.data.Players {
+		playerIDs = append(playerIDs, id)
+	}
+	sort.Slice(playerIDs, func(i, j int) bool { return playerIDs[i] < playerIDs[j] })
+	for _, id := range playerIDs {
+		p := e.data.Players[id]
 		for _, m := range e.data.Monsters {
 			if perception.CanSeeAt(p.View, m.Position, e.room) {
-				return e.setMode(core.ModeTurnBased, triggerID, triggerPreSpentFeet)
+				return p.EntityID, true
 			}
 		}
 	}
-	return nil
+	return "", false
 }
 
 // engagedMonsters returns the monsters at least one player currently has

--- a/encounter/combat_trigger_order_test.go
+++ b/encounter/combat_trigger_order_test.go
@@ -1,0 +1,333 @@
+package encounter_test
+
+// combat_trigger_order_test.go is the regression gate for rpg-toolkit#865:
+// a monster taking a full turn before the player whose action triggered
+// combat (found in a 2026-07-30 QA walk — a player moved into a boss's
+// detection range, and the transition's rolled initiative put the boss
+// FIRST because it simply won the d20 roll).
+//
+// Kirk's creative-director ruling (issue body): the entity that triggers
+// combat (opens the door / walks into sight) is ALWAYS initiative slot 1
+// (0-indexed: slot 0) -- its own roll is unused for placement -- and no
+// monster may act before that entity's turn completes. The transition must
+// also preserve whatever movement budget the trigger already spent getting
+// there (free-roam movement is unmetered, so nothing gated it, but it still
+// happened) rather than granting a full fresh turn on top of it.
+//
+// checkCombatEntry (combat.go) is the ONLY place a FreeRoam->TurnBased
+// transition can fire from a player's own action -- Move is the sole call
+// site that has a real acting entity (a mover); AddMonster/SeedMonsters have
+// no acting player (a monster simply becomes visible) and are deliberately
+// left at plain roll order (documented at their own call sites, not
+// re-tested here). The "door-interact-reveals-monsters" vector the issue
+// also calls out turns out NOT to be a separate code path: encounter.OpenDoor
+// never calls checkCombatEntry itself (confirmed by reading it and rpg-api's
+// Interact orchestrator, which dispatches to OpenDoor and nothing else) --
+// opening a door only rebuilds LoS-blocking geometry. Combat only actually
+// starts once the player's NEXT Move call re-evaluates checkCombatEntry
+// through the newly-opened doorway (pocket_clear_move_teardown_test.go and
+// combat_pockets_test.go's TestOpenDoorAndSightB_StartsFreshPocket already
+// exercise this shape). So the door vector's "the triggering player DID act
+// before the monster" QA observation was luck of the roll, not
+// correct-by-design behavior -- it funnels through the exact same Move-
+// triggered checkCombatEntry path movement-into-detection does, and
+// TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll below proves the
+// fix covers it too.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+)
+
+// sequenceRoller returns rolls from a fixed sequence in call order (wrapping
+// if exhausted), giving tests deterministic control over each individual
+// rollInitiative seed rather than fixedMaxRoller's uniform-tie behavior.
+// rollInitiative's own call order is: sorted playerIDs ascending, then
+// sorted engaged monster IDs ascending (combat.go's rollInitiative doc) --
+// tests using this roller pick entity IDs whose sort order matches the
+// sequence they hand it.
+type sequenceRoller struct {
+	rolls []int
+	i     int
+}
+
+func (r *sequenceRoller) Roll(_ context.Context, _ int) (int, error) {
+	v := r.rolls[r.i%len(r.rolls)]
+	r.i++
+	return v, nil
+}
+
+func (r *sequenceRoller) RollN(ctx context.Context, count, _ int) ([]int, error) {
+	out := make([]int, count)
+	for i := range out {
+		v, err := r.Roll(ctx, 20)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+type CombatTriggerOrderSuite struct {
+	suite.Suite
+	ctx       context.Context
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+}
+
+func TestCombatTriggerOrderSuite(t *testing.T) {
+	suite.Run(t, new(CombatTriggerOrderSuite))
+}
+
+func (s *CombatTriggerOrderSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+}
+
+func (s *CombatTriggerOrderSuite) TearDownTest() {
+	_ = s.broker.Close()
+	_ = s.transport.Close()
+}
+
+const (
+	triggerHeroPlayerID = core.PlayerID("hero")
+	triggerHeroEntityID = core.EntityID("char-hero")
+)
+
+// TestMove_TriggerForcedFirst_RegardlessOfRoll reproduces the exact QA
+// incident shape: a monster ID ("boss-boss") that sorts alphabetically
+// before the player's entity ID ("char-hero"), with fixedMaxRoller tying
+// every roll at 20 -- the OLD rollInitiative's tiebreak (ascending id) would
+// have put the monster first, exactly matching the QA-observed
+// `initiative: ['boss-boss', 'char_...']`. The player starts out of the
+// monster's LoS and moves into it; that Move is the trigger.
+func (s *CombatTriggerOrderSuite) TestMove_TriggerForcedFirst_RegardlessOfRoll() {
+	enc := encounter.New(s.ctx, "enc-trigger-order-1", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: triggerHeroPlayerID, EntityID: triggerHeroEntityID,
+		Position: core.Hex{Q: -10, R: 10, S: 0}, SightRange: 5,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: "boss-boss", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 30, MaxHP: 30,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
+		"test premise: the boss must be out of LoS until the move below")
+
+	s.Require().NoError(enc.Move(triggerHeroPlayerID, []core.Hex{
+		{Q: -5, R: 5, S: 0}, {Q: 0, R: 0, S: 0},
+	}))
+
+	s.Require().Equal(core.ModeTurnBased, enc.Mode())
+	s.Require().Equal([]core.EntityID{triggerHeroEntityID, "boss-boss"}, enc.ToData().Initiative,
+		"the moving player triggered combat and must go first, "+
+			"even though the monster's id wins the old ascending-id tiebreak (rpg-toolkit#865)")
+	s.Equal(triggerHeroEntityID, enc.ActiveActor())
+}
+
+// TestMove_OthersStillOrderedByRoll_TriggerRollDiscarded proves the fix is
+// scoped to the trigger's OWN placement only: a second player and a monster
+// not involved in triggering the transition must still sort by their own
+// rolls, descending, exactly as before this issue. The trigger's own roll
+// (5, the lowest of the three) is deliberately made low, "won" by nobody
+// looking, and discarded for its placement -- but it must not desync the
+// rolls assigned to the other two seeds.
+func (s *CombatTriggerOrderSuite) TestMove_OthersStillOrderedByRoll_TriggerRollDiscarded() {
+	// rollInitiative's call order: sorted playerIDs ascending, then sorted
+	// engaged-monster IDs ascending. "char-a-trigger" < "char-b-other"
+	// alphabetically, so the sequence below is [trigger, other, monster].
+	enc := encounter.New(s.ctx, "enc-trigger-order-2", s.broker,
+		encounter.WithRoller(&sequenceRoller{rolls: []int{5, 18, 10}}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "trigger", EntityID: "char-a-trigger",
+		Position: core.Hex{Q: -10, R: 10, S: 0}, SightRange: 5,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "other", EntityID: "char-b-other",
+		// Nowhere near the monster -- must not itself have LoS, or AddMonster
+		// below would trigger combat entry before the Move under test does.
+		Position: core.Hex{Q: 10, R: -10, S: 0}, SightRange: 5,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: "goblin-m", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: nobody has LoS to the goblin yet")
+
+	s.Require().NoError(enc.Move("trigger", []core.Hex{
+		{Q: -5, R: 5, S: 0}, {Q: 0, R: 0, S: 0},
+	}))
+
+	s.Require().Equal(core.ModeTurnBased, enc.Mode())
+	s.Equal([]core.EntityID{"char-a-trigger", "char-b-other", "goblin-m"}, enc.ToData().Initiative,
+		"trigger first despite its own low roll (5); the other two still sort by "+
+			"their own rolls descending (18 before 10), untouched by the fix")
+}
+
+// TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll covers the issue's
+// second vector. OpenDoor alone must NOT start combat (asserted below) --
+// the player must still walk through the doorway, and THAT Move is the
+// trigger, exactly like the movement-into-detection vector. The monster id
+// ("aaa-ambush") again sorts before the player's id, so the old ascending-id
+// tiebreak would have put it first.
+func (s *CombatTriggerOrderSuite) TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll() {
+	enc := encounter.New(s.ctx, "enc-trigger-order-door", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+	)
+	s.Require().NoError(enc.InitRoom(20, 20, environments.PatternEmpty))
+	s.Require().NoError(enc.AddDoor("door-1", lineHex(3), false))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: triggerHeroPlayerID, EntityID: triggerHeroEntityID,
+		Position: lineHex(0), SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: "aaa-ambush", Position: lineHex(6), HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: monster behind the closed door")
+
+	s.Require().NoError(enc.OpenDoor(triggerHeroPlayerID, "door-1"))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
+		"opening the door alone must not start combat -- encounter.OpenDoor never calls "+
+			"checkCombatEntry; only the player's subsequent move through the doorway does")
+
+	s.Require().NoError(enc.Move(triggerHeroPlayerID,
+		[]core.Hex{lineHex(1), lineHex(2), lineHex(3), lineHex(4), lineHex(5)}))
+
+	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting the monster through the open door must start combat")
+	s.Equal([]core.EntityID{triggerHeroEntityID, "aaa-ambush"}, enc.ToData().Initiative,
+		"the player who walked through the door triggered combat and must go first, "+
+			"even though the monster's id wins the old ascending-id tiebreak (rpg-toolkit#865)")
+}
+
+// hydratedFighterJSON builds a level-1 Human Fighter (30ft speed) character
+// blob for the budget-preservation tests below -- mirrors move_economy_test.go's
+// charliCharJSON / pocket_clear_move_teardown_test.go's erinCharJSON.
+func hydratedFighterJSON(t *testing.T, entityID core.EntityID, playerID core.PlayerID) json.RawMessage {
+	t.Helper()
+	charData := &dnd5eCharacter.Data{
+		ID: string(entityID), PlayerID: string(playerID),
+		Name: "Budget Test Fighter", Level: 1,
+		ClassID: classes.Fighter, RaceID: races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints: 12, MaxHitPoints: 12, ArmorClass: 16, ProficiencyBonus: 2,
+	}
+	raw, err := json.Marshal(charData)
+	if err != nil {
+		t.Fatalf("marshal fighter char data: %v", err)
+	}
+	return raw
+}
+
+const (
+	budgetPlayerID = core.PlayerID("budget-hero")
+	budgetEntityID = core.EntityID("char-budget-hero")
+	budgetMonster  = core.EntityID("goblin-budget")
+)
+
+// loadHydratedTriggerFixture builds a FREE_ROAM encounter with one hydrated
+// (LoadFromData-round-tripped, so heldCharacter/ActorTurnState see a real
+// *character.Character) Human Fighter far from a monster, so the caller can
+// Move the fighter into the monster's LoS and inspect the seeded economy.
+func (s *CombatTriggerOrderSuite) loadHydratedTriggerFixture() *encounter.Encounter {
+	s.T().Helper()
+	enc := encounter.New(s.ctx, "enc-trigger-budget", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: budgetPlayerID, EntityID: budgetEntityID,
+		// 10 hexes from the goblin at origin, SightRange 8: nothing shorter
+		// than a 2-hex approach brings it into view, giving both budget tests
+		// below room for a clean, exact hex count.
+		Position: core.Hex{Q: -10, R: 10, S: 0}, SightRange: 8,
+		HP: 12, MaxHP: 12, AC: 16, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+		DataJSON: hydratedFighterJSON(s.T(), budgetEntityID, budgetPlayerID),
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: budgetMonster, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: monster out of LoS")
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+	)
+	s.Require().NoError(err)
+	return loaded
+}
+
+// TestMove_PreCombatMovementBudget_PartiallyPreserved: the fighter (30ft
+// speed) walks 20ft (4 hexes) in free-roam to spot the goblin. Free-roam
+// movement is unmetered (tracksMovement is only true once already
+// InCombat()), so nothing gated that 20ft -- but the transition it triggers
+// must still account for it: the forced-first turn's seeded budget must be
+// 30-20=10ft, not a fresh 30ft on top of the 20ft already covered.
+func (s *CombatTriggerOrderSuite) TestMove_PreCombatMovementBudget_PartiallyPreserved() {
+	enc := s.loadHydratedTriggerFixture()
+
+	// 4 contiguous single-hex steps from (-10,10,0) toward the origin = 4
+	// hexes = 20ft, ending at (-6,6,0) -- hex-distance 6 from the goblin at
+	// the origin, inside the fixture's SightRange 8.
+	s.Require().NoError(enc.Move(budgetPlayerID, []core.Hex{
+		{Q: -9, R: 9, S: 0}, {Q: -8, R: 8, S: 0}, {Q: -7, R: 7, S: 0}, {Q: -6, R: 6, S: 0},
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode())
+	s.Require().Equal(budgetEntityID, enc.ActiveActor(), "the mover triggered combat and must go first")
+
+	state := enc.ActorTurnState(budgetEntityID)
+	s.Require().NotNil(state.Economy)
+	s.Equal(10, state.Economy.MovementRemaining,
+		"forced-first turn must seed 30ft speed minus the 20ft already spent reaching the goblin")
+}
+
+// TestMove_PreCombatMovementBudget_ClampedAtZero_NotNegative: the fighter
+// walks 40ft (8 hexes) -- MORE than its 30ft speed -- to spot the goblin
+// (legal because free-roam movement is unmetered). The forced-first turn's
+// seeded budget must floor at zero, never go negative.
+func (s *CombatTriggerOrderSuite) TestMove_PreCombatMovementBudget_ClampedAtZero_NotNegative() {
+	enc := s.loadHydratedTriggerFixture()
+
+	// 8 contiguous single-hex steps from (-10,10,0) toward the origin = 8
+	// hexes = 40ft, ending at (-2,2,0) -- hex-distance 2 from the goblin at
+	// the origin, comfortably inside the fixture's SightRange 8.
+	s.Require().NoError(enc.Move(budgetPlayerID, []core.Hex{
+		{Q: -9, R: 9, S: 0}, {Q: -8, R: 8, S: 0}, {Q: -7, R: 7, S: 0}, {Q: -6, R: 6, S: 0},
+		{Q: -5, R: 5, S: 0}, {Q: -4, R: 4, S: 0}, {Q: -3, R: 3, S: 0}, {Q: -2, R: 2, S: 0},
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode())
+	s.Require().Equal(budgetEntityID, enc.ActiveActor(), "the mover triggered combat and must go first")
+
+	state := enc.ActorTurnState(budgetEntityID)
+	s.Require().NotNil(state.Economy)
+	s.Equal(0, state.Economy.MovementRemaining,
+		"an over-speed free-roam approach must clamp the forced-first turn's budget at zero, not go negative")
+}

--- a/encounter/combat_trigger_order_test.go
+++ b/encounter/combat_trigger_order_test.go
@@ -485,3 +485,81 @@ func (s *CombatTriggerOrderSuite) TestSeedActiveActorIfUnseeded_HonorsPendingTri
 	s.Equal(10, state.Economy.MovementRemaining,
 		"the LoadFromData catch-up must honor the trigger's pre-spent 20ft, not reseed a full 30ft")
 }
+
+// --- PR #867 gate re-check: PendingTriggerSeed staleness ---
+
+// TestSeedActiveActorIfUnseeded_DoesNotApplyStalePendingFromEarlierTransition
+// covers the gate's re-check finding: Data.PendingTriggerSeed was written
+// only when preSpent > 0 (setMode, combat.go), and NOTHING cleared it --
+// not the ModeFreeRoam branch, not a later TurnBased transition that has
+// nothing pending for the same actor. Reproduced sequence: scout
+// (unhydrated) walks 20ft into the goblin's LoS, triggering combat and
+// stashing {scout, 20ft} (transition 1 -- scout has no held character yet).
+// The encounter exits back to FREE_ROAM (scout's position, and so its LoS,
+// is untouched). A wanderer who never gains LoS to anything then takes an
+// unrelated step; finding 1's fallback correctly attributes scout as the
+// trigger again (transition 2) -- but this time with a genuine pre-spent of
+// 0, since scout itself didn't move on this call. The stale {scout, 20ft}
+// stash from transition 1 must not survive to be misapplied to transition
+// 2's forced-first turn: scout must seed a full 30ft, not 30-20=10.
+func (s *CombatTriggerOrderSuite) TestSeedActiveActorIfUnseeded_DoesNotApplyStalePendingFromEarlierTransition() {
+	enc := encounter.New(s.ctx, "enc-attrib-3", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: budgetPlayerID, EntityID: budgetEntityID,
+		Position: core.Hex{Q: -10, R: 10, S: 0}, SightRange: 8,
+		HP: 12, MaxHP: 12, AC: 16, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+		DataJSON: hydratedFighterJSON(s.T(), budgetEntityID, budgetPlayerID),
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: budgetMonster, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode())
+
+	// Transition 1: scout (still unhydrated) walks 20ft into the goblin's
+	// LoS. Stashes {budgetEntityID, 20ft} since heldCharacter is nil.
+	s.Require().NoError(enc.Move(budgetPlayerID, []core.Hex{
+		{Q: -9, R: 9, S: 0}, {Q: -8, R: 8, S: 0}, {Q: -7, R: 7, S: 0}, {Q: -6, R: 6, S: 0},
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode())
+	s.Require().Equal(budgetEntityID, enc.ActiveActor())
+
+	// Exit back to FREE_ROAM (simulating a cleared pocket) -- scout's
+	// position, and therefore its LoS to the goblin, is untouched.
+	s.Require().NoError(enc.SetMode(core.ModeFreeRoam))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode())
+
+	// A wanderer with zero LoS to anything takes an unrelated step. Scout
+	// still has LoS to the goblin (never moved away), so this re-fires
+	// checkCombatEntry and (correctly, per finding 1) attributes SCOUT as
+	// the trigger again -- transition 2 -- but with a genuine pre-spent of
+	// 0, since scout didn't move on this call.
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: attribWandererPlayerID, EntityID: attribWandererEntityID,
+		Position: core.Hex{Q: -20, R: 20, S: 0}, SightRange: 5,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+		DataJSON: hydratedFighterJSON(s.T(), attribWandererEntityID, attribWandererPlayerID),
+	}))
+	s.Require().NoError(enc.Move(attribWandererPlayerID, []core.Hex{
+		{Q: -19, R: 19, S: 0},
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode())
+	s.Require().Equal(budgetEntityID, enc.ActiveActor(),
+		"scout, still the only entity with LoS to the goblin, must be the trigger again")
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(err)
+
+	state := loaded.ActorTurnState(budgetEntityID)
+	s.Require().NotNil(state.Economy)
+	s.Equal(30, state.Economy.MovementRemaining,
+		"transition 2's genuine pre-spent is 0 (scout didn't move this call) -- the LoadFromData "+
+			"catch-up must not misapply the stale 20ft stash left over from transition 1")
+}

--- a/encounter/combat_trigger_order_test.go
+++ b/encounter/combat_trigger_order_test.go
@@ -331,3 +331,157 @@ func (s *CombatTriggerOrderSuite) TestMove_PreCombatMovementBudget_ClampedAtZero
 	s.Equal(0, state.Economy.MovementRemaining,
 		"an over-speed free-roam approach must clamp the forced-first turn's budget at zero, not go negative")
 }
+
+// --- PR #867 review follow-up: trigger MISATTRIBUTION (gate finding 1) ---
+//
+// checkCombatEntry evaluates a GLOBAL predicate (any player x monster LoS
+// pair), but the caller only ever supplies ITS OWN candidate entity (Move's
+// mover). Before this fix, checkCombatEntry blindly forwarded that candidate
+// as the trigger the moment ANY pair matched -- even when the matching pair
+// had nothing to do with the caller. AddPlayer never itself calls
+// checkCombatEntry (only AddMonster/Move do), so a player seat added already
+// within an existing monster's LoS leaves the encounter sitting in FREE_ROAM,
+// unclaimed, until some OTHER player's action happens to re-evaluate the
+// check -- and that unrelated player would wrongly seize initiative slot 0
+// (and have its own unrelated movement wrongly docked) instead of the
+// player whose LoS actually fired the transition.
+
+const (
+	attribScoutPlayerID    = core.PlayerID("scout")
+	attribScoutEntityID    = core.EntityID("char-scout")
+	attribWandererPlayerID = core.PlayerID("wanderer")
+	attribWandererEntityID = core.EntityID("char-wanderer")
+	attribMonsterID        = core.EntityID("goblin-attrib")
+)
+
+// TestCheckCombatEntry_TriggerAttributedToActualLoSMatch_NotUnrelatedMover
+// reproduces the review's exact shape: the goblin is added first (zero
+// players -- no combat-entry check possible), then scout is added ALREADY
+// within its LoS (AddPlayer never checks combat entry, so mode stays
+// FREE_ROAM even though the pair is already formed), then wanderer -- who
+// can never see the goblin -- is added far away. wanderer's own unrelated
+// move (40ft, over its own 30ft speed) is what re-fires checkCombatEntry.
+// scout, not wanderer, must be forced into slot 0 with a genuinely full
+// budget; wanderer's own budget must not be docked for a walk that never
+// triggered anything on its behalf.
+func (s *CombatTriggerOrderSuite) TestCheckCombatEntry_TriggerAttributedToActualLoSMatch_NotUnrelatedMover() {
+	enc := encounter.New(s.ctx, "enc-attrib-1", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+	)
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: attribMonsterID, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: attribScoutPlayerID, EntityID: attribScoutEntityID,
+		// Already within the goblin's LoS the moment this seat is added.
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 5,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+		DataJSON: hydratedFighterJSON(s.T(), attribScoutEntityID, attribScoutPlayerID),
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
+		"test premise: AddPlayer never re-checks combat entry, so an already-visible "+
+			"scout leaves the encounter in FREE_ROAM until something else re-evaluates it")
+
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: attribWandererPlayerID, EntityID: attribWandererEntityID,
+		// Far from the goblin -- never has LoS to it, in this move or any other.
+		Position: core.Hex{Q: -20, R: 20, S: 0}, SightRange: 5,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+		DataJSON: hydratedFighterJSON(s.T(), attribWandererEntityID, attribWandererPlayerID),
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: still nobody has re-checked")
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(err)
+
+	// wanderer's own unrelated move (8 contiguous hexes = 40ft, over its own
+	// 30ft speed) is what re-fires checkCombatEntry; wanderer itself never
+	// gains LoS to the goblin.
+	s.Require().NoError(loaded.Move(attribWandererPlayerID, []core.Hex{
+		{Q: -19, R: 19, S: 0}, {Q: -18, R: 18, S: 0}, {Q: -17, R: 17, S: 0}, {Q: -16, R: 16, S: 0},
+		{Q: -15, R: 15, S: 0}, {Q: -14, R: 14, S: 0}, {Q: -13, R: 13, S: 0}, {Q: -12, R: 12, S: 0},
+	}))
+	s.Require().Equal(core.ModeTurnBased, loaded.Mode(),
+		"wanderer's move re-evaluates the stale LoS pair and starts combat")
+
+	s.Require().Equal(attribScoutEntityID, loaded.ActiveActor(),
+		"scout, whose own LoS actually makes checkCombatEntry fire, must be the forced trigger -- "+
+			"not wanderer, who merely happened to be the caller")
+
+	scoutState := loaded.ActorTurnState(attribScoutEntityID)
+	s.Require().NotNil(scoutState.Economy)
+	s.Equal(30, scoutState.Economy.MovementRemaining,
+		"scout never moved this call -- its forced-first turn must seed a genuinely full budget, "+
+			"not a deduction that belongs to wanderer's own unrelated walk")
+
+	// Cycle forward to wanderer's own turn and confirm its budget was never
+	// docked for a walk that didn't actually trigger anything on its behalf.
+	_, _, err = loaded.EndTurn(s.ctx, attribScoutEntityID)
+	s.Require().NoError(err)
+	for i := 0; loaded.ActiveActor() != attribWandererEntityID && i < 8; i++ {
+		_, _, err = loaded.EndTurn(s.ctx, loaded.ActiveActor())
+		s.Require().NoError(err)
+	}
+	s.Require().Equal(attribWandererEntityID, loaded.ActiveActor(), "setup must reach wanderer's turn")
+	wandererState := loaded.ActorTurnState(attribWandererEntityID)
+	s.Require().NotNil(wandererState.Economy)
+	s.Equal(30, wandererState.Economy.MovementRemaining,
+		"wanderer's own unrelated 40ft walk must not be docked from its budget -- it was never the trigger")
+}
+
+// --- PR #867 review follow-up: pending pre-spent survives an unhydrated
+// transition (gate finding 2) ---
+
+// TestSeedActiveActorIfUnseeded_HonorsPendingTriggerPreSpent covers
+// rpg-toolkit#757's LoadFromData catch-up path (seedActiveActorIfUnseeded):
+// a Move-triggered transition can fire on an encounter where the trigger has
+// no held character yet (production's New()+AddPlayer+AddMonster flow --
+// nothing is hydrated until a LoadFromData round-trip). seedActorTurn's
+// immediate call inside setMode no-ops in that case (no character to seed),
+// so the pre-spent deduction must be PERSISTED on e.data (not just a Go-only
+// local) for the later LoadFromData catch-up to still apply it -- otherwise
+// the catch-up hands the trigger a full, un-deducted budget.
+func (s *CombatTriggerOrderSuite) TestSeedActiveActorIfUnseeded_HonorsPendingTriggerPreSpent() {
+	enc := encounter.New(s.ctx, "enc-attrib-2", s.broker,
+		encounter.WithRoller(fixedMaxRoller{}),
+	)
+	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: budgetPlayerID, EntityID: budgetEntityID,
+		Position: core.Hex{Q: -10, R: 10, S: 0}, SightRange: 8,
+		HP: 12, MaxHP: 12, AC: 16, AttackBonus: 4,
+		DamageDice: dice1d6, DamageType: damageSlashing,
+		DataJSON: hydratedFighterJSON(s.T(), budgetEntityID, budgetPlayerID),
+	}))
+	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
+		ID: budgetMonster, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode())
+
+	// enc is New()-only -- NOT yet hydrated (only LoadFromData hydrates), so
+	// this Move-triggered transition fires with no held character for the
+	// trigger: seedActorTurn's immediate call no-ops, and the 20ft pre-spent
+	// deduction can only be honored later, by the LoadFromData catch-up.
+	s.Require().NoError(enc.Move(budgetPlayerID, []core.Hex{
+		{Q: -9, R: 9, S: 0}, {Q: -8, R: 8, S: 0}, {Q: -7, R: 7, S: 0}, {Q: -6, R: 6, S: 0},
+	}))
+	s.Require().Equal(core.ModeTurnBased, enc.Mode())
+	s.Require().Equal(budgetEntityID, enc.ActiveActor())
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+	var data encounter.Data
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(s.ctx, &data, s.broker, encounter.WithRoller(fixedMaxRoller{}))
+	s.Require().NoError(err)
+
+	state := loaded.ActorTurnState(budgetEntityID)
+	s.Require().NotNil(state.Economy)
+	s.Equal(10, state.Economy.MovementRemaining,
+		"the LoadFromData catch-up must honor the trigger's pre-spent 20ft, not reseed a full 30ft")
+}

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -69,6 +69,34 @@ type Data struct {
 	// wave 2+ wall destruction / door state would otherwise be unable to
 	// replay from a pattern.
 	Space *SpaceData `json:"space,omitempty"`
+
+	// PendingTriggerSeed carries a forced-first-turn movement deduction
+	// (rpg-toolkit#865 / PR #867 gate finding 2) for the entity in
+	// initiative slot 0 when the FreeRoam->TurnBased transition fired
+	// before that entity had a held character — production's
+	// New()+AddPlayer+AddMonster flow hydrates nothing until a LoadFromData
+	// round-trip, so setMode's own seedActorTurn call can't apply the
+	// deduction yet (heldCharacter returns nil) and would otherwise lose it
+	// as a Go-only local. Persisted here instead, and consumed (then
+	// cleared) by seedActiveActorIfUnseeded's LoadFromData catch-up the
+	// first time it successfully seeds that same actor's economy — see its
+	// doc comment. Nil whenever there's nothing pending: the common case is
+	// the trigger already had a held character, so setMode's own seed call
+	// applied the deduction immediately and never persisted it here at all.
+	PendingTriggerSeed *PendingTriggerSeedData `json:"pending_trigger_seed,omitempty"`
+}
+
+// PendingTriggerSeedData is PendingTriggerSeed's persisted shape: which
+// actor the deduction belongs to (so a later catch-up can refuse to apply a
+// stale entry to a different actor) and how many feet to dock off that
+// actor's first seeded movement budget.
+type PendingTriggerSeedData struct {
+	// ActorID is the entity the deduction belongs to — must match the actor
+	// being seeded, or the deduction is stale and must not be applied.
+	ActorID core.EntityID `json:"actor_id"`
+	// PreSpentMovementFeet is how many feet ActorID already traveled,
+	// unmetered, before the transition that forced it into slot 0.
+	PreSpentMovementFeet int `json:"pre_spent_movement_feet"`
 }
 
 // SpaceData is the persisted snapshot of an encounter's room: the wall

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -452,8 +452,10 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 	}
 	// Combat-entry check (rpg-toolkit#757): a newly-added monster may already
 	// be visible to an existing player (e.g. spawned inside an already-open
-	// LoS), so this mutation site needs the same check as Move.
-	return e.checkCombatEntry()
+	// LoS), so this mutation site needs the same check as Move. No trigger
+	// entity (rpg-toolkit#865): a monster appearing has no acting player to
+	// privilege into initiative slot 0, so this stays plain roll order.
+	return e.checkCombatEntry("", 0)
 }
 
 // addMonsterNoCombatCheck does everything AddMonster does except the
@@ -910,7 +912,16 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	// so this is a mutation site where a player-monster visibility pair can
 	// newly form. Runs after the MoveEvent/reveal/economy publishes above so
 	// a client sees "you moved" before "combat starts" (cause before effect).
-	if err := e.checkCombatEntry(); err != nil {
+	//
+	// rpg-toolkit#865: this move is the trigger candidate. If it flips
+	// FreeRoam->TurnBased, the mover — not whoever wins the initiative roll
+	// — goes first, and the distance it just traveled (unmetered: tracksMovement
+	// above was false, since the mover wasn't in combat yet) comes off its
+	// freshly-seeded first turn's movement budget rather than being forgotten.
+	// Recomputing pathCostFeet here (rather than threading a value from the
+	// tracksMovement branch above, which doesn't run pre-combat) is cheap and
+	// keeps this call self-contained.
+	if err := e.checkCombatEntry(p.EntityID, pathCostFeet(moverStart, traveledPath)); err != nil {
 		return err
 	}
 

--- a/encounter/pocket_clear_move_teardown_test.go
+++ b/encounter/pocket_clear_move_teardown_test.go
@@ -218,13 +218,24 @@ func (s *PocketClearMoveTeardownSuite) TestWithinPocket_MovementStillEnforced_Wh
 //
 // Pre-rpg-toolkit#865 this test asserted a full 30ft on the very turn the
 // pocket re-entry seeded — that was itself an instance of #865's bug: erin
-// walks 70ft (14 hexes) to reach group B, more than her 30ft speed, and the
-// old seedActorTurn granted a FRESH 30ft on top of that unmetered approach
-// regardless. #865 forces the mover who triggered the transition into
-// initiative slot 0 (fixedMaxRoller would have put her there anyway via the
-// ascending-id tiebreak — "char-erin" < "goblin-pcm-b" — but the forcing is
-// what's actually under test now) and makes her forced-first turn reflect
-// the 70ft she already spent, clamped at zero. The SECOND assertion below —
+// walked 70ft (more than her 30ft speed) to reach group B in one Move call,
+// and the old seedActorTurn granted a FRESH 30ft on top of that unmetered
+// approach regardless. #865 forces the mover who triggered the transition
+// into initiative slot 0 and makes her forced-first turn reflect however far
+// she'd already traveled THIS call.
+//
+// PR #867 gate finding 4: an earlier version of this test moved erin the
+// full 70ft in one call, so the forced-first assertion read 0 remaining —
+// indistinguishable from an accidentally-unseeded economy (which also reads
+// as a zero value) rather than a genuinely computed deduction. Split into
+// two Move calls instead: the first (k=0->k=4, 20ft) stays out of group B's
+// LoS and must NOT trigger anything; the second (k=4->k=8, 20ft) is the one
+// that actually crosses into LoS and triggers the transition, so ONLY its
+// own 20ft counts as pre-spent (pathCostFeet is per-call, not cumulative
+// across the whole free-roam approach — see Move's own doc comment). That
+// yields a genuine, diagnostic 30-20=10ft partial on the forced-first turn —
+// a value that could only come from the real deduction, not from any
+// degenerate all-zero or full-reseed code path. The SECOND assertion below —
 // a full 30ft on the turn AFTER that one — is what's left of this test's
 // original point: only the trigger's own forced-first turn carries the
 // pre-spent deduction; every ordinary turn boundary still seeds full speed.
@@ -239,28 +250,33 @@ func (s *PocketClearMoveTeardownSuite) TestPocketClear_ThenReEntry_ReseedsFullMo
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: pocket A cleared")
 
 	s.Require().NoError(enc.OpenDoor(pcmPlayerID, pcmDoorID))
-	// Move adjacent to group B (k=14, one hex from B at k=15) — gains LoS
-	// through the now-open door and re-triggers checkCombatEntry, exactly
-	// like combat_pockets_test.go's TestOpenDoorAndSightB_StartsFreshPocket.
-	// 14 hexes * 5ft = 70ft, deliberately more than erin's 30ft speed.
-	path := make([]core.Hex, 0, 14)
-	for k := 1; k <= 14; k++ {
-		path = append(path, lineHex(k))
-	}
-	s.Require().NoError(enc.Move(pcmPlayerID, path))
+
+	// First move: k=0 -> k=4 (4 hexes, 20ft). Distance to group B at k=15 is
+	// 11 hexes, still outside erin's SightRange 10 -- must NOT trigger.
+	s.Require().NoError(enc.Move(pcmPlayerID, []core.Hex{
+		lineHex(1), lineHex(2), lineHex(3), lineHex(4),
+	}))
+	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
+		"test premise: k=4 is still 11 hexes from group B, outside SightRange 10")
+
+	// Second move: k=4 -> k=8 (4 hexes, 20ft). Distance to group B is now 7
+	// hexes, inside SightRange 10 through the now-open door -- THIS call is
+	// the trigger, and only ITS OWN 20ft counts as pre-spent.
+	s.Require().NoError(enc.Move(pcmPlayerID, []core.Hex{
+		lineHex(5), lineHex(6), lineHex(7), lineHex(8),
+	}))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting group B must start a fresh pocket")
 
 	// rpg-toolkit#865: erin's own move just triggered this fresh pocket, so
 	// she is forced into initiative slot 0 and her forced-first turn's
-	// budget must reflect the 70ft she already spent getting here, clamped
-	// at zero rather than granting a fresh 30ft on top of it.
+	// budget must reflect the 20ft she spent on the TRIGGERING call only.
 	s.Require().Equal(pcmEntityID, enc.ActiveActor(),
 		"erin triggered this pocket and must go first (rpg-toolkit#865)")
 	triggered := enc.ActorTurnState(pcmEntityID)
 	s.Require().NotNil(triggered.Economy)
-	s.Equal(0, triggered.Economy.MovementRemaining,
-		"erin's forced-first turn must reflect the 70ft already spent reaching group B, "+
-			"clamped at zero rather than a fresh 30ft on top of it (rpg-toolkit#865)")
+	s.Equal(10, triggered.Economy.MovementRemaining,
+		"erin's forced-first turn must reflect the 20ft spent on the triggering move "+
+			"(30-20=10), not a fresh 30ft and not an accidentally-unseeded 0 (rpg-toolkit#865)")
 
 	// End erin's forced-first turn and lap all the way back around to her
 	// NEXT turn (through goblin-pcm-b) — an ordinary turn boundary, not the

--- a/encounter/pocket_clear_move_teardown_test.go
+++ b/encounter/pocket_clear_move_teardown_test.go
@@ -210,10 +210,24 @@ func (s *PocketClearMoveTeardownSuite) TestWithinPocket_MovementStillEnforced_Wh
 	s.ErrorIs(err, encounter.ErrInsufficientMovement)
 }
 
-// TestPocketClear_ThenReEntry_ReseedsFullMovementBudget proves re-engaging
-// a fresh pocket restores a full movement budget for the actor's turn —
-// SetMode(TurnBased)'s existing seedActorTurn->StartTurn call, unaffected
-// by this fix's teardown.
+// TestPocketClear_ThenReEntry_ReseedsFullMovementBudget proves re-engaging a
+// fresh pocket seeds the trigger's forced-first turn correctly and, on the
+// FOLLOWING turn boundary, still re-seeds a genuinely full movement budget —
+// SetMode(TurnBased)'s seedActorTurn->StartTurn call, unaffected by pocket
+// #808's teardown fix.
+//
+// Pre-rpg-toolkit#865 this test asserted a full 30ft on the very turn the
+// pocket re-entry seeded — that was itself an instance of #865's bug: erin
+// walks 70ft (14 hexes) to reach group B, more than her 30ft speed, and the
+// old seedActorTurn granted a FRESH 30ft on top of that unmetered approach
+// regardless. #865 forces the mover who triggered the transition into
+// initiative slot 0 (fixedMaxRoller would have put her there anyway via the
+// ascending-id tiebreak — "char-erin" < "goblin-pcm-b" — but the forcing is
+// what's actually under test now) and makes her forced-first turn reflect
+// the 70ft she already spent, clamped at zero. The SECOND assertion below —
+// a full 30ft on the turn AFTER that one — is what's left of this test's
+// original point: only the trigger's own forced-first turn carries the
+// pre-spent deduction; every ordinary turn boundary still seeds full speed.
 func (s *PocketClearMoveTeardownSuite) TestPocketClear_ThenReEntry_ReseedsFullMovementBudget() {
 	enc := s.loadErinVsTwoPockets()
 	s.endTurnUntilErin(enc)
@@ -228,6 +242,7 @@ func (s *PocketClearMoveTeardownSuite) TestPocketClear_ThenReEntry_ReseedsFullMo
 	// Move adjacent to group B (k=14, one hex from B at k=15) — gains LoS
 	// through the now-open door and re-triggers checkCombatEntry, exactly
 	// like combat_pockets_test.go's TestOpenDoorAndSightB_StartsFreshPocket.
+	// 14 hexes * 5ft = 70ft, deliberately more than erin's 30ft speed.
 	path := make([]core.Hex, 0, 14)
 	for k := 1; k <= 14; k++ {
 		path = append(path, lineHex(k))
@@ -235,11 +250,28 @@ func (s *PocketClearMoveTeardownSuite) TestPocketClear_ThenReEntry_ReseedsFullMo
 	s.Require().NoError(enc.Move(pcmPlayerID, path))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting group B must start a fresh pocket")
 
+	// rpg-toolkit#865: erin's own move just triggered this fresh pocket, so
+	// she is forced into initiative slot 0 and her forced-first turn's
+	// budget must reflect the 70ft she already spent getting here, clamped
+	// at zero rather than granting a fresh 30ft on top of it.
+	s.Require().Equal(pcmEntityID, enc.ActiveActor(),
+		"erin triggered this pocket and must go first (rpg-toolkit#865)")
+	triggered := enc.ActorTurnState(pcmEntityID)
+	s.Require().NotNil(triggered.Economy)
+	s.Equal(0, triggered.Economy.MovementRemaining,
+		"erin's forced-first turn must reflect the 70ft already spent reaching group B, "+
+			"clamped at zero rather than a fresh 30ft on top of it (rpg-toolkit#865)")
+
+	// End erin's forced-first turn and lap all the way back around to her
+	// NEXT turn (through goblin-pcm-b) — an ordinary turn boundary, not the
+	// one-time trigger seed, so it must re-seed a genuinely full budget.
+	_, _, err := enc.EndTurn(s.ctx, pcmEntityID)
+	s.Require().NoError(err)
 	s.endTurnUntilErin(enc)
 	post := enc.ActorTurnState(pcmEntityID)
 	s.Require().NotNil(post.Economy)
 	s.Equal(30, post.Economy.MovementRemaining,
-		"re-entering a fresh pocket must re-seed a full movement budget")
+		"the next ordinary turn boundary must re-seed a full movement budget")
 }
 
 // TestPocketClear_CombatScopedConditionPersists_NoEndCombatSweep proves the

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -194,7 +194,9 @@ func (e *Encounter) SeedMonsters(spawns []SpawnInstruction) error {
 			return fmt.Errorf("room %q: monster %q: %w", r.roomID, r.input.MonsterRef, err)
 		}
 	}
-	return e.checkCombatEntry()
+	// No trigger entity (rpg-toolkit#865): a batch spawn has no acting player
+	// to privilege into initiative slot 0, so this stays plain roll order.
+	return e.checkCombatEntry("", 0)
 }
 
 // validateSpawnBatch checks every instruction in spawns and resolves it

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -53,7 +53,18 @@ import (
 // actor) and EndTurn (the next actor). Errors are returned so the caller fails
 // the turn-boundary rather than advancing with an unseeded economy or a
 // silently-dropped turn-start signal.
-func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) error {
+//
+// preSpentMovementFeet (rpg-toolkit#865) is subtracted from the seeded
+// Speed before StartTurn runs — the combat-entry trigger's own free-roam
+// move that caused this very transition is otherwise invisible to the
+// fresh economy StartTurn seeds, which would let a player who walked (say)
+// 70ft to spot a monster ALSO get a full fresh 30ft of movement on the very
+// turn they were forced into by that walk. Every other caller (EndTurn,
+// seedActiveActorIfUnseeded) passes 0 — a normal turn boundary has nothing
+// to preserve. Clamped at zero rather than passed through negative: a
+// player who over-walked their speed getting into LoS starts their forced
+// first turn with no movement left, not a negative budget.
+func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID, preSpentMovementFeet int) error {
 	// NOT best-effort: the same failure semantics as EndTurn's TurnEndTopic
 	// publish. If this fails, Dodging/RecklessAttack never self-remove and
 	// Unconscious never auto-rolls death saves for this turn — a real error,
@@ -114,8 +125,12 @@ func (e *Encounter) seedActorTurn(ctx context.Context, actorID core.EntityID) er
 		return nil
 	}
 
+	seedSpeed := char.GetSpeed() - preSpentMovementFeet
+	if seedSpeed < 0 {
+		seedSpeed = 0
+	}
 	if _, err := char.StartTurn(ctx, &character.StartTurnInput{
-		Speed:      char.GetSpeed(),
+		Speed:      seedSpeed,
 		TurnNumber: e.data.Round,
 	}); err != nil {
 		return fmt.Errorf("seed turn economy for %q: %w", actorID, err)
@@ -166,7 +181,7 @@ func (e *Encounter) seedActiveActorIfUnseeded(ctx context.Context) error {
 	if char == nil || char.InCombat() {
 		return nil // NPC / stat-snapshot seat, or already seeded — nothing missed.
 	}
-	if err := e.seedActorTurn(ctx, actorID); err != nil {
+	if err := e.seedActorTurn(ctx, actorID, 0); err != nil {
 		return err
 	}
 	// #772/#782: see EndTurn's identical guard (combat.go) — seedActorTurn's

--- a/encounter/turn_economy.go
+++ b/encounter/turn_economy.go
@@ -181,7 +181,20 @@ func (e *Encounter) seedActiveActorIfUnseeded(ctx context.Context) error {
 	if char == nil || char.InCombat() {
 		return nil // NPC / stat-snapshot seat, or already seeded — nothing missed.
 	}
-	if err := e.seedActorTurn(ctx, actorID, 0); err != nil {
+
+	// PR #867 gate finding 2: a Move-triggered transition can have persisted
+	// a forced-first-turn movement deduction (setMode, combat.go) for THIS
+	// actor when it fired before any character was hydrated — honor it here
+	// instead of hardcoding a full reseed, and clear it once consumed so a
+	// later, unrelated catch-up never re-applies it. Only consumed when it
+	// actually names the actor being seeded right now — a pending entry for
+	// a different (or no-longer-active) actor is stale and left alone.
+	preSpent := 0
+	if pending := e.data.PendingTriggerSeed; pending != nil && pending.ActorID == actorID {
+		preSpent = pending.PreSpentMovementFeet
+		e.data.PendingTriggerSeed = nil
+	}
+	if err := e.seedActorTurn(ctx, actorID, preSpent); err != nil {
 		return err
 	}
 	// #772/#782: see EndTurn's identical guard (combat.go) — seedActorTurn's


### PR DESCRIPTION
## Root cause

`rollInitiative` (`encounter/combat.go`) had no concept of *who* caused a FreeRoam→TurnBased transition. `Encounter.Move`'s `checkCombatEntry` call flipped the encounter to `TURN_BASED` purely on a d20 roll, with ties broken by ascending entity ID — so a monster could legitimately win initiative (or win the tiebreak, as in the QA repro: `"boss-boss" < "char_..."`) and take a full turn, including a complete multiattack, before the player whose own move exposed them to the monster's line of sight ever got to act.

## The fix

- `checkCombatEntry` (`combat.go`) now takes `(triggerID core.EntityID, triggerPreSpentFeet int)` and forwards them into a new private `setMode` (the public `SetMode(mode)` is now a thin wrapper with no trigger — administrative/host-driven flips like `devseed --inject-combat` have no acting entity to privilege and keep pure roll order).
- `rollInitiative(triggerID)`: the trigger still rolls a d20 (so roller consumption/order is unchanged for every other seed — simpler to test and reason about), but its roll is discarded for placement — it's pulled out of the sorted list and forced into slot 0.
- Call sites: `Encounter.Move` passes the mover's entity ID and the feet it just traveled. `AddMonster` / `SeedMonsters` pass no trigger — a monster becoming visible has no acting player to privilege, so those stay plain roll order (documented at each call site; not in scope for #865 per the QA evidence, which only covers player-triggered vectors).
- `seedActorTurn` (`turn_economy.go`) gained a `preSpentMovementFeet` param: the trigger's forced-first turn is seeded at `speed - preSpentMovementFeet`, clamped at zero, instead of a full fresh budget. Every other turn boundary (`EndTurn`, `seedActiveActorIfUnseeded`) passes `0` — unaffected.

## Door-interact vector (the issue's second vector)

Investigated whether it's a separate code path. It isn't: `encounter.OpenDoor` never calls `checkCombatEntry` (confirmed by reading it, and by reading rpg-api's `Interact` orchestrator, which just dispatches to `OpenDoor`/`AttemptUnlock` and does no initiative computation of its own — the ordering logic lives entirely in the toolkit). Opening a door only rebuilds LoS-blocking geometry; combat only actually starts on the player's *next* `Move` through the doorway, which funnels through the exact same `Move`-triggered `checkCombatEntry` path the movement-into-detection vector uses. So the QA session where the door vector "ordered correctly" was luck of the roll, not a separate correct-by-design path — `TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll` proves the fix covers it too, and also pins that `OpenDoor` alone must not flip the mode.

## Spec enforcement, point by point

- **Trigger always slot 0, roll irrelevant**: `TestMove_TriggerForcedFirst_RegardlessOfRoll` reproduces the exact QA shape (monster id `"boss-boss"` sorting before the player's `"char-hero"`, `fixedMaxRoller` tying every roll at 20 so the old ascending-id tiebreak would put the monster first).
- **Everyone else still ordered by roll**: `TestMove_OthersStillOrderedByRoll_TriggerRollDiscarded` gives the trigger the lowest roll (5) and proves the other two seeds still sort by their own rolls descending (18 before 10) — the fix doesn't touch non-trigger ordering.
- **Remaining budget preserved, not reset**: `TestMove_PreCombatMovementBudget_PartiallyPreserved` (20ft spent pre-combat → 10ft seeded, not 30) and `TestMove_PreCombatMovementBudget_ClampedAtZero_NotNegative` (40ft spent, more than speed → clamped at 0, not negative).
- **Door vector**: `TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll`, as above.

## Test evidence (TDD: written first, confirmed failing against pre-fix code, then passing)

Stashed the fix (keeping only the new test file) and ran it against pre-fix `origin/main`:

```
--- FAIL: TestCombatTriggerOrderSuite (0.01s)
    --- FAIL: TestMove_OthersStillOrderedByRoll_TriggerRollDiscarded
        expected: [char-a-trigger char-b-other goblin-m]
        actual  : [char-b-other goblin-m char-a-trigger]
    --- FAIL: TestMove_PreCombatMovementBudget_ClampedAtZero_NotNegative
        expected: 0
        actual  : 30
    --- FAIL: TestMove_PreCombatMovementBudget_PartiallyPreserved
        expected: 10
        actual  : 30
    --- FAIL: TestMove_TriggerForcedFirst_RegardlessOfRoll
        expected: [char-hero boss-boss]
        actual  : [boss-boss char-hero]
    --- FAIL: TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll
        expected: [char-hero aaa-ambush]
        actual  : [aaa-ambush char-hero]
```

Restored the fix — same suite now:

```
--- PASS: TestCombatTriggerOrderSuite (0.01s)
    --- PASS: TestMove_OthersStillOrderedByRoll_TriggerRollDiscarded
    --- PASS: TestMove_PreCombatMovementBudget_ClampedAtZero_NotNegative
    --- PASS: TestMove_PreCombatMovementBudget_PartiallyPreserved
    --- PASS: TestMove_TriggerForcedFirst_RegardlessOfRoll
    --- PASS: TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll
```

Full module: `go test ./...` — all green (`ok github.com/KirkDiggler/rpg-toolkit/encounter 60.9s`, plus `core`/`dungeonspec`/`events`/`perception` subpackages).

`golangci-lint run ./...` — 68 pre-existing `goconst` issues exist unmodified on `origin/main` (verified by stashing and re-running); this PR adds zero new issues (69 → 68 after extracting one constant this diff introduced).

## Ambiguous calls flagged for review

- **AddMonster/SeedMonsters-triggered combat entry stays plain roll order.** A monster becoming visible (reinforcement spawn, or initial placement already in a player's LoS) has no acting player to force into slot 0. The issue's spec text ("opened the door / walked into sight") and QA evidence only describe player-action vectors, both of which funnel through `Move`. I judged this out of scope for #865 rather than inventing a rule the spec doesn't cover — flagging in case the intended scope was broader.
- **Only movement is budget-adjusted, not actions/bonus/reaction.** Free-roam movement never spends the primary action economy (only `Move`), so there's nothing else to preserve on the trigger's forced-first turn — action/bonus/reaction start fresh as normal.

---

## Update: independent gate review follow-up

An independent gate review verified the fix above (TDD failing-pre-fix reproduced byte-identical, test rewrite forced not gratuitous, no stale trigger across re-entry, no off-by-one, no soft-lock) and returned **PASS-WITH-FINDINGS**, with one major finding required before merge. All required findings are now fixed on this branch; commit history has the detail, this section summarizes.

### Finding 1 (major, fixed): trigger attributed to whoever called last, not whoever's LoS actually fired

`checkCombatEntry` evaluates a **global** predicate (any player × any monster LoS pair), but blindly forwarded the *caller's own candidate* (Move's mover) as the trigger the moment *any* pair matched — even when the matching pair had nothing to do with the caller. `AddPlayer` never itself calls `checkCombatEntry` (only `AddMonster`/`Move` do), so a player seat added already within an existing monster's LoS sits unclaimed in `FREE_ROAM` until some *other* player's action happens to re-evaluate the check. Reproduced (and independently re-verified) the gate's exact shape: a scout holds LoS to a monster (door-opened or otherwise already-formed, unclaimed pair); an unrelated "wanderer" with zero LoS to anything takes a step elsewhere; pre-fix, the wanderer wrongly seized initiative slot 0 *and* had its own unrelated walk wrongly docked from its budget, while the actually-exposed scout acted later, behind the monster.

Fixed by attributing the trigger to whoever's own LoS actually fires the transition: the caller's candidate if its own view has LoS to a monster, otherwise the first (deterministically sorted, since `e.data.Players` is a map) LoS-engaged player — with **no** pre-spent budget attributed to that fallback, since the caller had nothing to do with revealing the pair. New helpers `playerEntityHasMonsterLoS` / `firstEngagedPlayerEntityID` (`combat.go`). `triggerID == ""` (`AddMonster`/`SeedMonsters`) is untouched — same plain existence check as before, no attribution logic runs at all.

New test: `TestCheckCombatEntry_TriggerAttributedToActualLoSMatch_NotUnrelatedMover` — confirmed failing against the prior commit (`actual: char-wanderer`, expected `char-scout`), passing after the fix; also asserts the scout's forced-first turn seeds a genuinely full 30ft (not docked for wanderer's walk) and that wanderer's own budget is untouched once its turn comes up.

The "fully organic" path the gate also called out (a monster sighted mid-combat never joins the current pocket per existing pocket-scoping design; when the pocket clears back to `FREE_ROAM`, that already-visible monster sits unclaimed until the next *unrelated* Move re-checks) is the same underlying mechanism and is covered by the same fix — no separate code path exists for it.

### Finding 2 (minor, fixed): `seedActiveActorIfUnseeded` hardcoded the pre-spent deduction to 0

If a Move-triggered transition fires before the trigger has a held character (production's `New()`+`AddPlayer`+`AddMonster` flow — nothing is hydrated until a `LoadFromData` round-trip), `seedActorTurn`'s immediate call inside `setMode` no-ops (no character to seed), and the pre-spent deduction was lost as a Go-only local — `seedActiveActorIfUnseeded`'s later catch-up reseeded a **full** budget regardless (measured: a 20ft approach that should leave 10ft yielded 30ft after the round-trip). Not hit by production today (rpg-api's `MoveEntity` hydrates first) but a live trap for any future caller that doesn't.

Fixed by persisting the pending deduction on `Data` (new `PendingTriggerSeed *PendingTriggerSeedData` field, `data.go`) — survives the JSON round-trip — consumed and cleared by `seedActiveActorIfUnseeded` the first time it successfully seeds the *matching* actor (a pending entry for a different or no-longer-active actor is left alone as stale).

New test: `TestSeedActiveActorIfUnseeded_HonorsPendingTriggerPreSpent` — confirmed failing against the prior commit (30 instead of 10), passing after the fix.

### Finding 4 (minor, fixed): rewritten pocket re-entry test's first assertion (0) was indistinguishable from accidentally-unseeded

The previous update to `TestPocketClear_ThenReEntry_ReseedsFullMovementBudget` had Erin travel 70ft in one `Move` call, so the forced-first-turn assertion read `0` remaining — which reads identically whether the deduction was computed correctly (30−70, clamped) or the economy was simply never seeded at all. Split into two `Move` calls: the first (20ft) stays outside the new pocket's monster's sight range and must **not** trigger anything; the second (20ft) is the one that actually crosses into LoS and triggers the transition, so only *its own* 20ft counts as pre-spent (`pathCostFeet` is per-call, not cumulative — confirmed this is intentional, not something this PR should change). Result: a genuine, diagnostic `30−20=10` on the forced-first turn, still followed by a genuine full `30` on the next ordinary turn boundary. Both properties are now pinned by values that can only come from the real deduction logic.

### Finding 5 (documented, not coded, per explicit "don't spend much on this" instruction)

A mover knocked to 0 HP mid-move (e.g. by an opportunity attack during `iterateMovementSteps`) is still passed through as `triggerID` and can burn initiative slot 0 on what amounts to an automatic death-save roll. Verified this is mechanically harmless: `seedActorTurn`'s downed branch (`char.GetHitPoints() <= 0`) returns before ever reaching the `StartTurn`/pre-spent-deduction code, so no budget or ordering side effect follows from it burning the slot — the actor just gets an unavoidable death-save turn instead of a monster or another player going first that round. Not fixed, per the gate's own guidance not to spend effort here; flagging the behavior explicitly in case a future reviewer wants it addressed.

### Untouched, per instruction

**Finding 3 (AddMonster/SeedMonsters ordering)** is deliberately left as plain roll order, unchanged — awaiting Kirk's design ruling on whether a monster becoming visible with no acting player should have any privileged ordering at all. My original scope call stands.

### Verification

- Full module: `go test ./... -count=1` — all green.
- `golangci-lint run ./...` — still exactly 68 pre-existing `goconst` issues (verified against unmodified `origin/main`); this update adds zero new issues.
- TDD evidence for every new/changed assertion above: written first, confirmed failing against the prior commit with the exact wrong values shown, then confirmed passing after the fix — see commit `275fc9e` for full detail.

---

## Update 2: second gate re-check — PendingTriggerSeed staleness (blocker, fixed)

A second, narrower re-check independently verified findings 1 and 4 as fixed against the gate's own original repros (scout leads, wanderer undocked, deterministic ordering with two engaged players, caller-precedence branch correct), but found that the finding-2 fix (commit `275fc9e`) introduced a new blocker.

### Blocker: `PendingTriggerSeed` never cleared, only conditionally written

`setMode`'s `ModeTurnBased` branch wrote `Data.PendingTriggerSeed` only `if preSpent > 0 && heldCharacter == nil`, and nothing cleared it anywhere else — not the `ModeFreeRoam` branch, not a later `TurnBased` transition that has nothing pending. Proven sequence (public API, unhydrated encounter, verified by reproducing it myself before fixing): scout walks 20ft into a monster's LoS, triggering combat and stashing `{scout, 20ft}` (transition 1 — scout has no held character yet); the encounter exits back to `FREE_ROAM`; a wanderer with zero LoS to anything takes an unrelated step; finding 1's fallback correctly attributes scout as the trigger again (transition 2), this time with a genuine pre-spent of `0` — but the stale `{scout, 20ft}` stash from transition 1 survived (the `ActorID`-match guard in `seedActiveActorIfUnseeded` can't distinguish the two transitions, since it's the same actor both times) and got misapplied: scout was seeded `10ft` instead of a genuine full `30ft`.

Fixed by making the assignment in `setMode`'s `ModeTurnBased` branch **unconditional** — it now writes either the real stash or explicit `nil` on every transition, so the field can only ever reflect the most recent transition — plus a defensive clear in the `ModeFreeRoam` branch as belt-and-suspenders.

New test (TDD: written first, confirmed failing at `10` against the prior commit — matching the gate's exact report — then passing at `30` after the fix): `TestSeedActiveActorIfUnseeded_DoesNotApplyStalePendingFromEarlierTransition`.

### Cheap nit, also fixed

`firstEngagedPlayerEntityID`'s deterministic tie-break sorted by ascending `PlayerID`, while `rollInitiative` itself sorts its player seeds by ascending `EntityID` — "first" meant two different things in the two places. Aligned the fallback to sort by `EntityID` (mirroring `rollInitiative`'s own struct-slice-then-sort pattern rather than introducing a new map keyed on `EntityID`, since cross-seat `EntityID` uniqueness isn't structurally enforced elsewhere in this package either).

### Known limitation, surfaced but not addressed here (per instruction)

The gate raised a design-level concern for Kirk to weigh in on separately: `PendingTriggerSeed` lives on the encounter snapshot, while the action economy it mutates flushes to rpg-api's separate character store — the two writes aren't atomic, so a failure between them could in principle double-dock or lose the deduction. This is a cross-store consistency question, not something this PR's scope covers; noting it here as a known limitation rather than chasing it.

### Verification (this update)

- Full module: `go test ./... -count=1` — all green.
- `golangci-lint run ./...` — still exactly 68 pre-existing issues, zero new.
- Commit `6b952dd` has the full diff and rationale.

— asset-pipeline agent, on behalf of KirkDiggler

