### PR TITLE
feat(play/intel): per-observer intel — Surveil/Report, the truth-blind store

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'play/clock/**'
+      - 'play/intel/**'
 
 jobs:
   gorelease-play-clock:
@@ -24,3 +25,22 @@ jobs:
           fi
           cd play/clock
           go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base "${base#play/clock/}"
+
+  gorelease-play-intel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: gorelease play/intel
+        run: |
+          base=$(git tag -l 'play/intel/v*' --sort=-v:refname | head -1)
+          if [ -z "$base" ]; then
+            echo "no play/intel tag yet — first release, gate activates from the first tag"
+            exit 0
+          fi
+          cd play/intel
+          go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base "${base#play/intel/}"

--- a/play/intel/data.go
+++ b/play/intel/data.go
@@ -46,9 +46,12 @@ func (i *Intel) ToData() Data {
 	for obs, subjects := range i.holdings {
 		subjectMap := make(map[Subject]HoldingData)
 		for subj, h := range subjects {
-			// Deep-copy payload
-			payloadCopy := make([]byte, len(h.payload))
-			copy(payloadCopy, h.payload)
+			// Deep-copy payload (only when not nil)
+			var payloadCopy []byte
+			if h.payload != nil {
+				payloadCopy = make([]byte, len(h.payload))
+				copy(payloadCopy, h.payload)
+			}
 
 			// Copy CurrentVia slice
 			var currentViaCopy []Channel
@@ -86,8 +89,11 @@ func (i *Intel) ToData() Data {
 
 // LoadIntel reconstructs an Intel from persistent data.
 // Returns (*Intel, error). On error, returns nil Intel and error wrapping ErrInvalidData.
-// Validates in deterministic order: observer keys, subject keys, channels, CurrentVia.
-// All validation before any mutation (R5). Payload nil is legal (see HoldingData doc).
+// Validates all holdings: per-holding checks are in deterministic order (observer validation, nil/empty map checks,
+// subject key validation, channel validation, CurrentVia validation including empty-channel and duplicate detection).
+// On any defect, the load rejects with ErrInvalidData and no partial state is constructed (R5).
+// Rejections are indistinguishable by design (all wrapped as ErrInvalidData, no additional context).
+// All validation completes before any construction. Payload nil is legal (see HoldingData doc).
 // Deep-copies all data: mutating the caller's Data after LoadIntel will not
 // affect the loaded Intel (R4).
 func LoadIntel(data Data) (*Intel, error) {

--- a/play/intel/data.go
+++ b/play/intel/data.go
@@ -10,9 +10,9 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 )
 
-// IntelData is the persistent representation of Intel state.
+// Data is the persistent representation of Intel state.
 // Holdings maps observer ID → (subject → holding data).
-type IntelData struct {
+type Data struct {
 	Holdings map[core.EntityID]map[Subject]HoldingData `json:"holdings,omitempty"`
 }
 
@@ -29,17 +29,17 @@ type HoldingData struct {
 }
 
 // ToData returns a persistent snapshot of this Intel.
-// Returns zero IntelData (nil Holdings map, not empty non-nil) if Intel is empty (R8 idle convention).
-// All payloads and slices are deep-copied; mutating the returned IntelData
+// Returns zero Data (nil Holdings map, not empty non-nil) if Intel is empty (R8 idle convention).
+// All payloads and slices are deep-copied; mutating the returned Data
 // will not affect this Intel.
-func (i *Intel) ToData() IntelData {
+func (i *Intel) ToData() Data {
 	if len(i.holdings) == 0 {
 		// Idle convention: return zero value with nil map, not empty map
-		return IntelData{}
+		return Data{}
 	}
 
 	// Copy holdings map
-	result := IntelData{
+	result := Data{
 		Holdings: make(map[core.EntityID]map[Subject]HoldingData),
 	}
 
@@ -88,9 +88,9 @@ func (i *Intel) ToData() IntelData {
 // Returns (*Intel, error). On error, returns nil Intel and error wrapping ErrInvalidData.
 // Validates in deterministic order: observer keys, subject keys, channels, CurrentVia.
 // All validation before any mutation (R5). Payload nil is legal (see HoldingData doc).
-// Deep-copies all data: mutating the caller's IntelData after LoadIntel will not
+// Deep-copies all data: mutating the caller's Data after LoadIntel will not
 // affect the loaded Intel (R4).
-func LoadIntel(data IntelData) (*Intel, error) {
+func LoadIntel(data Data) (*Intel, error) {
 	// R5: validate everything first, then mutate
 	if data.Holdings != nil {
 		// Validate all keys and fields

--- a/play/intel/data.go
+++ b/play/intel/data.go
@@ -89,11 +89,14 @@ func (i *Intel) ToData() Data {
 
 // LoadIntel reconstructs an Intel from persistent data.
 // Returns (*Intel, error). On error, returns nil Intel and error wrapping ErrInvalidData.
-// Validates all holdings: per-holding checks are in deterministic order (observer validation, nil/empty map checks,
-// subject key validation, channel validation, CurrentVia validation including empty-channel and duplicate detection).
-// On any defect, the load rejects with ErrInvalidData and no partial state is constructed (R5).
-// Rejections are indistinguishable by design (all wrapped as ErrInvalidData, no additional context).
-// All validation completes before any construction. Payload nil is legal (see HoldingData doc).
+// Validates every holding: within a single holding the checks run in a fixed
+// order (observer key, nil/empty inner map, subject key, channel, CurrentVia
+// including empty-channel and duplicate detection), but observers and subjects
+// are visited in Go map order — which defect of a multi-defect Data is hit
+// first is NOT deterministic. That is unobservable by design: every rejection
+// is the same wrapped ErrInvalidData with no defect detail, and no partial
+// state is constructed (R5). All validation completes before any construction.
+// Payload nil is legal (see HoldingData doc).
 // Deep-copies all data: mutating the caller's Data after LoadIntel will not
 // affect the loaded Intel (R4).
 func LoadIntel(data Data) (*Intel, error) {

--- a/play/intel/data.go
+++ b/play/intel/data.go
@@ -1,0 +1,172 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intel
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// IntelData is the persistent representation of Intel state.
+// Holdings maps observer ID → (subject → holding data).
+type IntelData struct {
+	Holdings map[core.EntityID]map[Subject]HoldingData `json:"holdings,omitempty"`
+}
+
+// HoldingData is the persistent representation of a single holding.
+// Payload is the opaque testimony. Channel and At are provenance.
+// CurrentVia lists channels currently sustaining this holding.
+// All fields are omitempty: nil payload marshals to omitted field,
+// and empty CurrentVia marshals to omitted (since it's never an empty non-nil slice).
+type HoldingData struct {
+	Payload    []byte    `json:"payload,omitempty"`
+	Channel    Channel   `json:"channel,omitempty"`
+	At         uint64    `json:"at,omitempty"`
+	CurrentVia []Channel `json:"current_via,omitempty"`
+}
+
+// ToData returns a persistent snapshot of this Intel.
+// Returns zero IntelData (nil Holdings map, not empty non-nil) if Intel is empty (R8 idle convention).
+// All payloads and slices are deep-copied; mutating the returned IntelData
+// will not affect this Intel.
+func (i *Intel) ToData() IntelData {
+	if len(i.holdings) == 0 {
+		// Idle convention: return zero value with nil map, not empty map
+		return IntelData{}
+	}
+
+	// Copy holdings map
+	result := IntelData{
+		Holdings: make(map[core.EntityID]map[Subject]HoldingData),
+	}
+
+	for obs, subjects := range i.holdings {
+		subjectMap := make(map[Subject]HoldingData)
+		for subj, h := range subjects {
+			// Deep-copy payload
+			payloadCopy := make([]byte, len(h.payload))
+			copy(payloadCopy, h.payload)
+
+			// Copy CurrentVia slice
+			var currentViaCopy []Channel
+			if len(h.currentVia) > 0 {
+				currentViaCopy = make([]Channel, len(h.currentVia))
+				// Extract channels from map in sorted order for determinism
+				var channels []Channel
+				for ch := range h.currentVia {
+					channels = append(channels, ch)
+				}
+				slices.SortFunc(channels, func(a, b Channel) int {
+					if a < b {
+						return -1
+					}
+					if a > b {
+						return 1
+					}
+					return 0
+				})
+				copy(currentViaCopy, channels)
+			}
+
+			subjectMap[subj] = HoldingData{
+				Payload:    payloadCopy,
+				Channel:    h.channel,
+				At:         h.at,
+				CurrentVia: currentViaCopy,
+			}
+		}
+		result.Holdings[obs] = subjectMap
+	}
+
+	return result
+}
+
+// LoadIntel reconstructs an Intel from persistent data.
+// Returns (*Intel, error). On error, returns nil Intel and error wrapping ErrInvalidData.
+// Validates in deterministic order: observer keys, subject keys, channels, CurrentVia.
+// All validation before any mutation (R5). Payload nil is legal (see HoldingData doc).
+// Deep-copies all data: mutating the caller's IntelData after LoadIntel will not
+// affect the loaded Intel (R4).
+func LoadIntel(data IntelData) (*Intel, error) {
+	// R5: validate everything first, then mutate
+	if data.Holdings != nil {
+		// Validate all keys and fields
+		for obs, subjectMap := range data.Holdings {
+			// Empty observer key is rejected
+			if obs == "" {
+				return nil, fmt.Errorf("load intel: %w", ErrInvalidData)
+			}
+
+			// Nil inner map is rejected
+			if subjectMap == nil {
+				return nil, fmt.Errorf("load intel: %w", ErrInvalidData)
+			}
+
+			// Empty (non-nil) inner map is rejected (unreachable state)
+			if len(subjectMap) == 0 {
+				return nil, fmt.Errorf("load intel: %w", ErrInvalidData)
+			}
+
+			for subj, hd := range subjectMap {
+				// Empty subject key is rejected
+				if subj == "" {
+					return nil, fmt.Errorf("load intel: %w", ErrInvalidData)
+				}
+
+				// Empty holding Channel is rejected
+				if hd.Channel == "" {
+					return nil, fmt.Errorf("load intel: %w", ErrInvalidData)
+				}
+
+				// Validate CurrentVia: no empty channels, no duplicates
+				seen := make(map[Channel]struct{})
+				for _, ch := range hd.CurrentVia {
+					if ch == "" {
+						return nil, fmt.Errorf("load intel: %w", ErrInvalidData)
+					}
+					if _, dup := seen[ch]; dup {
+						return nil, fmt.Errorf("load intel: %w", ErrInvalidData)
+					}
+					seen[ch] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// All validated; now reconstruct the Intel
+	intel := &Intel{
+		holdings: make(map[core.EntityID]map[Subject]*holding),
+	}
+
+	if data.Holdings != nil {
+		for obs, subjectMap := range data.Holdings {
+			intel.holdings[obs] = make(map[Subject]*holding)
+			for subj, hd := range subjectMap {
+				// Deep-copy payload (nil payloads remain nil; empty payloads are copied)
+				var payloadCopy []byte
+				if hd.Payload != nil {
+					payloadCopy = make([]byte, len(hd.Payload))
+					copy(payloadCopy, hd.Payload)
+				}
+
+				// Convert CurrentVia slice to internal set
+				currentVia := make(map[Channel]struct{})
+				for _, ch := range hd.CurrentVia {
+					currentVia[ch] = struct{}{}
+				}
+
+				intel.holdings[obs][subj] = &holding{
+					payload:    payloadCopy,
+					channel:    hd.Channel,
+					at:         hd.At,
+					currentVia: currentVia,
+				}
+			}
+		}
+	}
+
+	return intel, nil
+}

--- a/play/intel/doc.go
+++ b/play/intel/doc.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package intel stores per-observer intel: channel-sourced, possibly
+// false, possibly stale holdings about opaque subjects. Two testimony
+// verbs — Surveil (sustained collection, complete-percept contract) and
+// Report (discrete testimony) — plus read queries and persistence. The
+// module never sees the world and cannot verify anything: illusions,
+// disguises, and planted lies are ordinary testimony. Deciders consult
+// HeldBy(themselves) and nothing else — monsters act on their intel,
+// not the world.
+//
+// Design contract: docs/ideas/play/intel/design.md (R1–R10). Leaf
+// module: depends only on core, no context.Context, deltas returned as
+// values, never published.
+package intel

--- a/play/intel/doorscene_test.go
+++ b/play/intel/doorscene_test.go
@@ -46,20 +46,20 @@ func TestDoorScene(t *testing.T) {
 		},
 		At: 1,
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "hearing testimony: Report succeeds")
 	require.Equal(t, []intel.Report{
 		{Subject: behindDoor3, Payload: []byte(crashingSound)},
-	}, reportOut.FirstContact)
-	require.Empty(t, reportOut.Updated)
+	}, reportOut.FirstContact, "hearing testimony: behind-door-3 lands FirstContact")
+	require.Empty(t, reportOut.Updated, "hearing testimony: no Updated yet")
 
 	// Verify holding: Held status (no CurrentVia), payload, channel, at
 	h1, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: behindDoor3})
-	require.NoError(t, err)
-	require.Equal(t, []byte(crashingSound), h1.Payload)
-	require.Equal(t, hearing, h1.Channel)
-	require.Equal(t, uint64(1), h1.At)
-	require.Nil(t, h1.CurrentVia)
-	require.Equal(t, intel.Held, h1.Status)
+	require.NoError(t, err, "hearing testimony: On() succeeds")
+	require.Equal(t, []byte(crashingSound), h1.Payload, "hearing testimony: payload is crashing")
+	require.Equal(t, hearing, h1.Channel, "hearing testimony: Channel is hearing")
+	require.Equal(t, uint64(1), h1.At, "hearing testimony: At timestamp is 1")
+	require.Nil(t, h1.CurrentVia, "hearing testimony: no CurrentVia (Report holds)")
+	require.Equal(t, intel.Held, h1.Status, "hearing testimony: Status is Held")
 
 	// ===== STEP 2: Sight elsewhere =====
 	// Surveil sight channel with goblin percept (goblin-near).
@@ -72,27 +72,30 @@ func TestDoorScene(t *testing.T) {
 		},
 		At: 2,
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "sight elsewhere: Surveil succeeds")
 	require.Equal(t, []intel.Report{
 		{Subject: goblin, Payload: []byte(goblinNear)},
-	}, surveilOut.FirstContact)
-	require.Empty(t, surveilOut.Refreshed)
-	require.Empty(t, surveilOut.Faded)
+	}, surveilOut.FirstContact, "sight elsewhere: goblin lands FirstContact")
+	require.Empty(t, surveilOut.Refreshed, "sight elsewhere: no Refreshed yet")
+	require.Empty(t, surveilOut.Faded, "sight elsewhere: no Faded yet")
 
 	// Verify goblin holding: Current status, sight channel, CurrentVia = [sight]
 	hGoblin, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: goblin})
-	require.NoError(t, err)
-	require.Equal(t, []byte(goblinNear), hGoblin.Payload)
-	require.Equal(t, sight, hGoblin.Channel)
-	require.Equal(t, uint64(2), hGoblin.At)
-	require.Equal(t, []intel.Channel{sight}, hGoblin.CurrentVia)
-	require.Equal(t, intel.Current, hGoblin.Status)
+	require.NoError(t, err, "sight elsewhere: On(goblin) succeeds")
+	require.Equal(t, []byte(goblinNear), hGoblin.Payload, "sight elsewhere: goblin payload is goblin-near")
+	require.Equal(t, sight, hGoblin.Channel, "sight elsewhere: goblin Channel is sight")
+	require.Equal(t, uint64(2), hGoblin.At, "sight elsewhere: goblin At is 2")
+	require.Equal(t, []intel.Channel{sight}, hGoblin.CurrentVia, "sight elsewhere: goblin CurrentVia is [sight]")
+	require.Equal(t, intel.Current, hGoblin.Status, "sight elsewhere: goblin Status is Current")
 
 	// Verify behind-door-3 still Held (unchanged)
 	h2, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: behindDoor3})
-	require.NoError(t, err)
-	require.Equal(t, []byte(crashingSound), h2.Payload)
-	require.Equal(t, intel.Held, h2.Status)
+	require.NoError(t, err, "sight elsewhere: On(behind-door-3) succeeds")
+	require.Equal(t, []byte(crashingSound), h2.Payload, "sight elsewhere: behind-door-3 payload unchanged (crashing)")
+	require.Equal(t, hearing, h2.Channel, "sight elsewhere: behind-door-3 Channel unchanged (hearing)")
+	require.Equal(t, uint64(1), h2.At, "sight elsewhere: behind-door-3 At unchanged (1)")
+	require.Nil(t, h2.CurrentVia, "sight elsewhere: behind-door-3 CurrentVia unchanged (nil)")
+	require.Equal(t, intel.Held, h2.Status, "sight elsewhere: behind-door-3 Status unchanged (Held)")
 
 	// ===== STEP 3: The goblin leaves =====
 	// Surveil sight channel with empty percept (nothing visible).
@@ -103,18 +106,19 @@ func TestDoorScene(t *testing.T) {
 		Percept:  []intel.Report{},
 		At:       3,
 	})
-	require.NoError(t, err)
-	require.Empty(t, surveilOut.FirstContact)
-	require.Empty(t, surveilOut.Refreshed)
-	require.Equal(t, []intel.Subject{goblin}, surveilOut.Faded)
+	require.NoError(t, err, "goblin fades: Surveil succeeds")
+	require.Empty(t, surveilOut.FirstContact, "goblin fades: no FirstContact")
+	require.Empty(t, surveilOut.Refreshed, "goblin fades: no Refreshed")
+	require.Equal(t, []intel.Subject{goblin}, surveilOut.Faded, "goblin fades: goblin in Faded")
 
 	// Verify ghost-goblin: Held status, payload still "goblin-near", Channel still sight
 	hGoblinGhost, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: goblin})
-	require.NoError(t, err)
-	require.Equal(t, []byte(goblinNear), hGoblinGhost.Payload)
-	require.Equal(t, sight, hGoblinGhost.Channel)
-	require.Nil(t, hGoblinGhost.CurrentVia) // Empty CurrentVia (no sustaining channels)
-	require.Equal(t, intel.Held, hGoblinGhost.Status)
+	require.NoError(t, err, "goblin fades: On(goblin) succeeds")
+	require.Equal(t, []byte(goblinNear), hGoblinGhost.Payload, "the ghost goblin: payload held (goblin-near)")
+	require.Equal(t, sight, hGoblinGhost.Channel, "the ghost goblin: Channel held (sight)")
+	require.Equal(t, uint64(2), hGoblinGhost.At, "the ghost goblin: At held at last observation (2)")
+	require.Nil(t, hGoblinGhost.CurrentVia, "the ghost goblin: CurrentVia nil (no sustaining channels)")
+	require.Equal(t, intel.Held, hGoblinGhost.Status, "the ghost goblin: held at last observation")
 
 	// ===== STEP 4: The door opens =====
 	// Surveil sight channel including behind-door-3 ("pots, floor").
@@ -129,19 +133,19 @@ func TestDoorScene(t *testing.T) {
 		},
 		At: 4,
 	})
-	require.NoError(t, err)
-	require.Empty(t, surveilOut.FirstContact)
-	require.Equal(t, []intel.Subject{behindDoor3}, surveilOut.Refreshed)
-	require.Empty(t, surveilOut.Faded)
+	require.NoError(t, err, "door opens: Surveil succeeds")
+	require.Empty(t, surveilOut.FirstContact, "door opens: no FirstContact (already held)")
+	require.Equal(t, []intel.Subject{behindDoor3}, surveilOut.Refreshed, "door opens: behind-door-3 in Refreshed")
+	require.Empty(t, surveilOut.Faded, "door opens: no Faded")
 
 	// Verify behind-door-3: Current status now, payload updated, Channel sight
 	hDoorOpen, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: behindDoor3})
