### PR TITLE
feat(monster): targeting end-to-end, decision rationale, no-fallback rider (#895)

### DIFF
--- a/encounter/abandon_test.go
+++ b/encounter/abandon_test.go
@@ -77,6 +77,7 @@ func (s *AbandonSuite) TestEnd_MidCombat_Abandoned_EndsEncounter_PersistsThrough
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(),
 		"alice is in LoS of the goblin — AddMonster must auto-enter combat")
@@ -207,6 +208,7 @@ func (s *AbandonSuite) TestEnd_AlreadyEnded_ReturnsErrEncounterEnded_NegativeCon
 			ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 			HP: 1, MaxHP: 7, AC: 15, Speed: 6,
 			AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+			DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 		}))
 
 		sub, err := s.broker.Subscribe(encID, "alice")

--- a/encounter/action_resolved_test.go
+++ b/encounter/action_resolved_test.go
@@ -51,6 +51,7 @@ func (s *ActionResolvedSuite) SetupTest() {
 		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
 		MonsterRef:  monsterRefGoblin,
 		AttackBonus: 4, DamageDice: "1d6+2", DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	var err error

--- a/encounter/addmonster_visibility_test.go
+++ b/encounter/addmonster_visibility_test.go
@@ -63,6 +63,7 @@ func (s *AddMonsterVisibilitySuite) TestAddMonster_IntoVisibleRange_AppearsBefor
 
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 2, R: 0, S: -2}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Equal(core.ModeTurnBased, s.enc.Mode(), "goblin visible at add time — combat must start")
 
@@ -100,6 +101,7 @@ func (s *AddMonsterVisibilitySuite) TestAddMonster_OutOfRange_NoAppearedEvent() 
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 20, R: 0, S: -20}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Equal(core.ModeFreeRoam, s.enc.Mode(), "goblin out of range — must not start combat")
 
@@ -124,6 +126,7 @@ func (s *AddMonsterVisibilitySuite) TestAddMonster_MidCombatReinforcement_Appear
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode(), "first goblin starts combat")
 	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond) // drain the first goblin's appear + mode change
@@ -131,6 +134,7 @@ func (s *AddMonsterVisibilitySuite) TestAddMonster_MidCombatReinforcement_Appear
 	// A second goblin, also within alice's sight range, added mid-combat.
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-2", Position: core.Hex{Q: 2, R: 0, S: -2}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-2"),
 	}))
 	s.Equal(core.ModeTurnBased, s.enc.Mode(), "still turn-based — no re-flip")
 
@@ -171,6 +175,7 @@ func (s *AddMonsterVisibilitySuite) TestAddMonster_VisibleToMultiplePlayers_Grou
 
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 
 	aliceEvts := collectEventsTyped(s.aliceSub, 500*time.Millisecond)

--- a/encounter/arcade_recovery_test.go
+++ b/encounter/arcade_recovery_test.go
@@ -159,6 +159,7 @@ func (s *ArcadeRecoverySuite) TestPostTPKCharacter_EntersNewEncounter_FullyResto
 		ID: arcGoblinID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), arcGoblinID),
 	}))
 
 	// PlayerData.HP must already read the restored value straight off
@@ -223,6 +224,7 @@ func (s *ArcadeRecoverySuite) TestExistingSeat_MidEncounterReload_DoesNotHeal() 
 		ID: arcGoblinID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), arcGoblinID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())

--- a/encounter/authored_edges_test.go
+++ b/encounter/authored_edges_test.go
@@ -367,6 +367,7 @@ func TestAuthoredEdges_BlockSparsePlayerAndNPCMovement(t *testing.T) {
 	far = nextDirectHexAcross(t, npcEncounter, solid.From, solid.To)
 	require.NoError(t, npcEncounter.AddMonster(encounter.MonsterInput{
 		ID: "npc", Position: solid.From, HP: 7, MaxHP: 7, AC: 12, Speed: 6,
+		DataJSON: testGoblinDataJSON(t, "npc"),
 	}))
 	require.NoError(t, npcEncounter.MoveNPCSteps("npc", []core.Hex{far}))
 	assert.Equal(t, solid.From, npcEncounter.ToData().Monsters["npc"].Position,

--- a/encounter/broker_test.go
+++ b/encounter/broker_test.go
@@ -184,3 +184,39 @@ func (s *BrokerSuite) TestBrokerCodec_ResourceChangedEvent_RoundTrip() {
 	s.Equal(2, received.Max)
 	s.True(received.PerPlayer["p-alice"].Visible)
 }
+
+// TestBrokerCodec_ActionResolvedEvent_RoundTrip_PreservesTargetRationale
+// proves TargetRationale (rpg-toolkit#895's decision-rationale field)
+// survives the broker's own encode/decode codec, not just
+// json.Marshal/Unmarshal in isolation (events_test.go's
+// TestActionResolvedEvent_JSONRoundTrip covers that layer) — the actual
+// wire path an NPC attack's rationale travels end to end.
+func (s *BrokerSuite) TestBrokerCodec_ActionResolvedEvent_RoundTrip_PreservesTargetRationale() {
+	sub, err := s.broker.Subscribe("enc:1", "p-alice")
+	s.Require().NoError(err)
+
+	original := events.NewActionResolvedEvent(
+		"enc:1", 9,
+		"goblin-1", "dnd5e:actions:strike", "char-alice",
+		"dnd5e:targeting:lowest-hp",
+		events.EconomyConsumed{Actions: 1},
+		map[core.PlayerID]events.ActionResolvedSlice{
+			"p-alice": {Visible: true},
+		},
+	)
+	s.Require().NoError(s.broker.Publish(original))
+
+	var received *events.ActionResolvedEvent
+	select {
+	case evt, ok := <-sub.Events():
+		s.Require().True(ok, "channel closed unexpectedly")
+		casted, ok := evt.(*events.ActionResolvedEvent)
+		s.Require().True(ok, "expected *events.ActionResolvedEvent, got %T", evt)
+		received = casted
+	case <-time.After(time.Second):
+		s.FailNow("did not receive ActionResolvedEvent in 1s")
+	}
+
+	s.Equal("dnd5e:targeting:lowest-hp", received.TargetRationale,
+		"decision rationale must survive the broker's encode/decode round trip")
+}

--- a/encounter/combat.go
+++ b/encounter/combat.go
@@ -1034,6 +1034,11 @@ func rollD20(r dice.Roller) int {
 // supplies the known cost; the menu/economy unification PR will source richer
 // consumption.
 //
+// targetRationale carries the NPC targeting-strategy ref (e.g.
+// "dnd5e:targeting:lowest-hp") on the monster→player attack path
+// (rpg-toolkit#895); the player→monster path always passes "" since a
+// player's target is a human choice, not an AI decision to explain.
+//
 // Audience routing matches Move / OpenDoor: viewers who cannot perceive
 // the attacker or the target are omitted from PerPlayer entirely (and so
 // are excluded from Audience()). The broker delivers only to listed
@@ -1045,6 +1050,7 @@ func (e *Encounter) publishAttackOutcome(
 	damageType string,
 	attackerPos, targetPos core.Hex,
 	actionRef string,
+	targetRationale string,
 	consumed events.EconomyConsumed,
 ) (core.CorrelationID, error) {
 	actionPerPlayer := make(map[core.PlayerID]events.ActionResolvedSlice)
@@ -1068,7 +1074,7 @@ func (e *Encounter) publishAttackOutcome(
 	corrID := e.correlationFor(actionSeq)
 	actionEvt := events.NewActionResolvedEvent(
 		e.data.ID, actionSeq,
-		attackerID, actionRef, targetID,
+		attackerID, actionRef, targetID, targetRationale,
 		consumed, actionPerPlayer,
 	)
 	if err := e.publishCorrelated(actionEvt, corrID); err != nil {

--- a/encounter/combat_entry_test.go
+++ b/encounter/combat_entry_test.go
@@ -46,6 +46,7 @@ func (s *CombatEntrySuite) TestAddMonster_VisibleToExistingPlayer_EntersCombat()
 
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 2, R: -2, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 
 	s.Equal(core.ModeTurnBased, s.enc.Mode())
@@ -61,6 +62,7 @@ func (s *CombatEntrySuite) TestMove_IntoMonsterLOS_EntersCombat() {
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Equal(core.ModeFreeRoam, s.enc.Mode(), "goblin out of LoS at add time — must not have entered combat yet")
 
@@ -99,6 +101,7 @@ func (s *CombatEntrySuite) TestIdempotent_AddMonsterAndMoveAfterCombatStarted() 
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 1, R: -1, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
 
@@ -109,6 +112,7 @@ func (s *CombatEntrySuite) TestIdempotent_AddMonsterAndMoveAfterCombatStarted() 
 	// seeded second goblin would never get a turn (Copilot review, PR #759).
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-2", Position: core.Hex{Q: 2, R: -2, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-2"),
 	}))
 	s.Equal(core.ModeTurnBased, s.enc.Mode())
 	s.Contains(s.enc.ToData().Initiative, core.EntityID("goblin-2"),

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -387,7 +387,7 @@ func (e *Encounter) applyAndPublishNPCOutcome(monster *MonsterData, player *Play
 		monster.ID, player.EntityID, outcome,
 		player.HP, player.MaxHP, damageType,
 		monster.Position, player.View.Position,
-		attackActionRef, attackEconomyConsumed(),
+		attackActionRef, monsterTargetingRationale(monster), attackEconomyConsumed(),
 	); err != nil {
 		return err
 	}
@@ -437,7 +437,7 @@ func (e *Encounter) applyAndPublishOutcome(
 		player.EntityID, monster.ID, outcome,
 		monster.HP, monster.MaxHP, damageType,
 		player.View.Position, monster.Position,
-		actionRef, consumed,
+		actionRef, "", consumed,
 	)
 	if err != nil {
 		return err

--- a/encounter/combat_phased_test.go
+++ b/encounter/combat_phased_test.go
@@ -135,6 +135,7 @@ func (s *PhasedTakeActionSuite) SetupTest() {
 		ID: gobEntityID, Position: encountercore.Hex{Q: 0, R: 1, S: -1},
 		HP: 10, MaxHP: 10, AC: 13, Speed: 30, AttackBonus: 4,
 		DamageDice: damage1d6plus1, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice/bob are in mutual LoS of the goblin, so AddMonster (above)
 	// already auto-transitioned to TURN_BASED; an explicit SetMode here
@@ -274,6 +275,7 @@ func (s *PhasedTakeActionSuite) TestLegacyResolverFallback() {
 		ID: gobEntityID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 10, MaxHP: 10, AC: 13, Speed: 30, AttackBonus: 4,
 		DamageDice: damage1d6plus1, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice is in LoS of the goblin, so AddMonster already auto-transitioned
 	// to TURN_BASED; an explicit SetMode here would be redundant and error.

--- a/encounter/combat_pockets_test.go
+++ b/encounter/combat_pockets_test.go
@@ -93,11 +93,13 @@ func (s *CombatPocketsSuite) SetupTest() {
 		ID: pocketGobB, Position: lineHex(6),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef: monsterRefGoblin,
+		DataJSON:   testGoblinDataJSON(s.T(), pocketGobB),
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: pocketGobA, Position: lineHex(1),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef: monsterRefGoblin,
+		DataJSON:   testGoblinDataJSON(s.T(), pocketGobA),
 	}))
 }
 

--- a/encounter/combat_resolver_test.go
+++ b/encounter/combat_resolver_test.go
@@ -83,6 +83,7 @@ func (s *CombatResolverWiringSuite) TestTakeAction_ErrNoCombatResolver() {
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice and the goblin are in mutual LoS, so AddMonster already
 	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
@@ -114,6 +115,7 @@ func (s *CombatResolverWiringSuite) TestTakeAction_UsesResolverOutcome() {
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice and the goblin are in mutual LoS, so AddMonster already
 	// auto-transitioned to TURN_BASED; an explicit SetMode here would be

--- a/encounter/combat_test.go
+++ b/encounter/combat_test.go
@@ -65,10 +65,21 @@ func (s *CombatSuite) SetupTest() {
 		DamageDice: "1d6+1", DamageType: damagePiercing,
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
-		ID:       gobEntityID,
-		Position: core.Hex{Q: 1, R: 0, S: -1},
+		ID: gobEntityID,
+		// Adjacent (distance 1) to BOTH alice {0,0,0} and bob {1,0,-1} —
+		// their shared hex-grid common neighbor — rather than co-located
+		// with bob (the original position, distance 0 from him). NPCAct now
+		// runs the real monster.TakeTurn AI (rpg-toolkit#895 no-fallback
+		// rider deleted the scripted fallback this fixture used to exercise
+		// instead), and PerceivedEntity.Adjacent is strictly distance==1, so
+		// a co-located target never reads as adjacent and CanActivate
+		// rejects it as out of melee range. Distance 1 from alice also
+		// keeps the player-attacks-goblin tests in this suite (e.g.
+		// TestTakeAction_PublishesAttackOutcome) in melee reach.
+		Position: core.Hex{Q: 1, R: -1, S: 0},
 		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
 		MonsterRef:  "dnd5e:monsters:goblin",
+		DataJSON:    testGoblinDataJSON(s.T(), gobEntityID),
 		AttackBonus: 4, DamageDice: "1d6+2", DamageType: damageSlashing,
 	}))
 
@@ -209,8 +220,23 @@ func (s *CombatSuite) TestTakeAction_PublishesAttackOutcome() {
 	)
 	s.Require().NoError(err)
 
-	seenAlice := collectTypes(s.aliceSub, 500*time.Millisecond)
-	s.Contains(seenAlice, "*events.AttackResolvedEvent")
+	seen := collectEventsTyped(s.aliceSub, 500*time.Millisecond)
+	var sawAttack, sawAction bool
+	for _, e := range seen {
+		switch ev := e.(type) {
+		case *events.AttackResolvedEvent:
+			sawAttack = true
+		case *events.ActionResolvedEvent:
+			sawAction = true
+			// Player-taken attacks are a human choice, not an AI targeting
+			// decision — TargetRationale must be empty (rpg-toolkit#895;
+			// the NPC-attack path is covered by
+			// npc_test.go's TestNPCAct_AttackPublishesTargetRationale).
+			s.Empty(ev.TargetRationale, "player-path attacks must emit an empty decision rationale")
+		}
+	}
+	s.True(sawAttack, "expected *events.AttackResolvedEvent")
+	s.True(sawAction, "expected *events.ActionResolvedEvent")
 }
 
 // TakeAction copies HasAdvantage/HasDisadvantage/AdvantageSources/
@@ -237,6 +263,7 @@ func (s *CombatSuite) TestTakeAction_PublishesAdvantageDisadvantageOnAttackResol
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice and the goblin are in mutual LoS, so AddMonster already
 	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
@@ -294,6 +321,7 @@ func (s *CombatSuite) TestTakeAction_RejectsNonCombatant() {
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice and the goblin are in mutual LoS, so AddMonster already
 	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
@@ -341,6 +369,7 @@ func (s *CombatSuite) TestTakeAction_HydratedPlayerBypassesFlatSnapshotGate() {
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	// Round-trip through Data so the hydration cascade runs — New/AddPlayer
@@ -398,6 +427,7 @@ func (s *CombatSuite) TestTakeAction_DataJSONWithoutLoadFromData_StillRejected()
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice and the goblin are in mutual LoS, so AddMonster already
 	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
@@ -470,10 +500,13 @@ func (s *CombatSuite) TestEndTurn_GuardsEmptyInitiative() {
 	s.ErrorIs(err, encounter.ErrNoCombatants)
 }
 
-// NPCAct (scripted path — no DataJSON) emits an attack event when a
-// player is reachable.
+// NPCAct emits an attack event when a player is reachable. Formerly named
+// TestNPCAct_ScriptedAttackPublishes and exercised via a no-DataJSON
+// monster (npcActScripted); that fallback is deleted (rpg-toolkit#895
+// no-fallback rider), so s.enc's goblin now carries real DataJSON and this
+// runs the normal hydrated NPCAct path instead.
 // s.enc is already TURN_BASED by SetupTest.
-func (s *CombatSuite) TestNPCAct_ScriptedAttackPublishes() {
+func (s *CombatSuite) TestNPCAct_AttackPublishes() {
 	for s.enc.ActiveActor() != gobEntityID {
 		_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
 		s.Require().NoError(err)
@@ -510,6 +543,7 @@ func (s *CombatSuite) TestTakeAction_OmitsNonViewersFromAudience() {
 		ID:       gob2EntityID,
 		Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP:       7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(s.T(), gob2EntityID),
 	}))
 	farAliceSub, err := s.broker.Subscribe("enc-combat-2", "alice")
 	s.Require().NoError(err)

--- a/encounter/combat_trigger_order_test.go
+++ b/encounter/combat_trigger_order_test.go
@@ -127,6 +127,7 @@ func (s *CombatTriggerOrderSuite) TestMove_TriggerForcedFirst_RegardlessOfRoll()
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: "boss-boss", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 30, MaxHP: 30,
+		DataJSON: testGoblinDataJSON(s.T(), "boss-boss"),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(),
 		"test premise: the boss must be out of LoS until the move below")
@@ -172,6 +173,7 @@ func (s *CombatTriggerOrderSuite) TestMove_OthersStillOrderedByRoll_TriggerRollD
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-m", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-m"),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: nobody has LoS to the goblin yet")
 
@@ -211,6 +213,7 @@ func (s *CombatTriggerOrderSuite) TestOpenDoorThenMove_TriggerForcedFirstRegardl
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: "aaa-ambush", Position: lineHex(6), HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "aaa-ambush"),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: monster behind the closed door")
 
@@ -281,6 +284,7 @@ func (s *CombatTriggerOrderSuite) loadHydratedTriggerFixture() *encounter.Encoun
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: budgetMonster, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), budgetMonster),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode(), "test premise: monster out of LoS")
 
@@ -380,6 +384,7 @@ func (s *CombatTriggerOrderSuite) TestCheckCombatEntry_TriggerAttributedToActual
 	)
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: attribMonsterID, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), attribMonsterID),
 	}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: attribScoutPlayerID, EntityID: attribScoutEntityID,
@@ -470,6 +475,7 @@ func (s *CombatTriggerOrderSuite) TestSeedActiveActorIfUnseeded_HonorsPendingTri
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: budgetMonster, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), budgetMonster),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode())
 
@@ -525,6 +531,7 @@ func (s *CombatTriggerOrderSuite) TestSeedActiveActorIfUnseeded_DoesNotApplyStal
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: budgetMonster, Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), budgetMonster),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, enc.Mode())
 

--- a/encounter/death_test.go
+++ b/encounter/death_test.go
@@ -95,6 +95,7 @@ func (s *DeathSuite) newSingleMonsterEnc(encID core.EncounterID) *encounter.Enco
 		HP:       1, MaxHP: 7, AC: 15, Speed: 6,
 		MonsterRef:  "dnd5e:monsters:goblin",
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	var err error
@@ -204,6 +205,7 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(),
 		"goblin-1 shares bob's hex — AddMonster must auto-enter combat")
