### PR TITLE
fix(monk): accurate 2014 weapon guidance in description + starting equipment choice

### DIFF
--- a/rulebooks/dnd5e/character/choices/monk_weapon_guidance_test.go
+++ b/rulebooks/dnd5e/character/choices/monk_weapon_guidance_test.go
@@ -1,0 +1,112 @@
+package choices
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// MonkWeaponGuidanceTestSuite guards rpg-toolkit#873: the Monk starting
+// equipment weapon choice must offer "simple melee weapon" (not the bare
+// "simple weapon" superset) and must not resolve to
+// weapons.CategorySimpleRanged - simple ranged weapons (dart, sling, light
+// crossbow) are not part of a Monk's weapon set in this game. Shortsword
+// stays the explicit, separate alternative option.
+type MonkWeaponGuidanceTestSuite struct {
+	suite.Suite
+}
+
+func TestMonkWeaponGuidanceSuite(t *testing.T) {
+	suite.Run(t, new(MonkWeaponGuidanceTestSuite))
+}
+
+// findMonkWeaponOption locates the MonkWeaponSimple option inside the
+// MonkWeaponsPrimary requirement, failing the test loudly if the shape has
+// moved instead of silently skipping assertions.
+func (s *MonkWeaponGuidanceTestSuite) findMonkWeaponOption() (req *EquipmentRequirement, opt *EquipmentOption) {
+	reqs := GetClassRequirements(classes.Monk)
+	s.Require().NotNil(reqs, "Monk should have requirements")
+
+	for _, r := range reqs.Equipment {
+		if r.ID != MonkWeaponsPrimary {
+			continue
+		}
+		req = r
+		for i := range r.Options {
+			if r.Options[i].ID == MonkWeaponSimple {
+				opt = &r.Options[i]
+			}
+		}
+	}
+
+	s.Require().NotNil(req, "MonkWeaponsPrimary requirement should exist")
+	s.Require().NotNil(opt, "MonkWeaponSimple option should exist under MonkWeaponsPrimary")
+	return req, opt
+}
+
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_LabelSaysSimpleMeleeWeapon() {
+	_, opt := s.findMonkWeaponOption()
+
+	lower := strings.ToLower(opt.Label)
+	s.Contains(lower, "simple melee weapon",
+		"MonkWeaponSimple option label should say 'simple melee weapon', got %q", opt.Label)
+}
+
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_CategoryChoiceLabelSaysSimpleMelee() {
+	_, opt := s.findMonkWeaponOption()
+
+	s.Require().Len(opt.CategoryChoices, 1, "MonkWeaponSimple should have exactly one category choice")
+	lower := strings.ToLower(opt.CategoryChoices[0].Label)
+	s.Contains(lower, "simple melee weapon",
+		"MonkWeaponSimple category choice label should say 'simple melee weapon', got %q",
+		opt.CategoryChoices[0].Label)
+}
+
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_ExcludesSimpleRangedCategory() {
+	_, opt := s.findMonkWeaponOption()
+
+	s.Require().Len(opt.CategoryChoices, 1)
+	categories := opt.CategoryChoices[0].Categories
+
+	s.NotContains(categories, weapons.CategorySimpleRanged,
+		"MonkWeaponSimple must NOT include CategorySimpleRanged - simple ranged weapons "+
+			"(dart, sling, light crossbow) are not part of a Monk's weapon set")
+}
+
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_IncludesSimpleMeleeCategory() {
+	_, opt := s.findMonkWeaponOption()
+
+	s.Require().Len(opt.CategoryChoices, 1)
+	categories := opt.CategoryChoices[0].Categories
+
+	s.Contains(categories, weapons.CategorySimpleMelee,
+		"MonkWeaponSimple must include CategorySimpleMelee")
+	s.Len(categories, 1,
+		"MonkWeaponSimple should resolve to exactly one category (simple melee), got %v", categories)
+}
+
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponShortsword_RemainsExplicitAlternative() {
+	req, _ := s.findMonkWeaponOption()
+
+	var shortswordOpt *EquipmentOption
+	for i := range req.Options {
+		if req.Options[i].ID == MonkWeaponShortsword {
+			shortswordOpt = &req.Options[i]
+		}
+	}
+
+	s.Require().NotNil(shortswordOpt, "MonkWeaponShortsword option should remain present")
+	s.Require().Len(shortswordOpt.Items, 1)
+	s.Equal(weapons.Shortsword, shortswordOpt.Items[0].ID,
+		"MonkWeaponShortsword should grant a concrete shortsword, not a category choice")
+	s.Empty(shortswordOpt.CategoryChoices,
+		"MonkWeaponShortsword is a fixed item, not a category choice")
+
+	// Choose exactly 1 between the two options.
+	s.Equal(1, req.Choose, "Monk should choose exactly one weapon option")
+	s.Len(req.Options, 2, "Monk weapon choice should offer exactly shortsword + simple melee weapon")
+}