-	require.NoError(t, err)
-	require.Equal(t, []byte(potsFloor), hDoorOpen.Payload)
-	require.Equal(t, sight, hDoorOpen.Channel)
-	require.Equal(t, uint64(4), hDoorOpen.At)
-	require.Equal(t, []intel.Channel{sight}, hDoorOpen.CurrentVia)
-	require.Equal(t, intel.Current, hDoorOpen.Status)
+	require.NoError(t, err, "door opens: On(behind-door-3) succeeds")
+	require.Equal(t, []byte(potsFloor), hDoorOpen.Payload, "door opens: payload refreshed (pots, floor)")
+	require.Equal(t, sight, hDoorOpen.Channel, "door opens: hearing-holding overwritten by sight")
+	require.Equal(t, uint64(4), hDoorOpen.At, "door opens: At updated to 4")
+	require.Equal(t, []intel.Channel{sight}, hDoorOpen.CurrentVia, "door opens: CurrentVia now [sight]")
+	require.Equal(t, intel.Current, hDoorOpen.Status, "door opens: Status now Current")
 
 	// ===== STEP 5: The charm =====
 	// Report on channel "charm", subject "the-stranger", payload "trusted-friend"
@@ -155,48 +159,51 @@ func TestDoorScene(t *testing.T) {
 		},
 		At: 5,
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "the charm: Report succeeds")
 	require.Equal(t, []intel.Report{
 		{Subject: theStranger, Payload: []byte(trustedFriend)},
-	}, reportOut.FirstContact)
-	require.Empty(t, reportOut.Updated)
+	}, reportOut.FirstContact, "the charm: the-stranger lands FirstContact")
+	require.Empty(t, reportOut.Updated, "the charm: no Updated")
 
 	// Verify charm-holding: Held status (Report has empty CurrentVia),
 	// payload is the false belief, Channel is charm
 	hCharm, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: theStranger})
-	require.NoError(t, err)
-	require.Equal(t, []byte(trustedFriend), hCharm.Payload)
-	require.Equal(t, charm, hCharm.Channel)
-	require.Equal(t, uint64(5), hCharm.At)
-	require.Nil(t, hCharm.CurrentVia)
-	require.Equal(t, intel.Held, hCharm.Status)
+	require.NoError(t, err, "the charm: On(the-stranger) succeeds")
+	require.Equal(t, []byte(trustedFriend), hCharm.Payload, "charm plants false belief: payload held faithfully")
+	require.Equal(t, charm, hCharm.Channel, "charm plants false belief: Channel is charm")
+	require.Equal(t, uint64(5), hCharm.At, "charm plants false belief: At is 5")
+	require.Nil(t, hCharm.CurrentVia, "charm plants false belief: no CurrentVia (Report holds)")
+	require.Equal(t, intel.Held, hCharm.Status, "charm plants false belief: Status is Held")
 
 	// ===== STEP 6: Final ledger =====
 	// HeldBy returns all holdings in sorted-by-Subject order.
 	// Expected order: behind-door-3, goblin, the-stranger
 	holdings, err := intelContainer.HeldBy(&intel.HeldByInput{Observer: alice})
-	require.NoError(t, err)
+	require.NoError(t, err, "final ledger: HeldBy succeeds")
 
-	require.Len(t, holdings, 3)
+	require.Len(t, holdings, 3, "final ledger: three holdings")
 
 	// behind-door-3: Current, sight channel, "pots, floor"
-	require.Equal(t, behindDoor3, holdings[0].Subject)
-	require.Equal(t, []byte(potsFloor), holdings[0].Payload)
-	require.Equal(t, sight, holdings[0].Channel)
-	require.Equal(t, []intel.Channel{sight}, holdings[0].CurrentVia)
-	require.Equal(t, intel.Current, holdings[0].Status)
+	require.Equal(t, behindDoor3, holdings[0].Subject, "final ledger: behind-door-3 is first")
+	require.Equal(t, []byte(potsFloor), holdings[0].Payload, "final ledger: behind-door-3 payload (pots, floor)")
+	require.Equal(t, sight, holdings[0].Channel, "final ledger: behind-door-3 Channel (sight)")
+	require.Equal(t, uint64(4), holdings[0].At, "final ledger: behind-door-3 At (4)")
+	require.Equal(t, []intel.Channel{sight}, holdings[0].CurrentVia, "final ledger: behind-door-3 CurrentVia ([sight])")
+	require.Equal(t, intel.Current, holdings[0].Status, "final ledger: behind-door-3 Status (Current)")
 
 	// goblin: Held ghost, sight channel, "goblin-near"
-	require.Equal(t, goblin, holdings[1].Subject)
-	require.Equal(t, []byte(goblinNear), holdings[1].Payload)
-	require.Equal(t, sight, holdings[1].Channel)
-	require.Nil(t, holdings[1].CurrentVia)
-	require.Equal(t, intel.Held, holdings[1].Status)
+	require.Equal(t, goblin, holdings[1].Subject, "final ledger: goblin is second")
+	require.Equal(t, []byte(goblinNear), holdings[1].Payload, "final ledger: goblin payload (goblin-near)")
+	require.Equal(t, sight, holdings[1].Channel, "final ledger: goblin Channel (sight)")
+	require.Equal(t, uint64(2), holdings[1].At, "final ledger: goblin At (2)")
+	require.Nil(t, holdings[1].CurrentVia, "final ledger: goblin ghost CurrentVia (nil)")
+	require.Equal(t, intel.Held, holdings[1].Status, "final ledger: goblin Status (Held)")
 
 	// the-stranger: Held, charm channel, "trusted-friend"
-	require.Equal(t, theStranger, holdings[2].Subject)
-	require.Equal(t, []byte(trustedFriend), holdings[2].Payload)
-	require.Equal(t, charm, holdings[2].Channel)
-	require.Nil(t, holdings[2].CurrentVia)
-	require.Equal(t, intel.Held, holdings[2].Status)
+	require.Equal(t, theStranger, holdings[2].Subject, "final ledger: the-stranger is third")
+	require.Equal(t, []byte(trustedFriend), holdings[2].Payload, "final ledger: the-stranger payload (trusted-friend)")
+	require.Equal(t, charm, holdings[2].Channel, "final ledger: the-stranger Channel (charm)")
+	require.Equal(t, uint64(5), holdings[2].At, "final ledger: the-stranger At (5)")
+	require.Nil(t, holdings[2].CurrentVia, "final ledger: the-stranger CurrentVia (nil)")
+	require.Equal(t, intel.Held, holdings[2].Status, "final ledger: the-stranger Status (Held)")
 }

--- a/play/intel/doorscene_test.go
+++ b/play/intel/doorscene_test.go
@@ -1,0 +1,202 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+)
+
+// TestDoorScene scripts the AC1 design narrative: hearing testimony on a
+// subject behind a door, a goblin appearing and fading as a ghost, the door
+// opening to reveal the source, and a false belief planted by charm.
+// Tests the full delta-transcript at each step and end-state holdings.
+func TestDoorScene(t *testing.T) {
+	const (
+		alice         = core.EntityID("alice")
+		behindDoor3   = intel.Subject("behind-door-3")
+		goblin        = intel.Subject("goblin")
+		theStranger   = intel.Subject("the-stranger")
+		hearing       = intel.Channel("hearing")
+		sight         = intel.Channel("sight")
+		charm         = intel.Channel("charm")
+		crashingSound = "crashing"
+		goblinNear    = "goblin-near"
+		potsFloor     = "pots, floor"
+		trustedFriend = "trusted-friend"
+	)
+
+	// Create container
+	intelContainer, err := intel.NewIntel()
+	require.NoError(t, err)
+
+	// ===== STEP 1: Hearing testimony =====
+	// Report on subject "behind-door-3", channel "hearing", payload "crashing"
+	// Expected: FirstContact contains behind-door-3, no Faded/Refreshed
+	reportOut, err := intelContainer.Report(&intel.ReportInput{
+		Observer: alice,
+		Channel:  hearing,
+		Reports: []intel.Report{
+			{Subject: behindDoor3, Payload: []byte(crashingSound)},
+		},
+		At: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []intel.Report{
+		{Subject: behindDoor3, Payload: []byte(crashingSound)},
+	}, reportOut.FirstContact)
+	require.Empty(t, reportOut.Updated)
+
+	// Verify holding: Held status (no CurrentVia), payload, channel, at
+	h1, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: behindDoor3})
+	require.NoError(t, err)
+	require.Equal(t, []byte(crashingSound), h1.Payload)
+	require.Equal(t, hearing, h1.Channel)
+	require.Equal(t, uint64(1), h1.At)
+	require.Nil(t, h1.CurrentVia)
+	require.Equal(t, intel.Held, h1.Status)
+
+	// ===== STEP 2: Sight elsewhere =====
+	// Surveil sight channel with goblin percept (goblin-near).
+	// Expected: FirstContact contains goblin, behind-door-3 untouched
+	surveilOut, err := intelContainer.Surveil(&intel.SurveilInput{
+		Observer: alice,
+		Channel:  sight,
+		Percept: []intel.Report{
+			{Subject: goblin, Payload: []byte(goblinNear)},
+		},
+		At: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []intel.Report{
+		{Subject: goblin, Payload: []byte(goblinNear)},
+	}, surveilOut.FirstContact)
+	require.Empty(t, surveilOut.Refreshed)
+	require.Empty(t, surveilOut.Faded)
+
+	// Verify goblin holding: Current status, sight channel, CurrentVia = [sight]
+	hGoblin, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: goblin})
+	require.NoError(t, err)
+	require.Equal(t, []byte(goblinNear), hGoblin.Payload)
+	require.Equal(t, sight, hGoblin.Channel)
+	require.Equal(t, uint64(2), hGoblin.At)
+	require.Equal(t, []intel.Channel{sight}, hGoblin.CurrentVia)
+	require.Equal(t, intel.Current, hGoblin.Status)
+
+	// Verify behind-door-3 still Held (unchanged)
+	h2, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: behindDoor3})
+	require.NoError(t, err)
+	require.Equal(t, []byte(crashingSound), h2.Payload)
+	require.Equal(t, intel.Held, h2.Status)
+
+	// ===== STEP 3: The goblin leaves =====
+	// Surveil sight channel with empty percept (nothing visible).
+	// Expected: Faded contains goblin, goblin becomes ghost (Held, last observation)
+	surveilOut, err = intelContainer.Surveil(&intel.SurveilInput{
+		Observer: alice,
+		Channel:  sight,
+		Percept:  []intel.Report{},
+		At:       3,
+	})
+	require.NoError(t, err)
+	require.Empty(t, surveilOut.FirstContact)
+	require.Empty(t, surveilOut.Refreshed)
+	require.Equal(t, []intel.Subject{goblin}, surveilOut.Faded)
+
+	// Verify ghost-goblin: Held status, payload still "goblin-near", Channel still sight
+	hGoblinGhost, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: goblin})
+	require.NoError(t, err)
+	require.Equal(t, []byte(goblinNear), hGoblinGhost.Payload)
+	require.Equal(t, sight, hGoblinGhost.Channel)
+	require.Nil(t, hGoblinGhost.CurrentVia) // Empty CurrentVia (no sustaining channels)
+	require.Equal(t, intel.Held, hGoblinGhost.Status)
+
+	// ===== STEP 4: The door opens =====
+	// Surveil sight channel including behind-door-3 ("pots, floor").
+	// The hearing-holding is overwritten because composition aimed the same subject.
+	// Expected: Refreshed (not FirstContact) because behind-door-3 was already held;
+	// Channel becomes sight, payload becomes "pots, floor", CurrentVia = [sight]
+	surveilOut, err = intelContainer.Surveil(&intel.SurveilInput{
+		Observer: alice,
+		Channel:  sight,
+		Percept: []intel.Report{
+			{Subject: behindDoor3, Payload: []byte(potsFloor)},
+		},
+		At: 4,
+	})
+	require.NoError(t, err)
+	require.Empty(t, surveilOut.FirstContact)
+	require.Equal(t, []intel.Subject{behindDoor3}, surveilOut.Refreshed)
+	require.Empty(t, surveilOut.Faded)
+
+	// Verify behind-door-3: Current status now, payload updated, Channel sight
+	hDoorOpen, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: behindDoor3})
+	require.NoError(t, err)
+	require.Equal(t, []byte(potsFloor), hDoorOpen.Payload)
+	require.Equal(t, sight, hDoorOpen.Channel)
+	require.Equal(t, uint64(4), hDoorOpen.At)
+	require.Equal(t, []intel.Channel{sight}, hDoorOpen.CurrentVia)
+	require.Equal(t, intel.Current, hDoorOpen.Status)
+
+	// ===== STEP 5: The charm =====
+	// Report on channel "charm", subject "the-stranger", payload "trusted-friend"
+	// (a false belief — intel is truth-blind).
+	// Expected: FirstContact, beliefs held faithfully
+	reportOut, err = intelContainer.Report(&intel.ReportInput{
+		Observer: alice,
+		Channel:  charm,
+		Reports: []intel.Report{
+			{Subject: theStranger, Payload: []byte(trustedFriend)},
+		},
+		At: 5,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []intel.Report{
+		{Subject: theStranger, Payload: []byte(trustedFriend)},
+	}, reportOut.FirstContact)
+	require.Empty(t, reportOut.Updated)
+
+	// Verify charm-holding: Held status (Report has empty CurrentVia),
+	// payload is the false belief, Channel is charm
+	hCharm, err := intelContainer.On(&intel.OnInput{Observer: alice, Subject: theStranger})
+	require.NoError(t, err)
+	require.Equal(t, []byte(trustedFriend), hCharm.Payload)
+	require.Equal(t, charm, hCharm.Channel)
+	require.Equal(t, uint64(5), hCharm.At)
+	require.Nil(t, hCharm.CurrentVia)
+	require.Equal(t, intel.Held, hCharm.Status)
+
+	// ===== STEP 6: Final ledger =====
+	// HeldBy returns all holdings in sorted-by-Subject order.
+	// Expected order: behind-door-3, goblin, the-stranger
+	holdings, err := intelContainer.HeldBy(&intel.HeldByInput{Observer: alice})
+	require.NoError(t, err)
+
+	require.Len(t, holdings, 3)
+
+	// behind-door-3: Current, sight channel, "pots, floor"
+	require.Equal(t, behindDoor3, holdings[0].Subject)
+	require.Equal(t, []byte(potsFloor), holdings[0].Payload)
+	require.Equal(t, sight, holdings[0].Channel)
+	require.Equal(t, []intel.Channel{sight}, holdings[0].CurrentVia)
+	require.Equal(t, intel.Current, holdings[0].Status)
+
+	// goblin: Held ghost, sight channel, "goblin-near"
+	require.Equal(t, goblin, holdings[1].Subject)
+	require.Equal(t, []byte(goblinNear), holdings[1].Payload)
+	require.Equal(t, sight, holdings[1].Channel)
+	require.Nil(t, holdings[1].CurrentVia)
+	require.Equal(t, intel.Held, holdings[1].Status)
+
+	// the-stranger: Held, charm channel, "trusted-friend"
+	require.Equal(t, theStranger, holdings[2].Subject)
+	require.Equal(t, []byte(trustedFriend), holdings[2].Payload)
+	require.Equal(t, charm, holdings[2].Channel)
+	require.Nil(t, holdings[2].CurrentVia)
+	require.Equal(t, intel.Held, holdings[2].Status)
+}

--- a/play/intel/errors.go
+++ b/play/intel/errors.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intel
+
+import "errors"
+
+// Sentinel errors — the module's error vocabulary (design: Errors).
+// All returned errors wrap exactly one of these; callers dispatch with
+// errors.Is. Messages are user-facing.
+var (
+	// ErrNilInput reports a nil *XxxInput. Caller defect, dedicated sentinel.
+	ErrNilInput = errors.New("nil input")
+	// ErrNoObserver reports an empty observer ID.
+	ErrNoObserver = errors.New("empty observer")
+	// ErrNoChannel reports an empty channel identifier — the vocabulary
+	// is open, but the identifier is required.
+	ErrNoChannel = errors.New("empty channel")
+	// ErrNoSubject reports a report or query with an empty subject.
+	ErrNoSubject = errors.New("empty subject")
+	// ErrNotHeld reports that the observer holds nothing on that subject.
+	ErrNotHeld = errors.New("nothing held on subject")
+	// ErrInvalidData reports persisted state rejected by LoadIntel (design R9).
+	ErrInvalidData = errors.New("invalid intel data")
+)

