### PR TITLE
feat(play/clock): Turn + Tick clocks, Milestone vocabulary, Transfer

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,0 +1,26 @@
+name: API Compatibility
+
+on:
+  pull_request:
+    paths:
+      - 'play/clock/**'
+
+jobs:
+  gorelease-play-clock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: gorelease play/clock
+        run: |
+          base=$(git tag -l 'play/clock/v*' --sort=-v:refname | head -1)
+          if [ -z "$base" ]; then
+            echo "no play/clock tag yet — first release, gate activates from the first tag"
+            exit 0
+          fi
+          cd play/clock
+          go run golang.org/x/exp/cmd/gorelease@latest -base "${base#play/clock/}"

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -23,4 +23,4 @@ jobs:
             exit 0
           fi
           cd play/clock
-          go run golang.org/x/exp/cmd/gorelease@latest -base "${base#play/clock/}"
+          go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base "${base#play/clock/}"

--- a/play/clock/doc.go
+++ b/play/clock/doc.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package clock provides scheduling policies for live play: who may act,
+// and what advances time. Two concrete clocks — Turn (a localized
+// initiative bubble) and Tick (the player-driven world clock) — plus the
+// Milestone vocabulary their verbs return and the Transfer helper that
+// moves an entity between clocks atomically.
+//
+// Design contract: docs/ideas/play/clock/design.md (R1–R10). This is a
+// leaf module: it depends only on core, takes no context.Context, returns
+// milestones as values, and never publishes.
+package clock

--- a/play/clock/dos2_test.go
+++ b/play/clock/dos2_test.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock_test
+
+// The DOS2 split-party scenario (design AC1): four players on the world
+// tick; two trigger a turn-based bubble; the distant pair keeps accruing
+// from their own moves; one wanders close and falls in at a
+// rulebook-chosen position; the round wraps; the fight ends; everyone
+// returns to the world clock. Asserts the full milestone transcript and
+// final state.
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDOS2SplitParty(t *testing.T) {
+	const (
+		alice  core.EntityID = "alice"
+		bob    core.EntityID = "bob"
+		carl   core.EntityID = "carl"
+		dana   core.EntityID = "dana"
+		goblin core.EntityID = "goblin"
+	)
+	world, err := clock.NewTick()
+	require.NoError(t, err)
+	var transcript []clock.Milestone
+	record := func(ms []clock.Milestone) { transcript = append(transcript, ms...) }
+
+	// Everyone free-roams: four players and a goblin on the world clock.
+	for _, id := range []core.EntityID{alice, bob, carl, dana, goblin} {
+		out, jerr := world.Join(&clock.JoinInput{ID: id})
+		require.NoError(t, jerr)
+		record(out.Milestones)
+	}
+
+	// Alice and Bob trigger a fight with the goblin: bubble forms.
+	// (Trigger detection is the composition's business; here the rulebook
+	// has rolled initiative.)
+	bubble := &clock.Turn{}
+	for _, id := range []core.EntityID{alice, goblin, bob} {
+		out, lerr := world.Leave(&clock.LeaveInput{ID: id})
+		require.NoError(t, lerr)
+		record(out.Milestones)
+	}
+	out, err := bubble.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{alice, goblin, bob}})
+	require.NoError(t, err)
+	record(out.Milestones)
+
+	// The distant pair keeps exploring: their own moves drive the world.
+	adv, err := world.Advance(&clock.AdvanceInput{Driver: carl, Displacement: 3})
+	require.NoError(t, err)
+	record(adv.Milestones)
+	// carl is both driver and member; the grant reaches every member (design: Tick)
+	require.Equal(t, []core.EntityID{carl, dana}, adv.Ready, "the distant pair accrues while the fight runs")
+
+	// A round of combat in the bubble.
+	for _, actor := range []core.EntityID{alice, goblin} {
+		end, eerr := bubble.End(&clock.EndInput{Actor: actor})
+		require.NoError(t, eerr)
+		record(end.Milestones)
+	}
+
+	// Carl wanders too close and falls in, slotted after the goblin.
+	tr, err := clock.Transfer(&clock.TransferInput{From: world, To: bubble, ID: carl, Pos: 2})
+	require.NoError(t, err)
+	record(tr.Milestones)
+	inBubble, err := bubble.Contains(&clock.ContainsInput{ID: carl})
+	require.NoError(t, err)
+	require.True(t, inBubble)
+
+	// Bob closes the round: the bubble wraps into round 2 with carl in the
+	// order — AC1's "rounds advance with End" exercised across a wrap.
+	end, err := bubble.End(&clock.EndInput{Actor: bob})
+	require.NoError(t, err)
+	require.True(t, end.RoundWrapped)
+	record(end.Milestones)
+
+	// Fight ends: dissolve and re-home everyone to the world clock.
+	dis, err := bubble.Dissolve(&clock.DissolveInput{})
+	require.NoError(t, err)
+	record(dis.Milestones)
+	require.ElementsMatch(t, []core.EntityID{alice, goblin, bob, carl}, dis.Members)
+	for _, id := range dis.Members {
+		out, jerr := world.Join(&clock.JoinInput{ID: id})
+		require.NoError(t, jerr)
+		record(out.Milestones)
+	}
+
+	// Final state: everyone back on the world clock; bubble idle.
+	members, err := world.Members()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []core.EntityID{alice, bob, carl, dana, goblin}, members)
+	_, err = bubble.Active()
+	require.ErrorIs(t, err, clock.ErrIdle)
+
+	// The transcript is API: assert it end to end.
+	require.Equal(t, []clock.Milestone{
+		{Kind: clock.MemberJoined, Subject: alice},
+		{Kind: clock.MemberJoined, Subject: bob},
+		{Kind: clock.MemberJoined, Subject: carl},
+		{Kind: clock.MemberJoined, Subject: dana},
+		{Kind: clock.MemberJoined, Subject: goblin},
+		{Kind: clock.MemberLeft, Subject: alice},
+		{Kind: clock.MemberLeft, Subject: goblin},
+		{Kind: clock.MemberLeft, Subject: bob},
+		{Kind: clock.RoundStarted, Round: 1},
+		{Kind: clock.TurnStarted, Subject: alice, Round: 1},
+		{Kind: clock.Ticked, Subject: carl},
+		{Kind: clock.TurnEnded, Subject: alice, Round: 1},
+		{Kind: clock.TurnStarted, Subject: goblin, Round: 1},
+		{Kind: clock.TurnEnded, Subject: goblin, Round: 1},
+		{Kind: clock.TurnStarted, Subject: bob, Round: 1},
+		{Kind: clock.MemberLeft, Subject: carl},
+		{Kind: clock.MemberJoined, Subject: carl, Round: 1},
+		{Kind: clock.TurnEnded, Subject: bob, Round: 1},
+		{Kind: clock.RoundStarted, Round: 2},
+		{Kind: clock.TurnStarted, Subject: alice, Round: 2},
+		{Kind: clock.Dissolved, Round: 2},
+		// Dissolve returns members in bubble order [alice, goblin, carl, bob]
+		// (carl inserted at Pos 2), and the rejoin loop follows it.
+		{Kind: clock.MemberJoined, Subject: alice},
+		{Kind: clock.MemberJoined, Subject: goblin},
+		{Kind: clock.MemberJoined, Subject: carl},
+		{Kind: clock.MemberJoined, Subject: bob},
+	}, transcript)
+}

--- a/play/clock/errors.go
+++ b/play/clock/errors.go
@@ -5,7 +5,7 @@ package clock
 
 import "errors"
 
