### PR TITLE
feat(spatial): add explicit managed-room membership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,32 +295,42 @@ func LoadJSON(data json.RawMessage) (ConditionBehavior, error) {
 The spatial module now includes multi-room orchestration capabilities:
 
 ```go
-// Create orchestrator
+// Create orchestrator. Event wiring is optional and observer-only.
 orchestrator := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
-    ID:       "dungeon-orchestrator",
-    Type:     "orchestrator",
-    EventBus: eventBus,
-    Layout:   spatial.LayoutTypeOrganic,
+    ID:     "dungeon-orchestrator",
+    Type:   "orchestrator",
+    Layout: spatial.LayoutTypeOrganic,
 })
+orchestrator.ConnectToEventBus(eventBus) // Optional observer publication.
+room1.ConnectToEventBus(eventBus)        // Optional room-event publication.
+room2.ConnectToEventBus(eventBus)
 
-// Add rooms
+// Add rooms, then mutate their membership through the managed seam.
 orchestrator.AddRoom(room1)
 orchestrator.AddRoom(room2)
+_, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+    RoomID: "room-1", Entity: hero, Position: spatial.Position{X: 9, Y: 5},
+})
 
-// Create connections
-door := spatial.CreateDoorConnection("door-1", "room-1", "room-2", 
-    spatial.Position{X: 9, Y: 5}, spatial.Position{X: 0, Y: 5})
+// Connections are abstract; the cost is spatial infrastructure.
+door := spatial.CreateDoorConnection("door-1", "room-1", "room-2", 1.0)
 orchestrator.AddConnection(door)
 
-// Move entities between rooms
-orchestrator.MoveEntityBetweenRooms("hero", "room-1", "room-2", "door-1")
+// Transition removes and returns the entity; the composition chooses its
+// destination position through a second managed placement.
+transitioned, err := orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+    EntityID: "hero", FromRoom: "room-1", ToRoom: "room-2", ConnectionID: "door-1",
+})
+_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+    RoomID: "room-2", Entity: transitioned.Entity, Position: spatial.Position{X: 0, Y: 5},
+})
 ```
 
 **Key Features**:
 - Connection types: doors, stairs, passages, portals, bridges, tunnels
 - Layout patterns: tower, branching, grid, organic
 - Entity tracking across rooms
-- Event-driven architecture
+- Observer-only event publication; spatial results return as values
 - Pathfinding between connected rooms
 
 ### Spawn Module Features (Completed)

--- a/docs/architecture/components/tools-spatial.md
+++ b/docs/architecture/components/tools-spatial.md
@@ -1,7 +1,7 @@
 ---
 name: tools/spatial module
 description: Hex/Square/Gridless rooms, multi-room orchestration, spatial queries, pathfinding — second-largest rpg-api dependency
-updated: 2026-05-04
+updated: 2026-08-10
 confidence: high — verified by reading pathfinder.go, orchestrator.go, connection.go, hex_grid.go, square_grid.go, and rpg-api's hot-path imports per audit 049
 ---
 
@@ -54,7 +54,8 @@ orchestrator — its dungeon graph lives in `tools/environments` (see
 | `orchestrator.go` | `Orchestrator` interface + `BasicRoomOrchestrator`, `LayoutOrchestrator` (unimplemented), `TransitionSystem` (unimplemented) |
 | `connection.go` | `Connection`, `BasicConnection` |
 | `connection_helpers.go` | `CreateDoorConnection`, `CreateStairsConnection`, etc. |
-| `basic_orchestrator.go` | `BasicRoomOrchestrator` implementation |
+| `basic_orchestrator.go` | `BasicRoomOrchestrator` room/connection/index implementation |
+| `managed_membership.go` | Additive `ManagedRoomMutator` verbs and returned spatial deltas |
 | `query_handler.go` | `SpatialQueryHandler` — multi-room entity queries |
 | `query_utils.go` | Filter helpers (`CreateCharacterFilter`, `CreateMonsterFilter`, etc.) |
 | `events.go` | Event types: `EntityPlacedEvent`, `EntityMovedEvent`, `RoomAddedEvent`, etc. |
@@ -95,6 +96,30 @@ entities live where in the encounter grid.
 `BasicRoomOrchestrator` tracks multiple rooms and their connections.
 `FindPath` is room-to-room (which sequence of rooms to traverse), not
 intra-room.
+
+Entity membership in managed rooms has one supported mutation seam:
+`ManagedRoomMutator` (`PlaceEntity`, `MoveEntity`, `RemoveEntity`, and
+`TransitionEntity`). Each verb returns a typed delta as a value and updates the
+room plus entity-to-room index synchronously. Rooms used alone remain directly
+mutable. After a room is added, direct mutation through a retained `Room` alias
+(or sharing one room across orchestrators) is unsupported because Go interfaces
+cannot enforce ownership and such bypasses can stale indexes.
+
+The event bus is observer-only. `BasicRoomOrchestrator` does not subscribe to
+`EntityPlacedTopic`, `EntityMovedTopic`, or `EntityRemovedTopic`; membership
+correctness therefore does not depend on a bus, topic wiring order, or rooms and
+orchestrator sharing a bus. Synchronous observers may re-enter read getters, but
+hosts serialize managed mutations and re-entrant managed mutation from an
+observer is outside the contract.
+
+Connections remain abstract and do not choose destination positions.
+`TransitionEntity` consequently removes and unindexes the entity, then returns
+the removed `core.Entity`, departure delta, and a transition with
+`PlacementRequired=true`. The composition completes physical membership with a
+later managed `PlaceEntity`. Until then, `GetEntityRoom` and
+`CanMoveEntityBetweenRooms` both answer false. The legacy
+`MoveEntityBetweenRooms` signature remains but discards this output and follows
+the same corrected departure-only semantics.
 
 Connection types (helper constructors in `connection_helpers.go`):
 - `CreateDoorConnection` — standard bidirectional door
@@ -150,7 +175,7 @@ environments.
 ## go.mod status
 
 Clean. Uses published versions for all dependencies:
-- `core v0.9.6`
+- `core v0.11.0`
 - `events v0.6.2`
 - `game v0.1.0`
 - `google/uuid v1.6.0`

--- a/tools/spatial/CLAUDE.md
+++ b/tools/spatial/CLAUDE.md
@@ -19,11 +19,11 @@ This module provides the mathematical foundation for position-based game systems
 ✅ **Events v0.6.1 compliant** (import ordering follows standard)
 ✅ **Comprehensive documentation** (43KB README.md)
 ✅ **Thread-safe operations** (proper mutex usage)
-✅ **Event-driven architecture** (typed topics)
+✅ **Observer event publication** (typed topics; never an internal result channel)
 
 ### Dependencies
-- `events v0.6.0` (v0.6.1 compatible, upgrade when available)
-- `core v0.9.0` (Entity interface)
+- `events v0.6.2`
+- `core v0.11.0` (`Entity` + shared `EntityID`)
 - `game` (Context pattern for data persistence)
 
 ## Key Architectural Decisions
@@ -38,7 +38,7 @@ Connections are **abstract links** between rooms, NOT physical objects:
 
 **Example**: A door connection links room A position (9,5) to room B position (0,5), but the door entity itself is placed in the room at that position by the game layer.
 
-### Event-Driven Architecture
+### Observer-Only Event Architecture
 
 Uses typed topics from events v0.6.0+:
 ```go
@@ -61,13 +61,20 @@ EntityRoomTransitionTopic
 LayoutChangedTopic
 ```
 
-**Important**: Always call `ConnectToEventBus()` after creating rooms/orchestrators.
+**Important**: `ConnectToEventBus()` is optional and enables observer
+publication only. Standalone rooms may be mutated directly. Once a room is
+added to a `BasicRoomOrchestrator`, use its `ManagedRoomMutator` verbs for
+placement, movement, removal, and transition; the orchestrator never consumes
+room events to maintain membership. Retained-room mutation and sharing one room
+across orchestrators are unsupported alias bypasses that can stale indexes.
 
 ### Thread Safety Pattern
 
 Both `BasicRoom` and `BasicRoomOrchestrator` use `sync.RWMutex`:
 - Read operations use `RLock()/RUnlock()`
 - Write operations use `Lock()/Unlock()`
+- Orchestrator locks are released before room calls and event publication
+- Hosts serialize managed mutations; concurrent reads remain safe
 - Triple-tracking system for efficient lookups (entities map, positions map, occupancy map)
 
 ## Grid Systems
@@ -224,11 +231,11 @@ door := spatial.CreateDoorConnection("door-1", "room-1", "room-2",
     spatial.Position{X: 9, Y: 5}, spatial.Position{X: 0, Y: 5})
 orchestrator.AddConnection(door)
 
-// 4. Track entities via event subscriptions
-spatial.EntityMovedTopic.On(eventBus).Subscribe(func(ctx context.Context, event spatial.EntityMovedEvent) error {
-    // Handle entity movement
-    return nil
+// 4. Mutate managed membership and consume returned values
+placed, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+    RoomID: "room-1", Entity: hero, Position: spatial.Position{X: 2, Y: 2},
 })
+// Optional subscriptions observe the same room event; they do not update the index.
 
 // 5. Use pathfinding for AI movement
 path, err := orchestrator.FindPath("room-1", "room-2")
@@ -421,7 +428,7 @@ s.Eventually(func() bool { return eventReceived }, time.Second, 10*time.Millisec
 ## Remember
 
 - **Spatial is infrastructure, not game rules**
-- **Event bus connection is always separate from creation**
+- **Event bus connection is optional, observer-only, and separate from creation**
 - **Import ordering matters for v0.6.1 compatibility**
 - **Thread safety is built-in - don't add extra locks**
 - **README.md is the source of truth for usage patterns**

--- a/tools/spatial/CLAUDE.md
+++ b/tools/spatial/CLAUDE.md
@@ -227,8 +227,7 @@ orchestrator.AddRoom(room1)
 orchestrator.AddRoom(room2)
 
 // 3. Connect rooms with typed connections
-door := spatial.CreateDoorConnection("door-1", "room-1", "room-2",
-    spatial.Position{X: 9, Y: 5}, spatial.Position{X: 0, Y: 5})
+door := spatial.CreateDoorConnection("door-1", "room-1", "room-2", 1.0)
 orchestrator.AddConnection(door)
 
 // 4. Mutate managed membership and consume returned values

--- a/tools/spatial/README.md
+++ b/tools/spatial/README.md
@@ -343,6 +343,70 @@ spatial.LayoutTypeGrid       // 2D grid arrangement
 spatial.LayoutTypeOrganic    // Irregular connections
 ```
 
+### Standalone rooms and managed rooms
+
+A `BasicRoom` remains a valid standalone spatial container: call its
+`PlaceEntity`, `MoveEntity`, and `RemoveEntity` methods directly. Once rooms
+participate in a multi-room field, entity membership mutation uses the
+orchestrator's additive `ManagedRoomMutator` seam instead:
+
+```go
+placed, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+    RoomID: "entrance-hall",
+    Entity: hero,
+    Position: spatial.Position{X: 10, Y: 10},
+})
+
+moved, err := orchestrator.MoveEntity(&spatial.MoveEntityInput{
+    RoomID: "entrance-hall",
+    EntityID: core.EntityID(hero.GetID()),
+    To: spatial.Position{X: 12, Y: 10},
+})
+```
+
+These verbs synchronously update both the room and the orchestrator's
+entity-to-room index and return typed spatial deltas as values. The event bus is
+an optional **observer tail only**: connecting no bus, connecting after rooms
+are added, or using different buses for rooms and the orchestrator does not
+change membership correctness or outputs. Spatial events retain their existing
+topics and payloads for observers, but the orchestrator never subscribes to
+room notifications to learn its own results.
+
+Go room interfaces are aliases, not ownership tokens. After `AddRoom`, retained
+room references can still bypass the managed seam, and the same room can be
+passed to more than one orchestrator. Both uses are unsupported because they
+can stale an index; #909 deliberately adds no callback or ownership-token
+machinery. Hosts serialize managed mutations. Concurrent read queries remain
+safe, but re-entrant managed mutation from a synchronous event observer is not
+a supported contract.
+
+A cross-room transition has two explicit steps because a connection does not
+choose a physical destination position:
+
+```go
+transitioned, err := orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+    EntityID: core.EntityID(hero.GetID()),
+    FromRoom: "entrance-hall",
+    ToRoom: "treasure-room",
+    ConnectionID: "main-door",
+})
+// transitioned.Entity is physically removed and unindexed;
+// transitioned.Transition.PlacementRequired is true.
+
+placed, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+    RoomID: "treasure-room",
+    Entity: transitioned.Entity,
+    Position: spatial.Position{X: 1, Y: 7},
+})
+```
+
+During the interval between those calls, `GetEntityRoom` returns false and
+`CanMoveEntityBetweenRooms` returns false. The legacy
+`MoveEntityBetweenRooms(string, string, string, string) error` signature is
+retained for source compatibility, but now has the same honest departure-only
+behavior and discards the explicit output. New compositions should use
+`TransitionEntity`.
+
 ### Basic Orchestrator Usage
 
 #### 1. Creating an Orchestrator
@@ -352,7 +416,6 @@ spatial.LayoutTypeOrganic    // Irregular connections
 orchestrator := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
     ID:       "dungeon-orchestrator",
     Type:     "orchestrator",
-    EventBus: eventBus,
     Layout:   spatial.LayoutTypeOrganic,
 })
 ```
