### PR TITLE
fix(encounter): gate action resolution on range/reach

### DIFF
--- a/encounter/boss_primary_axis_test.go
+++ b/encounter/boss_primary_axis_test.go
@@ -132,11 +132,16 @@ func TestInitDungeon_BossPrimaryAxis_FullRowWalkable(t *testing.T) {
 		enc := newTestEncounter(t)
 		require.NoError(t, enc.InitDungeon(bpaDungeonParams(seed)))
 
+		entrance := enc.ToData().Space.Entrance
 		require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 			PlayerID: alicePlayerID, EntityID: aliceEntityID,
-			Position: enc.ToData().Space.Entrance, SightRange: 30,
+			Position: entrance, SightRange: 30,
 		}))
+		// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to
+		// each door first (mirrors dungeon_test.go's identical fix).
+		require.NoError(t, enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 		require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+		require.NoError(t, enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 		require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor1ID))
 
 		for localX := 0; localX < dungeonBossWidth; localX++ {
@@ -166,11 +171,16 @@ func TestInitDungeon_BossPrimaryAxis_ClearWithObstaclesToo(t *testing.T) {
 		enc := newTestEncounter(t)
 		require.NoError(t, enc.InitDungeon(params))
 
+		entrance := enc.ToData().Space.Entrance
 		require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 			PlayerID: alicePlayerID, EntityID: aliceEntityID,
-			Position: enc.ToData().Space.Entrance, SightRange: 30,
+			Position: entrance, SightRange: 30,
 		}))
+		// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to
+		// each door first (mirrors dungeon_test.go's identical fix).
+		require.NoError(t, enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 		require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+		require.NoError(t, enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 		require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor1ID))
 
 		for localX := 0; localX < dungeonBossWidth; localX++ {

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -90,6 +90,17 @@ func (e *Encounter) TakeActionPhased(
 		return nil, ErrNoCombatResolver
 	}
 
+	// rpg-toolkit#864: one shared range gate applies to every actor. A
+	// 2026-07-30 QA walk found a 1-hex-reach melee weapon landing hits from
+	// 3 hexes away — nothing here ever consulted the attacker/target
+	// positions. Gated BEFORE the economy spend below (mirrors the
+	// door-verb ordering and the existing insufficient-movement
+	// precedent): an out-of-reach/out-of-range attack costs no action.
+	tRef := toolkitRef(ref)
+	if err := e.checkAttackRange(player, monster.Position, &tRef); err != nil {
+		return nil, err
+	}
+
 	// Validate + deduct the attack off the held character's two-level economy
 	// BEFORE resolving. This gates the attack on the economy: a character with no
 	// action left is rejected here (ErrActionUnaffordable) and the resolver never
@@ -115,7 +126,7 @@ func (e *Encounter) TakeActionPhased(
 	input := AttackInput{
 		AttackerID:          player.EntityID,
 		TargetID:            target.EntityID,
-		ActionRef:           toolkitRef(ref),
+		ActionRef:           tRef,
 		AttackerAttackBonus: player.AttackBonus,
 		AttackerDamageDice:  player.DamageDice,
 		AttackerDamageType:  player.DamageType,

--- a/encounter/combat_phased_test.go
+++ b/encounter/combat_phased_test.go
@@ -128,8 +128,11 @@ func (s *PhasedTakeActionSuite) SetupTest() {
 		HP: 18, MaxHP: 18, AC: 12, AttackBonus: 4,
 		DamageDice: "1d4", DamageType: damageSlashing,
 	}))
+	// rpg-toolkit#864: TakeActionPhased now gates melee attacks on reach (a
+	// flat stat-snapshot combatant defaults to 1 hex) — the goblin sits
+	// adjacent to alice (distinct from bob's hex) rather than 2 hexes out.
 	s.Require().NoError(s.enc.AddMonster(tkenc.MonsterInput{
-		ID: gobEntityID, Position: encountercore.Hex{Q: 2, R: 0, S: -2},
+		ID: gobEntityID, Position: encountercore.Hex{Q: 0, R: 1, S: -1},
 		HP: 10, MaxHP: 10, AC: 13, Speed: 30, AttackBonus: 4,
 		DamageDice: damage1d6plus1, DamageType: damageSlashing,
 	}))
@@ -266,8 +269,9 @@ func (s *PhasedTakeActionSuite) TestLegacyResolverFallback() {
 		HP: 30, MaxHP: 30, AC: 14, AttackBonus: 5,
 		DamageDice: damage1d8plus2, DamageType: damageSlashing,
 	}))
+	// rpg-toolkit#864: adjacent, not 2 hexes out — see SetupTest's identical note.
 	s.Require().NoError(enc.AddMonster(tkenc.MonsterInput{
-		ID: gobEntityID, Position: encountercore.Hex{Q: 2, R: 0, S: -2},
+		ID: gobEntityID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 10, MaxHP: 10, AC: 13, Speed: 30, AttackBonus: 4,
 		DamageDice: damage1d6plus1, DamageType: damageSlashing,
 	}))

--- a/encounter/combat_pockets_test.go
+++ b/encounter/combat_pockets_test.go
@@ -179,12 +179,15 @@ func (s *CombatPocketsSuite) TestOpenDoorAndSightB_StartsFreshPocket() {
 	))
 	s.Require().Equal(core.ModeFreeRoam, s.enc.Mode(), "test premise: pocket A cleared")
 
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to the
+	// door first (mirrors doors_slice1_test.go's identical fix).
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(1), lineHex(2)}))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, "door-1"))
 	// Move adjacent to group B (k=5, one hex from B at k=6) -- this is the
 	// Move call that gains LoS through the now-open door and re-triggers
 	// checkCombatEntry, exactly like doors_slice1_test.go's open-door-then-
 	// move pattern.
-	path := []core.Hex{lineHex(1), lineHex(2), lineHex(3), lineHex(4), lineHex(5)}
+	path := []core.Hex{lineHex(3), lineHex(4), lineHex(5)}
 	s.Require().NoError(s.enc.Move(alicePlayerID, path))
 
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode(), "sighting group B must start a fresh pocket")
@@ -202,9 +205,12 @@ func (s *CombatPocketsSuite) TestClearingB_LastMonster_FiresModeEnded() {
 		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
 		encounter.ActionTarget{EntityID: pocketGobA},
 	))
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to the
+	// door first (mirrors doors_slice1_test.go's identical fix).
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(1), lineHex(2)}))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, "door-1"))
 	s.Require().NoError(s.enc.Move(alicePlayerID,
-		[]core.Hex{lineHex(1), lineHex(2), lineHex(3), lineHex(4), lineHex(5)}))
+		[]core.Hex{lineHex(3), lineHex(4), lineHex(5)}))
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode(), "test premise: pocket B engaged")
 
 	sub, err := s.broker.Subscribe("enc-combat-pockets", alicePlayerID)

--- a/encounter/combat_trigger_order_test.go
+++ b/encounter/combat_trigger_order_test.go
@@ -191,6 +191,12 @@ func (s *CombatTriggerOrderSuite) TestMove_OthersStillOrderedByRoll_TriggerRollD
 // trigger, exactly like the movement-into-detection vector. The monster id
 // ("aaa-ambush") again sorts before the player's id, so the old ascending-id
 // tiebreak would have put it first.
+//
+// rpg-toolkit#864 rebase: OpenDoor now requires adjacency, so the player
+// first walks to lineHex(2) (one hex from the door at lineHex(3)) before
+// opening it — the original single Move from lineHex(0) through the doorway
+// is split into that approach plus the same walk-through, unchanged in
+// substance (still ends at lineHex(5), still the call that triggers combat).
 func (s *CombatTriggerOrderSuite) TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll() {
 	enc := encounter.New(s.ctx, "enc-trigger-order-door", s.broker,
 		encounter.WithRoller(fixedMaxRoller{}),
@@ -208,13 +214,17 @@ func (s *CombatTriggerOrderSuite) TestOpenDoorThenMove_TriggerForcedFirstRegardl
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: monster behind the closed door")
 
+	// rpg-toolkit#864: OpenDoor requires adjacency -- walk up to lineHex(2)
+	// (one hex from the door) first. The door is still closed, so this
+	// approach must not reveal or trigger anything.
+	s.Require().NoError(enc.Move(triggerHeroPlayerID, []core.Hex{lineHex(1), lineHex(2)}))
 	s.Require().NoError(enc.OpenDoor(triggerHeroPlayerID, "door-1"))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
 		"opening the door alone must not start combat -- encounter.OpenDoor never calls "+
 			"checkCombatEntry; only the player's subsequent move through the doorway does")
 
 	s.Require().NoError(enc.Move(triggerHeroPlayerID,
-		[]core.Hex{lineHex(1), lineHex(2), lineHex(3), lineHex(4), lineHex(5)}))
+		[]core.Hex{lineHex(3), lineHex(4), lineHex(5)}))
 
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting the monster through the open door must start combat")
 	s.Equal([]core.EntityID{triggerHeroEntityID, "aaa-ambush"}, enc.ToData().Initiative,

--- a/encounter/connector_column_walls_test.go
+++ b/encounter/connector_column_walls_test.go
@@ -233,11 +233,16 @@ func TestConnectorColumnWalls_DoorCellStaysWalkable(t *testing.T) {
 	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
 	data := enc.ToData()
 
+	entrance := data.Space.Entrance
 	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
-		Position: data.Space.Entrance, SightRange: 30,
+		Position: entrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to each
+	// door first (mirrors dungeon_test.go's identical fix).
+	require.NoError(t, enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 	require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+	require.NoError(t, enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 	require.NoError(t, enc.OpenDoor(alicePlayerID, dungeonDoor1ID))
 
 	room := enc.Room()

--- a/encounter/crypt_dungeon_test.go
+++ b/encounter/crypt_dungeon_test.go
@@ -114,11 +114,19 @@ func TestCryptDungeon_BossDoorLockPersistsAndUnlocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	cdEntrance := reloaded.ToData().Space.Entrance
 	require.NoError(t, reloaded.AddPlayer(encounter.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
-		Position: reloaded.ToData().Space.Entrance, SightRange: 30,
+		Position: cdEntrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor/AttemptUnlock require adjacency — walk
+	// alice up to each door first. CryptDungeonParams shares
+	// dungeon_test.go's threeRegionDungeonParams geometry (10/5/10, height
+	// 8), so its dungeonRegionFarEdgeHex helper applies directly here too.
+	require.NoError(t, reloaded.Move(alicePlayerID, straightRowPath(cdEntrance, dungeonRegionFarEdgeHex(0))))
 	require.NoError(t, reloaded.OpenDoor(alicePlayerID, cdEntranceDoorID))
+	require.NoError(t, reloaded.Move(alicePlayerID,
+		straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 
 	issued, err := reloaded.AttemptUnlock(alicePlayerID, cdBossDoorID)
 	require.NoError(t, err)
@@ -553,7 +561,12 @@ func TestCryptDungeon_EntranceToBossConnectivity_SurvivesSetPieces(t *testing.T)
 	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: entrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to each
+	// door first (mirrors dungeon_test.go's identical fix; CryptDungeonParams
+	// shares its threeRegionDungeonParams geometry).
+	require.NoError(t, enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 	require.NoError(t, enc.OpenDoor(alicePlayerID, cdEntranceDoorID))
+	require.NoError(t, enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 	require.NoError(t, enc.OpenDoor(alicePlayerID, cdBossDoorID))
 
 	reachable := reachableFrom(enc.Room(), entrance)
@@ -634,7 +647,12 @@ func TestCryptDungeon_EntranceToBossConnectivity_SurvivesDressingAcrossSeeds(t *
 		require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 			PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: entrance, SightRange: 30,
 		}), "seed %d", seed)
+		// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to
+		// each door first (mirrors this file's other fixed tests).
+		require.NoError(t, enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))), "seed %d", seed)
 		require.NoError(t, enc.OpenDoor(alicePlayerID, cdEntranceDoorID), "seed %d", seed)
+		require.NoError(t,
+			enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))), "seed %d", seed)
 		require.NoError(t, enc.OpenDoor(alicePlayerID, cdBossDoorID), "seed %d", seed)
 
 		reachable := reachableFrom(enc.Room(), entrance)

--- a/encounter/doors_slice1_test.go
+++ b/encounter/doors_slice1_test.go
@@ -123,8 +123,14 @@ func (s *DoorBlockingSuite) TestClosedDoor_MonsterCuesDoNotLeak() {
 
 // TestOpenDoor_UnblocksAndRevealsBeyond: opening the door must (1) let
 // movement pass through and (2) reveal the monster's hex in the same
-// action, without alice needing to walk up to it first.
+// action, without alice needing to walk all the way to it (only up to the
+// doorway).
+//
+// rpg-toolkit#864: OpenDoor requires adjacency, so alice walks to k=2 (one
+// hex short of the door, exactly where TestClosedDoor_BlocksMovement already
+// proves a closed door stops her) before opening it.
 func (s *DoorBlockingSuite) TestOpenDoor_UnblocksAndRevealsBeyond() {
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(1), lineHex(2)}))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, "door-1"))
 
 	s.False(
@@ -133,9 +139,10 @@ func (s *DoorBlockingSuite) TestOpenDoor_UnblocksAndRevealsBeyond() {
 	)
 	snap := s.enc.SnapshotFor(alicePlayerID)
 	s.True(snap.RevealedHexes.Has(lineHex(6)),
-		"opening the door must reveal the monster's hex beyond it in the same action, not require walking up to it")
+		"opening the door must reveal the monster's hex beyond it in the same action, "+
+			"without alice needing to walk any further than the doorway itself")
 