--- a/play/intel/errors_test.go
+++ b/play/intel/errors_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intel_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSentinelsAreDistinct(t *testing.T) {
+	sentinels := []error{
+		intel.ErrNilInput,
+		intel.ErrNoObserver,
+		intel.ErrNoChannel,
+		intel.ErrNoSubject,
+		intel.ErrNotHeld,
+		intel.ErrInvalidData,
+	}
+
+	// Each sentinel must be non-nil
+	for i, sentinel := range sentinels {
+		assert.NotNil(t, sentinel, "sentinel at index %d is nil", i)
+	}
+
+	// Pairwise distinct via errors.Is
+	for i, sentinelI := range sentinels {
+		for j, sentinelJ := range sentinels {
+			if i == j {
+				// Same sentinel should match itself
+				assert.True(t, errors.Is(sentinelI, sentinelJ),
+					"sentinel at index %d should match itself", i)
+			} else {
+				// Different sentinels should not match
+				assert.False(t, errors.Is(sentinelI, sentinelJ),
+					"sentinel at index %d should not match sentinel at index %d", i, j)
+			}
+		}
+	}
+}

--- a/play/intel/go.mod
+++ b/play/intel/go.mod
@@ -2,7 +2,10 @@ module github.com/KirkDiggler/rpg-toolkit/play/intel
 
 go 1.24
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
+	github.com/stretchr/testify v1.11.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/play/intel/go.mod
+++ b/play/intel/go.mod
@@ -1,0 +1,11 @@
+module github.com/KirkDiggler/rpg-toolkit/play/intel
+
+go 1.24
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/play/intel/go.sum
+++ b/play/intel/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/play/intel/go.sum
+++ b/play/intel/go.sum
@@ -1,3 +1,5 @@
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/play/intel/intel.go
+++ b/play/intel/intel.go
@@ -121,30 +121,37 @@ func (i *Intel) Report(in *ReportInput) (*ReportOutput, error) {
 		Updated:      []Subject{},
 	}
 