-// Sentinel errors — the module's state vocabulary (design: Errors).
+// Sentinel errors — the module's error vocabulary (design: Errors).
 // All returned errors wrap exactly one of these; callers dispatch with
 // errors.Is. Messages are user-facing.
 var (
@@ -31,4 +31,8 @@ var (
 	// ErrSameClock reports an operation that requires two distinct clocks
 	// (merging a clock into itself; transferring within one clock).
 	ErrSameClock = errors.New("operation requires two distinct clocks")
+	// ErrNilInput reports a nil *XxxInput, or a nil required field inside
+	// an otherwise-valid Input (Merge.Other, Transfer.From/To). Caller
+	// defects get their own sentinel; state sentinels stay pure.
+	ErrNilInput = errors.New("nil input")
 )

--- a/play/clock/errors.go
+++ b/play/clock/errors.go
@@ -28,4 +28,7 @@ var (
 	ErrInsufficientBudget = errors.New("insufficient budget")
 	// ErrInvalidData reports persisted state rejected by LoadTurn/LoadTick (design R9).
 	ErrInvalidData = errors.New("invalid clock data")
+	// ErrSameClock reports an operation that requires two distinct clocks
+	// (merging a clock into itself; transferring within one clock).
+	ErrSameClock = errors.New("operation requires two distinct clocks")
 )

--- a/play/clock/errors.go
+++ b/play/clock/errors.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package clock
 
 import "errors"

--- a/play/clock/errors.go
+++ b/play/clock/errors.go
@@ -1,0 +1,28 @@
+package clock
+
+import "errors"
+
+// Sentinel errors — the module's state vocabulary (design: Errors).
+// All returned errors wrap exactly one of these; callers dispatch with
+// errors.Is. Messages are user-facing.
+var (
+	// ErrIdle reports a clock with no order set / nothing to act on.
+	ErrIdle = errors.New("clock is idle")
+	// ErrNotActive reports that the named actor is not the active entity.
+	ErrNotActive = errors.New("not the active entity")
+	// ErrNotMember reports an entity that is not in this clock.
+	ErrNotMember = errors.New("entity is not a member of this clock")
+	// ErrDuplicateMember reports an entity already present.
+	ErrDuplicateMember = errors.New("entity is already a member of this clock")
+	// ErrBadPosition reports an insert position outside [0, len].
+	ErrBadPosition = errors.New("position out of range")
+	// ErrBadOrder reports an empty order or a merge order that is not a
+	// permutation of the union of both member sets.
+	ErrBadOrder = errors.New("invalid order")
+	// ErrBadAmount reports a non-positive spend or negative displacement.
+	ErrBadAmount = errors.New("invalid amount")
+	// ErrInsufficientBudget reports a spend exceeding the member's budget.
+	ErrInsufficientBudget = errors.New("insufficient budget")
+	// ErrInvalidData reports persisted state rejected by LoadTurn/LoadTick (design R9).
+	ErrInvalidData = errors.New("invalid clock data")
+)

--- a/play/clock/go.mod
+++ b/play/clock/go.mod
@@ -1,0 +1,14 @@
+module github.com/KirkDiggler/rpg-toolkit/play/clock
+
+go 1.25.3
+
+require (
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/play/clock/go.mod
+++ b/play/clock/go.mod
@@ -1,6 +1,6 @@
 module github.com/KirkDiggler/rpg-toolkit/play/clock
 
-go 1.25
+go 1.24
 
 require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0

--- a/play/clock/go.mod
+++ b/play/clock/go.mod
@@ -1,6 +1,6 @@
 module github.com/KirkDiggler/rpg-toolkit/play/clock
 
-go 1.25.3
+go 1.25
 
 require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0

--- a/play/clock/go.sum
+++ b/play/clock/go.sum
@@ -1,0 +1,12 @@
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/play/clock/milestone.go
+++ b/play/clock/milestone.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package clock
 
 import "github.com/KirkDiggler/rpg-toolkit/core"

--- a/play/clock/milestone.go
+++ b/play/clock/milestone.go
@@ -1,0 +1,35 @@
+package clock
+
+import "github.com/KirkDiggler/rpg-toolkit/core"
+
+// MilestoneKind names a temporal boundary a clock verb crossed.
+type MilestoneKind string
+
+// The closed v1 milestone kind set (design: Milestone).
+const (
+	// TurnStarted marks Subject's turn beginning.
+	TurnStarted MilestoneKind = "turn_started"
+	// TurnEnded marks Subject's turn ending.
+	TurnEnded MilestoneKind = "turn_ended"
+	// RoundStarted marks a new round beginning on a Turn clock.
+	RoundStarted MilestoneKind = "round_started"
+	// Ticked marks a world-clock advance driven by Subject.
+	Ticked MilestoneKind = "ticked"
+	// MemberJoined marks Subject joining a clock.
+	MemberJoined MilestoneKind = "member_joined"
+	// MemberLeft marks Subject leaving a clock.
+	MemberLeft MilestoneKind = "member_left"
+	// Merged marks two Turn clocks combining.
+	Merged MilestoneKind = "merged"
+	// Dissolved marks a Turn clock emptying at fight end.
+	Dissolved MilestoneKind = "dissolved"
+)
+
+// Milestone is a temporal boundary returned — never published — by the
+// verb that caused it, in causal order (design R4). Turn-emitted
+// milestones carry the clock's Round at the moment of emission.
+type Milestone struct {
+	Kind    MilestoneKind
+	Subject core.EntityID // zero when not about a specific entity
+	Round   int           // Turn clocks only; zero otherwise
+}

--- a/play/clock/milestone_test.go
+++ b/play/clock/milestone_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package clock_test
 
 import (
@@ -8,9 +11,14 @@ import (
 )
 
 func TestMilestoneKindVocabularyIsClosed(t *testing.T) {
-	kinds := []clock.MilestoneKind{
-		clock.TurnStarted, clock.TurnEnded, clock.RoundStarted, clock.Ticked,
-		clock.MemberJoined, clock.MemberLeft, clock.Merged, clock.Dissolved,
+	want := map[clock.MilestoneKind]string{
+		clock.TurnStarted: "turn_started", clock.TurnEnded: "turn_ended",
+		clock.RoundStarted: "round_started", clock.Ticked: "ticked",
+		clock.MemberJoined: "member_joined", clock.MemberLeft: "member_left",
+		clock.Merged: "merged", clock.Dissolved: "dissolved",
 	}
-	assert.Len(t, kinds, 8)
+	assert.Len(t, want, 8)
+	for kind, raw := range want {
+		assert.Equal(t, raw, string(kind))
+	}
 }

--- a/play/clock/milestone_test.go
+++ b/play/clock/milestone_test.go
@@ -1,0 +1,16 @@
+package clock_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMilestoneKindVocabularyIsClosed(t *testing.T) {
+	kinds := []clock.MilestoneKind{
+		clock.TurnStarted, clock.TurnEnded, clock.RoundStarted, clock.Ticked,
+		clock.MemberJoined, clock.MemberLeft, clock.Merged, clock.Dissolved,
+	}
+	assert.Len(t, kinds, 8)
+}

--- a/play/clock/nil_input_test.go
+++ b/play/clock/nil_input_test.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+)
+
+// TestNilInputsRefused sweeps every Input-taking function with a nil
+// Input (and nil required fields) and asserts ErrNilInput — the
+// deliberate-over-incidental revision of design R3.
+func TestNilInputsRefused(t *testing.T) {
+	turn := &clock.Turn{}
+	_, err := turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	require.NoError(t, err)
+	world, werr := clock.NewTick()
+	require.NoError(t, werr)
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"Turn.SetOrder", func() error { _, err := turn.SetOrder(nil); return err }},
+		{"Turn.End", func() error { _, err := turn.End(nil); return err }},
+		{"Turn.Insert", func() error { _, err := turn.Insert(nil); return err }},
+		{"Turn.Remove", func() error { _, err := turn.Remove(nil); return err }},
+		{"Turn.Merge", func() error { _, err := turn.Merge(nil); return err }},
+		{"Turn.Merge nil Other", func() error {
+			_, err := turn.Merge(&clock.MergeInput{Order: []core.EntityID{"a"}})
+			return err
+		}},
+		{"Turn.Dissolve", func() error { _, err := turn.Dissolve(nil); return err }},
+		{"Turn.Contains", func() error { _, err := turn.Contains(nil); return err }},
+		{"Turn.JoinMember", func() error { _, err := turn.JoinMember(nil); return err }},
+		{"Turn.LeaveMember", func() error { _, err := turn.LeaveMember(nil); return err }},
+		{"Tick.Join", func() error { _, err := world.Join(nil); return err }},
+		{"Tick.Leave", func() error { _, err := world.Leave(nil); return err }},
+		{"Tick.Advance", func() error { _, err := world.Advance(nil); return err }},
+		{"Tick.Spend", func() error { _, err := world.Spend(nil); return err }},
+		{"Tick.Budget", func() error { _, err := world.Budget(nil); return err }},
+		{"Tick.Contains", func() error { _, err := world.Contains(nil); return err }},
+		{"Tick.JoinMember", func() error { _, err := world.JoinMember(nil); return err }},
+		{"Tick.LeaveMember", func() error { _, err := world.LeaveMember(nil); return err }},
+		{"Transfer nil input", func() error { _, err := clock.Transfer(nil); return err }},
+		{"Transfer nil From", func() error {
+			_, err := clock.Transfer(&clock.TransferInput{To: turn, ID: "a"})
+			return err
+		}},
+		{"Transfer nil To", func() error {
+			_, err := clock.Transfer(&clock.TransferInput{From: turn, ID: "a"})
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ErrorIs(t, tc.call(), clock.ErrNilInput)
+		})
+	}
+	// guards precede all mutation: the populated turn is untouched
+	active, err := turn.Active()
+	require.NoError(t, err)
+	require.Equal(t, core.EntityID("a"), active)
+}

--- a/play/clock/tick.go
+++ b/play/clock/tick.go
@@ -208,6 +208,11 @@ func LoadTick(data TickData) (*Tick, error) {
 		if b < 0 {
 			return nil, fmt.Errorf("load tick: member %q budget %d: %w", id, b, ErrInvalidData)
 		}
+		if b > data.HighWater {
+			return nil, fmt.Errorf(
+				"load tick: member %q budget %d exceeds high water %d: %w",
+				id, b, data.HighWater, ErrInvalidData)
+		}
 	}
 	k := &Tick{
 		budgets:        copyIntMap(data.Budgets),
@@ -223,8 +228,31 @@ func LoadTick(data TickData) (*Tick, error) {
 	return k, nil
 }
 
+// JoinMember adapts Join to the Joiner seam (Pos is ignored; a world
+// clock is unordered).
+func (k *Tick) JoinMember(in *JoinMemberInput) (*JoinMemberOutput, error) {
+	out, err := k.Join(&JoinInput{ID: in.ID})
+	if err != nil {
+		return nil, err
+	}
+	return &JoinMemberOutput{Milestones: out.Milestones}, nil
+}
+
+// LeaveMember adapts Leave to the Leaver seam.
+func (k *Tick) LeaveMember(in *LeaveMemberInput) (*LeaveMemberOutput, error) {
+	out, err := k.Leave(&LeaveInput{ID: in.ID})
+	if err != nil {
+		return nil, err
+	}
+	return &LeaveMemberOutput{Milestones: out.Milestones}, nil
+}
+
+// copyIntMap deep-copies an entity→int map, normalizing empty (and nil)
+// to nil — the uniform idle-snapshot convention: an idle clock's ToData
+// deep-equals the zero Data value and marshals to {}. LoadTick
+// re-materializes nil to empty for its internal maps.
 func copyIntMap(m map[core.EntityID]int) map[core.EntityID]int {
-	if m == nil {
+	if len(m) == 0 {
 		return nil
 	}
 	out := make(map[core.EntityID]int, len(m))

--- a/play/clock/tick.go
+++ b/play/clock/tick.go
@@ -17,7 +17,7 @@ import (
 type Tick struct {
 	budgets        map[core.EntityID]int
 	driverProgress map[core.EntityID]int
-	highWater      int //nolint:unused // design: reserved for Task 9 (Advance)
+	highWater      int
 }
 
 // NewTick constructs a valid, idle world clock. The error return conforms
@@ -98,4 +98,74 @@ func (k *Tick) Members() ([]core.EntityID, error) {
 func (k *Tick) Contains(in *ContainsInput) (bool, error) {
 	_, ok := k.budgets[in.ID]
 	return ok, nil
+}
+
+// AdvanceInput reports a driver's displacement since their last report.
+// Units are the caller's; the clock never interprets them.
+type AdvanceInput struct {
+	Driver       core.EntityID
+	Displacement int
+}
+
+// AdvanceOutput reports the tick and which members now have budget.
+type AdvanceOutput struct {
+	Milestones []Milestone
+	Ready      []core.EntityID
+}
+
+// Advance records the driver's cumulative displacement; when it raises the
+// high-water mark, the delta is granted to every member's budget
+// (max-not-sum fairness — design: Tick). Drivers need not be members.
+// Errors: ErrBadAmount (negative displacement).
+func (k *Tick) Advance(in *AdvanceInput) (*AdvanceOutput, error) {
+	if in.Displacement < 0 {
+		return nil, fmt.Errorf("advance %q by %d: %w", in.Driver, in.Displacement, ErrBadAmount)
+	}
+	k.driverProgress[in.Driver] += in.Displacement
+	if p := k.driverProgress[in.Driver]; p > k.highWater {
+		delta := p - k.highWater
+		k.highWater = p
+		for id := range k.budgets {
+			k.budgets[id] += delta
+		}
+	}
+	ready := make([]core.EntityID, 0, len(k.budgets))
+	for id, b := range k.budgets {
+		if b > 0 {
+			ready = append(ready, id)
+		}
+	}
+	sort.Slice(ready, func(i, j int) bool { return ready[i] < ready[j] })
+	return &AdvanceOutput{
+		Milestones: []Milestone{{Kind: Ticked, Subject: in.Driver}},
+		Ready:      ready,
+	}, nil
+}
+
+// SpendInput deducts from a member's budget.
+type SpendInput struct {
+	ID     core.EntityID
+	Amount int
+}
+
+// SpendOutput reports the milestones Spend caused (none in the v1 kind set).
+type SpendOutput struct {
+	Milestones []Milestone
+}
+
+// Spend deducts Amount from the member's budget. Errors: ErrNotMember,
+// ErrBadAmount (non-positive), ErrInsufficientBudget.
+func (k *Tick) Spend(in *SpendInput) (*SpendOutput, error) {
+	b, ok := k.budgets[in.ID]
+	if !ok {
+		return nil, fmt.Errorf("spend %q: %w", in.ID, ErrNotMember)
+	}
+	if in.Amount <= 0 {
+		return nil, fmt.Errorf("spend %q amount %d: %w", in.ID, in.Amount, ErrBadAmount)
+	}
+	if in.Amount > b {
+		return nil, fmt.Errorf("spend %q amount %d exceeds budget %d: %w", in.ID, in.Amount, b, ErrInsufficientBudget)
+	}
+	k.budgets[in.ID] = b - in.Amount
+	return &SpendOutput{Milestones: nil}, nil
 }

--- a/play/clock/tick.go
+++ b/play/clock/tick.go
@@ -40,8 +40,11 @@ type JoinOutput struct {
 	Milestones []Milestone
 }
 
-// Join adds a member at budget 0. Errors: ErrDuplicateMember.
+// Join adds a member at budget 0. Errors: ErrNilInput, ErrDuplicateMember.
 func (k *Tick) Join(in *JoinInput) (*JoinOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("join: %w", ErrNilInput)
+	}
 	if _, ok := k.budgets[in.ID]; ok {
 		return nil, fmt.Errorf("join %q: %w", in.ID, ErrDuplicateMember)
 	}
@@ -59,8 +62,11 @@ type LeaveOutput struct {
 	Milestones []Milestone
 }
 
-// Leave removes a member and its budget. Errors: ErrNotMember.
+// Leave removes a member and its budget. Errors: ErrNilInput, ErrNotMember.
 func (k *Tick) Leave(in *LeaveInput) (*LeaveOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("leave: %w", ErrNilInput)
+	}
 	if _, ok := k.budgets[in.ID]; !ok {
 		return nil, fmt.Errorf("leave %q: %w", in.ID, ErrNotMember)
 	}
@@ -73,9 +79,12 @@ type BudgetInput struct {
 	ID core.EntityID
 }
 
-// Budget returns the member's current budget. Errors: ErrNotMember —
+// Budget returns the member's current budget. Errors: ErrNilInput, ErrNotMember —
 // never an ambiguous zero.
 func (k *Tick) Budget(in *BudgetInput) (int, error) {
+	if in == nil {
+		return 0, fmt.Errorf("budget: %w", ErrNilInput)
+	}
 	b, ok := k.budgets[in.ID]
 	if !ok {
 		return 0, fmt.Errorf("budget %q: %w", in.ID, ErrNotMember)
@@ -98,7 +107,11 @@ func (k *Tick) Members() ([]core.EntityID, error) {
 }
 
 // Contains reports membership; false is an answer.
+// Errors: ErrNilInput.
 func (k *Tick) Contains(in *ContainsInput) (bool, error) {
+	if in == nil {
+		return false, fmt.Errorf("contains: %w", ErrNilInput)
+	}
 	_, ok := k.budgets[in.ID]
 	return ok, nil
 }
@@ -121,8 +134,11 @@ type AdvanceOutput struct {
 // Advance records the driver's cumulative displacement; when it raises the
 // high-water mark, the delta is granted to every member's budget
 // (max-not-sum fairness — design: Tick). Drivers need not be members.
-// Errors: ErrBadAmount (negative displacement).
+// Errors: ErrNilInput, ErrBadAmount (negative displacement).
 func (k *Tick) Advance(in *AdvanceInput) (*AdvanceOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("advance: %w", ErrNilInput)
+	}
 	if in.Displacement < 0 {
 		return nil, fmt.Errorf("advance %q by %d: %w", in.Driver, in.Displacement, ErrBadAmount)
 	}
@@ -158,9 +174,12 @@ type SpendOutput struct {
 	Milestones []Milestone
 }
 
-// Spend deducts Amount from the member's budget. Errors: ErrNotMember,
+// Spend deducts Amount from the member's budget. Errors: ErrNilInput, ErrNotMember,
 // ErrBadAmount (non-positive), ErrInsufficientBudget.
 func (k *Tick) Spend(in *SpendInput) (*SpendOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("spend: %w", ErrNilInput)
+	}
 	b, ok := k.budgets[in.ID]
 	if !ok {
 		return nil, fmt.Errorf("spend %q: %w", in.ID, ErrNotMember)
@@ -232,8 +251,11 @@ func LoadTick(data TickData) (*Tick, error) {
 }
 
 // JoinMember adapts Join to the Joiner seam (Pos is ignored; a world
-// clock is unordered).
+// clock is unordered). Errors: ErrNilInput, and all errors from Join.
 func (k *Tick) JoinMember(in *JoinMemberInput) (*JoinMemberOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("join member: %w", ErrNilInput)
+	}
 	out, err := k.Join(&JoinInput{ID: in.ID})
 	if err != nil {
 		return nil, err
@@ -242,7 +264,11 @@ func (k *Tick) JoinMember(in *JoinMemberInput) (*JoinMemberOutput, error) {
 }
 
 // LeaveMember adapts Leave to the Leaver seam.
+// Errors: ErrNilInput, and all errors from Leave.
 func (k *Tick) LeaveMember(in *LeaveMemberInput) (*LeaveMemberOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("leave member: %w", ErrNilInput)
+	}
 	out, err := k.Leave(&LeaveInput{ID: in.ID})
 	if err != nil {
 		return nil, err

--- a/play/clock/tick.go
+++ b/play/clock/tick.go
@@ -86,6 +86,9 @@ func (k *Tick) Budget(in *BudgetInput) (int, error) {
 // Members returns the member set in stable (sorted) order. An empty clock
 // answers with an empty slice and nil error.
 func (k *Tick) Members() ([]core.EntityID, error) {
+	if len(k.budgets) == 0 {
+		return nil, nil
+	}
 	out := make([]core.EntityID, 0, len(k.budgets))
 	for id := range k.budgets {
 		out = append(out, id)

--- a/play/clock/tick.go
+++ b/play/clock/tick.go
@@ -17,7 +17,7 @@ import (
 type Tick struct {
 	budgets        map[core.EntityID]int
 	driverProgress map[core.EntityID]int
-	highWater      int //nolint:unused // design: reserved for Task 10
+	highWater      int //nolint:unused // design: reserved for Task 9 (Advance)
 }
 
 // NewTick constructs a valid, idle world clock. The error return conforms

--- a/play/clock/tick.go
+++ b/play/clock/tick.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// Tick is the player-driven world clock (design: Tick): it advances only
+// because players act. Accrual is high-water max-displacement. Construct
+// via NewTick or LoadTick; the zero value is not usable. Not safe for
+// concurrent use (design R10).
+type Tick struct {
+	budgets        map[core.EntityID]int
+	driverProgress map[core.EntityID]int
+	highWater      int //nolint:unused // design: reserved for Task 10
+}
+
+// NewTick constructs a valid, idle world clock. The error return conforms
+// to design R3(a); construction cannot fail today, but a future
+// TickConfig can.
+func NewTick() (*Tick, error) {
+	return &Tick{
+		budgets:        make(map[core.EntityID]int),
+		driverProgress: make(map[core.EntityID]int),
+	}, nil
+}
+
+// JoinInput names the entity joining the world clock.
+type JoinInput struct {
+	ID core.EntityID
+}
+
+// JoinOutput reports the milestones Join caused.
+type JoinOutput struct {
+	Milestones []Milestone
+}
+
+// Join adds a member at budget 0. Errors: ErrDuplicateMember.
+func (k *Tick) Join(in *JoinInput) (*JoinOutput, error) {
+	if _, ok := k.budgets[in.ID]; ok {
+		return nil, fmt.Errorf("join %q: %w", in.ID, ErrDuplicateMember)
+	}
+	k.budgets[in.ID] = 0
+	return &JoinOutput{Milestones: []Milestone{{Kind: MemberJoined, Subject: in.ID}}}, nil
+}
+
+// LeaveInput names the entity leaving the world clock.
+type LeaveInput struct {
+	ID core.EntityID
+}
+
+// LeaveOutput reports the milestones Leave caused.
+type LeaveOutput struct {
+	Milestones []Milestone
+}
+
+// Leave removes a member and its budget. Errors: ErrNotMember.
+func (k *Tick) Leave(in *LeaveInput) (*LeaveOutput, error) {
+	if _, ok := k.budgets[in.ID]; !ok {
+		return nil, fmt.Errorf("leave %q: %w", in.ID, ErrNotMember)
+	}
+	delete(k.budgets, in.ID)
+	return &LeaveOutput{Milestones: []Milestone{{Kind: MemberLeft, Subject: in.ID}}}, nil
+}
+
+// BudgetInput names the member whose budget is being read.
+type BudgetInput struct {
+	ID core.EntityID
+}
+
+// Budget returns the member's current budget. Errors: ErrNotMember —
+// never an ambiguous zero.
+func (k *Tick) Budget(in *BudgetInput) (int, error) {
+	b, ok := k.budgets[in.ID]
+	if !ok {
+		return 0, fmt.Errorf("budget %q: %w", in.ID, ErrNotMember)
+	}
+	return b, nil
+}
+
+// Members returns the member set in stable (sorted) order. An empty clock
+// answers with an empty slice and nil error.
+func (k *Tick) Members() ([]core.EntityID, error) {
+	out := make([]core.EntityID, 0, len(k.budgets))
+	for id := range k.budgets {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+// Contains reports membership; false is an answer.
+func (k *Tick) Contains(in *ContainsInput) (bool, error) {
+	_, ok := k.budgets[in.ID]
+	return ok, nil
+}

--- a/play/clock/tick.go
+++ b/play/clock/tick.go
@@ -110,7 +110,9 @@ type AdvanceInput struct {
 // AdvanceOutput reports the tick and which members now have budget.
 type AdvanceOutput struct {
 	Milestones []Milestone
-	Ready      []core.EntityID
+	// Ready is a snapshot — members with budget > 0 at this instant — not a
+	// became-ready event; a member with unspent budget reappears on every Advance.
+	Ready []core.EntityID
 }
 
 // Advance records the driver's cumulative displacement; when it raises the
@@ -168,4 +170,66 @@ func (k *Tick) Spend(in *SpendInput) (*SpendOutput, error) {
 	}
 	k.budgets[in.ID] = b - in.Amount
 	return &SpendOutput{Milestones: nil}, nil
+}
+
+// TickData is Tick's persisted shape (design R8). Plain data, no behavior.
+type TickData struct {
+	Budgets        map[core.EntityID]int `json:"budgets,omitempty"`
+	DriverProgress map[core.EntityID]int `json:"driver_progress,omitempty"`
+	HighWater      int                   `json:"high_water,omitempty"`
+}
+
+// ToData snapshots the clock. Family-convention exemption from R3 (design).
+func (k *Tick) ToData() TickData {
+	return TickData{
+		Budgets:        copyIntMap(k.budgets),
+		DriverProgress: copyIntMap(k.driverProgress),
+		HighWater:      k.highWater,
+	}
+}
+
+// LoadTick reconstructs a Tick from persisted state. A constructor, not a
+// verb — no milestones. Errors: ErrInvalidData for every R9 rejection.
+func LoadTick(data TickData) (*Tick, error) {
+	maxProgress := 0
+	for id, p := range data.DriverProgress {
+		if p < 0 {
+			return nil, fmt.Errorf("load tick: driver %q progress %d: %w", id, p, ErrInvalidData)
+		}
+		if p > maxProgress {
+			maxProgress = p
+		}
+	}
+	if data.HighWater < maxProgress {
+		return nil, fmt.Errorf("load tick: high water %d below max driver progress %d: %w",
+			data.HighWater, maxProgress, ErrInvalidData)
+	}
+	for id, b := range data.Budgets {
+		if b < 0 {
+			return nil, fmt.Errorf("load tick: member %q budget %d: %w", id, b, ErrInvalidData)
+		}
+	}
+	k := &Tick{
+		budgets:        copyIntMap(data.Budgets),
+		driverProgress: copyIntMap(data.DriverProgress),
+		highWater:      data.HighWater,
+	}
+	if k.budgets == nil {
+		k.budgets = make(map[core.EntityID]int)
+	}
+	if k.driverProgress == nil {
+		k.driverProgress = make(map[core.EntityID]int)
+	}
+	return k, nil
+}
+
+func copyIntMap(m map[core.EntityID]int) map[core.EntityID]int {
+	if m == nil {
+		return nil
+	}
+	out := make(map[core.EntityID]int, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }

--- a/play/clock/tick_test.go
+++ b/play/clock/tick_test.go
@@ -142,3 +142,91 @@ func (s *TickSuite) TestSpend() {
 	_, err = s.tick.Spend(&clock.SpendInput{ID: "zz", Amount: 1})
 	s.Require().ErrorIs(err, clock.ErrNotMember)
 }
+
+// TestAdvanceCrossDriverOvertake pins that the high-water mark is
+// per-clock: a second driver overtaking grants only the overtake delta.
+func (s *TickSuite) TestAdvanceCrossDriverOvertake() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 5})
+	s.Require().NoError(err)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p2", Displacement: 3})
+	s.Require().NoError(err) // p2 at 3, below the mark: no grant
+	b, err := s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal(5, b)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p2", Displacement: 4})
+	s.Require().NoError(err) // p2 cumulative 7 overtakes 5: grant 2, not 4
+	b, err = s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal(7, b)
+}
+
+// TestReadyOmitsSpentToZero pins the snapshot semantics' flip side.
+func (s *TickSuite) TestReadyOmitsSpentToZero() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 2})
+	s.Require().NoError(err)
+	_, err = s.tick.Spend(&clock.SpendInput{ID: "goblin", Amount: 2})
+	s.Require().NoError(err)
+	out, err := s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 0})
+	s.Require().NoError(err)
+	s.Empty(out.Ready, "a member spent to zero is not ready")
+}
+
+// TestSpendErrorPrecedence pins absent-member beating bad-amount.
+func (s *TickSuite) TestSpendErrorPrecedence() {
+	_, err := s.tick.Spend(&clock.SpendInput{ID: "absent", Amount: 0})
+	s.Require().ErrorIs(err, clock.ErrNotMember)
+}
+
+// TestDriverAlsoMemberAccruesOwnDisplacement pins the property AC1's
+// DOS2 spine relies on: a lone member-driver accrues exactly their own
+// displacement and appears in their own Ready.
+func (s *TickSuite) TestDriverAlsoMemberAccruesOwnDisplacement() {
+	const carl core.EntityID = "carl"
+	_, err := s.tick.Join(&clock.JoinInput{ID: carl})
+	s.Require().NoError(err)
+	out, err := s.tick.Advance(&clock.AdvanceInput{Driver: carl, Displacement: 3})
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{carl}, out.Ready)
+	b, err := s.tick.Budget(&clock.BudgetInput{ID: carl})
+	s.Require().NoError(err)
+	s.Equal(3, b)
+}
+
+func (s *TickSuite) TestTickRoundTrip() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 3})
+	s.Require().NoError(err)
+	_, err = s.tick.Spend(&clock.SpendInput{ID: "goblin", Amount: 1})
+	s.Require().NoError(err)
+	loaded, err := clock.LoadTick(s.tick.ToData())
+	s.Require().NoError(err)
+	s.Equal(s.tick.ToData(), loaded.ToData())
+	// behavior-identical: same high-water means no spurious grant
+	_, err = loaded.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 0})
+	s.Require().NoError(err)
+	b, err := loaded.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal(2, b)
+}
+
+func (s *TickSuite) TestLoadTickRejectsInvalid() {
+	cases := []struct {
+		name string
+		data clock.TickData
+	}{
+		{"negative budget", clock.TickData{Budgets: map[core.EntityID]int{"a": -1}}},
+		{"negative driver progress", clock.TickData{DriverProgress: map[core.EntityID]int{"p": -2}}},
+		{"high water below max progress", clock.TickData{DriverProgress: map[core.EntityID]int{"p": 5}, HighWater: 3}},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			_, err := clock.LoadTick(tc.data)
+			s.Require().ErrorIs(err, clock.ErrInvalidData)
+		})
+	}
+}

--- a/play/clock/tick_test.go
+++ b/play/clock/tick_test.go
@@ -75,3 +75,70 @@ func (s *TickSuite) TestMembersSortedOrder() {
 	s.Require().NoError(err)
 	s.Equal([]core.EntityID{"a", "b", "c"}, members)
 }
+
+func (s *TickSuite) TestAdvanceHighWaterMaxNotSum() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	// four players each report displacement 3: members accrue 3, not 12
+	for _, driver := range []core.EntityID{"p1", "p2", "p3", "p4"} {
+		out, aerr := s.tick.Advance(&clock.AdvanceInput{Driver: driver, Displacement: 3})
+		s.Require().NoError(aerr)
+		s.Equal([]clock.Milestone{{Kind: clock.Ticked, Subject: driver}}, out.Milestones)
+	}
+	b, err := s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal(3, b)
+
+	// p1 pulls ahead by 2 more (cumulative 5): delta 2 granted
+	out, err := s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 2})
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"goblin"}, out.Ready)
+	b, err = s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal(5, b)
+}
+
+func (s *TickSuite) TestAdvanceEdges() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	// zero displacement: legal, Ticked emitted, no grant
+	out, err := s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 0})
+	s.Require().NoError(err)
+	s.Empty(out.Ready)
+	// negative rejected, nothing changed (R5)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: -1})
+	s.Require().ErrorIs(err, clock.ErrBadAmount)
+	b, err := s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Zero(b)
+	// a member joining late starts at 0 and accrues only future deltas
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 4})
+	s.Require().NoError(err)
+	_, err = s.tick.Join(&clock.JoinInput{ID: "late"})
+	s.Require().NoError(err)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 1})
+	s.Require().NoError(err)
+	late, err := s.tick.Budget(&clock.BudgetInput{ID: "late"})
+	s.Require().NoError(err)
+	s.Equal(1, late)
+}
+
+func (s *TickSuite) TestSpend() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 3})
+	s.Require().NoError(err)
+	out, err := s.tick.Spend(&clock.SpendInput{ID: "goblin", Amount: 2})
+	s.Require().NoError(err)
+	s.Empty(out.Milestones) // Spend emits no milestones (closed kind set)
+	b, err := s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal(1, b)
+
+	_, err = s.tick.Spend(&clock.SpendInput{ID: "goblin", Amount: 2})
+	s.Require().ErrorIs(err, clock.ErrInsufficientBudget)
+	_, err = s.tick.Spend(&clock.SpendInput{ID: "goblin", Amount: 0})
+	s.Require().ErrorIs(err, clock.ErrBadAmount)
+	_, err = s.tick.Spend(&clock.SpendInput{ID: "zz", Amount: 1})
+	s.Require().ErrorIs(err, clock.ErrNotMember)
+}

