### PR TITLE
feat(play/record): the story log — Append/TrimBefore/SliceFor with tag question-surface

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'play/clock/**'
+      - 'play/record/**'
 
 jobs:
   gorelease-play-clock:
@@ -24,3 +25,21 @@ jobs:
           fi
           cd play/clock
           go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base "${base#play/clock/}"
+  gorelease-play-record:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: gorelease play/record
+        run: |
+          base=$(git tag -l 'play/record/v*' --sort=-v:refname | head -1)
+          if [ -z "$base" ]; then
+            echo "no play/record tag yet — first release, gate activates from the first tag"
+            exit 0
+          fi
+          cd play/record
+          go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base "${base#play/record/}"

--- a/play/record/data.go
+++ b/play/record/data.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package record
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// LogData is the persistent representation of a Log.
+// The zero value marshals to {} (design R8); the fresh-log encoding convention
+// stores NextSeq 0 for a never-appended log (runtime nextSeq 1), so LoadLog(LogData{})
+// yields a fresh log with NextSeq() == 1. Trimmed-empty logs store their real
+// NextSeq (always >= 2). Stored NextSeq 1 is never written and is rejected by LoadLog.
+type LogData struct {
+	// NextSeq is the sequence number the next Append will assign (or 0 for fresh).
+	NextSeq uint64 `json:"next_seq,omitempty"`
+	// Entries are the retained log entries, deep-copied from the runtime log.
+	Entries []EntryData `json:"entries,omitempty"`
+}
+
+// EntryData is the persistent representation of an Entry.
+type EntryData struct {
+	// Seq is the monotonic, gapless sequence assigned at Append.
+	Seq uint64 `json:"seq"`
+	// At is the optional caller-supplied provenance timestamp.
+	At uint64 `json:"at,omitempty"`
+	// Correlation is an opaque caller token grouping cause and effects.
+	Correlation string `json:"correlation,omitempty"`
+	// Audience is the roster of viewers.
+	Audience []core.EntityID `json:"audience,omitempty"`
+	// Tags is the caller-chosen question-surface.
+	Tags map[string]string `json:"tags,omitempty"`
+	// Payload is the opaque composition-encoded story beats.
+	Payload []byte `json:"payload"`
+}
+
+// ToData returns the persistent representation of the Log.
+// The fresh-log encoding convention (design R8): a never-appended log
+// (nextSeq == 1, no entries) returns the zero LogData (NextSeq 0, Entries nil).
+// A trimmed-empty log (nextSeq >= 2, no entries) stores the real NextSeq.
+// A populated log stores NextSeq and deep-copied entries.
+func (l *Log) ToData() LogData {
+	// Fresh log: nextSeq == 1 && no entries → return zero LogData
+	if l.nextSeq == 1 && len(l.entries) == 0 {
+		return LogData{}
+	}
+
+	// Populated or trimmed-empty: store the real NextSeq and deep-copied entries
+	data := LogData{
+		NextSeq: l.nextSeq,
+	}
+
+	if len(l.entries) > 0 {
+		data.Entries = make([]EntryData, len(l.entries))
+		for i, e := range l.entries {
+			data.Entries[i] = EntryData{
+				Seq:         e.seq,
+				At:          e.at,
+				Correlation: e.correlation,
+				Audience:    copyAudience(e.audience),
+				Tags:        copyTags(e.tags),
+				Payload:     copyPayload(e.payload),
+			}
+		}
+	}
+
+	return data
+}
+
+// LoadLog reconstructs a Log from persisted LogData.
+// Validates per design R9: rejects non-contiguous/zero Seqs, mismatched
+// NextSeq-to-lastSeq relationship, stored NextSeq 1 (fresh encodes as 0),
+// invalid audiences (empty IDs, duplicates), invalid tags (empty keys),
+// and nil payloads. Deep-copies all data; empty→nil normalization preserved.
+// Returns ErrInvalidData for any R9 rejection with verb-context wrapping.
+func LoadLog(data LogData) (*Log, error) {
+	// Empty data (zero LogData) → fresh log (nextSeq 1)
+	if data.NextSeq == 0 && len(data.Entries) == 0 {
+		return &Log{nextSeq: 1}, nil
+	}
+
+	// Validate empty-entries case
+	if len(data.Entries) == 0 {
+		// Stored NextSeq 1 is never written (fresh encodes as 0, trimmed-empty >= 2)
+		if data.NextSeq == 1 {
+			return nil, fmt.Errorf("load log: empty entries with next_seq 1 unreachable: %w", ErrInvalidData)
+		}
+		// Trimmed-empty: NextSeq >= 2 is legal
+		return &Log{nextSeq: data.NextSeq}, nil
+	}
+
+	// Non-empty: validate contiguity, NextSeq, and per-entry constraints
+
+	// Check contiguity: first seq >= 1, each seq == prev + 1
+	for i, ed := range data.Entries {
+		if ed.Seq == 0 {
+			return nil, fmt.Errorf("load log: entry[%d] seq 0: %w", i, ErrInvalidData)
+		}
+		if i > 0 {
+			prevSeq := data.Entries[i-1].Seq
+			if ed.Seq != prevSeq+1 {
+				msg := fmt.Sprintf(
+					"load log: entry[%d] seq %d not contiguous (prev %d)",
+					i, ed.Seq, prevSeq,
+				)
+				return nil, fmt.Errorf("%s: %w", msg, ErrInvalidData)
+			}
+		}
+	}
+
+	// Check NextSeq == lastSeq + 1 exactly
+	lastSeq := data.Entries[len(data.Entries)-1].Seq
+	if data.NextSeq != lastSeq+1 {
+		msg := fmt.Sprintf(
+			"load log: next_seq %d != last_seq+1 (%d+1=%d)",
+			data.NextSeq, lastSeq, lastSeq+1,
+		)
+		return nil, fmt.Errorf("%s: %w", msg, ErrInvalidData)
+	}
+
+	// Validate per-entry constraints
+	for i, ed := range data.Entries {
+		// Validate audience (no empty IDs, no duplicates)
+		if err := validateAudience(ed.Audience); err != nil {
+			return nil, fmt.Errorf("load log: entry[%d] audience: invalid data: %w", i, ErrInvalidData)
+		}
+
+		// Validate tags (no empty keys)
+		if err := validateTags(ed.Tags); err != nil {
+			return nil, fmt.Errorf("load log: entry[%d] tags: invalid data: %w", i, ErrInvalidData)
+		}
+
+		// Validate payload (not nil)
+		if ed.Payload == nil {
+			return nil, fmt.Errorf("load log: entry[%d] payload nil: %w", i, ErrInvalidData)
+		}
+	}
+
+	// All validation passed; deep-copy entries
+	entries := make([]entry, len(data.Entries))
+	for i, ed := range data.Entries {
+		entries[i] = entry{
+			seq:         ed.Seq,
+			at:          ed.At,
+			correlation: ed.Correlation,
+			audience:    copyAudience(ed.Audience),
+			tags:        copyTags(ed.Tags),
+			payload:     copyPayload(ed.Payload),
+		}
+	}
+
+	return &Log{
+		entries: entries,
+		nextSeq: data.NextSeq,
+	}, nil
+}