-	// Ensure observer map exists
+	// No testimony means no mutation (R9 unreachable state guard)
+	if len(deduped) == 0 {
+		return out, nil
+	}
+
+	// Ensure observer map exists (only after confirming work to do)
 	if _, exists := i.holdings[in.Observer]; !exists {
 		i.holdings[in.Observer] = make(map[Subject]*holding)
 	}
 
 	// Process each deduplicated report
 	for _, report := range deduped {
-		// Make a copy of the payload
-		payloadCopy := make([]byte, len(report.Payload))
-		copy(payloadCopy, report.Payload)
+		// Make two independent copies: one for storage, one for FirstContact (copy-out R4)
+		storageCopy := make([]byte, len(report.Payload))
+		copy(storageCopy, report.Payload)
 
 		if _, exists := i.holdings[in.Observer][report.Subject]; !exists {
-			// New subject: create holding and add to FirstContact
+			// New subject: create holding and add to FirstContact with independent copy
+			firstContactCopy := make([]byte, len(report.Payload))
+			copy(firstContactCopy, report.Payload)
 			i.holdings[in.Observer][report.Subject] = &holding{
-				payload:    payloadCopy,
+				payload:    storageCopy,
 				channel:    in.Channel,
 				at:         in.At,
 				currentVia: make(map[Channel]struct{}),
 			}
-			out.FirstContact = append(out.FirstContact, Report{Subject: report.Subject, Payload: payloadCopy})
+			out.FirstContact = append(out.FirstContact, Report{Subject: report.Subject, Payload: firstContactCopy})
 		} else {
 			// Known subject: overwrite payload, channel, at; leave currentVia untouched
 			h := i.holdings[in.Observer][report.Subject]
-			h.payload = payloadCopy
+			h.payload = storageCopy
 			h.channel = in.Channel
 			h.at = in.At
 			out.Updated = append(out.Updated, report.Subject)
@@ -183,10 +190,10 @@ func (i *Intel) HeldBy(in *HeldByInput) ([]Holding, error) {
 	}
 
 	// Sort by Subject (deterministic order)
-	for i := 0; i < len(results)-1; i++ {
-		for j := i + 1; j < len(results); j++ {
-			if results[j].Subject < results[i].Subject {
-				results[i], results[j] = results[j], results[i]
+	for idx := 0; idx < len(results)-1; idx++ {
+		for j := idx + 1; j < len(results); j++ {
+			if results[j].Subject < results[idx].Subject {
+				results[idx], results[j] = results[j], results[idx]
 			}
 		}
 	}

--- a/play/intel/intel.go
+++ b/play/intel/intel.go
@@ -314,7 +314,7 @@ func (i *Intel) HeldBy(in *HeldByInput) ([]Holding, error) {
 	}
 
 	// Collect and convert holdings to exported type
-	var results []Holding
+	results := make([]Holding, 0, len(observerHoldings))
 	for subject, h := range observerHoldings {
 		results = append(results, h.toHolding(subject))
 	}

--- a/play/intel/intel.go
+++ b/play/intel/intel.go
@@ -393,9 +393,12 @@ func dedupeReports(reports []Report) []Report {
 // toHolding converts an internal holding to an exported Holding,
 // deep-copying the payload and sorting CurrentVia.
 func (h *holding) toHolding(subject Subject) Holding {
-	// Deep-copy payload
-	payloadCopy := make([]byte, len(h.payload))
-	copy(payloadCopy, h.payload)
+	// Deep-copy payload (nil payloads remain nil; empty payloads are copied)
+	var payloadCopy []byte
+	if h.payload != nil {
+		payloadCopy = make([]byte, len(h.payload))
+		copy(payloadCopy, h.payload)
+	}
 
 	// Convert currentVia map to sorted slice
 	var currentVia []Channel

--- a/play/intel/intel.go
+++ b/play/intel/intel.go
@@ -5,6 +5,7 @@ package intel
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 )
@@ -166,13 +167,15 @@ func (i *Intel) Surveil(in *SurveilInput) (*SurveilOutput, error) {
 
 	// Sort Faded by Subject for deterministic transcripts; only assign if non-empty
 	if len(fadedSubjects) > 0 {
-		for i := 0; i < len(fadedSubjects)-1; i++ {
-			for j := i + 1; j < len(fadedSubjects); j++ {
-				if fadedSubjects[j] < fadedSubjects[i] {
-					fadedSubjects[i], fadedSubjects[j] = fadedSubjects[j], fadedSubjects[i]
-				}
+		slices.SortFunc(fadedSubjects, func(a, b Subject) int {
+			if a < b {
+				return -1
 			}
-		}
+			if a > b {
+				return 1
+			}
+			return 0
+		})
 		out.Faded = fadedSubjects
 	}
 
@@ -317,13 +320,15 @@ func (i *Intel) HeldBy(in *HeldByInput) ([]Holding, error) {
 	}
 
 	// Sort by Subject (deterministic order)
-	for idx := 0; idx < len(results)-1; idx++ {
-		for j := idx + 1; j < len(results); j++ {
-			if results[j].Subject < results[idx].Subject {
-				results[idx], results[j] = results[j], results[idx]
-			}
+	slices.SortFunc(results, func(a, b Holding) int {
+		if a.Subject < b.Subject {
+			return -1
 		}
-	}
+		if a.Subject > b.Subject {
+			return 1
+		}
+		return 0
+	})
 
 	return results, nil
 }
@@ -399,13 +404,15 @@ func (h *holding) toHolding(subject Subject) Holding {
 			currentVia = append(currentVia, ch)
 		}
 		// Sort for determinism
-		for i := 0; i < len(currentVia)-1; i++ {
-			for j := i + 1; j < len(currentVia); j++ {
-				if currentVia[j] < currentVia[i] {
-					currentVia[i], currentVia[j] = currentVia[j], currentVia[i]
-				}
+		slices.SortFunc(currentVia, func(a, b Channel) int {
+			if a < b {
+				return -1
 			}
-		}
+			if a > b {
+				return 1
+			}
+			return 0
+		})
 	}
 
 	// Derive status

--- a/play/intel/intel.go
+++ b/play/intel/intel.go
@@ -1,0 +1,300 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intel
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// Channel identifies a source of testimony (hearing, sight, smell, etc).
+// Sight is the one predeclared channel; vocabulary is open — physical
+// channels get physics from the stage, supernatural from rulebooks;
+// intel treats all identically.
+type Channel string
+
+// Sight is the predeclared visual channel.
+const Sight Channel = "sight"
+
+// Subject is an opaque, caller-chosen identification within an
+// observer's fidelity: a place key, an entity ID, a believed identity.
+// Choosing subjects is part of the testimony.
+type Subject string
+
+// Report is one piece of testimony: a subject and an opaque payload.
+// Payload is empty legal; nil and empty are the same legal empty payload.
+type Report struct {
+	Subject Subject
+	Payload []byte
+}
+
+// Status identifies whether a holding is Current or Held.
+// Status is derived, never stored: Current iff any channel sustains.
+type Status string
+
+const (
+	// Current indicates the subject is actively sustained by at least one channel.
+	Current Status = "current"
+	// Held indicates the subject is known but not actively sustained (a ghost).
+	Held Status = "held"
+)
+
+// Holding is the read-side value: a subject, payload, channel provenance,
+// timestamp, active channels (CurrentVia), and derived status. Channel and
+// At are provenance of the latest accepted testimony. Status is derived
+// (Current iff CurrentVia is non-empty).
+type Holding struct {
+	Subject    Subject
+	Payload    []byte
+	Channel    Channel
+	At         uint64
+	CurrentVia []Channel
+	Status     Status
+}
+
+// Intel is the container for all observers' intel holdings.
+// Not safe for concurrent use. Zero value not usable; construct via
+// NewIntel or LoadIntel.
+type Intel struct {
+	holdings map[core.EntityID]map[Subject]*holding
+}
+
+// internal holding struct stores the mutable state.
+type holding struct {
+	payload    []byte
+	channel    Channel
+	at         uint64
+	currentVia map[Channel]struct{}
+}
+
+// NewIntel creates a new Intel container.
+func NewIntel() (*Intel, error) {
+	return &Intel{
+		holdings: make(map[core.EntityID]map[Subject]*holding),
+	}, nil
+}
+
+// ReportInput is the input to the Report verb.
+type ReportInput struct {
+	Observer core.EntityID
+	Channel  Channel
+	Reports  []Report
+	At       uint64
+}
+
+// ReportOutput is the output of the Report verb.
+type ReportOutput struct {
+	FirstContact []Report
+	Updated      []Subject
+}
+
+// Report lands discrete testimony as HELD. Unknown subjects create new
+// holdings; known subjects are overwritten. Dedupes first, last wins,
+// survivor at last occurrence's position. Validates in order: nil → observer
+// → channel → subjects. All validation before any mutation (R5).
+func (i *Intel) Report(in *ReportInput) (*ReportOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("%w", ErrNilInput)
+	}
+
+	if in.Observer == "" {
+		return nil, fmt.Errorf("%w", ErrNoObserver)
+	}
+
+	if in.Channel == "" {
+		return nil, fmt.Errorf("%w", ErrNoChannel)
+	}
+
+	for _, report := range in.Reports {
+		if report.Subject == "" {
+			return nil, fmt.Errorf("%w", ErrNoSubject)
+		}
+	}
+
+	// Dedupe: last wins, survivor at last occurrence's position
+	deduped := dedupeReports(in.Reports)
+
+	out := &ReportOutput{
+		FirstContact: []Report{},
+		Updated:      []Subject{},
+	}
+
+	// Ensure observer map exists
+	if _, exists := i.holdings[in.Observer]; !exists {
+		i.holdings[in.Observer] = make(map[Subject]*holding)
+	}
+
+	// Process each deduplicated report
+	for _, report := range deduped {
+		// Make a copy of the payload
+		payloadCopy := make([]byte, len(report.Payload))
+		copy(payloadCopy, report.Payload)
+
+		if _, exists := i.holdings[in.Observer][report.Subject]; !exists {
+			// New subject: create holding and add to FirstContact
+			i.holdings[in.Observer][report.Subject] = &holding{
+				payload:    payloadCopy,
+				channel:    in.Channel,
+				at:         in.At,
+				currentVia: make(map[Channel]struct{}),
+			}
+			out.FirstContact = append(out.FirstContact, Report{Subject: report.Subject, Payload: payloadCopy})
+		} else {
+			// Known subject: overwrite payload, channel, at; leave currentVia untouched
+			h := i.holdings[in.Observer][report.Subject]
+			h.payload = payloadCopy
+			h.channel = in.Channel
+			h.at = in.At
+			out.Updated = append(out.Updated, report.Subject)
+		}
+	}
+
+	return out, nil
+}
+
+// HeldByInput is the input to the HeldBy query.
+type HeldByInput struct {
+	Observer core.EntityID
+}
+
+// HeldBy returns all holdings for an observer, sorted by Subject,
+// with statuses derived and payloads deep-copied. Unknown observer
+// returns empty slice, nil error.
+func (i *Intel) HeldBy(in *HeldByInput) ([]Holding, error) {
+	if in == nil {
+		return nil, fmt.Errorf("%w", ErrNilInput)
+	}
+
+	if in.Observer == "" {
+		return nil, fmt.Errorf("%w", ErrNoObserver)
+	}
+
+	observerHoldings, exists := i.holdings[in.Observer]
+	if !exists {
+		return []Holding{}, nil
+	}
+
+	// Collect and convert holdings to exported type
+	var results []Holding
+	for subject, h := range observerHoldings {
+		results = append(results, h.toHolding(subject))
+	}
+
+	// Sort by Subject (deterministic order)
+	for i := 0; i < len(results)-1; i++ {
+		for j := i + 1; j < len(results); j++ {
+			if results[j].Subject < results[i].Subject {
+				results[i], results[j] = results[j], results[i]
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// OnInput is the input to the On query.
+type OnInput struct {
+	Observer core.EntityID
+	Subject  Subject
+}
+
+// On returns a single holding for an observer and subject.
+// Returns ErrNotHeld if not held. Payload is deep-copied.
+func (i *Intel) On(in *OnInput) (Holding, error) {
+	if in == nil {
+		return Holding{}, fmt.Errorf("%w", ErrNilInput)
+	}
+
+	if in.Observer == "" {
+		return Holding{}, fmt.Errorf("%w", ErrNoObserver)
+	}
+
+	if in.Subject == "" {
+		return Holding{}, fmt.Errorf("%w", ErrNoSubject)
+	}
+
+	observerHoldings, exists := i.holdings[in.Observer]
+	if !exists {
+		return Holding{}, fmt.Errorf("%w", ErrNotHeld)
+	}
+
+	h, exists := observerHoldings[in.Subject]
+	if !exists {
+		return Holding{}, fmt.Errorf("%w", ErrNotHeld)
+	}
+
+	return h.toHolding(in.Subject), nil
+}
+
+// dedupeReports deduplicates reports, last wins, survivor at last
+// occurrence's position.
+func dedupeReports(reports []Report) []Report {
+	// Track last occurrence of each subject
+	lastOccurrence := make(map[Subject]int)
+	for i, report := range reports {
+		lastOccurrence[report.Subject] = i
+	}
+
+	// Build result with survivors in their last position order
+	seen := make(map[Subject]bool)
+	var result []Report
+	for i, report := range reports {
+		if lastOccurrence[report.Subject] == i && !seen[report.Subject] {
+			// This is the last occurrence of this subject
+			seen[report.Subject] = true
+		}
+	}
+
+	// Collect survivors in their last occurrence positions
+	for i, report := range reports {
+		if lastOccurrence[report.Subject] == i {
+			// Make a copy of the payload
+			payloadCopy := make([]byte, len(report.Payload))
+			copy(payloadCopy, report.Payload)
+			result = append(result, Report{Subject: report.Subject, Payload: payloadCopy})
+		}
+	}
+
+	return result
+}
+
+// toHolding converts an internal holding to an exported Holding,
+// deep-copying the payload and sorting CurrentVia.
+func (h *holding) toHolding(subject Subject) Holding {
+	// Deep-copy payload
+	payloadCopy := make([]byte, len(h.payload))
+	copy(payloadCopy, h.payload)
+
+	// Convert currentVia map to sorted slice
+	var currentVia []Channel
+	if len(h.currentVia) > 0 {
+		for ch := range h.currentVia {
+			currentVia = append(currentVia, ch)
+		}
+		// Sort for determinism
+		for i := 0; i < len(currentVia)-1; i++ {
+			for j := i + 1; j < len(currentVia); j++ {
+				if currentVia[j] < currentVia[i] {
+					currentVia[i], currentVia[j] = currentVia[j], currentVia[i]
+				}
+			}
+		}
+	}
+
+	// Derive status
+	status := Held
+	if len(h.currentVia) > 0 {
+		status = Current
+	}
+
+	return Holding{
+		Subject:    subject,
+		Payload:    payloadCopy,
+		Channel:    h.channel,
+		At:         h.at,
+		CurrentVia: currentVia,
+		Status:     status,
+	}
+}

--- a/play/intel/intel.go
+++ b/play/intel/intel.go
@@ -226,20 +226,20 @@ type ReportOutput struct {
 // → channel → subjects. All validation before any mutation (R5).
 func (i *Intel) Report(in *ReportInput) (*ReportOutput, error) {
 	if in == nil {
-		return nil, fmt.Errorf("%w", ErrNilInput)
+		return nil, fmt.Errorf("report: %w", ErrNilInput)
 	}
 
 	if in.Observer == "" {
-		return nil, fmt.Errorf("%w", ErrNoObserver)
+		return nil, fmt.Errorf("report: %w", ErrNoObserver)
 	}
 
 	if in.Channel == "" {
-		return nil, fmt.Errorf("%w", ErrNoChannel)
+		return nil, fmt.Errorf("report: %w", ErrNoChannel)
 	}
 
 	for _, report := range in.Reports {
 		if report.Subject == "" {
-			return nil, fmt.Errorf("%w", ErrNoSubject)
+			return nil, fmt.Errorf("report: %w", ErrNoSubject)
 		}
 	}
 
@@ -301,11 +301,11 @@ type HeldByInput struct {
 // returns empty slice, nil error.
 func (i *Intel) HeldBy(in *HeldByInput) ([]Holding, error) {
 	if in == nil {
-		return nil, fmt.Errorf("%w", ErrNilInput)
+		return nil, fmt.Errorf("held by: %w", ErrNilInput)
 	}
 
 	if in.Observer == "" {
-		return nil, fmt.Errorf("%w", ErrNoObserver)
+		return nil, fmt.Errorf("held by: %w", ErrNoObserver)
 	}
 
 	observerHoldings, exists := i.holdings[in.Observer]
@@ -343,25 +343,25 @@ type OnInput struct {
 // Returns ErrNotHeld if not held. Payload is deep-copied.
 func (i *Intel) On(in *OnInput) (Holding, error) {
 	if in == nil {
-		return Holding{}, fmt.Errorf("%w", ErrNilInput)
+		return Holding{}, fmt.Errorf("on: %w", ErrNilInput)
 	}
 
 	if in.Observer == "" {
-		return Holding{}, fmt.Errorf("%w", ErrNoObserver)
+		return Holding{}, fmt.Errorf("on: %w", ErrNoObserver)
 	}
 
 	if in.Subject == "" {
-		return Holding{}, fmt.Errorf("%w", ErrNoSubject)
+		return Holding{}, fmt.Errorf("on: %w", ErrNoSubject)
 	}
 
 	observerHoldings, exists := i.holdings[in.Observer]
 	if !exists {
-		return Holding{}, fmt.Errorf("%w", ErrNotHeld)
+		return Holding{}, fmt.Errorf("on: %w", ErrNotHeld)
 	}
 
 	h, exists := observerHoldings[in.Subject]
 	if !exists {
-		return Holding{}, fmt.Errorf("%w", ErrNotHeld)
+		return Holding{}, fmt.Errorf("on: %w", ErrNotHeld)
 	}
 
 	return h.toHolding(in.Subject), nil
@@ -380,10 +380,9 @@ func dedupeReports(reports []Report) []Report {
 	var result []Report
 	for i, report := range reports {
 		if lastOccurrence[report.Subject] == i {
-			// Make a copy of the payload
-			payloadCopy := make([]byte, len(report.Payload))
-			copy(payloadCopy, report.Payload)
-			result = append(result, Report{Subject: report.Subject, Payload: payloadCopy})
+			// Payload passed through as-is: both callers copy independently
+			// into storage and outputs, so a dedupe-level copy is redundant.
+			result = append(result, Report{Subject: report.Subject, Payload: report.Payload})
 		}
 	}
 

--- a/play/intel/intel.go
+++ b/play/intel/intel.go
@@ -76,12 +76,139 @@ func NewIntel() (*Intel, error) {
 	}, nil
 }
 
+// SurveilInput carries a complete percept for this observer+channel.
+type SurveilInput struct {
+	Observer core.EntityID
+	Channel  Channel
+	Percept  []Report
+	At       uint64
+}
+
+// SurveilOutput reports the deltas Surveil caused.
+type SurveilOutput struct {
+	FirstContact []Report
+	Refreshed    []Subject
+	Faded        []Subject
+}
+
 // ReportInput is the input to the Report verb.
 type ReportInput struct {
 	Observer core.EntityID
 	Channel  Channel
 	Reports  []Report
 	At       uint64
+}
+
+// Surveil records a complete percept for an observer+channel. Fading is
+// derived: every subject previously current via this channel but absent from
+// Percept has that channel removed from CurrentVia. If CurrentVia becomes
+// empty, the subject fades (still held — the ghost goblin). An empty Percept
+// is legal (seeing nothing: fades everything this channel sustained). Errors:
+// ErrNilInput, ErrNoObserver, ErrNoChannel, ErrNoSubject — validation first,
+// all before any mutation (R5).
+func (i *Intel) Surveil(in *SurveilInput) (*SurveilOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("surveil: %w", ErrNilInput)
+	}
+
+	if in.Observer == "" {
+		return nil, fmt.Errorf("surveil: %w", ErrNoObserver)
+	}
+
+	if in.Channel == "" {
+		return nil, fmt.Errorf("surveil: %w", ErrNoChannel)
+	}
+
+	for _, report := range in.Percept {
+		if report.Subject == "" {
+			return nil, fmt.Errorf("surveil: %w", ErrNoSubject)
+		}
+	}
+
+	// Dedupe percept (same as Report): last entry wins, survivor at last position
+	deduped := dedupeReports(in.Percept)
+	dedupeSubjectSet := make(map[Subject]struct{}, len(deduped))
+	for _, r := range deduped {
+		dedupeSubjectSet[r.Subject] = struct{}{}
+	}
+
+	out := &SurveilOutput{}
+
+	// Phantom-observer guard: lazy observer-map creation only after validation
+	// and only if the deduped percept is non-empty OR observer already exists
+	if len(deduped) == 0 && i.holdings[in.Observer] == nil {
+		// Empty percept for unknown observer must not create state
+		return out, nil
+	}
+
+	// Ensure observer exists if we're about to do something
+	if i.holdings[in.Observer] == nil {
+		i.holdings[in.Observer] = make(map[Subject]*holding)
+	}
+
+	// FADE PASS: from pre-mutation state, remove channel from holdings
+	// whose currentVia contains this channel AND subject absent from deduped percept
+	var fadedSubjects []Subject
+	for subj, h := range i.holdings[in.Observer] {
+		// Check if this subject was sustained by this channel
+		if _, ok := h.currentVia[in.Channel]; ok {
+			// Check if it's absent from the deduped percept
+			if _, present := dedupeSubjectSet[subj]; !present {
+				// Remove the channel
+				delete(h.currentVia, in.Channel)
+				// If currentVia is now empty, collect for Faded
+				if len(h.currentVia) == 0 {
+					fadedSubjects = append(fadedSubjects, subj)
+				}
+			}
+		}
+	}
+
+	// Sort Faded by Subject for deterministic transcripts; only assign if non-empty
+	if len(fadedSubjects) > 0 {
+		for i := 0; i < len(fadedSubjects)-1; i++ {
+			for j := i + 1; j < len(fadedSubjects); j++ {
+				if fadedSubjects[j] < fadedSubjects[i] {
+					fadedSubjects[i], fadedSubjects[j] = fadedSubjects[j], fadedSubjects[i]
+				}
+			}
+		}
+		out.Faded = fadedSubjects
+	}
+
+	// LAND PASS: in post-dedupe percept order
+	for _, report := range deduped {
+		h, exists := i.holdings[in.Observer][report.Subject]
+		if !exists {
+			// Unknown subject: create holding with independent payload copy
+			payloadCopy := make([]byte, len(report.Payload))
+			copy(payloadCopy, report.Payload)
+			i.holdings[in.Observer][report.Subject] = &holding{
+				payload:    payloadCopy,
+				channel:    in.Channel,
+				at:         in.At,
+				currentVia: map[Channel]struct{}{in.Channel: {}},
+			}
+			// Return independent copy for FirstContact
+			fcPayload := make([]byte, len(report.Payload))
+			copy(fcPayload, report.Payload)
+			out.FirstContact = append(out.FirstContact, Report{
+				Subject: report.Subject,
+				Payload: fcPayload,
+			})
+		} else {
+			// Known: overwrite payload (copy), channel, at, and add channel to currentVia
+			payloadCopy := make([]byte, len(report.Payload))
+			copy(payloadCopy, report.Payload)
+			h.payload = payloadCopy
+			h.channel = in.Channel
+			h.at = in.At
+			h.currentVia[in.Channel] = struct{}{}
+			out.Refreshed = append(out.Refreshed, report.Subject)
+		}
+	}
+
+	return out, nil
 }
 
 // ReportOutput is the output of the Report verb.
@@ -244,17 +371,8 @@ func dedupeReports(reports []Report) []Report {
 		lastOccurrence[report.Subject] = i
 	}
 
-	// Build result with survivors in their last position order
-	seen := make(map[Subject]bool)
-	var result []Report
-	for i, report := range reports {
-		if lastOccurrence[report.Subject] == i && !seen[report.Subject] {
-			// This is the last occurrence of this subject
-			seen[report.Subject] = true
-		}
-	}
-
 	// Collect survivors in their last occurrence positions
+	var result []Report
 	for i, report := range reports {
 		if lastOccurrence[report.Subject] == i {
 			// Make a copy of the payload

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -30,18 +30,25 @@ func (s *IntelSuite) holdingOn(observer core.EntityID, subject intel.Subject) in
 }
 
 func (s *IntelSuite) TestReportLandsHeldIntel() {
+	const (
+		testObserver = core.EntityID("alice")
+		testChannel  = intel.Channel("hearing")
+		testSubject  = intel.Subject("behind-door-3")
+		testPayload  = "crashing"
+		testAt       = uint64(5)
+	)
 	out, err := s.intel.Report(&intel.ReportInput{
-		Observer: "alice", Channel: intel.Channel("hearing"), At: 5,
-		Reports: []intel.Report{{Subject: "behind-door-3", Payload: []byte("crashing")}},
+		Observer: testObserver, Channel: testChannel, At: testAt,
+		Reports: []intel.Report{{Subject: testSubject, Payload: []byte(testPayload)}},
 	})
 	s.Require().NoError(err)
-	s.Equal([]intel.Report{{Subject: "behind-door-3", Payload: []byte("crashing")}}, out.FirstContact)
+	s.Equal([]intel.Report{{Subject: testSubject, Payload: []byte(testPayload)}}, out.FirstContact)
 	s.Empty(out.Updated)
 
-	h := s.holdingOn("alice", "behind-door-3")
-	s.Equal([]byte("crashing"), h.Payload)
-	s.Equal(intel.Channel("hearing"), h.Channel)
-	s.Equal(uint64(5), h.At)
+	h := s.holdingOn(testObserver, testSubject)
+	s.Equal([]byte(testPayload), h.Payload)
+	s.Equal(testChannel, h.Channel)
+	s.Equal(testAt, h.At)
 	s.Nil(h.CurrentVia)
 	s.Equal(intel.Held, h.Status)
 }
@@ -142,6 +149,344 @@ func (s *IntelSuite) TestReportEmptyReportsNoPhantomObserver() {
 	held2, err := s.intel.HeldBy(&intel.HeldByInput{Observer: ghostObs})
 	s.Require().NoError(err)
 	s.Len(held2, 1, "only real report should be held")
+}
+
+// --- Surveil Tests ---
+
+func (s *IntelSuite) TestSurveilFirstContactRefreshFade() {
+	const (
+		testObserver = core.EntityID("alice")
+		goblina      = intel.Subject("goblin-A")
+		hex1         = intel.Subject("hex-1")
+		wounded      = "wounded"
+		floor        = "floor"
+	)
+	out, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: testObserver, Channel: intel.Sight, At: 1,
+		Percept: []intel.Report{
+			{Subject: goblina, Payload: []byte(wounded)},
+			{Subject: hex1, Payload: []byte(floor)},
+		},
+	})
+	s.Require().NoError(err)
+	s.Len(out.FirstContact, 2)
+	s.Empty(out.Refreshed)
+	s.Empty(out.Faded)
+	s.Equal(intel.Current, s.holdingOn(testObserver, goblina).Status)
+	s.Equal([]intel.Channel{intel.Sight}, s.holdingOn(testObserver, goblina).CurrentVia)
+
+	// next percept: goblin gone, hex remains → ghost goblin fades, hex refreshes
+	out, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: testObserver, Channel: intel.Sight, At: 2,
+		Percept: []intel.Report{{Subject: hex1, Payload: []byte(floor)}},
+	})
+	s.Require().NoError(err)
+	s.Empty(out.FirstContact)
+	s.Equal([]intel.Subject{hex1}, out.Refreshed)
+	s.Equal([]intel.Subject{goblina}, out.Faded)
+	g := s.holdingOn(testObserver, goblina)
+	s.Equal(intel.Held, g.Status)
+	s.Equal([]byte(wounded), g.Payload, "the ghost goblin: held at last observation")
+	s.Nil(g.CurrentVia)
+}
+
+func (s *IntelSuite) TestSurveilPerChannelCurrency() {
+	const (
+		testObserver = core.EntityID("m")
+		preySubject  = intel.Subject("prey")
+		near         = "near"
+		tremorsense  = intel.Channel("tremorsense")
+	)
+	for _, ch := range []intel.Channel{intel.Sight, tremorsense} {
+		_, err := s.intel.Surveil(&intel.SurveilInput{Observer: testObserver, Channel: ch, At: 1,
+			Percept: []intel.Report{{Subject: preySubject, Payload: []byte(near)}}})
+		s.Require().NoError(err)
+	}
+	s.Equal([]intel.Channel{intel.Sight, tremorsense}, s.holdingOn(testObserver, preySubject).CurrentVia)
+	// sight loses it; tremorsense still sustains → NOT faded, still Current
+	out, err := s.intel.Surveil(&intel.SurveilInput{Observer: testObserver, Channel: intel.Sight, At: 2, Percept: nil})
+	s.Require().NoError(err)
+	s.Empty(out.Faded)
+	s.Equal(intel.Current, s.holdingOn(testObserver, preySubject).Status)
+	s.Equal([]intel.Channel{tremorsense}, s.holdingOn(testObserver, preySubject).CurrentVia)
+	// tremorsense loses it too → fades now
+	out, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: testObserver, Channel: tremorsense, At: 3, Percept: nil})
+	s.Require().NoError(err)
+	s.Equal([]intel.Subject{preySubject}, out.Faded)
+	s.Equal(intel.Held, s.holdingOn(testObserver, preySubject).Status)
+}
+
+// TestSurveilEmptyPerceptIsLegalAndFadesAll tests that an empty percept is
+// legal and fades all subjects sustained by that channel.
+func (s *IntelSuite) TestSurveilEmptyPerceptIsLegalAndFadesAll() {
+	const (
+		testObserver = core.EntityID("alice")
+		goblin1      = intel.Subject("goblin-1")
+		goblin2      = intel.Subject("goblin-2")
+		far          = "far"
+		nearStr      = "near"
+	)
+	// Set up two subjects
+	out, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: testObserver,
+		Channel:  intel.Sight,
+		At:       1,
+		Percept: []intel.Report{
+			{Subject: goblin1, Payload: []byte(far)},
+			{Subject: goblin2, Payload: []byte(nearStr)},
+		},
+	})
+	s.Require().NoError(err)
+	s.Len(out.FirstContact, 2)
+
+	// Empty percept fades both
+	out, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: testObserver,
+		Channel:  intel.Sight,
+		At:       2,
+		Percept:  []intel.Report{},
+	})
+	s.Require().NoError(err)
+	s.Empty(out.FirstContact)
+	s.Empty(out.Refreshed)
+	// Faded must be sorted by Subject
+	s.Equal([]intel.Subject{goblin1, goblin2}, out.Faded)
+
+	// Both are now Held with payloads retained
+	g1 := s.holdingOn(testObserver, goblin1)
+	s.Equal(intel.Held, g1.Status)
+	s.Equal([]byte(far), g1.Payload)
+
+	g2 := s.holdingOn(testObserver, goblin2)
+	s.Equal(intel.Held, g2.Status)
+	s.Equal([]byte(nearStr), g2.Payload)
+}
+
+// TestSurveilDoesNotDisturbReportedHoldings tests that Surveil does not
+// fade subjects that were held via Report (with nil CurrentVia).
+func (s *IntelSuite) TestSurveilDoesNotDisturbReportedHoldings() {
+	const (
+		testObserver  = core.EntityID("bob")
+		rumorChannel  = intel.Channel("rumor")
+		rumoredNPC    = intel.Subject("rumored-npc")
+		dangerous     = "dangerous"
+		visibleGoblin = intel.Subject("visible-goblin")
+		attacking     = "attacking"
+	)
+	// Report a subject (held, no channels sustaining it)
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: testObserver,
+		Channel:  rumorChannel,
+		At:       1,
+		Reports: []intel.Report{
+			{Subject: rumoredNPC, Payload: []byte(dangerous)},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Surveil sight percept without that subject
+	out, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: testObserver,
+		Channel:  intel.Sight,
+		At:       2,
+		Percept: []intel.Report{
+			{Subject: visibleGoblin, Payload: []byte(attacking)},
+		},
+	})
+	s.Require().NoError(err)
+	s.Len(out.FirstContact, 1)
+	s.Empty(out.Faded) // rumored-npc not faded
+	s.Empty(out.Refreshed)
+
+	// rumored-npc is still Held with payload intact
+	r := s.holdingOn(testObserver, rumoredNPC)
+	s.Equal(intel.Held, r.Status)
+	s.Equal([]byte(dangerous), r.Payload)
+	s.Nil(r.CurrentVia)
+}
+
+// TestReportOverwriteKeepsCurrency tests that Report can overwrite a
+// Surveil-held subject without changing CurrentVia or Status.
+func (s *IntelSuite) TestReportOverwriteKeepsCurrency() {
+	const (
+		testObserver = core.EntityID("charlie")
+		target       = intel.Subject("target")
+		tenMAway     = "10m away"
+		castingSpell = "casting a spell"
+		rumorCh      = intel.Channel("rumor")
+	)
+	// Surveil subject "target" via sight
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: testObserver,
+		Channel:  intel.Sight,
+		At:       1,
+		Percept: []intel.Report{
+			{Subject: target, Payload: []byte(tenMAway)},
+		},
+	})
+	s.Require().NoError(err)
+
+	h := s.holdingOn(testObserver, target)
+	s.Equal(intel.Current, h.Status)
+	s.Equal([]intel.Channel{intel.Sight}, h.CurrentVia)
+	s.Equal([]byte(tenMAway), h.Payload)
+
+	// Report new intel on same subject via "rumor"
+	out, err := s.intel.Report(&intel.ReportInput{
+		Observer: testObserver,
+		Channel:  rumorCh,
+		At:       2,
+		Reports: []intel.Report{
+			{Subject: target, Payload: []byte(castingSpell)},
+		},
+	})
+	s.Require().NoError(err)
+	s.Empty(out.FirstContact)
+	s.Equal([]intel.Subject{target}, out.Updated)
+
+	// Payload and Channel changed, but CurrentVia and Status unchanged
+	h = s.holdingOn(testObserver, target)
+	s.Equal(intel.Current, h.Status)
+	s.Equal([]intel.Channel{intel.Sight}, h.CurrentVia) // Unchanged
+	s.Equal([]byte(castingSpell), h.Payload)            // Overwritten
+	s.Equal(rumorCh, h.Channel)                         // Provenance changed
+}
+
+// TestSurveilValidationOrderAndDedupe tests validation order and deduplication.
+func (s *IntelSuite) TestSurveilValidationOrderAndDedupe() {
+	const (
+		dave   = core.EntityID("dave")
+		eve    = core.EntityID("eve")
+		dupe   = intel.Subject("dupe")
+		unique = intel.Subject("unique")
+		first  = "first"
+		only   = "only"
+		last   = "last"
+	)
+	// nil input
+	_, err := s.intel.Surveil(nil)
+	s.ErrorIs(err, intel.ErrNilInput)
+
+	// empty observer
+	_, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: "",
+		Channel:  intel.Sight,
+		Percept:  []intel.Report{},
+	})
+	s.ErrorIs(err, intel.ErrNoObserver)
+
+	// empty channel
+	_, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: dave,
+		Channel:  "",
+		Percept:  []intel.Report{},
+	})
+	s.ErrorIs(err, intel.ErrNoChannel)
+
+	// empty subject in percept
+	_, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: dave,
+		Channel:  intel.Sight,
+		Percept: []intel.Report{
+			{Subject: "", Payload: []byte("bad")},
+		},
+	})
+	s.ErrorIs(err, intel.ErrNoSubject)
+
+	// R5: guards precede all mutation (initial state unchanged after errors)
+	members, err := s.intel.HeldBy(&intel.HeldByInput{Observer: dave})
+	s.Require().NoError(err)
+	s.Empty(members)
+
+	// Dedupe: last entry wins, survivor at last position
+	out, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: eve,
+		Channel:  intel.Sight,
+		At:       1,
+		Percept: []intel.Report{
+			{Subject: dupe, Payload: []byte(first)},
+			{Subject: unique, Payload: []byte(only)},
+			{Subject: dupe, Payload: []byte(last)},
+		},
+	})
+	s.Require().NoError(err)
+	// FirstContact should have: unique first (at position 1 in original), then dupe (at last position)
+	s.Len(out.FirstContact, 2)
+	s.Equal(unique, out.FirstContact[0].Subject)
+	s.Equal([]byte(only), out.FirstContact[0].Payload)
+	s.Equal(dupe, out.FirstContact[1].Subject)
+	s.Equal([]byte(last), out.FirstContact[1].Payload)
+
+	// Verify the holding has the last payload
+	dupeholder := s.holdingOn(eve, dupe)
+	s.Equal([]byte(last), dupeholder.Payload)
+}
+
+// TestSurveilFadedSortedAndObserverIsolation tests that Faded is sorted by
+// Subject and that observers are isolated.
+func (s *IntelSuite) TestSurveilFadedSortedAndObserverIsolation() {
+	const (
+		alice   = core.EntityID("alice")
+		bob     = core.EntityID("bob")
+		zebra   = intel.Subject("zebra")
+		apple   = intel.Subject("apple")
+		moon    = intel.Subject("moon")
+		far     = "far"
+		nearStr = "near"
+		sky     = "sky"
+		bobSees = "bob sees"
+	)
+	// alice perceives three subjects
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: alice,
+		Channel:  intel.Sight,
+		At:       1,
+		Percept: []intel.Report{
+			{Subject: zebra, Payload: []byte(far)},
+			{Subject: apple, Payload: []byte(nearStr)},
+			{Subject: moon, Payload: []byte(sky)},
+		},
+	})
+	s.Require().NoError(err)
+
+	// bob perceives the same three subjects
+	_, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: bob,
+		Channel:  intel.Sight,
+		At:       1,
+		Percept: []intel.Report{
+			{Subject: zebra, Payload: []byte(bobSees)},
+			{Subject: apple, Payload: []byte(bobSees)},
+			{Subject: moon, Payload: []byte(bobSees)},
+		},
+	})
+	s.Require().NoError(err)
+
+	// alice loses all three
+	out, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: alice,
+		Channel:  intel.Sight,
+		At:       2,
+		Percept:  []intel.Report{},
+	})
+	s.Require().NoError(err)
+	// Faded must be sorted by Subject
+	s.Equal([]intel.Subject{apple, moon, zebra}, out.Faded)
+
+	// bob's holdings are untouched; all still Current
+	for _, subj := range []intel.Subject{zebra, apple, moon} {
+		h, err := s.intel.On(&intel.OnInput{Observer: bob, Subject: subj})
+		s.Require().NoError(err)
+		s.Equal(intel.Current, h.Status)
+	}
+
+	// alice's holdings are Held
+	for _, subj := range []intel.Subject{zebra, apple, moon} {
+		h, err := s.intel.On(&intel.OnInput{Observer: alice, Subject: subj})
+		s.Require().NoError(err)
+		s.Equal(intel.Held, h.Status)
+	}
 }
 
 func TestIntelSuite(t *testing.T) {

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 )
 
