### PR TITLE
fix(encounter): prevent occupied movement endpoints

### DIFF
--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -469,6 +469,28 @@ resolver's chain-prevented truncation already works. A fully-blocked first
 hex is a no-op (nil error, no state change, no events), matching the
 resolver's own "prevented at first step" semantics.
 
+### Creature endpoint occupancy (#893)
+
+The room cannot enforce creature occupancy because player and monster positions
+remain authoritative on `Encounter.Data`, not inside `spatial.Room`.
+`truncateAtOccupiedDestination` therefore runs immediately after geometry
+truncation in both player and NPC movement. It removes occupied trailing
+waypoints until the path has a legal final hex; if no legal prefix exists, the
+move is a viewer-safe no-op. This happens before movement resolution, economy
+spending, mutation, or publication, so the committed position and `MoveEvent`
+path describe the same actual outcome.
+
+The check reads the complete player/monster maps, never a viewer's perception,
+and returns no occupant identity. Hidden creatures consequently block the same
+way visible creatures do without being disclosed. Intermediate occupied hexes
+remain in the path: #893 establishes final-space legality and deliberately does
+not invent a movement-through rule. Under ADR-0034's pending split, this belongs
+in the dnd5e-coupled encounter loop because that loop owns creature positions,
+endpoints, audiences, and event delivery; generic `tools/spatial` already owns
+occupancy for entities actually placed in a `Room` and cannot enforce facts it
+does not hold. No creature-sharing exception exists in the current encounter
+contract; any future exception must be explicit and tested at this seam.
+
 ### Inline combat-entry self-transition
 
 `checkCombatEntry` (combat.go) mirrors `checkEncounterEnd`'s self-transition

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -804,6 +804,7 @@ func (e *Encounter) Move(playerID core.PlayerID, path []core.Hex) error {
 	// boundary crossings cannot be bypassed by sparse requests or partially
 	// budgeted/chain-run. Nil room remains the pre-wave-1 unblocked behavior.
 	path = e.truncateAtWall(moverStart, path)
+	path = e.truncateAtOccupiedDestination(p.EntityID, path)
 	if len(path) == 0 {
 		// Blocked at the very first requested hex. Nothing to publish —
 		// position unchanged, no events fire, nothing spent. Mirrors the

--- a/encounter/integration_test.go
+++ b/encounter/integration_test.go
@@ -120,7 +120,9 @@ func (s *IntegrationSuite) TestSlice_RoundTripPersistence() {
 	s.Require().NoError(err)
 	defer func() { _ = aliceSub2.Close() }()
 
-	s.Require().NoError(enc2.Move("alice", []core.Hex{{Q: 2, R: 0, S: -2}}))
+	// Bob occupies {2,0,-2}; use the adjacent free hex so this remains a
+	// persistence/event-flow test rather than an illegal endpoint request.
+	s.Require().NoError(enc2.Move("alice", []core.Hex{{Q: 2, R: -1, S: -1}}))
 
 	aliceEvents := collectTypes(aliceSub2, 500*time.Millisecond)
 	s.Contains(aliceEvents, "*events.MoveEvent",

--- a/encounter/movement_occupancy_test.go
+++ b/encounter/movement_occupancy_test.go
@@ -30,7 +30,7 @@ func (s *MovementOccupancySuite) SetupTest() {
 	s.enc = encounter.New(context.Background(), "enc-movement-occupancy", s.broker)
 
 	var err error
-	s.aliceSub, err = s.broker.Subscribe("enc-movement-occupancy", "alice")
+	s.aliceSub, err = s.broker.Subscribe("enc-movement-occupancy", alicePlayerID)
 	s.Require().NoError(err)
 }
 
@@ -42,7 +42,7 @@ func (s *MovementOccupancySuite) TearDownTest() {
 
 func (s *MovementOccupancySuite) addPlayer(sightRange int) {
 	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: "alice", EntityID: "char-alice", Position: core.Hex{}, SightRange: sightRange,
+		PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: core.Hex{}, SightRange: sightRange,
 	}))
 }
 
@@ -95,10 +95,10 @@ func (s *MovementOccupancySuite) TestPlayerMove_HiddenOccupiedDestinationStopsWi
 	s.addMonster("hidden-goblin", hidden)
 	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
 
-	s.Require().NoError(s.enc.Move("alice", []core.Hex{safe, hidden}))
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{safe, hidden}))
 
 	data := s.enc.ToData()
-	s.Equal(safe, data.Players["alice"].View.Position)
+	s.Equal(safe, data.Players[alicePlayerID].View.Position)
 	s.Equal(hidden, data.Monsters["hidden-goblin"].Position)
 
 	emitted := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
