### PR TITLE
feat(encounter): add runnable semantic regions

### DIFF
--- a/encounter/canvas.go
+++ b/encounter/canvas.go
@@ -79,7 +79,7 @@ func validateCanvasDungeonParams(params DungeonParams) error {
 		return err
 	}
 	if len(params.Regions) != 0 || len(params.Connectors) != 0 {
-		return fmt.Errorf("canvas dungeon must not contain regions or connectors")
+		return fmt.Errorf("canvas dungeon must not contain room-chain regions or connectors")
 	}
 	if params.PartyStart.SeatCount < 0 {
 		return fmt.Errorf("party start seat count must not be negative (got %d)", params.PartyStart.SeatCount)
@@ -102,6 +102,9 @@ func validateCanvasDungeonParams(params DungeonParams) error {
 			return fmt.Errorf("canvas placed obstacle %q at %v collides with %s", obstacle.ID, obstacle.At, prior)
 		}
 		occupied[obstacle.At] = fmt.Sprintf("canvas prop %q", obstacle.ID)
+	}
+	if _, err := validateSemanticRegionParams(params.SemanticRegions, floor); err != nil {
+		return err
 	}
 	for index, reserved := range params.AbsoluteReservedCells {
 		if reserved.Name == "" {
@@ -130,9 +133,14 @@ func generateCanvasDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 			BlocksMovement: obstacle.BlocksMovement, BlocksLoS: obstacle.BlocksLoS, Facing: obstacle.Facing,
 		}
 	}