-const (
-	testObserver = core.EntityID("alice")
-	testSubject  = intel.Subject("s")
-)
-
 type IntelSuite struct {
 	suite.Suite
 	intel *intel.Intel
@@ -56,6 +51,10 @@ func (s *IntelSuite) TestReportOverwritesLastWins() {
 }
 
 func (s *IntelSuite) overwriteTest(p1 string, at1 uint64, ch1 string, p2 string, at2 uint64, ch2 string) {
+	const (
+		testObserver = core.EntityID("alice")
+		testSubject  = intel.Subject("s")
+	)
 	_, err := s.intel.Report(&intel.ReportInput{
 		Observer: testObserver, Channel: intel.Channel(ch1), At: at1,
 		Reports: []intel.Report{{Subject: testSubject, Payload: []byte(p1)}},
@@ -99,6 +98,50 @@ func (s *IntelSuite) TestReportDedupeAndValidationOrder() {
 func (s *IntelSuite) TestReportAtBlindness() {
 	// Later testimony carrying a SMALLER At still wins
 	s.overwriteTest("v1", 9, "hearing", "v2", 3, "rumor")
+}
+
+func (s *IntelSuite) TestReportCopyOutPayload() {
+	// Pin: mutating returned FirstContact payload must not corrupt stored payload
+	out, err := s.intel.Report(&intel.ReportInput{
+		Observer: "alice", Channel: "hearing", At: 5,
+		Reports: []intel.Report{{Subject: "s", Payload: []byte("original")}},
+	})
+	s.Require().NoError(err)
+	s.Len(out.FirstContact, 1)
+
+	// Mutate the returned FirstContact payload
+	out.FirstContact[0].Payload[0] = 'X'
+
+	// Internal storage must be unchanged
+	h := s.holdingOn("alice", "s")
+	s.Equal([]byte("original"), h.Payload, "stored payload must be immune to mutation of FirstContact")
+}
+
+func (s *IntelSuite) TestReportEmptyReportsNoPhantomObserver() {
+	// Pin: empty/nil reports after dedupe must not create phantom observer state
+	const ghostObs = core.EntityID("ghost-obs")
+	out, err := s.intel.Report(&intel.ReportInput{
+		Observer: ghostObs, Channel: "c", Reports: nil,
+	})
+	s.Require().NoError(err)
+	s.Empty(out.FirstContact)
+	s.Empty(out.Updated)
+
+	// Verify no phantom state: HeldBy returns empty
+	held, err := s.intel.HeldBy(&intel.HeldByInput{Observer: ghostObs})
+	s.Require().NoError(err)
+	s.Empty(held, "empty reports must not create phantom observer")
+
+	// Verify subsequent normal flow doesn't linger: Report a real holding
+	out2, err := s.intel.Report(&intel.ReportInput{
+		Observer: ghostObs, Channel: "c",
+		Reports: []intel.Report{{Subject: "real", Payload: []byte("data")}},
+	})
+	s.Require().NoError(err)
+	s.Len(out2.FirstContact, 1)
+	held2, err := s.intel.HeldBy(&intel.HeldByInput{Observer: ghostObs})
+	s.Require().NoError(err)
+	s.Len(held2, 1, "only real report should be held")
 }
 
 func TestIntelSuite(t *testing.T) {

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -4,6 +4,8 @@
 package intel_test
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -824,6 +826,436 @@ func (s *QueriesSuite) TestDeciderContract() {
 	// - Try to open door (Current, sight confirmed)
 	// The contract: all this decision logic flows from HeldBy(itself) alone.
 	_ = myIntel // Decision logic would consume this
+}
+
+// PersistenceSuite tests the persistence layer: ToData/LoadIntel.
+type PersistenceSuite struct {
+	suite.Suite
+	intel *intel.Intel
+}
+
+func (s *PersistenceSuite) SetupTest() {
+	var err error
+	s.intel, err = intel.NewIntel()
+	s.Require().NoError(err)
+}
+
+// TestIdleConventionZeroValue tests that NewIntel().ToData() returns a zero
+// IntelData with nil map (not empty non-nil).
+func (s *PersistenceSuite) TestIdleConventionZeroValue() {
+	data := s.intel.ToData()
+	// Zero value: nil map, not empty non-nil
+	s.Nil(data.Holdings, "idle Intel should marshal to nil Holdings map")
+}
+
+// TestIdleConventionMarshalEmpty tests that zero IntelData marshals to "{}".
+func (s *PersistenceSuite) TestIdleConventionMarshalEmpty() {
+	data := s.intel.ToData()
+	b, err := json.Marshal(data)
+	s.Require().NoError(err)
+	s.Equal([]byte("{}"), b, "idle IntelData must marshal to empty object")
+}
+
+// TestIdleConventionLoadEmpty tests that LoadIntel(IntelData{}) succeeds
+// and the Intel is usable (verbs work).
+func (s *PersistenceSuite) TestIdleConventionLoadEmpty() {
+	loaded, err := intel.LoadIntel(intel.IntelData{})
+	s.Require().NoError(err)
+	// Verify it's usable: HeldBy on empty Intel succeeds
+	holdings, err := loaded.HeldBy(&intel.HeldByInput{Observer: "test"})
+	s.Require().NoError(err)
+	s.Empty(holdings)
+}
+
+// TestRoundTripSingleHolding tests round-trip of a single Report holding.
+func (s *PersistenceSuite) TestRoundTripSingleHolding() {
+	const (
+		obs     = core.EntityID("alice")
+		subject = intel.Subject("target")
+		payload = "test-data"
+		channel = intel.Channel("hearing")
+		at      = uint64(42)
+	)
+	// Create a holding
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: channel, At: at,
+		Reports: []intel.Report{{Subject: subject, Payload: []byte(payload)}},
+	})
+	s.Require().NoError(err)
+
+	// Snapshot
+	data := s.intel.ToData()
+
+	// Load
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err)
+
+	// Verify the holding is accessible
+	h, err := loaded.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal([]byte(payload), h.Payload)
+	s.Equal(channel, h.Channel)
+	s.Equal(at, h.At)
+	s.Nil(h.CurrentVia, "Report holding should have nil CurrentVia")
+	s.Equal(intel.Held, h.Status)
+}
+
+// TestRoundTripMultiChannelCurrent tests round-trip of a Current holding
+// with multiple sustaining channels.
+func (s *PersistenceSuite) TestRoundTripMultiChannelCurrent() {
+	const (
+		obs      = core.EntityID("bob")
+		subject  = intel.Subject("prey")
+		channel1 = intel.Channel("sight")
+		channel2 = intel.Channel("hearing")
+	)
+	// Create Current holding via sight
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel1, At: 1,
+		Percept: []intel.Report{{Subject: subject, Payload: []byte("v1")}},
+	})
+	s.Require().NoError(err)
+
+	// Sustain via hearing
+	_, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel2, At: 2,
+		Percept: []intel.Report{{Subject: subject, Payload: []byte("v2")}},
+	})
+	s.Require().NoError(err)
+
+	// Snapshot
+	data := s.intel.ToData()
+
+	// Load
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err)
+
+	// Verify the holding is Current with both channels
+	h, err := loaded.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal(intel.Current, h.Status)
+	s.Len(h.CurrentVia, 2)
+	s.ElementsMatch([]intel.Channel{channel1, channel2}, h.CurrentVia)
+}
+
+// TestRoundTripPostFadeState tests round-trip preserves faded (Held) state.
+func (s *PersistenceSuite) TestRoundTripPostFadeState() {
+	const (
+		obs     = core.EntityID("charlie")
+		subject = intel.Subject("ghost")
+		channel = intel.Channel("sight")
+	)
+	// Create Current holding
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel, At: 1,
+		Percept: []intel.Report{{Subject: subject, Payload: []byte("saw it")}},
+	})
+	s.Require().NoError(err)
+
+	// Fade it
+	_, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel, At: 2, Percept: []intel.Report{},
+	})
+	s.Require().NoError(err)
+
+	// Snapshot
+	data := s.intel.ToData()
+
+	// Load
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err)
+
+	// Verify holding is Held (faded state preserved)
+	h, err := loaded.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal(intel.Held, h.Status)
+	s.Nil(h.CurrentVia)
+}
+
+// TestRoundTripBehaviorIdentical tests that a Surveil after reload behaves
+// identically to the same Surveil on the original Intel.
+func (s *PersistenceSuite) TestRoundTripBehaviorIdentical() {
+	const (
+		obs     = core.EntityID("dave")
+		subj1   = intel.Subject("s1")
+		subj2   = intel.Subject("s2")
+		channel = intel.Channel("sight")
+	)
+	// Setup: create holdings, then snapshot and load
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel, At: 1,
+		Percept: []intel.Report{
+			{Subject: subj1, Payload: []byte("v1")},
+			{Subject: subj2, Payload: []byte("v2")},
+		},
+	})
+	s.Require().NoError(err)
+
+	data := s.intel.ToData()
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err)
+
+	// Apply same Surveil to both: only s1 present (s2 fades)
+	out1, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel, At: 2,
+		Percept: []intel.Report{{Subject: subj1, Payload: []byte("v1-refreshed")}},
+	})
+	s.Require().NoError(err)
+
+	out2, err := loaded.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel, At: 2,
+		Percept: []intel.Report{{Subject: subj1, Payload: []byte("v1-refreshed")}},
+	})
+	s.Require().NoError(err)
+
+	// Deltas must match
+	s.Equal(out1.FirstContact, out2.FirstContact, "FirstContact must match")
+	s.Equal(out1.Refreshed, out2.Refreshed, "Refreshed must match")
+	s.Equal(out1.Faded, out2.Faded, "Faded must match")
+
+	// Final state must match
+	h1, _ := s.intel.On(&intel.OnInput{Observer: obs, Subject: subj2})
+	h2, _ := loaded.On(&intel.OnInput{Observer: obs, Subject: subj2})
+	s.Equal(h1.Status, h2.Status, "final status must match")
+}
+
+// TestGoldenJSON tests that a populated holding marshals to exact JSON.
+func (s *PersistenceSuite) TestGoldenJSON() {
+	const (
+		obs     = core.EntityID("alice")
+		subject = intel.Subject("behind-door-3")
+		payload = "treasure"
+		channel = intel.Channel("hearing")
+		at      = uint64(5)
+	)
+	// Create holding
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: channel, At: at,
+		Reports: []intel.Report{{Subject: subject, Payload: []byte(payload)}},
+	})
+	s.Require().NoError(err)
+
+	data := s.intel.ToData()
+	b, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	// Unmarshal to verify structure: holdings[alice][behind-door-3] exists
+	// with payload (base64), channel, at; current_via omitted when nil
+	var unmarshaled map[string]interface{}
+	err = json.Unmarshal(b, &unmarshaled)
+	s.Require().NoError(err)
+
+	holdings, ok := unmarshaled["holdings"].(map[string]interface{})
+	s.Require().True(ok, "holdings key must exist and be a map")
+
+	aliceHoldings, ok := holdings[string(obs)].(map[string]interface{})
+	s.Require().True(ok, "alice holdings must exist and be a map")
+
+	doorHolding, ok := aliceHoldings[string(subject)].(map[string]interface{})
+	s.Require().True(ok, "behind-door-3 holding must exist and be a map")
+
+	// Verify fields: payload should be a base64-encoded string (json.Marshal encodes []byte as base64)
+	payloadStr, ok := doorHolding["payload"].(string)
+	s.Require().True(ok, "payload must be a string (base64-encoded)")
+	// Verify the base64 string decodes to original payload by round-tripping through json.Marshal
+	var decodedPayload []byte
+	err = json.Unmarshal([]byte(`"`+payloadStr+`"`), &decodedPayload)
+	s.Require().NoError(err)
+	s.Equal([]byte(payload), decodedPayload)
+
+	channelStr, ok := doorHolding["channel"].(string)
+	s.Require().True(ok, "channel must be a string")
+	s.Equal(channel, intel.Channel(channelStr))
+
+	atNum, ok := doorHolding["at"].(float64)
+	s.Require().True(ok, "at must be a number")
+	s.Equal(at, uint64(atNum))
+
+	// current_via should be omitted (nil)
+	_, hasCurrentVia := doorHolding["current_via"]
+	s.False(hasCurrentVia, "current_via should be omitted when nil")
+}
+
+// TestSnapshotImmutability tests that mutating runtime Intel after ToData
+// doesn't affect the snapshot.
+func (s *PersistenceSuite) TestSnapshotImmutability() {
+	const obs = core.EntityID("eve")
+	// Create initial holding
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "c", At: 1,
+		Reports: []intel.Report{{Subject: "s", Payload: []byte("original")}},
+	})
+	s.Require().NoError(err)
+
+	// Snapshot
+	data := s.intel.ToData()
+
+	// Mutate the runtime Intel
+	_, err = s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "c", At: 2,
+		Reports: []intel.Report{{Subject: "s", Payload: []byte("modified")}},
+	})
+	s.Require().NoError(err)
+
+	// Load snapshot: must have original payload
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err)
+	h, err := loaded.On(&intel.OnInput{Observer: obs, Subject: "s"})
+	s.Require().NoError(err)
+	s.Equal([]byte("original"), h.Payload, "snapshot payload must be unchanged")
+}
+
+// TestLoadSnapshotMutationImmunity tests that mutating the caller's IntelData
+// maps after LoadIntel doesn't affect the loaded Intel.
+func (s *PersistenceSuite) TestLoadSnapshotMutationImmunity() {
+	const obs = core.EntityID("frank")
+	// Create holding
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "c", At: 1,
+		Reports: []intel.Report{{Subject: "s", Payload: []byte("original")}},
+	})
+	s.Require().NoError(err)
+
+	data := s.intel.ToData()
+
+	// Load first
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err)
+
+	// Mutate the data's maps AFTER LoadIntel (in-place index write, not append)
+	observerHoldings := data.Holdings[obs]
+	// Modify an existing holding's payload
+	for _, h := range observerHoldings {
+		h.Payload[0] = 'X'
+	}
+
+	// Verify loaded Intel is immune to snapshot mutations
+	h, err := loaded.On(&intel.OnInput{Observer: obs, Subject: "s"})
+	s.Require().NoError(err)
+	s.Equal([]byte("original"), h.Payload, "loaded Intel must be immune to caller mutations after LoadIntel")
+}
+
+// TestR9EmptyObserverKey tests that empty observer key is rejected.
+func (s *PersistenceSuite) TestR9EmptyObserverKey() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"": {}, // Empty observer key
+		},
+	}
+	_, err := intel.LoadIntel(data)
+	s.Require().True(errors.Is(err, intel.ErrInvalidData), "empty observer key must be rejected")
+}
+
+// TestR9EmptySubjectKey tests that empty subject key is rejected.
+func (s *PersistenceSuite) TestR9EmptySubjectKey() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"alice": {"": {}}, // Empty subject key
+		},
+	}
+	_, err := intel.LoadIntel(data)
+	s.Require().True(errors.Is(err, intel.ErrInvalidData), "empty subject key must be rejected")
+}
+
+// TestR9DuplicateCurrentVia tests that duplicate channels in CurrentVia are rejected.
+func (s *PersistenceSuite) TestR9DuplicateCurrentVia() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"alice": {
+				"target": {
+					Payload:    []byte("data"),
+					Channel:    "sight",
+					At:         1,
+					CurrentVia: []intel.Channel{"sight", "sight"}, // Duplicate
+				},
+			},
+		},
+	}
+	_, err := intel.LoadIntel(data)
+	s.Require().True(errors.Is(err, intel.ErrInvalidData), "duplicate CurrentVia channels must be rejected")
+}
+
+// TestR9EmptyHoldingChannel tests that empty holding Channel is rejected.
+func (s *PersistenceSuite) TestR9EmptyHoldingChannel() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"alice": {
+				"target": {
+					Payload: []byte("data"),
+					Channel: "", // Empty channel
+					At:      1,
+				},
+			},
+		},
+	}
+	_, err := intel.LoadIntel(data)
+	s.Require().True(errors.Is(err, intel.ErrInvalidData), "empty holding Channel must be rejected")
+}
+
+// TestR9EmptyChannelInCurrentVia tests that empty channel in CurrentVia is rejected.
+func (s *PersistenceSuite) TestR9EmptyChannelInCurrentVia() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"alice": {
+				"target": {
+					Payload:    []byte("data"),
+					Channel:    "sight",
+					At:         1,
+					CurrentVia: []intel.Channel{""}, // Empty channel
+				},
+			},
+		},
+	}
+	_, err := intel.LoadIntel(data)
+	s.Require().True(errors.Is(err, intel.ErrInvalidData), "empty channel in CurrentVia must be rejected")
+}
+
+// TestR9NilInnerMap tests that nil inner map is rejected.
+func (s *PersistenceSuite) TestR9NilInnerMap() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"alice": nil, // Nil inner map
+		},
+	}
+	_, err := intel.LoadIntel(data)
+	s.Require().True(errors.Is(err, intel.ErrInvalidData), "nil inner map must be rejected")
+}
+
+// TestR9EmptyInnerMap tests that empty (non-nil) inner map is rejected.
+func (s *PersistenceSuite) TestR9EmptyInnerMap() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"alice": {}, // Empty non-nil map
+		},
+	}
+	_, err := intel.LoadIntel(data)
+	s.Require().True(errors.Is(err, intel.ErrInvalidData), "empty inner map must be rejected")
+}
+
+// TestNilPayloadLegal tests that nil payload in HoldingData is legal.
+func (s *PersistenceSuite) TestNilPayloadLegal() {
+	data := intel.IntelData{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			"alice": {
+				"target": {
+					Payload: nil, // Nil payload is legal
+					Channel: "sight",
+					At:      1,
+				},
+			},
+		},
+	}
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err, "nil payload must be legal")
+
+	// Verify it loads and is usable
+	h, err := loaded.On(&intel.OnInput{Observer: "alice", Subject: "target"})
+	s.Require().NoError(err)
+	s.Nil(h.Payload, "nil payload should load as nil")
+}
+
+func TestPersistenceSuite(t *testing.T) {
+	suite.Run(t, new(PersistenceSuite))
 }
 
 func TestQueriesSuite(t *testing.T) {

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package intel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+)
+
+const (
+	testObserver = core.EntityID("alice")
+	testSubject  = intel.Subject("s")
+)
+
+type IntelSuite struct {
+	suite.Suite
+	intel *intel.Intel
+}
+
+func (s *IntelSuite) SetupTest() {
+	var err error
+	s.intel, err = intel.NewIntel()
+	s.Require().NoError(err)
+}
+
+func (s *IntelSuite) holdingOn(observer core.EntityID, subject intel.Subject) intel.Holding {
+	h, err := s.intel.On(&intel.OnInput{Observer: observer, Subject: subject})
+	s.Require().NoError(err)
+	return h
+}
+
+func (s *IntelSuite) TestReportLandsHeldIntel() {
+	out, err := s.intel.Report(&intel.ReportInput{
+		Observer: "alice", Channel: intel.Channel("hearing"), At: 5,
+		Reports: []intel.Report{{Subject: "behind-door-3", Payload: []byte("crashing")}},
+	})
+	s.Require().NoError(err)
+	s.Equal([]intel.Report{{Subject: "behind-door-3", Payload: []byte("crashing")}}, out.FirstContact)
+	s.Empty(out.Updated)
+
+	h := s.holdingOn("alice", "behind-door-3")
+	s.Equal([]byte("crashing"), h.Payload)
+	s.Equal(intel.Channel("hearing"), h.Channel)
+	s.Equal(uint64(5), h.At)
+	s.Nil(h.CurrentVia)
+	s.Equal(intel.Held, h.Status)
+}
+
+func (s *IntelSuite) TestReportOverwritesLastWins() {
+	s.overwriteTest("v1", 5, "hearing", "v2", 9, "rumor")
+}
+
+func (s *IntelSuite) overwriteTest(p1 string, at1 uint64, ch1 string, p2 string, at2 uint64, ch2 string) {
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: testObserver, Channel: intel.Channel(ch1), At: at1,
+		Reports: []intel.Report{{Subject: testSubject, Payload: []byte(p1)}},
+	})
+	s.Require().NoError(err)
+	out, err := s.intel.Report(&intel.ReportInput{
+		Observer: testObserver, Channel: intel.Channel(ch2), At: at2,
+		Reports: []intel.Report{{Subject: testSubject, Payload: []byte(p2)}},
+	})
+	s.Require().NoError(err)
+	s.Empty(out.FirstContact)
+	s.Equal([]intel.Subject{testSubject}, out.Updated)
+	h := s.holdingOn(testObserver, testSubject)
+	s.Equal([]byte(p2), h.Payload)
+	s.Equal(intel.Channel(ch2), h.Channel) // provenance follows latest testimony
+	s.Equal(at2, h.At)
+}
+
+func (s *IntelSuite) TestReportDedupeAndValidationOrder() {
+	// dedupe-first, last wins, survivor at last occurrence's position
+	out, err := s.intel.Report(&intel.ReportInput{Observer: "a", Channel: "c", Reports: []intel.Report{
+		{Subject: "x", Payload: []byte("old")}, {Subject: "y", Payload: []byte("y")},
+		{Subject: "x", Payload: []byte("new")},
+	}})
+	s.Require().NoError(err)
+	s.Equal([]intel.Report{{Subject: "y", Payload: []byte("y")}, {Subject: "x", Payload: []byte("new")}}, out.FirstContact)
+	// validation order: nil → observer → channel → subjects; first failure wins; R5 no mutation
+	_, err = s.intel.Report(nil)
+	s.Require().ErrorIs(err, intel.ErrNilInput)
+	_, err = s.intel.Report(&intel.ReportInput{Observer: "", Channel: "", Reports: []intel.Report{{Subject: ""}}})
+	s.Require().ErrorIs(err, intel.ErrNoObserver)
+	_, err = s.intel.Report(&intel.ReportInput{Observer: "a", Channel: "", Reports: []intel.Report{{Subject: ""}}})
+	s.Require().ErrorIs(err, intel.ErrNoChannel)
+	_, err = s.intel.Report(&intel.ReportInput{Observer: "a", Channel: "c", Reports: []intel.Report{{Subject: ""}}})
+	s.Require().ErrorIs(err, intel.ErrNoSubject)
+	held, err := s.intel.HeldBy(&intel.HeldByInput{Observer: "a"})
+	s.Require().NoError(err)
+	s.Len(held, 2, "failed calls changed nothing (R5)")
+}
+
+func (s *IntelSuite) TestReportAtBlindness() {
+	// Later testimony carrying a SMALLER At still wins
+	s.overwriteTest("v1", 9, "hearing", "v2", 3, "rumor")
+}
+
+func TestIntelSuite(t *testing.T) {
+	suite.Run(t, new(IntelSuite))
+}

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -543,7 +543,7 @@ func (s *QueriesSuite) TestHeldByUnknownObserverEmptyNil() {
 	holdings, err := s.intel.HeldBy(&intel.HeldByInput{Observer: "ghost-obs"})
 	s.Require().NoError(err)
 	s.Empty(holdings)
-	s.NotNil(holdings) // Must be empty slice, not nil
+	s.NotNil(holdings, "must be empty slice, not nil")
 }
 
 // TestHeldByNilInputReturnsErrNilInput verifies guard clause.