--- a/play/clock/tick_test.go
+++ b/play/clock/tick_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/stretchr/testify/suite"
+)
+
+type TickSuite struct {
+	suite.Suite
+	tick *clock.Tick
+}
+
+func (s *TickSuite) SetupTest() {
+	var err error
+	s.tick, err = clock.NewTick()
+	s.Require().NoError(err)
+}
+
+func TestTickSuite(t *testing.T) { suite.Run(t, new(TickSuite)) }
+
+//nolint:goconst // goconst exemption for test string
+func (s *TickSuite) TestJoinLeave() {
+	out, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal([]clock.Milestone{{Kind: clock.MemberJoined, Subject: "goblin"}}, out.Milestones)
+	b, err := s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Zero(b)
+
+	_, err = s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().ErrorIs(err, clock.ErrDuplicateMember)
+
+	lout, err := s.tick.Leave(&clock.LeaveInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal([]clock.Milestone{{Kind: clock.MemberLeft, Subject: "goblin"}}, lout.Milestones)
+	_, err = s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().ErrorIs(err, clock.ErrNotMember)
+	_, err = s.tick.Leave(&clock.LeaveInput{ID: "goblin"})
+	s.Require().ErrorIs(err, clock.ErrNotMember)
+}
+
+func (s *TickSuite) TestMembersEmptySliceConvention() {
+	members, err := s.tick.Members()
+	s.Require().NoError(err)
+	s.Empty(members)
+}

--- a/play/clock/tick_test.go
+++ b/play/clock/tick_test.go
@@ -6,6 +6,7 @@ package clock_test
 import (
 	"testing"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/play/clock"
 	"github.com/stretchr/testify/suite"
 )
@@ -23,7 +24,7 @@ func (s *TickSuite) SetupTest() {
 
 func TestTickSuite(t *testing.T) { suite.Run(t, new(TickSuite)) }
 
-//nolint:goconst // goconst exemption for test string
+//nolint:goconst // repeated test fixture ID; _test.go exclusions inert until toolkit#904
 func (s *TickSuite) TestJoinLeave() {
 	out, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
 	s.Require().NoError(err)
@@ -48,4 +49,29 @@ func (s *TickSuite) TestMembersEmptySliceConvention() {
 	members, err := s.tick.Members()
 	s.Require().NoError(err)
 	s.Empty(members)
+}
+
+// TestContainsAndMembersDistinguishZeroBudgetFromAbsent pins that a member
+// at budget 0 is still a member — the distinction Ready (budget > 0) will
+// tempt callers to blur once Advance lands.
+func (s *TickSuite) TestContainsAndMembersDistinguishZeroBudgetFromAbsent() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	got, err := s.tick.Contains(&clock.ContainsInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.True(got, "zero-budget member is still a member")
+	got, err = s.tick.Contains(&clock.ContainsInput{ID: "absent"})
+	s.Require().NoError(err)
+	s.False(got)
+}
+
+// TestMembersSortedOrder pins deterministic ordering against map iteration.
+func (s *TickSuite) TestMembersSortedOrder() {
+	for _, id := range []core.EntityID{"c", "a", "b"} {
+		_, err := s.tick.Join(&clock.JoinInput{ID: id})
+		s.Require().NoError(err)
+	}
+	members, err := s.tick.Members()
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"a", "b", "c"}, members)
 }

--- a/play/clock/tick_test.go
+++ b/play/clock/tick_test.go
@@ -4,6 +4,7 @@
 package clock_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -150,8 +151,9 @@ func (s *TickSuite) TestAdvanceCrossDriverOvertake() {
 	s.Require().NoError(err)
 	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 5})
 	s.Require().NoError(err)
-	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p2", Displacement: 3})
+	out, err := s.tick.Advance(&clock.AdvanceInput{Driver: "p2", Displacement: 3})
 	s.Require().NoError(err) // p2 at 3, below the mark: no grant
+	s.Equal([]core.EntityID{"goblin"}, out.Ready, "unspent member reappears on a no-grant Advance")
 	b, err := s.tick.Budget(&clock.BudgetInput{ID: "goblin"})
 	s.Require().NoError(err)
 	s.Equal(5, b)
@@ -222,6 +224,8 @@ func (s *TickSuite) TestLoadTickRejectsInvalid() {
 		{"negative budget", clock.TickData{Budgets: map[core.EntityID]int{"a": -1}}},
 		{"negative driver progress", clock.TickData{DriverProgress: map[core.EntityID]int{"p": -2}}},
 		{"high water below max progress", clock.TickData{DriverProgress: map[core.EntityID]int{"p": 5}, HighWater: 3}},
+		{"negative high water", clock.TickData{HighWater: -1}},
+		{"budget above high water", clock.TickData{Budgets: map[core.EntityID]int{"a": 3}, HighWater: 2}},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -229,4 +233,63 @@ func (s *TickSuite) TestLoadTickRejectsInvalid() {
 			s.Require().ErrorIs(err, clock.ErrInvalidData)
 		})
 	}