@@ -211,6 +213,7 @@ func (s *DeathSuite) TestSlice_OneOfTwoMonstersDies_EncounterContinues() {
 		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gob2EntityID),
 	}))
 	s.Require().Contains(enc.ToData().Initiative, core.EntityID(gob2EntityID),
 		"goblin-2 was added after the auto-transition and must still join initiative")
@@ -273,6 +276,7 @@ func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(),
 		"goblin-1 is in alice's LoS — AddMonster must auto-enter combat")
@@ -280,6 +284,7 @@ func (s *DeathSuite) TestSlice_EndTurnSkipsDeadActor() {
 		ID: gob2EntityID, Position: core.Hex{Q: 2, R: 0, S: -2},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gob2EntityID),
 	}))
 	s.Require().Contains(enc.ToData().Initiative, core.EntityID(gob2EntityID),
 		"goblin-2 was added after the auto-transition and must still join initiative")
@@ -336,6 +341,7 @@ func (s *DeathSuite) TestSlice_EncounterEndedBroadcastsToAll() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 1, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	var err error
@@ -400,6 +406,7 @@ func (s *DeathSuite) TestSlice_PlayerDies_PartialOnly() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	var err error
@@ -532,6 +539,7 @@ func (s *DeathSuite) TestSlice_PlayerDeath_NotRePublishedOnReHit() {
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	var err error

--- a/encounter/doors_slice1_test.go
+++ b/encounter/doors_slice1_test.go
@@ -70,6 +70,7 @@ func (s *DoorBlockingSuite) SetupTest() {
 		ID: gobEntityID, Position: lineHex(6),
 		HP: 7, MaxHP: 7, AC: 12, Speed: 30,
 		DamageDice: dice1d6, DamageType: damagePiercing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	var err error

--- a/encounter/dungeon_completion_test.go
+++ b/encounter/dungeon_completion_test.go
@@ -193,14 +193,17 @@ func (s *DungeonCompletionSuite) TestClearingEarlyPockets_ThenVictoryOnLastHosti
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: dcBossGoblinID, Position: dungeonRegionFarEdgeHex(2),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6, MonsterRef: monsterRefGoblin,
+		DataJSON: testGoblinDataJSON(s.T(), dcBossGoblinID),
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: dcCorridorGoblinID, Position: dungeonRegionFarEdgeHex(1),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6, MonsterRef: monsterRefGoblin,
+		DataJSON: testGoblinDataJSON(s.T(), dcCorridorGoblinID),
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: dcEntranceGoblinID, Position: dungeonRegionFarEdgeHex(0),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6, MonsterRef: monsterRefGoblin,
+		DataJSON: testGoblinDataJSON(s.T(), dcEntranceGoblinID),
 	}))
 
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting the entrance goblin must auto-start the first pocket")
@@ -349,10 +352,12 @@ func (s *DungeonCompletionSuite) TestTPKMidDungeon_EndsWithCanonicalReason_Hosti
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: dcBossGoblinID, Position: dungeonRegionFarEdgeHex(2),
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6, MonsterRef: monsterRefGoblin,
+		DataJSON: testGoblinDataJSON(s.T(), dcBossGoblinID),
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: dcCorridorGoblinID, Position: dungeonRegionFarEdgeHex(1),
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6, MonsterRef: monsterRefGoblin,
+		DataJSON: testGoblinDataJSON(s.T(), dcCorridorGoblinID),
 	}))
 	// rpg-toolkit#864: NPCAct's scripted fallback (no DataJSON — this
 	// goblin's shape) now gates melee attacks on reach and has no movement
@@ -365,6 +370,7 @@ func (s *DungeonCompletionSuite) TestTPKMidDungeon_EndsWithCanonicalReason_Hosti
 		ID: dcEntranceGoblinID, Position: dcRowHex(1),
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), dcEntranceGoblinID),
 	}))
 	s.Require().Equal(core.ModeTurnBased, enc.Mode(), "sighting the entrance goblin must start the first pocket")
 

--- a/encounter/dungeon_completion_test.go
+++ b/encounter/dungeon_completion_test.go
@@ -359,13 +359,16 @@ func (s *DungeonCompletionSuite) TestTPKMidDungeon_EndsWithCanonicalReason_Hosti
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6, MonsterRef: monsterRefGoblin,
 		DataJSON: testGoblinDataJSON(s.T(), dcCorridorGoblinID),
 	}))
-	// rpg-toolkit#864: NPCAct's scripted fallback (no DataJSON — this
-	// goblin's shape) now gates melee attacks on reach and has no movement
-	// logic of its own, so the goblin spawns adjacent to alice (X=1, vs.
-	// alice's entrance at X=0) rather than at the far edge (X=9) — nothing
-	// else in this test depends on the goblin's exact starting column, only
-	// that it's within LoS (dcSightRange comfortably covers the whole
-	// fixture regardless).
+	// This goblin has real DataJSON (rpg-toolkit#895 no-fallback rider —
+	// NPCAct always runs the hydrated monster.TakeTurn AI now, never the
+	// deleted scripted fallback), so it spawns adjacent to alice (X=1, vs.
+	// alice's entrance at X=0) rather than at the far edge (X=9) to
+	// guarantee the single NPCAct call below lands its kill immediately —
+	// the test wants alice dead in one hit, not dependent on however many
+	// turns the AI's own pathing takes to close distance. Nothing else in
+	// this test depends on the goblin's exact starting column, only that
+	// it's within LoS (dcSightRange comfortably covers the whole fixture
+	// regardless).
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: dcEntranceGoblinID, Position: dcRowHex(1),
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6,

--- a/encounter/dungeonspec/canvas_test.go
+++ b/encounter/dungeonspec/canvas_test.go
@@ -163,8 +163,7 @@ func TestCanvasMonsterPlacementTargeting(t *testing.T) {
 		compiled, err := Load([]byte(yaml))
 		require.NoError(t, err)
 		require.Len(t, compiled.Spawns, 1)
-		require.NotNil(t, compiled.Spawns[0].Targeting)
-		require.Equal(t, monster.TargetLowestAC, *compiled.Spawns[0].Targeting)
+		require.Equal(t, monster.TargetLowestAC, compiled.Spawns[0].Targeting)
 	})
 }
 