-	path := []core.Hex{lineHex(1), lineHex(2), lineHex(3), lineHex(4)}
+	path := []core.Hex{lineHex(3), lineHex(4)}
 	s.Require().NoError(s.enc.Move(alicePlayerID, path))
 	after := s.enc.ToData().Players[alicePlayerID].View.Position
 	s.Equal(lineHex(4), after, "an open door must let movement pass straight through")
@@ -143,10 +150,12 @@ func (s *DoorBlockingSuite) TestOpenDoor_UnblocksAndRevealsBeyond() {
 
 // TestOpenDoor_MonsterCuesReachThroughOpenDoor: the mirror of
 // TestClosedDoor_MonsterCuesDoNotLeak — once the door is open, the exact
-// same monster move DOES reach alice.
+// same monster move DOES reach alice. rpg-toolkit#864: alice walks adjacent
+// first (OpenDoor requires it), same as TestOpenDoor_UnblocksAndRevealsBeyond.
 func (s *DoorBlockingSuite) TestOpenDoor_MonsterCuesReachThroughOpenDoor() {
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(1), lineHex(2)}))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, "door-1"))
-	drainSub(s.aliceSub, 200*time.Millisecond) // drain the DoorOpened/HexRevealed pair
+	drainSub(s.aliceSub, 200*time.Millisecond) // drain alice's Move + the DoorOpened/HexRevealed pair
 
 	s.Require().NoError(s.enc.MoveNPCSteps(gobEntityID, []core.Hex{lineHex(7)}))
 

--- a/encounter/dungeon_completion_test.go
+++ b/encounter/dungeon_completion_test.go
@@ -212,6 +212,13 @@ func (s *DungeonCompletionSuite) TestClearingEarlyPockets_ThenVictoryOnLastHosti
 	s.Require().NoError(err)
 
 	dcEndTurnUntilActive(s.ctx, &s.Suite, enc, aliceEntityID)
+	// rpg-toolkit#864: TakeAction now gates melee attacks on reach — alice
+	// spawns at the entrance's near edge (X=0), 9 hexes from the goblin at
+	// the far edge (X=9), so she must walk up to X=8 (adjacent) first. A
+	// stat-snapshot player (no DataJSON) isn't gated on movement budget
+	// (Move's tracksMovement check requires a held character), so this is a
+	// free repositioning, not a turn-economy change.
+	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(0, 8)))
 	s.Require().NoError(enc.TakeAction(alicePlayerID,
 		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
 		encounter.ActionTarget{EntityID: dcEntranceGoblinID},
@@ -232,8 +239,13 @@ func (s *DungeonCompletionSuite) TestClearingEarlyPockets_ThenVictoryOnLastHosti
 	// LoS on the corridor goblin (boss goblin stays hidden behind the still-
 	// closed door 1), clear it. Boss goblin remains -- must exit to
 	// FREE_ROAM again, still not end the encounter. ---
+	// rpg-toolkit#864: OpenDoor requires adjacency too — alice is at X=8
+	// (from the entrance-goblin attack above), door0 sits at X=10, so she
+	// steps up to X=9 first. The subsequent move into the corridor now
+	// starts from X=9 (her real position), not X=0.
+	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(8, 9)))
 	s.Require().NoError(enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
-	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(0, dungeonRegionStarts()[1])))
+	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(9, dungeonRegionStarts()[1])))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "moving into LoS of the corridor goblin must start a fresh pocket")
 	s.True(func() bool {
 		for _, id := range enc.ToData().Initiative {
@@ -248,6 +260,10 @@ func (s *DungeonCompletionSuite) TestClearingEarlyPockets_ThenVictoryOnLastHosti
 	s.Require().NoError(err)
 
 	dcEndTurnUntilActive(s.ctx, &s.Suite, enc, aliceEntityID)
+	// rpg-toolkit#864: alice is at the corridor's near edge (X=11) after the
+	// move above; the corridor goblin sits at the far edge (X=15), so she
+	// steps up to X=14 (adjacent) before attacking.
+	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(dungeonRegionStarts()[1], 14)))
 	s.Require().NoError(enc.TakeAction(alicePlayerID,
 		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
 		encounter.ActionTarget{EntityID: dcCorridorGoblinID},
@@ -266,14 +282,21 @@ func (s *DungeonCompletionSuite) TestClearingEarlyPockets_ThenVictoryOnLastHosti
 	// --- Final pocket (boss): open door 1, move into the boss region to
 	// gain LoS on the boss goblin -- the LAST hostile anywhere -- and kill
 	// it. This must end the whole dungeon in victory. ---
+	// rpg-toolkit#864: alice is at X=14 (from the corridor-goblin attack
+	// above); door1 sits at X=16, so she steps up to X=15 (adjacent) first.
+	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(14, 15)))
 	s.Require().NoError(enc.OpenDoor(alicePlayerID, dungeonDoor1ID))
-	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(dungeonRegionStarts()[1], dungeonRegionStarts()[2])))
+	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(15, dungeonRegionStarts()[2])))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "moving into LoS of the boss goblin must start the final pocket")
 
 	sub3, err := s.broker.Subscribe("enc-dungeon-completion-victory", alicePlayerID)
 	s.Require().NoError(err)
 
 	dcEndTurnUntilActive(s.ctx, &s.Suite, enc, aliceEntityID)
+	// rpg-toolkit#864: alice is at the boss region's near edge (X=17); the
+	// boss goblin sits at the far edge (X=26), so she steps up to X=25
+	// (adjacent) before attacking.
+	s.Require().NoError(enc.Move(alicePlayerID, dcPathTo(dungeonRegionStarts()[2], 25)))
 	s.Require().NoError(enc.TakeAction(alicePlayerID,
 		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
 		encounter.ActionTarget{EntityID: dcBossGoblinID},
@@ -331,8 +354,15 @@ func (s *DungeonCompletionSuite) TestTPKMidDungeon_EndsWithCanonicalReason_Hosti
 		ID: dcCorridorGoblinID, Position: dungeonRegionFarEdgeHex(1),
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6, MonsterRef: monsterRefGoblin,
 	}))
+	// rpg-toolkit#864: NPCAct's scripted fallback (no DataJSON — this
+	// goblin's shape) now gates melee attacks on reach and has no movement
+	// logic of its own, so the goblin spawns adjacent to alice (X=1, vs.
+	// alice's entrance at X=0) rather than at the far edge (X=9) — nothing
+	// else in this test depends on the goblin's exact starting column, only
+	// that it's within LoS (dcSightRange comfortably covers the whole
+	// fixture regardless).
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID: dcEntranceGoblinID, Position: dungeonRegionFarEdgeHex(0),
+		ID: dcEntranceGoblinID, Position: dcRowHex(1),
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
 	}))

--- a/encounter/dungeon_test.go
+++ b/encounter/dungeon_test.go
@@ -447,7 +447,12 @@ func (s *DungeonSuite) TestOpeningBothDoors_ConnectsEntranceThroughToBoss() {
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
 		Position: entrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to each
+	// door along the generator's guaranteed wall-free required path before
+	// opening it (mirrors TwoChamberSuite's identical fix).
+	s.Require().NoError(s.enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+	s.Require().NoError(s.enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, dungeonDoor1ID))
 
 	reachable := reachableFrom(s.enc.Room(), entrance)

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -1288,8 +1288,10 @@ func (e *Encounter) applyAndPublishMove(
 	return corrID, nil
 }
 
-// OpenDoor applies an open-door action. Marks the door open, rebuilds
-// e.room so the door's cell stops blocking movement/LoS (rpg-toolkit#790 —
+// OpenDoor applies an open-door action. Requires playerID to be adjacent to
+// the door (rpg-toolkit#864 — wrapped ErrOutOfRange otherwise). Marks the
+// door open, rebuilds e.room so the door's cell stops blocking
+// movement/LoS (rpg-toolkit#790 —
 // see rebuildRoomFromData), and publishes the cause event (DoorOpenedEvent)
 // plus a HexRevealedEvent for any viewer whose vision grew — the room
 // rebuild happens BEFORE the per-viewer ProjectDoorOpen calls below so
@@ -1317,6 +1319,15 @@ func (e *Encounter) OpenDoor(playerID core.PlayerID, doorID core.EntityID) error
 	}
 	if door.Open {
 		return fmt.Errorf("door %q already open", doorID)
+	}
+	// rpg-toolkit#864: Interact/door actions require adjacency. A 2026-07-30
+	// QA walk found this verb reachable from anywhere on the map (a door
+	// opened from 10 hexes away) — range is a parameter of the action, not
+	// an exception, so this gate lives here rather than in the orchestrator
+	// (rpg-api's Interact only classifies locked-vs-unlocked and dispatches;
+	// see encounter.DoorData's own docs on that split).
+	if err := checkInteractReach(p.View.Position, door.Position); err != nil {
+		return fmt.Errorf("door %q: %w", doorID, err)
 	}
 
 	door.Open = true

--- a/encounter/encounter_test.go
+++ b/encounter/encounter_test.go
@@ -228,7 +228,10 @@ func (s *EncounterSuite) TestOpenDoor_PublishesEvents() {
 		PlayerID: "bob", EntityID: "char-bob",
 		Position: core.Hex{Q: 50, R: -25, S: -25}, SightRange: 4,
 	}))
-	s.Require().NoError(e.AddDoor("door-1", core.Hex{Q: 2, R: 0, S: -2}, false))
+	// rpg-toolkit#864: OpenDoor requires adjacency — door is 1 hex from
+	// alice (was 2; unrelated to what this test actually proves: event
+	// publishing + bob's out-of-range non-delivery).
+	s.Require().NoError(e.AddDoor("door-1", core.Hex{Q: 1, R: 0, S: -1}, false))
 
 	aliceSub, _ := s.broker.Subscribe("enc-1", "alice")
 	bobSub, _ := s.broker.Subscribe("enc-1", "bob")

--- a/encounter/integration_test.go
+++ b/encounter/integration_test.go
@@ -70,9 +70,22 @@ func (s *IntegrationSuite) TestSlice_MoveTowardEachOther() {
 		"bob within distance 2 should see alice move")
 }
 
-// Door opens at distance 4 from alice (sight range 4) and distance 2 from
-// bob (sight range 4). Both should see the door event.
+// Door opens at distance 2 from bob (sight range 4) — bob's perception of
+// the DoorOpenedEvent from a distance is the audience-routing behavior this
+// test proves; both alice and bob should see the door event.
+//
+// rpg-toolkit#864: OpenDoor requires adjacency, so alice must first walk to
+// a door-adjacent hex (a diagonal detour around bob's cell at {2,0,-2},
+// rather than straight down the same row alice/bob/the door all share) —
+// she was previously calling OpenDoor from 4 hexes away, exploiting the
+// missing gate.
 func (s *IntegrationSuite) TestSlice_OpenDoor() {
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{
+		{Q: 1, R: 0, S: -1}, {Q: 2, R: -1, S: -1}, {Q: 3, R: -1, S: -2}, {Q: 4, R: -1, S: -3},
+	}))
+	drainSub(s.aliceSub, 200*time.Millisecond)
+	drainSub(s.bobSub, 200*time.Millisecond)
+
 	s.Require().NoError(s.enc.OpenDoor("alice", "door-east"))
 
 	aliceEvents := collectTypes(s.aliceSub, 500*time.Millisecond)

--- a/encounter/locked_connector_test.go
+++ b/encounter/locked_connector_test.go
@@ -242,7 +242,11 @@ func (s *LockedBossDoorSuite) TestFailedCheck_LeavesDoorLockedRecoverableAndBloc
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
 		Position: entrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor/AttemptUnlock require adjacency — walk
+	// alice up to each door first (mirrors dungeon_test.go's identical fix).
+	s.Require().NoError(s.enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+	s.Require().NoError(s.enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 
 	_, err := s.enc.AttemptUnlock(alicePlayerID, dungeonDoor1ID)
 	s.Require().NoError(err)
@@ -281,7 +285,11 @@ func (s *LockedBossDoorSuite) TestSuccessfulCheck_UnlocksOpensAndRevealsBossRegi
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
 		Position: entrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor/AttemptUnlock require adjacency — walk
+	// alice up to each door first (mirrors dungeon_test.go's identical fix).
+	s.Require().NoError(s.enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, dungeonDoor0ID))
+	s.Require().NoError(s.enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 
 	boss := regionHexSet(data.Space, dungeonRegionIDBoss)
 	before := s.enc.ToData().Players[alicePlayerID].View.KnownHexSet()

--- a/encounter/midturn_unconscious_economy_test.go
+++ b/encounter/midturn_unconscious_economy_test.go
@@ -110,8 +110,15 @@ func (s *MidTurnUnconsciousEconomySuite) SetupTest() {
 		DamageDice: damage1d8plus2, DamageType: damageSlashing,
 		DataJSON: s.aliceLowHPSeededCharDataJSON(),
 	}))