@@ -106,7 +106,7 @@ func (s *MovementOccupancySuite) TestPlayerMove_HiddenOccupiedDestinationStopsWi
 	for _, event := range emitted {
 		switch event := event.(type) {
 		case *events.MoveEvent:
-			if event.Mover == "char-alice" {
+			if event.Mover == aliceEntityID {
 				move = event
 			}
 		case *events.EntityAppearedEvent:
@@ -119,7 +119,7 @@ func (s *MovementOccupancySuite) TestPlayerMove_HiddenOccupiedDestinationStopsWi
 	s.NotContains(move.PerPlayer, core.PlayerID("hidden-goblin"))
 	s.T().Logf("occupancy trace: mover=char-alice proposed=%v actual=%v final=%v "+
 		"occupant_visible_to_alice=false emitted_events=%d",
-		[]core.Hex{safe, hidden}, move.Path, data.Players["alice"].View.Position, len(emitted))
+		[]core.Hex{safe, hidden}, move.Path, data.Players[alicePlayerID].View.Position, len(emitted))
 }
 
 // TestPlayerMove_CanPassThroughOccupiedHex pins the requested scope: creature
@@ -131,10 +131,10 @@ func (s *MovementOccupancySuite) TestPlayerMove_CanPassThroughOccupiedHex() {
 	s.addMonster("goblin", occupied)
 	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
 
-	s.Require().NoError(s.enc.Move("alice", []core.Hex{occupied, destination}))
-	s.Equal(destination, s.enc.ToData().Players["alice"].View.Position)
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{occupied, destination}))
+	s.Equal(destination, s.enc.ToData().Players[alicePlayerID].View.Position)
 
-	move := s.moveEventFor("char-alice")
+	move := s.moveEventFor(aliceEntityID)
 	s.Require().NotNil(move)
 	s.Equal([]core.Hex{occupied, destination}, move.Path)
 }
@@ -147,7 +147,7 @@ func (s *MovementOccupancySuite) TestPlayerMove_OccupiedFirstDestinationIsViewer
 	s.addMonster("goblin", occupied)
 	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
 
-	s.Require().NoError(s.enc.Move("alice", []core.Hex{occupied}))
-	s.Equal(core.Hex{}, s.enc.ToData().Players["alice"].View.Position)
-	s.Nil(s.moveEventFor("char-alice"), "a refused move must not emit a MoveEvent")
+	s.Require().NoError(s.enc.Move(alicePlayerID, []core.Hex{occupied}))
+	s.Equal(core.Hex{}, s.enc.ToData().Players[alicePlayerID].View.Position)
+	s.Nil(s.moveEventFor(aliceEntityID), "a refused move must not emit a MoveEvent")
 }

