### PR TITLE
feat(equipment): resolve category choice options

### DIFF
--- a/rulebooks/dnd5e/armor/armor.go
+++ b/rulebooks/dnd5e/armor/armor.go
@@ -252,6 +252,15 @@ var All = map[ArmorID]Armor{
 	},
 }
 
+// armorOrder is the authoritative presentation order for the armor registry.
+// All remains the ID lookup index.
+var armorOrder = []ArmorID{
+	Padded, Leather, StuddedLeather,
+	Hide, ChainShirt, ScaleMail, Breastplate, HalfPlate,
+	RingMail, ChainMail, Splint, Plate,
+	Shield,
+}
+
 // GetByID returns armor by its ID
 func GetByID(id ArmorID) (Armor, error) {
 	armor, ok := All[id]
@@ -267,10 +276,11 @@ func GetByID(id ArmorID) (Armor, error) {
 	return armor, nil
 }
 
-// GetByCategory returns all armor in a category
+// GetByCategory returns all armor in a category in registry order.
 func GetByCategory(cat ArmorCategory) []Armor {
 	var result []Armor
-	for _, a := range All {
+	for _, id := range armorOrder {
+		a := All[id]
 		if a.Category == cat {
 			result = append(result, a)
 		}

--- a/rulebooks/dnd5e/character/choices/category_choice_options_test.go
+++ b/rulebooks/dnd5e/character/choices/category_choice_options_test.go
@@ -144,6 +144,37 @@ func (s *CategoryChoiceOptionsTestSuite) TestSubclassOptionsAreIndependentAcross
 	}
 }
 
+func (s *CategoryChoiceOptionsTestSuite) TestCategoryOptionsPreserveRegistryOrderAcrossRepeatedAndConcurrentCalls() {
+	expected := []shared.EquipmentID{
+		weapons.Club, weapons.Dagger, weapons.Handaxe, weapons.Javelin, weapons.Greatclub,
+		weapons.LightHammer, weapons.Mace, weapons.Quarterstaff, weapons.Sickle, weapons.Spear,
+		weapons.LightCrossbow, weapons.Shortbow, weapons.Dart, weapons.Sling,
+	}
+
+	for range 10 {
+		_, simple := monkWeaponSimpleOption(s)
+		s.Equal(expected, equipmentItemIDsInOrder(simple.CategoryChoices[0].Options))
+	}
+
+	const readers = 64
+	results := make(chan []shared.EquipmentID, readers)
+	var waitGroup sync.WaitGroup
+	for range readers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			requirements := GetClassRequirements(classes.Monk)
+			_, simple := monkWeaponSimpleOptionFromRequirements(requirements)
+			results <- equipmentItemIDsInOrder(simple.CategoryChoices[0].Options)
+		}()
+	}
+	waitGroup.Wait()
+	close(results)
+	for actual := range results {
+		s.Equal(expected, actual)
+	}
+}
+
 func (s *CategoryChoiceOptionsTestSuite) TestOptionsAreDetailedDeterministicAndDuplicateFree() {
 	for _, classID := range implementedClasses {
 		first := classCategoryChoices(GetClassRequirements(classID))
@@ -206,7 +237,10 @@ var implementedClasses = []classes.Class{
 }
 
 func monkWeaponSimpleOption(s *CategoryChoiceOptionsTestSuite) (*EquipmentRequirement, *EquipmentOption) {
-	requirements := GetClassRequirements(classes.Monk)
+	return monkWeaponSimpleOptionFromRequirements(GetClassRequirements(classes.Monk))
+}
+
+func monkWeaponSimpleOptionFromRequirements(requirements *Requirements) (*EquipmentRequirement, *EquipmentOption) {
 	for _, requirement := range requirements.Equipment {
 		if requirement.ID != MonkWeaponsPrimary {
 			continue
@@ -217,8 +251,7 @@ func monkWeaponSimpleOption(s *CategoryChoiceOptionsTestSuite) (*EquipmentRequir
 			}
 		}
 	}
-	s.FailNow("MonkWeaponSimple should exist")
-	return nil, nil
+	panic("MonkWeaponSimple should exist")
 }
 
 func classCategoryChoices(requirements *Requirements) []EquipmentCategoryChoice {
@@ -244,6 +277,14 @@ func allCategoryCandidates() []shared.EquipmentID {
 	}
 	for id := range items.All {
 		result = append(result, id)
+	}
+	return result
+}
+
+func equipmentItemIDsInOrder(items []EquipmentItem) []shared.EquipmentID {
+	result := make([]shared.EquipmentID, len(items))
+	for i, item := range items {
+		result[i] = item.ID
 	}
 	return result
 }

--- a/rulebooks/dnd5e/character/choices/category_choice_options_test.go
+++ b/rulebooks/dnd5e/character/choices/category_choice_options_test.go
@@ -1,0 +1,257 @@
+package choices
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/items"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/tools"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// CategoryChoiceOptionsTestSuite verifies that category-choice options are the
+// same concrete items accepted by the category validator.
+type CategoryChoiceOptionsTestSuite struct {
+	suite.Suite
+	validator *Validator
+}
+
+func TestCategoryChoiceOptionsSuite(t *testing.T) {
+	suite.Run(t, new(CategoryChoiceOptionsTestSuite))
+}
+
+func (s *CategoryChoiceOptionsTestSuite) SetupTest() {
+	s.validator = NewValidator()
+}
+
+func (s *CategoryChoiceOptionsTestSuite) TestExpansionMatchesValidatorForEveryClassCategoryChoice() {
+	for _, classID := range implementedClasses {
+		s.Run(string(classID), func() {
+			for _, choice := range classCategoryChoices(GetClassRequirements(classID)) {
+				expanded := equipmentItemIDs(choice.Options)
+				expected := make(map[shared.EquipmentID]struct{})
+
+				for _, id := range allCategoryCandidates() {
+					if s.categorySelectionValid(choice, id) {
+						expected[id] = struct{}{}
+					}
+				}
+
+				s.Equal(expected, expanded,
+					"category choice %q must enumerate exactly the IDs the validator accepts", choice.Label)
+			}
+		})
+	}
+}
+
+func (s *CategoryChoiceOptionsTestSuite) TestWeaponChoicesIncludeBothMeleeAndRangedMembership() {
+	for _, classID := range implementedClasses {
+		for _, choice := range classCategoryChoices(GetClassRequirements(classID)) {
+			if choice.Type != shared.EquipmentTypeWeapon {
+				continue
+			}
+
+			categories := make(map[shared.EquipmentCategory]struct{}, len(choice.Categories))
+			for _, category := range choice.Categories {
+				categories[category] = struct{}{}
+			}
+			options := equipmentItemIDs(choice.Options)
+
+			if _, ok := categories[weapons.CategorySimpleMelee]; ok {
+				if _, ranged := categories[weapons.CategorySimpleRanged]; ranged {
+					s.Contains(options, weapons.Club, "%s simple choice must include melee weapons", choice.Label)
+					s.Contains(options, weapons.Dart, "%s simple choice must include ranged weapons", choice.Label)
+				}
+			}
+			if _, ok := categories[weapons.CategoryMartialMelee]; ok {
+				if _, ranged := categories[weapons.CategoryMartialRanged]; ranged {
+					s.Contains(options, weapons.Longsword, "%s martial choice must include melee weapons", choice.Label)
+					s.Contains(options, weapons.Longbow, "%s martial choice must include ranged weapons", choice.Label)
+				}
+			}
+		}
+	}
+}
+
+func (s *CategoryChoiceOptionsTestSuite) TestMonkSimpleWeaponOptionsIncludeRangedWeaponsAndKeepShortswordSeparate() {
+	_, monkSimple := monkWeaponSimpleOption(s)
+	s.Require().Len(monkSimple.CategoryChoices, 1)
+	options := equipmentItemIDs(monkSimple.CategoryChoices[0].Options)
+
+	s.Contains(options, weapons.Dart)
+	s.Contains(options, weapons.LightCrossbow)
+	s.Len(options, len(weapons.GetSimpleWeapons()),
+		"Monk's any-simple-weapon option must track the complete equippable simple weapon registry")
+	s.NotContains(options, weapons.Shortsword,
+		"shortsword is the separate Monk starting-equipment alternative, not a simple-weapon option")
+
+	reqs := GetClassRequirements(classes.Monk)
+	var shortswordOption *EquipmentOption
+	for _, req := range reqs.Equipment {
+		if req.ID != MonkWeaponsPrimary {
+			continue
+		}
+		for i := range req.Options {
+			if req.Options[i].ID == MonkWeaponShortsword {
+				shortswordOption = &req.Options[i]
+			}
+		}
+	}
+	s.Require().NotNil(shortswordOption)
+	s.Require().Len(shortswordOption.Items, 1)
+	s.Equal(weapons.Shortsword, shortswordOption.Items[0].ID)
+}
+
+func (s *CategoryChoiceOptionsTestSuite) TestSpecialWeaponsAreNeitherExpandedNorValid() {
+	// The requirements builder populates options; this test uses a real Monk
+	// choice so expansion and validation both exercise the production path.
+	_, monkSimple := monkWeaponSimpleOption(s)
+	choice := monkSimple.CategoryChoices[0]
+
+	s.NotContains(equipmentItemIDs(choice.Options), weapons.UnarmedStrike)
+	s.False(s.categorySelectionValid(choice, weapons.UnarmedStrike))
+}
+
+func (s *CategoryChoiceOptionsTestSuite) TestSubclassOptionsAreIndependentAcrossConcurrentRequirements() {
+	const readers = 64
+	var waitGroup sync.WaitGroup
+	errors := make(chan string, readers)
+
+	for range readers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			requirements := GetClassRequirementsWithSubclass(classes.Cleric, 1, classes.WarDomain)
+			for _, choice := range classCategoryChoices(requirements) {
+				if choice.Label != "Choose a martial weapon" {
+					continue
+				}
+				if len(choice.Options) == 0 {
+					errors <- "War Domain martial options were not enriched"
+				}
+			}
+		}()
+	}
+	waitGroup.Wait()
+	close(errors)
+	for err := range errors {
+		s.Fail(err)
+	}
+}
+
+func (s *CategoryChoiceOptionsTestSuite) TestOptionsAreDetailedDeterministicAndDuplicateFree() {
+	for _, classID := range implementedClasses {
+		first := classCategoryChoices(GetClassRequirements(classID))
+		second := classCategoryChoices(GetClassRequirements(classID))
+		s.Require().Len(second, len(first))
+
+		for i, choice := range first {
+			ids := make(map[shared.EquipmentID]struct{}, len(choice.Options))
+			for _, item := range choice.Options {
+				s.NotEmpty(item.ID)
+				s.Equal(1, item.Quantity, "each category selection grants one item")
+				s.NotNil(item.Detail, "option %q must have resolved detail", item.ID)
+				if item.Detail != nil {
+					s.NotEmpty(item.Detail.Name)
+					if choice.Type == shared.EquipmentTypeWeapon {
+						s.NotNil(item.Detail.Weapon, "weapon option %q must include weapon stats", item.ID)
+						if item.Detail.Weapon != nil {
+							s.NotEmpty(item.Detail.Weapon.Damage)
+						}
+					}
+				}
+				_, duplicate := ids[item.ID]
+				s.False(duplicate, "option %q appears more than once", item.ID)
+				ids[item.ID] = struct{}{}
+			}
+			s.Equal(choice.Options, second[i].Options, "options must be deterministic")
+		}
+	}
+}
+
+func (s *CategoryChoiceOptionsTestSuite) categorySelectionValid(choice EquipmentCategoryChoice, id shared.EquipmentID) bool {
+	requirements := &Requirements{EquipmentCategories: []*EquipmentCategoryRequirement{{
+		ID:         "category-choice-options-test",
+		Choose:     1,
+		Type:       choice.Type,
+		Categories: choice.Categories,
+	}}}
+	submissions := NewSubmissions()
+	submissions.Add(Submission{
+		Category: shared.ChoiceEquipment,
+		ChoiceID: "category-choice-options-test",
+		Values:   []shared.SelectionID{id},
+	})
+	return s.validator.Validate(requirements, submissions).Valid
+}
+
+var implementedClasses = []classes.Class{
+	classes.Barbarian,
+	classes.Bard,
+	classes.Cleric,
+	classes.Druid,
+	classes.Fighter,
+	classes.Monk,
+	classes.Paladin,
+	classes.Ranger,
+	classes.Rogue,
+	classes.Sorcerer,
+	classes.Warlock,
+	classes.Wizard,
+}
+
+func monkWeaponSimpleOption(s *CategoryChoiceOptionsTestSuite) (*EquipmentRequirement, *EquipmentOption) {
+	requirements := GetClassRequirements(classes.Monk)
+	for _, requirement := range requirements.Equipment {
+		if requirement.ID != MonkWeaponsPrimary {
+			continue
+		}
+		for i := range requirement.Options {
+			if requirement.Options[i].ID == MonkWeaponSimple {
+				return requirement, &requirement.Options[i]
+			}
+		}
+	}
+	s.FailNow("MonkWeaponSimple should exist")
+	return nil, nil
+}
+
+func classCategoryChoices(requirements *Requirements) []EquipmentCategoryChoice {
+	var result []EquipmentCategoryChoice
+	for _, requirement := range requirements.Equipment {
+		for _, option := range requirement.Options {
+			result = append(result, option.CategoryChoices...)
+		}
+	}
+	return result
+}
+
+func allCategoryCandidates() []shared.EquipmentID {
+	result := make([]shared.EquipmentID, 0, len(weapons.All)+len(armor.All)+len(tools.All)+len(items.All))
+	for id := range weapons.All {
+		result = append(result, id)
+	}
+	for id := range armor.All {
+		result = append(result, id)
+	}
+	for id := range tools.All {
+		result = append(result, id)
+	}
+	for id := range items.All {
+		result = append(result, id)
+	}
+	return result
+}
+
+func equipmentItemIDs(items []EquipmentItem) map[shared.EquipmentID]struct{} {
+	result := make(map[shared.EquipmentID]struct{}, len(items))
+	for _, item := range items {
+		result[item.ID] = struct{}{}
+	}
+	return result
+}

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -87,6 +87,22 @@ func enrichEquipmentRequirements(reqs []*EquipmentRequirement) []*EquipmentRequi
 			for j := range req.Options[i].Items {
 				req.Options[i].Items[j].Detail = equipment.ResolveEquipmentDetail(req.Options[i].Items[j].ID)
 			}