+}
+
+// TestTickIdleSnapshotConvention pins the uniform idle convention and the
+// snapshot's immunity to later verbs (Turn's analog pins already exist).
+func (s *TickSuite) TestTickIdleSnapshotConvention() {
+	s.Equal(clock.TickData{}, s.tick.ToData(), "idle ToData deep-equals the zero value")
+	idleRaw, err := json.Marshal(s.tick.ToData())
+	s.Require().NoError(err)
+	s.JSONEq(`{}`, string(idleRaw))
+	loaded, err := clock.LoadTick(clock.TickData{})
+	s.Require().NoError(err)
+	_, err = loaded.Join(&clock.JoinInput{ID: "a"}) // usable, like NewTick
+	s.Require().NoError(err)
+}
+
+// TestTickDataWireShape pins the JSON persistence contract (Turn's analog
+// exists; tag renames are invisible to gorelease).
+func (s *TickSuite) TestTickDataWireShape() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 3})
+	s.Require().NoError(err)
+	raw, err := json.Marshal(s.tick.ToData())
+	s.Require().NoError(err)
+	s.JSONEq(`{"budgets":{"goblin":3},"driver_progress":{"p1":3},"high_water":3}`, string(raw))
+	var back clock.TickData
+	s.Require().NoError(json.Unmarshal(raw, &back))
+	loaded, err := clock.LoadTick(back)
+	s.Require().NoError(err)
+	s.Equal(s.tick.ToData(), loaded.ToData())
+}
+
+// TestTickSnapshotImmuneToLaterVerbs mirrors Turn's snapshot pin.
+func (s *TickSuite) TestTickSnapshotImmuneToLaterVerbs() {
+	_, err := s.tick.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	snap := s.tick.ToData()
+	_, err = s.tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 3})
+	s.Require().NoError(err)
+	s.Equal(0, snap.Budgets["goblin"], "snapshot must not observe later grants")
+}
+
+// TestLoadTickBankedMark pins the pruning note's behavioral half: a mark
+// above all surviving progress loads fine and grants nothing until overtaken.
+func (s *TickSuite) TestLoadTickBankedMark() {
+	loaded, err := clock.LoadTick(clock.TickData{HighWater: 5})
+	s.Require().NoError(err)
+	_, err = loaded.Join(&clock.JoinInput{ID: "goblin"})
+	s.Require().NoError(err)
+	_, err = loaded.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 5})
+	s.Require().NoError(err) // reaches the mark exactly: no grant
+	b, err := loaded.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Zero(b)
+	_, err = loaded.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 1})
+	s.Require().NoError(err) // overtakes: grant 1
+	b, err = loaded.Budget(&clock.BudgetInput{ID: "goblin"})
+	s.Require().NoError(err)
+	s.Equal(1, b)
 }

--- a/play/clock/transfer.go
+++ b/play/clock/transfer.go
@@ -47,6 +47,9 @@ type TransferOutput struct {
 // contract; milestones are reported in leave-then-join order per the
 // design regardless.
 func Transfer(in *TransferInput) (*TransferOutput, error) {
+	if in.From == in.To {
+		return nil, fmt.Errorf("transfer %q: from and to are the same clock: %w", in.ID, ErrSameClock)
+	}
 	join, err := in.To.JoinMember(&JoinMemberInput{ID: in.ID, Pos: in.Pos})
 	if err != nil {
 		return nil, fmt.Errorf("transfer %q: join: %w", in.ID, err)
@@ -54,7 +57,9 @@ func Transfer(in *TransferInput) (*TransferOutput, error) {
 	leave, err := in.From.LeaveMember(&LeaveMemberInput{ID: in.ID})
 	if err != nil {
 		if _, undoErr := in.To.LeaveMember(&LeaveMemberInput{ID: in.ID}); undoErr != nil {
-			return nil, fmt.Errorf("transfer %q: leave failed (%v) and compensation failed: %w", in.ID, err, undoErr)
+			return nil, fmt.Errorf(
+				"transfer %q: leave failed (%v) and compensation failed — %q may remain on both clocks: %w",
+				in.ID, err, in.ID, undoErr)
 		}
 		return nil, fmt.Errorf("transfer %q: leave: %w", in.ID, err)
 	}

--- a/play/clock/transfer.go
+++ b/play/clock/transfer.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// Leaver is the leaving half of the Membership seam.
+type Leaver interface {
+	LeaveMember(in *LeaveMemberInput) (*LeaveMemberOutput, error)
+}
+
+// Joiner is the joining half of the Membership seam.
+type Joiner interface {
+	JoinMember(in *JoinMemberInput) (*JoinMemberOutput, error)
+}
+
+// Membership is what Transfer requires of both sides: the ability to
+// join AND leave, so a failed transfer can compensate (design: Transfer).
+type Membership interface {
+	Leaver
+	Joiner
+}
+
+// TransferInput moves ID from one clock to another, Pos choosing its slot
+// when To is ordered. Both From and To must be non-nil.
+type TransferInput struct {
+	From Membership
+	To   Membership
+	ID   core.EntityID
+	Pos  int
+}
+
+// TransferOutput reports the transfer's milestones, leave-then-join.
+type TransferOutput struct {
+	Milestones []Milestone
+}
+
+// Transfer moves ID between clocks upholding one-clock-per-entity (R6):
+// on any failure both clocks are unchanged and the underlying sentinel
+// propagates. Execution is join-first with compensating leave — the
+// transient dual membership is invisible under R10's single-threaded
+// contract; milestones are reported in leave-then-join order per the
+// design regardless.
+func Transfer(in *TransferInput) (*TransferOutput, error) {
+	join, err := in.To.JoinMember(&JoinMemberInput{ID: in.ID, Pos: in.Pos})
+	if err != nil {
+		return nil, fmt.Errorf("transfer %q: join: %w", in.ID, err)
+	}
+	leave, err := in.From.LeaveMember(&LeaveMemberInput{ID: in.ID})
+	if err != nil {
+		if _, undoErr := in.To.LeaveMember(&LeaveMemberInput{ID: in.ID}); undoErr != nil {
+			return nil, fmt.Errorf("transfer %q: leave failed (%v) and compensation failed: %w", in.ID, err, undoErr)
+		}
+		return nil, fmt.Errorf("transfer %q: leave: %w", in.ID, err)
+	}
+	return &TransferOutput{
+		Milestones: append(append([]Milestone(nil), leave.Milestones...), join.Milestones...),
+	}, nil
+}

--- a/play/clock/transfer.go
+++ b/play/clock/transfer.go
@@ -45,8 +45,14 @@ type TransferOutput struct {
 // propagates. Execution is join-first with compensating leave — the
 // transient dual membership is invisible under R10's single-threaded
 // contract; milestones are reported in leave-then-join order per the
-// design regardless.
+// design regardless. Errors: ErrNilInput, ErrSameClock, and errors from Join/Leave.
 func Transfer(in *TransferInput) (*TransferOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("transfer: %w", ErrNilInput)
+	}
+	if in.From == nil || in.To == nil {
+		return nil, fmt.Errorf("transfer %q: %w", in.ID, ErrNilInput)
+	}
 	if in.From == in.To {
 		return nil, fmt.Errorf("transfer %q: from and to are the same clock: %w", in.ID, ErrSameClock)
 	}

--- a/play/clock/transfer_test.go
+++ b/play/clock/transfer_test.go
@@ -11,51 +11,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:goconst // repeated test fixture ID; _test.go exclusions inert until toolkit#904
-const ghostID core.EntityID = "ghost"
-
-//nolint:goconst // repeated test fixture ID; _test.go exclusions inert until toolkit#904
 func TestTransferTickToTurn(t *testing.T) {
+	const carl core.EntityID = "carl"
 	tick, err := clock.NewTick()
 	require.NoError(t, err)
-	_, err = tick.Join(&clock.JoinInput{ID: "carl"})
+	_, err = tick.Join(&clock.JoinInput{ID: carl})
 	require.NoError(t, err)
 	turn := &clock.Turn{}
 	_, err = turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
 	require.NoError(t, err)
 
-	out, err := clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: "carl", Pos: 1})
+	out, err := clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: carl, Pos: 1})
 	require.NoError(t, err)
 	// milestones reported leave-then-join (design: Transfer), regardless of execution order
 	require.Equal(t, []clock.Milestone{
-		{Kind: clock.MemberLeft, Subject: "carl"},
-		{Kind: clock.MemberJoined, Subject: "carl", Round: 1},
+		{Kind: clock.MemberLeft, Subject: carl},
+		{Kind: clock.MemberJoined, Subject: carl, Round: 1},
 	}, out.Milestones)
-	inTurn, err := turn.Contains(&clock.ContainsInput{ID: "carl"})
+	inTurn, err := turn.Contains(&clock.ContainsInput{ID: carl})
 	require.NoError(t, err)
 	require.True(t, inTurn)
-	inTick, err := tick.Contains(&clock.ContainsInput{ID: "carl"})
+	inTick, err := tick.Contains(&clock.ContainsInput{ID: carl})
 	require.NoError(t, err)
 	require.False(t, inTick, "one clock per entity")
 }
 
 func TestTransferFailureLeavesBothUnchanged(t *testing.T) {
+	const carl core.EntityID = "carl"
 	tick, err := clock.NewTick()
 	require.NoError(t, err)
-	_, err = tick.Join(&clock.JoinInput{ID: "carl"})
+	_, err = tick.Join(&clock.JoinInput{ID: carl})
 	require.NoError(t, err)
 	_, err = tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 3})
 	require.NoError(t, err)
 	idleTurn := &clock.Turn{} // join will refuse: ErrIdle
 
 	tickBefore, turnBefore := tick.ToData(), idleTurn.ToData()
-	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: idleTurn, ID: "carl", Pos: 0})
+	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: idleTurn, ID: carl, Pos: 0})
 	require.ErrorIs(t, err, clock.ErrIdle, "underlying sentinel propagates")
 	require.Equal(t, tickBefore, tick.ToData(), "From unchanged (R6)")
 	require.Equal(t, turnBefore, idleTurn.ToData(), "To unchanged (R6)")
 }
 
 func TestTransferAbsentMemberCompensates(t *testing.T) {
+	const ghost core.EntityID = "ghost"
 	tick, err := clock.NewTick()
 	require.NoError(t, err)
 	turn := &clock.Turn{}
@@ -63,7 +62,7 @@ func TestTransferAbsentMemberCompensates(t *testing.T) {
 	require.NoError(t, err)
 
 	turnBefore := turn.ToData()
-	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: ghostID, Pos: 0})
+	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: ghost, Pos: 0})
 	require.ErrorIs(t, err, clock.ErrNotMember)
 	require.Equal(t, turnBefore, turn.ToData(), "join was compensated (R6)")
 }

--- a/play/clock/transfer_test.go
+++ b/play/clock/transfer_test.go
@@ -86,3 +86,54 @@ func TestTransferSameClockRefused(t *testing.T) {
 	require.ErrorIs(t, err, clock.ErrSameClock)
 	require.Equal(t, before, turn.ToData())
 }
+
+// TestTransferTurnToTick pins the consumer-facing direction (fleeing a
+// bubble back to the world clock — rpg-api's monster free-roam path):
+// Pos is ignored by the unordered world clock, the new member starts at
+// budget zero, and milestones report leave-then-join.
+func TestTransferTurnToTick(t *testing.T) {
+	const dana core.EntityID = "dana"
+	turn := &clock.Turn{}
+	_, err := turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", dana}})
+	require.NoError(t, err)
+	world, err := clock.NewTick()
+	require.NoError(t, err)
+
+	out, err := clock.Transfer(&clock.TransferInput{From: turn, To: world, ID: dana, Pos: 99})
+	require.NoError(t, err)
+	require.Equal(t, []clock.Milestone{
+		{Kind: clock.MemberLeft, Subject: dana, Round: 1},
+		{Kind: clock.MemberJoined, Subject: dana},
+	}, out.Milestones)
+	inWorld, err := world.Contains(&clock.ContainsInput{ID: dana})
+	require.NoError(t, err)
+	require.True(t, inWorld)
+	inTurn, err := turn.Contains(&clock.ContainsInput{ID: dana})
+	require.NoError(t, err)
+	require.False(t, inTurn, "one clock per entity")
+	b, err := world.Budget(&clock.BudgetInput{ID: dana})
+	require.NoError(t, err)
+	require.Zero(t, b, "fresh world member starts at zero budget")
+
+	// error branch of the Tick-side Joiner adapter: duplicate propagates
+	_, err = world.JoinMember(&clock.JoinMemberInput{ID: dana, Pos: 0})
+	require.ErrorIs(t, err, clock.ErrDuplicateMember)
+}
+
+// TestTransferTurnToTickAbsentCompensates covers Turn.LeaveMember's error
+// branch and the Tick-side compensation (R6 both directions).
+func TestTransferTurnToTickAbsentCompensates(t *testing.T) {
+	const ghost core.EntityID = "ghost"
+	turn := &clock.Turn{}
+	_, err := turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	require.NoError(t, err)
+	world, err := clock.NewTick()
+	require.NoError(t, err)
+	turnBefore, worldBefore := turn.ToData(), world.ToData()
+
+	out, err := clock.Transfer(&clock.TransferInput{From: turn, To: world, ID: ghost, Pos: 0})
+	require.ErrorIs(t, err, clock.ErrNotMember)
+	require.Nil(t, out, "failed transfer emits nothing")
+	require.Equal(t, turnBefore, turn.ToData(), "From unchanged (R6)")
+	require.Equal(t, worldBefore, world.ToData(), "To unchanged — Tick-side compensation (R6)")
+}

--- a/play/clock/transfer_test.go
+++ b/play/clock/transfer_test.go
@@ -47,7 +47,8 @@ func TestTransferFailureLeavesBothUnchanged(t *testing.T) {
 	idleTurn := &clock.Turn{} // join will refuse: ErrIdle
 
 	tickBefore, turnBefore := tick.ToData(), idleTurn.ToData()
-	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: idleTurn, ID: carl, Pos: 0})
+	out, err := clock.Transfer(&clock.TransferInput{From: tick, To: idleTurn, ID: carl, Pos: 0})
+	require.Nil(t, out, "failed transfer emits nothing")
 	require.ErrorIs(t, err, clock.ErrIdle, "underlying sentinel propagates")
 	require.Equal(t, tickBefore, tick.ToData(), "From unchanged (R6)")
 	require.Equal(t, turnBefore, idleTurn.ToData(), "To unchanged (R6)")
@@ -61,8 +62,27 @@ func TestTransferAbsentMemberCompensates(t *testing.T) {
 	_, err = turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
 	require.NoError(t, err)
 
+	tickBefore := tick.ToData()
 	turnBefore := turn.ToData()
-	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: ghost, Pos: 0})
+	out, err := clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: ghost, Pos: 0})
+	require.Nil(t, out, "failed transfer emits nothing")
 	require.ErrorIs(t, err, clock.ErrNotMember)
+	require.Equal(t, tickBefore, tick.ToData(), "From unchanged (R6)")
 	require.Equal(t, turnBefore, turn.ToData(), "join was compensated (R6)")