--- a/encounter/movement_occupancy_test.go
+++ b/encounter/movement_occupancy_test.go
@@ -1,0 +1,153 @@
+package encounter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/events"
+)
+
+type MovementOccupancySuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	enc       *encounter.Encounter
+	aliceSub  *encounter.Subscription
+}
+
+func TestMovementOccupancySuite(t *testing.T) {
+	suite.Run(t, new(MovementOccupancySuite))
+}
+
+func (s *MovementOccupancySuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	s.enc = encounter.New(context.Background(), "enc-movement-occupancy", s.broker)
+
+	var err error
+	s.aliceSub, err = s.broker.Subscribe("enc-movement-occupancy", "alice")
+	s.Require().NoError(err)
+}
+
+func (s *MovementOccupancySuite) TearDownTest() {
+	s.Require().NoError(s.aliceSub.Close())
+	s.Require().NoError(s.broker.Close())
+	s.Require().NoError(s.transport.Close())
+}
+
+func (s *MovementOccupancySuite) addPlayer(sightRange int) {
+	s.Require().NoError(s.enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "char-alice", Position: core.Hex{}, SightRange: sightRange,
+	}))
+}
+
+func (s *MovementOccupancySuite) addMonster(id string, position core.Hex) {
+	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
+		ID: core.EntityID(id), Position: position, HP: 7, MaxHP: 7,
+	}))
+}
+
+func (s *MovementOccupancySuite) moveEventFor(mover core.EntityID) *events.MoveEvent {
+	for _, event := range collectEventsTyped(s.aliceSub, 500*time.Millisecond) {
+		if move, ok := event.(*events.MoveEvent); ok && move.Mover == mover {
+			return move
+		}
+	}
+	return nil
+}
+
+// TestNPCMove_OccupiedMonsterDestinationStopsAtLegalPrefix reproduces the
+// authoritative monster-on-monster overlap: encounter movement owns both
+// positions, while the reconstructed spatial room does not contain creatures.
+func (s *MovementOccupancySuite) TestNPCMove_OccupiedMonsterDestinationStopsAtLegalPrefix() {
+	s.addPlayer(10)
+	s.addMonster("goblin-mover", core.Hex{Q: 3, R: 0, S: -3})
+	s.addMonster("goblin-occupant", core.Hex{Q: 1, R: 0, S: -1})
+	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
+
+	requested := []core.Hex{{Q: 2, R: 0, S: -2}, {Q: 1, R: 0, S: -1}}
+	s.Require().NoError(s.enc.MoveNPCSteps("goblin-mover", requested))
+
+	data := s.enc.ToData()
+	s.Equal(core.Hex{Q: 2, R: 0, S: -2}, data.Monsters["goblin-mover"].Position)
+	s.Equal(core.Hex{Q: 1, R: 0, S: -1}, data.Monsters["goblin-occupant"].Position)
+
+	move := s.moveEventFor("goblin-mover")
+	s.Require().NotNil(move)
+	s.Equal([]core.Hex{{Q: 2, R: 0, S: -2}}, move.Path,
+		"the authoritative event must carry the actual legal path, not the occupied intent")
+	s.T().Logf("occupancy trace: mover=goblin-mover proposed=%v actual=%v final=%v occupant_visible_to_alice=true",
+		requested, move.Path, data.Monsters["goblin-mover"].Position)
+}
+
+// TestPlayerMove_HiddenOccupiedDestinationStopsWithoutIdentityLeak reproduces
+// the stranded-player shape. SightRange zero keeps the occupying monster out of
+// Alice's audience; legality still comes from full encounter state.
+func (s *MovementOccupancySuite) TestPlayerMove_HiddenOccupiedDestinationStopsWithoutIdentityLeak() {
+	s.addPlayer(0)
+	hidden := core.Hex{Q: 2, R: 0, S: -2}
+	safe := core.Hex{Q: 1, R: 0, S: -1}
+	s.addMonster("hidden-goblin", hidden)
+	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
+
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{safe, hidden}))
+
+	data := s.enc.ToData()
+	s.Equal(safe, data.Players["alice"].View.Position)
+	s.Equal(hidden, data.Monsters["hidden-goblin"].Position)
+
+	emitted := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
+	var move *events.MoveEvent
+	for _, event := range emitted {
+		switch event := event.(type) {
+		case *events.MoveEvent:
+			if event.Mover == "char-alice" {
+				move = event
+			}
+		case *events.EntityAppearedEvent:
+			s.NotEqual(core.EntityID("hidden-goblin"), event.Entity,
+				"occupancy refusal must not reveal the hidden occupant")
+		}
+	}
+	s.Require().NotNil(move)
+	s.Equal([]core.Hex{safe}, move.Path)
+	s.NotContains(move.PerPlayer, core.PlayerID("hidden-goblin"))
+	s.T().Logf("occupancy trace: mover=char-alice proposed=%v actual=%v final=%v "+
+		"occupant_visible_to_alice=false emitted_events=%d",
+		[]core.Hex{safe, hidden}, move.Path, data.Players["alice"].View.Position, len(emitted))
+}
+
+// TestPlayerMove_CanPassThroughOccupiedHex pins the requested scope: creature
+// occupancy constrains the final space, not every crossed space.
+func (s *MovementOccupancySuite) TestPlayerMove_CanPassThroughOccupiedHex() {
+	s.addPlayer(10)
+	occupied := core.Hex{Q: 1, R: 0, S: -1}
+	destination := core.Hex{Q: 2, R: 0, S: -2}
+	s.addMonster("goblin", occupied)
+	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
+
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{occupied, destination}))
+	s.Equal(destination, s.enc.ToData().Players["alice"].View.Position)
+
+	move := s.moveEventFor("char-alice")
+	s.Require().NotNil(move)
+	s.Equal([]core.Hex{occupied, destination}, move.Path)
+}
+
+// TestPlayerMove_OccupiedFirstDestinationIsViewerSafeNoOp covers the case with
+// no legal prefix: no state or event claims movement occurred.
+func (s *MovementOccupancySuite) TestPlayerMove_OccupiedFirstDestinationIsViewerSafeNoOp() {
+	s.addPlayer(10)
+	occupied := core.Hex{Q: 1, R: 0, S: -1}
+	s.addMonster("goblin", occupied)
+	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond)
+
+	s.Require().NoError(s.enc.Move("alice", []core.Hex{occupied}))
+	s.Equal(core.Hex{}, s.enc.ToData().Players["alice"].View.Position)
+	s.Nil(s.moveEventFor("char-alice"), "a refused move must not emit a MoveEvent")
+}