@@ -596,7 +596,7 @@ func (s *QueriesSuite) TestOnUnknownSubjectReturnsErrNotHeld() {
 
 	holding, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: "never-held"})
 	s.Require().ErrorIs(err, intel.ErrNotHeld)
-	s.Equal(intel.Holding{}, holding) // Zero value, not guessable
+	s.Equal(intel.Holding{}, holding, "must be zero value, not guessable")
 }
 
 // TestOnUnknownObserverReturnsErrNotHeld when observer has no holdings.
@@ -624,6 +624,14 @@ func (s *QueriesSuite) TestOnEmptyObserverReturnsErrNoObserver() {
 func (s *QueriesSuite) TestOnEmptySubjectReturnsErrNoSubject() {
 	holding, err := s.intel.On(&intel.OnInput{Observer: "alice", Subject: ""})
 	s.Require().ErrorIs(err, intel.ErrNoSubject)
+	s.Equal(intel.Holding{}, holding)
+}
+
+// TestOnMultiDefectOrderingObserverFirst pins that when both Observer and
+// Subject are empty, ErrNoObserver is returned (Observer checked first).
+func (s *QueriesSuite) TestOnMultiDefectOrderingObserverFirst() {
+	holding, err := s.intel.On(&intel.OnInput{Observer: "", Subject: ""})
+	s.Require().ErrorIs(err, intel.ErrNoObserver)
 	s.Equal(intel.Holding{}, holding)
 }
 
@@ -694,6 +702,29 @@ func (s *QueriesSuite) TestOnCopyOutCurrentVia() {
 	s.Equal([]intel.Channel{intel.Sight}, holding2.CurrentVia)
 }
 
+// TestHeldByCopyOutCurrentVia verifies that mutating a returned holding's
+// CurrentVia slice from HeldBy does not corrupt internal state.
+func (s *QueriesSuite) TestHeldByCopyOutCurrentVia() {
+	const obs = core.EntityID("charlie")
+	const subject = intel.Subject("target")
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: intel.Sight, At: 1,
+		Percept: []intel.Report{{Subject: subject, Payload: []byte("sight")}},
+	})
+	s.Require().NoError(err)
+
+	// Get holdings, find the target, mutate its CurrentVia slice element
+	holdings, err := s.intel.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	s.Len(holdings, 1)
+	holdings[0].CurrentVia[0] = "modified"
+
+	// Query again: internal state unchanged
+	holdings2, err := s.intel.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	s.Equal([]intel.Channel{intel.Sight}, holdings2[0].CurrentVia)
+}
+
 // TestHeldByCopyOutFromInputMutation verifies that if a caller mutates
 // a Report input slice AFTER calling Report, HeldBy sees unchanged state.
 func (s *QueriesSuite) TestHeldByCopyOutFromInputMutation() {
@@ -723,32 +754,6 @@ func (s *QueriesSuite) TestHeldByCopyOutFromInputMutation() {
 		}
 	}
 	s.Equal([]byte("p1"), s1Holding.Payload)
-}
-
-// TestOnCopyOutFromInputMutation verifies copy-out immunity for On input.
-func (s *QueriesSuite) TestOnCopyOutFromInputMutation() {
-	const obs = core.EntityID("bob")
-	const subject = intel.Subject("target")
-	_, err := s.intel.Report(&intel.ReportInput{
-		Observer: obs, Channel: "c", At: 1,
-		Reports: []intel.Report{{Subject: subject, Payload: []byte("original")}},
-	})
-	s.Require().NoError(err)
-
-	// Query and then mutate the input struct's fields
-	input := &intel.OnInput{Observer: obs, Subject: subject}
-	holding, err := s.intel.On(input)
-	s.Require().NoError(err)
-	s.Equal([]byte("original"), holding.Payload)
-
-	// Mutate the input
-	input.Observer = "modified"
-	input.Subject = "modified-subject"
-
-	// Re-query with original observer/subject via a new input
-	holding2, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: subject})
-	s.Require().NoError(err)
-	s.Equal([]byte("original"), holding2.Payload)
 }
 
 // TestDeciderContract is the normative integration test: an NPC decider
@@ -781,11 +786,20 @@ func (s *QueriesSuite) TestDeciderContract() {
 	})
 	s.Require().NoError(err)
 
-	// Fade the smell sense, so treasure becomes Held (no longer Current)
-	_, err = s.intel.Surveil(&intel.SurveilInput{
-		Observer: monsterID, Channel: "smell", At: 0, Percept: []intel.Report{},
+	// Surveil on smell channel with treasure, making it Current via smell
+	out, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: monsterID, Channel: "smell", At: 80,
+		Percept: []intel.Report{{Subject: treasure, Payload: []byte("gold scent")}},
 	})
 	s.Require().NoError(err)
+	s.Equal([]intel.Subject{treasure}, out.Refreshed, "treasure refreshed via smell")
+
+	// Fade the smell sense by surveilling with empty percept, so treasure becomes Held
+	out, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: monsterID, Channel: "smell", At: 90, Percept: []intel.Report{},
+	})
+	s.Require().NoError(err)
+	s.Equal([]intel.Subject{treasure}, out.Faded, "treasure faded when smell lost it")
 
 	// NPC DECIDER: consult HeldBy(itself) and nothing else
 	myIntel, err := s.intel.HeldBy(&intel.HeldByInput{Observer: monsterID})

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -6,6 +6,7 @@ package intel_test
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -842,6 +843,12 @@ func (s *PersistenceSuite) SetupTest() {
 	s.Require().NoError(err)
 }
 