+	floor := canvasFloorHexes(params.Width, params.Height)
+	semanticRegions, err := validateSemanticRegionParams(params.SemanticRegions, floor)
+	if err != nil {
+		return nil, err
+	}
 	return &dungeonLayout{
 		width: params.Width, entrance: reservation.anchor, obstacles: obstacles,
-		partyStartPositions: reservation.positions(),
+		semanticRegions: semanticRegions, partyStartPositions: reservation.positions(),
 	}, nil
 }
 

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -314,8 +314,10 @@ func (sd *SpaceData) RegionAt(h core.Hex) (string, bool) {
 	if sd == nil {
 		return "", false
 	}
-	if id, ok := sd.SemanticRegionAt(h); ok {
-		return id, true
+	if sd.FloorSource == FloorSourceCanvas {
+		if id, ok := sd.SemanticRegionAt(h); ok {
+			return id, true
+		}
 	}
 	for _, r := range sd.Regions {
 		if r.Hexes.Has(h) {

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -174,6 +174,11 @@ type SpaceData struct {
 	// exactly one implicit region.
 	Regions []RegionData `json:"regions,omitempty"`
 
+	// SemanticRegions are authored canvas scopes. Unlike legacy Regions, they
+	// have no geometry authority: cells are semantic facts only and containment
+	// is recomputed on every use/load.
+	SemanticRegions []SemanticRegionData `json:"semantic_regions,omitempty"`
+
 	// Theme is opaque cosmetic metadata (e.g. "crypt") that InitDungeon
 	// carries through from DungeonParams.Theme without interpreting —
 	// rpg-toolkit#814's Approved Slice 3 corrections are explicit that the
@@ -308,6 +313,9 @@ const (
 func (sd *SpaceData) RegionAt(h core.Hex) (string, bool) {
 	if sd == nil {
 		return "", false
+	}
+	if id, ok := sd.SemanticRegionAt(h); ok {
+		return id, true
 	}
 	for _, r := range sd.Regions {
 		if r.Hexes.Has(h) {

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -49,6 +49,10 @@ type DungeonParams struct {
 	// required — a single region has nowhere to connect to.
 	Regions []DungeonRegionParams
 
+	// SemanticRegions are canvas-authored scopes. They never route through the
+	// room-chain generator and cannot create walls, doors, or content.
+	SemanticRegions []SemanticRegionParams
+
 	// Connectors is the ordered list of doors joining consecutive regions:
 	// Connectors[i] joins Regions[i] to Regions[i+1]. Must have exactly
 	// len(Regions)-1 entries.
@@ -379,6 +383,7 @@ func (e *Encounter) InitDungeon(params DungeonParams) error {
 		DungeonKey:          dungeonKey,
 		AuthoredEdges:       authoredEdges,
 		Regions:             layout.regions,
+		SemanticRegions:     layout.semanticRegions,
 		Theme:               params.Theme,
 		Obstacles:           layout.obstacles,
 	}
@@ -584,10 +589,11 @@ func validateDungeonParams(params DungeonParams) error {
 // after the call, not off this. Mirrors two_chamber.go's (now retired)
 // twoChamberLayout, generalized to N regions.
 type dungeonLayout struct {
-	walls    []environments.WallSegmentData
-	width    int
-	regions  []RegionData
-	entrance spatial.CubeCoordinate
+	walls           []environments.WallSegmentData
+	width           int
+	regions         []RegionData
+	semanticRegions []SemanticRegionData
+	entrance        spatial.CubeCoordinate
 	// doors[i] is the door cube coordinate joining Regions[i] to
 	// Regions[i+1] — parallel to params.Connectors.
 	doors []spatial.CubeCoordinate

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -432,11 +432,36 @@ func compileCanvas(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, error
 		cc.entrance = FloorPlanCell{0, 0}
 	}
 
+	semanticRegions := make([]encounter.SemanticRegionParams, len(spec.Regions))
+	for index, region := range spec.Regions {
+		cells := make([]core.Hex, 0, len(region.Cells))
+		seen := make(map[[2]int]struct{}, len(region.Cells))
+		for _, cell := range region.Cells {
+			if _, duplicate := seen[cell]; duplicate {
+				continue
+			}
+			seen[cell] = struct{}{}
+			cells = append(cells, canvasHex(FloorPlanCell{Column: cell[0], Row: cell[1]}))
+		}
+		sort.Slice(cells, func(i, j int) bool { return floorPlanCellLess(cellFromHex(cells[i]), cellFromHex(cells[j])) })
+		var archetype *encounter.RegionArchetype
+		if region.Archetype != nil {
+			value := encounter.RegionArchetype(*region.Archetype)
+			archetype = &value
+		}
+		semanticRegions[index] = encounter.SemanticRegionParams{
+			ID: region.ID, Name: region.Name, Archetype: archetype, Cells: cells,
+		}
+		for _, cell := range region.Cells {
+			cc.regionCells = append(cc.regionCells, namedCanvasCell{name: region.ID, cell: cell})
+		}
+	}
 	params := encounter.DungeonParams{
 		Key: spec.Key, Width: spec.Canvas.Width, Height: spec.Canvas.Height, Theme: spec.Theme,
-		FloorSource:   encounter.FloorSourceCanvas,
-		PartyStart:    encounter.PartyStartParams{SeatCount: config.PartyStartSeatCount},
-		AuthoredEdges: edges,
+		SemanticRegions: semanticRegions,
+		FloorSource:     encounter.FloorSourceCanvas,
+		PartyStart:      encounter.PartyStartParams{SeatCount: config.PartyStartSeatCount},
+		AuthoredEdges:   edges,
 	}
 	anchor := canvasHex(cc.entrance)
 	params.PartyStart.Anchor = &anchor

--- a/encounter/dungeonspec/floor_plan.go
+++ b/encounter/dungeonspec/floor_plan.go
@@ -50,9 +50,20 @@ type FloorPlanConnector struct {
 	Column     int
 }
 
+// FloorPlanRegion is one authoring semantic scope. ParentID is derived and
+// nil for root-parented/empty scopes; Cells are canonical absolute extents.
+type FloorPlanRegion struct {
+	ID        string
+	Name      *string
+	Archetype *string
+	Cells     []FloorPlanCell
+	ParentID  *string
+}
+
 // FloorPlan is the provider-owned authoring projection.
 type FloorPlan struct {
 	Rooms      []FloorPlanRoom
+	Regions    []FloorPlanRegion
 	Connectors []FloorPlanConnector
 	// Width is the canvas width only; room chains leave it zero to preserve
 	// the wire contract's canvas-only field semantics.
@@ -115,6 +126,21 @@ func BuildFloorPlan(ctx context.Context, in BuildFloorPlanInput) (FloorPlan, err
 	}
 	if data.Space.FloorSource == encounter.FloorSourceCanvas {
 		plan.Width = data.Space.Width
+		for _, region := range data.Space.SemanticRegions {
+			projected := FloorPlanRegion{ID: region.ID, Name: cloneString(region.Name)}
+			if region.Archetype != nil {
+				value := string(*region.Archetype)
+				projected.Archetype = &value
+			}
+			if parent, ok := data.Space.SemanticRegionParent(region.ID); ok {
+				projected.ParentID = &parent
+			}
+			for cell := range region.Cells {
+				projected.Cells = append(projected.Cells, cellFromHex(cell))
+			}
+			sort.Slice(projected.Cells, func(i, j int) bool { return floorPlanCellLess(projected.Cells[i], projected.Cells[j]) })
+			plan.Regions = append(plan.Regions, projected)
+		}
 		cells, err := runtimeCanvasFloorCells(data.Space.Width, data.Space.Height)
 		if err != nil {
 			return FloorPlan{}, fmt.Errorf("validate canvas floor cells: %w", err)
@@ -173,6 +199,14 @@ func runtimeCanvasFloorCells(width, height int) ([]FloorPlanCell, error) {
 		return cells[i].Row < cells[j].Row
 	})
 	return cells, nil
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }
 
 func cellFromHex(h core.Hex) FloorPlanCell {

--- a/encounter/dungeonspec/regions_test.go
+++ b/encounter/dungeonspec/regions_test.go
@@ -1,0 +1,87 @@
+package dungeonspec
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/require"
+)
+
+const runnableRegionsFixture = `version: 1
+key: semantic-scopes
+name: Semantic Scopes
+canvas: { width: 5, height: 3 }
+rooms: []
+regions:
+  - id: outer
+    name: Outer
+    archetype: chamber
+    cells: [[0,0], [0,1], [1,0], [1,1], [1,1]]
+  - id: inner
+    cells: [[0,0]]
+  - id: disconnected
+    archetype: boss
+    cells: [[3,0], [4,2]]
+  - id: empty
+    cells: []
+`
+
+func TestRunnableSemanticRegionsCompileProjectAndReload(t *testing.T) {
+	compiled, err := LoadWithConfig([]byte(runnableRegionsFixture), LoadConfig{PartyStartSeatCount: 1})
+	require.NoError(t, err)
+	require.Len(t, compiled.Params.SemanticRegions, 4)
+	require.Len(t, compiled.Params.SemanticRegions[0].Cells, 4, "same-scope duplicate cells canonicalize")
+
+	plan, err := BuildFloorPlan(context.Background(), BuildFloorPlanInput{Compiled: compiled, Seed: 1})
+	require.NoError(t, err)
+	regionIDs := []string{plan.Regions[0].ID, plan.Regions[1].ID, plan.Regions[2].ID, plan.Regions[3].ID}
+	require.Equal(t, []string{"outer", "inner", "disconnected", "empty"}, regionIDs)
+	require.Equal(t, "outer", *plan.Regions[1].ParentID)
+	require.Nil(t, plan.Regions[3].ParentID)
+	require.Len(t, plan.Regions[0].Cells, 4)
+
+	broker := encounter.NewBroker(encounter.NewInMemoryTransport())
+	enc := encounter.New(context.Background(), "semantic", broker)
+	require.NoError(t, enc.InitDungeon(compiled.Params))
+	inner := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	root := core.HexFromPosition(spatial.Position{X: 2, Y: 2})
+	require.Equal(t, "inner", enc.ToData().Space.ZoneAt(inner).ID)
+	innerZone := enc.ToData().Space.ZoneAt(inner)
+	require.Equal(t, encounter.ArchetypeChamber, *innerZone.Archetype, "archetype inherits from outer")
+	require.Empty(t, enc.ToData().Space.ZoneAt(root).ID)
+
+	payload, err := json.Marshal(enc.ToData())
+	require.NoError(t, err)
+	require.NotContains(t, string(payload), "parent_id", "derived parents are never durable facts")
+	var restored encounter.Data
+	require.NoError(t, json.Unmarshal(payload, &restored))
+	reloaded, err := encounter.LoadFromData(context.Background(), &restored, broker)
+	require.NoError(t, err)
+	parent, ok := reloaded.ToData().Space.SemanticRegionParent("inner")
+	require.True(t, ok)
+	require.Equal(t, "outer", parent)
+	require.Equal(t, "inner", reloaded.ToData().Space.ZoneAt(inner).ID)
+}
+
+func TestSemanticRegionStructuralRejectsOnlyScopeFailures(t *testing.T) {
+	cases := map[string]string{
+		"duplicate id":          strings.Replace(runnableRegionsFixture, "- id: inner", "- id: outer", 1),
+		"out of floor":          strings.Replace(runnableRegionsFixture, "cells: [[0,0]]", "cells: [[9,9]]", 1),
+		"unsupported archetype": strings.Replace(runnableRegionsFixture, "archetype: chamber", "archetype: library", 1),
+		"partial overlap":       strings.Replace(runnableRegionsFixture, "cells: [[0,0]]", "cells: [[0,0], [2,2]]", 1),
+		"equal overlap": strings.Replace(
+			runnableRegionsFixture, "cells: [[0,0]]", "cells: [[0,0], [0,1], [1,0], [1,1]]", 1,
+		),
+	}
+	for name, source := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Load([]byte(source))
+			require.Error(t, err)
+		})
+	}
+}

--- a/encounter/dungeonspec/regions_test.go
+++ b/encounter/dungeonspec/regions_test.go
@@ -68,6 +68,40 @@ func TestRunnableSemanticRegionsCompileProjectAndReload(t *testing.T) {
 	require.Equal(t, "inner", reloaded.ToData().Space.ZoneAt(inner).ID)
 }
 
+func TestRunnableSemanticRegionRoleLightweightCases(t *testing.T) {
+	const header = `version: 1
+key: lightweight-regions
+name: Lightweight Regions
+canvas: { width: 4, height: 4 }
+rooms: []
+`
+	cases := map[string]string{
+		"zero regions": header,
+		"no explicit role": header + `regions:
+  - { id: unlabeled, cells: [[0,0]] }
+`,
+		"empty only": header + `regions:
+  - { id: empty, cells: [] }
+`,
+		"one explicit role": header + `regions:
+  - { id: entry, archetype: entrance, cells: [[0,0]] }
+`,
+		"many explicit roles": header + `regions:
+  - { id: entry, archetype: entrance, cells: [[0,0]] }
+  - { id: hall, archetype: chamber, cells: [[1,0]] }
+  - { id: corridor, archetype: corridor, cells: [[2,0]] }
+  - { id: boss-a, archetype: boss, cells: [[3,0]] }
+  - { id: boss-b, archetype: boss, cells: [[3,1]] }
+`,
+	}
+	for name, source := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := LoadWithConfig([]byte(source), LoadConfig{PartyStartSeatCount: 1})
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestSemanticRegionStructuralRejectsOnlyScopeFailures(t *testing.T) {
 	cases := map[string]string{
 		"duplicate id":          strings.Replace(runnableRegionsFixture, "- id: inner", "- id: outer", 1),

--- a/encounter/dungeonspec/spec.go
+++ b/encounter/dungeonspec/spec.go
@@ -30,6 +30,10 @@ type DungeonSpec struct {
 	// Room-chain mode rejects every top-level entry at a field-specific
 	// validation path.
 	Place []PlacedEntry `yaml:"place,omitempty"`
+	// Regions are authored semantic scopes over the structural floor. They are
+	// deliberately separate from legacy Rooms: their cells are absolute and
+	// never feed room-chain generation.
+	Regions []RegionSpec `yaml:"regions,omitempty"`
 	// roomsShape preserves the authored YAML form for canvas validation.
 	// A nil Rooms slice alone cannot distinguish omitted, null, and [] input.
 	roomsShape roomsShape
@@ -48,6 +52,15 @@ const (
 type CanvasSpec struct {
 	Width  int `yaml:"width"`
 	Height int `yaml:"height"`
+}
+
+// RegionSpec is one authored semantic scope. Cells are absolute odd-q
+// [column,row] coordinates; nil/empty is a runnable empty scope.
+type RegionSpec struct {
+	ID        string   `yaml:"id"`
+	Name      *string  `yaml:"name,omitempty"`
+	Archetype *string  `yaml:"archetype,omitempty"`
+	Cells     [][2]int `yaml:"cells"`
 }
 
 // RoomSpec is one room in a dungeon spec.

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -77,6 +77,9 @@ func Validate(spec *DungeonSpec) error {
 	if spec.Canvas != nil {
 		return validateCanvas(spec)
 	}
+	if err := validateNoRegionsInRoomChain(spec); err != nil {
+		return err
+	}
 	if spec.Height < minHeight {
 		return fmt.Errorf("height must be at least %d, got %d", minHeight, spec.Height)
 	}
@@ -149,6 +152,13 @@ func Validate(spec *DungeonSpec) error {
 	return nil
 }
 
+func validateNoRegionsInRoomChain(spec *DungeonSpec) error {
+	if len(spec.Regions) != 0 {
+		return fmt.Errorf("regions require canvas mode (non-empty rooms and regions are incompatible)")
+	}
+	return nil
+}
+
 func validateCanvas(spec *DungeonSpec) error {
 	cellCount, err := encounter.ValidateCanvasDimensions(spec.Canvas.Width, spec.Canvas.Height)
 	if err != nil {
@@ -188,7 +198,67 @@ func validateCanvas(spec *DungeonSpec) error {
 			return fmt.Errorf("start %v conflicts with %q", *spec.Start, prior)
 		}
 	}
+	if err := validateRegions(spec.Regions, floor); err != nil {
+		return err
+	}
 	return validateWallsOnFloor(spec, floor, spec.Canvas.Width, spec.Canvas.Height)
+}
+
+// validateRegions enforces only the runnable semantic-scope structural rules.
+// Content, role cardinality, connectedness, and empty scopes are intentionally
+// not semantic validation concerns in this wave.
+func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
+	seenIDs := make(map[string]int, len(regions))
+	sets := make([]map[[2]int]struct{}, len(regions))
+	for i, region := range regions {
+		if region.ID == "" {
+			return fmt.Errorf("regions[%d].id must not be empty", i)
+		}
+		if first, duplicate := seenIDs[region.ID]; duplicate {
+			return fmt.Errorf("regions[%d].id %q duplicates regions[%d]", i, region.ID, first)
+		}
+		seenIDs[region.ID] = i
+		if region.Archetype != nil {
+			if *region.Archetype == "" {
+				return fmt.Errorf("regions[%d].archetype: explicit empty archetype is unsupported", i)
+			}
+			if err := validateArchetype(*region.Archetype); err != nil {
+				return fmt.Errorf("regions[%d].archetype: %w", i, err)
+			}
+		}
+		if region.Cells == nil {
+			return fmt.Errorf("regions[%d].cells is required (use [] for an empty scope)", i)
+		}
+		sets[i] = make(map[[2]int]struct{}, len(region.Cells))
+		for j, cell := range region.Cells {
+			if _, ok := floor[cell]; !ok {
+				return fmt.Errorf("regions[%d].cells[%d] %v is out of canvas floor footprint", i, j, cell)
+			}
+			sets[i][cell] = struct{}{} // same-region duplicates canonicalize
+		}
+	}
+	for left := range sets {
+		for right := left + 1; right < len(sets); right++ {
+			if len(sets[left]) == 0 || len(sets[right]) == 0 {
+				continue
+			}
+			intersection := 0
+			for cell := range sets[left] {
+				if _, ok := sets[right][cell]; ok {
+					intersection++
+				}
+			}
+			if intersection == 0 {
+				continue
+			}
+			leftInsideRight := intersection == len(sets[left]) && len(sets[left]) < len(sets[right])
+			rightInsideLeft := intersection == len(sets[right]) && len(sets[right]) < len(sets[left])
+			if !leftInsideRight && !rightInsideLeft {
+				return fmt.Errorf("regions %q and %q have equal or partial overlap", regions[left].ID, regions[right].ID)
+			}
+		}
+	}
+	return nil
 }
 func validateCanvasPlacement(path string, e PlacedEntry) error {
 	typ, err := refParts(e.Ref)

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -92,17 +92,8 @@ func Validate(spec *DungeonSpec) error {
 	if err := validateChain(spec); err != nil {
 		return err
 	}
-	for i := range spec.Rooms {
-		room := &spec.Rooms[i]
-		if room.Width < minWidth {
-			return fmt.Errorf("room %q: width must be at least %d, got %d", room.ID, minWidth, room.Width)
-		}
-		if err := validateArchetype(room.Archetype); err != nil {
-			return fmt.Errorf("room %q: %w", room.ID, err)
-		}
-		if err := validatePattern(room.Pattern); err != nil {
-			return fmt.Errorf("room %q: %w", room.ID, err)
-		}
+	if err := validateRoomDefinitions(spec.Rooms); err != nil {
+		return err
 	}
 	bossRoom, err := validateBossCardinality(spec.Rooms)
 	if err != nil {
@@ -147,6 +138,22 @@ func Validate(spec *DungeonSpec) error {
 			if err = validateLocked(&spec.Connectors[i]); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func validateRoomDefinitions(rooms []RoomSpec) error {
+	for i := range rooms {
+		room := &rooms[i]
+		if room.Width < minWidth {
+			return fmt.Errorf("room %q: width must be at least %d, got %d", room.ID, minWidth, room.Width)
+		}
+		if err := validateArchetype(room.Archetype); err != nil {
+			return fmt.Errorf("room %q: %w", room.ID, err)
+		}
+		if err := validatePattern(room.Pattern); err != nil {
+			return fmt.Errorf("room %q: %w", room.ID, err)
 		}
 	}
 	return nil

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -545,6 +545,7 @@ func (e *Encounter) addMonsterNoCombatCheck(input MonsterInput) error {
 		}
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), mon.ID, mon.Position, viewers,
+			e.eventObservationsForAudience(mon.Position, viewers),
 		)); err != nil {
 			return fmt.Errorf("publish monster appeared on add: %w", err)
 		}
@@ -1235,6 +1236,7 @@ func (e *Encounter) applyAndPublishMove(
 		return "", fmt.Errorf("publish move: %w", err)
 	}
 	if len(revealPerPlayer) > 0 {
+		e.attachRevealObservations(revealPerPlayer)
 		if err := e.broker.Publish(events.NewHexRevealedEvent(
 			e.data.ID, e.nextSeq(), revealPerPlayer,
 		)); err != nil {
@@ -1253,6 +1255,7 @@ func (e *Encounter) applyAndPublishMove(
 	for hex, viewers := range appearedByHex {
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), p.EntityID, hex, viewers,
+			e.eventObservationsForAudience(hex, viewers),
 		)); err != nil {
 			return "", fmt.Errorf("publish entity appeared: %w", err)
 		}
@@ -1264,6 +1267,7 @@ func (e *Encounter) applyAndPublishMove(
 	if len(disappearedPerPlayer) > 0 {
 		if err := e.broker.Publish(events.NewEntityDisappearedEvent(
 			e.data.ID, e.nextSeq(), p.EntityID, disappearedPerPlayer,
+			e.eventObservationsForPositions(disappearedPerPlayer),
 		)); err != nil {
 			return "", fmt.Errorf("publish entity disappeared: %w", err)
 		}
@@ -1294,17 +1298,19 @@ func (e *Encounter) applyAndPublishMove(
 		p.EntityID, p.View.SightRange, moverStart, traveledPath,
 	)
 	for _, m := range monsterAppeared {
+		audience := map[core.PlayerID]struct{}{playerID: {}}
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
-			e.data.ID, e.nextSeq(), m.ID, m.Position,
-			map[core.PlayerID]struct{}{playerID: {}},
+			e.data.ID, e.nextSeq(), m.ID, m.Position, audience,
+			e.eventObservationsForAudience(m.Position, audience),
 		)); err != nil {
 			return "", fmt.Errorf("publish monster appeared: %w", err)
 		}
 	}
 	for _, m := range monsterDisappeared {
+		disappeared := map[core.PlayerID]core.Hex{playerID: m.Position}
 		if err := e.broker.Publish(events.NewEntityDisappearedEvent(
-			e.data.ID, e.nextSeq(), m.ID,
-			map[core.PlayerID]core.Hex{playerID: m.Position},
+			e.data.ID, e.nextSeq(), m.ID, disappeared,
+			e.eventObservationsForPositions(disappeared),
 		)); err != nil {
 			return "", fmt.Errorf("publish monster disappeared: %w", err)
 		}
@@ -1399,6 +1405,7 @@ func (e *Encounter) OpenDoor(playerID core.PlayerID, doorID core.EntityID) error
 		return fmt.Errorf("publish door: %w", err)
 	}
 	if len(revealPerPlayer) > 0 {
+		e.attachRevealObservations(revealPerPlayer)
 		if err := e.broker.Publish(events.NewHexRevealedEvent(
 			e.data.ID, e.nextSeq(), revealPerPlayer,
 		)); err != nil {
@@ -1446,6 +1453,7 @@ func (e *Encounter) publishRevealedObstacles(reveals map[core.PlayerID]events.He
 		}
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), obstacle.ID, obstacle.Position, audience,
+			e.eventObservationsForAudience(obstacle.Position, audience),
 		)); err != nil {
 			return fmt.Errorf("publish revealed obstacle %q: %w", obstacle.ID, err)
 		}

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -1255,7 +1255,7 @@ func (e *Encounter) applyAndPublishMove(
 	for hex, viewers := range appearedByHex {
 		if err := e.broker.Publish(events.NewEntityAppearedEvent(
 			e.data.ID, e.nextSeq(), p.EntityID, hex, viewers,
-			e.eventObservationsForAudience(hex, viewers),
+			e.eventObservationsForAppearance(hex, viewers, p.EntityID),
 		)); err != nil {
 			return "", fmt.Errorf("publish entity appeared: %w", err)
 		}

--- a/encounter/events/entity_appeared.go
+++ b/encounter/events/entity_appeared.go
@@ -27,6 +27,8 @@ type EntityAppearedEvent struct {
 	Entity    core.EntityID
 	Position  core.Hex
 	PerPlayer map[core.PlayerID]struct{}
+	// Observations is each recipient's immutable-at-publish observation of Position.
+	Observations map[core.PlayerID]KnownHex `json:"observations,omitempty"`
 }
 
 // NewEntityAppearedEvent constructs an EntityAppearedEvent. The encounter is
@@ -37,13 +39,19 @@ func NewEntityAppearedEvent(
 	entity core.EntityID,
 	position core.Hex,
 	perPlayer map[core.PlayerID]struct{},
+	observations ...map[core.PlayerID]KnownHex,
 ) *EntityAppearedEvent {
+	var observed map[core.PlayerID]KnownHex
+	if len(observations) > 0 {
+		observed = observations[0]
+	}
 	return &EntityAppearedEvent{
-		encID:     encID,
-		seq:       seq,
-		Entity:    entity,
-		Position:  position,
-		PerPlayer: perPlayer,
+		encID:        encID,
+		seq:          seq,
+		Entity:       entity,
+		Position:     position,
+		PerPlayer:    perPlayer,
+		Observations: observed,
 	}
 }
 
@@ -62,23 +70,25 @@ func (e *EntityAppearedEvent) Audience() AudienceSet { return audienceFromMap(e.
 // entityAppearedWire is the on-wire shape — used only by MarshalJSON / UnmarshalJSON.
 type entityAppearedWire struct {
 	metaWire
-	EncID     core.EncounterID           `json:"encounter_id"`
-	Seq       uint64                     `json:"sequence"`
-	Entity    core.EntityID              `json:"entity"`
-	Position  core.Hex                   `json:"position"`
-	PerPlayer map[core.PlayerID]struct{} `json:"per_player"`
+	EncID        core.EncounterID           `json:"encounter_id"`
+	Seq          uint64                     `json:"sequence"`
+	Entity       core.EntityID              `json:"entity"`
+	Position     core.Hex                   `json:"position"`
+	PerPlayer    map[core.PlayerID]struct{} `json:"per_player"`
+	Observations map[core.PlayerID]KnownHex `json:"observations,omitempty"`
 }
 
 // MarshalJSON exposes encID and seq under stable JSON field names without
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *EntityAppearedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(entityAppearedWire{
-		metaWire:  e.toWire(),
-		EncID:     e.encID,
-		Seq:       e.seq,
-		Entity:    e.Entity,
-		Position:  e.Position,
-		PerPlayer: e.PerPlayer,
+		metaWire:     e.toWire(),
+		EncID:        e.encID,
+		Seq:          e.seq,
+		Entity:       e.Entity,
+		Position:     e.Position,
+		PerPlayer:    e.PerPlayer,
+		Observations: e.Observations,
 	})
 }
 
@@ -95,5 +105,6 @@ func (e *EntityAppearedEvent) UnmarshalJSON(b []byte) error {
 	e.Entity = w.Entity
 	e.Position = w.Position
 	e.PerPlayer = w.PerPlayer
+	e.Observations = w.Observations
 	return nil
 }

--- a/encounter/events/entity_disappeared.go
+++ b/encounter/events/entity_disappeared.go
@@ -21,6 +21,8 @@ type EntityDisappearedEvent struct {
 	seq       uint64
 	Entity    core.EntityID
 	PerPlayer map[core.PlayerID]core.Hex
+	// Observations snapshots each viewer's last authorized hex fact at publish.
+	Observations map[core.PlayerID]KnownHex `json:"observations,omitempty"`
 }
 
 // NewEntityDisappearedEvent constructs an EntityDisappearedEvent. The encounter
@@ -30,12 +32,18 @@ func NewEntityDisappearedEvent(
 	seq uint64,
 	entity core.EntityID,
 	perPlayer map[core.PlayerID]core.Hex,
+	observations ...map[core.PlayerID]KnownHex,
 ) *EntityDisappearedEvent {
+	var observed map[core.PlayerID]KnownHex
+	if len(observations) > 0 {
+		observed = observations[0]
+	}
 	return &EntityDisappearedEvent{
-		encID:     encID,
-		seq:       seq,
-		Entity:    entity,
-		PerPlayer: perPlayer,
+		encID:        encID,
+		seq:          seq,
+		Entity:       entity,
+		PerPlayer:    perPlayer,
+		Observations: observed,
 	}
 }
 
@@ -54,21 +62,23 @@ func (e *EntityDisappearedEvent) Audience() AudienceSet { return audienceFromMap
 // entityDisappearedWire is the on-wire shape — used only by MarshalJSON / UnmarshalJSON.
 type entityDisappearedWire struct {
 	metaWire
-	EncID     core.EncounterID           `json:"encounter_id"`
-	Seq       uint64                     `json:"sequence"`
-	Entity    core.EntityID              `json:"entity"`
-	PerPlayer map[core.PlayerID]core.Hex `json:"per_player"`
+	EncID        core.EncounterID           `json:"encounter_id"`
+	Seq          uint64                     `json:"sequence"`
+	Entity       core.EntityID              `json:"entity"`
+	PerPlayer    map[core.PlayerID]core.Hex `json:"per_player"`
+	Observations map[core.PlayerID]KnownHex `json:"observations,omitempty"`
 }
 
 // MarshalJSON exposes encID and seq under stable JSON field names without
 // making the Go fields exported. Implements encoding/json.Marshaler.
 func (e *EntityDisappearedEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(entityDisappearedWire{
-		metaWire:  e.toWire(),
-		EncID:     e.encID,
-		Seq:       e.seq,
-		Entity:    e.Entity,
-		PerPlayer: e.PerPlayer,
+		metaWire:     e.toWire(),
+		EncID:        e.encID,
+		Seq:          e.seq,
+		Entity:       e.Entity,
+		PerPlayer:    e.PerPlayer,
+		Observations: e.Observations,
 	})
 }
 
@@ -84,5 +94,6 @@ func (e *EntityDisappearedEvent) UnmarshalJSON(b []byte) error {
 	e.seq = w.Seq
 	e.Entity = w.Entity
 	e.PerPlayer = w.PerPlayer
+	e.Observations = w.Observations
 	return nil
 }

--- a/encounter/events/hex_revealed.go
+++ b/encounter/events/hex_revealed.go
@@ -20,15 +20,17 @@ type HexRevealedEvent struct {
 	PerPlayer map[core.PlayerID]HexRevealedSlice
 }
 
-// HexRevealedSlice is each viewer's projection — newly visible hexes
-// and (in future slices) entities for that player.
+// HexRevealedSlice is each viewer's projection — newly visible hexes and
+// their complete, provider-observed facts. Observations is computed from the
+// viewer's memory immediately after the reveal is refreshed and before this
+// event publishes; consumers map it directly and never re-read world state.
 //
-// Slice 1 emits Hexes only; Entities is reserved for shape stability so
-// future slices can add entity-visibility accumulation without a JSON
-// migration.
+// Hexes remains for compatibility. Observations is sorted by position and has
+// one entry for each reveal coordinate that belongs to the encounter space.
 type HexRevealedSlice struct {
-	Hexes    core.HexSet        `json:"hexes"`
-	Entities []EntityVisibility `json:"entities,omitempty"`
+	Hexes        core.HexSet        `json:"hexes"`
+	Observations []KnownHex         `json:"observations,omitempty"`
+	Entities     []EntityVisibility `json:"entities,omitempty"`
 }
 
 // EntityVisibility names an entity that has become visible to a player.

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -112,6 +112,65 @@ func knownHexesToEvents(known map[core.Hex]perception.HexObservation) []events.K
 	return out
 }
 
+// observedHexesFor returns immutable-at-publish event facts for exactly hexes.
+// It reads the viewer's already-refreshed memory rather than global SpaceData,
+// preserving the same fog authorization and remembered ZoneID that KnownHexes
+// exposes. The result is position-sorted by knownHexesToEvents.
+func (e *Encounter) observedHexesFor(playerID core.PlayerID, hexes core.HexSet) []events.KnownHex {
+	known := e.KnownHexes(playerID)
+	selected := make(map[core.Hex]perception.HexObservation, len(hexes))
+	for hex := range hexes {
+		if observation, ok := known[hex]; ok {
+			selected[hex] = observation
+		}
+	}
+	return knownHexesToEvents(selected)
+}
+
+// observedHexFor returns one viewer's event-time fact for hex.
+func (e *Encounter) observedHexFor(playerID core.PlayerID, hex core.Hex) (events.KnownHex, bool) {
+	observations := e.observedHexesFor(playerID, core.NewHexSet(hex))
+	if len(observations) == 0 {
+		return events.KnownHex{}, false
+	}
+	return observations[0], true
+}
+
+// attachRevealObservations snapshots each reveal's authorized facts after every
+// caller refresh is complete and before broker publication.
+func (e *Encounter) attachRevealObservations(reveals map[core.PlayerID]events.HexRevealedSlice) {
+	for playerID, reveal := range reveals {
+		reveal.Observations = e.observedHexesFor(playerID, reveal.Hexes)
+		reveals[playerID] = reveal
+	}
+}
+
+// eventObservationsForPositions snapshots one fact per viewer at a shared
+// entity-event position. Missing observations are omitted rather than inferred.
+func (e *Encounter) eventObservationsForPositions(
+	positions map[core.PlayerID]core.Hex,
+) map[core.PlayerID]events.KnownHex {
+	out := make(map[core.PlayerID]events.KnownHex, len(positions))
+	for playerID, position := range positions {
+		if observation, ok := e.observedHexFor(playerID, position); ok {
+			out[playerID] = observation
+		}
+	}
+	return out
+}
+
+// eventObservationsForAudience snapshots one shared position for every entity
+// event recipient.
+func (e *Encounter) eventObservationsForAudience(
+	position core.Hex, audience map[core.PlayerID]struct{},
+) map[core.PlayerID]events.KnownHex {
+	positions := make(map[core.PlayerID]core.Hex, len(audience))
+	for playerID := range audience {
+		positions[playerID] = position
+	}
+	return e.eventObservationsForPositions(positions)
+}
+
 // refreshObservations writes a fresh, current-world-truth HexObservation
 // into view.Memory for every hex in hexes — the one place this package
 // tells a viewer's memory "this is what you now, authoritatively, see".

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -87,7 +87,7 @@ func knownHexesToEvents(known map[core.Hex]perception.HexObservation) []events.K
 		for _, c := range o.Contents {
 			contents = append(contents, events.KnownHexPlacement{
 				EntityID: c.EntityID,
-				Facing:   c.Facing,
+				Facing:   cloneFacing(c.Facing),
 			})
 		}
 		out = append(out, events.KnownHex{
@@ -169,6 +169,33 @@ func (e *Encounter) eventObservationsForAudience(
 		positions[playerID] = position
 	}
 	return e.eventObservationsForPositions(positions)
+}
+
+// eventObservationsForAppearance snapshots a transition-time appearance. The
+// mover's persisted position may already be its final destination when a
+// pass-through appearance is published for an intermediate hex, so canonical
+// current-memory facts need a single event-time placement overlay here.
+func (e *Encounter) eventObservationsForAppearance(
+	position core.Hex, audience map[core.PlayerID]struct{}, entityID core.EntityID,
+) map[core.PlayerID]events.KnownHex {
+	out := e.eventObservationsForAudience(position, audience)
+	for playerID, observation := range out {
+		found := false
+		for _, content := range observation.Contents {
+			if content.EntityID == entityID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			observation.Contents = append(observation.Contents, events.KnownHexPlacement{EntityID: entityID})
+			sort.Slice(observation.Contents, func(i, j int) bool {
+				return observation.Contents[i].EntityID < observation.Contents[j].EntityID
+			})
+			out[playerID] = observation
+		}
+	}
+	return out
 }
 
 // refreshObservations writes a fresh, current-world-truth HexObservation
@@ -297,6 +324,14 @@ func (e *Encounter) isSpaceHex(h core.Hex) bool {
 // Player and monster placements carry no facing override. Static obstacles
 // retain their persisted optional facing, so visible and remembered placement
 // observations keep explicit E = 0 distinct from absence.
+func cloneFacing(value *uint32) *uint32 {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
 func (e *Encounter) placementsAt(h core.Hex) []perception.Placement {
 	var out []perception.Placement
 	for _, p := range e.data.Players {
@@ -312,7 +347,7 @@ func (e *Encounter) placementsAt(h core.Hex) []perception.Placement {
 	if e.data.Space != nil {
 		for _, o := range e.data.Space.Obstacles {
 			if o.Position == h {
-				out = append(out, perception.Placement{EntityID: o.ID, Facing: o.Facing})
+				out = append(out, perception.Placement{EntityID: o.ID, Facing: cloneFacing(o.Facing)})
 			}
 		}
 	}

--- a/encounter/live_knowledge_event_test.go
+++ b/encounter/live_knowledge_event_test.go
@@ -1,0 +1,64 @@
+package encounter
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	liveKnowledgeAliceID = "alice"
+	liveKnowledgeBobID   = "bob"
+)
+
+func TestHexRevealedEventSnapshotsViewerObservations(t *testing.T) {
+	innerHex := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	rootHex := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
+	inner := ArchetypeChamber
+	alice := perception.NewView(liveKnowledgeAliceID, innerHex, 0)
+	alice.Observe(perception.HexObservation{
+		Position: innerHex, State: perception.KnowledgeStateVisible, ZoneID: "inner",
+	})
+	alice.Observe(perception.HexObservation{Position: rootHex, State: perception.KnowledgeStateVisible})
+	bob := perception.NewView(liveKnowledgeBobID, rootHex, 0)
+	bob.Observe(perception.HexObservation{Position: rootHex, State: perception.KnowledgeStateVisible})
+	e := &Encounter{data: &Data{
+		Players: map[core.PlayerID]*PlayerData{
+			liveKnowledgeAliceID: {ID: liveKnowledgeAliceID, View: alice},
+			liveKnowledgeBobID:   {ID: liveKnowledgeBobID, View: bob},
+		},
+		Space: &SpaceData{SemanticRegions: []SemanticRegionData{{
+			ID: "inner", Archetype: &inner, Cells: core.HexSet{innerHex: {}},
+		}}},
+	}}
+	reveals := map[core.PlayerID]events.HexRevealedSlice{
+		liveKnowledgeAliceID: {Hexes: core.NewHexSet(innerHex, rootHex)},
+		liveKnowledgeBobID:   {Hexes: core.NewHexSet(rootHex)},
+	}
+
+	e.attachRevealObservations(reveals)
+	event := events.NewHexRevealedEvent("enc", 1, reveals)
+	aliceFacts := knownHexesByPosition(event.PerPlayer[liveKnowledgeAliceID].Observations)
+	bobFacts := knownHexesByPosition(event.PerPlayer[liveKnowledgeBobID].Observations)
+	require.Equal(t, "inner", aliceFacts[innerHex].ZoneID)
+	require.Empty(t, aliceFacts[rootHex].ZoneID)
+	require.Empty(t, bobFacts[rootHex].ZoneID)
+	require.NotContains(t, bobFacts, innerHex, "each viewer receives only their own observations")
+
+	// The event payload is detached from later memory/space changes.
+	alice.Memory[innerHex] = perception.HexObservation{Position: innerHex, ZoneID: "changed"}
+	e.data.Space.SemanticRegions = nil
+	require.Equal(t, "inner", aliceFacts[innerHex].ZoneID)
+}
+
+func knownHexesByPosition(observations []events.KnownHex) map[core.Hex]events.KnownHex {
+	out := make(map[core.Hex]events.KnownHex, len(observations))
+	for _, observation := range observations {
+		out[observation.Position] = observation
+	}
+	return out
+}

--- a/encounter/live_knowledge_event_test.go
+++ b/encounter/live_knowledge_event_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	liveKnowledgeAliceID = "alice"
-	liveKnowledgeBobID   = "bob"
+	liveKnowledgeAliceID       = "alice"
+	liveKnowledgeBobID         = "bob"
+	liveKnowledgeAliceEntityID = "alice-entity"
 )
 
 func TestHexRevealedEventSnapshotsViewerObservations(t *testing.T) {
@@ -83,7 +84,7 @@ func TestMovePassThroughAppearanceSnapshotsTransitionPlacement(t *testing.T) {
 	appearedAt := core.Hex{Q: 2, R: 0, S: -2}
 	end := core.Hex{Q: 4, R: 0, S: -4}
 	require.NoError(t, e.AddPlayer(PlayerInput{
-		PlayerID: liveKnowledgeAliceID, EntityID: "alice-entity", Position: start, SightRange: 0,
+		PlayerID: liveKnowledgeAliceID, EntityID: liveKnowledgeAliceEntityID, Position: start, SightRange: 0,
 	}))
 	require.NoError(t, e.AddPlayer(PlayerInput{
 		PlayerID: liveKnowledgeBobID, EntityID: "bob-entity", Position: appearedAt, SightRange: 0,
@@ -103,11 +104,11 @@ func TestMovePassThroughAppearanceSnapshotsTransitionPlacement(t *testing.T) {
 		case event := <-subscription.Events():
 			switch typed := event.(type) {
 			case *events.EntityAppearedEvent:
-				if typed.Entity == "alice-entity" {
+				if typed.Entity == liveKnowledgeAliceEntityID {
 					appeared = typed
 				}
 			case *events.EntityDisappearedEvent:
-				if typed.Entity == "alice-entity" {
+				if typed.Entity == liveKnowledgeAliceEntityID {
 					disappeared = typed
 				}
 			}
@@ -118,10 +119,10 @@ func TestMovePassThroughAppearanceSnapshotsTransitionPlacement(t *testing.T) {
 	appearance := appeared.Observations[liveKnowledgeBobID]
 	require.Equal(t, appearedAt, appearance.Position)
 	require.Empty(t, appearance.ZoneID)
-	require.Contains(t, knownHexEntityIDs(appearance), core.EntityID("alice-entity"))
+	require.Contains(t, knownHexEntityIDs(appearance), core.EntityID(liveKnowledgeAliceEntityID))
 	disappearance := disappeared.Observations[liveKnowledgeBobID]
 	require.Equal(t, appearedAt, disappearance.Position)
-	require.NotContains(t, knownHexEntityIDs(disappearance), core.EntityID("alice-entity"),
+	require.NotContains(t, knownHexEntityIDs(disappearance), core.EntityID(liveKnowledgeAliceEntityID),
 		"disappearance observations represent post-disappearance memory")
 }
 

--- a/encounter/live_knowledge_event_test.go
+++ b/encounter/live_knowledge_event_test.go
@@ -1,7 +1,9 @@
 package encounter
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
@@ -19,9 +21,12 @@ func TestHexRevealedEventSnapshotsViewerObservations(t *testing.T) {
 	innerHex := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
 	rootHex := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
 	inner := ArchetypeChamber
+	facing := uint32(1)
 	alice := perception.NewView(liveKnowledgeAliceID, innerHex, 0)
 	alice.Observe(perception.HexObservation{
 		Position: innerHex, State: perception.KnowledgeStateVisible, ZoneID: "inner",
+		Edges:    []perception.Edge{{From: innerHex, To: rootHex, BlocksMovement: true}},
+		Contents: []perception.Placement{{EntityID: "prop", Facing: &facing}},
 	})
 	alice.Observe(perception.HexObservation{Position: rootHex, State: perception.KnowledgeStateVisible})
 	bob := perception.NewView(liveKnowledgeBobID, rootHex, 0)
@@ -42,9 +47,19 @@ func TestHexRevealedEventSnapshotsViewerObservations(t *testing.T) {
 
 	e.attachRevealObservations(reveals)
 	event := events.NewHexRevealedEvent("enc", 1, reveals)
+	audience := map[core.PlayerID]struct{}{liveKnowledgeAliceID: {}}
+	appeared := events.NewEntityAppearedEvent(
+		"enc", 2, "prop", innerHex, audience, e.eventObservationsForAudience(innerHex, audience),
+	)
+	disappeared := events.NewEntityDisappearedEvent(
+		"enc", 3, "prop", map[core.PlayerID]core.Hex{liveKnowledgeAliceID: innerHex},
+		e.eventObservationsForPositions(map[core.PlayerID]core.Hex{liveKnowledgeAliceID: innerHex}),
+	)
 	aliceFacts := knownHexesByPosition(event.PerPlayer[liveKnowledgeAliceID].Observations)
 	bobFacts := knownHexesByPosition(event.PerPlayer[liveKnowledgeBobID].Observations)
 	require.Equal(t, "inner", aliceFacts[innerHex].ZoneID)
+	require.Len(t, aliceFacts[innerHex].Edges, 1)
+	require.True(t, aliceFacts[innerHex].Edges[0].BlocksMovement)
 	require.Empty(t, aliceFacts[rootHex].ZoneID)
 	require.Empty(t, bobFacts[rootHex].ZoneID)
 	require.NotContains(t, bobFacts, innerHex, "each viewer receives only their own observations")
@@ -52,7 +67,70 @@ func TestHexRevealedEventSnapshotsViewerObservations(t *testing.T) {
 	// The event payload is detached from later memory/space changes.
 	alice.Memory[innerHex] = perception.HexObservation{Position: innerHex, ZoneID: "changed"}
 	e.data.Space.SemanticRegions = nil
+	facing = 5
 	require.Equal(t, "inner", aliceFacts[innerHex].ZoneID)
+	require.Equal(t, uint32(1), *aliceFacts[innerHex].Contents[0].Facing)
+	require.Equal(t, uint32(1), *appeared.Observations[liveKnowledgeAliceID].Contents[0].Facing)
+	require.Equal(t, uint32(1), *disappeared.Observations[liveKnowledgeAliceID].Contents[0].Facing)
+}
+
+func TestMovePassThroughAppearanceSnapshotsTransitionPlacement(t *testing.T) {
+	transport := NewInMemoryTransport()
+	broker := NewBroker(transport)
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+	e := New(context.Background(), "pass-through", broker)
+	start := core.Hex{Q: 0, R: 0, S: 0}
+	appearedAt := core.Hex{Q: 2, R: 0, S: -2}
+	end := core.Hex{Q: 4, R: 0, S: -4}
+	require.NoError(t, e.AddPlayer(PlayerInput{
+		PlayerID: liveKnowledgeAliceID, EntityID: "alice-entity", Position: start, SightRange: 0,
+	}))
+	require.NoError(t, e.AddPlayer(PlayerInput{
+		PlayerID: liveKnowledgeBobID, EntityID: "bob-entity", Position: appearedAt, SightRange: 0,
+	}))
+	subscription, err := broker.Subscribe("pass-through", liveKnowledgeBobID)
+	require.NoError(t, err)
+	defer func() { _ = subscription.Close() }()
+
+	require.NoError(t, e.Move(liveKnowledgeAliceID, []core.Hex{
+		{Q: 1, R: 0, S: -1}, appearedAt, {Q: 3, R: 0, S: -3}, end,
+	}))
+	var appeared *events.EntityAppearedEvent
+	var disappeared *events.EntityDisappearedEvent
+	deadline := time.After(time.Second)
+	for appeared == nil || disappeared == nil {
+		select {
+		case event := <-subscription.Events():
+			switch typed := event.(type) {
+			case *events.EntityAppearedEvent:
+				if typed.Entity == "alice-entity" {
+					appeared = typed
+				}
+			case *events.EntityDisappearedEvent:
+				if typed.Entity == "alice-entity" {
+					disappeared = typed
+				}
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for pass-through transition events")
+		}
+	}
+	appearance := appeared.Observations[liveKnowledgeBobID]
+	require.Equal(t, appearedAt, appearance.Position)
+	require.Empty(t, appearance.ZoneID)
+	require.Contains(t, knownHexEntityIDs(appearance), core.EntityID("alice-entity"))
+	disappearance := disappeared.Observations[liveKnowledgeBobID]
+	require.Equal(t, appearedAt, disappearance.Position)
+	require.NotContains(t, knownHexEntityIDs(disappearance), core.EntityID("alice-entity"),
+		"disappearance observations represent post-disappearance memory")
+}
+
+func knownHexEntityIDs(observation events.KnownHex) []core.EntityID {
+	ids := make([]core.EntityID, 0, len(observation.Contents))
+	for _, content := range observation.Contents {
+		ids = append(ids, content.EntityID)
+	}
+	return ids
 }
 
 func knownHexesByPosition(observations []events.KnownHex) map[core.Hex]events.KnownHex {

--- a/encounter/semantic_regions.go
+++ b/encounter/semantic_regions.go
@@ -1,0 +1,249 @@
+package encounter
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// SemanticRegionParams is authored semantic scope input for a canvas dungeon.
+// It does not affect structural geometry, edges, content, or traversal.
+type SemanticRegionParams struct {
+	ID        string
+	Name      *string
+	Archetype *RegionArchetype
+	Cells     []core.Hex
+}
+
+// SemanticRegionData is the durable authored fact set for one semantic scope.
+// Parent and innermost lookup are intentionally derived, never serialized.
+type SemanticRegionData struct {
+	ID        string           `json:"id"`
+	Name      *string          `json:"name,omitempty"`
+	Archetype *RegionArchetype `json:"archetype,omitempty"`
+	Cells     core.HexSet      `json:"cells"`
+}
+
+// Zone is fog-authorized metadata for a semantic scope. It deliberately has no
+// cells or membership index; callers receive only disclosed zones and ancestors.
+type Zone struct {
+	ID        string
+	Name      *string
+	Archetype *RegionArchetype
+	ParentID  *string
+}
+
+// SemanticRegionAt returns the deterministic innermost declared scope at h.
+// Root/unpainted cells return an empty ID and false.
+func (sd *SpaceData) SemanticRegionAt(h core.Hex) (string, bool) {
+	if sd == nil {
+		return "", false
+	}
+	regions := sd.semanticRegions()
+	owner := -1
+	for i := range regions {
+		if !regions[i].Cells.Has(h) {
+			continue
+		}
+		if owner == -1 || len(regions[i].Cells) < len(regions[owner].Cells) ||
+			(len(regions[i].Cells) == len(regions[owner].Cells) && regions[i].ID < regions[owner].ID) {
+			owner = i
+		}
+	}
+	if owner == -1 {
+		return "", false
+	}
+	return regions[owner].ID, true
+}
+
+// SemanticRegionParent returns the smallest strict-superset parent. Empty
+// scopes intentionally have root as parent.
+func (sd *SpaceData) SemanticRegionParent(id string) (string, bool) {
+	regions := sd.semanticRegions()
+	index := semanticRegionIndex(regions, id)
+	if index < 0 || len(regions[index].Cells) == 0 {
+		return "", false
+	}
+	parent := -1
+	for i := range regions {
+		if i == index || len(regions[i].Cells) <= len(regions[index].Cells) ||
+			!hexSetContains(regions[i].Cells, regions[index].Cells) {
+			continue
+		}
+		if parent == -1 || len(regions[i].Cells) < len(regions[parent].Cells) ||
+			(len(regions[i].Cells) == len(regions[parent].Cells) && regions[i].ID < regions[parent].ID) {
+			parent = i
+		}
+	}
+	if parent < 0 {
+		return "", false
+	}
+	return regions[parent].ID, true
+}
+
+// ZoneAt resolves a cell's innermost scope metadata, inheriting archetype
+// innermost-to-root. Root cells return an empty Zone.
+func (sd *SpaceData) ZoneAt(h core.Hex) Zone {
+	id, ok := sd.SemanticRegionAt(h)
+	if !ok {
+		return Zone{}
+	}
+	return sd.zoneByID(id)
+}
+
+// AuthorizedZones returns only scopes referenced by disclosed observations and
+// their ancestors, in deterministic ID order.
+func (e *Encounter) AuthorizedZones(playerID core.PlayerID) []Zone {
+	if e == nil || e.data == nil || e.data.Space == nil {
+		return nil
+	}
+	known := e.KnownHexes(playerID)
+	needed := make(map[string]struct{})
+	for h := range known {
+		if id, ok := e.data.Space.SemanticRegionAt(h); ok {
+			for id != "" {
+				needed[id] = struct{}{}
+				parent, hasParent := e.data.Space.SemanticRegionParent(id)
+				if !hasParent {
+					break
+				}
+				id = parent
+			}
+		}
+	}
+	out := make([]Zone, 0, len(needed))
+	for id := range needed {
+		out = append(out, e.data.Space.zoneByID(id))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func (sd *SpaceData) zoneByID(id string) Zone {
+	regions := sd.semanticRegions()
+	index := semanticRegionIndex(regions, id)
+	if index < 0 {
+		return Zone{}
+	}
+	region := regions[index]
+	zone := Zone{ID: region.ID, Name: cloneString(region.Name)}
+	if region.Archetype != nil {
+		value := *region.Archetype
+		zone.Archetype = &value
+	}
+	if parent, ok := sd.SemanticRegionParent(id); ok {
+		zone.ParentID = &parent
+	}
+	for current := index; current >= 0 && zone.Archetype == nil; {
+		parent, ok := sd.SemanticRegionParent(regions[current].ID)
+		if !ok {
+			break
+		}
+		current = semanticRegionIndex(regions, parent)
+		if current >= 0 && regions[current].Archetype != nil {
+			value := *regions[current].Archetype
+			zone.Archetype = &value
+		}
+	}
+	return zone
+}
+
+func (sd *SpaceData) semanticRegions() []SemanticRegionData {
+	if sd == nil {
+		return nil
+	}
+	return sd.SemanticRegions
+}
+
+func semanticRegionIndex(regions []SemanticRegionData, id string) int {
+	for i := range regions {
+		if regions[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func hexSetContains(outer, inner core.HexSet) bool {
+	for h := range inner {
+		if !outer.Has(h) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func validateSemanticRegionParams(
+	regions []SemanticRegionParams, floor map[core.Hex]struct{},
+) ([]SemanticRegionData, error) {
+	out := make([]SemanticRegionData, len(regions))
+	seen := make(map[string]int, len(regions))
+	for i, region := range regions {
+		if region.ID == "" {
+			return nil, fmt.Errorf("semantic region %d: id required", i)
+		}
+		if first, exists := seen[region.ID]; exists {
+			return nil, fmt.Errorf("semantic region %d (%q): duplicate id (already used by %d)", i, region.ID, first)
+		}
+		seen[region.ID] = i
+		if region.Archetype != nil {
+			switch *region.Archetype {
+			case ArchetypeEntrance, ArchetypeChamber, ArchetypeCorridor, ArchetypeBoss:
+			default:
+				return nil, fmt.Errorf("semantic region %q: unsupported archetype %q", region.ID, *region.Archetype)
+			}
+		}
+		cells := make(core.HexSet, len(region.Cells))
+		for _, h := range region.Cells {
+			if _, ok := floor[h]; !ok {
+				return nil, fmt.Errorf("semantic region %q cell %v is outside structural floor", region.ID, h)
+			}
+			cells[h] = struct{}{}
+		}
+		out[i] = SemanticRegionData{ID: region.ID, Name: cloneString(region.Name), Archetype: region.Archetype, Cells: cells}
+	}
+	for i := range out {
+		for j := i + 1; j < len(out); j++ {
+			if len(out[i].Cells) == 0 || len(out[j].Cells) == 0 {
+				continue
+			}
+			intersects := false
+			for h := range out[i].Cells {
+				if out[j].Cells.Has(h) {
+					intersects = true
+					break
+				}
+			}
+			if !intersects {
+				continue
+			}
+			leftInside := len(out[i].Cells) < len(out[j].Cells) && hexSetContains(out[j].Cells, out[i].Cells)
+			rightInside := len(out[j].Cells) < len(out[i].Cells) && hexSetContains(out[i].Cells, out[j].Cells)
+			if !leftInside && !rightInside {
+				return nil, fmt.Errorf("semantic regions %q and %q have equal or partial overlap", out[i].ID, out[j].ID)
+			}
+		}
+	}
+	return out, nil
+}
+
+func validateSemanticRegionData(regions []SemanticRegionData, floor map[core.Hex]struct{}) error {
+	params := make([]SemanticRegionParams, len(regions))
+	for i, region := range regions {
+		params[i] = SemanticRegionParams{ID: region.ID, Name: region.Name, Archetype: region.Archetype}
+		for h := range region.Cells {
+			params[i].Cells = append(params[i].Cells, h)
+		}
+	}
+	_, err := validateSemanticRegionParams(params, floor)
+	return err
+}

--- a/encounter/semantic_regions.go
+++ b/encounter/semantic_regions.go
@@ -89,42 +89,56 @@ func (sd *SpaceData) ZoneAt(h core.Hex) Zone {
 	if !ok {
 		return Zone{}
 	}
-	return sd.zoneByID(id)
+	zone, _ := sd.zoneByID(id)
+	return zone
 }
 
-// AuthorizedZones returns only scopes referenced by disclosed observations and
-// their ancestors, in deterministic ID order.
+// AuthorizedZones returns only scopes named by this viewer's persisted known
+// observations and their ancestors, in deterministic ID order. It never
+// re-resolves observation coordinates against current membership: an empty
+// observed ZoneID remains root, even if that coordinate is painted later.
+//
+// LoadFromData validates that every non-empty observed ID resolves in this
+// immutable SpaceData snapshot. The current API returns no error, so a
+// hand-built invalid in-memory aggregate still omits an unresolvable ID safely
+// rather than guessing from coordinates.
 func (e *Encounter) AuthorizedZones(playerID core.PlayerID) []Zone {
 	if e == nil || e.data == nil || e.data.Space == nil {
 		return nil
 	}
+	regions := e.data.Space.semanticRegions()
 	known := e.KnownHexes(playerID)
 	needed := make(map[string]struct{})
-	for h := range known {
-		if id, ok := e.data.Space.SemanticRegionAt(h); ok {
-			for id != "" {
-				needed[id] = struct{}{}
-				parent, hasParent := e.data.Space.SemanticRegionParent(id)
-				if !hasParent {
-					break
-				}
-				id = parent
+	for _, observation := range known {
+		id := observation.ZoneID
+		if id == "" || semanticRegionIndex(regions, id) < 0 {
+			continue
+		}
+		for id != "" {
+			needed[id] = struct{}{}
+			parent, hasParent := e.data.Space.SemanticRegionParent(id)
+			if !hasParent {
+				break
 			}
+			id = parent
 		}
 	}
 	out := make([]Zone, 0, len(needed))
 	for id := range needed {
-		out = append(out, e.data.Space.zoneByID(id))
+		zone, ok := e.data.Space.zoneByID(id)
+		if ok {
+			out = append(out, zone)
+		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
 }
 
-func (sd *SpaceData) zoneByID(id string) Zone {
+func (sd *SpaceData) zoneByID(id string) (Zone, bool) {
 	regions := sd.semanticRegions()
 	index := semanticRegionIndex(regions, id)
 	if index < 0 {
-		return Zone{}
+		return Zone{}, false
 	}
 	region := regions[index]
 	zone := Zone{ID: region.ID, Name: cloneString(region.Name)}
@@ -146,7 +160,7 @@ func (sd *SpaceData) zoneByID(id string) Zone {
 			zone.Archetype = &value
 		}
 	}
-	return zone
+	return zone, true
 }
 
 func (sd *SpaceData) semanticRegions() []SemanticRegionData {
@@ -234,6 +248,30 @@ func validateSemanticRegionParams(
 		}
 	}
 	return out, nil
+}
+
+// validateObservedZoneIDs keeps persisted viewer memory and immutable canvas
+// scope facts in one snapshot-consistency domain. It intentionally applies only
+// to canvas semantic regions: legacy room-chain observations use RegionData IDs.
+func validateObservedZoneIDs(players map[core.PlayerID]*PlayerData, space *SpaceData) error {
+	regions := space.semanticRegions()
+	for playerID, player := range players {
+		if player == nil || player.View == nil {
+			continue
+		}
+		for hex, observation := range player.View.Memory {
+			if observation.ZoneID == "" {
+				continue
+			}
+			if semanticRegionIndex(regions, observation.ZoneID) < 0 {
+				return fmt.Errorf(
+					"player %q known hex %v references missing semantic zone %q",
+					playerID, hex, observation.ZoneID,
+				)
+			}
+		}
+	}
+	return nil
 }
 
 func validateSemanticRegionData(regions []SemanticRegionData, floor map[core.Hex]struct{}) error {

--- a/encounter/semantic_regions.go
+++ b/encounter/semantic_regions.go
@@ -196,6 +196,14 @@ func cloneString(value *string) *string {
 	return &clone
 }
 
+func cloneRegionArchetype(value *RegionArchetype) *RegionArchetype {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
 func validateSemanticRegionParams(
 	regions []SemanticRegionParams, floor map[core.Hex]struct{},
 ) ([]SemanticRegionData, error) {
@@ -223,7 +231,9 @@ func validateSemanticRegionParams(
 			}
 			cells[h] = struct{}{}
 		}
-		out[i] = SemanticRegionData{ID: region.ID, Name: cloneString(region.Name), Archetype: region.Archetype, Cells: cells}
+		out[i] = SemanticRegionData{
+			ID: region.ID, Name: cloneString(region.Name), Archetype: cloneRegionArchetype(region.Archetype), Cells: cells,
+		}
 	}
 	for i := range out {
 		for j := i + 1; j < len(out); j++ {

--- a/encounter/semantic_regions_test.go
+++ b/encounter/semantic_regions_test.go
@@ -1,0 +1,37 @@
+package encounter
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizedZonesDisclosesOnlyKnownScopeAncestors(t *testing.T) {
+	a := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	b := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
+	hidden := core.HexFromPosition(spatial.Position{X: 2, Y: 0})
+	chamber := ArchetypeChamber
+	view := perception.NewView("viewer", a, 0)
+	view.Observe(perception.HexObservation{Position: a, State: perception.KnowledgeStateVisible})
+	view.Observe(perception.HexObservation{Position: b, State: perception.KnowledgeStateRemembered})
+	enc := &Encounter{data: &Data{
+		Players: map[core.PlayerID]*PlayerData{"viewer": {ID: "viewer", View: view}},
+		Space: &SpaceData{SemanticRegions: []SemanticRegionData{
+			{ID: "outer", Archetype: &chamber, Cells: core.HexSet{a: {}, b: {}}},
+			{ID: "inner", Cells: core.HexSet{a: {}}},
+			{ID: "hidden", Cells: core.HexSet{hidden: {}}},
+		}},
+	}}
+
+	zones := enc.AuthorizedZones("viewer")
+	require.Equal(t, []string{"inner", "outer"}, []string{zones[0].ID, zones[1].ID})
+	require.Equal(t, "outer", *zones[0].ParentID)
+	require.Equal(t, chamber, *zones[0].Archetype, "inner inherits its property")
+	require.Nil(t, zones[1].ParentID)
+	for _, zone := range zones {
+		require.NotEqual(t, "hidden", zone.ID)
+	}
+}

--- a/encounter/semantic_regions_test.go
+++ b/encounter/semantic_regions_test.go
@@ -1,6 +1,8 @@
 package encounter
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
@@ -13,6 +15,39 @@ const (
 	semanticViewerID = "viewer"
 	semanticInnerID  = "inner"
 )
+
+func TestInitDungeonClonesSemanticArchetypeParam(t *testing.T) {
+	cell := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	archetype := ArchetypeChamber
+	enc := New(context.Background(), "clone-archetype", NewBroker(NewInMemoryTransport()))
+	require.NoError(t, enc.InitDungeon(DungeonParams{
+		FloorSource: FloorSourceCanvas, Width: 2, Height: 2,
+		PartyStart: PartyStartParams{SeatCount: 1},
+		SemanticRegions: []SemanticRegionParams{{
+			ID: "scope", Archetype: &archetype, Cells: []core.Hex{cell},
+		}},
+	}))
+	archetype = ArchetypeBoss
+
+	zone := enc.ToData().Space.ZoneAt(cell)
+	require.Equal(t, ArchetypeChamber, *zone.Archetype)
+	require.Equal(t, ArchetypeChamber, *enc.ToData().Space.SemanticRegions[0].Archetype)
+	payload, err := json.Marshal(enc.ToData())
+	require.NoError(t, err)
+	require.Contains(t, string(payload), `"archetype":"chamber"`)
+}
+
+func TestRegionAtLegacySpaceIgnoresSemanticRegions(t *testing.T) {
+	cell := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	space := &SpaceData{
+		FloorSource:     FloorSourceRoomChain,
+		Regions:         []RegionData{{ID: "legacy", Hexes: core.NewHexSet(cell)}},
+		SemanticRegions: []SemanticRegionData{{ID: "semantic", Cells: core.NewHexSet(cell)}},
+	}
+	id, ok := space.RegionAt(cell)
+	require.True(t, ok)
+	require.Equal(t, "legacy", id)
+}
 
 func TestAuthorizedZonesDisclosesOnlyKnownScopeAncestors(t *testing.T) {
 	a := core.HexFromPosition(spatial.Position{X: 0, Y: 0})

--- a/encounter/semantic_regions_test.go
+++ b/encounter/semantic_regions_test.go
@@ -9,29 +9,75 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	semanticViewerID = "viewer"
+	semanticInnerID  = "inner"
+)
+
 func TestAuthorizedZonesDisclosesOnlyKnownScopeAncestors(t *testing.T) {
 	a := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
 	b := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
 	hidden := core.HexFromPosition(spatial.Position{X: 2, Y: 0})
 	chamber := ArchetypeChamber
-	view := perception.NewView("viewer", a, 0)
-	view.Observe(perception.HexObservation{Position: a, State: perception.KnowledgeStateVisible})
-	view.Observe(perception.HexObservation{Position: b, State: perception.KnowledgeStateRemembered})
+	view := perception.NewView(semanticViewerID, a, 0)
+	view.Observe(perception.HexObservation{
+		Position: a, State: perception.KnowledgeStateVisible, ZoneID: semanticInnerID,
+	})
+	view.Observe(perception.HexObservation{
+		Position: b, State: perception.KnowledgeStateRemembered,
+	})
 	enc := &Encounter{data: &Data{
-		Players: map[core.PlayerID]*PlayerData{"viewer": {ID: "viewer", View: view}},
+		Players: map[core.PlayerID]*PlayerData{semanticViewerID: {ID: semanticViewerID, View: view}},
 		Space: &SpaceData{SemanticRegions: []SemanticRegionData{
 			{ID: "outer", Archetype: &chamber, Cells: core.HexSet{a: {}, b: {}}},
-			{ID: "inner", Cells: core.HexSet{a: {}}},
+			{ID: semanticInnerID, Cells: core.HexSet{a: {}}},
 			{ID: "hidden", Cells: core.HexSet{hidden: {}}},
 		}},
 	}}
 
-	zones := enc.AuthorizedZones("viewer")
-	require.Equal(t, []string{"inner", "outer"}, []string{zones[0].ID, zones[1].ID})
+	zones := enc.AuthorizedZones(semanticViewerID)
+	require.Equal(t, []string{semanticInnerID, "outer"}, []string{zones[0].ID, zones[1].ID})
 	require.Equal(t, "outer", *zones[0].ParentID)
 	require.Equal(t, chamber, *zones[0].Archetype, "inner inherits its property")
 	require.Nil(t, zones[1].ParentID)
 	for _, zone := range zones {
 		require.NotEqual(t, "hidden", zone.ID)
 	}
+}
+
+func TestAuthorizedZonesRemembersRootWithoutDisclosingLaterPaint(t *testing.T) {
+	painted := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	view := perception.NewView(semanticViewerID, painted, 0)
+	view.Observe(perception.HexObservation{
+		Position: painted, State: perception.KnowledgeStateRemembered,
+		// Empty ZoneID is the persisted observation that this was root.
+	})
+	enc := &Encounter{data: &Data{
+		Players: map[core.PlayerID]*PlayerData{semanticViewerID: {ID: semanticViewerID, View: view}},
+		Space: &SpaceData{SemanticRegions: []SemanticRegionData{{
+			ID: "painted-later", Cells: core.HexSet{painted: {}},
+		}}},
+	}}
+
+	require.Empty(t, enc.AuthorizedZones(semanticViewerID))
+}
+
+func TestLoadFromDataRejectsDanglingObservedZoneID(t *testing.T) {
+	known := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	view := perception.NewView(semanticViewerID, known, 0)
+	view.Observe(perception.HexObservation{
+		Position: known, State: perception.KnowledgeStateRemembered, ZoneID: "missing-zone",
+	})
+	data := &Data{
+		Players: map[core.PlayerID]*PlayerData{semanticViewerID: {ID: semanticViewerID, View: view}},
+		Space: &SpaceData{
+			FloorSource: FloorSourceCanvas,
+			Width:       1,
+			Height:      1,
+		},
+	}
+	broker := NewBroker(NewInMemoryTransport())
+
+	_, err := LoadFromData(t.Context(), data, broker)
+	require.ErrorContains(t, err, "references missing semantic zone \"missing-zone\"")
 }

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -156,7 +156,10 @@ func (e *Encounter) rebuildRoomFromData() error {
 			return fmt.Errorf("validate canvas dimensions: %w", err)
 		}
 		if len(sd.Regions) != 0 {
-			return fmt.Errorf("canvas space must not contain regions")
+			return fmt.Errorf("canvas space must not contain room-chain regions")
+		}
+		if err := validateSemanticRegionData(sd.SemanticRegions, canvasFloorHexes(sd.Width, sd.Height)); err != nil {
+			return fmt.Errorf("validate semantic regions: %w", err)
 		}
 	}
 	authoredByKey := authoredEdgesByKey(sd)

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -107,6 +107,25 @@ func snapshotWalls(room spatial.Room) []environments.WallSegmentData {
 	return walls
 }
 
+// validateCanvasSpace validates the durable canvas floor and semantic facts as
+// one snapshot. Viewer ZoneIDs are validated against the same immutable scope
+// set, never against a coordinate-derived replacement.
+func validateCanvasSpace(space *SpaceData, players map[core.PlayerID]*PlayerData) error {
+	if _, err := ValidateCanvasDimensions(space.Width, space.Height); err != nil {
+		return fmt.Errorf("validate canvas dimensions: %w", err)
+	}
+	if len(space.Regions) != 0 {
+		return fmt.Errorf("canvas space must not contain room-chain regions")
+	}
+	if err := validateSemanticRegionData(space.SemanticRegions, canvasFloorHexes(space.Width, space.Height)); err != nil {
+		return fmt.Errorf("validate semantic regions: %w", err)
+	}
+	if err := validateObservedZoneIDs(players, space); err != nil {
+		return fmt.Errorf("validate viewer zone observations: %w", err)
+	}
+	return nil
+}
+
 // registerRoom wires room into a fresh orchestrator for this Encounter
 // instance. Both are transient — reconstructed at New/LoadFromData exactly
 // like e.bus and e.combatants, never serialized.
@@ -152,14 +171,8 @@ func (e *Encounter) rebuildRoomFromData() error {
 		return fmt.Errorf("validate floor source: %w", err)
 	}
 	if source == FloorSourceCanvas {
-		if _, err := ValidateCanvasDimensions(sd.Width, sd.Height); err != nil {
-			return fmt.Errorf("validate canvas dimensions: %w", err)
-		}
-		if len(sd.Regions) != 0 {
-			return fmt.Errorf("canvas space must not contain room-chain regions")
-		}
-		if err := validateSemanticRegionData(sd.SemanticRegions, canvasFloorHexes(sd.Width, sd.Height)); err != nil {
-			return fmt.Errorf("validate semantic regions: %w", err)
+		if err := validateCanvasSpace(sd, e.data.Players); err != nil {
+			return err
 		}
 	}
 	authoredByKey := authoredEdgesByKey(sd)


### PR DESCRIPTION
## Summary
Implements Dungeon YAML v0.3 Wave 1 provider seam for #888.

Authority: rpg-project merge `3ee1efbc214d5e77ddcbe84dea6acc1cdae86f1a`; exact v0.3 spec SHA-256 `b6dd63abf3c989ad760042c5b9aeeda28ee65383de37e04999863ecccd198366`.

- Strict YAML `regions` source ingress for canvas mode with canonical same-region cell dedupe and bounded structural validation.
- Separate semantic region Params/Data from legacy room-chain Regions; authored facts only persist and containment/innermost/property inheritance recompute from cells.
- `BuildFloorPlan` projects declaration-ordered semantic regions, canonical cells, and derived parents without semantic edges.
- Knowledge observations use innermost zone IDs; `Encounter.AuthorizedZones(playerID)` exposes only known scopes plus ancestors, with no extent/global membership leak.

## Provider API for rpg-api#773
- `dungeonspec.Load` / `LoadWithPrevious`, then `dungeonspec.BuildFloorPlan` (`FloorPlan.Regions`).
- `Encounter.KnownHexes(playerID)` for per-hex `ZoneID`, and `Encounter.AuthorizedZones(playerID)` for fog-authorized `Zone` metadata.

## Tests
- `go test ./dungeonspec ./...` passes.
- `make pre-commit` was attempted; its existing core coverage parser fails while evaluating `core/mock` (unrelated to this change).
- `golangci-lint run ./...` reports existing repository goconst findings and existing gocyclo findings; no findings in new semantic files.

## Known learning gaps
- API mapper integration and wire-level production evidence remain rpg-api#773 work.
- This provider intentionally adds no region edit event, trigger, transition, role/content/spawn validation, or geometry behavior.

Expected release: `encounter/v0.50.0` if still next.

Refs #888