--- a/encounter/movement_occupancy_test.go
+++ b/encounter/movement_occupancy_test.go
@@ -116,7 +116,9 @@ func (s *MovementOccupancySuite) TestPlayerMove_HiddenOccupiedDestinationStopsWi
 	}
 	s.Require().NotNil(move)
 	s.Equal([]core.Hex{safe}, move.Path)
-	s.NotContains(move.PerPlayer, core.PlayerID("hidden-goblin"))
+	s.Require().Len(move.PerPlayer, 1, "the move is addressed only to its moving player")
+	_, addressedToMover := move.PerPlayer[core.PlayerID(alicePlayerID)]
+	s.True(addressedToMover)
 	s.T().Logf("occupancy trace: mover=char-alice proposed=%v actual=%v final=%v "+
 		"occupant_visible_to_alice=false emitted_events=%d",
 		[]core.Hex{safe, hidden}, move.Path, data.Players[alicePlayerID].View.Position, len(emitted))

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -309,6 +309,7 @@ func (e *Encounter) applyNPCMovementSteps(mon *MonsterData, path []encountercore
 	// path, so an NPC cannot bypass cell blockers or authored boundaries. Nil
 	// room remains a no-op.
 	path = e.truncateAtWall(moverStart, path)
+	path = e.truncateAtOccupiedDestination(mon.ID, path)
 	if len(path) == 0 {
 		return nil // Blocked at the very first hex.
 	}

--- a/encounter/obstacle_reveal_test.go
+++ b/encounter/obstacle_reveal_test.go
@@ -200,7 +200,9 @@ func (s *ObstacleRevealSuite) TestMove_CrossTransitionAudience() {
 	s.Equal(map[core.PlayerID]struct{}{alicePlayerID: {}}, aliceFirst[0].PerPlayer)
 	s.Empty(obstacleAppearancesFor(collectEventsTyped(bobSub, 300*time.Millisecond), "pillar-1"))
 
-	s.Require().NoError(s.enc.Move(bobPlayerID, []core.Hex{lineHex(1)}))
+	// Alice now occupies lineHex(1). Bob stops at the free lineHex(4),
+	// which newly brings the pillar at lineHex(3) into his sight range.
+	s.Require().NoError(s.enc.Move(bobPlayerID, []core.Hex{lineHex(4)}))
 	s.Empty(obstacleAppearancesFor(collectEventsTyped(aliceSub, 300*time.Millisecond), "pillar-1"))
 	bobLater := obstacleAppearancesFor(collectEventsTyped(bobSub, 300*time.Millisecond), "pillar-1")
 	s.Require().Len(bobLater, 1)

--- a/encounter/pocket_clear_move_teardown_test.go
+++ b/encounter/pocket_clear_move_teardown_test.go
@@ -217,7 +217,9 @@ func (s *PocketClearMoveTeardownSuite) TestWithinPocket_MovementStillEnforced_Wh
 		[]core.Hex{spendHex, lineHex(0), spendHex, lineHex(0), spendHex, lineHex(0)}))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "test premise: pocket A still active, group A alive")
 