+			for j := range req.Options[i].CategoryChoices {
+				choice := &req.Options[i].CategoryChoices[j]
+				eligible, err := eligibleEquipment(choice.Type, choice.Categories)
+				if err != nil {
+					continue
+				}
+				choice.Options = make([]EquipmentItem, 0, len(eligible))
+				for _, item := range eligible {
+					id := shared.EquipmentID(item.EquipmentID())
+					choice.Options = append(choice.Options, EquipmentItem{
+						ID:       id,
+						Quantity: 1,
+						Detail:   equipment.ResolveEquipmentDetail(id),
+					})
+				}
+			}
 		}
 	}
 	return reqs
@@ -94,10 +110,11 @@ func enrichEquipmentRequirements(reqs []*EquipmentRequirement) []*EquipmentRequi
 
 // EquipmentCategoryChoice represents a category-based equipment selection within an option
 type EquipmentCategoryChoice struct {
-	Choose     int                        `json:"choose"`     // How many to choose (e.g., 1 or 2)
-	Type       shared.EquipmentType       `json:"type"`       // Equipment type (weapon, armor, etc.)
-	Categories []shared.EquipmentCategory `json:"categories"` // Categories to choose from
-	Label      string                     `json:"label"`      // e.g., "Choose a martial weapon"
+	Choose     int                        `json:"choose"`            // How many to choose (e.g., 1 or 2)
+	Type       shared.EquipmentType       `json:"type"`              // Equipment type (weapon, armor, etc.)
+	Categories []shared.EquipmentCategory `json:"categories"`        // Categories to choose from
+	Label      string                     `json:"label"`             // e.g., "Choose a martial weapon"
+	Options    []EquipmentItem            `json:"options,omitempty"` // Concrete, validator-eligible choices
 }
 
 // EquipmentCategoryRequirement defines equipment choices from categories (e.g., "choose 2 martial weapons")