+}
+
+func TestTransferSameClockRefused(t *testing.T) {
+	const ghost core.EntityID = "ghost"
+	turn := &clock.Turn{}
+	_, err := turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	require.NoError(t, err)
+	before := turn.ToData()
+	// present entity
+	_, err = clock.Transfer(&clock.TransferInput{From: turn, To: turn, ID: "a", Pos: 0})
+	require.ErrorIs(t, err, clock.ErrSameClock)
+	require.Equal(t, before, turn.ToData())
+	// absent entity — the case that silently "succeeded" pre-guard
+	_, err = clock.Transfer(&clock.TransferInput{From: turn, To: turn, ID: ghost, Pos: 0})
+	require.ErrorIs(t, err, clock.ErrSameClock)
+	require.Equal(t, before, turn.ToData())
 }

--- a/play/clock/transfer_test.go
+++ b/play/clock/transfer_test.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:goconst // repeated test fixture ID; _test.go exclusions inert until toolkit#904
+const ghostID core.EntityID = "ghost"
+
+//nolint:goconst // repeated test fixture ID; _test.go exclusions inert until toolkit#904
+func TestTransferTickToTurn(t *testing.T) {
+	tick, err := clock.NewTick()
+	require.NoError(t, err)
+	_, err = tick.Join(&clock.JoinInput{ID: "carl"})
+	require.NoError(t, err)
+	turn := &clock.Turn{}
+	_, err = turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+	require.NoError(t, err)
+
+	out, err := clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: "carl", Pos: 1})
+	require.NoError(t, err)
+	// milestones reported leave-then-join (design: Transfer), regardless of execution order
+	require.Equal(t, []clock.Milestone{
+		{Kind: clock.MemberLeft, Subject: "carl"},
+		{Kind: clock.MemberJoined, Subject: "carl", Round: 1},
+	}, out.Milestones)
+	inTurn, err := turn.Contains(&clock.ContainsInput{ID: "carl"})
+	require.NoError(t, err)
+	require.True(t, inTurn)
+	inTick, err := tick.Contains(&clock.ContainsInput{ID: "carl"})
+	require.NoError(t, err)
+	require.False(t, inTick, "one clock per entity")
+}
+
+func TestTransferFailureLeavesBothUnchanged(t *testing.T) {
+	tick, err := clock.NewTick()
+	require.NoError(t, err)
+	_, err = tick.Join(&clock.JoinInput{ID: "carl"})
+	require.NoError(t, err)
+	_, err = tick.Advance(&clock.AdvanceInput{Driver: "p1", Displacement: 3})
+	require.NoError(t, err)
+	idleTurn := &clock.Turn{} // join will refuse: ErrIdle
+
+	tickBefore, turnBefore := tick.ToData(), idleTurn.ToData()
+	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: idleTurn, ID: "carl", Pos: 0})
+	require.ErrorIs(t, err, clock.ErrIdle, "underlying sentinel propagates")
+	require.Equal(t, tickBefore, tick.ToData(), "From unchanged (R6)")
+	require.Equal(t, turnBefore, idleTurn.ToData(), "To unchanged (R6)")
+}
+
+func TestTransferAbsentMemberCompensates(t *testing.T) {
+	tick, err := clock.NewTick()
+	require.NoError(t, err)
+	turn := &clock.Turn{}
+	_, err = turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	require.NoError(t, err)
+
+	turnBefore := turn.ToData()
+	_, err = clock.Transfer(&clock.TransferInput{From: tick, To: turn, ID: ghostID, Pos: 0})
+	require.ErrorIs(t, err, clock.ErrNotMember)
+	require.Equal(t, turnBefore, turn.ToData(), "join was compensated (R6)")
+}

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -28,8 +28,11 @@ type SetOrderOutput struct {
 }
 
 // SetOrder replaces the order, starting round 1 with the first member
-// active. Errors: ErrBadOrder (empty), ErrDuplicateMember.
+// active. Errors: ErrNilInput, ErrBadOrder (empty), ErrDuplicateMember.
 func (t *Turn) SetOrder(in *SetOrderInput) (*SetOrderOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("set order: %w", ErrNilInput)
+	}
 	if len(in.Order) == 0 {
 		return nil, fmt.Errorf("set order: order is empty: %w", ErrBadOrder)
 	}
@@ -77,7 +80,11 @@ type ContainsInput struct {
 }
 
 // Contains reports membership; false is an answer, never an error today.
+// Errors: ErrNilInput.
 func (t *Turn) Contains(in *ContainsInput) (bool, error) {
+	if in == nil {
+		return false, fmt.Errorf("contains: %w", ErrNilInput)
+	}
 	return t.indexOf(in.ID) >= 0, nil
 }
 
@@ -102,9 +109,12 @@ type EndOutput struct {
 	RoundWrapped bool
 }
 
-// End advances past Actor's turn. Errors: ErrIdle, ErrNotActive (with no
+// End advances past Actor's turn. Errors: ErrNilInput, ErrIdle, ErrNotActive (with no
 // state change — R5).
 func (t *Turn) End(in *EndInput) (*EndOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("end turn: %w", ErrNilInput)
+	}
 	if len(t.order) == 0 {
 		return nil, fmt.Errorf("end turn: %w", ErrIdle)
 	}
@@ -137,10 +147,13 @@ type InsertOutput struct {
 	Milestones []Milestone
 }
 
-// Insert adds a member at Pos. Errors: ErrIdle (bubbles start via
+// Insert adds a member at Pos. Errors: ErrNilInput, ErrIdle (bubbles start via
 // SetOrder), ErrDuplicateMember, ErrBadPosition. Inserting at or before
 // the active position keeps the currently active entity active.
 func (t *Turn) Insert(in *InsertInput) (*InsertOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("insert: %w", ErrNilInput)
+	}
 	if len(t.order) == 0 {
 		return nil, fmt.Errorf("insert %q: %w", in.ID, ErrIdle)
 	}
@@ -172,8 +185,11 @@ type RemoveOutput struct {
 }
 
 // Remove drops a member, keeping the active entity correct (design: Turn
