### PR TITLE
feat(encounter): canonical region-union floor lifecycle (#897)

### DIFF
--- a/docs/adr/0035-canvas-floor-mask-and-envelope.md
+++ b/docs/adr/0035-canvas-floor-mask-and-envelope.md
@@ -1,0 +1,53 @@
+# ADR-0035: Persist one canvas floor mask and its envelope
+
+**Status:** Accepted
+**Date:** 2026-08-09
+**Issue:** rpg-toolkit#897
+
+## Context
+
+Dungeon YAML v0.3 treated every in-bounds canvas cell as floor. v0.4 adds
+`canvas.floor_source: regions`, where bounds remain workspace legality but only
+the canonical union of `regions[].cells` is playable. Re-deriving either a
+rectangle or union independently in placement, movement, LoS, fog, or reload
+would create multiple authorities and let in-bounds void leak into mechanics.
+
+Authored documents and running encounters also have different lifecycles:
+a complete authored candidate is recompiled standalone, while a running
+encounter must survive later source edits unchanged.
+
+## Decision
+
+Canvas compilation produces one canonical sorted floor mask and one canonical
+set of normalized floor/void envelope pairs. `DungeonParams` carries both into
+`InitDungeon`; `SpaceData.FloorCells` and `SpaceData.EnvelopeEdges` persist the
+exact started snapshot. Reload validates canonical order, envelope completeness,
+edge ownership, every entity/obstacle/start position, and remembered fog cells
+against that snapshot. It never consults authored YAML.
+
+A masked runtime grid makes only persisted floor cells valid. Movement/pathing,
+placement and spatial queries consume that grid. The room wrapper rejects LoS
+rays that cross a void cell, and perception rejects invalid targets before
+adding them to visible/remembered knowledge. Envelope records project from the
+single floor owner only; void cells never gain runtime records.
+
+`dungeonspec.CompileDungeon` is the complete-candidate provider seam. Draft mode
+projects structurally valid empty/tiny/disconnected masks with an optional
+entrance. Strict mode additionally requires a nonempty connected floor and a
+complete same-component party-start reservation. Authored validation is returned
+as ordered `FieldError` records; cancellation/provider failures remain Go errors.
+No previous compiled candidate is accepted.
+
+Legacy canvas snapshots that omit the new fields continue to reload as the v0.3
+bounds rectangle. Newly initialized bounds canvases persist their full rectangle
+and outer envelope explicitly.
+
+## Consequences
+
+- Region edits cannot inherit stale occupancy, entrance, or party seats.
+- In-bounds void is mechanically identical to off-canvas space for placement,
+  pathing, movement, reachability, LoS and fog.
+- Running encounters retain the exact mask/edges they started with.
+- The envelope wire stays the existing undirected pair representation, including
+  actual off-canvas neighbor coordinates; no void `HexRecord` is introduced.
+- Room-chain generation and its existing region/connector behavior are unchanged.

--- a/docs/adr/0035-canvas-floor-mask-and-envelope.md
+++ b/docs/adr/0035-canvas-floor-mask-and-envelope.md
@@ -32,9 +32,11 @@ adding them to visible/remembered knowledge. Envelope records project from the
 single floor owner only; void cells never gain runtime records.
 
 `dungeonspec.CompileDungeon` is the complete-candidate provider seam. Draft mode
-projects structurally valid empty/tiny/disconnected masks with an optional
-entrance. Strict mode additionally requires a nonempty connected floor and a
-complete same-component party-start reservation. Authored validation is returned
+relaxes runnability only for `floor_source: regions`, projecting structurally
+valid empty/tiny/disconnected masks with an optional entrance. Omitted/explicit
+`bounds` retains the v0.3 runtime-backed projection gate in both modes. Strict
+region mode additionally requires a nonempty connected floor and a complete
+same-component party-start reservation. Authored validation is returned
 as ordered `FieldError` records; cancellation/provider failures remain Go errors.
 No previous compiled candidate is accepted.
 

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -834,8 +834,9 @@ input.ID)`, #757) can grow the roster after this event already published.
 accepts complete standalone source bytes, Draft/Strict mode, PartyStartSeatCount
 and PreviewSeed; it never accepts a previous compiled value or display/source
 name. Draft returns canonical projections for structurally valid empty, tiny or
-disconnected region unions. Strict additionally requires a nonempty connected
-mask and a same-component complete party-start reservation. Authored failures are
+disconnected region unions only; omitted/explicit `bounds` keeps the v0.3
+runtime-backed projection gate. Strict region compilation additionally requires
+a nonempty connected mask and a same-component complete party-start reservation. Authored failures are
 ordered `FieldError{Field,Message,Code}` values; infrastructure failures remain
 Go errors.
 

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -1,7 +1,7 @@
 ---
 name: encounter module
 description: Orchestrator-facing SDK for running an encounter end-to-end — sealed event taxonomy, process-scoped Broker, transient Encounter aggregate, combatant hydration cascade, discrete-phase combat orchestration, MovementResolver seam (both movement directions), walled-room space + wall-aware LoS + inline combat entry
-updated: 2026-07-13
+updated: 2026-08-09
 confidence: high — #689 made LoadFromData own combatant hydration (the #684 double-subscribe cure); Wave 2.11d shipped discrete-phase combat; Wave 2.11e extended CompleteTakeAction to accept either PvE attack direction AND added MovementResolver for per-step movement in BOTH directions; #697 (TakeAction wave, ADR-0032) deleted the attack-only gate — non-attack refs delegate to the held character's economy/menu, turn-start seeding moved into the engine, ActorTurnState exposes the menu as data; #757 (the walled room) added SpaceData, wall-aware VisibleHexesAt/CanSeeAt, wall-blocked movement, and inline combat-entry self-transition
 ---
 
@@ -827,6 +827,26 @@ same backing slice — mirrors `applyAndPublishMove`'s
 `append([]core.Hex(nil), traveledPath...)` pattern, since `AddMonster`'s
 mid-combat reinforcement path (`e.data.Initiative = append(e.data.Initiative,
 input.ID)`, #757) can grow the roster after this event already published.
+
+## Canonical canvas floor masks (Dungeon YAML v0.4 Wave A)
+
+`dungeonspec.CompileDungeon` is the native protobuf-free authoring seam. It
+accepts complete standalone source bytes, Draft/Strict mode, PartyStartSeatCount
+and PreviewSeed; it never accepts a previous compiled value or display/source
+name. Draft returns canonical projections for structurally valid empty, tiny or
+disconnected region unions. Strict additionally requires a nonempty connected
+mask and a same-component complete party-start reservation. Authored failures are
+ordered `FieldError{Field,Message,Code}` values; infrastructure failures remain
+Go errors.
+
+Canvas compilation resolves omission/`bounds` to the v0.3 rectangle and
+`regions` to the canonical deduplicated union. `DungeonParams.FloorCells` and
+`EnvelopeEdges` carry that one truth into runtime; `SpaceData` persists both as
+the exact encounter snapshot. Reload validates, rather than regenerates, them.
+The masked runtime grid is shared by placement, movement/pathing and targeting;
+LoS rays fail closed across void, and perception never records invalid cells.
+Envelope pairs retain actual void/off-canvas endpoints but attach to knowledge
+only at their single floor owner. See ADR-0035.
 
 ## Implementation notes worth keeping
 

--- a/docs/architecture/components/encounter.md
+++ b/docs/architecture/components/encounter.md
@@ -837,15 +837,18 @@ name. Draft returns canonical projections for structurally valid empty, tiny or
 disconnected region unions only; omitted/explicit `bounds` keeps the v0.3
 runtime-backed projection gate. Strict region compilation additionally requires
 a nonempty connected mask and a same-component complete party-start reservation. Authored failures are
-ordered `FieldError{Field,Message,Code}` values; infrastructure failures remain
-Go errors.
+ordered `FieldError{Field,Message,Code}` values produced at decode/validation
+sources (including YAML merge-key expansion and exact nested/indexed paths),
+never by parsing prose; infrastructure failures remain Go errors.
 
 Canvas compilation resolves omission/`bounds` to the v0.3 rectangle and
 `regions` to the canonical deduplicated union. `DungeonParams.FloorCells` and
 `EnvelopeEdges` carry that one truth into runtime; `SpaceData` persists both as
 the exact encounter snapshot. Reload validates, rather than regenerates, them.
 The masked runtime grid is shared by placement, movement/pathing and targeting;
-LoS rays fail closed across void, and perception never records invalid cells.
+target reach validates both endpoints and every direct-ray position against that
+grid (never the mutable strict-start flag or wall state). LoS rays fail closed
+across void, and perception never records invalid cells.
 Envelope pairs retain actual void/off-canvas endpoints but attach to knowledge
 only at their single floor owner. See ADR-0035.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,6 +11,16 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't let 
 
 ## Active work
 
+**#897 — Dungeon YAML v0.4 Wave A canonical region floor (2026-08-09).**
+`dungeonspec.CompileDungeon` now compiles complete standalone Draft/Strict
+candidates and returns exact field records separately from Go infrastructure
+errors. Canvas omission/`bounds` preserves the rectangle; `regions` compiles one
+canonical union mask, complete floor/void envelope, optional derived entrance,
+and semantic-region containment projection. The exact mask/envelope persist in
+`SpaceData` and rebuild a masked room used by placement, pathing/movement, LoS
+and fog. Running encounter reload validates its started snapshot and never
+consults later authored source. See ADR-0035 and the encounter component doc.
+
 **#880 / draft PR #881 — Dungeon Builder authored-edge Phase 2B (2026-08-04).**
 `dungeonspec` compiles strict dungeon-scoped `walls: [{from, to, kind}]` into
 normalized absolute pointy-top odd-q offset `[column,row]` `AuthoredEdge`

--- a/encounter/authored_edges.go
+++ b/encounter/authored_edges.go
@@ -121,7 +121,7 @@ func validateAndNormalizeAuthoredEdges(params DungeonParams) ([]AuthoredEdge, er
 // not a seed-dependent open-cell sample.
 func semanticDungeonFloorHexes(params DungeonParams) map[core.Hex]struct{} {
 	if params.FloorSource == FloorSourceCanvas {
-		return canvasFloorHexes(params.Width, params.Height)
+		return canvasFloorForParams(params)
 	}
 	capacity := 0
 	for _, region := range params.Regions {
@@ -357,7 +357,7 @@ func persistedAuthoredFloor(space *SpaceData) (map[core.Hex]struct{}, error) {
 		if len(space.Regions) != 0 {
 			return nil, fmt.Errorf("persisted canvas floor must not infer membership from regions")
 		}
-		return canvasFloorHexes(space.Width, space.Height), nil
+		return canvasFloorForSpace(space), nil
 	}
 	floor := make(map[core.Hex]struct{})
 	for _, region := range space.Regions {

--- a/encounter/canvas.go
+++ b/encounter/canvas.go
@@ -74,9 +74,118 @@ func canvasFloorContainsDimensions(width, height int, hex core.Hex) bool {
 	return hex.R == -hex.Q-hex.S
 }
 
+func canvasFloorForParams(params DungeonParams) map[core.Hex]struct{} {
+	if params.FloorCells == nil {
+		return canvasFloorHexes(params.Width, params.Height)
+	}
+	floor := make(map[core.Hex]struct{}, len(params.FloorCells))
+	for _, hex := range params.FloorCells {
+		floor[hex] = struct{}{}
+	}
+	return floor
+}
+
+func canvasFloorForSpace(space *SpaceData) map[core.Hex]struct{} {
+	if space.FloorCells == nil {
+		return canvasFloorHexes(space.Width, space.Height)
+	}
+	floor := make(map[core.Hex]struct{}, len(space.FloorCells))
+	for _, hex := range space.FloorCells {
+		floor[hex] = struct{}{}
+	}
+	return floor
+}
+
+func validateCanonicalFloorCells(width, height int, cells []core.Hex) error {
+	var previous floorOrderHex
+	seen := make(map[core.Hex]struct{}, len(cells))
+	for index, hex := range cells {
+		if !hex.ToCube().IsValid() || !canvasFloorContainsDimensions(width, height, hex) {
+			return fmt.Errorf("floor cell %d %v is outside canvas bounds", index, hex)
+		}
+		ordered := floorPlanOrderHex(hex)
+		if index > 0 && !previous.less(ordered) {
+			return fmt.Errorf("floor cells are not canonical sorted or contain a duplicate at index %d", index)
+		}
+		if _, duplicate := seen[hex]; duplicate {
+			return fmt.Errorf("floor cells contain duplicate %v", hex)
+		}
+		seen[hex] = struct{}{}
+		previous = ordered
+	}
+	return nil
+}
+
+// floorOrderHex gives stable offset-coordinate ordering without making
+// dungeonspec's projection types a dependency of encounter.
+type floorOrderHex struct{ column, row int }
+
+func floorPlanOrderHex(hex core.Hex) floorOrderHex {
+	position := hex.ToPosition()
+	return floorOrderHex{column: int(position.X), row: int(position.Y)}
+}
+func (h floorOrderHex) less(other floorOrderHex) bool {
+	return h.column < other.column || h.column == other.column && h.row < other.row
+}
+
+func canonicalCanvasFloorCells(params DungeonParams) []core.Hex {
+	cells := append([]core.Hex(nil), params.FloorCells...)
+	if params.FloorCells == nil {
+		for hex := range canvasFloorHexes(params.Width, params.Height) {
+			cells = append(cells, hex)
+		}
+		sort.Slice(cells, func(i, j int) bool { return floorPlanOrderHex(cells[i]).less(floorPlanOrderHex(cells[j])) })
+	}
+	return cells
+}
+
+func canvasEnvelopeEdges(floor map[core.Hex]struct{}) []GeneratedEdge {
+	edges := make([]GeneratedEdge, 0)
+	seen := make(map[generatedEdgeKey]struct{})
+	for owner := range floor {
+		for _, neighborCube := range owner.ToCube().GetNeighbors() {
+			neighbor := core.HexFromCube(neighborCube)
+			if _, isFloor := floor[neighbor]; isFloor {
+				continue
+			}
+			from, to := normalizeAuthoredEndpoints(owner, neighbor)
+			key := newGeneratedEdgeKey(from, to)
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			edges = append(edges, GeneratedEdge{From: from, To: to, Kind: GeneratedEdgeKindSolid})
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool { return generatedEdgeLess(edges[i], edges[j]) })
+	return edges
+}
+
+func generatedEdgesEqual(left, right GeneratedEdge) bool {
+	return left.From == right.From && left.To == right.To && left.Kind == right.Kind && left.DoorID == right.DoorID
+}
+
+func validateEnvelopeEdges(floor map[core.Hex]struct{}, edges []GeneratedEdge) error {
+	expected := canvasEnvelopeEdges(floor)
+	if len(edges) != len(expected) {
+		return fmt.Errorf("envelope edges: got %d records, want %d", len(edges), len(expected))
+	}
+	for index := range expected {
+		if !generatedEdgesEqual(edges[index], expected[index]) {
+			return fmt.Errorf("envelope edge %d is not the canonical floor/void pair", index)
+		}
+	}
+	return nil
+}
+
 func validateCanvasDungeonParams(params DungeonParams) error {
 	if _, err := ValidateCanvasDimensions(params.Width, params.Height); err != nil {
 		return err
+	}
+	if params.FloorCells != nil {
+		if err := validateCanonicalFloorCells(params.Width, params.Height, params.FloorCells); err != nil {
+			return fmt.Errorf("canvas floor: %w", err)
+		}
 	}
 	if len(params.Regions) != 0 || len(params.Connectors) != 0 {
 		return fmt.Errorf("canvas dungeon must not contain room-chain regions or connectors")
@@ -84,7 +193,23 @@ func validateCanvasDungeonParams(params DungeonParams) error {
 	if params.PartyStart.SeatCount < 0 {
 		return fmt.Errorf("party start seat count must not be negative (got %d)", params.PartyStart.SeatCount)
 	}
-	floor := canvasFloorHexes(params.Width, params.Height)
+	floor := canvasFloorForParams(params)
+	if params.RequireConnectedFloor {
+		if len(floor) == 0 {
+			return fmt.Errorf("canvas structural floor must not be empty")
+		}
+		for anchor := range floor {
+			if len(connectedFloorComponent(anchor, floor)) != len(floor) {
+				return fmt.Errorf("canvas structural floor must be connected")
+			}
+			break
+		}
+	}
+	if params.EnvelopeEdges != nil {
+		if err := validateEnvelopeEdges(floor, params.EnvelopeEdges); err != nil {
+			return err
+		}
+	}
 	occupied := make(map[core.Hex]string, len(params.AbsolutePlacedObstacles)+len(params.AbsoluteReservedCells))
 	seenIDs := make(map[core.EntityID]int, len(params.AbsolutePlacedObstacles))
 	for index, obstacle := range params.AbsolutePlacedObstacles {
@@ -133,7 +258,7 @@ func generateCanvasDungeonLayout(params DungeonParams) (*dungeonLayout, error) {
 			BlocksMovement: obstacle.BlocksMovement, BlocksLoS: obstacle.BlocksLoS, Facing: obstacle.Facing,
 		}
 	}
-	floor := canvasFloorHexes(params.Width, params.Height)
+	floor := canvasFloorForParams(params)
 	semanticRegions, err := validateSemanticRegionParams(params.SemanticRegions, floor)
 	if err != nil {
 		return nil, err
@@ -149,15 +274,7 @@ func resolveCanvasPartyStartReservation(params DungeonParams) (partyStartReserva
 	if seatCount == 0 {
 		seatCount = 1
 	}
-	anchor := core.HexFromPosition(spatial.Position{}).ToCube()
-	if params.PartyStart.Anchor != nil {
-		anchor = params.PartyStart.Anchor.ToCube()
-	}
-	floor := canvasFloorHexes(params.Width, params.Height)
-	anchorHex := core.HexFromCube(anchor)
-	if _, ok := floor[anchorHex]; !ok {
-		return partyStartReservation{}, fmt.Errorf("party start anchor %v is outside canvas floor", anchorHex)
-	}
+	floor := canvasFloorForParams(params)
 	blockers := make(map[core.Hex]string, len(params.AbsolutePlacedObstacles)+len(params.AbsoluteReservedCells))
 	for _, obstacle := range params.AbsolutePlacedObstacles {
 		blockers[obstacle.At] = fmt.Sprintf("canvas prop %q", obstacle.ID)
@@ -165,17 +282,32 @@ func resolveCanvasPartyStartReservation(params DungeonParams) (partyStartReserva
 	for _, reserved := range params.AbsoluteReservedCells {
 		blockers[reserved.At] = reserved.Name
 	}
-	if blocker, blocked := blockers[anchorHex]; blocked {
-		return partyStartReservation{}, fmt.Errorf("party start anchor %v collides with %s", anchorHex, blocker)
+
+	anchors := append([]core.Hex(nil), params.FloorCells...)
+	if params.FloorCells == nil {
+		for hex := range floor {
+			anchors = append(anchors, hex)
+		}
 	}
-	type candidate struct {
-		hex                core.Hex
-		col, row, distance int
+	sort.Slice(anchors, func(i, j int) bool { return floorPlanOrderHex(anchors[i]).less(floorPlanOrderHex(anchors[j])) })
+	if params.PartyStart.Anchor != nil {
+		anchors = []core.Hex{*params.PartyStart.Anchor}
 	}
-	candidates := make([]candidate, 0, params.Width*params.Height-1)
-	for col := 0; col < params.Width; col++ {
-		for row := 0; row < params.Height; row++ {
-			cell := core.HexFromPosition(spatial.Position{X: float64(col), Y: float64(row)})
+
+	for _, anchorHex := range anchors {
+		if _, ok := floor[anchorHex]; !ok {
+			continue
+		}
+		if _, blocked := blockers[anchorHex]; blocked {
+			continue
+		}
+		component := connectedFloorComponent(anchorHex, floor)
+		type candidate struct {
+			hex                core.Hex
+			col, row, distance int
+		}
+		candidates := make([]candidate, 0, len(component)-1)
+		for cell := range component {
 			if cell == anchorHex {
 				continue
 			}
@@ -184,29 +316,60 @@ func resolveCanvasPartyStartReservation(params DungeonParams) (partyStartReserva
 			}
 			pos := cell.ToPosition()
 			candidates = append(candidates, candidate{
-				hex: cell, col: int(pos.X), row: int(pos.Y), distance: anchor.Distance(cell.ToCube()),
+				hex: cell, col: int(pos.X), row: int(pos.Y),
+				distance: anchorHex.ToCube().Distance(cell.ToCube()),
 			})
 		}
-	}
-	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].distance != candidates[j].distance {
-			return candidates[i].distance < candidates[j].distance
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].distance != candidates[j].distance {
+				return candidates[i].distance < candidates[j].distance
+			}
+			if candidates[i].row != candidates[j].row {
+				return candidates[i].row < candidates[j].row
+			}
+			return candidates[i].col < candidates[j].col
+		})
+		if len(candidates)+1 < seatCount {
+			continue
 		}
-		if candidates[i].row != candidates[j].row {
-			return candidates[i].row < candidates[j].row
+		seats := make([]spatial.CubeCoordinate, 0, seatCount)
+		seats = append(seats, anchorHex.ToCube())
+		for index := 0; index < seatCount-1; index++ {
+			seats = append(seats, candidates[index].hex.ToCube())
 		}
-		return candidates[i].col < candidates[j].col
-	})
-	if len(candidates)+1 < seatCount {
-		return partyStartReservation{}, fmt.Errorf(
-			"party start anchor at [%d,%d] requires %d seats but canvas has only %d available authored floor cells",
-			int(anchorHex.ToPosition().X), int(anchorHex.ToPosition().Y), seatCount, len(candidates)+1,
-		)
+		return partyStartReservation{anchor: anchorHex.ToCube(), seats: seats}, nil
 	}
-	seats := make([]spatial.CubeCoordinate, 0, seatCount)
-	seats = append(seats, anchor)
-	for index := 0; index < seatCount-1; index++ {
-		seats = append(seats, candidates[index].hex.ToCube())
+	if params.PartyStart.Anchor != nil {
+		anchor := *params.PartyStart.Anchor
+		if _, ok := floor[anchor]; !ok {
+			return partyStartReservation{}, fmt.Errorf("party start anchor %v is outside canvas floor", anchor)
+		}
+		if blocker, blocked := blockers[anchor]; blocked {
+			return partyStartReservation{}, fmt.Errorf("party start anchor %v collides with %s", anchor, blocker)
+		}
 	}
-	return partyStartReservation{anchor: anchor, seats: seats}, nil
+	return partyStartReservation{}, fmt.Errorf(
+		"canvas floor has no same-component party start envelope with %d seats", seatCount,
+	)
+}
+
+func connectedFloorComponent(anchor core.Hex, floor map[core.Hex]struct{}) map[core.Hex]struct{} {
+	component := map[core.Hex]struct{}{anchor: {}}
+	queue := []core.Hex{anchor}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, neighbor := range current.ToCube().GetNeighbors() {
+			hex := core.HexFromCube(neighbor)
+			if _, ok := floor[hex]; !ok {
+				continue
+			}
+			if _, seen := component[hex]; seen {
+				continue
+			}
+			component[hex] = struct{}{}
+			queue = append(queue, hex)
+		}
+	}
+	return component
 }

--- a/encounter/combat_phased.go
+++ b/encounter/combat_phased.go
@@ -100,6 +100,9 @@ func (e *Encounter) TakeActionPhased(
 	if err := e.checkAttackRange(player, monster.Position, &tRef); err != nil {
 		return nil, err
 	}
+	if !e.hasClearStructuralReach(player.View.Position, monster.Position) {
+		return nil, fmt.Errorf("%w: %q is not reachable across the structural floor", ErrUnknownTarget, target.EntityID)
+	}
 
 	// Validate + deduct the attack off the held character's two-level economy
 	// BEFORE resolving. This gates the attack on the economy: a character with no

--- a/encounter/data.go
+++ b/encounter/data.go
@@ -143,6 +143,19 @@ type SpaceData struct {
 	Width  int `json:"width"`
 	Height int `json:"height"`
 
+	// FloorCells is the canonical structural-floor snapshot for canvas
+	// encounters. Legacy snapshots may omit it and reload as the v0.3 bounds
+	// rectangle; new snapshots always persist the complete sorted set.
+	FloorCells []core.Hex `json:"floor_cells,omitempty"`
+
+	// EnvelopeEdges is the complete canonical floor/void boundary snapshot.
+	// Each pair has exactly one FloorCells owner; the other endpoint may be an
+	// in-canvas void or an actual off-canvas neighbor.
+	EnvelopeEdges []GeneratedEdge `json:"envelope_edges,omitempty"`
+
+	// RequireConnectedFloor persists the strict region-union start/reload gate.
+	RequireConnectedFloor bool `json:"require_connected_floor,omitempty"`
+
 	// Entrance is the toolkit-resolved party-start anchor for an InitDungeon
 	// space. It may be an authored absolute start in any semantic region, not
 	// only the entrance archetype. Zero value (the zero Hex) remains the value

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -34,6 +34,20 @@ type DungeonParams struct {
 	// Width is required only for canvas floors; room-chain width derives from Regions.
 	Width int
 
+	// FloorCells is the complete canonical canvas floor. Nil retains the v0.3
+	// bounds rectangle for direct/legacy callers; dungeonspec always supplies
+	// an explicit sorted snapshot for newly compiled canvas documents.
+	FloorCells []core.Hex
+
+	// EnvelopeEdges is the canonical generated boundary between FloorCells and
+	// void/off-canvas neighbors. It is persisted verbatim into SpaceData.
+	EnvelopeEdges []GeneratedEdge
+
+	// RequireConnectedFloor marks region-union candidates that must pass the
+	// runnable floor gate whenever InitDungeon is attempted. Bounds canvases
+	// leave it false for v0.3 compatibility.
+	RequireConnectedFloor bool
+
 	// AbsolutePlacedObstacles and AbsoluteReservedCells are absolute authored
 	// content accepted only with FloorSourceCanvas. The latter reserves absolute
 	// monster spawns from party seating before any geometry is generated.
@@ -374,18 +388,28 @@ func (e *Encounter) InitDungeon(params DungeonParams) error {
 	}
 	source, _ := floorSourceKind(params.FloorSource)
 	space := &SpaceData{
-		Walls:               layout.walls,
-		Width:               layout.width,
-		Height:              params.Height,
-		FloorSource:         source,
-		Entrance:            core.HexFromCube(layout.entrance),
-		PartyStartPositions: layout.partyStartPositions,
-		DungeonKey:          dungeonKey,
-		AuthoredEdges:       authoredEdges,
-		Regions:             layout.regions,
-		SemanticRegions:     layout.semanticRegions,
-		Theme:               params.Theme,
-		Obstacles:           layout.obstacles,
+		Walls:                 layout.walls,
+		Width:                 layout.width,
+		Height:                params.Height,
+		FloorSource:           source,
+		FloorCells:            nil,
+		EnvelopeEdges:         nil,
+		RequireConnectedFloor: params.RequireConnectedFloor,
+		Entrance:              core.HexFromCube(layout.entrance),
+		PartyStartPositions:   layout.partyStartPositions,
+		DungeonKey:            dungeonKey,
+		AuthoredEdges:         authoredEdges,
+		Regions:               layout.regions,
+		SemanticRegions:       layout.semanticRegions,
+		Theme:                 params.Theme,
+		Obstacles:             layout.obstacles,
+	}
+	if source == FloorSourceCanvas {
+		space.FloorCells = canonicalCanvasFloorCells(params)
+		space.EnvelopeEdges = append([]GeneratedEdge(nil), params.EnvelopeEdges...)
+		if params.EnvelopeEdges == nil {
+			space.EnvelopeEdges = canvasEnvelopeEdges(canvasFloorForParams(params))
+		}
 	}
 
 	// Validate overlay against the generated connector records before mutating

--- a/encounter/dungeon.go
+++ b/encounter/dungeon.go
@@ -44,8 +44,8 @@ type DungeonParams struct {
 	EnvelopeEdges []GeneratedEdge
 
 	// RequireConnectedFloor marks region-union candidates that must pass the
-	// runnable floor gate whenever InitDungeon is attempted. Bounds canvases
-	// leave it false for v0.3 compatibility.
+	// runnable floor gate whenever InitDungeon is attempted. It is not a runtime
+	// mechanics authority: persisted FloorCells and the masked grid are.
 	RequireConnectedFloor bool
 
 	// AbsolutePlacedObstacles and AbsoluteReservedCells are absolute authored

--- a/encounter/dungeonspec/authored_error.go
+++ b/encounter/dungeonspec/authored_error.go
@@ -54,7 +54,9 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 				child = path + "." + key.Value
 			}
 			if !ok {
-				return authoredError(child, "unknown_field", "decode dungeon spec: line %d: %s is not a supported field", key.Line, child)
+				return authoredError(
+					child, "unknown_field", "decode dungeon spec: line %d: %s is not a supported field", key.Line, child,
+				)
 			}
 			if err := validateYAMLShape(value, fieldType, child); err != nil {
 				return err

--- a/encounter/dungeonspec/authored_error.go
+++ b/encounter/dungeonspec/authored_error.go
@@ -1,0 +1,113 @@
+package dungeonspec
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type authoredValidationError struct {
+	field   string
+	code    string
+	message string
+}
+
+func (e *authoredValidationError) Error() string { return e.message }
+
+func authoredError(field, code, format string, args ...any) error {
+	return &authoredValidationError{field: field, code: code, message: fmt.Sprintf(format, args...)}
+}
+
+func authoredWrap(field, code string, err error) error {
+	return &authoredValidationError{field: field, code: code, message: err.Error()}
+}
+
+// validateYAMLShape walks the authored YAML node alongside the public grammar.
+// It supplies exact structural paths before yaml.v3's prose-only KnownFields
+// errors can erase nesting/index information.
+func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
+	if node == nil {
+		return authoredError(path, "invalid_yaml", "decode dungeon spec: %s is missing", path)
+	}
+	if node.Kind == yaml.AliasNode {
+		return validateYAMLShape(node.Alias, typ, path)
+	}
+	if node.Tag == "!!null" {
+		return nil
+	}
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	switch typ.Kind() {
+	case reflect.Struct:
+		if node.Kind != yaml.MappingNode {
+			return authoredError(path, "invalid_yaml", "decode dungeon spec: %s must be a mapping", path)
+		}
+		fields := yamlStructFields(typ)
+		for index := 0; index < len(node.Content); index += 2 {
+			key, value := node.Content[index], node.Content[index+1]
+			fieldType, ok := fields[key.Value]
+			child := key.Value
+			if path != "spec" {
+				child = path + "." + key.Value
+			}
+			if !ok {
+				return authoredError(child, "unknown_field", "decode dungeon spec: line %d: %s is not a supported field", key.Line, child)
+			}
+			if err := validateYAMLShape(value, fieldType, child); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Slice:
+		if node.Kind != yaml.SequenceNode {
+			return authoredError(path, "invalid_yaml", "decode dungeon spec: %s must be a sequence", path)
+		}
+		for index, child := range node.Content {
+			if err := validateYAMLShape(child, typ.Elem(), fmt.Sprintf("%s[%d]", path, index)); err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.Array:
+		if node.Kind != yaml.SequenceNode || len(node.Content) != typ.Len() {
+			return authoredError(path, "invalid_yaml", "decode dungeon spec: %s must be a %d-item sequence", path, typ.Len())
+		}
+		for index, child := range node.Content {
+			if err := validateYAMLShape(child, typ.Elem(), fmt.Sprintf("%s[%d]", path, index)); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		if node.Kind != yaml.ScalarNode {
+			return authoredError(path, "invalid_yaml", "decode dungeon spec: %s has an invalid YAML shape", path)
+		}
+		target := reflect.New(typ).Interface()
+		if err := node.Decode(target); err != nil {
+			return authoredWrap(path, "invalid_yaml", fmt.Errorf("decode dungeon spec: %w", err))
+		}
+		return nil
+	}
+}
+
+func yamlStructFields(typ reflect.Type) map[string]reflect.Type {
+	out := make(map[string]reflect.Type, typ.NumField())
+	for index := 0; index < typ.NumField(); index++ {
+		field := typ.Field(index)
+		if field.PkgPath != "" {
+			continue
+		}
+		tag := strings.Split(field.Tag.Get("yaml"), ",")[0]
+		if tag == "-" {
+			continue
+		}
+		if tag == "" {
+			tag = strings.ToLower(field.Name)
+		}
+		out[tag] = field.Type
+	}
+	return out
+}

--- a/encounter/dungeonspec/authored_error.go
+++ b/encounter/dungeonspec/authored_error.go
@@ -48,6 +48,12 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 		fields := yamlStructFields(typ)
 		for index := 0; index < len(node.Content); index += 2 {
 			key, value := node.Content[index], node.Content[index+1]
+			if key.Value == "<<" {
+				if err := validateYAMLMerge(value, typ, path); err != nil {
+					return err
+				}
+				continue
+			}
 			fieldType, ok := fields[key.Value]
 			child := key.Value
 			if path != "spec" {
@@ -93,6 +99,27 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 		}
 		return nil
 	}
+}
+
+func validateYAMLMerge(node *yaml.Node, typ reflect.Type, path string) error {
+	if node.Kind == yaml.AliasNode {
+		return validateYAMLShape(node.Alias, typ, path)
+	}
+	if node.Kind == yaml.SequenceNode {
+		for _, merged := range node.Content {
+			if merged.Kind != yaml.AliasNode && merged.Kind != yaml.MappingNode {
+				return authoredError(path, "invalid_yaml", "decode dungeon spec: %s merge must contain mappings", path)
+			}
+			if err := validateYAMLShape(merged, typ, path); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if node.Kind == yaml.MappingNode {
+		return validateYAMLShape(node, typ, path)
+	}
+	return authoredError(path, "invalid_yaml", "decode dungeon spec: %s merge must be a mapping or alias sequence", path)
 }
 
 func yamlStructFields(typ reflect.Type) map[string]reflect.Type {

--- a/encounter/dungeonspec/authored_error.go
+++ b/encounter/dungeonspec/authored_error.go
@@ -28,11 +28,22 @@ func authoredWrap(field, code string, err error) error {
 // It supplies exact structural paths before yaml.v3's prose-only KnownFields
 // errors can erase nesting/index information.
 func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
+	return validateYAMLShapeActive(node, typ, path, make(map[*yaml.Node]struct{}))
+}
+
+func validateYAMLShapeActive(
+	node *yaml.Node, typ reflect.Type, path string, active map[*yaml.Node]struct{},
+) error {
 	if node == nil {
 		return authoredError(path, "invalid_yaml", "decode dungeon spec: %s is missing", path)
 	}
+	if _, recursive := active[node]; recursive {
+		return authoredError(path, "invalid_yaml", "decode dungeon spec: YAML alias cycle at %s", path)
+	}
+	active[node] = struct{}{}
+	defer delete(active, node)
 	if node.Kind == yaml.AliasNode {
-		return validateYAMLShape(node.Alias, typ, path)
+		return validateYAMLShapeActive(node.Alias, typ, path, active)
 	}
 	if node.Tag == "!!null" {
 		return nil
@@ -49,7 +60,7 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 		for index := 0; index < len(node.Content); index += 2 {
 			key, value := node.Content[index], node.Content[index+1]
 			if key.Value == "<<" {
-				if err := validateYAMLMerge(value, typ, path); err != nil {
+				if err := validateYAMLMerge(value, typ, path, active); err != nil {
 					return err
 				}
 				continue
@@ -64,7 +75,7 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 					child, "unknown_field", "decode dungeon spec: line %d: %s is not a supported field", key.Line, child,
 				)
 			}
-			if err := validateYAMLShape(value, fieldType, child); err != nil {
+			if err := validateYAMLShapeActive(value, fieldType, child, active); err != nil {
 				return err
 			}
 		}
@@ -74,7 +85,7 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 			return authoredError(path, "invalid_yaml", "decode dungeon spec: %s must be a sequence", path)
 		}
 		for index, child := range node.Content {
-			if err := validateYAMLShape(child, typ.Elem(), fmt.Sprintf("%s[%d]", path, index)); err != nil {
+			if err := validateYAMLShapeActive(child, typ.Elem(), fmt.Sprintf("%s[%d]", path, index), active); err != nil {
 				return err
 			}
 		}
@@ -84,7 +95,7 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 			return authoredError(path, "invalid_yaml", "decode dungeon spec: %s must be a %d-item sequence", path, typ.Len())
 		}
 		for index, child := range node.Content {
-			if err := validateYAMLShape(child, typ.Elem(), fmt.Sprintf("%s[%d]", path, index)); err != nil {
+			if err := validateYAMLShapeActive(child, typ.Elem(), fmt.Sprintf("%s[%d]", path, index), active); err != nil {
 				return err
 			}
 		}
@@ -101,23 +112,30 @@ func validateYAMLShape(node *yaml.Node, typ reflect.Type, path string) error {
 	}
 }
 
-func validateYAMLMerge(node *yaml.Node, typ reflect.Type, path string) error {
-	if node.Kind == yaml.AliasNode {
-		return validateYAMLShape(node.Alias, typ, path)
+func validateYAMLMerge(
+	node *yaml.Node, typ reflect.Type, path string, active map[*yaml.Node]struct{},
+) error {
+	if node == nil {
+		return authoredError(path, "invalid_yaml", "decode dungeon spec: %s merge is missing", path)
+	}
+	if node.Kind == yaml.AliasNode || node.Kind == yaml.MappingNode {
+		return validateYAMLShapeActive(node, typ, path, active)
 	}
 	if node.Kind == yaml.SequenceNode {
+		if _, recursive := active[node]; recursive {
+			return authoredError(path, "invalid_yaml", "decode dungeon spec: YAML alias cycle at %s", path)
+		}
+		active[node] = struct{}{}
+		defer delete(active, node)
 		for _, merged := range node.Content {
 			if merged.Kind != yaml.AliasNode && merged.Kind != yaml.MappingNode {
 				return authoredError(path, "invalid_yaml", "decode dungeon spec: %s merge must contain mappings", path)
 			}
-			if err := validateYAMLShape(merged, typ, path); err != nil {
+			if err := validateYAMLShapeActive(merged, typ, path, active); err != nil {
 				return err
 			}
 		}
 		return nil
-	}
-	if node.Kind == yaml.MappingNode {
-		return validateYAMLShape(node, typ, path)
 	}
 	return authoredError(path, "invalid_yaml", "decode dungeon spec: %s merge must be a mapping or alias sequence", path)
 }

--- a/encounter/dungeonspec/canvas_runtime_test.go
+++ b/encounter/dungeonspec/canvas_runtime_test.go
@@ -95,14 +95,19 @@ func TestCanvasRuntime_InitializesPersistsAndSeedsAbsoluteContent(t *testing.T) 
 		Compiled: compiled, Seed: 27,
 	})
 	require.NoError(t, err)
-	require.Equal(t, dungeonspec.FloorPlanCell{Column: 0, Row: 0}, plan.Entrance)
+	require.Equal(t, &dungeonspec.FloorPlanCell{Column: 0, Row: 0}, plan.Entrance)
 	require.Len(t, plan.FloorCells, 15)
 	for column := 0; column < 5; column++ {
 		for row := 0; row < 3; row++ {
 			require.Contains(t, plan.FloorCells, dungeonspec.FloorPlanCell{Column: column, Row: row})
 		}
 	}
-	require.Equal(t, "canvas-runtime-authored-door-1--3-2--1--2-1", plan.Edges[0].DoorID)
+	require.Contains(t, plan.Edges, dungeonspec.FloorPlanEdge{
+		From:   dungeonspec.FloorPlanCell{Column: 1, Row: 1},
+		To:     dungeonspec.FloorPlanCell{Column: 1, Row: 2},
+		Kind:   dungeonspec.FloorPlanEdgeKindDoor,
+		DoorID: "canvas-runtime-authored-door-1--3-2--1--2-1",
+	})
 
 	payload, err := json.Marshal(data)
 	require.NoError(t, err)

--- a/encounter/dungeonspec/canvas_test.go
+++ b/encounter/dungeonspec/canvas_test.go
@@ -33,12 +33,11 @@ func Test883CanvasModeAndProviderContract(t *testing.T) {
 	require.Equal(t, 4, plan.Width)
 	require.Equal(t, 2, plan.Height)
 	require.Equal(t, []FloorPlanCell{{0, 0}, {0, 1}, {1, 0}, {1, 1}, {2, 0}, {2, 1}, {3, 0}, {3, 1}}, plan.FloorCells)
-	require.Equal(t, FloorPlanCell{1, 1}, plan.Entrance)
-	require.Equal(t, []FloorPlanEdge{{
+	require.Equal(t, &FloorPlanCell{1, 1}, plan.Entrance)
+	require.Contains(t, plan.Edges, FloorPlanEdge{
 		From: FloorPlanCell{1, 0}, To: FloorPlanCell{1, 1},
-		Kind:   FloorPlanEdgeKindDoor,
-		DoorID: "canvas-provider-contract-authored-door-1--2-1--1--1-0",
-	}}, plan.Edges)
+		Kind: FloorPlanEdgeKindDoor, DoorID: "canvas-provider-contract-authored-door-1--2-1--1--1-0",
+	})
 }
 
 func Test883CanvasModeMatrixAndShrink(t *testing.T) {
@@ -107,7 +106,7 @@ walls:
 			DoorID: "room-provider-door-crossing-boss", FromRoomID: crossingRoomID, ToRoomID: archetypeBoss, Column: 26,
 		},
 	}, plan.Connectors)
-	require.Equal(t, FloorPlanCell{Column: 0, Row: 4}, plan.Entrance)
+	require.Equal(t, &FloorPlanCell{Column: 0, Row: 4}, plan.Entrance)
 
 	doorIDs := make(map[string]bool, len(plan.Edges))
 	for _, edge := range plan.Edges {

--- a/encounter/dungeonspec/compile.go
+++ b/encounter/dungeonspec/compile.go
@@ -402,9 +402,13 @@ func compileFacing(label *string) (*uint32, error) {
 
 type canvasCompiled struct {
 	width, height int
-	entrance      FloorPlanCell
-	occupancy     []canvasSourceOccupancy // source order for LoadWithPrevious
-	regionCells   []namedCanvasCell       // internal-only synthetic test seam
+	floorSource   FloorSource
+	floorCells    []FloorPlanCell
+	entrance      *FloorPlanCell
+	envelope      []encounter.GeneratedEdge
+	regions       []FloorPlanRegion
+	occupancy     []canvasSourceOccupancy // retained for legacy LoadWithPrevious callers
+	regionCells   []namedCanvasCell
 }
 
 type canvasSourceOccupancy struct {
@@ -425,12 +429,36 @@ func compileCanvas(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, error
 	if err != nil {
 		return CompiledDungeon{}, err
 	}
-	cc := &canvasCompiled{width: spec.Canvas.Width, height: spec.Canvas.Height}
-	if spec.Start != nil {
-		cc.entrance = FloorPlanCell{spec.Start[0], spec.Start[1]}
-	} else {
-		cc.entrance = FloorPlanCell{0, 0}
+	cc := &canvasCompiled{
+		width: spec.Canvas.Width, height: spec.Canvas.Height,
+		floorSource: FloorSource(spec.Canvas.FloorSource),
 	}
+	if cc.floorSource == "" {
+		cc.floorSource = FloorSourceBounds
+	}
+	floorSet := make(map[[2]int]struct{})
+	if cc.floorSource == FloorSourceRegions {
+		for _, region := range spec.Regions {
+			for _, cell := range region.Cells {
+				floorSet[cell] = struct{}{}
+			}
+		}
+	} else {
+		for col := 0; col < spec.Canvas.Width; col++ {
+			for row := 0; row < spec.Canvas.Height; row++ {
+				floorSet[[2]int{col, row}] = struct{}{}
+			}
+		}
+	}
+	for cell := range floorSet {
+		cc.floorCells = append(cc.floorCells, FloorPlanCell{Column: cell[0], Row: cell[1]})
+	}
+	sort.Slice(cc.floorCells, func(i, j int) bool { return floorPlanCellLess(cc.floorCells[i], cc.floorCells[j]) })
+	floorHexes := make([]core.Hex, len(cc.floorCells))
+	for index, cell := range cc.floorCells {
+		floorHexes[index] = canvasHex(cell)
+	}
+	cc.envelope = compileEnvelope(floorHexes)
 
 	semanticRegions := make([]encounter.SemanticRegionParams, len(spec.Regions))
 	for index, region := range spec.Regions {
@@ -458,13 +486,14 @@ func compileCanvas(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, error
 	}
 	params := encounter.DungeonParams{
 		Key: spec.Key, Width: spec.Canvas.Width, Height: spec.Canvas.Height, Theme: spec.Theme,
-		SemanticRegions: semanticRegions,
-		FloorSource:     encounter.FloorSourceCanvas,
-		PartyStart:      encounter.PartyStartParams{SeatCount: config.PartyStartSeatCount},
-		AuthoredEdges:   edges,
+		SemanticRegions: semanticRegions, FloorCells: floorHexes, EnvelopeEdges: cc.envelope,
+		FloorSource: encounter.FloorSourceCanvas, RequireConnectedFloor: cc.floorSource == FloorSourceRegions,
+		PartyStart: encounter.PartyStartParams{SeatCount: config.PartyStartSeatCount}, AuthoredEdges: edges,
 	}
-	anchor := canvasHex(cc.entrance)
-	params.PartyStart.Anchor = &anchor
+	if spec.Start != nil {
+		anchor := canvasHex(FloorPlanCell{Column: spec.Start[0], Row: spec.Start[1]})
+		params.PartyStart.Anchor = &anchor
+	}
 	spawns := make([]SpawnInstruction, 0, len(spec.Place))
 	for index, entry := range spec.Place {
 		refType, err := refParts(entry.Ref)
@@ -502,7 +531,150 @@ func compileCanvas(spec *DungeonSpec, config LoadConfig) (CompiledDungeon, error
 	if spec.Start != nil {
 		cc.occupancy = append(cc.occupancy, canvasSourceOccupancy{source: "start", cell: *spec.Start})
 	}
+	cc.regions = compileFloorPlanRegions(spec.Regions)
+	cc.entrance = resolveDraftEntrance(cc.floorCells, spec.Start, spec.Place, config.PartyStartSeatCount)
 	return CompiledDungeon{Params: params, Spawns: spawns, canvas: cc}, nil
+}
+
+func compileEnvelope(floorCells []core.Hex) []encounter.GeneratedEdge {
+	floor := make(map[core.Hex]struct{}, len(floorCells))
+	for _, cell := range floorCells {
+		floor[cell] = struct{}{}
+	}
+	seen := make(map[wallEdgeKey]struct{})
+	var edges []encounter.GeneratedEdge
+	for owner := range floor {
+		for _, cube := range owner.ToCube().GetNeighbors() {
+			neighbor := core.HexFromCube(cube)
+			if _, ok := floor[neighbor]; ok {
+				continue
+			}
+			from, to := owner, neighbor
+			if wallHexLess(to, from) {
+				from, to = to, from
+			}
+			key := newWallEdgeKey(from, to)
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			edges = append(edges, encounter.GeneratedEdge{From: from, To: to, Kind: encounter.GeneratedEdgeKindSolid})
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if wallHexLess(edges[i].From, edges[j].From) {
+			return true
+		}
+		if wallHexLess(edges[j].From, edges[i].From) {
+			return false
+		}
+		return wallHexLess(edges[i].To, edges[j].To)
+	})
+	return edges
+}
+
+func compileFloorPlanRegions(regions []RegionSpec) []FloorPlanRegion {
+	out := make([]FloorPlanRegion, len(regions))
+	sets := make([]map[[2]int]struct{}, len(regions))
+	for i, region := range regions {
+		sets[i] = make(map[[2]int]struct{}, len(region.Cells))
+		out[i] = FloorPlanRegion{ID: region.ID, Name: cloneString(region.Name), Archetype: cloneString(region.Archetype)}
+		for _, cell := range region.Cells {
+			sets[i][cell] = struct{}{}
+		}
+		for cell := range sets[i] {
+			out[i].Cells = append(out[i].Cells, FloorPlanCell{Column: cell[0], Row: cell[1]})
+		}
+		sort.Slice(out[i].Cells, func(a, b int) bool { return floorPlanCellLess(out[i].Cells[a], out[i].Cells[b]) })
+	}
+	for child := range sets {
+		if len(sets[child]) == 0 {
+			continue
+		}
+		parent := -1
+		for candidate := range sets {
+			if child == candidate || len(sets[candidate]) <= len(sets[child]) {
+				continue
+			}
+			contains := true
+			for cell := range sets[child] {
+				if _, ok := sets[candidate][cell]; !ok {
+					contains = false
+					break
+				}
+			}
+			if contains && (parent == -1 || len(sets[candidate]) < len(sets[parent])) {
+				parent = candidate
+			}
+		}
+		if parent >= 0 {
+			id := regions[parent].ID
+			out[child].ParentID = &id
+		}
+	}
+	return out
+}
+
+func resolveDraftEntrance(
+	floorCells []FloorPlanCell,
+	authored *[2]int,
+	placements []PlacedEntry,
+	seatCount int,
+) *FloorPlanCell {
+	if seatCount < 1 {
+		return nil
+	}
+	floor := make(map[[2]int]struct{}, len(floorCells))
+	for _, cell := range floorCells {
+		floor[[2]int{cell.Column, cell.Row}] = struct{}{}
+	}
+	blocked := make(map[[2]int]struct{}, len(placements))
+	for _, placement := range placements {
+		blocked[placement.At] = struct{}{}
+	}
+	anchors := append([]FloorPlanCell(nil), floorCells...)
+	if authored != nil {
+		anchors = []FloorPlanCell{{Column: authored[0], Row: authored[1]}}
+	}
+	for _, anchor := range anchors {
+		key := [2]int{anchor.Column, anchor.Row}
+		if _, ok := floor[key]; !ok {
+			continue
+		}
+		if _, no := blocked[key]; no {
+			continue
+		}
+		component := map[[2]int]struct{}{key: {}}
+		queue := [][2]int{key}
+		for len(queue) > 0 {
+			current := queue[0]
+			queue = queue[1:]
+			h := canvasHex(FloorPlanCell{Column: current[0], Row: current[1]})
+			for _, cube := range h.ToCube().GetNeighbors() {
+				pos := core.HexFromCube(cube).ToPosition()
+				next := [2]int{int(pos.X), int(pos.Y)}
+				if _, ok := floor[next]; !ok {
+					continue
+				}
+				if _, seen := component[next]; seen {
+					continue
+				}
+				component[next] = struct{}{}
+				queue = append(queue, next)
+			}
+		}
+		available := 0
+		for cell := range component {
+			if _, no := blocked[cell]; !no {
+				available++
+			}
+		}
+		if available >= seatCount {
+			value := anchor
+			return &value
+		}
+	}
+	return nil
 }
 
 func validatePreviousCanvas(candidate, previous CompiledDungeon) error {

--- a/encounter/dungeonspec/compile_contract_test.go
+++ b/encounter/dungeonspec/compile_contract_test.go
@@ -91,6 +91,53 @@ connectors: [{ from: entrance, to: boss }]
 	}
 }
 
+func TestCompileDungeonAliasCyclesReturnTypedErrors(t *testing.T) {
+	cycles := []string{
+		`version: 1
+key: self-cycle
+name: Self Cycle
+height: 7
+rooms: &rooms
+  - *rooms
+`,
+		`version: 1
+key: multi-cycle
+name: Multi Cycle
+height: 7
+rooms:
+  - &first
+    <<: &second
+      <<: *first
+`,
+	}
+	for _, source := range cycles {
+		out := compileCandidate(t, source, dungeonspec.CompileModeDraft, 1)
+		require.Equal(t, "rooms[0]", out.FieldErrors[0].Field)
+		require.Equal(t, "invalid_yaml", out.FieldErrors[0].Code)
+		require.Contains(t, out.FieldErrors[0].Message, "alias cycle")
+	}
+}
+
+func TestCompileDungeonSupportsOrdinaryAliases(t *testing.T) {
+	source := `version: 1
+key: ordinary-alias
+name: Ordinary Alias
+height: 7
+start: &anchor [0,0]
+rooms:
+  - { id: entrance, archetype: entrance, width: 7, pattern: empty }
+  - id: boss
+    archetype: boss
+    width: 7
+    pattern: empty
+    boss: { ref: "dnd5e:monsters:skeleton", at: *anchor }
+connectors: [{ from: entrance, to: boss }]
+`
+	out := compileCandidate(t, source, dungeonspec.CompileModeStrict, 1)
+	require.Empty(t, out.FieldErrors)
+	require.NotNil(t, out.FloorPlan)
+}
+
 func TestCompileDungeonRoomChainErrorsAreTypedAtSource(t *testing.T) {
 	cases := []struct{ name, source, field, code string }{
 		{

--- a/encounter/dungeonspec/compile_contract_test.go
+++ b/encounter/dungeonspec/compile_contract_test.go
@@ -1,0 +1,137 @@
+package dungeonspec_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+)
+
+const roomChainContractSource = `version: 1
+key: contract
+name: Contract
+height: 7
+rooms:
+  - { id: entrance, archetype: entrance, width: 7, pattern: empty }
+  - id: boss
+    archetype: boss
+    width: 7
+    pattern: empty
+    boss: { ref: "dnd5e:monsters:skeleton", at: [1,1] }
+connectors: [{ from: entrance, to: boss }]
+`
+
+const (
+	contractOutsideFloor = "outside_floor"
+	contractStartPath    = "start"
+)
+
+func TestCompileDungeonSupportsYAMLMergeKeysWithExactMergedPaths(t *testing.T) {
+	valid := []string{
+		`version: 1
+key: anchor-merge
+name: Anchor Merge
+height: 7
+rooms:
+  - &base { id: entrance, archetype: entrance, width: 7, pattern: empty }
+  - <<: *base
+    id: boss
+    archetype: boss
+    boss: { ref: "dnd5e:monsters:skeleton", at: [1,1] }
+connectors: [{ from: entrance, to: boss }]
+`,
+		`version: 1
+key: sequence-merge
+name: Sequence Merge
+height: 7
+rooms:
+  - &entrance { id: entrance, archetype: entrance, width: 7, pattern: empty }
+  - &chamber { id: chamber, archetype: chamber, width: 7, pattern: empty }
+  - <<: [*entrance, *chamber]
+    id: boss
+    archetype: boss
+    boss: { ref: "dnd5e:monsters:skeleton", at: [1,1] }
+connectors:
+  - { from: entrance, to: chamber }
+  - { from: chamber, to: boss }
+`,
+	}
+	for _, source := range valid {
+		out := compileCandidate(t, source, dungeonspec.CompileModeStrict, 1)
+		require.Empty(t, out.FieldErrors)
+		require.NotNil(t, out.FloorPlan)
+	}
+
+	invalid := []string{
+		`version: 1
+key: bad-merge
+name: Bad Merge
+height: 7
+rooms:
+  - <<: &bad { id: entrance, archetype: entrance, width: 7, pattern: empty, mystery: true }
+  - { id: boss, archetype: boss, width: 7, pattern: empty, boss: { ref: "dnd5e:monsters:skeleton", at: [1,1] } }
+connectors: [{ from: entrance, to: boss }]
+`,
+		`version: 1
+key: bad-sequence-merge
+name: Bad Sequence Merge
+height: 7
+rooms:
+  - <<: [ &base { id: entrance, archetype: entrance, width: 7, pattern: empty }, &bad { mystery: true } ]
+  - { id: boss, archetype: boss, width: 7, pattern: empty, boss: { ref: "dnd5e:monsters:skeleton", at: [1,1] } }
+connectors: [{ from: entrance, to: boss }]
+`,
+	}
+	for _, source := range invalid {
+		out := compileCandidate(t, source, dungeonspec.CompileModeDraft, 1)
+		require.Equal(t, "rooms[0].mystery", out.FieldErrors[0].Field)
+		require.Equal(t, "unknown_field", out.FieldErrors[0].Code)
+	}
+}
+
+func TestCompileDungeonRoomChainErrorsAreTypedAtSource(t *testing.T) {
+	cases := []struct{ name, source, field, code string }{
+		{
+			name:   "room width",
+			source: strings.Replace(roomChainContractSource, "width: 7, pattern: empty", "width: 3, pattern: empty", 1),
+			field:  "rooms[0].width", code: "invalid_dimension",
+		},
+		{
+			name:   "connector",
+			source: strings.Replace(roomChainContractSource, "from: entrance", "from: boss", 1),
+			field:  "connectors[0]", code: "invalid_chain",
+		},
+		{
+			name:   "boss ref",
+			source: strings.Replace(roomChainContractSource, "dnd5e:monsters:skeleton", "dnd5e:props:pillar", 1),
+			field:  "rooms[1].boss.ref", code: "invalid_ref",
+		},
+		{
+			name: "nested placed at",
+			source: strings.Replace(roomChainContractSource,
+				"  - { id: entrance, archetype: entrance, width: 7, pattern: empty }",
+				"  - { id: entrance, archetype: entrance, width: 7, pattern: empty, "+
+					"place: [{ ref: 'dnd5e:props:pillar', at: [99,0] }] }", 1),
+			field: "rooms[0].place[0].at", code: contractOutsideFloor,
+		},
+		{
+			name:   "wall endpoint",
+			source: roomChainContractSource + "walls: [{ from: [99,0], to: [1,0], kind: solid }]\n",
+			field:  "walls[0].from", code: contractOutsideFloor,
+		},
+		{
+			name:   "start connector",
+			source: roomChainContractSource + "start: [7,3]\n",
+			field:  contractStartPath, code: contractOutsideFloor,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := compileCandidate(t, tc.source, dungeonspec.CompileModeDraft, 1)
+			require.Equal(t, tc.field, out.FieldErrors[0].Field)
+			require.Equal(t, tc.code, out.FieldErrors[0].Code)
+		})
+	}
+}

--- a/encounter/dungeonspec/compile_dungeon.go
+++ b/encounter/dungeonspec/compile_dungeon.go
@@ -18,7 +18,10 @@ const (
 	CompileModeStrict CompileMode = "strict"
 )
 
-const fieldCanvasFloorSource = "canvas.floor_source"
+const (
+	fieldCanvasFloorSource = "canvas.floor_source"
+	fieldStart             = "start"
+)
 
 // FieldError is ordered provider-authored validation feedback.
 type FieldError struct{ Field, Message, Code string }
@@ -56,10 +59,18 @@ func CompileDungeon(ctx context.Context, in *CompileDungeonInput) (*CompileDunge
 	}
 	spec, err := Decode(in.Source)
 	if err != nil {
-		return validationOutput(fieldErrorFor(err)), nil
+		field, authored := fieldErrorFor(err)
+		if !authored {
+			return nil, fmt.Errorf("dungeonspec: decode candidate: %w", err)
+		}
+		return validationOutput(field), nil
 	}
 	if err := Validate(spec); err != nil {
-		return validationOutput(fieldErrorFor(err)), nil
+		field, authored := fieldErrorFor(err)
+		if !authored {
+			return nil, fmt.Errorf("dungeonspec: validate candidate: %w", err)
+		}
+		return validationOutput(field), nil
 	}
 	compiled, err := compileWithConfig(spec, LoadConfig{PartyStartSeatCount: in.PartyStartSeatCount})
 	if err != nil {
@@ -72,7 +83,7 @@ func CompileDungeon(ctx context.Context, in *CompileDungeonInput) (*CompileDunge
 			}
 		}
 		if err := validateCompiledRuntime(ctx, compiled, in.PreviewSeed); err != nil {
-			return validationOutput(fieldErrorFor(err)), nil
+			return validationOutput(runnableFieldError(compiled, err)), nil
 		}
 	}
 	plan, err := BuildFloorPlan(ctx, BuildFloorPlanInput{Compiled: compiled, Seed: in.PreviewSeed})
@@ -82,7 +93,7 @@ func CompileDungeon(ctx context.Context, in *CompileDungeonInput) (*CompileDunge
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
-		return validationOutput(fieldErrorFor(err)), nil
+		return validationOutput(runnableFieldError(compiled, err)), nil
 	}
 	return &CompileDungeonOutput{Compiled: compiled, FloorPlan: &plan}, nil
 }
@@ -103,7 +114,7 @@ func strictRegionValidation(compiled CompiledDungeon) *FieldError {
 	if canvas.entrance == nil {
 		field := fieldCanvasFloorSource
 		if compiled.Params.PartyStart.Anchor != nil {
-			field = "start"
+			field = fieldStart
 		}
 		return &FieldError{
 			Field: field, Message: "no floor anchor has a complete same-component party start envelope",
@@ -143,10 +154,18 @@ func strictRegionValidation(compiled CompiledDungeon) *FieldError {
 	return nil
 }
 
-func fieldErrorFor(err error) FieldError {
+func fieldErrorFor(err error) (FieldError, bool) {
 	var authored *authoredValidationError
-	if errors.As(err, &authored) {
-		return FieldError{Field: authored.field, Message: authored.message, Code: authored.code}
+	if !errors.As(err, &authored) {
+		return FieldError{}, false
 	}
-	return FieldError{Field: "spec", Message: err.Error(), Code: "invalid_candidate"}
+	return FieldError{Field: authored.field, Message: authored.message, Code: authored.code}, true
+}
+
+func runnableFieldError(compiled CompiledDungeon, err error) FieldError {
+	field := "rooms"
+	if compiled.canvas != nil {
+		field = fieldStart
+	}
+	return FieldError{Field: field, Message: err.Error(), Code: "not_runnable"}
 }

--- a/encounter/dungeonspec/compile_dungeon.go
+++ b/encounter/dungeonspec/compile_dungeon.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 )
@@ -43,9 +41,12 @@ type CompileDungeonOutput struct {
 
 // CompileDungeon is the protobuf-free complete-candidate provider seam used by
 // API adapters. It never accepts previous compiled state or source metadata.
-func CompileDungeon(ctx context.Context, in CompileDungeonInput) (*CompileDungeonOutput, error) {
+func CompileDungeon(ctx context.Context, in *CompileDungeonInput) (*CompileDungeonOutput, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+	if in == nil {
+		return nil, fmt.Errorf("dungeonspec: nil CompileDungeonInput")
 	}
 	if in.Mode != CompileModeDraft && in.Mode != CompileModeStrict {
 		return nil, fmt.Errorf("dungeonspec: unknown compile mode %q", in.Mode)
@@ -142,28 +143,10 @@ func strictRegionValidation(compiled CompiledDungeon) *FieldError {
 	return nil
 }
 
-var sourcePathPattern = regexp.MustCompile(
-	`(?:^|: |\b)((?:canvas\.floor_source|start|` +
-		`place\[\d+\](?:\.[a-z_]+)?|walls\[\d+\](?:\.[a-z_]+)?|` +
-		`regions\[\d+\](?:\.[a-z_]+)?|rooms\[\d+\](?:\.[a-z_]+)?))`,
-)
-
 func fieldErrorFor(err error) FieldError {
-	message := err.Error()
-	field := ""
-	if match := sourcePathPattern.FindStringSubmatch(message); len(match) > 1 {
-		field = match[1]
+	var authored *authoredValidationError
+	if errors.As(err, &authored) {
+		return FieldError{Field: authored.field, Message: authored.message, Code: authored.code}
 	}
-	code := "invalid_candidate"
-	switch {
-	case strings.Contains(message, "decode dungeon spec"),
-		strings.Contains(message, "empty dungeon spec"),
-		strings.Contains(message, "multi-document"):
-		code = "invalid_yaml"
-	case strings.Contains(message, "duplicates regions"), strings.Contains(message, "equal cell set"):
-		code = "duplicate_region"
-	case strings.Contains(message, "outside structural floor"), strings.Contains(message, "not a semantic floor cell"):
-		code = "outside_floor"
-	}
-	return FieldError{Field: field, Message: message, Code: code}
+	return FieldError{Field: "spec", Message: err.Error(), Code: "invalid_candidate"}
 }

--- a/encounter/dungeonspec/compile_dungeon.go
+++ b/encounter/dungeonspec/compile_dungeon.go
@@ -1,0 +1,167 @@
+package dungeonspec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+)
+
+// CompileMode selects structural authoring preview or runnable compilation.
+type CompileMode string
+
+const (
+	// CompileModeDraft permits structurally valid non-runnable projections.
+	CompileModeDraft CompileMode = "draft"
+	// CompileModeStrict requires a runnable candidate.
+	CompileModeStrict CompileMode = "strict"
+)
+
+const fieldCanvasFloorSource = "canvas.floor_source"
+
+// FieldError is ordered provider-authored validation feedback.
+type FieldError struct{ Field, Message, Code string }
+
+// CompileDungeonInput is one complete standalone authored candidate.
+type CompileDungeonInput struct {
+	Source              []byte
+	Mode                CompileMode
+	PartyStartSeatCount int
+	PreviewSeed         int64
+}
+
+// CompileDungeonOutput is either a complete result or FieldErrors. Infrastructure
+// failures use CompileDungeon's Go error return.
+type CompileDungeonOutput struct {
+	Compiled    CompiledDungeon
+	FloorPlan   *FloorPlan
+	FieldErrors []FieldError
+}
+
+// CompileDungeon is the protobuf-free complete-candidate provider seam used by
+// API adapters. It never accepts previous compiled state or source metadata.
+func CompileDungeon(ctx context.Context, in CompileDungeonInput) (*CompileDungeonOutput, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if in.Mode != CompileModeDraft && in.Mode != CompileModeStrict {
+		return nil, fmt.Errorf("dungeonspec: unknown compile mode %q", in.Mode)
+	}
+	if in.PartyStartSeatCount < 1 {
+		return nil, fmt.Errorf("dungeonspec: PartyStartSeatCount must be at least 1")
+	}
+	spec, err := Decode(in.Source)
+	if err != nil {
+		return validationOutput(fieldErrorFor(err)), nil
+	}
+	if err := Validate(spec); err != nil {
+		return validationOutput(fieldErrorFor(err)), nil
+	}
+	compiled, err := compileWithConfig(spec, LoadConfig{PartyStartSeatCount: in.PartyStartSeatCount})
+	if err != nil {
+		return nil, fmt.Errorf("dungeonspec: compile candidate: %w", err)
+	}
+	if in.Mode == CompileModeStrict && compiled.canvas != nil && compiled.canvas.floorSource == FloorSourceRegions {
+		if validation := strictRegionValidation(compiled); validation != nil {
+			return validationOutput(*validation), nil
+		}
+		if err := validateCompiledRuntime(ctx, compiled, in.PreviewSeed); err != nil {
+			return validationOutput(fieldErrorFor(err)), nil
+		}
+	}
+	plan, err := BuildFloorPlan(ctx, BuildFloorPlanInput{Compiled: compiled, Seed: in.PreviewSeed})
+	if err != nil {
+		// Init/generator rejections describe authored content for this complete
+		// candidate; cancellations and provider failures remain Go errors.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return validationOutput(fieldErrorFor(err)), nil
+	}
+	return &CompileDungeonOutput{Compiled: compiled, FloorPlan: &plan}, nil
+}
+
+func validationOutput(field FieldError) *CompileDungeonOutput {
+	return &CompileDungeonOutput{FieldErrors: []FieldError{field}}
+}
+
+func strictRegionValidation(compiled CompiledDungeon) *FieldError {
+	canvas := compiled.canvas
+	if len(canvas.floorCells) == 0 {
+		return &FieldError{
+			Field:   fieldCanvasFloorSource,
+			Message: "region-union floor must not be empty in strict mode",
+			Code:    "floor_empty",
+		}
+	}
+	if canvas.entrance == nil {
+		field := fieldCanvasFloorSource
+		if compiled.Params.PartyStart.Anchor != nil {
+			field = "start"
+		}
+		return &FieldError{
+			Field: field, Message: "no floor anchor has a complete same-component party start envelope",
+			Code: "entrance_unavailable",
+		}
+	}
+	floor := make(map[[2]int]struct{}, len(canvas.floorCells))
+	for _, cell := range canvas.floorCells {
+		floor[[2]int{cell.Column, cell.Row}] = struct{}{}
+	}
+	anchor := [2]int{canvas.entrance.Column, canvas.entrance.Row}
+	component := map[[2]int]struct{}{anchor: {}}
+	queue := [][2]int{anchor}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		h := canvasHex(FloorPlanCell{Column: current[0], Row: current[1]})
+		for _, cube := range h.ToCube().GetNeighbors() {
+			pos := core.HexFromCube(cube).ToPosition()
+			next := [2]int{int(pos.X), int(pos.Y)}
+			if _, ok := floor[next]; !ok {
+				continue
+			}
+			if _, seen := component[next]; seen {
+				continue
+			}
+			component[next] = struct{}{}
+			queue = append(queue, next)
+		}
+	}
+	if len(component) != len(floor) {
+		return &FieldError{
+			Field: fieldCanvasFloorSource, Message: "region-union floor must be connected in strict mode",
+			Code: "floor_disconnected",
+		}
+	}
+	return nil
+}
+
+var sourcePathPattern = regexp.MustCompile(
+	`(?:^|: |\b)((?:canvas\.floor_source|start|` +
+		`place\[\d+\](?:\.[a-z_]+)?|walls\[\d+\](?:\.[a-z_]+)?|` +
+		`regions\[\d+\](?:\.[a-z_]+)?|rooms\[\d+\](?:\.[a-z_]+)?))`,
+)
+
+func fieldErrorFor(err error) FieldError {
+	message := err.Error()
+	field := ""
+	if match := sourcePathPattern.FindStringSubmatch(message); len(match) > 1 {
+		field = match[1]
+	}
+	code := "invalid_candidate"
+	switch {
+	case strings.Contains(message, "decode dungeon spec"),
+		strings.Contains(message, "empty dungeon spec"),
+		strings.Contains(message, "multi-document"):
+		code = "invalid_yaml"
+	case strings.Contains(message, "duplicates regions"), strings.Contains(message, "equal cell set"):
+		code = "duplicate_region"
+	case strings.Contains(message, "outside structural floor"), strings.Contains(message, "not a semantic floor cell"):
+		code = "outside_floor"
+	}
+	return FieldError{Field: field, Message: message, Code: code}
+}

--- a/encounter/dungeonspec/compile_dungeon.go
+++ b/encounter/dungeonspec/compile_dungeon.go
@@ -64,9 +64,11 @@ func CompileDungeon(ctx context.Context, in CompileDungeonInput) (*CompileDungeo
 	if err != nil {
 		return nil, fmt.Errorf("dungeonspec: compile candidate: %w", err)
 	}
-	if in.Mode == CompileModeStrict && compiled.canvas != nil && compiled.canvas.floorSource == FloorSourceRegions {
-		if validation := strictRegionValidation(compiled); validation != nil {
-			return validationOutput(*validation), nil
+	if in.Mode == CompileModeStrict && compiled.canvas != nil {
+		if compiled.canvas.floorSource == FloorSourceRegions {
+			if validation := strictRegionValidation(compiled); validation != nil {
+				return validationOutput(*validation), nil
+			}
 		}
 		if err := validateCompiledRuntime(ctx, compiled, in.PreviewSeed); err != nil {
 			return validationOutput(fieldErrorFor(err)), nil

--- a/encounter/dungeonspec/decode.go
+++ b/encounter/dungeonspec/decode.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -21,6 +22,19 @@ import (
 // or silently dropping everything after the first document.
 func Decode(raw []byte) (*DungeonSpec, error) {
 	shape, hasCanvas := dungeonRoomsShape(raw)
+	var document yaml.Node
+	if err := yaml.Unmarshal(raw, &document); err != nil {
+		return nil, authoredWrap("spec", "invalid_yaml", fmt.Errorf("decode dungeon spec: %w", err))
+	}
+	if len(document.Content) == 0 {
+		return nil, authoredError("spec", "invalid_yaml", "empty dungeon spec")
+	}
+	if hasCanvas && shape == roomsInvalid {
+		return nil, authoredError("rooms", "invalid_yaml", "canvas mode rooms must be an explicit empty sequence (rooms: [])")
+	}
+	if err := validateYAMLShape(document.Content[0], reflect.TypeOf(DungeonSpec{}), "spec"); err != nil {
+		return nil, err
+	}
 
 	dec := yaml.NewDecoder(bytes.NewReader(raw))
 	dec.KnownFields(true)
@@ -28,12 +42,12 @@ func Decode(raw []byte) (*DungeonSpec, error) {
 	var spec DungeonSpec
 	if err := dec.Decode(&spec); err != nil {
 		if errors.Is(err, io.EOF) {
-			return nil, errors.New("empty dungeon spec")
+			return nil, authoredError("spec", "invalid_yaml", "empty dungeon spec")
 		}
 		if hasCanvas && shape == roomsInvalid {
-			return nil, errors.New("canvas mode rooms must be an explicit empty sequence (rooms: [])")
+			return nil, authoredError("rooms", "invalid_yaml", "canvas mode rooms must be an explicit empty sequence (rooms: [])")
 		}
-		return nil, fmt.Errorf("decode dungeon spec: %w", err)
+		return nil, authoredWrap("spec", "invalid_yaml", fmt.Errorf("decode dungeon spec: %w", err))
 	}
 
 	// A second call to Decode reads the next YAML document in the stream,
@@ -43,7 +57,7 @@ func Decode(raw []byte) (*DungeonSpec, error) {
 	// stray `---` documents.
 	var extra DungeonSpec
 	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
-		return nil, errors.New("multi-document YAML not supported: a dungeon spec is one document")
+		return nil, authoredError("spec", "invalid_yaml", "multi-document YAML not supported: a dungeon spec is one document")
 	}
 
 	spec.roomsShape = shape

--- a/encounter/dungeonspec/decode.go
+++ b/encounter/dungeonspec/decode.go
@@ -45,7 +45,9 @@ func Decode(raw []byte) (*DungeonSpec, error) {
 			return nil, authoredError("spec", "invalid_yaml", "empty dungeon spec")
 		}
 		if hasCanvas && shape == roomsInvalid {
-			return nil, authoredError("rooms", "invalid_yaml", "canvas mode rooms must be an explicit empty sequence (rooms: [])")
+			return nil, authoredError(
+				"rooms", "invalid_yaml", "canvas mode rooms must be an explicit empty sequence (rooms: [])",
+			)
 		}
 		return nil, authoredWrap("spec", "invalid_yaml", fmt.Errorf("decode dungeon spec: %w", err))
 	}

--- a/encounter/dungeonspec/floor_plan.go
+++ b/encounter/dungeonspec/floor_plan.go
@@ -110,7 +110,7 @@ func validateCompiledRuntime(ctx context.Context, compiled CompiledDungeon, seed
 // BuildFloorPlan projects canonical compiler facts for canvas candidates and
 // initialized runtime facts for legacy room-chain candidates.
 func BuildFloorPlan(ctx context.Context, in BuildFloorPlanInput) (FloorPlan, error) {
-	if in.Compiled.canvas != nil {
+	if in.Compiled.canvas != nil && in.Compiled.canvas.floorSource == FloorSourceRegions {
 		return buildCanvasFloorPlan(in.Compiled), nil
 	}
 	params := in.Compiled.Params

--- a/encounter/dungeonspec/floor_plan.go
+++ b/encounter/dungeonspec/floor_plan.go
@@ -60,20 +60,31 @@ type FloorPlanRegion struct {
 	ParentID  *string
 }
 
+// FloorSource is the resolved authored canvas floor source.
+type FloorSource string
+
+const (
+	// FloorSourceBounds resolves omission and explicit bounds to the v0.3 rectangle.
+	FloorSourceBounds FloorSource = "bounds"
+	// FloorSourceRegions resolves floor from the canonical region-cell union.
+	FloorSourceRegions FloorSource = "regions"
+)
+
 // FloorPlan is the provider-owned authoring projection.
 type FloorPlan struct {
-	Rooms      []FloorPlanRoom
-	Regions    []FloorPlanRegion
-	Connectors []FloorPlanConnector
+	FloorSource FloorSource
+	Rooms       []FloorPlanRoom
+	Regions     []FloorPlanRegion
+	Connectors  []FloorPlanConnector
 	// Width is the canvas width only; room chains leave it zero to preserve
 	// the wire contract's canvas-only field semantics.
 	Width   int
 	Height  int
 	DoorRow int
-	// FloorCells is the v0.3 canvas structural-floor projection only. It is
+	// FloorCells is the complete canonical canvas structural-floor projection. It is
 	// nil for room chains because their region-only data omits connector cells.
 	FloorCells []FloorPlanCell
-	Entrance   FloorPlanCell
+	Entrance   *FloorPlanCell
 	Edges      []FloorPlanEdge
 }
 
@@ -83,11 +94,25 @@ type BuildFloorPlanInput struct {
 	Seed     int64
 }
 
-// BuildFloorPlan initializes a throwaway toolkit encounter and projects its
-// persisted spatial facts. It intentionally does not derive identity, floor
-// membership, generated edges, or authored overlays from CompiledDungeon: the
-// initialized encounter is the same runtime truth used by real startup.
+func validateCompiledRuntime(ctx context.Context, compiled CompiledDungeon, seed int64) error {
+	params := compiled.Params
+	params.RandomSeed = seed
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+	preview := encounter.New(ctx, "dungeon-runtime-validation", broker)
+	if err := preview.InitDungeon(params); err != nil {
+		return fmt.Errorf("init dungeon: %w", err)
+	}
+	return nil
+}
+
+// BuildFloorPlan projects canonical compiler facts for canvas candidates and
+// initialized runtime facts for legacy room-chain candidates.
 func BuildFloorPlan(ctx context.Context, in BuildFloorPlanInput) (FloorPlan, error) {
+	if in.Compiled.canvas != nil {
+		return buildCanvasFloorPlan(in.Compiled), nil
+	}
 	params := in.Compiled.Params
 	params.RandomSeed = in.Seed
 	transport := encounter.NewInMemoryTransport()
@@ -104,7 +129,8 @@ func BuildFloorPlan(ctx context.Context, in BuildFloorPlanInput) (FloorPlan, err
 	if data.Space == nil {
 		return FloorPlan{}, fmt.Errorf("init dungeon: no persisted space")
 	}
-	plan := FloorPlan{Height: data.Space.Height, Entrance: cellFromHex(data.Space.Entrance)}
+	entrance := cellFromHex(data.Space.Entrance)
+	plan := FloorPlan{FloorSource: FloorSourceBounds, Height: data.Space.Height, Entrance: &entrance}
 
 	if data.Space.FloorSource == encounter.FloorSourceRoomChain {
 		plan.DoorRow = data.Space.Height / 2
@@ -175,6 +201,52 @@ func BuildFloorPlan(ctx context.Context, in BuildFloorPlanInput) (FloorPlan, err
 		return plan.Edges[i].DoorID < plan.Edges[j].DoorID
 	})
 	return plan, nil
+}
+
+func buildCanvasFloorPlan(compiled CompiledDungeon) FloorPlan {
+	canvas := compiled.canvas
+	plan := FloorPlan{
+		FloorSource: canvas.floorSource, Width: canvas.width, Height: canvas.height,
+		FloorCells: append([]FloorPlanCell(nil), canvas.floorCells...), Entrance: cloneFloorPlanCell(canvas.entrance),
+		Regions: append([]FloorPlanRegion(nil), canvas.regions...),
+	}
+	for _, edge := range canvas.envelope {
+		from, to := cellFromHex(edge.From), cellFromHex(edge.To)
+		if floorPlanCellLess(to, from) {
+			from, to = to, from
+		}
+		plan.Edges = append(plan.Edges, FloorPlanEdge{From: from, To: to, Kind: FloorPlanEdgeKindSolid})
+	}
+	for _, edge := range compiled.Params.AuthoredEdges {
+		from, to := cellFromHex(edge.From), cellFromHex(edge.To)
+		if floorPlanCellLess(to, from) {
+			from, to = to, from
+		}
+		plan.Edges = append(plan.Edges, FloorPlanEdge{
+			From: from, To: to, Kind: FloorPlanEdgeKind(edge.Kind), DoorID: string(edge.DoorID),
+		})
+	}
+	sort.Slice(plan.Edges, func(i, j int) bool {
+		if plan.Edges[i].From != plan.Edges[j].From {
+			return floorPlanCellLess(plan.Edges[i].From, plan.Edges[j].From)
+		}
+		if plan.Edges[i].To != plan.Edges[j].To {
+			return floorPlanCellLess(plan.Edges[i].To, plan.Edges[j].To)
+		}
+		if plan.Edges[i].Kind != plan.Edges[j].Kind {
+			return plan.Edges[i].Kind < plan.Edges[j].Kind
+		}
+		return plan.Edges[i].DoorID < plan.Edges[j].DoorID
+	})
+	return plan
+}
+
+func cloneFloorPlanCell(value *FloorPlanCell) *FloorPlanCell {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }
 
 func floorPlanCellLess(left, right FloorPlanCell) bool {

--- a/encounter/dungeonspec/spec.go
+++ b/encounter/dungeonspec/spec.go
@@ -50,8 +50,9 @@ const (
 
 // CanvasSpec is the explicit structural floor source for canvas mode.
 type CanvasSpec struct {
-	Width  int `yaml:"width"`
-	Height int `yaml:"height"`
+	Width       int    `yaml:"width"`
+	Height      int    `yaml:"height"`
+	FloorSource string `yaml:"floor_source,omitempty"`
 }
 
 // RegionSpec is one authored semantic scope. Cells are absolute odd-q

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -63,16 +63,16 @@ const (
 // per-cell place-block check.
 func Validate(spec *DungeonSpec) error {
 	if spec.Version != 1 {
-		return fmt.Errorf("unsupported spec version %d (must be 1)", spec.Version)
+		return authoredError("version", "unsupported_version", "unsupported spec version %d (must be 1)", spec.Version)
 	}
 	if strings.TrimSpace(spec.Key) == "" {
-		return fmt.Errorf("key must not be empty")
+		return authoredError("key", "invalid_key", "key must not be empty")
 	}
 	if !validKey(spec.Key) {
-		return fmt.Errorf("key %q must use only lowercase letters, digits, and hyphens", spec.Key)
+		return authoredError("key", "invalid_key", "key %q must use only lowercase letters, digits, and hyphens", spec.Key)
 	}
 	if strings.TrimSpace(spec.Name) == "" {
-		return fmt.Errorf("name must not be empty")
+		return authoredError("name", "invalid_name", "name must not be empty")
 	}
 	if spec.Canvas != nil {
 		return validateCanvas(spec)
@@ -167,15 +167,21 @@ func validateNoRegionsInRoomChain(spec *DungeonSpec) error {
 }
 
 func validateCanvas(spec *DungeonSpec) error {
+	if spec.Canvas.Width < 1 {
+		return authoredError("canvas.width", "invalid_dimension", "canvas width must be positive, got %d", spec.Canvas.Width)
+	}
+	if spec.Canvas.Height < 1 {
+		return authoredError("canvas.height", "invalid_dimension", "canvas height must be positive, got %d", spec.Canvas.Height)
+	}
 	cellCount, err := encounter.ValidateCanvasDimensions(spec.Canvas.Width, spec.Canvas.Height)
 	if err != nil {
-		return err
+		return authoredError("canvas", "invalid_dimension", "%v", err)
 	}
 	if spec.roomsShape != roomsSequence || len(spec.Rooms) != 0 {
-		return fmt.Errorf("canvas mode rooms must be an explicit empty sequence (rooms: [])")
+		return authoredError("rooms", "invalid_canvas_rooms", "canvas mode rooms must be an explicit empty sequence (rooms: [])")
 	}
 	if len(spec.Connectors) != 0 {
-		return fmt.Errorf("canvas mode does not support connectors")
+		return authoredError("connectors", "unsupported_capability", "canvas mode does not support connectors")
 	}
 	bounds := make(map[[2]int]struct{}, cellCount)
 	for c := 0; c < spec.Canvas.Width; c++ {
@@ -197,8 +203,8 @@ func validateCanvas(spec *DungeonSpec) error {
 			}
 		}
 	default:
-		return fmt.Errorf(
-			"canvas.floor_source: invalid value %q (must be %q or %q)",
+		return authoredError(
+			"canvas.floor_source", "invalid_floor_source", "invalid floor source %q (must be %q or %q)",
 			spec.Canvas.FloorSource, FloorSourceBounds, FloorSourceRegions,
 		)
 	}
@@ -206,10 +212,10 @@ func validateCanvas(spec *DungeonSpec) error {
 	for i, e := range spec.Place {
 		path := fmt.Sprintf("place[%d]", i)
 		if _, ok := floor[e.At]; !ok {
-			return fmt.Errorf("%s.at %v is outside structural floor", path, e.At)
+			return authoredError(path+".at", "outside_floor", "%s.at %v is outside structural floor", path, e.At)
 		}
 		if prior, ok := occupied[e.At]; ok {
-			return fmt.Errorf("%s.at %v is already occupied by %q", path, e.At, prior)
+			return authoredError(path+".at", "occupied", "%s.at %v is already occupied by %q", path, e.At, prior)
 		}
 		occupied[e.At] = e.Ref
 		if err := validateCanvasPlacement(path, e); err != nil {
@@ -218,10 +224,10 @@ func validateCanvas(spec *DungeonSpec) error {
 	}
 	if spec.Start != nil {
 		if _, ok := floor[*spec.Start]; !ok {
-			return fmt.Errorf("start %v is outside structural floor", *spec.Start)
+			return authoredError("start", "outside_floor", "start %v is outside structural floor", *spec.Start)
 		}
 		if prior, ok := occupied[*spec.Start]; ok {
-			return fmt.Errorf("start %v conflicts with %q", *spec.Start, prior)
+			return authoredError("start", "occupied", "start %v conflicts with %q", *spec.Start, prior)
 		}
 	}
 	return validateWallsOnFloor(spec, floor, spec.Canvas.Width, spec.Canvas.Height)
@@ -235,27 +241,27 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 	sets := make([]map[[2]int]struct{}, len(regions))
 	for i, region := range regions {
 		if region.ID == "" {
-			return fmt.Errorf("regions[%d].id must not be empty", i)
+			return authoredError(fmt.Sprintf("regions[%d].id", i), "invalid_region", "regions[%d].id must not be empty", i)
 		}
 		if first, duplicate := seenIDs[region.ID]; duplicate {
-			return fmt.Errorf("regions[%d].id %q duplicates regions[%d]", i, region.ID, first)
+			return authoredError(fmt.Sprintf("regions[%d].id", i), "duplicate_region", "regions[%d].id %q duplicates regions[%d]", i, region.ID, first)
 		}
 		seenIDs[region.ID] = i
 		if region.Archetype != nil {
 			if *region.Archetype == "" {
-				return fmt.Errorf("regions[%d].archetype: explicit empty archetype is unsupported", i)
+				return authoredError(fmt.Sprintf("regions[%d].archetype", i), "invalid_region", "regions[%d].archetype: explicit empty archetype is unsupported", i)
 			}
 			if err := validateArchetype(*region.Archetype); err != nil {
-				return fmt.Errorf("regions[%d].archetype: %w", i, err)
+				return authoredError(fmt.Sprintf("regions[%d].archetype", i), "invalid_region", "regions[%d].archetype: %v", i, err)
 			}
 		}
 		if region.Cells == nil {
-			return fmt.Errorf("regions[%d].cells is required (use [] for an empty scope)", i)
+			return authoredError(fmt.Sprintf("regions[%d].cells", i), "invalid_region", "regions[%d].cells is required (use [] for an empty scope)", i)
 		}
 		sets[i] = make(map[[2]int]struct{}, len(region.Cells))
 		for j, cell := range region.Cells {
 			if _, ok := floor[cell]; !ok {
-				return fmt.Errorf("regions[%d].cells[%d] %v is out of canvas floor footprint", i, j, cell)
+				return authoredError(fmt.Sprintf("regions[%d].cells[%d]", i, j), "outside_floor", "regions[%d].cells[%d] %v is out of canvas floor footprint", i, j, cell)
 			}
 			sets[i][cell] = struct{}{} // same-region duplicates canonicalize
 		}
@@ -270,7 +276,7 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 			}
 			equal := len(sets[left]) == len(sets[right]) && intersection == len(sets[left])
 			if equal {
-				return fmt.Errorf("regions[%d].cells: equal cell set duplicates regions[%d].cells", right, left)
+				return authoredError(fmt.Sprintf("regions[%d].cells", right), "duplicate_region", "regions[%d].cells: equal cell set duplicates regions[%d].cells", right, left)
 			}
 			if intersection == 0 {
 				continue
@@ -278,7 +284,7 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 			leftInsideRight := intersection == len(sets[left]) && len(sets[left]) < len(sets[right])
 			rightInsideLeft := intersection == len(sets[right]) && len(sets[right]) < len(sets[left])
 			if !leftInsideRight && !rightInsideLeft {
-				return fmt.Errorf("regions[%d].cells: partial overlap with regions[%d].cells", right, left)
+				return authoredError(fmt.Sprintf("regions[%d].cells", right), "region_overlap", "regions[%d].cells: partial overlap with regions[%d].cells", right, left)
 			}
 		}
 	}
@@ -287,31 +293,31 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 func validateCanvasPlacement(path string, e PlacedEntry) error {
 	typ, err := refParts(e.Ref)
 	if err != nil {
-		return fmt.Errorf("%s: %w", path, err)
+		return authoredError(path+".ref", "invalid_ref", "%s.ref: %v", path, err)
 	}
 	if typ != refTypeProps && typ != refTypeMonsters {
-		return fmt.Errorf("%s.ref %q must be props or monsters", path, e.Ref)
+		return authoredError(path+".ref", "invalid_ref", "%s.ref %q must be props or monsters", path, e.Ref)
 	}
 	if e.Facing != nil {
 		if typ != refTypeProps || !isFloorMount(e.Mount) {
-			return fmt.Errorf("%s.facing: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
+			return authoredError(path+".facing", "unsupported_capability", "%s.facing: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
 		}
 		if err := validateFacing(*e.Facing); err != nil {
-			return fmt.Errorf("%s.facing: %w", path, err)
+			return authoredError(path+".facing", "invalid_facing", "%s.facing: %v", path, err)
 		}
 	}
 	if !isFloorMount(e.Mount) {
-		return fmt.Errorf("%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
+		return authoredError(path+".mount", "unsupported_capability", "%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
 	}
 	if typ == refTypeMonsters {
 		if _, ok := monsters.ByRef(e.Ref); !ok {
-			return fmt.Errorf("%s.ref %q: unknown monster ref (known: %s)", path, e.Ref, strings.Join(monsters.Refs(), ", "))
+			return authoredError(path+".ref", "invalid_ref", "%s.ref %q: unknown monster ref (known: %s)", path, e.Ref, strings.Join(monsters.Refs(), ", "))
 		}
 		if e.BlocksMovement != nil {
-			return fmt.Errorf("%s.blocks_movement: only valid on props", path)
+			return authoredError(path+".blocks_movement", "invalid_placement", "%s.blocks_movement: only valid on props", path)
 		}
 		if e.BlocksLoS != nil {
-			return fmt.Errorf("%s.blocks_los: only valid on props", path)
+			return authoredError(path+".blocks_los", "invalid_placement", "%s.blocks_los: only valid on props", path)
 		}
 	}
 	return nil
@@ -699,38 +705,38 @@ func validateWallsOnFloor(spec *DungeonSpec, floor map[[2]int]struct{}, totalWid
 		switch wall.Kind {
 		case string(encounter.GeneratedEdgeKindSolid), string(encounter.GeneratedEdgeKindDoor):
 		default:
-			return fmt.Errorf("walls[%d].kind: invalid kind %q (must be %q or %q)", index, wall.Kind,
+			return authoredError(fmt.Sprintf("walls[%d].kind", index), "invalid_wall", "walls[%d].kind: invalid kind %q (must be %q or %q)", index, wall.Kind,
 				encounter.GeneratedEdgeKindSolid, encounter.GeneratedEdgeKindDoor)
 		}
 		if wall.Lock != nil {
 			if wall.Kind == string(encounter.GeneratedEdgeKindSolid) {
-				return fmt.Errorf("walls[%d].lock: lock only valid on door", index)
+				return authoredError(fmt.Sprintf("walls[%d].lock", index), "invalid_wall", "walls[%d].lock: lock only valid on door", index)
 			}
 			if len(wall.Lock.Options) == 0 {
-				return fmt.Errorf("walls[%d].lock.options: must contain at least one option", index)
+				return authoredError(fmt.Sprintf("walls[%d].lock.options", index), "invalid_wall", "walls[%d].lock.options: must contain at least one option", index)
 			}
 			for oi, option := range wall.Lock.Options {
 				if option.DC < minLockDC || option.DC > maxLockDC {
-					return fmt.Errorf("walls[%d].lock.options[%d].dc: must be between %d and %d", index, oi, minLockDC, maxLockDC)
+					return authoredError(fmt.Sprintf("walls[%d].lock.options[%d].dc", index, oi), "invalid_wall", "walls[%d].lock.options[%d].dc: must be between %d and %d", index, oi, minLockDC, maxLockDC)
 				}
 				if _, err := abilities.GetByID(option.Ability); err != nil {
-					return fmt.Errorf("walls[%d].lock.options[%d].ability: invalid ability %q", index, oi, option.Ability)
+					return authoredError(fmt.Sprintf("walls[%d].lock.options[%d].ability", index, oi), "invalid_wall", "walls[%d].lock.options[%d].ability: invalid ability %q", index, oi, option.Ability)
 				}
 			}
 		}
 		if from == to {
-			return fmt.Errorf("walls[%d]: endpoints must be distinct", index)
+			return authoredError(fmt.Sprintf("walls[%d]", index), "invalid_wall", "walls[%d]: endpoints must be distinct", index)
 		}
 		if from.ToCube().Distance(to.ToCube()) != 1 {
-			return fmt.Errorf("walls[%d]: endpoints must be adjacent pointy-top odd-q floor hexes", index)
+			return authoredError(fmt.Sprintf("walls[%d]", index), "invalid_wall", "walls[%d]: endpoints must be adjacent pointy-top odd-q floor hexes", index)
 		}
 
 		key := newWallEdgeKey(from, to)
 		if first, exists := seen[key]; exists {
 			if seenKinds[first] == wall.Kind {
-				return fmt.Errorf("walls[%d]: duplicate of walls[%d] (including reversed endpoints)", index, first)
+				return authoredError(fmt.Sprintf("walls[%d]", index), "duplicate_wall", "walls[%d]: duplicate of walls[%d] (including reversed endpoints)", index, first)
 			}
-			return fmt.Errorf("walls[%d]: conflicting kind with walls[%d] on the same undirected edge", index, first)
+			return authoredError(fmt.Sprintf("walls[%d]", index), "conflicting_wall", "walls[%d]: conflicting kind with walls[%d] on the same undirected edge", index, first)
 		}
 		seen[key] = index
 		seenKinds = append(seenKinds, wall.Kind)
@@ -774,13 +780,13 @@ func validateWallEndpoint(
 ) (core.Hex, error) {
 	path := fmt.Sprintf("walls[%d].%s", wallIndex, field)
 	if at == nil {
-		return core.Hex{}, fmt.Errorf("%s: required absolute [column, row] floor cell", path)
+		return core.Hex{}, authoredError(path, "invalid_wall", "%s: required absolute [column, row] floor cell", path)
 	}
 	if at[0] < 0 || at[0] >= totalWidth || at[1] < 0 || at[1] >= height {
-		return core.Hex{}, fmt.Errorf("%s %v is out of dungeon floor footprint", path, *at)
+		return core.Hex{}, authoredError(path, "outside_floor", "%s %v is out of dungeon floor footprint", path, *at)
 	}
 	if _, ok := floor[*at]; !ok {
-		return core.Hex{}, fmt.Errorf("%s %v is a connector gap/door cell, not a semantic floor cell", path, *at)
+		return core.Hex{}, authoredError(path, "outside_floor", "%s %v is a connector gap/door cell, not a semantic floor cell", path, *at)
 	}
 	return core.HexFromPosition(spatial.Position{X: float64(at[0]), Y: float64(at[1])}), nil
 }

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -171,14 +171,18 @@ func validateCanvas(spec *DungeonSpec) error {
 		return authoredError("canvas.width", "invalid_dimension", "canvas width must be positive, got %d", spec.Canvas.Width)
 	}
 	if spec.Canvas.Height < 1 {
-		return authoredError("canvas.height", "invalid_dimension", "canvas height must be positive, got %d", spec.Canvas.Height)
+		return authoredError(
+			"canvas.height", "invalid_dimension", "canvas height must be positive, got %d", spec.Canvas.Height,
+		)
 	}
 	cellCount, err := encounter.ValidateCanvasDimensions(spec.Canvas.Width, spec.Canvas.Height)
 	if err != nil {
 		return authoredError("canvas", "invalid_dimension", "%v", err)
 	}
 	if spec.roomsShape != roomsSequence || len(spec.Rooms) != 0 {
-		return authoredError("rooms", "invalid_canvas_rooms", "canvas mode rooms must be an explicit empty sequence (rooms: [])")
+		return authoredError(
+			"rooms", "invalid_canvas_rooms", "canvas mode rooms must be an explicit empty sequence (rooms: [])",
+		)
 	}
 	if len(spec.Connectors) != 0 {
 		return authoredError("connectors", "unsupported_capability", "canvas mode does not support connectors")
@@ -244,24 +248,36 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 			return authoredError(fmt.Sprintf("regions[%d].id", i), "invalid_region", "regions[%d].id must not be empty", i)
 		}
 		if first, duplicate := seenIDs[region.ID]; duplicate {
-			return authoredError(fmt.Sprintf("regions[%d].id", i), "duplicate_region", "regions[%d].id %q duplicates regions[%d]", i, region.ID, first)
+			return authoredError(
+				fmt.Sprintf("regions[%d].id", i), "duplicate_region",
+				"regions[%d].id %q duplicates regions[%d]", i, region.ID, first,
+			)
 		}
 		seenIDs[region.ID] = i
 		if region.Archetype != nil {
 			if *region.Archetype == "" {
-				return authoredError(fmt.Sprintf("regions[%d].archetype", i), "invalid_region", "regions[%d].archetype: explicit empty archetype is unsupported", i)
+				return authoredError(
+					fmt.Sprintf("regions[%d].archetype", i), "invalid_region",
+					"regions[%d].archetype: explicit empty archetype is unsupported", i,
+				)
 			}
 			if err := validateArchetype(*region.Archetype); err != nil {
 				return authoredError(fmt.Sprintf("regions[%d].archetype", i), "invalid_region", "regions[%d].archetype: %v", i, err)
 			}
 		}
 		if region.Cells == nil {
-			return authoredError(fmt.Sprintf("regions[%d].cells", i), "invalid_region", "regions[%d].cells is required (use [] for an empty scope)", i)
+			return authoredError(
+				fmt.Sprintf("regions[%d].cells", i), "invalid_region",
+				"regions[%d].cells is required (use [] for an empty scope)", i,
+			)
 		}
 		sets[i] = make(map[[2]int]struct{}, len(region.Cells))
 		for j, cell := range region.Cells {
 			if _, ok := floor[cell]; !ok {
-				return authoredError(fmt.Sprintf("regions[%d].cells[%d]", i, j), "outside_floor", "regions[%d].cells[%d] %v is out of canvas floor footprint", i, j, cell)
+				return authoredError(
+					fmt.Sprintf("regions[%d].cells[%d]", i, j), "outside_floor",
+					"regions[%d].cells[%d] %v is out of canvas floor footprint", i, j, cell,
+				)
 			}
 			sets[i][cell] = struct{}{} // same-region duplicates canonicalize
 		}
@@ -276,7 +292,10 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 			}
 			equal := len(sets[left]) == len(sets[right]) && intersection == len(sets[left])
 			if equal {
-				return authoredError(fmt.Sprintf("regions[%d].cells", right), "duplicate_region", "regions[%d].cells: equal cell set duplicates regions[%d].cells", right, left)
+				return authoredError(
+					fmt.Sprintf("regions[%d].cells", right), "duplicate_region",
+					"regions[%d].cells: equal cell set duplicates regions[%d].cells", right, left,
+				)
 			}
 			if intersection == 0 {
 				continue
@@ -284,7 +303,10 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 			leftInsideRight := intersection == len(sets[left]) && len(sets[left]) < len(sets[right])
 			rightInsideLeft := intersection == len(sets[right]) && len(sets[right]) < len(sets[left])
 			if !leftInsideRight && !rightInsideLeft {
-				return authoredError(fmt.Sprintf("regions[%d].cells", right), "region_overlap", "regions[%d].cells: partial overlap with regions[%d].cells", right, left)
+				return authoredError(
+					fmt.Sprintf("regions[%d].cells", right), "region_overlap",
+					"regions[%d].cells: partial overlap with regions[%d].cells", right, left,
+				)
 			}
 		}
 	}
@@ -300,18 +322,27 @@ func validateCanvasPlacement(path string, e PlacedEntry) error {
 	}
 	if e.Facing != nil {
 		if typ != refTypeProps || !isFloorMount(e.Mount) {
-			return authoredError(path+".facing", "unsupported_capability", "%s.facing: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
+			return authoredError(
+				path+".facing", "unsupported_capability", "%s.facing: %s: %s",
+				path, unsupportedCapability, facingFloorPropsOnly,
+			)
 		}
 		if err := validateFacing(*e.Facing); err != nil {
 			return authoredError(path+".facing", "invalid_facing", "%s.facing: %v", path, err)
 		}
 	}
 	if !isFloorMount(e.Mount) {
-		return authoredError(path+".mount", "unsupported_capability", "%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
+		return authoredError(
+			path+".mount", "unsupported_capability", "%s.mount: %s: mounted placements are not supported",
+			path, unsupportedCapability,
+		)
 	}
 	if typ == refTypeMonsters {
 		if _, ok := monsters.ByRef(e.Ref); !ok {
-			return authoredError(path+".ref", "invalid_ref", "%s.ref %q: unknown monster ref (known: %s)", path, e.Ref, strings.Join(monsters.Refs(), ", "))
+			return authoredError(
+				path+".ref", "invalid_ref", "%s.ref %q: unknown monster ref (known: %s)",
+				path, e.Ref, strings.Join(monsters.Refs(), ", "),
+			)
 		}
 		if e.BlocksMovement != nil {
 			return authoredError(path+".blocks_movement", "invalid_placement", "%s.blocks_movement: only valid on props", path)
@@ -705,22 +736,38 @@ func validateWallsOnFloor(spec *DungeonSpec, floor map[[2]int]struct{}, totalWid
 		switch wall.Kind {
 		case string(encounter.GeneratedEdgeKindSolid), string(encounter.GeneratedEdgeKindDoor):
 		default:
-			return authoredError(fmt.Sprintf("walls[%d].kind", index), "invalid_wall", "walls[%d].kind: invalid kind %q (must be %q or %q)", index, wall.Kind,
-				encounter.GeneratedEdgeKindSolid, encounter.GeneratedEdgeKindDoor)
+			return authoredError(
+				fmt.Sprintf("walls[%d].kind", index), "invalid_wall",
+				"walls[%d].kind: invalid kind %q (must be %q or %q)", index, wall.Kind,
+				encounter.GeneratedEdgeKindSolid, encounter.GeneratedEdgeKindDoor,
+			)
 		}
 		if wall.Lock != nil {
 			if wall.Kind == string(encounter.GeneratedEdgeKindSolid) {
-				return authoredError(fmt.Sprintf("walls[%d].lock", index), "invalid_wall", "walls[%d].lock: lock only valid on door", index)
+				return authoredError(
+					fmt.Sprintf("walls[%d].lock", index), "invalid_wall",
+					"walls[%d].lock: lock only valid on door", index,
+				)
 			}
 			if len(wall.Lock.Options) == 0 {
-				return authoredError(fmt.Sprintf("walls[%d].lock.options", index), "invalid_wall", "walls[%d].lock.options: must contain at least one option", index)
+				return authoredError(
+					fmt.Sprintf("walls[%d].lock.options", index), "invalid_wall",
+					"walls[%d].lock.options: must contain at least one option", index,
+				)
 			}
 			for oi, option := range wall.Lock.Options {
 				if option.DC < minLockDC || option.DC > maxLockDC {
-					return authoredError(fmt.Sprintf("walls[%d].lock.options[%d].dc", index, oi), "invalid_wall", "walls[%d].lock.options[%d].dc: must be between %d and %d", index, oi, minLockDC, maxLockDC)
+					return authoredError(
+						fmt.Sprintf("walls[%d].lock.options[%d].dc", index, oi), "invalid_wall",
+						"walls[%d].lock.options[%d].dc: must be between %d and %d",
+						index, oi, minLockDC, maxLockDC,
+					)
 				}
 				if _, err := abilities.GetByID(option.Ability); err != nil {
-					return authoredError(fmt.Sprintf("walls[%d].lock.options[%d].ability", index, oi), "invalid_wall", "walls[%d].lock.options[%d].ability: invalid ability %q", index, oi, option.Ability)
+					return authoredError(
+						fmt.Sprintf("walls[%d].lock.options[%d].ability", index, oi), "invalid_wall",
+						"walls[%d].lock.options[%d].ability: invalid ability %q", index, oi, option.Ability,
+					)
 				}
 			}
 		}
@@ -728,15 +775,24 @@ func validateWallsOnFloor(spec *DungeonSpec, floor map[[2]int]struct{}, totalWid
 			return authoredError(fmt.Sprintf("walls[%d]", index), "invalid_wall", "walls[%d]: endpoints must be distinct", index)
 		}
 		if from.ToCube().Distance(to.ToCube()) != 1 {
-			return authoredError(fmt.Sprintf("walls[%d]", index), "invalid_wall", "walls[%d]: endpoints must be adjacent pointy-top odd-q floor hexes", index)
+			return authoredError(
+				fmt.Sprintf("walls[%d]", index), "invalid_wall",
+				"walls[%d]: endpoints must be adjacent pointy-top odd-q floor hexes", index,
+			)
 		}
 
 		key := newWallEdgeKey(from, to)
 		if first, exists := seen[key]; exists {
 			if seenKinds[first] == wall.Kind {
-				return authoredError(fmt.Sprintf("walls[%d]", index), "duplicate_wall", "walls[%d]: duplicate of walls[%d] (including reversed endpoints)", index, first)
+				return authoredError(
+					fmt.Sprintf("walls[%d]", index), "duplicate_wall",
+					"walls[%d]: duplicate of walls[%d] (including reversed endpoints)", index, first,
+				)
 			}
-			return authoredError(fmt.Sprintf("walls[%d]", index), "conflicting_wall", "walls[%d]: conflicting kind with walls[%d] on the same undirected edge", index, first)
+			return authoredError(
+				fmt.Sprintf("walls[%d]", index), "conflicting_wall",
+				"walls[%d]: conflicting kind with walls[%d] on the same undirected edge", index, first,
+			)
 		}
 		seen[key] = index
 		seenKinds = append(seenKinds, wall.Kind)
@@ -786,7 +842,9 @@ func validateWallEndpoint(
 		return core.Hex{}, authoredError(path, "outside_floor", "%s %v is out of dungeon floor footprint", path, *at)
 	}
 	if _, ok := floor[*at]; !ok {
-		return core.Hex{}, authoredError(path, "outside_floor", "%s %v is a connector gap/door cell, not a semantic floor cell", path, *at)
+		return core.Hex{}, authoredError(
+			path, "outside_floor", "%s %v is a connector gap/door cell, not a semantic floor cell", path, *at,
+		)
 	}
 	return core.HexFromPosition(spatial.Position{X: float64(at[0]), Y: float64(at[1])}), nil
 }

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -177,17 +177,36 @@ func validateCanvas(spec *DungeonSpec) error {
 	if len(spec.Connectors) != 0 {
 		return fmt.Errorf("canvas mode does not support connectors")
 	}
-	floor := make(map[[2]int]struct{}, cellCount)
+	bounds := make(map[[2]int]struct{}, cellCount)
 	for c := 0; c < spec.Canvas.Width; c++ {
 		for r := 0; r < spec.Canvas.Height; r++ {
-			floor[[2]int{c, r}] = struct{}{}
+			bounds[[2]int{c, r}] = struct{}{}
 		}
+	}
+	if err := validateRegions(spec.Regions, bounds); err != nil {
+		return err
+	}
+	floor := bounds
+	switch spec.Canvas.FloorSource {
+	case "", string(FloorSourceBounds):
+	case string(FloorSourceRegions):
+		floor = make(map[[2]int]struct{})
+		for _, region := range spec.Regions {
+			for _, cell := range region.Cells {
+				floor[cell] = struct{}{}
+			}
+		}
+	default:
+		return fmt.Errorf(
+			"canvas.floor_source: invalid value %q (must be %q or %q)",
+			spec.Canvas.FloorSource, FloorSourceBounds, FloorSourceRegions,
+		)
 	}
 	occupied := map[[2]int]string{}
 	for i, e := range spec.Place {
 		path := fmt.Sprintf("place[%d]", i)
 		if _, ok := floor[e.At]; !ok {
-			return fmt.Errorf("%s.at %v is out of canvas floor footprint", path, e.At)
+			return fmt.Errorf("%s.at %v is outside structural floor", path, e.At)
 		}
 		if prior, ok := occupied[e.At]; ok {
 			return fmt.Errorf("%s.at %v is already occupied by %q", path, e.At, prior)
@@ -199,14 +218,11 @@ func validateCanvas(spec *DungeonSpec) error {
 	}
 	if spec.Start != nil {
 		if _, ok := floor[*spec.Start]; !ok {
-			return fmt.Errorf("start %v is out of canvas floor footprint", *spec.Start)
+			return fmt.Errorf("start %v is outside structural floor", *spec.Start)
 		}
 		if prior, ok := occupied[*spec.Start]; ok {
 			return fmt.Errorf("start %v conflicts with %q", *spec.Start, prior)
 		}
-	}
-	if err := validateRegions(spec.Regions, floor); err != nil {
-		return err
 	}
 	return validateWallsOnFloor(spec, floor, spec.Canvas.Width, spec.Canvas.Height)
 }
@@ -246,14 +262,15 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 	}
 	for left := range sets {
 		for right := left + 1; right < len(sets); right++ {
-			if len(sets[left]) == 0 || len(sets[right]) == 0 {
-				continue
-			}
 			intersection := 0
 			for cell := range sets[left] {
 				if _, ok := sets[right][cell]; ok {
 					intersection++
 				}
+			}
+			equal := len(sets[left]) == len(sets[right]) && intersection == len(sets[left])
+			if equal {
+				return fmt.Errorf("regions[%d].cells: equal cell set duplicates regions[%d].cells", right, left)
 			}
 			if intersection == 0 {
 				continue
@@ -261,7 +278,7 @@ func validateRegions(regions []RegionSpec, floor map[[2]int]struct{}) error {
 			leftInsideRight := intersection == len(sets[left]) && len(sets[left]) < len(sets[right])
 			rightInsideLeft := intersection == len(sets[right]) && len(sets[right]) < len(sets[left])
 			if !leftInsideRight && !rightInsideLeft {
-				return fmt.Errorf("regions %q and %q have equal or partial overlap", regions[left].ID, regions[right].ID)
+				return fmt.Errorf("regions[%d].cells: partial overlap with regions[%d].cells", right, left)
 			}
 		}
 	}

--- a/encounter/dungeonspec/validate.go
+++ b/encounter/dungeonspec/validate.go
@@ -81,10 +81,10 @@ func Validate(spec *DungeonSpec) error {
 		return err
 	}
 	if spec.Height < minHeight {
-		return fmt.Errorf("height must be at least %d, got %d", minHeight, spec.Height)
+		return authoredError("height", "invalid_dimension", "height must be at least %d, got %d", minHeight, spec.Height)
 	}
 	if len(spec.Rooms) < minRooms {
-		return fmt.Errorf("must have at least %d rooms, got %d", minRooms, len(spec.Rooms))
+		return authoredError("rooms", "invalid_rooms", "must have at least %d rooms, got %d", minRooms, len(spec.Rooms))
 	}
 	if err := validateUniqueRoomIDs(spec.Rooms); err != nil {
 		return err
@@ -99,7 +99,7 @@ func Validate(spec *DungeonSpec) error {
 	if err != nil {
 		return err
 	}
-	if err = validateBossAxis(bossRoom, spec.Height); err != nil {
+	if err = validateBossAxis(bossRoom, spec.Height, roomPointerIndex(spec.Rooms, bossRoom)); err != nil {
 		return err
 	}
 	if err = validateM1Restrictions(spec, bossRoom); err != nil {
@@ -107,16 +107,20 @@ func Validate(spec *DungeonSpec) error {
 	}
 	for i := range spec.Rooms {
 		room := &spec.Rooms[i]
-		for _, o := range room.Obstacles {
-			if _, err := refParts(o.Ref); err != nil {
-				return fmt.Errorf("room %q: obstacle %w", room.ID, err)
+		for obstacleIndex, obstacle := range room.Obstacles {
+			path := fmt.Sprintf("rooms[%d].obstacles[%d]", i, obstacleIndex)
+			if _, err := refParts(obstacle.Ref); err != nil {
+				return authoredError(path+".ref", "invalid_ref", "%s.ref: %v", path, err)
 			}
-			if o.Count < minCount {
-				return fmt.Errorf("room %q: obstacle %q count must be at least %d, got %d", room.ID, o.Ref, minCount, o.Count)
+			if obstacle.Count < minCount {
+				return authoredError(
+					path+".count", "invalid_count", "%s.count must be at least %d, got %d",
+					path, minCount, obstacle.Count,
+				)
 			}
 		}
 	}
-	if err = validateBossRef(bossRoom); err != nil {
+	if err = validateBossRef(bossRoom, roomPointerIndex(spec.Rooms, bossRoom)); err != nil {
 		return err
 	}
 	for i := range spec.Rooms {
@@ -135,7 +139,7 @@ func Validate(spec *DungeonSpec) error {
 	}
 	for i := range spec.Connectors {
 		if spec.Connectors[i].Locked != nil {
-			if err = validateLocked(&spec.Connectors[i]); err != nil {
+			if err = validateLocked(&spec.Connectors[i], i); err != nil {
 				return err
 			}
 		}
@@ -146,14 +150,18 @@ func Validate(spec *DungeonSpec) error {
 func validateRoomDefinitions(rooms []RoomSpec) error {
 	for i := range rooms {
 		room := &rooms[i]
+		path := fmt.Sprintf("rooms[%d]", i)
 		if room.Width < minWidth {
-			return fmt.Errorf("room %q: width must be at least %d, got %d", room.ID, minWidth, room.Width)
+			return authoredError(
+				path+".width", "invalid_dimension", "%s.width must be at least %d, got %d",
+				path, minWidth, room.Width,
+			)
 		}
 		if err := validateArchetype(room.Archetype); err != nil {
-			return fmt.Errorf("room %q: %w", room.ID, err)
+			return authoredError(path+".archetype", "invalid_archetype", "%s.archetype: %v", path, err)
 		}
 		if err := validatePattern(room.Pattern); err != nil {
-			return fmt.Errorf("room %q: %w", room.ID, err)
+			return authoredError(path+".pattern", "invalid_pattern", "%s.pattern: %v", path, err)
 		}
 	}
 	return nil
@@ -161,7 +169,10 @@ func validateRoomDefinitions(rooms []RoomSpec) error {
 
 func validateNoRegionsInRoomChain(spec *DungeonSpec) error {
 	if len(spec.Regions) != 0 {
-		return fmt.Errorf("regions require canvas mode (non-empty rooms and regions are incompatible)")
+		return authoredError(
+			"regions", "unsupported_capability",
+			"regions require canvas mode (non-empty rooms and regions are incompatible)",
+		)
 	}
 	return nil
 }
@@ -378,24 +389,33 @@ func validKey(key string) bool {
 // validateBossCardinality is a separate, permanent check C0 never touches).
 func validateM1Restrictions(spec *DungeonSpec, bossRoom *RoomSpec) error {
 	for i := range spec.Rooms {
-		room := &spec.Rooms[i]
-		if len(room.Monsters) > 0 {
-			return fmt.Errorf("room %q: monsters: rolled monster placement lands in M2", room.ID)
+		if len(spec.Rooms[i].Monsters) > 0 {
+			return authoredError(
+				fmt.Sprintf("rooms[%d].monsters", i), "unsupported_capability",
+				"rolled monster placement lands in M2",
+			)
 		}
 	}
 	if bossRoom.Boss.At == nil {
-		return fmt.Errorf("room %q: boss.at: rolled monster placement lands in M2", bossRoom.ID)
+		index := roomPointerIndex(spec.Rooms, bossRoom)
+		return authoredError(
+			fmt.Sprintf("rooms[%d].boss.at", index), "unsupported_capability",
+			"rolled monster placement lands in M2",
+		)
 	}
 	return nil
 }
 
 func validateUniqueRoomIDs(rooms []RoomSpec) error {
-	seen := make(map[string]bool, len(rooms))
-	for _, room := range rooms {
-		if seen[room.ID] {
-			return fmt.Errorf("duplicate room id %q", room.ID)
+	seen := make(map[string]int, len(rooms))
+	for index, room := range rooms {
+		if first, duplicate := seen[room.ID]; duplicate {
+			return authoredError(
+				fmt.Sprintf("rooms[%d].id", index), "duplicate_room",
+				"duplicate room id %q at rooms[%d].id (already used by rooms[%d].id)", room.ID, index, first,
+			)
 		}
-		seen[room.ID] = true
+		seen[room.ID] = index
 	}
 	return nil
 }
@@ -404,13 +424,18 @@ func validateUniqueRoomIDs(rooms []RoomSpec) error {
 // in a single linear chain, in room order (rooms[i] -> rooms[i+1]).
 func validateChain(spec *DungeonSpec) error {
 	if len(spec.Connectors) != len(spec.Rooms)-1 {
-		return fmt.Errorf("connectors must form a linear chain: expected %d connectors for %d rooms, got %d",
-			len(spec.Rooms)-1, len(spec.Rooms), len(spec.Connectors))
+		return authoredError(
+			"connectors", "invalid_chain", "connectors must form a linear chain: expected %d connectors for %d rooms, got %d",
+			len(spec.Rooms)-1, len(spec.Rooms), len(spec.Connectors),
+		)
 	}
-	for i, c := range spec.Connectors {
-		if c.From != spec.Rooms[i].ID || c.To != spec.Rooms[i+1].ID {
-			return fmt.Errorf("connectors must form a linear chain: connector %d (%s -> %s) must join room %q to room %q",
-				i, c.From, c.To, spec.Rooms[i].ID, spec.Rooms[i+1].ID)
+	for i, connector := range spec.Connectors {
+		if connector.From != spec.Rooms[i].ID || connector.To != spec.Rooms[i+1].ID {
+			return authoredError(
+				fmt.Sprintf("connectors[%d]", i), "invalid_chain",
+				"connectors must form a linear chain: connector %d (%s -> %s) must join room %q to room %q",
+				i, connector.From, connector.To, spec.Rooms[i].ID, spec.Rooms[i+1].ID,
+			)
 		}
 	}
 	return nil
@@ -449,6 +474,15 @@ func validatePattern(pattern string) error {
 // archetype with a non-nil Boss entry) and that no other room declares one.
 // The boss-required half is permanent (never lifted by M2's Task C0); it is
 // distinct from the at-pinning check in Validate, which is M1-only.
+func roomPointerIndex(rooms []RoomSpec, target *RoomSpec) int {
+	for index := range rooms {
+		if &rooms[index] == target {
+			return index
+		}
+	}
+	return 0
+}
+
 func validateBossCardinality(rooms []RoomSpec) (*RoomSpec, error) {
 	var bossRoom *RoomSpec
 	bossCount := 0
@@ -457,41 +491,54 @@ func validateBossCardinality(rooms []RoomSpec) (*RoomSpec, error) {
 		if room.Archetype == archetypeBoss {
 			bossCount++
 			if room.Boss == nil {
-				return nil, fmt.Errorf("room %q: boss room must declare boss", room.ID)
+				return nil, authoredError(
+					fmt.Sprintf("rooms[%d].boss", i), "missing_boss", "boss room must declare boss",
+				)
 			}
 			bossRoom = room
 		} else if room.Boss != nil {
-			return nil, fmt.Errorf("room %q: boss entry only on the boss room", room.ID)
+			return nil, authoredError(
+				fmt.Sprintf("rooms[%d].boss", i), "invalid_boss", "boss entry only on the boss room",
+			)
 		}
 	}
 	if bossCount != 1 {
-		return nil, fmt.Errorf("dungeon must have exactly one boss room, found %d", bossCount)
+		return nil, authoredError(
+			"rooms", "invalid_boss_count", "dungeon must have exactly one boss room, found %d", bossCount,
+		)
 	}
 	return bossRoom, nil
 }
 
-func validateBossAxis(bossRoom *RoomSpec, height int) error {
+func validateBossAxis(bossRoom *RoomSpec, height, roomIndex int) error {
 	axis := min(bossRoom.Width, height)
 	if axis <= bossAxisMin {
-		return fmt.Errorf("room %q: boss room primary axis (min(width, height)=%d) must exceed %d",
-			bossRoom.ID, axis, bossAxisMin)
+		return authoredError(
+			fmt.Sprintf("rooms[%d].width", roomIndex), "invalid_boss_axis",
+			"boss room primary axis (min(width, height)=%d) must exceed %d", axis, bossAxisMin,
+		)
 	}
 	return nil
 }
 
 // validateBossRef checks the boss room's monster ref: shape, that it names
 // a monster (not a prop), and that it resolves via the registry.
-func validateBossRef(bossRoom *RoomSpec) error {
+func validateBossRef(bossRoom *RoomSpec, roomIndex int) error {
+	path := fmt.Sprintf("rooms[%d].boss.ref", roomIndex)
 	refType, err := refParts(bossRoom.Boss.Ref)
 	if err != nil {
-		return fmt.Errorf("room %q: boss %w", bossRoom.ID, err)
+		return authoredError(path, "invalid_ref", "%s: %v", path, err)
 	}
 	if refType != refTypeMonsters {
-		return fmt.Errorf("room %q: boss ref %q must be a monster ref, got type %q", bossRoom.ID, bossRoom.Boss.Ref, refType)
+		return authoredError(
+			path, "invalid_ref", "%s %q must be a monster ref, got type %q", path, bossRoom.Boss.Ref, refType,
+		)
 	}
 	if _, ok := monsters.ByRef(bossRoom.Boss.Ref); !ok {
-		return fmt.Errorf("room %q: boss ref %q: unknown monster ref (known: %s)",
-			bossRoom.ID, bossRoom.Boss.Ref, strings.Join(monsters.Refs(), ", "))
+		return authoredError(
+			path, "invalid_ref", "%s %q: unknown monster ref (known: %s)",
+			path, bossRoom.Boss.Ref, strings.Join(monsters.Refs(), ", "),
+		)
 	}
 	return nil
 }
@@ -504,79 +551,112 @@ func validatePlaceBlock(room *RoomSpec, height, roomIndex int) error {
 		// Scattered interior walls are seed-rolled — no at cell can be
 		// guaranteed clear or non-wall at author time (design.md §Design
 		// delta), so the load-time contract can't hold for this combination.
-		return fmt.Errorf("room %q: place/boss.at not allowed with pattern: scattered", room.ID)
+		return authoredError(
+			fmt.Sprintf("rooms[%d].pattern", roomIndex), "invalid_pattern",
+			"place/boss.at not allowed with pattern: scattered",
+		)
 	}
 
 	doorRow := height / 2
 	occupied := make(map[[2]int]string, len(room.Place)+1)
 
 	if room.Boss != nil && room.Boss.Facing != nil {
-		return fmt.Errorf("rooms[%d].boss.facing: %s: %s", roomIndex, unsupportedCapability, facingFloorPropsOnly)
+		return authoredError(
+			fmt.Sprintf("rooms[%d].boss.facing", roomIndex), "unsupported_capability",
+			"rooms[%d].boss.facing: %s: %s", roomIndex, unsupportedCapability, facingFloorPropsOnly,
+		)
 	}
 	if room.Boss != nil && room.Boss.At != nil {
 		at := *room.Boss.At
 		if err := checkCellBounds(room, height, at); err != nil {
-			return fmt.Errorf("room %q: boss.at %w", room.ID, err)
+			return authoredError(
+				fmt.Sprintf("rooms[%d].boss.at", roomIndex), "outside_floor", "boss.at: %v", err,
+			)
 		}
 		if at[1] == doorRow {
-			return fmt.Errorf("room %q: boss.at %v is on the reserved row (height/2=%d)", room.ID, at, doorRow)
+			return authoredError(
+				fmt.Sprintf("rooms[%d].boss.at", roomIndex), "reserved_cell",
+				"boss.at %v is on the reserved row (height/2=%d)", at, doorRow,
+			)
 		}
 		occupied[at] = room.Boss.Ref
 	}
 
 	for entryIndex, entry := range room.Place {
 		if err := checkCellBounds(room, height, entry.At); err != nil {
-			return fmt.Errorf("room %q: place %q %w", room.ID, entry.Ref, err)
+			return authoredError(
+				fmt.Sprintf("rooms[%d].place[%d].at", roomIndex, entryIndex), "outside_floor",
+				"place %q at %v: %v", entry.Ref, entry.At, err,
+			)
 		}
 		if entry.At[1] == doorRow {
-			return fmt.Errorf("room %q: place %q at %v is on the reserved row (height/2=%d)",
-				room.ID, entry.Ref, entry.At, doorRow)
+			return authoredError(
+				fmt.Sprintf("rooms[%d].place[%d].at", roomIndex, entryIndex), "reserved_cell",
+				"place %q at %v is on the reserved row (height/2=%d)", entry.Ref, entry.At, doorRow,
+			)
 		}
 		if occupant, ok := occupied[entry.At]; ok {
-			return fmt.Errorf("room %q: place %q at %v is already placed (occupied by %q)",
-				room.ID, entry.Ref, entry.At, occupant)
+			return authoredError(
+				fmt.Sprintf("rooms[%d].place[%d].at", roomIndex, entryIndex), "occupied",
+				"place %q at %v is already placed (occupied by %q)", entry.Ref, entry.At, occupant,
+			)
 		}
 		occupied[entry.At] = entry.Ref
 
 		refType, err := refParts(entry.Ref)
 		if err != nil {
-			return fmt.Errorf("room %q: place %w", room.ID, err)
+			return authoredError(
+				fmt.Sprintf("rooms[%d].place[%d].ref", roomIndex, entryIndex), "invalid_ref", "%v", err,
+			)
 		}
 		// Ref-type routing must be checked before the flags-only-on-props
 		// check below: an entry with an unrecognized ref type should always
 		// report that error, not whichever check happens to run first.
 		if refType != refTypeProps && refType != refTypeMonsters {
-			return fmt.Errorf("room %q: place ref %q must be props or monsters, got type %q",
-				room.ID, entry.Ref, refType)
+			return authoredError(
+				fmt.Sprintf("rooms[%d].place[%d].ref", roomIndex, entryIndex), "invalid_ref",
+				"place ref %q must be props or monsters, got type %q", entry.Ref, refType,
+			)
 		}
 
 		path := fmt.Sprintf("rooms[%d].place[%d]", roomIndex, entryIndex)
 		if entry.Facing != nil {
 			if refType != refTypeProps || !isFloorMount(entry.Mount) {
-				return fmt.Errorf("%s.facing: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
+				return authoredError(
+					path+".facing", "unsupported_capability", "%s.facing: %s: %s",
+					path, unsupportedCapability, facingFloorPropsOnly,
+				)
 			}
 			if err := validateFacing(*entry.Facing); err != nil {
-				return fmt.Errorf("%s.facing: %w", path, err)
+				return authoredError(path+".facing", "invalid_facing", "%s.facing: %v", path, err)
 			}
 		}
 		if !isFloorMount(entry.Mount) {
-			return fmt.Errorf("%s.mount: %s: mounted placements are not supported", path, unsupportedCapability)
+			return authoredError(
+				path+".mount", "unsupported_capability", "%s.mount: %s: mounted placements are not supported",
+				path, unsupportedCapability,
+			)
 		}
 
 		if room.Boss != nil && entry.Ref == room.Boss.Ref {
-			return fmt.Errorf("room %q: boss ref may not also appear in place (ref %q)", room.ID, entry.Ref)
+			return authoredError(
+				path+".ref", "duplicate_boss", "%s.ref: boss ref may not also appear in place (ref %q)",
+				path, entry.Ref,
+			)
 		}
 
 		if refType == refTypeMonsters {
 			if _, ok := monsters.ByRef(entry.Ref); !ok {
-				return fmt.Errorf("room %q: place %q: unknown monster ref (known: %s)",
-					room.ID, entry.Ref, strings.Join(monsters.Refs(), ", "))
+				return authoredError(
+					path+".ref", "invalid_ref", "%s.ref %q: unknown monster ref (known: %s)",
+					path, entry.Ref, strings.Join(monsters.Refs(), ", "),
+				)
 			}
 			if entry.BlocksMovement != nil {
-				return fmt.Errorf("room %q: place %q: blocks_movement only valid on props", room.ID, entry.Ref)
+				return authoredError(path+".blocks_movement", "invalid_placement", "%s.blocks_movement only valid on props", path)
 			}
 			if entry.BlocksLoS != nil {
-				return fmt.Errorf("room %q: place %q: blocks_los only valid on props", room.ID, entry.Ref)
+				return authoredError(path+".blocks_los", "invalid_placement", "%s.blocks_los only valid on props", path)
 			}
 		}
 	}
@@ -590,16 +670,21 @@ func validatePlaceBlock(room *RoomSpec, height, roomIndex int) error {
 func validateTopLevelPlace(entries []PlacedEntry) error {
 	for index, entry := range entries {
 		if entry.Facing != nil {
-			return fmt.Errorf("place[%d].facing: %s: %s", index, unsupportedCapability, facingFloorPropsOnly)
+			path := fmt.Sprintf("place[%d].facing", index)
+			return authoredError(path, "unsupported_capability", "%s: %s: %s", path, unsupportedCapability, facingFloorPropsOnly)
 		}
 		if entry.Mount != nil {
-			return fmt.Errorf("place[%d].mount: %s: mounted placements are not supported", index, unsupportedCapability)
+			path := fmt.Sprintf("place[%d].mount", index)
+			return authoredError(
+				path, "unsupported_capability", "%s: %s: mounted placements are not supported",
+				path, unsupportedCapability,
+			)
 		}
 	}
 	if len(entries) == 0 {
 		return nil
 	}
-	return fmt.Errorf("place[0]: %s: top-level placement is not supported", unsupportedCapability)
+	return authoredError("place[0]", "unsupported_capability", "top-level placement is not supported")
 }
 
 func isFloorMount(mount *string) bool {
@@ -653,7 +738,7 @@ func validateStart(spec *DungeonSpec) error {
 	}
 	at := *spec.Start
 	if at[1] < 0 || at[1] >= spec.Height {
-		return fmt.Errorf("start %v out of bounds: row %d not in [0,%d)", at, at[1], spec.Height)
+		return authoredError("start", "outside_floor", "start %v out of bounds: row %d not in [0,%d)", at, at[1], spec.Height)
 	}
 
 	starts := make([]int, len(spec.Rooms))
@@ -666,7 +751,9 @@ func validateStart(spec *DungeonSpec) error {
 		}
 	}
 	if at[0] < 0 || at[0] >= totalWidth {
-		return fmt.Errorf("start %v out of bounds: column %d not in [0,%d)", at, at[0], totalWidth)
+		return authoredError(
+			"start", "outside_floor", "start %v out of bounds: column %d not in [0,%d)", at, at[0], totalWidth,
+		)
 	}
 
 	roomIndex := -1
@@ -675,18 +762,20 @@ func validateStart(spec *DungeonSpec) error {
 			continue
 		}
 		if roomIndex != -1 {
-			return fmt.Errorf("start %v belongs to more than one semantic room", at)
+			return authoredError("start", "invalid_start", "start %v belongs to more than one semantic room", at)
 		}
 		roomIndex = i
 	}
 	if roomIndex == -1 {
-		return fmt.Errorf("start %v is a connector gap/door cell, not a semantic room floor cell", at)
+		return authoredError(
+			"start", "outside_floor", "start %v is a connector gap/door cell, not a semantic room floor cell", at,
+		)
 	}
 
 	room := &spec.Rooms[roomIndex]
 	local := [2]int{at[0] - starts[roomIndex], at[1]}
 	if room.Boss != nil && room.Boss.At != nil && *room.Boss.At == local {
-		return fmt.Errorf("start %v conflicts with pinned boss in room %q", at, room.ID)
+		return authoredError("start", "occupied", "start %v conflicts with pinned boss in room %q", at, room.ID)
 	}
 	for _, entry := range room.Place {
 		if entry.At != local {
@@ -694,14 +783,19 @@ func validateStart(spec *DungeonSpec) error {
 		}
 		refType, err := refParts(entry.Ref)
 		if err != nil {
-			return fmt.Errorf("start %v: place %q: %w", at, entry.Ref, err)
+			return authoredError("start", "invalid_ref", "start %v: place %q: %v", at, entry.Ref, err)
 		}
 		switch refType {
 		case refTypeMonsters:
-			return fmt.Errorf("start %v conflicts with placed monster %q in room %q", at, entry.Ref, room.ID)
+			return authoredError(
+				"start", "occupied", "start %v conflicts with placed monster %q in room %q", at, entry.Ref, room.ID,
+			)
 		case refTypeProps:
 			if boolOrTrue(entry.BlocksMovement) {
-				return fmt.Errorf("start %v conflicts with movement-blocking prop %q in room %q", at, entry.Ref, room.ID)
+				return authoredError(
+					"start", "occupied", "start %v conflicts with movement-blocking prop %q in room %q",
+					at, entry.Ref, room.ID,
+				)
 			}
 		}
 	}
@@ -873,23 +967,24 @@ func wallHexLess(left, right core.Hex) bool {
 
 // validateLocked checks a connector's lock, prefixing errors with the
 // connector's location (from -> to) since a spec can have several.
-func validateLocked(c *ConnectorSpec) error {
+func validateLocked(c *ConnectorSpec, connectorIndex int) error {
 	locked := c.Locked
+	path := fmt.Sprintf("connectors[%d].locked", connectorIndex)
 	if locked.DC < minLockDC || locked.DC > maxLockDC {
-		return fmt.Errorf("connector %q -> %q: lock dc must be between %d and %d, got %d",
-			c.From, c.To, minLockDC, maxLockDC, locked.DC)
+		return authoredError(
+			path+".dc", "invalid_lock", "lock dc must be between %d and %d, got %d",
+			minLockDC, maxLockDC, locked.DC,
+		)
 	}
 	if _, err := abilities.GetByID(locked.Ability); err != nil {
-		// abilities.GetByID's error (verified empirically) renders as just
-		// "invalid ability" — its valid_options live only in structured
-		// metadata callers don't see via Error(). Build the known-abilities
-		// list ourselves, parallel to the monster known-refs treatment.
 		known := make([]string, 0, len(abilities.List()))
-		for _, a := range abilities.List() {
-			known = append(known, string(a))
+		for _, ability := range abilities.List() {
+			known = append(known, string(ability))
 		}
-		return fmt.Errorf("connector %q -> %q: lock ability %q: %w (known: %s)",
-			c.From, c.To, locked.Ability, err, strings.Join(known, ", "))
+		return authoredError(
+			path+".ability", "invalid_lock", "lock ability %q: %v (known: %s)",
+			locked.Ability, err, strings.Join(known, ", "),
+		)
 	}
 	return nil
 }

--- a/encounter/dungeonspec/wave_a_test.go
+++ b/encounter/dungeonspec/wave_a_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	toolkitcore "github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
 	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
@@ -24,6 +25,22 @@ regions:
     cells: [[1,1], [1,2], [1,3], [2,1], [2,3], [3,1], [3,2], [3,3]]
 `
 
