### PR TITLE
fix(ci): add safe manual recovery dispatches

### DIFF
--- a/.github/workflows/auto-tag-modules-safe.yml
+++ b/.github/workflows/auto-tag-modules-safe.yml
@@ -3,6 +3,8 @@ name: Auto Tag Modules (Safe)
 on:
   push:
     branches: [ main ]
+  # Dispatch from main to rerun the same idempotent tagging algorithm.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,9 +16,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # Tag the commit selected by the triggering event, with all tags available.
+        ref: ${{ github.sha }}
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
     
+    - name: Verify manual target
+      if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+      run: |
+        echo "Manual tag recovery must be dispatched from main; refusing ${GITHUB_REF}."
+        exit 1
+
     - name: Set up Git
       run: |
         git config user.name "github-actions[bot]"

--- a/.github/workflows/ci-optimized.yml
+++ b/.github/workflows/ci-optimized.yml
@@ -45,6 +45,14 @@ jobs:
           exit 0
         fi
         
+        # Manual recovery validates the selected main commit in full. Its
+        # parent diff may contain only workflow files, not the missed module.
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "should_run_all=true" >> $GITHUB_OUTPUT
+          echo "Running all checks for manual recovery"
+          exit 0
+        fi
+
         # Check if PR has "full-check" label
         if [[ "${{ contains(github.event.pull_request.labels.*.name, 'full-check') }}" == "true" ]]; then
           echo "should_run_all=true" >> $GITHUB_OUTPUT
@@ -52,15 +60,9 @@ jobs:
           exit 0
         fi
         
-        # Get list of changed files. A manual dispatch has no push before/after
-        # fields, so compare the selected main commit to its parent; use full CI
-        # if that parent is unavailable.
+        # Get list of changed files
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.go$' || true)
-        elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && ! git rev-parse --verify HEAD^ >/dev/null; then
-          echo "Selected main commit has no parent; running all checks"
-          echo "should_run_all=true" >> $GITHUB_OUTPUT
-          exit 0
         else
           CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep '\.go$' || true)
         fi

--- a/.github/workflows/ci-optimized.yml
+++ b/.github/workflows/ci-optimized.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Dispatch from main to check its selected commit without push-event fields.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -23,7 +25,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # Keep every job on the commit selected by the triggering event.
+        ref: ${{ github.sha }}
         fetch-depth: 0
+
+    - name: Verify manual target
+      if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+      run: |
+        echo "Manual CI recovery must be dispatched from main; refusing ${GITHUB_REF}."
+        exit 1
     
     - name: Detect changed modules
       id: detect
@@ -42,9 +52,15 @@ jobs:
           exit 0
         fi
         
-        # Get list of changed files
+        # Get list of changed files. A manual dispatch has no push before/after
+        # fields, so compare the selected main commit to its parent; use full CI
+        # if that parent is unavailable.
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.go$' || true)
+        elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && ! git rev-parse --verify HEAD^ >/dev/null; then
+          echo "Selected main commit has no parent; running all checks"
+          echo "should_run_all=true" >> $GITHUB_OUTPUT
+          exit 0
         else
           CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep '\.go$' || true)
         fi
@@ -95,6 +111,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.sha }}
     
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -153,6 +171,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.sha }}
     
     - name: Set up Go
       uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

Adds a minimal `workflow_dispatch` recovery path to the existing CI Optimized and Auto Tag Modules (Safe) workflows.

- Both recovery paths refuse a dispatch not selected from `main`.
- CI checks the exact event SHA. A manual recovery unconditionally runs all modules, rather than deriving scope from the immediate parent diff.
- Auto-tag checks the exact event SHA with full history/tags and otherwise retains the existing idempotent module-change, bump, and remote-tag checks unchanged.

## Exact missed-merge evidence

PR #889 merged to `main` as `3cee912cf87ce4dc319bdaeb86cdd2943b80fc36`. Issue #891 records that GitHub Actions dispatched zero runs for that SHA despite Actions being enabled, no skip marker, and `encounter/**` changes. At the issue's report time, `encounter/v0.50.0` did not exist and the latest tag was `encounter/v0.49.1`.

The focused review found the initial parent-diff approach insufficient: after #892 itself merges, its parent diff contains only workflow files, so changed-module CI would falsely succeed without testing #889. Commit `988f9ec` corrects only that finding by making `workflow_dispatch` set `should_run_all=true` before label/diff selection.

## Validation

- Full actionlint reports only the pre-existing `actions/cache@v3` age diagnostic in CI Optimized; the same diagnostic is excluded and the two changed workflows then pass actionlint.
- Both changed workflow files parse with PyYAML.
- Faithful local event simulation at the workflow-only `HEAD^..HEAD` case produced: `workflow_dispatch` => `should_run_all=true`; normal `push` to `refs/heads/main` => `should_run_all=true`; normal PR without Go files => `modules=[]`, `should_run_all=false`; PR with `full-check` => `should_run_all=true`.
- `make pre-commit` again ran core/events formatting, tidy, lint, and initial race tests successfully, then failed in its pre-existing core coverage parser on mock output (`76.5%` reported); no files changed.

## Recovery plan after merge

1. From Actions, run **CI Optimized** with branch `main` (no inputs).
2. After CI succeeds, run **Auto Tag Modules (Safe)** with branch `main` (no inputs).
3. Verify the workflow-created `encounter/v0.50.0` tag targets/contains `3cee912cf87ce4dc319bdaeb86cdd2943b80fc36` and that the Go proxy resolves it.

## Nonclaims

No workflow was dispatched, no tag or release was manually created, no product code or module version policy changed, and normal `push` triggers remain present and unchanged. The focused review's other pre-existing hardening suggestions (execution-time main rebinding, concurrency, cache upgrade, and permission refactor) were intentionally not included.

Closes #891

Signed: rpg-toolkit-member agent, on behalf of KirkDiggler