-// verbs). Errors: ErrNotMember.
+// verbs). Errors: ErrNilInput, ErrNotMember.
 func (t *Turn) Remove(in *RemoveInput) (*RemoveOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("remove: %w", ErrNilInput)
+	}
 	idx := t.indexOf(in.ID)
 	if idx < 0 {
 		return nil, fmt.Errorf("remove %q: %w", in.ID, ErrNotMember)
@@ -213,8 +229,14 @@ type MergeOutput struct {
 // of the union of both member sets. The receiver's active entity remains
 // active and its round is retained; Other is reset to the zero/idle state.
 // Other must be non-nil and distinct from the receiver.
-// Errors: ErrIdle (idle receiver), ErrSameClock, ErrBadOrder.
+// Errors: ErrNilInput, ErrIdle (idle receiver), ErrSameClock, ErrBadOrder.
 func (t *Turn) Merge(in *MergeInput) (*MergeOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("merge: %w", ErrNilInput)
+	}
+	if in.Other == nil {
+		return nil, fmt.Errorf("merge: %w", ErrNilInput)
+	}
 	if len(t.order) == 0 {
 		return nil, fmt.Errorf("merge: receiver: %w", ErrIdle)
 	}
@@ -264,8 +286,11 @@ type DissolveOutput struct {
 
 // Dissolve empties the clock at fight end. Members transfers the internal slice; the clock
 // drops its reference in the same call — the sanctioned exception to the module's copy-on-read
-// convention (design: Dissolve row). Errors: ErrIdle (already empty).
-func (t *Turn) Dissolve(_ *DissolveInput) (*DissolveOutput, error) {
+// convention (design: Dissolve row). Errors: ErrNilInput, ErrIdle (already empty).
+func (t *Turn) Dissolve(in *DissolveInput) (*DissolveOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("dissolve: %w", ErrNilInput)
+	}
 	if len(t.order) == 0 {
 		return nil, fmt.Errorf("dissolve: %w", ErrIdle)
 	}
@@ -354,7 +379,11 @@ type LeaveMemberOutput struct {
 }
 
 // JoinMember adapts Insert to the Joiner seam.
+// Errors: ErrNilInput, and all errors from Insert.
 func (t *Turn) JoinMember(in *JoinMemberInput) (*JoinMemberOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("join member: %w", ErrNilInput)
+	}
 	out, err := t.Insert(&InsertInput{ID: in.ID, Pos: in.Pos})
 	if err != nil {
 		return nil, err
@@ -363,7 +392,11 @@ func (t *Turn) JoinMember(in *JoinMemberInput) (*JoinMemberOutput, error) {
 }
 
 // LeaveMember adapts Remove to the Leaver seam.
+// Errors: ErrNilInput, and all errors from Remove.
 func (t *Turn) LeaveMember(in *LeaveMemberInput) (*LeaveMemberOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("leave member: %w", ErrNilInput)
+	}
 	out, err := t.Remove(&RemoveInput{ID: in.ID})
 	if err != nil {
 		return nil, err

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -125,3 +125,72 @@ func (t *Turn) End(in *EndInput) (*EndOutput, error) {
 	ms = append(ms, Milestone{Kind: TurnStarted, Subject: next, Round: t.round})
 	return &EndOutput{Milestones: ms, Next: next, RoundWrapped: wrapped}, nil
 }
+
+// InsertInput places a fall-in or reinforcement at a caller-chosen position.
+type InsertInput struct {
+	ID  core.EntityID
+	Pos int
+}
+
+// InsertOutput reports the milestones Insert caused.
+type InsertOutput struct {
+	Milestones []Milestone
+}
+
+// Insert adds a member at Pos. Errors: ErrIdle (bubbles start via
+// SetOrder), ErrDuplicateMember, ErrBadPosition. Inserting at or before
+// the active position keeps the currently active entity active.
+func (t *Turn) Insert(in *InsertInput) (*InsertOutput, error) {
+	if len(t.order) == 0 {
+		return nil, fmt.Errorf("insert %q: %w", in.ID, ErrIdle)
+	}
+	if t.indexOf(in.ID) >= 0 {
+		return nil, fmt.Errorf("insert %q: %w", in.ID, ErrDuplicateMember)
+	}
+	if in.Pos < 0 || in.Pos > len(t.order) {
+		return nil, fmt.Errorf("insert %q at %d (order length %d): %w", in.ID, in.Pos, len(t.order), ErrBadPosition)
+	}
+	t.order = append(t.order, "")
+	copy(t.order[in.Pos+1:], t.order[in.Pos:])
+	t.order[in.Pos] = in.ID
+	if in.Pos <= t.activeIdx {
+		t.activeIdx++
+	}
+	return &InsertOutput{Milestones: []Milestone{
+		{Kind: MemberJoined, Subject: in.ID, Round: t.round},
+	}}, nil
+}
+
+// RemoveInput names the member leaving (death, flight, transfer).
+type RemoveInput struct {
+	ID core.EntityID
+}
+
+// RemoveOutput reports the milestones Remove caused.
+type RemoveOutput struct {
+	Milestones []Milestone
+}
+
+// Remove drops a member, keeping the active entity correct (design: Turn
+// verbs). Errors: ErrNotMember.
+func (t *Turn) Remove(in *RemoveInput) (*RemoveOutput, error) {
+	idx := t.indexOf(in.ID)
+	if idx < 0 {
+		return nil, fmt.Errorf("remove %q: %w", in.ID, ErrNotMember)
+	}
+	wasActive := idx == t.activeIdx
+	t.order = append(t.order[:idx], t.order[idx+1:]...)
+	ms := []Milestone{{Kind: MemberLeft, Subject: in.ID, Round: t.round}}
+	switch {
+	case len(t.order) == 0:
+		t.activeIdx = 0
+	case wasActive:
+		if t.activeIdx >= len(t.order) {
+			t.activeIdx = 0 // active was last; next is first, round unchanged
+		}
+		ms = append(ms, Milestone{Kind: TurnStarted, Subject: t.order[t.activeIdx], Round: t.round})
+	case idx < t.activeIdx:
+		t.activeIdx--
+	}
+	return &RemoveOutput{Milestones: ms}, nil
+}

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -278,3 +278,48 @@ func (t *Turn) Dissolve(_ *DissolveInput) (*DissolveOutput, error) {
 		Milestones: []Milestone{{Kind: Dissolved, Round: round}},
 	}, nil
 }
+
+// TurnData is Turn's persisted shape (design R8). Plain data, no behavior.
+type TurnData struct {
+	Order     []core.EntityID `json:"order,omitempty"`
+	ActiveIdx int             `json:"active_idx,omitempty"`
+	Round     int             `json:"round,omitempty"`
+}
+
+// ToData snapshots the clock. Family-convention exemption from R3 (design).
+func (t *Turn) ToData() TurnData {
+	return TurnData{
+		Order:     append([]core.EntityID(nil), t.order...),
+		ActiveIdx: t.activeIdx,
+		Round:     t.round,
+	}
+}
+
+// LoadTurn reconstructs a Turn from persisted state. A constructor, not a
+// verb — no milestones. Errors: ErrInvalidData for every R9 rejection.
+func LoadTurn(data TurnData) (*Turn, error) {
+	if len(data.Order) == 0 {
+		if data.ActiveIdx != 0 {
+			return nil, fmt.Errorf("load turn: idle clock with active idx %d: %w", data.ActiveIdx, ErrInvalidData)
+		}
+		return &Turn{round: data.Round}, nil
+	}
+	seen := make(map[core.EntityID]struct{}, len(data.Order))
+	for _, id := range data.Order {
+		if _, dup := seen[id]; dup {
+			return nil, fmt.Errorf("load turn: duplicate member %q: %w", id, ErrInvalidData)
+		}
+		seen[id] = struct{}{}
+	}
+	if data.ActiveIdx < 0 || data.ActiveIdx >= len(data.Order) {
+		return nil, fmt.Errorf(
+			"load turn: active idx %d out of range [0,%d): %w",
+			data.ActiveIdx, len(data.Order), ErrInvalidData,
+		)
+	}
+	return &Turn{
+		order:     append([]core.EntityID(nil), data.Order...),
+		activeIdx: data.ActiveIdx,
+		round:     data.Round,
+	}, nil
+}

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -331,3 +331,42 @@ func LoadTurn(data TurnData) (*Turn, error) {
 		round:     data.Round,
 	}, nil
 }
+
+// JoinMemberInput is the Joiner seam's input shape.
+type JoinMemberInput struct {
+	ID  core.EntityID
+	Pos int
+}
+
+// JoinMemberOutput is the Joiner seam's output shape.
+type JoinMemberOutput struct {
+	Milestones []Milestone
+}
+
+// LeaveMemberInput is the Leaver seam's input shape.
+type LeaveMemberInput struct {
+	ID core.EntityID
+}
+
+// LeaveMemberOutput is the Leaver seam's output shape.
+type LeaveMemberOutput struct {
+	Milestones []Milestone
+}
+
+// JoinMember adapts Insert to the Joiner seam.
+func (t *Turn) JoinMember(in *JoinMemberInput) (*JoinMemberOutput, error) {
+	out, err := t.Insert(&InsertInput{ID: in.ID, Pos: in.Pos})
+	if err != nil {
+		return nil, err
+	}
+	return &JoinMemberOutput{Milestones: out.Milestones}, nil
+}
+
+// LeaveMember adapts Remove to the Leaver seam.
+func (t *Turn) LeaveMember(in *LeaveMemberInput) (*LeaveMemberOutput, error) {
+	out, err := t.Remove(&RemoveInput{ID: in.ID})
+	if err != nil {
+		return nil, err
+	}
+	return &LeaveMemberOutput{Milestones: out.Milestones}, nil
+}

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -213,13 +213,13 @@ type MergeOutput struct {
 // of the union of both member sets. The receiver's active entity remains
 // active and its round is retained; Other is reset to the zero/idle state.
 // Other must be non-nil and distinct from the receiver.
-// Errors: ErrIdle (idle receiver), ErrBadOrder.
+// Errors: ErrIdle (idle receiver), ErrSameClock, ErrBadOrder.
 func (t *Turn) Merge(in *MergeInput) (*MergeOutput, error) {
 	if len(t.order) == 0 {
 		return nil, fmt.Errorf("merge: receiver: %w", ErrIdle)
 	}
 	if in.Other == t {
-		return nil, fmt.Errorf("merge: cannot merge a clock into itself: %w", ErrBadOrder)
+		return nil, fmt.Errorf("merge: cannot merge a clock into itself: %w", ErrSameClock)
 	}
 	union := make(map[core.EntityID]struct{}, len(t.order)+len(in.Other.order))
 	for _, id := range t.order {

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// Turn is a localized initiative bubble (design: Turn). The zero value is
+// valid and idle. Not safe for concurrent use (design R10).
+type Turn struct {
+	order     []core.EntityID
+	activeIdx int
+	round     int
+}
+
+// SetOrderInput carries the rulebook-rolled initiative order.
+type SetOrderInput struct {
+	Order []core.EntityID
+}
+
+// SetOrderOutput reports the milestones SetOrder caused.
+type SetOrderOutput struct {
+	Milestones []Milestone
+}
+
+// SetOrder replaces the order, starting round 1 with the first member
+// active. Errors: ErrBadOrder (empty), ErrDuplicateMember.
+func (t *Turn) SetOrder(in *SetOrderInput) (*SetOrderOutput, error) {
+	if len(in.Order) == 0 {
+		return nil, fmt.Errorf("set order: empty: %w", ErrBadOrder)
+	}
+	seen := make(map[core.EntityID]struct{}, len(in.Order))
+	for _, id := range in.Order {
+		if _, dup := seen[id]; dup {
+			return nil, fmt.Errorf("set order: %q appears twice: %w", id, ErrDuplicateMember)
+		}
+		seen[id] = struct{}{}
+	}
+	t.order = append([]core.EntityID(nil), in.Order...)
+	t.activeIdx = 0
+	t.round = 1
+	return &SetOrderOutput{Milestones: []Milestone{
+		{Kind: RoundStarted, Round: 1},
+		{Kind: TurnStarted, Subject: t.order[0], Round: 1},
+	}}, nil
+}
+
+// Active returns the entity whose turn it is; ErrIdle when no order is set.
+func (t *Turn) Active() (core.EntityID, error) {
+	if len(t.order) == 0 {
+		return "", fmt.Errorf("active: %w", ErrIdle)
+	}
+	return t.order[t.activeIdx], nil
+}
+
+// Round returns the current round; ErrIdle when no order is set.
+func (t *Turn) Round() (int, error) {
+	if len(t.order) == 0 {
+		return 0, fmt.Errorf("round: %w", ErrIdle)
+	}
+	return t.round, nil
+}
+
+// Order returns a copy of the current order. An idle clock answers with an
+// empty slice and nil error — an empty list is an answer.
+func (t *Turn) Order() ([]core.EntityID, error) {
+	return append([]core.EntityID(nil), t.order...), nil
+}
+
+// ContainsInput names the entity being asked about.
+type ContainsInput struct {
+	ID core.EntityID
+}
+
+// Contains reports membership; false is an answer, never an error today.
+func (t *Turn) Contains(in *ContainsInput) (bool, error) {
+	return t.indexOf(in.ID) >= 0, nil
+}
+
+func (t *Turn) indexOf(id core.EntityID) int {
+	for i, m := range t.order {
+		if m == id {
+			return i
+		}
+	}
+	return -1
+}

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -31,7 +31,7 @@ type SetOrderOutput struct {
 // active. Errors: ErrBadOrder (empty), ErrDuplicateMember.
 func (t *Turn) SetOrder(in *SetOrderInput) (*SetOrderOutput, error) {
 	if len(in.Order) == 0 {
-		return nil, fmt.Errorf("set order: empty: %w", ErrBadOrder)
+		return nil, fmt.Errorf("set order: order is empty: %w", ErrBadOrder)
 	}
 	seen := make(map[core.EntityID]struct{}, len(in.Order))
 	for _, id := range in.Order {
@@ -88,4 +88,40 @@ func (t *Turn) indexOf(id core.EntityID) int {
 		}
 	}
 	return -1
+}
+
+// EndInput names the actor ending their turn.
+type EndInput struct {
+	Actor core.EntityID
+}
+
+// EndOutput reports what End caused and who acts next.
+type EndOutput struct {
+	Milestones   []Milestone
+	Next         core.EntityID
+	RoundWrapped bool
+}
+
+// End advances past Actor's turn. Errors: ErrIdle, ErrNotActive (with no
+// state change — R5).
+func (t *Turn) End(in *EndInput) (*EndOutput, error) {
+	if len(t.order) == 0 {
+		return nil, fmt.Errorf("end turn: %w", ErrIdle)
+	}
+	active := t.order[t.activeIdx]
+	if in.Actor != active {
+		return nil, fmt.Errorf("end turn: %q is not the active entity (%q is): %w", in.Actor, active, ErrNotActive)
+	}
+	ms := []Milestone{{Kind: TurnEnded, Subject: active, Round: t.round}}
+	t.activeIdx++
+	wrapped := false
+	if t.activeIdx >= len(t.order) {
+		t.activeIdx = 0
+		t.round++
+		wrapped = true
+		ms = append(ms, Milestone{Kind: RoundStarted, Round: t.round})
+	}
+	next := t.order[t.activeIdx]
+	ms = append(ms, Milestone{Kind: TurnStarted, Subject: next, Round: t.round})
+	return &EndOutput{Milestones: ms, Next: next, RoundWrapped: wrapped}, nil
 }

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -211,10 +211,14 @@ type MergeOutput struct {
 // Merge absorbs Other's members under Order, which must be a permutation
 // of the union of both member sets. The receiver's active entity remains
 // active and its round is retained; Other is reset to the zero/idle state.
+// Other must be non-nil and distinct from the receiver.
 // Errors: ErrIdle (idle receiver), ErrBadOrder.
 func (t *Turn) Merge(in *MergeInput) (*MergeOutput, error) {
 	if len(t.order) == 0 {
 		return nil, fmt.Errorf("merge: receiver: %w", ErrIdle)
+	}
+	if in.Other == t {
+		return nil, fmt.Errorf("merge: cannot merge a clock into itself: %w", ErrBadOrder)
 	}
 	union := make(map[core.EntityID]struct{}, len(t.order)+len(in.Other.order))
 	for _, id := range t.order {
@@ -251,11 +255,15 @@ type DissolveInput struct{}
 
 // DissolveOutput returns the members for the composition to re-home.
 type DissolveOutput struct {
+	// Members transfers the internal slice; the clock drops its reference in the same call —
+	// the sanctioned exception to the module's copy-on-read convention (design: Dissolve row).
 	Members    []core.EntityID
 	Milestones []Milestone
 }
 
-// Dissolve empties the clock at fight end. Errors: ErrIdle (already empty).
+// Dissolve empties the clock at fight end. Members transfers the internal slice; the clock
+// drops its reference in the same call — the sanctioned exception to the module's copy-on-read
+// convention (design: Dissolve row). Errors: ErrIdle (already empty).
 func (t *Turn) Dissolve(_ *DissolveInput) (*DissolveOutput, error) {
 	if len(t.order) == 0 {
 		return nil, fmt.Errorf("dissolve: %w", ErrIdle)

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -185,6 +185,7 @@ func (t *Turn) Remove(in *RemoveInput) (*RemoveOutput, error) {
 	switch {
 	case len(t.order) == 0:
 		t.activeIdx = 0
+		t.round = 0
 	case wasActive:
 		if t.activeIdx >= len(t.order) {
 			t.activeIdx = 0 // active was last; next is first, round unchanged

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -181,6 +181,7 @@ func (t *Turn) Remove(in *RemoveInput) (*RemoveOutput, error) {
 	wasActive := idx == t.activeIdx
 	t.order = append(t.order[:idx], t.order[idx+1:]...)
 	ms := []Milestone{{Kind: MemberLeft, Subject: in.ID, Round: t.round}}
+	// order matters: sole-member removal is also wasActive; wasActive arm indexes into possibly-empty order
 	switch {
 	case len(t.order) == 0:
 		t.activeIdx = 0
@@ -193,4 +194,79 @@ func (t *Turn) Remove(in *RemoveInput) (*RemoveOutput, error) {
 		t.activeIdx--
 	}
 	return &RemoveOutput{Milestones: ms}, nil
+}
+
+// MergeInput combines Other into the receiver under a caller-supplied
+// interleaved order (the rulebook decides how initiatives mesh).
+type MergeInput struct {
+	Other *Turn
+	Order []core.EntityID
+}
+
+// MergeOutput reports the milestones Merge caused.
+type MergeOutput struct {
+	Milestones []Milestone
+}
+
+// Merge absorbs Other's members under Order, which must be a permutation
+// of the union of both member sets. The receiver's active entity remains
+// active and its round is retained; Other is reset to the zero/idle state.
+// Errors: ErrIdle (idle receiver), ErrBadOrder.
+func (t *Turn) Merge(in *MergeInput) (*MergeOutput, error) {
+	if len(t.order) == 0 {
+		return nil, fmt.Errorf("merge: receiver: %w", ErrIdle)
+	}
+	union := make(map[core.EntityID]struct{}, len(t.order)+len(in.Other.order))
+	for _, id := range t.order {
+		union[id] = struct{}{}
+	}
+	for _, id := range in.Other.order {
+		union[id] = struct{}{}
+	}
+	if len(in.Order) != len(union) {
+		return nil, fmt.Errorf("merge: order has %d entries, union has %d: %w", len(in.Order), len(union), ErrBadOrder)
+	}
+	seen := make(map[core.EntityID]struct{}, len(in.Order))
+	for _, id := range in.Order {
+		if _, ok := union[id]; !ok {
+			return nil, fmt.Errorf("merge: %q is in neither clock: %w", id, ErrBadOrder)
+		}
+		if _, dup := seen[id]; dup {
+			return nil, fmt.Errorf("merge: %q appears twice: %w", id, ErrBadOrder)
+		}
+		seen[id] = struct{}{}
+	}
+	active := t.order[t.activeIdx]
+	t.order = append([]core.EntityID(nil), in.Order...)
+	t.activeIdx = t.indexOf(active)
+	in.Other.order = nil
+	in.Other.activeIdx = 0
+	in.Other.round = 0
+	return &MergeOutput{Milestones: []Milestone{{Kind: Merged, Round: t.round}}}, nil
+}
+
+// DissolveInput is empty today; verbs keep their Input struct for
+// additive evolution (design R3(b)).
+type DissolveInput struct{}
+
+// DissolveOutput returns the members for the composition to re-home.
+type DissolveOutput struct {
+	Members    []core.EntityID
+	Milestones []Milestone
+}
+
+// Dissolve empties the clock at fight end. Errors: ErrIdle (already empty).
+func (t *Turn) Dissolve(_ *DissolveInput) (*DissolveOutput, error) {
+	if len(t.order) == 0 {
+		return nil, fmt.Errorf("dissolve: %w", ErrIdle)
+	}
+	members := t.order
+	round := t.round
+	t.order = nil
+	t.activeIdx = 0
+	t.round = 0
+	return &DissolveOutput{
+		Members:    members,
+		Milestones: []Milestone{{Kind: Dissolved, Round: round}},
+	}, nil
 }

--- a/play/clock/turn.go
+++ b/play/clock/turn.go
@@ -280,6 +280,7 @@ func (t *Turn) Dissolve(_ *DissolveInput) (*DissolveOutput, error) {
 }
 
 // TurnData is Turn's persisted shape (design R8). Plain data, no behavior.
+// An idle snapshot has nil Order and marshals to {}.
 type TurnData struct {
 	Order     []core.EntityID `json:"order,omitempty"`
 	ActiveIdx int             `json:"active_idx,omitempty"`
@@ -302,7 +303,10 @@ func LoadTurn(data TurnData) (*Turn, error) {
 		if data.ActiveIdx != 0 {
 			return nil, fmt.Errorf("load turn: idle clock with active idx %d: %w", data.ActiveIdx, ErrInvalidData)
 		}
-		return &Turn{round: data.Round}, nil
+		if data.Round != 0 {
+			return nil, fmt.Errorf("load turn: idle clock with round %d: %w", data.Round, ErrInvalidData)
+		}
+		return &Turn{}, nil
 	}
 	seen := make(map[core.EntityID]struct{}, len(data.Order))
 	for _, id := range data.Order {
@@ -316,6 +320,9 @@ func LoadTurn(data TurnData) (*Turn, error) {
 			"load turn: active idx %d out of range [0,%d): %w",
 			data.ActiveIdx, len(data.Order), ErrInvalidData,
 		)
+	}
+	if data.Round < 1 {
+		return nil, fmt.Errorf("load turn: round %d with non-empty order: %w", data.Round, ErrInvalidData)
 	}
 	return &Turn{
 		order:     append([]core.EntityID(nil), data.Order...),

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -399,3 +399,75 @@ func (s *TurnSuite) TestDissolve() {
 	_, err = s.turn.Active()
 	s.Require().ErrorIs(err, clock.ErrIdle)
 }
+
+func (s *TurnSuite) TestToDataSnapshotIsImmuneToLaterVerbs() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+	s.Require().NoError(err)
+	snap := s.turn.ToData()
+	_, err = s.turn.Remove(&clock.RemoveInput{ID: "b"})
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"a", "b", "c"}, snap.Order, "snapshot must not observe later mutations")
+}
+
+func (s *TurnSuite) TestTurnRoundTrip() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+	s.Require().NoError(err)
+	_, err = s.turn.End(&clock.EndInput{Actor: "a"})
+	s.Require().NoError(err)
+	data := s.turn.ToData()
+	loaded, err := clock.LoadTurn(data)
+	s.Require().NoError(err)
+	s.Equal(s.turn.ToData(), loaded.ToData())
+	// behavior-identical: same next actor on End
+	out, err := loaded.End(&clock.EndInput{Actor: "b"})
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("c"), out.Next)
+}
+
+func (s *TurnSuite) TestRoundTripAfterMergeAndDissolve() {
+	// design AC3: post-merge and post-dissolve are named round-trip states
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+	s.Require().NoError(err)
+	other := &clock.Turn{}
+	_, err = other.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"x"}})
+	s.Require().NoError(err)
+	_, err = s.turn.Merge(&clock.MergeInput{Other: other, Order: []core.EntityID{"a", "x", "b"}})
+	s.Require().NoError(err)
+	merged, err := clock.LoadTurn(s.turn.ToData())
+	s.Require().NoError(err)
+	s.Equal(s.turn.ToData(), merged.ToData())
+	drained, err := clock.LoadTurn(other.ToData()) // drained Other is canonical idle
+	s.Require().NoError(err)
+	s.Equal(other.ToData(), drained.ToData())
+
+	_, err = s.turn.Dissolve(&clock.DissolveInput{})
+	s.Require().NoError(err)
+	idle, err := clock.LoadTurn(s.turn.ToData()) // post-dissolve is canonical idle
+	s.Require().NoError(err)
+	s.Equal(s.turn.ToData(), idle.ToData())
+}
+
+func (s *TurnSuite) TestLoadTurnRejectsInvalid() {
+	cases := []struct {
+		name string
+		data clock.TurnData
+	}{
+		{"duplicate members", clock.TurnData{Order: []core.EntityID{"a", "a"}, Round: 1}},
+		{"active idx out of range", clock.TurnData{Order: []core.EntityID{"a"}, ActiveIdx: 1, Round: 1}},
+		{"negative active idx", clock.TurnData{Order: []core.EntityID{"a"}, ActiveIdx: -1, Round: 1}},
+		{"idle with nonzero active idx", clock.TurnData{ActiveIdx: 2}},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			_, err := clock.LoadTurn(tc.data)
+			s.Require().ErrorIs(err, clock.ErrInvalidData)
+		})
+	}
+}
+
+func (s *TurnSuite) TestLoadTurnAcceptsCanonicalIdle() {
+	loaded, err := clock.LoadTurn(clock.TurnData{})
+	s.Require().NoError(err)
+	_, err = loaded.Active()
+	s.Require().ErrorIs(err, clock.ErrIdle)
+}

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -363,6 +363,27 @@ func (s *TurnSuite) TestMergeErrors() {
 	otherOrder, err := other.Order()
 	s.Require().NoError(err)
 	s.Equal([]core.EntityID{"x"}, otherOrder, "failed merge leaves Other intact (R5)")
+	orderAfter, err := s.turn.Order()
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"a"}, orderAfter)
+	roundAfter, err := s.turn.Round()
+	s.Require().NoError(err)
+	s.Equal(1, roundAfter)
+
+	// self-merge must refuse, not silently destroy the receiver
+	_, err = s.turn.Merge(&clock.MergeInput{Other: s.turn, Order: []core.EntityID{"a"}})
+	s.Require().ErrorIs(err, clock.ErrBadOrder)
+	activeSelf, err := s.turn.Active()
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("a"), activeSelf)
+
+	// same length, wrong member: exercises the "in neither clock" branch
+	_, err = s.turn.Merge(&clock.MergeInput{Other: other, Order: []core.EntityID{"ghost", "x"}})
+	s.Require().ErrorIs(err, clock.ErrBadOrder)
+
+	// same length, duplicate: exercises the "appears twice" branch
+	_, err = s.turn.Merge(&clock.MergeInput{Other: other, Order: []core.EntityID{"x", "x"}})
+	s.Require().ErrorIs(err, clock.ErrBadOrder)
 }
 
 func (s *TurnSuite) TestDissolve() {

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -90,6 +90,21 @@ func (s *TurnSuite) TestSetOrderReplacesAndFailedSetOrderChangesNothing() {
 	active, err = s.turn.Active()
 	s.Require().NoError(err)
 	s.Equal(core.EntityID("x"), active)
+
+	// wrap into round 2, then a further replacement must reset to round 1
+	_, err = s.turn.End(&clock.EndInput{Actor: "x"})
+	s.Require().NoError(err)
+	_, err = s.turn.End(&clock.EndInput{Actor: "y"})
+	s.Require().NoError(err)
+	round, err := s.turn.Round()
+	s.Require().NoError(err)
+	s.Equal(2, round)
+	out, err = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"z"}})
+	s.Require().NoError(err)
+	s.Equal([]clock.Milestone{
+		{Kind: clock.RoundStarted, Round: 1},
+		{Kind: clock.TurnStarted, Subject: "z", Round: 1},
+	}, out.Milestones)
 }
 
 // TestNoAliasingThroughSetOrderOrOrder pins the defensive-copy invariants.
@@ -142,4 +157,118 @@ func (s *TurnSuite) TestEndErrors() {
 	active, err := s.turn.Active() // unchanged (R5)
 	s.Require().NoError(err)
 	s.Equal(core.EntityID("a"), active)
+}
+
+// TestEndSingleMemberWraps pins Next == Actor on a one-member clock —
+// every End wraps, and a composition loop waiting for Active to change
+// would hang; this pin documents the contract.
+func (s *TurnSuite) TestEndSingleMemberWraps() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	s.Require().NoError(err)
+	out, err := s.turn.End(&clock.EndInput{Actor: "a"})
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("a"), out.Next)
+	s.True(out.RoundWrapped)
+	s.Equal([]clock.Milestone{
+		{Kind: clock.TurnEnded, Subject: "a", Round: 1},
+		{Kind: clock.RoundStarted, Round: 2},
+		{Kind: clock.TurnStarted, Subject: "a", Round: 2},
+	}, out.Milestones)
+}
+
+func (s *TurnSuite) TestInsertKeepsActiveEntityActive() {
+	cases := []struct {
+		name string
+		pos  int
+	}{
+		{"before active", 0},
+		{"at active", 1},
+		{"after active", 2},
+		{"at end", 3},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			// fresh clock per subtest; advance so "b" (idx 1) is active
+			s.turn = &clock.Turn{}
+			_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+			s.Require().NoError(err)
+			_, err = s.turn.End(&clock.EndInput{Actor: "a"})
+			s.Require().NoError(err)
+
+			out, err := s.turn.Insert(&clock.InsertInput{ID: "x", Pos: tc.pos})
+			s.Require().NoError(err)
+			s.Equal([]clock.Milestone{{Kind: clock.MemberJoined, Subject: "x", Round: 1}}, out.Milestones)
+			active, err := s.turn.Active()
+			s.Require().NoError(err)
+			s.Equal(core.EntityID("b"), active, "active entity must survive insert at pos %d", tc.pos)
+		})
+	}
+}
+
+func (s *TurnSuite) TestInsertErrors() {
+	_, err := s.turn.Insert(&clock.InsertInput{ID: "x", Pos: 0})
+	s.Require().ErrorIs(err, clock.ErrIdle)
+	_, err = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	s.Require().NoError(err)
+	_, err = s.turn.Insert(&clock.InsertInput{ID: "a", Pos: 0})
+	s.Require().ErrorIs(err, clock.ErrDuplicateMember)
+	_, err = s.turn.Insert(&clock.InsertInput{ID: "x", Pos: 2})
+	s.Require().ErrorIs(err, clock.ErrBadPosition)
+	_, err = s.turn.Insert(&clock.InsertInput{ID: "x", Pos: -1})
+	s.Require().ErrorIs(err, clock.ErrBadPosition)
+}
+
+func (s *TurnSuite) TestRemoveSemantics() {
+	// design Remove row: non-active adjusts index; active advances
+	// (MemberLeft, TurnStarted{next}, round unchanged even from last slot);
+	// last member empties the clock (MemberLeft only).
+	s.Run("non-active before active", func() {
+		s.turn = &clock.Turn{}
+		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+		_, _ = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+		out, err := s.turn.Remove(&clock.RemoveInput{ID: "a"})
+		s.Require().NoError(err)
+		s.Equal([]clock.Milestone{{Kind: clock.MemberLeft, Subject: "a", Round: 1}}, out.Milestones)
+		active, _ := s.turn.Active()
+		s.Equal(core.EntityID("b"), active)
+	})
+	s.Run("active mid-order", func() {
+		s.turn = &clock.Turn{}
+		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+		_, _ = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+		out, err := s.turn.Remove(&clock.RemoveInput{ID: "b"})
+		s.Require().NoError(err)
+		s.Equal([]clock.Milestone{
+			{Kind: clock.MemberLeft, Subject: "b", Round: 1},
+			{Kind: clock.TurnStarted, Subject: "c", Round: 1},
+		}, out.Milestones)
+	})
+	s.Run("active in last slot: next is first, round unchanged", func() {
+		s.turn = &clock.Turn{}
+		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+		_, _ = s.turn.End(&clock.EndInput{Actor: "a"}) // b active, last slot
+		out, err := s.turn.Remove(&clock.RemoveInput{ID: "b"})
+		s.Require().NoError(err)
+		s.Equal([]clock.Milestone{
+			{Kind: clock.MemberLeft, Subject: "b", Round: 1},
+			{Kind: clock.TurnStarted, Subject: "a", Round: 1},
+		}, out.Milestones)
+		round, _ := s.turn.Round()
+		s.Equal(1, round)
+	})
+	s.Run("last member empties", func() {
+		s.turn = &clock.Turn{}
+		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+		out, err := s.turn.Remove(&clock.RemoveInput{ID: "a"})
+		s.Require().NoError(err)
+		s.Equal([]clock.Milestone{{Kind: clock.MemberLeft, Subject: "a", Round: 1}}, out.Milestones)
+		_, err = s.turn.Active()
+		s.Require().ErrorIs(err, clock.ErrIdle)
+	})
+	s.Run("absent errors", func() {
+		s.turn = &clock.Turn{}
+		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+		_, err := s.turn.Remove(&clock.RemoveInput{ID: "zz"})
+		s.Require().ErrorIs(err, clock.ErrNotMember)
+	})
 }

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -4,6 +4,7 @@
 package clock_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -456,6 +457,10 @@ func (s *TurnSuite) TestLoadTurnRejectsInvalid() {
 		{"active idx out of range", clock.TurnData{Order: []core.EntityID{"a"}, ActiveIdx: 1, Round: 1}},
 		{"negative active idx", clock.TurnData{Order: []core.EntityID{"a"}, ActiveIdx: -1, Round: 1}},
 		{"idle with nonzero active idx", clock.TurnData{ActiveIdx: 2}},
+		{"negative round with order", clock.TurnData{Order: []core.EntityID{"a"}, Round: -3}},
+		{"zero round with order", clock.TurnData{Order: []core.EntityID{"a"}}},
+		{"idle with nonzero round", clock.TurnData{Round: 5}},
+		{"idle with negative active idx", clock.TurnData{ActiveIdx: -1}},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -470,4 +475,25 @@ func (s *TurnSuite) TestLoadTurnAcceptsCanonicalIdle() {
 	s.Require().NoError(err)
 	_, err = loaded.Active()
 	s.Require().ErrorIs(err, clock.ErrIdle)
+}
+
+// TestTurnDataWireShape pins the JSON persistence contract — tag renames
+// are invisible to gorelease and would orphan every stored snapshot.
+func (s *TurnSuite) TestTurnDataWireShape() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+	s.Require().NoError(err)
+	_, err = s.turn.End(&clock.EndInput{Actor: "a"})
+	s.Require().NoError(err)
+	raw, err := json.Marshal(s.turn.ToData())
+	s.Require().NoError(err)
+	s.JSONEq(`{"order":["a","b"],"active_idx":1,"round":1}`, string(raw))
+	var back clock.TurnData
+	s.Require().NoError(json.Unmarshal(raw, &back))
+	loaded, err := clock.LoadTurn(back)
+	s.Require().NoError(err)
+	s.Equal(s.turn.ToData(), loaded.ToData())
+	// idle snapshot marshals to {}
+	idleRaw, err := json.Marshal(clock.TurnData{})
+	s.Require().NoError(err)
+	s.JSONEq(`{}`, string(idleRaw))
 }

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -387,7 +387,7 @@ func (s *TurnSuite) TestMergeErrors() {
 
 	// self-merge must refuse, not silently destroy the receiver
 	_, err = s.turn.Merge(&clock.MergeInput{Other: s.turn, Order: []core.EntityID{"a"}})
-	s.Require().ErrorIs(err, clock.ErrBadOrder)
+	s.Require().ErrorIs(err, clock.ErrSameClock)
 	activeSelf, err := s.turn.Active()
 	s.Require().NoError(err)
 	s.Equal(core.EntityID("a"), activeSelf)

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -318,6 +318,20 @@ func (s *TurnSuite) TestRemoveSemantics() {
 	})
 }
 
