### PR TITLE
feat(core): add EntityID shared identity newtype

### DIFF
--- a/core/entity.go
+++ b/core/entity.go
@@ -4,6 +4,13 @@
 // Package core provides the fundamental interfaces and types for the RPG toolkit.
 package core
 
+// EntityID is the shared identity value for game entities across toolkit
+// modules. Leaf modules (play/*) key members, subjects, and audiences by
+// EntityID so composition layers never pay a conversion tax between
+// module-local ID newtypes. Entity.GetID() remains string for
+// compatibility; EntityID(entity.GetID()) bridges.
+type EntityID string
+
 // EntityType identifies the category of an entity.
 // Rulebooks and modules define constants of this type for their entities.
 type EntityType string

--- a/core/entity_test.go
+++ b/core/entity_test.go
@@ -150,3 +150,14 @@ func TestEntity_NilHandling(t *testing.T) {
 	// This should panic
 	_ = entity.GetID()
 }
+
+func TestEntityIDIsStringNewtype(t *testing.T) {
+	id := core.EntityID("goblin-1")
+	if string(id) != "goblin-1" {
+		t.Fatalf("EntityID round-trip: got %q", string(id))
+	}
+	var zero core.EntityID
+	if zero != "" {
+		t.Fatalf("zero EntityID should be empty string")
+	}
+}

--- a/core/entity_test.go
+++ b/core/entity_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -151,7 +152,8 @@ func TestEntity_NilHandling(t *testing.T) {
 	_ = entity.GetID()
 }
 
-func TestEntityIDIsStringNewtype(t *testing.T) {
+// TestEntityID_StringNewtype verifies EntityID is a distinct named string type, not an alias.
+func TestEntityID_StringNewtype(t *testing.T) {
 	id := core.EntityID("goblin-1")
 	if string(id) != "goblin-1" {
 		t.Fatalf("EntityID round-trip: got %q", string(id))
@@ -159,5 +161,11 @@ func TestEntityIDIsStringNewtype(t *testing.T) {
 	var zero core.EntityID
 	if zero != "" {
 		t.Fatalf("zero EntityID should be empty string")
+	}
+	// Critical: verify it's a distinct named type, not an alias.
+	// If EntityID were defined as `type EntityID = string`, this assertion would fail
+	// because reflect would report "string", defeating the type's purpose.
+	if got := reflect.TypeOf(id).Name(); got != "EntityID" {
+		t.Fatalf("EntityID should be a distinct named type, not an alias; reflect reports %q", got)
 	}
 }


### PR DESCRIPTION
Additive string newtype; shared identity vocabulary for the play/ leaf family per docs/ideas/play/clock/design.md (Prerequisite section). No behavior change to any existing code.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)