@@ -870,7 +887,7 @@ func getBardEquipmentRequirements() []*EquipmentRequirement {
 						{
 							Choose:     1,
 							Type:       "tool",
-							Categories: []shared.EquipmentCategory{shared.EquipmentCategory("musical-instruments")},
+							Categories: []shared.EquipmentCategory{equipment.CategoryMusicalInstruments},
 							Label:      "Choose a musical instrument",
 						},
 					},
@@ -1396,7 +1413,7 @@ func getDruidEquipmentRequirements() []*EquipmentRequirement {
 						{
 							Choose:     1,
 							Type:       "tool",
-							Categories: []shared.EquipmentCategory{shared.EquipmentCategory("druidic-foci")},
+							Categories: []shared.EquipmentCategory{equipment.CategoryDruidicFoci},
 							Label:      "Choose a druidic focus",
 						},
 					},
@@ -1545,7 +1562,7 @@ func getPaladinEquipmentRequirements() []*EquipmentRequirement {
 						{
 							Choose:     1,
 							Type:       "tool",
-							Categories: []shared.EquipmentCategory{shared.EquipmentCategory("holy-symbols")},
+							Categories: []shared.EquipmentCategory{equipment.CategoryHolySymbols},
 							Label:      "Choose a holy symbol",
 						},
 					},