+func (s *PersistenceSuite) holdingOn(observer core.EntityID, subject intel.Subject) intel.Holding {
+	h, err := s.intel.On(&intel.OnInput{Observer: observer, Subject: subject})
+	s.Require().NoError(err)
+	return h
+}
+
 // TestIdleConventionZeroValue tests that NewIntel().ToData() returns a zero
 // Data with nil map (not empty non-nil).
 func (s *PersistenceSuite) TestIdleConventionZeroValue() {
@@ -975,7 +982,8 @@ func (s *PersistenceSuite) TestRoundTripPostFadeState() {
 }
 
 // TestRoundTripBehaviorIdentical tests that a Surveil after reload behaves
-// identically to the same Surveil on the original Intel.
+// identically to the same Surveil on the original Intel, including full state
+// comparison and set-semantics idempotence of re-Surveil on the same channel.
 func (s *PersistenceSuite) TestRoundTripBehaviorIdentical() {
 	const (
 		obs     = core.EntityID("dave")
@@ -1015,25 +1023,41 @@ func (s *PersistenceSuite) TestRoundTripBehaviorIdentical() {
 	s.Equal(out1.Refreshed, out2.Refreshed, "Refreshed must match")
 	s.Equal(out1.Faded, out2.Faded, "Faded must match")
 
-	// Final state must match
-	h1, _ := s.intel.On(&intel.OnInput{Observer: obs, Subject: subj2})
-	h2, _ := loaded.On(&intel.OnInput{Observer: obs, Subject: subj2})
-	s.Equal(h1.Status, h2.Status, "final status must match")
+	// Full HeldBy state must match (deep comparison)
+	holdings1, err := s.intel.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	holdings2, err := loaded.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	s.True(reflect.DeepEqual(holdings1, holdings2), "HeldBy results pre and post reload must be fully equal")
+
+	// Test set-semantics idempotence: re-Surveil same channel with same percept should not duplicate CurrentVia
+	out3, err := loaded.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: channel, At: 3,
+		Percept: []intel.Report{{Subject: subj1, Payload: []byte("v1-refreshed")}},
+	})
+	s.Require().NoError(err)
+	s.Empty(out3.FirstContact, "re-Surveil same subject should not add to FirstContact")
+	s.Equal([]intel.Subject{subj1}, out3.Refreshed, "re-Surveil same subject should Refresh")
+
+	h := s.holdingOn(obs, subj1)
+	s.Len(h.CurrentVia, 1, "CurrentVia should still have exactly one entry (set semantics, not duplicated)")
+	s.Equal(channel, h.CurrentVia[0], "CurrentVia should still be the original channel")
 }
 
-// TestGoldenJSON tests that a populated holding marshals to exact JSON.
+// TestGoldenJSON tests that holdings marshal to exact JSON strings (wire format),
+// pinning Held (no CurrentVia) and Current (with CurrentVia) shapes.
 func (s *PersistenceSuite) TestGoldenJSON() {
+	// Test 1: Held shape (Report-only, no CurrentVia)
 	const (
-		obs     = core.EntityID("alice")
-		subject = intel.Subject("behind-door-3")
-		payload = "treasure"
-		channel = intel.Channel("hearing")
-		at      = uint64(5)
+		alice    = core.EntityID("alice")
+		heldSubj = intel.Subject("behind-door-3")
+		payload1 = "treasure"
+		channel1 = intel.Channel("hearing")
+		at1      = uint64(5)
 	)
-	// Create holding
 	_, err := s.intel.Report(&intel.ReportInput{
-		Observer: obs, Channel: channel, At: at,
-		Reports: []intel.Report{{Subject: subject, Payload: []byte(payload)}},
+		Observer: alice, Channel: channel1, At: at1,
+		Reports: []intel.Report{{Subject: heldSubj, Payload: []byte(payload1)}},
 	})
 	s.Require().NoError(err)
 
@@ -1041,45 +1065,103 @@ func (s *PersistenceSuite) TestGoldenJSON() {
 	b, err := json.Marshal(data)
 	s.Require().NoError(err)
 
-	// Unmarshal to verify structure: holdings[alice][behind-door-3] exists
-	// with payload (base64), channel, at; current_via omitted when nil
-	var unmarshaled map[string]interface{}
-	err = json.Unmarshal(b, &unmarshaled)
+	// Pin exact string for Held shape (payload is base64("treasure") = "dHJlYXN1cmU=")
+	goldenHeld := `{"holdings":{"alice":{"behind-door-3":{"payload":"dHJlYXN1cmU=","channel":"hearing","at":5}}}}`
+	s.Equal(goldenHeld, string(b), "Held shape must match exact JSON (payload base64, no current_via)")
+
+	// Test 2: Current shape (via Surveil, with CurrentVia)
+	const (
+		currentSubj = intel.Subject("goblin")
+		payload2    = "near"
+		channel2    = intel.Channel("sight")
+		at2         = uint64(5)
+	)
+	intel2, err := intel.NewIntel()
 	s.Require().NoError(err)
 
-	holdings, ok := unmarshaled["holdings"].(map[string]interface{})
-	s.Require().True(ok, "holdings key must exist and be a map")
-
-	aliceHoldings, ok := holdings[string(obs)].(map[string]interface{})
-	s.Require().True(ok, "alice holdings must exist and be a map")
-
-	doorHolding, ok := aliceHoldings[string(subject)].(map[string]interface{})
-	s.Require().True(ok, "behind-door-3 holding must exist and be a map")
-
-	// Verify fields: payload should be a base64-encoded string (json.Marshal encodes []byte as base64)
-	payloadStr, ok := doorHolding["payload"].(string)
-	s.Require().True(ok, "payload must be a string (base64-encoded)")
-	// Verify the base64 string decodes to original payload by round-tripping through json.Marshal
-	var decodedPayload []byte
-	err = json.Unmarshal([]byte(`"`+payloadStr+`"`), &decodedPayload)
+	_, err = intel2.Surveil(&intel.SurveilInput{
+		Observer: alice, Channel: channel2, At: at2,
+		Percept: []intel.Report{{Subject: currentSubj, Payload: []byte(payload2)}},
+	})
 	s.Require().NoError(err)
-	s.Equal([]byte(payload), decodedPayload)
 
-	channelStr, ok := doorHolding["channel"].(string)
-	s.Require().True(ok, "channel must be a string")
-	s.Equal(channel, intel.Channel(channelStr))
+	data2 := intel2.ToData()
+	b2, err := json.Marshal(data2)
+	s.Require().NoError(err)
 
-	atNum, ok := doorHolding["at"].(float64)
-	s.Require().True(ok, "at must be a number")
-	s.Equal(at, uint64(atNum))
-
-	// current_via should be omitted (nil)
-	_, hasCurrentVia := doorHolding["current_via"]
-	s.False(hasCurrentVia, "current_via should be omitted when nil")
+	// Pin exact string for Current shape
+	// (payload is base64("near") = "bmVhcg==", current_via has "sight")
+	golden := `{"holdings":{"alice":{"goblin":{"payload":"bmVhcg==","channel":"sight","at":5,"current_via":["sight"]}}}}`
+	s.Equal(golden, string(b2), "Current shape must match exact JSON wire format")
 }
 
-// TestSnapshotImmutability tests that mutating runtime Intel after ToData
-// doesn't affect the snapshot.
+// TestMixedProvenanceChannelNotInCurrentVia pins that Channel ∉ CurrentVia is legal.
+// This occurs when Report overwrites a Surveil-established holding, rewriting payload/Channel/At
+// while leaving CurrentVia (the sustaining channels) intact. This mixed provenance is legal
+// and must round-trip through ToData/LoadIntel without rejection.
+func (s *PersistenceSuite) TestMixedProvenanceChannelNotInCurrentVia() {
+	const (
+		obs     = core.EntityID("alice")
+		subject = intel.Subject("goblin")
+		ch1     = intel.Channel("sight")
+		ch2     = intel.Channel("hearing")
+	)
+
+	// Step 1: Surveil via "sight" establishes subject as Current
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: ch1, At: 1,
+		Percept: []intel.Report{{Subject: subject, Payload: []byte("see it")}},
+	})
+	s.Require().NoError(err)
+
+	h := s.holdingOn(obs, subject)
+	s.Equal(intel.Current, h.Status)
+	s.Equal([]intel.Channel{ch1}, h.CurrentVia)
+	s.Equal([]byte("see it"), h.Payload)
+	s.Equal(ch1, h.Channel)
+
+	// Step 2: Report via "hearing" channel overwrites payload, channel, at but NOT currentVia
+	// This creates the mixed-provenance state: Channel="hearing" but CurrentVia=["sight"]
+	_, err = s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: ch2, At: 2,
+		Reports: []intel.Report{{Subject: subject, Payload: []byte("hear it")}},
+	})
+	s.Require().NoError(err)
+
+	h = s.holdingOn(obs, subject)
+	s.Equal(intel.Current, h.Status, "still Current because sight sustains it")
+	s.Equal([]intel.Channel{ch1}, h.CurrentVia, "CurrentVia unchanged from Surveil")
+	s.Equal([]byte("hear it"), h.Payload, "Payload overwritten by Report")
+	s.Equal(ch2, h.Channel, "Channel changed to Report's channel")
+
+	// Step 3: Verify mixed provenance round-trips through ToData→LoadIntel→ToData
+	data := s.intel.ToData()
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err, "LoadIntel must accept mixed-provenance holding")
+
+	h2, err := loaded.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal(h.Status, h2.Status)
+	s.Equal(h.CurrentVia, h2.CurrentVia)
+	s.Equal(h.Payload, h2.Payload)
+	s.Equal(h.Channel, h2.Channel)
+
+	// Step 4: Verify ToData deep-equals pre-reload
+	data2 := loaded.ToData()
+	holdings1 := data.Holdings[obs][subject]
+	holdings2 := data2.Holdings[obs][subject]
+	s.Equal(holdings1.Payload, holdings2.Payload)
+	s.Equal(holdings1.Channel, holdings2.Channel)
+	s.Equal(holdings1.At, holdings2.At)
+	s.Equal(holdings1.CurrentVia, holdings2.CurrentVia)
+
+	// Step 5: Commentary: This pins mixed provenance as LEGAL. A future Channel∈CurrentVia
+	// "tightening" would make LoadIntel reject the module's own snapshots (R8 violation).
+	// Such a rule would break persistence layer semantics and is not permitted.
+}
+
+// TestSnapshotImmutability tests that both mutating snapshot data after ToData
+// and mutating runtime Intel doesn't affect the original or vice versa (genuine aliasing detection).
 func (s *PersistenceSuite) TestSnapshotImmutability() {
 	const obs = core.EntityID("eve")
 	// Create initial holding
@@ -1092,19 +1174,32 @@ func (s *PersistenceSuite) TestSnapshotImmutability() {
 	// Snapshot
 	data := s.intel.ToData()
 
-	// Mutate the runtime Intel
+	// SNAPSHOT MUTATION: mutate the snapshot data's payload in-place
+	// This tests that the backing arrays are NOT aliased
+	h := data.Holdings[obs]["s"]
+	if len(h.Payload) > 0 {
+		h.Payload[0] = 'X'
+	}
+
+	// Verify original runtime Intel is unchanged (aliasing detection)
+	runtimeHolding, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: "s"})
+	s.Require().NoError(err)
+	s.Equal([]byte("original"), runtimeHolding.Payload, "runtime payload must be immune to snapshot byte mutations")
+
+	// Also test runtime mutation doesn't affect snapshot
 	_, err = s.intel.Report(&intel.ReportInput{
 		Observer: obs, Channel: "c", At: 2,
 		Reports: []intel.Report{{Subject: "s", Payload: []byte("modified")}},
 	})
 	s.Require().NoError(err)
 
-	// Load snapshot: must have original payload
+	// Load snapshot: must have original payload (first byte still 'X' from our mutation, not 'm')
 	loaded, err := intel.LoadIntel(data)
 	s.Require().NoError(err)
-	h, err := loaded.On(&intel.OnInput{Observer: obs, Subject: "s"})
+	snapshotHolding, err := loaded.On(&intel.OnInput{Observer: obs, Subject: "s"})
 	s.Require().NoError(err)
-	s.Equal([]byte("original"), h.Payload, "snapshot payload must be unchanged")
+	expected := []byte("Xriginal")
+	s.Equal(expected, snapshotHolding.Payload, "snapshot must retain mutations (immune to runtime changes)")
 }
 
 // TestLoadSnapshotMutationImmunity tests that mutating the caller's Data
@@ -1275,6 +1370,38 @@ func (s *PersistenceSuite) TestNilPayloadLegal() {
 	h, err := loaded.On(&intel.OnInput{Observer: alice, Subject: target})
 	s.Require().NoError(err)
 	s.Nil(h.Payload, "nil payload should load as nil")
+}
+
+// TestNilPayloadRoundTrip tests that nil payload is preserved through ToData→LoadIntel→ToData.
+func (s *PersistenceSuite) TestNilPayloadRoundTrip() {
+	const (
+		alice  = core.EntityID("alice")
+		target = intel.Subject("target")
+	)
+	data := intel.Data{
+		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
+			alice: {
+				target: {
+					Payload: nil, // Nil payload
+					Channel: "sight",
+					At:      1,
+				},
+			},
+		},
+	}
+	loaded, err := intel.LoadIntel(data)
+	s.Require().NoError(err)
+
+	// Round-trip: LoadIntel → ToData → LoadIntel → ToData
+	data2 := loaded.ToData()
+	loaded2, err := intel.LoadIntel(data2)
+	s.Require().NoError(err)
+
+	data3 := loaded2.ToData()
+
+	// Verify both Data instances have nil payload
+	s.Nil(data2.Holdings[alice][target].Payload)
+	s.Nil(data3.Holdings[alice][target].Payload)
 }
 
 func TestPersistenceSuite(t *testing.T) {

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -489,6 +489,333 @@ func (s *IntelSuite) TestSurveilFadedSortedAndObserverIsolation() {
 	}
 }
 