-	err := enc.Move(pcmPlayerID, []core.Hex{spendHex})
+	// spendHex is occupied by pocket A's goblin, so request another free
+	// destination: this test isolates budget exhaustion from endpoint occupancy.
+	err := enc.Move(pcmPlayerID, []core.Hex{lineHex(2)})
 	s.Require().Error(err, "a genuinely exhausted budget must still reject movement while in combat")
 	s.ErrorIs(err, encounter.ErrInsufficientMovement)
 }

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -459,27 +459,28 @@ func (e *Encounter) truncateAtWall(moverStart core.Hex, path []core.Hex) []core.
 // No creature-sharing exception exists in the current encounter contract; a
 // future explicit rule must be tested and applied at this seam.
 func (e *Encounter) truncateAtOccupiedDestination(moverID core.EntityID, path []core.Hex) []core.Hex {
-	for len(path) > 0 && e.occupiedByOtherCreature(moverID, path[len(path)-1]) {
-		path = path[:len(path)-1]
-	}
-	return path
-}
-
-// occupiedByOtherCreature consults the full authoritative encounter state,
-// never a viewer's filtered perception, and intentionally returns no occupant
-// identity so movement refusal cannot leak a hidden creature.
-func (e *Encounter) occupiedByOtherCreature(moverID core.EntityID, hex core.Hex) bool {
+	occupied := make(map[core.Hex]struct{}, len(e.data.Players)+len(e.data.Monsters))
 	for _, player := range e.data.Players {
-		if player.EntityID != moverID && player.View != nil && player.View.Position == hex {
-			return true
+		if player.EntityID != moverID && player.View != nil {
+			occupied[player.View.Position] = struct{}{}
 		}
 	}
 	for _, monster := range e.data.Monsters {
-		if monster.ID != moverID && monster.Position == hex {
-			return true
+		if monster.ID != moverID {
+			occupied[monster.Position] = struct{}{}
 		}
 	}
-	return false
+
+	// Consult the full authoritative encounter state, never a viewer's
+	// filtered perception. The set contains no occupant identities, so this
+	// refusal path cannot leak a hidden creature.
+	for len(path) > 0 {
+		if _, blocked := occupied[path[len(path)-1]]; !blocked {
+			break
+		}
+		path = path[:len(path)-1]
+	}
+	return path
 }
 
 // isRoomSegmentTraversable rejects any direct requested segment that cannot

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -447,6 +447,41 @@ func (e *Encounter) truncateAtWall(moverStart core.Hex, path []core.Hex) []core.
 	return path
 }
 
+// truncateAtOccupiedDestination removes trailing destinations occupied by a
+// different creature. Encounter Data is authoritative for creature positions:
+// players and monsters deliberately are not placed in the reconstructed
+// spatial.Room, which owns only walls, doors, and obstacles. Keeping this check
+// in the encounter loop therefore reconciles the actual endpoint before rule
+// resolution, economy spending, state mutation, or audience-projected events.
+//
+// Only the endpoint is constrained. Occupied intermediate cells remain in the
+// path so this invariant does not silently introduce a movement-through rule.
+// No creature-sharing exception exists in the current encounter contract; a
+// future explicit rule must be tested and applied at this seam.
+func (e *Encounter) truncateAtOccupiedDestination(moverID core.EntityID, path []core.Hex) []core.Hex {
+	for len(path) > 0 && e.occupiedByOtherCreature(moverID, path[len(path)-1]) {
+		path = path[:len(path)-1]
+	}
+	return path
+}
+
+// occupiedByOtherCreature consults the full authoritative encounter state,
+// never a viewer's filtered perception, and intentionally returns no occupant
+// identity so movement refusal cannot leak a hidden creature.
+func (e *Encounter) occupiedByOtherCreature(moverID core.EntityID, hex core.Hex) bool {
+	for _, player := range e.data.Players {
+		if player.EntityID != moverID && player.View != nil && player.View.Position == hex {
+			return true
+		}
+	}
+	for _, monster := range e.data.Monsters {
+		if monster.ID != moverID && monster.Position == hex {
+			return true
+		}
+	}
+	return false
+}
+
 // isRoomSegmentTraversable rejects any direct requested segment that cannot
 // be verified as a complete, contiguous in-grid ray. Encounter movement does
 // not place players or monsters in spatial.Room, so it must perform this


### PR DESCRIPTION
## Summary
- reconcile player and NPC movement endpoints against authoritative encounter creature positions
- fall back to the last legal path prefix (or a viewer-safe no-op) before resolver, economy, mutation, and event work
- preserve movement through occupied intermediate cells and document why the current ADR-0034 seam is encounter-owned
- update legacy fixtures that unintentionally requested newly-illegal occupied endpoints

## Evidence
- red reproduction: new deterministic suite initially placed both monster and player movers onto occupied endpoints and emitted the occupied requested path
- `go test -race ./... -count=1` from `encounter/` — PASS (94.4s)
- targeted movement/space/perception/OA suites — PASS
- integration trace:
  - visible monster mover: proposed `[{2 0 -2} {1 0 -1}]`, actual `[{2 0 -2}]`, final `{2 0 -2}`
  - hidden player destination: proposed `[{1 0 -1} {2 0 -2}]`, actual `[{1 0 -1}]`, final `{1 0 -1}`, no hidden occupant identity event
- `make pre-commit` was run; core/events formatting, tidy, lint, and core race tests passed, then the repository's existing coverage parser failed while reading the multi-package `core/mock` output (`coverage: 0.0% ... syntax error`). No core/events files changed.

## Boundary
`spatial.Room` already enforces occupancy for entities placed into it, but encounter creatures are intentionally stored only in `Encounter.Data`. The dnd5e-coupled encounter loop therefore owns this invariant under ADR-0034's pending split because it owns creature positions, actual endpoints, audience projection, and emitted movement events. No API/web collision logic or hidden-state projection is added.

Closes #893

— platform agent, on behalf of KirkDiggler