@@ -1664,7 +1681,7 @@ func getSorcererEquipmentRequirements() []*EquipmentRequirement {
 						{
 							Choose:     1,
 							Type:       "tool",
-							Categories: []shared.EquipmentCategory{shared.EquipmentCategory("arcane-foci")},
+							Categories: []shared.EquipmentCategory{equipment.CategoryArcaneFoci},
 							Label:      "Choose an arcane focus",
 						},
 					},
@@ -1737,7 +1754,7 @@ func getWarlockEquipmentRequirements() []*EquipmentRequirement {
 						{
 							Choose:     1,
 							Type:       "tool",
-							Categories: []shared.EquipmentCategory{shared.EquipmentCategory("arcane-foci")},
+							Categories: []shared.EquipmentCategory{equipment.CategoryArcaneFoci},
 							Label:      "Choose an arcane focus",
 						},
 					},
@@ -1797,6 +1814,7 @@ func GetClassRequirementsWithSubclass(class classes.Class, level int, subclass c
 
 	// Apply the modifications
 	ApplySubclassModifications(reqs, mods)
+	reqs.Equipment = enrichEquipmentRequirements(reqs.Equipment)
 
 	return reqs
 }

--- a/rulebooks/dnd5e/character/choices/subclass_modifications.go
+++ b/rulebooks/dnd5e/character/choices/subclass_modifications.go
@@ -91,7 +91,7 @@ func ApplySubclassModifications(reqs *Requirements, mods *SubclassModifications)
 	for reqID, options := range mods.AdditionalEquipmentOptions {
 		for i, eq := range reqs.Equipment {
 			if eq.ID == reqID {
-				reqs.Equipment[i].Options = append(reqs.Equipment[i].Options, options...)
+				reqs.Equipment[i].Options = append(reqs.Equipment[i].Options, cloneEquipmentOptions(options)...)
 				break
 			}
 		}
@@ -101,6 +101,23 @@ func ApplySubclassModifications(reqs *Requirements, mods *SubclassModifications)
 	if mods.ModifyFunction != nil {
 		mods.ModifyFunction(reqs)
 	}
+}
+
+// cloneEquipmentOptions prevents a requirement-enrichment pass from mutating
+// the shared subclass definition used to construct later character choices.
+func cloneEquipmentOptions(options []EquipmentOption) []EquipmentOption {
+	cloned := make([]EquipmentOption, len(options))
+	for i, option := range options {
+		cloned[i] = option
+		cloned[i].Items = append([]EquipmentItem(nil), option.Items...)
+		cloned[i].CategoryChoices = make([]EquipmentCategoryChoice, len(option.CategoryChoices))
+		for j, choice := range option.CategoryChoices {
+			cloned[i].CategoryChoices[j] = choice
+			cloned[i].CategoryChoices[j].Categories = append([]shared.EquipmentCategory(nil), choice.Categories...)
+			cloned[i].CategoryChoices[j].Options = append([]EquipmentItem(nil), choice.Options...)
+		}
+	}
+	return cloned
 }
 
 // subclassModifications defines all subclass modifications