+// QueriesSuite tests the read-side queries: HeldBy and On.
+type QueriesSuite struct {
+	suite.Suite
+	intel *intel.Intel
+}
+
+func (s *QueriesSuite) SetupTest() {
+	var err error
+	s.intel, err = intel.NewIntel()
+	s.Require().NoError(err)
+}
+
+// TestHeldByMultiHoldingSortedBySubject tests that HeldBy returns multiple
+// holdings sorted by Subject with derived statuses.
+func (s *QueriesSuite) TestHeldByMultiHoldingSortedBySubject() {
+	const obs = core.EntityID("alice")
+	// Report three subjects in non-alphabetical order
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "hearing", At: 1,
+		Reports: []intel.Report{
+			{Subject: "zebra", Payload: []byte("z")},
+			{Subject: "apple", Payload: []byte("a")},
+			{Subject: "moon", Payload: []byte("m")},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Query all holdings
+	holdings, err := s.intel.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	s.Len(holdings, 3)
+
+	// Verify sorted by Subject
+	s.Equal(intel.Subject("apple"), holdings[0].Subject)
+	s.Equal(intel.Subject("moon"), holdings[1].Subject)
+	s.Equal(intel.Subject("zebra"), holdings[2].Subject)
+
+	// Verify payloads
+	s.Equal([]byte("a"), holdings[0].Payload)
+	s.Equal([]byte("m"), holdings[1].Payload)
+	s.Equal([]byte("z"), holdings[2].Payload)
+
+	// Verify derived statuses (Report → Held, no sustaining channels)
+	s.Equal(intel.Held, holdings[0].Status)
+	s.Equal(intel.Held, holdings[1].Status)
+	s.Equal(intel.Held, holdings[2].Status)
+}
+
+// TestHeldByUnknownObserverEmptyNil tests that an unknown observer
+// returns empty slice, nil error (not a guessable zero value).
+func (s *QueriesSuite) TestHeldByUnknownObserverEmptyNil() {
+	holdings, err := s.intel.HeldBy(&intel.HeldByInput{Observer: "ghost-obs"})
+	s.Require().NoError(err)
+	s.Empty(holdings)
+	s.NotNil(holdings) // Must be empty slice, not nil
+}
+
+// TestHeldByNilInputReturnsErrNilInput verifies guard clause.
+func (s *QueriesSuite) TestHeldByNilInputReturnsErrNilInput() {
+	holdings, err := s.intel.HeldBy(nil)
+	s.Require().ErrorIs(err, intel.ErrNilInput)
+	s.Nil(holdings)
+}
+
+// TestHeldByEmptyObserverReturnsErrNoObserver verifies field validation.
+func (s *QueriesSuite) TestHeldByEmptyObserverReturnsErrNoObserver() {
+	holdings, err := s.intel.HeldBy(&intel.HeldByInput{Observer: ""})
+	s.Require().ErrorIs(err, intel.ErrNoObserver)
+	s.Nil(holdings)
+}
+
+// TestOnFound returns the holding when observer and subject are held.
+func (s *QueriesSuite) TestOnFound() {
+	const (
+		obs     = core.EntityID("bob")
+		subject = intel.Subject("target")
+		payload = "payload data"
+		channel = intel.Channel("sight")
+		at      = uint64(42)
+	)
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: channel, At: at,
+		Reports: []intel.Report{{Subject: subject, Payload: []byte(payload)}},
+	})
+	s.Require().NoError(err)
+
+	holding, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal(subject, holding.Subject)
+	s.Equal([]byte(payload), holding.Payload)
+	s.Equal(channel, holding.Channel)
+	s.Equal(at, holding.At)
+	s.Equal(intel.Held, holding.Status)
+}
+
+// TestOnUnknownSubjectReturnsErrNotHeld when subject never held.
+func (s *QueriesSuite) TestOnUnknownSubjectReturnsErrNotHeld() {
+	const obs = core.EntityID("charlie")
+	// Report something, but not the subject we query
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "ch", At: 1,
+		Reports: []intel.Report{{Subject: "other", Payload: nil}},
+	})
+	s.Require().NoError(err)
+
+	holding, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: "never-held"})
+	s.Require().ErrorIs(err, intel.ErrNotHeld)
+	s.Equal(intel.Holding{}, holding) // Zero value, not guessable
+}
+
+// TestOnUnknownObserverReturnsErrNotHeld when observer has no holdings.
+func (s *QueriesSuite) TestOnUnknownObserverReturnsErrNotHeld() {
+	holding, err := s.intel.On(&intel.OnInput{Observer: "unknown", Subject: "any"})
+	s.Require().ErrorIs(err, intel.ErrNotHeld)
+	s.Equal(intel.Holding{}, holding)
+}
+
+// TestOnNilInputReturnsErrNilInput verifies guard clause.
+func (s *QueriesSuite) TestOnNilInputReturnsErrNilInput() {
+	holding, err := s.intel.On(nil)
+	s.Require().ErrorIs(err, intel.ErrNilInput)
+	s.Equal(intel.Holding{}, holding)
+}
+
+// TestOnEmptyObserverReturnsErrNoObserver verifies field validation order.
+func (s *QueriesSuite) TestOnEmptyObserverReturnsErrNoObserver() {
+	holding, err := s.intel.On(&intel.OnInput{Observer: "", Subject: "x"})
+	s.Require().ErrorIs(err, intel.ErrNoObserver)
+	s.Equal(intel.Holding{}, holding)
+}
+
+// TestOnEmptySubjectReturnsErrNoSubject verifies field validation order.
+func (s *QueriesSuite) TestOnEmptySubjectReturnsErrNoSubject() {
+	holding, err := s.intel.On(&intel.OnInput{Observer: "alice", Subject: ""})
+	s.Require().ErrorIs(err, intel.ErrNoSubject)
+	s.Equal(intel.Holding{}, holding)
+}
+
+// TestHeldByCopyOutPayload verifies that mutating a returned holding's
+// payload does not corrupt internal state.
+func (s *QueriesSuite) TestHeldByCopyOutPayload() {
+	const obs = core.EntityID("alice")
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "c", At: 1,
+		Reports: []intel.Report{{Subject: "s", Payload: []byte("original")}},
+	})
+	s.Require().NoError(err)
+
+	// Get holdings, mutate the payload
+	holdings, err := s.intel.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	s.Len(holdings, 1)
+	holdings[0].Payload[0] = 'X'
+
+	// Query again: internal state unchanged
+	holdings2, err := s.intel.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	s.Equal([]byte("original"), holdings2[0].Payload)
+}
+
+// TestOnCopyOutPayload verifies that mutating a returned holding's
+// payload from On does not corrupt internal state.
+func (s *QueriesSuite) TestOnCopyOutPayload() {
+	const obs = core.EntityID("bob")
+	const subject = intel.Subject("target")
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "c", At: 1,
+		Reports: []intel.Report{{Subject: subject, Payload: []byte("original")}},
+	})
+	s.Require().NoError(err)
+
+	// Get holding, mutate payload
+	holding, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	holding.Payload[0] = 'Y'
+
+	// Query again: internal state unchanged
+	holding2, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal([]byte("original"), holding2.Payload)
+}
+
+// TestOnCopyOutCurrentVia verifies that mutating a returned holding's
+// CurrentVia slice does not corrupt internal state.
+func (s *QueriesSuite) TestOnCopyOutCurrentVia() {
+	const obs = core.EntityID("alice")
+	const subject = intel.Subject("target")
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: obs, Channel: intel.Sight, At: 1,
+		Percept: []intel.Report{{Subject: subject, Payload: []byte("sight")}},
+	})
+	s.Require().NoError(err)
+
+	// Get holding, mutate CurrentVia slice
+	holding, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Len(holding.CurrentVia, 1)
+	holding.CurrentVia[0] = "modified"
+
+	// Query again: internal state unchanged
+	holding2, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal([]intel.Channel{intel.Sight}, holding2.CurrentVia)
+}
+
+// TestHeldByCopyOutFromInputMutation verifies that if a caller mutates
+// a Report input slice AFTER calling Report, HeldBy sees unchanged state.
+func (s *QueriesSuite) TestHeldByCopyOutFromInputMutation() {
+	const obs = core.EntityID("alice")
+	reports := []intel.Report{
+		{Subject: "s1", Payload: []byte("p1")},
+		{Subject: "s2", Payload: []byte("p2")},
+	}
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "c", At: 1, Reports: reports,
+	})
+	s.Require().NoError(err)
+
+	// Mutate the input slice
+	reports[0].Payload[0] = 'X'
+	reports[0].Subject = "mutated"
+
+	// Query: should see original state
+	holdings, err := s.intel.HeldBy(&intel.HeldByInput{Observer: obs})
+	s.Require().NoError(err)
+	// holdings should be sorted by subject, so s1 comes first, s2 second
+	var s1Holding intel.Holding
+	for _, h := range holdings {
+		if h.Subject == "s1" {
+			s1Holding = h
+			break
+		}
+	}
+	s.Equal([]byte("p1"), s1Holding.Payload)
+}
+
+// TestOnCopyOutFromInputMutation verifies copy-out immunity for On input.
+func (s *QueriesSuite) TestOnCopyOutFromInputMutation() {
+	const obs = core.EntityID("bob")
+	const subject = intel.Subject("target")
+	_, err := s.intel.Report(&intel.ReportInput{
+		Observer: obs, Channel: "c", At: 1,
+		Reports: []intel.Report{{Subject: subject, Payload: []byte("original")}},
+	})
+	s.Require().NoError(err)
+
+	// Query and then mutate the input struct's fields
+	input := &intel.OnInput{Observer: obs, Subject: subject}
+	holding, err := s.intel.On(input)
+	s.Require().NoError(err)
+	s.Equal([]byte("original"), holding.Payload)
+
+	// Mutate the input
+	input.Observer = "modified"
+	input.Subject = "modified-subject"
+
+	// Re-query with original observer/subject via a new input
+	holding2, err := s.intel.On(&intel.OnInput{Observer: obs, Subject: subject})
+	s.Require().NoError(err)
+	s.Equal([]byte("original"), holding2.Payload)
+}
+
+// TestDeciderContract is the normative integration test: an NPC decider
+// consults HeldBy(itself) and nothing else. This documents the core contract
+// and verifies that HeldBy provides all necessary information for decision-making.
+func (s *QueriesSuite) TestDeciderContract() {
+	const (
+		monsterID  = core.EntityID("goblin-1")
+		treasure   = intel.Subject("treasure")
+		adventurer = intel.Subject("adventurer-party")
+		obstacle   = intel.Subject("stone-door")
+	)
+
+	// Setup: monster has various intel from different channels.
+	// Sight: active percept of adventurers and stone door
+	// Smell: lingering awareness of treasure (sustain faded - remembered goblin intel)
+	_, err := s.intel.Surveil(&intel.SurveilInput{
+		Observer: monsterID, Channel: intel.Sight, At: 100,
+		Percept: []intel.Report{
+			{Subject: adventurer, Payload: []byte("group of 4, armed")},
+			{Subject: obstacle, Payload: []byte("10ft tall, sealed")},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Report: secondhand intel about treasure (supernatural channel)
+	_, err = s.intel.Report(&intel.ReportInput{
+		Observer: monsterID, Channel: "whispers", At: 50,
+		Reports: []intel.Report{{Subject: treasure, Payload: []byte("gold in chamber")}},
+	})
+	s.Require().NoError(err)
+
+	// Fade the smell sense, so treasure becomes Held (no longer Current)
+	_, err = s.intel.Surveil(&intel.SurveilInput{
+		Observer: monsterID, Channel: "smell", At: 0, Percept: []intel.Report{},
+	})
+	s.Require().NoError(err)
+
+	// NPC DECIDER: consult HeldBy(itself) and nothing else
+	myIntel, err := s.intel.HeldBy(&intel.HeldByInput{Observer: monsterID})
+	s.Require().NoError(err)
+	s.Len(myIntel, 3)
+
+	// Verify all holdings are present and correctly ordered (sorted by Subject)
+	// Expected order: adventurer, obstacle, treasure
+	s.Equal(adventurer, myIntel[0].Subject)
+	s.Equal(obstacle, myIntel[1].Subject)
+	s.Equal(treasure, myIntel[2].Subject)
+
+	// Verify statuses: adventurer and obstacle are Current (sight sustains them),
+	// treasure is Held (no sustaining channel).
+	s.Equal(intel.Current, myIntel[0].Status)
+	s.Equal(intel.Current, myIntel[1].Status)
+	s.Equal(intel.Held, myIntel[2].Status)
+
+	// Verify the monster can act based on this alone:
+	// - Attack adventurers (Current, sight confirmed)
+	// - Search for treasure despite not seeing it (Held, remembered via whispers)
+	// - Try to open door (Current, sight confirmed)
+	// The contract: all this decision logic flows from HeldBy(itself) alone.
+	_ = myIntel // Decision logic would consume this
+}
+
+func TestQueriesSuite(t *testing.T) {
+	suite.Run(t, new(QueriesSuite))
+}
+
 func TestIntelSuite(t *testing.T) {
 	suite.Run(t, new(IntelSuite))
 }

--- a/play/intel/intel_test.go
+++ b/play/intel/intel_test.go
@@ -110,9 +110,10 @@ func (s *IntelSuite) TestReportAtBlindness() {
 }
 
 func (s *IntelSuite) TestReportCopyOutPayload() {
+	const alice = core.EntityID("alice")
 	// Pin: mutating returned FirstContact payload must not corrupt stored payload
 	out, err := s.intel.Report(&intel.ReportInput{
-		Observer: "alice", Channel: "hearing", At: 5,
+		Observer: alice, Channel: "hearing", At: 5,
 		Reports: []intel.Report{{Subject: "s", Payload: []byte("original")}},
 	})
 	s.Require().NoError(err)
@@ -122,7 +123,7 @@ func (s *IntelSuite) TestReportCopyOutPayload() {
 	out.FirstContact[0].Payload[0] = 'X'
 
 	// Internal storage must be unchanged
-	h := s.holdingOn("alice", "s")
+	h := s.holdingOn(alice, "s")
 	s.Equal([]byte("original"), h.Payload, "stored payload must be immune to mutation of FirstContact")
 }
 
@@ -624,7 +625,8 @@ func (s *QueriesSuite) TestOnEmptyObserverReturnsErrNoObserver() {
 
 // TestOnEmptySubjectReturnsErrNoSubject verifies field validation order.
 func (s *QueriesSuite) TestOnEmptySubjectReturnsErrNoSubject() {
-	holding, err := s.intel.On(&intel.OnInput{Observer: "alice", Subject: ""})
+	const alice = core.EntityID("alice")
+	holding, err := s.intel.On(&intel.OnInput{Observer: alice, Subject: ""})
 	s.Require().ErrorIs(err, intel.ErrNoSubject)
 	s.Equal(intel.Holding{}, holding)
 }
@@ -841,25 +843,25 @@ func (s *PersistenceSuite) SetupTest() {
 }
 
 // TestIdleConventionZeroValue tests that NewIntel().ToData() returns a zero
-// IntelData with nil map (not empty non-nil).
+// Data with nil map (not empty non-nil).
 func (s *PersistenceSuite) TestIdleConventionZeroValue() {
 	data := s.intel.ToData()
 	// Zero value: nil map, not empty non-nil
 	s.Nil(data.Holdings, "idle Intel should marshal to nil Holdings map")
 }
 
-// TestIdleConventionMarshalEmpty tests that zero IntelData marshals to "{}".
+// TestIdleConventionMarshalEmpty tests that zero Data marshals to "{}".
 func (s *PersistenceSuite) TestIdleConventionMarshalEmpty() {
 	data := s.intel.ToData()
 	b, err := json.Marshal(data)
 	s.Require().NoError(err)
-	s.Equal([]byte("{}"), b, "idle IntelData must marshal to empty object")
+	s.Equal([]byte("{}"), b, "idle Data must marshal to empty object")
 }
 
-// TestIdleConventionLoadEmpty tests that LoadIntel(IntelData{}) succeeds
+// TestIdleConventionLoadEmpty tests that LoadIntel(Data{}) succeeds
 // and the Intel is usable (verbs work).
 func (s *PersistenceSuite) TestIdleConventionLoadEmpty() {
-	loaded, err := intel.LoadIntel(intel.IntelData{})
+	loaded, err := intel.LoadIntel(intel.Data{})
 	s.Require().NoError(err)
 	// Verify it's usable: HeldBy on empty Intel succeeds
 	holdings, err := loaded.HeldBy(&intel.HeldByInput{Observer: "test"})
@@ -1105,7 +1107,7 @@ func (s *PersistenceSuite) TestSnapshotImmutability() {
 	s.Equal([]byte("original"), h.Payload, "snapshot payload must be unchanged")
 }
 
-// TestLoadSnapshotMutationImmunity tests that mutating the caller's IntelData
+// TestLoadSnapshotMutationImmunity tests that mutating the caller's Data
 // maps after LoadIntel doesn't affect the loaded Intel.
 func (s *PersistenceSuite) TestLoadSnapshotMutationImmunity() {
 	const obs = core.EntityID("frank")
@@ -1137,7 +1139,7 @@ func (s *PersistenceSuite) TestLoadSnapshotMutationImmunity() {
 
 // TestR9EmptyObserverKey tests that empty observer key is rejected.
 func (s *PersistenceSuite) TestR9EmptyObserverKey() {
-	data := intel.IntelData{
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
 			"": {}, // Empty observer key
 		},
@@ -1148,9 +1150,10 @@ func (s *PersistenceSuite) TestR9EmptyObserverKey() {
 
 // TestR9EmptySubjectKey tests that empty subject key is rejected.
 func (s *PersistenceSuite) TestR9EmptySubjectKey() {
-	data := intel.IntelData{
+	const alice = core.EntityID("alice")
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
-			"alice": {"": {}}, // Empty subject key
+			alice: {"": {}}, // Empty subject key
 		},
 	}
 	_, err := intel.LoadIntel(data)
@@ -1159,14 +1162,19 @@ func (s *PersistenceSuite) TestR9EmptySubjectKey() {
 
 // TestR9DuplicateCurrentVia tests that duplicate channels in CurrentVia are rejected.
 func (s *PersistenceSuite) TestR9DuplicateCurrentVia() {
-	data := intel.IntelData{
+	const (
+		alice  = core.EntityID("alice")
+		target = intel.Subject("target")
+		sight  = intel.Channel("sight")
+	)
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
-			"alice": {
-				"target": {
+			alice: {
+				target: {
 					Payload:    []byte("data"),
-					Channel:    "sight",
+					Channel:    sight,
 					At:         1,
-					CurrentVia: []intel.Channel{"sight", "sight"}, // Duplicate
+					CurrentVia: []intel.Channel{sight, sight}, // Duplicate
 				},
 			},
 		},
@@ -1177,10 +1185,14 @@ func (s *PersistenceSuite) TestR9DuplicateCurrentVia() {
 
 // TestR9EmptyHoldingChannel tests that empty holding Channel is rejected.
 func (s *PersistenceSuite) TestR9EmptyHoldingChannel() {
-	data := intel.IntelData{
+	const (
+		alice  = core.EntityID("alice")
+		target = intel.Subject("target")
+	)
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
-			"alice": {
-				"target": {
+			alice: {
+				target: {
 					Payload: []byte("data"),
 					Channel: "", // Empty channel
 					At:      1,
@@ -1194,12 +1206,17 @@ func (s *PersistenceSuite) TestR9EmptyHoldingChannel() {
 
 // TestR9EmptyChannelInCurrentVia tests that empty channel in CurrentVia is rejected.
 func (s *PersistenceSuite) TestR9EmptyChannelInCurrentVia() {
-	data := intel.IntelData{
+	const (
+		alice  = core.EntityID("alice")
+		target = intel.Subject("target")
+		sight  = intel.Channel("sight")
+	)
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
-			"alice": {
-				"target": {
+			alice: {
+				target: {
 					Payload:    []byte("data"),
-					Channel:    "sight",
+					Channel:    sight,
 					At:         1,
 					CurrentVia: []intel.Channel{""}, // Empty channel
 				},
@@ -1212,9 +1229,10 @@ func (s *PersistenceSuite) TestR9EmptyChannelInCurrentVia() {
 
 // TestR9NilInnerMap tests that nil inner map is rejected.
 func (s *PersistenceSuite) TestR9NilInnerMap() {
-	data := intel.IntelData{
+	const alice = core.EntityID("alice")
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
-			"alice": nil, // Nil inner map
+			alice: nil, // Nil inner map
 		},
 	}
 	_, err := intel.LoadIntel(data)
@@ -1223,9 +1241,10 @@ func (s *PersistenceSuite) TestR9NilInnerMap() {
 
 // TestR9EmptyInnerMap tests that empty (non-nil) inner map is rejected.
 func (s *PersistenceSuite) TestR9EmptyInnerMap() {
-	data := intel.IntelData{
+	const alice = core.EntityID("alice")
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
-			"alice": {}, // Empty non-nil map
+			alice: {}, // Empty non-nil map
 		},
 	}
 	_, err := intel.LoadIntel(data)
@@ -1234,10 +1253,14 @@ func (s *PersistenceSuite) TestR9EmptyInnerMap() {
 
 // TestNilPayloadLegal tests that nil payload in HoldingData is legal.
 func (s *PersistenceSuite) TestNilPayloadLegal() {
-	data := intel.IntelData{
+	const (
+		alice  = core.EntityID("alice")
+		target = intel.Subject("target")
+	)
+	data := intel.Data{
 		Holdings: map[core.EntityID]map[intel.Subject]intel.HoldingData{
-			"alice": {
-				"target": {
+			alice: {
+				target: {
 					Payload: nil, // Nil payload is legal
 					Channel: "sight",
 					At:      1,
@@ -1249,7 +1272,7 @@ func (s *PersistenceSuite) TestNilPayloadLegal() {
 	s.Require().NoError(err, "nil payload must be legal")
 
 	// Verify it loads and is usable
-	h, err := loaded.On(&intel.OnInput{Observer: "alice", Subject: "target"})
+	h, err := loaded.On(&intel.OnInput{Observer: alice, Subject: target})
 	s.Require().NoError(err)
 	s.Nil(h.Payload, "nil payload should load as nil")
 }


### PR DESCRIPTION
## What

`play/intel` v0: the bookkeeper of belief — a per-observer, truth-blind store of holdings. Compositions report testimony (`Report`) and sustain observation (`Surveil`, the complete-percept contract with fade); deciders read their own beliefs (`HeldBy`/`On`) and nothing else. The stage owns sense physics; intel owns what each mind currently believes — which is how deception is native: an illusion is a surveilled falsehood, a charm is a reported lie.

Design and plan: #906 (`docs/ideas/play/intel/` — brainstorm, design, plan). This PR implements that design exactly; the docs PR merges alongside as ratification, with execution addenda logging every fix cycle — including one design amendment ratified during execution (the family naming law's namesake-collision clause: `intel.Data`, not `intel.IntelData`).

## Family laws held

- Depends on `core` + stdlib only; no events, no spatial, no siblings, no rulebooks
- No `context.Context`; not concurrency-safe by contract
- Signature law: single `*XxxInput` params, `*XxxOutput` deltas returned (never published); error-last everywhere; `ErrNilInput` guards first
- R5 atomicity; R6 last-testimony-wins with no channel/verb preference; no randomness
- Persistence: `ToData() Data` / package-level `LoadIntel(data Data) (*Intel, error)`, data by value; idle snapshot marshals `{}`; R9 load validation rejects every unreachable state and accepts every reachable one — including mixed provenance (a `Report` overwrite leaving `Channel` outside a `Surveil`-established `CurrentVia`), pinned so a future "tightening" cannot make the module reject its own snapshots
- 6 sentinels, every one `errors.Is`-tested

## Evidence

- 55 tests green; `golangci-lint` 0 issues; zero `nolint` directives
- AC1 door scene (`doorscene_test.go`): hearing testimony through the door; the ghost goblin holding its last observation after fading; the same-subject overwrite when the door opens (`Refreshed`, channel and payload flip); a charm planting a false belief that `On` returns faithfully — full delta transcript asserted at every step
- Golden JSON pins both wire shapes (held and current) with exact string equality; snapshot/load aliasing immunity pinned with in-place mutations — all three pins mutation-proven (each shown to fail under the exact breakage it guards)
- Compat gate: `gorelease-play-intel` job added to `compat.yml` (heads-up: one-hunk conflict with #907's record hunk; whichever merges second rebases trivially)

— asset-pipeline agent, on behalf of KirkDiggler