--- a/rulebooks/dnd5e/character/choices/monk_weapon_guidance_test.go
+++ b/rulebooks/dnd5e/character/choices/monk_weapon_guidance_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package choices
 
 import (
@@ -10,12 +13,20 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
 
-// MonkWeaponGuidanceTestSuite guards rpg-toolkit#873: the Monk starting
-// equipment weapon choice must offer "simple melee weapon" (not the bare
-// "simple weapon" superset) and must not resolve to
-// weapons.CategorySimpleRanged - simple ranged weapons (dart, sling, light
-// crossbow) are not part of a Monk's weapon set in this game. Shortsword
-// stays the explicit, separate alternative option.
+// MonkWeaponGuidanceTestSuite guards rpg-toolkit#873/#874: the Monk
+// *starting equipment* weapon choice is the 2014 PHB "a shortsword or any
+// simple weapon" option, and it must stay that broad - offering simple
+// MELEE and simple RANGED weapons alike, plus the explicit shortsword
+// alternative.
+//
+// This is deliberately broader than (and must not be confused with) the
+// Martial Arts "monk weapon" set described in classes.Description(Monk)
+// and enforced by conditions/actions.isMonkWeapon (shortsword + simple
+// melee weapons without Heavy/Two-Handed). Narrowing the starting-equipment
+// picker to melee-only would incorrectly block legitimate 2014 starting
+// gear picks (dart, sling, light crossbow) that a Monk is entitled to at
+// character creation even though they won't benefit from Martial Arts.
+// See monk_description_test.go in classes for the Martial Arts contract.
 type MonkWeaponGuidanceTestSuite struct {
 	suite.Suite
 }
@@ -48,36 +59,32 @@ func (s *MonkWeaponGuidanceTestSuite) findMonkWeaponOption() (req *EquipmentRequ
 	return req, opt
 }
 
-func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_LabelSaysSimpleMeleeWeapon() {
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_LabelSaysAnySimpleWeapon() {
 	_, opt := s.findMonkWeaponOption()
 
 	lower := strings.ToLower(opt.Label)
-	s.Contains(lower, "simple melee weapon",
-		"MonkWeaponSimple option label should say 'simple melee weapon', got %q", opt.Label)
+	s.Contains(lower, "any simple weapon",
+		"MonkWeaponSimple option label should say 'any simple weapon' (2014 PHB starting "+
+			"equipment text), got %q", opt.Label)
+	s.NotContains(lower, "melee",
+		"MonkWeaponSimple label must not be narrowed to melee-only - starting equipment is "+
+			"'any simple weapon', got %q", opt.Label)
 }
 
-func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_CategoryChoiceLabelSaysSimpleMelee() {
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_CategoryChoiceLabelSaysSimpleWeapon() {
 	_, opt := s.findMonkWeaponOption()
 
 	s.Require().Len(opt.CategoryChoices, 1, "MonkWeaponSimple should have exactly one category choice")
 	lower := strings.ToLower(opt.CategoryChoices[0].Label)
-	s.Contains(lower, "simple melee weapon",
-		"MonkWeaponSimple category choice label should say 'simple melee weapon', got %q",
+	s.Contains(lower, "simple weapon",
+		"MonkWeaponSimple category choice label should say 'simple weapon', got %q",
+		opt.CategoryChoices[0].Label)
+	s.NotContains(lower, "melee",
+		"MonkWeaponSimple category choice label must not be narrowed to melee-only, got %q",
 		opt.CategoryChoices[0].Label)
 }
 
-func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_ExcludesSimpleRangedCategory() {
-	_, opt := s.findMonkWeaponOption()
-
-	s.Require().Len(opt.CategoryChoices, 1)
-	categories := opt.CategoryChoices[0].Categories
-
-	s.NotContains(categories, weapons.CategorySimpleRanged,
-		"MonkWeaponSimple must NOT include CategorySimpleRanged - simple ranged weapons "+
-			"(dart, sling, light crossbow) are not part of a Monk's weapon set")
-}
-
-func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_IncludesSimpleMeleeCategory() {
+func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_IncludesBothSimpleCategories() {
 	_, opt := s.findMonkWeaponOption()
 
 	s.Require().Len(opt.CategoryChoices, 1)
@@ -85,8 +92,13 @@ func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponSimple_IncludesSimpleMeleeCa
 
 	s.Contains(categories, weapons.CategorySimpleMelee,
 		"MonkWeaponSimple must include CategorySimpleMelee")
-	s.Len(categories, 1,
-		"MonkWeaponSimple should resolve to exactly one category (simple melee), got %v", categories)
+	s.Contains(categories, weapons.CategorySimpleRanged,
+		"MonkWeaponSimple must include CategorySimpleRanged - the 2014 Monk starting equipment "+
+			"option is 'any simple weapon', which includes ranged simple weapons "+
+			"(dart, sling, light crossbow), unlike the narrower Martial Arts 'monk weapon' set")
+	s.Len(categories, 2,
+		"MonkWeaponSimple should resolve to exactly both simple categories (melee + ranged), got %v",
+		categories)
 }
 
 func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponShortsword_RemainsExplicitAlternative() {
@@ -108,5 +120,5 @@ func (s *MonkWeaponGuidanceTestSuite) TestMonkWeaponShortsword_RemainsExplicitAl
 
 	// Choose exactly 1 between the two options.
 	s.Equal(1, req.Choose, "Monk should choose exactly one weapon option")
-	s.Len(req.Options, 2, "Monk weapon choice should offer exactly shortsword + simple melee weapon")
+	s.Len(req.Options, 2, "Monk weapon choice should offer exactly shortsword + any simple weapon")
 }

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -1419,14 +1419,18 @@ func getMonkEquipmentRequirements() []*EquipmentRequirement {
 					Label: "Shortsword",
 				},
 				{
+					// Monk's weapon set is shortswords + simple MELEE weapons only
+					// (no Heavy/Special monk weapons, and simple ranged weapons like
+					// darts/slings/light crossbow are not "monk weapons" here) - see
+					// rpg-toolkit#873.
 					ID:    MonkWeaponSimple,
-					Label: "Any simple weapon",
+					Label: "Any simple melee weapon",
 					CategoryChoices: []EquipmentCategoryChoice{
 						{
 							Choose:     1,
 							Type:       shared.EquipmentTypeWeapon,
-							Categories: []shared.EquipmentCategory{weapons.CategorySimpleMelee, weapons.CategorySimpleRanged},
-							Label:      "Choose a simple weapon",
+							Categories: []shared.EquipmentCategory{weapons.CategorySimpleMelee},
+							Label:      "Choose a simple melee weapon",
 						},
 					},
 				},

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -1419,18 +1419,20 @@ func getMonkEquipmentRequirements() []*EquipmentRequirement {
 					Label: "Shortsword",
 				},
 				{
-					// Monk's weapon set is shortswords + simple MELEE weapons only
-					// (no Heavy/Special monk weapons, and simple ranged weapons like
-					// darts/slings/light crossbow are not "monk weapons" here) - see
-					// rpg-toolkit#873.
+					// 2014 Monk starting equipment offers "a shortsword or any simple
+					// weapon" - this is the general equipment-proficiency choice, not
+					// the narrower Martial Arts "monk weapon" set (shortsword + simple
+					// MELEE weapons without Heavy/Two-Handed) described in
+					// classes.Description(Monk). Do not narrow this to melee-only -
+					// see rpg-toolkit#873/#874.
 					ID:    MonkWeaponSimple,
-					Label: "Any simple melee weapon",
+					Label: "Any simple weapon",
 					CategoryChoices: []EquipmentCategoryChoice{
 						{
 							Choose:     1,
 							Type:       shared.EquipmentTypeWeapon,
-							Categories: []shared.EquipmentCategory{weapons.CategorySimpleMelee},
-							Label:      "Choose a simple melee weapon",
+							Categories: []shared.EquipmentCategory{weapons.CategorySimpleMelee, weapons.CategorySimpleRanged},
+							Label:      "Choose a simple weapon",
 						},
 					},
 				},

--- a/rulebooks/dnd5e/classes/classes.go
+++ b/rulebooks/dnd5e/classes/classes.go
@@ -409,7 +409,7 @@ func Description(c Class) string {
 	case Monk:
 		return "A master of martial arts, harnessing inner power through discipline. " +
 			"Monk weapons are shortswords and simple melee weapons without the " +
-			"Heavy or Special property"
+			"Heavy or Two-Handed property"
 	case Paladin:
 		return "A holy warrior bound to a sacred oath, smiting foes with divine might"
 	case Ranger:

--- a/rulebooks/dnd5e/classes/classes.go
+++ b/rulebooks/dnd5e/classes/classes.go
@@ -407,7 +407,9 @@ func Description(c Class) string {
 	case Fighter:
 		return "A master of martial combat, skilled with a variety of weapons and armor"
 	case Monk:
-		return "A master of martial arts, harnessing inner power through discipline"
+		return "A master of martial arts, harnessing inner power through discipline. " +
+			"Monk weapons are shortswords and simple melee weapons without the " +
+			"Heavy or Special property"
 	case Paladin:
 		return "A holy warrior bound to a sacred oath, smiting foes with divine might"
 	case Ranger:

--- a/rulebooks/dnd5e/classes/monk_description_test.go
+++ b/rulebooks/dnd5e/classes/monk_description_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package classes
 
 import (
@@ -8,10 +11,17 @@ import (
 )
 
 // MonkDescriptionTestSuite guards the accuracy of Monk's weapon guidance in
-// Description(Monk) (rpg-toolkit#873): it must state the actual "monk
-// weapon" set - shortswords and simple melee weapons without the Heavy or
-// Special property - so a reader of the description doesn't come away with
-// a wrong (or absent) picture of what a Monk can use.
+// Description(Monk) (rpg-toolkit#873/#874): it must state the actual
+// "monk weapon" set used by the Martial Arts rule engine
+// (conditions.isMonkWeapon / actions.isMonkWeapon) - shortswords and simple
+// melee weapons without the Heavy or Two-Handed property - so a reader of
+// the description doesn't come away with a wrong picture of what a Monk's
+// Martial Arts feature applies to.
+//
+// This is deliberately narrower than (and must not be confused with) the
+// Monk's 2014 *starting equipment* choice, which offers "a shortsword or
+// any simple weapon" (melee OR ranged) - see monk_weapon_guidance_test.go
+// in character/choices for that contract.
 type MonkDescriptionTestSuite struct {
 	suite.Suite
 }
@@ -30,25 +40,34 @@ func (s *MonkDescriptionTestSuite) TestDescription_Monk_MentionsShortswordAndSim
 		"Monk description should state monk weapons are simple MELEE weapons")
 }
 
-func (s *MonkDescriptionTestSuite) TestDescription_Monk_ExcludesHeavyAndSpecial() {
+func (s *MonkDescriptionTestSuite) TestDescription_Monk_ExcludesHeavyAndTwoHanded() {
 	desc := Description(Monk)
 	lower := strings.ToLower(desc)
 
-	// The description should call out that Heavy/Special weapons are NOT
-	// monk weapons - not silently omit the exclusion.
+	// Must match the actual rule engine's exclusions
+	// (conditions.isMonkWeapon / actions.isMonkWeapon check Heavy and
+	// Two-Handed - PropertySpecial is declared but never assigned to any
+	// weapon and never checked anywhere in this codebase, so it must not
+	// be claimed here).
 	s.Contains(lower, "heavy",
 		"Monk description should note Heavy weapons are excluded from the monk weapon set")
-	s.Contains(lower, "special",
-		"Monk description should note Special weapons are excluded from the monk weapon set")
+	s.Contains(lower, "two-handed",
+		"Monk description should note Two-Handed weapons are excluded from the monk weapon set "+
+			"(matches isMonkWeapon's actual check, not the unused PropertySpecial)")
+	s.NotContains(lower, "special",
+		"Monk description must not claim a 'Special' exclusion - PropertySpecial is dead in this "+
+			"codebase and isMonkWeapon() does not check it")
 }
 
 func (s *MonkDescriptionTestSuite) TestDescription_Monk_DoesNotClaimSimpleRanged() {
 	desc := Description(Monk)
 	lower := strings.ToLower(desc)
 
-	// "simple ranged" (or a bare unqualified "simple weapons" without
-	// "melee") must not appear - the description scopes monk weapons to
-	// MELEE simple weapons plus shortswords, not the full simple-weapon set.
+	// "simple ranged" must not appear in the description - the Martial
+	// Arts monk-weapon set is scoped to MELEE simple weapons plus
+	// shortswords. (Simple ranged weapons remain a valid *starting
+	// equipment* pick, per the 2014 "any simple weapon" text - that's a
+	// separate, broader contract covered in the choices package.)
 	s.NotContains(lower, "simple ranged",
 		"Monk description must not claim simple ranged weapons as monk weapons")
 }
@@ -57,6 +76,6 @@ func (s *MonkDescriptionTestSuite) TestDescription_OtherClasses_Unchanged() {
 	// Guard against collateral edits: only Monk's description gained
 	// weapon-guidance text in this change.
 	s.NotEmpty(Description(Fighter))
-	s.NotContains(strings.ToLower(Description(Fighter)), "heavy or special")
+	s.NotContains(strings.ToLower(Description(Fighter)), "heavy or two-handed")
 	s.NotEmpty(Description(Barbarian))
 }

--- a/rulebooks/dnd5e/classes/monk_description_test.go
+++ b/rulebooks/dnd5e/classes/monk_description_test.go
@@ -1,0 +1,62 @@
+package classes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// MonkDescriptionTestSuite guards the accuracy of Monk's weapon guidance in
+// Description(Monk) (rpg-toolkit#873): it must state the actual "monk
+// weapon" set - shortswords and simple melee weapons without the Heavy or
+// Special property - so a reader of the description doesn't come away with
+// a wrong (or absent) picture of what a Monk can use.
+type MonkDescriptionTestSuite struct {
+	suite.Suite
+}
+
+func TestMonkDescriptionSuite(t *testing.T) {
+	suite.Run(t, new(MonkDescriptionTestSuite))
+}
+
+func (s *MonkDescriptionTestSuite) TestDescription_Monk_MentionsShortswordAndSimpleMelee() {
+	desc := Description(Monk)
+	lower := strings.ToLower(desc)
+
+	s.Contains(lower, "shortsword",
+		"Monk description should mention shortswords as a monk weapon")
+	s.Contains(lower, "simple melee weapon",
+		"Monk description should state monk weapons are simple MELEE weapons")
+}
+
+func (s *MonkDescriptionTestSuite) TestDescription_Monk_ExcludesHeavyAndSpecial() {
+	desc := Description(Monk)
+	lower := strings.ToLower(desc)
+
+	// The description should call out that Heavy/Special weapons are NOT
+	// monk weapons - not silently omit the exclusion.
+	s.Contains(lower, "heavy",
+		"Monk description should note Heavy weapons are excluded from the monk weapon set")
+	s.Contains(lower, "special",
+		"Monk description should note Special weapons are excluded from the monk weapon set")
+}
+
+func (s *MonkDescriptionTestSuite) TestDescription_Monk_DoesNotClaimSimpleRanged() {
+	desc := Description(Monk)
+	lower := strings.ToLower(desc)
+
+	// "simple ranged" (or a bare unqualified "simple weapons" without
+	// "melee") must not appear - the description scopes monk weapons to
+	// MELEE simple weapons plus shortswords, not the full simple-weapon set.
+	s.NotContains(lower, "simple ranged",
+		"Monk description must not claim simple ranged weapons as monk weapons")
+}
+
+func (s *MonkDescriptionTestSuite) TestDescription_OtherClasses_Unchanged() {
+	// Guard against collateral edits: only Monk's description gained
+	// weapon-guidance text in this change.
+	s.NotEmpty(Description(Fighter))
+	s.NotContains(strings.ToLower(Description(Fighter)), "heavy or special")
+	s.NotEmpty(Description(Barbarian))
+}


### PR DESCRIPTION
## What

Fixes a Monk (2014) weapon-guidance inaccuracy, and its accompanying tests,
without narrowing starting equipment:

1. `classes.Description(Monk)` never mentioned weapons. Now concisely states
   the Martial Arts "monk weapon" set: shortswords and simple melee weapons
   without the Heavy or Two-Handed property — matching
   `isMonkWeapon()` in `rulebooks/dnd5e/conditions/martial_arts.go` and
   `rulebooks/dnd5e/actions/martial_arts_granter.go` exactly. (An earlier
   revision of this PR said "Heavy or Special"; `weapons.PropertySpecial` is
   dead code — declared, never assigned to any weapon, never checked
   anywhere in this module — so that wording was corrected to match the
   engine it describes, per gate-review finding.)
2. The Monk **starting-equipment** `MonkWeaponSimple` category-choice in
   `getMonkEquipmentRequirements()` remains, and stays, the pre-existing 2014
   "any simple weapon" shape: it resolves from **both**
   `CategorySimpleMelee` and `CategorySimpleRanged`, labeled "Any simple
   weapon" / "Choose a simple weapon". An earlier revision of this PR
   narrowed this to simple-melee-only, conflating the Martial Arts
   "monk weapon" set with the broader 2014 starting-equipment rule ("a
   shortsword or any simple weapon" — melee or ranged). Per direction, that
   distinction belongs in the class description only, not in narrowing what
   a Monk can pick as starting gear. Reverted to the original
   categories/labels.

`ClassData[Monk].Weapons` / the granted `WeaponProficiencies`
(`WeaponSimple` + `WeaponShortsword`) are **untouched** — that's general
weapon proficiency (can-wield), which the existing 2014 model already gets
right and is out of scope for this fix.

## Why

Surfaced while reviewing rpg-project#173 (equipment-enrichment /
concrete-options architecture decision, Party Assembles wave) — Monk's
weapon set was called out there as the sharp edge of category-choice
eligibility drift. This PR is **not** that contract work and does **not**
touch the deferred toolkit#872 (category-choice → concrete enriched
`EquipmentItem` resolution). No new contract, proto field, or API/web
special-case — purely a toolkit-only description correction that stands on
its own; starting equipment shape is unchanged from `main`.

## Tests

- `rulebooks/dnd5e/classes/monk_description_test.go` — description text
  mentions shortsword + simple melee weapon, states the Heavy/Two-Handed
  exclusion (matching `isMonkWeapon()`), explicitly asserts "special" is
  **not** present, and does not claim "simple ranged".
- `rulebooks/dnd5e/character/choices/monk_weapon_guidance_test.go` —
  `MonkWeaponSimple` option/category-choice labels say "any simple weapon"
  (not melee-only); `Categories` includes **both** `CategorySimpleMelee`
  and `CategorySimpleRanged`; asserts "melee" is absent from the label text;
  `MonkWeaponShortsword` remains the explicit, separate fixed-item
  alternative.

## Gates run

- `cd rulebooks/dnd5e && go build ./... && go vet ./... && go test -race ./...` — all green.
- `golangci-lint run ./...` (rulebooks/dnd5e) — 0 issues.
- Full `make test-all` (all modules) — green except two **pre-existing**
  `go mod tidy` drift failures in `mechanics/spells` and
  `mechanics/conditions`, verified present on `main` before this change
  (unrelated to this diff).
- `gofmt -s -l` on changed files — clean.

## History

- Initial revision (`db106c0`) narrowed starting equipment to melee-only and
  used "Heavy or Special" in the description — both incorrect, caught by a
  gate review (Heavy/Special mismatch with the engine) and a suppressed
  Copilot review comment (same root cause).
- Current revision (`005bd10`) restores starting equipment to the pre-PR
  any-simple-weapon shape and fixes the description to say "Heavy or
  Two-Handed", matching the engine. See PR comments for the individual
  gate-finding and Copilot-comment replies.

## Related

- Closes #873.
- Related context (not a dependency, no new contract needed): rpg-project#173.
- Deferred, not repurposed: #872.

## Base

`origin/main`

— asset-pipeline agent, on behalf of KirkDiggler