+	// rpg-toolkit#864: both tests below have alice TakeAction against this
+	// goblin right after her one-step Move to {1,0,-1} — TakeAction now
+	// gates melee attacks on reach, so the goblin sits adjacent to that
+	// post-move position rather than 5 hexes from alice's start. The OA
+	// itself is synthetic (stubMovementResolver.publishOnStep fires
+	// unconditionally on step 0, independent of real geometry/threat-range),
+	// so the goblin's exact position was never load-bearing for that part.
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
-		ID: mueGoblinID, Position: core.Hex{Q: 5, R: 0, S: -5},
+		ID: mueGoblinID, Position: core.Hex{Q: 2, R: 0, S: -2},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
 	}))
@@ -130,9 +137,9 @@ func (s *MidTurnUnconsciousEconomySuite) SetupTest() {
 	s.enc = loaded
 
 	// alice's DataJSON carries a pre-seeded economy, so cycling to her turn
-	// doesn't depend on SetMode's seedActorTurn call to populate it. She and
-	// the goblin are far enough apart that AddMonster (above, before the
-	// round-trip) didn't auto-enter combat — flip explicitly.
+	// doesn't depend on SetMode's seedActorTurn call to populate it. Whether
+	// AddMonster (above, before the round-trip) already auto-entered combat
+	// via mutual LoS or not, this flips explicitly only if needed.
 	if s.enc.Mode() != core.ModeTurnBased {
 		s.Require().NoError(s.enc.SetMode(core.ModeTurnBased))
 	}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -414,10 +414,21 @@ func (e *Encounter) applyCapturedAttacks(
 		// both fights) — this catches a bug in that AI-side gate, or a
 		// future monster action that skips it, the same way the player path
 		// hard-gates rather than trusting the caller.
+		//
+		// Gate-review finding (blocker 1): skip (continue), do NOT return an
+		// error. This loop can carry multiple captured attacks (a
+		// multiattack monster's several swings, possibly at different
+		// targets); erroring here would both wedge the encounter (NPCAct's
+		// caller only advances the turn on success — see npcActScripted's
+		// identical note) and discard whatever EARLIER attacks in this same
+		// loop already applied damage/events for, which cannot be undone.
+		// One out-of-reach swing (e.g. a target that Disengaged mid-turn, if
+		// that ever lands) simply doesn't connect; any other captured
+		// attacks in this turn still resolve normally.
 		if atk.IsMelee {
 			reach := meleeReachForCombatant(e.combatantFor(mon.ID))
-			if err := checkReach(mon.Position, targetPlayer.View.Position, reach, "reach"); err != nil {
-				return err
+			if checkReach(mon.Position, targetPlayer.View.Position, reach, "reach") != nil {
+				continue
 			}
 		}
 
@@ -1033,9 +1044,18 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	// Before this, npcActScripted always attacked whichever player was
 	// closest regardless of distance — a real, separate entry point into
 	// the resolver the QA-reported bug's gate must also cover.
+	//
+	// Gate-review finding (blocker 1): the closest player being out of
+	// reach is "nothing to do this turn", the same as the target==nil case
+	// two lines up — NOT an error. This verb has no other action to fall
+	// back to (it's the whole scripted turn), and NPCAct's caller (rpg-api's
+	// driveNPCChain) only calls EndTurn after NPCAct returns successfully;
+	// returning an error here would make an out-of-reach monster wedge the
+	// encounter forever (every retry hits the identical rejection). A
+	// monster that can't reach anyone simply passes its turn.
 	reach := meleeReachForCombatant(e.combatantFor(mon.ID))
-	if err := checkReach(mon.Position, target.View.Position, reach, "reach"); err != nil {
-		return err
+	if checkReach(mon.Position, target.View.Position, reach, "reach") != nil {
+		return nil
 	}
 	outcome, err := e.combatResolver.ResolveAttack(AttackInput{
 		AttackerID:          mon.ID,

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -401,6 +401,26 @@ func (e *Encounter) applyCapturedAttacks(
 			continue
 		}
 
+		// rpg-toolkit#864: the same shared range gate the player attack path
+		// uses (TakeActionPhased), applied here so no actor is an exception.
+		// Melee-only: dnd5eEvents.AttackEvent carries IsMelee but no numeric
+		// range, and MonsterData has no range field to consult for ranged
+		// attacks without inventing new plumbing — a gap worth its own
+		// follow-up issue. This is defense-in-depth rather than the primary
+		// gate for monsters: monster.TakeTurn's own action selection
+		// (actions.MeleeAction/RangedAction.CanActivate) already rejects an
+		// out-of-reach/out-of-range choice before any AttackEvent publishes
+		// (the QA walk observed monster AI correctly closing to adjacency in
+		// both fights) — this catches a bug in that AI-side gate, or a
+		// future monster action that skips it, the same way the player path
+		// hard-gates rather than trusting the caller.
+		if atk.IsMelee {
+			reach := meleeReachForCombatant(e.combatantFor(mon.ID))
+			if err := checkReach(mon.Position, targetPlayer.View.Position, reach, "reach"); err != nil {
+				return err
+			}
+		}
+
 		input := AttackInput{
 			AttackerID:          mon.ID,
 			TargetID:            targetID,
@@ -1006,6 +1026,16 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	target := e.closestPlayer(mon.Position)
 	if target == nil {
 		return nil
+	}
+	// rpg-toolkit#864: this fallback has no ranged/melee action distinction
+	// at all (it's a single flat stat-snapshot "attack"), so it gates as
+	// melee — same shared gate as applyCapturedAttacks/TakeActionPhased.
+	// Before this, npcActScripted always attacked whichever player was
+	// closest regardless of distance — a real, separate entry point into
+	// the resolver the QA-reported bug's gate must also cover.
+	reach := meleeReachForCombatant(e.combatantFor(mon.ID))
+	if err := checkReach(mon.Position, target.View.Position, reach, "reach"); err != nil {
+		return err
 	}
 	outcome, err := e.combatResolver.ResolveAttack(AttackInput{
 		AttackerID:          mon.ID,

--- a/encounter/npc_targeting_downed_test.go
+++ b/encounter/npc_targeting_downed_test.go
@@ -58,25 +58,35 @@ func (s *NPCTargetingDownedSuite) TearDownTest() {
 // TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer is the closestPlayer
 // regression proof, reproducing the exact reported soft-lock: a downed player
 // positioned CLOSER to the goblin than the alive player. npcActScripted has
-// no adjacency gate (unlike the DataJSON/Scimitar path), so pre-fix this
-// deterministically attacks the corpse every single turn. Across 3 goblin
-// turns, the fix must make the goblin attack ONLY the live player, never the
-// downed one.
+// no adjacency gate of its own (unlike the DataJSON/Scimitar path's
+// MeleeAction.CanActivate) — pre-#733-fix this deterministically attacks the
+// corpse every single turn. Across 3 goblin turns, the fix must make the
+// goblin attack ONLY the live player, never the downed one.
+//
+// rpg-toolkit#864: npcActScripted now also gates on reach (the shared
+// range/reach validation every actor's attack path goes through), so the
+// live player must be positioned within melee reach of the goblin, not just
+// "farther than the downed one" — the downed player sits on the goblin's own
+// hex (distance 0, the closest possible) and the live player one hex away
+// (distance 1, still in reach), preserving "downed is strictly closer" while
+// keeping the correct target attackable.
 func (s *NPCTargetingDownedSuite) TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer() {
 	encID := core.EncounterID("enc-ntd-scripted")
 	enc := encounter.New(s.ctx, encID, s.broker,
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 1, damageType: damageSlashing}),
 	)
-	// Downed player is adjacent (distance 1) — strictly closer than alive.
+	// Downed player co-located with the goblin (distance 0) — strictly
+	// closer than the alive player.
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "ntd-down", EntityID: ntdDownEntityID,
-		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		Position: core.Hex{}, SightRange: 10,
 		HP: 0, MaxHP: 12, AC: 10,
 	}))
-	// Alive player is farther away (distance 3).
+	// Alive player is one hex away (distance 1) — farther than the downed
+	// player, but still within the goblin's default melee reach.
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: ntdAlivePlayerID, EntityID: ntdAliveEntityID,
-		Position: core.Hex{Q: 3, R: 0, S: -3}, SightRange: 10,
+		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
 		HP: 12, MaxHP: 12, AC: 10,
 	}))
 	// No DataJSON — triggers the scripted (closestPlayer) path.

--- a/encounter/obstacle_placement_test.go
+++ b/encounter/obstacle_placement_test.go
@@ -265,7 +265,13 @@ func TestInitDungeon_ObstaclePlacement_PreservesEntranceToBossConnectivity(t *te
 	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: entrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to each
+	// door first. This fixture's region widths/height (10/5/10, height 8)
+	// are identical to dungeon_test.go's threeRegionDungeonParams shape, so
+	// its dungeonRegionFarEdgeHex helper applies directly here too.
+	require.NoError(t, enc.Move(alicePlayerID, straightRowPath(entrance, dungeonRegionFarEdgeHex(0))))
 	require.NoError(t, enc.OpenDoor(alicePlayerID, doorID0))
+	require.NoError(t, enc.Move(alicePlayerID, straightRowPath(dungeonRegionFarEdgeHex(0), dungeonRegionFarEdgeHex(1))))
 	require.NoError(t, enc.OpenDoor(alicePlayerID, doorID1))
 
 	reachable := reachableFrom(enc.Room(), entrance)

--- a/encounter/obstacle_reveal_test.go
+++ b/encounter/obstacle_reveal_test.go
@@ -164,6 +164,10 @@ func (s *ObstacleRevealSuite) TestOpenDoor_RevealsStaticObstacleToOnlyNewlyRevea
 	bobSub := s.subscribe(bobPlayerID)
 	carolSub := s.subscribe(obstacleRevealCarolPlayerID)
 
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to the
+	// door first (mirrors doors_slice1_test.go's identical fix).
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(2)}))
+	drainSub(aliceSub, 200*time.Millisecond)
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, "door-1"))
 
 	aliceAppeared := obstacleAppearances(collectEventsTyped(aliceSub, 300*time.Millisecond))
@@ -214,9 +218,13 @@ func (s *ObstacleRevealSuite) TestOpenDoor_FollowUpMoveDoesNotReappear() {
 	}))
 	aliceSub := s.subscribe(alicePlayerID)
 
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to the
+	// door first (mirrors doors_slice1_test.go's identical fix).
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(2)}))
+	drainSub(aliceSub, 200*time.Millisecond)
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, "door-1"))
 	s.Require().Len(obstacleAppearancesFor(collectEventsTyped(aliceSub, 300*time.Millisecond), "altar-1"), 1)
-	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(1)}))
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(3)}))
 	s.Empty(obstacleAppearancesFor(collectEventsTyped(aliceSub, 300*time.Millisecond), "altar-1"))
 }
 