@@ -365,14 +428,12 @@ room1 := spatial.NewBasicRoom(spatial.BasicRoomConfig{
     ID:       "entrance-hall",
     Type:     "chamber",
     Grid:     spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
-    EventBus: eventBus,
 })
 
 room2 := spatial.NewBasicRoom(spatial.BasicRoomConfig{
     ID:       "treasure-room",
     Type:     "chamber", 
     Grid:     spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 15, Height: 15}),
-    EventBus: eventBus,
 })
 
 // Add to orchestrator
@@ -386,35 +447,21 @@ err = orchestrator.AddRoom(room2)
 // Create a door connection
 door := spatial.CreateDoorConnection(
     "main-door",
-    "entrance-hall",        // From room
-    "treasure-room",        // To room
-    spatial.Position{X: 19, Y: 10}, // Exit position in entrance-hall
-    spatial.Position{X: 0, Y: 7},   // Entry position in treasure-room
+    "entrance-hall", // From room
+    "treasure-room", // To room
+    1.0,             // Traversal cost
 )
 
 // Add connection to orchestrator
 err := orchestrator.AddConnection(door)
 ```
 
-#### 4. Moving Entities Between Rooms
+#### 4. Transitioning Entities Between Rooms
 
-```go
-// Place entity in first room
-hero := &Character{id: "hero", entityType: "character"}
-err := room1.PlaceEntity(hero, spatial.Position{X: 10, Y: 10})
-
-// Move entity to second room through connection
-err = orchestrator.MoveEntityBetweenRooms(
-    "hero",           // Entity ID
-    "entrance-hall",  // From room
-    "treasure-room",  // To room
-    "main-door",      // Connection ID
-)
-
-// Check which room contains the entity
-roomID, exists := orchestrator.GetEntityRoom("hero")
-// roomID will be "treasure-room"
-```
+Use the managed placement and transition verbs shown above. `TransitionEntity`
+returns the removed `core.Entity`, the departure delta, and the logical
+transition; the composition then chooses the destination position and calls
+managed `PlaceEntity`. No subscriber is required to recover either result.
 
 ### Connection Helper Functions
 
@@ -424,9 +471,7 @@ The module provides helper functions for creating different connection types:
 ```go
 // Bidirectional door (most common)
 door := spatial.CreateDoorConnection(
-    "door-1", "room-a", "room-b",
-    spatial.Position{X: 10, Y: 0},  // Exit position
-    spatial.Position{X: 5, Y: 19},  // Entry position
+    "door-1", "room-a", "room-b", 1.0,
 )
 // Cost: 1.0, Reversible: true, Requirements: none
 ```
@@ -435,9 +480,7 @@ door := spatial.CreateDoorConnection(
 ```go
 // Stairs between floors
 stairs := spatial.CreateStairsConnection(
-    "stairs-up", "floor-1", "floor-2",
-    spatial.Position{X: 10, Y: 10},
-    spatial.Position{X: 10, Y: 10},
+    "stairs-up", "floor-1", "floor-2", 2.0,
     true, // goingUp - adds "can_climb" requirement
 )
 // Cost: 2.0, Reversible: true, Requirements: ["can_climb"] if going up
@@ -447,9 +490,7 @@ stairs := spatial.CreateStairsConnection(
 ```go
 // Magical portal
 portal := spatial.CreatePortalConnection(
-    "magic-portal", "material-plane", "feywild",
-    spatial.Position{X: 5, Y: 5},
-    spatial.Position{X: 12, Y: 8},
+    "magic-portal", "material-plane", "feywild", 0.5,
     true, // bidirectional
 )
 // Cost: 0.5, Requirements: ["can_use_portals"]
@@ -459,9 +500,7 @@ portal := spatial.CreatePortalConnection(
 ```go
 // Hidden passage
 secret := spatial.CreateSecretPassageConnection(
-    "secret-passage", "library", "hidden-chamber",
-    spatial.Position{X: 0, Y: 10},
-    spatial.Position{X: 15, Y: 10},
+    "secret-passage", "library", "hidden-chamber", 1.0,
     []string{"found_secret", "has_key"}, // Custom requirements
 )
 // Cost: 1.0, Reversible: true, Requirements: custom

--- a/tools/spatial/README.md
+++ b/tools/spatial/README.md
@@ -530,8 +530,7 @@ for i := 0; i < len(floors)-1; i++ {
         fmt.Sprintf("stairs-%d-%d", i+1, i+2),
         floors[i].GetID(),
         floors[i+1].GetID(),
-        spatial.Position{X: 10, Y: 10},
-        spatial.Position{X: 10, Y: 10},
+        2.0,
         true, // going up
     )
     orchestrator.AddConnection(stairs)
@@ -578,8 +577,7 @@ for i, branchID := range branches {
         fmt.Sprintf("door-to-%s", branchID),
         "central-hub",
         branchID,
-        positions[i],
-        spatial.Position{X: 10, Y: 10}, // Center of branch room
+        1.0,
     )
     orchestrator.AddConnection(door)
 }
@@ -717,17 +715,11 @@ func CreateDungeonExample() {
     
     // Create connections
     door1 := spatial.CreateDoorConnection(
-        "entrance-to-corridor",
-        "entrance", "corridor",
-        spatial.Position{X: 19, Y: 10},
-        spatial.Position{X: 0, Y: 5},
+        "entrance-to-corridor", "entrance", "corridor", 1.0,
     )
     
     door2 := spatial.CreateDoorConnection(
-        "corridor-to-treasure",
-        "corridor", "treasure",
-        spatial.Position{X: 29, Y: 5},
-        spatial.Position{X: 0, Y: 7},
+        "corridor-to-treasure", "corridor", "treasure", 1.0,
     )
     
     orchestrator.AddConnection(door1)
@@ -1287,22 +1279,22 @@ The module provides helper functions for creating common connection types:
 
 ```go
 // Door connection (bidirectional, cost 1.0)
-func CreateDoorConnection(id, fromRoom, toRoom string, fromPos, toPos Position) *BasicConnection
+func CreateDoorConnection(id, fromRoom, toRoom string, cost float64) *BasicConnection
 
 // Stair connection (bidirectional, cost 2.0, may have climb requirement)
-func CreateStairsConnection(id, fromRoom, toRoom string, fromPos, toPos Position, goingUp bool) *BasicConnection
+func CreateStairsConnection(id, fromRoom, toRoom string, cost float64, goingUp bool) *BasicConnection
 
 // Secret passage (bidirectional, cost 1.0, requires discovery)
-func CreateSecretPassageConnection(id, fromRoom, toRoom string, fromPos, toPos Position, requirements []string) *BasicConnection
+func CreateSecretPassageConnection(id, fromRoom, toRoom string, cost float64, requirements []string) *BasicConnection
 
 // Portal connection (configurable direction, cost 0.5, requires portal use)
-func CreatePortalConnection(id, fromRoom, toRoom string, fromPos, toPos Position, bidirectional bool) *BasicConnection
+func CreatePortalConnection(id, fromRoom, toRoom string, cost float64, bidirectional bool) *BasicConnection
 
 // Bridge connection (bidirectional, cost 1.0)
-func CreateBridgeConnection(id, fromRoom, toRoom string, fromPos, toPos Position) *BasicConnection
+func CreateBridgeConnection(id, fromRoom, toRoom string, cost float64) *BasicConnection
 
 // Tunnel connection (bidirectional, cost 1.5)
-func CreateTunnelConnection(id, fromRoom, toRoom string, fromPos, toPos Position) *BasicConnection
+func CreateTunnelConnection(id, fromRoom, toRoom string, cost float64) *BasicConnection
 ```
 
 ### Query System
@@ -1460,7 +1452,7 @@ eventBus.SubscribeFunc(spatial.EventConnectionAdded, 0, func(ctx context.Context
 
 ```go
 // Create locked door that can be unlocked
-door := spatial.CreateDoorConnection("treasure-door", "hallway", "treasure-room", pos1, pos2)
+door := spatial.CreateDoorConnection("treasure-door", "hallway", "treasure-room", 1.0)
 door.SetPassable(false) // Initially locked
 door.AddRequirement("has_key")
 orchestrator.AddConnection(door)
@@ -1526,8 +1518,7 @@ func createTowerDungeon(orchestrator spatial.RoomOrchestrator, floors int) {
                 fmt.Sprintf("stairs-%d", i),
                 fmt.Sprintf("floor-%d", i-1),
                 fmt.Sprintf("floor-%d", i),
-                spatial.Position{X: 10, Y: 10},
-                spatial.Position{X: 10, Y: 10},
+                2.0,
                 true, // going up
             )
             orchestrator.AddConnection(stairs)
@@ -1545,11 +1536,7 @@ func createBranchingDungeon(orchestrator spatial.RoomOrchestrator, hubRoom spati
         
         // Connect each branch to hub
         door := spatial.CreateDoorConnection(
-            fmt.Sprintf("hub-to-branch-%d", i),
-            hubRoom.GetID(),
-            branch.GetID(),
-            getHubExitPosition(i),
-            getBranchEntryPosition(),
+            fmt.Sprintf("hub-to-branch-%d", i), hubRoom.GetID(), branch.GetID(), 1.0,
         )
         orchestrator.AddConnection(door)
     }
@@ -1573,7 +1560,7 @@ func TestOrchestratorBehavior(t *testing.T) {
     orchestrator.AddRoom(room1)
     orchestrator.AddRoom(room2)
     
-    door := spatial.CreateDoorConnection("door1", "room1", "room2", pos1, pos2)
+    door := spatial.CreateDoorConnection("door1", "room1", "room2", 1.0)
     orchestrator.AddConnection(door)
     
     // Test entity movement

--- a/tools/spatial/README.md
+++ b/tools/spatial/README.md
@@ -678,36 +678,36 @@ eventBus.SubscribeFunc(spatial.EventEntityTransitionBegan, 0, func(ctx context.C
 ```go
 func CreateDungeonExample() {
     // Setup
-    eventBus := events.NewBus()
+    eventBus := events.NewEventBus()
     orchestrator := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
-        ID:       "dungeon-orchestrator",
-        Type:     "orchestrator",
-        EventBus: eventBus,
-        Layout:   spatial.LayoutTypeBranching,
+        ID:     "dungeon-orchestrator",
+        Type:   "orchestrator",
+        Layout: spatial.LayoutTypeBranching,
     })
+    orchestrator.ConnectToEventBus(eventBus) // Optional observer publication.
     
     // Create rooms
     entrance := spatial.NewBasicRoom(spatial.BasicRoomConfig{
         ID:       "entrance",
         Type:     "chamber",
         Grid:     spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
-        EventBus: eventBus,
     })
     
     corridor := spatial.NewBasicRoom(spatial.BasicRoomConfig{
         ID:       "corridor",
         Type:     "hallway",
         Grid:     spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 30, Height: 10}),
-        EventBus: eventBus,
     })
     
     treasureRoom := spatial.NewBasicRoom(spatial.BasicRoomConfig{
         ID:       "treasure",
         Type:     "chamber",
         Grid:     spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 15, Height: 15}),