--- a/encounter/dungeonspec/canvas_test.go
+++ b/encounter/dungeonspec/canvas_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 )
 
 const canvasFixture = `version: 1
@@ -128,6 +130,42 @@ func TestCanvasMonsterPlacementRejectsPropOnlyFlagsAtFieldPath(t *testing.T) {
 			require.ErrorContains(t, err, "only valid on props")
 		})
 	}
+}
+
+// TestCanvasMonsterPlacementTargeting covers rpg-toolkit#895's targeting
+// field on canvas-mode monster placements: rejected on a props ref (mirrors
+// TestCanvasMonsterPlacementRejectsPropOnlyFlagsAtFieldPath's own props/
+// monsters-only pattern, inverted), rejected when unparseable, and — when
+// valid — threaded all the way into the compiled SpawnInstruction.
+func TestCanvasMonsterPlacementTargeting(t *testing.T) {
+	t.Run("rejected on a props ref", func(t *testing.T) {
+		yaml := strings.Replace(canvasFixture,
+			"  - { ref: \"dnd5e:props:altar\", at: [1, 0], facing: W }",
+			"  - { ref: \"dnd5e:props:altar\", at: [1, 0], targeting: closest }", 1)
+		_, err := Load([]byte(yaml))
+		require.ErrorContains(t, err, "place[0].targeting")
+		require.ErrorContains(t, err, "only valid on monsters")
+	})
+
+	t.Run("unparseable value rejected", func(t *testing.T) {
+		yaml := strings.Replace(canvasFixture,
+			"  - { ref: \"dnd5e:props:altar\", at: [1, 0], facing: W }",
+			"  - { ref: \"dnd5e:monsters:skeleton\", at: [1, 0], targeting: nearest }", 1)
+		_, err := Load([]byte(yaml))
+		require.ErrorContains(t, err, "place[0].targeting")
+		require.ErrorContains(t, err, `invalid targeting strategy "nearest"`)
+	})
+
+	t.Run("valid value threads into the compiled SpawnInstruction", func(t *testing.T) {
+		yaml := strings.Replace(canvasFixture,
+			"  - { ref: \"dnd5e:props:altar\", at: [1, 0], facing: W }",
+			"  - { ref: \"dnd5e:monsters:skeleton\", at: [1, 0], targeting: lowest-ac }", 1)
+		compiled, err := Load([]byte(yaml))
+		require.NoError(t, err)
+		require.Len(t, compiled.Spawns, 1)
+		require.NotNil(t, compiled.Spawns[0].Targeting)
+		require.Equal(t, monster.TargetLowestAC, *compiled.Spawns[0].Targeting)
+	})
 }
 
 func Test883CanvasFacingAndLockGrammar(t *testing.T) {

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -134,6 +135,10 @@ func compileWithConfig(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, e
 		at := encounter.LocalHex{Col: bossRoom.Boss.At[0], Row: bossRoom.Boss.At[1]}
 		bossAt = &at
 	}
+	bossTargeting, err := compileTargeting(bossRoom.Boss.Targeting)
+	if err != nil {
+		return CompiledDungeon{}, fmt.Errorf("room %q: boss targeting: %w", bossRoom.ID, err)
+	}
 	// Capacity is a hint, not a bound: sized for the boss spawn plus one
 	// per room, but a room's place list can name several monster entries
 	// (growing past the hint) or none at all (falling short of it) --
@@ -144,6 +149,7 @@ func compileWithConfig(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, e
 		MonsterRef: bossRoom.Boss.Ref,
 		Count:      1,
 		At:         bossAt,
+		Targeting:  bossTargeting,
 	})
 
 	regions := make([]encounter.DungeonRegionParams, len(spec.Rooms))
@@ -266,6 +272,10 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 			})
 		case refTypeMonsters:
 			at := encounter.LocalHex{Col: entry.At[0], Row: entry.At[1]}
+			targeting, err := compileTargeting(entry.Targeting)
+			if err != nil {
+				return encounter.DungeonRegionParams{}, nil, fmt.Errorf("place %q targeting: %w", entry.Ref, err)
+			}
 			// Reserve this cell the same way as the boss's own pinned
 			// boss.at above -- a placed monster never becomes a
 			// PlacedObstacleSpec, so without this InitDungeon's
@@ -277,6 +287,7 @@ func compileRoom(room *RoomSpec) (encounter.DungeonRegionParams, []SpawnInstruct
 				MonsterRef: entry.Ref,
 				Count:      1,
 				At:         &at,
+				Targeting:  targeting,
 			})
 		default:
 			// Phrasing matches validatePlaceBlock's "must be props or
@@ -400,6 +411,22 @@ func compileFacing(label *string) (*uint32, error) {
 	return &value, nil
 }
 
+// compileTargeting parses an author-facing targeting label (Validate
+// already checked it parses; this trusts that and re-checks defensively,
+// mirroring compileFacing) into the pointer shape SpawnInstruction.Targeting
+// requires — nil in, nil out, so an omitted targeting field never overrides
+// a monster's own ctor default (rpg-toolkit#895).
+func compileTargeting(label *string) (*monster.TargetingStrategy, error) {
+	if label == nil {
+		return nil, nil
+	}
+	value, err := monster.ParseTargetingStrategy(*label)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
 type canvasCompiled struct {
 	width, height int
 	entrance      FloorPlanCell
@@ -485,7 +512,13 @@ func compileCanvas(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, error
 			})
 		case refTypeMonsters:
 			absoluteAt := at
-			spawns = append(spawns, SpawnInstruction{MonsterRef: entry.Ref, Count: 1, AbsoluteAt: &absoluteAt})
+			targeting, err := compileTargeting(entry.Targeting)
+			if err != nil {
+				return CompiledDungeon{}, fmt.Errorf("place[%d].targeting: %w", index, err)
+			}
+			spawns = append(spawns, SpawnInstruction{
+				MonsterRef: entry.Ref, Count: 1, AbsoluteAt: &absoluteAt, Targeting: targeting,
+			})
 			params.AbsoluteReservedCells = append(params.AbsoluteReservedCells, encounter.AbsoluteReservedCell{
 				At: at, Name: fmt.Sprintf("placed monster %q (place[%d])", entry.Ref, index),
 			})

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -413,18 +413,16 @@ func compileFacing(label *string) (*uint32, error) {
 
 // compileTargeting parses an author-facing targeting label (Validate
 // already checked it parses; this trusts that and re-checks defensively,
-// mirroring compileFacing) into the pointer shape SpawnInstruction.Targeting
-// requires — nil in, nil out, so an omitted targeting field never overrides
-// a monster's own ctor default (rpg-toolkit#895).
-func compileTargeting(label *string) (*monster.TargetingStrategy, error) {
+// mirroring compileFacing) into the value shape SpawnInstruction.Targeting
+// requires — nil in, TargetingUnspecified out, so an omitted targeting
+// field never overrides a monster's own ctor default (rpg-toolkit#895
+// gate-review hardening: TargetingUnspecified is the zero value precisely
+// so this no longer needs a pointer to express "unset").
+func compileTargeting(label *string) (monster.TargetingStrategy, error) {
 	if label == nil {
-		return nil, nil
+		return monster.TargetingUnspecified, nil
 	}
-	value, err := monster.ParseTargetingStrategy(*label)
-	if err != nil {
-		return nil, err
-	}
-	return &value, nil
+	return monster.ParseTargetingStrategy(*label)
 }
 
 type canvasCompiled struct {

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -304,8 +304,8 @@ connectors:
 
 	boss := compiled.Spawns[0] // boss-first ordering unchanged
 	assert.Equal(t, "dnd5e:monsters:skeleton-captain", boss.MonsterRef)
-	require.NotNil(t, boss.Targeting, "boss spawn (compileWithConfig) must thread its targeting override")
-	assert.Equal(t, monster.TargetLowestHP, *boss.Targeting)
+	assert.Equal(t, monster.TargetLowestHP, boss.Targeting,
+		"boss spawn (compileWithConfig) must thread its targeting override")
 
 	var skeletonSpawn *dungeonspec.SpawnInstruction
 	for i := range compiled.Spawns {
@@ -314,17 +314,19 @@ connectors:
 		}
 	}
 	require.NotNil(t, skeletonSpawn)
-	require.NotNil(t, skeletonSpawn.Targeting,
+	assert.Equal(t, monster.TargetClosest, skeletonSpawn.Targeting,
 		"place-block refTypeMonsters spawn (compileRoom) must thread its targeting override")
-	assert.Equal(t, monster.TargetClosest, *skeletonSpawn.Targeting)
 
 	// The unmodified placedTombYAML fixture (no targeting: anywhere) must
-	// still compile both spawns with a nil Targeting -- omitted, not a
-	// zero-value TargetClosest standing in for "unset."
+	// still compile both spawns with TargetingUnspecified -- omitted, not a
+	// zero-value TargetClosest standing in for "unset" (rpg-toolkit#895
+	// gate-review hardening moved TargetClosest off the zero value
+	// specifically so this distinction holds by construction).
 	unset, err := dungeonspec.Load([]byte(placedTombYAML))
 	require.NoError(t, err)
 	for i := range unset.Spawns {
-		assert.Nil(t, unset.Spawns[i].Targeting, "spawn %q: omitted targeting must compile to nil, not TargetClosest",
+		assert.Equal(t, monster.TargetingUnspecified, unset.Spawns[i].Targeting,
+			"spawn %q: omitted targeting must compile to TargetingUnspecified, not TargetClosest",
 			unset.Spawns[i].MonsterRef)
 	}
 }

--- a/encounter/dungeonspec/compile_test.go
+++ b/encounter/dungeonspec/compile_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,6 +260,73 @@ func TestLoad_BossAtCompilesToSpawnPosition(t *testing.T) {
 	assert.Equal(t, "dnd5e:monsters:skeleton-captain", boss.MonsterRef)
 	require.NotNil(t, boss.At)
 	assert.Equal(t, encounter.LocalHex{Col: 7, Row: 5}, *boss.At)
+}
+
+// TestLoad_TargetingCompilesAtBothWiringSites (rpg-toolkit#895): a
+// SpawnInstruction.Targeting override reaches the compiled dungeon from
+// BOTH sites that build one — the boss spawn (compileWithConfig) and a
+// room-chain place entry's refTypeMonsters case (compileRoom) — and a
+// spawn whose author left targeting unset compiles with a nil Targeting
+// (never a zero-value TargetClosest standing in for "unset", which would
+// silently stomp a ctor's own non-closest default at seed time).
+// placedTombWithTargetingYAML is placedTombYAML plus `targeting:` on the
+// boss and the skeleton place entry — kept as its own fixture rather than
+// mutating placedTombYAML itself, which several other tests in this file
+// assert exact PlacedObstacles/Spawns shapes against.
+func TestLoad_TargetingCompilesAtBothWiringSites(t *testing.T) {
+	const placedTombWithTargetingYAML = `
+version: 1
+key: reference-tomb
+name: The Reference Tomb
+theme: crypt
+height: 8
+rooms:
+  - id: entrance
+    archetype: entrance
+    width: 6
+  - id: tomb
+    archetype: boss
+    width: 12
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [7, 5], targeting: lowest-health }
+    place:
+      - { ref: "dnd5e:props:coffin",        at: [6, 3], blocks_los: false }
+      - { ref: "dnd5e:props:altar",         at: [9, 3] }
+      - { ref: "dnd5e:props:statue-reaper", at: [1, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 1] }
+      - { ref: "dnd5e:props:brazier",       at: [3, 6] }
+      - { ref: "dnd5e:monsters:skeleton",   at: [4, 2], targeting: closest }
+connectors:
+  - { from: entrance, to: tomb }
+`
+	compiled, err := dungeonspec.Load([]byte(placedTombWithTargetingYAML))
+	require.NoError(t, err)
+	require.Len(t, compiled.Spawns, 2)
+
+	boss := compiled.Spawns[0] // boss-first ordering unchanged
+	assert.Equal(t, "dnd5e:monsters:skeleton-captain", boss.MonsterRef)
+	require.NotNil(t, boss.Targeting, "boss spawn (compileWithConfig) must thread its targeting override")
+	assert.Equal(t, monster.TargetLowestHP, *boss.Targeting)
+
+	var skeletonSpawn *dungeonspec.SpawnInstruction
+	for i := range compiled.Spawns {
+		if compiled.Spawns[i].MonsterRef == "dnd5e:monsters:skeleton" {
+			skeletonSpawn = &compiled.Spawns[i]
+		}
+	}
+	require.NotNil(t, skeletonSpawn)
+	require.NotNil(t, skeletonSpawn.Targeting,
+		"place-block refTypeMonsters spawn (compileRoom) must thread its targeting override")
+	assert.Equal(t, monster.TargetClosest, *skeletonSpawn.Targeting)
+
+	// The unmodified placedTombYAML fixture (no targeting: anywhere) must
+	// still compile both spawns with a nil Targeting -- omitted, not a
+	// zero-value TargetClosest standing in for "unset."
+	unset, err := dungeonspec.Load([]byte(placedTombYAML))
+	require.NoError(t, err)
+	for i := range unset.Spawns {
+		assert.Nil(t, unset.Spawns[i].Targeting, "spawn %q: omitted targeting must compile to nil, not TargetClosest",
+			unset.Spawns[i].MonsterRef)
+	}
 }
 
 // TestLoad_SameBytesProduceIdenticalCompiledDungeon: Load has no source of

--- a/encounter/dungeonspec/spec.go
+++ b/encounter/dungeonspec/spec.go
@@ -88,6 +88,9 @@ type BossEntry struct {
 	// Facing is decoded solely so unsupported boss-facing input can fail at
 	// its supplied field path. Boss-facing behavior is outside Slice #178.
 	Facing *string `yaml:"facing,omitempty"`
+	// Targeting overrides the boss's targeting strategy — same vocabulary
+	// and nil-means-omitted shape as PlacedEntry.Targeting (rpg-toolkit#895).
+	Targeting *string `yaml:"targeting,omitempty"`
 }
 
 // ObstacleEntry is a count-based rolled obstacle for a room.
@@ -116,6 +119,12 @@ type PlacedEntry struct {
 	// field path. Slice #178 supports floor placements only and never
 	// compiles mount behavior.
 	Mount *string `yaml:"mount,omitempty"`
+	// Targeting overrides the placed monster's targeting strategy (one of
+	// "closest" | "lowest-health" | "lowest-ac" — monster.ParseTargetingStrategy,
+	// rpg-toolkit#895). Nil represents both an omitted field and explicit
+	// YAML null; only valid on a monsters ref, never a props ref (validate.go
+	// mirrors blocks_movement's own props-only restriction, inverted).
+	Targeting *string `yaml:"targeting,omitempty"`
 }
 
 // WallSpec is one strict authored edge from the top-level walls grammar.

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -286,6 +287,9 @@ func validateCanvasPlacement(path string, e PlacedEntry) error {
 	if !isFloorMount(e.Mount) {
 		return fmt.Errorf("%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
 	}
+	if typ == refTypeProps && e.Targeting != nil {
+		return fmt.Errorf("%s.targeting: only valid on monsters", path)
+	}
 	if typ == refTypeMonsters {
 		if _, ok := monsters.ByRef(e.Ref); !ok {
 			return fmt.Errorf("%s.ref %q: unknown monster ref (known: %s)", path, e.Ref, strings.Join(monsters.Refs(), ", "))
@@ -295,6 +299,11 @@ func validateCanvasPlacement(path string, e PlacedEntry) error {
 		}
 		if e.BlocksLoS != nil {
 			return fmt.Errorf("%s.blocks_los: only valid on props", path)
+		}
+		if e.Targeting != nil {
+			if _, err := monster.ParseTargetingStrategy(*e.Targeting); err != nil {
+				return fmt.Errorf("%s.targeting: %w", path, err)
+			}
 		}
 	}
 	return nil
@@ -439,6 +448,11 @@ func validateBossRef(bossRoom *RoomSpec) error {
 		return fmt.Errorf("room %q: boss ref %q: unknown monster ref (known: %s)",
 			bossRoom.ID, bossRoom.Boss.Ref, strings.Join(monsters.Refs(), ", "))
 	}
+	if bossRoom.Boss.Targeting != nil {
+		if _, err := monster.ParseTargetingStrategy(*bossRoom.Boss.Targeting); err != nil {
+			return fmt.Errorf("room %q: boss targeting: %w", bossRoom.ID, err)
+		}
+	}
 	return nil
 }
 
@@ -484,49 +498,72 @@ func validatePlaceBlock(room *RoomSpec, height, roomIndex int) error {
 		}
 		occupied[entry.At] = entry.Ref
 
-		refType, err := refParts(entry.Ref)
-		if err != nil {
-			return fmt.Errorf("room %q: place %w", room.ID, err)
-		}
-		// Ref-type routing must be checked before the flags-only-on-props
-		// check below: an entry with an unrecognized ref type should always
-		// report that error, not whichever check happens to run first.
-		if refType != refTypeProps && refType != refTypeMonsters {
-			return fmt.Errorf("room %q: place ref %q must be props or monsters, got type %q",
-				room.ID, entry.Ref, refType)
-		}
-
 		path := fmt.Sprintf("rooms[%d].place[%d]", roomIndex, entryIndex)
-		if entry.Facing != nil {
-			if refType != refTypeProps || !isFloorMount(entry.Mount) {
-				return fmt.Errorf("%s.facing: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
-			}
-			if err := validateFacing(*entry.Facing); err != nil {
-				return fmt.Errorf("%s.facing: %w", path, err)
-			}
-		}
-		if !isFloorMount(entry.Mount) {
-			return fmt.Errorf("%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
-		}
-
-		if room.Boss != nil && entry.Ref == room.Boss.Ref {
-			return fmt.Errorf("room %q: boss ref may not also appear in place (ref %q)", room.ID, entry.Ref)
-		}
-
-		if refType == refTypeMonsters {
-			if _, ok := monsters.ByRef(entry.Ref); !ok {
-				return fmt.Errorf("room %q: place %q: unknown monster ref (known: %s)",
-					room.ID, entry.Ref, strings.Join(monsters.Refs(), ", "))
-			}
-			if entry.BlocksMovement != nil {
-				return fmt.Errorf("room %q: place %q: blocks_movement only valid on props", room.ID, entry.Ref)
-			}
-			if entry.BlocksLoS != nil {
-				return fmt.Errorf("room %q: place %q: blocks_los only valid on props", room.ID, entry.Ref)
-			}
+		if err := validatePlaceEntry(room, entry, path); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// validatePlaceEntry validates everything about one room-chain place entry
+// that doesn't depend on cell occupancy (validatePlaceBlock's own loop body
+// handles bounds/reserved-row/collision before calling this) — ref shape
+// and type, facing/mount capability gating, the boss-ref-not-duplicated
+// rule, and the props/monsters-only fields (blocks_movement/blocks_los,
+// targeting). Split out of validatePlaceBlock to keep that function's own
+// cyclomatic complexity under the linter's threshold.
+func validatePlaceEntry(room *RoomSpec, entry PlacedEntry, path string) error {
+	refType, err := refParts(entry.Ref)
+	if err != nil {
+		return fmt.Errorf("room %q: place %w", room.ID, err)
+	}
+	// Ref-type routing must be checked before the flags-only-on-props
+	// check below: an entry with an unrecognized ref type should always
+	// report that error, not whichever check happens to run first.
+	if refType != refTypeProps && refType != refTypeMonsters {
+		return fmt.Errorf("room %q: place ref %q must be props or monsters, got type %q",
+			room.ID, entry.Ref, refType)
+	}
+
+	if entry.Facing != nil {
+		if refType != refTypeProps || !isFloorMount(entry.Mount) {
+			return fmt.Errorf("%s.facing: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
+		}
+		if err := validateFacing(*entry.Facing); err != nil {
+			return fmt.Errorf("%s.facing: %w", path, err)
+		}
+	}
+	if !isFloorMount(entry.Mount) {
+		return fmt.Errorf("%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
+	}
+
+	if room.Boss != nil && entry.Ref == room.Boss.Ref {
+		return fmt.Errorf("room %q: boss ref may not also appear in place (ref %q)", room.ID, entry.Ref)
+	}
+
+	if refType == refTypeProps && entry.Targeting != nil {
+		return fmt.Errorf("room %q: place %q: targeting only valid on monsters", room.ID, entry.Ref)
+	}
+
+	if refType == refTypeMonsters {
+		if _, ok := monsters.ByRef(entry.Ref); !ok {
+			return fmt.Errorf("room %q: place %q: unknown monster ref (known: %s)",
+				room.ID, entry.Ref, strings.Join(monsters.Refs(), ", "))
+		}
+		if entry.BlocksMovement != nil {
+			return fmt.Errorf("room %q: place %q: blocks_movement only valid on props", room.ID, entry.Ref)
+		}
+		if entry.BlocksLoS != nil {
+			return fmt.Errorf("room %q: place %q: blocks_los only valid on props", room.ID, entry.Ref)
+		}
+		if entry.Targeting != nil {
+			if _, err := monster.ParseTargetingStrategy(*entry.Targeting); err != nil {
+				return fmt.Errorf("room %q: place %q: targeting: %w", room.ID, entry.Ref, err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/encounter/dungeonspec/validate_test.go
+++ b/encounter/dungeonspec/validate_test.go
@@ -251,6 +251,26 @@ func TestValidate_Table(t *testing.T) {
 			b := true
 			tomb(s).Place[5].BlocksMovement = &b // Place[5] is the skeleton (monster) entry
 		}, "blocks_movement only valid on props"},
+		{"targeting set on a prop place entry is rejected", "", func(s *dungeonspec.DungeonSpec) {
+			v := "closest"
+			tomb(s).Place[0].Targeting = &v // Place[0] is a prop entry (coffin)
+		}, "targeting only valid on monsters"},
+		{"targeting with an unparseable value on a monster place entry is rejected", "", func(s *dungeonspec.DungeonSpec) {
+			v := "nearest"
+			tomb(s).Place[5].Targeting = &v // Place[5] is the skeleton (monster) entry
+		}, `invalid targeting strategy "nearest"`},
+		{"targeting valid on a monster place entry is accepted", "", func(s *dungeonspec.DungeonSpec) {
+			v := "lowest-health"
+			tomb(s).Place[5].Targeting = &v // Place[5] is the skeleton (monster) entry
+		}, ""},
+		{"targeting with an unparseable value on the boss is rejected", "", func(s *dungeonspec.DungeonSpec) {
+			v := "nearest"
+			tomb(s).Boss.Targeting = &v
+		}, `invalid targeting strategy "nearest"`},
+		{"targeting valid on the boss is accepted", "", func(s *dungeonspec.DungeonSpec) {
+			v := "lowest-ac"
+			tomb(s).Boss.Targeting = &v
+		}, ""},
 		{"boss ref duplicated in place is rejected", "", func(s *dungeonspec.DungeonSpec) {
 			tomb(s).Place = append(tomb(s).Place, dungeonspec.PlacedEntry{Ref: tomb(s).Boss.Ref, At: [2]int{0, 0}})
 		}, "boss ref may not also appear in place"},

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -455,6 +455,15 @@ func (e *Encounter) AddDoor(id core.EntityID, position core.Hex, open bool) erro
 	return nil
 }
 
+// ErrMonsterDataRequired is returned by AddMonster when input.DataJSON is
+// empty (rpg-toolkit#895 no-fallback rider). A monster with no serialized
+// monster.Data cannot be rehydrated by NPCAct — before this rider, NPCAct
+// silently degraded to npcActScripted's minimal closest-player attack
+// instead. Every production seeder (encounter/seed_monsters.go) already
+// marshals DataJSON via monster.ToData(); this rejects the gap at the
+// door instead of letting it surface later as a confusing NPCAct failure.
+var ErrMonsterDataRequired = errors.New("monster DataJSON is required")
+
 // AddMonster registers a monster seat. Mirrors AddPlayer / AddDoor and is
 // the primary fixture verb for tests and orchestrator-driven seeding.
 //
@@ -489,6 +498,9 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 func (e *Encounter) addMonsterNoCombatCheck(input MonsterInput) error {
 	if input.ID == "" {
 		return errors.New("monster ID required")
+	}
+	if len(input.DataJSON) == 0 {
+		return fmt.Errorf("%w: %q", ErrMonsterDataRequired, input.ID)
 	}
 	if _, exists := e.data.Monsters[input.ID]; exists {
 		return fmt.Errorf("monster %q already in encounter", input.ID)

--- a/encounter/encounter_end_condition_sweep_test.go
+++ b/encounter/encounter_end_condition_sweep_test.go
@@ -153,6 +153,7 @@ func (s *EncounterEndConditionSweepSuite) loadRagingBarbVsGoblin(charJSON json.R
 		HP:       1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef:  monsterRefGoblin,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())

--- a/encounter/encounter_test.go
+++ b/encounter/encounter_test.go
@@ -56,6 +56,44 @@ func (s *EncounterSuite) TestAddPlayer_RejectsDuplicate() {
 	s.Error(e.AddPlayer(input))
 }
 
+// TestAddMonster_RejectsEmptyDataJSON is the no-fallback rider
+// (rpg-toolkit#895): AddMonster used to accept an empty-DataJSON monster
+// and NPCAct would silently degrade to npcActScripted's minimal
+// closest-player attack. That fallback is deleted; AddMonster now rejects
+// the gap at the door with a typed sentinel error.
+func (s *EncounterSuite) TestAddMonster_RejectsEmptyDataJSON() {
+	e := encounter.New(context.Background(), "enc-1", s.broker)
+	err := e.AddMonster(encounter.MonsterInput{
+		ID: "goblin-1", Position: core.Hex{}, HP: 7, MaxHP: 7,
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrMonsterDataRequired)
+}
+
+// TestNPCAct_LoudErrorOnEmptyDataJSON: NPCAct itself must also reject an
+// empty-DataJSON monster with a typed sentinel error (rpg-toolkit#895).
+// AddMonster's own rejection (above) makes this unreachable through the
+// public API — the guard is instead reached here via LoadFromData, which
+// round-trips whatever Data it is handed without re-validating it, the
+// same way a caller that mutated MonsterData directly could reach it.
+func (s *EncounterSuite) TestNPCAct_LoudErrorOnEmptyDataJSON() {
+	data := &encounter.Data{
+		ID:         "enc-1",
+		Mode:       core.ModeTurnBased,
+		Initiative: []core.EntityID{"goblin-1"},
+		Monsters: map[core.EntityID]*encounter.MonsterData{
+			"goblin-1": {ID: "goblin-1", Position: core.Hex{}, HP: 7, MaxHP: 7, AC: 15},
+		},
+	}
+	e, err := encounter.LoadFromData(context.Background(), data, s.broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: "slashing"}))
+	s.Require().NoError(err)
+
+	err = e.NPCAct(context.Background(), "goblin-1")
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrMonsterNotRehydratable)
+}
+
 // ToData / LoadFromData round-trips through JSON cleanly. This test is
 // load-bearing because earlier iterations of this design failed JSON
 // round-trip for HexSet (struct map keys) — the types subpackage's

--- a/encounter/events/action_resolved.go
+++ b/encounter/events/action_resolved.go
@@ -32,6 +32,13 @@ type ActionResolvedEvent struct {
 	// TargetID is the primary target, when the action has one. Empty for
 	// self / no-target actions (Dodge, Dash).
 	TargetID core.EntityID
+	// TargetRationale names WHY this target was chosen, as a canonical ref
+	// (e.g. "dnd5e:targeting:lowest-hp" — see
+	// rulebooks/dnd5e/monster.TargetingStrategy.Ref). Populated only on the
+	// NPC/monster attack path, where a targeting strategy made the
+	// decision (rpg-toolkit#895); empty for player-taken actions, which
+	// have no AI decision to explain.
+	TargetRationale string
 	// EconomyConsumed reports what this action spent off the turn economy.
 	EconomyConsumed EconomyConsumed
 	// PerPlayer is the per-viewer visibility projection.
@@ -75,6 +82,7 @@ func NewActionResolvedEvent(
 	actorID core.EntityID,
 	actionRef string,
 	targetID core.EntityID,
+	targetRationale string,
 	consumed EconomyConsumed,
 	perPlayer map[core.PlayerID]ActionResolvedSlice,
 ) *ActionResolvedEvent {
@@ -84,6 +92,7 @@ func NewActionResolvedEvent(
 		ActorID:         actorID,
 		ActionRef:       actionRef,
 		TargetID:        targetID,
+		TargetRationale: targetRationale,
 		EconomyConsumed: consumed,
 		PerPlayer:       perPlayer,
 	}
@@ -108,6 +117,7 @@ type actionResolvedWire struct {
 	ActorID         core.EntityID                         `json:"actor_id"`
 	ActionRef       string                                `json:"action_ref"`
 	TargetID        core.EntityID                         `json:"target_id,omitempty"`
+	TargetRationale string                                `json:"target_rationale,omitempty"`
 	EconomyConsumed EconomyConsumed                       `json:"economy_consumed"`
 	PerPlayer       map[core.PlayerID]ActionResolvedSlice `json:"per_player"`
 }
@@ -122,6 +132,7 @@ func (e *ActionResolvedEvent) MarshalJSON() ([]byte, error) {
 		ActorID:         e.ActorID,
 		ActionRef:       e.ActionRef,
 		TargetID:        e.TargetID,
+		TargetRationale: e.TargetRationale,
 		EconomyConsumed: e.EconomyConsumed,
 		PerPlayer:       e.PerPlayer,
 	})
@@ -140,6 +151,7 @@ func (e *ActionResolvedEvent) UnmarshalJSON(b []byte) error {
 	e.ActorID = w.ActorID
 	e.ActionRef = w.ActionRef
 	e.TargetID = w.TargetID
+	e.TargetRationale = w.TargetRationale
 	e.EconomyConsumed = w.EconomyConsumed
 	e.PerPlayer = w.PerPlayer
 	return nil

--- a/encounter/events/events_test.go
+++ b/encounter/events/events_test.go
@@ -110,7 +110,7 @@ func (s *EventsSuite) TestSpineMeta_StampAndAccessors() {
 		events.NewMoveEvent("enc-1", 1, "bob", core.Hex{}, nil, nil, "", nil),
 		events.NewAttackResolvedEvent("enc-1", 2, "a", "b", true, false, 1, 1, 1, false, false, nil, nil, nil),
 		events.NewDamageDealtEvent("enc-1", 3, "a", "b", 1, "slashing", 1, 1, nil),
-		events.NewActionResolvedEvent("enc-1", 4, "a", "dnd5e:action:attack", "b",
+		events.NewActionResolvedEvent("enc-1", 4, "a", "dnd5e:action:attack", "b", "",
 			events.EconomyConsumed{Actions: 1}, nil),
 	}
 	for _, e := range samples {
@@ -155,6 +155,7 @@ func (s *EventsSuite) TestActionResolvedEvent_JSONRoundTrip() {
 
 	original := events.NewActionResolvedEvent(
 		"enc-1", 21, "char-alice", "dnd5e:actions:strike", "goblin-1",
+		"dnd5e:targeting:lowest-hp",
 		events.EconomyConsumed{
 			Actions:         1,
 			GrantedConsumed: map[string]int{"attacks": 1},
@@ -177,6 +178,8 @@ func (s *EventsSuite) TestActionResolvedEvent_JSONRoundTrip() {
 	s.Equal(core.EntityID("char-alice"), decoded.ActorID)
 	s.Equal("dnd5e:actions:strike", decoded.ActionRef)
 	s.Equal(core.EntityID("goblin-1"), decoded.TargetID)
+	s.Equal("dnd5e:targeting:lowest-hp", decoded.TargetRationale,
+		"decision rationale must survive the JSON round trip (rpg-toolkit#895)")
 	s.Equal(1, decoded.EconomyConsumed.Actions)
 	s.Equal(1, decoded.EconomyConsumed.GrantedConsumed["attacks"])
 	s.Equal(at, decoded.OccurredAt())

--- a/encounter/exit_combat_test.go
+++ b/encounter/exit_combat_test.go
@@ -91,6 +91,7 @@ func (s *EncounterEndConditionSweepSuite) TestKillingBlow_ExitCombat_IdempotentO
 		HP:       1, MaxHP: 7, AC: 5,
 		MonsterRef:  monsterRefGoblin,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// The killing blow triggers checkEncounterEnd -> endCombatForPlayers,
 	// which now calls ExitCombat alongside EndCombat for every held player.

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808195750-c65dfff20cca
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808232907-1eb7569a9e1f
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.2-0.20260804121443-8f30f27a61ae
 	github.com/stretchr/testify v1.11.1

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.2-0.20260804104832-df6a2f5171ef
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808195750-c65dfff20cca
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.2-0.20260804121443-8f30f27a61ae
 	github.com/stretchr/testify v1.11.1

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808195750-c65dfff20cca h1:bN6FRBqfsipkWcDbUn9CmRVuL3cUXMoyp+xx1nKuikI=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808195750-c65dfff20cca/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808232907-1eb7569a9e1f h1:7GrfqNctqd7q4FTRS8TQex3KjFTy6jHvwSbC7P67Iv0=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808232907-1eb7569a9e1f/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3 h1:MIfL0WWHeeVJIDHntEDlzN+mXphq7HGYuadxa/I6pEc=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/
 github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.2-0.20260804104832-df6a2f5171ef h1:Rftg2VWheatzbb404YB0OeP3Po3JUfPc/Z8nxbulQC0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.2-0.20260804104832-df6a2f5171ef/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808195750-c65dfff20cca h1:bN6FRBqfsipkWcDbUn9CmRVuL3cUXMoyp+xx1nKuikI=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808195750-c65dfff20cca/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3 h1:MIfL0WWHeeVJIDHntEDlzN+mXphq7HGYuadxa/I6pEc=
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=

--- a/encounter/hydration_test.go
+++ b/encounter/hydration_test.go
@@ -117,6 +117,7 @@ func (s *HydrationCascadeSuite) loadEncounterWithRogue() *tkenc.Encounter {
 		ID: hydrGoblinID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), hydrGoblinID),
 	}))
 
 	// Round-trip through Data so we exercise the production load path.
@@ -311,6 +312,7 @@ func (s *HydrationCascadeSuite) TestResolver_ReceivesHeldEntity() {
 		ID: hydrGoblinID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), hydrGoblinID),
 	}))
 
 	enc2 := s.reloadViaWithResolver(enc, spy)
@@ -343,6 +345,7 @@ func (s *HydrationCascadeSuite) TestResolver_NoDataJSON_FallsBack() {
 		ID: hydrGoblinID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), hydrGoblinID),
 	}))
 
 	enc2 := s.reloadViaWithResolver(enc, spy)

--- a/encounter/initiative_rolled_test.go
+++ b/encounter/initiative_rolled_test.go
@@ -66,6 +66,7 @@ func (s *InitiativeRolledSuite) TestSetMode_InitiativeRolled_SequencedBetweenMod
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
 
@@ -118,6 +119,7 @@ func (s *InitiativeRolledSuite) TestEndTurn_DoesNotRepublishInitiativeRolled() {
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
 	s.Require().Equal(core.EntityID("char-alice"), s.enc.ActiveActor(),
@@ -145,6 +147,7 @@ func (s *InitiativeRolledSuite) TestSetMode_FreeRoamTransition_NoInitiativeRolle
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 1, R: 0, S: -1}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Require().Equal(core.ModeTurnBased, s.enc.Mode())
 	_ = collectEventsTyped(s.aliceSub, 300*time.Millisecond) // drain the entry transition's events

--- a/encounter/integration_test.go
+++ b/encounter/integration_test.go
@@ -246,6 +246,7 @@ func (s *ConditionPersistenceSuite) TestSlice_ConditionStatePersistsAcrossAttack
 		Position: core.Hex{Q: 1},
 		HP:       20, MaxHP: 20, AC: 12,
 		DamageDice: dice1d6, DamageType: damagePiercing,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 
 	// alice and the goblin are in mutual LoS, so AddMonster already
@@ -306,6 +307,7 @@ func (s *ConditionPersistenceSuite) TestSlice_ReactionReadinessPersistsThroughRo
 		Position: core.Hex{Q: 1},
 		HP:       10, MaxHP: 10, AC: 11,
 		DamageDice: "1d4", DamageType: damagePiercing,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 
 	// Mutate readiness before serialising.

--- a/encounter/knowledge_internal_test.go
+++ b/encounter/knowledge_internal_test.go
@@ -62,6 +62,7 @@ func (s *KnowledgeInternalSuite) TestKnownHexes_WitnessedRemoval_UpdatesImmediat
 	goblinHex := core.Hex{Q: 2, R: -2, S: 0}
 	s.Require().NoError(e.AddMonster(MonsterInput{
 		ID: knowledgeGobEntityID, Position: goblinHex, HP: 1, MaxHP: 1, AC: 10,
+		DataJSON: smGoblinDataJSON(s.T(), knowledgeGobEntityID),
 	}))
 
 	before := e.KnownHexes(knowledgeAlicePlayerID)
@@ -129,6 +130,7 @@ func (s *KnowledgeInternalSuite) TestKnownHexes_WitnessedRemoval_OnlyRefreshesWi
 	goblinHex := core.Hex{Q: 0, R: 0, S: 0}
 	s.Require().NoError(e.AddMonster(MonsterInput{
 		ID: knowledgeGobEntityID, Position: goblinHex, HP: 1, MaxHP: 1, AC: 10,
+		DataJSON: smGoblinDataJSON(s.T(), knowledgeGobEntityID),
 	}))
 	// bystander is far from the goblin and never sees it at all.
 	s.Require().NoError(e.AddPlayer(PlayerInput{

--- a/encounter/knowledge_test.go
+++ b/encounter/knowledge_test.go
@@ -169,6 +169,7 @@ func (s *KnowledgeSuite) TestKnownHexes_ReSight_AtomicallyRefreshesContent() {
 	// mutation — proven directly by re-reading, not just asserted).
 	s.Require().NoError(e.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: targetHex, HP: 7, MaxHP: 7, AC: 12,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	stillStale := e.KnownHexes(alicePlayerID)
 	s.Empty(contentIDs(stillStale[targetHex]),
@@ -203,6 +204,7 @@ func (s *KnowledgeSuite) TestKnownHexes_HiddenMutation_LeavesUnrelatedMemoryUnto
 	// A monster spawns far outside alice's sight.
 	s.Require().NoError(e.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: hidden, HP: 7, MaxHP: 7, AC: 12,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	after := e.KnownHexes(alicePlayerID)
@@ -237,6 +239,7 @@ func (s *KnowledgeSuite) TestKnownHexes_MultiViewer_Isolation() {
 	aliceOnlyHex := core.Hex{Q: 2, R: -2, S: 0}
 	s.Require().NoError(e.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: aliceOnlyHex, HP: 7, MaxHP: 7, AC: 12,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	// alice's own move refreshes her memory of aliceOnlyHex (per the
 	// AddPlayer/AddMonster ordering note elsewhere in this file).
@@ -285,6 +288,7 @@ func (s *KnowledgeSuite) TestKnownHexes_PersistReload_SurvivesWithoutConsultingW
 	goblinHex := core.Hex{Q: 2, R: -2, S: 0}
 	s.Require().NoError(e1.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: goblinHex, HP: 7, MaxHP: 7, AC: 12,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 	s.Require().NoError(e1.Move(alicePlayerID, []core.Hex{{Q: 1, R: -1, S: 0}}))
 	s.Require().NoError(e1.Move(alicePlayerID, []core.Hex{{Q: 30, R: -30, S: 0}}))
@@ -329,6 +333,7 @@ func (s *KnowledgeSuite) TestKnownHexes_DuplicateReconciliation_Idempotent() {
 	}))
 	s.Require().NoError(e.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: -1, S: 0}, HP: 7, MaxHP: 7, AC: 12,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	first := e.KnownHexes(alicePlayerID)

--- a/encounter/midturn_unconscious_economy_test.go
+++ b/encounter/midturn_unconscious_economy_test.go
@@ -121,6 +121,7 @@ func (s *MidTurnUnconsciousEconomySuite) SetupTest() {
 		ID: mueGoblinID, Position: core.Hex{Q: 2, R: 0, S: -2},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), mueGoblinID),
 	}))
 
 	// Round-trip through Data so the hydration cascade holds alice's

--- a/encounter/monster_fixture_test.go
+++ b/encounter/monster_fixture_test.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// monster_fixture_test.go provides one shared helper for hand-built
+// MonsterInput/AddMonster fixtures across this package's test files.
+//
+// rpg-toolkit#895's no-fallback rider makes AddMonster reject empty
+// DataJSON (NPCAct's old empty-DataJSON fallback, npcActScripted, is
+// deleted). Before this rider, most fixtures in this package left
+// DataJSON unset — fine for tests that never rehydrate the monster onto
+// the rules engine, but no longer accepted at all. testGoblinDataJSON
+// gives every such fixture a real, rehydratable registry monster instead
+// of a bespoke stat blob.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+)
+
+// testGoblinDataJSON returns valid, rehydratable monster.Data JSON for a
+// real registry goblin with the given entity id. Takes core.EntityID (not
+// string) because most fixture IDs across this package are already typed
+// core.EntityID constants (MonsterInput.ID's own type) — untyped string
+// constants/literals convert to it implicitly, so this accepts both without
+// per-call-site conversions.
+func testGoblinDataJSON(t *testing.T, id core.EntityID) []byte {
+	t.Helper()
+	b, err := json.Marshal(monster.NewGoblin(string(id)).ToData())
+	require.NoError(t, err)
+	return b
+}

--- a/encounter/monster_visibility_test.go
+++ b/encounter/monster_visibility_test.go
@@ -58,6 +58,7 @@ func (s *MonsterVisibilitySuite) TestMoveIntoMonsterLOS_AppearsOnTheSameMoveThat
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, s.enc.Mode(), "goblin out of LoS at add time")
 
@@ -110,6 +111,7 @@ func (s *MonsterVisibilitySuite) TestMoveOutOfMonsterLOS_Disappears() {
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	s.Require().Equal(core.ModeFreeRoam, s.enc.Mode(), "goblin out of LoS at add time")
 
@@ -158,6 +160,7 @@ func (s *MonsterVisibilitySuite) TestStaysVisible_NoAppearDisappearEvents() {
 	}))
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: "goblin-1", Position: core.Hex{Q: 0, R: 0, S: 0}, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), "goblin-1"),
 	}))
 	// AddMonster flips the mode AND publishes EntityAppearedEvent (the goblin
 	// is visible at add time — rpg-toolkit#764) — drain both so the

--- a/encounter/move_resolver_test.go
+++ b/encounter/move_resolver_test.go
@@ -318,6 +318,7 @@ func (s *MovementResolverSuite) addGoblinForNPCMovementTests() {
 		AttackBonus: 4,
 		DamageDice:  damage1d6plus1,
 		DamageType:  damageSlashing,
+		DataJSON:    testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 }
 

--- a/encounter/movement_occupancy_test.go
+++ b/encounter/movement_occupancy_test.go
@@ -49,6 +49,7 @@ func (s *MovementOccupancySuite) addPlayer(sightRange int) {
 func (s *MovementOccupancySuite) addMonster(id string, position core.Hex) {
 	s.Require().NoError(s.enc.AddMonster(encounter.MonsterInput{
 		ID: core.EntityID(id), Position: position, HP: 7, MaxHP: 7,
+		DataJSON: testGoblinDataJSON(s.T(), core.EntityID(id)),
 	}))
 }
 

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -52,11 +52,15 @@ func (e *Encounter) NPCAct(ctx context.Context, npcID encountercore.EntityID) er
 		return ErrNoCombatResolver
 	}
 	if len(mon.DataJSON) == 0 {
-		// No rehydratable monster — fall back to a minimal scripted attack
-		// against the closest reachable player, using the monster's stored
-		// AttackBonus / DamageDice / DamageType. This keeps the verb
-		// non-blocking when the orchestrator only seeded the snapshot fields.
-		return e.npcActScripted(ctx, mon)
+		// No-fallback rider (rpg-toolkit#895): an empty-DataJSON monster used
+		// to fall back to npcActScripted's minimal closest-player attack,
+		// which had no targeting strategy, no decision rationale, and its
+		// own separate (and looser) combat gating. AddMonster now rejects
+		// empty DataJSON outright (encounter.go), so this branch should be
+		// unreachable via the public API; it stays as a loud typed error
+		// rather than a silent scripted fallback in case a caller mutates
+		// MonsterData directly.
+		return fmt.Errorf("%w: %q", ErrMonsterNotRehydratable, npcID)
 	}
 
 	// Wave 2.11d: use the encounter-scoped bus instead of a fresh per-call
@@ -1024,63 +1028,32 @@ func (e *Encounter) applyCapturedConditions(mon *MonsterData, conds []dnd5eEvent
 	return nil
 }
 
-// npcActScripted runs a minimal attack against the closest player when
-// the monster has no DataJSON to rehydrate. Used for tests and
-// orchestrator-seeded fixtures that don't carry a serialized monster.
-//
-// Delegates to the wired CombatResolver (same as applyCapturedAttacks and
-// TakeAction). The resolver guard at NPCAct entry ensures combatResolver
-// is non-nil before this path is reached.
-//
-// Wave 2.10: same partial player-death semantics as applyCapturedAttacks
-// — fires EntityDiedEvent on a player kill (only on HP transition, not
-// whenever HP is 0) but does not remove the player or end the encounter.
-func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
-	target := e.closestPlayer(mon.Position)
-	if target == nil {
-		return nil
+// ErrMonsterNotRehydratable is returned by NPCAct when a monster has empty
+// DataJSON (rpg-toolkit#895 no-fallback rider). Before this rider, NPCAct
+// silently fell back to npcActScripted's minimal closest-player attack
+// (no targeting strategy, no decision rationale, looser combat gating);
+// that fallback is deleted, so an empty-DataJSON monster is now a loud
+// error instead of quietly degraded behavior. AddMonster (encounter.go)
+// rejects empty DataJSON outright, so this should be unreachable via the
+// public API — it exists for callers that mutate MonsterData directly.
+var ErrMonsterNotRehydratable = errors.New("monster has no DataJSON to rehydrate: empty-DataJSON fallback removed")
+
+// monsterTargetingRationale derives the decision-rationale ref
+// (rpg-toolkit#895, e.g. "dnd5e:targeting:lowest-hp") for a monster's NPC
+// attack from its persisted targeting strategy. Used on both the inline
+// NPC-attack path (applyCapturedAttacks, via applyAndPublishNPCOutcome) and
+// the Shield-resume path (CompleteTakeAction), which have no live
+// *monster.Monster instance in common but always have MonsterData.DataJSON
+// — the no-fallback rider (AddMonster, encounter.go) guarantees it is never
+// empty for any monster reachable here. Best-effort: a DataJSON that fails
+// to unmarshal returns "" rather than failing attack resolution over a
+// descriptive field.
+func monsterTargetingRationale(mon *MonsterData) string {
+	var data monster.Data
+	if err := json.Unmarshal(mon.DataJSON, &data); err != nil {
+		return ""
 	}
-	// rpg-toolkit#864: this fallback has no ranged/melee action distinction
-	// at all (it's a single flat stat-snapshot "attack"), so it gates as
-	// melee — same shared gate as applyCapturedAttacks/TakeActionPhased.
-	// Before this, npcActScripted always attacked whichever player was
-	// closest regardless of distance — a real, separate entry point into
-	// the resolver the QA-reported bug's gate must also cover.
-	//
-	// Gate-review finding (blocker 1): the closest player being out of
-	// reach is "nothing to do this turn", the same as the target==nil case
-	// two lines up — NOT an error. This verb has no other action to fall
-	// back to (it's the whole scripted turn), and NPCAct's caller (rpg-api's
-	// driveNPCChain) only calls EndTurn after NPCAct returns successfully;
-	// returning an error here would make an out-of-reach monster wedge the
-	// encounter forever (every retry hits the identical rejection). A
-	// monster that can't reach anyone simply passes its turn.
-	reach := meleeReachForCombatant(e.combatantFor(mon.ID))
-	if checkReach(mon.Position, target.View.Position, reach, "reach") != nil {
-		return nil
-	}
-	outcome, err := e.combatResolver.ResolveAttack(AttackInput{
-		AttackerID:          mon.ID,
-		TargetID:            target.EntityID,
-		ActionRef:           core.Ref{Module: "dnd5e", Type: "action", ID: actionIDAttack},
-		AttackerAttackBonus: mon.AttackBonus,
-		AttackerDamageDice:  mon.DamageDice,
-		AttackerDamageType:  mon.DamageType,
-		TargetAC:            target.AC,
-		EventBus:            e.bus,
-		Attacker:            e.combatantFor(mon.ID),
-		Defender:            e.combatantFor(target.EntityID),
-	})
-	if err != nil {
-		return fmt.Errorf("combat resolver: %w", err)
-	}
-	if outcome == nil {
-		return fmt.Errorf("combat resolver: nil outcome with nil error")
-	}
-	// Wave 2.11e: share the NPC-attacker outcome publish path. Same
-	// rationale as applyCapturedAttacks above — inline scripted attacks
-	// and the phased Shield-resume direction must emit identical shapes.
-	return e.applyAndPublishNPCOutcome(mon, target, outcome)
+	return data.Targeting.Ref()
 }
 
 // buildPerception assembles the PerceptionData a monster needs to choose
@@ -1214,28 +1187,6 @@ type playerEntity struct {
 func (p *playerEntity) GetID() string            { return p.id }
 func (p *playerEntity) GetType() core.EntityType { return "character" }
 func (p *playerEntity) GetName() string          { return p.name }
-
-// closestPlayer returns the LIVE player (HP>0) nearest the given hex, or nil
-// if the encounter has no live players. #733: a downed player (HP<=0) is
-// never returned — before this fix, npcActScripted (the caller) would keep
-// targeting/attacking a downed player round after round, since nothing
-// filtered by HP. The existing "no players" nil-return path already covers
-// the all-downed case correctly (the caller treats nil as "nothing to do").
-func (e *Encounter) closestPlayer(from encountercore.Hex) *PlayerData {
-	var best *PlayerData
-	bestDist := -1
-	for _, p := range e.data.Players {
-		if p.HP <= 0 {
-			continue
-		}
-		d := hexDistance(from, p.View.Position)
-		if best == nil || d < bestDist {
-			best = p
-			bestDist = d
-		}
-	}
-	return best
-}
 
 // findPlayerByEntityID returns the player whose EntityID matches id.
 func (e *Encounter) findPlayerByEntityID(id encountercore.EntityID) *PlayerData {

--- a/encounter/npc_targeting_downed_test.go
+++ b/encounter/npc_targeting_downed_test.go
@@ -2,15 +2,15 @@ package encounter_test
 
 // rpg-toolkit#733 — playtest evidence: a goblin kept attacking a corpse
 // round after round because nothing filtered NPC targeting by player HP.
-// Two call sites feed a monster's targeting:
-//   - closestPlayer (scripted path, no monster DataJSON) — exercised here via
-//     npcActScripted / NPCAct directly.
-//   - buildPerception (full monster.TakeTurn path, DataJSON present) — feeds
-//     monster.PerceptionData.Enemies, which ClosestEnemy()/TargetLowestHP/
-//     TargetLowestAC all read from.
+// buildPerception (full monster.TakeTurn path) feeds
+// monster.PerceptionData.Enemies, which ClosestEnemy()/TargetLowestHP/
+// TargetLowestAC all read from, and must skip any player at HP<=0 (dead or
+// unconscious) — this file proves it never targets the downed player,
+// across multiple turns.
 //
-// Both must skip any player at HP<=0 (dead or unconscious) — this file
-// proves both never target the downed player, across multiple turns.
+// A second call site, closestPlayer (the npcActScripted empty-DataJSON
+// fallback path), had its own equivalent test here; rpg-toolkit#895's
+// no-fallback rider deleted npcActScripted and closestPlayer along with it.
 
 import (
 	"context"
@@ -55,84 +55,13 @@ func (s *NPCTargetingDownedSuite) TearDownTest() {
 	_ = s.transport.Close()
 }
 
-// TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer is the closestPlayer
-// regression proof, reproducing the exact reported soft-lock: a downed player
-// positioned CLOSER to the goblin than the alive player. npcActScripted has
-// no adjacency gate of its own (unlike the DataJSON/Scimitar path's
-// MeleeAction.CanActivate) — pre-#733-fix this deterministically attacks the
-// corpse every single turn. Across 3 goblin turns, the fix must make the
-// goblin attack ONLY the live player, never the downed one.
-//
-// rpg-toolkit#864: npcActScripted now also gates on reach (the shared
-// range/reach validation every actor's attack path goes through), so the
-// live player must be positioned within melee reach of the goblin, not just
-// "farther than the downed one" — the downed player sits on the goblin's own
-// hex (distance 0, the closest possible) and the live player one hex away
-// (distance 1, still in reach), preserving "downed is strictly closer" while
-// keeping the correct target attackable.
-func (s *NPCTargetingDownedSuite) TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer() {
-	encID := core.EncounterID("enc-ntd-scripted")
-	enc := encounter.New(s.ctx, encID, s.broker,
-		encounter.WithCombatResolver(alwaysHitResolver{damage: 1, damageType: damageSlashing}),
-	)
-	// Downed player co-located with the goblin (distance 0) — strictly
-	// closer than the alive player.
-	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: "ntd-down", EntityID: ntdDownEntityID,
-		Position: core.Hex{}, SightRange: 10,
-		HP: 0, MaxHP: 12, AC: 10,
-	}))
-	// Alive player is one hex away (distance 1) — farther than the downed
-	// player, but still within the goblin's default melee reach.
-	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: ntdAlivePlayerID, EntityID: ntdAliveEntityID,
-		Position: core.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
-		HP: 12, MaxHP: 12, AC: 10,
-	}))
-	// No DataJSON — triggers the scripted (closestPlayer) path.
-	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID: gobEntityID, Position: core.Hex{},
-		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-	}))
-
-	aliceSub, err := s.broker.Subscribe(encID, ntdAlivePlayerID)
-	s.Require().NoError(err)
-	defer func() { _ = aliceSub.Close() }()
-
-	// The downed player is in LoS of the goblin, so AddMonster already
-	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
-	// redundant and error.
-
-	for turn := 0; turn < 3; turn++ {
-		for enc.ActiveActor() != gobEntityID {
-			_, _, endErr := enc.EndTurn(s.ctx, enc.ActiveActor())
-			s.Require().NoError(endErr)
-		}
-		drainSub(aliceSub, 50*time.Millisecond)
-
-		s.Require().NoError(enc.NPCAct(s.ctx, gobEntityID))
-
-		seen := collectEventsTyped(aliceSub, 300*time.Millisecond)
-		var attack *events.AttackResolvedEvent
-		for _, e := range seen {
-			if a, ok := e.(*events.AttackResolvedEvent); ok {
-				attack = a
-			}
-		}
-		s.Require().NotNil(attack, "turn %d: goblin must attack someone", turn)
-		s.Equal(ntdAliveEntityID, attack.TargetID,
-			"turn %d: goblin must target the live player, never the downed one (closestPlayer HP filter)", turn)
-
-		_, _, endErr := enc.EndTurn(s.ctx, gobEntityID)
-		s.Require().NoError(endErr)
-	}
-}
-
 // TestFullAIPath_BuildPerception_NeverTargetsDownedPlayer is the
 // buildPerception regression proof, using the full monster.TakeTurn AI path
-// (DataJSON goblin, ClosestEnemy() targeting via ScimitarAction) rather than
-// the scripted stand-in. The downed player is adjacent (would be
+// (DataJSON goblin, ClosestEnemy() targeting via ScimitarAction) — the ONLY
+// path left after rpg-toolkit#895's no-fallback rider deleted npcActScripted
+// and its closestPlayer targeting helper (a second formerly-tested call site,
+// TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer, went with them).
+// The downed player is adjacent (would be
 // ClosestEnemy() and in melee range pre-fix); the alive player is farther
 // and non-adjacent. This asserts the negative: across the goblin's turn(s),
 // it never attacks or damages the downed player. (It does not assert the

--- a/encounter/npc_test.go
+++ b/encounter/npc_test.go
@@ -20,8 +20,10 @@ import (
 // monsterRefGoblin is the canonical monster ref used across NPC fixtures.
 const monsterRefGoblin = "dnd5e:monsters:goblin"
 
-// NPCSuite covers the full NPCAct path through monster.TakeTurn —
-// distinct from CombatSuite which uses the scripted DataJSON-less path.
+// NPCSuite covers the full NPCAct path through monster.TakeTurn. CombatSuite
+// used to cover a second, scripted DataJSON-less path (npcActScripted);
+// rpg-toolkit#895's no-fallback rider deleted it, so every monster fixture
+// in this package now goes through this same hydrated path.
 type NPCSuite struct {
 	suite.Suite
 	ctx       context.Context
@@ -96,6 +98,35 @@ func (s *NPCSuite) TestNPCAct_GoblinTakeTurn_PublishesAttack() {
 	s.Contains(seen, "*events.AttackResolvedEvent")
 }
 
+// TestNPCAct_AttackPublishesTargetRationale is the NPC-path half of the
+// decision-rationale proof (rpg-toolkit#895; the player-path "must be
+// empty" half is TestTakeAction_PublishesAttackOutcome in combat_test.go).
+// SetupTest's goblin never calls SetTargeting, so it carries TargetClosest
+// (the iota-zero default) — its ActionResolvedEvent must still carry the
+// explicit "dnd5e:targeting:closest" ref, not an empty string, proving
+// TargetRationale is populated from the monster's real strategy rather
+// than left as its own zero value.
+func (s *NPCSuite) TestNPCAct_AttackPublishesTargetRationale() {
+	for s.enc.ActiveActor() != gobEntityID {
+		_, _, err := s.enc.EndTurn(context.Background(), s.enc.ActiveActor())
+		s.Require().NoError(err)
+	}
+	drainSub(s.aliceSub, 100*time.Millisecond)
+
+	err := s.enc.NPCAct(s.ctx, gobEntityID)
+	s.Require().NoError(err)
+
+	seen := collectEventsTyped(s.aliceSub, time.Second)
+	var action *encevents.ActionResolvedEvent
+	for _, e := range seen {
+		if a, ok := e.(*encevents.ActionResolvedEvent); ok {
+			action = a
+		}
+	}
+	s.Require().NotNil(action, "expected an ActionResolvedEvent")
+	s.Equal("dnd5e:targeting:closest", action.TargetRationale)
+}
+
 // NPCAct outside TURN_BASED returns ErrNotTurnBased. Own monster-less
 // encounter so the fixture stays FreeRoam (the shared s.enc is already
 // TURN_BASED by setup time — alice and the goblin start in mutual LoS).
@@ -156,34 +187,6 @@ func (s *NPCSuite) TestNPCAct_ErrNoCombatResolver() {
 	}
 
 	err = enc.NPCAct(s.ctx, gobEntityID)
-	s.ErrorIs(err, encounter.ErrNoCombatResolver)
-}
-
-// NPCAct (scripted path — no DataJSON) returns ErrNoCombatResolver when
-// no resolver is wired.
-func (s *NPCSuite) TestNPCAct_Scripted_ErrNoCombatResolver() {
-	enc := encounter.New(context.Background(), "enc-npc-scripted-no-resolver", s.broker)
-	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: alicePlayerID, EntityID: aliceEntityID,
-		Position: core.Hex{}, SightRange: 10,
-		HP: 12, MaxHP: 12, AC: 14,
-	}))
-	// No DataJSON — triggers the scripted path.
-	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
-		ID:       gobEntityID,
-		Position: core.Hex{Q: 1, R: 0, S: -1},
-		HP:       7, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-	}))
-	// alice and the goblin are in mutual LoS, so AddMonster already
-	// auto-transitioned to TURN_BASED; an explicit SetMode here would be
-	// redundant and error.
-	for enc.ActiveActor() != gobEntityID {
-		_, _, endErr := enc.EndTurn(context.Background(), enc.ActiveActor())
-		s.Require().NoError(endErr)
-	}
-
-	err := enc.NPCAct(s.ctx, gobEntityID)
 	s.ErrorIs(err, encounter.ErrNoCombatResolver)
 }
 

--- a/encounter/pocket_clear_move_teardown_test.go
+++ b/encounter/pocket_clear_move_teardown_test.go
@@ -138,11 +138,13 @@ func (s *PocketClearMoveTeardownSuite) loadErinVsTwoPockets() *encounter.Encount
 		ID: pcmGobB, Position: lineHex(25),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef: monsterRefGoblin,
+		DataJSON:   testGoblinDataJSON(s.T(), pcmGobB),
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: pcmGobA, Position: lineHex(1),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef: monsterRefGoblin,
+		DataJSON:   testGoblinDataJSON(s.T(), pcmGobA),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())
@@ -335,11 +337,13 @@ func (s *PocketClearMoveTeardownSuite) TestPocketClear_CombatScopedConditionPers
 		ID: pcmGobB, Position: lineHex(15),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef: monsterRefGoblin,
+		DataJSON:   testGoblinDataJSON(s.T(), pcmGobB),
 	}))
 	s.Require().NoError(enc.AddMonster(encounter.MonsterInput{
 		ID: pcmGobA, Position: lineHex(1),
 		HP: 1, MaxHP: 7, AC: 5, Speed: 6,
 		MonsterRef: monsterRefGoblin,
+		DataJSON:   testGoblinDataJSON(s.T(), pcmGobA),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())

--- a/encounter/range_gate_test.go
+++ b/encounter/range_gate_test.go
@@ -226,6 +226,7 @@ func TestTakeAction_MeleeAttackBeyondReach_Rejected(t *testing.T) {
 	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 3, R: 0, S: -3},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(t, gobEntityID),
 	}))
 	endTurnUntilActive(t, enc, aliceEntityID)
 
@@ -253,6 +254,7 @@ func TestTakeAction_MeleeAttackAtReach_Succeeds(t *testing.T) {
 	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(t, gobEntityID),
 	}))
 	endTurnUntilActive(t, enc, aliceEntityID)
 
@@ -301,6 +303,7 @@ func hydrateWeaponWielder(
 	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
 		ID: gobEntityID, Position: monsterPos,
 		HP: 7, MaxHP: 7, AC: 15,
+		DataJSON: testGoblinDataJSON(t, gobEntityID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())
@@ -383,80 +386,21 @@ func TestTakeAction_ShortbowRange_BeyondLongRange_Rejected(t *testing.T) {
 	require.True(t, errors.Is(err, encounter.ErrOutOfRange), "got: %v", err)
 }
 
-// --- NPCAct scripted attack (monster path, no DataJSON) ---------------------
-
-// TestNPCAct_ScriptedAttackBeyondReach_PassesTurnWithoutWedging is the
-// gate-review regression for blocker 1: npcActScripted originally returned
-// the ErrOutOfRange from the shared gate directly, and NPCAct propagated it
-// as a hard failure. rpg-api's driveNPCChain only calls EndTurn after a
-// SUCCESSFUL NPCAct, so an out-of-reach monster (the closest player simply
-// too far away) would error on every single retry and the encounter would
-// be wedged forever — turn never advances, nobody can act. The fix: an
-// out-of-reach target is "nothing to do this turn" (same as the existing
-// target==nil case), not an error — NPCAct succeeds, no attack resolves,
-// and the turn ends normally afterward.
-func TestNPCAct_ScriptedAttackBeyondReach_PassesTurnWithoutWedging(t *testing.T) {
-	transport, broker := newRangeGateBroker()
-	defer func() { _ = broker.Close(); _ = transport.Close() }()
-
-	enc := encounter.New(context.Background(), "enc-rg-npc-distant", broker,
-		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
-	)
-	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: alicePlayerID, EntityID: aliceEntityID,
-		Position: core.Hex{}, SightRange: 20,
-		HP: 12, MaxHP: 12, AC: 14,
-	}))
-	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
-		ID: gobEntityID, Position: core.Hex{Q: 3, R: 0, S: -3},
-		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-		// No DataJSON: NPCAct falls back to npcActScripted, the "different
-		// entry point" the issue's spec calls out — it must be gated too.
-	}))
-	endTurnUntilActive(t, enc, gobEntityID)
-
-	err := enc.NPCAct(context.Background(), gobEntityID)
-	require.NoError(t, err, "an out-of-reach scripted attack must pass the turn, not error")
-	require.Equal(t, 12, enc.ToData().Players[alicePlayerID].HP, "no attack resolved, so no damage")
-
-	// The turn must be free to end normally — proving the encounter isn't
-	// wedged (the exact failure mode blocker 1 fixes).
-	_, _, endErr := enc.EndTurn(context.Background(), gobEntityID)
-	require.NoError(t, endErr)
-	require.Equal(t, core.EntityID(aliceEntityID), enc.ActiveActor(),
-		"turn must advance to alice, not stay stuck on the goblin")
-}
-
-func TestNPCAct_ScriptedAttackAtReach_Succeeds(t *testing.T) {
-	transport, broker := newRangeGateBroker()
-	defer func() { _ = broker.Close(); _ = transport.Close() }()
-
-	enc := encounter.New(context.Background(), "enc-rg-npc-adjacent", broker,
-		encounter.WithCombatResolver(alwaysHitResolver{damage: 8, damageType: damageSlashing}),
-	)
-	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
-		PlayerID: alicePlayerID, EntityID: aliceEntityID,
-		Position: core.Hex{}, SightRange: 20,
-		HP: 12, MaxHP: 12, AC: 14,
-	}))
-	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
-		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
-		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
-		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
-	}))
-	endTurnUntilActive(t, enc, gobEntityID)
-
-	err := enc.NPCAct(context.Background(), gobEntityID)
-	require.NoError(t, err)
-}
-
 // --- applyCapturedAttacks skip semantics (hydrated monster path) -----------
+//
+// This section used to be paired with an "NPCAct scripted attack (monster
+// path, no DataJSON)" section proving the same out-of-reach-doesn't-wedge
+// behavior for npcActScripted, the empty-DataJSON fallback. rpg-toolkit#895's
+// no-fallback rider deleted npcActScripted (AddMonster now rejects empty
+// DataJSON outright), so that section — and its own reach gate — no longer
+// exists; this hydrated-monster path is the only one left.
 
 // TestNPCAct_HydratedMonster_OutOfReachCapturedAttack_SkipsWithoutWedging is
-// the gate-review regression for blocker 1's other call site
-// (applyCapturedAttacks, the hydrated-monster path — the scripted-fallback
-// path above covers npcActScripted).
+// the gate-review regression for blocker 1: applyCapturedAttacks must skip
+// (not error) a captured attack the shared gate rejects as out of reach,
+// the same "nothing to do this turn" treatment target==nil already gets —
+// erroring here would wedge the encounter (rpg-api's driveNPCChain only
+// calls EndTurn after a SUCCESSFUL NPCAct).
 //
 // Builds a monster whose own melee action reports an inflated reach (3, via
 // a weapon name — "unmatched-claw" — that doesn't match anything in the

--- a/encounter/reaction_readiness_test.go
+++ b/encounter/reaction_readiness_test.go
@@ -65,6 +65,7 @@ func (s *ReactionReadinessSuite) addCombatMonster(id string) {
 		AC:         12,
 		DamageDice: dice1d6,
 		DamageType: damagePiercing,
+		DataJSON:   testGoblinDataJSON(s.T(), core.EntityID(id)),
 	}))
 }
 
@@ -100,7 +101,10 @@ func (s *ReactionReadinessSuite) TestAddMonster_WithoutCombatStats_DoesNotSeedOA
 		HP:    5,
 		MaxHP: 5,
 		AC:    10,
-		// No DamageDice — this is a passive prop, not a combatant
+		// No DamageDice — this is a passive prop, not a combatant. DataJSON
+		// is still required (rpg-toolkit#895 no-fallback rider) even though
+		// OA readiness itself keys off DamageDice, not DataJSON content.
+		DataJSON: testGoblinDataJSON(s.T(), "prop-1"),
 	}))
 	s.False(s.enc.IsReactionReady("prop-1", encounter.OAReactionRef),
 		"non-combatant monster should not have OA seeded")

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -45,6 +45,15 @@ type SpawnInstruction struct {
 	// canvas has an explicit floor source rather than synthetic regions.
 	// Exactly one of At and AbsoluteAt must be present for a placed spawn.
 	AbsoluteAt *core.Hex
+
+	// Targeting overrides the spawned monster's targeting strategy
+	// (rpg-toolkit#895). Nil means unset — the ctor's own default (e.g.
+	// wolf.go's TargetLowestHP) is left alone. This MUST be a pointer:
+	// TargetClosest is iota-zero, so a non-pointer field could never
+	// distinguish "author wrote targeting: closest" (which must override
+	// a non-closest ctor default) from "author omitted targeting entirely"
+	// (which must NOT).
+	Targeting *monster.TargetingStrategy
 }
 
 // resolvedSpawn is one SpawnInstruction after it has passed every
@@ -280,6 +289,9 @@ func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpa
 		}
 
 		mon := ctor(string(id))
+		if spawn.Targeting != nil {
+			mon.SetTargeting(*spawn.Targeting)
+		}
 		dataJSON, err := json.Marshal(mon.ToData())
 		if err != nil {
 			return nil, fmt.Errorf("room %q: monster %q: marshal monster data: %w", spawn.RoomID, spawn.MonsterRef, err)
@@ -350,6 +362,9 @@ func (e *Encounter) validateAbsoluteCanvasSpawn(
 			"canvas monster %q: absolute position %v collides with %s", spawn.MonsterRef, *spawn.AbsoluteAt, occupant)
 	}
 	mon := ctor(string(id))
+	if spawn.Targeting != nil {
+		mon.SetTargeting(*spawn.Targeting)
+	}
 	dataJSON, err := json.Marshal(mon.ToData())
 	if err != nil {
 		return resolvedSpawn{}, fmt.Errorf("canvas monster %q: marshal monster data: %w", spawn.MonsterRef, err)

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -47,13 +47,14 @@ type SpawnInstruction struct {
 	AbsoluteAt *core.Hex
 
 	// Targeting overrides the spawned monster's targeting strategy
-	// (rpg-toolkit#895). Nil means unset — the ctor's own default (e.g.
-	// wolf.go's TargetLowestHP) is left alone. This MUST be a pointer:
-	// TargetClosest is iota-zero, so a non-pointer field could never
-	// distinguish "author wrote targeting: closest" (which must override
-	// a non-closest ctor default) from "author omitted targeting entirely"
-	// (which must NOT).
-	Targeting *monster.TargetingStrategy
+	// (rpg-toolkit#895). monster.TargetingUnspecified (the zero value) means
+	// unset — the ctor's own default (e.g. wolf.go's TargetLowestHP) is left
+	// alone. A plain value is safe here, not a pointer: gate-review hardening
+	// moved TargetClosest off the zero value specifically so "author wrote
+	// targeting: closest" (which must override a non-closest ctor default)
+	// and "author omitted targeting entirely" (which must NOT) are
+	// structurally distinguishable without pointer nil-checks.
+	Targeting monster.TargetingStrategy
 }
 
 // resolvedSpawn is one SpawnInstruction after it has passed every
@@ -289,8 +290,8 @@ func (e *Encounter) validateSpawnBatch(spawns []SpawnInstruction) ([]resolvedSpa
 		}
 
 		mon := ctor(string(id))
-		if spawn.Targeting != nil {
-			mon.SetTargeting(*spawn.Targeting)
+		if spawn.Targeting != monster.TargetingUnspecified {
+			mon.SetTargeting(spawn.Targeting)
 		}
 		dataJSON, err := json.Marshal(mon.ToData())
 		if err != nil {
@@ -362,8 +363,8 @@ func (e *Encounter) validateAbsoluteCanvasSpawn(
 			"canvas monster %q: absolute position %v collides with %s", spawn.MonsterRef, *spawn.AbsoluteAt, occupant)
 	}
 	mon := ctor(string(id))
-	if spawn.Targeting != nil {
-		mon.SetTargeting(*spawn.Targeting)
+	if spawn.Targeting != monster.TargetingUnspecified {
+		mon.SetTargeting(spawn.Targeting)
 	}
 	dataJSON, err := json.Marshal(mon.ToData())
 	if err != nil {

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -39,6 +39,11 @@ const (
 	smRefSkeletonCaptain = "dnd5e:monsters:skeleton-captain"
 	smRefSkeleton        = "dnd5e:monsters:skeleton"
 	smRefZombie          = "dnd5e:monsters:zombie"
+	// smRefWolf's ctor (monsters.NewWolf) calls SetTargeting(TargetLowestHP)
+	// by default — used by the SpawnInstruction.Targeting tests below to
+	// prove a nil Targeting preserves that ctor default and an explicit
+	// override beats it.
+	smRefWolf = "dnd5e:monsters:wolf"
 
 	smObstacleRefCrate  = "test:obstacles:crate"
 	smObstacleRefCandle = "test:obstacles:candle"
@@ -89,6 +94,18 @@ func smNewEncounter(t *testing.T) *Encounter {
 func marshalData(t *testing.T, enc *Encounter) []byte {
 	t.Helper()
 	b, err := json.Marshal(enc.ToData())
+	require.NoError(t, err)
+	return b
+}
+
+// smGoblinDataJSON returns valid, rehydratable monster.Data JSON for a real
+// registry goblin. rpg-toolkit#895's no-fallback rider makes AddMonster
+// reject empty DataJSON, so every hand-built MonsterInput fixture in this
+// package needs a real serialized monster now, not just SeedMonsters-driven
+// ones (which already marshal DataJSON via the real ctor path).
+func smGoblinDataJSON(t *testing.T, id string) []byte {
+	t.Helper()
+	b, err := json.Marshal(monster.NewGoblin(id).ToData())
 	require.NoError(t, err)
 	return b
 }
@@ -332,6 +349,61 @@ func TestSeedMonsters_OpportunityAttackReadySeeded(t *testing.T) {
 		"the flat combat-snapshot AttackBonus must be populated from the monster's own attack action")
 	require.NotEmpty(t, m.DamageDice, "the flat combat-snapshot DamageDice must be populated")
 	require.NotEmpty(t, m.DamageType, "the flat combat-snapshot DamageType must be populated")
+}
+
+// smSpawnedTargeting spawns a single instance of ref via SeedMonsters with
+// the given Targeting override (nil is a legal "unset" value), then
+// unmarshals the resulting monster's DataJSON to read back its persisted
+// TargetingStrategy — the survival proof every targeting test below needs.
+func smSpawnedTargeting(t *testing.T, ref string, targeting *monster.TargetingStrategy) monster.TargetingStrategy {
+	t.Helper()
+	enc := smNewEncounter(t)
+	require.NoError(t, enc.InitDungeon(smDungeonParams()))
+	at := LocalHex{Col: 1, Row: 2}
+	require.NoError(t, enc.SeedMonsters([]SpawnInstruction{
+		{RoomID: smRoomIDEntrance, MonsterRef: ref, Count: 1, At: &at, Targeting: targeting},
+	}))
+	data := enc.ToData()
+	require.Len(t, data.Monsters, 1)
+	var mon *MonsterData
+	for _, m := range data.Monsters {
+		mon = m
+	}
+	require.NotNil(t, mon)
+	var monData monster.Data
+	require.NoError(t, json.Unmarshal(mon.DataJSON, &monData))
+	return monData.Targeting
+}
+
+// TestSeedMonsters_TargetingSurvivesIntoDataJSON: an explicit
+// SpawnInstruction.Targeting override reaches the spawned monster's
+// DataJSON (rpg-toolkit#895) — SetTargeting is applied before ToData()
+// marshals it, not after.
+func TestSeedMonsters_TargetingSurvivesIntoDataJSON(t *testing.T) {
+	want := monster.TargetLowestAC
+	got := smSpawnedTargeting(t, smRefSkeleton, &want)
+	require.Equal(t, monster.TargetLowestAC, got)
+}
+
+// TestSeedMonsters_NilTargetingPreservesCtorDefault: a nil
+// SpawnInstruction.Targeting (the "author omitted targeting" shape) must
+// leave the constructor's own default alone — wolf.go's NewWolf calls
+// SetTargeting(TargetLowestHP), and TargetClosest's iota-zero value would
+// silently stomp that default if Targeting were anything but a pointer.
+func TestSeedMonsters_NilTargetingPreservesCtorDefault(t *testing.T) {
+	got := smSpawnedTargeting(t, smRefWolf, nil)
+	require.Equal(t, monster.TargetLowestHP, got, "nil Targeting must not override the wolf ctor's own default")
+}
+
+// TestSeedMonsters_ExplicitClosestBeatsCtorDefault: an explicit
+// targeting: closest MUST override wolf's non-closest ctor default —
+// the exact case a non-pointer Targeting field (TargetClosest == 0)
+// could never express, since it would be indistinguishable from "unset."
+func TestSeedMonsters_ExplicitClosestBeatsCtorDefault(t *testing.T) {
+	want := monster.TargetClosest
+	got := smSpawnedTargeting(t, smRefWolf, &want)
+	require.Equal(t, monster.TargetClosest, got,
+		"explicit targeting: closest must beat the wolf ctor's TargetLowestHP default")
 }
 
 // TestSeedMonsters_MidBatchInvalidInstructionLeavesEncounterUnchanged:
@@ -606,7 +678,10 @@ func TestSeedMonsters_ExistingMonsterCollisionRejected(t *testing.T) {
 
 	at := LocalHex{Col: 1, Row: 2}
 	pos := core.HexFromPosition(spatial.Position{X: float64(at.Col), Y: float64(at.Row)})
-	require.NoError(t, enc.AddMonster(MonsterInput{ID: "hand-placed-goblin", Position: pos, HP: 7, MaxHP: 7}))
+	require.NoError(t, enc.AddMonster(MonsterInput{
+		ID: "hand-placed-goblin", Position: pos, HP: 7, MaxHP: 7,
+		DataJSON: smGoblinDataJSON(t, "hand-placed-goblin"),
+	}))
 
 	err := enc.SeedMonsters([]SpawnInstruction{
 		{RoomID: smRoomIDEntrance, MonsterRef: smRefSkeleton, Count: 1, At: &at},

--- a/encounter/seed_monsters_test.go
+++ b/encounter/seed_monsters_test.go
@@ -352,10 +352,11 @@ func TestSeedMonsters_OpportunityAttackReadySeeded(t *testing.T) {
 }
 
 // smSpawnedTargeting spawns a single instance of ref via SeedMonsters with
-// the given Targeting override (nil is a legal "unset" value), then
-// unmarshals the resulting monster's DataJSON to read back its persisted
-// TargetingStrategy — the survival proof every targeting test below needs.
-func smSpawnedTargeting(t *testing.T, ref string, targeting *monster.TargetingStrategy) monster.TargetingStrategy {
+// the given Targeting override (monster.TargetingUnspecified, the zero
+// value, is a legal "unset" value), then unmarshals the resulting monster's
+// DataJSON to read back its persisted TargetingStrategy — the survival
+// proof every targeting test below needs.
+func smSpawnedTargeting(t *testing.T, ref string, targeting monster.TargetingStrategy) monster.TargetingStrategy {
 	t.Helper()
 	enc := smNewEncounter(t)
 	require.NoError(t, enc.InitDungeon(smDungeonParams()))
@@ -380,30 +381,37 @@ func smSpawnedTargeting(t *testing.T, ref string, targeting *monster.TargetingSt
 // DataJSON (rpg-toolkit#895) — SetTargeting is applied before ToData()
 // marshals it, not after.
 func TestSeedMonsters_TargetingSurvivesIntoDataJSON(t *testing.T) {
-	want := monster.TargetLowestAC
-	got := smSpawnedTargeting(t, smRefSkeleton, &want)
+	got := smSpawnedTargeting(t, smRefSkeleton, monster.TargetLowestAC)
 	require.Equal(t, monster.TargetLowestAC, got)
 }
 
-// TestSeedMonsters_NilTargetingPreservesCtorDefault: a nil
-// SpawnInstruction.Targeting (the "author omitted targeting" shape) must
-// leave the constructor's own default alone — wolf.go's NewWolf calls
-// SetTargeting(TargetLowestHP), and TargetClosest's iota-zero value would
-// silently stomp that default if Targeting were anything but a pointer.
-func TestSeedMonsters_NilTargetingPreservesCtorDefault(t *testing.T) {
-	got := smSpawnedTargeting(t, smRefWolf, nil)
-	require.Equal(t, monster.TargetLowestHP, got, "nil Targeting must not override the wolf ctor's own default")
+// TestSeedMonsters_UnspecifiedTargetingPreservesCtorDefault: a
+// TargetingUnspecified SpawnInstruction.Targeting (the "author omitted
+// targeting" shape, and now the zero value) must leave the constructor's
+// own default alone — wolf.go's NewWolf calls SetTargeting(TargetLowestHP),
+// and stomping that default is exactly what a naive unconditional
+// SetTargeting call would do.
+func TestSeedMonsters_UnspecifiedTargetingPreservesCtorDefault(t *testing.T) {
+	got := smSpawnedTargeting(t, smRefWolf, monster.TargetingUnspecified)
+	require.Equal(t, monster.TargetLowestHP, got,
+		"TargetingUnspecified must not override the wolf ctor's own default")
 }
 
 // TestSeedMonsters_ExplicitClosestBeatsCtorDefault: an explicit
-// targeting: closest MUST override wolf's non-closest ctor default —
-// the exact case a non-pointer Targeting field (TargetClosest == 0)
-// could never express, since it would be indistinguishable from "unset."
+// targeting: closest MUST override wolf's non-closest ctor default — the
+// exact case that was indistinguishable from "unset" back when TargetClosest
+// was the zero value. Asserts the raw persisted value is literally 1, not
+// just symbolically equal to the TargetClosest constant: rpg-toolkit#895
+// gate-review hardening's whole point is that persisted "closest" (1) is
+// now distinguishable from persisted "unset" (TargetingUnspecified, 0)
+// forever, by construction — not just by construction-time discipline that
+// a future accidental renumbering could quietly undo while keeping this
+// assertion's symbolic comparison passing.
 func TestSeedMonsters_ExplicitClosestBeatsCtorDefault(t *testing.T) {
-	want := monster.TargetClosest
-	got := smSpawnedTargeting(t, smRefWolf, &want)
+	got := smSpawnedTargeting(t, smRefWolf, monster.TargetClosest)
 	require.Equal(t, monster.TargetClosest, got,
 		"explicit targeting: closest must beat the wolf ctor's TargetLowestHP default")
+	require.EqualValues(t, 1, got, "persisted targeting must be the literal value 1, not 0 (unset)")
 }
 
 // TestSeedMonsters_MidBatchInvalidInstructionLeavesEncounterUnchanged:

--- a/encounter/take_character_action.go
+++ b/encounter/take_character_action.go
@@ -292,7 +292,9 @@ func (e *Encounter) publishActionResolved(
 	seq := e.nextSeq()
 	corrID := e.correlationFor(seq)
 	evt := events.NewActionResolvedEvent(
-		e.data.ID, seq, actorID, actionRef, targetID, consumed, perPlayer,
+		// Non-attack actions have no targeting-strategy decision to explain
+		// (rpg-toolkit#895) — rationale is always empty here.
+		e.data.ID, seq, actorID, actionRef, targetID, "", consumed, perPlayer,
 	)
 	return corrID, e.publishCorrelated(evt, corrID)
 }

--- a/encounter/tpk_test.go
+++ b/encounter/tpk_test.go
@@ -73,38 +73,33 @@ func (s *TPKSuite) TearDownTest() {
 // TestMultiPlayer_OneDeath_DoesNotEndEncounter_BothDeaths_EndsAsTPK is the
 // two-player goal-behavior proof: alice and bob are both flat-snapshot
 // seats (instant death on 0 HP, #733's non-hydrated fallback) facing one
-// goblin. The goblin kills alice first — encounter continues (bob alive) —
-// then, on its NEXT turn, closestPlayer retargets to bob (alice is now
-// permanently excluded) and kills him too — only THEN must the encounter
-// end, with Reason "tpk".
+// hydrated goblin. The goblin kills alice first — encounter continues (bob
+// alive) — then, on its NEXT turn, targets bob (alice's HP<=0 excludes her
+// from buildPerception's enemy list — #733) and kills him too — only THEN
+// must the encounter end, with Reason "tpk".
 func (s *TPKSuite) TestMultiPlayer_OneDeath_DoesNotEndEncounter_BothDeaths_EndsAsTPK() {
 	encID := encountercore.EncounterID("enc-tpk-multi")
 	enc := encounter.New(s.ctx, encID, s.broker, encounter.WithRoller(fixedMaxRoller{}),
 		encounter.WithCombatResolver(alwaysHitResolver{damage: 999, damageType: damageSlashing}))
 
-	// alice is closer to the goblin than bob, so closestPlayer targets her
-	// first; once she's down (HP<=0, excluded), the goblin's next act must
-	// retarget to bob.
-	//
-	// rpg-toolkit#864: npcActScripted now gates melee attacks on reach (the
-	// goblin here has no DataJSON, so it defaults to 1 hex), and BOTH goblin
-	// acts must land — alice's first, then bob's once alice is excluded. So
-	// alice is co-located with the goblin (distance 0, strictly closer) and
-	// bob sits one hex away (distance 1, strictly farther but still in
-	// reach) rather than the old "far enough that map-iteration tie-break
-	// can't matter" distance-4 spot, which is now out of reach.
+	// alice and bob are both exactly 1 hex from the goblin (its default
+	// melee reach, and the only distance PerceivedEntity.Adjacent treats as
+	// in range — a co-located distance-0 hex, this fixture's shape before
+	// rpg-toolkit#895 gave the goblin real DataJSON and put it through the
+	// full monster.TakeTurn AI instead of the deleted npcActScripted
+	// fallback, never reads as Adjacent). Tied at distance 1, the goblin's
+	// default TargetClosest strategy breaks the tie by entity id
+	// (sortEnemiesByDistance, npc.go) — "char-tpk-alice" < "char-tpk-bob"
+	// deterministically picks alice first, matching this test's intent
+	// without relying on distance to force the order.
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "alice", EntityID: tpkAliceEntityID,
-		Position: encountercore.Hex{Q: 1, R: 0, S: -1}, SightRange: 10,
+		Position: encountercore.Hex{Q: 2, R: -1, S: -1}, SightRange: 10,
 		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
 		DamageDice: tpkDamageDice, DamageType: damageSlashing,
 	}))
 	s.Require().NoError(enc.AddPlayer(encounter.PlayerInput{
 		PlayerID: "bob", EntityID: tpkBobEntityID,
-		// Strictly farther from the goblin than alice (distance 1 vs. 0),
-		// so closestPlayer's tie-break (map iteration order, non-
-		// deterministic) can never accidentally pick bob first — and still
-		// within the goblin's 1-hex melee reach for its second act.
 		Position: encountercore.Hex{Q: 0, R: 0, S: 0}, SightRange: 10,
 		HP: 1, MaxHP: 12, AC: 10, AttackBonus: 4,
 		DamageDice: tpkDamageDice, DamageType: damageSlashing,
@@ -113,6 +108,7 @@ func (s *TPKSuite) TestMultiPlayer_OneDeath_DoesNotEndEncounter_BothDeaths_EndsA
 		ID: tpkGoblinID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), tpkGoblinID),
 	}))
 
 	sub, err := s.broker.Subscribe(encID, "bob")
@@ -138,7 +134,7 @@ func (s *TPKSuite) TestMultiPlayer_OneDeath_DoesNotEndEncounter_BothDeaths_EndsA
 	}
 	drainSub(sub, 100*time.Millisecond)
 
-	// Second goblin act: closestPlayer excludes downed alice, so this must
+	// Second goblin act: buildPerception excludes downed alice, so this must
 	// hit bob — the last living player. The encounter must now end as tpk.
 	s.Require().NoError(enc.NPCAct(s.ctx, tpkGoblinID))
 	s.Equal(encountercore.ModeEnded, enc.Mode())
@@ -199,6 +195,7 @@ func (s *TPKSuite) TestTPK_RunsEndOfCombatSweep_ExitCombatClearsEconomy() {
 		ID: tpkGoblinID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), tpkGoblinID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())
@@ -313,6 +310,7 @@ func (s *TPKSuite) TestTPK_DeadFlagDoesNotLeakAcrossEncounters() {
 		ID: tpkGoblinID, Position: encountercore.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 5, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), tpkGoblinID),
 	}))
 	raw, err := json.Marshal(encA.ToData())
 	s.Require().NoError(err)

--- a/encounter/turn_economy_downed_test.go
+++ b/encounter/turn_economy_downed_test.go
@@ -156,6 +156,7 @@ func (s *TurnEconomyDownedSuite) TestDownedPlayerTurnStart_ZeroesEconomy_NotRese
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())
@@ -271,6 +272,7 @@ func (s *TurnEconomyDownedSuite) TestDownedPlayerRevivedByNat20MidTurnStart_Rese
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())
@@ -408,6 +410,7 @@ func (s *TurnEconomyDownedSuite) TestDownedPlayerViaRealCombat_StaysZeroedAcross
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())

--- a/encounter/unconscious_zero_hp_test.go
+++ b/encounter/unconscious_zero_hp_test.go
@@ -141,12 +141,14 @@ func (s *UnconsciousZeroHPSuite) charDataJSON(id, playerID string) json.RawMessa
 }
 
 // buildEncounter constructs a 1-hydrated-player (alice, HP=1 — always
-// guaranteed lethal via alwaysHitResolver's 999 damage) + 1-scripted-monster
-// (goblin, no DataJSON) encounter wired with roller, then round-trips
-// through ToData/LoadFromData so the cascade hydrates alice's character
-// (mirrors turn_start_revival_test.go's loadEncounter). alice's starting HP
-// is not a caller-varying concern across this file's tests — every one of
-// them needs the same guaranteed-knockdown setup.
+// guaranteed lethal via alwaysHitResolver's 999 damage) + 1 rehydratable
+// goblin encounter wired with roller, then round-trips through
+// ToData/LoadFromData so the cascade hydrates alice's character (mirrors
+// turn_start_revival_test.go's loadEncounter). alice's starting HP is not a
+// caller-varying concern across this file's tests — every one of them needs
+// the same guaranteed-knockdown setup. The goblin used to rely on
+// npcActScripted's empty-DataJSON fallback; that fallback is deleted
+// (rpg-toolkit#895 no-fallback rider), so it is now a real registry goblin.
 func (s *UnconsciousZeroHPSuite) buildEncounter(
 	encID core.EncounterID, roller encounter.Option,
 ) *encounter.Encounter {
@@ -165,6 +167,7 @@ func (s *UnconsciousZeroHPSuite) buildEncounter(
 		ID: gobEntityID, Position: core.Hex{Q: 1, R: 0, S: -1},
 		HP: 7, MaxHP: 7, AC: 15, Speed: 6,
 		AttackBonus: 4, DamageDice: damage1d6plus2, DamageType: damageSlashing,
+		DataJSON: testGoblinDataJSON(s.T(), gobEntityID),
 	}))
 
 	raw, err := json.Marshal(enc.ToData())

--- a/rulebooks/dnd5e/monster/behavior_test.go
+++ b/rulebooks/dnd5e/monster/behavior_test.go
@@ -426,6 +426,79 @@ func (s *BehaviorTestSuite) TestTakeTurnMovesAndAttacks() {
 		result.Actions[0].ActionID, result.Actions[0].TargetID, result.Actions[0].Success)
 }
 
+// TestTakeTurnMovesTowardStrategyTargetNotClosest is the missing test named
+// by rpg-toolkit#895: a monster with TargetLowestHP must move toward the
+// wounded DISTANT enemy, not the closer healthy one. Before the #895
+// refactor, moveTowardEnemy always pathed toward PerceptionData.ClosestEnemy()
+// regardless of the monster's targeting strategy, so movement and the
+// eventual attack target could disagree about who the monster was engaging.
+//
+// The two enemies are placed along DIFFERENT hex directions from the
+// monster (not colinear) so "moved toward the wounded enemy" and "moved
+// toward the closer enemy" are distinguishable outcomes, not just different
+// distances along the same line.
+func (s *BehaviorTestSuite) TestTakeTurnMovesTowardStrategyTargetNotClosest() {
+	goblin := NewGoblin("goblin-1")
+	goblin.bus = s.bus
+	goblin.SetTargeting(TargetLowestHP)
+
+	closerHealthy := spatial.CubeCoordinate{X: 3, Y: 0, Z: -3}  // 3 hexes away, different direction
+	distantWounded := spatial.CubeCoordinate{X: 6, Y: -6, Z: 0} // 6 hexes away
+
+	perception := &PerceptionData{
+		MyPosition: hexAt(0),
+		Enemies: []PerceivedEntity{
+			{
+				Entity:   &mockTarget{id: "closer-healthy", name: "Healthy Fighter"},
+				Position: closerHealthy,
+				Distance: 3,
+				Adjacent: false,
+				HP:       30, // healthy
+			},
+			{
+				Entity:   &mockTarget{id: "distant-wounded", name: "Wounded Wizard"},
+				Position: distantWounded,
+				Distance: 6,
+				Adjacent: false,
+				HP:       2, // wounded — TargetLowestHP must prefer this one
+			},
+		},
+	}
+
+	input := &TurnInput{
+		Bus:           s.bus,
+		ActionEconomy: combat.NewActionEconomy(),
+		Perception:    perception,
+		Roller:        dice.NewRoller(),
+		Speed:         6, // Goblin speed in hexes
+	}
+
+	result, err := goblin.TakeTurn(s.ctx, input)
+	s.Require().NoError(err)
+
+	// Moved toward the wounded distant enemy: ends up adjacent to it.
+	s.Require().NotEmpty(result.Movement, "monster should have moved")
+	finalPos := result.Movement[len(result.Movement)-1]
+	s.Equal(1, finalPos.Distance(distantWounded),
+		"should end up adjacent to the wounded distant enemy, not the closer healthy one")
+
+	// Did NOT end up adjacent to the closer healthy enemy — confirms this is
+	// a different outcome than closest-enemy movement would have produced.
+	s.NotEqual(1, finalPos.Distance(closerHealthy),
+		"should not end up adjacent to the closer healthy enemy")
+
+	// Perception reflects the real outcome: wounded target now adjacent,
+	// healthy one still is not.
+	s.True(perception.Enemies[1].Adjacent, "wounded distant enemy should now be adjacent")
+	s.False(perception.Enemies[0].Adjacent, "closer healthy enemy should still not be adjacent")
+
+	// The eventual attack (once in range) targets the same wounded enemy —
+	// movement and attack targeting agree.
+	s.Require().Len(result.Actions, 1, "Expected one attack action")
+	s.Equal("distant-wounded", result.Actions[0].TargetID,
+		"attack should target the same strategy-chosen enemy movement engaged")
+}
+
 func (s *BehaviorTestSuite) TestTakeTurnTraversalPredicateControlsAStar() {
 	s.Run("detours around blocked crossing", func() {
 		start := hexAt(0)

--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -646,10 +646,15 @@ func (m *Monster) selectStrategyTargetIndex(enemies []PerceivedEntity) int {
 		}
 		return lowestIdx
 
-	case TargetClosest:
+	case TargetingUnspecified, TargetClosest:
 		fallthrough
 	default:
-		// Default behavior: pick closest (first in list, as Enemies is sorted by distance)
+		// Unspecified (a freshly-constructed Monster's zero value) behaves
+		// identically to TargetClosest: pick closest (first in list, as
+		// Enemies is sorted by distance). Named explicitly alongside
+		// TargetClosest rather than left to fall through default only, so
+		// this reads as an intentional decision-time equivalence, not an
+		// accident of the zero value landing in default (rpg-toolkit#895).
 		return 0
 	}
 }

--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -457,8 +457,17 @@ func (m *Monster) TakeTurn(ctx context.Context, input *TurnInput) (*TurnResult, 
 		Movement:  make([]spatial.CubeCoordinate, 0),
 	}
 
-	// Move toward closest enemy if not adjacent
-	m.moveTowardEnemy(input, result)
+	// Move toward the monster's strategy-chosen target (not necessarily the
+	// closest enemy) if not already adjacent to it. Computed pre-move, from
+	// the full enemy list, so movement and attack target selection agree on
+	// who the monster is engaging this turn (rpg-toolkit#895).
+	var moveTarget *PerceivedEntity
+	if input.Perception != nil {
+		if idx := m.selectStrategyTargetIndex(input.Perception.Enemies); idx >= 0 {
+			moveTarget = &input.Perception.Enemies[idx]
+		}
+	}
+	m.moveTowardEnemy(input, result, moveTarget)
 
 	// Keep selecting actions until resources exhausted
 	for m.hasResources(input.ActionEconomy) {
@@ -594,8 +603,22 @@ func (m *Monster) selectTarget(action MonsterAction, perception *PerceptionData)
 
 // selectTargetByStrategy applies the monster's targeting strategy to select from available enemies
 func (m *Monster) selectTargetByStrategy(enemies []PerceivedEntity) core.Entity {
-	if len(enemies) == 0 {
+	idx := m.selectStrategyTargetIndex(enemies)
+	if idx < 0 {
 		return nil
+	}
+	return enemies[idx].Entity
+}
+
+// selectStrategyTargetIndex applies the monster's targeting strategy to pick
+// an index into enemies, or -1 if enemies is empty. It is the shared
+// selection logic behind selectTargetByStrategy (attack targeting, returns
+// core.Entity) and TakeTurn's pre-move target selection (movement, needs the
+// chosen enemy's Position too — rpg-toolkit#895) so the two never disagree
+// about who the monster is engaging.
+func (m *Monster) selectStrategyTargetIndex(enemies []PerceivedEntity) int {
+	if len(enemies) == 0 {
+		return -1
 	}
 
 	switch m.targeting {
@@ -609,7 +632,7 @@ func (m *Monster) selectTargetByStrategy(enemies []PerceivedEntity) core.Entity 
 				lowestIdx = i
 			}
 		}
-		return enemies[lowestIdx].Entity
+		return lowestIdx
 
 	case TargetLowestAC:
 		// Find enemy with lowest AC
@@ -621,27 +644,35 @@ func (m *Monster) selectTargetByStrategy(enemies []PerceivedEntity) core.Entity 
 				lowestIdx = i
 			}
 		}
-		return enemies[lowestIdx].Entity
+		return lowestIdx
 
 	case TargetClosest:
 		fallthrough
 	default:
 		// Default behavior: pick closest (first in list, as Enemies is sorted by distance)
-		return enemies[0].Entity
+		return 0
 	}
 }
 
-// moveTowardEnemy moves the monster toward the closest enemy if not already adjacent.
-// Uses A* pathfinding to navigate around obstacles.
+// moveTowardEnemy moves the monster toward target (the strategy-chosen
+// enemy for this turn, computed by TakeTurn — rpg-toolkit#895) if not
+// already adjacent to it. Uses A* pathfinding to navigate around obstacles.
 // Updates perception data to reflect new position after movement.
-func (m *Monster) moveTowardEnemy(input *TurnInput, result *TurnResult) {
-	if input.Perception == nil || len(input.Perception.Enemies) == 0 {
+//
+// Locked edge policies (rpg-toolkit#895 design): if target is unpathable,
+// the monster stalls in place rather than falling back to the closest
+// enemy — this falls out of the existing "no valid path" bail below with no
+// special-case code. If the monster is currently adjacent to a DIFFERENT
+// enemy than target, it still moves toward target, walking out of that
+// melee and accepting the opportunity attack — this falls out of checking
+// target.Adjacent instead of "is any enemy adjacent."
+func (m *Monster) moveTowardEnemy(input *TurnInput, result *TurnResult, target *PerceivedEntity) {
+	if input.Perception == nil || target == nil {
 		return
 	}
 
-	closest := input.Perception.ClosestEnemy()
-	if closest == nil || closest.Adjacent {
-		// Already adjacent or no enemy - no movement needed
+	if target.Adjacent {
+		// Already adjacent to our target - no movement needed
 		return
 	}
 
@@ -670,13 +701,13 @@ func (m *Monster) moveTowardEnemy(input *TurnInput, result *TurnResult) {
 	if input.Perception.TraversalPredicate != nil {
 		path = pathFinder.FindPathWithTraversal(
 			input.Perception.MyPosition,
-			closest.Position,
+			target.Position,
 			blocked,
 			input.Perception.TraversalPredicate,
 			input.Perception.TraversalLimit,
 		)
 	} else {
-		path = pathFinder.FindPath(input.Perception.MyPosition, closest.Position, blocked)
+		path = pathFinder.FindPath(input.Perception.MyPosition, target.Position, blocked)
 	}
 
 	if len(path) == 0 {

--- a/rulebooks/dnd5e/monster/monster_test.go
+++ b/rulebooks/dnd5e/monster/monster_test.go
@@ -227,7 +227,7 @@ func (s *MonsterTestSuite) TestMoveTowardEnemy_AroundObstacle() {
 		Movement: make([]spatial.CubeCoordinate, 0),
 	}
 
-	monster.moveTowardEnemy(input, result)
+	monster.moveTowardEnemy(input, result, &perception.Enemies[0])
 
 	s.Require().NotEmpty(result.Movement, "monster should move")
 
@@ -284,7 +284,7 @@ func (s *MonsterTestSuite) TestMoveTowardEnemy_TrappedStaysPut() {
 		Movement: make([]spatial.CubeCoordinate, 0),
 	}
 
-	monster.moveTowardEnemy(input, result)
+	monster.moveTowardEnemy(input, result, &perception.Enemies[0])
 
 	// Should not move at all
 	s.Empty(result.Movement, "trapped monster should not move")

--- a/rulebooks/dnd5e/monster/scimitar_action.go
+++ b/rulebooks/dnd5e/monster/scimitar_action.go
@@ -88,10 +88,23 @@ func (s *ScimitarAction) CanActivate(_ context.Context, _ core.Entity, input Mon
 	if input.Target == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "no target for scimitar attack")
 	}
+	if input.Perception == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "no perception data")
+	}
 
-	// Target must be adjacent (5ft reach)
-	closest := input.Perception.ClosestEnemy()
-	if closest == nil || !closest.Adjacent {
+	// The SELECTED target must be adjacent (5ft reach) — not merely the
+	// closest enemy (rpg-toolkit#895: a targeting strategy can pick a
+	// non-closest enemy, and movement/attack targeting must agree on who
+	// the monster is engaging). Matches the pattern already used by
+	// actions.MeleeAction/BiteAction in the sibling actions/ package.
+	targetInReach := false
+	for _, enemy := range input.Perception.Enemies {
+		if enemy.Entity.GetID() == input.Target.GetID() {
+			targetInReach = enemy.Adjacent
+			break
+		}
+	}
+	if !targetInReach {
 		return rpgerr.New(rpgerr.CodeOutOfRange, "target not in melee range")
 	}
 

--- a/rulebooks/dnd5e/monster/targeting.go
+++ b/rulebooks/dnd5e/monster/targeting.go
@@ -8,10 +8,26 @@ import "fmt"
 // TargetingStrategy defines how a monster selects targets from available enemies
 type TargetingStrategy int
 
-// Targeting strategy constants
+// Targeting strategy constants. TargetingUnspecified is deliberately the
+// zero value (proto-style "unset" sentinel), NOT TargetClosest — with
+// TargetClosest = 0, "author explicitly wrote closest" and "author wrote
+// nothing" were structurally indistinguishable at every layer (SpawnInstruction,
+// persisted Data, etc.), and every place that needed to tell them apart had
+// to compensate positionally (a *TargetingStrategy pointer, careful nil
+// checks that must never be forgotten). Giving Unspecified its own value
+// makes "closest" and "unset" distinguishable by construction, not by
+// convention — rpg-toolkit#895 gate-review hardening.
 const (
+	// TargetingUnspecified means no targeting strategy was set — the zero
+	// value, both for a freshly zero-valued Monster and for any
+	// SpawnInstruction/persisted Data that never named one. Decision-time
+	// behavior is IDENTICAL to TargetClosest everywhere targeting is
+	// consulted (selectStrategyTargetIndex, Ref) — this is a storage-level
+	// distinction, not a fourth decision. Never returned by
+	// ParseTargetingStrategy: it names an absence, not an authorable choice.
+	TargetingUnspecified TargetingStrategy = iota
 	// TargetClosest selects the nearest enemy (default behavior)
-	TargetClosest TargetingStrategy = iota
+	TargetClosest
 	// TargetLowestHP focuses fire on wounded enemies
 	TargetLowestHP
 	// TargetLowestAC attacks the enemy with lowest armor class
@@ -28,6 +44,11 @@ const (
 	targetingLabelClosest      = "closest"
 	targetingLabelLowestHealth = "lowest-health"
 	targetingLabelLowestAC     = "lowest-ac"
+	// targetingLabelUnspecified is TargetingUnspecified's String() label
+	// only — it is NOT part of ParseTargetingStrategy's accepted vocabulary.
+	// An author can choose "closest", never "unspecified"; the latter names
+	// an absence, not a choice.
+	targetingLabelUnspecified = "unspecified"
 )
 
 // SetTargeting sets the monster's targeting strategy
@@ -59,11 +80,17 @@ func ParseTargetingStrategy(s string) (TargetingStrategy, error) {
 }
 
 // String returns the author-facing label for the strategy ("closest" |
-// "lowest-health" | "lowest-ac"), the inverse of ParseTargetingStrategy. An
-// unrecognized value (never produced by this package) falls back to
-// "closest" rather than panicking or returning garbage.
+// "lowest-health" | "lowest-ac"), the inverse of ParseTargetingStrategy for
+// every value ParseTargetingStrategy can produce. TargetingUnspecified gets
+// its own label, "unspecified" — never parseable, never emitted to
+// authoring, but distinct from "closest" here so String() never lies about
+// which value it was called on. An unrecognized value (never produced by
+// this package) falls back to "closest" rather than panicking or returning
+// garbage.
 func (s TargetingStrategy) String() string {
 	switch s {
+	case TargetingUnspecified:
+		return targetingLabelUnspecified
 	case TargetLowestHP:
 		return targetingLabelLowestHealth
 	case TargetLowestAC:
@@ -80,13 +107,19 @@ func (s TargetingStrategy) String() string {
 // events.ActionResolvedEvent.TargetRationale on the NPC attack path. Note the
 // "lowest-hp" segment here intentionally differs from String()'s
 // "lowest-health" author-facing label — see the package-level doc comment.
+//
+// TargetingUnspecified maps to the SAME ref as TargetClosest, deliberately:
+// decision-time behavior for the two is identical (closest-enemy targeting
+// IS what an unspecified-strategy monster does), so the rationale reported
+// for that decision must read the same regardless of which zero-adjacent
+// value produced it.
 func (s TargetingStrategy) Ref() string {
 	switch s {
 	case TargetLowestHP:
 		return "dnd5e:targeting:lowest-hp"
 	case TargetLowestAC:
 		return "dnd5e:targeting:lowest-ac"
-	case TargetClosest:
+	case TargetingUnspecified, TargetClosest:
 		fallthrough
 	default:
 		return "dnd5e:targeting:closest"

--- a/rulebooks/dnd5e/monster/targeting.go
+++ b/rulebooks/dnd5e/monster/targeting.go
@@ -3,6 +3,8 @@
 
 package monster
 
+import "fmt"
+
 // TargetingStrategy defines how a monster selects targets from available enemies
 type TargetingStrategy int
 
@@ -16,6 +18,18 @@ const (
 	TargetLowestAC
 )
 
+// Author-facing targeting strategy labels — the vocabulary ParseTargetingStrategy
+// accepts and String() returns. "lowest-health" (not "lowest-hp") is deliberate:
+// it matches the authored dungeonspec YAML vocabulary. The decision-rationale
+// ref segment (see Ref) is spelled differently ("lowest-hp") to match the
+// ActionResolvedEvent.TargetRationale vocabulary from rpg-toolkit#895 — the two
+// are not interchangeable.
+const (
+	targetingLabelClosest      = "closest"
+	targetingLabelLowestHealth = "lowest-health"
+	targetingLabelLowestAC     = "lowest-ac"
+)
+
 // SetTargeting sets the monster's targeting strategy
 func (m *Monster) SetTargeting(strategy TargetingStrategy) {
 	m.targeting = strategy
@@ -24,4 +38,57 @@ func (m *Monster) SetTargeting(strategy TargetingStrategy) {
 // Targeting returns the monster's current targeting strategy
 func (m *Monster) Targeting() TargetingStrategy {
 	return m.targeting
+}
+
+// ParseTargetingStrategy parses the author-facing targeting vocabulary
+// ("closest" | "lowest-health" | "lowest-ac") into a TargetingStrategy. Any
+// other value, including the empty string, is rejected — callers that want
+// TargetClosest as a default must not call this on an absent/omitted value.
+func ParseTargetingStrategy(s string) (TargetingStrategy, error) {
+	switch s {
+	case targetingLabelClosest:
+		return TargetClosest, nil
+	case targetingLabelLowestHealth:
+		return TargetLowestHP, nil
+	case targetingLabelLowestAC:
+		return TargetLowestAC, nil
+	default:
+		return 0, fmt.Errorf("invalid targeting strategy %q (must be %q, %q, or %q)",
+			s, targetingLabelClosest, targetingLabelLowestHealth, targetingLabelLowestAC)
+	}
+}
+
+// String returns the author-facing label for the strategy ("closest" |
+// "lowest-health" | "lowest-ac"), the inverse of ParseTargetingStrategy. An
+// unrecognized value (never produced by this package) falls back to
+// "closest" rather than panicking or returning garbage.
+func (s TargetingStrategy) String() string {
+	switch s {
+	case TargetLowestHP:
+		return targetingLabelLowestHealth
+	case TargetLowestAC:
+		return targetingLabelLowestAC
+	case TargetClosest:
+		fallthrough
+	default:
+		return targetingLabelClosest
+	}
+}
+
+// Ref returns the canonical decision-rationale ref for this targeting
+// strategy (rpg-toolkit#895), threaded into
+// events.ActionResolvedEvent.TargetRationale on the NPC attack path. Note the
+// "lowest-hp" segment here intentionally differs from String()'s
+// "lowest-health" author-facing label — see the package-level doc comment.
+func (s TargetingStrategy) Ref() string {
+	switch s {
+	case TargetLowestHP:
+		return "dnd5e:targeting:lowest-hp"
+	case TargetLowestAC:
+		return "dnd5e:targeting:lowest-ac"
+	case TargetClosest:
+		fallthrough
+	default:
+		return "dnd5e:targeting:closest"
+	}
 }

--- a/rulebooks/dnd5e/monster/targeting_test.go
+++ b/rulebooks/dnd5e/monster/targeting_test.go
@@ -6,6 +6,7 @@ package monster
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -218,4 +219,46 @@ func (s *TargetingTestSuite) TestTargetingSerialization() {
 // Run the suite
 func TestTargetingSuite(t *testing.T) {
 	suite.Run(t, new(TargetingTestSuite))
+}
+
+// TestParseTargetingStrategy_Table covers the parse/String round trip for
+// every accepted label, plus the rejection paths (rpg-toolkit#895).
+func TestParseTargetingStrategy_Table(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    TargetingStrategy
+		wantErr bool
+	}{
+		{name: "closest", input: "closest", want: TargetClosest},
+		{name: "lowest-health", input: "lowest-health", want: TargetLowestHP},
+		{name: "lowest-ac", input: "lowest-ac", want: TargetLowestAC},
+		{name: "empty string rejected", input: "", wantErr: true},
+		{name: "unknown value rejected", input: "random", wantErr: true},
+		{name: "lowest-hp is not the author-facing label", input: "lowest-hp", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTargetingStrategy(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.input)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+			// String() is the inverse of ParseTargetingStrategy for every
+			// accepted label.
+			require.Equal(t, tc.input, got.String())
+		})
+	}
+}
+
+// TestTargetingStrategy_Ref verifies the decision-rationale ref mapping used
+// by ActionResolvedEvent.TargetRationale (rpg-toolkit#895). The "lowest-hp"
+// ref segment deliberately differs from String()'s "lowest-health" label.
+func TestTargetingStrategy_Ref(t *testing.T) {
+	require.Equal(t, "dnd5e:targeting:closest", TargetClosest.Ref())
+	require.Equal(t, "dnd5e:targeting:lowest-hp", TargetLowestHP.Ref())
+	require.Equal(t, "dnd5e:targeting:lowest-ac", TargetLowestAC.Ref())
 }

--- a/rulebooks/dnd5e/monster/targeting_test.go
+++ b/rulebooks/dnd5e/monster/targeting_test.go
@@ -131,9 +131,21 @@ func (s *TargetingTestSuite) TestTargetLowestAC() {
 	s.Equal("enemy-3", target.GetID(), "should select enemy with lowest AC (12)")
 }
 
-// TestTargetingDefault verifies default targeting strategy is TargetClosest
+// TestTargetingDefault verifies a freshly-constructed monster's stored
+// targeting strategy is TargetingUnspecified (the zero value) — NOT
+// TargetClosest. rpg-toolkit#895 gate-review hardening deliberately moved
+// TargetClosest off the zero value so "unset" and "explicit closest" are
+// distinguishable in storage; this proves the zero value really is
+// Unspecified now, and that it still SELECTS exactly like TargetClosest
+// would (the decision-time equivalence, not a fourth strategy).
 func (s *TargetingTestSuite) TestTargetingDefault() {
-	s.Equal(TargetClosest, s.monster.Targeting(), "default targeting should be TargetClosest")
+	s.Equal(TargetingUnspecified, s.monster.Targeting(),
+		"a fresh monster's targeting must be the zero value, TargetingUnspecified, not TargetClosest")
+
+	action := NewScimitarAction(ScimitarConfig{AttackBonus: 4, DamageDice: "1d6+2"})
+	target := s.monster.selectTarget(action, s.perception)
+	s.Require().NotNil(target)
+	s.Equal("enemy-1", target.GetID(), "TargetingUnspecified must select exactly like TargetClosest")
 }
 
 // TestTargetingNoEnemies verifies selectTarget returns nil when no enemies available
@@ -236,6 +248,7 @@ func TestParseTargetingStrategy_Table(t *testing.T) {
 		{name: "empty string rejected", input: "", wantErr: true},
 		{name: "unknown value rejected", input: "random", wantErr: true},
 		{name: "lowest-hp is not the author-facing label", input: "lowest-hp", wantErr: true},
+		{name: "unspecified is not an authorable choice", input: "unspecified", wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -261,4 +274,20 @@ func TestTargetingStrategy_Ref(t *testing.T) {
 	require.Equal(t, "dnd5e:targeting:closest", TargetClosest.Ref())
 	require.Equal(t, "dnd5e:targeting:lowest-hp", TargetLowestHP.Ref())
 	require.Equal(t, "dnd5e:targeting:lowest-ac", TargetLowestAC.Ref())
+	require.Equal(t, "dnd5e:targeting:closest", TargetingUnspecified.Ref(),
+		"unspecified must report the same rationale as closest — that IS the decision being made")
+}
+
+// TestTargetingStrategy_ZeroValueIsUnspecified locks in the gate-review
+// hardening (rpg-toolkit#895): TargetingUnspecified, not TargetClosest, is
+// the zero value. This is what lets a SpawnInstruction/persisted Data tell
+// "author explicitly wrote closest" apart from "author wrote nothing" by
+// construction — the entire point of the enum renumbering.
+func TestTargetingStrategy_ZeroValueIsUnspecified(t *testing.T) {
+	var zero TargetingStrategy
+	require.Equal(t, TargetingUnspecified, zero)
+	require.NotEqual(t, TargetClosest, zero, "TargetClosest must not be the zero value")
+	require.Equal(t, "unspecified", zero.String())
+	require.Equal(t, "closest", TargetClosest.String(),
+		"TargetClosest keeps its own distinct label even though it now behaves like the zero value would")
 }

--- a/rulebooks/dnd5e/monster/targeting_test.go
+++ b/rulebooks/dnd5e/monster/targeting_test.go
@@ -255,7 +255,14 @@ func TestParseTargetingStrategy_Table(t *testing.T) {
 			got, err := ParseTargetingStrategy(tc.input)
 			if tc.wantErr {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.input)
+				require.Contains(t, err.Error(), "invalid targeting strategy")
+				// require.Contains(err.Error(), tc.input) would be a no-op
+				// for the empty-string case (every string contains ""),
+				// silently skipping the one check that matters most there
+				// — only assert the specific bad value when it's non-empty.
+				if tc.input != "" {
+					require.Contains(t, err.Error(), tc.input)
+				}
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
## Summary

Implements rpg-toolkit#895 (Monster AI slice 1): targeting strategy end-to-end from dungeonspec YAML through seeded monsters and NPC combat, plus a decision-rationale event field and a no-fallback rider that deletes the scripted-monster escape hatch. Includes a follow-up gate-review hardening pass (Kirk-approved) that removed a structural zero-value collision the initial pointer-based fix only compensated for positionally.

## What changed, per module

### `rulebooks/dnd5e`

- `monster/targeting.go`: `ParseTargetingStrategy(string)` / `String()` for the author-facing vocabulary (`closest | lowest-health | lowest-ac`), plus `TargetingStrategy.Ref()` for the decision-rationale ref vocabulary (`dnd5e:targeting:closest|lowest-hp|lowest-ac` — note `lowest-hp` there deliberately differs from `String()`'s `lowest-health`, matching the issue text).
- `monster/monster.go`: `TakeTurn` now computes the strategy-chosen target *before* moving (via a new `selectStrategyTargetIndex`, which `selectTargetByStrategy` also delegates to) and `moveTowardEnemy` takes that target instead of hardcoding `ClosestEnemy()`. Locked edge policies: an unpathable strategy target stalls in place (falls out of the existing "no path" bail, no special-casing needed); a monster adjacent to a non-target still moves toward its real target and eats the OA.
- `monster/scimitar_action.go`: fixed a latent bug the new movement test surfaced — `CanActivate` checked `ClosestEnemy().Adjacent` instead of the *actual selected target's* adjacency, so a non-closest strategy target in melee range could be wrongly rejected. Brought in line with the already-correct pattern in `actions/melee.go` and `actions/bite.go`.
- **Follow-up hardening**: `TargetingStrategy`'s enum is renumbered so `TargetingUnspecified` (new), not `TargetClosest`, is the zero value (`Unspecified=0, Closest=1, LowestHP=2, LowestAC=3`). With `TargetClosest` at iota-zero, "author explicitly wrote closest" and "author wrote nothing" were structurally indistinguishable at every layer (persisted `Data`, `SpawnInstruction`), and safety depended entirely on callers remembering pointer nil-checks. `ParseTargetingStrategy`'s vocabulary is unchanged (`"unspecified"` is never an authorable choice — `String()` labels it but `ParseTargetingStrategy` rejects it as input); `Ref()` and target selection both treat `Unspecified` identically to `TargetClosest` at decision time (a storage-level distinction, not a fourth behavior). Persisted-data compat is a non-issue: pre-pre-alpha, encounters carry a 24h TTL, and both seeders spawn monsters fresh at seed time.

### `encounter`

- `dungeonspec`: `PlacedEntry`/`BossEntry` gain `Targeting *string`; `validate.go` rejects it on prop refs (mirrors the `blocks_movement`-only-on-props pattern, inverted) and rejects unparseable values via `ParseTargetingStrategy`; `compile.go` threads it into `SpawnInstruction` at **three** sites — boss spawn, room-chain `refTypeMonsters`, and canvas-mode `refTypeMonsters` (the issue named two; canvas mode is a real third wiring path that would otherwise silently drop an authored override — see "beyond the brief" below).
- `seed_monsters.go`: `SpawnInstruction.Targeting` — **originally a `*monster.TargetingStrategy` pointer** (nil meant unset, since `TargetClosest` was iota-zero and explicit `targeting: closest` had to beat a ctor default like the wolf's `TargetLowestHP`), **simplified to a plain `monster.TargetingStrategy` value** once the rulebooks hardening above made `TargetingUnspecified` the zero value — the pointer was only ever compensating for that collision. Applied via `SetTargeting` after the ctor, before `ToData()`/marshal, at **both** construction sites (room-chain/boss and canvas), now via a direct `!= monster.TargetingUnspecified` check instead of a nil-check-and-dereference.
- `events/action_resolved.go`: `ActionResolvedEvent.TargetRationale string`, threaded through `NewActionResolvedEvent`/the wire struct/Marshal/Unmarshal.
- `combat.go` / `combat_phased.go` / `npc.go`: `publishAttackOutcome` gains a `targetRationale` param. The NPC-attack path (both the inline `applyCapturedAttacks` route and the Shield-resume route) derives it from a new `monsterTargetingRationale` helper that unmarshals the monster's own `DataJSON` — deliberately *not* threaded from the live `*monster.Monster` instance, because the resume path has no such instance in scope; `DataJSON` is the one thing both paths share, and the no-fallback rider guarantees it's never empty. Player-path attacks and non-attack actions always pass `""`.
- `encounter.go` / `npc.go`: no-fallback rider — `AddMonster` rejects empty `DataJSON` (`ErrMonsterDataRequired`); `npcActScripted` and its now-dead `closestPlayer` helper are deleted; `NPCAct` returns `ErrMonsterNotRehydratable` instead of silently degrading.

## Consumer-side ripple (rpg-api)

The no-fallback rider (`AddMonster` rejecting empty `DataJSON`) is a breaking behavior change for any consumer that hand-constructs `MonsterInput` without one. rpg-api's own test suite has ~9 pre-existing suites doing exactly that; they'll need fixtures once rpg-api bumps its pin to this branch. This is deliberate, Kirk-decided behavior (the whole point of the rider), and is being handled on the rpg-api side directly — flagging here so it isn't a surprise in review.

## Beyond the brief (seam findings)

- **Canvas mode is a third `SpawnInstruction` wiring path**, not just a variant of the two named in the issue. `compile.go`'s `compileCanvas` and `seed_monsters.go`'s `validateAbsoluteCanvasSpawn` both needed the same `Targeting` threading, and `validate.go`'s `validateCanvasPlacement` needed the same props/parse checks as `validatePlaceBlock`. Slices 2–3 should know: any future per-monster spec field probably needs the same 3-compile-site / 2-seed-site treatment, not 2/1.
- **The no-fallback rider's blast radius is the whole `encounter` test package**, not just NPC-behavior fixtures. `AddMonster` rejecting empty `DataJSON` unconditionally broke ~50 files' worth of hand-built `MonsterInput{}` fixtures that had nothing to do with NPC behavior (visibility, movement, knowledge, doors, etc.) — they just happened to place a monster without DataJSON. Added one shared test helper (`testGoblinDataJSON` for `package encounter_test`, `smGoblinDataJSON` for the internal `package encounter` files) and rebuilt every call site. (The same ripple hit rpg-api, above.)
- **Two tests were positionally tuned for the deleted scripted path** and needed real fixes, not just a `DataJSON:` bolt-on, once they started running the real `monster.TakeTurn` AI: `TestMultiPlayer_OneDeath_DoesNotEndEncounter_BothDeaths_EndsAsTPK` (co-located distance-0 target never reads as `Adjacent`, since that flag is strictly `distance == 1`) and `TestNPCAct_AttackPublishes` (same issue, goblin co-located with bob). Fixed by repositioning to real distance-1 hexes; the TPK test's tie-break now relies on `sortEnemiesByDistance`'s deterministic entity-id ordering instead of an artificial distance gap.
- **One test was retired as redundant, not patched**: `TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer` tested `closestPlayer`'s own downed-player filter specifically; with `closestPlayer` deleted, `TestFullAIPath_BuildPerception_NeverTargetsDownedPlayer` (same file) already covers the only remaining call site.
- **`validatePlaceBlock`'s cyclomatic complexity crossed the linter's threshold** once targeting checks were added; extracted the per-entry validation into `validatePlaceEntry` rather than suppressing the lint.

## Test evidence

`rulebooks/dnd5e` (`go test ./...`): all packages `ok`, including `monster`, `monster/actions`, `monster/monsters` — covers both the initial targeting work and the Unspecified=0 renumbering.

`encounter` (`go test ./...`): all packages `ok` — `encounter` (~70s, full suite), `encounter/core`, `encounter/dungeonspec`, `encounter/events`, `encounter/perception` — covers both the initial threading work and the SpawnInstruction.Targeting value-type simplification.

Both modules, after every commit including the hardening pass: `go build ./...`, `go vet ./...`, `gofmt -l .` / `goimports -l .` clean, `go mod tidy` no-op (beyond the deliberate pseudo-version bumps), `golangci-lint run --config=../.golangci.yml ./...` clean except pre-existing `goconst` debt (repeated fixture strings like `"alice"`/`"bob"` across the whole package, unrelated to this change — confirmed no new findings from either pass beyond one `gocyclo` and one `lll` hit, both fixed in-branch).

Local-env gameplay evidence (a `lowest-health` skeleton ignoring a closer healthy fighter to chase the wounded wizard, per the issue's acceptance criterion) has not been run — that's flagged as pre-merge evidence to land before merge, not something this PR claims.

## Deviations from the brief

- Canvas mode threading (3rd compile site, 2nd seed site) — not named in the issue, added because it's a real gap in the same feature, detailed above.
- `validatePlaceBlock` was split into `validatePlaceBlock` + `validatePlaceEntry` to stay under the gocyclo threshold — a pure extraction, no behavior change.
- One pre-existing test (`TestScriptedPath_ClosestPlayer_NeverTargetsDownedPlayer`) and two pre-existing range-gate tests (`TestNPCAct_ScriptedAttackBeyondReach_PassesTurnWithoutWedging`, `TestNPCAct_ScriptedAttackAtReach_Succeeds`) were deleted rather than patched, since their entire subject (`npcActScripted`'s own behavior) no longer exists and their residual coverage was already duplicated by adjacent tests in the same files.
- The `TargetingUnspecified=0` renumbering and `SpawnInstruction.Targeting` pointer→value simplification (both `rulebooks/dnd5e` and `encounter` sections above) were a design-review addition after the initial implementation, not in the original issue text — Kirk-approved gate-review hardening, not a self-directed scope change.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