+const ringSnapshotSource = `version: 1
+key: ring-snapshot
+name: Ring Snapshot
+canvas: { width: 5, height: 5, floor_source: regions }
+rooms: []
+start: [1, 1]
+regions:
+  - id: ring
+    cells: [[1,1], [1,2], [1,3], [2,1], [2,3], [3,1], [3,2], [3,3]]
+place:
+  - { ref: "dnd5e:props:pillar", at: [1,3] }
+  - { ref: "dnd5e:monsters:skeleton", at: [3,3] }
+walls:
+  - { from: [3,1], to: [3,2], kind: door }
+`
+
 func compileCandidate(
 	t *testing.T,
 	source string,
@@ -31,7 +48,7 @@ func compileCandidate(
 	seats int,
 ) *dungeonspec.CompileDungeonOutput {
 	t.Helper()
-	out, err := dungeonspec.CompileDungeon(context.Background(), dungeonspec.CompileDungeonInput{
+	out, err := dungeonspec.CompileDungeon(context.Background(), &dungeonspec.CompileDungeonInput{
 		Source: []byte(source), Mode: mode, PartyStartSeatCount: seats, PreviewSeed: 17,
 	})
 	require.NoError(t, err)
@@ -51,6 +68,24 @@ func TestWaveARegionRingProjectsCanonicalMaskAndCompleteEnvelope(t *testing.T) {
 			require.True(t, cellLess(out.FloorPlan.FloorCells[index-1], cell))
 		}
 	}
+	expectedEnvelope := make(map[[2]dungeonspec.FloorPlanCell]struct{})
+	for cell := range floor {
+		hex := core.HexFromPosition(structuralPosition(cell.Column, cell.Row))
+		for _, neighbor := range hex.ToCube().GetNeighbors() {
+			position := core.HexFromCube(neighbor).ToPosition()
+			other := dungeonspec.FloorPlanCell{Column: int(position.X), Row: int(position.Y)}
+			if _, inside := floor[other]; inside {
+				continue
+			}
+			from, to := cell, other
+			if cellLess(to, from) {
+				from, to = to, from
+			}
+			expectedEnvelope[[2]dungeonspec.FloorPlanCell{from, to}] = struct{}{}
+		}
+	}
+	require.Len(t, out.FloorPlan.Edges, 28, "8-cell ring must expose 22 exterior plus 6 hole edges")
+	require.Len(t, out.FloorPlan.Edges, len(expectedEnvelope), "envelope must include complete exterior plus hole")
 	center := dungeonspec.FloorPlanCell{Column: 2, Row: 2}
 	centerEdges := 0
 	for index, edge := range out.FloorPlan.Edges {
@@ -58,11 +93,16 @@ func TestWaveARegionRingProjectsCanonicalMaskAndCompleteEnvelope(t *testing.T) {
 		_, toFloor := floor[edge.To]
 		require.NotEqual(t, fromFloor, toFloor, "edge %d must have exactly one floor owner: %+v", index, edge)
 		require.Equal(t, dungeonspec.FloorPlanEdgeKindSolid, edge.Kind)
+		pair := [2]dungeonspec.FloorPlanCell{edge.From, edge.To}
+		_, expected := expectedEnvelope[pair]
+		require.True(t, expected, "unexpected envelope pair %+v", edge)
+		delete(expectedEnvelope, pair)
 		if edge.From == center || edge.To == center {
 			centerEdges++
 		}
 	}
 	require.Equal(t, 6, centerEdges, "the one-cell interior void must have its complete six-side envelope")
+	require.Empty(t, expectedEnvelope, "every exterior and hole pair must be projected")
 
 	rim := `version: 1
 key: rim
@@ -119,6 +159,16 @@ regions:
 	rejected := compileCandidate(t, islands, dungeonspec.CompileModeStrict, 4)
 	require.Equal(t, "canvas.floor_source", rejected.FieldErrors[0].Field)
 	require.Equal(t, "floor_disconnected", rejected.FieldErrors[0].Code)
+	withoutIslandB := `version: 1
+key: islands
+name: Islands
+canvas: { width: 6, height: 3, floor_source: regions }
+rooms: []
+regions: [{ id: large, cells: [[0,0], [0,1], [1,0], [1,1]] }]
+`
+	runnable := compileCandidate(t, withoutIslandB, dungeonspec.CompileModeStrict, 4)
+	require.Empty(t, runnable.FieldErrors)
+	require.Equal(t, dungeonspec.FloorPlanCell{Column: 0, Row: 0}, *runnable.FloorPlan.Entrance)
 }
 
 func TestWaveABoundsOmissionAndCompleteCandidateReplacement(t *testing.T) {
@@ -128,9 +178,11 @@ name: Bounds
 canvas: { width: 3, height: 2 }
 rooms: []
 `
-	plan := compileCandidate(t, omitted, dungeonspec.CompileModeDraft, 1).FloorPlan
+	plan := compileCandidate(t, omitted, dungeonspec.CompileModeDraft, 4).FloorPlan
 	require.Equal(t, dungeonspec.FloorSourceBounds, plan.FloorSource)
 	require.Len(t, plan.FloorCells, 6)
+	require.Equal(t, dungeonspec.FloorPlanCell{Column: 0, Row: 0}, *plan.Entrance,
+		"omitted start must resolve to the first canonical PartyCap-capable anchor")
 
 	previous := `version: 1
 key: replace
@@ -175,21 +227,51 @@ regions: [{ id: floor, cells: [[0,0], [0,1], [1,0], [1,1]] }]
 	}
 }
 
-func TestWaveAStrictBoundsRunsRunnableCandidateGate(t *testing.T) {
-	source := `version: 1
+func TestWaveABoundsDraftRetainsV03RuntimeGate(t *testing.T) {
+	for _, floorSource := range []string{"", ", floor_source: bounds"} {
+		source := fmt.Sprintf(`version: 1
 key: blocked-bounds
 name: Blocked Bounds
-canvas: { width: 1, height: 1 }
+canvas: { width: 1, height: 1%s }
 rooms: []
 regions: []
 place: [{ ref: "dnd5e:props:pillar", at: [0,0] }]
-`
-	draft := compileCandidate(t, source, dungeonspec.CompileModeDraft, 1)
-	require.Empty(t, draft.FieldErrors)
-	require.Nil(t, draft.FloorPlan.Entrance)
-	strict := compileCandidate(t, source, dungeonspec.CompileModeStrict, 1)
-	require.NotEmpty(t, strict.FieldErrors)
-	require.Equal(t, "start", strict.FieldErrors[0].Field)
+`, floorSource)
+		for _, mode := range []dungeonspec.CompileMode{dungeonspec.CompileModeDraft, dungeonspec.CompileModeStrict} {
+			out := compileCandidate(t, source, mode, 1)
+			require.NotEmpty(t, out.FieldErrors, "%s bounds must retain v0.3 runtime projection gate", mode)
+			require.Nil(t, out.FloorPlan)
+		}
+	}
+}
+
+func TestWaveAFieldErrorsAreStructurallyPathAware(t *testing.T) {
+	cases := []struct{ name, source, field, code string }{
+		{name: "root shape", source: "- not-a-spec\n", field: "spec", code: "invalid_yaml"},
+		{name: "unknown root", source: ringSource + "unknown_root: true\n", field: "unknown_root", code: "unknown_field"},
+		{name: "unknown nested indexed", source: `version: 1
+key: bad
+name: Bad
+canvas: { width: 2, height: 2, floor_source: regions }
+rooms: []
+regions: [{ id: r, cells: [], unknown_cell_rule: true }]
+`, field: "regions[0].unknown_cell_rule", code: "unknown_field"},
+		{name: "invalid indexed value", source: `version: 1
+key: bad
+name: Bad
+canvas: { width: 2, height: 2, floor_source: regions }
+rooms: []
+regions: [{ id: r, cells: [oops] }]
+`, field: "regions[0].cells[0]", code: "invalid_yaml"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := compileCandidate(t, tc.source, dungeonspec.CompileModeDraft, 1)
+			require.Equal(t, []dungeonspec.FieldError{{
+				Field: tc.field, Message: out.FieldErrors[0].Message, Code: tc.code,
+			}}, out.FieldErrors)
+		})
+	}
 }
 
 func TestWaveADuplicateEmptyRegionsHasExactPath(t *testing.T) {
@@ -207,8 +289,60 @@ regions:
 	require.Equal(t, "duplicate_region", out.FieldErrors[0].Code)
 }
 
-func TestWaveASnapshotReloadAndVoidMechanicsUsePersistedMask(t *testing.T) {
+func TestWaveASnapshotRejectsDuplicateEmptySemanticSets(t *testing.T) {
+	compiled := compileCandidate(t, ringSource, dungeonspec.CompileModeStrict, 1)
+	require.Empty(t, compiled.FieldErrors)
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+	enc := encounter.New(context.Background(), "duplicate-empty-snapshot", broker)
+	require.NoError(t, enc.InitDungeon(compiled.Compiled.Params))
+	snapshot := enc.ToData()
+	snapshot.Space.SemanticRegions = append(snapshot.Space.SemanticRegions,
+		encounter.SemanticRegionData{ID: "empty-a", Cells: core.HexSet{}},
+		encounter.SemanticRegionData{ID: "empty-b", Cells: core.HexSet{}},
+	)
+	_, err := encounter.LoadFromData(context.Background(), snapshot, broker)
+	require.ErrorContains(t, err, "equal cell sets")
+}
+
+type movementQueryEntity struct{}
+
+func (movementQueryEntity) GetID() string                   { return "movement-query" }
+func (movementQueryEntity) GetType() toolkitcore.EntityType { return "test" }
+
+func TestWaveAPublicRoomAndQueryMovementRetainContiguousVoidRay(t *testing.T) {
 	compiled := compileCandidate(t, ringSource, dungeonspec.CompileModeStrict, 4)
+	require.Empty(t, compiled.FieldErrors)
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+	enc := encounter.New(context.Background(), "public-ring-query", broker)
+	require.NoError(t, enc.InitDungeon(compiled.Compiled.Params))
+	from := structuralPosition(1, 1)
+	to := structuralPosition(3, 3)
+	void := structuralPosition(2, 2)
+	ray := enc.Room().GetLineOfSight(from, to)
+	require.Contains(t, ray, void, "public Room ray must retain the intermediate void instead of deleting it")
+	for index := 1; index < len(ray); index++ {
+		require.True(t, enc.Room().GetGrid().IsAdjacent(ray[index-1], ray[index]))
+	}
+	handler := spatial.NewSpatialQueryHandler()
+	handler.RegisterRoom(enc.Room())
+	valid, path, _, err := spatial.NewQueryUtils(handler).QueryMovement(
+		context.Background(), movementQueryEntity{}, from, to, enc.Room().GetID(),
+	)
+	require.NoError(t, err)
+	require.False(t, valid, "public movement query must reject a direct ray with any void intermediate")
+	require.Equal(t, ray, path)
+	for index := 1; index < len(path); index++ {
+		require.True(t, enc.Room().GetGrid().IsAdjacent(path[index-1], path[index]),
+			"returned query path must never be discontinuous")
+	}
+}
+
+func TestWaveASnapshotReloadAndVoidMechanicsUsePersistedMask(t *testing.T) {
+	compiled := compileCandidate(t, ringSnapshotSource, dungeonspec.CompileModeStrict, 4)
 	require.Empty(t, compiled.FieldErrors)
 	ctx := context.Background()
 	transport := encounter.NewInMemoryTransport()
@@ -216,6 +350,7 @@ func TestWaveASnapshotReloadAndVoidMechanicsUsePersistedMask(t *testing.T) {
 	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
 	enc := encounter.New(ctx, "wave-a-mask", broker)
 	require.NoError(t, enc.InitDungeon(compiled.Compiled.Params))
+	require.NoError(t, enc.SeedMonsters(compiled.Compiled.Spawns))
 	floorBefore := append([]core.Hex(nil), enc.ToData().Space.FloorCells...)
 	edgesBefore := append([]encounter.GeneratedEdge(nil), enc.ToData().Space.EnvelopeEdges...)
 	void := core.HexFromPosition(structuralPosition(2, 2))
@@ -228,7 +363,11 @@ func TestWaveASnapshotReloadAndVoidMechanicsUsePersistedMask(t *testing.T) {
 	}))
 	require.NotContains(t, enc.KnownHexes("alice"), void)
 	acrossVoid := core.HexFromPosition(structuralPosition(3, 3))
-	require.NoError(t, enc.AddMonster(encounter.MonsterInput{ID: "hidden", Position: acrossVoid, HP: 1, MaxHP: 1}))
+	require.Len(t, enc.ToData().Monsters, 1)
+	for _, monster := range enc.ToData().Monsters {
+		require.NotEmpty(t, monster.DataJSON, "compiled monster snapshot must carry real hydratable data")
+		require.Equal(t, acrossVoid, monster.Position)
+	}
 	require.Equal(t, core.ModeFreeRoam, enc.Mode(), "target across void must not be reachable/visible")
 	require.NoError(t, enc.Move("alice", []core.Hex{void}))
 	require.Equal(t, start, enc.SnapshotFor("alice").Position)
@@ -240,6 +379,11 @@ func TestWaveASnapshotReloadAndVoidMechanicsUsePersistedMask(t *testing.T) {
 	require.True(t, enc.Room().IsLineOfSightBlocked(start.ToPosition(), acrossVoid.ToPosition()))
 
 	snapshot := enc.ToData()
+	require.Equal(t, start, snapshot.Space.Entrance)
+	require.Len(t, snapshot.Space.PartyStartPositions, 4)
+	require.Len(t, snapshot.Space.Obstacles, 1)
+	require.Len(t, snapshot.Monsters, 1)
+	require.Len(t, snapshot.Doors, 1)
 	edited := `version: 1
 key: ring-room
 name: Ring Room
@@ -252,6 +396,11 @@ regions: [{ id: new, cells: [[0,0], [0,1], [1,0], [1,1]] }]
 	require.NoError(t, err)
 	require.Equal(t, floorBefore, reloaded.ToData().Space.FloorCells)
 	require.Equal(t, edgesBefore, reloaded.ToData().Space.EnvelopeEdges)
+	require.Equal(t, snapshot.Space.Entrance, reloaded.ToData().Space.Entrance)
+	require.Equal(t, snapshot.Space.PartyStartPositions, reloaded.ToData().Space.PartyStartPositions)
+	require.Len(t, reloaded.ToData().Space.Obstacles, 1)
+	require.Len(t, reloaded.ToData().Monsters, 1)
+	require.Len(t, reloaded.ToData().Doors, 1)
 	require.False(t, reloaded.Room().GetGrid().IsValidPosition(void.ToPosition()))
 }
 

--- a/encounter/dungeonspec/wave_a_test.go
+++ b/encounter/dungeonspec/wave_a_test.go
@@ -1,0 +1,246 @@
+package dungeonspec_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/dungeonspec"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+const ringSource = `version: 1
+key: ring-room
+name: Ring Room
+canvas: { width: 5, height: 5, floor_source: regions }
+rooms: []
+start: [1, 1]
+regions:
+  - id: ring
+    cells: [[1,1], [1,2], [1,3], [2,1], [2,3], [3,1], [3,2], [3,3]]
+`
+
+func compileCandidate(
+	t *testing.T,
+	source string,
+	mode dungeonspec.CompileMode,
+	seats int,
+) *dungeonspec.CompileDungeonOutput {
+	t.Helper()
+	out, err := dungeonspec.CompileDungeon(context.Background(), dungeonspec.CompileDungeonInput{
+		Source: []byte(source), Mode: mode, PartyStartSeatCount: seats, PreviewSeed: 17,
+	})
+	require.NoError(t, err)
+	return out
+}
+
+func TestWaveARegionRingProjectsCanonicalMaskAndCompleteEnvelope(t *testing.T) {
+	out := compileCandidate(t, ringSource, dungeonspec.CompileModeDraft, 4)
+	require.Empty(t, out.FieldErrors)
+	require.NotNil(t, out.FloorPlan)
+	require.Equal(t, dungeonspec.FloorSourceRegions, out.FloorPlan.FloorSource)
+	require.Len(t, out.FloorPlan.FloorCells, 8)
+	floor := make(map[dungeonspec.FloorPlanCell]struct{}, 8)
+	for index, cell := range out.FloorPlan.FloorCells {
+		floor[cell] = struct{}{}
+		if index > 0 {
+			require.True(t, cellLess(out.FloorPlan.FloorCells[index-1], cell))
+		}
+	}
+	center := dungeonspec.FloorPlanCell{Column: 2, Row: 2}
+	centerEdges := 0
+	for index, edge := range out.FloorPlan.Edges {
+		_, fromFloor := floor[edge.From]
+		_, toFloor := floor[edge.To]
+		require.NotEqual(t, fromFloor, toFloor, "edge %d must have exactly one floor owner: %+v", index, edge)
+		require.Equal(t, dungeonspec.FloorPlanEdgeKindSolid, edge.Kind)
+		if edge.From == center || edge.To == center {
+			centerEdges++
+		}
+	}
+	require.Equal(t, 6, centerEdges, "the one-cell interior void must have its complete six-side envelope")
+
+	rim := `version: 1
+key: rim
+name: Rim
+canvas: { width: 2, height: 2, floor_source: regions }
+rooms: []
+regions: [{ id: rim, cells: [[0,0]] }]
+`
+	rimPlan := compileCandidate(t, rim, dungeonspec.CompileModeDraft, 1).FloorPlan
+	require.Len(t, rimPlan.Edges, 6)
+	offCanvas := 0
+	for _, edge := range rimPlan.Edges {
+		for _, endpoint := range []dungeonspec.FloorPlanCell{edge.From, edge.To} {
+			if endpoint.Column < 0 || endpoint.Row < 0 || endpoint.Column >= 2 || endpoint.Row >= 2 {
+				offCanvas++
+			}
+		}
+	}
+	require.Positive(t, offCanvas, "rim envelope must preserve actual off-canvas neighbor coordinates")
+}
+
+func TestWaveATinyAndDisconnectedDraftLifecycle(t *testing.T) {
+	tiny := `version: 1
+key: tiny
+name: Tiny
+canvas: { width: 3, height: 2, floor_source: regions }
+rooms: []
+regions: [{ id: tiny, cells: [[0,0], [1,0]] }]
+`
+	draft := compileCandidate(t, tiny, dungeonspec.CompileModeDraft, 4)
+	require.Empty(t, draft.FieldErrors)
+	require.Nil(t, draft.FloorPlan.Entrance)
+	strict := compileCandidate(t, tiny, dungeonspec.CompileModeStrict, 4)
+	require.Equal(t, "canvas.floor_source", strict.FieldErrors[0].Field)
+	require.Equal(t, "entrance_unavailable", strict.FieldErrors[0].Code)
+
+	islands := `version: 1
+key: islands
+name: Islands
+canvas: { width: 6, height: 3, floor_source: regions }
+rooms: []
+regions:
+  - { id: large, cells: [[0,0], [0,1], [1,0], [1,1]] }
+  - { id: island, cells: [[5,2]] }
+`
+	projected := compileCandidate(t, islands, dungeonspec.CompileModeDraft, 4)
+	require.Empty(t, projected.FieldErrors)
+	require.NotNil(t, projected.FloorPlan.Entrance)
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+	preview := encounter.New(context.Background(), "draft-cannot-start", broker)
+	require.Error(t, preview.InitDungeon(projected.Compiled.Params))
+	rejected := compileCandidate(t, islands, dungeonspec.CompileModeStrict, 4)
+	require.Equal(t, "canvas.floor_source", rejected.FieldErrors[0].Field)
+	require.Equal(t, "floor_disconnected", rejected.FieldErrors[0].Code)
+}
+
+func TestWaveABoundsOmissionAndCompleteCandidateReplacement(t *testing.T) {
+	omitted := `version: 1
+key: bounds
+name: Bounds
+canvas: { width: 3, height: 2 }
+rooms: []
+`
+	plan := compileCandidate(t, omitted, dungeonspec.CompileModeDraft, 1).FloorPlan
+	require.Equal(t, dungeonspec.FloorSourceBounds, plan.FloorSource)
+	require.Len(t, plan.FloorCells, 6)
+
+	previous := `version: 1
+key: replace
+name: Replace
+canvas: { width: 4, height: 2 }
+rooms: []
+place: [{ ref: "dnd5e:props:pillar", at: [3,0] }]
+`
+	require.Empty(t, compileCandidate(t, previous, dungeonspec.CompileModeDraft, 1).FieldErrors)
+	shrunk := `version: 1
+key: replace
+name: Replace
+canvas: { width: 2, height: 2 }
+rooms: []
+`
+	replacement := compileCandidate(t, shrunk, dungeonspec.CompileModeDraft, 1)
+	require.Empty(t, replacement.FieldErrors)
+	require.Len(t, replacement.FloorPlan.FloorCells, 4)
+}
+
+func TestWaveARemovedFloorRejectsDependentContentAtExactPaths(t *testing.T) {
+	base := `version: 1
+key: removed-content
+name: Removed Content
+canvas: { width: 3, height: 3, floor_source: regions }
+rooms: []
+regions: [{ id: floor, cells: [[0,0], [0,1], [1,0], [1,1]] }]
+%s
+`
+	cases := []struct{ name, content, field string }{
+		{name: "start", content: "start: [2,2]", field: "start"},
+		{name: "prop", content: `place: [{ ref: "dnd5e:props:pillar", at: [2,2] }]`, field: "place[0].at"},
+		{name: "monster", content: `place: [{ ref: "dnd5e:monsters:skeleton", at: [2,2] }]`, field: "place[0].at"},
+		{name: "wall", content: `walls: [{ from: [0,0], to: [2,2], kind: solid }]`, field: "walls[0].to"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := compileCandidate(t, fmt.Sprintf(base, tc.content), dungeonspec.CompileModeDraft, 1)
+			require.Equal(t, tc.field, out.FieldErrors[0].Field)
+			require.Equal(t, "outside_floor", out.FieldErrors[0].Code)
+		})
+	}
+}
+
+func TestWaveADuplicateEmptyRegionsHasExactPath(t *testing.T) {
+	source := `version: 1
+key: empty-duplicates
+name: Empty Duplicates
+canvas: { width: 2, height: 2, floor_source: regions }
+rooms: []
+regions:
+  - { id: first, cells: [] }
+  - { id: second, cells: [] }
+`
+	out := compileCandidate(t, source, dungeonspec.CompileModeDraft, 1)
+	require.Equal(t, "regions[1].cells", out.FieldErrors[0].Field)
+	require.Equal(t, "duplicate_region", out.FieldErrors[0].Code)
+}
+
+func TestWaveASnapshotReloadAndVoidMechanicsUsePersistedMask(t *testing.T) {
+	compiled := compileCandidate(t, ringSource, dungeonspec.CompileModeStrict, 4)
+	require.Empty(t, compiled.FieldErrors)
+	ctx := context.Background()
+	transport := encounter.NewInMemoryTransport()
+	broker := encounter.NewBroker(transport)
+	t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+	enc := encounter.New(ctx, "wave-a-mask", broker)
+	require.NoError(t, enc.InitDungeon(compiled.Compiled.Params))
+	floorBefore := append([]core.Hex(nil), enc.ToData().Space.FloorCells...)
+	edgesBefore := append([]encounter.GeneratedEdge(nil), enc.ToData().Space.EnvelopeEdges...)
+	void := core.HexFromPosition(structuralPosition(2, 2))
+	start := core.HexFromPosition(structuralPosition(1, 1))
+	require.Error(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "void", EntityID: "void", Position: void, SightRange: 4,
+	}))
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: "alice", EntityID: "alice", Position: start, SightRange: 4,
+	}))
+	require.NotContains(t, enc.KnownHexes("alice"), void)
+	acrossVoid := core.HexFromPosition(structuralPosition(3, 3))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{ID: "hidden", Position: acrossVoid, HP: 1, MaxHP: 1}))
+	require.Equal(t, core.ModeFreeRoam, enc.Mode(), "target across void must not be reachable/visible")
+	require.NoError(t, enc.Move("alice", []core.Hex{void}))
+	require.Equal(t, start, enc.SnapshotFor("alice").Position)
+	require.Error(t, enc.AddObstacle("void-prop", "dnd5e:props:pillar", void, true, true))
+	require.NoError(t, enc.Move("alice", []core.Hex{acrossVoid}),
+		"a sparse request must fail closed without surfacing an infrastructure error")
+	require.Equal(t, start, enc.SnapshotFor("alice").Position)
+	require.False(t, enc.Room().GetGrid().IsValidPosition(void.ToPosition()))
+	require.True(t, enc.Room().IsLineOfSightBlocked(start.ToPosition(), acrossVoid.ToPosition()))
+
+	snapshot := enc.ToData()
+	edited := `version: 1
+key: ring-room
+name: Ring Room
+canvas: { width: 2, height: 2, floor_source: regions }
+rooms: []
+regions: [{ id: new, cells: [[0,0], [0,1], [1,0], [1,1]] }]
+`
+	require.Empty(t, compileCandidate(t, edited, dungeonspec.CompileModeStrict, 4).FieldErrors)
+	reloaded, err := encounter.LoadFromData(ctx, snapshot, broker)
+	require.NoError(t, err)
+	require.Equal(t, floorBefore, reloaded.ToData().Space.FloorCells)
+	require.Equal(t, edgesBefore, reloaded.ToData().Space.EnvelopeEdges)
+	require.False(t, reloaded.Room().GetGrid().IsValidPosition(void.ToPosition()))
+}
+
+func cellLess(a, b dungeonspec.FloorPlanCell) bool {
+	return a.Column < b.Column || a.Column == b.Column && a.Row < b.Row
+}
+func structuralPosition(column, row int) spatial.Position {
+	return spatial.Position{X: float64(column), Y: float64(row)}
+}

--- a/encounter/dungeonspec/wave_a_test.go
+++ b/encounter/dungeonspec/wave_a_test.go
@@ -19,7 +19,6 @@ key: ring-room
 name: Ring Room
 canvas: { width: 5, height: 5, floor_source: regions }
 rooms: []
-start: [1, 1]
 regions:
   - id: ring
     cells: [[1,1], [1,2], [1,3], [2,1], [2,3], [3,1], [3,2], [3,3]]
@@ -60,6 +59,8 @@ func TestWaveARegionRingProjectsCanonicalMaskAndCompleteEnvelope(t *testing.T) {
 	require.Empty(t, out.FieldErrors)
 	require.NotNil(t, out.FloorPlan)
 	require.Equal(t, dungeonspec.FloorSourceRegions, out.FloorPlan.FloorSource)
+	require.Equal(t, dungeonspec.FloorPlanCell{Column: 1, Row: 1}, *out.FloorPlan.Entrance,
+		"omitted region start must use the first canonical PartyCap-capable anchor")
 	require.Len(t, out.FloorPlan.FloorCells, 8)
 	floor := make(map[dungeonspec.FloorPlanCell]struct{}, 8)
 	for index, cell := range out.FloorPlan.FloorCells {
@@ -213,7 +214,7 @@ regions: [{ id: floor, cells: [[0,0], [0,1], [1,0], [1,1]] }]
 %s
 `
 	cases := []struct{ name, content, field string }{
-		{name: "start", content: "start: [2,2]", field: "start"},
+		{name: contractStartPath, content: "start: [2,2]", field: contractStartPath},
 		{name: "prop", content: `place: [{ ref: "dnd5e:props:pillar", at: [2,2] }]`, field: "place[0].at"},
 		{name: "monster", content: `place: [{ ref: "dnd5e:monsters:skeleton", at: [2,2] }]`, field: "place[0].at"},
 		{name: "wall", content: `walls: [{ from: [0,0], to: [2,2], kind: solid }]`, field: "walls[0].to"},

--- a/encounter/dungeonspec/wave_a_test.go
+++ b/encounter/dungeonspec/wave_a_test.go
@@ -175,6 +175,23 @@ regions: [{ id: floor, cells: [[0,0], [0,1], [1,0], [1,1]] }]
 	}
 }
 
+func TestWaveAStrictBoundsRunsRunnableCandidateGate(t *testing.T) {
+	source := `version: 1
+key: blocked-bounds
+name: Blocked Bounds
+canvas: { width: 1, height: 1 }
+rooms: []
+regions: []
+place: [{ ref: "dnd5e:props:pillar", at: [0,0] }]
+`
+	draft := compileCandidate(t, source, dungeonspec.CompileModeDraft, 1)
+	require.Empty(t, draft.FieldErrors)
+	require.Nil(t, draft.FloorPlan.Entrance)
+	strict := compileCandidate(t, source, dungeonspec.CompileModeStrict, 1)
+	require.NotEmpty(t, strict.FieldErrors)
+	require.Equal(t, "start", strict.FieldErrors[0].Field)
+}
+
 func TestWaveADuplicateEmptyRegionsHasExactPath(t *testing.T) {
 	source := `version: 1
 key: empty-duplicates

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -329,6 +329,9 @@ func LoadFromData(ctx context.Context, data *Data, b *Broker, opts ...Option) (*
 // Spell-cost reactions (Shield, Counterspell) are seeded false and require
 // the player to opt in via SetReactionReady.
 func (e *Encounter) AddPlayer(input PlayerInput) error {
+	if e.room != nil && !e.room.GetGrid().IsValidPosition(input.Position.ToPosition()) {
+		return fmt.Errorf("player %q position %v is outside structural floor", input.PlayerID, input.Position)
+	}
 	if _, exists := e.data.Players[input.PlayerID]; exists {
 		return fmt.Errorf("player %q already in encounter", input.PlayerID)
 	}
@@ -436,6 +439,9 @@ func restoreForNewSeat(hp, maxHP int, dataJSON json.RawMessage) (int, int, json.
 // why a caller holding an old Room()/RoomOrchestrator() reference across
 // this call would observe stale geometry.
 func (e *Encounter) AddDoor(id core.EntityID, position core.Hex, open bool) error {
+	if e.room != nil && !e.room.GetGrid().IsValidPosition(position.ToPosition()) {
+		return fmt.Errorf("add door %q: position %v is outside structural floor", id, position)
+	}
 	if authoredEndpointContains(e.data.Space, position) {
 		return fmt.Errorf("add door %q: position %v is an authored edge endpoint", id, position)
 	}
@@ -487,6 +493,9 @@ func (e *Encounter) AddMonster(input MonsterInput) error {
 // unchanged for every other caller — this is a pure extraction, not a
 // behavior change.
 func (e *Encounter) addMonsterNoCombatCheck(input MonsterInput) error {
+	if e.room != nil && !e.room.GetGrid().IsValidPosition(input.Position.ToPosition()) {
+		return fmt.Errorf("monster %q position %v is outside structural floor", input.ID, input.Position)
+	}
 	if input.ID == "" {
 		return errors.New("monster ID required")
 	}

--- a/encounter/encounter.go
+++ b/encounter/encounter.go
@@ -230,6 +230,26 @@ func New(ctx context.Context, id core.EncounterID, b *Broker, opts ...Option) *E
 	return e
 }
 
+func validatePersistedActorEntries(
+	players map[core.PlayerID]*PlayerData,
+	monsters map[core.EntityID]*MonsterData,
+) error {
+	for id, player := range players {
+		if player == nil {
+			return fmt.Errorf("validate player %q: null player state", id)
+		}
+		if player.View == nil {
+			return fmt.Errorf("validate player %q: view is required", id)
+		}
+	}
+	for id, monster := range monsters {
+		if monster == nil {
+			return fmt.Errorf("validate monster %q: null monster state", id)
+		}
+	}
+	return nil
+}
+
 // LoadFromData rehydrates an encounter from persisted state.
 //
 // #689: LoadFromData OWNS combatant hydration. A fresh encounter-scoped dnd5e
@@ -268,6 +288,9 @@ func LoadFromData(ctx context.Context, data *Data, b *Broker, opts ...Option) (*
 	}
 	if data.Mode == core.ModeUnspecified {
 		data.Mode = core.ModeFreeRoam
+	}
+	if err := validatePersistedActorEntries(data.Players, data.Monsters); err != nil {
+		return nil, err
 	}
 	if err := validatePersistedDoors(data.Doors); err != nil {
 		return nil, fmt.Errorf("validate doors: %w", err)

--- a/encounter/floor_mask.go
+++ b/encounter/floor_mask.go
@@ -71,15 +71,15 @@ type floorMaskRoom struct {
 
 func (r *floorMaskRoom) GetGrid() spatial.Grid { return r.grid }
 func (r *floorMaskRoom) GetLineOfSight(from, to spatial.Position) []spatial.Position {
-	ray := r.grid.GetLineOfSight(from, to)
-	out := make([]spatial.Position, 0, len(ray))
-	for _, pos := range ray {
-		if r.grid.IsValidPosition(pos) {
-			out = append(out, pos)
-		}
-	}
-	return out
+	return r.grid.GetLineOfSight(from, to)
 }
+func (r *floorMaskRoom) IsBoundaryMovementBlocked(from, to spatial.Position) bool {
+	if !r.grid.IsValidPosition(from) || !r.grid.IsValidPosition(to) {
+		return true
+	}
+	return r.BasicRoom.IsBoundaryMovementBlocked(from, to)
+}
+
 func (r *floorMaskRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
 	if !r.grid.IsValidPosition(from) || !r.grid.IsValidPosition(to) {
 		return true

--- a/encounter/floor_mask.go
+++ b/encounter/floor_mask.go
@@ -1,0 +1,96 @@
+package encounter
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// floorMaskGrid keeps canvas dimensions as workspace bounds while making the
+// persisted structural-floor mask the only mechanically valid set of cells.
+// Line rays intentionally retain void cells so movement and the room wrapper
+// can fail closed when a direct crossing leaves the floor.
+type floorMaskGrid struct {
+	base  *spatial.HexGrid
+	floor map[spatial.Position]struct{}
+}
+
+func newFloorMaskGrid(width, height int, floor map[coreHex]struct{}) *floorMaskGrid {
+	positions := make(map[spatial.Position]struct{}, len(floor))
+	for hex := range floor {
+		positions[hex.ToPosition()] = struct{}{}
+	}
+	return &floorMaskGrid{
+		base: spatial.NewHexGrid(spatial.HexGridConfig{
+			Width: float64(width), Height: float64(height), Orientation: spatial.HexOrientationPointyTop,
+		}),
+		floor: positions,
+	}
+}
+
+// coreHex is a local alias declared below to keep constructors readable.
+type coreHex = core.Hex
+
+func (g *floorMaskGrid) GetShape() spatial.GridShape                { return g.base.GetShape() }
+func (g *floorMaskGrid) GetDimensions() spatial.Dimensions          { return g.base.GetDimensions() }
+func (g *floorMaskGrid) Distance(from, to spatial.Position) float64 { return g.base.Distance(from, to) }
+func (g *floorMaskGrid) IsAdjacent(a, b spatial.Position) bool      { return g.base.IsAdjacent(a, b) }
+func (g *floorMaskGrid) IsValidPosition(pos spatial.Position) bool {
+	if !g.base.IsValidPosition(pos) {
+		return false
+	}
+	_, ok := g.floor[pos]
+	return ok
+}
+func (g *floorMaskGrid) GetNeighbors(pos spatial.Position) []spatial.Position {
+	return filterFloorPositions(g.base.GetNeighbors(pos), g)
+}
+func (g *floorMaskGrid) GetLineOfSight(from, to spatial.Position) []spatial.Position {
+	return g.base.GetLineOfSight(from, to)
+}
+func (g *floorMaskGrid) GetPositionsInRange(center spatial.Position, radius float64) []spatial.Position {
+	return filterFloorPositions(g.base.GetPositionsInRange(center, radius), g)
+}
+func filterFloorPositions(in []spatial.Position, grid *floorMaskGrid) []spatial.Position {
+	out := make([]spatial.Position, 0, len(in))
+	for _, pos := range in {
+		if grid.IsValidPosition(pos) {
+			out = append(out, pos)
+		}
+	}
+	return out
+}
+
+// floorMaskRoom closes the two gaps a masked Grid alone cannot express through
+// BasicRoom: a direct LoS ray crossing void must block, and envelope boundaries
+// may have an intentionally invalid void endpoint so are not registered as
+// ordinary two-floor boundaries.
+type floorMaskRoom struct {
+	*spatial.BasicRoom
+	grid *floorMaskGrid
+}
+
+func (r *floorMaskRoom) GetGrid() spatial.Grid { return r.grid }
+func (r *floorMaskRoom) GetLineOfSight(from, to spatial.Position) []spatial.Position {
+	ray := r.grid.GetLineOfSight(from, to)
+	out := make([]spatial.Position, 0, len(ray))
+	for _, pos := range ray {
+		if r.grid.IsValidPosition(pos) {
+			out = append(out, pos)
+		}
+	}
+	return out
+}
+func (r *floorMaskRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
+	if !r.grid.IsValidPosition(from) || !r.grid.IsValidPosition(to) {
+		return true
+	}
+	for _, pos := range r.grid.GetLineOfSight(from, to) {
+		if !r.grid.IsValidPosition(pos) {
+			return true
+		}
+	}
+	return r.BasicRoom.IsLineOfSightBlocked(from, to)
+}
+
+var _ spatial.Grid = (*floorMaskGrid)(nil)
+var _ spatial.BoundaryAwareRoom = (*floorMaskRoom)(nil)

--- a/encounter/floor_mask_attack_scope_test.go
+++ b/encounter/floor_mask_attack_scope_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	floorMaskDamageDice = "1d6"
 	floorMaskActionType = "action"
+	floorMaskAttackID   = "attack"
 )
 
 func scopedBoundsWithWall(t *testing.T, id core.EncounterID, broker *encounter.Broker) *encounter.Encounter {
@@ -76,7 +77,7 @@ func TestBoundsCanvasPlayerAttackPreservesV03BoundaryBehavior(t *testing.T) {
 	require.NoError(t, enc.SetMode(core.ModeTurnBased))
 	endTurnUntilActive(t, enc, aliceEntityID)
 	require.NoError(t, enc.TakeAction(alicePlayerID,
-		encounter.ActionRef{Module: "dnd5e", Type: floorMaskActionType, ID: "attack"},
+		encounter.ActionRef{Module: "dnd5e", Type: floorMaskActionType, ID: floorMaskAttackID},
 		encounter.ActionTarget{EntityID: gobEntityID},
 	))
 	require.Equal(t, 3, enc.ToData().Monsters[gobEntityID].HP,

--- a/encounter/floor_mask_attack_scope_test.go
+++ b/encounter/floor_mask_attack_scope_test.go
@@ -20,6 +20,7 @@ const (
 	floorMaskDamageDice = "1d6"
 	floorMaskActionType = "action"
 	floorMaskAttackID   = "attack"
+	floorMaskRefModule  = "dnd5e"
 )
 
 func scopedBoundsWithWall(t *testing.T, id core.EncounterID, broker *encounter.Broker) *encounter.Encounter {
@@ -77,7 +78,7 @@ func TestBoundsCanvasPlayerAttackPreservesV03BoundaryBehavior(t *testing.T) {
 	require.NoError(t, enc.SetMode(core.ModeTurnBased))
 	endTurnUntilActive(t, enc, aliceEntityID)
 	require.NoError(t, enc.TakeAction(alicePlayerID,
-		encounter.ActionRef{Module: "dnd5e", Type: floorMaskActionType, ID: floorMaskAttackID},
+		encounter.ActionRef{Module: floorMaskRefModule, Type: floorMaskActionType, ID: floorMaskAttackID},
 		encounter.ActionTarget{EntityID: gobEntityID},
 	))
 	require.Equal(t, 3, enc.ToData().Monsters[gobEntityID].HP,

--- a/encounter/floor_mask_attack_scope_test.go
+++ b/encounter/floor_mask_attack_scope_test.go
@@ -85,6 +85,31 @@ func TestBoundsCanvasPlayerAttackPreservesV03BoundaryBehavior(t *testing.T) {
 		"Wave A must not add a bounds/wall LoS gate to the established player attack path")
 }
 
+func TestRoomChainPlayerAttackPreservesV03Behavior(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+	enc := encounter.New(context.Background(), "room-chain-player", broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 4, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.InitRoom(2, 1, "empty"))
+	left := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	right := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: left, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: right, HP: 7, MaxHP: 7, AC: 12, Speed: 30,
+		MonsterRef: monsterRefGoblin, DataJSON: realGoblinJSON(t, gobEntityID),
+	}))
+	endTurnUntilActive(t, enc, aliceEntityID)
+	require.NoError(t, enc.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: floorMaskRefModule, Type: floorMaskActionType, ID: floorMaskAttackID},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	require.Equal(t, 3, enc.ToData().Monsters[gobEntityID].HP)
+}
+
 func TestBoundsCanvasNPCActionPreservesV03BoundaryBehavior(t *testing.T) {
 	transport, broker := newRangeGateBroker()
 	defer func() { _ = broker.Close(); _ = transport.Close() }()

--- a/encounter/floor_mask_attack_scope_test.go
+++ b/encounter/floor_mask_attack_scope_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
+const (
+	floorMaskDamageDice = "1d6"
+	floorMaskActionType = "action"
+)
+
 func scopedBoundsWithWall(t *testing.T, id core.EncounterID, broker *encounter.Broker) *encounter.Encounter {
 	t.Helper()
 	left := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
@@ -41,7 +46,7 @@ func realGoblinJSON(t *testing.T, id core.EntityID) []byte {
 func realRangedMonsterJSON(t *testing.T, id core.EntityID) []byte {
 	t.Helper()
 	config, err := json.Marshal(monsteractions.RangedConfig{
-		Name: "test-bow", AttackBonus: 4, DamageDice: "1d6", RangeNormal: 30,
+		Name: "test-bow", AttackBonus: 4, DamageDice: floorMaskDamageDice, RangeNormal: 30,
 		RangeLong: 120, DamageType: damage.Piercing,
 	})
 	require.NoError(t, err)
@@ -71,7 +76,7 @@ func TestBoundsCanvasPlayerAttackPreservesV03BoundaryBehavior(t *testing.T) {
 	require.NoError(t, enc.SetMode(core.ModeTurnBased))
 	endTurnUntilActive(t, enc, aliceEntityID)
 	require.NoError(t, enc.TakeAction(alicePlayerID,
-		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionRef{Module: "dnd5e", Type: floorMaskActionType, ID: "attack"},
 		encounter.ActionTarget{EntityID: gobEntityID},
 	))
 	require.Equal(t, 3, enc.ToData().Monsters[gobEntityID].HP,

--- a/encounter/floor_mask_attack_scope_test.go
+++ b/encounter/floor_mask_attack_scope_test.go
@@ -1,0 +1,107 @@
+package encounter_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	monsteractions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+func scopedBoundsWithWall(t *testing.T, id core.EncounterID, broker *encounter.Broker) *encounter.Encounter {
+	t.Helper()
+	left := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	right := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
+	enc := encounter.New(context.Background(), id, broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 4, damageType: damageSlashing}),
+	)
+	require.NoError(t, enc.InitDungeon(encounter.DungeonParams{
+		Key: string(id), FloorSource: encounter.FloorSourceCanvas, Width: 2, Height: 1,
+		PartyStart:    encounter.PartyStartParams{Anchor: &left, SeatCount: 1},
+		AuthoredEdges: []encounter.AuthoredEdge{{From: left, To: right, Kind: encounter.GeneratedEdgeKindSolid}},
+	}))
+	return enc
+}
+
+func realGoblinJSON(t *testing.T, id core.EntityID) []byte {
+	t.Helper()
+	raw, err := json.Marshal(monster.NewGoblin(string(id)).ToData())
+	require.NoError(t, err)
+	return raw
+}
+
+func realRangedMonsterJSON(t *testing.T, id core.EntityID) []byte {
+	t.Helper()
+	config, err := json.Marshal(monsteractions.RangedConfig{
+		Name: "test-bow", AttackBonus: 4, DamageDice: "1d6", RangeNormal: 30,
+		RangeLong: 120, DamageType: damage.Piercing,
+	})
+	require.NoError(t, err)
+	raw, err := json.Marshal(&monster.Data{
+		ID: string(id), Name: "Ranged Test Monster", HitPoints: 7, MaxHitPoints: 7, ArmorClass: 12,
+		Senses:  monster.SensesData{PassivePerception: 10},
+		Actions: []monster.ActionData{{Ref: *refs.MonsterActions.Ranged(), Config: config}},
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+func TestBoundsCanvasPlayerAttackPreservesV03BoundaryBehavior(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+	enc := scopedBoundsWithWall(t, "bounds-player-boundary", broker)
+	left := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	right := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: left, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14, DamageDice: damage1d8plus2, DamageType: damageSlashing,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: right, HP: 7, MaxHP: 7, AC: 12, Speed: 30,
+		MonsterRef: monsterRefGoblin, DataJSON: realGoblinJSON(t, gobEntityID),
+	}))
+	require.NoError(t, enc.SetMode(core.ModeTurnBased))
+	endTurnUntilActive(t, enc, aliceEntityID)
+	require.NoError(t, enc.TakeAction(alicePlayerID,
+		encounter.ActionRef{Module: "dnd5e", Type: "action", ID: "attack"},
+		encounter.ActionTarget{EntityID: gobEntityID},
+	))
+	require.Equal(t, 3, enc.ToData().Monsters[gobEntityID].HP,
+		"Wave A must not add a bounds/wall LoS gate to the established player attack path")
+}
+
+func TestBoundsCanvasNPCActionPreservesV03BoundaryBehavior(t *testing.T) {
+	transport, broker := newRangeGateBroker()
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+	enc := scopedBoundsWithWall(t, "bounds-npc-boundary", broker)
+	left := core.HexFromPosition(spatial.Position{X: 0, Y: 0})
+	right := core.HexFromPosition(spatial.Position{X: 1, Y: 0})
+	require.NoError(t, enc.AddPlayer(encounter.PlayerInput{
+		PlayerID: alicePlayerID, EntityID: aliceEntityID, Position: right, SightRange: 10,
+		HP: 12, MaxHP: 12, AC: 14,
+	}))
+	require.NoError(t, enc.AddMonster(encounter.MonsterInput{
+		ID: gobEntityID, Position: left, HP: 7, MaxHP: 7, AC: 12, Speed: 0,
+		MonsterRef: monsterRefGoblin, DataJSON: realRangedMonsterJSON(t, gobEntityID),
+	}))
+	snapshot := enc.ToData()
+	snapshot.Mode = core.ModeTurnBased
+	snapshot.Initiative = []core.EntityID{gobEntityID, aliceEntityID}
+	snapshot.ActiveIdx = 0
+	snapshot.Round = 1
+	loaded, err := encounter.LoadFromData(context.Background(), snapshot, broker,
+		encounter.WithCombatResolver(alwaysHitResolver{damage: 4, damageType: damageSlashing}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, loaded.NPCAct(context.Background(), gobEntityID))
+	require.Less(t, loaded.ToData().Players[alicePlayerID].HP, 12,
+		"real hydrated NPC action must retain bounds behavior; region-only mask gate must not suppress it")
+}

--- a/encounter/floor_mask_internal_test.go
+++ b/encounter/floor_mask_internal_test.go
@@ -1,0 +1,36 @@
+package encounter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type FloorMaskReachSuite struct{ suite.Suite }
+
+func TestFloorMaskReachSuite(t *testing.T) { suite.Run(t, new(FloorMaskReachSuite)) }
+
+func (s *FloorMaskReachSuite) TestTargetReachRejectsLineAcrossVoid() {
+	ctx := context.Background()
+	transport := NewInMemoryTransport()
+	broker := NewBroker(transport)
+	defer func() { _ = broker.Close(); _ = transport.Close() }()
+	enc := New(ctx, "floor-mask-reach", broker)
+	cells := [][2]int{{1, 1}, {1, 2}, {1, 3}, {2, 1}, {2, 3}, {3, 1}, {3, 2}, {3, 3}}
+	floor := make([]core.Hex, len(cells))
+	for index, cell := range cells {
+		floor[index] = core.HexFromPosition(spatial.Position{X: float64(cell[0]), Y: float64(cell[1])})
+	}
+	anchor := floor[0]
+	s.Require().NoError(enc.InitDungeon(DungeonParams{
+		FloorSource: FloorSourceCanvas, Width: 5, Height: 5, FloorCells: floor,
+		RequireConnectedFloor: true, PartyStart: PartyStartParams{Anchor: &anchor, SeatCount: 1},
+	}))
+	acrossVoid := core.HexFromPosition(spatial.Position{X: 3, Y: 3})
+	s.False(enc.hasClearStructuralReach(anchor, acrossVoid))
+	s.True(enc.hasClearStructuralReach(anchor, core.HexFromPosition(spatial.Position{X: 1, Y: 2})))
+}

--- a/encounter/floor_mask_internal_test.go
+++ b/encounter/floor_mask_internal_test.go
@@ -28,9 +28,15 @@ func (s *FloorMaskReachSuite) TestTargetReachRejectsLineAcrossVoid() {
 	anchor := floor[0]
 	s.Require().NoError(enc.InitDungeon(DungeonParams{
 		FloorSource: FloorSourceCanvas, Width: 5, Height: 5, FloorCells: floor,
-		RequireConnectedFloor: true, PartyStart: PartyStartParams{Anchor: &anchor, SeatCount: 1},
+		RequireConnectedFloor: false, PartyStart: PartyStartParams{Anchor: &anchor, SeatCount: 1},
 	}))
 	acrossVoid := core.HexFromPosition(spatial.Position{X: 3, Y: 3})
+	s.False(enc.ToData().Space.RequireConnectedFloor)
 	s.False(enc.hasClearStructuralReach(anchor, acrossVoid))
 	s.True(enc.hasClearStructuralReach(anchor, core.HexFromPosition(spatial.Position{X: 1, Y: 2})))
+	reloaded, err := LoadFromData(ctx, enc.ToData(), broker)
+	s.Require().NoError(err)
+	s.False(reloaded.ToData().Space.RequireConnectedFloor)
+	s.False(reloaded.hasClearStructuralReach(anchor, acrossVoid),
+		"persisted mask must reject target reach even when the mutable runnable flag is false")
 }

--- a/encounter/generated_edges.go
+++ b/encounter/generated_edges.go
@@ -26,10 +26,10 @@ const (
 // and doors use their threshold cell plus the designated passage neighbor.
 // DoorID is populated only when Kind is GeneratedEdgeKindDoor.
 type GeneratedEdge struct {
-	From   core.Hex
-	To     core.Hex
-	Kind   GeneratedEdgeKind
-	DoorID core.EntityID
+	From   core.Hex          `json:"from"`
+	To     core.Hex          `json:"to"`
+	Kind   GeneratedEdgeKind `json:"kind"`
+	DoorID core.EntityID     `json:"door_id,omitempty"`
 }
 
 // DescribeGeneratedEdgesInput reserves an explicit input boundary for the
@@ -105,6 +105,7 @@ type generatedEdgeRecord struct {
 	blocksMovement       bool
 	blocksLoS            bool
 	observeBothEndpoints bool
+	observationOwner     *core.Hex
 }
 
 type generatedEdgeKey struct {
@@ -210,6 +211,19 @@ func (e *Encounter) canonicalGeneratedEdgeRecordsWithOverlay(
 	}
 
 	if e.data.Space != nil {
+		floor := canvasFloorForSpace(e.data.Space)
+		for _, edge := range e.data.Space.EnvelopeEdges {
+			owner := edge.From
+			if _, ok := floor[owner]; !ok {
+				owner = edge.To
+			}
+			record := generatedEdgeRecord{
+				edge: edge, blocksMovement: true, blocksLoS: true, observationOwner: &owner,
+			}
+			if err := add(record); err != nil {
+				return nil, err
+			}
+		}
 		for _, wall := range e.data.Space.Walls {
 			if !wall.BlocksMovement && !wall.BlocksLoS {
 				continue

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.70.2-0.20260804104832-df6a2f5171ef
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.2-0.20260804121443-8f30f27a61ae
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.2-0.20260804121443-8f30f27a61ae h1:ZrItdvQvqnVcv5zERWaWeigJbgRWOAt359HUk3o9T8U=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.5.2-0.20260804121443-8f30f27a61ae/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857 h1:cVyWXDe/fEaQLwyub4N732O/juf0tkzQCUR1rwJz8PY=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/encounter/knowledge.go
+++ b/encounter/knowledge.go
@@ -384,7 +384,11 @@ func (e *Encounter) edgesByHex() (map[core.Hex][]perception.Edge, error) {
 			observed.DoorOpen = door.Open
 			observed.DoorLocked = door.Locked
 		}
-		out[edge.From] = append(out[edge.From], observed)
+		owner := edge.From
+		if record.observationOwner != nil {
+			owner = *record.observationOwner
+		}
+		out[owner] = append(out[owner], observed)
 		if record.observeBothEndpoints && edge.From != edge.To {
 			out[edge.To] = append(out[edge.To], observed)
 		}

--- a/encounter/load_actor_validation_test.go
+++ b/encounter/load_actor_validation_test.go
@@ -12,9 +12,19 @@ import (
 
 func TestLoadFromDataRejectsNullActorMapEntriesBeforeHydration(t *testing.T) {
 	cases := []struct{ name, raw, want string }{
-		{name: "null player", raw: `{"id":"nil-player","players":{"alice":null}}`, want: `validate player "alice": null player state`},
-		{name: "missing player view", raw: `{"id":"nil-view","players":{"alice":{"id":"alice","entity_id":"alice"}}}`, want: `validate player "alice": view is required`},
-		{name: "null monster", raw: `{"id":"nil-monster","monsters":{"goblin":null}}`, want: `validate monster "goblin": null monster state`},
+		{
+			name: "null player", raw: `{"id":"nil-player","players":{"alice":null}}`,
+			want: `validate player "alice": null player state`,
+		},
+		{
+			name: "missing player view",
+			raw:  `{"id":"nil-view","players":{"alice":{"id":"alice","entity_id":"alice"}}}`,
+			want: `validate player "alice": view is required`,
+		},
+		{
+			name: "null monster", raw: `{"id":"nil-monster","monsters":{"goblin":null}}`,
+			want: `validate monster "goblin": null monster state`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/encounter/load_actor_validation_test.go
+++ b/encounter/load_actor_validation_test.go
@@ -1,0 +1,31 @@
+package encounter_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+)
+
+func TestLoadFromDataRejectsNullActorMapEntriesBeforeHydration(t *testing.T) {
+	cases := []struct{ name, raw, want string }{
+		{name: "null player", raw: `{"id":"nil-player","players":{"alice":null}}`, want: `validate player "alice": null player state`},
+		{name: "missing player view", raw: `{"id":"nil-view","players":{"alice":{"id":"alice","entity_id":"alice"}}}`, want: `validate player "alice": view is required`},
+		{name: "null monster", raw: `{"id":"nil-monster","monsters":{"goblin":null}}`, want: `validate monster "goblin": null monster state`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var data encounter.Data
+			require.NoError(t, json.Unmarshal([]byte(tc.raw), &data))
+			transport := encounter.NewInMemoryTransport()
+			broker := encounter.NewBroker(transport)
+			t.Cleanup(func() { _ = broker.Close(); _ = transport.Close() })
+			loaded, err := encounter.LoadFromData(context.Background(), &data, broker)
+			require.Nil(t, loaded)
+			require.EqualError(t, err, tc.want)
+		})
+	}
+}

--- a/encounter/npc.go
+++ b/encounter/npc.go
@@ -427,6 +427,9 @@ func (e *Encounter) applyCapturedAttacks(
 		// One out-of-reach swing (e.g. a target that Disengaged mid-turn, if
 		// that ever lands) simply doesn't connect; any other captured
 		// attacks in this turn still resolve normally.
+		if !e.hasClearStructuralReach(mon.Position, targetPlayer.View.Position) {
+			continue
+		}
 		if atk.IsMelee {
 			reach := meleeReachForCombatant(e.combatantFor(mon.ID))
 			if checkReach(mon.Position, targetPlayer.View.Position, reach, "reach") != nil {
@@ -1055,6 +1058,9 @@ func (e *Encounter) npcActScripted(_ context.Context, mon *MonsterData) error {
 	// returning an error here would make an out-of-reach monster wedge the
 	// encounter forever (every retry hits the identical rejection). A
 	// monster that can't reach anyone simply passes its turn.
+	if !e.hasClearStructuralReach(mon.Position, target.View.Position) {
+		return nil
+	}
 	reach := meleeReachForCombatant(e.combatantFor(mon.ID))
 	if checkReach(mon.Position, target.View.Position, reach, "reach") != nil {
 		return nil

--- a/encounter/perception/los_stub.go
+++ b/encounter/perception/los_stub.go
@@ -42,8 +42,11 @@ func VisibleHexesAt(from core.Hex, sightRange int, room spatial.Room) core.HexSe
 				continue
 			}
 			h := core.Hex{Q: from.Q + dq, R: from.R + dr, S: from.S + ds}
-			if room != nil && room.IsLineOfSightBlocked(fromPos, h.ToPosition()) {
-				continue
+			if room != nil {
+				targetPos := h.ToPosition()
+				if !room.GetGrid().IsValidPosition(targetPos) || room.IsLineOfSightBlocked(fromPos, targetPos) {
+					continue
+				}
 			}
 			out[h] = struct{}{}
 		}
@@ -62,8 +65,11 @@ func CanSeeAt(viewer *View, target core.Hex, room spatial.Room) bool {
 	if HexDistance(viewer.Position, target) > viewer.SightRange {
 		return false
 	}
-	if room != nil && room.IsLineOfSightBlocked(viewer.Position.ToPosition(), target.ToPosition()) {
-		return false
+	if room != nil {
+		targetPos := target.ToPosition()
+		if !room.GetGrid().IsValidPosition(targetPos) || room.IsLineOfSightBlocked(viewer.Position.ToPosition(), targetPos) {
+			return false
+		}
 	}
 	return true
 }

--- a/encounter/range_gate.go
+++ b/encounter/range_gate.go
@@ -79,7 +79,7 @@ func checkReach(from, to core.Hex, limit int, label string) error {
 }
 
 func (e *Encounter) hasClearStructuralReach(from, to core.Hex) bool {
-	if e.room == nil {
+	if e.room == nil || e.data == nil || e.data.Space == nil || !e.data.Space.RequireConnectedFloor {
 		return true
 	}
 	grid := e.room.GetGrid()

--- a/encounter/range_gate.go
+++ b/encounter/range_gate.go
@@ -78,6 +78,16 @@ func checkReach(from, to core.Hex, limit int, label string) error {
 	return nil
 }
 
+func (e *Encounter) hasClearStructuralReach(from, to core.Hex) bool {
+	if e.room == nil {
+		return true
+	}
+	grid := e.room.GetGrid()
+	fromPosition, toPosition := from.ToPosition(), to.ToPosition()
+	return grid.IsValidPosition(fromPosition) && grid.IsValidPosition(toPosition) &&
+		!e.room.IsLineOfSightBlocked(fromPosition, toPosition)
+}
+
 // checkInteractReach gates legacy generated-door verbs on the actor being
 // adjacent to the door's single blocked cell.
 func checkInteractReach(actorPos, doorPos core.Hex) error {

--- a/encounter/range_gate.go
+++ b/encounter/range_gate.go
@@ -79,13 +79,20 @@ func checkReach(from, to core.Hex, limit int, label string) error {
 }
 
 func (e *Encounter) hasClearStructuralReach(from, to core.Hex) bool {
-	if e.room == nil || e.data == nil || e.data.Space == nil || !e.data.Space.RequireConnectedFloor {
+	if e.room == nil {
 		return true
 	}
 	grid := e.room.GetGrid()
 	fromPosition, toPosition := from.ToPosition(), to.ToPosition()
-	return grid.IsValidPosition(fromPosition) && grid.IsValidPosition(toPosition) &&
-		!e.room.IsLineOfSightBlocked(fromPosition, toPosition)
+	if !grid.IsValidPosition(fromPosition) || !grid.IsValidPosition(toPosition) {
+		return false
+	}
+	for _, position := range grid.GetLineOfSight(fromPosition, toPosition) {
+		if !grid.IsValidPosition(position) {
+			return false
+		}
+	}
+	return true
 }
 
 // checkInteractReach gates legacy generated-door verbs on the actor being

--- a/encounter/seed_monsters.go
+++ b/encounter/seed_monsters.go
@@ -329,7 +329,8 @@ func (e *Encounter) validateAbsoluteCanvasSpawn(
 	if e.data.Space == nil || e.data.Space.FloorSource != FloorSourceCanvas {
 		return resolvedSpawn{}, fmt.Errorf("canvas monster %q: no canvas dungeon initialized", spawn.MonsterRef)
 	}
-	if !canvasFloorContainsDimensions(e.data.Space.Width, e.data.Space.Height, *spawn.AbsoluteAt) {
+	floor := canvasFloorForSpace(e.data.Space)
+	if _, ok := floor[*spawn.AbsoluteAt]; !ok {
 		return resolvedSpawn{}, fmt.Errorf(
 			"canvas monster %q: absolute position %v is outside canvas floor", spawn.MonsterRef, *spawn.AbsoluteAt)
 	}

--- a/encounter/semantic_regions.go
+++ b/encounter/semantic_regions.go
@@ -237,6 +237,9 @@ func validateSemanticRegionParams(
 	}
 	for i := range out {
 		for j := i + 1; j < len(out); j++ {
+			if len(out[i].Cells) == len(out[j].Cells) && hexSetContains(out[i].Cells, out[j].Cells) {
+				return nil, fmt.Errorf("semantic regions %q and %q have equal cell sets", out[i].ID, out[j].ID)
+			}
 			if len(out[i].Cells) == 0 || len(out[j].Cells) == 0 {
 				continue
 			}

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -110,20 +110,97 @@ func snapshotWalls(room spatial.Room) []environments.WallSegmentData {
 // validateCanvasSpace validates the durable canvas floor and semantic facts as
 // one snapshot. Viewer ZoneIDs are validated against the same immutable scope
 // set, never against a coordinate-derived replacement.
-func validateCanvasSpace(space *SpaceData, players map[core.PlayerID]*PlayerData) error {
+func validateCanvasSpace(
+	space *SpaceData,
+	players map[core.PlayerID]*PlayerData,
+	monsters map[core.EntityID]*MonsterData,
+) error {
 	if _, err := ValidateCanvasDimensions(space.Width, space.Height); err != nil {
 		return fmt.Errorf("validate canvas dimensions: %w", err)
 	}
 	if len(space.Regions) != 0 {
 		return fmt.Errorf("canvas space must not contain room-chain regions")
 	}
-	if err := validateSemanticRegionData(space.SemanticRegions, canvasFloorHexes(space.Width, space.Height)); err != nil {
+	if space.FloorCells != nil {
+		if err := validateCanonicalFloorCells(space.Width, space.Height, space.FloorCells); err != nil {
+			return fmt.Errorf("validate floor cells: %w", err)
+		}
+	}
+	floor := canvasFloorForSpace(space)
+	if space.RequireConnectedFloor {
+		if len(floor) == 0 {
+			return fmt.Errorf("structural floor must not be empty")
+		}
+		for anchor := range floor {
+			if len(connectedFloorComponent(anchor, floor)) != len(floor) {
+				return fmt.Errorf("structural floor must be connected")
+			}
+			break
+		}
+	}
+	if space.FloorCells != nil || space.EnvelopeEdges != nil {
+		if err := validateEnvelopeEdges(floor, space.EnvelopeEdges); err != nil {
+			return fmt.Errorf("validate envelope: %w", err)
+		}
+	}
+	if err := validateSemanticRegionData(space.SemanticRegions, floor); err != nil {
 		return fmt.Errorf("validate semantic regions: %w", err)
+	}
+	if _, ok := floor[space.Entrance]; !ok {
+		return fmt.Errorf("entrance %v is outside structural floor", space.Entrance)
+	}
+	for index, seat := range space.PartyStartPositions {
+		if _, ok := floor[seat]; !ok {
+			return fmt.Errorf("party start position %d %v is outside structural floor", index, seat)
+		}
+	}
+	for _, obstacle := range space.Obstacles {
+		if _, ok := floor[obstacle.Position]; !ok {
+			return fmt.Errorf("obstacle %q at %v is outside structural floor", obstacle.ID, obstacle.Position)
+		}
+	}
+	for id, player := range players {
+		if player == nil || player.View == nil {
+			continue
+		}
+		if _, ok := floor[player.View.Position]; !ok {
+			return fmt.Errorf("player %q at %v is outside structural floor", id, player.View.Position)
+		}
+		for known := range player.View.Memory {
+			if _, ok := floor[known]; !ok {
+				return fmt.Errorf("player %q known hex %v is outside structural floor", id, known)
+			}
+		}
+	}
+	for id, monster := range monsters {
+		if monster == nil {
+			continue
+		}
+		if _, ok := floor[monster.Position]; !ok {
+			return fmt.Errorf("monster %q at %v is outside structural floor", id, monster.Position)
+		}
 	}
 	if err := validateObservedZoneIDs(players, space); err != nil {
 		return fmt.Errorf("validate viewer zone observations: %w", err)
 	}
 	return nil
+}
+
+func newEncounterSpatialRoom(
+	id core.EncounterID,
+	space *SpaceData,
+	source FloorSourceKind,
+) (spatial.Room, spatial.Grid) {
+	if source == FloorSourceCanvas {
+		grid := newFloorMaskGrid(space.Width, space.Height, canvasFloorForSpace(space))
+		base := spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: string(id), Type: "encounter_room", Grid: grid})
+		return &floorMaskRoom{BasicRoom: base, grid: grid}, grid
+	}
+	grid := spatial.NewHexGrid(spatial.HexGridConfig{
+		Width: float64(space.Width), Height: float64(space.Height), Orientation: spatial.HexOrientationPointyTop,
+	})
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: string(id), Type: "encounter_room", Grid: grid})
+	return room, grid
 }
 
 // registerRoom wires room into a fresh orchestrator for this Encounter
@@ -171,7 +248,7 @@ func (e *Encounter) rebuildRoomFromData() error {
 		return fmt.Errorf("validate floor source: %w", err)
 	}
 	if source == FloorSourceCanvas {
-		if err := validateCanvasSpace(sd, e.data.Players); err != nil {
+		if err := validateCanvasSpace(sd, e.data.Players, e.data.Monsters); err != nil {
 			return err
 		}
 	}
@@ -179,16 +256,7 @@ func (e *Encounter) rebuildRoomFromData() error {
 	if _, err := e.canonicalGeneratedEdgeRecordsWithOverlay(authoredByKey); err != nil {
 		return fmt.Errorf("validate effective generated edges: %w", err)
 	}
-	grid := spatial.NewHexGrid(spatial.HexGridConfig{
-		Width:       float64(sd.Width),
-		Height:      float64(sd.Height),
-		Orientation: spatial.HexOrientationPointyTop,
-	})
-	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
-		ID:   string(e.data.ID),
-		Type: "encounter_room",
-		Grid: grid,
-	})
+	room, grid := newEncounterSpatialRoom(e.data.ID, sd, source)
 	placed := make(map[spatial.CubeCoordinate]struct{}, len(sd.Walls)+len(e.data.Doors))
 	// placeWallBlocker places (or, if cube is already occupied, no-ops) an
 	// indestructible blocking WallEntity at cube — shared by both the
@@ -298,7 +366,7 @@ func (e *Encounter) rebuildRoomFromData() error {
 			if !blocks {
 				continue // Open authored doors deliberately register no blocker.
 			}
-			if err := room.RegisterBoundary(spatial.Boundary{
+			if err := room.(spatial.BoundaryAwareRoom).RegisterBoundary(spatial.Boundary{
 				From:              edge.From.ToPosition(),
 				To:                edge.To.ToPosition(),
 				BlocksMovement:    true,

--- a/encounter/space.go
+++ b/encounter/space.go
@@ -358,6 +358,10 @@ func (e *Encounter) rebuildRoomFromData() error {
 		}
 	}
 	if len(sd.AuthoredEdges) > 0 {
+		boundaryRoom, ok := room.(spatial.BoundaryAwareRoom)
+		if !ok {
+			return fmt.Errorf("spatial room does not support authored boundaries")
+		}
 		for _, edge := range sd.AuthoredEdges {
 			blocks := edge.Kind == GeneratedEdgeKindSolid
 			if edge.Kind == GeneratedEdgeKindDoor {
@@ -366,7 +370,7 @@ func (e *Encounter) rebuildRoomFromData() error {
 			if !blocks {
 				continue // Open authored doors deliberately register no blocker.
 			}
-			if err := room.(spatial.BoundaryAwareRoom).RegisterBoundary(spatial.Boundary{
+			if err := boundaryRoom.RegisterBoundary(spatial.Boundary{
 				From:              edge.From.ToPosition(),
 				To:                edge.To.ToPosition(),
 				BlocksMovement:    true,

--- a/tools/spatial/query_handler.go
+++ b/tools/spatial/query_handler.go
@@ -146,6 +146,19 @@ func (h *SpatialQueryHandler) handleMovement(_ context.Context, data *QueryMovem
 	// with registered boundaries additionally reject any blocked consecutive
 	// crossing in the direct ray.
 	data.Valid = room.CanPlaceEntity(data.Entity, data.To)
+	if data.Valid {
+		previous := data.From
+		for index, step := range data.Path {
+			startsAtOrigin := index == 0 && step.Equals(data.From)
+			requiresAdjacentSteps := room.GetGrid().GetShape() != GridShapeGridless
+			if !room.GetGrid().IsValidPosition(step) ||
+				(requiresAdjacentSteps && !startsAtOrigin && !room.GetGrid().IsAdjacent(previous, step)) {
+				data.Valid = false
+				break
+			}
+			previous = step
+		}
+	}
 	if data.Valid && hasBoundaries {
 		for i := 1; i < len(data.Path); i++ {
 			if boundaryRoom.IsBoundaryMovementBlocked(data.Path[i-1], data.Path[i]) {

--- a/tools/spatial/query_handler_test.go
+++ b/tools/spatial/query_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/events"
@@ -347,4 +348,33 @@ func (s *QueryHandlerTestSuite) TestFilterFactories() {
 // Run the test suite
 func TestQueryHandlerSuite(t *testing.T) {
 	suite.Run(t, new(QueryHandlerTestSuite))
+}
+
+type movementMaskGrid struct {
+	*spatial.HexGrid
+	void spatial.Position
+}
+
+func (g *movementMaskGrid) IsValidPosition(position spatial.Position) bool {
+	return !position.Equals(g.void) && g.HexGrid.IsValidPosition(position)
+}
+
+func TestQueryMovementRejectsInvalidIntermediateWithoutBreakingRay(t *testing.T) {
+	base := spatial.NewHexGrid(spatial.HexGridConfig{
+		Width: 5, Height: 5, Orientation: spatial.HexOrientationPointyTop,
+	})
+	grid := &movementMaskGrid{HexGrid: base, void: spatial.Position{X: 2, Y: 2}}
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: "masked-query", Type: "room", Grid: grid})
+	handler := spatial.NewSpatialQueryHandler()
+	handler.RegisterRoom(room)
+	from, to := spatial.Position{X: 1, Y: 1}, spatial.Position{X: 3, Y: 3}
+	valid, path, _, err := spatial.NewQueryUtils(handler).QueryMovement(
+		context.Background(), NewMockEntity("walker", "character"), from, to, room.GetID(),
+	)
+	require.NoError(t, err)
+	require.False(t, valid)
+	require.Contains(t, path, grid.void)
+	for index := 1; index < len(path); index++ {
+		require.True(t, base.IsAdjacent(path[index-1], path[index]))
+	}
 }


### PR DESCRIPTION
## Summary

Implements RATIFIED Dungeon YAML v0.4 Wave A as one canonical region-union floor authority across standalone compilation, runtime mechanics, persistence, reload, and projection.

Closes #897

## Public provider seam

`encounter/dungeonspec.CompileDungeon(ctx, *CompileDungeonInput) (*CompileDungeonOutput, error)` accepts only:

- complete standalone `Source []byte`
- `CompileModeDraft | CompileModeStrict`
- `PartyStartSeatCount`
- `PreviewSeed`

It accepts no previous compiled state and no source/display name. Success returns `CompiledDungeon` plus `*FloorPlan`; authored failures return ordered `[]FieldError{Field, Message, Code}`; infrastructure/cancellation failures remain Go errors. The floor plan carries resolved `bounds|regions`, sorted complete cells, declared regions plus derived parents, optional entrance, and canonical complete pair edges with stable authored-door identities.

## What changed

- Strict decode for optional `canvas.floor_source`; omission/`bounds` preserves the v0.3 rectangle and `regions` compiles the deduplicated region-cell union. The structural path walk expands yaml.v3 `<<` merges (alias and sequence-of-alias forms), reports merged unknown fields at the receiving canonical path, and uses an active-node guard so generic/merge alias self- or multi-node cycles return typed `invalid_yaml` instead of recursing.
- Equal/partially overlapping region sets reject at exact paths, including duplicate empty sets; same-region duplicates canonicalize.
- Draft relaxation applies only to `floor_source: regions`: it projects empty/tiny/disconnected masks and complete envelopes with optional entrance. Omitted/explicit `bounds` retains the v0.3 runtime-backed `BuildFloorPlan` gate in both modes. Strict regions require nonempty connected floor and a same-component complete PartyCap reservation; Draft params cannot bypass that by calling `InitDungeon`.
- Every candidate compiles standalone. The native seam never calls `LoadWithPrevious`; deletions/shrinks are judged only from the submitted complete source.
- `DungeonParams.FloorCells/EnvelopeEdges` carry floor authority into start; `RequireConnectedFloor` is only the strict runnable-start/reload gate. `SpaceData` persists the exact canonical mask/envelope/gate, party seats, edges, regions and entities; reload validates that snapshot without authored YAML.
- A masked room grid makes void invalid for placement, pathing/movement, monster traversal, region-floor target reachability, LoS, visibility and fog. Public Room rays retain contiguous intermediate void cells and spatial `QueryMovement` rejects any invalid/discontinuous ray; `encounter` now consumes the same-branch spatial module fix. Target reach validates both endpoints and every direct-ray position against the persisted room grid, regardless of `RequireConnectedFloor`, and deliberately does not consult walls/boundaries; sparse-mask void rejects while established room-chain/bounds barrier attack behavior is preserved. Envelope knowledge attaches only to its one floor owner; no void record is created.
- Room-chain behavior remains unchanged. New bounds canvases explicitly persist their rectangle/envelope; legacy snapshots that omit them retain v0.3 rectangle reload behavior. Reload rejects nil player/monster entries, missing player views, and duplicate equal semantic sets (including two empty sets) as ordinary errors before hydration.
- ADR-0035 and encounter/status docs record the lifecycle.

## Discriminating tests

`encounter/dungeonspec/wave_a_test.go` covers:

- omitted-start 5x5 region ring = first canonical PartyCap-capable `[1,1]`, exactly 8 sorted cells and 28 complete envelope pairs (22 exterior + six-edge hole), one floor owner per pair
- rim fixture with actual negative/off-bound neighbor coordinates
- tiny Draft success + nil entrance and Strict rejection
- disconnected Draft projection + first canonical qualifying entrance, direct-start/Strict rejection, then strict success after deleting island B
- omission/bounds regression, including first canonical PartyCap-capable omitted start and occupied-1x1 Draft failure
- standalone complete-candidate deletion/shrink
- structural exact paths/codes for root shape, unknown root/nested fields, invalid indexed values, every representative room-chain field (`rooms[0].place[0].at`, boss, connector, wall, start), and removed canvas content (no prose parsing); valid ordinary/merge aliases, invalid merged-field fixtures, and self-/multi-node alias-cycle regressions
- duplicate empty regions exact path/code
- strict start plus exact persisted entrance/seats, prop, real hydratable monster, door, mask/envelope; unrelated recompilation is shown not to mutate that snapshot
- void rejection for direct player placement, obstacle placement, movement/sparse path, target visibility/reachability, LoS and fog; public contiguous Room ray + `QueryMovement` rejection; adversarial explicit-mask InitDungeon + reload with `RequireConnectedFloor:false`; public real-data player/NPC bounds and room-chain action compatibility

Existing canvas, room-chain, authored edge, movement, visibility and encounter suites remain green.

## Consolidated REQUEST_CHANGES correction

The review passes removed regex/message inference in favor of typed authored errors at every general/room-chain/canvas validation source plus a merge-aware reflective YAML node/path walk; corrected Draft bounds lifecycle and pointer input; added snapshot duplicate/nil-state validation; fixed the public spatial movement ray seam; made persisted grid validity—not the mutable strict-start flag or walls—the target-reach authority; strengthened every requested lifecycle fixture; and use real monster data on Wave A/NPC paths. No registry-replacement behavior is claimed or implemented.

## Checks

- `cd encounter && go build ./...` — PASS
- `cd encounter && go vet ./...` — PASS
- `cd encounter && go test ./...` — PASS
- `cd encounter && go test -race ./...` — PASS
- `cd encounter && go mod tidy` — no diff
- `encounter`: `golangci-lint run --config=../.golangci.yml ./...` — no new/non-goconst findings; only the current main's 77 repository-wide `goconst` findings
- `tools/spatial`: native test/race/build/vet PASS; lint has only its 22 pre-existing `goconst` findings
- `git diff --check` — PASS
- root `make pre-commit` — core/events fmt/tidy/lint and core race tests PASS, then the known coverage-parser defect misreads the `core/mock` output as a numeric percentage and exits with shell syntax errors (unchanged by this encounter/spatial PR)

## #896 overlap

PR #896 landed on `main` as `105c841` during the final re-review. This branch merged updated `origin/main` exactly once in `dfc0392` (never rebased or cherry-picked). Conflict resolution preserves #896's deletion of `npcActScripted`, targeting fields/strategy/rationale, required real monster data, and the mask gate only in the real `applyCapturedAttacks` path, while retaining this PR's persisted floor authority and typed exact-path targeting validation.

## Downstream API adjustment

At approved rpg-api head `60db039ce2ddd710ad5c15e18c07a8d092a28c2c`, replace the temporary `LoadWithConfig` + `buildFloorPlan` adapter composition with one call to the native seam above. Map `CompileMode`, `FieldError`, `FloorSource`, and floor-plan records field-for-field; do not parse messages. `FloorPlan.Entrance` is now `*dungeonspec.FloorPlanCell`, so the adapter's current value-taking `floorPlanCellPtrFromProvider` helper must accept the provider pointer (or map it directly). Keep API source/display name as API metadata; it is intentionally absent from toolkit output.

— rpg-toolkit agent, on behalf of KirkDiggler