--- a/play/record/data.go
+++ b/play/record/data.go
@@ -94,6 +94,11 @@ func LoadLog(data LogData) (*Log, error) {
 
 	// Non-empty: validate contiguity, NextSeq, and per-entry constraints
 
+	// Reject NextSeq 0 on non-empty path (fresh encodes as 0; 0 with entries is unreachable)
+	if data.NextSeq == 0 {
+		return nil, fmt.Errorf("load log: next seq 0 with entries: %w", ErrInvalidData)
+	}
+
 	// Check contiguity: first seq >= 1, each seq == prev + 1
 	for i, ed := range data.Entries {
 		if ed.Seq == 0 {
@@ -125,12 +130,14 @@ func LoadLog(data LogData) (*Log, error) {
 	for i, ed := range data.Entries {
 		// Validate audience (no empty IDs, no duplicates)
 		if err := validateAudience(ed.Audience); err != nil {
-			return nil, fmt.Errorf("load log: entry[%d] audience: invalid data: %w", i, ErrInvalidData)
+			// Include validation detail in message without double-wrapping
+			return nil, fmt.Errorf("load log: entry[%d] %v: %w", i, err, ErrInvalidData)
 		}
 
 		// Validate tags (no empty keys)
 		if err := validateTags(ed.Tags); err != nil {
-			return nil, fmt.Errorf("load log: entry[%d] tags: invalid data: %w", i, ErrInvalidData)
+			// Include validation detail in message without double-wrapping
+			return nil, fmt.Errorf("load log: entry[%d] %v: %w", i, err, ErrInvalidData)
 		}
 
 		// Validate payload (not nil)

--- a/play/record/doc.go
+++ b/play/record/doc.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package record is the retained story: an append-only, sequence-ordered,
+// audience-projected, tag-queryable log of opaque entries. Storage and
+// query only — streaming the appends is the host's business; payloads and
+// tag vocabularies belong to the composition; record never interprets.
+//
+// Design contract: docs/ideas/play/record/design.md (R1–R10). Leaf module:
+// depends only on core, takes no context.Context, returns results as
+// values, and never publishes.
+package record

--- a/play/record/errors.go
+++ b/play/record/errors.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package record
+
+import "errors"
+
+// Sentinel errors — the module's error vocabulary (design: Errors).
+// All returned errors wrap exactly one of these; callers dispatch with
+// errors.Is. Messages are user-facing.
+var (
+	// ErrNilInput reports a nil *XxxInput. Caller defect, dedicated sentinel.
+	ErrNilInput = errors.New("nil input")
+	// ErrBadAudience reports an audience with empty IDs or duplicates.
+	ErrBadAudience = errors.New("invalid audience")
+	// ErrBadTag reports a tag (or filter) key that is empty.
+	ErrBadTag = errors.New("invalid tag key")
+	// ErrNoPayload reports a nil payload (empty non-nil is legal).
+	ErrNoPayload = errors.New("nil payload")
+	// ErrBadSeq reports a trim point beyond NextSeq — you cannot forget the future.
+	ErrBadSeq = errors.New("sequence out of range")
+	// ErrNoViewer reports an empty viewer ID.
+	ErrNoViewer = errors.New("empty viewer")
+	// ErrInvalidData reports persisted state rejected by LoadLog (design R9).
+	ErrInvalidData = errors.New("invalid log data")
+)

--- a/play/record/errors_test.go
+++ b/play/record/errors_test.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package record_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/record"
+)
+
+// TestSentinelsAreDistinct verifies all error sentinels are non-nil and pairwise distinct.
+func TestSentinelsAreDistinct(t *testing.T) {
+	sentinels := []error{
+		record.ErrNilInput,
+		record.ErrBadAudience,
+		record.ErrBadTag,
+		record.ErrNoPayload,
+		record.ErrBadSeq,
+		record.ErrNoViewer,
+		record.ErrInvalidData,
+	}
+
+	// Assert each sentinel is non-nil
+	for i, sentinel := range sentinels {
+		if sentinel == nil {
+			t.Errorf("sentinel[%d] is nil", i)
+		}
+	}
+
+	// Assert pairwise distinctness
+	for i := 0; i < len(sentinels); i++ {
+		for j := 0; j < len(sentinels); j++ {
+			if i != j && errors.Is(sentinels[i], sentinels[j]) {
+				t.Errorf("sentinel[%d] and sentinel[%d] are not distinct", i, j)
+			}
+		}
+	}
+}

--- a/play/record/go.mod
+++ b/play/record/go.mod
@@ -1,3 +1,14 @@
 module github.com/KirkDiggler/rpg-toolkit/play/record
 
 go 1.24
+
+require (
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/play/record/go.mod
+++ b/play/record/go.mod
@@ -1,0 +1,3 @@
+module github.com/KirkDiggler/rpg-toolkit/play/record
+
+go 1.24

--- a/play/record/go.sum
+++ b/play/record/go.sum
@@ -1,0 +1,12 @@
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/play/record/log.go
+++ b/play/record/log.go
@@ -1,0 +1,249 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package record
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// Log is the retained story: an append-only, sequence-ordered, audience-projected
+// log of opaque entries. It provides storage and query only.
+//
+// Not safe for concurrent use (design R10). The zero value is not usable;
+// construct via NewLog or LoadLog.
+type Log struct {
+	entries []entry
+	nextSeq uint64
+}
+
+// entry is the internal representation of a log entry, with deep-copied
+// fields and nil-normalized empty containers.
+type entry struct {
+	seq         uint64
+	at          uint64
+	correlation string
+	audience    []core.EntityID
+	tags        map[string]string
+	payload     []byte
+}
+
+// Entry is the read-side value returned from queries.
+type Entry struct {
+	// Seq is the monotonic, gapless, strictly-increasing sequence assigned
+	// by Append and never renumbered by TrimBefore.
+	Seq uint64
+	// At is the optional caller-supplied provenance timestamp (e.g., wall
+	// clock). The log's order is Seq; At is informational.
+	At uint64
+	// Correlation is an opaque caller token grouping cause and effects
+	// across entries. Empty is legal (an uncorrelated beat).
+	Correlation string
+	// Audience is the roster of viewers; materialized and duplicate-free.
+	// Empty (nil or empty slice) means no viewer — the GM/debug beat.
+	// "Everyone" is an explicit roster, never implicit.
+	Audience []core.EntityID
+	// Tags is the caller-chosen question-surface: queryable metadata.
+	// Typical keys: "kind" (e.g., "intel.first_contact", "clock.turn_started"),
+	// "observer", "subject", "actor". Record never interprets keys or values;
+	// keys MUST be non-empty (enforced at Append). Empty values are legal
+	// (flags); nil/empty tags are legal (an unaskable beat).
+	Tags map[string]string
+	// Payload is opaque composition-encoded story beats (leaf deltas, outcomes).
+	// Record never interprets.
+	Payload []byte
+}
+
+// AppendInput is the input to the Append verb.
+type AppendInput struct {
+	// At is the optional caller-supplied provenance timestamp.
+	At uint64
+	// Correlation is an opaque caller token grouping cause and effects.
+	Correlation string
+	// Audience is the roster of viewers. MUST be duplicate-free with no empty
+	// IDs. Empty-non-nil is legal and normalized to nil on store.
+	Audience []core.EntityID
+	// Tags is the caller-chosen question-surface. Keys MUST be non-empty;
+	// values may be anything including empty. Empty-non-nil is legal and
+	// normalized to nil on store.
+	Tags map[string]string
+	// Payload is opaque composition-encoded story beats. MUST be non-nil
+	// (empty non-nil is legal).
+	Payload []byte
+}
+
+// AppendOutput is the output of the Append verb.
+type AppendOutput struct {
+	// Seq is the assigned sequence number, monotonic and gapless from 1.
+	Seq uint64
+}
+
+// AllInput is the input to the All query.
+type AllInput struct {
+	// FromSeq is the inclusive lower bound of sequences to return.
+	FromSeq uint64
+}
+
+// NewLog returns a fresh Log ready for use.
+// Returns (*Log, error) per family law (cannot fail today; error slot reserved).
+func NewLog() (*Log, error) {
+	return &Log{nextSeq: 1}, nil
+}
+
+// Append appends one immutable entry to the log, assigning the next Seq.
+// Validates per the design's Append verb, first-failure-wins in order:
+// nil guard, Audience (no empty IDs or duplicates), Tags (no empty keys),
+// Payload (not nil, empty non-nil legal). On error, no state changed (R5).
+// Audience and tags are defensively copied, with empty-non-nil normalized
+// to nil on store (family nil-container convention).
+func (l *Log) Append(in *AppendInput) (*AppendOutput, error) {
+	// Step 1: nil guard
+	if in == nil {
+		return nil, fmt.Errorf("%w", ErrNilInput)
+	}
+
+	// Step 2: validate audience (no empty IDs, no duplicates)
+	if err := l.validateAudience(in.Audience); err != nil {
+		return nil, err
+	}
+
+	// Step 3: validate tags (no empty keys)
+	if err := l.validateTags(in.Tags); err != nil {
+		return nil, err
+	}
+
+	// Step 4: validate payload (must be non-nil)
+	if in.Payload == nil {
+		return nil, fmt.Errorf("%w", ErrNoPayload)
+	}
+
+	// All validation passed; now mutate state (R5 atomicity)
+	seq := l.nextSeq
+	l.nextSeq++
+
+	// Deep copy and normalize audience
+	var aud []core.EntityID
+	if len(in.Audience) > 0 {
+		aud = make([]core.EntityID, len(in.Audience))
+		copy(aud, in.Audience)
+	}
+
+	// Deep copy and normalize tags
+	var tgs map[string]string
+	if len(in.Tags) > 0 {
+		tgs = make(map[string]string, len(in.Tags))
+		for k, v := range in.Tags {
+			tgs[k] = v
+		}
+	}
+
+	// Copy payload
+	p := make([]byte, len(in.Payload))
+	copy(p, in.Payload)
+
+	// Append entry
+	l.entries = append(l.entries, entry{
+		seq:         seq,
+		at:          in.At,
+		correlation: in.Correlation,
+		audience:    aud,
+		tags:        tgs,
+		payload:     p,
+	})
+
+	return &AppendOutput{Seq: seq}, nil
+}
+
+// NextSeq returns the sequence number the next Append will assign.
+// Zero-arg read, never errs today; the error slot is the law's.
+func (l *Log) NextSeq() (uint64, error) {
+	return l.nextSeq, nil
+}
+
+// All returns every retained entry with Seq >= in.FromSeq, in Seq order.
+// Nil guard → ErrNilInput. Copy-out: returned entries MUST NOT alias
+// internal state (nil stays nil, non-nil is deep-copied).
+func (l *Log) All(in *AllInput) ([]Entry, error) {
+	if in == nil {
+		return nil, fmt.Errorf("%w", ErrNilInput)
+	}
+
+	var result []Entry
+	for _, e := range l.entries {
+		if e.seq >= in.FromSeq {
+			result = append(result, l.entryToCopy(e))
+		}
+	}
+	return result, nil
+}
+
+// entryToCopy converts an internal entry to an exported Entry with deep copies.
+func (l *Log) entryToCopy(e entry) Entry {
+	return Entry{
+		Seq:         e.seq,
+		At:          e.at,
+		Correlation: e.correlation,
+		Audience:    copyAudience(e.audience),
+		Tags:        copyTags(e.tags),
+		Payload:     copyPayload(e.payload),
+	}
+}
+
+// validateAudience checks that audience is duplicate-free with no empty IDs.
+func (l *Log) validateAudience(aud []core.EntityID) error {
+	seen := make(map[core.EntityID]bool)
+	for _, id := range aud {
+		if id == "" {
+			return fmt.Errorf("%w", ErrBadAudience)
+		}
+		if seen[id] {
+			return fmt.Errorf("%w", ErrBadAudience)
+		}
+		seen[id] = true
+	}
+	return nil
+}
+
+// validateTags checks that all keys are non-empty.
+func (l *Log) validateTags(tags map[string]string) error {
+	for k := range tags {
+		if k == "" {
+			return fmt.Errorf("%w", ErrBadTag)
+		}
+	}
+	return nil
+}
+
+// copyAudience returns a deep copy of the audience, or nil if empty.
+func copyAudience(aud []core.EntityID) []core.EntityID {
+	if len(aud) == 0 {
+		return nil
+	}
+	result := make([]core.EntityID, len(aud))
+	copy(result, aud)
+	return result
+}
+
+// copyTags returns a deep copy of the tags map, or nil if empty.
+func copyTags(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(tags))
+	for k, v := range tags {
+		result[k] = v
+	}
+	return result
+}
+
+// copyPayload returns a deep copy of the payload bytes.
+func copyPayload(p []byte) []byte {
+	if len(p) == 0 {
+		return make([]byte, 0)
+	}
+	result := make([]byte, len(p))
+	copy(result, p)
+	return result
+}

--- a/play/record/log.go
+++ b/play/record/log.go
@@ -80,10 +80,26 @@ type AppendOutput struct {
 	Seq uint64
 }
 
+// SliceForInput is the input to the SliceFor query.
+type SliceForInput struct {
+	// Viewer is the audience member whose story is requested. MUST be non-empty.
+	Viewer core.EntityID
+	// FromSeq is the inclusive lower bound of sequences to return.
+	FromSeq uint64
+	// Tags is an optional AND-exact-match filter. Nil/empty = no filter; keys
+	// must be non-empty. Every tag key must be present in the entry with exactly
+	// the given value; an entry with nil tags fails any non-empty filter.
+	Tags map[string]string
+}
+
 // AllInput is the input to the All query.
 type AllInput struct {
 	// FromSeq is the inclusive lower bound of sequences to return.
 	FromSeq uint64
+	// Tags is an optional AND-exact-match filter. Nil/empty = no filter; keys
+	// must be non-empty. Every tag key must be present in the entry with exactly
+	// the given value; an entry with nil tags fails any non-empty filter.
+	Tags map[string]string
 }
 
 // TrimBeforeInput is the input to the TrimBefore verb.
@@ -218,21 +234,84 @@ func (l *Log) TrimBefore(in *TrimBeforeInput) (*TrimBeforeOutput, error) {
 	return &TrimBeforeOutput{Removed: removed}, nil
 }
 
-// All returns every retained entry with Seq >= in.FromSeq, in Seq order.
-// Nil guard → ErrNilInput. Copy-out: returned entries MUST NOT alias
-// internal state (nil stays nil, non-nil is deep-copied).
+// All returns every retained entry with Seq >= in.FromSeq matching the optional
+// tag filter, in Seq order. This is the GM/debug/host view.
+// Nil guard → ErrNilInput; filter-key validation → ErrBadTag. Copy-out: returned
+// entries MUST NOT alias internal state (nil stays nil, non-nil is deep-copied).
 func (l *Log) All(in *AllInput) ([]Entry, error) {
 	if in == nil {
 		return nil, fmt.Errorf("all: %w", ErrNilInput)
 	}
 
+	// Validate filter keys (no empty keys)
+	if err := validateTags(in.Tags); err != nil {
+		return nil, fmt.Errorf("all: tag key: %w", err)
+	}
+
 	var result []Entry
 	for _, e := range l.entries {
-		if e.seq >= in.FromSeq {
+		if e.seq >= in.FromSeq && matchTags(e.tags, in.Tags) {
 			result = append(result, copyEntryOut(e))
 		}
 	}
 	return result, nil
+}
+
+// SliceFor returns entries with Seq >= in.FromSeq whose audience contains Viewer
+// AND which carry every given tag key with exactly the given value (AND semantics;
+// nil/empty Tags = no filter). This is the reconnect/replay call for a specific viewer.
+// Validation first-failure-wins: nil → ErrNilInput, empty viewer → ErrNoViewer,
+// filter keys non-empty → ErrBadTag. Copy-out: returned entries MUST NOT alias
+// internal state (nil stays nil, non-nil is deep-copied).
+func (l *Log) SliceFor(in *SliceForInput) ([]Entry, error) {
+	if in == nil {
+		return nil, fmt.Errorf("slice for: %w", ErrNilInput)
+	}
+
+	if in.Viewer == "" {
+		return nil, fmt.Errorf("slice for: %w", ErrNoViewer)
+	}
+
+	// Validate filter keys (no empty keys)
+	if err := validateTags(in.Tags); err != nil {
+		return nil, fmt.Errorf("slice for: tag key: %w", err)
+	}
+
+	var result []Entry
+	for _, e := range l.entries {
+		if e.seq >= in.FromSeq && containsViewer(e.audience, in.Viewer) && matchTags(e.tags, in.Tags) {
+			result = append(result, copyEntryOut(e))
+		}
+	}
+	return result, nil
+}
+
+// matchTags checks whether every tag key in the filter is present in entryTags
+// with exactly the given value. Empty filter → true (no filter means everything matches).
+// Note: an entry with nil tags fails any non-empty filter.
+func matchTags(entryTags, filter map[string]string) bool {
+	// No filter means everything matches
+	if len(filter) == 0 {
+		return true
+	}
+
+	// Every filter key must be present in entryTags with exactly the value
+	for k, v := range filter {
+		if entryTags[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// containsViewer checks whether the audience slice contains the given viewer.
+func containsViewer(audience []core.EntityID, viewer core.EntityID) bool {
+	for _, id := range audience {
+		if id == viewer {
+			return true
+		}
+	}
+	return false
 }
 
 // copyEntryOut converts an internal entry to an exported Entry with deep copies.

--- a/play/record/log.go
+++ b/play/record/log.go
@@ -297,7 +297,8 @@ func matchTags(entryTags, filter map[string]string) bool {
 
 	// Every filter key must be present in entryTags with exactly the value
 	for k, v := range filter {
-		if entryTags[k] != v {
+		val, ok := entryTags[k]
+		if !ok || val != v {
 			return false
 		}
 	}

--- a/play/record/log.go
+++ b/play/record/log.go
@@ -101,22 +101,22 @@ func NewLog() (*Log, error) {
 func (l *Log) Append(in *AppendInput) (*AppendOutput, error) {
 	// Step 1: nil guard
 	if in == nil {
-		return nil, fmt.Errorf("%w", ErrNilInput)
+		return nil, fmt.Errorf("append: %w", ErrNilInput)
 	}
 
 	// Step 2: validate audience (no empty IDs, no duplicates)
-	if err := l.validateAudience(in.Audience); err != nil {
-		return nil, err
+	if err := validateAudience(in.Audience); err != nil {
+		return nil, fmt.Errorf("append: %w", err)
 	}
 
 	// Step 3: validate tags (no empty keys)
-	if err := l.validateTags(in.Tags); err != nil {
-		return nil, err
+	if err := validateTags(in.Tags); err != nil {
+		return nil, fmt.Errorf("append: %w", err)
 	}
 
 	// Step 4: validate payload (must be non-nil)
 	if in.Payload == nil {
-		return nil, fmt.Errorf("%w", ErrNoPayload)
+		return nil, fmt.Errorf("append: %w", ErrNoPayload)
 	}
 
 	// All validation passed; now mutate state (R5 atomicity)
@@ -167,20 +167,20 @@ func (l *Log) NextSeq() (uint64, error) {
 // internal state (nil stays nil, non-nil is deep-copied).
 func (l *Log) All(in *AllInput) ([]Entry, error) {
 	if in == nil {
-		return nil, fmt.Errorf("%w", ErrNilInput)
+		return nil, fmt.Errorf("all: %w", ErrNilInput)
 	}
 
 	var result []Entry
 	for _, e := range l.entries {
 		if e.seq >= in.FromSeq {
-			result = append(result, l.entryToCopy(e))
+			result = append(result, copyEntryOut(e))
 		}
 	}
 	return result, nil
 }
 
-// entryToCopy converts an internal entry to an exported Entry with deep copies.
-func (l *Log) entryToCopy(e entry) Entry {
+// copyEntryOut converts an internal entry to an exported Entry with deep copies.
+func copyEntryOut(e entry) Entry {
 	return Entry{
 		Seq:         e.seq,
 		At:          e.at,
@@ -192,14 +192,14 @@ func (l *Log) entryToCopy(e entry) Entry {
 }
 
 // validateAudience checks that audience is duplicate-free with no empty IDs.
-func (l *Log) validateAudience(aud []core.EntityID) error {
+func validateAudience(aud []core.EntityID) error {
 	seen := make(map[core.EntityID]bool)
 	for _, id := range aud {
 		if id == "" {
-			return fmt.Errorf("%w", ErrBadAudience)
+			return fmt.Errorf("audience: %w", ErrBadAudience)
 		}
 		if seen[id] {
-			return fmt.Errorf("%w", ErrBadAudience)
+			return fmt.Errorf("audience: duplicate %q: %w", id, ErrBadAudience)
 		}
 		seen[id] = true
 	}
@@ -207,10 +207,10 @@ func (l *Log) validateAudience(aud []core.EntityID) error {
 }
 
 // validateTags checks that all keys are non-empty.
-func (l *Log) validateTags(tags map[string]string) error {
+func validateTags(tags map[string]string) error {
 	for k := range tags {
 		if k == "" {
-			return fmt.Errorf("%w", ErrBadTag)
+			return fmt.Errorf("tag key: empty: %w", ErrBadTag)
 		}
 	}
 	return nil

--- a/play/record/log.go
+++ b/play/record/log.go
@@ -86,6 +86,21 @@ type AllInput struct {
 	FromSeq uint64
 }
 
+// TrimBeforeInput is the input to the TrimBefore verb.
+type TrimBeforeInput struct {
+	// Seq is the exclusive upper bound of sequences to remove.
+	// Entries with Seq < in.Seq are dropped. Trimming at or below the oldest
+	// retained Seq is a no-op; in.Seq == NextSeq is legal and empties the log;
+	// in.Seq > NextSeq errors ErrBadSeq.
+	Seq uint64
+}
+
+// TrimBeforeOutput is the output of the TrimBefore verb.
+type TrimBeforeOutput struct {
+	// Removed is the count of entries dropped by this call.
+	Removed int
+}
+
 // NewLog returns a fresh Log ready for use.
 // Returns (*Log, error) per family law (cannot fail today; error slot reserved).
 func NewLog() (*Log, error) {
@@ -160,6 +175,47 @@ func (l *Log) Append(in *AppendInput) (*AppendOutput, error) {
 // Zero-arg read, never errs today; the error slot is the law's.
 func (l *Log) NextSeq() (uint64, error) {
 	return l.nextSeq, nil
+}
+
+// TrimBefore drops all entries with Seq < in.Seq. Retention is the
+// composition's policy made visible (design brainstorm §4). Trimming at or
+// below the oldest retained Seq is a no-op (Removed: 0), not an error;
+// in.Seq == NextSeq is legal and empties the log; in.Seq > NextSeq errors
+// ErrBadSeq (you cannot forget the future). Never renumbers entries.
+// Nil guard → ErrNilInput; bad Seq → ErrBadSeq (R5 atomicity: on error, no
+// state changed).
+func (l *Log) TrimBefore(in *TrimBeforeInput) (*TrimBeforeOutput, error) {
+	// Step 1: nil guard
+	if in == nil {
+		return nil, fmt.Errorf("trim before: %w", ErrNilInput)
+	}
+
+	// Step 2: validate Seq (cannot trim beyond NextSeq)
+	if in.Seq > l.nextSeq {
+		return nil, fmt.Errorf("trim before: seq %d beyond next %d: %w", in.Seq, l.nextSeq, ErrBadSeq)
+	}
+
+	// All validation passed; find the cut point (first entry with seq >= in.Seq)
+	cut := len(l.entries) // default: all entries are removed (if log is empty, cut stays 0)
+	for i, e := range l.entries {
+		if e.seq >= in.Seq {
+			cut = i
+			break
+		}
+	}
+
+	// Count how many entries will be removed
+	removed := cut
+
+	// Trim entries by re-slicing; defensively copy the tail to avoid holding
+	// the old backing array in memory
+	if cut < len(l.entries) {
+		l.entries = append([]entry(nil), l.entries[cut:]...)
+	} else {
+		l.entries = nil
+	}
+
+	return &TrimBeforeOutput{Removed: removed}, nil
 }
 
 // All returns every retained entry with Seq >= in.FromSeq, in Seq order.

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -5,6 +5,7 @@ package record_test
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -641,9 +642,10 @@ func (s *RecordSuite) TestLoadLogRejectsInvalid() {
 		{
 			name: "next seq 0 with max uint64 seq",
 			data: record.LogData{
-				NextSeq: 0, // Wraparound: math.MaxUint64+1 == 0
+				NextSeq: 0, // The forgery: math.MaxUint64+1 wraps to 0, so the
+				// NextSeq == lastSeq+1 contiguity check alone would accept this
 				Entries: []record.EntryData{
-					{Seq: 1, Payload: []byte("p")}, // Just Seq 1; NextSeq 0 is the issue
+					{Seq: math.MaxUint64, Payload: []byte("p")},
 				},
 			},
 		},

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	alice      = "alice"
+	bob        = "bob"
+	door3      = "door-3"
+	kind       = "kind"
+	subject    = "subject"
+	flag       = "flag"
+	mutated    = "mutated"
+	kindShared = "shared"
+	kindIntel  = "intel.first_contact"
+	kindGMNote = "gm.note"
+	kindClock  = "clock.turn_started"
+	actorKey   = "actor"
+)
+
 type RecordSuite struct {
 	suite.Suite
 	log *record.Log
@@ -23,11 +38,10 @@ func (s *RecordSuite) SetupTest() {
 }
 
 func (s *RecordSuite) TestAppendAssignsGaplessSeqFromOne() {
-	const alice = "alice"
 	out, err := s.log.Append(&record.AppendInput{
 		At: 7, Correlation: "act-1",
-		Audience: []core.EntityID{alice, "bob"},
-		Tags:     map[string]string{"kind": "clock.turn_started", "actor": alice},
+		Audience: []core.EntityID{alice, bob},
+		Tags:     map[string]string{kind: kindClock, actorKey: alice},
 		Payload:  []byte(`{"x":1}`),
 	})
 	s.Require().NoError(err)
@@ -67,7 +81,6 @@ func (s *RecordSuite) TestAppendValidationOrderAndSentinels() {
 }
 
 func (s *RecordSuite) TestAppendNormalizesAndCopies() {
-	const alice = "alice"
 	aud := []core.EntityID{alice}
 	tags := map[string]string{"k": "v"}
 	payload := []byte("p")
@@ -75,8 +88,8 @@ func (s *RecordSuite) TestAppendNormalizesAndCopies() {
 		At: 42, Correlation: "test-corr", Audience: aud, Tags: tags, Payload: payload,
 	})
 	s.Require().NoError(err)
-	aud[0] = "mutated"
-	tags["k"] = "mutated"
+	aud[0] = mutated
+	tags["k"] = mutated
 	payload[0] = 'X'
 	all, err := s.log.All(&record.AllInput{FromSeq: 1})
 	s.Require().NoError(err)
@@ -107,6 +120,17 @@ func (s *RecordSuite) appendN(n int) {
 		_, err := s.log.Append(&record.AppendInput{Payload: []byte("p")})
 		s.Require().NoError(err)
 	}
+}
+
+// appendBeat appends a beat with the given audience, tags, and payload.
+// Panics on error.
+func (s *RecordSuite) appendBeat(aud []core.EntityID, tags map[string]string, payload string) {
+	_, err := s.log.Append(&record.AppendInput{
+		Audience: aud,
+		Tags:     tags,
+		Payload:  []byte(payload),
+	})
+	s.Require().NoError(err)
 }
 
 // seqs maps entries to their Seq values.
@@ -164,6 +188,105 @@ func (s *RecordSuite) TestTrimBefore() {
 	out, err = freshLog.TrimBefore(&record.TrimBeforeInput{Seq: 1})
 	s.Require().NoError(err)
 	s.Equal(0, out.Removed)
+}
+
+func (s *RecordSuite) TestSliceForProjectsAudienceAndTags() {
+	s.appendBeat([]core.EntityID{alice, bob}, map[string]string{kind: kindShared}, "b1")
+	s.appendBeat([]core.EntityID{alice}, map[string]string{kind: kindIntel, subject: door3}, "b2")
+	s.appendBeat([]core.EntityID{bob}, map[string]string{kind: kindIntel, subject: door3}, "b3")
+	s.appendBeat(nil, map[string]string{kind: kindGMNote}, "b4") // empty audience: no viewer
+
+	aliceSlice, err := s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1})
+	s.Require().NoError(err)
+	s.Equal([]uint64{1, 2}, seqs(aliceSlice))
+
+	firsts, err := s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1,
+		Tags: map[string]string{kind: kindIntel}})
+	s.Require().NoError(err)
+	s.Equal([]uint64{2}, seqs(firsts))
+
+	door, err := s.log.All(&record.AllInput{FromSeq: 1, Tags: map[string]string{subject: door3}})
+	s.Require().NoError(err)
+	s.Equal([]uint64{2, 3}, seqs(door))
+
+	gm, err := s.log.All(&record.AllInput{FromSeq: 1, Tags: map[string]string{kind: kindGMNote}})
+	s.Require().NoError(err)
+	s.Equal([]uint64{4}, seqs(gm))
+	for _, v := range []core.EntityID{alice, bob} {
+		sl, serr := s.log.SliceFor(&record.SliceForInput{Viewer: v, FromSeq: 4})
+		s.Require().NoError(serr)
+		s.Empty(sl, "empty audience means no viewer")
+	}
+}
+
+func (s *RecordSuite) TestSliceForAndAllErrorHandling() {
+	// All(nil) → ErrNilInput
+	_, err := s.log.All(nil)
+	s.Require().ErrorIs(err, record.ErrNilInput)
+
+	// SliceFor(nil) → ErrNilInput
+	_, err = s.log.SliceFor(nil)
+	s.Require().ErrorIs(err, record.ErrNilInput)
+
+	// Empty viewer → ErrNoViewer
+	_, err = s.log.SliceFor(&record.SliceForInput{Viewer: "", FromSeq: 1})
+	s.Require().ErrorIs(err, record.ErrNoViewer)
+
+	// SliceFor with empty filter key → ErrBadTag
+	_, err = s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1,
+		Tags: map[string]string{"": "x"}})
+	s.Require().ErrorIs(err, record.ErrBadTag)
+
+	// Viewer-before-tags precedence: {Viewer: "", Tags: {"": "x"}} → ErrNoViewer
+	_, err = s.log.SliceFor(&record.SliceForInput{Viewer: "", FromSeq: 1,
+		Tags: map[string]string{"": "x"}})
+	s.Require().ErrorIs(err, record.ErrNoViewer)
+
+	// All with empty filter key → ErrBadTag
+	_, err = s.log.All(&record.AllInput{FromSeq: 1, Tags: map[string]string{"": "x"}})
+	s.Require().ErrorIs(err, record.ErrBadTag)
+
+	// R5: none of these mutate (NextSeq still 1)
+	next, err := s.log.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(1), next)
+}
+
+func (s *RecordSuite) TestEmptyValueTagFilter() {
+	// Append one beat with empty value and one with non-empty
+	s.appendBeat([]core.EntityID{alice}, map[string]string{flag: ""}, "b1")
+	s.appendBeat([]core.EntityID{alice}, map[string]string{flag: "y"}, "b2")
+
+	// Filter {flag: ""} returns only the first
+	result, err := s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1,
+		Tags: map[string]string{flag: ""}})
+	s.Require().NoError(err)
+	s.Equal([]uint64{1}, seqs(result))
+}
+
+func (s *RecordSuite) TestCopyOutImmunity() {
+	// Append a beat
+	s.appendBeat([]core.EntityID{alice}, map[string]string{"k": "v"}, "payload")
+
+	// Query and mutate the result
+	results, err := s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1})
+	s.Require().NoError(err)
+	s.Len(results, 1)
+
+	// Mutate the result's Audience, Tags, and Payload
+	if results[0].Audience != nil {
+		results[0].Audience[0] = mutated
+	}
+	results[0].Tags["k"] = mutated
+	results[0].Payload[0] = 'X'
+
+	// Re-query and verify the original is unchanged
+	results2, err := s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1})
+	s.Require().NoError(err)
+	s.Len(results2, 1)
+	s.Equal([]core.EntityID{alice}, results2[0].Audience)
+	s.Equal(map[string]string{"k": "v"}, results2[0].Tags)
+	s.Equal([]byte("payload"), results2[0].Payload)
 }
 
 func TestRecordSuite(t *testing.T) {

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package record_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/record"
+	"github.com/stretchr/testify/suite"
+)
+
+type RecordSuite struct {
+	suite.Suite
+	log *record.Log
+}
+
+func (s *RecordSuite) SetupTest() {
+	var err error
+	s.log, err = record.NewLog()
+	s.Require().NoError(err)
+}
+
+func (s *RecordSuite) TestAppendAssignsGaplessSeqFromOne() {
+	//nolint:goconst
+	out, err := s.log.Append(&record.AppendInput{
+		At: 7, Correlation: "act-1",
+		Audience: []core.EntityID{"alice", "bob"},
+		Tags:     map[string]string{"kind": "clock.turn_started", "actor": "alice"},
+		Payload:  []byte(`{"x":1}`),
+	})
+	s.Require().NoError(err)
+	s.Equal(uint64(1), out.Seq)
+	out, err = s.log.Append(&record.AppendInput{Audience: []core.EntityID{"alice"}, Payload: []byte{}})
+	s.Require().NoError(err)
+	s.Equal(uint64(2), out.Seq)
+	next, err := s.log.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(3), next)
+}
+
+func (s *RecordSuite) TestAppendValidationOrderAndSentinels() {
+	_, err := s.log.Append(nil)
+	s.Require().ErrorIs(err, record.ErrNilInput)
+	// multi-defect input: audience checked before tags before payload
+	_, err = s.log.Append(&record.AppendInput{
+		Audience: []core.EntityID{"a", "a"},
+		Tags:     map[string]string{"": "x"},
+		Payload:  nil,
+	})
+	s.Require().ErrorIs(err, record.ErrBadAudience)
+	_, err = s.log.Append(&record.AppendInput{Tags: map[string]string{"": "x"}, Payload: nil})
+	s.Require().ErrorIs(err, record.ErrBadTag)
+	_, err = s.log.Append(&record.AppendInput{Payload: nil})
+	s.Require().ErrorIs(err, record.ErrNoPayload)
+	_, err = s.log.Append(&record.AppendInput{Audience: []core.EntityID{""}, Payload: []byte{}})
+	s.Require().ErrorIs(err, record.ErrBadAudience)
+	// R5: nothing changed
+	next, err := s.log.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(1), next)
+}
+
+func (s *RecordSuite) TestAppendNormalizesAndCopies() {
+	aud := []core.EntityID{"alice"}
+	tags := map[string]string{"k": "v"}
+	_, err := s.log.Append(&record.AppendInput{Audience: aud, Tags: tags, Payload: []byte("p")})
+	s.Require().NoError(err)
+	aud[0] = "mutated"
+	tags["k"] = "mutated"
+	all, err := s.log.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{"alice"}, all[0].Audience)
+	s.Equal(map[string]string{"k": "v"}, all[0].Tags)
+	// empty-non-nil normalized to nil on store (family convention)
+	_, err = s.log.Append(&record.AppendInput{
+		Audience: []core.EntityID{}, Tags: map[string]string{}, Payload: []byte("q"),
+	})
+	s.Require().NoError(err)
+	all, err = s.log.All(&record.AllInput{FromSeq: 2})
+	s.Require().NoError(err)
+	s.Nil(all[0].Audience)
+	s.Nil(all[0].Tags)
+}
+
+func TestRecordSuite(t *testing.T) {
+	suite.Run(t, new(RecordSuite))
+}

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -23,16 +23,16 @@ func (s *RecordSuite) SetupTest() {
 }
 
 func (s *RecordSuite) TestAppendAssignsGaplessSeqFromOne() {
-	//nolint:goconst
+	const alice = "alice"
 	out, err := s.log.Append(&record.AppendInput{
 		At: 7, Correlation: "act-1",
-		Audience: []core.EntityID{"alice", "bob"},
-		Tags:     map[string]string{"kind": "clock.turn_started", "actor": "alice"},
+		Audience: []core.EntityID{alice, "bob"},
+		Tags:     map[string]string{"kind": "clock.turn_started", "actor": alice},
 		Payload:  []byte(`{"x":1}`),
 	})
 	s.Require().NoError(err)
 	s.Equal(uint64(1), out.Seq)
-	out, err = s.log.Append(&record.AppendInput{Audience: []core.EntityID{"alice"}, Payload: []byte{}})
+	out, err = s.log.Append(&record.AppendInput{Audience: []core.EntityID{alice}, Payload: []byte{}})
 	s.Require().NoError(err)
 	s.Equal(uint64(2), out.Seq)
 	next, err := s.log.NextSeq()
@@ -63,7 +63,8 @@ func (s *RecordSuite) TestAppendValidationOrderAndSentinels() {
 }
 
 func (s *RecordSuite) TestAppendNormalizesAndCopies() {
-	aud := []core.EntityID{"alice"}
+	const alice = "alice"
+	aud := []core.EntityID{alice}
 	tags := map[string]string{"k": "v"}
 	_, err := s.log.Append(&record.AppendInput{Audience: aud, Tags: tags, Payload: []byte("p")})
 	s.Require().NoError(err)
@@ -71,7 +72,7 @@ func (s *RecordSuite) TestAppendNormalizesAndCopies() {
 	tags["k"] = "mutated"
 	all, err := s.log.All(&record.AllInput{FromSeq: 1})
 	s.Require().NoError(err)
-	s.Equal([]core.EntityID{"alice"}, all[0].Audience)
+	s.Equal([]core.EntityID{alice}, all[0].Audience)
 	s.Equal(map[string]string{"k": "v"}, all[0].Tags)
 	// empty-non-nil normalized to nil on store (family convention)
 	_, err = s.log.Append(&record.AppendInput{

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -11,21 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const (
-	alice      = "alice"
-	bob        = "bob"
-	door3      = "door-3"
-	kind       = "kind"
-	subject    = "subject"
-	flag       = "flag"
-	mutated    = "mutated"
-	kindShared = "shared"
-	kindIntel  = "intel.first_contact"
-	kindGMNote = "gm.note"
-	kindClock  = "clock.turn_started"
-	actorKey   = "actor"
-)
-
 type RecordSuite struct {
 	suite.Suite
 	log *record.Log
@@ -38,6 +23,13 @@ func (s *RecordSuite) SetupTest() {
 }
 
 func (s *RecordSuite) TestAppendAssignsGaplessSeqFromOne() {
+	const (
+		alice     = "alice"
+		bob       = "bob"
+		kind      = "kind"
+		kindClock = "clock.turn_started"
+		actorKey  = "actor"
+	)
 	out, err := s.log.Append(&record.AppendInput{
 		At: 7, Correlation: "act-1",
 		Audience: []core.EntityID{alice, bob},
@@ -81,6 +73,10 @@ func (s *RecordSuite) TestAppendValidationOrderAndSentinels() {
 }
 
 func (s *RecordSuite) TestAppendNormalizesAndCopies() {
+	const (
+		alice   = "alice"
+		mutated = "mutated"
+	)
 	aud := []core.EntityID{alice}
 	tags := map[string]string{"k": "v"}
 	payload := []byte("p")
@@ -191,6 +187,16 @@ func (s *RecordSuite) TestTrimBefore() {
 }
 
 func (s *RecordSuite) TestSliceForProjectsAudienceAndTags() {
+	const (
+		alice      = "alice"
+		bob        = "bob"
+		door3      = "door-3"
+		kind       = "kind"
+		subject    = "subject"
+		kindShared = "shared"
+		kindIntel  = "intel.first_contact"
+		kindGMNote = "gm.note"
+	)
 	s.appendBeat([]core.EntityID{alice, bob}, map[string]string{kind: kindShared}, "b1")
 	s.appendBeat([]core.EntityID{alice}, map[string]string{kind: kindIntel, subject: door3}, "b2")
 	s.appendBeat([]core.EntityID{bob}, map[string]string{kind: kindIntel, subject: door3}, "b3")
@@ -220,6 +226,7 @@ func (s *RecordSuite) TestSliceForProjectsAudienceAndTags() {
 }
 
 func (s *RecordSuite) TestSliceForAndAllErrorHandling() {
+	const alice = "alice"
 	// All(nil) → ErrNilInput
 	_, err := s.log.All(nil)
 	s.Require().ErrorIs(err, record.ErrNilInput)
@@ -253,18 +260,34 @@ func (s *RecordSuite) TestSliceForAndAllErrorHandling() {
 }
 
 func (s *RecordSuite) TestEmptyValueTagFilter() {
-	// Append one beat with empty value and one with non-empty
+	const (
+		alice = "alice"
+		flag  = "flag"
+	)
+	// Append beats: one with empty value, one with non-empty, one with nil tags, one missing the key
 	s.appendBeat([]core.EntityID{alice}, map[string]string{flag: ""}, "b1")
 	s.appendBeat([]core.EntityID{alice}, map[string]string{flag: "y"}, "b2")
+	s.appendBeat([]core.EntityID{alice}, nil, "b3")                                 // nil tags
+	s.appendBeat([]core.EntityID{alice}, map[string]string{"other": "value"}, "b4") // missing the key
 
 	// Filter {flag: ""} returns only the first
 	result, err := s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1,
 		Tags: map[string]string{flag: ""}})
 	s.Require().NoError(err)
-	s.Equal([]uint64{1}, seqs(result))
+	s.Equal([]uint64{1}, seqs(result), "only entry with flag='' should match")
+
+	// Verify nil-tags entry does NOT match filter
+	s.NotContains(seqs(result), uint64(3), "entry with nil tags must not match {flag: ''} filter")
+
+	// Verify missing-key entry does NOT match filter
+	s.NotContains(seqs(result), uint64(4), "entry with tags missing the key must not match {flag: ''} filter")
 }
 
 func (s *RecordSuite) TestCopyOutImmunity() {
+	const (
+		alice   = "alice"
+		mutated = "mutated"
+	)
 	// Append a beat
 	s.appendBeat([]core.EntityID{alice}, map[string]string{"k": "v"}, "payload")
 

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -4,6 +4,7 @@
 package record_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -310,6 +311,350 @@ func (s *RecordSuite) TestCopyOutImmunity() {
 	s.Equal([]core.EntityID{alice}, results2[0].Audience)
 	s.Equal(map[string]string{"k": "v"}, results2[0].Tags)
 	s.Equal([]byte("payload"), results2[0].Payload)
+}
+
+func (s *RecordSuite) TestPersistenceIdleConvention() {
+	// Fresh log: NewLog().ToData() → zero LogData
+	freshLog, err := record.NewLog()
+	s.Require().NoError(err)
+	data := freshLog.ToData()
+	s.Equal(record.LogData{}, data, "fresh log ToData must equal zero LogData")
+
+	// Zero LogData marshals to {}
+	jsonBytes, err := json.Marshal(data)
+	s.Require().NoError(err)
+	s.Equal([]byte("{}"), jsonBytes, "zero LogData must marshal to {}")
+
+	// LoadLog(LogData{}) → fresh log with NextSeq() == 1
+	loaded, err := record.LoadLog(record.LogData{})
+	s.Require().NoError(err)
+	next, err := loaded.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(1), next, "loaded fresh log must have NextSeq == 1")
+
+	// Append to fresh loaded log gets Seq 1
+	out, err := loaded.Append(&record.AppendInput{Payload: []byte("p")})
+	s.Require().NoError(err)
+	s.Equal(uint64(1), out.Seq, "first append after LoadLog(zero) must get Seq 1")
+}
+
+func (s *RecordSuite) TestPersistenceRoundTrips() {
+	const (
+		alice   = "alice"
+		bob     = "bob"
+		kind    = "kind"
+		intelK  = "intel.first_contact"
+		subject = "subject"
+		door3   = "door-3"
+	)
+
+	// Case (a): populated round-trip
+	s.appendBeat([]core.EntityID{alice, bob}, map[string]string{kind: intelK}, "b1")
+	s.appendBeat([]core.EntityID{alice}, map[string]string{kind: intelK, subject: door3}, "b2")
+	s.appendBeat([]core.EntityID{bob}, map[string]string{subject: door3}, "b3")
+
+	// ToData, LoadLog, ToData again → identical
+	data1 := s.log.ToData()
+	loaded, err := record.LoadLog(data1)
+	s.Require().NoError(err)
+	data2 := loaded.ToData()
+	s.Equal(data1, data2, "round-trip ToData/LoadLog/ToData must preserve data")
+
+	// Append after reload continues sequence at Seq 4
+	out, err := loaded.Append(&record.AppendInput{Payload: []byte("b4")})
+	s.Require().NoError(err)
+	s.Equal(uint64(4), out.Seq, "append after reload must continue sequence")
+
+	// SliceFor identical pre/post
+	alicePre, err := s.log.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1})
+	s.Require().NoError(err)
+	alicePost, err := loaded.SliceFor(&record.SliceForInput{Viewer: alice, FromSeq: 1})
+	s.Require().NoError(err)
+	s.Equal(seqs(alicePre), seqs(alicePost), "SliceFor must be identical pre/post load")
+
+	// Case (b): trimmed-empty
+	log2, err := record.NewLog()
+	s.Require().NoError(err)
+	_, err = log2.Append(&record.AppendInput{Payload: []byte("a")})
+	s.Require().NoError(err)
+	_, err = log2.Append(&record.AppendInput{Payload: []byte("b")})
+	s.Require().NoError(err)
+	_, err = log2.TrimBefore(&record.TrimBeforeInput{Seq: 3})
+	s.Require().NoError(err)
+
+	trimData := log2.ToData()
+	s.Equal(uint64(3), trimData.NextSeq, "trimmed-empty must store NextSeq 3")
+	s.Nil(trimData.Entries, "trimmed-empty must have nil entries")
+
+	trimLoaded, err := record.LoadLog(trimData)
+	s.Require().NoError(err)
+	next, err := trimLoaded.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(3), next, "loaded trimmed-empty must have NextSeq 3")
+
+	// Next append gets Seq 3
+	out, err = trimLoaded.Append(&record.AppendInput{Payload: []byte("p")})
+	s.Require().NoError(err)
+	s.Equal(uint64(3), out.Seq, "append after trimmed-empty load must get Seq 3")
+
+	// Case (c): post-trim POPULATED (natural-mistake catcher)
+	log3, err := record.NewLog()
+	s.Require().NoError(err)
+	for i := 0; i < 4; i++ {
+		_, err := log3.Append(&record.AppendInput{Payload: []byte("p")})
+		s.Require().NoError(err)
+	}
+	_, err = log3.TrimBefore(&record.TrimBeforeInput{Seq: 3})
+	s.Require().NoError(err)
+
+	trimPopData := log3.ToData()
+	// Must have entries [3, 4], NextSeq 5
+	s.NotNil(trimPopData.Entries)
+	s.Len(trimPopData.Entries, 2)
+	s.Equal(uint64(3), trimPopData.Entries[0].Seq)
+	s.Equal(uint64(4), trimPopData.Entries[1].Seq)
+	s.Equal(uint64(5), trimPopData.NextSeq)
+
+	// LoadLog MUST accept (no contiguity check demanding start at 1)
+	trimPopLoaded, err := record.LoadLog(trimPopData)
+	s.Require().NoError(err)
+	next, err = trimPopLoaded.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(5), next)
+
+	// Behavior identical after reload
+	all3Pre, err := log3.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	allLoaded, err := trimPopLoaded.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Equal(seqs(all3Pre), seqs(allLoaded), "post-trim populated must be behavior-identical after reload")
+}
+
+func (s *RecordSuite) TestPersistenceGoldenJSON() {
+	const (
+		alice = "alice"
+		kind  = "kind"
+		kindX = "x"
+	)
+	// Populated log with ONE entry
+	_, err := s.log.Append(&record.AppendInput{
+		At: 7, Correlation: "c1",
+		Audience: []core.EntityID{alice},
+		Tags:     map[string]string{kind: kindX},
+		Payload:  []byte("p"),
+	})
+	s.Require().NoError(err)
+
+	data := s.log.ToData()
+	jsonBytes, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	// Exact golden JSON format with payload base64-encoded.
+	expectedJSON := `{"next_seq":2,"entries":[{"seq":1,"at":7,"correlation":"c1",` +
+		`"audience":["alice"],"tags":{"kind":"x"},"payload":"cA=="}]}`
+	s.JSONEq(expectedJSON, string(jsonBytes), "populated log must marshal to exact golden JSON")
+
+	// Trimmed-empty marshals {"next_seq":3}
+	trimLog, err := record.NewLog()
+	s.Require().NoError(err)
+	_, err = trimLog.Append(&record.AppendInput{Payload: []byte("a")})
+	s.Require().NoError(err)
+	_, err = trimLog.Append(&record.AppendInput{Payload: []byte("b")})
+	s.Require().NoError(err)
+	_, err = trimLog.TrimBefore(&record.TrimBeforeInput{Seq: 3})
+	s.Require().NoError(err)
+
+	trimData := trimLog.ToData()
+	trimJSON, err := json.Marshal(trimData)
+	s.Require().NoError(err)
+	trimExpected := `{"next_seq":3}`
+	s.JSONEq(trimExpected, string(trimJSON), "trimmed-empty must marshal to {\"next_seq\":3}")
+
+	// Unmarshal populated string → LoadLog → behavior-identical
+	var loadedData record.LogData
+	err = json.Unmarshal([]byte(expectedJSON), &loadedData)
+	s.Require().NoError(err)
+	loadedLog, err := record.LoadLog(loadedData)
+	s.Require().NoError(err)
+	all, err := loadedLog.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Len(all, 1)
+	s.Equal(uint64(1), all[0].Seq)
+	s.Equal(uint64(7), all[0].At)
+	s.Equal("c1", all[0].Correlation)
+	s.Equal([]core.EntityID{alice}, all[0].Audience)
+	s.Equal(map[string]string{kind: kindX}, all[0].Tags)
+	s.Equal([]byte("p"), all[0].Payload)
+}
+
+func (s *RecordSuite) TestLoadLogRejectsInvalid() {
+	const alice = "alice"
+	// Table of rejection cases; each must return ErrInvalidData
+	testCases := []struct {
+		name string
+		data record.LogData
+	}{
+		{
+			name: "non-contiguous seqs [1,3]",
+			data: record.LogData{
+				NextSeq: 4,
+				Entries: []record.EntryData{
+					{Seq: 1, Payload: []byte("p")},
+					{Seq: 3, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "duplicate seqs [1,1]",
+			data: record.LogData{
+				NextSeq: 2,
+				Entries: []record.EntryData{
+					{Seq: 1, Payload: []byte("p")},
+					{Seq: 1, Payload: []byte("q")},
+				},
+			},
+		},
+		{
+			name: "out-of-order [2,1]",
+			data: record.LogData{
+				NextSeq: 3,
+				Entries: []record.EntryData{
+					{Seq: 2, Payload: []byte("p")},
+					{Seq: 1, Payload: []byte("q")},
+				},
+			},
+		},
+		{
+			name: "zero seq",
+			data: record.LogData{
+				NextSeq: 1,
+				Entries: []record.EntryData{
+					{Seq: 0, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "non-empty with NextSeq == lastSeq (shortfall)",
+			data: record.LogData{
+				NextSeq: 1, // last seq is 1
+				Entries: []record.EntryData{
+					{Seq: 1, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "non-empty with NextSeq == lastSeq+2 (slack)",
+			data: record.LogData{
+				NextSeq: 4, // last seq is 1
+				Entries: []record.EntryData{
+					{Seq: 1, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "empty with NextSeq 1",
+			data: record.LogData{
+				NextSeq: 1,
+				Entries: nil,
+			},
+		},
+		{
+			name: "audience with empty ID",
+			data: record.LogData{
+				NextSeq: 2,
+				Entries: []record.EntryData{
+					{Seq: 1, Audience: []core.EntityID{""}, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "audience with duplicates",
+			data: record.LogData{
+				NextSeq: 2,
+				Entries: []record.EntryData{
+					{Seq: 1, Audience: []core.EntityID{alice, alice}, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "tag map with empty key",
+			data: record.LogData{
+				NextSeq: 2,
+				Entries: []record.EntryData{
+					{Seq: 1, Tags: map[string]string{"": "x"}, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "nil payload entry",
+			data: record.LogData{
+				NextSeq: 2,
+				Entries: []record.EntryData{
+					{Seq: 1, Payload: nil},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			_, err := record.LoadLog(tc.data)
+			s.ErrorIs(err, record.ErrInvalidData, "must return ErrInvalidData for %s", tc.name)
+		})
+	}
+}
+
+func (s *RecordSuite) TestSnapshotImmunity() {
+	const alice = "alice"
+
+	// ToData then Append → snapshot unchanged
+	s.appendBeat([]core.EntityID{alice}, map[string]string{"k": "v"}, "b1")
+	data1 := s.log.ToData()
+
+	_, err := s.log.Append(&record.AppendInput{Payload: []byte("b2")})
+	s.Require().NoError(err)
+
+	data2 := s.log.ToData()
+	s.NotEqual(data1, data2, "ToData snapshot must change after Append")
+	// Verify data1 still has only 1 entry
+	s.Len(data1.Entries, 1)
+	s.Equal(uint64(2), data1.NextSeq)
+
+	// Load-side aliasing: mutate the caller's LogData after LoadLog → log unchanged
+	log2, err := record.NewLog()
+	s.Require().NoError(err)
+	_, err = log2.Append(&record.AppendInput{
+		At:       42,
+		Audience: []core.EntityID{alice},
+		Tags:     map[string]string{"k": "v"},
+		Payload:  []byte("p"),
+	})
+	s.Require().NoError(err)
+	data3 := log2.ToData()
+
+	// LoadLog first (this makes a deep copy)
+	loaded, err := record.LoadLog(data3)
+	s.Require().NoError(err)
+
+	// NOW mutate the caller's data3
+	data3.NextSeq = 99
+	if len(data3.Entries) > 0 {
+		data3.Entries[0].Audience = append(data3.Entries[0].Audience, "mutated")
+		data3.Entries[0].Tags["mutated"] = "yes"
+		data3.Entries[0].Payload = []byte("mutated")
+	}
+
+	// Re-query loaded and verify unchanged (deep-copy immunity)
+	all, err := loaded.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Len(all, 1)
+	s.Equal(uint64(1), all[0].Seq)
+	s.Equal([]core.EntityID{alice}, all[0].Audience,
+		"loaded entry must have original audience (not mutated)")
+	s.Equal(map[string]string{"k": "v"}, all[0].Tags,
+		"loaded entry must have original tags (not mutated)")
+	s.Equal([]byte("p"), all[0].Payload,
+		"loaded entry must have original payload (not mutated)")
 }
 
 func TestRecordSuite(t *testing.T) {

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -60,20 +60,35 @@ func (s *RecordSuite) TestAppendValidationOrderAndSentinels() {
 	next, err := s.log.NextSeq()
 	s.Require().NoError(err)
 	s.Equal(uint64(1), next)
+	// R5 entry purity: no entry stored by any failed call
+	all, err := s.log.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Empty(all)
 }
 
 func (s *RecordSuite) TestAppendNormalizesAndCopies() {
 	const alice = "alice"
 	aud := []core.EntityID{alice}
 	tags := map[string]string{"k": "v"}
-	_, err := s.log.Append(&record.AppendInput{Audience: aud, Tags: tags, Payload: []byte("p")})
+	payload := []byte("p")
+	_, err := s.log.Append(&record.AppendInput{
+		At: 42, Correlation: "test-corr", Audience: aud, Tags: tags, Payload: payload,
+	})
 	s.Require().NoError(err)
 	aud[0] = "mutated"
 	tags["k"] = "mutated"
+	payload[0] = 'X'
 	all, err := s.log.All(&record.AllInput{FromSeq: 1})
 	s.Require().NoError(err)
+	// Envelope-fidelity: Seq, At, Correlation preserved exactly
+	s.Equal(uint64(1), all[0].Seq)
+	s.Equal(uint64(42), all[0].At)
+	s.Equal("test-corr", all[0].Correlation)
+	// Audience and tags copied, not aliased
 	s.Equal([]core.EntityID{alice}, all[0].Audience)
 	s.Equal(map[string]string{"k": "v"}, all[0].Tags)
+	// Payload copied, not aliased
+	s.Equal([]byte("p"), all[0].Payload)
 	// empty-non-nil normalized to nil on store (family convention)
 	_, err = s.log.Append(&record.AppendInput{
 		Audience: []core.EntityID{}, Tags: map[string]string{}, Payload: []byte("q"),

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -485,6 +485,41 @@ func (s *RecordSuite) TestPersistenceGoldenJSON() {
 	s.Equal([]core.EntityID{alice}, all[0].Audience)
 	s.Equal(map[string]string{kind: kindX}, all[0].Tags)
 	s.Equal([]byte("p"), all[0].Payload)
+
+	// Pin empty-payload round-trip (legal: presence with no content)
+	emptyPayloadLog, err := record.NewLog()
+	s.Require().NoError(err)
+	_, err = emptyPayloadLog.Append(&record.AppendInput{Payload: []byte("")})
+	s.Require().NoError(err)
+
+	emptyPayloadData := emptyPayloadLog.ToData()
+	emptyPayloadJSON, err := json.Marshal(emptyPayloadData)
+	s.Require().NoError(err)
+
+	// Unmarshal and LoadLog
+	var emptyPayloadLoaded record.LogData
+	err = json.Unmarshal(emptyPayloadJSON, &emptyPayloadLoaded)
+	s.Require().NoError(err)
+	emptyPayloadReloaded, err := record.LoadLog(emptyPayloadLoaded)
+	s.Require().NoError(err)
+
+	// Verify payload is empty but non-nil
+	allEmpty, err := emptyPayloadReloaded.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Len(allEmpty, 1)
+	s.NotNil(allEmpty[0].Payload, "empty payload must be non-nil")
+	s.Equal([]byte(""), allEmpty[0].Payload, "empty payload must be empty bytes")
+
+	// Pin empty non-nil Entries slice (trimmed-empty NextSeq >= 2 accepted)
+	trimmedData := record.LogData{
+		NextSeq: 42,
+		Entries: []record.EntryData{}, // explicitly empty non-nil slice
+	}
+	trimmedReloaded, err := record.LoadLog(trimmedData)
+	s.Require().NoError(err)
+	nextTrimmed, err := trimmedReloaded.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(42), nextTrimmed, "trimmed-empty with explicit empty slice must accept NextSeq >= 2")
 }
 
 func (s *RecordSuite) TestLoadLogRejectsInvalid() {
@@ -594,20 +629,42 @@ func (s *RecordSuite) TestLoadLogRejectsInvalid() {
 				},
 			},
 		},
+		{
+			name: "next seq 0 with entries (wraparound catch)",
+			data: record.LogData{
+				NextSeq: 0, // Would wrap arithmetic if not checked early
+				Entries: []record.EntryData{
+					{Seq: 1, Payload: []byte("p")},
+				},
+			},
+		},
+		{
+			name: "next seq 0 with max uint64 seq",
+			data: record.LogData{
+				NextSeq: 0, // Wraparound: math.MaxUint64+1 == 0
+				Entries: []record.EntryData{
+					{Seq: 1, Payload: []byte("p")}, // Just Seq 1; NextSeq 0 is the issue
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			_, err := record.LoadLog(tc.data)
+			result, err := record.LoadLog(tc.data)
+			s.Nil(result, "LoadLog must return nil *Log on ErrInvalidData")
 			s.ErrorIs(err, record.ErrInvalidData, "must return ErrInvalidData for %s", tc.name)
 		})
 	}
 }
 
 func (s *RecordSuite) TestSnapshotImmunity() {
-	const alice = "alice"
+	const (
+		alice   = "alice"
+		mutated = "mutated"
+	)
 
-	// ToData then Append → snapshot unchanged
+	// Part 1: ToData then Append → snapshot unchanged
 	s.appendBeat([]core.EntityID{alice}, map[string]string{"k": "v"}, "b1")
 	data1 := s.log.ToData()
 
@@ -620,32 +677,75 @@ func (s *RecordSuite) TestSnapshotImmunity() {
 	s.Len(data1.Entries, 1)
 	s.Equal(uint64(2), data1.NextSeq)
 
-	// Load-side aliasing: mutate the caller's LogData after LoadLog → log unchanged
+	// Part 2: ToData side nested mutation immunity — mutate returned data in-place,
+	// then re-query the SOURCE log and verify it's unchanged
 	log2, err := record.NewLog()
 	s.Require().NoError(err)
 	_, err = log2.Append(&record.AppendInput{
 		At:       42,
 		Audience: []core.EntityID{alice},
 		Tags:     map[string]string{"k": "v"},
+		Payload:  []byte("payload"),
+	})
+	s.Require().NoError(err)
+
+	data := log2.ToData()
+	// In-place mutations on returned data
+	if len(data.Entries) > 0 {
+		if len(data.Entries[0].Audience) > 0 {
+			data.Entries[0].Audience[0] = mutated
+		}
+		if data.Entries[0].Tags != nil {
+			data.Entries[0].Tags["k"] = mutated
+		}
+		if len(data.Entries[0].Payload) > 0 {
+			data.Entries[0].Payload[0] = 'X'
+		}
+	}
+
+	// Re-query SOURCE log and verify unchanged
+	all, err := log2.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Len(all, 1)
+	s.Equal([]core.EntityID{alice}, all[0].Audience,
+		"source log must have original audience after ToData mutation")
+	s.Equal(map[string]string{"k": "v"}, all[0].Tags,
+		"source log must have original tags after ToData mutation")
+	s.Equal([]byte("payload"), all[0].Payload,
+		"source log must have original payload after ToData mutation")
+
+	// Part 3: LoadLog side aliasing immunity — mutate caller's LogData after
+	// LoadLog, then re-query the loaded log and verify it's unchanged
+	log3, err := record.NewLog()
+	s.Require().NoError(err)
+	_, err = log3.Append(&record.AppendInput{
+		At:       42,
+		Audience: []core.EntityID{alice},
+		Tags:     map[string]string{"k": "v"},
 		Payload:  []byte("p"),
 	})
 	s.Require().NoError(err)
-	data3 := log2.ToData()
+	data3 := log3.ToData()
 
 	// LoadLog first (this makes a deep copy)
 	loaded, err := record.LoadLog(data3)
 	s.Require().NoError(err)
 
-	// NOW mutate the caller's data3
-	data3.NextSeq = 99
+	// NOW mutate the caller's data3 in-place
 	if len(data3.Entries) > 0 {
-		data3.Entries[0].Audience = append(data3.Entries[0].Audience, "mutated")
-		data3.Entries[0].Tags["mutated"] = "yes"
-		data3.Entries[0].Payload = []byte("mutated")
+		if len(data3.Entries[0].Audience) > 0 {
+			data3.Entries[0].Audience[0] = mutated
+		}
+		if data3.Entries[0].Tags != nil {
+			data3.Entries[0].Tags["k"] = mutated
+		}
+		if len(data3.Entries[0].Payload) > 0 {
+			data3.Entries[0].Payload[0] = 'X'
+		}
 	}
 
 	// Re-query loaded and verify unchanged (deep-copy immunity)
-	all, err := loaded.All(&record.AllInput{FromSeq: 1})
+	all, err = loaded.All(&record.AllInput{FromSeq: 1})
 	s.Require().NoError(err)
 	s.Len(all, 1)
 	s.Equal(uint64(1), all[0].Seq)

--- a/play/record/log_test.go
+++ b/play/record/log_test.go
@@ -100,6 +100,72 @@ func (s *RecordSuite) TestAppendNormalizesAndCopies() {
 	s.Nil(all[0].Tags)
 }
 
+// appendN appends n entries to the log, each with payload []byte("p") and no
+// audience or tags. Panics on error.
+func (s *RecordSuite) appendN(n int) {
+	for i := 0; i < n; i++ {
+		_, err := s.log.Append(&record.AppendInput{Payload: []byte("p")})
+		s.Require().NoError(err)
+	}
+}
+
+// seqs maps entries to their Seq values.
+func seqs(es []record.Entry) []uint64 {
+	result := make([]uint64, len(es))
+	for i, e := range es {
+		result[i] = e.Seq
+	}
+	return result
+}
+
+func (s *RecordSuite) TestTrimBefore() {
+	// Case 1: appendN(4), TrimBefore{Seq: 3} → Removed: 2; All{FromSeq: 1} returns [3, 4]
+	s.appendN(4)
+	out, err := s.log.TrimBefore(&record.TrimBeforeInput{Seq: 3})
+	s.Require().NoError(err)
+	s.Equal(2, out.Removed)
+	all, err := s.log.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Equal([]uint64{3, 4}, seqs(all))
+
+	// Case 2: TrimBefore{Seq: 3} again → Removed: 0, no error
+	out, err = s.log.TrimBefore(&record.TrimBeforeInput{Seq: 3})
+	s.Require().NoError(err)
+	s.Equal(0, out.Removed)
+
+	// Case 3: TrimBefore{Seq: 5} (== NextSeq) → legal, Removed: 2, log now empty
+	out, err = s.log.TrimBefore(&record.TrimBeforeInput{Seq: 5})
+	s.Require().NoError(err)
+	s.Equal(2, out.Removed)
+	all, err = s.log.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Empty(all)
+	next, err := s.log.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(5), next)
+
+	// Case 4: TrimBefore{Seq: 6} (> NextSeq) → ErrBadSeq, state unchanged
+	_, err = s.log.TrimBefore(&record.TrimBeforeInput{Seq: 6})
+	s.Require().ErrorIs(err, record.ErrBadSeq)
+	next, err = s.log.NextSeq()
+	s.Require().NoError(err)
+	s.Equal(uint64(5), next)
+	all, err = s.log.All(&record.AllInput{FromSeq: 1})
+	s.Require().NoError(err)
+	s.Empty(all)
+
+	// Case 5: TrimBefore(nil) → ErrNilInput
+	_, err = s.log.TrimBefore(nil)
+	s.Require().ErrorIs(err, record.ErrNilInput)
+
+	// Case 6: Fresh log, TrimBefore{Seq: 1} → Removed: 0, no error
+	freshLog, err := record.NewLog()
+	s.Require().NoError(err)
+	out, err = freshLog.TrimBefore(&record.TrimBeforeInput{Seq: 1})
+	s.Require().NoError(err)
+	s.Equal(0, out.Removed)
+}
+
 func TestRecordSuite(t *testing.T) {
 	suite.Run(t, new(RecordSuite))
 }

--- a/play/record/story_test.go
+++ b/play/record/story_test.go
@@ -50,7 +50,7 @@ func TestTwoViewerStory(t *testing.T) {
 		map[string]string{kind: clockStart, actor: string(opener)},
 		"shared-1",
 	)
-	require.Equal(t, uint64(1), seq1)
+	require.Equal(t, uint64(1), seq1, "seq1 should be 1")
 
 	// Beat 2: opener's big reveal — only the door opener sees the first contact.
 	seq2 := appendBeat(
@@ -58,7 +58,7 @@ func TestTwoViewerStory(t *testing.T) {
 		map[string]string{kind: intelFirst, subject: room7},
 		"opener-reveal",
 	)
-	require.Equal(t, uint64(2), seq2)
+	require.Equal(t, uint64(2), seq2, "seq2 should be 2")
 
 	// Beat 3: follower's smaller reveal — only the door follower sees their first contact.
 	seq3 := appendBeat(
@@ -66,7 +66,7 @@ func TestTwoViewerStory(t *testing.T) {
 		map[string]string{kind: intelFirst, subject: room7},
 		"follower-reveal",
 	)
-	require.Equal(t, uint64(3), seq3)
+	require.Equal(t, uint64(3), seq3, "seq3 should be 3")
 
 	// Beat 4: GM-only beat — empty audience means NO VIEWER.
 	seq4 := appendBeat(
@@ -74,7 +74,7 @@ func TestTwoViewerStory(t *testing.T) {
 		map[string]string{kind: gmNote},
 		"gm-1",
 	)
-	require.Equal(t, uint64(4), seq4)
+	require.Equal(t, uint64(4), seq4, "seq4 should be 4")
 
 	// Beat 5: shared — both viewers see the turn end.
 	seq5 := appendBeat(
@@ -82,7 +82,7 @@ func TestTwoViewerStory(t *testing.T) {
 		map[string]string{kind: clockEnd, actor: string(opener)},
 		"shared-2",
 	)
-	require.Equal(t, uint64(5), seq5)
+	require.Equal(t, uint64(5), seq5, "seq5 should be 5")
 
 	// Helper to extract seq values from entries.
 	seqs := func(es []record.Entry) []uint64 {
@@ -146,6 +146,23 @@ func TestTwoViewerStory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []uint64{1}, seqs(turnStart), "clock.turn_started seqs should be [1]")
 
+	// Multi-key AND filter pin: All(Tags {"kind": "clock.turn_started", "actor": opener}) → [1]
+	// (proves AND-not-OR: filtering by actor alone returns [1,5], two-key filter returns [1])
+	turnStartWithOpener, err := log.All(&record.AllInput{
+		FromSeq: 1,
+		Tags:    map[string]string{kind: clockStart, actor: string(opener)},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, seqs(turnStartWithOpener), "kind AND actor filter should return [1] (AND semantics, not OR)")
+
+	// All(Tags {"actor": opener}) alone → [1,5] (both beats have same actor, different kinds)
+	actorOnly, err := log.All(&record.AllInput{
+		FromSeq: 1,
+		Tags:    map[string]string{actor: string(opener)},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 5}, seqs(actorOnly), "actor filter alone should return [1,5]")
+
 	// Assertion (e): GM beat invisible to both viewers; SliceFor(opener, FromSeq 4) → [5] only.
 	openerAfter4, err := log.SliceFor(&record.SliceForInput{Viewer: opener, FromSeq: 4})
 	require.NoError(t, err)
@@ -184,17 +201,13 @@ func TestTwoViewerStory(t *testing.T) {
 	// Re-run assertions on loaded log.
 	openerLoaded, err := loadedLog.SliceFor(&record.SliceForInput{Viewer: opener, FromSeq: 1})
 	require.NoError(t, err)
-	require.Equal(t, seqs(openerPostTrim), seqs(openerLoaded), "loaded opener slice mismatch")
+	require.Equal(t, openerPostTrim, openerLoaded, "loaded opener slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
 
 	followerLoaded, err := loadedLog.SliceFor(&record.SliceForInput{Viewer: follower, FromSeq: 1})
 	require.NoError(t, err)
-	require.Equal(t, seqs(followerPostTrim), seqs(followerLoaded), "loaded follower slice mismatch")
+	require.Equal(t, followerPostTrim, followerLoaded, "loaded follower slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
 
 	allLoaded, err := loadedLog.All(&record.AllInput{FromSeq: 1})
 	require.NoError(t, err)
-	require.Equal(t, seqs(allPostTrim), seqs(allLoaded), "loaded all slice mismatch")
-
-	// Verify payloads and audience survive round-trip.
-	require.Equal(t, []byte("follower-reveal"), followerLoaded[0].Payload, "loaded payload mismatch")
-	require.Equal(t, []core.EntityID{follower}, followerLoaded[0].Audience, "loaded audience mismatch")
+	require.Equal(t, allPostTrim, allLoaded, "loaded all slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
 }

--- a/play/record/story_test.go
+++ b/play/record/story_test.go
@@ -153,7 +153,8 @@ func TestTwoViewerStory(t *testing.T) {
 		Tags:    map[string]string{kind: clockStart, actor: string(opener)},
 	})
 	require.NoError(t, err)
-	require.Equal(t, []uint64{1}, seqs(turnStartWithOpener), "kind AND actor filter should return [1] (AND semantics, not OR)")
+	require.Equal(t, []uint64{1}, seqs(turnStartWithOpener),
+		"kind AND actor filter should return [1] (AND semantics, not OR)")
 
 	// All(Tags {"actor": opener}) alone → [1,5] (both beats have same actor, different kinds)
 	actorOnly, err := log.All(&record.AllInput{
@@ -201,13 +202,16 @@ func TestTwoViewerStory(t *testing.T) {
 	// Re-run assertions on loaded log.
 	openerLoaded, err := loadedLog.SliceFor(&record.SliceForInput{Viewer: opener, FromSeq: 1})
 	require.NoError(t, err)
-	require.Equal(t, openerPostTrim, openerLoaded, "loaded opener slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
+	require.Equal(t, openerPostTrim, openerLoaded,
+		"loaded opener slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
 
 	followerLoaded, err := loadedLog.SliceFor(&record.SliceForInput{Viewer: follower, FromSeq: 1})
 	require.NoError(t, err)
-	require.Equal(t, followerPostTrim, followerLoaded, "loaded follower slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
+	require.Equal(t, followerPostTrim, followerLoaded,
+		"loaded follower slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
 
 	allLoaded, err := loadedLog.All(&record.AllInput{FromSeq: 1})
 	require.NoError(t, err)
-	require.Equal(t, allPostTrim, allLoaded, "loaded all slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
+	require.Equal(t, allPostTrim, allLoaded,
+		"loaded all slice mismatch (full-fidelity: Seq, At, Correlation, Audience, Tags, Payload)")
 }

--- a/play/record/story_test.go
+++ b/play/record/story_test.go
@@ -1,0 +1,200 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package record_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/record"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTwoViewerStory is the AC1 integration spine: a two-viewer dungeon story
+// with shared beats, per-viewer reveals, a GM-only beat, retention, and round-trip
+// persistence. Tests mixed audience projection, tag filtering across differently-shaped
+// beats, sequence gaplessness post-trim, and deep-copy immunity.
+func TestTwoViewerStory(t *testing.T) {
+	const (
+		opener     = core.EntityID("door-opener")
+		follower   = core.EntityID("door-follower")
+		room7      = "room-7"
+		kind       = "kind"
+		actor      = "actor"
+		subject    = "subject"
+		clockStart = "clock.turn_started"
+		clockEnd   = "clock.turn_ended"
+		intelFirst = "intel.first_contact"
+		gmNote     = "gm.note"
+	)
+
+	// Create the log.
+	log, err := record.NewLog()
+	require.NoError(t, err)
+
+	// Append beats in order (use helper closure for repeated appends).
+	appendBeat := func(aud []core.EntityID, tags map[string]string, payload string) uint64 {
+		out, err := log.Append(&record.AppendInput{
+			Audience: aud,
+			Tags:     tags,
+			Payload:  []byte(payload),
+		})
+		require.NoError(t, err)
+		return out.Seq
+	}
+
+	// Beat 1: shared — both viewers see the turn start.
+	seq1 := appendBeat(
+		[]core.EntityID{opener, follower},
+		map[string]string{kind: clockStart, actor: string(opener)},
+		"shared-1",
+	)
+	require.Equal(t, uint64(1), seq1)
+
+	// Beat 2: opener's big reveal — only the door opener sees the first contact.
+	seq2 := appendBeat(
+		[]core.EntityID{opener},
+		map[string]string{kind: intelFirst, subject: room7},
+		"opener-reveal",
+	)
+	require.Equal(t, uint64(2), seq2)
+
+	// Beat 3: follower's smaller reveal — only the door follower sees their first contact.
+	seq3 := appendBeat(
+		[]core.EntityID{follower},
+		map[string]string{kind: intelFirst, subject: room7},
+		"follower-reveal",
+	)
+	require.Equal(t, uint64(3), seq3)
+
+	// Beat 4: GM-only beat — empty audience means NO VIEWER.
+	seq4 := appendBeat(
+		nil,
+		map[string]string{kind: gmNote},
+		"gm-1",
+	)
+	require.Equal(t, uint64(4), seq4)
+
+	// Beat 5: shared — both viewers see the turn end.
+	seq5 := appendBeat(
+		[]core.EntityID{opener, follower},
+		map[string]string{kind: clockEnd, actor: string(opener)},
+		"shared-2",
+	)
+	require.Equal(t, uint64(5), seq5)
+
+	// Helper to extract seq values from entries.
+	seqs := func(es []record.Entry) []uint64 {
+		result := make([]uint64, len(es))
+		for i, e := range es {
+			result[i] = e.Seq
+		}
+		return result
+	}
+
+	// Helper to extract payloads from entries.
+	payloads := func(es []record.Entry) []string {
+		result := make([]string, len(es))
+		for i, e := range es {
+			result[i] = string(e.Payload)
+		}
+		return result
+	}
+
+	// Assertion (a): SliceFor(opener, FromSeq 1) → exactly seqs [1,2,5], payloads match.
+	openerSlice, err := log.SliceFor(&record.SliceForInput{Viewer: opener, FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 5}, seqs(openerSlice), "opener should see seqs [1,2,5]")
+	expectedOpener := []string{"shared-1", "opener-reveal", "shared-2"}
+	require.Equal(t, expectedOpener, payloads(openerSlice), "opener payloads mismatch")
+
+	// Assertion (b): SliceFor(follower, FromSeq 1) → exactly seqs [1,3,5].
+	followerSlice, err := log.SliceFor(&record.SliceForInput{Viewer: follower, FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 3, 5}, seqs(followerSlice), "follower should see seqs [1,3,5]")
+	expectedFollower := []string{"shared-1", "follower-reveal", "shared-2"}
+	require.Equal(t, expectedFollower, payloads(followerSlice), "follower payloads mismatch")
+
+	// Assertion (c): Unfiltered All(FromSeq 1) → all five seqs [1..5].
+	allSeqs, err := log.All(&record.AllInput{FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3, 4, 5}, seqs(allSeqs), "all should return seqs [1..5]")
+
+	// Assertion (d): Tag questions across mixed shapes.
+	// SliceFor(opener, Tags {"kind": "intel.first_contact"}) → [2]
+	openerIntel, err := log.SliceFor(&record.SliceForInput{
+		Viewer: opener, FromSeq: 1,
+		Tags: map[string]string{kind: intelFirst},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{2}, seqs(openerIntel), "opener intel seqs should be [2]")
+
+	// All(Tags {"subject": "room-7"}) → [2,3]
+	subjectRoom, err := log.All(&record.AllInput{
+		FromSeq: 1,
+		Tags:    map[string]string{subject: room7},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{2, 3}, seqs(subjectRoom), "subject room-7 seqs should be [2,3]")
+
+	// All(Tags {"kind": "clock.turn_started"}) → [1]
+	turnStart, err := log.All(&record.AllInput{
+		FromSeq: 1,
+		Tags:    map[string]string{kind: clockStart},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, seqs(turnStart), "clock.turn_started seqs should be [1]")
+
+	// Assertion (e): GM beat invisible to both viewers; SliceFor(opener, FromSeq 4) → [5] only.
+	openerAfter4, err := log.SliceFor(&record.SliceForInput{Viewer: opener, FromSeq: 4})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{5}, seqs(openerAfter4), "opener FromSeq 4 should see [5] only (seq 4 excluded)")
+
+	// Same for follower.
+	followerAfter4, err := log.SliceFor(&record.SliceForInput{Viewer: follower, FromSeq: 4})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{5}, seqs(followerAfter4), "follower FromSeq 4 should see [5] only")
+
+	// Assertion (f): Retention; TrimBefore{Seq: 3} (both clients "acknowledged" through 2).
+	trimOut, err := log.TrimBefore(&record.TrimBeforeInput{Seq: 3})
+	require.NoError(t, err)
+	require.Equal(t, 2, trimOut.Removed, "trim should remove 2 entries")
+
+	// After trim, SliceFor(opener, FromSeq 1) → [5] only (opener isn't in seq 3's audience).
+	openerPostTrim, err := log.SliceFor(&record.SliceForInput{Viewer: opener, FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{5}, seqs(openerPostTrim), "opener post-trim should see [5]")
+
+	// SliceFor(follower, FromSeq 1) → [3,5].
+	followerPostTrim, err := log.SliceFor(&record.SliceForInput{Viewer: follower, FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{3, 5}, seqs(followerPostTrim), "follower post-trim should see [3,5]")
+
+	// Seqs NEVER renumbered; All(FromSeq 1) → [3,4,5].
+	allPostTrim, err := log.All(&record.AllInput{FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{3, 4, 5}, seqs(allPostTrim), "all post-trim should return [3,4,5] (seqs never renumbered)")
+
+	// Assertion (g): Round-trip mid-story; LoadLog(log.ToData()) → same SliceFor results.
+	data := log.ToData()
+	loadedLog, err := record.LoadLog(data)
+	require.NoError(t, err)
+
+	// Re-run assertions on loaded log.
+	openerLoaded, err := loadedLog.SliceFor(&record.SliceForInput{Viewer: opener, FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, seqs(openerPostTrim), seqs(openerLoaded), "loaded opener slice mismatch")
+
+	followerLoaded, err := loadedLog.SliceFor(&record.SliceForInput{Viewer: follower, FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, seqs(followerPostTrim), seqs(followerLoaded), "loaded follower slice mismatch")
+
+	allLoaded, err := loadedLog.All(&record.AllInput{FromSeq: 1})
+	require.NoError(t, err)
+	require.Equal(t, seqs(allPostTrim), seqs(allLoaded), "loaded all slice mismatch")
+
+	// Verify payloads and audience survive round-trip.
+	require.Equal(t, []byte("follower-reveal"), followerLoaded[0].Payload, "loaded payload mismatch")
+	require.Equal(t, []core.EntityID{follower}, followerLoaded[0].Audience, "loaded audience mismatch")
+}


### PR DESCRIPTION
## What

`play/record` v0: the retained story — an append-only, sequence-ordered, audience-projected log of opaque entries with per-viewer replay (`SliceFor`), a host view (`All`), and explicit retention (`TrimBefore`). Storage and query only; delivery stays on the host wire.

Design and plan: #906 (`docs/ideas/play/record/` — brainstorm, design, plan). This PR implements that design exactly; the docs PR merges alongside as ratification, with execution addenda logging every fix cycle.

## Family laws held

- Depends on `core` + stdlib only; no events, no spatial, no siblings, no rulebooks
- No `context.Context`; not concurrency-safe by contract
- Signature law: single `*XxxInput` params, `*XxxOutput` mutation results, error-last everywhere; `ErrNilInput` guards first
- R5 atomicity (validation before mutation); R6 gapless monotonic `Seq`, never renumbered by `TrimBefore`
- Persistence: `ToData() LogData` / `LoadLog(LogData) (*Log, error)`; idle snapshot marshals `{}`; fresh-log encoding (stored `NextSeq` 0 = fresh, 1 = rejected, >= 2 = trimmed-empty); R9 load validation rejects every unreachable state — including a uint64-wraparound forgery caught in review
- 7 sentinels, every one `errors.Is`-tested

## Evidence

- 30 tests green; `golangci-lint` 0 issues; zero `nolint` directives
- AC1 two-viewer story spine (`story_test.go`): shared beats, per-viewer reveals, a GM-only beat, tag questions across mixed-shape beats, trim-then-replay without renumbering, full-fidelity post-trim persistence round-trip
- Golden JSON pins the wire shape; copy-out immunity pinned with in-place mutations
- Compat gate: `gorelease-play-record` job added to `compat.yml` (faithful clone of the clock job)

— asset-pipeline agent, on behalf of KirkDiggler