@@ -253,6 +261,12 @@ func (s *ObstacleRevealSuite) TestOpenDoor_ObstacleAppearanceFollowsHexRevealed(
 	}))
 	aliceSub := s.subscribe(alicePlayerID)
 
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to the
+	// door first (mirrors doors_slice1_test.go's identical fix), draining
+	// her own Move/HexRevealed events so they don't precede DoorOpenedEvent
+	// in the ordering assertions below.
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{lineHex(2)}))
+	drainSub(aliceSub, 200*time.Millisecond)
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, "door-1"))
 	observedEvents := collectEventsTyped(aliceSub, 300*time.Millisecond)
 	doorIdx := eventIndex(observedEvents, func(evt events.EncounterEvent) bool {

--- a/encounter/pocket_clear_move_teardown_test.go
+++ b/encounter/pocket_clear_move_teardown_test.go
@@ -100,7 +100,7 @@ func (s *PocketClearMoveTeardownSuite) erinCharJSON() json.RawMessage {
 }
 
 // loadErinVsTwoPockets builds group A (visible immediately, k=1) and group
-// B (behind a closed door at k=10, monster at k=15) with erin's DataJSON
+// B (behind a closed door at k=10, monster at k=25) with erin's DataJSON
 // attached, then round-trips through ToData/LoadFromData
 // (loadRagingBarbVsGoblin's technique) so the cascade hydrates erin's
 // *character.Character onto the returned encounter's combatant map —
@@ -108,12 +108,24 @@ func (s *PocketClearMoveTeardownSuite) erinCharJSON() json.RawMessage {
 // BEFORE group A (combat_pockets_test.go's ordering note): group A's own
 // AddMonster call must be what triggers checkCombatEntry, scoping
 // initiative to the engaged pocket only.
+//
+// Group B sits at k=25, not #865's original k=15 (rpg-toolkit#864 rebase):
+// OpenDoor now requires adjacency, so erin must stand at k=9 (one hex from
+// the door at k=10) before opening it — and from k=9, k=15 is only 6 hexes
+// away, already inside SightRange 10 the instant the door opens, leaving no
+// room for TestPocketClear_ThenReEntry_ReseedsFullMovementBudget's
+// two-move "still safe / now triggers" split (#867 gate finding 4's fix).
+// k=25 restores that room: k=9 is 16 hexes from group B (well out of
+// range), so there's a genuine safe zone to walk through after opening the
+// door before crossing into SightRange. The room is sized to comfortably
+// fit k=25 (see InitRoom below), mirroring doors_slice1_test.go's
+// "generously-sized room" convention.
 func (s *PocketClearMoveTeardownSuite) loadErinVsTwoPockets() *encounter.Encounter {
 	s.T().Helper()
 	enc := encounter.New(s.ctx, "enc-pocket-clear-move-teardown", s.broker,
 		encounter.WithRoller(fixedMaxRoller{}),
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
-	s.Require().NoError(enc.InitRoom(20, 20, environments.PatternEmpty))
+	s.Require().NoError(enc.InitRoom(40, 40, environments.PatternEmpty))
 	s.Require().NoError(enc.AddDoor(pcmDoorID, lineHex(10), false))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: pcmPlayerID, EntityID: pcmEntityID,
@@ -123,7 +135,7 @@ func (s *PocketClearMoveTeardownSuite) loadErinVsTwoPockets() *encounter.Encount
 		DataJSON: s.erinCharJSON(),
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID: pcmGobB, Position: lineHex(15),
+		ID: pcmGobB, Position: lineHex(25),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef: monsterRefGoblin,
 	}))
@@ -228,8 +240,10 @@ func (s *PocketClearMoveTeardownSuite) TestWithinPocket_MovementStillEnforced_Wh
 // full 70ft in one call, so the forced-first assertion read 0 remaining —
 // indistinguishable from an accidentally-unseeded economy (which also reads
 // as a zero value) rather than a genuinely computed deduction. Split into
-// two Move calls instead: the first (k=0->k=4, 20ft) stays out of group B's
-// LoS and must NOT trigger anything; the second (k=4->k=8, 20ft) is the one
+// two Move calls instead — see the walk below for the exact waypoints,
+// shifted by rpg-toolkit#864's adjacency rebase (loadErinVsTwoPockets' doc
+// comment explains why group B moved from k=15 to k=25): the first stays
+// out of group B's LoS and must NOT trigger anything; the second is the one
 // that actually crosses into LoS and triggers the transition, so ONLY its
 // own 20ft counts as pre-spent (pathCostFeet is per-call, not cumulative
 // across the whole free-roam approach — see Move's own doc comment). That
@@ -249,21 +263,24 @@ func (s *PocketClearMoveTeardownSuite) TestPocketClear_ThenReEntry_ReseedsFullMo
 	))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: pocket A cleared")
 
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk erin (still at
+	// k=0; the attack above doesn't move her) up to the door at k=10 first.
+	s.Require().NoError(enc.Move(pcmPlayerID, []core.Hex{lineHex(9)}))
 	s.Require().NoError(enc.OpenDoor(pcmPlayerID, pcmDoorID))
 
-	// First move: k=0 -> k=4 (4 hexes, 20ft). Distance to group B at k=15 is
-	// 11 hexes, still outside erin's SightRange 10 -- must NOT trigger.
+	// First move: k=9 -> k=13 (4 hexes, 20ft). Distance to group B at k=25
+	// is 12 hexes, still outside erin's SightRange 10 -- must NOT trigger.
 	s.Require().NoError(enc.Move(pcmPlayerID, []core.Hex{
-		lineHex(1), lineHex(2), lineHex(3), lineHex(4),
+		lineHex(10), lineHex(11), lineHex(12), lineHex(13),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
-		"test premise: k=4 is still 11 hexes from group B, outside SightRange 10")
+		"test premise: k=13 is still 12 hexes from group B, outside SightRange 10")
 
-	// Second move: k=4 -> k=8 (4 hexes, 20ft). Distance to group B is now 7
-	// hexes, inside SightRange 10 through the now-open door -- THIS call is
-	// the trigger, and only ITS OWN 20ft counts as pre-spent.
+	// Second move: k=13 -> k=17 (4 hexes, 20ft). Distance to group B is now
+	// 8 hexes, inside SightRange 10 through the now-open door -- THIS call
+	// is the trigger, and only ITS OWN 20ft counts as pre-spent.
 	s.Require().NoError(enc.Move(pcmPlayerID, []core.Hex{
-		lineHex(5), lineHex(6), lineHex(7), lineHex(8),
+		lineHex(14), lineHex(15), lineHex(16), lineHex(17),
 	}))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting group B must start a fresh pocket")
 

--- a/encounter/prompts.go
+++ b/encounter/prompts.go
@@ -129,6 +129,7 @@ type SubmitCheckResult struct {
 //   - door not in encounter: wrapped fmt.Errorf
 //   - player not in encounter: wrapped fmt.Errorf
 //   - door not locked: ErrDoorNotLocked
+//   - player not adjacent to the door (rpg-toolkit#864): wrapped ErrOutOfRange
 //   - player already has a pending prompt: ErrPromptAlreadyPending
 //
 // Does not publish any broker event — prompts are persisted state, not
@@ -136,7 +137,8 @@ type SubmitCheckResult struct {
 // Data.PendingPrompts (or via the PromptIssued return value on this
 // call) and translating to the wire shape.
 func (e *Encounter) AttemptUnlock(playerID core.PlayerID, doorID core.EntityID) (PromptIssued, error) {
-	if _, ok := e.data.Players[playerID]; !ok {
+	p, ok := e.data.Players[playerID]
+	if !ok {
 		return PromptIssued{}, fmt.Errorf("player %q not in encounter", playerID)
 	}
 	door, ok := e.data.Doors[doorID]
@@ -145,6 +147,14 @@ func (e *Encounter) AttemptUnlock(playerID core.PlayerID, doorID core.EntityID) 
 	}
 	if !door.Locked {
 		return PromptIssued{}, fmt.Errorf("%w: %q", ErrDoorNotLocked, doorID)
+	}
+	// rpg-toolkit#864: Interact/door actions require adjacency, including
+	// the locked-door branch — a 2026-07-30 QA walk found the DC-12 skill
+	// check itself issuable (and passable) from 16 hexes away. Gated before
+	// the pending-prompt check below so a distant attempt never issues the
+	// prompt at all, not even one the player could resolve from range.
+	if err := checkInteractReach(p.View.Position, door.Position); err != nil {
+		return PromptIssued{}, fmt.Errorf("door %q: %w", doorID, err)
 	}
 	if _, pending := e.data.PendingPrompts[playerID]; pending {
 		return PromptIssued{}, fmt.Errorf("%w: player %q", ErrPromptAlreadyPending, playerID)

--- a/encounter/prompts.go
+++ b/encounter/prompts.go
@@ -289,10 +289,17 @@ func (e *Encounter) dispatchPromptAction(playerID core.PlayerID, target core.Ent
 		// The skill check itself still resolved (SubmitCheck's caller sees
 		// Success=true — the roll was good), but the dispatch fails; the
 		// existing "downstream OpenDoor error" contract on SubmitCheck's
-		// doc comment already covers this exact shape (prompt CLEARED, not
-		// stranded, dispatch failure surfaced to the caller) — a walk-away
-		// consumes the attempt. The player must AttemptUnlock again from
-		// within reach; there is no partial/silent unlock.
+		// doc comment already covers this exact shape (prompt CLEARED from
+		// THIS in-memory Encounter, dispatch failure surfaced to the
+		// caller). What that means for the player is host-dependent, not a
+		// toolkit guarantee either way: rpg-api's SubmitCheck orchestrator
+		// does not persist the encounter when the verb returns an error, so
+		// the previously-saved (still-pending) prompt in its store survives
+		// untouched, and the player can walk back and resubmit against the
+		// original prompt. What the toolkit DOES guarantee is the property
+		// that actually matters — the door stays genuinely Locked either
+		// way, so there is no partial/silent unlock regardless of how a
+		// given host handles the stranded-or-not prompt.
 		player, ok := e.data.Players[playerID]
 		if !ok {
 			return fmt.Errorf("player %q not in encounter", playerID)

--- a/encounter/prompts.go
+++ b/encounter/prompts.go
@@ -273,6 +273,33 @@ func (e *Encounter) dispatchPromptAction(playerID core.PlayerID, target core.Ent
 		if !ok {
 			return fmt.Errorf("door %q not in encounter", target)
 		}
+		// Gate-review finding (blocker 2, rpg-toolkit#864): re-check reach
+		// HERE, after the skill check resolved but BEFORE committing
+		// door.Locked = false. AttemptUnlock only checks reach at the
+		// moment the prompt is ISSUED; between then and this SubmitCheck
+		// resolving it, the player is free to walk away. Without this
+		// re-check, Locked would be cleared unconditionally below and any
+		// LATER in-reach OpenDoor call (via a fresh Interact once the
+		// player walks back) would open the door for free — the DC check
+		// permanently bypassed. Checking before mutating Locked means a
+		// walk-away either fails cleanly here (Locked stays true, the door
+		// stays genuinely locked) or the player was still in reach and
+		// nothing changes.
+		//
+		// The skill check itself still resolved (SubmitCheck's caller sees
+		// Success=true — the roll was good), but the dispatch fails; the
+		// existing "downstream OpenDoor error" contract on SubmitCheck's
+		// doc comment already covers this exact shape (prompt CLEARED, not
+		// stranded, dispatch failure surfaced to the caller) — a walk-away
+		// consumes the attempt. The player must AttemptUnlock again from
+		// within reach; there is no partial/silent unlock.
+		player, ok := e.data.Players[playerID]
+		if !ok {
+			return fmt.Errorf("player %q not in encounter", playerID)
+		}
+		if err := checkInteractReach(player.View.Position, door.Position); err != nil {
+			return fmt.Errorf("door %q: %w", target, err)
+		}
 		// Clear the lock flag before OpenDoor so the door round-trips as
 		// unlocked-and-open (not locked-and-open) for any subsequent
 		// snapshot or verb.

--- a/encounter/range_gate.go
+++ b/encounter/range_gate.go
@@ -1,0 +1,144 @@
+package encounter
+
+// range_gate.go — the shared range/reach validation gate for rpg-toolkit#864.
+//
+// A 2026-07-30 QA walk found NO range/reach validation anywhere in the
+// action-resolution path: Interact opened (and unlocked) doors from 10-16
+// hexes away, and a 1-hex-reach melee weapon landed a hit from 3 hexes.
+// Positions were already tracked (tools/spatial via encounter/core.Hex +
+// hexDistance) — the action paths simply never consulted them.
+//
+// Kirk's spec (the issue body): one validation gate at action resolution,
+// applying to ALL actors (players and monsters). Interact/door actions
+// require adjacency (reach 1); melee attacks use weapon reach (default 1
+// hex); ranged attacks use the weapon's range. Range is a parameter of the
+// action, not an exception.
+//
+// This file is the single shared gate every call site below consults:
+//   - OpenDoor / AttemptUnlock (encounter.go / prompts.go): checkInteractReach
+//   - TakeActionPhased, the player attack path (combat_phased.go):
+//     (*Encounter).checkAttackRange
+//   - applyCapturedAttacks / npcActScripted, the monster attack paths
+//     (npc.go): meleeReachForCombatant + checkReach directly
+//
+// Deliberately NOT touched: encounter/combat.go's SetMode/setMode/
+// rollInitiative/checkCombatEntry/seedActorTurn and the Move path — those
+// are rpg-toolkit#867's (in-flight, PR #867) initiative-ordering surface;
+// this gate lives entirely in new call sites plus the door/attack verbs
+// listed above, none of which #867 touches.
+
+import (
+	"errors"
+	"fmt"
+
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// ErrOutOfRange is returned by action verbs (Interact-class door verbs, and
+// both the player and NPC attack paths) when the target is farther from the
+// actor than the action's reach/range permits. rpg-toolkit#864: range is a
+// parameter of the action, not an exception — every gated verb wraps this
+// same sentinel so callers (and rpg-api's status-code mapping) can recognize
+// the refusal uniformly regardless of which action produced it.
+var ErrOutOfRange = errors.New("target out of range")
+
+const (
+	// interactReachHexes is the fixed adjacency reach for Interact-class
+	// verbs (OpenDoor, AttemptUnlock). Doors have no weapon/reach concept of
+	// their own — the issue's spec is explicit: "Interact requires
+	// adjacency (reach 1)".
+	interactReachHexes = 1
+
+	// defaultMeleeReachHexes is the melee reach used when the attacker has
+	// no real weapon to consult: a flat stat-snapshot combatant (today's
+	// common case for UI-created characters — a known separate bug that
+	// leaves them unarmed), a monster's natural weapon (bite/claw — no
+	// catalog entry to resolve), or a weapon-resolution error. 1 hex (5ft)
+	// is the D&D 5e default and the reach of the canonical unarmed strike.
+	defaultMeleeReachHexes = 1
+
+	// reachWeaponHexes is the melee reach granted by the Reach weapon
+	// property (10ft — glaive, halberd, spear-with-reach-variant, pike).
+	reachWeaponHexes = 2
+)
+
+// checkReach is the shared distance gate underlying every range-gated verb
+// in this file: an error (wrapping ErrOutOfRange) when hexDistance(from, to)
+// exceeds max, nil otherwise. label distinguishes "reach" (melee/interact,
+// a fixed adjacency-style limit) from "range" (ranged weapons, a genuine
+// distance limit) in the error text — mirrors the existing precondition
+// style (e.g. ErrInsufficientMovement's callers in encounter.go).
+func checkReach(from, to core.Hex, limit int, label string) error {
+	if d := hexDistance(from, to); d > limit {
+		return fmt.Errorf("%w: %d hexes, %s %d", ErrOutOfRange, d, label, limit)
+	}
+	return nil
+}
+
+// checkInteractReach gates a door verb (OpenDoor, AttemptUnlock) on the
+// actor being adjacent to the door.
+func checkInteractReach(actorPos, doorPos core.Hex) error {
+	return checkReach(actorPos, doorPos, interactReachHexes, "reach")
+}
+
+// meleeReachForWeapon resolves the reach (in hexes) w grants: 2 for a Reach
+// weapon, 1 otherwise — including w == nil, the "no weapon resolved" case
+// (flat stat-snapshot combatant, natural weapon, or a lookup miss).
+func meleeReachForWeapon(w *weapons.Weapon) int {
+	if w != nil && w.HasProperty(weapons.PropertyReach) {
+		return reachWeaponHexes
+	}
+	return defaultMeleeReachHexes
+}
+
+// meleeReachForCombatant resolves melee reach via combat.MeleeWeaponProvider
+// — the same seam opportunity-attack resolution already uses
+// (rpg-toolkit#722) to answer "which weapon would this combatant swing."
+// Used by the monster attack path (applyCapturedAttacks, npcActScripted),
+// which has no per-ActionRef weapon selection the way the player path's
+// Character.WeaponForActionRef gives (see checkAttackRange). Falls back to
+// defaultMeleeReachHexes when attacker doesn't implement the provider (a
+// nil combat.Combatant included) or reports no weapon (natural attacks like
+// bite/claw, or a flat stat-snapshot monster).
+func meleeReachForCombatant(attacker combat.Combatant) int {
+	provider, ok := attacker.(combat.MeleeWeaponProvider)
+	if !ok {
+		return defaultMeleeReachHexes
+	}
+	return meleeReachForWeapon(provider.MeleeWeapon())
+}
+
+// checkAttackRange gates a player attack (TakeActionPhased) on the target
+// being within reach (melee) or range (ranged) of the weapon this specific
+// ActionRef actually swings. Resolves the real weapon via
+// Character.WeaponForActionRef (rpg-toolkit#712 — the same ref->weapon
+// mapping the real combat resolver uses), so an off_hand_strike or
+// unarmed_strike/flurry_strike gates on the weapon it will actually attack
+// with rather than always the main-hand weapon. A player with no hydrated
+// character (a flat stat-snapshot seat) has no weapon to consult and is
+// gated as melee at the default reach — see defaultMeleeReachHexes.
+//
+// Ranged weapon range is checked against the weapon's LONG range (not
+// Normal) — D&D 5e RAW imposes disadvantage beyond Normal range, not a hard
+// block; only beyond Long range is the attack impossible. weapons.Weapon.Range
+// is stored in feet; combat.FeetPerGridUnit converts to the encounter SDK's
+// hex grid.
+func (e *Encounter) checkAttackRange(player *PlayerData, targetPos core.Hex, ref *toolkitcore.Ref) error {
+	attackerPos := player.View.Position
+
+	var w *weapons.Weapon
+	if char := e.heldCharacter(player.EntityID); char != nil {
+		if sel, err := char.WeaponForActionRef(ref); err == nil && sel != nil {
+			w = sel.Weapon
+		}
+	}
+
+	if w != nil && w.IsRanged() && w.Range != nil {
+		rangeHexes := w.Range.Long / int(combat.FeetPerGridUnit)
+		return checkReach(attackerPos, targetPos, rangeHexes, "range")
+	}
+	return checkReach(attackerPos, targetPos, meleeReachForWeapon(w), "reach")
+}

--- a/encounter/range_gate.go
+++ b/encounter/range_gate.go
@@ -136,6 +136,20 @@ func (e *Encounter) checkAttackRange(player *PlayerData, targetPos core.Hex, ref
 		}
 	}
 
+	// Gate-review note (rpg-toolkit#864 minor item): deliberately keyed on
+	// w.IsRanged() (the weapon's Category), NOT "w.Range != nil". A thrown
+	// weapon (dagger/handaxe/javelin: CategorySimpleMelee + PropertyThrown)
+	// carries real Range data in the catalog, but the only ActionRef this
+	// gate sees today is the standard melee "attack" (or a granted strike) —
+	// there is no distinct "thrown_attack" ref yet, so WeaponForActionRef's
+	// default case always resolves the ordinary melee swing for a dagger,
+	// not a throw. Keying on Range!=nil instead of category would silently
+	// gate a normal melee dagger swing on its 60ft THROWN range rather than
+	// 5ft melee reach — wrong for the common case (any rogue swinging a
+	// dagger) to fix a case that can't happen yet (no thrown ref exists to
+	// route here). When a thrown-attack ref is added, IT should consult
+	// w.Range explicitly for its own gating rather than this default case
+	// being widened to guess at intent from the weapon's stats alone.
 	if w != nil && w.IsRanged() && w.Range != nil {
 		rangeHexes := w.Range.Long / int(combat.FeetPerGridUnit)
 		return checkReach(attackerPos, targetPos, rangeHexes, "range")

--- a/encounter/range_gate_internal_test.go
+++ b/encounter/range_gate_internal_test.go
@@ -1,0 +1,117 @@
+package encounter
+
+// range_gate_internal_test.go — white-box unit coverage for the pure
+// distance/reach helpers in range_gate.go (rpg-toolkit#864). Lives in
+// package encounter (not encounter_test) so it can exercise the unexported
+// helpers (checkReach, meleeReachForWeapon, meleeReachForCombatant) directly
+// with hand-built fixtures, rather than driving a full hydrated
+// character/monster through TakeActionPhased/NPCAct just to prove the
+// weapon-reach arithmetic — that integration coverage lives in
+// combat_phased_test.go / combat_test.go (encounter_test package).
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// bareCombatant is a minimal combat.Combatant test double that does NOT
+// implement combat.MeleeWeaponProvider — exercises meleeReachForCombatant's
+// type-assertion fallback (the "attacker has no weapon-resolution seam"
+// case, e.g. a future combatant type that never adopts the provider).
+type bareCombatant struct{}
+
+func (bareCombatant) GetID() string        { return "bare" }
+func (bareCombatant) GetHitPoints() int    { return 1 }
+func (bareCombatant) GetMaxHitPoints() int { return 1 }
+func (bareCombatant) AC() int              { return 10 }
+func (bareCombatant) ApplyDamage(_ context.Context, _ *combat.ApplyDamageInput) *combat.ApplyDamageResult {
+	return &combat.ApplyDamageResult{}
+}
+func (bareCombatant) IsDirty() bool                       { return false }
+func (bareCombatant) MarkClean()                          {}
+func (bareCombatant) AbilityScores() shared.AbilityScores { return shared.AbilityScores{} }
+func (bareCombatant) ProficiencyBonus() int               { return 0 }
+func (bareCombatant) PassivePerception() int              { return 10 }
+
+// meleeWeaponCombatant embeds bareCombatant and additionally implements
+// combat.MeleeWeaponProvider — stands in for a hydrated character/monster
+// whose MeleeWeapon() would otherwise require full LoadFromData plumbing.
+type meleeWeaponCombatant struct {
+	bareCombatant
+	weapon *weapons.Weapon
+}
+
+func (m meleeWeaponCombatant) MeleeWeapon() *weapons.Weapon { return m.weapon }
+
+var (
+	_ combat.Combatant           = bareCombatant{}
+	_ combat.Combatant           = meleeWeaponCombatant{}
+	_ combat.MeleeWeaponProvider = meleeWeaponCombatant{}
+)
+
+func TestCheckReach_WithinMax_NoError(t *testing.T) {
+	err := checkReach(core.Hex{Q: 0, R: 0, S: 0}, core.Hex{Q: 1, R: 0, S: -1}, 1, "reach")
+	require.NoError(t, err)
+}
+
+func TestCheckReach_BeyondMax_WrapsErrOutOfRange(t *testing.T) {
+	err := checkReach(core.Hex{Q: 0, R: 0, S: 0}, core.Hex{Q: 3, R: 0, S: -3}, 1, "reach")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrOutOfRange))
+	require.Contains(t, err.Error(), "3 hexes")
+	require.Contains(t, err.Error(), "reach 1")
+}
+
+func TestCheckInteractReach_Adjacent_NoError(t *testing.T) {
+	err := checkInteractReach(core.Hex{Q: 0, R: 0, S: 0}, core.Hex{Q: 1, R: 0, S: -1})
+	require.NoError(t, err)
+}
+
+func TestCheckInteractReach_Distant_ErrOutOfRange(t *testing.T) {
+	err := checkInteractReach(core.Hex{Q: 0, R: 0, S: 0}, core.Hex{Q: 10, R: 0, S: -10})
+	require.True(t, errors.Is(err, ErrOutOfRange))
+}
+
+func TestMeleeReachForWeapon_Nil_DefaultsToOne(t *testing.T) {
+	require.Equal(t, 1, meleeReachForWeapon(nil))
+}
+
+func TestMeleeReachForWeapon_NonReachWeapon_IsOne(t *testing.T) {
+	w, err := weapons.GetByID(weapons.Scimitar)
+	require.NoError(t, err)
+	require.Equal(t, 1, meleeReachForWeapon(&w))
+}
+
+func TestMeleeReachForWeapon_ReachProperty_IsTwo(t *testing.T) {
+	w, err := weapons.GetByID(weapons.Glaive)
+	require.NoError(t, err)
+	require.Equal(t, 2, meleeReachForWeapon(&w))
+}
+
+func TestMeleeReachForCombatant_ProviderWithReachWeapon_IsTwo(t *testing.T) {
+	glaive, err := weapons.GetByID(weapons.Glaive)
+	require.NoError(t, err)
+	reach := meleeReachForCombatant(meleeWeaponCombatant{weapon: &glaive})
+	require.Equal(t, 2, reach)
+}
+
+func TestMeleeReachForCombatant_ProviderWithNoWeapon_DefaultsToOne(t *testing.T) {
+	reach := meleeReachForCombatant(meleeWeaponCombatant{weapon: nil})
+	require.Equal(t, 1, reach)
+}
+
+func TestMeleeReachForCombatant_NilCombatant_DefaultsToOne(t *testing.T) {
+	require.Equal(t, 1, meleeReachForCombatant(nil))
+}
+
+func TestMeleeReachForCombatant_NonProvider_DefaultsToOne(t *testing.T) {
+	require.Equal(t, 1, meleeReachForCombatant(bareCombatant{}))
+}

--- a/encounter/range_gate_test.go
+++ b/encounter/range_gate_test.go
@@ -1,0 +1,312 @@
+package encounter_test
+
+// range_gate_test.go is the integration regression gate for rpg-toolkit#864:
+// a 2026-07-30 QA walk found no range/reach validation anywhere in the
+// action-resolution path — Interact opened (and unlocked) doors from 10-16
+// hexes away, and a 1-hex-reach melee weapon landed a hit from 3 hexes away.
+//
+// Each pair of tests below proves BOTH halves of the fix: the distant call
+// is rejected with encounter.ErrOutOfRange (and produces no side effect —
+// door stays closed/locked, no prompt issued, no attack resolves), and the
+// adjacent/in-range call still succeeds exactly as before. Covers all three
+// call sites the issue's spec names (Interact/door, player melee attack,
+// monster attack) plus the Reach weapon property's 2-hex extension.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+func newRangeGateBroker() (*encounter.InMemoryTransport, *encounter.Broker) {
+	transport := encounter.NewInMemoryTransport()
+	return transport, encounter.NewBroker(transport)
+}
+
+// --- OpenDoor (Interact, unlocked door) -------------------------------------
+
+func TestOpenDoor_DistantPlayer_Rejected(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	enc := encounter.New(context.Background(), "enc-rg-door-distant", broker)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+	}))
+	require.NoError(t, enc.AddDoor("door-1", core.Hex{Q: 10, R: 0, S: -10}, false))
+
+	err := enc.OpenDoor(alicePlayerID, "door-1")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+	require.False(t, enc.ToData().Doors["door-1"].Open, "door must remain closed when the actor is out of reach")
+}
+
+func TestOpenDoor_AdjacentPlayer_Succeeds(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	enc := encounter.New(context.Background(), "enc-rg-door-adjacent", broker)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+	}))
+	require.NoError(t, enc.AddDoor("door-1", core.Hex{Q: 1, R: 0, S: -1}, false))
+
+	err := enc.OpenDoor(alicePlayerID, "door-1")
+	require.NoError(t, err)
+	require.True(t, enc.ToData().Doors["door-1"].Open)
+}
+
+// --- AttemptUnlock (Interact, locked door) ----------------------------------
+
+func TestAttemptUnlock_DistantPlayer_RejectedBeforePromptIssued(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	resolver := &fakeResolver{abilityMod: 3, abilityOK: true, toolBonus: 2, toolOK: true}
+	enc := encounter.New(context.Background(), "enc-rg-unlock-distant", broker,
+		encounter.WithCharacterResolver(resolver),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+	}))
+	require.NoError(t, enc.AddDoor("door-1", core.Hex{Q: 16, R: 0, S: -16}, false))
+	door := enc.ToData().Doors["door-1"]
+	door.Locked = true
+	door.LockDC = 12
+	door.LockAbility = abilityDEX
+
+	_, err := enc.AttemptUnlock(alicePlayerID, "door-1")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+	require.NotContains(t, enc.ToData().PendingPrompts, core.PlayerID(alicePlayerID),
+		"the skill-check prompt must never be issued when the actor is out of reach")
+}
+
+func TestAttemptUnlock_AdjacentPlayer_IssuesPrompt(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	resolver := &fakeResolver{abilityMod: 3, abilityOK: true, toolBonus: 2, toolOK: true}
+	enc := encounter.New(context.Background(), "enc-rg-unlock-adjacent", broker,
+		encounter.WithCharacterResolver(resolver),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+	}))
+	require.NoError(t, enc.AddDoor("door-1", core.Hex{Q: 1, R: 0, S: -1}, false))
+	door := enc.ToData().Doors["door-1"]
+	door.Locked = true
+	door.LockDC = 12
+	door.LockAbility = abilityDEX
+
+	issued, err := enc.AttemptUnlock(alicePlayerID, "door-1")
+	require.NoError(t, err)
+	require.Equal(t, 12, issued.DC)
+	require.Contains(t, enc.ToData().PendingPrompts, core.PlayerID(alicePlayerID))
+}
+
+// --- TakeAction melee attack (player path) ----------------------------------
+
+// endTurnUntilActive advances turns until actorID is active. Fixtures here
+// place the actor first in a two-entity roster often enough that this is a
+// no-op, but it guards the flip either way (mirrors combat_test.go's
+// identical inline pattern).
+func endTurnUntilActive(t *testing.T, enc *encounter.Encounter, actorID core.EntityID) {
+	t.Helper()
+	for enc.ActiveActor() != actorID {
+		_, _, err := enc.EndTurn(context.Background(), enc.ActiveActor())
+		require.NoError(t, err)
+	}
+}
+
+func TestTakeAction_MeleeAttackBeyondReach_Rejected(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	enc := encounter.New(context.Background(), "enc-rg-melee-distant", broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 3, R: 0, S: -3},
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+	endTurnUntilActive(t, enc, aliceEntityID)
+
+	err := enc.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+}
+
+func TestTakeAction_MeleeAttackAtReach_Succeeds(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	enc := encounter.New(context.Background(), "enc-rg-melee-adjacent", broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+		HP: 12, MaxHP: 12, AC: 14, AttackBonus: 4,
+		DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+	endTurnUntilActive(t, enc, aliceEntityID)
+
+	err := enc.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	require.NoError(t, err)
+}
+
+// --- TakeAction melee attack with a Reach weapon (rpg-toolkit#864 spec:
+// "melee attacks use weapon reach") ------------------------------------------
+
+// hydrateGlaiveWielder builds+round-trips (via LoadFromData, mirroring
+// combat_test.go's hydration pattern) a player whose equipped main-hand
+// weapon is the Reach-property glaive, at pos, against a monster at
+// monsterPos. Returns the loaded encounter with alice active.
+func hydrateGlaiveWielder(t *testing.T, broker *encounter.Broker, id string, monsterPos core.Hex) *encounter.Encounter {
+	t.Helper()
+	charData := &dnd5eCharacter.Data{
+		ID: aliceEntityID, Name: "Alice", Level: 1, ProficiencyBonus: 2,
+		HitPoints: 12, MaxHitPoints: 12,
+		Inventory: []dnd5eCharacter.InventoryItemData{
+			{Type: shared.EquipmentTypeWeapon, ID: weapons.Glaive, Quantity: 1},
+		},
+		EquipmentSlots: dnd5eCharacter.EquipmentSlots{
+			dnd5eCharacter.SlotMainHand: weapons.Glaive,
+		},
+	}
+	charJSON, err := json.Marshal(charData)
+	require.NoError(t, err)
+
+	enc := encounter.New(context.Background(), core.EncounterID(id), broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+		HP: 12, MaxHP: 12,
+		DataJSON: charJSON,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: monsterPos,
+		HP: 7, MaxHP: 7, AC: 15,
+	}))
+
+	raw, err := json.Marshal(enc.ToData())
+	require.NoError(t, err)
+	var data encounter.Data
+	require.NoError(t, json.Unmarshal(raw, &data))
+	loaded, err := encounter.LoadFromData(context.Background(), &data, broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	require.NoError(t, err)
+	endTurnUntilActive(t, loaded, aliceEntityID)
+	return loaded
+}
+
+func TestTakeAction_GlaiveReach_TwoHexes_Succeeds(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	loaded := hydrateGlaiveWielder(t, broker, "enc-rg-glaive-ok", core.Hex{Q: 2, R: 0, S: -2})
+
+	err := loaded.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	require.NoError(t, err, "the glaive's Reach property must extend melee reach to 2 hexes")
+}
+
+func TestTakeAction_GlaiveReach_ThreeHexes_Rejected(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	loaded := hydrateGlaiveWielder(t, broker, "enc-rg-glaive-reject", core.Hex{Q: 3, R: 0, S: -3})
+
+	err := loaded.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+}
+
+// --- NPCAct scripted attack (monster path, no DataJSON) ---------------------
+
+func TestNPCAct_ScriptedAttackBeyondReach_Rejected(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	enc := encounter.New(context.Background(), "enc-rg-npc-distant", broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 3, R: 0, S: -3},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		// No DataJSON: NPCAct falls back to npcActScripted, the "different
+		// entry point" the issue's spec calls out — it must be gated too.
+	}))
+	endTurnUntilActive(t, enc, gobEntityID)
+
+	err := enc.NPCAct(context.Background(), gobEntityID)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+}
+
+func TestNPCAct_ScriptedAttackAtReach_Succeeds(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	enc := encounter.New(context.Background(), "enc-rg-npc-adjacent", broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
+		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+	}))
+	endTurnUntilActive(t, enc, gobEntityID)
+
+	err := enc.NPCAct(context.Background(), gobEntityID)
+	require.NoError(t, err)
+}