+// TestRemoveLastMemberRoundTrips pins that attrition-ended fights persist
+// as canonical idle — without Remove's round reset, the R9 guard would
+// reject the snapshot and the save would be unloadable.
+func (s *TurnSuite) TestRemoveLastMemberRoundTrips() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	s.Require().NoError(err)
+	_, err = s.turn.Remove(&clock.RemoveInput{ID: "a"})
+	s.Require().NoError(err)
+	s.Equal(clock.TurnData{}, s.turn.ToData(), "post-attrition state is canonical idle")
+	loaded, err := clock.LoadTurn(s.turn.ToData())
+	s.Require().NoError(err)
+	s.Equal(clock.TurnData{}, loaded.ToData())
+}
+
 func (s *TurnSuite) TestMergeCombinesBubbles() {
 	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
 	s.Require().NoError(err)
@@ -461,6 +475,7 @@ func (s *TurnSuite) TestLoadTurnRejectsInvalid() {
 		{"zero round with order", clock.TurnData{Order: []core.EntityID{"a"}}},
 		{"idle with nonzero round", clock.TurnData{Round: 5}},
 		{"idle with negative active idx", clock.TurnData{ActiveIdx: -1}},
+		{"idle with negative round", clock.TurnData{Round: -3}},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -474,6 +489,8 @@ func (s *TurnSuite) TestLoadTurnAcceptsCanonicalIdle() {
 	loaded, err := clock.LoadTurn(clock.TurnData{})
 	s.Require().NoError(err)
 	_, err = loaded.Active()
+	s.Require().ErrorIs(err, clock.ErrIdle)
+	_, err = loaded.Round()
 	s.Require().ErrorIs(err, clock.ErrIdle)
 }
 

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package clock_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/stretchr/testify/suite"
+)
+
+type TurnSuite struct {
+	suite.Suite
+	turn *clock.Turn
+}
+
+func (s *TurnSuite) SetupTest() { s.turn = &clock.Turn{} }
+
+func TestTurnSuite(t *testing.T) { suite.Run(t, new(TurnSuite)) }
+
+func (s *TurnSuite) TestZeroValueIsIdle() {
+	_, err := s.turn.Active()
+	s.Require().ErrorIs(err, clock.ErrIdle)
+	_, err = s.turn.Round()
+	s.Require().ErrorIs(err, clock.ErrIdle)
+	order, err := s.turn.Order()
+	s.Require().NoError(err) // empty list is an answer
+	s.Empty(order)
+}
+
+func (s *TurnSuite) TestSetOrderStartsRoundOne() {
+	out, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+	s.Require().NoError(err)
+	s.Equal([]clock.Milestone{
+		{Kind: clock.RoundStarted, Round: 1},
+		{Kind: clock.TurnStarted, Subject: "a", Round: 1},
+	}, out.Milestones)
+	active, err := s.turn.Active()
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("a"), active)
+	round, err := s.turn.Round()
+	s.Require().NoError(err)
+	s.Equal(1, round)
+}
+
+func (s *TurnSuite) TestSetOrderRejectsEmptyAndDuplicates() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: nil})
+	s.Require().ErrorIs(err, clock.ErrBadOrder)
+	_, err = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "a"}})
+	s.Require().ErrorIs(err, clock.ErrDuplicateMember)
+	_, err = s.turn.Active() // still idle after both rejections (R5 atomicity)
+	s.Require().ErrorIs(err, clock.ErrIdle)
+}
+
+func (s *TurnSuite) TestContains() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	s.Require().NoError(err)
+	got, err := s.turn.Contains(&clock.ContainsInput{ID: "a"})
+	s.Require().NoError(err)
+	s.True(got)
+	got, err = s.turn.Contains(&clock.ContainsInput{ID: "zz"})
+	s.Require().NoError(err)
+	s.False(got)
+}

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -361,7 +361,6 @@ func (s *TurnSuite) TestMergeCombinesBubbles() {
 	s.Empty(otherOrder)
 }
 