--- a/rulebooks/dnd5e/character/choices/validation.go
+++ b/rulebooks/dnd5e/character/choices/validation.go
@@ -259,6 +259,15 @@ func (v *Validator) validateEquipment(req *EquipmentRequirement, submissions *Su
 	return nil
 }
 
+// eligibleEquipment is the single category-membership path for both validation
+// and concrete category-choice expansion.
+func eligibleEquipment(
+	equipType shared.EquipmentType,
+	categories []shared.EquipmentCategory,
+) ([]equipment.Equipment, error) {
+	return equipment.GetByCategory(equipType, categories)
+}
+
 func (v *Validator) validateEquipmentCategory(
 	req *EquipmentCategoryRequirement,
 	submissions *Submissions,
@@ -280,8 +289,9 @@ func (v *Validator) validateEquipmentCategory(
 				}
 			}
 
-			// Get all valid equipment IDs for the categories
-			validEquipment, err := equipment.GetByCategory(req.Type, req.Categories)
+			// Get all valid equipment IDs through the same membership path used
+			// to expand category choices for clients.
+			validEquipment, err := eligibleEquipment(req.Type, req.Categories)
 			if err != nil {
 				return &ValidationError{
 					Category: shared.ChoiceEquipment,

--- a/rulebooks/dnd5e/equipment/equipment.go
+++ b/rulebooks/dnd5e/equipment/equipment.go
@@ -2,8 +2,6 @@
 package equipment
 
 import (
-	"sort"
-
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/ammunition"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
@@ -140,8 +138,9 @@ func GetByCategory(equipType shared.EquipmentType, categories []shared.Equipment
 		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "category queries not supported for this equipment type")
 	}
 
-	// Registries are maps, so normalize their traversal to a stable order and
-	// collapse any repeated category membership before exposing choices.
+	// Each registry API supplies its explicit registry order. Retain the first
+	// occurrence while collapsing an ID that belongs to more than one requested
+	// category, so category choices preserve that order without duplicate options.
 	seen := make(map[string]struct{}, len(result))
 	unique := make([]Equipment, 0, len(result))
 	for _, item := range result {
@@ -151,9 +150,6 @@ func GetByCategory(equipType shared.EquipmentType, categories []shared.Equipment
 		seen[item.EquipmentID()] = struct{}{}
 		unique = append(unique, item)
 	}
-	sort.Slice(unique, func(i, j int) bool {
-		return unique[i].EquipmentID() < unique[j].EquipmentID()
-	})
 
 	return unique, nil
 }

--- a/rulebooks/dnd5e/equipment/equipment.go
+++ b/rulebooks/dnd5e/equipment/equipment.go
@@ -2,6 +2,8 @@
 package equipment
 
 import (
+	"sort"
+
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/ammunition"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
@@ -10,6 +12,17 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/tools"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+const (
+	// CategoryMusicalInstruments selects all musical instruments.
+	CategoryMusicalInstruments shared.EquipmentCategory = "musical-instruments"
+	// CategoryDruidicFoci selects druidic focuses.
+	CategoryDruidicFoci shared.EquipmentCategory = "druidic-foci"
+	// CategoryHolySymbols selects holy symbols.
+	CategoryHolySymbols shared.EquipmentCategory = "holy-symbols"
+	// CategoryArcaneFoci selects arcane focuses.
+	CategoryArcaneFoci shared.EquipmentCategory = "arcane-foci"
 )
 
 // Equipment represents any item that can be owned, carried, or equipped
@@ -103,9 +116,44 @@ func GetByCategory(equipType shared.EquipmentType, categories []shared.Equipment
 			}
 		}
 
+	case shared.EquipmentTypeTool:
+		for _, cat := range categories {
+			switch cat {
+			case CategoryMusicalInstruments:
+				for _, tool := range tools.GetByCategory(tools.CategoryMusical) {
+					toolCopy := tool
+					result = append(result, &toolCopy)
+				}
+			case CategoryDruidicFoci:
+				item := items.All[items.DruidicFocus]
+				result = append(result, &item)
+			case CategoryHolySymbols:
+				item := items.All[items.HolySymbol]
+				result = append(result, &item)
+			case CategoryArcaneFoci:
+				item := items.All[items.ArcaneFocus]
+				result = append(result, &item)
+			}
+		}
+
 	default:
 		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "category queries not supported for this equipment type")
 	}
 
-	return result, nil
+	// Registries are maps, so normalize their traversal to a stable order and
+	// collapse any repeated category membership before exposing choices.
+	seen := make(map[string]struct{}, len(result))
+	unique := make([]Equipment, 0, len(result))
+	for _, item := range result {
+		if _, ok := seen[item.EquipmentID()]; ok {
+			continue
+		}
+		seen[item.EquipmentID()] = struct{}{}
+		unique = append(unique, item)
+	}
+	sort.Slice(unique, func(i, j int) bool {
+		return unique[i].EquipmentID() < unique[j].EquipmentID()
+	})
+
+	return unique, nil
 }

--- a/rulebooks/dnd5e/tools/tools.go
+++ b/rulebooks/dnd5e/tools/tools.go
@@ -458,6 +458,17 @@ var All = map[ToolID]Tool{
 	},
 }
 
+// toolOrder is the authoritative presentation order for the tool registry.
+// All remains the ID lookup index.
+var toolOrder = []ToolID{
+	AlchemistSupplies, BrewerSupplies, CalligrapherSupplies, CarpenterTools, CartographerTools,
+	CobblerTools, CookUtensils, GlassblowerTools, JewelerTools, LeatherworkerTools, MasonTools,
+	PainterSupplies, PotterTools, SmithTools, TinkerTools, WeaverTools, WoodcarverTools,
+	DiceSet, DragonchessSet, PlayingCardSet, ThreeDragonAnte,
+	Bagpipes, Drum, Dulcimer, Flute, Lute, Lyre, Horn, PanFlute, Shawm, Viol,
+	DisguiseKit, ForgeryKit, HerbalismKit, NavigatorTools, PoisonerKit, ThievesTools, VehiclesLand, VehiclesWater,
+}
+
 // GetByID returns a tool by its ID
 func GetByID(id ToolID) (Tool, error) {
 	tool, ok := All[id]
@@ -473,10 +484,11 @@ func GetByID(id ToolID) (Tool, error) {
 	return tool, nil
 }
 
-// GetByCategory returns all tools in a category
+// GetByCategory returns all tools in a category in registry order.
 func GetByCategory(cat ToolCategory) []Tool {
 	var result []Tool
-	for _, t := range All {
+	for _, id := range toolOrder {
+		t := All[id]
 		if t.Category == cat {
 			result = append(result, t)
 		}

--- a/rulebooks/dnd5e/weapons/weapons.go
+++ b/rulebooks/dnd5e/weapons/weapons.go
@@ -467,11 +467,23 @@ func GetByID(id WeaponID) (Weapon, error) {
 	return w, nil
 }
 
-// GetByCategory returns all equippable weapons in a category.
+// weaponOrder is the authoritative presentation order for the weapon registry.
+// Keep it aligned with the source registry groups above; All remains the ID lookup index.
+var weaponOrder = []WeaponID{
+	Club, Dagger, Handaxe, Javelin, Greatclub, LightHammer, Mace, Quarterstaff, Sickle, Spear,
+	Greatsword, Longsword, Rapier, Shortsword, Battleaxe, Flail, Glaive, Greataxe, Halberd, Lance,
+	Maul, Morningstar, Pike, Scimitar, Trident, WarPick, Warhammer, Whip,
+	LightCrossbow, Shortbow, Dart, Sling,
+	HeavyCrossbow, Longbow, Blowgun, HandCrossbow, Net,
+	UnarmedStrike,
+}
+
+// GetByCategory returns all equippable weapons in their registry order.
 // Special weapons like UnarmedStrike are excluded since they are not equippable.
 func GetByCategory(cat WeaponCategory) []Weapon {
 	var result []Weapon
-	for _, w := range All {
+	for _, id := range weaponOrder {
+		w := All[id]
 		if w.Category == cat && !isSpecialWeapon(w.ID) {
 			result = append(result, w)
 		}


### PR DESCRIPTION
## Summary
- resolve every `EquipmentCategoryChoice` to deterministic, duplicate-free concrete `EquipmentItem` options with quantity `1` and resolved detail
- share one category-membership helper between expansion and validator; include existing tool/focus categories and retain registry special-weapon exclusion
- retain the 2014 Monk starting-equipment rule: shortsword **or any simple weapon** (simple melee and ranged); Martial Arts remains separate
- clone subclass options before enrichment so concurrent subclass requirement construction cannot mutate the shared registry

## Tests
- `cd rulebooks/dnd5e && go test -race ./...`
- `cd rulebooks/dnd5e && golangci-lint run ./...`
- `go test -race ./character/choices -run '^TestCategoryChoiceOptionsSuite$' -count=25`
- independent self-review: PASS

## Repository gates
- `make pre-commit` was run but fails in pre-existing root coverage accounting: it reports `core/mock` and 76.5% despite the changed `rulebooks/dnd5e` module passing its own race/lint gates.
- `make test-all` is blocked before this module by pre-existing `mechanics/spells`: `go: updates to go.mod needed; to update it: go mod tidy`.
- `make lint-all` is blocked before this module by pre-existing `mechanics/proficiency/simple_test.go:40` `goconst`.

Ready for review. Implements Phase 2 of rpg-project#173.

Closes #872