--- a/encounter/range_gate_test.go
+++ b/encounter/range_gate_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	dnd5eCharacter "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	monsteractions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
@@ -120,6 +124,76 @@ func TestAttemptUnlock_AdjacentPlayer_IssuesPrompt(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 12, issued.DC)
 	require.Contains(t, enc.ToData().PendingPrompts, core.PlayerID(alicePlayerID))
+}
+
+// TestSubmitCheck_PlayerWalksAwayBeforeSubmitting_LockSurvives is the
+// gate-review regression for blocker 2 (rpg-toolkit#864): dispatchPromptAction
+// (prompts.go) used to set door.Locked = false unconditionally before
+// calling the now-fallible OpenDoor, and nothing re-checked reach at
+// SubmitCheck time. Exploit sequence: AttemptUnlock while adjacent (issues
+// the prompt), walk away, SubmitCheck with a roll that clears the DC —
+// Locked got cleared, OpenDoor then failed on distance (door left
+// closed-but-unlocked), and walking back let a later OpenDoor open it for
+// free — the DC check permanently bypassed.
+//
+// The fix re-checks reach in dispatchPromptAction before committing
+// Locked = false. This test drives the exact walk-away sequence and proves
+// the lock survives: the dispatch fails (wrapping ErrOutOfRange) while the
+// check itself is still reported as having succeeded (Success: true — the
+// roll was genuinely good, only the "open it right now" dispatch failed),
+// the prompt is consumed (not left stranded, matching the existing
+// downstream-OpenDoor-error contract on SubmitCheck), and — the part that
+// actually matters — the door is STILL Locked afterward, so a fresh
+// AttemptUnlock from back in reach is required rather than a free unlock.
+func TestSubmitCheck_PlayerWalksAwayBeforeSubmitting_LockSurvives(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	resolver := &fakeResolver{abilityMod: 3, abilityOK: true, toolBonus: 2, toolOK: true}
+	enc := encounter.New(context.Background(), "enc-rg-unlock-walkaway", broker,
+		encounter.WithCharacterResolver(resolver),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+	}))
+	require.NoError(t, enc.AddDoor("door-1", core.Hex{Q: 1, R: 0, S: -1}, false))
+	door := enc.ToData().Doors["door-1"]
+	door.Locked = true
+	door.LockDC = 12
+	door.LockAbility = abilityDEX
+
+	// Adjacent: AttemptUnlock issues the prompt normally.
+	_, err := enc.AttemptUnlock(alicePlayerID, "door-1")
+	require.NoError(t, err)
+
+	// Walk away before resolving the check.
+	require.NoError(t, enc.Move(alicePlayerID, []core.Hex{
+		{Q: 2, R: 0, S: -2}, {Q: 3, R: 0, S: -3}, {Q: 4, R: 0, S: -4}, {Q: 5, R: 0, S: -5},
+	}))
+
+	// roll(15) + abilityMod(3) = 18 (no LockTool set, so toolBonus doesn't
+	// apply), comfortably clears DC 12.
+	res, err := enc.SubmitCheck(alicePlayerID, 15)
+	require.Error(t, err, "the dispatch must fail once the player has left reach")
+	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+	require.True(t, res.Success, "the roll itself still succeeded — only the dispatch (opening the door right now) failed")
+	require.Equal(t, 18, res.Total)
+
+	doorAfter := enc.ToData().Doors["door-1"]
+	require.True(t, doorAfter.Locked,
+		"the door must remain genuinely locked — this is the free-unlock-bypass gate finding")
+	require.False(t, doorAfter.Open)
+	require.NotContains(t, enc.ToData().PendingPrompts, core.PlayerID(alicePlayerID),
+		"the consumed attempt's prompt must not be left stranded")
+
+	// Walk back and confirm the lock genuinely still requires a fresh
+	// check — not a free, silent bypass.
+	require.NoError(t, enc.Move(alicePlayerID, []core.Hex{
+		{Q: 4, R: 0, S: -4}, {Q: 3, R: 0, S: -3}, {Q: 2, R: 0, S: -2}, {Q: 1, R: 0, S: -1},
+	}))
+	_, err = enc.AttemptUnlock(alicePlayerID, "door-1")
+	require.NoError(t, err, "back in reach, a fresh AttemptUnlock must work normally")
 }
 
 // --- TakeAction melee attack (player path) ----------------------------------
@@ -311,7 +385,17 @@ func TestTakeAction_ShortbowRange_BeyondLongRange_Rejected(t *testing.T) {
 
 // --- NPCAct scripted attack (monster path, no DataJSON) ---------------------
 
-func TestNPCAct_ScriptedAttackBeyondReach_Rejected(t *testing.T) {
+// TestNPCAct_ScriptedAttackBeyondReach_PassesTurnWithoutWedging is the
+// gate-review regression for blocker 1: npcActScripted originally returned
+// the ErrOutOfRange from the shared gate directly, and NPCAct propagated it
+// as a hard failure. rpg-api's driveNPCChain only calls EndTurn after a
+// SUCCESSFUL NPCAct, so an out-of-reach monster (the closest player simply
+// too far away) would error on every single retry and the encounter would
+// be wedged forever — turn never advances, nobody can act. The fix: an
+// out-of-reach target is "nothing to do this turn" (same as the existing
+// target==nil case), not an error — NPCAct succeeds, no attack resolves,
+// and the turn ends normally afterward.
+func TestNPCAct_ScriptedAttackBeyondReach_PassesTurnWithoutWedging(t *testing.T) {
 	transport, broker := newRangeGateBroker()
 	defer func() { _ = broker.Close(); _ = transport.Close() }()
 
@@ -333,8 +417,15 @@ func TestNPCAct_ScriptedAttackBeyondReach_Rejected(t *testing.T) {
 	endTurnUntilActive(t, enc, gobEntityID)
 
 	err := enc.NPCAct(context.Background(), gobEntityID)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+	require.NoError(t, err, "an out-of-reach scripted attack must pass the turn, not error")
+	require.Equal(t, 12, enc.ToData().Players[alicePlayerID].HP, "no attack resolved, so no damage")
+
+	// The turn must be free to end normally — proving the encounter isn't
+	// wedged (the exact failure mode blocker 1 fixes).
+	_, _, endErr := enc.EndTurn(context.Background(), gobEntityID)
+	require.NoError(t, endErr)
+	require.Equal(t, core.EntityID(aliceEntityID), enc.ActiveActor(),
+		"turn must advance to alice, not stay stuck on the goblin")
 }
 
 func TestNPCAct_ScriptedAttackAtReach_Succeeds(t *testing.T) {
@@ -358,4 +449,72 @@ func TestNPCAct_ScriptedAttackAtReach_Succeeds(t *testing.T) {
 
 	err := enc.NPCAct(context.Background(), gobEntityID)
 	require.NoError(t, err)
+}
+
+// --- applyCapturedAttacks skip semantics (hydrated monster path) -----------
+
+// TestNPCAct_HydratedMonster_OutOfReachCapturedAttack_SkipsWithoutWedging is
+// the gate-review regression for blocker 1's other call site
+// (applyCapturedAttacks, the hydrated-monster path — the scripted-fallback
+// path above covers npcActScripted).
+//
+// Builds a monster whose own melee action reports an inflated reach (3, via
+// a weapon name — "unmatched-claw" — that doesn't match anything in the
+// weapons catalog, so the shared gate's meleeReachForCombatant can't
+// resolve a real weapon and falls back to the 1-hex default). This models
+// a real mismatch class: a monster whose configured reach doesn't line up
+// with what the shared catalog-driven gate can independently verify (e.g.
+// a bug in the monster's own action config, or any reach not backed by a
+// cataloged weapon).
+//
+// The monster's speed (2) is deliberately too small to close the initial
+// 4-hex gap to adjacency in one turn (moveTowardEnemy always tries to close
+// to adjacency first) — after moving 2 hexes it's 2 hexes from the player:
+// within its OWN inflated reach (3), so monster.TakeTurn selects and swings
+// the melee action, but beyond the shared gate's independently-resolved
+// reach (1) — applyCapturedAttacks must skip this captured attack rather
+// than error and wedge the encounter.
+func TestNPCAct_HydratedMonster_OutOfReachCapturedAttack_SkipsWithoutWedging(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	meleeCfg := monsteractions.MeleeConfig{
+		Name: "unmatched-claw", AttackBonus: 4, DamageDice: "1d6",
+		Reach: 3, DamageType: damage.Slashing,
+	}
+	cfgJSON, err := json.Marshal(meleeCfg)
+	require.NoError(t, err)
+	monData := &monster.Data{
+		ID: gobEntityID, Name: "Test Monster", HitPoints: 7, MaxHitPoints: 7, ArmorClass: 15,
+		Senses: monster.SensesData{PassivePerception: 10},
+		Actions: []monster.ActionData{
+			{Ref: *refs.MonsterActions.Melee(), Config: cfgJSON},
+		},
+	}
+	monJSON, err := json.Marshal(monData)
+	require.NoError(t, err)
+
+	enc := encounter.New(context.Background(), "enc-rg-npc-hydrated-skip", broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID,
+		Position: core.Hex{}, SightRange: 20,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: core.Hex{Q: 4, R: 0, S: -4},
+		HP: 7, MaxHP: 7, AC: 15, Speed: 2,
+		DataJSON: monJSON,
+	}))
+	endTurnUntilActive(t, enc, gobEntityID)
+
+	err = enc.NPCAct(context.Background(), gobEntityID)
+	require.NoError(t, err, "an out-of-reach captured attack must be skipped, not error/wedge the turn")
+	require.Equal(t, 12, enc.ToData().Players[alicePlayerID].HP, "the skipped attack must deal no damage")
+
+	_, _, endErr := enc.EndTurn(context.Background(), gobEntityID)
+	require.NoError(t, endErr)
+	require.Equal(t, core.EntityID(aliceEntityID), enc.ActiveActor(),
+		"turn must advance to alice, not stay stuck on the goblin")
 }

--- a/encounter/range_gate_test.go
+++ b/encounter/range_gate_test.go
@@ -27,6 +27,10 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
 
+// aliceCharacterName is the display name on the hydrated-character fixtures
+// below (hydrateWeaponWielder) — extracted to a constant to satisfy goconst.
+const aliceCharacterName = "Alice"
+
 func newRangeGateBroker() (*encounter.InMemoryTransport, *encounter.Broker) {
 	transport := encounter.NewInMemoryTransport()
 	return transport, encounter.NewBroker(transport)
@@ -188,20 +192,24 @@ func TestTakeAction_MeleeAttackAtReach_Succeeds(t *testing.T) {
 // --- TakeAction melee attack with a Reach weapon (rpg-toolkit#864 spec:
 // "melee attacks use weapon reach") ------------------------------------------
 
-// hydrateGlaiveWielder builds+round-trips (via LoadFromData, mirroring
+// hydrateWeaponWielder builds+round-trips (via LoadFromData, mirroring
 // combat_test.go's hydration pattern) a player whose equipped main-hand
-// weapon is the Reach-property glaive, at pos, against a monster at
-// monsterPos. Returns the loaded encounter with alice active.
-func hydrateGlaiveWielder(t *testing.T, broker *encounter.Broker, id string, monsterPos core.Hex) *encounter.Encounter {
+// weapon is weaponID, at the origin, against a monster at monsterPos.
+// Returns the loaded encounter with alice active. Shared by the glaive
+// (melee Reach) and shortbow (ranged) fixtures below — only the weapon and
+// sight range vary between them.
+func hydrateWeaponWielder(
+	t *testing.T, broker *encounter.Broker, id string, weaponID string, sightRange int, monsterPos core.Hex,
+) *encounter.Encounter {
 	t.Helper()
 	charData := &dnd5eCharacter.Data{
-		ID: aliceEntityID, Name: "Alice", Level: 1, ProficiencyBonus: 2,
+		ID: aliceEntityID, Name: aliceCharacterName, Level: 1, ProficiencyBonus: 2,
 		HitPoints: 12, MaxHitPoints: 12,
 		Inventory: []dnd5eCharacter.InventoryItemData{
-			{Type: shared.EquipmentTypeWeapon, ID: weapons.Glaive, Quantity: 1},
+			{Type: shared.EquipmentTypeWeapon, ID: weaponID, Quantity: 1},
 		},
 		EquipmentSlots: dnd5eCharacter.EquipmentSlots{
-			dnd5eCharacter.SlotMainHand: weapons.Glaive,
+			dnd5eCharacter.SlotMainHand: weaponID,
 		},
 	}
 	charJSON, err := json.Marshal(charData)
@@ -212,7 +220,7 @@ func hydrateGlaiveWielder(t *testing.T, broker *encounter.Broker, id string, mon
 	)
 	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
-		Position: core.Hex{}, SightRange: 20,
+		Position: core.Hex{}, SightRange: sightRange,
 		HP: 12, MaxHP: 12,
 		DataJSON: charJSON,
 	}))
@@ -237,7 +245,7 @@ func TestTakeAction_GlaiveReach_TwoHexes_Succeeds(t *testing.T) {
 	transport, broker := newRangeGateBroker()
 	defer func() { _ = broker.Close(); _ = transport.Close() }()
 
-	loaded := hydrateGlaiveWielder(t, broker, "enc-rg-glaive-ok", core.Hex{Q: 2, R: 0, S: -2})
+	loaded := hydrateWeaponWielder(t, broker, "enc-rg-glaive-ok", weapons.Glaive, 20, core.Hex{Q: 2, R: 0, S: -2})
 
 	err := loaded.TakeAction(alicePlayerID,
 		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
@@ -250,7 +258,48 @@ func TestTakeAction_GlaiveReach_ThreeHexes_Rejected(t *testing.T) {
 	transport, broker := newRangeGateBroker()
 	defer func() { _ = broker.Close(); _ = transport.Close() }()
 
-	loaded := hydrateGlaiveWielder(t, broker, "enc-rg-glaive-reject", core.Hex{Q: 3, R: 0, S: -3})
+	loaded := hydrateWeaponWielder(t, broker, "enc-rg-glaive-reject", weapons.Glaive, 20, core.Hex{Q: 3, R: 0, S: -3})
+
+	err := loaded.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
+}
+
+// --- TakeAction ranged attack with a Shortbow (rpg-toolkit#864 spec:
+// "ranged attacks use the weapon's range") -----------------------------------
+
+// shortbowRangeLongHexes is weapons.Shortbow's long range (320ft) converted
+// to hexes (5ft/hex) — mirrors checkAttackRange's own conversion.
+const shortbowRangeLongHexes = 320 / 5
+
+// shortbowSightRange comfortably covers shortbowRangeLongHexes±4 so
+// AddMonster's mutual-LoS check auto-transitions to TURN_BASED in both the
+// success and rejection fixtures below.
+const shortbowSightRange = shortbowRangeLongHexes + 10
+
+func TestTakeAction_ShortbowRange_WithinLongRange_Succeeds(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	loaded := hydrateWeaponWielder(t, broker, "enc-rg-shortbow-ok", weapons.Shortbow, shortbowSightRange,
+		core.Hex{Q: shortbowRangeLongHexes - 4, R: 0, S: -(shortbowRangeLongHexes - 4)})
+
+	err := loaded.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	)
+	require.NoError(t, err, "a target well within the shortbow's long range must not be gated as melee")
+}
+
+func TestTakeAction_ShortbowRange_BeyondLongRange_Rejected(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+
+	loaded := hydrateWeaponWielder(t, broker, "enc-rg-shortbow-reject", weapons.Shortbow, shortbowSightRange,
+		core.Hex{Q: shortbowRangeLongHexes + 4, R: 0, S: -(shortbowRangeLongHexes + 4)})
 
 	err := loaded.TakeAction(alicePlayerID,
 		encounter.ActionRef{Module: refModuleDnd5e, Type: refTypeAction, ID: actionIDAttackTest},

--- a/encounter/tpk_test.go
+++ b/encounter/tpk_test.go
@@ -85,18 +85,27 @@ func (s *TPKSuite) TestMultiPlayer_OneDeath_DoesNotEndEncounter_BothDeaths_EndsA
 	// alice is closer to the goblin than bob, so closestPlayer targets her
 	// first; once she's down (HP<=0, excluded), the goblin's next act must
 	// retarget to bob.
+	//
+	// rpg-toolkit#864: npcActScripted now gates melee attacks on reach (the
+	// goblin here has no DataJSON, so it defaults to 1 hex), and BOTH goblin
+	// acts must land — alice's first, then bob's once alice is excluded. So
+	// alice is co-located with the goblin (distance 0, strictly closer) and
+	// bob sits one hex away (distance 1, strictly farther but still in
+	// reach) rather than the old "far enough that map-iteration tie-break
+	// can't matter" distance-4 spot, which is now out of reach.
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: tpkAliceEntityID,
-		Position: encountercore.Hex{}, SightRange: 10,
+		Position: encountercore.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
 		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
 		DamageDice: tpkDamageDice, DamageType: damageSlashing,
 	}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "bob", EntityID: tpkBobEntityID,
-		// Strictly farther from the goblin than alice's distance-1 spot, so
-		// closestPlayer's tie-break (map iteration order, non-deterministic)
-		// can never accidentally pick bob first.
-		Position: encountercore.Hex{Q: 4, R: 0, S: -4}, SightRange: 10,
+		// Strictly farther from the goblin than alice (distance 1 vs. 0),
+		// so closestPlayer's tie-break (map iteration order, non-
+		// deterministic) can never accidentally pick bob first — and still
+		// within the goblin's 1-hex melee reach for its second act.
+		Position: encountercore.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
 		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
 		DamageDice: tpkDamageDice, DamageType: damageSlashing,
 	}))

--- a/encounter/two_chamber_test.go
+++ b/encounter/two_chamber_test.go
@@ -108,6 +108,30 @@ func doorAdjacentChamber1Hex() core.Hex {
 	return core.HexFromPosition(spatial.Position{X: float64(chamberW - 1), Y: float64(chamberH / 2)})
 }
 
+// straightRowPath returns the Move-ready hex sequence from just after from
+// up to and including to, stepping one X unit at a time along a shared row
+// (from.ToPosition().Y must equal to.ToPosition().Y) — the shape of the
+// generator's own guaranteed wall-free "required path" between an entrance
+// and a door-adjacent cell. rpg-toolkit#864: OpenDoor/AttemptUnlock now
+// require the actor to actually be adjacent, so fixtures across this
+// package's dungeon/chamber tests use this to walk there via Move first,
+// instead of teleporting a player next to a door they've never approached.
+func straightRowPath(from, to core.Hex) []core.Hex {
+	fp, tp := from.ToPosition(), to.ToPosition()
+	step := 1.0
+	if tp.X < fp.X {
+		step = -1.0
+	}
+	var path []core.Hex
+	for x := fp.X + step; ; x += step {
+		path = append(path, core.HexFromPosition(spatial.Position{X: x, Y: fp.Y}))
+		if x == tp.X {
+			break
+		}
+	}
+	return path
+}
+
 // TwoChamberSuite exercises InitTwoChamberRoom's fixed named-seed layout
 // (slice2TwoChambersSeed) — a fresh Encounter per test.
 type TwoChamberSuite struct {
@@ -178,6 +202,9 @@ func (s *TwoChamberSuite) TestOpenDoor_ConnectsEntranceThroughDoorToChamber2() {
 		PlayerID: alicePlayerID, EntityID: aliceEntityID,
 		Position: entrance, SightRange: 30,
 	}))
+	// rpg-toolkit#864: OpenDoor requires adjacency — walk alice up to the
+	// door along the generator's guaranteed wall-free required path first.
+	s.Require().NoError(s.enc.Move(alicePlayerID, straightRowPath(entrance, doorAdjacentChamber1Hex())))
 	s.Require().NoError(s.enc.OpenDoor(alicePlayerID, twoChamberDoorID))
 
 	reachable := reachableFrom(s.enc.Room(), entrance)


### PR DESCRIPTION
Fixes #864.

## Bug

A 2026-07-30 QA walk found **no range/reach validation anywhere in the action-resolution path**:

- Interact opened a closed (unlocked) door from 10 hexes away.
- Interact on a *locked* door triggered and passed its DC-12 dex skill check from 16 hexes away — the entire lock mechanic was reachable from anywhere on the map.
- A melee attack with a 1-hex-reach weapon executed and resolved server-side against a target 3 hexes away.

Positions were already tracked (`tools/spatial` via `encounter/core.Hex` + the package's existing `hexDistance` helper) — the action paths simply never consulted them.

## Fix

One shared gate (`encounter/range_gate.go`, new file):

- `ErrOutOfRange` sentinel, wrapped by every gated verb.
- `checkReach`/`checkInteractReach` — the underlying hex-distance check.
- `meleeReachForWeapon`/`meleeReachForCombatant` — resolve melee reach from a real weapon via `combat.MeleeWeaponProvider` (the existing seam opportunity-attack resolution already uses, #722), defaulting to 1 hex when no weapon is resolvable.
- `(*Encounter).checkAttackRange` — the player attack path's gate, resolving the *specific* weapon for the submitted ActionRef via `Character.WeaponForActionRef` (#712), so ranged weapons gate on `Range.Long` (feet→hexes via `combat.FeetPerGridUnit`) and melee gates on reach (2 hexes for the Reach property, 1 otherwise).

Wired into every action-resolution entry point that mutates world state from a position:

- `Encounter.OpenDoor` (`encounter/encounter.go`) — adjacency (reach 1).
- `Encounter.AttemptUnlock` (`encounter/prompts.go`) — adjacency, checked *before* the skill-check prompt is issued (a distant attempt must never even see the prompt).
- `Encounter.TakeActionPhased` (`encounter/combat_phased.go`) — the player attack path, gated *before* the economy spend (an out-of-range attack costs no action, mirroring the existing insufficient-movement precedent).
- `Encounter.applyCapturedAttacks` and `Encounter.npcActScripted` (`encounter/npc.go`) — **both** monster attack entry points. `npcActScripted` (the no-DataJSON fallback) had zero range validation of its own — a second, previously-untested bug this PR also fixes.

## What range data existed vs. what's defaulted

- **Melee, both players and monsters**: real weapon reach via `combat.MeleeWeaponProvider` — already-wired, no new plumbing. Falls back to the D&D 5e default (1 hex) when the attacker has no held character (today's common case: UI-created characters are unarmed, a known separate bug), a monster's natural weapon (bite/claw has no catalog entry), or weapon resolution errors.
- **Ranged, players**: `checkAttackRange` resolves the weapon via `Character.WeaponForActionRef` and gates on `Range.Long` when it's a ranged weapon (feet→hexes via `combat.FeetPerGridUnit`) — proven end-to-end with a hydrated character + Shortbow fixture (within 320ft/64-hex long range succeeds, beyond it rejects).
- **Ranged, monsters** (rpg-toolkit#866 covers the underlying accessor/event gap): **not numerically gated** — `dnd5eEvents.AttackEvent` carries `IsMelee` but no numeric range, and `MonsterData` has no range field to consult without inventing new plumbing. Melee IS gated on both monster paths. In practice this is defense-in-depth, not the primary gate: `monster.TakeTurn`'s own action selection (`actions.MeleeAction`/`actions.RangedAction.CanActivate`) already rejects an out-of-reach/out-of-range choice before any `AttackEvent` publishes — the QA walk observed monster AI correctly closing to adjacency in both fights.

## TDD evidence

`encounter/range_gate_test.go` + `encounter/range_gate_internal_test.go` were written and run **before** wiring anything in, confirming RED: a distant `OpenDoor`, a distant `AttemptUnlock` (prompt issued from 16 hexes), a 3-hex melee `TakeAction`, and `npcActScripted`'s distant scripted attack all currently succeeded. After wiring in the 4 gates, all flip to GREEN. Coverage: adjacent door/unlock succeed, distant door/unlock rejected (unlock rejected *before* the prompt is issued), melee at reach succeeds, melee beyond reach rejected, Reach-weapon melee succeeds at 2 hexes and is rejected at 3, Shortbow ranged attack succeeds within its 64-hex long range and is rejected beyond it, both monster attack entry points (hydrated + scripted-fallback) gated and tested at both distances. Full `go test ./...` green (including `-race`); `golangci-lint` clean on every file this PR touches.

## Gate-review fixes (round 2)

The first gate pass verified the range/reach math, ordering, and boundaries as correct, and confirmed the fixture repairs were honest (zero assertion lines changed to make a test pass). It found two real defects, both stemming from making previously-*infallible* verbs *fallible*:

1. **Unreachable monster wedges the encounter.** `npcActScripted` and `applyCapturedAttacks` originally `return`ed the gate's error directly; `NPCAct` propagated it, and rpg-api's `driveNPCChain` only calls `EndTurn` after a *successful* `NPCAct` — so an out-of-reach monster errored identically on every retry and the encounter never advanced, permanently. Fixed by following the file's own existing convention (the `closestPlayer == nil` → "nothing to do this turn" case, `npcActScripted`): an out-of-reach target is a no-op, not an error. `npcActScripted` now returns `nil` (skips its whole turn, same as no target); `applyCapturedAttacks` `continue`s past just the out-of-reach captured attack (a multiattack monster's other swings, if any, and any *earlier* attacks in the same loop that already applied damage, are unaffected — nothing is unwound). Both are TDD'd with a genuine RED→GREEN cycle (verified by temporarily reverting each fix and confirming the new tests fail): `TestNPCAct_ScriptedAttackBeyondReach_PassesTurnWithoutWedging` and `TestNPCAct_HydratedMonster_OutOfReachCapturedAttack_SkipsWithoutWedging` (the latter also closes the "fifth wire site has no dedicated RED test" minor finding) — both assert `NPCAct` returns no error, no damage was dealt, and a subsequent `EndTurn` succeeds and advances the active actor (proving no wedge).
2. **Failed unlock-dispatch destroyed the lock (free-unlock bypass).** `dispatchPromptAction` set `door.Locked = false` *before* calling the now-fallible `OpenDoor`, and nothing re-checked reach at `SubmitCheck` time. Exploit: `AttemptUnlock` while adjacent (issues the prompt) → walk away → `SubmitCheck` with a passing roll → `Locked` gets cleared, `OpenDoor` then fails on distance (door left closed-but-unlocked) → walk back → a later `OpenDoor` opens it for free, the DC check permanently bypassed. Fixed by re-checking `checkInteractReach` in `dispatchPromptAction` *before* committing `Locked = false`. Decision on what happens to the pending prompt: the check itself still resolves as successful (`SubmitCheckResult.Success: true`, matching the honest roll), but the dispatch fails and the prompt is cleared from *this* in-memory `Encounter` — the existing "downstream OpenDoor error" contract already documented on `SubmitCheck`'s doc comment covers this exact shape without needing new special-casing. What that means for the player is host-dependent, not a toolkit guarantee (rpg-api's `SubmitCheck` orchestrator doesn't persist on error, so its store keeps the original prompt and the player can resubmit after walking back) — what the toolkit *does* guarantee is the property that matters: the door stays genuinely `Locked` either way. TDD'd with `TestSubmitCheck_PlayerWalksAwayBeforeSubmitting_LockSurvives`, which drives the exact walk-away sequence and was verified RED→GREEN the same way (temporarily reverted, confirmed the door goes permanently unlocked, restored the fix).

Also fixed per the gate's minor findings:
- Thrown weapons (dagger/handaxe/javelin: `CategorySimpleMelee` + `PropertyThrown` + real catalog `Range` 20-60/30-120ft) are still gated as ordinary 1-hex melee for the standard "attack" ref — documented *why* in `checkAttackRange` rather than switching the condition to "has Range data": no `thrown_attack` ActionRef exists yet, so `WeaponForActionRef`'s only case in play always resolves the ordinary melee swing; keying on `Range != nil` instead of category would incorrectly gate a normal melee dagger swing on its 60ft thrown range. When a thrown-attack ref is added, it should consult `Range` explicitly for its own gating.

Full `go test ./...` green (including `-race`) after these fixes; no new lint.

### Known scope boundaries (explicitly NOT addressed here, per Kirk's pending rulings)

- **Ranged attacks through walls/closed doors are not LoS-gated** — this PR is a distance-only gate (a shortbow can still "kill through a closed door" if the target is within hex range). Line-of-sight gating for ranged attacks is a separate design question awaiting a ruling.
- **Spells and abilities are not gated by this PR** — they dispatch through `takeCharacterAction` before reaching this gate (the gate only sits in front of Interact/door verbs and the two attack paths). Whether/how spell range should be validated is out of scope here.

### Coordination with #867 — rebase done

#867 merged to main first as planned; this branch has been rebased onto it (force-pushed, head `c8b26c6`). Both known collision points are resolved:

- **`encounter/pocket_clear_move_teardown_test.go`** (hard conflict): #867's `TestPocketClear_ThenReEntry_ReseedsFullMovementBudget` rewrite proves a specific diagnostic — a two-move split where the first leg (20ft) must NOT trigger combat and the second leg (20ft) is the exact amount attributed as pre-spent on the trigger's forced-first turn (30-20=10ft remaining, chosen specifically to be distinguishable from an accidentally-unseeded 0). That fixture had erin starting the whole approach from k=0, walking straight through the door at k=10 in two hops toward group B at k=15. This PR's adjacency requirement means erin must now stand at k=9 (one hex from the door) before `OpenDoor` — and from k=9, k=15 is only 6 hexes away, already inside `SightRange` 10 the instant the door opens, leaving no room for a "still safe" first leg at all. Resolution: moved group B from k=15 to k=25 (and the room from 20×20 to a comfortably-sized 40×40 to fit it) so there's a genuine gap to walk through after reaching the door-adjacent position — the two-move split, its exact waypoints (shifted but still 4 hexes/20ft each), and the 30-20=10ft assertion are otherwise unchanged. Full reasoning is in the updated doc comment on `loadErinVsTwoPockets`.
- **#867's `TestOpenDoorThenMove_TriggerForcedFirstRegardlessOfRoll`** (`combat_trigger_order_test.go`, opened a door from 3 hexes away): repositioned to walk to the hex adjacent to the door first, then continue through it — same pattern as every other door-verb fixture this PR already touched, no change to what the test proves.

Also applied the queued nit from the last gate pass: softened the `dispatchPromptAction` comment (see finding 2 above) to stop overstating "a walk-away consumes the attempt" as a toolkit-wide guarantee when it's actually host-dependent.

Full `go test ./...` green (including `-race`) after the rebase; no new lint. CI is green on the rebased head (`c8b26c6`): `ci-status` and `test-changed (encounter, 1.25.x)` both pass.

## Flagged for review

1. **rpg-api status-code mapping gap**: for the attack path (`TakeAction` / `EndTurn`→`NPCAct`), `ErrOutOfRange` isn't in rpg-api's existing sentinel switch (`take_action.go`/`end_turn.go`), so it surfaces as `codes.Internal` on the wire rather than `FailedPrecondition` until a small rpg-api follow-up adds it. Left as-is per this PR's toolkit-only scope — tracked as rpg-api#747. The door path needs no such follow-up — rpg-api's `wrapDoorVerbErr` already generically wraps any non-sentinel door-verb error to `FailedPrecondition`.
2. Monster ranged-attack numeric range gating (see above) — a real gap, but inventing the plumbing felt out of scope for this fix. Tied to rpg-toolkit#866 (the monster accessor/event gap that would need to close first for this to have real data to gate on).
3. Fixing the ~28 pre-existing tests this correctness change broke (they called these verbs from unrealistic distances, exploiting the missing gate) meant repositioning fixtures/inserting `Move` calls across ~20 files — always preserving each test's original intent, never weakening the new gate.

— asset-pipeline agent, on behalf of KirkDiggler
