### PR TITLE
feat(dungeon): Dungeon Builder toolkit provider wave

### DIFF
--- a/encounter/data.go
+++ b/encounter/data.go
@@ -139,13 +139,17 @@ type SpaceData struct {
 	Width  int `json:"width"`
 	Height int `json:"height"`
 
-	// Entrance is the designated spawn-anchor cell for chamber 1, set by
-	// multi-chamber generators (Wave 2 Slice 2's InitTwoChamberRoom).
-	// Replaces the roomCenterHex() placeholder downstream (rpg-api#648).
-	// Zero value (the zero Hex) for single-room InitRoom spaces, which have
-	// no entrance concept — callers fall back to their own placement (e.g.
-	// room center) when Entrance is the zero Hex.
+	// Entrance is the toolkit-resolved party-start anchor for an InitDungeon
+	// space. It may be an authored absolute start in any semantic region, not
+	// only the entrance archetype. Zero value (the zero Hex) remains the value
+	// for single-room InitRoom spaces, which have no party-start concept.
 	Entrance core.Hex `json:"entrance"`
+
+	// PartyStartPositions is the deterministic ordered party-start envelope
+	// selected by InitDungeon before generated blockers. Position zero always
+	// equals Entrance. It is persisted so reloads and runtime startup resolve
+	// the same seats without re-running layout selection.
+	PartyStartPositions []core.Hex `json:"party_start_positions,omitempty"`
 
 	// Regions tags every hex by chamber for multi-chamber spaces (Wave 2
 	// Slice 2) — scopes spawn placement and, via LoS, combat pockets
@@ -251,8 +255,8 @@ type RegionData struct {
 type RegionArchetype string
 
 const (
-	// ArchetypeEntrance tags the region containing SpaceData.Entrance —
-	// the dungeon's starting region.
+	// ArchetypeEntrance tags a start-side semantic region. An authored
+	// SpaceData.Entrance may instead be in any semantic region.
 	ArchetypeEntrance RegionArchetype = "entrance"
 	// ArchetypeChamber tags a generic interior region with no more
 	// specific role — remains in the vocabulary for future templates even

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -227,6 +227,11 @@ type ObstacleData struct {
 	// true for any line of sight passing through this obstacle's hex,
 	// exactly like a wall.
 	BlocksLoS bool `json:"blocks_los"`
+
+	// Facing is optional authored floor-prop metadata in canonical
+	// E,NE,NW,W,SW,SE = 0..5 order. Nil means no override; a non-nil pointer
+	// to zero is explicit E and must remain present across persistence.
+	Facing *uint32 `json:"facing,omitempty"`
 }
 
 // RegionData tags a named set of hexes as one chamber/region within a

--- a/encounter/death.go
+++ b/encounter/death.go
@@ -132,7 +132,9 @@ func (e *Encounter) killEntity(monsterID, killerID core.EntityID) error {
 	// no refresh here — they never had authorized knowledge of that hex's
 	// contents to correct.
 	for _, viewerID := range witnesses {
-		e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(dyingPos))
+		if err := e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(dyingPos)); err != nil {
+			return fmt.Errorf("refresh death observation for player %q: %w", viewerID, err)
+		}
 	}
 
 	// Broadcast removal — every player must drop the entity from local

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -48,6 +48,11 @@ type DungeonParams struct {
 	// InitTwoChamberRoom (rpg-toolkit#787).
 	RandomSeed int64
 
+	// PartyStart configures the resolved party-start anchor and ordered
+	// reservation. It is separate from per-region ReservedCells because a
+	// party start may validly occupy a room's door row.
+	PartyStart PartyStartParams
+
 	// Theme is opaque metadata copied verbatim to SpaceData.Theme — see
 	// that field's doc. Never interpreted here.
 	Theme string
@@ -273,13 +278,14 @@ func (e *Encounter) InitDungeon(params DungeonParams) error {
 
 	previousSpace := e.data.Space
 	e.data.Space = &SpaceData{
-		Walls:     layout.walls,
-		Width:     layout.width,
-		Height:    params.Height,
-		Entrance:  core.HexFromCube(layout.entrance),
-		Regions:   layout.regions,
-		Theme:     params.Theme,
-		Obstacles: layout.obstacles,
+		Walls:               layout.walls,
+		Width:               layout.width,
+		Height:              params.Height,
+		Entrance:            core.HexFromCube(layout.entrance),
+		PartyStartPositions: layout.partyStartPositions,
+		Regions:             layout.regions,
+		Theme:               params.Theme,
+		Obstacles:           layout.obstacles,
 	}
 
 	stagedDoorIDs := make([]core.EntityID, 0, len(layout.doors))
@@ -323,6 +329,9 @@ func validateDungeonParams(params DungeonParams) error {
 	}
 	if params.Height < 4 {
 		return fmt.Errorf("dungeon height must be at least 4 (got %d)", params.Height)
+	}
+	if params.PartyStart.SeatCount < 0 {
+		return fmt.Errorf("party start seat count must not be negative (got %d)", params.PartyStart.SeatCount)
 	}
 	for i, r := range params.Regions {
 		if r.Width < 4 {
@@ -416,6 +425,9 @@ type dungeonLayout struct {
 	// region, in absolute coordinates — rpg-toolkit#819. See
 	// placeRegionObstacles.
 	obstacles []ObstacleData
+	// partyStartPositions is the stored deterministic reservation exposed by
+	// ResolvePartySpawnPositions. Index zero is always entrance.
+	partyStartPositions []core.Hex
 }
 
 // generateDungeonLayout builds each region's independently wall-generated
@@ -476,6 +488,14 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 	}
 	totalWidth := x - 1 // no trailing boundary column after the last region
 
+	// Resolve every party seat before generating a single wall or obstacle.
+	// The reservation is then threaded through the wall safety paths, the
+	// discrete wall boundary, and the obstacle candidate pools below.
+	partyStart, err := resolvePartyStartReservation(params, starts, totalWidth, doorRow)
+	if err != nil {
+		return nil, err
+	}
+
 	var segs []environments.WallSegmentData
 	regions := make([]RegionData, n)
 	doors := make([]spatial.CubeCoordinate, n-1)
@@ -493,7 +513,7 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 
 	for i, r := range params.Regions {
 		local := spatial.Position{X: 0, Y: float64(doorRow)}
-		var requiredPaths []environments.Path
+		requiredPaths := make([]environments.Path, 0, 1+len(partyStart.seats))
 		switch {
 		case n == 1:
 			// unreachable: validateDungeonParams enforces n>=2
@@ -540,6 +560,8 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 			}
 		}
 
+		requiredPaths = append(requiredPaths, partyStart.requiredPathsForRegion(i, starts[i])...)
+
 		pattern := r.Pattern
 		if pattern == "" {
 			pattern = environments.PatternRandom
@@ -549,6 +571,7 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 			return nil, fmt.Errorf("generate region %d (%q) walls: %w", i, r.ID, err)
 		}
 		regionWalls := regionWallSegments(walls, starts[i], 0)
+		regionWalls = partyStart.stripPartyStartWalls(i, regionWalls)
 		if r.Archetype == ArchetypeBoss {
 			// Construction-time discrete safeguard (rpg-toolkit#819),
 			// applied BEFORE this call's result is committed to
@@ -579,16 +602,17 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 			Hexes:     core.NewHexSet(hexesFromCubes(regionCubes(r.Width, params.Height, starts[i]))...),
 		}
 		regionObstacles, err := placeRegionObstacles(placeRegionObstaclesParams{
-			regionID:  r.ID,
-			specs:     r.Obstacles,
-			placed:    r.PlacedObstacles,
-			reserved:  r.ReservedCells,
-			width:     r.Width,
-			height:    params.Height,
-			offsetX:   starts[i],
-			doorRow:   doorRow,
-			wallCubes: wallCubeSet(regionWalls),
-			seed:      obstacleSeeds[i],
+			regionID:      r.ID,
+			specs:         r.Obstacles,
+			placed:        r.PlacedObstacles,
+			reserved:      r.ReservedCells,
+			partyReserved: partyStart.seatsByRegion[i],
+			width:         r.Width,
+			height:        params.Height,
+			offsetX:       starts[i],
+			doorRow:       doorRow,
+			wallCubes:     wallCubeSet(regionWalls),
+			seed:          obstacleSeeds[i],
 		})
 		if err != nil {
 			return nil, fmt.Errorf("place region %d (%q) obstacles: %w", i, r.ID, err)
@@ -648,16 +672,14 @@ func generateDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 	// left as degenerate Start==End entries.
 	segs = append(segs, connectorBoundaryEdgeWalls(blocked, connectorFlankingCubes, totalWidth, params.Height)...)
 
-	entrance := spatial.OffsetCoordinateToCubeWithOrientation(
-		spatial.Position{X: 0, Y: float64(doorRow)}, spatial.HexOrientationPointyTop)
-
 	return &dungeonLayout{
-		walls:     segs,
-		width:     totalWidth,
-		regions:   regions,
-		entrance:  entrance,
-		doors:     doors,
-		obstacles: obstacles,
+		walls:               segs,
+		width:               totalWidth,
+		regions:             regions,
+		entrance:            partyStart.anchor,
+		doors:               doors,
+		obstacles:           obstacles,
+		partyStartPositions: partyStart.positions(),
 	}, nil
 }
 
@@ -977,16 +999,17 @@ func stripReservedAxisWalls(
 // region's geometry plus its caller-supplied specs — so the function
 // signature doesn't grow an eighth positional argument as #819 evolves.
 type placeRegionObstaclesParams struct {
-	regionID  string
-	specs     []ObstacleSpec
-	placed    []PlacedObstacleSpec
-	reserved  []LocalHex
-	width     int
-	height    int
-	offsetX   int
-	doorRow   int
-	wallCubes map[spatial.CubeCoordinate]struct{}
-	seed      int64
+	regionID      string
+	specs         []ObstacleSpec
+	placed        []PlacedObstacleSpec
+	reserved      []LocalHex
+	partyReserved map[spatial.CubeCoordinate]struct{}
+	width         int
+	height        int
+	offsetX       int
+	doorRow       int
+	wallCubes     map[spatial.CubeCoordinate]struct{}
+	seed          int64
 }
 
 // placeRegionObstacles computes the ObstacleData instances for every
@@ -1053,6 +1076,11 @@ type placeRegionObstaclesParams struct {
 // candidate pool, but never emits any ObstacleData of its own — it exists
 // purely to keep the rolled draw off a cell something else (a compiled
 // place: monster, or a pinned boss.at) already occupies.
+//
+// p.partyReserved is deliberately separate from p.reserved: it is the
+// dungeon-wide party-start envelope selected before wall generation, and its
+// anchor may legally be on doorRow where ordinary ReservedCells are invalid.
+// Every rolled obstacle skips those cells in both draw-order paths.
 func placeRegionObstacles(p placeRegionObstaclesParams) ([]ObstacleData, error) {
 	placedData, placedCubes, err := placeVerbatimObstacles(p)
 	if err != nil {
@@ -1076,6 +1104,11 @@ func placeRegionObstacles(p placeRegionObstaclesParams) ([]ObstacleData, error) 
 	for cube := range reservedCubes {
 		if _, already := excluded[cube]; !already {
 			excluded[cube] = "" // reserved, not placed -- no obstacle name to report
+		}
+	}
+	for cube := range p.partyReserved {
+		if _, already := excluded[cube]; !already {
+			excluded[cube] = "" // party-start reservation, no obstacle data
 		}
 	}
 

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -172,6 +172,24 @@ type ObstacleSpec struct {
 	PreferBorder bool
 }
 
+// FacingEast is the canonical east-facing hex-direction index. These six
+// values are intentionally aligned with the canonical YAML labels: E, NE, NW,
+// W, SW, SE. They are metadata only; encounter geometry and collision do not
+// interpret them.
+const (
+	FacingEast uint32 = iota
+	// FacingNortheast is the canonical northeast-facing hex-direction index.
+	FacingNortheast
+	// FacingNorthwest is the canonical northwest-facing hex-direction index.
+	FacingNorthwest
+	// FacingWest is the canonical west-facing hex-direction index.
+	FacingWest
+	// FacingSouthwest is the canonical southwest-facing hex-direction index.
+	FacingSouthwest
+	// FacingSoutheast is the canonical southeast-facing hex-direction index.
+	FacingSoutheast
+)
+
 // LocalHex is a region-local (pre-offsetX) grid cell: Col in [0,width),
 // Row in [0,height) (the dungeon-shared height) — exactly the local (x,y)
 // frame regionObstacleCandidates already scans (see that function's doc).
@@ -204,6 +222,11 @@ type PlacedObstacleSpec struct {
 	// ObstacleData, same as ObstacleSpec's fields of the same name.
 	BlocksMovement bool
 	BlocksLoS      bool
+
+	// Facing is optional authored hex-facing metadata. A nil value is absent;
+	// a non-nil pointer to FacingEast is the explicit E = 0 override. It is
+	// copied to ObstacleData without affecting position or collision behavior.
+	Facing *uint32
 }
 
 // DungeonConnectorParams configures the door joining two consecutive
@@ -1245,6 +1268,7 @@ func placeVerbatimObstacles(p placeRegionObstaclesParams) ([]ObstacleData, map[s
 			Position:       core.HexFromCube(cube),
 			BlocksMovement: spec.BlocksMovement,
 			BlocksLoS:      spec.BlocksLoS,
+			Facing:         spec.Facing,
 		})
 	}
 	return out, placedCubes, nil

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // SpawnInstruction is encounter's OWN type (defined in
@@ -17,6 +18,18 @@ import (
 // struct, so CompiledDungeon.Spawns can be passed directly to
 // enc.SeedMonsters(compiled.Spawns) with zero conversion.
 type SpawnInstruction = encounter.SpawnInstruction
+
+// normalProductPartyStartSeats is the effective API lobby PartyCap for this
+// authored-dungeon product configuration. It is compiled into DungeonParams,
+// not treated as a universal encounter limit.
+const normalProductPartyStartSeats = 4
+
+// LoadConfig supplies host-owned composition values to dungeonspec
+// compilation. PartyStartSeatCount must be positive; it is the host's party
+// capacity for this initialized dungeon, not a universal toolkit maximum.
+type LoadConfig struct {
+	PartyStartSeatCount int
+}
 
 // CompiledDungeon is a dungeon spec compiled down to what the engine and
 // SeedMonsters actually consume: engine params ready for InitDungeon, and
@@ -47,6 +60,17 @@ type CompiledDungeon struct {
 // entry for that seeding pass rather than erroring, so an author-placed
 // monster in a party's starting sightline needs the party added first.
 func Load(raw []byte) (CompiledDungeon, error) {
+	return LoadWithConfig(raw, LoadConfig{PartyStartSeatCount: normalProductPartyStartSeats})
+}
+
+// LoadWithConfig decodes, validates, and compiles a spec using the supplied
+// host party capacity. Preview and runtime should pass the same positive
+// PartyStartSeatCount so they build the same reservation.
+func LoadWithConfig(raw []byte, config LoadConfig) (CompiledDungeon, error) {
+	if config.PartyStartSeatCount < 1 {
+		return CompiledDungeon{}, fmt.Errorf(
+			"party start seat count must be at least 1 (got %d)", config.PartyStartSeatCount)
+	}
 	spec, err := Decode(raw)
 	if err != nil {
 		return CompiledDungeon{}, err
@@ -54,7 +78,7 @@ func Load(raw []byte) (CompiledDungeon, error) {
 	if err := Validate(spec); err != nil {
 		return CompiledDungeon{}, err
 	}
-	return compile(spec)
+	return compileWithConfig(spec, config)
 }
 
 // compile assumes spec has already passed Validate -- every ref shape,
@@ -63,6 +87,12 @@ func Load(raw []byte) (CompiledDungeon, error) {
 // this package's style elsewhere, in case that assumption is ever violated
 // by a future caller.
 func compile(spec *DungeonSpec) (CompiledDungeon, error) {
+	return compileWithConfig(spec, LoadConfig{PartyStartSeatCount: normalProductPartyStartSeats})
+}
+
+// compileWithConfig compiles a validated spec using the same host party-start
+// reservation supplied at LoadWithConfig's public boundary.
+func compileWithConfig(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, error) {
 	var bossRoom *RoomSpec
 	for i := range spec.Rooms {
 		if spec.Rooms[i].Boss != nil {
@@ -116,12 +146,22 @@ func compile(spec *DungeonSpec) (CompiledDungeon, error) {
 		connectors[i] = compileConnector(spec.Key, &spec.Connectors[i])
 	}
 
+	partyStart := encounter.PartyStartParams{SeatCount: config.PartyStartSeatCount}
+	if spec.Start != nil {
+		anchor := core.HexFromPosition(spatial.Position{
+			X: float64(spec.Start[0]),
+			Y: float64(spec.Start[1]),
+		})
+		partyStart.Anchor = &anchor
+	}
+
 	return CompiledDungeon{
 		Params: encounter.DungeonParams{
 			Regions:    regions,
 			Connectors: connectors,
 			Height:     spec.Height,
 			Theme:      spec.Theme,
+			PartyStart: partyStart,
 		},
 		Spawns: spawns,
 	}, nil

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -231,11 +231,16 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 		}
 		switch refType {
 		case refTypeProps:
+			facing, err := compileFacing(entry.Facing)
+			if err != nil {
+				return encounter.DungeonRegionParams{}, nil, fmt.Errorf("place %q facing: %w", entry.Ref, err)
+			}
 			region.PlacedObstacles = append(region.PlacedObstacles, encounter.PlacedObstacleSpec{
 				Ref:            entry.Ref,
 				At:             encounter.LocalHex{Col: entry.At[0], Row: entry.At[1]},
 				BlocksMovement: boolOrTrue(entry.BlocksMovement),
 				BlocksLoS:      boolOrTrue(entry.BlocksLoS),
+				Facing:         facing,
 			})
 		case refTypeMonsters:
 			at := encounter.LocalHex{Col: entry.At[0], Row: entry.At[1]}
@@ -304,4 +309,18 @@ func boolOrTrue(b *bool) bool {
 		return true
 	}
 	return *b
+}
+
+// compileFacing maps an optional canonical YAML facing label to its persisted
+// numeric index. Validate normally guarantees the label is known; this guard
+// keeps compileRoom from silently accepting a bad direct call.
+func compileFacing(label *string) (*uint32, error) {
+	if label == nil {
+		return nil, nil
+	}
+	value, err := facingValue(*label)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
 }

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -5,6 +5,8 @@ package dungeonspec_test
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
@@ -14,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const facingCoffinRef = "dnd5e:props:coffin"
 
 func TestLoad_GeneratesDeterministicDoorIDs(t *testing.T) {
 	// placedTombYAML: key "reference-tomb", 2 rooms (entrance, tomb), 1 connector —
@@ -84,6 +88,114 @@ func regionByID(t *testing.T, regions []encounter.DungeonRegionParams, id string
 	}
 	t.Fatalf("no region %q in compiled regions", id)
 	return nil
+}
+
+// TestLoad_FloorPropFacingCompilesEveryCanonicalDirection covers Slice #178's
+// canonical YAML mapping. The six labels must compile in their fixed
+// E,NE,NW,W,SW,SE -> 0..5 order; no current compiler path may strip them.
+func TestLoad_FloorPropFacingCompilesEveryCanonicalDirection(t *testing.T) {
+	const facingYAML = `
+version: 1
+key: facing-check
+name: Facing Check
+height: 8
+rooms:
+  - {id: entrance, archetype: entrance, width: 6}
+  - id: tomb
+    archetype: boss
+    width: 8
+    boss: {ref: "dnd5e:monsters:skeleton-captain", at: [4, 5]}
+    place:
+      - {ref: "` + facingCoffinRef + `", at: [0, 0], facing: E}
+      - {ref: "dnd5e:props:altar", at: [1, 0], facing: NE}
+      - {ref: "dnd5e:props:statue-reaper", at: [2, 0], facing: NW}
+      - {ref: "dnd5e:props:brazier", at: [3, 0], facing: W}
+      - {ref: "dnd5e:props:candles", at: [4, 0], facing: SW}
+      - {ref: "dnd5e:props:wall-banner", at: [5, 0], facing: SE}
+connectors:
+  - {from: entrance, to: tomb}
+`
+
+	compiled, err := dungeonspec.Load([]byte(facingYAML))
+	require.NoError(t, err)
+	tomb := regionByID(t, compiled.Params.Regions, "tomb")
+	require.Len(t, tomb.PlacedObstacles, 6)
+	for index, obstacle := range tomb.PlacedObstacles {
+		require.NotNil(t, obstacle.Facing, "placement %d must retain facing presence", index)
+		assert.Equal(t, uint32(index), *obstacle.Facing)
+	}
+}
+
+// TestLoad_FloorPropFacingPreservesEastAndAbsence runs the actual compiler and
+// dungeon initializer so E=0 remains a present override while omitted/null
+// stay absent through the persisted obstacle state. Rolled obstacles must
+// never gain a facing from this metadata path.
+func TestLoad_FloorPropFacingPreservesEastAndAbsence(t *testing.T) {
+	withEast := strings.Replace(placedTombYAML,
+		"at: [6, 3], blocks_los: false }",
+		"at: [6, 3], blocks_los: false, facing: E }", 1)
+	withNull := strings.Replace(placedTombYAML,
+		"at: [6, 3], blocks_los: false }",
+		"at: [6, 3], blocks_los: false, facing: null }", 1)
+
+	omitted, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	nullFacing, err := dungeonspec.Load([]byte(withNull))
+	require.NoError(t, err)
+	east, err := dungeonspec.Load([]byte(withEast))
+	require.NoError(t, err)
+
+	omittedProp := regionByID(t, omitted.Params.Regions, "tomb").PlacedObstacles[0]
+	nullProp := regionByID(t, nullFacing.Params.Regions, "tomb").PlacedObstacles[0]
+	eastProp := regionByID(t, east.Params.Regions, "tomb").PlacedObstacles[0]
+	assert.Nil(t, omittedProp.Facing)
+	assert.Nil(t, nullProp.Facing)
+	require.NotNil(t, eastProp.Facing)
+	assert.Equal(t, encounter.FacingEast, *eastProp.Facing)
+
+	east.Params.Regions[0].Obstacles = []encounter.ObstacleSpec{{
+		Ref: "dnd5e:props:pillar", Count: 1, BlocksMovement: true, BlocksLoS: true,
+	}}
+	east.Params.RandomSeed = 19
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+	enc := encounter.New(context.Background(), "facing-persistence", broker)
+	require.NoError(t, enc.InitDungeon(east.Params))
+
+	var authored, rolled *encounter.ObstacleData
+	for index := range enc.ToData().Space.Obstacles {
+		obstacle := &enc.ToData().Space.Obstacles[index]
+		switch obstacle.Ref {
+		case facingCoffinRef:
+			authored = obstacle
+		case "dnd5e:props:pillar":
+			rolled = obstacle
+		}
+	}
+	require.NotNil(t, authored)
+	require.NotNil(t, authored.Facing)
+	assert.Equal(t, encounter.FacingEast, *authored.Facing)
+	require.NotNil(t, rolled)
+	assert.Nil(t, rolled.Facing)
+
+	payload, err := json.Marshal(enc.ToData())
+	require.NoError(t, err)
+	var persisted encounter.Data
+	require.NoError(t, json.Unmarshal(payload, &persisted))
+	reloaded, err := encounter.LoadFromData(context.Background(), &persisted, broker)
+	require.NoError(t, err)
+	var reloadedAuthored *encounter.ObstacleData
+	for index := range reloaded.ToData().Space.Obstacles {
+		obstacle := &reloaded.ToData().Space.Obstacles[index]
+		if obstacle.Ref == facingCoffinRef {
+			reloadedAuthored = obstacle
+			break
+		}
+	}
+	require.NotNil(t, reloadedAuthored)
+	require.NotNil(t, reloadedAuthored.Facing)
+	assert.Equal(t, encounter.FacingEast, *reloadedAuthored.Facing)
 }
 
 func TestLoad_PlaceRoutesByRefType(t *testing.T) {

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -120,9 +120,17 @@ connectors:
 	require.NoError(t, err)
 	tomb := regionByID(t, compiled.Params.Regions, "tomb")
 	require.Len(t, tomb.PlacedObstacles, 6)
+	wantFacings := []uint32{
+		encounter.FacingEast,
+		encounter.FacingNortheast,
+		encounter.FacingNorthwest,
+		encounter.FacingWest,
+		encounter.FacingSouthwest,
+		encounter.FacingSoutheast,
+	}
 	for index, obstacle := range tomb.PlacedObstacles {
 		require.NotNil(t, obstacle.Facing, "placement %d must retain facing presence", index)
-		assert.Equal(t, uint32(index), *obstacle.Facing)
+		assert.Equal(t, wantFacings[index], *obstacle.Facing)
 	}
 }
 

--- a/encounter/dungeonspec/decode_test.go
+++ b/encounter/dungeonspec/decode_test.go
@@ -4,6 +4,7 @@
 package dungeonspec_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
@@ -52,6 +53,46 @@ func TestDecode_EmptyInputReturnsFriendlyError(t *testing.T) {
 	_, err := dungeonspec.Decode([]byte(""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty dungeon spec")
+}
+
+// TestDecode_PlaceFacingPreservesPresence distinguishes omitted/null from an
+// explicit canonical label before compilation. The compiler relies on this
+// pointer presence so explicit E can survive as numeric zero.
+func TestDecode_PlaceFacingPreservesPresence(t *testing.T) {
+	withEast := strings.Replace(placedTombYAML,
+		"at: [6, 3], blocks_los: false }",
+		"at: [6, 3], blocks_los: false, facing: E }", 1)
+	withNull := strings.Replace(placedTombYAML,
+		"at: [6, 3], blocks_los: false }",
+		"at: [6, 3], blocks_los: false, facing: null }", 1)
+
+	cases := []struct {
+		name       string
+		raw        string
+		wantFacing *string
+	}{
+		{name: "omitted", raw: placedTombYAML},
+		{name: "explicit null", raw: withNull},
+		{name: "explicit east", raw: withEast, wantFacing: stringPtr("E")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := dungeonspec.Decode([]byte(tc.raw))
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFacing, spec.Rooms[1].Place[0].Facing)
+		})
+	}
+}
+
+func stringPtr(value string) *string { return &value }
+
+func TestDecode_PlaceFacingRejectsNonScalarShape(t *testing.T) {
+	raw := strings.Replace(placedTombYAML,
+		"at: [6, 3], blocks_los: false }",
+		"at: [6, 3], blocks_los: false, facing: [E] }", 1)
+	_, err := dungeonspec.Decode([]byte(raw))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode dungeon spec")
 }
 
 func TestDecode_PlaceBlockRoundTrips(t *testing.T) {

--- a/encounter/dungeonspec/spec.go
+++ b/encounter/dungeonspec/spec.go
@@ -17,6 +17,10 @@ type DungeonSpec struct {
 	Start      *[2]int         `yaml:"start,omitempty"`
 	Rooms      []RoomSpec      `yaml:"rooms"`
 	Connectors []ConnectorSpec `yaml:"connectors"`
+	// Place is decoded solely to reject unsupported top-level placement,
+	// including facing, at a field-specific validation path. Slice #178
+	// supports only existing room-scoped floor props.
+	Place []PlacedEntry `yaml:"place,omitempty"`
 }
 
 // RoomSpec is one room in a dungeon spec.
@@ -41,6 +45,9 @@ type MonsterEntry struct {
 type BossEntry struct {
 	Ref string  `yaml:"ref"`
 	At  *[2]int `yaml:"at,omitempty"` // design delta: nil = unpinned (v1 behavior)
+	// Facing is decoded solely so unsupported boss-facing input can fail at
+	// its supplied field path. Boss-facing behavior is outside Slice #178.
+	Facing *string `yaml:"facing,omitempty"`
 }
 
 // ObstacleEntry is a count-based rolled obstacle for a room.
@@ -61,6 +68,14 @@ type PlacedEntry struct {
 	At             [2]int `yaml:"at"` // [col, row], room-local — static-placement delta, rpg-toolkit#842
 	BlocksMovement *bool  `yaml:"blocks_movement,omitempty"`
 	BlocksLoS      *bool  `yaml:"blocks_los,omitempty"`
+	// Facing is the optional canonical YAML label. Nil represents both an
+	// omitted field and explicit YAML null; explicit E remains non-nil and
+	// compiles to the present numeric value zero.
+	Facing *string `yaml:"facing,omitempty"`
+	// Mount is decoded only to reject mounted-facing input at its supplied
+	// field path. Slice #178 supports floor placements only and never
+	// compiles mount behavior.
+	Mount *string `yaml:"mount,omitempty"`
 }
 
 // ConnectorSpec joins two rooms, optionally behind a locked check.

--- a/encounter/dungeonspec/spec.go
+++ b/encounter/dungeonspec/spec.go
@@ -7,11 +7,14 @@ package dungeonspec
 
 // DungeonSpec is the top-level decoded shape of a dungeon spec file.
 type DungeonSpec struct {
-	Version    int             `yaml:"version"`
-	Key        string          `yaml:"key"`
-	Name       string          `yaml:"name"`
-	Theme      string          `yaml:"theme"`
-	Height     int             `yaml:"height"`
+	Version int    `yaml:"version"`
+	Key     string `yaml:"key"`
+	Name    string `yaml:"name"`
+	Theme   string `yaml:"theme"`
+	Height  int    `yaml:"height"`
+	// Start is an optional absolute [column,row] party-start anchor. Nil
+	// represents both an omitted YAML field and an explicit YAML null.
+	Start      *[2]int         `yaml:"start,omitempty"`
 	Rooms      []RoomSpec      `yaml:"rooms"`
 	Connectors []ConnectorSpec `yaml:"connectors"`
 }

--- a/encounter/dungeonspec/start_test.go
+++ b/encounter/dungeonspec/start_test.go
@@ -1,0 +1,318 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dungeonspec_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// partyStartProbe lets the seed sweep assert a resolved seat is truly
+// placeable in the reconstructed spatial room, rather than merely absent from
+// one serialized obstacle slice.
+type partyStartProbe struct{}
+
+const startDecodeError = "decode dungeon spec"
+
+func (partyStartProbe) GetID() string                   { return "party-start-probe" }
+func (partyStartProbe) GetType() toolkitcore.EntityType { return "party-start-probe" }
+
+func TestDecode_StartOptionalNullAndStrictShape(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantStart *[2]int
+		wantErr   string
+	}{
+		{"omitted is nil", placedTombYAML, nil, ""},
+		{"explicit null is nil", placedTombYAML + "\nstart: null\n", nil, ""},
+		{"absolute pair decodes", placedTombYAML + "\nstart: [7, 4]\n", &[2]int{7, 4}, ""},
+		{"one coordinate rejected", placedTombYAML + "\nstart: [7]\n", nil, startDecodeError},
+		{"three coordinates rejected", placedTombYAML + "\nstart: [7, 4, 2]\n", nil, startDecodeError},
+		{"scalar rejected", placedTombYAML + "\nstart: 7\n", nil, startDecodeError},
+		{"noninteger coordinate rejected", placedTombYAML + "\nstart: [7, north]\n", nil, startDecodeError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := dungeonspec.Decode([]byte(tc.yaml))
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStart, spec.Start)
+		})
+	}
+}
+
+func TestValidate_StartAbsoluteRoomDoorRowAndStaticConflicts(t *testing.T) {
+	decodeValid := func(t *testing.T) *dungeonspec.DungeonSpec {
+		t.Helper()
+		spec, err := dungeonspec.Decode([]byte(validM1YAML))
+		require.NoError(t, err)
+		return spec
+	}
+
+	// validM1YAML's start columns are 0 (entrance), 11 (gallery), 20
+	// (corridor), and 27 (tomb). Every semantic archetype accepts its own
+	// absolute door-row start; this is deliberately unlike room-local place.
+	for _, tc := range []struct {
+		name string
+		at   [2]int
+	}{
+		{"entrance", [2]int{0, 4}},
+		{"chamber", [2]int{11, 4}},
+		{"corridor", [2]int{20, 4}},
+		{"boss", [2]int{27, 4}},
+	} {
+		t.Run("door-row accepted in "+tc.name, func(t *testing.T) {
+			spec := decodeValid(t)
+			spec.Start = &tc.at
+			require.NoError(t, dungeonspec.Validate(spec))
+		})
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*dungeonspec.DungeonSpec)
+		wantErr string
+	}{
+		{
+			name: "connector door cell rejected",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				at := [2]int{10, 4} // entrance's right-hand connector/door column
+				spec.Start = &at
+			},
+			wantErr: "connector gap/door cell",
+		},
+		{
+			name: "out of footprint rejected",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				at := [2]int{39, 4} // total width is 39, so this is just outside
+				spec.Start = &at
+			},
+			wantErr: "out of bounds",
+		},
+		{
+			name: "outside floor row rejected",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				at := [2]int{0, 8}
+				spec.Start = &at
+			},
+			wantErr: "out of bounds",
+		},
+		{
+			name: "movement-blocking prop rejected",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				at := [2]int{33, 3} // tomb starts at 27; coffin is local [6,3]
+				spec.Start = &at
+			},
+			wantErr: "movement-blocking prop",
+		},
+		{
+			name: "placed monster rejected",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				at := [2]int{31, 2} // tomb-local placed skeleton [4,2]
+				spec.Start = &at
+			},
+			wantErr: "placed monster",
+		},
+		{
+			name: "pinned boss rejected",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				at := [2]int{34, 5} // tomb-local boss.at [7,5]
+				spec.Start = &at
+			},
+			wantErr: "pinned boss",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := decodeValid(t)
+			tc.mutate(spec)
+			err := dungeonspec.Validate(spec)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	t.Run("nonblocking prop does not conflict", func(t *testing.T) {
+		spec := decodeValid(t)
+		falseValue := false
+		// The coffin is tomb-local [6,3], absolute [33,3]. A start only
+		// conflicts with a prop if it blocks movement.
+		tomb(spec).Place[0].BlocksMovement = &falseValue
+		at := [2]int{33, 3}
+		spec.Start = &at
+		require.NoError(t, dungeonspec.Validate(spec))
+	})
+}
+
+func TestLoad_StartCompilesAbsoluteAnchorAndNormalFourSeatReservation(t *testing.T) {
+	// The tomb begins at absolute column 7 in this two-room fixture. If start
+	// were accidentally treated like a tomb-local coordinate, this would land
+	// at column 14 instead of the asserted absolute column 7.
+	compiled, err := dungeonspec.Load([]byte(placedTombYAML + "\nstart: [7, 4]\n"))
+	require.NoError(t, err)
+	require.NotNil(t, compiled.Params.PartyStart.Anchor)
+	assert.Equal(t, core.HexFromPosition(spatial.Position{X: 7, Y: 4}), *compiled.Params.PartyStart.Anchor)
+	assert.Equal(t, 4, compiled.Params.PartyStart.SeatCount)
+
+	compiled.Params.RandomSeed = 44
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+	enc := encounter.New(context.Background(), "absolute-start-compile", broker)
+	require.NoError(t, enc.InitDungeon(compiled.Params))
+	require.Equal(t, *compiled.Params.PartyStart.Anchor, enc.ToData().Space.Entrance)
+
+	positions, err := enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 4})
+	require.NoError(t, err)
+	require.Len(t, positions.Positions, 4)
+	require.Equal(t, enc.ToData().Space.Entrance, positions.Positions[0])
+}
+
+func TestLoadWithConfig_UsesHostPartyCapacity(t *testing.T) {
+	compiled, err := dungeonspec.LoadWithConfig([]byte(placedTombYAML), dungeonspec.LoadConfig{
+		PartyStartSeatCount: 2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, compiled.Params.PartyStart.SeatCount)
+
+	_, err = dungeonspec.LoadWithConfig([]byte(placedTombYAML), dungeonspec.LoadConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "party start seat count must be at least 1")
+}
+
+func TestLoad_OmittedAndNullStartPreserveGeneratedBehavior(t *testing.T) {
+	omitted, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	nullStart, err := dungeonspec.Load([]byte(placedTombYAML + "\nstart: null\n"))
+	require.NoError(t, err)
+	require.Equal(t, omitted, nullStart, "omitted and explicit null compile identically")
+
+	build := func(compiled dungeonspec.CompiledDungeon) *encounter.Data {
+		compiled.Params.RandomSeed = 73
+		transport := encounter.NewInMemoryTransport()
+		broker := encounter.NewBroker(transport)
+		t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+		enc := encounter.New(context.Background(), "omitted-null-start", broker)
+		require.NoError(t, enc.InitDungeon(compiled.Params))
+		return enc.ToData()
+	}
+	omittedData := build(omitted)
+	nullData := build(nullStart)
+	require.Equal(t, omittedData.Space.Entrance, nullData.Space.Entrance)
+	require.Equal(t, omittedData.Space.PartyStartPositions, nullData.Space.PartyStartPositions)
+	require.Equal(t, omittedData.Space.Walls, nullData.Space.Walls)
+	require.Equal(t, omittedData.Space.Obstacles, nullData.Space.Obstacles)
+	require.Equal(t, core.HexFromPosition(spatial.Position{X: 0, Y: 4}), omittedData.Space.Entrance)
+	require.Equal(t, []core.Hex{
+		core.HexFromPosition(spatial.Position{X: 0, Y: 4}),
+		core.HexFromPosition(spatial.Position{X: 1, Y: 4}),
+		core.HexFromPosition(spatial.Position{X: 2, Y: 4}),
+		core.HexFromPosition(spatial.Position{X: 3, Y: 4}),
+	}, omittedData.Space.PartyStartPositions, "generated start uses its existing clear entrance-to-door route")
+}
+
+// TestLoad_AuthoredStartReservationSurvivesScatteredPreferBorderSeeds runs the
+// dungeonspec compiler's actual scattered -> random mapping plus both rolled
+// obstacle paths over a named sweep. No seed may block, move, or reorder any
+// normal four-seat reservation.
+func TestLoad_AuthoredStartReservationSurvivesScatteredPreferBorderSeeds(t *testing.T) {
+	const authoredStartSweepYAML = `
+version: 1
+key: authored-start-sweep
+name: Authored Start Sweep
+height: 8
+start: [14, 4]
+rooms:
+  - id: entry
+    archetype: entrance
+    width: 8
+    pattern: scattered
+    obstacles:
+      - { ref: "dnd5e:props:pillar", count: 12 }
+  - id: gallery
+    archetype: chamber
+    width: 10
+    pattern: scattered
+    obstacles:
+      - { ref: "dnd5e:props:bone-pile", count: 28, prefer_border: true }
+      - { ref: "dnd5e:props:obelisk", count: 25 }
+  - id: tomb
+    archetype: boss
+    width: 8
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [4, 5] }
+connectors:
+  - { from: entry, to: gallery }
+  - { from: gallery, to: tomb }
+`
+	compiled, err := dungeonspec.Load([]byte(authoredStartSweepYAML))
+	require.NoError(t, err)
+
+	var want []core.Hex
+	for seed := int64(1); seed <= 50; seed++ {
+		params := compiled.Params
+		params.RandomSeed = seed
+		transport := encounter.NewInMemoryTransport()
+		broker := encounter.NewBroker(transport)
+		enc := encounter.New(context.Background(), "authored-start-seed-sweep", broker)
+		require.NoError(t, enc.InitDungeon(params), "seed %d", seed)
+
+		positions, resolveErr := enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 4})
+		require.NoError(t, resolveErr, "seed %d", seed)
+		if want == nil {
+			want = append([]core.Hex(nil), positions.Positions...)
+		} else {
+			require.Equal(t, want, positions.Positions, "seed %d", seed)
+		}
+		require.Equal(t, core.HexFromPosition(spatial.Position{X: 14, Y: 4}), positions.Positions[0], "seed %d", seed)
+
+		seen := make(map[core.Hex]struct{}, 4)
+		for slot, position := range positions.Positions {
+			_, duplicate := seen[position]
+			require.False(t, duplicate, "seed %d seat %d", seed, slot)
+			seen[position] = struct{}{}
+			require.True(t, enc.Room().CanPlaceEntity(partyStartProbe{}, position.ToPosition()),
+				"seed %d seat %d must remain usable", seed, slot)
+		}
+		_ = broker.Close()
+		_ = transport.Close()
+	}
+}
+
+func TestWorkbenchReport_AuthoredStartUsesPartyMarker(t *testing.T) {
+	report, err := dungeonspec.WorkbenchReport([]byte(placedTombYAML+"\nstart: [7, 4]\n"), 42)
+	require.NoError(t, err)
+	assert.Contains(t, report, "@ party start")
+	assert.Contains(t, report, "......D@...........")
+}
+
+func TestResolvePartySpawnPositions_TooLargeRequestCarriesCounts(t *testing.T) {
+	compiled, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+	enc := encounter.New(context.Background(), "party-start-capacity", broker)
+	require.NoError(t, enc.InitDungeon(compiled.Params))
+
+	_, err = enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 5})
+	require.Error(t, err)
+	var capacityErr *encounter.PartySpawnCapacityError
+	require.True(t, errors.As(err, &capacityErr))
+	assert.Equal(t, 5, capacityErr.Requested)
+	assert.Equal(t, 4, capacityErr.Available)
+}

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -128,6 +128,10 @@ func Validate(spec *DungeonSpec) error {
 		}
 	}
 
+	if err := validateStart(spec); err != nil {
+		return err
+	}
+
 	for i := range spec.Connectors {
 		c := &spec.Connectors[i]
 		if c.Locked != nil {
@@ -347,6 +351,71 @@ func checkCellBounds(room *RoomSpec, height int, at [2]int) error {
 	}
 	if at[1] < 0 || at[1] >= height {
 		return fmt.Errorf("out of bounds: row %d not in [0,%d)", at[1], height)
+	}
+	return nil
+}
+
+// validateStart checks the optional absolute party-start anchor against the
+// declared linear semantic-room layout and known authored blocking content.
+// It intentionally does not inspect generated walls or rolled obstacles: both
+// depend on a later seed and are protected by encounter's party reservation.
+func validateStart(spec *DungeonSpec) error {
+	if spec.Start == nil {
+		return nil
+	}
+	at := *spec.Start
+	if at[1] < 0 || at[1] >= spec.Height {
+		return fmt.Errorf("start %v out of bounds: row %d not in [0,%d)", at, at[1], spec.Height)
+	}
+
+	starts := make([]int, len(spec.Rooms))
+	totalWidth := 0
+	for i, room := range spec.Rooms {
+		starts[i] = totalWidth
+		totalWidth += room.Width
+		if i < len(spec.Rooms)-1 {
+			totalWidth++ // connector column
+		}
+	}
+	if at[0] < 0 || at[0] >= totalWidth {
+		return fmt.Errorf("start %v out of bounds: column %d not in [0,%d)", at, at[0], totalWidth)
+	}
+
+	roomIndex := -1
+	for i, room := range spec.Rooms {
+		if at[0] < starts[i] || at[0] >= starts[i]+room.Width {
+			continue
+		}
+		if roomIndex != -1 {
+			return fmt.Errorf("start %v belongs to more than one semantic room", at)
+		}
+		roomIndex = i
+	}
+	if roomIndex == -1 {
+		return fmt.Errorf("start %v is a connector gap/door cell, not a semantic room floor cell", at)
+	}
+
+	room := &spec.Rooms[roomIndex]
+	local := [2]int{at[0] - starts[roomIndex], at[1]}
+	if room.Boss != nil && room.Boss.At != nil && *room.Boss.At == local {
+		return fmt.Errorf("start %v conflicts with pinned boss in room %q", at, room.ID)
+	}
+	for _, entry := range room.Place {
+		if entry.At != local {
+			continue
+		}
+		refType, err := refParts(entry.Ref)
+		if err != nil {
+			return fmt.Errorf("start %v: place %q: %w", at, entry.Ref, err)
+		}
+		switch refType {
+		case refTypeMonsters:
+			return fmt.Errorf("start %v conflicts with placed monster %q in room %q", at, entry.Ref, room.ID)
+		case refTypeProps:
+			if boolOrTrue(entry.BlocksMovement) {
+				return fmt.Errorf("start %v conflicts with movement-blocking prop %q in room %q", at, entry.Ref, room.ID)
+			}
+		}
 	}
 	return nil
 }

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
 )
@@ -24,6 +25,9 @@ const (
 const (
 	refTypeProps    = "props"
 	refTypeMonsters = "monsters"
+
+	unsupportedCapability = "unsupported capability"
+	facingFloorPropsOnly  = "facing only supported on room-scoped floor props"
 )
 
 // The spec's author-facing pattern vocabulary, shared between
@@ -123,9 +127,12 @@ func Validate(spec *DungeonSpec) error {
 	}
 
 	for i := range spec.Rooms {
-		if err := validatePlaceBlock(&spec.Rooms[i], spec.Height); err != nil {
+		if err := validatePlaceBlock(&spec.Rooms[i], spec.Height, i); err != nil {
 			return err
 		}
+	}
+	if err := validateTopLevelPlace(spec.Place); err != nil {
+		return err
 	}
 
 	if err := validateStart(spec); err != nil {
@@ -275,7 +282,7 @@ func validateBossRef(bossRoom *RoomSpec) error {
 
 // validatePlaceBlock validates one room's place block plus its (optional)
 // pinned boss.at, which share one collision domain.
-func validatePlaceBlock(room *RoomSpec, height int) error {
+func validatePlaceBlock(room *RoomSpec, height, roomIndex int) error {
 	hasPinned := len(room.Place) > 0 || (room.Boss != nil && room.Boss.At != nil)
 	if room.Pattern == patternScattered && hasPinned {
 		// Scattered interior walls are seed-rolled — no at cell can be
@@ -287,6 +294,9 @@ func validatePlaceBlock(room *RoomSpec, height int) error {
 	doorRow := height / 2
 	occupied := make(map[[2]int]string, len(room.Place)+1)
 
+	if room.Boss != nil && room.Boss.Facing != nil {
+		return fmt.Errorf("rooms[%d].boss.facing: %s: %s", roomIndex, unsupportedCapability, facingFloorPropsOnly)
+	}
 	if room.Boss != nil && room.Boss.At != nil {
 		at := *room.Boss.At
 		if err := checkCellBounds(room, height, at); err != nil {
@@ -298,7 +308,7 @@ func validatePlaceBlock(room *RoomSpec, height int) error {
 		occupied[at] = room.Boss.Ref
 	}
 
-	for _, entry := range room.Place {
+	for entryIndex, entry := range room.Place {
 		if err := checkCellBounds(room, height, entry.At); err != nil {
 			return fmt.Errorf("room %q: place %q %w", room.ID, entry.Ref, err)
 		}
@@ -324,6 +334,19 @@ func validatePlaceBlock(room *RoomSpec, height int) error {
 				room.ID, entry.Ref, refType)
 		}
 
+		path := fmt.Sprintf("rooms[%d].place[%d]", roomIndex, entryIndex)
+		if entry.Facing != nil {
+			if refType != refTypeProps || entry.Mount != nil {
+				return fmt.Errorf("%s.facing: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
+			}
+			if err := validateFacing(*entry.Facing); err != nil {
+				return fmt.Errorf("%s.facing: %w", path, err)
+			}
+		}
+		if entry.Mount != nil {
+			return fmt.Errorf("%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
+		}
+
 		if room.Boss != nil && entry.Ref == room.Boss.Ref {
 			return fmt.Errorf("room %q: boss ref may not also appear in place (ref %q)", room.ID, entry.Ref)
 		}
@@ -343,6 +366,51 @@ func validatePlaceBlock(room *RoomSpec, height int) error {
 	}
 
 	return nil
+}
+
+// validateTopLevelPlace retains the canonical syntax long enough to reject
+// unsupported top-level placement capability at the author-supplied field.
+// It deliberately never compiles or maps entries into room-scoped placement.
+func validateTopLevelPlace(entries []PlacedEntry) error {
+	for index, entry := range entries {
+		if entry.Facing != nil {
+			return fmt.Errorf("place[%d].facing: %s: %s", index, unsupportedCapability, facingFloorPropsOnly)
+		}
+		if entry.Mount != nil {
+			return fmt.Errorf("place[%d].mount: %s: mounted placements are not supported", index, unsupportedCapability)
+		}
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	return fmt.Errorf("place[0]: %s: top-level placement is not supported", unsupportedCapability)
+}
+
+// validateFacing rejects labels outside the one canonical hex-facing vocabulary.
+func validateFacing(label string) error {
+	_, err := facingValue(label)
+	return err
+}
+
+// facingValue maps one canonical YAML label to the persisted runtime index.
+func facingValue(label string) (uint32, error) {
+	switch label {
+	case "E":
+		return encounter.FacingEast, nil
+	case "NE":
+		return encounter.FacingNortheast, nil
+	case "NW":
+		return encounter.FacingNorthwest, nil
+	case "W":
+		return encounter.FacingWest, nil
+	case "SW":
+		return encounter.FacingSouthwest, nil
+	case "SE":
+		return encounter.FacingSoutheast, nil
+	default:
+		return 0, fmt.Errorf("invalid facing %q (must be %q, %q, %q, %q, %q, or %q)",
+			label, "E", "NE", "NW", "W", "SW", "SE")
+	}
 }
 
 func checkCellBounds(room *RoomSpec, height int, at [2]int) error {

--- a/encounter/dungeonspec/validate_test.go
+++ b/encounter/dungeonspec/validate_test.go
@@ -19,10 +19,98 @@ func tomb(s *dungeonspec.DungeonSpec) *dungeonspec.RoomSpec {
 
 // Shared substrings used by more than one table row below (goconst).
 const (
-	errRefShape    = "must be shaped like module:type:id"
-	errM1Rolled    = "rolled monster placement lands in M2"
-	errOutOfBounds = "out of bounds"
+	errRefShape              = "must be shaped like module:type:id"
+	errM1Rolled              = "rolled monster placement lands in M2"
+	errOutOfBounds           = "out of bounds"
+	errUnsupportedCapability = "unsupported capability"
 )
+
+// TestValidate_FacingStrictlyScopesCanonicalFloorProps proves facing is neither
+// stripped nor broadly accepted: only existing room-scoped floor props may
+// carry it, while unsupported forms name the exact supplied field path.
+func TestValidate_FacingStrictlyScopesCanonicalFloorProps(t *testing.T) {
+	decode := func(t *testing.T) *dungeonspec.DungeonSpec {
+		t.Helper()
+		spec, err := dungeonspec.Decode([]byte(placedTombYAML))
+		require.NoError(t, err)
+		return spec
+	}
+
+	for _, label := range []string{"E", "NE", "NW", "W", "SW", "SE"} {
+		t.Run("floor prop accepts "+label, func(t *testing.T) {
+			spec := decode(t)
+			spec.Rooms[1].Place[0].Facing = &label
+			require.NoError(t, dungeonspec.Validate(spec))
+		})
+	}
+
+	cases := []struct {
+		name     string
+		mutate   func(*dungeonspec.DungeonSpec)
+		wantPath string
+		wantErr  string
+	}{
+		{
+			name: "floor prop rejects unknown label with vocabulary",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				label := "N"
+				spec.Rooms[1].Place[0].Facing = &label
+			},
+			wantPath: "rooms[1].place[0].facing",
+			wantErr:  `must be "E", "NE", "NW", "W", "SW", or "SE"`,
+		},
+		{
+			name: "monster place facing is unsupported",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				label := "E"
+				spec.Rooms[1].Place[5].Facing = &label
+			},
+			wantPath: "rooms[1].place[5].facing",
+			wantErr:  errUnsupportedCapability,
+		},
+		{
+			name: "boss facing is unsupported",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				label := "SW"
+				spec.Rooms[1].Boss.Facing = &label
+			},
+			wantPath: "rooms[1].boss.facing",
+			wantErr:  errUnsupportedCapability,
+		},
+		{
+			name: "mounted prop facing is unsupported",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				label, mount := "NE", "wall"
+				spec.Rooms[1].Place[0].Facing = &label
+				spec.Rooms[1].Place[0].Mount = &mount
+			},
+			wantPath: "rooms[1].place[0].facing",
+			wantErr:  errUnsupportedCapability,
+		},
+		{
+			name: "top level facing is unsupported at its own entry path",
+			mutate: func(spec *dungeonspec.DungeonSpec) {
+				label := "E"
+				spec.Place = []dungeonspec.PlacedEntry{
+					{Ref: "dnd5e:props:candles", At: [2]int{1, 1}},
+					{Ref: "dnd5e:props:candles", At: [2]int{2, 1}, Facing: &label},
+				}
+			},
+			wantPath: "place[1].facing",
+			wantErr:  errUnsupportedCapability,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := decode(t)
+			tc.mutate(spec)
+			err := dungeonspec.Validate(spec)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantPath)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
 
 func TestValidate_Table(t *testing.T) {
 	cases := []struct {

--- a/encounter/dungeonspec/workbench.go
+++ b/encounter/dungeonspec/workbench.go
@@ -140,7 +140,7 @@ func writePlacedObstacles(b *strings.Builder, regions []encounter.DungeonRegionP
 
 // floorPlanLegend documents the ASCII floor plan's marker vocabulary,
 // printed once ahead of the grid so the symbols are self-describing.
-const floorPlanLegend = "floor plan (. floor, # wall, D door, o obstacle, @ entrance):"
+const floorPlanLegend = "floor plan (. floor, # wall, D door, o obstacle, @ party start):"
 
 // writeFloorPlan renders the encounter's committed Space (plus its Doors
 // and Entrance, which live on Data/SpaceData respectively) as an ASCII
@@ -148,7 +148,7 @@ const floorPlanLegend = "floor plan (. floor, # wall, D door, o obstacle, @ entr
 // (rolled or placed alike -- writePlacedObstacles already calls out
 // placed ones by name and exact coordinate separately, so the map doesn't
 // need a second, distinct marker to carry that distinction too), '@' the
-// designated entrance cell (SpaceData.Entrance).
+// toolkit-resolved party-start anchor (SpaceData.Entrance).
 //
 // SpaceData.Walls carries two shapes (see that field's doc): degenerate
 // (Start == End) is an actual blocked interior hex, marked at Start;
@@ -181,7 +181,7 @@ func writeFloorPlan(b *strings.Builder, data *encounter.Data) {
 	// set's bounds check is load-bearing, not merely defensive
 	// (rpg-toolkit#848/#849 gate review finding 7): every wall/door/
 	// obstacle coordinate is in-bounds by InitDungeon's own validation,
-	// Entrance by construction -- EXCEPT a boundary-edge segment's End
+	// PartyStart/Entrance by construction -- EXCEPT a boundary-edge segment's End
 	// when it lands outside the room (the outer-perimeter case,
 	// rpg-toolkit#834). The loop below calls set(End, '#') unconditionally
 	// for every non-degenerate wall entry and deliberately relies on this

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -349,7 +349,10 @@ func (e *Encounter) AddPlayer(input PlayerInput) error {
 	// seat's own entity on its own starting hex (and any other
 	// already-seated entity that happens to share it), the same way any
 	// other viewer's own-position observation works.
-	e.refreshObservations(view, perception.VisibleHexesAt(input.Position, input.SightRange, e.room))
+	visible := perception.VisibleHexesAt(input.Position, input.SightRange, e.room)
+	if err := e.refreshObservations(view, visible); err != nil {
+		return fmt.Errorf("refresh new player %q observations: %w", input.PlayerID, err)
+	}
 
 	// Seed default OA readiness for combatants. Free-cost reactions default
 	// on so players do not need to opt in every fight.
@@ -523,7 +526,9 @@ func (e *Encounter) addMonsterNoCombatCheck(input MonsterInput) error {
 		// finds the monster, since it's stationary and just-stored at
 		// mon.Position.
 		for viewerID := range viewers {
-			e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(mon.Position))
+			if err := e.refreshObservations(e.data.Players[viewerID].View, core.NewHexSet(mon.Position)); err != nil {
+				return fmt.Errorf("refresh monster appearance for player %q: %w", viewerID, err)
+			}
 		}
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), mon.ID, mon.Position, viewers,
@@ -1104,7 +1109,9 @@ func (e *Encounter) applyAndPublishMove(
 	//    is what makes re-sight (a hex the mover once knew, lost, and is
 	//    now back in range of) atomically correct (rpg-toolkit#851).
 	p.View.Position = end
-	e.refreshObservations(p.View, newVisible)
+	if err := e.refreshObservations(p.View, newVisible); err != nil {
+		return "", fmt.Errorf("refresh mover observations: %w", err)
+	}
 
 	// 3. Per-player projection.
 	movePerPlayer := make(map[core.PlayerID]events.MovePlayerSlice)
@@ -1140,7 +1147,9 @@ func (e *Encounter) applyAndPublishMove(
 		}
 		if revealSlice != nil {
 			if revealSlice.Hexes != nil {
-				e.refreshObservations(other.View, revealSlice.Hexes)
+				if err := e.refreshObservations(other.View, revealSlice.Hexes); err != nil {
+					return "", fmt.Errorf("refresh reveal for player %q: %w", otherID, err)
+				}
 			}
 			revealPerPlayer[otherID] = *revealSlice
 		}
@@ -1172,7 +1181,9 @@ func (e *Encounter) applyAndPublishMove(
 		// ProjectVisibilityTransition's doc for that disappearance case,
 		// handled separately below).
 		if len(seenSegments) > 0 {
-			e.refreshObservations(other.View, core.NewHexSet(seenSegments...))
+			if err := e.refreshObservations(other.View, core.NewHexSet(seenSegments...)); err != nil {
+				return "", fmt.Errorf("refresh move observation for player %q: %w", otherID, err)
+			}
 		}
 		appearedAt, disappearedAt := perception.ProjectVisibilityTransition(
 			moverStart, traveledPath, seenSegments, other.View, visible,
@@ -1356,7 +1367,9 @@ func (e *Encounter) OpenDoor(playerID core.PlayerID, doorID core.EntityID) error
 			// new ones. Bounded by this viewer's own sight range, same cost
 			// class as their own move's reveal.
 			visible := perception.VisibleHexesAt(viewer.View.Position, viewer.View.SightRange, e.room)
-			e.refreshObservations(viewer.View, visible)
+			if err := e.refreshObservations(viewer.View, visible); err != nil {
+				return fmt.Errorf("refresh door observation for player %q: %w", viewerID, err)
+			}
 		}
 		if revealSlice != nil {
 			revealPerPlayer[viewerID] = *revealSlice

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -205,6 +205,7 @@ func (s *EventsSuite) TestMoveEvent_AudienceFromPerPlayer() {
 // Path[0] which is the first traveled STEP; a real, non-zero From here
 // guards against the two silently collapsing back to the same value).
 func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
+	facingEast := uint32(0)
 	original := events.NewMoveEvent("enc-1", 42, "bob", core.Hex{Q: 0, R: 0, S: 0},
 		[]core.Hex{{Q: 1, R: -1, S: 0}, {Q: 2, R: -1, S: -1}},
 		map[core.PlayerID]events.MovePlayerSlice{
@@ -218,7 +219,7 @@ func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
 			{
 				Position: core.Hex{Q: 0, R: 0, S: 0},
 				State:    2,
-				Contents: []events.KnownHexPlacement{{EntityID: "bob", Facing: 3}},
+				Contents: []events.KnownHexPlacement{{EntityID: "bob", Facing: &facingEast}},
 			},
 			{
 				Position: core.Hex{Q: 1, R: -1, S: 0},
@@ -247,6 +248,10 @@ func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
 	s.Equal(original.PerPlayer["alice"].SeenSegments, decoded.PerPlayer["alice"].SeenSegments)
 	s.Equal(core.PlayerID("bob-player"), decoded.MoverPlayerID)
 	s.Equal(original.MoverKnownHexes, decoded.MoverKnownHexes)
+	s.Require().Len(decoded.MoverKnownHexes[0].Contents, 1)
+	s.Require().NotNil(decoded.MoverKnownHexes[0].Contents[0].Facing)
+	s.Equal(uint32(0), *decoded.MoverKnownHexes[0].Contents[0].Facing,
+		"event JSON must retain explicit E rather than collapsing it to absence")
 }
 
 // A nil moverKnownHexes normalizes to an empty (never nil) slice — the NPC

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -254,6 +254,27 @@ func (s *EventsSuite) TestMoveEvent_JSONRoundTrip() {
 		"event JSON must retain explicit E rather than collapsing it to absence")
 }
 
+// TestKnownHexPlacementFacingJSONDistinguishesLegacyZero verifies event replay
+// follows the same presence rule as persisted perception memory: legacy
+// mandatory Facing:0 is absent, while a current lowercase facing:0 is E.
+func (s *EventsSuite) TestKnownHexPlacementFacingJSONDistinguishesLegacyZero() {
+	facingEast := uint32(0)
+	current := events.KnownHexPlacement{EntityID: "authored-prop", Facing: &facingEast}
+	payload, err := json.Marshal(current)
+	s.Require().NoError(err)
+	s.Contains(string(payload), `"facing":0`)
+	s.NotContains(string(payload), `"Facing":0`)
+
+	var replay events.KnownHexPlacement
+	s.Require().NoError(json.Unmarshal(payload, &replay))
+	s.Require().NotNil(replay.Facing)
+	s.Equal(uint32(0), *replay.Facing)
+
+	var legacy events.KnownHexPlacement
+	s.Require().NoError(json.Unmarshal([]byte(`{"EntityID":"legacy-player","Facing":0}`), &legacy))
+	s.Nil(legacy.Facing)
+}
+
 // A nil moverKnownHexes normalizes to an empty (never nil) slice — the NPC
 // mover path (encounter/npc.go) always passes nil, and a consumer ranging
 // over MoverKnownHexes unconditionally must never nil-panic or need its own

--- a/encounter/events/known_hex.go
+++ b/encounter/events/known_hex.go
@@ -46,6 +46,7 @@ type KnownHexEdge struct {
 // KnownHexPlacement mirrors encounter/perception.Placement.
 type KnownHexPlacement struct {
 	EntityID core.EntityID
-	// Facing is a hex-direction index 0-5.
-	Facing int
+	// Facing is optional canonical hex-facing metadata. Pointer presence
+	// distinguishes absent from explicit E = 0 through event serialization.
+	Facing *uint32
 }

--- a/encounter/events/known_hex.go
+++ b/encounter/events/known_hex.go
@@ -1,6 +1,10 @@
 package events
 
-import "github.com/KirkDiggler/rpg-toolkit/encounter/core"
+import (
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
 
 // KnownHex is one hex's complete authorized knowledge for a viewer, as
 // carried by MoveEvent.MoverKnownHexes.
@@ -49,4 +53,41 @@ type KnownHexPlacement struct {
 	// Facing is optional canonical hex-facing metadata. Pointer presence
 	// distinguishes absent from explicit E = 0 through event serialization.
 	Facing *uint32
+}
+
+type knownHexPlacementWire struct {
+	EntityID core.EntityID `json:"EntityID"`
+	Facing   *uint32       `json:"facing,omitempty"`
+}
+
+// MarshalJSON writes optional facing under a lowercase key so explicit E = 0
+// remains present without colliding with legacy known-hex event JSON.
+func (p KnownHexPlacement) MarshalJSON() ([]byte, error) {
+	return json.Marshal(knownHexPlacementWire(p))
+}
+
+// UnmarshalJSON restores current optional facing and ignores the legacy
+// uppercase "Facing":0 emitted by the old mandatory field. That zero meant
+// absent, not authored E, so accepting it would invent orientation on replay.
+func (p *KnownHexPlacement) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	var entityID core.EntityID
+	if rawEntityID, ok := fields["EntityID"]; ok {
+		if err := json.Unmarshal(rawEntityID, &entityID); err != nil {
+			return err
+		}
+	}
+	var facing *uint32
+	if rawFacing, ok := fields["facing"]; ok {
+		if err := json.Unmarshal(rawFacing, &facing); err != nil {
+			return err
+		}
+	}
+	p.EntityID = entityID
+	p.Facing = facing
+	return nil
 }

--- a/encounter/generated_edges.go
+++ b/encounter/generated_edges.go
@@ -1,0 +1,188 @@
+package encounter
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// GeneratedEdgeKind identifies the runtime barrier represented by a
+// GeneratedEdge.
+type GeneratedEdgeKind string
+
+const (
+	// GeneratedEdgeKindSolid is a generated, non-door barrier. Solid edges
+	// never carry an entity identity.
+	GeneratedEdgeKindSolid GeneratedEdgeKind = "solid"
+	// GeneratedEdgeKindDoor is a connector door barrier. DoorID identifies
+	// the existing DoorData record that owns its lifecycle.
+	GeneratedEdgeKindDoor GeneratedEdgeKind = "door"
+)
+
+// GeneratedEdge is one canonical physical edge in an initialized encounter's
+// current generated geometry. From and To retain the runtime canonical
+// orientation: solid edges use SpaceData.Walls' Start/End and doors use their
+// threshold cell plus the designated passage neighbor. DoorID is populated
+// only when Kind is GeneratedEdgeKindDoor.
+type GeneratedEdge struct {
+	From   core.Hex
+	To     core.Hex
+	Kind   GeneratedEdgeKind
+	DoorID core.EntityID
+}
+
+// DescribeGeneratedEdgesInput reserves an explicit input boundary for the
+// generated-edge describe operation. The current encounter already owns the
+// initialized geometry, so no regeneration or caller-provided geometry is
+// accepted.
+type DescribeGeneratedEdgesInput struct{}
+
+// DescribeGeneratedEdgesOutput contains one record for every undirected
+// physical generated barrier edge in the encounter's current geometry.
+type DescribeGeneratedEdgesOutput struct {
+	Edges []GeneratedEdge
+}
+
+// DescribeGeneratedEdges exposes the canonical generated wall and connector
+// door geometry for an already-initialized encounter. It deduplicates
+// equivalent reversed solid records, preserves their canonical source
+// endpoints, and rejects conflicting records for the same physical edge.
+//
+// This is an authoring-safe read seam: callers project its result directly and
+// must not inspect SpaceData.Walls or Doors to derive competing geometry.
+func (e *Encounter) DescribeGeneratedEdges(_ DescribeGeneratedEdgesInput) (DescribeGeneratedEdgesOutput, error) {
+	records, err := e.canonicalGeneratedEdgeRecords()
+	if err != nil {
+		return DescribeGeneratedEdgesOutput{}, err
+	}
+	output := DescribeGeneratedEdgesOutput{Edges: make([]GeneratedEdge, len(records))}
+	for i, record := range records {
+		output.Edges[i] = record.edge
+	}
+	return output, nil
+}
+
+type generatedEdgeRecord struct {
+	edge           GeneratedEdge
+	blocksMovement bool
+	blocksLoS      bool
+}
+
+type generatedEdgeKey struct {
+	first  core.Hex
+	second core.Hex
+}
+
+// canonicalGeneratedEdgeRecords is the single canonicalizer for both the
+// public authoring seam and per-viewer knowledge. Its key normalizes an edge
+// only for duplicate detection; GeneratedEdge retains the source's runtime
+// orientation, while the private record retains blocking semantics knowledge
+// must preserve.
+func (e *Encounter) canonicalGeneratedEdgeRecords() ([]generatedEdgeRecord, error) {
+	records := make([]generatedEdgeRecord, 0)
+	seen := make(map[generatedEdgeKey]int)
+	add := func(record generatedEdgeRecord) error {
+		key := newGeneratedEdgeKey(record.edge.From, record.edge.To)
+		if index, exists := seen[key]; exists {
+			existing := records[index]
+			if existing.edge.Kind == record.edge.Kind &&
+				existing.edge.DoorID == record.edge.DoorID &&
+				existing.blocksMovement == record.blocksMovement &&
+				existing.blocksLoS == record.blocksLoS {
+				return nil
+			}
+			return fmt.Errorf("conflicting generated edges at %v to %v: %s/%q conflicts with %s/%q",
+				record.edge.From, record.edge.To, existing.edge.Kind, existing.edge.DoorID,
+				record.edge.Kind, record.edge.DoorID)
+		}
+		seen[key] = len(records)
+		records = append(records, record)
+		return nil
+	}
+
+	if e.data.Space != nil {
+		for _, wall := range e.data.Space.Walls {
+			if !wall.BlocksMovement && !wall.BlocksLoS {
+				continue
+			}
+			if err := add(generatedEdgeRecord{
+				edge: GeneratedEdge{
+					From: core.HexFromCube(wall.Start),
+					To:   core.HexFromCube(wall.End),
+					Kind: GeneratedEdgeKindSolid,
+				},
+				blocksMovement: wall.BlocksMovement,
+				blocksLoS:      wall.BlocksLoS,
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	doorIDs := make([]core.EntityID, 0, len(e.data.Doors))
+	for id, door := range e.data.Doors {
+		if door != nil {
+			doorIDs = append(doorIDs, id)
+		}
+	}
+	sort.Slice(doorIDs, func(i, j int) bool { return doorIDs[i] < doorIDs[j] })
+	for _, id := range doorIDs {
+		door := e.data.Doors[id]
+		if err := add(generatedEdgeRecord{
+			edge: GeneratedEdge{
+				From:   door.Position,
+				To:     e.doorPassageNeighbor(door),
+				Kind:   GeneratedEdgeKindDoor,
+				DoorID: id,
+			},
+			blocksMovement: !door.Open,
+			blocksLoS:      !door.Open,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return generatedEdgeLess(records[i].edge, records[j].edge)
+	})
+	return records, nil
+}
+
+// newGeneratedEdgeKey gives an undirected physical edge a comparable key
+// without changing the endpoint orientation exposed to callers.
+func newGeneratedEdgeKey(from, to core.Hex) generatedEdgeKey {
+	if generatedHexLess(to, from) {
+		return generatedEdgeKey{first: to, second: from}
+	}
+	return generatedEdgeKey{first: from, second: to}
+}
+
+func generatedEdgeLess(left, right GeneratedEdge) bool {
+	if generatedHexLess(left.From, right.From) {
+		return true
+	}
+	if generatedHexLess(right.From, left.From) {
+		return false
+	}
+	if generatedHexLess(left.To, right.To) {
+		return true
+	}
+	if generatedHexLess(right.To, left.To) {
+		return false
+	}
+	if left.Kind != right.Kind {
+		return left.Kind < right.Kind
+	}
+	return left.DoorID < right.DoorID
+}
+
+func generatedHexLess(left, right core.Hex) bool {
+	if left.Q != right.Q {
+		return left.Q < right.Q
+	}
+	if left.R != right.R {
+		return left.R < right.R
+	}
+	return left.S < right.S
+}

--- a/encounter/generated_edges.go
+++ b/encounter/generated_edges.go
@@ -21,10 +21,10 @@ const (
 )
 
 // GeneratedEdge is one canonical physical edge in an initialized encounter's
-// current generated geometry. From and To retain the runtime canonical
-// orientation: solid edges use SpaceData.Walls' Start/End and doors use their
-// threshold cell plus the designated passage neighbor. DoorID is populated
-// only when Kind is GeneratedEdgeKindDoor.
+// current generated geometry. From and To are always distinct and retain the
+// runtime canonical orientation: solid edges use SpaceData.Walls' Start/End
+// and doors use their threshold cell plus the designated passage neighbor.
+// DoorID is populated only when Kind is GeneratedEdgeKindDoor.
 type GeneratedEdge struct {
 	From   core.Hex
 	To     core.Hex
@@ -56,9 +56,14 @@ func (e *Encounter) DescribeGeneratedEdges(_ DescribeGeneratedEdgesInput) (Descr
 	if err != nil {
 		return DescribeGeneratedEdgesOutput{}, err
 	}
-	output := DescribeGeneratedEdgesOutput{Edges: make([]GeneratedEdge, len(records))}
-	for i, record := range records {
-		output.Edges[i] = record.edge
+	output := DescribeGeneratedEdgesOutput{Edges: make([]GeneratedEdge, 0, len(records))}
+	for _, record := range records {
+		// Degenerate source records are cell blockers for viewer knowledge,
+		// not physical edges for authoring/proto projection.
+		if record.edge.From == record.edge.To {
+			continue
+		}
+		output.Edges = append(output.Edges, record.edge)
 	}
 	return output, nil
 }
@@ -74,15 +79,24 @@ type generatedEdgeKey struct {
 	second core.Hex
 }
 
-// canonicalGeneratedEdgeRecords is the single canonicalizer for both the
-// public authoring seam and per-viewer knowledge. Its key normalizes an edge
-// only for duplicate detection; GeneratedEdge retains the source's runtime
-// orientation, while the private record retains blocking semantics knowledge
-// must preserve.
+// canonicalGeneratedEdgeRecords is the single canonical barrier source for
+// both the public authoring seam and per-viewer knowledge. It retains every
+// degenerate cell-blocker record for viewer memory. Only distinct-endpoint
+// physical edges receive undirected deduplication and conflict checks.
+// GeneratedEdge retains the source's runtime orientation, while the private
+// record retains blocking semantics knowledge must preserve.
 func (e *Encounter) canonicalGeneratedEdgeRecords() ([]generatedEdgeRecord, error) {
 	records := make([]generatedEdgeRecord, 0)
 	seen := make(map[generatedEdgeKey]int)
 	add := func(record generatedEdgeRecord) error {
+		// Start==End is a valid cell-blocker/self-loop representation. It is
+		// not a physical edge, so a co-located wall and door must both reach
+		// viewer memory rather than being deduplicated or treated as a conflict.
+		if record.edge.From == record.edge.To {
+			records = append(records, record)
+			return nil
+		}
+
 		key := newGeneratedEdgeKey(record.edge.From, record.edge.To)
 		if index, exists := seen[key]; exists {
 			existing := records[index]
@@ -149,8 +163,8 @@ func (e *Encounter) canonicalGeneratedEdgeRecords() ([]generatedEdgeRecord, erro
 	return records, nil
 }
 
-// newGeneratedEdgeKey gives an undirected physical edge a comparable key
-// without changing the endpoint orientation exposed to callers.
+// newGeneratedEdgeKey gives a distinct-endpoint undirected physical edge a
+// comparable key without changing the endpoint orientation exposed to callers.
 func newGeneratedEdgeKey(from, to core.Hex) generatedEdgeKey {
 	if generatedHexLess(to, from) {
 		return generatedEdgeKey{first: to, second: from}

--- a/encounter/generated_edges_test.go
+++ b/encounter/generated_edges_test.go
@@ -1,0 +1,116 @@
+package encounter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+)
+
+// TestDescribeGeneratedEdges_ThreeRoomGeometry verifies the authoring seam
+// against deterministic multi-room geometry rather than reconstructing it
+// from DungeonParams. The initialized encounter is the canonical runtime
+// truth: it contains exterior boundary edges, connector-facing solid edges,
+// and the connector doors the authoring API needs to project.
+func TestDescribeGeneratedEdges_ThreeRoomGeometry(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
+
+	output, err := enc.DescribeGeneratedEdges(encounter.DescribeGeneratedEdgesInput{})
+	require.NoError(t, err)
+	require.NotEmpty(t, output.Edges)
+
+	var exterior, interiorSolid, door *encounter.GeneratedEdge
+	for i := range output.Edges {
+		edge := &output.Edges[i]
+		switch {
+		case edge.Kind == encounter.GeneratedEdgeKindDoor && edge.DoorID == dungeonDoor0ID:
+			door = edge
+		case edge.Kind == encounter.GeneratedEdgeKindSolid && edge.From != edge.To && !inBounds(edge.To, enc.ToData().Space):
+			exterior = edge
+		case edge.Kind == encounter.GeneratedEdgeKindSolid && edge.From != edge.To && inBounds(edge.To, enc.ToData().Space):
+			interiorSolid = edge
+		}
+	}
+
+	require.NotNil(t, exterior, "generated geometry must include an exterior solid edge")
+	require.NotNil(t, interiorSolid, "generated geometry must include an interior-facing connector solid edge")
+	require.NotNil(t, door, "generated geometry must include the connector door")
+	require.Equal(t, dungeonDoor0ID, door.DoorID)
+	require.Empty(t, exterior.DoorID)
+	require.Empty(t, interiorSolid.DoorID)
+}
+
+// TestDescribeGeneratedEdges_DeduplicatesReverseSolidsAndRejectsConflicts
+// pins the seam's one-record-per-physical-edge rule. Legacy duplicated wall
+// records may be reversed, so equivalent solid entries collapse; a door on
+// that same physical edge is a conflict and is rejected rather than leaking
+// competing authoring geometry to a caller.
+func TestDescribeGeneratedEdges_DeduplicatesReverseSolidsAndRejectsConflicts(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitDungeon(threeRegionDungeonParams(dungeonSeed)))
+
+	data := enc.ToData()
+	var original environments.WallSegmentData
+	for _, wall := range data.Space.Walls {
+		if wall.Start != wall.End {
+			original = wall
+			break
+		}
+	}
+	require.NotEqual(t, original.Start, original.End, "fixture requires a physical boundary edge")
+
+	data.Space.Walls = append(data.Space.Walls, environments.WallSegmentData{
+		Start:          original.End,
+		End:            original.Start,
+		BlocksMovement: original.BlocksMovement,
+		BlocksLoS:      original.BlocksLoS,
+	})
+	output, err := enc.DescribeGeneratedEdges(encounter.DescribeGeneratedEdgesInput{})
+	require.NoError(t, err)
+
+	matches := 0
+	for _, edge := range output.Edges {
+		if edge.Kind == encounter.GeneratedEdgeKindSolid && sameUndirectedEdge(edge.From, edge.To,
+			core.HexFromCube(original.Start), core.HexFromCube(original.End)) {
+			matches++
+		}
+	}
+	require.Equal(t, 1, matches, "reversed equivalent solid walls must collapse to one physical edge")
+
+	var door encounter.GeneratedEdge
+	for _, edge := range output.Edges {
+		if edge.Kind == encounter.GeneratedEdgeKindDoor {
+			door = edge
+			break
+		}
+	}
+	require.NotEmpty(t, door.DoorID, "fixture requires a connector door")
+	data.Space.Walls = append(data.Space.Walls, environments.WallSegmentData{
+		Start:          door.From.ToCube(),
+		End:            door.To.ToCube(),
+		BlocksMovement: true,
+		BlocksLoS:      true,
+	})
+	_, err = enc.DescribeGeneratedEdges(encounter.DescribeGeneratedEdgesInput{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflicting generated edges")
+}
+
+// inBounds asks the generated SpaceData's dimensions whether a hex lies in
+// the combined dungeon grid. It deliberately does not reproduce generator
+// layout arithmetic.
+func inBounds(hex core.Hex, space *encounter.SpaceData) bool {
+	position := hex.ToPosition()
+	return int(position.X) >= 0 && int(position.X) < space.Width &&
+		int(position.Y) >= 0 && int(position.Y) < space.Height
+}
+
+// sameUndirectedEdge compares two physical edges without imposing an endpoint
+// ordering on the exported record itself.
+func sameUndirectedEdge(aFrom, aTo, bFrom, bTo core.Hex) bool {
+	return (aFrom == bFrom && aTo == bTo) || (aFrom == bTo && aTo == bFrom)
+}

--- a/encounter/generated_edges_test.go
+++ b/encounter/generated_edges_test.go
@@ -1,6 +1,7 @@
 package encounter_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,8 @@ func TestDescribeGeneratedEdges_ThreeRoomGeometry(t *testing.T) {
 	var exterior, interiorSolid, door *encounter.GeneratedEdge
 	for i := range output.Edges {
 		edge := &output.Edges[i]
+		require.NotEqual(t, edge.From, edge.To,
+			"authoring output must contain only physical edges that can project to proto walls")
 		switch {
 		case edge.Kind == encounter.GeneratedEdgeKindDoor && edge.DoorID == dungeonDoor0ID:
 			door = edge
@@ -42,6 +45,47 @@ func TestDescribeGeneratedEdges_ThreeRoomGeometry(t *testing.T) {
 	require.Equal(t, dungeonDoor0ID, door.DoorID)
 	require.Empty(t, exterior.DoorID)
 	require.Empty(t, interiorSolid.DoorID)
+}
+
+// TestDescribeGeneratedEdges_ExcludesCellBlockersButViewerMemoryRetainsThem
+// keeps Slice #176's authoring seam physical-only without changing the
+// established viewer-memory meaning of degenerate barriers. A solid and door
+// may validly share a blocked cell: neither is a physical edge, and both must
+// remain observable to a viewer.
+func TestDescribeGeneratedEdges_ExcludesCellBlockersButViewerMemoryRetainsThem(t *testing.T) {
+	origin := core.Hex{}
+	data := encounter.NewData("enc-cell-blockers")
+	data.Space = &encounter.SpaceData{
+		Walls: []environments.WallSegmentData{{
+			Start: origin.ToCube(), End: origin.ToCube(), BlocksMovement: true, BlocksLoS: true,
+		}},
+		Width: 10, Height: 10,
+	}
+	data.Doors["door-colocated"] = &encounter.DoorData{
+		ID: "door-colocated", Position: origin,
+	}
+
+	transport := encounter.NewInMemoryTransport()
+	defer func() { _ = transport.Close() }()
+	broker := encounter.NewBroker(transport)
+	defer func() { _ = broker.Close() }()
+	enc, err := encounter.LoadFromData(context.Background(), data, broker)
+	require.NoError(t, err)
+
+	output, err := enc.DescribeGeneratedEdges(encounter.DescribeGeneratedEdgesInput{})
+	require.NoError(t, err, "co-located self-loop barriers are not a physical-edge conflict")
+	require.Empty(t, output.Edges, "cell blockers must not escape the physical-edge authoring seam")
+
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "viewer", EntityID: "viewer-character", Position: origin, SightRange: 1,
+	}))
+	observed := enc.KnownHexes("viewer")[origin].Edges
+	require.Len(t, observed, 2, "viewer memory retains both co-located cell blockers")
+	for _, edge := range observed {
+		require.Equal(t, origin, edge.From)
+		require.Equal(t, origin, edge.To)
+	}
+	require.Equal(t, "door-colocated", observed[1].DoorID)
 }
 
 // TestDescribeGeneratedEdges_DeduplicatesReverseSolidsAndRejectsConflicts

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -235,8 +235,9 @@ func (e *Encounter) isSpaceHex(h core.Hex) bool {
 // unchanged data could disagree on order, breaking Memory.Observe's
 // idempotency guarantee (see its doc).
 //
-// Facing is always the Placement zero value: nothing in the toolkit tracks
-// entity facing today (perception.Placement's own doc says so plainly).
+// Player and monster placements carry no facing override. Static obstacles
+// retain their persisted optional facing, so visible and remembered placement
+// observations keep explicit E = 0 distinct from absence.
 func (e *Encounter) placementsAt(h core.Hex) []perception.Placement {
 	var out []perception.Placement
 	for _, p := range e.data.Players {
@@ -252,7 +253,7 @@ func (e *Encounter) placementsAt(h core.Hex) []perception.Placement {
 	if e.data.Space != nil {
 		for _, o := range e.data.Space.Obstacles {
 			if o.Position == h {
-				out = append(out, perception.Placement{EntityID: o.ID})
+				out = append(out, perception.Placement{EntityID: o.ID, Facing: o.Facing})
 			}
 		}
 	}

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -256,49 +256,37 @@ func (e *Encounter) placementsAt(h core.Hex) []perception.Placement {
 	return out
 }
 
-// edgesByHex indexes every wall and door segment in the encounter's
-// persisted room by the hex it sits on, so refreshObservations can attach
-// a hex's own edges without re-scanning every wall/door per hex. Mirrors
-// rpg-api's OWN edgesByHex (knowledge_adapter.go) — that copy becomes dead
-// code once rpg-api consumes this method instead of re-deriving it from
-// world truth it has no business reading directly.
+// edgesByHex indexes the canonical generated edges by their From endpoint
+// for viewer observations. generatedEdges is also the public authoring seam,
+// so knowledge and authoring cannot drift into separate wall canonicalizers.
 //
 // Each hex's edge list is sorted by (To.Q, To.R, To.S) then DoorID for
 // deterministic output — the same idempotency reasoning as placementsAt.
 func (e *Encounter) edgesByHex() map[core.Hex][]perception.Edge {
 	out := make(map[core.Hex][]perception.Edge)
-	if e.data.Space != nil {
-		for _, w := range e.data.Space.Walls {
-			if !w.BlocksMovement && !w.BlocksLoS {
-				// Not a barrier worth remembering — matches the wire
-				// boundary's own "not a wall worth putting on the wire" gate.
-				continue
-			}
-			from := core.HexFromCube(w.Start)
-			out[from] = append(out[from], perception.Edge{
-				From:           from,
-				To:             core.HexFromCube(w.End),
-				BlocksMovement: w.BlocksMovement,
-				BlocksLoS:      w.BlocksLoS,
-			})
-		}
+	generated, err := e.canonicalGeneratedEdgeRecords()
+	if err != nil {
+		// Invalid, conflicting persisted geometry cannot be represented
+		// honestly as per-viewer knowledge. DescribeGeneratedEdges exposes
+		// the diagnostic to hosts; this internal observation helper cannot
+		// widen its callers' mutation signatures.
+		return out
 	}
-	for id, door := range e.data.Doors {
-		if door == nil {
-			continue
+	for _, record := range generated {
+		edge := record.edge
+		observed := perception.Edge{
+			From:           edge.From,
+			To:             edge.To,
+			BlocksMovement: record.blocksMovement,
+			BlocksLoS:      record.blocksLoS,
 		}
-		out[door.Position] = append(out[door.Position], perception.Edge{
-			From: door.Position,
-			To:   e.doorPassageNeighbor(door),
-			// A closed door blocks both; an open one blocks neither — the
-			// observer reads DoorOpen/DoorLocked, so these flags describe
-			// the barrier rather than re-deriving the door's kind.
-			BlocksMovement: !door.Open,
-			BlocksLoS:      !door.Open,
-			DoorID:         string(id),
-			DoorOpen:       door.Open,
-			DoorLocked:     door.Locked,
-		})
+		if edge.Kind == GeneratedEdgeKindDoor {
+			door := e.data.Doors[edge.DoorID]
+			observed.DoorID = string(edge.DoorID)
+			observed.DoorOpen = door.Open
+			observed.DoorLocked = door.Locked
+		}
+		out[edge.From] = append(out[edge.From], observed)
 	}
 	for h, edges := range out {
 		sort.Slice(edges, func(i, j int) bool {

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -150,11 +150,14 @@ func knownHexesToEvents(known map[core.Hex]perception.HexObservation) []events.K
 // viewer refreshes), absent from every other hex, and absent everywhere
 // for a pass-through mover whose final hex isn't a hex this viewer saw at
 // all. See applyAndPublishMove's call site for the full reasoning.
-func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet) {
+func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet) error {
 	if view == nil || len(hexes) == 0 {
-		return
+		return nil
 	}
-	edges := e.edgesByHex()
+	edges, err := e.edgesByHex()
+	if err != nil {
+		return err
+	}
 	for h := range hexes {
 		// rpg-toolkit#859: hexes is frequently a raw perception.VisibleHexesAt
 		// disc (sight-range radius around a position), which has no notion of
@@ -178,6 +181,7 @@ func (e *Encounter) refreshObservations(view *perception.View, hexes core.HexSet
 		}
 		view.Observe(obs)
 	}
+	return nil
 }
 
 // isSpaceHex reports whether h is actually part of this encounter's space —
@@ -256,21 +260,17 @@ func (e *Encounter) placementsAt(h core.Hex) []perception.Placement {
 	return out
 }
 
-// edgesByHex indexes the canonical generated edges by their From endpoint
-// for viewer observations. generatedEdges is also the public authoring seam,
+// edgesByHex indexes the canonical generated barriers by their From endpoint
+// for viewer observations. DescribeGeneratedEdges projects the same source,
 // so knowledge and authoring cannot drift into separate wall canonicalizers.
 //
 // Each hex's edge list is sorted by (To.Q, To.R, To.S) then DoorID for
 // deterministic output — the same idempotency reasoning as placementsAt.
-func (e *Encounter) edgesByHex() map[core.Hex][]perception.Edge {
+func (e *Encounter) edgesByHex() (map[core.Hex][]perception.Edge, error) {
 	out := make(map[core.Hex][]perception.Edge)
 	generated, err := e.canonicalGeneratedEdgeRecords()
 	if err != nil {
-		// Invalid, conflicting persisted geometry cannot be represented
-		// honestly as per-viewer knowledge. DescribeGeneratedEdges exposes
-		// the diagnostic to hosts; this internal observation helper cannot
-		// widen its callers' mutation signatures.
-		return out
+		return nil, err
 	}
 	for _, record := range generated {
 		edge := record.edge
@@ -304,7 +304,7 @@ func (e *Encounter) edgesByHex() map[core.Hex][]perception.Edge {
 		})
 		out[h] = edges
 	}
-	return out
+	return out, nil
 }
 
 // doorPassageNeighbor returns door's designated passage-edge neighbor: the

--- a/encounter/knowledge_internal_test.go
+++ b/encounter/knowledge_internal_test.go
@@ -78,6 +78,48 @@ func (s *KnowledgeInternalSuite) TestKnownHexes_WitnessedRemoval_UpdatesImmediat
 		"a witnessed removal must clear Contents immediately, without waiting for alice's next move")
 }
 
+// TestKnownHexes_AuthoredObstacleFacingSurvivesVisibleRememberedAndEventPaths
+// proves the optional authored prop metadata is carried by the actual
+// placement/observation paths rather than only surviving in SpaceData.
+func (s *KnowledgeInternalSuite) TestKnownHexes_AuthoredObstacleFacingSurvivesVisibleRememberedAndEventPaths() {
+	e := New(context.Background(), "enc-facing-knowledge", s.broker)
+	target := core.Hex{Q: 1, R: -1, S: 0}
+	facing := FacingEast
+	e.data.Space = &SpaceData{Obstacles: []ObstacleData{{
+		ID: "facing-prop", Ref: "dnd5e:props:statue-reaper", Position: target, Facing: &facing,
+	}}}
+	s.Require().NoError(e.AddPlayer(PlayerInput{
+		PlayerID: knowledgeAlicePlayerID, EntityID: knowledgeAliceEntityID,
+		Position: core.Hex{}, SightRange: 2,
+	}))
+
+	assertFacing := func(known map[core.Hex]perception.HexObservation, state perception.KnowledgeState) {
+		s.T().Helper()
+		observation, ok := known[target]
+		s.Require().True(ok)
+		s.Equal(state, observation.State)
+		s.Require().Len(observation.Contents, 1)
+		s.Equal(core.EntityID("facing-prop"), observation.Contents[0].EntityID)
+		s.Require().NotNil(observation.Contents[0].Facing)
+		s.Equal(FacingEast, *observation.Contents[0].Facing)
+
+		for _, hex := range knownHexesToEvents(known) {
+			if hex.Position != target {
+				continue
+			}
+			s.Require().Len(hex.Contents, 1)
+			s.Require().NotNil(hex.Contents[0].Facing)
+			s.Equal(FacingEast, *hex.Contents[0].Facing)
+			return
+		}
+		s.T().Fatal("target hex missing from known-hex event projection")
+	}
+
+	assertFacing(e.KnownHexes(knowledgeAlicePlayerID), perception.KnowledgeStateVisible)
+	e.data.Players[knowledgeAlicePlayerID].View.Position = core.Hex{Q: 20, R: -20, S: 0}
+	assertFacing(e.KnownHexes(knowledgeAlicePlayerID), perception.KnowledgeStateRemembered)
+}
+
 // TestKnownHexes_WitnessedRemoval_OnlyRefreshesWitnesses proves the killer
 // (who may see only the killer's position, not the dying monster's hex) is
 // not force-refreshed for a hex they never had knowledge of, and a

--- a/encounter/knowledge_internal_test.go
+++ b/encounter/knowledge_internal_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 )
 
 // Test-package fixture identifiers (extracted to satisfy goconst — mirrors
@@ -97,6 +98,31 @@ func (s *KnowledgeInternalSuite) TestKnownHexes_WitnessedRemoval_OnlyRefreshesWi
 
 	known := e.KnownHexes("bystander")
 	s.NotContains(known, goblinHex, "a viewer with no LoS to the dying monster must gain no knowledge of its hex")
+}
+
+// TestRefreshObservations_CanonicalizationFailurePreservesMemory proves a
+// malformed physical-edge conflict aborts a refresh before Memory.Observe can
+// replace any established geometry with empty or partial edges.
+func (s *KnowledgeInternalSuite) TestRefreshObservations_CanonicalizationFailurePreservesMemory() {
+	e := New(context.Background(), "enc-1", s.broker)
+	origin := core.Hex{}
+	s.Require().NoError(e.AddPlayer(PlayerInput{
+		PlayerID: knowledgeAlicePlayerID, EntityID: knowledgeAliceEntityID,
+		Position: origin, SightRange: 1,
+	}))
+	before := e.KnownHexes(knowledgeAlicePlayerID)
+
+	neighbor := core.Hex{Q: 1, R: -1, S: 0}
+	e.data.Space = &SpaceData{Walls: []environments.WallSegmentData{
+		{Start: origin.ToCube(), End: neighbor.ToCube(), BlocksMovement: true, BlocksLoS: true},
+		{Start: neighbor.ToCube(), End: origin.ToCube(), BlocksMovement: true, BlocksLoS: false},
+	}}
+
+	err := e.refreshObservations(e.data.Players[knowledgeAlicePlayerID].View, core.NewHexSet(origin, neighbor))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "conflicting generated edges")
+	s.Equal(before, e.KnownHexes(knowledgeAlicePlayerID),
+		"failed canonicalization must not replace remembered observations")
 }
 
 func contentEntityIDs(obs perception.HexObservation) []core.EntityID {

--- a/encounter/party_start.go
+++ b/encounter/party_start.go
@@ -1,0 +1,295 @@
+package encounter
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// PartyStartParams configures the toolkit-owned party-start reservation for a
+// dungeon. Anchor is optional: nil retains InitDungeon's generated entrance.
+// SeatCount is the number of ordered positions to reserve; zero keeps the
+// legacy one-seat reservation at the resolved anchor. Hosts set SeatCount to
+// their party capacity rather than treating any value as a toolkit-wide limit.
+type PartyStartParams struct {
+	// Anchor is an optional absolute encounter hex. It must be inside exactly
+	// one region, never in a connector column, and must not collide with
+	// authored blocking content.
+	Anchor *core.Hex
+
+	// SeatCount is the number of ordered party positions to reserve. Zero
+	// reserves only Anchor for backwards-compatible direct InitDungeon callers.
+	SeatCount int
+}
+
+// ResolvePartySpawnPositionsInput requests ordered party-start positions for
+// one encounter startup.
+type ResolvePartySpawnPositionsInput struct {
+	// Count is the number of party members to seat.
+	Count int
+}
+
+// ResolvePartySpawnPositionsOutput contains the first requested positions from
+// the encounter's stored party-start reservation. Positions[0] is always the
+// same hex as SpaceData.Entrance.
+type ResolvePartySpawnPositionsOutput struct {
+	Positions []core.Hex
+}
+
+// PartySpawnCapacityError reports an attempted party-start request larger than
+// the initialized dungeon's stored reservation.
+type PartySpawnCapacityError struct {
+	Requested int
+	Available int
+}
+
+// Error describes the requested and available party-start seat counts.
+func (e *PartySpawnCapacityError) Error() string {
+	return fmt.Sprintf(
+		"party spawn request for %d position(s) exceeds %d reserved party-start seat(s)",
+		e.Requested, e.Available,
+	)
+}
+
+// ResolvePartySpawnPositions returns the first Count deterministic positions
+// from the party-start reservation created by InitDungeon. It never searches,
+// relocates, or falls back: a request larger than the available reservation
+// returns PartySpawnCapacityError and no positions.
+func (e *Encounter) ResolvePartySpawnPositions(
+	in ResolvePartySpawnPositionsInput,
+) (ResolvePartySpawnPositionsOutput, error) {
+	if in.Count < 1 {
+		return ResolvePartySpawnPositionsOutput{}, fmt.Errorf(
+			"party spawn request count must be at least 1 (got %d)", in.Count)
+	}
+	if e.data.Space == nil {
+		return ResolvePartySpawnPositionsOutput{}, fmt.Errorf("resolve party spawn positions: no dungeon initialized")
+	}
+	available := len(e.data.Space.PartyStartPositions)
+	if in.Count > available {
+		return ResolvePartySpawnPositionsOutput{}, &PartySpawnCapacityError{
+			Requested: in.Count,
+			Available: available,
+		}
+	}
+	positions := append([]core.Hex(nil), e.data.Space.PartyStartPositions[:in.Count]...)
+	return ResolvePartySpawnPositionsOutput{Positions: positions}, nil
+}
+
+type partyStartReservation struct {
+	anchor        spatial.CubeCoordinate
+	seats         []spatial.CubeCoordinate
+	seatsByRegion []map[spatial.CubeCoordinate]struct{}
+	regionIndex   int
+}
+
+// resolvePartyStartReservation selects every party seat from declared semantic
+// floor cells before InitDungeon generates any walls or obstacles. Seat order is
+// deterministic. A generated anchor first uses its existing entrance-to-door
+// row, preserving the legacy generator's clear route; an authored anchor uses
+// increasing hex distance, with offset row/column as stable tie-breakers. All
+// seats remain in the anchor's semantic region, so a closed connector cannot
+// split an assembling party.
+func resolvePartyStartReservation(
+	params DungeonParams, starts []int, totalWidth, doorRow int,
+) (partyStartReservation, error) {
+	seatCount := params.PartyStart.SeatCount
+	if seatCount == 0 {
+		seatCount = 1
+	}
+
+	anchor := spatial.OffsetCoordinateToCubeWithOrientation(
+		spatial.Position{X: 0, Y: float64(doorRow)}, spatial.HexOrientationPointyTop)
+	if params.PartyStart.Anchor != nil {
+		anchor = params.PartyStart.Anchor.ToCube()
+	}
+	if anchor.X+anchor.Y+anchor.Z != 0 {
+		return partyStartReservation{}, fmt.Errorf("party start anchor %v is not a valid cube coordinate", anchor)
+	}
+	anchorPosition := anchor.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+	anchorCol, anchorRow := int(anchorPosition.X), int(anchorPosition.Y)
+	if anchorCol < 0 || anchorCol >= totalWidth || anchorRow < 0 || anchorRow >= params.Height {
+		return partyStartReservation{}, fmt.Errorf(
+			"party start anchor at col=%d row=%d is outside dungeon footprint width=%d height=%d",
+			anchorCol, anchorRow, totalWidth, params.Height)
+	}
+
+	regionIndex := -1
+	for i, region := range params.Regions {
+		if anchorCol < starts[i] || anchorCol >= starts[i]+region.Width {
+			continue
+		}
+		if regionIndex != -1 {
+			return partyStartReservation{}, fmt.Errorf(
+				"party start anchor at col=%d row=%d belongs to more than one region", anchorCol, anchorRow)
+		}
+		regionIndex = i
+	}
+	if regionIndex == -1 {
+		return partyStartReservation{}, fmt.Errorf(
+			"party start anchor at col=%d row=%d is a connector gap, not a semantic room cell", anchorCol, anchorRow)
+	}
+
+	blockers := authoredPartyStartBlockers(params, starts)
+	if blocker, blocked := blockers[anchor]; blocked {
+		return partyStartReservation{}, fmt.Errorf(
+			"party start anchor at col=%d row=%d collides with authored blocking %s", anchorCol, anchorRow, blocker)
+	}
+
+	type candidate struct {
+		cube     spatial.CubeCoordinate
+		col, row int
+		distance int
+	}
+	candidates := make([]candidate, 0, params.Regions[regionIndex].Width*params.Height-1)
+	for localCol := 0; localCol < params.Regions[regionIndex].Width; localCol++ {
+		for row := 0; row < params.Height; row++ {
+			col := starts[regionIndex] + localCol
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(
+				spatial.Position{X: float64(col), Y: float64(row)}, spatial.HexOrientationPointyTop)
+			if cube == anchor {
+				continue
+			}
+			if _, blocked := blockers[cube]; blocked {
+				continue
+			}
+			candidates = append(candidates, candidate{
+				cube:     cube,
+				col:      col,
+				row:      row,
+				distance: anchor.Distance(cube),
+			})
+		}
+	}
+	generatedAnchor := params.PartyStart.Anchor == nil
+	sort.Slice(candidates, func(i, j int) bool {
+		if generatedAnchor {
+			leftOnRoute := candidates[i].row == doorRow
+			rightOnRoute := candidates[j].row == doorRow
+			if leftOnRoute != rightOnRoute {
+				return leftOnRoute
+			}
+			if leftOnRoute && candidates[i].col != candidates[j].col {
+				return candidates[i].col < candidates[j].col
+			}
+		}
+		if candidates[i].distance != candidates[j].distance {
+			return candidates[i].distance < candidates[j].distance
+		}
+		if candidates[i].row != candidates[j].row {
+			return candidates[i].row < candidates[j].row
+		}
+		return candidates[i].col < candidates[j].col
+	})
+	if 1+len(candidates) < seatCount {
+		return partyStartReservation{}, fmt.Errorf(
+			"party start anchor at col=%d row=%d requires %d seats but region %q has only %d usable authored floor cells",
+			anchorCol, anchorRow, seatCount, params.Regions[regionIndex].ID, 1+len(candidates))
+	}
+
+	reservation := partyStartReservation{
+		anchor:        anchor,
+		seats:         make([]spatial.CubeCoordinate, 0, seatCount),
+		seatsByRegion: make([]map[spatial.CubeCoordinate]struct{}, len(params.Regions)),
+		regionIndex:   regionIndex,
+	}
+	reservation.seatsByRegion[regionIndex] = make(map[spatial.CubeCoordinate]struct{}, seatCount)
+	reservation.seats = append(reservation.seats, anchor)
+	reservation.seatsByRegion[regionIndex][anchor] = struct{}{}
+	for i := 0; i < seatCount-1; i++ {
+		reservation.seats = append(reservation.seats, candidates[i].cube)
+		reservation.seatsByRegion[regionIndex][candidates[i].cube] = struct{}{}
+	}
+	return reservation, nil
+}
+
+// authoredPartyStartBlockers returns the known authored cells a party seat
+// cannot occupy before generated geometry exists: movement-blocking placed
+// props and every ReservedCells marker, which dungeonspec uses for placed
+// monsters and pinned bosses. Invalid direct InitDungeon inputs are left to
+// their established placement validators later in generation.
+func authoredPartyStartBlockers(
+	params DungeonParams, starts []int,
+) map[spatial.CubeCoordinate]string {
+	blockers := make(map[spatial.CubeCoordinate]string)
+	for i, region := range params.Regions {
+		for _, placed := range region.PlacedObstacles {
+			if !placed.BlocksMovement || !validLocalPartyStartCell(placed.At, region.Width, params.Height) {
+				continue
+			}
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(spatial.Position{
+				X: float64(starts[i] + placed.At.Col), Y: float64(placed.At.Row),
+			}, spatial.HexOrientationPointyTop)
+			blockers[cube] = fmt.Sprintf("placed obstacle %q", placed.Ref)
+		}
+		for _, reserved := range region.ReservedCells {
+			if !validLocalPartyStartCell(reserved, region.Width, params.Height) {
+				continue
+			}
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(spatial.Position{
+				X: float64(starts[i] + reserved.Col), Y: float64(reserved.Row),
+			}, spatial.HexOrientationPointyTop)
+			blockers[cube] = "reserved monster or boss cell"
+		}
+	}
+	return blockers
+}
+
+func validLocalPartyStartCell(cell LocalHex, width, height int) bool {
+	return cell.Col >= 0 && cell.Col < width && cell.Row >= 0 && cell.Row < height
+}
+
+// requiredPathsForRegion extends the normal generator safety paths with the
+// precomputed party envelope. The discrete strip below remains necessary
+// because environments' continuous-line path check cannot prove every
+// rounded hex cell is clear.
+func (r partyStartReservation) requiredPathsForRegion(regionIndex, offsetX int) []environments.Path {
+	if regionIndex != r.regionIndex || len(r.seats) < 2 {
+		return nil
+	}
+	anchorPosition := r.anchor.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+	from := spatial.Position{X: anchorPosition.X - float64(offsetX), Y: anchorPosition.Y}
+	paths := make([]environments.Path, 0, len(r.seats)-1)
+	for i, seat := range r.seats[1:] {
+		seatPosition := seat.ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+		paths = append(paths, environments.Path{
+			From:    from,
+			To:      spatial.Position{X: seatPosition.X - float64(offsetX), Y: seatPosition.Y},
+			Width:   dungeonPathWidth,
+			Purpose: fmt.Sprintf("party-start-seat-%d", i+1),
+		})
+	}
+	return paths
+}
+
+// stripPartyStartWalls enforces the precomputed party reservation at the
+// discretized blocker boundary. It removes candidate pattern walls before they
+// are added to the layout or handed to obstacle placement; it is not a seed
+// retry, anchor relocation, or fallback placement.
+func (r partyStartReservation) stripPartyStartWalls(
+	regionIndex int, walls []environments.WallSegmentData,
+) []environments.WallSegmentData {
+	reserved := r.seatsByRegion[regionIndex]
+	if len(reserved) == 0 {
+		return walls
+	}
+	out := make([]environments.WallSegmentData, 0, len(walls))
+	for _, wall := range walls {
+		if _, protected := reserved[wall.Start]; protected {
+			continue
+		}
+		out = append(out, wall)
+	}
+	return out
+}
+
+func (r partyStartReservation) positions() []core.Hex {
+	positions := make([]core.Hex, len(r.seats))
+	for i, seat := range r.seats {
+		positions[i] = core.HexFromCube(seat)
+	}
+	return positions
+}

--- a/encounter/party_start_test.go
+++ b/encounter/party_start_test.go
@@ -1,0 +1,177 @@
+package encounter_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/require"
+)
+
+// partyStartHex converts an absolute authoring column/row into the encounter
+// coordinate type accepted by DungeonParams.PartyStart.
+func partyStartHex(column, row int) core.Hex {
+	return core.HexFromPosition(spatial.Position{X: float64(column), Y: float64(row)})
+}
+
+// partyStartParams places an authored anchor in the second semantic room's
+// door row. That proves an authored start is not constrained to the entrance
+// archetype or ordinary ReservedCells' door-row rule.
+func partyStartParams(seed int64) encounter.DungeonParams {
+	anchor := partyStartHex(13, 4) // second room begins at absolute column 9
+	return encounter.DungeonParams{
+		Height:     8,
+		RandomSeed: seed,
+		PartyStart: encounter.PartyStartParams{Anchor: &anchor, SeatCount: 4},
+		Regions: []encounter.DungeonRegionParams{
+			{ID: "entry", Archetype: encounter.ArchetypeEntrance, Width: 8, Pattern: environments.PatternEmpty},
+			{
+				ID: "gallery", Archetype: encounter.ArchetypeChamber, Width: 10, Pattern: environments.PatternRandom,
+				Obstacles: []encounter.ObstacleSpec{
+					// Exercise the preferential border candidate path and the
+					// normal/scattered candidate path in every seed.
+					{Ref: "test:props:border", Count: 28, BlocksMovement: true, PreferBorder: true},
+					{Ref: "test:props:scattered", Count: 25, BlocksMovement: true},
+				},
+			},
+		},
+		Connectors: []encounter.DungeonConnectorParams{{DoorID: "entry-gallery"}},
+	}
+}
+
+// TestInitDungeon_PartyStartReservationSurvivesScatteredAndPreferBorderSeeds
+// proves the anchor and all normal seats are selected before both random wall
+// generation and both rolled-obstacle draw paths. The deliberately named seed
+// sweep covers random/scattered walls plus PreferBorder and normal obstacles.
+func TestInitDungeon_PartyStartReservationSurvivesScatteredAndPreferBorderSeeds(t *testing.T) {
+	var want []core.Hex
+	for seed := int64(1); seed <= 50; seed++ {
+		enc := newTestEncounter(t)
+		require.NoError(t, enc.InitDungeon(partyStartParams(seed)), "seed %d", seed)
+
+		positions, err := enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 4})
+		require.NoError(t, err, "seed %d", seed)
+		require.Len(t, positions.Positions, 4, "seed %d", seed)
+		require.Equal(t, enc.ToData().Space.Entrance, positions.Positions[0], "seed %d", seed)
+		require.Equal(t, partyStartHex(13, 4), positions.Positions[0], "seed %d", seed)
+
+		if want == nil {
+			want = append([]core.Hex(nil), positions.Positions...)
+		} else {
+			require.Equal(t, want, positions.Positions, "seed %d must not relocate or reorder party seats", seed)
+		}
+
+		seen := make(map[core.Hex]struct{}, len(positions.Positions))
+		for slot, position := range positions.Positions {
+			_, duplicate := seen[position]
+			require.False(t, duplicate, "seed %d: duplicate party-start seat %d at %v", seed, slot, position)
+			seen[position] = struct{}{}
+
+			roomID, inRoom := enc.ToData().Space.RegionAt(position)
+			require.True(t, inRoom, "seed %d seat %d must remain in a semantic room", seed, slot)
+			require.Equal(t, "gallery", roomID, "seed %d seat %d must remain in the authored anchor room", seed, slot)
+			require.True(t, enc.Room().CanPlaceEntity(probeEntity{}, position.ToPosition()),
+				"seed %d seat %d at %v must remain usable, not a wall or rolled obstacle", seed, slot, position)
+		}
+	}
+}
+
+// TestResolvePartySpawnPositions_OrderedAndCapacityBounded owns the API seam:
+// callers receive an immutable ordered prefix, and an oversized request returns
+// a typed requested-versus-available error without inventing a fifth position.
+func TestResolvePartySpawnPositions_OrderedAndCapacityBounded(t *testing.T) {
+	enc := newTestEncounter(t)
+	require.NoError(t, enc.InitDungeon(partyStartParams(42)))
+
+	all, err := enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 4})
+	require.NoError(t, err)
+	seats := append([]core.Hex(nil), all.Positions...)
+	one, err := enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 1})
+	require.NoError(t, err)
+	require.Equal(t, all.Positions[:1], one.Positions)
+	require.Equal(t, enc.ToData().Space.Entrance, all.Positions[0])
+
+	// Output is a copy rather than an alias to persisted SpaceData.
+	all.Positions[0] = core.Hex{}
+	again, err := enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 1})
+	require.NoError(t, err)
+	require.Equal(t, enc.ToData().Space.Entrance, again.Positions[0])
+
+	// The stored reservation survives the ordinary persisted-data reload path;
+	// startup never needs to derive positions from spatial coordinates again.
+	reloadTransport := encounter.NewInMemoryTransport()
+	reloadBroker := encounter.NewBroker(reloadTransport)
+	t.Cleanup(func() { _ = reloadBroker.Close(); _ = reloadTransport.Close() })
+	reloaded, err := encounter.LoadFromData(context.Background(), enc.ToData(), reloadBroker)
+	require.NoError(t, err)
+	reloadedSeats, err := reloaded.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 4})
+	require.NoError(t, err)
+	require.Equal(t, seats, reloadedSeats.Positions)
+	require.Equal(t, enc.ToData().Space.Entrance, reloaded.ToData().Space.Entrance)
+
+	// A four-member caller maps ordered members straight onto the toolkit
+	// seats; no position arithmetic or secondary placement policy is needed.
+	for i, position := range seats {
+		playerID := core.PlayerID(fmt.Sprintf("party-player-%d", i))
+		require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+			PlayerID: playerID,
+			EntityID: core.EntityID(fmt.Sprintf("party-character-%d", i)),
+			Position: position, SightRange: 1,
+		}))
+		require.Equal(t, position, enc.ToData().Players[playerID].View.Position)
+	}
+
+	_, err = enc.ResolvePartySpawnPositions(encounter.ResolvePartySpawnPositionsInput{Count: 5})
+	require.Error(t, err)
+	var capacityErr *encounter.PartySpawnCapacityError
+	require.True(t, errors.As(err, &capacityErr))
+	require.Equal(t, 5, capacityErr.Requested)
+	require.Equal(t, 4, capacityErr.Available)
+}
+
+// TestInitDungeon_PartyStartReservationRejectsInsufficientCapacity proves a
+// capacity failure stops generation rather than moving the authored anchor or
+// silently reducing the envelope.
+func TestInitDungeon_PartyStartReservationRejectsInsufficientCapacity(t *testing.T) {
+	anchor := partyStartHex(0, 2)
+	params := encounter.DungeonParams{
+		Height: 4,
+		PartyStart: encounter.PartyStartParams{
+			Anchor:    &anchor,
+			SeatCount: 17, // a 4x4 semantic room has exactly 16 cells
+		},
+		Regions: []encounter.DungeonRegionParams{
+			{ID: "entry", Archetype: encounter.ArchetypeEntrance, Width: 4, Pattern: environments.PatternEmpty},
+			{ID: "gallery", Archetype: encounter.ArchetypeChamber, Width: 4, Pattern: environments.PatternEmpty},
+		},
+		Connectors: []encounter.DungeonConnectorParams{{DoorID: "entry-gallery"}},
+	}
+	enc := newTestEncounter(t)
+	err := enc.InitDungeon(params)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires 17 seats")
+	require.Contains(t, err.Error(), "only 16")
+	require.Nil(t, enc.ToData().Space, "capacity failure must not commit a relocated/fallback dungeon")
+}
+
+// TestInitDungeon_PartyStartReservationRejectsDirectAuthoredBlocker is the
+// engine-side defense behind dungeonspec.Validate: direct toolkit callers get
+// the same no-collision guarantee before a room is committed.
+func TestInitDungeon_PartyStartReservationRejectsDirectAuthoredBlocker(t *testing.T) {
+	anchor := partyStartHex(1, 1)
+	params := partyStartParams(1)
+	params.PartyStart = encounter.PartyStartParams{Anchor: &anchor, SeatCount: 4}
+	params.Regions[0].PlacedObstacles = []encounter.PlacedObstacleSpec{{
+		Ref: "test:props:blocking", At: encounter.LocalHex{Col: 1, Row: 1}, BlocksMovement: true,
+	}}
+	enc := newTestEncounter(t)
+	err := enc.InitDungeon(params)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "collides with authored blocking")
+	require.Nil(t, enc.ToData().Space)
+}

--- a/encounter/perception/knowledge.go
+++ b/encounter/perception/knowledge.go
@@ -88,14 +88,14 @@ const (
 // viewer sees it face south. On the entity, one viewer's sighting would
 // rewrite every other viewer's memory.
 //
-// Facing is always the zero value today for the same reason TerrainKind
-// is always Unspecified: nothing in the toolkit tracks entity facing yet.
-// The field stays on the shape rather than being added later as a
-// migration.
+// Facing is absent for players, monsters, and rolled obstacles. A
+// room-scoped authored floor prop may carry a canonical E,NE,NW,W,SW,SE =
+// 0..5 override. Pointer presence distinguishes absent from explicit E = 0
+// and persists with this observation for remembered placement rendering.
 type Placement struct {
 	EntityID core.EntityID
-	// Facing is a hex-direction index 0-5.
-	Facing int
+	// Facing is an optional hex-direction index in canonical 0-5 order.
+	Facing *uint32
 }
 
 // Edge is a wall or door on one hex's boundary, AS OBSERVED by this viewer.

--- a/encounter/perception/knowledge.go
+++ b/encounter/perception/knowledge.go
@@ -98,6 +98,46 @@ type Placement struct {
 	Facing *uint32
 }
 
+type placementWire struct {
+	EntityID core.EntityID `json:"EntityID"`
+	Facing   *uint32       `json:"facing,omitempty"`
+}
+
+// MarshalJSON writes optional facing under a lowercase key so presence is
+// representable without colliding with legacy Placement JSON. Before facing
+// became optional, every placement serialized an uppercase "Facing":0 even
+// though no authored override existed.
+func (p Placement) MarshalJSON() ([]byte, error) {
+	return json.Marshal(placementWire(p))
+}
+
+// UnmarshalJSON restores a current optional facing field and deliberately
+// ignores legacy uppercase "Facing":0. That historical zero was emitted for
+// every placement by the old non-optional field, so treating it as explicit E
+// would fabricate authored orientation for persisted viewer memory.
+func (p *Placement) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	var entityID core.EntityID
+	if rawEntityID, ok := fields["EntityID"]; ok {
+		if err := json.Unmarshal(rawEntityID, &entityID); err != nil {
+			return err
+		}
+	}
+	var facing *uint32
+	if rawFacing, ok := fields["facing"]; ok {
+		if err := json.Unmarshal(rawFacing, &facing); err != nil {
+			return err
+		}
+	}
+	p.EntityID = entityID
+	p.Facing = facing
+	return nil
+}
+
 // Edge is a wall or door on one hex's boundary, AS OBSERVED by this viewer.
 //
 // Edges hang off the hex rather than living in one global wall list because

--- a/encounter/perception/project_test.go
+++ b/encounter/perception/project_test.go
@@ -1,6 +1,7 @@
 package perception_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
@@ -191,6 +192,39 @@ func (s *ProjectSuite) TestProjectVisibilityTransition_LeaveLoS_EmptySeenSegment
 // TestView_ObserveIdempotent covers rpg-toolkit#851's acceptance bar
 // "duplicate reconciliation is idempotent": applying the identical
 // observation twice must leave Memory unchanged, both in size and content.
+// TestPlacementFacingJSONDistinguishesCurrentPresenceFromLegacyZero protects
+// persisted viewer memory from the old mandatory Facing:0 encoding while
+// retaining a newly authored explicit E = 0 override.
+func (s *ProjectSuite) TestPlacementFacingJSONDistinguishesCurrentPresenceFromLegacyZero() {
+	hex := core.Hex{Q: 1, R: -1, S: 0}
+	facingEast := uint32(0)
+	current := perception.NewMemory()
+	current.Observe(perception.HexObservation{
+		Position: hex,
+		State:    perception.KnowledgeStateVisible,
+		Contents: []perception.Placement{{EntityID: "authored-prop", Facing: &facingEast}},
+	})
+
+	payload, err := json.Marshal(current)
+	s.Require().NoError(err)
+	s.Contains(string(payload), `"facing":0`)
+	s.NotContains(string(payload), `"Facing":0`)
+
+	var reloaded perception.Memory
+	s.Require().NoError(json.Unmarshal(payload, &reloaded))
+	s.Require().NotNil(reloaded[hex].Contents[0].Facing)
+	s.Equal(uint32(0), *reloaded[hex].Contents[0].Facing)
+
+	const legacyMemory = `[
+		{"position":{"Q":1,"R":-1,"S":0},"state":1,
+		 "contents":[{"EntityID":"legacy-player","Facing":0}]}
+	]`
+	var legacy perception.Memory
+	s.Require().NoError(json.Unmarshal([]byte(legacyMemory), &legacy))
+	s.Require().Len(legacy[hex].Contents, 1)
+	s.Nil(legacy[hex].Contents[0].Facing)
+}
+
 func (s *ProjectSuite) TestView_ObserveIdempotent() {
 	viewer := perception.NewView("alice", core.Hex{}, 3)
 	h := core.Hex{Q: 1, R: 0, S: -1}


### PR DESCRIPTION
## Provider-wave decision

This is the sole `rpg-toolkit` provider PR for [rpg-project#175](https://github.com/KirkDiggler/rpg-project/issues/175), tracked by [rpg-toolkit#875](https://github.com/KirkDiggler/rpg-toolkit/issues/875). It accumulates related toolkit changes requested by the API and web consumers while they implement the ordered specimen slices [rpg-project#176](https://github.com/KirkDiggler/rpg-project/issues/176)–[#180](https://github.com/KirkDiggler/rpg-project/issues/180).

Do not open ceremonial per-slice toolkit PRs or release tags. The project issues remain cross-repository slice trackers and are referenced here without closing them; #875 remains the one toolkit wave ledger for this one provider PR.

## Current gated state — do not merge

Current head [`7b58d3f`](https://github.com/KirkDiggler/rpg-toolkit/commit/7b58d3fa98a35c1fcc76e96d64b2539b4a567284) remains **gated PASS for the generated-edges capability below**. That PASS applies only to this head. Any future commit requires a fresh independent gate before another merge-ready claim.

**Do not merge #876 now.** Merge only when API and web consumers have stopped requesting related Dungeon Builder toolkit changes. The single released toolkit tag follows that merge.

Unrelated toolkit work is not held by this provider branch: it remains free to use separate issues, branches, PRs, gates, and independent merges.

## Current implementation: generated wall and door truth

- Adds `Encounter.DescribeGeneratedEdges(DescribeGeneratedEdgesInput) (DescribeGeneratedEdgesOutput, error)`, returning one canonical record per undirected physical edge from an already-initialized encounter.
- Exports solid/door kind, canonical runtime endpoints, and stable connector `DoorID`; solids carry no ID.
- Uses one canonical barrier source for authoring and viewer knowledge: self-loop cell blockers remain visible to memory, while only distinct-endpoint physical edges are deduplicated and conflict-checked.
- Does not regenerate dungeon geometry or require API inspection of `SpaceData.Walls`/`Doors`.

## Generated-edges gate evidence

- Deterministic three-room geometry proves exterior solid, interior-facing solid, connector-door output, and physical-only exported endpoints.
- Co-located self-loop solid/door records stay in viewer memory but do not appear in exported geometry or conflict.
- Reverse-solid deduplication and real physical-edge conflict rejection.
- A canonicalization failure aborts viewer refresh without replacing remembered observations.
- `cd encounter && go test -count=1 -race ./...`
- `cd encounter && go vet ./...`
- `cd encounter && golangci-lint run --new-from-rev=origin/main ./...`

## Checks note

`make pre-commit` is not a valid changed-module gate: it only exercises `core` and `events`, not `encounter`, and fails before either module's coverage gate because its core coverage parser includes `core/mock` (reported 76.5%, threshold 80%). This is verified identical on base `origin/main` (`bc64440`) and head `7b58d3f`: both exit 2 at `Makefile:99`. The touched encounter-module gates above are green.

Closes #875

References (no closing semantics):
- KirkDiggler/rpg-project#175
- KirkDiggler/rpg-project#176
- KirkDiggler/rpg-project#177
- KirkDiggler/rpg-project#178
- KirkDiggler/rpg-project#179
- KirkDiggler/rpg-project#180

---
— platform agent, on behalf of KirkDiggler