-        EventBus: eventBus,
     })
-    
+    entrance.ConnectToEventBus(eventBus) // Optional room-event publication.
+    corridor.ConnectToEventBus(eventBus)
+    treasureRoom.ConnectToEventBus(eventBus)
+
     // Add rooms to orchestrator
     orchestrator.AddRoom(entrance)
     orchestrator.AddRoom(corridor)
@@ -725,18 +725,33 @@ func CreateDungeonExample() {
     orchestrator.AddConnection(door1)
     orchestrator.AddConnection(door2)
     
-    // Place entities
+    // Place entities through the managed seam.
     hero := &Character{id: "hero", entityType: "character"}
     monster := &Character{id: "orc", entityType: "monster"}
-    
-    entrance.PlaceEntity(hero, spatial.Position{X: 5, Y: 5})
-    treasureRoom.PlaceEntity(monster, spatial.Position{X: 10, Y: 10})
-    
-    // Move hero through dungeon
-    orchestrator.MoveEntityBetweenRooms("hero", "entrance", "corridor", "entrance-to-corridor")
-    orchestrator.MoveEntityBetweenRooms("hero", "corridor", "treasure", "corridor-to-treasure")
-    
-    // Hero is now in treasure room with the monster
+    _, _ = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+        RoomID: "entrance", Entity: hero, Position: spatial.Position{X: 5, Y: 5},
+    })
+    _, _ = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+        RoomID: "treasure", Entity: monster, Position: spatial.Position{X: 10, Y: 10},
+    })
+
+    // Each abstract transition returns the entity for caller-chosen placement.
+    toCorridor, _ := orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+        EntityID: "hero", FromRoom: "entrance", ToRoom: "corridor",
+        ConnectionID: "entrance-to-corridor",
+    })
+    _, _ = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+        RoomID: "corridor", Entity: toCorridor.Entity, Position: spatial.Position{X: 1, Y: 1},
+    })
+    toTreasure, _ := orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+        EntityID: "hero", FromRoom: "corridor", ToRoom: "treasure",
+        ConnectionID: "corridor-to-treasure",
+    })
+    _, _ = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+        RoomID: "treasure", Entity: toTreasure.Entity, Position: spatial.Position{X: 1, Y: 1},
+    })
+
+    // Hero is physically placed and indexed in the treasure room.
     heroRoom, _ := orchestrator.GetEntityRoom("hero")
     fmt.Printf("Hero is in: %s\n", heroRoom) // "treasure"
 }
@@ -1548,10 +1563,8 @@ func createBranchingDungeon(orchestrator spatial.RoomOrchestrator, hubRoom spati
 ```go
 func TestOrchestratorBehavior(t *testing.T) {
     // Setup
-    eventBus := events.NewBus()
     orchestrator := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
-        ID:       "test-orchestrator",
-        EventBus: eventBus,
+        ID: "test-orchestrator",
     })
     
     // Create test scenario
@@ -1563,24 +1576,30 @@ func TestOrchestratorBehavior(t *testing.T) {
     door := spatial.CreateDoorConnection("door1", "room1", "room2", 1.0)
     orchestrator.AddConnection(door)
     
-    // Test entity movement
+    // Test managed placement and transition.
     entity := createTestEntity("hero")
-    room1.PlaceEntity(entity, spatial.Position{X: 5, Y: 5})
-    
-    // Verify initial state
+    _, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+        RoomID: "room1", Entity: entity, Position: spatial.Position{X: 5, Y: 5},
+    })
+    assert.NoError(t, err)
     roomID, exists := orchestrator.GetEntityRoom("hero")
     assert.True(t, exists)
     assert.Equal(t, "room1", roomID)
-    
-    // Test movement
-    err := orchestrator.MoveEntityBetweenRooms("hero", "room1", "room2", "door1")
+
+    transitioned, err := orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+        EntityID: "hero", FromRoom: "room1", ToRoom: "room2", ConnectionID: "door1",
+    })
     assert.NoError(t, err)
-    
-    // Verify final state
+    _, exists = orchestrator.GetEntityRoom("hero")
+    assert.False(t, exists, "transition is unplaced until managed placement")
+    _, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+        RoomID: "room2", Entity: transitioned.Entity, Position: spatial.Position{X: 1, Y: 1},
+    })
+    assert.NoError(t, err)
     roomID, exists = orchestrator.GetEntityRoom("hero")
     assert.True(t, exists)
     assert.Equal(t, "room2", roomID)
-    
+
     // Test pathfinding
     path, err := orchestrator.FindPath("room1", "room2", entity)
     assert.NoError(t, err)

--- a/tools/spatial/basic_orchestrator.go
+++ b/tools/spatial/basic_orchestrator.go
@@ -27,16 +27,10 @@ type BasicRoomOrchestrator struct {
 	entityRoomTransition  events.TypedTopic[EntityRoomTransitionEvent]
 	layoutChanged         events.TypedTopic[LayoutChangedEvent]
 
-	// Entity event subscriptions
-	entityPlacements events.TypedTopic[EntityPlacedEvent]
-	entityMovements  events.TypedTopic[EntityMovedEvent]
-	entityRemovals   events.TypedTopic[EntityRemovedEvent]
-
-	rooms         map[RoomID]Room
-	connections   map[ConnectionID]Connection
-	entityRooms   map[EntityID]RoomID // entityID -> roomID mapping
-	layout        LayoutType
-	subscriptions []string // Track event subscription IDs for entity events
+	rooms       map[RoomID]Room
+	connections map[ConnectionID]Connection
+	entityRooms map[EntityID]RoomID // entityID -> roomID mapping
+	layout      LayoutType
 }
 
 // BasicRoomOrchestratorConfig holds configuration for creating a basic room orchestrator
@@ -59,13 +53,12 @@ func NewBasicRoomOrchestrator(config BasicRoomOrchestratorConfig) *BasicRoomOrch
 	}
 
 	return &BasicRoomOrchestrator{
-		id:            id,
-		entityType:    config.Type,
-		rooms:         make(map[RoomID]Room),
-		connections:   make(map[ConnectionID]Connection),
-		entityRooms:   make(map[EntityID]RoomID),
-		layout:        layout,
-		subscriptions: make([]string, 0),
+		id:          id,
+		entityType:  config.Type,
+		rooms:       make(map[RoomID]Room),
+		connections: make(map[ConnectionID]Connection),
+		entityRooms: make(map[EntityID]RoomID),
+		layout:      layout,
 	}
 }
 
@@ -90,11 +83,6 @@ func (bro *BasicRoomOrchestrator) SetEventBus(bus events.EventBus) {
 	bro.entityTransitionEnded = EntityTransitionEndedTopic.On(bus)
 	bro.entityRoomTransition = EntityRoomTransitionTopic.On(bus)
 	bro.layoutChanged = LayoutChangedTopic.On(bus)
-
-	// Connect entity event subscriptions
-	bro.entityPlacements = EntityPlacedTopic.On(bus)
-	bro.entityMovements = EntityMovedTopic.On(bus)
-	bro.entityRemovals = EntityRemovedTopic.On(bus)
 }
 
 // GetEventBus returns the current event bus (implements EventBusIntegration)
@@ -118,107 +106,81 @@ func (bro *BasicRoomOrchestrator) GetType() core.EntityType {
 	return core.EntityType(bro.entityType)
 }
 
-// AddRoom adds a room to the orchestrator
+// AddRoom adds a room to the orchestrator. Entities already in the room are
+// indexed synchronously. Adding a room that duplicates an entity already
+// indexed in another managed room fails without changing the orchestrator.
 func (bro *BasicRoomOrchestrator) AddRoom(room Room) error {
 	if room == nil {
 		return fmt.Errorf("room cannot be nil")
 	}
 
-	bro.mu.Lock()
-	defer bro.mu.Unlock()
-
 	roomID := RoomID(room.GetID())
+	roomType := string(room.GetType())
+	entities := room.GetAllEntities()
+
+	bro.mu.Lock()
 	if _, exists := bro.rooms[roomID]; exists {
+		bro.mu.Unlock()
 		return fmt.Errorf("room %s already exists", roomID)
 	}
-
-	bro.rooms[roomID] = room
-
-	// Track all entities currently in this room
-	entities := room.GetAllEntities()
 	for entityIDStr := range entities {
 		entityID := EntityID(entityIDStr)
-		bro.entityRooms[entityID] = roomID
-	}
-
-	// Subscribe to entity events using typed subscriptions (only once)
-	if len(bro.subscriptions) == 0 && bro.entityPlacements != nil {
-		ctx := context.Background()
-		sub1, _ := bro.entityPlacements.Subscribe(ctx, bro.handleEntityPlacedTyped)
-		sub2, _ := bro.entityMovements.Subscribe(ctx, bro.handleEntityMovedTyped)
-		sub3, _ := bro.entityRemovals.Subscribe(ctx, bro.handleEntityRemovedTyped)
-		bro.subscriptions = append(bro.subscriptions, sub1, sub2, sub3)
-	}
-
-	// Emit typed event
-	if bro.roomAdded != nil {
-		event := RoomAddedEvent{
-			OrchestratorID: bro.id.String(),
-			RoomID:         room.GetID(),
-			RoomType:       string(room.GetType()),
-			AddedAt:        time.Now(),
+		if indexedRoom, exists := bro.entityRooms[entityID]; exists {
+			bro.mu.Unlock()
+			return fmt.Errorf("entity %s is already indexed in room %s", entityID, indexedRoom)
 		}
-		_ = bro.roomAdded.Publish(context.Background(), event)
 	}
+	bro.rooms[roomID] = room
+	for entityIDStr := range entities {
+		bro.entityRooms[EntityID(entityIDStr)] = roomID
+	}
+	topic := bro.roomAdded
+	orchestratorID := bro.id.String()
+	bro.mu.Unlock()
 
+	if topic != nil {
+		_ = topic.Publish(context.Background(), RoomAddedEvent{
+			OrchestratorID: orchestratorID,
+			RoomID:         roomID.String(),
+			RoomType:       roomType,
+			AddedAt:        time.Now(),
+		})
+	}
 	return nil
 }
 
-// RemoveRoom removes a room from the orchestrator
+// RemoveRoom removes a room from the orchestrator.
 func (bro *BasicRoomOrchestrator) RemoveRoom(roomIDStr string) error {
 	bro.mu.Lock()
-	defer bro.mu.Unlock()
-
 	roomID := RoomID(roomIDStr)
-	_, exists := bro.rooms[roomID]
-	if !exists {
+	if _, exists := bro.rooms[roomID]; !exists {
+		bro.mu.Unlock()
 		return fmt.Errorf("room %s not found", roomID)
 	}
 
-	// Remove all entity mappings for this room - collect keys first
-	toRemoveEntities := make([]EntityID, 0)
 	for entityID, mappedRoomID := range bro.entityRooms {
 		if mappedRoomID == roomID {
-			toRemoveEntities = append(toRemoveEntities, entityID)
+			delete(bro.entityRooms, entityID)
 		}
 	}
-	for _, entityID := range toRemoveEntities {
-		delete(bro.entityRooms, entityID)
-	}
-
-	// Remove connections that reference this room - collect keys first
-	toRemoveConnections := make([]ConnectionID, 0)
 	for connID, conn := range bro.connections {
 		if conn.GetFromRoom() == roomIDStr || conn.GetToRoom() == roomIDStr {
-			toRemoveConnections = append(toRemoveConnections, connID)
+			delete(bro.connections, connID)
 		}
 	}
-	for _, connID := range toRemoveConnections {
-		delete(bro.connections, connID)
-	}
-
 	delete(bro.rooms, roomID)
+	topic := bro.roomRemoved
+	orchestratorID := bro.id.String()
+	bro.mu.Unlock()
 
-	// Clean up subscriptions when last room is removed
-	if len(bro.rooms) == 0 && bro.entityPlacements != nil {
-		ctx := context.Background()
-		for _, subID := range bro.subscriptions {
-			_ = bro.entityPlacements.Unsubscribe(ctx, subID)
-		}
-		bro.subscriptions = nil
-	}
-
-	// Emit typed event
-	if bro.roomRemoved != nil {
-		event := RoomRemovedEvent{
-			OrchestratorID: bro.id.String(),
+	if topic != nil {
+		_ = topic.Publish(context.Background(), RoomRemovedEvent{
+			OrchestratorID: orchestratorID,
 			RoomID:         roomIDStr,
 			Reason:         "removed",
 			RemovedAt:      time.Now(),
-		}
-		_ = bro.roomRemoved.Publish(context.Background(), event)
+		})
 	}
-
 	return nil
 }
 
@@ -243,73 +205,68 @@ func (bro *BasicRoomOrchestrator) GetAllRooms() map[string]Room {
 	return result
 }
 
-// AddConnection creates a connection between two rooms
+// AddConnection creates a connection between two rooms.
 func (bro *BasicRoomOrchestrator) AddConnection(connection Connection) error {
 	if connection == nil {
 		return fmt.Errorf("connection cannot be nil")
 	}
-
-	bro.mu.Lock()
-	defer bro.mu.Unlock()
-
 	connID := ConnectionID(connection.GetID())
-	if _, exists := bro.connections[connID]; exists {
-		return fmt.Errorf("connection %s already exists", connID)
-	}
-
-	// Validate that both rooms exist
 	fromRoom := RoomID(connection.GetFromRoom())
 	toRoom := RoomID(connection.GetToRoom())
+	connectionType := string(connection.GetConnectionType())
 
+	bro.mu.Lock()
+	if _, exists := bro.connections[connID]; exists {
+		bro.mu.Unlock()
+		return fmt.Errorf("connection %s already exists", connID)
+	}
 	if _, exists := bro.rooms[fromRoom]; !exists {
+		bro.mu.Unlock()
 		return fmt.Errorf("from room %s does not exist", fromRoom)
 	}
-
 	if _, exists := bro.rooms[toRoom]; !exists {
+		bro.mu.Unlock()
 		return fmt.Errorf("to room %s does not exist", toRoom)
 	}
-
 	bro.connections[connID] = connection
+	topic := bro.connectionAdded
+	orchestratorID := bro.id.String()
+	bro.mu.Unlock()
 
-	// Emit typed event
-	if bro.connectionAdded != nil {
-		event := ConnectionAddedEvent{
-			OrchestratorID: bro.id.String(),
-			ConnectionID:   connection.GetID(),
-			FromRoom:       connection.GetFromRoom(),
-			ToRoom:         connection.GetToRoom(),
-			ConnectionType: string(connection.GetConnectionType()),
+	if topic != nil {
+		_ = topic.Publish(context.Background(), ConnectionAddedEvent{
+			OrchestratorID: orchestratorID,
+			ConnectionID:   connID.String(),
+			FromRoom:       fromRoom.String(),
+			ToRoom:         toRoom.String(),
+			ConnectionType: connectionType,
 			AddedAt:        time.Now(),
-		}
-		_ = bro.connectionAdded.Publish(context.Background(), event)
+		})
 	}
-
 	return nil
 }
 
-// RemoveConnection removes a connection
+// RemoveConnection removes a connection.
 func (bro *BasicRoomOrchestrator) RemoveConnection(connectionIDStr string) error {
 	bro.mu.Lock()
-	defer bro.mu.Unlock()
-
 	connectionID := ConnectionID(connectionIDStr)
 	if _, exists := bro.connections[connectionID]; !exists {
+		bro.mu.Unlock()
 		return fmt.Errorf("connection %s not found", connectionID)
 	}
-
 	delete(bro.connections, connectionID)
+	topic := bro.connectionRemoved
+	orchestratorID := bro.id.String()
+	bro.mu.Unlock()
 
-	// Emit typed event
-	if bro.connectionRemoved != nil {
-		event := ConnectionRemovedEvent{
-			OrchestratorID: bro.id.String(),
+	if topic != nil {
+		_ = topic.Publish(context.Background(), ConnectionRemovedEvent{
+			OrchestratorID: orchestratorID,
 			ConnectionID:   connectionIDStr,
 			Reason:         "removed",
 			RemovedAt:      time.Now(),
-		}
-		_ = bro.connectionRemoved.Publish(context.Background(), event)
+		})
 	}
-
 	return nil
 }
 
@@ -347,110 +304,35 @@ func (bro *BasicRoomOrchestrator) GetAllConnections() map[string]Connection {
 	return result
 }
 
-// MoveEntityBetweenRooms moves an entity from one room to another (ADR-0015: Abstract Connections)
+// MoveEntityBetweenRooms preserves the legacy signature for source
+// compatibility. It performs a logical transition only: the entity is removed
+// from the source and remains unplaced and unindexed until PlaceEntity chooses
+// a destination position. New compositions should call TransitionEntity and
+// consume its explicit output.
 func (bro *BasicRoomOrchestrator) MoveEntityBetweenRooms(
 	entityIDStr, fromRoomStr, toRoomStr, connectionIDStr string,
 ) error {
-	bro.mu.Lock()
-	defer bro.mu.Unlock()
-
-	entityID := EntityID(entityIDStr)
-	fromRoom := RoomID(fromRoomStr)
-	toRoom := RoomID(toRoomStr)
-	connectionID := ConnectionID(connectionIDStr)
-
-	if !bro.canMoveEntityBetweenRoomsUnsafe(entityID, fromRoom, toRoom, connectionID) {
-		return fmt.Errorf("cannot move entity %s from %s to %s via %s", entityID, fromRoom, toRoom, connectionID)
-	}
-
-	// Get the rooms
-	fromRoomObj, exists := bro.rooms[fromRoom]
-	if !exists {
-		return fmt.Errorf("from room %s not found", fromRoom)
-	}
-
-	// Verify entity exists in source room
-	entities := fromRoomObj.GetAllEntities()
-	if _, exists := entities[entityIDStr]; !exists {
-		return fmt.Errorf("entity %s not found in room %s", entityID, fromRoom)
-	}
-
-	// Remove from source room
-	err := fromRoomObj.RemoveEntity(entityIDStr)
-	if err != nil {
-		return fmt.Errorf("failed to remove entity from source room: %w", err)
-	}
-
-	// Update entity room mapping
-	bro.entityRooms[entityID] = toRoom
-
-	// Emit typed transition event for game to handle positioning (ADR-0015)
-	if bro.entityRoomTransition != nil {
-		event := EntityRoomTransitionEvent{
-			EntityID:  entityIDStr,
-			FromRoom:  fromRoomStr,
-			ToRoom:    toRoomStr,
-			Reason:    fmt.Sprintf("connection:%s", connectionIDStr),
-			Timestamp: time.Now(),
-		}
-		_ = bro.entityRoomTransition.Publish(context.Background(), event)
-	}
-
-	return nil
+	_, err := bro.TransitionEntity(&TransitionEntityInput{
+		EntityID:     core.EntityID(entityIDStr),
+		FromRoom:     RoomID(fromRoomStr),
+		ToRoom:       RoomID(toRoomStr),
+		ConnectionID: ConnectionID(connectionIDStr),
+	})
+	return err
 }
 
-// CanMoveEntityBetweenRooms checks if entity movement is possible
+// CanMoveEntityBetweenRooms checks whether an indexed, physically present
+// entity can depart through the named connection.
 func (bro *BasicRoomOrchestrator) CanMoveEntityBetweenRooms(
 	entityIDStr, fromRoomStr, toRoomStr, connectionIDStr string,
 ) bool {
-	bro.mu.RLock()
-	defer bro.mu.RUnlock()
-
-	entityID := EntityID(entityIDStr)
-	fromRoom := RoomID(fromRoomStr)
-	toRoom := RoomID(toRoomStr)
-	connectionID := ConnectionID(connectionIDStr)
-
-	return bro.canMoveEntityBetweenRoomsUnsafe(entityID, fromRoom, toRoom, connectionID)
-}
-
-// canMoveEntityBetweenRoomsUnsafe is the internal version that doesn't acquire locks
-func (bro *BasicRoomOrchestrator) canMoveEntityBetweenRoomsUnsafe(
-	entityID EntityID, fromRoom, toRoom RoomID, connectionID ConnectionID,
-) bool {
-	// Check if entity is in the from room
-	if currentRoom, exists := bro.entityRooms[entityID]; !exists || currentRoom != fromRoom {
-		return false
-	}
-
-	// Check if connection exists
-	connection, exists := bro.connections[connectionID]
-	if !exists {
-		return false
-	}
-
-	// Check if connection links the specified rooms (forward or reverse direction)
-	forwardDirection := connection.GetFromRoom() == fromRoom.String() && connection.GetToRoom() == toRoom.String()
-	reverseDirection := connection.IsReversible() && connection.GetFromRoom() == toRoom.String() &&
-		connection.GetToRoom() == fromRoom.String()
-
-	if !forwardDirection && !reverseDirection {
-		return false
-	}
-
-	// Check if connection is passable
-	fromRoomObj, exists := bro.rooms[fromRoom]
-	if !exists {
-		return false
-	}
-
-	entities := fromRoomObj.GetAllEntities()
-	entity, exists := entities[entityID.String()]
-	if !exists {
-		return false
-	}
-
-	return connection.IsPassable(entity)
+	_, _, _, _, ok := bro.transitionSource(
+		core.EntityID(entityIDStr),
+		RoomID(fromRoomStr),
+		RoomID(toRoomStr),
+		ConnectionID(connectionIDStr),
+	)
+	return ok
 }
 
 // GetEntityRoom returns which room contains the entity
@@ -515,68 +397,29 @@ func (bro *BasicRoomOrchestrator) FindPath(fromRoom, toRoom string, entity core.
 	return nil, fmt.Errorf("no path found from %s to %s", fromRoom, toRoom)
 }
 
-// GetLayout returns the current layout pattern
+// GetLayout returns the current layout pattern.
 func (bro *BasicRoomOrchestrator) GetLayout() LayoutType {
+	bro.mu.RLock()
+	defer bro.mu.RUnlock()
 	return bro.layout
 }
 
-// SetLayout configures the arrangement pattern
+// SetLayout configures the arrangement pattern.
 func (bro *BasicRoomOrchestrator) SetLayout(layout LayoutType) error {
+	bro.mu.Lock()
 	oldLayout := bro.layout
 	bro.layout = layout
+	topic := bro.layoutChanged
+	orchestratorID := bro.id.String()
+	bro.mu.Unlock()
 
-	// Emit typed event
-	if bro.layoutChanged != nil {
-		event := LayoutChangedEvent{
-			OrchestratorID: bro.id.String(),
+	if topic != nil {
+		_ = topic.Publish(context.Background(), LayoutChangedEvent{
+			OrchestratorID: orchestratorID,
 			OldLayout:      string(oldLayout),
 			NewLayout:      string(layout),
 			ChangedAt:      time.Now(),
-		}
-		_ = bro.layoutChanged.Publish(context.Background(), event)
+		})
 	}
-
-	return nil
-}
-
-// handleEntityPlacedTyped handles typed entity placement events to track entity locations
-func (bro *BasicRoomOrchestrator) handleEntityPlacedTyped(_ context.Context, event EntityPlacedEvent) error {
-	// Only track if this room is managed by this orchestrator
-	roomTypedID := RoomID(event.RoomID)
-	if _, exists := bro.rooms[roomTypedID]; !exists {
-		return nil
-	}
-
-	entityID := EntityID(event.EntityID)
-	bro.entityRooms[entityID] = roomTypedID
-
-	return nil
-}
-
-// handleEntityMovedTyped handles typed entity movement events to update tracking
-func (bro *BasicRoomOrchestrator) handleEntityMovedTyped(_ context.Context, event EntityMovedEvent) error {
-	// Only track if this room is managed by this orchestrator
-	roomTypedID := RoomID(event.RoomID)
-	if _, exists := bro.rooms[roomTypedID]; !exists {
-		return nil
-	}
-
-	entityID := EntityID(event.EntityID)
-	bro.entityRooms[entityID] = roomTypedID
-
-	return nil
-}
-
-// handleEntityRemovedTyped handles typed entity removal events to update tracking
-func (bro *BasicRoomOrchestrator) handleEntityRemovedTyped(_ context.Context, event EntityRemovedEvent) error {
-	// Only track if this room is managed by this orchestrator
-	roomTypedID := RoomID(event.RoomID)
-	if _, exists := bro.rooms[roomTypedID]; !exists {
-		return nil
-	}
-
-	entityID := EntityID(event.EntityID)
-	delete(bro.entityRooms, entityID)
-
 	return nil
 }

--- a/tools/spatial/doc.go
+++ b/tools/spatial/doc.go
@@ -31,7 +31,14 @@
 //   - behavior: Provides position queries for AI decisions
 //   - spawn: Validates entity placement
 //   - environments: Provides room infrastructure
-//   - events: Publishes movement and room transition events
+//   - events: Optionally publishes movement and room transition observations
+//
+// Standalone rooms are directly mutable. Entity membership in rooms added to a
+// BasicRoomOrchestrator is mutated through ManagedRoomMutator, whose verbs return
+// spatial deltas as values. Events are observer-only and are never consumed by
+// the orchestrator as a hidden result channel. Cross-room TransitionEntity
+// returns the removed entity and leaves it unplaced until managed PlaceEntity
+// chooses a destination position.
 //
 // The spatial package is the foundation for any position-based mechanics
 // but deliberately avoids encoding any game rules about how space is used.

--- a/tools/spatial/examples_test.go
+++ b/tools/spatial/examples_test.go
@@ -347,9 +347,11 @@ func TestMultiRoomOrchestration(t *testing.T) {
 	err = orchestrator.AddConnection(door)
 	require.NoError(t, err)
 
-	// Create and place entity
+	// Create and place entity through the managed-room mutation seam.
 	hero := NewMockEntity("hero", "character")
-	err = room1.PlaceEntity(hero, spatial.Position{X: 5, Y: 5})
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-1", Entity: hero, Position: spatial.Position{X: 5, Y: 5},
+	})
 	require.NoError(t, err)
 
 	// Test pathfinding between rooms
@@ -361,15 +363,23 @@ func TestMultiRoomOrchestration(t *testing.T) {
 	canMove := orchestrator.CanMoveEntityBetweenRooms("hero", "room-1", "room-2", "door-1")
 	assert.True(t, canMove)
 
-	err = orchestrator.MoveEntityBetweenRooms("hero", "room-1", "room-2", "door-1")
+	transition, err := orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+		EntityID: "hero", FromRoom: "room-1", ToRoom: "room-2", ConnectionID: "door-1",
+	})
 	require.NoError(t, err)
+	assert.True(t, transition.Transition.PlacementRequired)
+	_, exists := orchestrator.GetEntityRoom("hero")
+	assert.False(t, exists, "transition is unplaced until the composition chooses a position")
 
-	// Verify entity is now in room-2
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-2", Entity: transition.Entity, Position: spatial.Position{X: 1, Y: 1},
+	})
+	require.NoError(t, err)
 	currentRoom, exists := orchestrator.GetEntityRoom("hero")
 	assert.True(t, exists)
 	assert.Equal(t, "room-2", currentRoom)
 
-	t.Logf("Successfully moved hero from room-1 to room-2 through door-1")
+	t.Logf("Successfully transitioned and placed hero from room-1 to room-2 through door-1")
 }
 
 // TestConnectionTypes demonstrates different connection types

--- a/tools/spatial/go.mod
+++ b/tools/spatial/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.5
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.9.6
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0
 	github.com/google/uuid v1.6.0

--- a/tools/spatial/go.sum
+++ b/tools/spatial/go.sum
@@ -1,5 +1,5 @@
-github.com/KirkDiggler/rpg-toolkit/core v0.9.6 h1:Mqd7jxxiXOfD0vQYzoOrtoa+fqKbVGIY5/Oo7pqbGBk=
-github.com/KirkDiggler/rpg-toolkit/core v0.9.6/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=

--- a/tools/spatial/managed_membership.go
+++ b/tools/spatial/managed_membership.go
@@ -1,0 +1,314 @@
+package spatial
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// ManagedRoomMutator is the supported mutation seam for entity membership in
+// rooms owned by a BasicRoomOrchestrator. Hosts serialize mutating calls; read
+// methods remain safe to call concurrently.
+type ManagedRoomMutator interface {
+	PlaceEntity(in *PlaceEntityInput) (*PlaceEntityOutput, error)
+	MoveEntity(in *MoveEntityInput) (*MoveEntityOutput, error)
+	RemoveEntity(in *RemoveEntityInput) (*RemoveEntityOutput, error)
+	TransitionEntity(in *TransitionEntityInput) (*TransitionEntityOutput, error)
+}
+
+// EntityPlacementDelta describes a completed placement in a managed room.
+type EntityPlacementDelta struct {
+	EntityID core.EntityID
+	RoomID   RoomID
+	Position Position
+}
+
+// EntityMovementDelta describes a completed move within one managed room.
+type EntityMovementDelta struct {
+	EntityID core.EntityID
+	RoomID   RoomID
+	From     Position
+	To       Position
+}
+
+// EntityRemovalDelta describes a completed removal from a managed room.
+type EntityRemovalDelta struct {
+	EntityID core.EntityID
+	RoomID   RoomID
+	Position Position
+}
+
+// EntityTransitionDelta describes a logical room transition after departure.
+// PlacementRequired is true because TransitionEntity does not choose a
+// destination position and therefore does not claim destination membership.
+type EntityTransitionDelta struct {
+	EntityID          core.EntityID
+	FromRoom          RoomID
+	ToRoom            RoomID
+	ConnectionID      ConnectionID
+	PlacementRequired bool
+}
+
+// PlaceEntityInput names an entity, managed room, and destination position.
+type PlaceEntityInput struct {
+	RoomID   RoomID
+	Entity   core.Entity
+	Position Position
+}
+
+// PlaceEntityOutput returns the completed spatial placement as a value.
+type PlaceEntityOutput struct {
+	Delta EntityPlacementDelta
+}
+
+// MoveEntityInput names a managed entity and its new in-room position.
+type MoveEntityInput struct {
+	RoomID   RoomID
+	EntityID core.EntityID
+	To       Position
+}
+
+// MoveEntityOutput returns the completed spatial movement as a value.
+type MoveEntityOutput struct {
+	Delta EntityMovementDelta
+}
+
+// RemoveEntityInput names an entity to remove from a managed room.
+type RemoveEntityInput struct {
+	RoomID   RoomID
+	EntityID core.EntityID
+}
+
+// RemoveEntityOutput returns the removed entity and completed spatial delta.
+type RemoveEntityOutput struct {
+	Entity core.Entity
+	Delta  EntityRemovalDelta
+}
+
+// TransitionEntityInput names a logical transition through a connection.
+type TransitionEntityInput struct {
+	EntityID     core.EntityID
+	FromRoom     RoomID
+	ToRoom       RoomID
+	ConnectionID ConnectionID
+}
+
+// TransitionEntityOutput returns the removed entity, its departure, and the
+// logical transition that a composition must finish with PlaceEntity.
+type TransitionEntityOutput struct {
+	Entity     core.Entity
+	Departure  EntityRemovalDelta
+	Transition EntityTransitionDelta
+}
+
+// PlaceEntity places an entity in a managed room and synchronously indexes its
+// membership. Room publication remains an observer tail and is not consumed by
+// the orchestrator.
+func (bro *BasicRoomOrchestrator) PlaceEntity(in *PlaceEntityInput) (*PlaceEntityOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("place entity: input cannot be nil")
+	}
+	if in.Entity == nil {
+		return nil, fmt.Errorf("place entity: entity cannot be nil")
+	}
+
+	entityID := core.EntityID(in.Entity.GetID())
+	bro.mu.RLock()
+	room, roomExists := bro.rooms[in.RoomID]
+	currentRoom, indexed := bro.entityRooms[EntityID(entityID)]
+	bro.mu.RUnlock()
+	if !roomExists {
+		return nil, fmt.Errorf("place entity: room %s not found", in.RoomID)
+	}
+	if indexed {
+		return nil, fmt.Errorf("place entity: entity %s is already indexed in room %s", entityID, currentRoom)
+	}
+
+	if err := room.PlaceEntity(in.Entity, in.Position); err != nil {
+		return nil, fmt.Errorf("place entity in room %s: %w", in.RoomID, err)
+	}
+
+	bro.mu.Lock()
+	bro.entityRooms[EntityID(entityID)] = in.RoomID
+	bro.mu.Unlock()
+
+	return &PlaceEntityOutput{Delta: EntityPlacementDelta{
+		EntityID: entityID,
+		RoomID:   in.RoomID,
+		Position: in.Position,
+	}}, nil
+}
+
+// MoveEntity moves an indexed entity within its managed room and returns the
+// completed movement. The index remains unchanged.
+func (bro *BasicRoomOrchestrator) MoveEntity(in *MoveEntityInput) (*MoveEntityOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("move entity: input cannot be nil")
+	}
+
+	room, err := bro.indexedRoom(in.RoomID, in.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("move entity: %w", err)
+	}
+	from, exists := room.GetEntityPosition(string(in.EntityID))
+	if !exists {
+		return nil, fmt.Errorf("move entity: entity %s has no position in room %s", in.EntityID, in.RoomID)
+	}
+	if err := room.MoveEntity(string(in.EntityID), in.To); err != nil {
+		return nil, fmt.Errorf("move entity in room %s: %w", in.RoomID, err)
+	}
+
+	return &MoveEntityOutput{Delta: EntityMovementDelta{
+		EntityID: in.EntityID,
+		RoomID:   in.RoomID,
+		From:     from,
+		To:       in.To,
+	}}, nil
+}
+
+// RemoveEntity removes an indexed entity from its managed room, synchronously
+// clears membership, and returns both the entity and spatial removal.
+func (bro *BasicRoomOrchestrator) RemoveEntity(in *RemoveEntityInput) (*RemoveEntityOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("remove entity: input cannot be nil")
+	}
+
+	room, err := bro.indexedRoom(in.RoomID, in.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("remove entity: %w", err)
+	}
+	entity, position, err := entityAndPosition(room, in.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("remove entity: %w", err)
+	}
+	if err := room.RemoveEntity(string(in.EntityID)); err != nil {
+		return nil, fmt.Errorf("remove entity from room %s: %w", in.RoomID, err)
+	}
+
+	bro.mu.Lock()
+	delete(bro.entityRooms, EntityID(in.EntityID))
+	bro.mu.Unlock()
+
+	return &RemoveEntityOutput{
+		Entity: entity,
+		Delta: EntityRemovalDelta{
+			EntityID: in.EntityID,
+			RoomID:   in.RoomID,
+			Position: position,
+		},
+	}, nil
+}
+
+// TransitionEntity removes an entity from its source room through a passable
+// connection and leaves it deliberately unplaced and unindexed. The returned
+// entity and transition value let a composition choose a destination position
+// and finish the operation through PlaceEntity.
+func (bro *BasicRoomOrchestrator) TransitionEntity(
+	in *TransitionEntityInput,
+) (*TransitionEntityOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("transition entity: input cannot be nil")
+	}
+
+	room, connection, entity, position, ok := bro.transitionSource(
+		in.EntityID, in.FromRoom, in.ToRoom, in.ConnectionID,
+	)
+	if !ok {
+		return nil, fmt.Errorf(
+			"cannot transition entity %s from %s to %s via %s",
+			in.EntityID, in.FromRoom, in.ToRoom, in.ConnectionID,
+		)
+	}
+	if err := room.RemoveEntity(string(in.EntityID)); err != nil {
+		return nil, fmt.Errorf("remove entity from source room: %w", err)
+	}
+
+	bro.mu.Lock()
+	delete(bro.entityRooms, EntityID(in.EntityID))
+	topic := bro.entityRoomTransition
+	bro.mu.Unlock()
+
+	if topic != nil {
+		_ = topic.Publish(context.Background(), EntityRoomTransitionEvent{
+			EntityID:  string(in.EntityID),
+			FromRoom:  in.FromRoom.String(),
+			ToRoom:    in.ToRoom.String(),
+			Reason:    fmt.Sprintf("connection:%s", connection.GetID()),
+			Timestamp: time.Now(),
+		})
+	}
+
+	return &TransitionEntityOutput{
+		Entity: entity,
+		Departure: EntityRemovalDelta{
+			EntityID: in.EntityID,
+			RoomID:   in.FromRoom,
+			Position: position,
+		},
+		Transition: EntityTransitionDelta{
+			EntityID:          in.EntityID,
+			FromRoom:          in.FromRoom,
+			ToRoom:            in.ToRoom,
+			ConnectionID:      in.ConnectionID,
+			PlacementRequired: true,
+		},
+	}, nil
+}
+
+func (bro *BasicRoomOrchestrator) indexedRoom(roomID RoomID, entityID core.EntityID) (Room, error) {
+	bro.mu.RLock()
+	indexedRoom, indexed := bro.entityRooms[EntityID(entityID)]
+	room, roomExists := bro.rooms[roomID]
+	bro.mu.RUnlock()
+	if !roomExists {
+		return nil, fmt.Errorf("room %s not found", roomID)
+	}
+	if !indexed || indexedRoom != roomID {
+		return nil, fmt.Errorf("entity %s is not indexed in room %s", entityID, roomID)
+	}
+	return room, nil
+}
+
+func entityAndPosition(room Room, entityID core.EntityID) (core.Entity, Position, error) {
+	entities := room.GetAllEntities()
+	entity, exists := entities[string(entityID)]
+	if !exists {
+		return nil, Position{}, fmt.Errorf("entity %s not found in room %s", entityID, room.GetID())
+	}
+	position, exists := room.GetEntityPosition(string(entityID))
+	if !exists {
+		return nil, Position{}, fmt.Errorf("entity %s has no position in room %s", entityID, room.GetID())
+	}
+	return entity, position, nil
+}
+
+func (bro *BasicRoomOrchestrator) transitionSource(
+	entityID core.EntityID,
+	fromRoom RoomID,
+	toRoom RoomID,
+	connectionID ConnectionID,
+) (Room, Connection, core.Entity, Position, bool) {
+	bro.mu.RLock()
+	indexedRoom, indexed := bro.entityRooms[EntityID(entityID)]
+	room, sourceExists := bro.rooms[fromRoom]
+	_, destinationExists := bro.rooms[toRoom]
+	connection, connectionExists := bro.connections[connectionID]
+	bro.mu.RUnlock()
+
+	if !indexed || indexedRoom != fromRoom || !sourceExists || !destinationExists || !connectionExists {
+		return nil, nil, nil, Position{}, false
+	}
+	forward := connection.GetFromRoom() == fromRoom.String() && connection.GetToRoom() == toRoom.String()
+	reverse := connection.IsReversible() && connection.GetFromRoom() == toRoom.String() &&
+		connection.GetToRoom() == fromRoom.String()
+	if !forward && !reverse {
+		return nil, nil, nil, Position{}, false
+	}
+	entity, position, err := entityAndPosition(room, entityID)
+	if err != nil || !connection.IsPassable(entity) {
+		return nil, nil, nil, Position{}, false
+	}
+	return room, connection, entity, position, true
+}

--- a/tools/spatial/managed_orchestrator_test.go
+++ b/tools/spatial/managed_orchestrator_test.go
@@ -1,0 +1,410 @@
+package spatial_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type ManagedOrchestratorSuite struct {
+	suite.Suite
+}
+
+func TestManagedOrchestratorSuite(t *testing.T) {
+	suite.Run(t, new(ManagedOrchestratorSuite))
+}
+
+func (s *ManagedOrchestratorSuite) TestManagedMembershipWithoutBus() {
+	orchestrator, roomA, roomB := newManagedField()
+	s.Require().NoError(orchestrator.AddRoom(roomA))
+	s.Require().NoError(orchestrator.AddRoom(roomB))
+	s.Require().NoError(orchestrator.AddConnection(spatial.CreateDoorConnection(
+		"door-ab", "room-a", "room-b", 1,
+	)))
+
+	hero := NewMockEntity("hero", "character")
+	placed, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-a", Entity: hero, Position: spatial.Position{X: 1, Y: 1},
+	})
+	s.Require().NoError(err)
+	s.Equal(spatial.EntityPlacementDelta{
+		EntityID: "hero", RoomID: "room-a", Position: spatial.Position{X: 1, Y: 1},
+	}, placed.Delta)
+	roomID, ok := orchestrator.GetEntityRoom("hero")
+	s.True(ok)
+	s.Equal("room-a", roomID)
+	s.True(orchestrator.CanMoveEntityBetweenRooms("hero", "room-a", "room-b", "door-ab"))
+
+	moved, err := orchestrator.MoveEntity(&spatial.MoveEntityInput{
+		RoomID: "room-a", EntityID: "hero", To: spatial.Position{X: 2, Y: 1},
+	})
+	s.Require().NoError(err)
+	s.Equal(spatial.EntityMovementDelta{
+		EntityID: "hero", RoomID: "room-a",
+		From: spatial.Position{X: 1, Y: 1}, To: spatial.Position{X: 2, Y: 1},
+	}, moved.Delta)
+
+	removed, err := orchestrator.RemoveEntity(&spatial.RemoveEntityInput{
+		RoomID: "room-a", EntityID: "hero",
+	})
+	s.Require().NoError(err)
+	s.Equal(spatial.EntityRemovalDelta{
+		EntityID: "hero", RoomID: "room-a", Position: spatial.Position{X: 2, Y: 1},
+	}, removed.Delta)
+	s.Same(hero, removed.Entity)
+	_, ok = orchestrator.GetEntityRoom("hero")
+	s.False(ok)
+	s.False(orchestrator.CanMoveEntityBetweenRooms("hero", "room-a", "room-b", "door-ab"))
+
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-a", Entity: hero, Position: spatial.Position{X: 3, Y: 1},
+	})
+	s.Require().NoError(err)
+	transitioned, err := orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+		EntityID: "hero", FromRoom: "room-a", ToRoom: "room-b", ConnectionID: "door-ab",
+	})
+	s.Require().NoError(err)
+	s.Equal(spatial.EntityRemovalDelta{
+		EntityID: "hero", RoomID: "room-a", Position: spatial.Position{X: 3, Y: 1},
+	}, transitioned.Departure)
+	s.Same(hero, transitioned.Entity)
+	s.Equal(spatial.EntityTransitionDelta{
+		EntityID: "hero", FromRoom: "room-a", ToRoom: "room-b",
+		ConnectionID: "door-ab", PlacementRequired: true,
+	}, transitioned.Transition)
+	_, ok = orchestrator.GetEntityRoom("hero")
+	s.False(ok, "a logical transition without a position must leave the entity honestly unplaced")
+	s.Empty(roomA.GetAllEntities())
+	s.Empty(roomB.GetAllEntities())
+	s.False(orchestrator.CanMoveEntityBetweenRooms("hero", "room-b", "room-a", "door-ab"))
+
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-b", Entity: hero, Position: spatial.Position{X: 4, Y: 1},
+	})
+	s.Require().NoError(err)
+	roomID, ok = orchestrator.GetEntityRoom("hero")
+	s.True(ok)
+	s.Equal("room-b", roomID)
+	s.True(orchestrator.CanMoveEntityBetweenRooms("hero", "room-b", "room-a", "door-ab"))
+}
+
+func (s *ManagedOrchestratorSuite) TestBusWiringDoesNotAffectManagedMembership() {
+	s.Run("bus connected after rooms", func() {
+		orchestrator, roomA, roomB := newManagedField()
+		s.Require().NoError(orchestrator.AddRoom(roomA))
+		s.Require().NoError(orchestrator.AddRoom(roomB))
+		orchestrator.ConnectToEventBus(events.NewEventBus())
+		_, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+			RoomID: "room-a", Entity: NewMockEntity("late-bus", "character"),
+			Position: spatial.Position{X: 1, Y: 1},
+		})
+		s.Require().NoError(err)
+		roomID, ok := orchestrator.GetEntityRoom("late-bus")
+		s.True(ok)
+		s.Equal("room-a", roomID)
+	})
+
+	s.Run("rooms and orchestrator use different buses", func() {
+		orchestrator, roomA, roomB := newManagedField()
+		roomA.ConnectToEventBus(events.NewEventBus())
+		roomB.ConnectToEventBus(events.NewEventBus())
+		orchestrator.ConnectToEventBus(events.NewEventBus())
+		s.Require().NoError(orchestrator.AddRoom(roomA))
+		s.Require().NoError(orchestrator.AddRoom(roomB))
+		_, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+			RoomID: "room-b", Entity: NewMockEntity("split-bus", "character"),
+			Position: spatial.Position{X: 1, Y: 1},
+		})
+		s.Require().NoError(err)
+		roomID, ok := orchestrator.GetEntityRoom("split-bus")
+		s.True(ok)
+		s.Equal("room-b", roomID)
+	})
+}
+
+func (s *ManagedOrchestratorSuite) TestAddRoomIndexesExistingEntities() {
+	orchestrator, roomA, _ := newManagedField()
+	s.Require().NoError(roomA.PlaceEntity(
+		NewMockEntity("already-there", "character"), spatial.Position{X: 1, Y: 1},
+	))
+	s.Require().NoError(orchestrator.AddRoom(roomA))
+	roomID, ok := orchestrator.GetEntityRoom("already-there")
+	s.True(ok)
+	s.Equal("room-a", roomID)
+}
+
+func newManagedField() (*spatial.BasicRoomOrchestrator, *spatial.BasicRoom, *spatial.BasicRoom) {
+	orchestrator := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
+		ID: "field", Type: "orchestrator",
+	})
+	room := func(id string) *spatial.BasicRoom {
+		return spatial.NewBasicRoom(spatial.BasicRoomConfig{
+			ID: id, Type: "chamber",
+			Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10}),
+		})
+	}
+	return orchestrator, room("room-a"), room("room-b")
+}
+
+var _ spatial.ManagedRoomMutator = (*spatial.BasicRoomOrchestrator)(nil)
+var _ core.Entity = (*MockEntity)(nil)
+
+func (s *ManagedOrchestratorSuite) TestAddRoomRejectsDuplicateEntityWithoutPartialMutation() {
+	orchestrator, roomA, roomB := newManagedField()
+	s.Require().NoError(roomA.PlaceEntity(
+		NewMockEntity("duplicate", "character"), spatial.Position{X: 1, Y: 1},
+	))
+	s.Require().NoError(roomB.PlaceEntity(
+		NewMockEntity("duplicate", "monster"), spatial.Position{X: 2, Y: 2},
+	))
+	s.Require().NoError(orchestrator.AddRoom(roomA))
+
+	err := orchestrator.AddRoom(roomB)
+	s.Require().Error(err)
+	_, added := orchestrator.GetRoom("room-b")
+	s.False(added, "failed AddRoom must not partially add the room")
+	roomID, indexed := orchestrator.GetEntityRoom("duplicate")
+	s.True(indexed)
+	s.Equal("room-a", roomID)
+}
+
+func (s *ManagedOrchestratorSuite) TestManagedEventsRemainObserverOnlyAndCausal() {
+	bus := events.NewEventBus()
+	orchestrator, roomA, roomB := newManagedField()
+	orchestrator.ConnectToEventBus(bus)
+	roomA.ConnectToEventBus(bus)
+	roomB.ConnectToEventBus(bus)
+	s.Require().NoError(orchestrator.AddRoom(roomA))
+	s.Require().NoError(orchestrator.AddRoom(roomB))
+	s.Require().NoError(orchestrator.AddConnection(spatial.CreateDoorConnection(
+		"door-ab", "room-a", "room-b", 1,
+	)))
+
+	var order []string
+	var placed []spatial.EntityPlacedEvent
+	var moved []spatial.EntityMovedEvent
+	var removed []spatial.EntityRemovedEvent
+	var transitioned []spatial.EntityRoomTransitionEvent
+	_, err := spatial.EntityPlacedTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, event spatial.EntityPlacedEvent,
+	) error {
+		_, _ = orchestrator.GetEntityRoom(event.EntityID) // synchronous re-entrant read must not deadlock
+		order = append(order, "placed")
+		placed = append(placed, event)
+		return nil
+	})
+	s.Require().NoError(err)
+	_, err = spatial.EntityMovedTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, event spatial.EntityMovedEvent,
+	) error {
+		_, _ = orchestrator.GetEntityRoom(event.EntityID)
+		order = append(order, "moved")
+		moved = append(moved, event)
+		return nil
+	})
+	s.Require().NoError(err)
+	_, err = spatial.EntityRemovedTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, event spatial.EntityRemovedEvent,
+	) error {
+		_, _ = orchestrator.GetEntityRoom(event.EntityID)
+		order = append(order, "removed")
+		removed = append(removed, event)
+		return nil
+	})
+	s.Require().NoError(err)
+	_, err = spatial.EntityRoomTransitionTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, event spatial.EntityRoomTransitionEvent,
+	) error {
+		_, _ = orchestrator.GetEntityRoom(event.EntityID)
+		order = append(order, "transition")
+		transitioned = append(transitioned, event)
+		return nil
+	})
+	s.Require().NoError(err)
+
+	hero := NewMockEntity("observer-hero", "character")
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-a", Entity: hero, Position: spatial.Position{X: 1, Y: 1},
+	})
+	s.Require().NoError(err)
+	_, err = orchestrator.MoveEntity(&spatial.MoveEntityInput{
+		RoomID: "room-a", EntityID: "observer-hero", To: spatial.Position{X: 2, Y: 1},
+	})
+	s.Require().NoError(err)
+	s.Require().NoError(orchestrator.MoveEntityBetweenRooms(
+		"observer-hero", "room-a", "room-b", "door-ab",
+	))
+	removedHero := NewMockEntity("removed-hero", "character")
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-a", Entity: removedHero, Position: spatial.Position{X: 3, Y: 1},
+	})
+	s.Require().NoError(err)
+	_, err = orchestrator.RemoveEntity(&spatial.RemoveEntityInput{
+		RoomID: "room-a", EntityID: "removed-hero",
+	})
+	s.Require().NoError(err)
+
+	s.Equal([]string{"placed", "moved", "removed", "transition", "placed", "removed"}, order)
+	s.Equal([]spatial.EntityPlacedEvent{
+		{
+			EntityID: "observer-hero", Position: spatial.Position{X: 1, Y: 1},
+			RoomID: "room-a", GridType: "square",
+		},
+		{
+			EntityID: "removed-hero", Position: spatial.Position{X: 3, Y: 1},
+			RoomID: "room-a", GridType: "square",
+		},
+	}, placed)
+	s.Equal([]spatial.EntityMovedEvent{{
+		EntityID:     "observer-hero",
+		FromPosition: spatial.Position{X: 1, Y: 1}, ToPosition: spatial.Position{X: 2, Y: 1},
+		RoomID: "room-a", MovementType: "normal",
+	}}, moved)
+	s.Equal([]spatial.EntityRemovedEvent{
+		{
+			EntityID: "observer-hero", Position: spatial.Position{X: 2, Y: 1},
+			RoomID: "room-a", RemovalType: "normal",
+		},
+		{
+			EntityID: "removed-hero", Position: spatial.Position{X: 3, Y: 1},
+			RoomID: "room-a", RemovalType: "normal",
+		},
+	}, removed)
+	s.Require().Len(transitioned, 1)
+	s.Equal("observer-hero", transitioned[0].EntityID)
+	s.Equal("room-a", transitioned[0].FromRoom)
+	s.Equal("room-b", transitioned[0].ToRoom)
+	s.Equal("connection:door-ab", transitioned[0].Reason)
+	s.False(transitioned[0].Timestamp.IsZero())
+}
+
+func (s *ManagedOrchestratorSuite) TestObserverFailureAndValidationFailureDoNotControlMutation() {
+	bus := events.NewEventBus()
+	orchestrator, roomA, roomB := newManagedField()
+	orchestrator.ConnectToEventBus(bus)
+	roomA.ConnectToEventBus(bus)
+	s.Require().NoError(orchestrator.AddRoom(roomA))
+	s.Require().NoError(orchestrator.AddRoom(roomB))
+	s.Require().NoError(orchestrator.AddConnection(spatial.CreateDoorConnection(
+		"door-ab", "room-a", "room-b", 1,
+	)))
+	var placed, moved, removed, transitioned int
+	_, err := spatial.EntityPlacedTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, _ spatial.EntityPlacedEvent,
+	) error {
+		placed++
+		return errors.New("observer failed")
+	})
+	s.Require().NoError(err)
+	_, err = spatial.EntityMovedTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, _ spatial.EntityMovedEvent,
+	) error {
+		moved++
+		return nil
+	})
+	s.Require().NoError(err)
+	_, err = spatial.EntityRemovedTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, _ spatial.EntityRemovedEvent,
+	) error {
+		removed++
+		return nil
+	})
+	s.Require().NoError(err)
+	_, err = spatial.EntityRoomTransitionTopic.On(bus).Subscribe(context.Background(), func(
+		_ context.Context, _ spatial.EntityRoomTransitionEvent,
+	) error {
+		transitioned++
+		return nil
+	})
+	s.Require().NoError(err)
+
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "missing", Entity: NewMockEntity("rejected", "character"),
+		Position: spatial.Position{X: 1, Y: 1},
+	})
+	s.Require().Error(err)
+	s.Zero(placed)
+
+	hero := NewMockEntity("fallible-observer", "character")
+	out, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-a", Entity: hero, Position: spatial.Position{X: 1, Y: 1},
+	})
+	s.Require().NoError(err, "subscriber errors are observer-tail failures, not mutation results")
+	s.Equal(core.EntityID("fallible-observer"), out.Delta.EntityID)
+	roomID, indexed := orchestrator.GetEntityRoom("fallible-observer")
+	s.True(indexed)
+	s.Equal("room-a", roomID)
+
+	_, err = orchestrator.MoveEntity(&spatial.MoveEntityInput{
+		RoomID: "room-a", EntityID: "fallible-observer", To: spatial.Position{X: 99, Y: 99},
+	})
+	s.Require().Error(err)
+	_, err = orchestrator.RemoveEntity(&spatial.RemoveEntityInput{
+		RoomID: "room-b", EntityID: "fallible-observer",
+	})
+	s.Require().Error(err)
+	_, err = orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+		EntityID: "fallible-observer", FromRoom: "room-a", ToRoom: "room-b", ConnectionID: "missing",
+	})
+	s.Require().Error(err)
+	position, exists := roomA.GetEntityPosition("fallible-observer")
+	s.True(exists)
+	s.Equal(spatial.Position{X: 1, Y: 1}, position)
+	s.Equal(1, placed)
+	s.Zero(moved)
+	s.Zero(removed)
+	s.Zero(transitioned)
+}
+
+func (s *ManagedOrchestratorSuite) TestEntityNotificationsAreObserverOnlyAndRaceFree() {
+	bus := events.NewEventBus()
+	orchestrator := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
+		ID:   "field",
+		Type: "orchestrator",
+	})
+	orchestrator.ConnectToEventBus(bus)
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   "room-a",
+		Type: "chamber",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10}),
+	})
+	s.Require().NoError(orchestrator.AddRoom(room))
+
+	topic := spatial.EntityPlacedTopic.On(bus)
+	const workers = 8
+	const publications = 500
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers*publications)
+	wg.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func(worker int) {
+			defer wg.Done()
+			for n := 0; n < publications; n++ {
+				entityID := fmt.Sprintf("observer-event-%d-%d", worker, n)
+				if err := topic.Publish(context.Background(), spatial.EntityPlacedEvent{
+					EntityID: entityID,
+					RoomID:   "room-a",
+				}); err != nil {
+					errCh <- err
+				}
+				_, _ = orchestrator.GetEntityRoom(entityID)
+			}
+		}(worker)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		s.Require().NoError(err)
+	}
+
+	_, tracked := orchestrator.GetEntityRoom("observer-event-0-0")
+	s.False(tracked, "observer notifications must not mutate the orchestrator index")
+}

--- a/tools/spatial/orchestrator.go
+++ b/tools/spatial/orchestrator.go
@@ -54,7 +54,9 @@ type Connection interface {
 	GetRequirements() []string
 }
 
-// RoomOrchestrator manages multiple rooms and their connections
+// RoomOrchestrator is the legacy topology and query contract for multiple
+// rooms. BasicRoomOrchestrator also implements the additive ManagedRoomMutator
+// entity-membership seam; this interface stays unchanged for source compatibility.
 type RoomOrchestrator interface {
 	core.Entity
 	EventBusIntegration
@@ -86,7 +88,9 @@ type RoomOrchestrator interface {
 	// GetAllConnections returns all connections
 	GetAllConnections() map[string]Connection
 
-	// MoveEntityBetweenRooms moves an entity from one room to another
+	// MoveEntityBetweenRooms performs a logical departure through a connection.
+	// The entity is unplaced until ManagedRoomMutator.PlaceEntity selects a
+	// destination position. Prefer TransitionEntity for its explicit output.
 	MoveEntityBetweenRooms(entityID, fromRoom, toRoom, connectionID string) error
 
 	// CanMoveEntityBetweenRooms checks if entity movement is possible

--- a/tools/spatial/orchestrator_test.go
+++ b/tools/spatial/orchestrator_test.go
@@ -136,88 +136,54 @@ func TestBasicConnectionSystem(t *testing.T) {
 }
 
 func TestEntityMovementBetweenRooms(t *testing.T) {
-	t.Skip("Skipping until spawn layer is implemented to handle entity placement via events (ADR-0015)")
-	// Setup
 	eventBus := events.NewEventBus()
 	orchestrator := spatial.NewBasicRoomOrchestrator(spatial.BasicRoomOrchestratorConfig{
-		ID:     "movement-orchestrator",
-		Type:   "orchestrator",
-		Layout: spatial.LayoutTypeOrganic,
+		ID: "movement-orchestrator", Type: "orchestrator", Layout: spatial.LayoutTypeOrganic,
 	})
 	orchestrator.ConnectToEventBus(eventBus)
-
-	// Create rooms
-	grid1 := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10})
 	room1 := spatial.NewBasicRoom(spatial.BasicRoomConfig{
-		ID:   "room-a",
-		Type: "chamber",
-		Grid: grid1,
+		ID: "room-a", Type: "chamber",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10}),
 	})
 	room1.ConnectToEventBus(eventBus)
-
-	grid2 := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10})
 	room2 := spatial.NewBasicRoom(spatial.BasicRoomConfig{
-		ID:   "room-b",
-		Type: "chamber",
-		Grid: grid2,
+		ID: "room-b", Type: "chamber",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10}),
 	})
 	room2.ConnectToEventBus(eventBus)
+	require.NoError(t, orchestrator.AddRoom(room1))
+	require.NoError(t, orchestrator.AddRoom(room2))
+	require.NoError(t, orchestrator.AddConnection(spatial.CreateDoorConnection(
+		"door-ab", "room-a", "room-b", 1,
+	)))
 
-	err := orchestrator.AddRoom(room1)
-	require.NoError(t, err)
-	err = orchestrator.AddRoom(room2)
-	require.NoError(t, err)
-
-	// Create connection
-	door := spatial.CreateDoorConnection(
-		"door-ab",
-		"room-a", "room-b",
-		1.0, // Standard movement cost
-	)
-	err = orchestrator.AddConnection(door)
-	require.NoError(t, err)
-
-	// Create and place an entity
 	entity := NewMockEntity("hero", "character")
-	err = room1.PlaceEntity(entity, spatial.Position{X: 5, Y: 5})
+	_, err := orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-a", Entity: entity, Position: spatial.Position{X: 5, Y: 5},
+	})
 	require.NoError(t, err)
-
-	// Verify entity room tracking
 	currentRoom, exists := orchestrator.GetEntityRoom("hero")
 	assert.True(t, exists)
 	assert.Equal(t, "room-a", currentRoom)
+	assert.True(t, orchestrator.CanMoveEntityBetweenRooms("hero", "room-a", "room-b", "door-ab"))
 
-	// Test movement capability
-	canMove := orchestrator.CanMoveEntityBetweenRooms("hero", "room-a", "room-b", "door-ab")
-	assert.True(t, canMove)
+	// The legacy wrapper keeps its signature but now reports the physical
+	// truth: departure leaves the entity unplaced until managed placement.
+	require.NoError(t, orchestrator.MoveEntityBetweenRooms("hero", "room-a", "room-b", "door-ab"))
+	_, exists = orchestrator.GetEntityRoom("hero")
+	assert.False(t, exists)
+	assert.Empty(t, room1.GetAllEntities())
+	assert.Empty(t, room2.GetAllEntities())
+	assert.False(t, orchestrator.CanMoveEntityBetweenRooms("hero", "room-b", "room-a", "door-ab"))
 
-	// Test actual movement
-	err = orchestrator.MoveEntityBetweenRooms("hero", "room-a", "room-b", "door-ab")
+	_, err = orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID: "room-b", Entity: entity, Position: spatial.Position{X: 4, Y: 4},
+	})
 	require.NoError(t, err)
-
-	// Verify entity moved
-	currentRoom, exists = orchestrator.GetEntityRoom("hero")
-	assert.True(t, exists)
-	assert.Equal(t, "room-b", currentRoom)
-
-	// Verify entity is no longer in source room (ADR-0015: Abstract Connections)
-	entitiesInRoomA := room1.GetAllEntities()
-	assert.NotContains(t, entitiesInRoomA, "hero")
-
-	// Note: In abstract connection mode, entity placement in destination room
-	// is handled by game layer via events. The orchestrator only tracks logical room assignment.
-
-	// Test reverse movement (door is bidirectional)
-	canMoveBack := orchestrator.CanMoveEntityBetweenRooms("hero", "room-b", "room-a", "door-ab")
-	assert.True(t, canMoveBack)
-
-	err = orchestrator.MoveEntityBetweenRooms("hero", "room-b", "room-a", "door-ab")
-	require.NoError(t, err)
-
-	// Verify entity moved back
-	currentRoom, exists = orchestrator.GetEntityRoom("hero")
-	assert.True(t, exists)
-	assert.Equal(t, "room-a", currentRoom)
+	assert.True(t, orchestrator.CanMoveEntityBetweenRooms("hero", "room-b", "room-a", "door-ab"))
+	require.NoError(t, orchestrator.MoveEntityBetweenRooms("hero", "room-b", "room-a", "door-ab"))
+	_, exists = orchestrator.GetEntityRoom("hero")
+	assert.False(t, exists)
 }
 
 func TestPathfinding(t *testing.T) {


### PR DESCRIPTION
## Summary

- add the additive `ManagedRoomMutator` seam on `BasicRoomOrchestrator`, with single-input placement, movement, removal, and transition verbs returning typed spatial deltas
- remove the orchestrator's entity-event subscriptions so its entity→room index is updated synchronously by the mutation authority rather than by observer notifications
- make positionless room transitions honest: transition returns the removed `core.Entity`, leaves it unplaced/unindexed with `PlacementRequired=true`, and lets the composition finish through managed placement
- preserve standalone `Room` mutation, existing observer topics/payloads/order, and the shipped `RoomOrchestrator` interface
- reject duplicate pre-populated entity IDs during `AddRoom` without partial mutation and document the unsupported Go-alias bypasses

## Verification

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go test -race -coverprofile=/tmp/rpg-toolkit-909-spatial-coverage.txt -covermode=atomic -count=1 ./...` — 75.6%
- `go build ./...`
- `go vet ./...`
- `golangci-lint v2.3.1 run ./...` — 0 issues (the CI-pinned version)
- `gorelease ... -base v0.7.0` — compatible additive API; suggested `tools/spatial/v0.8.0`
- focused pre-fix race reproduction reported `entityRooms` concurrent map writes/read-write races and could terminate with `fatal error: concurrent map writes`; the retained focused test is green under `-race`
- root `make pre-commit` reached green core/events format, tidy, lint, and core race tests, then hit the existing core coverage-parser defect (`core/mock coverage: 0.0%` text passed into `bc`); the changed spatial module's pinned CI-equivalent gates above are green

## Compatibility

The exported API change is additive and `RoomOrchestrator` is unchanged. The intentional behavioral correction is that legacy `MoveEntityBetweenRooms` no longer claims destination membership without a destination position: after departure, `GetEntityRoom` and `CanMoveEntityBetweenRooms` return false until managed `PlaceEntity`. `gorelease` classifies the API as compatible and recommends the next minor tag, `tools/spatial/v0.8.0`.

Closes #909

— rpg-toolkit agent, on behalf of KirkDiggler