### PR TITLE
fix(character): validate nested category equipment choices

### DIFF
--- a/rulebooks/dnd5e/character/category_equipment_test.go
+++ b/rulebooks/dnd5e/character/category_equipment_test.go
@@ -2,6 +2,8 @@ package character_test
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -114,6 +116,123 @@ func (s *CategoryBasedEquipmentTestSuite) TestBarbarianSecondaryWeaponCategoryCh
 	s.Require().NotEmpty(secondaryWeaponChoice.EquipmentSelection, "Should have equipment selection")
 	s.Assert().Contains(secondaryWeaponChoice.EquipmentSelection, weapons.Spear,
 		"Should have the selected spear in equipment selection")
+}
+
+func (s *CategoryBasedEquipmentTestSuite) TestMonkCategoryChoiceRejectsEverySpecialWeaponViaSetClass() {
+	requirements := choices.GetClassRequirements(classes.Monk)
+	_, monkSimple := monkWeaponSimpleOptionFromRequirements(requirements)
+	advertised := make(map[shared.EquipmentID]struct{}, len(monkSimple.CategoryChoices[0].Options))
+	for _, item := range monkSimple.CategoryChoices[0].Options {
+		advertised[item.ID] = struct{}{}
+	}
+
+	for specialID := range weapons.SpecialWeapons {
+		s.Run(string(specialID), func() {
+			_, offered := advertised[specialID]
+			s.False(offered, "special weapons must never be advertised as category choices")
+
+			draft := character.LoadDraftFromData(&character.DraftData{
+				ID:       "draft-monk-special-" + string(specialID),
+				PlayerID: "player-test",
+			})
+			err := draft.SetClass(monkClassInput(specialID))
+
+			s.Require().Error(err)
+			s.ErrorContains(err, "Invalid equipment choice '"+string(specialID)+"'")
+			for _, choice := range draft.Choices() {
+				s.NotContains(choice.EquipmentSelection, specialID,
+					"rejected category equipment must not be recorded in the draft")
+			}
+		})
+	}
+}
+
+func (s *CategoryBasedEquipmentTestSuite) TestMonkCategoryChoiceAppliesExactlyAdvertisedWeaponOptions() {
+	requirements := choices.GetClassRequirements(classes.Monk)
+	_, monkSimple := monkWeaponSimpleOptionFromRequirements(requirements)
+	advertised := make(map[shared.EquipmentID]struct{}, len(monkSimple.CategoryChoices[0].Options))
+	for _, item := range monkSimple.CategoryChoices[0].Options {
+		advertised[item.ID] = struct{}{}
+	}
+
+	for weaponID := range weapons.All {
+		s.Run(string(weaponID), func() {
+			_, offered := advertised[weaponID]
+			draft := character.LoadDraftFromData(&character.DraftData{
+				ID:       "draft-monk-" + string(weaponID),
+				PlayerID: "player-test",
+			})
+			err := draft.SetClass(monkClassInput(weaponID))
+
+			if offered {
+				s.Require().NoError(err, "advertised equipment must be accepted through Draft.SetClass")
+				return
+			}
+			s.Require().Error(err, "unadvertised equipment must be rejected through Draft.SetClass")
+		})
+	}
+}
+
+func (s *CategoryBasedEquipmentTestSuite) TestMonkCategoryChoiceAppliesAdvertisedOptionsConcurrently() {
+	_, monkSimple := monkWeaponSimpleOptionFromRequirements(choices.GetClassRequirements(classes.Monk))
+	options := monkSimple.CategoryChoices[0].Options
+	const workers = 64
+
+	errors := make(chan string, workers)
+	var waitGroup sync.WaitGroup
+	for worker := range workers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			item := options[worker%len(options)]
+			draft := character.LoadDraftFromData(&character.DraftData{
+				ID:       fmt.Sprintf("draft-monk-concurrent-%d", worker),
+				PlayerID: "player-test",
+			})
+			if err := draft.SetClass(monkClassInput(item.ID)); err != nil {
+				errors <- fmt.Sprintf("%s: %v", item.ID, err)
+			}
+		}()
+	}
+	waitGroup.Wait()
+	close(errors)
+	for err := range errors {
+		s.Fail(err)
+	}
+}
+
+func monkClassInput(weaponID shared.EquipmentID) *character.SetClassInput {
+	return &character.SetClassInput{
+		ClassID: classes.Monk,
+		Choices: character.ClassChoices{
+			Skills: []skills.Skill{skills.Acrobatics, skills.Athletics},
+			Equipment: []character.EquipmentChoiceSelection{
+				{
+					ChoiceID:           choices.MonkWeaponsPrimary,
+					OptionID:           choices.MonkWeaponSimple,
+					CategorySelections: []shared.EquipmentID{weaponID},
+				},
+				{
+					ChoiceID: choices.MonkPack,
+					OptionID: choices.MonkPackExplorer,
+				},
+			},
+		},
+	}
+}
+
+func monkWeaponSimpleOptionFromRequirements(requirements *choices.Requirements) (*choices.EquipmentRequirement, *choices.EquipmentOption) {
+	for _, requirement := range requirements.Equipment {
+		if requirement.ID != choices.MonkWeaponsPrimary {
+			continue
+		}
+		for i := range requirement.Options {
+			if requirement.Options[i].ID == choices.MonkWeaponSimple {
+				return requirement, &requirement.Options[i]
+			}
+		}
+	}
+	panic("MonkWeaponSimple should exist")
 }
 
 func TestCategoryBasedEquipmentTestSuite(t *testing.T) {

--- a/rulebooks/dnd5e/character/category_equipment_test.go
+++ b/rulebooks/dnd5e/character/category_equipment_test.go
@@ -2,6 +2,7 @@ package character_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -199,6 +200,92 @@ func (s *CategoryBasedEquipmentTestSuite) TestMonkCategoryChoiceAppliesAdvertise
 	for err := range errors {
 		s.Fail(err)
 	}
+}
+
+func (s *CategoryBasedEquipmentTestSuite) TestPersistedMonkCategoryChoiceRevalidatesNestedSelection() {
+	invalidDraft := s.loadPersistedMonkCategoryDraft(weapons.UnarmedStrike)
+
+	err := invalidDraft.ValidateChoices()
+	s.Error(err, "persisted unarmed strike must fail final choice validation")
+	s.ErrorContains(err, "monk-weapons-primary")
+	s.ErrorContains(err, "monk-weapon-b")
+	s.ErrorContains(err, "unarmed-strike")
+
+	char, err := invalidDraft.ToCharacter(s.ctx, "persisted-monk-invalid", s.bus)
+	s.Error(err, "persisted unarmed strike must not finalize into a character")
+	s.Nil(char)
+
+	for _, test := range []struct {
+		name     string
+		weaponID shared.EquipmentID
+	}{
+		{name: "valid simple melee club", weaponID: weapons.Club},
+		{name: "valid simple ranged shortbow", weaponID: weapons.Shortbow},
+	} {
+		s.Run(test.name, func() {
+			draft := s.loadPersistedMonkCategoryDraft(test.weaponID)
+
+			s.Require().NoError(draft.ValidateChoices())
+			char, err := draft.ToCharacter(s.ctx, "persisted-monk-"+string(test.weaponID), s.bus)
+			s.Require().NoError(err)
+			s.Require().NotNil(char)
+
+			found := false
+			for _, item := range char.ToData().Inventory {
+				if item.ID == test.weaponID {
+					found = true
+					break
+				}
+			}
+			s.True(found, "finalized inventory must retain the valid persisted choice %q", test.weaponID)
+		})
+	}
+}
+
+// loadPersistedMonkCategoryDraft round-trips the exact serialized shape that
+// origin/main accepted for a Monk's nested category selection before this PR.
+func (s *CategoryBasedEquipmentTestSuite) loadPersistedMonkCategoryDraft(weaponID shared.EquipmentID) *character.Draft {
+	const baseCreatedMonkDraftJSON = `{
+		"id": "base-persisted-monk",
+		"player_id": "player",
+		"name": "Persisted Monk",
+		"race": "human",
+		"class": "monk",
+		"background": "hermit",
+		"base_ability_scores": {
+			"cha": 12,
+			"con": 13,
+			"dex": 14,
+			"int": 8,
+			"str": 10,
+			"wis": 15
+		},
+		"choices": [
+			{"category": "name", "source": "player", "name": "Persisted Monk"},
+			{"category": "ability_scores", "source": "player", "ability_scores": {"cha": 12, "con": 13, "dex": 14, "int": 8, "str": 10, "wis": 15}},
+			{"category": "languages", "source": "race", "choice_id": "human-language", "languages": ["elvish"]},
+			{"category": "skills", "source": "class", "choice_id": "monk-skills", "skills": ["acrobatics", "stealth"]},
+			{"category": "tool_proficiency", "source": "class", "choice_id": "monk-tools", "tools": ["brewer-supplies"]},
+			{"category": "equipment", "source": "class", "choice_id": "monk-weapons-primary", "option_id": "monk-weapon-b", "equipment": ["unarmed-strike"]},
+			{"category": "equipment", "source": "class", "choice_id": "monk-pack", "option_id": "monk-pack-b", "equipment": ["explorer-pack"]}
+		],
+		"progress": 31
+	}`
+
+	var data character.DraftData
+	s.Require().NoError(json.Unmarshal([]byte(baseCreatedMonkDraftJSON), &data))
+	for i := range data.Choices {
+		choice := &data.Choices[i]
+		if choice.ChoiceID == choices.MonkWeaponsPrimary {
+			choice.EquipmentSelection = []shared.SelectionID{weaponID}
+			break
+		}
+	}
+
+	serialized, err := json.Marshal(data)
+	s.Require().NoError(err)
+	s.Require().NoError(json.Unmarshal(serialized, &data))
+	return character.LoadDraftFromData(&data)
 }
 
 func monkClassInput(weaponID shared.EquipmentID) *character.SetClassInput {

--- a/rulebooks/dnd5e/character/choices/requirements.go
+++ b/rulebooks/dnd5e/character/choices/requirements.go
@@ -89,7 +89,7 @@ func enrichEquipmentRequirements(reqs []*EquipmentRequirement) []*EquipmentRequi
 			}
 			for j := range req.Options[i].CategoryChoices {
 				choice := &req.Options[i].CategoryChoices[j]
-				eligible, err := eligibleEquipment(choice.Type, choice.Categories)
+				eligible, err := EligibleEquipment(choice.Type, choice.Categories)
 				if err != nil {
 					continue
 				}

--- a/rulebooks/dnd5e/character/choices/validation.go
+++ b/rulebooks/dnd5e/character/choices/validation.go
@@ -259,9 +259,10 @@ func (v *Validator) validateEquipment(req *EquipmentRequirement, submissions *Su
 	return nil
 }
 
-// eligibleEquipment is the single category-membership path for both validation
-// and concrete category-choice expansion.
-func eligibleEquipment(
+// EligibleEquipment returns the complete ordered set of equipment allowed by a
+// category choice. Requirement expansion and every category-selection validator
+// must use this function so clients are never offered a value the rules reject.
+func EligibleEquipment(
 	equipType shared.EquipmentType,
 	categories []shared.EquipmentCategory,
 ) ([]equipment.Equipment, error) {
@@ -291,7 +292,7 @@ func (v *Validator) validateEquipmentCategory(
 
 			// Get all valid equipment IDs through the same membership path used
 			// to expand category choices for clients.
-			validEquipment, err := eligibleEquipment(req.Type, req.Categories)
+			validEquipment, err := EligibleEquipment(req.Type, req.Categories)
 			if err != nil {
 				return &ValidationError{
 					Category: shared.ChoiceEquipment,

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -687,6 +687,7 @@ func (d *Draft) ValidateChoices() error {
 
 	// Convert draft choices to submissions
 	submissions := choices.NewSubmissions()
+	requirements := choices.GetClassRequirementsWithSubclass(d.class, 1, d.subclass)
 
 	// Process stored choices into submissions
 	for _, choice := range d.choices {
@@ -704,6 +705,10 @@ func (d *Draft) ValidateChoices() error {
 			}
 		case shared.ChoiceEquipment:
 			if len(choice.EquipmentSelection) > 0 {
+				if err := d.validatePersistedCategoryEquipmentChoice(choice, requirements); err != nil {
+					return err
+				}
+
 				// Validate all equipment IDs exist before adding to submissions
 				for _, equipID := range choice.EquipmentSelection {
 					_, err := equipment.GetByID(equipID)
@@ -812,6 +817,74 @@ func (d *Draft) ValidateChoices() error {
 			d.baseAbilityScores[abilities.CHA] > 0 {
 			d.progress.Set(ProgressAbilityScores)
 		}
+	}
+
+	return nil
+}
+
+// validatePersistedCategoryEquipmentChoice verifies the nested selections in a
+// serialized bundle choice before that choice is reduced to its option ID for
+// the general requirements validator.
+func (d *Draft) validatePersistedCategoryEquipmentChoice(
+	choice choices.ChoiceData,
+	requirements *choices.Requirements,
+) error {
+	if choice.OptionID == "" {
+		return nil
+	}
+
+	requirement := d.findEquipmentRequirement(choice.ChoiceID, requirements)
+	if requirement == nil {
+		return nil
+	}
+
+	option := d.findEquipmentOption(choice.OptionID, requirement)
+	if option == nil || len(option.CategoryChoices) == 0 {
+		return nil
+	}
+
+	categorySelectionCount := 0
+	for _, categoryChoice := range option.CategoryChoices {
+		categorySelectionCount += categoryChoice.Choose
+	}
+
+	expectedSelectionCount := len(option.Items) + categorySelectionCount
+	if len(choice.EquipmentSelection) != expectedSelectionCount {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"invalid persisted equipment selection for choice '%s' option '%s': expected %d items, got %d",
+			choice.ChoiceID, choice.OptionID, expectedSelectionCount, len(choice.EquipmentSelection))
+	}
+
+	selectionOffset := len(option.Items)
+	for _, categoryChoice := range option.CategoryChoices {
+		eligibleEquipment, err := choices.EligibleEquipment(categoryChoice.Type, categoryChoice.Categories)
+		if err != nil {
+			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"failed to resolve persisted equipment categories for choice '%s' option '%s': %v",
+				choice.ChoiceID, choice.OptionID, err)
+		}
+
+		eligibleIDs := make(map[shared.SelectionID]struct{}, len(eligibleEquipment))
+		for _, eligible := range eligibleEquipment {
+			eligibleIDs[eligible.EquipmentID()] = struct{}{}
+		}
+
+		selected := choice.EquipmentSelection[selectionOffset : selectionOffset+categoryChoice.Choose]
+		seen := make(map[shared.SelectionID]struct{}, len(selected))
+		for _, equipmentID := range selected {
+			if _, eligible := eligibleIDs[equipmentID]; !eligible {
+				return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"invalid persisted category equipment selection for choice '%s' option '%s': '%s' is not eligible",
+					choice.ChoiceID, choice.OptionID, equipmentID)
+			}
+			if _, duplicate := seen[equipmentID]; duplicate {
+				return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"invalid persisted category equipment selection for choice '%s' option '%s': duplicate '%s'",
+					choice.ChoiceID, choice.OptionID, equipmentID)
+			}
+			seen[equipmentID] = struct{}{}
+		}
+		selectionOffset += categoryChoice.Choose
 	}
 
 	return nil

--- a/rulebooks/dnd5e/character/draft.go
+++ b/rulebooks/dnd5e/character/draft.go
@@ -1524,11 +1524,36 @@ func (d *Draft) validateCategorySelections(
 			selection.OptionID, totalRequired, len(selection.CategorySelections))
 	}
 
-	// Validate each equipment ID exists
-	for _, equipID := range selection.CategorySelections {
-		if _, err := equipment.GetByID(equipID); err != nil {
-			return nil, rpgerr.Newf(rpgerr.CodeNotFound, "invalid equipment ID '%s'", equipID)
+	selectionOffset := 0
+	for _, categoryChoice := range option.CategoryChoices {
+		validEquipment, err := choices.EligibleEquipment(categoryChoice.Type, categoryChoice.Categories)
+		if err != nil {
+			return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"failed to resolve equipment categories for option '%s': %v", selection.OptionID, err)
 		}
+
+		validIDs := make(map[shared.EquipmentID]struct{}, len(validEquipment))
+		for _, eligible := range validEquipment {
+			validIDs[eligible.EquipmentID()] = struct{}{}
+		}
+
+		selected := selection.CategorySelections[selectionOffset : selectionOffset+categoryChoice.Choose]
+		seen := make(map[shared.EquipmentID]struct{}, len(selected))
+		for _, equipID := range selected {
+			if _, err := equipment.GetByID(equipID); err != nil {
+				return nil, rpgerr.Newf(rpgerr.CodeNotFound, "invalid equipment ID '%s'", equipID)
+			}
+			if _, valid := validIDs[equipID]; !valid {
+				return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"Invalid equipment choice '%s' - must be from specified categories", equipID)
+			}
+			if _, duplicate := seen[equipID]; duplicate {
+				return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"Cannot choose the same item '%s' multiple times", equipID)
+			}
+			seen[equipID] = struct{}{}
+		}
+		selectionOffset += categoryChoice.Choose
 	}
 
 	return selection.CategorySelections, nil


### PR DESCRIPTION
## Summary

Fixes the provider-contract integrity gap found while gating rpg-api#764: nested `Draft.SetClass` category selections previously verified only registry existence, so they could persist a value that `ListClasses` does not advertise.

- make `choices.EligibleEquipment` the one authoritative ordered category-resolution path for requirement expansion, final choice validation, and nested draft application
- enforce the resolved category set (and per-category duplicate rule) before a nested selection is recorded
- retain the full simple melee/ranged and martial melee/ranged registries from #877; fixed `unarmed-strike` behavior remains available outside equipment category choices

## Discrimination coverage

- real `Draft.SetClass` applies every advertised Monk simple weapon and rejects every unadvertised registered weapon
- every special weapon (including `unarmed-strike`) is absent from the advertised options, rejected through the real apply path, and not recorded
- existing category-validator parity coverage proves expanded options equal category-valid values for every class choice; concurrent independent draft applications and requirement expansion run under `-race`

## Gates

- red before fix: `go test ./character -run '^TestCategoryBasedEquipmentTestSuite/TestMonkCategoryChoiceRejectsSpecialWeaponViaSetClass$' -count=1` failed with `An error is expected but got nil.`
- `go test -race ./character -run '^TestCategoryBasedEquipmentTestSuite/TestMonkCategoryChoice' -count=25`
- `go test -race ./character/choices -run '^TestCategoryChoiceOptionsSuite$' -count=25`
- `go test -race ./...` and `golangci-lint run ./...` in `rulebooks/dnd5e`
- changed-module CI equivalent (`go fmt`, `go mod tidy`, lint, `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`)

`make pre-commit` remains blocked by the pre-existing root coverage parser/accounting failure: `core/mock` is included and reports 76.5% versus the 80% threshold. The changed dnd5e module gates pass.

Blocks rpg-api#764 and completes the toolkit provider integrity work for rpg-project#173.

Closes #878