-//nolint:goconst // repeated test fixture ID; _test.go exclusions inert until toolkit#904
 func (s *TurnSuite) TestMergeErrors() {
 	other := &clock.Turn{}
 	_, err := other.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"x"}})

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -180,11 +180,12 @@ func (s *TurnSuite) TestInsertKeepsActiveEntityActive() {
 	cases := []struct {
 		name string
 		pos  int
+		want []core.EntityID
 	}{
-		{"before active", 0},
-		{"at active", 1},
-		{"after active", 2},
-		{"at end", 3},
+		{"before active", 0, []core.EntityID{"x", "a", "b", "c"}},
+		{"at active", 1, []core.EntityID{"a", "x", "b", "c"}},
+		{"after active", 2, []core.EntityID{"a", "b", "x", "c"}},
+		{"at end", 3, []core.EntityID{"a", "b", "c", "x"}},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -201,6 +202,9 @@ func (s *TurnSuite) TestInsertKeepsActiveEntityActive() {
 			active, err := s.turn.Active()
 			s.Require().NoError(err)
 			s.Equal(core.EntityID("b"), active, "active entity must survive insert at pos %d", tc.pos)
+			order, err := s.turn.Order()
+			s.Require().NoError(err)
+			s.Equal(tc.want, order)
 		})
 	}
 }
@@ -222,53 +226,155 @@ func (s *TurnSuite) TestRemoveSemantics() {
 	// design Remove row: non-active adjusts index; active advances
 	// (MemberLeft, TurnStarted{next}, round unchanged even from last slot);
 	// last member empties the clock (MemberLeft only).
+	//nolint:dupl // different test case: removes before active, not after
 	s.Run("non-active before active", func() {
 		s.turn = &clock.Turn{}
-		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
-		_, _ = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+		_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+		s.Require().NoError(err)
+		_, err = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+		s.Require().NoError(err)
 		out, err := s.turn.Remove(&clock.RemoveInput{ID: "a"})
 		s.Require().NoError(err)
 		s.Equal([]clock.Milestone{{Kind: clock.MemberLeft, Subject: "a", Round: 1}}, out.Milestones)
-		active, _ := s.turn.Active()
+		active, err := s.turn.Active()
+		s.Require().NoError(err)
 		s.Equal(core.EntityID("b"), active)
+		order, err := s.turn.Order()
+		s.Require().NoError(err)
+		s.Equal([]core.EntityID{"b", "c"}, order)
+	})
+	//nolint:dupl // different test case: removes after active, not before
+	s.Run("non-active after active", func() {
+		s.turn = &clock.Turn{}
+		_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+		s.Require().NoError(err)
+		_, err = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+		s.Require().NoError(err)
+		out, err := s.turn.Remove(&clock.RemoveInput{ID: "c"})
+		s.Require().NoError(err)
+		s.Equal([]clock.Milestone{{Kind: clock.MemberLeft, Subject: "c", Round: 1}}, out.Milestones)
+		active, err := s.turn.Active()
+		s.Require().NoError(err)
+		s.Equal(core.EntityID("b"), active)
+		order, err := s.turn.Order()
+		s.Require().NoError(err)
+		s.Equal([]core.EntityID{"a", "b"}, order)
 	})
 	s.Run("active mid-order", func() {
 		s.turn = &clock.Turn{}
-		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
-		_, _ = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+		_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+		s.Require().NoError(err)
+		_, err = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+		s.Require().NoError(err)
 		out, err := s.turn.Remove(&clock.RemoveInput{ID: "b"})
 		s.Require().NoError(err)
 		s.Equal([]clock.Milestone{
 			{Kind: clock.MemberLeft, Subject: "b", Round: 1},
 			{Kind: clock.TurnStarted, Subject: "c", Round: 1},
 		}, out.Milestones)
+		order, err := s.turn.Order()
+		s.Require().NoError(err)
+		s.Equal([]core.EntityID{"a", "c"}, order)
 	})
 	s.Run("active in last slot: next is first, round unchanged", func() {
 		s.turn = &clock.Turn{}
-		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
-		_, _ = s.turn.End(&clock.EndInput{Actor: "a"}) // b active, last slot
+		_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+		s.Require().NoError(err)
+		_, err = s.turn.End(&clock.EndInput{Actor: "a"}) // b active, last slot
+		s.Require().NoError(err)
 		out, err := s.turn.Remove(&clock.RemoveInput{ID: "b"})
 		s.Require().NoError(err)
 		s.Equal([]clock.Milestone{
 			{Kind: clock.MemberLeft, Subject: "b", Round: 1},
 			{Kind: clock.TurnStarted, Subject: "a", Round: 1},
 		}, out.Milestones)
-		round, _ := s.turn.Round()
+		round, err := s.turn.Round()
+		s.Require().NoError(err)
 		s.Equal(1, round)
+		order, err := s.turn.Order()
+		s.Require().NoError(err)
+		s.Equal([]core.EntityID{"a"}, order)
 	})
 	s.Run("last member empties", func() {
 		s.turn = &clock.Turn{}
-		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+		_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+		s.Require().NoError(err)
 		out, err := s.turn.Remove(&clock.RemoveInput{ID: "a"})
 		s.Require().NoError(err)
 		s.Equal([]clock.Milestone{{Kind: clock.MemberLeft, Subject: "a", Round: 1}}, out.Milestones)
 		_, err = s.turn.Active()
 		s.Require().ErrorIs(err, clock.ErrIdle)
+		order, err := s.turn.Order()
+		s.Require().NoError(err)
+		s.Empty(order)
 	})
 	s.Run("absent errors", func() {
 		s.turn = &clock.Turn{}
-		_, _ = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
-		_, err := s.turn.Remove(&clock.RemoveInput{ID: "zz"})
+		_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+		s.Require().NoError(err)
+		_, err = s.turn.Remove(&clock.RemoveInput{ID: "zz"})
 		s.Require().ErrorIs(err, clock.ErrNotMember)
 	})
+}
+
+func (s *TurnSuite) TestMergeCombinesBubbles() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+	s.Require().NoError(err)
+	_, err = s.turn.End(&clock.EndInput{Actor: "a"}) // b active
+	s.Require().NoError(err)
+	other := &clock.Turn{}
+	_, err = other.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"x", "y"}})
+	s.Require().NoError(err)
+
+	out, err := s.turn.Merge(&clock.MergeInput{Other: other, Order: []core.EntityID{"x", "b", "y", "a"}})
+	s.Require().NoError(err)
+	s.Equal([]clock.Milestone{{Kind: clock.Merged, Round: 1}}, out.Milestones)
+	active, err := s.turn.Active()
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("b"), active, "receiving clock's active entity remains active")
+	round, err := s.turn.Round()
+	s.Require().NoError(err)
+	s.Equal(1, round, "receiver's round retained")
+	order, err := s.turn.Order()
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"x", "b", "y", "a"}, order)
+	// Other reset to zero/idle state
+	_, err = other.Active()
+	s.Require().ErrorIs(err, clock.ErrIdle)
+	otherOrder, err := other.Order()
+	s.Require().NoError(err)
+	s.Empty(otherOrder)
+}
+
+func (s *TurnSuite) TestMergeErrors() {
+	other := &clock.Turn{}
+	_, err := other.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"x"}})
+	s.Require().NoError(err)
+	_, err = s.turn.Merge(&clock.MergeInput{Other: other, Order: []core.EntityID{"x"}})
+	s.Require().ErrorIs(err, clock.ErrIdle, "idle receiver refuses merge")
+
+	_, err = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a"}})
+	s.Require().NoError(err)
+	_, err = s.turn.Merge(&clock.MergeInput{Other: other, Order: []core.EntityID{"a", "x", "ghost"}})
+	s.Require().ErrorIs(err, clock.ErrBadOrder, "order must be an exact permutation of the union")
+	activeAfter, err := s.turn.Active()
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("a"), activeAfter, "failed merge changes nothing (R5)")
+	otherOrder, err := other.Order()
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"x"}, otherOrder, "failed merge leaves Other intact (R5)")
+}
+
+func (s *TurnSuite) TestDissolve() {
+	_, err := s.turn.Dissolve(&clock.DissolveInput{})
+	s.Require().ErrorIs(err, clock.ErrIdle, "dissolving an empty clock errors")
+
+	_, err = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+	s.Require().NoError(err)
+	out, err := s.turn.Dissolve(&clock.DissolveInput{})
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"a", "b"}, out.Members)
+	s.Equal([]clock.Milestone{{Kind: clock.Dissolved, Round: 1}}, out.Milestones)
+	_, err = s.turn.Active()
+	s.Require().ErrorIs(err, clock.ErrIdle)
 }

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -28,6 +28,9 @@ func (s *TurnSuite) TestZeroValueIsIdle() {
 	order, err := s.turn.Order()
 	s.Require().NoError(err) // empty list is an answer
 	s.Empty(order)
+	got, err := s.turn.Contains(&clock.ContainsInput{ID: "a"})
+	s.Require().NoError(err)
+	s.False(got) // false is an answer, idle included
 }
 
 func (s *TurnSuite) TestSetOrderStartsRoundOne() {
@@ -63,4 +66,80 @@ func (s *TurnSuite) TestContains() {
 	got, err = s.turn.Contains(&clock.ContainsInput{ID: "zz"})
 	s.Require().NoError(err)
 	s.False(got)
+}
+
+// TestSetOrderReplacesAndFailedSetOrderChangesNothing pins R5 from a
+// populated clock and the design's replacement semantics.
+func (s *TurnSuite) TestSetOrderReplacesAndFailedSetOrderChangesNothing() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b", "c"}})
+	s.Require().NoError(err)
+	_, err = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"x", "x"}})
+	s.Require().ErrorIs(err, clock.ErrDuplicateMember)
+	active, err := s.turn.Active()
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("a"), active)
+	order, err := s.turn.Order()
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"a", "b", "c"}, order)
+	out, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"x", "y"}})
+	s.Require().NoError(err)
+	s.Equal([]clock.Milestone{
+		{Kind: clock.RoundStarted, Round: 1},
+		{Kind: clock.TurnStarted, Subject: "x", Round: 1},
+	}, out.Milestones)
+	active, err = s.turn.Active()
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("x"), active)
+}
+
+// TestNoAliasingThroughSetOrderOrOrder pins the defensive-copy invariants.
+func (s *TurnSuite) TestNoAliasingThroughSetOrderOrOrder() {
+	in := []core.EntityID{"a", "b"}
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: in})
+	s.Require().NoError(err)
+	in[0] = "mutated"
+	order, err := s.turn.Order()
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"a", "b"}, order)
+	order[1] = "mutated"
+	again, err := s.turn.Order()
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"a", "b"}, again)
+}
+
+func (s *TurnSuite) TestEndAdvancesAndWraps() {
+	_, err := s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+	s.Require().NoError(err)
+
+	out, err := s.turn.End(&clock.EndInput{Actor: "a"})
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("b"), out.Next)
+	s.False(out.RoundWrapped)
+	s.Equal([]clock.Milestone{
+		{Kind: clock.TurnEnded, Subject: "a", Round: 1},
+		{Kind: clock.TurnStarted, Subject: "b", Round: 1},
+	}, out.Milestones)
+
+	out, err = s.turn.End(&clock.EndInput{Actor: "b"})
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("a"), out.Next)
+	s.True(out.RoundWrapped)
+	// Wrap: TurnEnded carries the OLD round; RoundStarted/TurnStarted the NEW (design: Milestone).
+	s.Equal([]clock.Milestone{
+		{Kind: clock.TurnEnded, Subject: "b", Round: 1},
+		{Kind: clock.RoundStarted, Round: 2},
+		{Kind: clock.TurnStarted, Subject: "a", Round: 2},
+	}, out.Milestones)
+}
+
+func (s *TurnSuite) TestEndErrors() {
+	_, err := s.turn.End(&clock.EndInput{Actor: "a"})
+	s.Require().ErrorIs(err, clock.ErrIdle)
+	_, err = s.turn.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"a", "b"}})
+	s.Require().NoError(err)
+	_, err = s.turn.End(&clock.EndInput{Actor: "b"})
+	s.Require().ErrorIs(err, clock.ErrNotActive)
+	active, err := s.turn.Active() // unchanged (R5)
+	s.Require().NoError(err)
+	s.Equal(core.EntityID("a"), active)
 }

--- a/play/clock/turn_test.go
+++ b/play/clock/turn_test.go
@@ -361,6 +361,7 @@ func (s *TurnSuite) TestMergeCombinesBubbles() {
 	s.Empty(otherOrder)
 }
 
+//nolint:goconst // repeated test fixture ID; _test.go exclusions inert until toolkit#904
 func (s *TurnSuite) TestMergeErrors() {
 	other := &clock.Turn{}
 	_, err := other.SetOrder(&clock.SetOrderInput{Order: []core.EntityID{"x"}})


### PR DESCRIPTION
First `play/` leaf module of the encounter reset (journey 051, PR #901 — recommend merging that docs PR first so `doc.go`'s design reference resolves on main).

Implements `docs/ideas/play/clock/design.md` exactly: **Turn** (localized initiative bubble: SetOrder/End/Insert/Remove/Merge/Dissolve), **Tick** (player-driven world clock: high-water max-displacement Advance, Spend), the 8-kind **Milestone** vocabulary (returned as values, never published), ten sentinel errors with `errors.Is` dispatch, **Membership seams + atomic Transfer** (join-first with compensating leave; `ErrSameClock` distinctness guard), and `ToData`/`LoadTurn`/`LoadTick` persistence with reachable-states-only validation.

**Evidence**: AC1 DOS2 split-party transcript test green (25 milestones asserted end-to-end, independently re-derived from the verb implementations by review); AC2 invariants including byte-identical Transfer-failure state; AC3 round-trips at every named state including attrition-ended fights; AC4 `compat.yml` gorelease gate (pinned version, activates from first tag); AC6 all ten sentinels `errors.Is`-tested. Coverage 99.5% — the sole uncovered branch is Transfer's defensive double-failure, unreachable with in-module clocks. Leaf laws hold: deps = core v0.11.0 + stdlib (testify in tests), zero `context.Context`, zero randomness.

**Process**: every task implemented by a fresh subagent and passed through independent spec-compliance + code-quality review with fix cycles. Defects the pipeline caught before this PR: self-merge and self-transfer silent corruption, an attrition-save round-trip regression, an alias-passable type test, mutant-survivable index-drift coverage, and an unpinned JSON wire contract. Full audit trail in `docs/ideas/play/clock/plan.md`'s Execution addenda (PR #901 branch).

Prerequisite core.EntityID landed via #902 (merged, tagged core v0.11.0).

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq