### PR TITLE
feat(play/interrupt): the ledger of open windows — Pose/Answer custody

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -6,6 +6,7 @@ on:
       - 'play/clock/**'
       - 'play/intel/**'
       - 'play/record/**'
+      - 'play/interrupt/**'
 
 jobs:
   gorelease-play-clock:
@@ -64,3 +65,22 @@ jobs:
           fi
           cd play/record
           go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base "${base#play/record/}"
+
+  gorelease-play-interrupt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: gorelease play/interrupt
+        run: |
+          base=$(git tag -l 'play/interrupt/v*' --sort=-v:refname | head -1)
+          if [ -z "$base" ]; then
+            echo "no play/interrupt tag yet — first release, gate activates from the first tag"
+            exit 0
+          fi
+          cd play/interrupt
+          go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base "${base#play/interrupt/}"

--- a/play/interrupt/data.go
+++ b/play/interrupt/data.go
@@ -42,6 +42,12 @@ func (l *Ledger) ToData() LedgerData {
 		return LedgerData{}
 	}
 
+	// All-answered: NextID persists, Windows stays nil — symmetric with
+	// the zero-value shape a caller writes as LedgerData{NextID: n}.
+	if len(l.windows) == 0 {
+		return LedgerData{NextID: l.nextID}
+	}
+
 	// Deep-copy each window's options and payload
 	windowsCopy := make([]WindowData, len(l.windows))
 	for i, w := range l.windows {
@@ -91,9 +97,10 @@ func (l *Ledger) ToData() LedgerData {
 func LoadLedger(data LedgerData) (*Ledger, error) {
 	// R5: validate everything first, then construct
 
-	// R9: NextID == 0 with windows present
-	if data.NextID == 0 && len(data.Windows) > 0 {
-		return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+	// R9: a stored NextID of 1 is unreachable (the record precedent:
+	// 0 = fresh, first Pose advances to 2; ToData never emits 1).
+	if data.NextID == 1 {
+		return nil, fmt.Errorf("load ledger: next_id 1 is unreachable: %w", ErrInvalidData)
 	}
 
 	// R9: per-window validations
@@ -101,27 +108,29 @@ func LoadLedger(data LedgerData) (*Ledger, error) {
 	for i, wd := range data.Windows {
 		// R9: window ID of 0
 		if wd.ID == 0 {
-			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+			return nil, fmt.Errorf("load ledger: window[%d]: id 0: %w", i, ErrInvalidData)
 		}
 
 		// R9: strictly ascending IDs (covers duplicates and descending)
 		if i > 0 && wd.ID <= prevID {
-			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+			return nil, fmt.Errorf("load ledger: window[%d]: id not ascending: %w", i, ErrInvalidData)
 		}
 
-		// R9: ID >= NextID
+		// R9: ID >= NextID. With NextID 0 every window ID trips this, so
+		// it also subsumes NextID-0-with-windows — including the
+		// math.MaxUint64 wraparound forgery — with no dedicated branch.
 		if uint64(wd.ID) >= data.NextID {
-			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+			return nil, fmt.Errorf("load ledger: window[%d]: id >= next_id: %w", i, ErrInvalidData)
 		}
 
 		// R9: empty audience
 		if wd.Audience == "" {
-			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+			return nil, fmt.Errorf("load ledger: window[%d]: empty audience: %w", i, ErrInvalidData)
 		}
 
 		// R9: nil or empty options
 		if len(wd.Options) == 0 {
-			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+			return nil, fmt.Errorf("load ledger: window[%d]: no options: %w", i, ErrInvalidData)
 		}
 
 		// R9: per-option validations
@@ -129,12 +138,12 @@ func LoadLedger(data LedgerData) (*Ledger, error) {
 		for _, opt := range wd.Options {
 			// R9: empty option token
 			if opt == "" {
-				return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+				return nil, fmt.Errorf("load ledger: window[%d]: empty option: %w", i, ErrInvalidData)
 			}
 
 			// R9: duplicate option
 			if _, exists := seen[opt]; exists {
-				return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+				return nil, fmt.Errorf("load ledger: window[%d]: duplicate option: %w", i, ErrInvalidData)
 			}
 			seen[opt] = struct{}{}
 		}

--- a/play/interrupt/data.go
+++ b/play/interrupt/data.go
@@ -81,15 +81,16 @@ func (l *Ledger) ToData() LedgerData {
 // Deep-copies all data: mutating the caller's LedgerData after LoadLedger will not
 // affect the loaded Ledger (R4).
 //
-// R9 validations (deterministic order):
-// - NextID == 0 with any windows present (IDs are assigned from 1; violation covers wraparound forgery)
-// - Any window ID of 0 (IDs start from 1)
-// - Window IDs not strictly ascending in slice order (covers duplicates and descending)
-// - Any window ID >= NextID (ID must be less than the next ID to assign)
-// - Empty audience (required for every window)
-// - Nil or empty options slice (required for every window — liveness guard)
-// - Any empty option token (required for every option)
-// - Any duplicate option token within a window (options are distinct choices)
+// R9 validations, in the implementation's deterministic order:
+// - A stored NextID of exactly 1 (fresh is 0; the first Pose advances to 2)
+// - Then per window, in slice order:
+//   - Window ID of 0 (IDs start from 1)
+//   - IDs not strictly ascending (covers duplicates and descending)
+//   - ID >= NextID — with NextID 0 every window trips this, so it also
+//     subsumes NextID-0-with-windows, wraparound forgery included
+//   - Empty audience
+//   - Nil or empty options slice (liveness guard)
+//   - Any empty option token, then any duplicate option token
 //
 // Nil payload is LEGAL — Pose accepts nil payloads (reachable by design),
 // and payload is omitempty, so rejecting would make LoadLedger refuse the module's own snapshots.

--- a/play/interrupt/data.go
+++ b/play/interrupt/data.go
@@ -1,0 +1,176 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package interrupt
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// LedgerData is the persistent representation of a Ledger.
+// It marshals to empty JSON {} when idle (R8 convention).
+// NextID is the next ID to assign; Windows is the ordered slice of open windows.
+type LedgerData struct {
+	NextID  uint64       `json:"next_id,omitempty"`
+	Windows []WindowData `json:"windows,omitempty"`
+}
+
+// WindowData is the persistent representation of an open Window.
+// ID, Audience, and Options are never empty in reachable states (no omitempty).
+// Payload is omitempty because nil payloads are legal (reachable by design via Pose).
+// At is opaque provenance and omitempty to save space in common idle cases.
+type WindowData struct {
+	ID       WindowID      `json:"id"`
+	Audience core.EntityID `json:"audience"`
+	Options  []Option      `json:"options"`
+	Payload  []byte        `json:"payload,omitempty"`
+	At       uint64        `json:"at,omitempty"`
+}
+
+// ToData returns a persistent snapshot of this Ledger.
+// Returns zero LedgerData (nil Windows slice, NextID normalized to 0) if Ledger is idle.
+// Idle = no windows ever posed (NextID == 1, the initial state).
+// All-answered = windows were posed but now closed (NextID > 1, Windows empty);
+// NextID persists so IDs are never reused within an encounter.
+// All options and payload bytes are deep-copied; mutating the returned LedgerData
+// will not affect this Ledger (R8 snapshot immunity).
+func (l *Ledger) ToData() LedgerData {
+	if len(l.windows) == 0 && l.nextID == 1 {
+		// Idle convention: return zero value, marshals to {}
+		return LedgerData{}
+	}
+
+	// Deep-copy each window's options and payload
+	windowsCopy := make([]WindowData, len(l.windows))
+	for i, w := range l.windows {
+		optionsCopy := make([]Option, len(w.Options))
+		copy(optionsCopy, w.Options)
+
+		var payloadCopy []byte
+		if w.Payload != nil {
+			payloadCopy = make([]byte, len(w.Payload))
+			copy(payloadCopy, w.Payload)
+		}
+
+		windowsCopy[i] = WindowData{
+			ID:       w.ID,
+			Audience: w.Audience,
+			Options:  optionsCopy,
+			Payload:  payloadCopy,
+			At:       w.At,
+		}
+	}
+
+	return LedgerData{
+		NextID:  l.nextID,
+		Windows: windowsCopy,
+	}
+}
+
+// LoadLedger reconstructs a Ledger from persistent data.
+// Validates every field against R9 in a fixed order before constructing anything (R5).
+// Returns (*Ledger, error). On error, returns nil and error wrapping ErrInvalidData.
+// Deep-copies all data: mutating the caller's LedgerData after LoadLedger will not
+// affect the loaded Ledger (R4).
+//
+// R9 validations (deterministic order):
+// - NextID == 0 with any windows present (IDs are assigned from 1; violation covers wraparound forgery)
+// - Any window ID of 0 (IDs start from 1)
+// - Window IDs not strictly ascending in slice order (covers duplicates and descending)
+// - Any window ID >= NextID (ID must be less than the next ID to assign)
+// - Empty audience (required for every window)
+// - Nil or empty options slice (required for every window — liveness guard)
+// - Any empty option token (required for every option)
+// - Any duplicate option token within a window (options are distinct choices)
+//
+// Nil payload is LEGAL — Pose accepts nil payloads (reachable by design),
+// and payload is omitempty, so rejecting would make LoadLedger refuse the module's own snapshots.
+// At is never validated (opaque provenance).
+func LoadLedger(data LedgerData) (*Ledger, error) {
+	// R5: validate everything first, then construct
+
+	// R9: NextID == 0 with windows present
+	if data.NextID == 0 && len(data.Windows) > 0 {
+		return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+	}
+
+	// R9: per-window validations
+	var prevID WindowID
+	for i, wd := range data.Windows {
+		// R9: window ID of 0
+		if wd.ID == 0 {
+			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+		}
+
+		// R9: strictly ascending IDs (covers duplicates and descending)
+		if i > 0 && wd.ID <= prevID {
+			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+		}
+
+		// R9: ID >= NextID
+		if uint64(wd.ID) >= data.NextID {
+			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+		}
+
+		// R9: empty audience
+		if wd.Audience == "" {
+			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+		}
+
+		// R9: nil or empty options
+		if len(wd.Options) == 0 {
+			return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+		}
+
+		// R9: per-option validations
+		seen := make(map[Option]struct{})
+		for _, opt := range wd.Options {
+			// R9: empty option token
+			if opt == "" {
+				return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+			}
+
+			// R9: duplicate option
+			if _, exists := seen[opt]; exists {
+				return nil, fmt.Errorf("load ledger: %w", ErrInvalidData)
+			}
+			seen[opt] = struct{}{}
+		}
+
+		prevID = wd.ID
+	}
+
+	// All validated; now reconstruct the Ledger with deep-copied data
+	windowsCopy := make([]Window, len(data.Windows))
+	for i, wd := range data.Windows {
+		optionsCopy := make([]Option, len(wd.Options))
+		copy(optionsCopy, wd.Options)
+
+		var payloadCopy []byte
+		if wd.Payload != nil {
+			payloadCopy = make([]byte, len(wd.Payload))
+			copy(payloadCopy, wd.Payload)
+		}
+
+		windowsCopy[i] = Window{
+			ID:       wd.ID,
+			Audience: wd.Audience,
+			Options:  optionsCopy,
+			Payload:  payloadCopy,
+			At:       wd.At,
+		}
+	}
+
+	// Normalize NextID: idle case (NextID == 0 from marshaled {}) starts at 1
+	nextID := data.NextID
+	if nextID == 0 {
+		nextID = 1
+	}
+
+	return &Ledger{
+		nextID:  nextID,
+		windows: windowsCopy,
+	}, nil
+}

--- a/play/interrupt/doc.go
+++ b/play/interrupt/doc.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package interrupt is the ledger of open windows: suspension-as-value
+// custody for resolutions that stop and wait for an outside decision.
+// Pose opens a window (one audience entity, offered option tokens, an
+// opaque frozen payload); Answer validates, closes it, and returns the
+// envelope for the rulebook to resume. The module never interprets an
+// option, a choice, or a payload byte — custody, not execution. Human
+// and machine deciders are indistinguishable here: an auto-taken
+// reaction is an ordinary Pose answered immediately by composition.
+//
+// Design contract: docs/ideas/play/interrupt/design.md (R1–R10). Leaf
+// module: depends only on core, no context.Context, deltas returned as
+// values, never published.
+package interrupt

--- a/play/interrupt/errors.go
+++ b/play/interrupt/errors.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package interrupt
+
+import "errors"
+
+// Sentinel errors — the module's error vocabulary (design: Errors).
+// All returned errors wrap exactly one of these; callers dispatch with
+// errors.Is. Messages are user-facing.
+var (
+	// ErrNilInput reports a nil *XxxInput. Caller defect, dedicated sentinel.
+	ErrNilInput = errors.New("nil input")
+	// ErrNoAudience reports an empty audience entity ID (Pose.Audience,
+	// Answer.By, PendingFor.Audience).
+	ErrNoAudience = errors.New("empty audience")
+	// ErrNoOptions reports a Pose with no options — an unanswerable
+	// window would deadlock the encounter (the liveness guard).
+	ErrNoOptions = errors.New("no options offered")
+	// ErrNoOption reports an empty option token (in Pose options or as
+	// an Answer choice).
+	ErrNoOption = errors.New("empty option")
+	// ErrDuplicateOption reports a repeated option token within one window.
+	ErrDuplicateOption = errors.New("duplicate option")
+	// ErrNotOpen reports no open window with that ID — unknown, never
+	// posed, or already answered (one answer per window).
+	ErrNotOpen = errors.New("window not open")
+	// ErrNotAudience reports an answerer who is not the window's audience.
+	ErrNotAudience = errors.New("not the window's audience")
+	// ErrNotOffered reports a choice that is not among the window's options.
+	ErrNotOffered = errors.New("choice not offered")
+	// ErrInvalidData reports persisted state rejected by LoadLedger (design R9).
+	ErrInvalidData = errors.New("invalid ledger data")
+)

--- a/play/interrupt/errors_test.go
+++ b/play/interrupt/errors_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package interrupt_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/interrupt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSentinelsAreDistinct(t *testing.T) {
+	sentinels := []error{
+		interrupt.ErrNilInput,
+		interrupt.ErrNoAudience,
+		interrupt.ErrNoOptions,
+		interrupt.ErrNoOption,
+		interrupt.ErrDuplicateOption,
+		interrupt.ErrNotOpen,
+		interrupt.ErrNotAudience,
+		interrupt.ErrNotOffered,
+		interrupt.ErrInvalidData,
+	}
+
+	// Each sentinel must be non-nil
+	for i, sentinel := range sentinels {
+		assert.NotNil(t, sentinel, "sentinel at index %d is nil", i)
+	}
+
+	// Pairwise distinct via errors.Is
+	for i, sentinelI := range sentinels {
+		for j, sentinelJ := range sentinels {
+			if i == j {
+				// Same sentinel should match itself
+				assert.True(t, errors.Is(sentinelI, sentinelJ),
+					"sentinel at index %d should match itself", i)
+			} else {
+				// Different sentinels should not match
+				assert.False(t, errors.Is(sentinelI, sentinelJ),
+					"sentinel at index %d should not match sentinel at index %d", i, j)
+			}
+		}
+	}
+}

--- a/play/interrupt/go.mod
+++ b/play/interrupt/go.mod
@@ -1,0 +1,11 @@
+module github.com/KirkDiggler/rpg-toolkit/play/interrupt
+
+go 1.24
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/play/interrupt/go.mod
+++ b/play/interrupt/go.mod
@@ -2,7 +2,10 @@ module github.com/KirkDiggler/rpg-toolkit/play/interrupt
 
 go 1.24
 
-require github.com/stretchr/testify v1.9.0
+require (
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
+	github.com/stretchr/testify v1.9.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/play/interrupt/go.sum
+++ b/play/interrupt/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/play/interrupt/go.sum
+++ b/play/interrupt/go.sum
@@ -1,3 +1,5 @@
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/play/interrupt/ledger.go
+++ b/play/interrupt/ledger.go
@@ -116,6 +116,79 @@ func (l *Ledger) Pose(in *PoseInput) (*PoseOutput, error) {
 	}, nil
 }
 
+// AnswerInput carries the parameters for closing an interrupt window.
+type AnswerInput struct {
+	Window WindowID
+	By     core.EntityID
+	Choice Option
+}
+
+// AnswerOutput reports the window that was closed and the choice that was accepted.
+type AnswerOutput struct {
+	Window Window
+	Choice Option
+}
+
+// Answer closes an open interrupt window. Validates in order: nil input, audience (By),
+// choice (empty), lookup by ID, authorization (By must match window's audience),
+// membership (Choice must be in options). On any validation error, the window remains
+// open and unchanged (R5 atomicity). On success, removes the window from the ledger
+// and returns a deep copy of the window plus the accepted choice. One answer per
+// window: a second Answer to the same ID is ErrNotOpen.
+func (l *Ledger) Answer(in *AnswerInput) (*AnswerOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("answer: %w", ErrNilInput)
+	}
+
+	if in.By == "" {
+		return nil, fmt.Errorf("answer: %w", ErrNoAudience)
+	}
+
+	if in.Choice == "" {
+		return nil, fmt.Errorf("answer: %w", ErrNoOption)
+	}
+
+	// Lookup the window by ID
+	windowIndex := -1
+	var window Window
+	for i, w := range l.windows {
+		if w.ID == in.Window {
+			windowIndex = i
+			window = w
+			break
+		}
+	}
+
+	if windowIndex == -1 {
+		return nil, fmt.Errorf("answer: %w", ErrNotOpen)
+	}
+
+	// Check authorization: By must match the window's audience
+	if in.By != window.Audience {
+		return nil, fmt.Errorf("answer: %w", ErrNotAudience)
+	}
+
+	// Check membership: Choice must be in the window's options
+	found := false
+	for _, opt := range window.Options {
+		if opt == in.Choice {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("answer: %w", ErrNotOffered)
+	}
+
+	// All validation passed; splice out the window and return a deep copy
+	l.windows = append(l.windows[:windowIndex], l.windows[windowIndex+1:]...)
+
+	return &AnswerOutput{
+		Window: l.copyWindow(window),
+		Choice: in.Choice,
+	}, nil
+}
+
 // PendingForInput carries the query for open windows an audience may answer.
 type PendingForInput struct {
 	Audience core.EntityID

--- a/play/interrupt/ledger.go
+++ b/play/interrupt/ledger.go
@@ -180,11 +180,16 @@ func (l *Ledger) Answer(in *AnswerInput) (*AnswerOutput, error) {
 		return nil, fmt.Errorf("answer: %w", ErrNotOffered)
 	}
 
-	// All validation passed; splice out the window and return a deep copy
+	// All validation passed; splice out the window. The envelope is
+	// returned WITHOUT a defensive copy — ownership transfer (design,
+	// Answer row): after removal nothing internal retains the window,
+	// so a copy here would guard nothing and its pin could never fail.
+	// Queries copy out because internal state stays; Answer transfers
+	// because it removes.
 	l.windows = append(l.windows[:windowIndex], l.windows[windowIndex+1:]...)
 
 	return &AnswerOutput{
-		Window: l.copyWindow(window),
+		Window: window,
 		Choice: in.Choice,
 	}, nil
 }

--- a/play/interrupt/ledger.go
+++ b/play/interrupt/ledger.go
@@ -133,7 +133,8 @@ type AnswerOutput struct {
 // choice (empty), lookup by ID, authorization (By must match window's audience),
 // membership (Choice must be in options). On any validation error, the window remains
 // open and unchanged (R5 atomicity). On success, removes the window from the ledger
-// and returns a deep copy of the window plus the accepted choice. One answer per
+// and returns the window itself plus the accepted choice — ownership transfer, not a
+// copy (design, Answer row): after removal nothing internal retains it. One answer per
 // window: a second Answer to the same ID is ErrNotOpen.
 func (l *Ledger) Answer(in *AnswerInput) (*AnswerOutput, error) {
 	if in == nil {
@@ -186,7 +187,12 @@ func (l *Ledger) Answer(in *AnswerInput) (*AnswerOutput, error) {
 	// so a copy here would guard nothing and its pin could never fail.
 	// Queries copy out because internal state stays; Answer transfers
 	// because it removes.
-	l.windows = append(l.windows[:windowIndex], l.windows[windowIndex+1:]...)
+	copy(l.windows[windowIndex:], l.windows[windowIndex+1:])
+	// Zero the vacated tail slot: without this the backing array would
+	// retain the transferred window's option/payload slices (visible to
+	// nothing, but "nothing internal retains it" should be literally true).
+	l.windows[len(l.windows)-1] = Window{}
+	l.windows = l.windows[:len(l.windows)-1]
 
 	return &AnswerOutput{
 		Window: window,

--- a/play/interrupt/ledger.go
+++ b/play/interrupt/ledger.go
@@ -1,0 +1,172 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package interrupt
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// WindowID is a unique identifier for an open window, assigned monotonically from 1.
+type WindowID uint64
+
+// Option is an opaque token representing one offered choice.
+// The module validates only non-emptiness and uniqueness within a window.
+type Option string
+
+// Window is the read-side value representing an open interrupt window.
+// The Audience is the entity authorized to answer; Options are the offered choices;
+// Payload is opaque frozen resolution data; At is caller-supplied provenance.
+type Window struct {
+	ID       WindowID
+	Audience core.EntityID
+	Options  []Option
+	Payload  []byte
+	At       uint64
+}
+
+// Ledger is the container for all open windows in an encounter.
+// It tracks interrupt windows and assigns monotonically increasing IDs.
+// Not safe for concurrent use. Construct via NewLedger.
+type Ledger struct {
+	nextID  uint64
+	windows []Window
+}
+
+// NewLedger creates a new empty Ledger.
+func NewLedger() (*Ledger, error) {
+	return &Ledger{
+		nextID:  1,
+		windows: make([]Window, 0),
+	}, nil
+}
+
+// PoseInput carries the parameters for opening a new interrupt window.
+type PoseInput struct {
+	Audience core.EntityID
+	Options  []Option
+	Payload  []byte
+	At       uint64
+}
+
+// PoseOutput reports the window that was opened.
+type PoseOutput struct {
+	Window Window
+}
+
+// Pose opens a new interrupt window. Validates in order: nil input, audience,
+// options (non-empty), then per-option in slice order: empty token, duplicate.
+// On any validation error, no state changes (R5 atomicity). On success, assigns
+// a monotonically increasing ID, deep-copies the options and payload, appends
+// to the ledger, and returns the stored window (deep-copied).
+func (l *Ledger) Pose(in *PoseInput) (*PoseOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("pose: %w", ErrNilInput)
+	}
+
+	if in.Audience == "" {
+		return nil, fmt.Errorf("pose: %w", ErrNoAudience)
+	}
+
+	if len(in.Options) == 0 {
+		return nil, fmt.Errorf("pose: %w", ErrNoOptions)
+	}
+
+	// Validate options in order: empty first, then duplicates
+	seen := make(map[Option]struct{})
+	for _, opt := range in.Options {
+		if opt == "" {
+			return nil, fmt.Errorf("pose: %w", ErrNoOption)
+		}
+		if _, exists := seen[opt]; exists {
+			return nil, fmt.Errorf("pose: %w", ErrDuplicateOption)
+		}
+		seen[opt] = struct{}{}
+	}
+
+	// All validation passed; now assign ID and store
+	id := WindowID(l.nextID)
+	l.nextID++
+
+	// Deep-copy options and payload
+	optionsCopy := make([]Option, len(in.Options))
+	copy(optionsCopy, in.Options)
+
+	var payloadCopy []byte
+	if in.Payload != nil {
+		payloadCopy = make([]byte, len(in.Payload))
+		copy(payloadCopy, in.Payload)
+	}
+
+	// Create and append the window
+	window := Window{
+		ID:       id,
+		Audience: in.Audience,
+		Options:  optionsCopy,
+		Payload:  payloadCopy,
+		At:       in.At,
+	}
+	l.windows = append(l.windows, window)
+
+	// Return a deep copy of the stored window
+	return &PoseOutput{
+		Window: l.copyWindow(window),
+	}, nil
+}
+
+// PendingForInput carries the query for open windows an audience may answer.
+type PendingForInput struct {
+	Audience core.EntityID
+}
+
+// PendingFor returns all open windows for a given audience in pose order,
+// with deep-copied options and payload. Unknown audience returns empty slice, nil error.
+// Validates: nil input, audience. Returns ErrNilInput or ErrNoAudience on defective input.
+func (l *Ledger) PendingFor(in *PendingForInput) ([]Window, error) {
+	if in == nil {
+		return nil, fmt.Errorf("pending-for: %w", ErrNilInput)
+	}
+
+	if in.Audience == "" {
+		return nil, fmt.Errorf("pending-for: %w", ErrNoAudience)
+	}
+
+	result := make([]Window, 0, len(l.windows))
+	for _, w := range l.windows {
+		if w.Audience == in.Audience {
+			result = append(result, l.copyWindow(w))
+		}
+	}
+	return result, nil
+}
+
+// Open returns all open windows in pose order, with deep-copied options and payload.
+func (l *Ledger) Open() ([]Window, error) {
+	result := make([]Window, 0, len(l.windows))
+	for _, w := range l.windows {
+		result = append(result, l.copyWindow(w))
+	}
+	return result, nil
+}
+
+// copyWindow returns a deep copy of a window with independent options and payload.
+func (l *Ledger) copyWindow(w Window) Window {
+	optionsCopy := make([]Option, len(w.Options))
+	copy(optionsCopy, w.Options)
+
+	var payloadCopy []byte
+	if w.Payload != nil {
+		payloadCopy = make([]byte, len(w.Payload))
+		copy(payloadCopy, w.Payload)
+	}
+
+	return Window{
+		ID:       w.ID,
+		Audience: w.Audience,
+		Options:  optionsCopy,
+		Payload:  payloadCopy,
+		At:       w.At,
+	}
+}

--- a/play/interrupt/ledger.go
+++ b/play/interrupt/ledger.go
@@ -126,11 +126,11 @@ type PendingForInput struct {
 // Validates: nil input, audience. Returns ErrNilInput or ErrNoAudience on defective input.
 func (l *Ledger) PendingFor(in *PendingForInput) ([]Window, error) {
 	if in == nil {
-		return nil, fmt.Errorf("pending-for: %w", ErrNilInput)
+		return nil, fmt.Errorf("pending for: %w", ErrNilInput)
 	}
 
 	if in.Audience == "" {
-		return nil, fmt.Errorf("pending-for: %w", ErrNoAudience)
+		return nil, fmt.Errorf("pending for: %w", ErrNoAudience)
 	}
 
 	result := make([]Window, 0, len(l.windows))

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -4,6 +4,8 @@
 package interrupt_test
 
 import (
+	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -24,6 +26,7 @@ const (
 	optShield    = "shield"
 	optDecline   = "decline"
 	optCorrupted = "corrupted"
+	optAttack    = "attack"
 	testMonster  = "monster"
 	testGrunk    = "grunk"
 )
@@ -160,7 +163,7 @@ func (s *LedgerSuite) TestSeveralWindowsOneAudience() {
 func (s *LedgerSuite) TestAudienceIsolation() {
 	_, err := s.ledger.Pose(&interrupt.PoseInput{
 		Audience: testAudience,
-		Options:  []interrupt.Option{optShield},
+		Options:  []interrupt.Option{testShield},
 		Payload:  []byte("frozen"),
 		At:       1,
 	})
@@ -267,7 +270,10 @@ func (s *LedgerSuite) TestPoseAtomicityFromPopulatedState() {
 	s.Require().Len(open, 1, "failed Pose must not add a window (R5)")
 	s.Equal(first.Window, open[0], "failed Pose must not disturb existing windows (R5)")
 
-	second, err := s.ledger.Pose(&interrupt.PoseInput{Audience: "grunk", Options: []interrupt.Option{"attack"}})
+	second, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testGrunk),
+		Options:  []interrupt.Option{optAttack},
+	})
 	s.Require().NoError(err)
 	s.Equal(interrupt.WindowID(2), second.Window.ID, "failed Pose must not consume an ID (R5)")
 }
@@ -444,7 +450,7 @@ func (s *LedgerSuite) TestQueryValidation() {
 // returns the table's windows in the order they were posed, not
 // grouped by audience.
 func (s *LedgerSuite) TestOpenPoseOrderInterleaved() {
-	for _, aud := range []core.EntityID{testAudience, "grunk", testAudience} {
+	for _, aud := range []core.EntityID{testAudience, testGrunk, testAudience} {
 		_, err := s.ledger.Pose(&interrupt.PoseInput{Audience: aud, Options: []interrupt.Option{optShield}})
 		s.Require().NoError(err)
 	}
@@ -482,6 +488,552 @@ func (s *LedgerSuite) TestDeciderContract() {
 	open, err := s.ledger.Open()
 	s.Require().NoError(err)
 	s.Empty(open, "posed and answered in one host call — the world never observed a wait")
+}
+
+// PersistenceSuite tests persistence via ToData/LoadLedger (Task 5, R8/R9).
+type PersistenceSuite struct {
+	suite.Suite
+}
+
+// TestIdleToDataDeepEqualsZero pins R8 idle convention: NewLedger().ToData()
+// deep-equals the zero LedgerData (not a struct with empty slices).
+func (s *PersistenceSuite) TestIdleToDataDeepEqualsZero() {
+	idle, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+	data := idle.ToData()
+	zero := interrupt.LedgerData{}
+	s.Equal(zero, data, "idle ledger ToData must deep-equal zero LedgerData")
+}
+
+// TestIdleToDataMarshalToEmptyJSON pins R8: idle marshals to exactly {}.
+func (s *PersistenceSuite) TestIdleToDataMarshalToEmptyJSON() {
+	idle, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+	data := idle.ToData()
+	bs, err := json.Marshal(data)
+	s.Require().NoError(err)
+	s.Equal([]byte("{}"), bs, "idle ledger must marshal to exactly {}")
+}
+
+// TestIdleLoadLedgerUsable pins idle load must be usable (can Pose, gets ID 1).
+func (s *PersistenceSuite) TestIdleLoadLedgerUsable() {
+	ledger, err := interrupt.LoadLedger(interrupt.LedgerData{})
+	s.Require().NoError(err)
+	s.NotNil(ledger)
+
+	// Can Pose and gets ID 1
+	out, err := ledger.Pose(&interrupt.PoseInput{
+		Audience: "test",
+		Options:  []interrupt.Option{"opt"},
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(1), out.Window.ID)
+}
+
+// TestRoundTripFresh pins fresh state round-trip.
+func (s *PersistenceSuite) TestRoundTripFresh() {
+	ledger1, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	data := ledger1.ToData()
+	ledger2, err := interrupt.LoadLedger(data)
+	s.Require().NoError(err)
+
+	// Both should be idle
+	open1, err := ledger1.Open()
+	s.Require().NoError(err)
+	s.Empty(open1)
+
+	open2, err := ledger2.Open()
+	s.Require().NoError(err)
+	s.Empty(open2)
+}
+
+// TestRoundTripOpenWindows pins round-trip with open windows including nil payload.
+func (s *PersistenceSuite) TestRoundTripOpenWindows() {
+	ledger1, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	// Pose window 1: with payload
+	out1, err := ledger1.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  []byte("frozen"),
+		At:       7,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(1), out1.Window.ID)
+
+	// Pose window 2: nil payload
+	out2, err := ledger1.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testGrunk),
+		Options:  []interrupt.Option{optAttack, testDecline},
+		Payload:  nil,
+		At:       0,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(2), out2.Window.ID)
+
+	// Snapshot and reload
+	data := ledger1.ToData()
+	ledger2, err := interrupt.LoadLedger(data)
+	s.Require().NoError(err)
+
+	// Verify both windows are present and intact
+	open, err := ledger2.Open()
+	s.Require().NoError(err)
+	s.Len(open, 2)
+	s.Equal(interrupt.WindowID(1), open[0].ID)
+	s.Equal(core.EntityID("aldric"), open[0].Audience)
+	s.Equal([]byte("frozen"), open[0].Payload)
+	s.Equal(uint64(7), open[0].At)
+
+	s.Equal(interrupt.WindowID(2), open[1].ID)
+	s.Equal(core.EntityID("grunk"), open[1].Audience)
+	s.Nil(open[1].Payload)
+	s.Equal(uint64(0), open[1].At)
+}
+
+// TestRoundTripAllAnswered pins all-answered state (NextID > 0, zero windows).
+func (s *PersistenceSuite) TestRoundTripAllAnswered() {
+	ledger1, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	// Pose and answer
+	out, err := ledger1.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  []byte("frozen"),
+	})
+	s.Require().NoError(err)
+
+	_, err = ledger1.Answer(&interrupt.AnswerInput{
+		Window: out.Window.ID,
+		By:     testAudience,
+		Choice: testShield,
+	})
+	s.Require().NoError(err)
+
+	// Snapshot and reload
+	data := ledger1.ToData()
+	ledger2, err := interrupt.LoadLedger(data)
+	s.Require().NoError(err)
+
+	// No open windows
+	open, err := ledger2.Open()
+	s.Require().NoError(err)
+	s.Empty(open)
+
+	// But next Pose continues the ID sequence
+	out2, err := ledger2.Pose(&interrupt.PoseInput{
+		Audience: testGrunk,
+		Options:  []interrupt.Option{optAttack},
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(2), out2.Window.ID)
+}
+
+// TestRoundTripAnswerIntact pins Answer after reload returns same envelope.
+func (s *PersistenceSuite) TestRoundTripAnswerIntact() {
+	ledger1, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	posed, err := ledger1.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{testShield},
+		Payload:  []byte("frozen"),
+	})
+	s.Require().NoError(err)
+
+	// Snapshot before answer
+	data := ledger1.ToData()
+	ledger2, err := interrupt.LoadLedger(data)
+	s.Require().NoError(err)
+
+	// Answer on reloaded ledger
+	answer, err := ledger2.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     testAudience,
+		Choice: testShield,
+	})
+	s.Require().NoError(err)
+	s.Equal(posed.Window.ID, answer.Window.ID)
+	s.Equal([]byte("frozen"), answer.Window.Payload)
+}
+
+// TestGoldenJSONFresh pins fresh state golden JSON.
+func (s *PersistenceSuite) TestGoldenJSONFresh() {
+	idle, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+	data := idle.ToData()
+	bs, err := json.Marshal(data)
+	s.Require().NoError(err)
+	s.Equal(string(bs), "{}")
+}
+
+// TestGoldenJSONOpen pins open windows golden JSON with exact-string pin.
+func (s *PersistenceSuite) TestGoldenJSONOpen() {
+	ledger, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	// Pose two windows as per design spec
+	_, err = ledger.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  []byte("frozen"),
+		At:       7,
+	})
+	s.Require().NoError(err)
+
+	_, err = ledger.Pose(&interrupt.PoseInput{
+		Audience: testGrunk,
+		Options:  []interrupt.Option{optAttack, testDecline},
+		Payload:  nil,
+		At:       0,
+	})
+	s.Require().NoError(err)
+
+	data := ledger.ToData()
+	bs, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	expected := `{"next_id":3,"windows":[{"id":1,"audience":"aldric",` +
+		`"options":["shield","decline"],"payload":"ZnJvemVu","at":7},` +
+		`{"id":2,"audience":"grunk","options":["attack","decline"]}]}`
+	s.Equal(expected, string(bs))
+}
+
+// TestGoldenJSONAllAnswered pins all-answered state golden JSON.
+func (s *PersistenceSuite) TestGoldenJSONAllAnswered() {
+	ledger, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	out, err := ledger.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  []byte("frozen"),
+	})
+	s.Require().NoError(err)
+
+	_, err = ledger.Answer(&interrupt.AnswerInput{
+		Window: out.Window.ID,
+		By:     testAudience,
+		Choice: testShield,
+	})
+	s.Require().NoError(err)
+
+	data := ledger.ToData()
+	bs, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	expected := `{"next_id":2}`
+	s.Equal(expected, string(bs))
+}
+
+// TestToDataSnapshotImmunity pins ToData immunity: mutating returned Data
+// must not affect ledger.
+func (s *PersistenceSuite) TestToDataSnapshotImmunity() {
+	ledger, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	_, err = ledger.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  []byte("frozen"),
+	})
+	s.Require().NoError(err)
+
+	data := ledger.ToData()
+
+	// Mutate returned data's slices
+	if len(data.Windows) > 0 {
+		data.Windows[0].Payload[0] = 'X'
+		if len(data.Windows[0].Options) > 0 {
+			data.Windows[0].Options[0] = "corrupted"
+		}
+	}
+
+	// Re-query: internal state unchanged
+	open, err := ledger.Open()
+	s.Require().NoError(err)
+	s.Len(open, 1)
+	s.Equal([]byte("frozen"), open[0].Payload)
+	s.Equal([]interrupt.Option{testShield, testDecline}, open[0].Options)
+}
+
+// TestLoadLedgerAliasing pins LoadLedger immunity: mutating caller's Data
+// after Load must not affect ledger.
+func (s *PersistenceSuite) TestLoadLedgerAliasing() {
+	ledger1, err := interrupt.NewLedger()
+	s.Require().NoError(err)
+
+	_, err = ledger1.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  []byte("frozen"),
+	})
+	s.Require().NoError(err)
+
+	data := ledger1.ToData()
+
+	// Load the ledger
+	ledger2, err := interrupt.LoadLedger(data)
+	s.Require().NoError(err)
+
+	// Mutate the caller's data
+	if len(data.Windows) > 0 {
+		data.Windows[0].Payload[0] = 'X'
+		if len(data.Windows[0].Options) > 0 {
+			data.Windows[0].Options[0] = "corrupted"
+		}
+	}
+
+	// Loaded ledger is unaffected
+	open, err := ledger2.Open()
+	s.Require().NoError(err)
+	s.Len(open, 1)
+	s.Equal([]byte("frozen"), open[0].Payload)
+	s.Equal([]interrupt.Option{testShield, testDecline}, open[0].Options)
+}
+
+// TestR9RejectionNextIDZeroWithWindows rejects R9: NextID == 0 with windows present.
+func (s *PersistenceSuite) TestR9RejectionNextIDZeroWithWindows() {
+	data := interrupt.LedgerData{
+		NextID: 0,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield},
+				Payload:  []byte("frozen"),
+				At:       0,
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionWindowIDZero rejects R9: window ID of 0.
+func (s *PersistenceSuite) TestR9RejectionWindowIDZero() {
+	data := interrupt.LedgerData{
+		NextID: 1,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       0,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionDescendingIDs rejects R9: window IDs not strictly ascending.
+func (s *PersistenceSuite) TestR9RejectionDescendingIDs() {
+	data := interrupt.LedgerData{
+		NextID: 3,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       2,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield},
+			},
+			{
+				ID:       1,
+				Audience: testGrunk,
+				Options:  []interrupt.Option{optAttack},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionDuplicateIDs rejects R9: duplicate window IDs.
+func (s *PersistenceSuite) TestR9RejectionDuplicateIDs() {
+	data := interrupt.LedgerData{
+		NextID: 2,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield},
+			},
+			{
+				ID:       1,
+				Audience: testGrunk,
+				Options:  []interrupt.Option{optAttack},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionIDEqualNextID rejects R9: window ID == NextID.
+func (s *PersistenceSuite) TestR9RejectionIDEqualNextID() {
+	data := interrupt.LedgerData{
+		NextID: 1,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionIDGreaterNextID rejects R9: window ID > NextID.
+func (s *PersistenceSuite) TestR9RejectionIDGreaterNextID() {
+	data := interrupt.LedgerData{
+		NextID: 1,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       2,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionEmptyAudience rejects R9: empty audience.
+func (s *PersistenceSuite) TestR9RejectionEmptyAudience() {
+	data := interrupt.LedgerData{
+		NextID: 2,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: "",
+				Options:  []interrupt.Option{testShield},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionNilOptions rejects R9: nil options.
+func (s *PersistenceSuite) TestR9RejectionNilOptions() {
+	data := interrupt.LedgerData{
+		NextID: 2,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: testAudience,
+				Options:  nil,
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionEmptyOptionsSlice rejects R9: empty options slice.
+func (s *PersistenceSuite) TestR9RejectionEmptyOptionsSlice() {
+	data := interrupt.LedgerData{
+		NextID: 2,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: testAudience,
+				Options:  []interrupt.Option{},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionEmptyOptionToken rejects R9: empty option token.
+func (s *PersistenceSuite) TestR9RejectionEmptyOptionToken() {
+	data := interrupt.LedgerData{
+		NextID: 2,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield, "", "decline"},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionDuplicateOption rejects R9: duplicate option within a window.
+func (s *PersistenceSuite) TestR9RejectionDuplicateOption() {
+	data := interrupt.LedgerData{
+		NextID: 2,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       1,
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield, "decline", "shield"},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9AcceptanceNextIDWithZeroWindows pins R9 acceptance: NextID > 0
+// with zero windows MUST load (all-answered state).
+func (s *PersistenceSuite) TestR9AcceptanceNextIDWithZeroWindows() {
+	data := interrupt.LedgerData{
+		NextID:  3,
+		Windows: []interrupt.WindowData{},
+	}
+	ledger, err := interrupt.LoadLedger(data)
+	s.Require().NoError(err)
+	s.NotNil(ledger)
+
+	// Verify next Pose continues ID sequence
+	out, err := ledger.Pose(&interrupt.PoseInput{
+		Audience: "grunk",
+		Options:  []interrupt.Option{"attack"},
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(3), out.Window.ID)
+}
+
+// TestR9WraparoundForgerMaxUint64 rejects R9: window with ID MaxUint64 and NextID 0.
+func (s *PersistenceSuite) TestR9WraparoundForgerMaxUint64() {
+	data := interrupt.LedgerData{
+		NextID: 0,
+		Windows: []interrupt.WindowData{
+			{
+				ID:       interrupt.WindowID(math.MaxUint64),
+				Audience: testAudience,
+				Options:  []interrupt.Option{testShield},
+			},
+		},
+	}
+	_, err := interrupt.LoadLedger(data)
+	s.Require().Error(err)
+	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+func TestPersistenceSuite(t *testing.T) {
+	suite.Run(t, new(PersistenceSuite))
 }
 
 func TestLedgerSuite(t *testing.T) {

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -13,9 +13,17 @@ import (
 )
 
 const (
-	testAldric  = core.EntityID("aldric")
-	testShield  = interrupt.Option("shield")
-	testDecline = interrupt.Option("decline")
+	testAldric  = core.EntityID(testAudience)
+	testShield  = interrupt.Option(optShield)
+	testDecline = interrupt.Option(optDecline)
+)
+
+// Shared test vocabulary (goconst: repeated literals become consts).
+const (
+	testAudience = "aldric"
+	optShield    = "shield"
+	optDecline   = "decline"
+	optCorrupted = "corrupted"
 )
 
 type LedgerSuite struct {
@@ -149,8 +157,8 @@ func (s *LedgerSuite) TestSeveralWindowsOneAudience() {
 
 func (s *LedgerSuite) TestAudienceIsolation() {
 	_, err := s.ledger.Pose(&interrupt.PoseInput{
-		Audience: "aldric",
-		Options:  []interrupt.Option{"shield"},
+		Audience: testAudience,
+		Options:  []interrupt.Option{optShield},
 		Payload:  []byte("frozen"),
 		At:       1,
 	})
@@ -160,7 +168,7 @@ func (s *LedgerSuite) TestAudienceIsolation() {
 	s.Require().NoError(err)
 	s.Empty(pending, "bob should see no windows for aldric")
 
-	pendingAldric, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: "aldric"})
+	pendingAldric, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAudience})
 	s.Require().NoError(err)
 	s.Len(pendingAldric, 1, "aldric should see their own window")
 }
@@ -187,6 +195,79 @@ func (s *LedgerSuite) TestAtIsOpaque() {
 	s.Len(open, 2)
 	s.Equal(uint64(9), open[0].At, "At values stored verbatim, no ordering")
 	s.Equal(uint64(2), open[1].At)
+}
+
+// TestCopyOutImmunity pins the copy-out direction on all three read
+// surfaces (AC2): mutating a returned Window must never corrupt the
+// ledger's internal state.
+func (s *LedgerSuite) TestCopyOutImmunity() {
+	posed, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{optShield, optDecline},
+		Payload:  []byte("frozen"),
+		At:       7,
+	})
+	s.Require().NoError(err)
+
+	// Surface 1: Pose's returned Window
+	posed.Window.Options[0] = optCorrupted
+	posed.Window.Payload[0] = 'X'
+
+	// Surface 2: PendingFor
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAudience})
+	s.Require().NoError(err)
+	s.Require().Len(pending, 1)
+	s.Equal(interrupt.Option(optShield), pending[0].Options[0],
+		"mutating Pose's returned Options corrupted the ledger")
+	s.Equal([]byte("frozen"), pending[0].Payload,
+		"mutating Pose's returned Payload corrupted the ledger")
+	pending[0].Options[1] = optCorrupted
+	pending[0].Payload[0] = 'Y'
+
+	// Surface 3: Open
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Require().Len(open, 1)
+	s.Equal([]interrupt.Option{optShield, optDecline}, open[0].Options,
+		"mutating PendingFor's returned Options corrupted the ledger")
+	s.Equal([]byte("frozen"), open[0].Payload,
+		"mutating PendingFor's returned Payload corrupted the ledger")
+	open[0].Options[0] = optCorrupted
+	open[0].Payload[0] = 'Z'
+
+	// Final independent read: everything above was mutation of copies only.
+	final, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAudience})
+	s.Require().NoError(err)
+	s.Require().Len(final, 1)
+	s.Equal([]interrupt.Option{optShield, optDecline}, final[0].Options,
+		"mutating Open's returned Options corrupted the ledger")
+	s.Equal([]byte("frozen"), final[0].Payload,
+		"mutating Open's returned Payload corrupted the ledger")
+}
+
+// TestPoseAtomicityFromPopulatedState pins R5 from a non-empty ledger:
+// a failed Pose leaves existing windows untouched and consumes no ID.
+func (s *LedgerSuite) TestPoseAtomicityFromPopulatedState() {
+	first, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testAudience,
+		Options:  []interrupt.Option{optShield, optDecline},
+		Payload:  []byte("frozen"),
+		At:       7,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(1), first.Window.ID)
+
+	_, err = s.ledger.Pose(&interrupt.PoseInput{Audience: testAudience, Options: []interrupt.Option{"x", "x"}})
+	s.Require().ErrorIs(err, interrupt.ErrDuplicateOption)
+
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Require().Len(open, 1, "failed Pose must not add a window (R5)")
+	s.Equal(first.Window, open[0], "failed Pose must not disturb existing windows (R5)")
+
+	second, err := s.ledger.Pose(&interrupt.PoseInput{Audience: "grunk", Options: []interrupt.Option{"attack"}})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(2), second.Window.ID, "failed Pose must not consume an ID (R5)")
 }
 
 func TestLedgerSuite(t *testing.T) {

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -614,8 +614,11 @@ func (s *PersistenceSuite) TestRoundTripAllAnswered() {
 	})
 	s.Require().NoError(err)
 
-	// Snapshot and reload
+	// Snapshot and reload. All-answered emits nil Windows: the snapshot
+	// deep-equals the literal a caller would write (T5 review Q2).
 	data := ledger1.ToData()
+	s.Equal(interrupt.LedgerData{NextID: 2}, data,
+		"all-answered snapshot must deep-equal the zero-Windows literal")
 	ledger2, err := interrupt.LoadLedger(data)
 	s.Require().NoError(err)
 
@@ -668,7 +671,7 @@ func (s *PersistenceSuite) TestGoldenJSONFresh() {
 	data := idle.ToData()
 	bs, err := json.Marshal(data)
 	s.Require().NoError(err)
-	s.Equal(string(bs), "{}")
+	s.Equal("{}", string(bs))
 }
 
 // TestGoldenJSONOpen pins open windows golden JSON with exact-string pin.
@@ -742,23 +745,31 @@ func (s *PersistenceSuite) TestToDataSnapshotImmunity() {
 		Payload:  []byte("frozen"),
 	})
 	s.Require().NoError(err)
+	_, err = ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testGrunk),
+		Options:  []interrupt.Option{optAttack, testDecline},
+		Payload:  []byte("frozen-2"),
+	})
+	s.Require().NoError(err)
 
 	data := ledger.ToData()
+	s.Require().Len(data.Windows, 2)
 
-	// Mutate returned data's slices
-	if len(data.Windows) > 0 {
-		data.Windows[0].Payload[0] = 'X'
-		if len(data.Windows[0].Options) > 0 {
-			data.Windows[0].Options[0] = "corrupted"
-		}
+	// Mutate EVERY window's slices — a partial copy that only protects
+	// window[0] must fail this pin (T5 review F1).
+	for i := range data.Windows {
+		data.Windows[i].Payload[0] = 'X'
+		data.Windows[i].Options[0] = optCorrupted
 	}
 
-	// Re-query: internal state unchanged
+	// Re-query: internal state unchanged for every window
 	open, err := ledger.Open()
 	s.Require().NoError(err)
-	s.Len(open, 1)
-	s.Equal([]byte("frozen"), open[0].Payload)
+	s.Require().Len(open, 2)
+	s.Equal([]byte("frozen"), open[0].Payload, "window[0] options/payload must be copied out")
 	s.Equal([]interrupt.Option{testShield, testDecline}, open[0].Options)
+	s.Equal([]byte("frozen-2"), open[1].Payload, "every window must be copied out, not only the first")
+	s.Equal([]interrupt.Option{optAttack, testDecline}, open[1].Options)
 }
 
 // TestLoadLedgerAliasing pins LoadLedger immunity: mutating caller's Data
@@ -774,25 +785,35 @@ func (s *PersistenceSuite) TestLoadLedgerAliasing() {
 	})
 	s.Require().NoError(err)
 
+	_, err = ledger1.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testGrunk),
+		Options:  []interrupt.Option{optAttack, testDecline},
+		Payload:  []byte("frozen-2"),
+	})
+	s.Require().NoError(err)
+
 	data := ledger1.ToData()
+	s.Require().Len(data.Windows, 2)
 
 	// Load the ledger
 	ledger2, err := interrupt.LoadLedger(data)
 	s.Require().NoError(err)
 
-	// Mutate the caller's data
-	if len(data.Windows) > 0 {
-		data.Windows[0].Payload[0] = 'X'
-		if len(data.Windows[0].Options) > 0 {
-			data.Windows[0].Options[0] = "corrupted"
-		}
+	// Mutate EVERY window of the caller's data — a partial copy-in that
+	// only protects window[0] must fail this pin (T5 review F2).
+	for i := range data.Windows {
+		data.Windows[i].Payload[0] = 'X'
+		data.Windows[i].Options[0] = optCorrupted
 	}
 
 	// Loaded ledger is unaffected
 	open, err := ledger2.Open()
 	s.Require().NoError(err)
-	s.Len(open, 1)
+	s.Require().Len(open, 2)
 	s.Equal([]byte("frozen"), open[0].Payload)
+	s.Equal([]byte("frozen-2"), open[1].Payload, "every window's payload must be copied in, not only the first")
+	s.Equal([]interrupt.Option{optAttack, testDecline}, open[1].Options,
+		"every window's options must be copied in, not only the first")
 	s.Equal([]interrupt.Option{testShield, testDecline}, open[0].Options)
 }
 
@@ -1030,6 +1051,13 @@ func (s *PersistenceSuite) TestR9WraparoundForgerMaxUint64() {
 	_, err := interrupt.LoadLedger(data)
 	s.Require().Error(err)
 	s.ErrorIs(err, interrupt.ErrInvalidData)
+}
+
+// TestR9RejectionNextIDOne pins the record precedent: a stored next_id
+// of 1 is unreachable (0 = fresh; the first Pose advances it to 2).
+func (s *PersistenceSuite) TestR9RejectionNextIDOne() {
+	_, err := interrupt.LoadLedger(interrupt.LedgerData{NextID: 1})
+	s.Require().ErrorIs(err, interrupt.ErrInvalidData)
 }
 
 func TestPersistenceSuite(t *testing.T) {

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -28,6 +28,7 @@ const (
 	optCorrupted = "corrupted"
 	optAttack    = "attack"
 	testMonster  = "monster"
+	testFighter  = "fighter"
 	testGrunk    = "grunk"
 )
 
@@ -344,7 +345,7 @@ func (s *LedgerSuite) TestAnswerValidationOrderAndAtomicity() {
 	s.Require().ErrorIs(err, interrupt.ErrNotOpen)
 	_, err = s.ledger.Answer(&interrupt.AnswerInput{
 		Window: posed.Window.ID,
-		By:     "fighter",
+		By:     testFighter,
 		Choice: interrupt.Option(optShield),
 	})
 	s.Require().ErrorIs(err, interrupt.ErrNotAudience)
@@ -430,7 +431,7 @@ func (s *LedgerSuite) TestAnswerValidationComboAuthorizationBeforeMembership() {
 	posed, err := s.ledger.Pose(&interrupt.PoseInput{Audience: testAudience,
 		Options: []interrupt.Option{optShield, optDecline}, Payload: []byte("frozen")})
 	s.Require().NoError(err)
-	_, err = s.ledger.Answer(&interrupt.AnswerInput{Window: posed.Window.ID, By: "fighter", Choice: "fireball"})
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{Window: posed.Window.ID, By: testFighter, Choice: "fireball"})
 	s.Require().ErrorIs(err, interrupt.ErrNotAudience,
 		"wrong audience + unoffered choice: authorization must win (design: shape, existence, authorization, membership)")
 	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAudience})

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -24,6 +24,7 @@ const (
 	optShield    = "shield"
 	optDecline   = "decline"
 	optCorrupted = "corrupted"
+	testGrunk    = "grunk"
 )
 
 type LedgerSuite struct {
@@ -268,6 +269,200 @@ func (s *LedgerSuite) TestPoseAtomicityFromPopulatedState() {
 	second, err := s.ledger.Pose(&interrupt.PoseInput{Audience: "grunk", Options: []interrupt.Option{"attack"}})
 	s.Require().NoError(err)
 	s.Equal(interrupt.WindowID(2), second.Window.ID, "failed Pose must not consume an ID (R5)")
+}
+
+func (s *LedgerSuite) TestAnswerClosesAndReturnsEnvelope() {
+	posed, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options: []interrupt.Option{
+			interrupt.Option(optShield),
+			interrupt.Option(optDecline),
+		},
+		Payload: []byte("frozen"),
+		At:      7,
+	})
+	s.Require().NoError(err)
+	out, err := s.ledger.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     core.EntityID(testAudience),
+		Choice: interrupt.Option(optShield),
+	})
+	s.Require().NoError(err)
+	s.Equal(posed.Window, out.Window, "the envelope returns intact — custody proven")
+	s.Equal(interrupt.Option(optShield), out.Choice)
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{
+		Audience: core.EntityID(testAudience),
+	})
+	s.Require().NoError(err)
+	s.Empty(pending, "answered windows leave the ledger")
+	// one answer per window
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     core.EntityID(testAudience),
+		Choice: interrupt.Option(optShield),
+	})
+	s.Require().ErrorIs(err, interrupt.ErrNotOpen)
+}
+
+func (s *LedgerSuite) TestAnswerValidationOrderAndAtomicity() {
+	posed, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options: []interrupt.Option{
+			interrupt.Option(optShield),
+			interrupt.Option(optDecline),
+		},
+		Payload: []byte("frozen"),
+	})
+	s.Require().NoError(err)
+	// shape → existence → authorization → membership; first failure wins
+	_, err = s.ledger.Answer(nil)
+	s.Require().ErrorIs(err, interrupt.ErrNilInput)
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     "",
+		Choice: "",
+	})
+	s.Require().ErrorIs(err, interrupt.ErrNoAudience)
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     core.EntityID(testAudience),
+		Choice: "",
+	})
+	s.Require().ErrorIs(err, interrupt.ErrNoOption)
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{
+		Window: 99,
+		By:     core.EntityID(testAudience),
+		Choice: interrupt.Option(optShield),
+	})
+	s.Require().ErrorIs(err, interrupt.ErrNotOpen)
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     "fighter",
+		Choice: interrupt.Option(optShield),
+	})
+	s.Require().ErrorIs(err, interrupt.ErrNotAudience)
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     core.EntityID(testAudience),
+		Choice: "fireball",
+	})
+	s.Require().ErrorIs(err, interrupt.ErrNotOffered)
+	// R5: every failure left the window open and unchanged
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{
+		Audience: core.EntityID(testAudience),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(pending, 1)
+	s.Equal(posed.Window, pending[0])
+}
+
+func (s *LedgerSuite) TestAnswerWindowIDZeroIsNotOpen() {
+	_, err := s.ledger.Answer(&interrupt.AnswerInput{
+		Window: 0,
+		By:     core.EntityID(testAudience),
+		Choice: interrupt.Option(optShield),
+	})
+	s.Require().ErrorIs(err, interrupt.ErrNotOpen,
+		"Window ID 0 is never-posed, not a shape error")
+}
+
+func (s *LedgerSuite) TestAnswerRemovesExactlyOne() {
+	// Pose three windows: two for aldric, one for grunk
+	out1, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options:  []interrupt.Option{"opt1"},
+		Payload:  []byte("p1"),
+		At:       1,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(1), out1.Window.ID)
+	out2, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testGrunk),
+		Options:  []interrupt.Option{"opt2"},
+		Payload:  []byte("p2"),
+		At:       2,
+	})
+	s.Require().NoError(err)
+	out3, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options:  []interrupt.Option{"opt3"},
+		Payload:  []byte("p3"),
+		At:       3,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(3), out3.Window.ID)
+
+	// Answer the middle one (ID 2, grunk's window)
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{
+		Window: out2.Window.ID,
+		By:     core.EntityID(testGrunk),
+		Choice: "opt2",
+	})
+	s.Require().NoError(err)
+
+	// Verify the others remain, in pose order
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Len(open, 2)
+	s.Equal(interrupt.WindowID(1), open[0].ID, "first window remains")
+	s.Equal(interrupt.WindowID(3), open[1].ID, "third window remains in pose order")
+
+	// Verify next Pose still gets monotonic ID
+	out4, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: "alice",
+		Options:  []interrupt.Option{"opt4"},
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(4), out4.Window.ID, "next Pose continues monotonic sequence")
+}
+
+func (s *LedgerSuite) TestAnswerEnvelopeCopyOut() {
+	posed, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options: []interrupt.Option{
+			interrupt.Option(optShield),
+			interrupt.Option(optDecline),
+		},
+		Payload: []byte("frozen"),
+		At:      7,
+	})
+	s.Require().NoError(err)
+
+	// Also pose a sibling window for the same audience
+	sibling, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options:  []interrupt.Option{"sibling-opt"},
+		Payload:  []byte("sibling-payload"),
+		At:       8,
+	})
+	s.Require().NoError(err)
+
+	// Answer the first window
+	out, err := s.ledger.Answer(&interrupt.AnswerInput{
+		Window: posed.Window.ID,
+		By:     core.EntityID(testAudience),
+		Choice: interrupt.Option(optShield),
+	})
+	s.Require().NoError(err)
+
+	// Mutate the returned envelope
+	out.Window.Options[0] = "mutated"
+	out.Window.Payload[0] = 'X'
+
+	// Verify sibling is untouched via PendingFor
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{
+		Audience: core.EntityID(testAudience),
+	})
+	s.Require().NoError(err)
+	s.Len(pending, 1)
+	s.Equal(sibling.Window, pending[0],
+		"sibling window unaffected by mutation of returned envelope")
+
+	// Verify Open also reflects uncorrupted state
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Len(open, 1)
+	s.Equal(sibling.Window, open[0], "Open reflects uncorrupted state")
 }
 
 func TestLedgerSuite(t *testing.T) {

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -1,0 +1,194 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package interrupt_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/interrupt"
+)
+
+const (
+	testAldric  = core.EntityID("aldric")
+	testShield  = interrupt.Option("shield")
+	testDecline = interrupt.Option("decline")
+)
+
+type LedgerSuite struct {
+	suite.Suite
+	ledger *interrupt.Ledger
+}
+
+func (s *LedgerSuite) SetupTest() {
+	var err error
+	s.ledger, err = interrupt.NewLedger()
+	s.Require().NoError(err)
+}
+
+func (s *LedgerSuite) TestPoseOpensWindow() {
+	out, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testAldric,
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  []byte("frozen-attack"),
+		At:       7,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(1), out.Window.ID, "IDs are monotonic from 1")
+	s.Equal(testAldric, out.Window.Audience)
+	s.Equal([]interrupt.Option{testShield, testDecline}, out.Window.Options)
+	s.Equal([]byte("frozen-attack"), out.Window.Payload)
+	s.Equal(uint64(7), out.Window.At)
+
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAldric})
+	s.Require().NoError(err)
+	s.Len(pending, 1)
+	s.Equal(out.Window, pending[0])
+}
+
+func (s *LedgerSuite) TestPoseValidationOrderAndAtomicity() {
+	// validation order: nil → audience → no options → empty option → duplicate
+	_, err := s.ledger.Pose(nil)
+	s.Require().ErrorIs(err, interrupt.ErrNilInput)
+	_, err = s.ledger.Pose(&interrupt.PoseInput{Audience: "", Options: nil})
+	s.Require().ErrorIs(err, interrupt.ErrNoAudience)
+	_, err = s.ledger.Pose(&interrupt.PoseInput{Audience: "a", Options: nil})
+	s.Require().ErrorIs(err, interrupt.ErrNoOptions)
+	_, err = s.ledger.Pose(&interrupt.PoseInput{Audience: "a", Options: []interrupt.Option{"x", "", "x"}})
+	s.Require().ErrorIs(err, interrupt.ErrNoOption, "empty token found before the duplicate")
+	_, err = s.ledger.Pose(&interrupt.PoseInput{Audience: "a", Options: []interrupt.Option{"x", "y", "x"}})
+	s.Require().ErrorIs(err, interrupt.ErrDuplicateOption)
+
+	// R5: none of those consumed an ID or opened a window
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Empty(open)
+	out, err := s.ledger.Pose(&interrupt.PoseInput{Audience: "a", Options: []interrupt.Option{"x"}})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(1), out.Window.ID, "failed poses consume no IDs")
+}
+
+func (s *LedgerSuite) TestPoseNilPayloadIsLegal() {
+	out, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testAldric,
+		Options:  []interrupt.Option{testShield},
+		Payload:  nil,
+		At:       5,
+	})
+	s.Require().NoError(err)
+	s.Nil(out.Window.Payload, "nil payload must be legal and stored as nil")
+
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAldric})
+	s.Require().NoError(err)
+	s.Len(pending, 1)
+	s.Nil(pending[0].Payload)
+}
+
+func (s *LedgerSuite) TestPoseCopyIn() {
+	options := []interrupt.Option{testShield, testDecline}
+	payload := []byte("frozen-attack")
+
+	out, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testAldric,
+		Options:  options,
+		Payload:  payload,
+		At:       7,
+	})
+	s.Require().NoError(err)
+
+	// Mutate the caller's slices after the pose
+	if len(options) > 0 {
+		options[0] = "mutated"
+	}
+	if len(payload) > 0 {
+		payload[0] = 'X'
+	}
+
+	// Re-query and verify stored data is unchanged
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAldric})
+	s.Require().NoError(err)
+	s.Len(pending, 1)
+	s.Equal([]interrupt.Option{testShield, testDecline}, pending[0].Options,
+		"stored options must be immune to caller mutation")
+	s.Equal([]byte("frozen-attack"), pending[0].Payload,
+		"stored payload must be immune to caller mutation")
+
+	// Also verify the returned window from Pose
+	s.Equal([]interrupt.Option{testShield, testDecline}, out.Window.Options)
+	s.Equal([]byte("frozen-attack"), out.Window.Payload)
+}
+
+func (s *LedgerSuite) TestSeveralWindowsOneAudience() {
+	out1, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testAldric,
+		Options:  []interrupt.Option{"option1"},
+		Payload:  []byte("payload1"),
+		At:       1,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(1), out1.Window.ID)
+
+	out2, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testAldric,
+		Options:  []interrupt.Option{"option2"},
+		Payload:  []byte("payload2"),
+		At:       2,
+	})
+	s.Require().NoError(err)
+	s.Equal(interrupt.WindowID(2), out2.Window.ID)
+
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAldric})
+	s.Require().NoError(err)
+	s.Len(pending, 2)
+	s.Equal(interrupt.WindowID(1), pending[0].ID, "windows in pose order")
+	s.Equal(interrupt.WindowID(2), pending[1].ID, "windows in pose order")
+}
+
+func (s *LedgerSuite) TestAudienceIsolation() {
+	_, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: "aldric",
+		Options:  []interrupt.Option{"shield"},
+		Payload:  []byte("frozen"),
+		At:       1,
+	})
+	s.Require().NoError(err)
+
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: "bob"})
+	s.Require().NoError(err)
+	s.Empty(pending, "bob should see no windows for aldric")
+
+	pendingAldric, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: "aldric"})
+	s.Require().NoError(err)
+	s.Len(pendingAldric, 1, "aldric should see their own window")
+}
+
+func (s *LedgerSuite) TestAtIsOpaque() {
+	out1, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: "a",
+		Options:  []interrupt.Option{"x"},
+		At:       9,
+	})
+	s.Require().NoError(err)
+	s.Equal(uint64(9), out1.Window.At)
+
+	out2, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: "a",
+		Options:  []interrupt.Option{"y"},
+		At:       2,
+	})
+	s.Require().NoError(err)
+	s.Equal(uint64(2), out2.Window.At)
+
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Len(open, 2)
+	s.Equal(uint64(9), open[0].At, "At values stored verbatim, no ordering")
+	s.Equal(uint64(2), open[1].At)
+}
+
+func TestLedgerSuite(t *testing.T) {
+	suite.Run(t, new(LedgerSuite))
+}

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -416,53 +416,19 @@ func (s *LedgerSuite) TestAnswerRemovesExactlyOne() {
 	s.Equal(interrupt.WindowID(4), out4.Window.ID, "next Pose continues monotonic sequence")
 }
 
-func (s *LedgerSuite) TestAnswerEnvelopeCopyOut() {
-	posed, err := s.ledger.Pose(&interrupt.PoseInput{
-		Audience: core.EntityID(testAudience),
-		Options: []interrupt.Option{
-			interrupt.Option(optShield),
-			interrupt.Option(optDecline),
-		},
-		Payload: []byte("frozen"),
-		At:      7,
-	})
+// TestAnswerValidationComboAuthorizationBeforeMembership pins the
+// order the design calls out by name: wrong audience AND unoffered
+// choice in one call — authorization is checked before membership.
+func (s *LedgerSuite) TestAnswerValidationComboAuthorizationBeforeMembership() {
+	posed, err := s.ledger.Pose(&interrupt.PoseInput{Audience: testAudience,
+		Options: []interrupt.Option{optShield, optDecline}, Payload: []byte("frozen")})
 	s.Require().NoError(err)
-
-	// Also pose a sibling window for the same audience
-	sibling, err := s.ledger.Pose(&interrupt.PoseInput{
-		Audience: core.EntityID(testAudience),
-		Options:  []interrupt.Option{"sibling-opt"},
-		Payload:  []byte("sibling-payload"),
-		At:       8,
-	})
+	_, err = s.ledger.Answer(&interrupt.AnswerInput{Window: posed.Window.ID, By: "fighter", Choice: "fireball"})
+	s.Require().ErrorIs(err, interrupt.ErrNotAudience,
+		"wrong audience + unoffered choice: authorization must win (design: shape, existence, authorization, membership)")
+	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAudience})
 	s.Require().NoError(err)
-
-	// Answer the first window
-	out, err := s.ledger.Answer(&interrupt.AnswerInput{
-		Window: posed.Window.ID,
-		By:     core.EntityID(testAudience),
-		Choice: interrupt.Option(optShield),
-	})
-	s.Require().NoError(err)
-
-	// Mutate the returned envelope
-	out.Window.Options[0] = "mutated"
-	out.Window.Payload[0] = 'X'
-
-	// Verify sibling is untouched via PendingFor
-	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{
-		Audience: core.EntityID(testAudience),
-	})
-	s.Require().NoError(err)
-	s.Len(pending, 1)
-	s.Equal(sibling.Window, pending[0],
-		"sibling window unaffected by mutation of returned envelope")
-
-	// Verify Open also reflects uncorrupted state
-	open, err := s.ledger.Open()
-	s.Require().NoError(err)
-	s.Len(open, 1)
-	s.Equal(sibling.Window, open[0], "Open reflects uncorrupted state")
+	s.Require().Len(pending, 1, "failed Answer left the window open (R5)")
 }
 
 func TestLedgerSuite(t *testing.T) {

--- a/play/interrupt/ledger_test.go
+++ b/play/interrupt/ledger_test.go
@@ -24,6 +24,7 @@ const (
 	optShield    = "shield"
 	optDecline   = "decline"
 	optCorrupted = "corrupted"
+	testMonster  = "monster"
 	testGrunk    = "grunk"
 )
 
@@ -429,6 +430,58 @@ func (s *LedgerSuite) TestAnswerValidationComboAuthorizationBeforeMembership() {
 	pending, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testAudience})
 	s.Require().NoError(err)
 	s.Require().Len(pending, 1, "failed Answer left the window open (R5)")
+}
+
+// TestQueryValidation pins the query-side input guards (Task 4).
+func (s *LedgerSuite) TestQueryValidation() {
+	_, err := s.ledger.PendingFor(nil)
+	s.Require().ErrorIs(err, interrupt.ErrNilInput)
+	_, err = s.ledger.PendingFor(&interrupt.PendingForInput{Audience: ""})
+	s.Require().ErrorIs(err, interrupt.ErrNoAudience)
+}
+
+// TestOpenPoseOrderInterleaved pins pose order across audiences: Open
+// returns the table's windows in the order they were posed, not
+// grouped by audience.
+func (s *LedgerSuite) TestOpenPoseOrderInterleaved() {
+	for _, aud := range []core.EntityID{testAudience, "grunk", testAudience} {
+		_, err := s.ledger.Pose(&interrupt.PoseInput{Audience: aud, Options: []interrupt.Option{optShield}})
+		s.Require().NoError(err)
+	}
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Require().Len(open, 3)
+	s.Equal(interrupt.WindowID(1), open[0].ID, "pose order, not audience grouping")
+	s.Equal(interrupt.WindowID(2), open[1].ID)
+	s.Equal(interrupt.WindowID(3), open[2].ID)
+	s.Equal(core.EntityID("grunk"), open[1].Audience)
+}
+
+// TestDeciderContract is executable documentation of the design's
+// decider contract: a machine decider is shown ONLY its own pending
+// windows (PendingFor(itself)) and answers through the ordinary verb —
+// indistinguishable from a human. This is how auto-OA and monster
+// reactions ride the same machinery as the Shield prompt.
+func (s *LedgerSuite) TestDeciderContract() {
+	_, err := s.ledger.Pose(&interrupt.PoseInput{
+		Audience: testMonster, Options: []interrupt.Option{"take-oa", optDecline}})
+	s.Require().NoError(err)
+
+	// The decider's entire view: its own pending windows. Not the world,
+	// not other audiences' windows.
+	view, err := s.ledger.PendingFor(&interrupt.PendingForInput{Audience: testMonster})
+	s.Require().NoError(err)
+	s.Require().Len(view, 1)
+
+	// Policy decider: always take the opportunity attack.
+	choice := view[0].Options[0]
+	out, err := s.ledger.Answer(&interrupt.AnswerInput{Window: view[0].ID, By: testMonster, Choice: choice})
+	s.Require().NoError(err)
+	s.Equal(interrupt.Option("take-oa"), out.Choice)
+
+	open, err := s.ledger.Open()
+	s.Require().NoError(err)
+	s.Empty(open, "posed and answered in one host call — the world never observed a wait")
 }
 
 func TestLedgerSuite(t *testing.T) {

--- a/play/interrupt/shieldscene_test.go
+++ b/play/interrupt/shieldscene_test.go
@@ -1,0 +1,241 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package interrupt_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/interrupt"
+)
+
+// TestShieldScene implements AC1: the narrative integration spine as
+// ONE plain-function test (the family exception for integration spines).
+// The scene unfolds in nine beats, each with a narrative failure message.
+// Fixture bytes stand in for the frozen resolution (the rulebook's half).
+func TestShieldScene(t *testing.T) {
+	frozenFixture := []byte("frozen-attack-post-hit-pre-damage")
+
+	// Beat 1: The freeze — an attack resolution freezes
+	ledger, err := interrupt.NewLedger()
+	require.NoError(t, err, "create ledger")
+
+	posed, err := ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testAudience),
+		Options:  []interrupt.Option{testShield, testDecline},
+		Payload:  frozenFixture,
+		At:       7,
+	})
+	require.NoError(t, err, "pose attack freeze")
+	require.Equal(t, interrupt.WindowID(1), posed.Window.ID,
+		"beat 1: window ID must be 1 (first window)")
+	require.Equal(t, core.EntityID(testAudience), posed.Window.Audience,
+		"beat 1: audience must be aldric")
+	require.Equal(t, []interrupt.Option{testShield, testDecline}, posed.Window.Options,
+		"beat 1: options must match")
+	require.Equal(t, frozenFixture, posed.Window.Payload,
+		"beat 1: payload must preserve fixture bytes")
+	require.Equal(t, uint64(7), posed.Window.At,
+		"beat 1: At must preserve timestamp")
+
+	// Beat 2: The button renders — PendingFor("aldric") shows exactly
+	// one window with options in offered order (this is what the wizard's
+	// client draws)
+	pending, err := ledger.PendingFor(&interrupt.PendingForInput{
+		Audience: core.EntityID(testAudience),
+	})
+	require.NoError(t, err, "beat 2: query pending")
+	require.Len(t, pending, 1, "beat 2: exactly one window for aldric")
+	require.Equal(t, interrupt.WindowID(1), pending[0].ID,
+		"beat 2: window ID in pending")
+	require.Equal(t, []interrupt.Option{testShield, testDecline}, pending[0].Options,
+		"beat 2: options in offered order")
+
+	// Beat 3: The table waits — Open() shows one window (this is "waiting
+	// on Aldric…" rendering)
+	open, err := ledger.Open()
+	require.NoError(t, err, "beat 3: query open")
+	require.Len(t, open, 1, "beat 3: exactly one window open")
+	require.Equal(t, interrupt.WindowID(1), open[0].ID,
+		"beat 3: window ID in open")
+
+	// Beat 4: Wrong hands — the fighter tries to answer Aldric's window,
+	// gets ErrNotAudience; assert via fresh PendingFor that the window
+	// is untouched (R5)
+	_, err = ledger.Answer(&interrupt.AnswerInput{
+		Window: interrupt.WindowID(1),
+		By:     core.EntityID(testMonster),
+		Choice: testShield,
+	})
+	require.ErrorIs(t, err, interrupt.ErrNotAudience,
+		"beat 4: fighter cannot answer aldric's window")
+
+	// Verify window untouched via PendingFor
+	pendingAfterWrongHands, err := ledger.PendingFor(&interrupt.PendingForInput{
+		Audience: core.EntityID(testAudience),
+	})
+	require.NoError(t, err, "beat 4: re-query pending after rejection")
+	require.Len(t, pendingAfterWrongHands, 1, "beat 4: window must survive bad answer")
+	require.Equal(t, interrupt.WindowID(1), pendingAfterWrongHands[0].ID,
+		"beat 4: window ID unchanged")
+	require.Equal(t, frozenFixture, pendingAfterWrongHands[0].Payload,
+		"beat 4: payload unchanged after rejection")
+
+	// Beat 5: Wrong spell — Aldric tries choice "fireball" (not offered),
+	// gets ErrNotOffered; window still open
+	_, err = ledger.Answer(&interrupt.AnswerInput{
+		Window: interrupt.WindowID(1),
+		By:     core.EntityID(testAudience),
+		Choice: interrupt.Option("fireball"),
+	})
+	require.ErrorIs(t, err, interrupt.ErrNotOffered,
+		"beat 5: offered choice 'fireball' is not in options")
+
+	// Window still open
+	openAfterWrongSpell, err := ledger.Open()
+	require.NoError(t, err, "beat 5: re-query open after bad choice")
+	require.Len(t, openAfterWrongSpell, 1, "beat 5: window must survive bad choice")
+
+	// Beat 6: The click — Aldric answers "shield"; envelope returned with
+	// Payload byte-identical to posed fixture (custody proven); Choice
+	// "shield"; PendingFor empty; Open empty
+	answered, err := ledger.Answer(&interrupt.AnswerInput{
+		Window: interrupt.WindowID(1),
+		By:     core.EntityID(testAudience),
+		Choice: testShield,
+	})
+	require.NoError(t, err, "beat 6: aldric answers shield")
+	require.Equal(t, interrupt.WindowID(1), answered.Window.ID,
+		"beat 6: returned envelope has correct ID")
+	require.Equal(t, core.EntityID(testAudience), answered.Window.Audience,
+		"beat 6: returned envelope has correct audience")
+	require.Equal(t, []interrupt.Option{testShield, testDecline},
+		answered.Window.Options, "beat 6: returned envelope preserves options")
+	require.Equal(t, frozenFixture, answered.Window.Payload,
+		"beat 6: returned envelope has byte-identical payload — custody proven")
+	require.Equal(t, testShield, answered.Choice,
+		"beat 6: returned choice is shield")
+
+	// PendingFor now empty
+	pendingAfterAnswer, err := ledger.PendingFor(&interrupt.PendingForInput{
+		Audience: core.EntityID(testAudience),
+	})
+	require.NoError(t, err, "beat 6: query pending after answer")
+	require.Empty(t, pendingAfterAnswer, "beat 6: no pending windows for aldric")
+
+	// Open empty
+	openAfterAnswer, err := ledger.Open()
+	require.NoError(t, err, "beat 6: query open after answer")
+	require.Empty(t, openAfterAnswer, "beat 6: no windows open")
+
+	// Beat 7: The auto-OA beat — Pose a window to "grunk" (options
+	// ["take-oa","decline"]) and Answer it immediately as a policy
+	// decider — NO queries between pose and answer. Assert the returned
+	// choice; the ledger cannot tell a policy answer from a human one.
+	poseOA, err := ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(testGrunk),
+		Options: []interrupt.Option{
+			interrupt.Option("take-oa"),
+			interrupt.Option(optDecline),
+		},
+		Payload: []byte("oa-opportunity"),
+		At:      8,
+	})
+	require.NoError(t, err, "beat 7: pose OA window")
+	require.Equal(t, interrupt.WindowID(2), poseOA.Window.ID,
+		"beat 7: second window gets ID 2")
+
+	// Answer immediately (no queries between)
+	answeredOA, err := ledger.Answer(&interrupt.AnswerInput{
+		Window: poseOA.Window.ID,
+		By:     core.EntityID(testGrunk),
+		Choice: interrupt.Option("take-oa"),
+	})
+	require.NoError(t, err, "beat 7: answer OA window immediately")
+	require.Equal(t, interrupt.WindowID(2), answeredOA.Window.ID,
+		"beat 7: returned envelope from OA beat")
+	require.Equal(t, interrupt.Option("take-oa"), answeredOA.Choice,
+		"beat 7: returned choice from auto-OA answer")
+
+	// Beat 8: The sequential beat — a second human window posed ONLY AFTER
+	// beat 7 resolved; assert IDs strictly ascending across the whole scene
+	poseSecond, err := ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID("wizard"),
+		Options: []interrupt.Option{
+			interrupt.Option("cast-spell"),
+			interrupt.Option("hold"),
+		},
+		Payload: []byte("wizard-action"),
+		At:      9,
+	})
+	require.NoError(t, err, "beat 8: pose second human window")
+	require.Equal(t, interrupt.WindowID(3), poseSecond.Window.ID,
+		"beat 8: third window gets ID 3")
+
+	openAfterSequential, err := ledger.Open()
+	require.NoError(t, err, "beat 8: query open after all poses")
+	require.Len(t, openAfterSequential, 1, "beat 8: one window still open (wizard's)")
+	require.Equal(t, interrupt.WindowID(3), openAfterSequential[0].ID,
+		"beat 8: open window is the wizard's (ID 3)")
+	require.Equal(t, core.EntityID("wizard"), openAfterSequential[0].Audience,
+		"beat 8: correct audience")
+
+	// Beat 9: Mid-scene persistence (bonus honesty beat) — between beats
+	// 3 and 4 (conceptually, though we check it here after all action),
+	// ToData → LoadLedger into a SECOND ledger and assert PendingFor
+	// on the reloaded ledger shows the same window state. The suspended
+	// question survives a process boundary, which is the module's whole
+	// reason to exist.
+	//
+	// For this test, we simulate persistence at the point after beat 6
+	// (first window answered, second OA window answered, third window
+	// still pending). We snapshot, reload, and verify the state.
+	data := ledger.ToData()
+	require.Greater(t, data.NextID, uint64(0),
+		"beat 9: NextID must be > 0")
+	require.Len(t, data.Windows, 1,
+		"beat 9: one window in persisted data")
+	require.Equal(t, interrupt.WindowID(3), data.Windows[0].ID,
+		"beat 9: persisted window is the wizard's (ID 3)")
+
+	// Reload into a second ledger
+	ledger2, err := interrupt.LoadLedger(data)
+	require.NoError(t, err, "beat 9: load ledger from data")
+
+	// Verify PendingFor on the reloaded ledger
+	pendingReloaded, err := ledger2.PendingFor(&interrupt.PendingForInput{
+		Audience: core.EntityID("wizard"),
+	})
+	require.NoError(t, err, "beat 9: query pending on reloaded ledger")
+	require.Len(t, pendingReloaded, 1,
+		"beat 9: reloaded ledger has wizard's window")
+	require.Equal(t, interrupt.WindowID(3), pendingReloaded[0].ID,
+		"beat 9: reloaded window ID matches")
+	require.Equal(t, []interrupt.Option{
+		interrupt.Option("cast-spell"),
+		interrupt.Option("hold"),
+	}, pendingReloaded[0].Options,
+		"beat 9: reloaded options match")
+	require.Equal(t, []byte("wizard-action"), pendingReloaded[0].Payload,
+		"beat 9: reloaded payload matches")
+
+	// Continue the scene on the ORIGINAL ledger (beat 9 requirement)
+	finalAnswer, err := ledger.Answer(&interrupt.AnswerInput{
+		Window: interrupt.WindowID(3),
+		By:     core.EntityID("wizard"),
+		Choice: interrupt.Option("hold"),
+	})
+	require.NoError(t, err, "beat 9: answer wizard window on original ledger")
+	require.Equal(t, interrupt.WindowID(3), finalAnswer.Window.ID,
+		"beat 9: final answer envelope correct")
+	require.Equal(t, interrupt.Option("hold"), finalAnswer.Choice,
+		"beat 9: wizard chose hold")
+
+	// Verify original ledger is now empty
+	openFinal, err := ledger.Open()
+	require.NoError(t, err, "beat 9: final query on original ledger")
+	require.Empty(t, openFinal, "beat 9: original ledger now empty")
+}

--- a/play/interrupt/shieldscene_test.go
+++ b/play/interrupt/shieldscene_test.go
@@ -67,11 +67,11 @@ func TestShieldScene(t *testing.T) {
 	// is untouched (R5)
 	_, err = ledger.Answer(&interrupt.AnswerInput{
 		Window: interrupt.WindowID(1),
-		By:     core.EntityID(testMonster),
+		By:     core.EntityID(testFighter),
 		Choice: testShield,
 	})
 	require.ErrorIs(t, err, interrupt.ErrNotAudience,
-		"beat 4: fighter cannot answer aldric's window")
+		"beat 4: the fighter cannot answer aldric's window")
 
 	// Verify window untouched via PendingFor
 	pendingAfterWrongHands, err := ledger.PendingFor(&interrupt.PendingForInput{


### PR DESCRIPTION
## What

`play/interrupt` v0.1: **the ledger of open windows** — suspension-as-value custody for resolutions that stop and wait for an outside decision. Axis three's leaf half.

- `Pose` opens a window (one audience entity, opaque option tokens owned by the rulebook, opaque frozen payload, caller-stamped `At`); IDs monotonic from 1, the ID doubling as the resume token.
- `Answer` validates (shape → existence → authorization → membership, first failure wins), closes the window, and returns the envelope — **ownership transfer**, not copy-out (design amendment, Task 3 review): after the splice nothing internal retains it.
- `PendingFor` (the player's prompt — the Shield button) and `Open` (the table's state — "waiting on Aldric…"), pose-ordered, copy-out pinned.
- `ToData() LedgerData` / `LoadLedger` — R8 idle-`{}`, R9 reject-unreachable-accept-reachable (incl. the wraparound forgery via the subsuming `ID >= NextID` check, and stored `next_id` 1 per the record precedent), golden-JSON exact-string pins for all three wire shapes.

Design contract: `docs/ideas/play/interrupt/design.md` on PR #912 (stays open through this PR; merges as ratification, incl. two execution amendments: ownership transfer, R9 refinements). Family laws R1–R10 held: core+stdlib only, no context.Context, deltas returned never published, not concurrency-safe, no randomness.

## Acceptance evidence

- **AC1** — `TestShieldScene`: nine narrative beats — freeze → button renders → table waits → wrong hands (`ErrNotAudience`) → wrong spell (`ErrNotOffered`) → the click (envelope byte-identical, custody proven) → auto-OA (pose + policy-answer, zero queries between: the ledger cannot tell machine from human) → sequential posing (IDs strictly ascending) → mid-scene persistence (the suspended question survives a reload — the module's reason to exist).
- **AC2/AC3** — 47 tests; R5 atomicity from empty AND populated states; copy-out immunity mutation-proven on every aliasable surface; every R9 rejection tested; round-trips at every distinct state; behavior-identical after reload.
- **AC4** — `compat.yml` grows the fourth gorelease job + path filter.
- **Mutation-proof discipline held throughout**: every pin shown to FAIL under the exact breakage it guards, from Task 1 — including 43 mutations in the Task 5 adversarial review (three surviving mutants were all pin defects; fixed and re-proven) and a 6,000-state randomized reachability walk with zero refuses-own-snapshot failures.

## Review trail

Per-task pipeline: cheap implementers, combined spec+quality reviews at each step, high-rigor adversarial review on persistence. Findings that drew blood, all fixed in-tree with proofs: unpinned copy-out on three read surfaces (T2), an unfalsifiable envelope pin that became the ownership-transfer design amendment (T3), two window[0]-only aliasing pins and a dead guard branch (T5).

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq
