### PR TITLE
Document monster-first D&D 5e rulebook onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ not shipped.
 ## Architecture and module map
 
 The repository has no root `go.mod`. It currently contains 22 Go module roots,
-each with its own dependencies, tests, versions, and module-prefixed Git tag.
+each with its own dependency/version boundary and module-prefixed Git tags.
+Each module has its own test command, although some packages/modules currently
+contain no test files.
 Dependency direction is generally **Core → Mechanics / Play primitives → Tools
 → Rulebooks**; higher layers may import lower ones, not the reverse.
 

--- a/README.md
+++ b/README.md
@@ -1,349 +1,127 @@
 # RPG Toolkit
 
-A modular Go toolkit for building RPG game mechanics that showcases architectural excellence through its revolutionary event system design.
+RPG Toolkit is a collection of independently versioned Go modules for building
+RPG rules engines and game hosts. It contains reusable foundations and tools, a
+D&D 5e rulebook, and a currently D&D-5e-coupled encounter SDK. The toolkit owns
+game rules; a host owns storage, transport, and request orchestration.
 
-## The Architectural Achievement: Typed Topics Pattern
+## Start here
 
-**We solved the fundamental tension between compile-time type safety and runtime flexibility in event-driven systems.**
+Choose the shortest route for the work you are doing:
 
-### The Problem We Faced
+- **Add D&D 5e content:** read the [D&D 5e rulebook guide](rulebooks/dnd5e/README.md),
+  then follow [Add a D&D 5e monster](docs/how-to/add-a-dnd5e-monster.md).
+  A simple, supported monster is the recommended first contribution.
+- **Use a module from Go:** see [Install and use](#install-and-use), then read the
+  README or package documentation nearest that module.
+- **Change a mechanic:** read [How to add a mechanic](docs/how-to/add-a-mechanic.md)
+  and the relevant code and tests.
+- **Understand the architecture:** start with the
+  [architecture overview](docs/architecture/overview.md), then read only the
+  linked [ADRs](docs/adr/README.md) and [journey notes](docs/journey/README.md)
+  relevant to the change.
+- **Contribute to the repository:** see [Documentation and contributor
+  navigation](docs/README.md) and [How to run tests](docs/how-to/run-tests.md).
 
-In RPG mechanics, event ordering matters. Rage damage must apply after base multipliers but before resistance. Critical hits multiply before armor reduces. Traditional event systems forced us to choose:
-- **Type Safety**: Rigid, compile-time checked, but inflexible
-- **Runtime Flexibility**: Dynamic, extensible, but error-prone
+Current behavior is defined by code and tests. ADRs record decisions; journey
+notes record rationale and history. Plans and ideas may describe APIs that have
+not shipped.
 
-Our original system was a 2000+ line nightmare of runtime type assertions, magic strings, and three overlapping patterns that nobody wanted to touch.
+## Architecture and module map
 
-### The Solution: `.On(bus)` Pattern
+The repository has no root `go.mod`. It currently contains 22 Go module roots,
+each with its own dependencies, tests, versions, and module-prefixed Git tag.
+Dependency direction is generally **Core → Mechanics / Play primitives → Tools
+→ Rulebooks**; higher layers may import lower ones, not the reverse.
 
-We discovered an elegant pattern that provides both type safety AND flexibility:
+| Layer | Current modules | Responsibility |
+|---|---|---|
+| Core | `core`, `dice`, `events`, `game`, `items`, `rpgerr` | IDs and refs, actions, dice, event chains, shared game context, base item contracts, errors |
+| Mechanics | `mechanics/conditions`, `effects`, `features`, `proficiency`, `resources`, `spells` | Rule-agnostic mechanic building blocks |
+| Play primitives | `play/clock`, `intel`, `interrupt`, `record` | Small reusable time, knowledge, interruption, and record contracts; these currently depend only on Core |
+| Tools | `tools/environments`, `selectables`, `spatial`, `spawn` | Environment graphs, weighted selection, positioning, and placement |
+| Rulebooks | `rulebooks/dnd5e` | D&D 5e content and rules, including characters, combat, monsters, conditions, and refs |
+| Current composition | `encounter` | Encounter aggregate and host-facing composition; it imports `rulebooks/dnd5e` today and is not rulebook-agnostic |
 
-```go
-// Before: Magic strings and runtime type assertions everywhere
-bus.Subscribe(combat.TopicAttack, func(e any) error {
-    attack, ok := e.(*AttackEvent)  // Runtime type assertion
-    if !ok {
-        return errors.New("wrong event type")
-    }
-    // ... handle attack
-})
+The top-level `behavior/` and `spawn/` directories contain package-design stubs,
+not additional Go modules or usable implementations. Use the module map in the
+[architecture overview](docs/architecture/overview.md) for current seams and
+clearly labelled migration plans.
 
-// After: Type-safe, IDE-friendly, beautiful
-// combat.AttackTopic defined as: var AttackTopic = events.DefineTypedTopic[AttackEvent](TopicAttack)
-attacks := combat.AttackTopic.On(bus)
-attacks.Subscribe(ctx, func(ctx context.Context, e AttackEvent) error {
-    // e is already typed correctly, no assertions needed
-    return nil
-})
-```
+## Install and use
 
-### The Magic: Staged Chain Processing
-
-For complex mechanics like rage damage, we needed ordered processing. Our ChainedTopic pattern elegantly solves this:
-
-```go
-// AttackChain defined as: var AttackChain = events.DefineChainedTopic[AttackEvent](TopicAttackChain)
-attackChain := combat.AttackChain.On(bus)
-
-// Features add modifiers at specific stages
-attackChain.SubscribeWithChain(ctx, func(ctx context.Context, e AttackEvent, chain Chain) (Chain, error) {
-    if character.HasFeature(features.Rage) && character.IsRaging() {
-        // Rage bonus applies at Conditions stage, after Features but before Equipment
-        chain.Add(StageConditions, features.RageModifier, func(ctx context.Context, e AttackEvent) (AttackEvent, error) {
-            e.Damage += rageBonus
-            return e, nil
-        })
-    }
-    return chain, nil
-})
-
-// Execute chain - all modifiers apply in correct order
-result, _ := chain.Execute(ctx, attack)
-```
-
-### The Impact
-
-- **75% Code Reduction**: From 2000+ lines to ~500 lines
-- **100% Type Safety**: No runtime type assertions
-- **Zero Magic Strings**: Everything is compile-time checked
-- **93.5% Test Coverage**: Proven reliability
-- **IDE Autocomplete**: Full IntelliSense support
-
-The key insight: **"Features are dynamic, topics are static!"** This resolves the impedance mismatch between compile-time safety and runtime feature loading.
-
-[Read the full architectural journey →](docs/adr/0024-typed-topics-pattern.md)
-
-📚 **[View Complete Architecture Showcase →](docs/ARCHITECTURE_SHOWCASE.md)** - Deep dive into all our architectural achievements
-
-## Why RPG Toolkit Matters
-
-This isn't just another RPG library. It's a demonstration of solving hard architectural problems elegantly:
-
-1. **Event-Driven Without the Pain**: Our typed topics pattern makes events as easy as method calls
-2. **Data-Driven Runtime**: Load features from JSON, apply them with type safety
-3. **Clean Architecture**: Each layer has clear boundaries and responsibilities
-4. **Production Proven**: Extracted from a live Discord bot serving real games
-
-## Architecture Overview
-
-### Three-Layer Design
-
-```
-┌─────────────────────────────────────────────────┐
-│                  Game Server                    │
-│         (Orchestration, Storage, API)           │
-│              Knows: It's D&D 5e                 │
-│         Doesn't Know: What a "fighter" is       │
-└─────────────────────────────────────────────────┘
-                         ↓
-┌─────────────────────────────────────────────────┐
-│                   Rulebooks                     │
-│            (Game Rules & Mechanics)             │
-│         Knows: What a "fighter" is              │
-│      Provides: Feature/Condition interfaces     │
-└─────────────────────────────────────────────────┘
-                         ↓
-┌─────────────────────────────────────────────────┐
-│                  RPG Toolkit                    │
-│            (Foundation & Building Blocks)       │
-│    Events, Actions, Effects, Dice, Spatial      │
-│         Makes implementing rules fun            │
-└─────────────────────────────────────────────────┘
-```
-
-### Core Modules
-
-```
-rpg-toolkit/
-├── events/         # The typed topics pattern lives here
-├── actions/        # Action[T] for anything activatable
-├── effects/        # Event-driven reactions
-├── dice/           # Lazy evaluation (rolls when needed)
-├── spatial/        # Grid systems and positioning
-├── spawn/          # Entity spawning engine
-└── rulebooks/
-    └── dnd5e/      # D&D 5e implementation
-```
-
-## Getting Started
+Install the module you need, not the repository root. For example:
 
 ```bash
-# Install the toolkit
-go get github.com/KirkDiggler/rpg-toolkit
+go get github.com/KirkDiggler/rpg-toolkit/core@latest
+go get github.com/KirkDiggler/rpg-toolkit/events@latest
+go get github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e@latest
 ```
 
-```go
-import "github.com/KirkDiggler/rpg-toolkit/events"
+Then import the exact package:
 
-// Define topic constants - explicit and reusable
-const (
-    TopicDamage events.Topic = "combat.damage"
-    TopicHeal   events.Topic = "combat.heal"
+```go
+import (
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
-// Define your event types
-type DamageEvent struct {
-    TargetID string
-    Amount   int
-    Type     string
+constructor, ok := monsters.ByRef(refs.Monsters.Bandit().String())
+if !ok {
+    // handle an unsupported content ref
 }
-
-// Create typed topics using constants
-var (
-    DamageTopic = events.DefineTypedTopic[DamageEvent](TopicDamage)
-    HealTopic   = events.DefineTypedTopic[HealEvent](TopicHeal)
-)
-
-// Connect and use with full type safety
-func main() {
-    bus := events.NewEventBus()
-    damage := DamageTopic.On(bus)
-
-    damage.Subscribe(ctx, func(ctx context.Context, e DamageEvent) error {
-        fmt.Printf("Target %s takes %d %s damage\n", e.TargetID, e.Amount, e.Type)
-        return nil
-    })
-}
+bandit := constructor("bandit-1")
+data := bandit.ToData() // serializable rulebook-owned data; your host stores it
 ```
 
-## The Relationship Pattern: Breakable Connections
+`@latest` asks Go for the latest published version of that module. Releases are
+tagged by module path in this repository (for example,
+`rulebooks/dnd5e/v0.72.0`), while Go source imports remain the module paths shown
+above. Do not add a local `replace` directive to committed code.
 
-Another architectural achievement: **Relationships that can be severed from either end.**
+For development, clone the repository and run commands from the module being
+changed:
 
-The challenge: Bless affects 3 targets through the caster's concentration. If the caster takes damage and fails a save, all blessed targets lose the effect. But each effect needs to track its source for proper cleanup.
-
-```go
-// Create the relationship - caster maintains concentration on multiple targets
-relationshipMgr.CreateRelationship(
-    RelationshipConcentration,
-    cleric,
-    []Condition{blessFighter, blessRogue, blessWizard},
-    nil,
-)
-
-// When cleric takes damage and fails save...
-relationshipMgr.BreakAllRelationships(cleric)
-// All three bless effects are automatically removed!
-
-// Or if cleric casts a different concentration spell...
-relationshipMgr.CreateRelationship(RelationshipConcentration, cleric, []Condition{holdPerson}, nil)
-// Previous concentration automatically breaks - all bless effects removed
+```bash
+git clone https://github.com/KirkDiggler/rpg-toolkit.git
+cd rpg-toolkit/rulebooks/dnd5e
+go test -race ./...
+golangci-lint run ./...
 ```
 
-This pattern elegantly handles:
-- **Concentration**: One caster, multiple targets, broken by damage or new spell
-- **Auras**: Effects that exist only while source is in range
-- **Channeled**: Requires continuous action from source
-- **Linked**: Conditions that must be removed together
+See [How to run tests](docs/how-to/run-tests.md) for repository-wide commands.
 
-## Real-World Example: Implementing Rage
+## Rulebook contribution model
 
-Here's how the barbarian rage feature uses our architecture:
+A rulebook contribution is not “enter a stat block and assume every sentence
+works.” It composes content from capabilities the rulebook already implements.
+When a creature clause needs new rules behavior, stop and scope that mechanic
+separately rather than silently dropping the clause or describing proposed
+behavior as shipped.
 
-```go
-// The feature subscribes to attack chains
-func (r *RageFeature) Apply(bus events.EventBus) error {
-    attacks := combat.AttackChain.On(bus)
+The monster guide makes that contract concrete:
 
-    // Add rage damage at the right stage
-    attacks.SubscribeWithChain(ctx, func(ctx context.Context, e AttackEvent, chain Chain) (Chain, error) {
-        if e.AttackerID == r.characterID && r.isActive {
-            chain.Add(StageConditions, "rage_damage", func(ctx context.Context, e AttackEvent) (AttackEvent, error) {
-                e.Damage += r.damageBonus
-                return e, nil
-            })
-        }
-        return chain, nil
-    })
+1. establish an allowed source and attribution;
+2. compare every clause with supported action, trait, targeting, and persistence
+   behavior;
+3. add the ref, factory, registry entry, and tests;
+4. prove construction and the applicable `ToData` / load / `ToData` round trip.
 
-    // Also handle damage resistance
-    damage := combat.DamageChain.On(bus)
-    damage.SubscribeWithChain(ctx, func(ctx context.Context, e DamageEvent, chain Chain) (Chain, error) {
-        if e.TargetID == r.characterID && r.isActive && isPhysical(e.Type) {
-            // Resistance applies at final stage, after all other modifiers
-            chain.Add(StageFinal, "rage_resistance", func(ctx context.Context, e DamageEvent) (DamageEvent, error) {
-                e.Amount = e.Amount / 2
-                return e, nil
-            })
-        }
-        return chain, nil
-    })
-}
-```
-
-## Key Patterns
-
-### Spells as Actions[T]
-Spells are just Actions with typed inputs - no special framework needed:
-
-```go
-// Bless is an Action with target selection
-type BlessAction struct{}
-
-func (b *BlessAction) Activate(ctx context.Context, caster Entity, input BlessInput) error {
-    // Consume spell slot
-    // Create bless effects for each target
-    // Establish concentration relationship
-    relationshipMgr.CreateRelationship(
-        RelationshipConcentration,
-        caster,
-        []Condition{bless1, bless2, bless3},
-        nil,
-    )
-}
-
-// The relationship manager handles all the complexity:
-// - Breaking concentration when damaged
-// - Removing all effects when concentration breaks
-// - Preventing multiple concentration spells
-```
-
-### Action[T] Pattern
-Anything activatable (spells, abilities, items) uses our generic Action pattern:
-
-```go
-type Action[T any] interface {
-    Activate(ctx context.Context, source, target Entity, data T) error
-    Validate(ctx context.Context, source Entity) error
-}
-```
-
-### Lazy Dice Pattern
-Dice don't roll until needed, enabling proper sequencing:
-
-```go
-blessedAttack := dice.D20(1).Plus(dice.D4(1))  // Not rolled yet
-// ... modifiers can still be added ...
-result := blessedAttack.GetValue()  // NOW it rolls
-```
-
-### Effect Pattern
-React to events without coupling:
-
-```go
-type Effect interface {
-    OnEvent(ctx context.Context, event Event) error
-    GetTriggerEvents() []string
-}
-```
-
-## Performance Metrics
-
-- **Event Processing**: < 1μs per event dispatch
-- **Chain Execution**: < 10μs for 10-stage chains
-- **Memory**: 60% less allocation than traditional observer pattern
-- **Concurrency**: Lock-free event dispatch using channels
-
-## Development Status
-
-🚀 **Production Patterns, Actively Evolving**
-
-The typed topics pattern is complete and battle-tested. We're now building out the full toolkit around these proven foundations.
-
-### Complete
-- ✅ Typed Topics event system with `.On(bus)` pattern
-- ✅ Staged chain processing for ordered modifiers
-- ✅ Dice system with lazy evaluation
-- ✅ Spatial system with multi-room orchestration
-- ✅ Spawn engine with constraint system
-- ✅ Core action and effect patterns
-
-### In Progress
-- 🔧 D&D 5e rulebook implementation
-- 🔧 Equipment and inventory systems
-- 🔧 Enhanced conditions and features
+**Continue:** [Add a D&D 5e monster →](docs/how-to/add-a-dnd5e-monster.md)
 
 ## Documentation
 
-### 🏆 Portfolio & Architecture
-- **[Architecture Showcase](docs/ARCHITECTURE_SHOWCASE.md)** - Complete portfolio of architectural achievements
-- [ADR-0024: Typed Topics Pattern](docs/adr/0024-typed-topics-pattern.md) - The breakthrough event system design
-
-### 📖 The Journey
-Want to see how we got here? Check out our design evolution:
-- [Journey: The Typed Topics Discovery](docs/journey/024-typed-topics-discovery.md)
-- [Full Journey Documentation](docs/journey/) - All design decisions and evolution
-- [Architecture Decision Records](docs/adr/) - Formal architectural decisions
-
-## Contributing
-
-This is currently a personal portfolio project, but I welcome discussions about the architecture and patterns. Feel free to open issues for architectural discussions or pattern suggestions.
+- [Documentation index](docs/README.md)
+- [Current status](docs/status.md) and [quality scorecard](docs/quality.md)
+- [Architecture overview](docs/architecture/overview.md) and
+  [data model](docs/architecture/data-model.md)
+- [Architecture Decision Records](docs/adr/README.md)
+- [Journey notes](docs/journey/README.md)
+- [Historical plans](docs/plans/) and [design ideas](docs/ideas/) — context only;
+  verify status banners and current code before following them
 
 ## License
 
-GNU General Public License v3.0 - see [LICENSE](LICENSE)
-
-### Why GPL?
-- **Open Innovation**: Architectural patterns should be shared
-- **Improvements Stay Open**: Enhancements benefit everyone
-- **Commercial Licensing Available**: Contact for proprietary use
-
-## Acknowledgments
-
-- Patterns extracted from [dnd-bot-discord](https://github.com/KirkDiggler/dnd-bot-discord)
-- Inspired by the challenge of making complex RPG mechanics maintainable
-- Special thanks to the Go community for excellent tooling
-
----
-
-*"The best architectures make hard problems look easy. Our typed topics pattern turns event-driven spaghetti into readable, type-safe beauty."*
+Code is licensed under GNU GPL v3.0; see [LICENSE](LICENSE). Third-party or
+adapted game content may also require source-specific attribution. The monster
+contribution guide defines the minimum provenance gate for new content.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,44 +1,77 @@
-# RPG Toolkit Documentation
+# RPG Toolkit documentation
 
-This directory contains the primary documentation for the RPG Toolkit project.
+Use progressive disclosure: start with the route for your task, then read the
+nearest package README, only the ADRs/journey notes it links, and finally the
+code and tests. Code/tests are behavior truth. ADRs record decisions; journeys
+record rationale/history. Status, architecture summaries, plans, and how-tos can
+lag and must be verified.
 
-## Structure
+## Task routes
 
-### Active Documentation
+### Contribute rulebook content
 
-- **[adr/](adr/)** - Architectural Decision Records
-  - Formal records of significant architectural decisions
-  - Numbered ADRs documenting the "what" and "why" of major design choices
-  - See [adr/README.md](adr/README.md) for the index
+1. [D&D 5e rulebook mental model](../rulebooks/dnd5e/README.md)
+2. [Add a D&D 5e monster](how-to/add-a-dnd5e-monster.md) — recommended first contribution
+3. [Nearest monster package guide](../rulebooks/dnd5e/monster/README.md)
+4. [Add another rulebook entry](how-to/add-a-rulebook-entry.md)
 
-- **[journey/](journey/)** - Development Journey Logs
-  - Chronological exploration and discovery logs
-  - Documents the thinking process, experiments, and evolution of ideas
-  - Captures the "how we got here" story
-  - See [journey/README.md](journey/README.md) for the index
+The monster route includes content provenance, unsupported-clause stop rules,
+current factory/registry paths, and full load/round-trip expectations.
 
-### Archive
+### Change behavior
 
-- **[archive/](archive/)** - Historical Documentation
-  - Older design documents, planning materials, and examples
-  - Preserved for reference but not actively maintained
-  - Can be selectively restored if needed
-  - Includes: design docs, planning materials, issues analysis, examples, guides, diagrams, and reference materials
+1. [Architecture overview](architecture/overview.md)
+2. [Data model and persistence](architecture/data-model.md)
+3. [Add a mechanic](how-to/add-a-mechanic.md)
+4. The nearest [component guide](architecture/components/)
+5. Targeted [ADR](adr/README.md) and [journey](journey/README.md) entries linked
+   by that guide
 
-## Documentation Philosophy
+### Develop and verify
 
-Per the project's CLAUDE.md guidelines:
+- [Run tests](how-to/run-tests.md)
+- [Fix local `go.mod` replace directives](how-to/fix-go-mod-replace-directives.md)
+- [Current status](status.md)
+- [Quality scorecard](quality.md)
 
-1. **Journey Docs** (`journey/`): Tell the story of exploration and decisions
-2. **ADRs** (`adr/`): Formal architectural decisions
-3. **READMEs**: Concise summaries of what exists
+## Current-reference documentation
 
-## Contributing
+- [Architecture overview](architecture/overview.md) — modules, layer direction,
+  host boundary, and clearly labelled pending migrations
+- [Data model](architecture/data-model.md) — runtime/data and
+  `ToData`/`LoadFromData` patterns
+- [Component guides](architecture/components/) — current package/module seams;
+  verify their update/confidence header and code before relying on details
+- [How-to guides](how-to/) — task instructions
+- [Status](status.md) and [quality](quality.md) — current health summaries
 
-When adding new documentation:
+## Permanent architecture history
 
-- **ADRs**: Use for formal architectural decisions that affect the whole system
-- **Journey logs**: Use for exploration, design thinking, and development narratives
-- **Archive**: Don't add new docs here - this is for historical preservation only
+- [Architecture Decision Records](adr/README.md) — binding decisions unless
+  superseded by a later ADR; do not delete or rewrite history
+- [Journey notes](journey/README.md) — exploration and rationale; not necessarily
+  the current API
 
-For active feature planning and ideas, consider creating an `ideas/` directory when needed.
+## Historical and proposed material
+
+- [`plans/`](plans/) contains implementation plans from particular moments.
+  Some shipped, some were superseded, and snippets may no longer compile.
+- [`ideas/`](ideas/) contains design exploration and proposals. A design title
+  does not mean the API exists.
+- [`archive/`](archive/) is historical reference only.
+
+Monster behavior documents now carry explicit status banners. Start from the
+[current monster README](../rulebooks/dnd5e/monster/README.md), not a historical
+plan.
+
+## Adding documentation
+
+- Add an ADR for a durable architectural decision; retain superseded ADRs and
+  mark the superseding record.
+- Add a journey note for exploration/rationale that future contributors need.
+- Add a how-to for a repeatable current task, with exact paths and commands
+  verified against the code.
+- Put current goals, non-goals, seams, load/persistence ownership, and targeted
+  history links in the nearest real module/package README or AGENTS file.
+- Do not create new archive material, duplicate role policy, or present a plan
+  as current behavior.

--- a/docs/architecture/components/rulebook-dnd5e.md
+++ b/docs/architecture/components/rulebook-dnd5e.md
@@ -388,35 +388,39 @@ Subclass modifications live in `subclass_modifications.go`. The `submissions.go`
 file is the input shape rpg-api converts proto requests into. Implementation
 notes are in `character/choices/CHOICES_SYSTEM.md`.
 
-## monster/ — note on sibling sub-packages
+## monster/ — runtime, actions, content, and traits
 
-`monster/` is imported by 14 rpg-api files. **Important nuance**:
-`monster/actions` and `monster/monsters` are **sibling sub-packages** of
-`monster/`, not subdirectories in the import sense — they cannot be reached
-through `monster/` because of an import cycle. rpg-api imports them directly
-where it needs them: `monster/actions` from
-`internal/orchestrators/encounter/monster_turns.go` (1 file) and
-`monster/monsters` from `internal/components/dungeon/monster_factory.go` and
-`internal/orchestrators/encounter/orchestrator_test.go` (2 files). The audit
-at `docs/journey/049-rpg-api-toolkit-usage-audit.md` Section 1 incorrectly
-records both as 0 files; this needs a follow-up correction to the audit.
+Monster support currently spans four packages inside the single D&D 5e module:
 
-The built-in monster factory functions like `NewGoblin` live in
-`rulebooks/dnd5e/monster/monster.go` (search for `func NewGoblin`), **not** in
-`monster/monsters/`. `monster/monsters/` contains `Bandit`, `BrownBear`, and
-`Ghoul` — newer additions. `monster/actions/` contains `Bite`, `Melee`,
-`Ranged`, `Multiattack` — the action types monsters compose into their
-turns.
-
-Top symbols rpg-api consumes from `monster/`:
-
-| Symbol | Role |
+| Package | Current owner |
 |---|---|
-| `monster.Data` | persisted monster shape (62 references; deprecation comment in rpg-api repository at `internal/repositories/encounters/repository.go` flags migration in flight) |
-| `monster.LoadFromData` | reconstitute a Monster from Data + bus |
-| `monster.PerceivedEntity`, `monster.PerceptionData` | perception output |
-| `monster.NewGoblin`, `monster.ScimitarConfig` | encounter-setup helpers |
-| `monster.ActionData`, `monster.TypeMeleeAttack`, `monster.TypeRangedAttack`, `monster.TakeDamage` | action plumbing |
+| `monster` | Runtime `Monster`, persisted `Data`, perception/action contracts, `TakeTurn`, targeting, base `LoadFromData`/`ToData`; also the older `NewGoblin` factory |
+| `monster/actions` | Loadable generic action implementations and `LoadMonsterActions` |
+| `monster/monsters` | Built-in factory functions and canonical-ref constructor registry |
+| `monstertraits` | Condition-style trait loader and implementations |
+
+`monster/actions` and `monster/monsters` are directly imported subpackages; they
+are not surfaced through package `monster`. The registry in
+`monster/monsters/registry.go` is the current author/load seam and is consumed by
+encounter seeding and dungeonspec validation.
+
+Monster reload is deliberately multi-step today: `monster.LoadFromData` creates
+the base runtime object, `monster/actions.LoadMonsterActions` restores action
+implementations, and `monstertraits.LoadMonsterConditions` loads and applies
+persisted traits. The encounter hydration cascade owns those steps for held
+combatants. `monster.LoadFromData` alone is not a complete factory round trip.
+
+`Monster.TakeTurn` is the shipped tactics/decision path. It chooses a targeting
+strategy, moves via `tools/spatial` A*, scores and activates actions, and returns
+movement/action attempts. Generic attack actions publish D&D 5e attack events;
+the currently D&D-5e-coupled top-level encounter module captures those events
+and delegates hit/damage to its `CombatResolver`.
+
+See the [current monster README](../../../rulebooks/dnd5e/monster/README.md) and
+[monster contribution guide](../../how-to/add-a-dnd5e-monster.md) for the exact
+current paths, known unsupported clauses, and the clearly labelled proposal to
+flatten built-in content to `rulebooks/dnd5e/monsters` later without creating a
+new module.
 
 ## initiative/ — round/turn tracker
 

--- a/docs/architecture/components/rulebook-dnd5e.md
+++ b/docs/architecture/components/rulebook-dnd5e.md
@@ -12,9 +12,11 @@ confidence: high — verified by directory listing, grep over public symbols, rp
 **Grade:** B+
 
 The top of the dependency tree. The most actively worked module. Implements
-all D&D 5e game rules: character creation and leveling, combat resolution,
-initiative, features (Rage, Second Wind, Martial Arts, etc.), conditions
-(Raging, Dodging, Unconscious, etc.), spells, monsters, and dungeon layouts.
+the D&D 5e rules and content currently supported by this toolkit: character
+creation and leveling paths, combat resolution, initiative, selected features
+(Rage, Second Wind, Martial Arts, etc.), conditions (Raging, Dodging,
+Unconscious, etc.), spells, monsters, and dungeon layouts. It is not a complete
+implementation of every D&D 5e rule or content clause.
 
 ## What rpg-api consumes
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-toolkit architecture overview
 description: Module dependency map + rules-vs-room seam (two diagrams), persistence pattern, and the boundary with rpg-api — lead-framed with toolkit-as-product
-updated: 2026-07-04
+updated: 2026-08-10
 confidence: high — diagrams verified against go.mod files 2026-07-04; encounter boundary per ADR-0034
 ---
 
@@ -122,6 +122,8 @@ Conditions and features use a JSON variant of the same pattern:
 
 The difference: `LoadFromData` is used when the data schema is homogeneous (one struct type per entity); `LoadJSON` is used when the loader routes by ref (multiple condition/feature types serialized to the same opaque blob field).
 
+Monster reload currently composes both forms and is explicitly multi-step: `monster.LoadFromData` restores the base entity, `monster/actions.LoadMonsterActions` restores polymorphic actions, and `monstertraits.LoadMonsterConditions` routes and applies trait JSON. The encounter hydration cascade owns all three. See the [current monster README](../../rulebooks/dnd5e/monster/README.md).
+
 ## The boundary rule
 
 ```
@@ -188,6 +190,10 @@ infrastructure at the general layer.
 | events | `events/` | Core | EventBus, BusEffect, TypedTopic, ChainedTopic |
 | game | `game/` | Core | game.Context pattern for passing game state through event chains |
 | items | `items/` | Core | Item/EquippableItem/WeaponItem interfaces — base only, no implementation |
+| play/clock | `play/clock/` | Play primitive | Explicit clock state and advance contracts |
+| play/intel | `play/intel/` | Play primitive | Viewer knowledge/intelligence facts and merge contracts |
+| play/interrupt | `play/interrupt/` | Play primitive | Owned interruption windows and answer custody contracts |
+| play/record | `play/record/` | Play primitive | Append-only play record contracts |
 | mechanics/effects | `mechanics/effects/` | Mechanics | Shared effect infrastructure (tracker, behaviors) |
 | mechanics/conditions | `mechanics/conditions/` | Mechanics | Condition manager, simple/enhanced condition types |
 | mechanics/resources | `mechanics/resources/` | Mechanics | Resource pools (spell slots, ki, rage uses) |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -213,10 +213,8 @@ infrastructure at the general layer.
 ## Code violations against these rules (2026-05-02)
 
 ### Rule: No local `replace` directives on main
-**Violated by four modules committed to main:**
-- `items/go.mod` — `replace github.com/KirkDiggler/rpg-toolkit/core => ../core`
+**Violated by two modules committed to main (verified 2026-08-10):**
 - `mechanics/conditions/go.mod` — 4 replace directives (`core`, `dice`, `events`, `effects`)
-- `mechanics/proficiency/go.mod` — `replace github.com/KirkDiggler/rpg-toolkit/mechanics/effects => ../effects`
 - `mechanics/spells/go.mod` — 6 replace directives (`core`, `dice`, `events`, `conditions`, `effects`, `resources`)
 
 Tracked in issue #613. These work locally but break CI because published module resolution fails when directives are present.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -204,7 +204,7 @@ infrastructure at the general layer.
 | tools/environments | `tools/environments/` | Tools | Environment persistence, graph generation, multi-room dungeon graph |
 | tools/selectables | `tools/selectables/` | Tools | Weighted random selection tables |
 | tools/spawn | `tools/spawn/` | Tools | 4-phase entity spawn engine |
-| rulebooks/dnd5e | `rulebooks/dnd5e/` | Rulebooks | Full D&D 5e rules: character, combat, initiative, spells, monsters, dungeon — **plus the encounter loop** (post-split) |
+| rulebooks/dnd5e | `rulebooks/dnd5e/` | Rulebooks | Currently supported D&D 5e rules and content: character, combat, initiative, spells, monsters, dungeon — **plus the encounter loop** (post-split) |
 | encounter loop | `rulebooks/dnd5e/encounter/` *(migration pending; today `encounter/`)* | Rulebooks (D&D 5e) | The dnd5e game loop: turn loop, hydration cascade, resolver seam, verb dispatch, prompts. A **package inside** the dnd5e module in the end-state — merges in per ADR-0034 (kills the pseudo-version dance). |
 | broker | `broker/` *(new; migration pending)* | Primitive | Pub/sub fan-out + game-event timestamp authority + the `Transport` seam. Extracted from the encounter (ADR-0034). |
 | eventspine | `eventspine/` *(new; migration pending)* | Primitive | Sealed event-interface mechanism + audience routing. Extracted from the encounter; concrete dnd5e events stay with the loop (ADR-0034). |

--- a/docs/how-to/add-a-dnd5e-monster.md
+++ b/docs/how-to/add-a-dnd5e-monster.md
@@ -50,7 +50,7 @@ Allowed inputs are:
    required attribution and change notices preserved. The primary official
    source for 2014 D&D 5e open content is the
    [System Reference Document 5.1 PDF](https://media.wizards.com/2023/downloads/dnd/SRD_CC_v5.1.pdf),
-   released under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+   released under CC BY 4.0.
 
 Do **not** copy monster statistics, descriptive text, abilities, or other clauses
 from a closed Monster Manual or another unlicensed book. A monster also appearing
@@ -59,19 +59,41 @@ SRD version only. Do not treat a third-party API, wiki, video, search result, or
 model memory as the legal source unless its own provenance and license are
 verified.
 
-For adapted SRD 5.1 content, preserve an attribution record in the PR and add a
-short source comment next to the factory when values are derived from it. At a
-minimum record:
+### Required SRD 5.1 notice
 
-```text
-Source: System Reference Document 5.1 by Wizards of the Coast LLC
-Source URL: https://media.wizards.com/2023/downloads/dnd/SRD_CC_v5.1.pdf
-License: CC BY 4.0 — https://creativecommons.org/licenses/by/4.0/
-Changes: <identify renaming, omitted clauses, or other adaptation>
+Do not invent, abbreviate, or paraphrase an SRD attribution. WotC's SRD 5.1
+Legal Information instructs users to include this exact statement in their own
+work:
+
+> This work includes material taken from the System Reference Document 5.1
+> (“SRD 5.1”) by Wizards of the Coast LLC and available at
+> https://dnd.wizards.com/resources/systems-reference-document. The SRD 5.1 is
+> licensed under the Creative Commons Attribution 4.0 International License
+> available at https://creativecommons.org/licenses/by/4.0/legalcode.
+
+For any SRD-derived contribution, preserve that statement verbatim in the
+repository-root `NOTICE` file. If `NOTICE` does not exist, the content PR must
+create it. A distributed source archive, game build, or other work containing
+the SRD-derived material must also carry the exact statement in its included
+legal notices/credits; keeping it only in a PR description is not sufficient.
+Do not add any other attribution regarding Wizards beyond the statement above,
+per the SRD's own instruction.
+
+Record adaptations separately from the verbatim attribution. In the same
+`NOTICE`, use a separate “Modifications to SRD-derived material” heading and
+identify conversions, renaming, omissions, or other changes. Repeat the relevant
+change note next to the factory without adding another Wizards credit, for
+example:
+
+```go
+// Adaptation: converted movement and attack ranges from feet to hex counts;
+// omitted clauses not supported by the current rulebook.
 ```
 
-This is a minimum repository guardrail, not legal advice. If the source's terms
-cannot be satisfied confidently, use original content or stop for human review.
+Also repeat the modification summary in the PR so reviewers can check fidelity,
+but do not rely on the PR as the distributed notice. This repository guidance
+is not legal advice. If the source terms or required notice cannot be satisfied
+confidently, use original content or stop for human review.
 
 ## 2. Choose the lane clause by clause
 
@@ -171,7 +193,7 @@ code after taking the separately scoped new-mechanic lane.
 Use the existing one-action bandit as the worked **structural** pattern. Do
 not copy its distance literals: the older factories use feet-shaped values such
 as `Reach: 5` and `RangeNormal: 80`, while the current generic action configs
-and `PerceptionData.Distance` interpret reach/ranges as hex counts. New content
+and `PerceivedEntity.Distance` interpret reach/ranges as hex counts. New content
 must use current units (5 feet = 1 hex) and pin them in tests.
 
 - factory: [`monster/monsters/bandit.go`](../../rulebooks/dnd5e/monster/monsters/bandit.go)
@@ -224,10 +246,50 @@ factory
   → loaded.ToData
 ```
 
-Assert that ID/ref, current and max HP, AC, ability scores, speed, targeting,
-action ref/config, and supported trait JSON survive as applicable. Use a real
-event bus and clean up the loaded monster. For a trait, assert its actual chain
-behavior as well as JSON presence; serialization alone does not prove a rule.
+Use [`monster/actions/integration_test.go`](../../rulebooks/dnd5e/monster/actions/integration_test.go)
+as the current action-hydration example. A new factory test should extend that
+proof to JSON and the complete applicable definition, following this concise
+skeleton (names abbreviated):
+
+```go
+ctx := context.Background()
+bus := events.NewEventBus() // test-local: discard the whole bus after the test
+before := NewExampleBeast("example-1").ToData()
+raw, err := json.Marshal(before)
+require.NoError(t, err)
+var persisted monster.Data
+require.NoError(t, json.Unmarshal(raw, &persisted))
+
+loaded, err := monster.LoadFromData(ctx, &persisted, bus)
+require.NoError(t, err)
+require.NoError(t, actions.LoadMonsterActions(loaded, persisted.Actions))
+require.NoError(t, monstertraits.LoadMonsterConditions(
+    ctx, loaded, persisted.Conditions, bus, dice.NewRoller(),
+))
+
+after := loaded.ToData()
+require.Equal(t, before.Ref.String(), after.Ref.String())
+require.Equal(t, before.HitPoints, after.HitPoints)
+require.Equal(t, before.Speed, after.Speed)
+require.Len(t, loaded.Actions(), len(before.Actions))
+require.Equal(t, "claw", loaded.Actions()[0].GetID())
+require.Equal(t, monster.TypeMeleeAttack, loaded.Actions()[0].ActionType())
+require.Equal(t, before.Actions[0].Ref, after.Actions[0].Ref)
+require.JSONEq(t, string(before.Actions[0].Config), string(after.Actions[0].Config))
+```
+
+Also assert max HP, AC, all six ability scores, targeting, every action (not just
+the first), and supported trait JSON/behavior as applicable. For a trait, assert
+its actual chain behavior as well as JSON presence; serialization alone does not
+prove a rule.
+
+`Monster.Cleanup` removes only the base monster's own subscriptions; it does
+**not** remove trait subscriptions applied by `LoadMonsterConditions`. The
+simplest test isolation is one bus per test and discarding that bus with the
+loaded graph. If a test intentionally reuses a long-lived bus, call `Remove` on
+each condition returned by `loaded.GetConditions()` before
+`loaded.Cleanup(ctx)`. Do not claim `Monster.Cleanup` alone cleans the full
+hydrated monster.
 
 The encounter hydration cascade already performs these loading steps, but a
 rulebook content test should keep the factory contract understandable without
@@ -267,7 +329,11 @@ Makefile, so do not report one as if it existed.
 ### Provenance
 
 - [ ] Human approved an original or permissively licensed source.
-- [ ] PR records source, URL/reference, license, attribution, and adaptations.
+- [ ] For SRD-derived content, the exact SRD 5.1 attribution statement is in
+      root `NOTICE` and the distribution's legal notices/credits, with no other
+      Wizards attribution.
+- [ ] Modifications are recorded separately in `NOTICE`, beside the factory,
+      and in the PR.
 - [ ] No closed Monster Manual or unverified aggregator content was copied.
 
 ### Capability and scope
@@ -298,6 +364,6 @@ Makefile, so do not report one as if it existed.
 - [ ] Focused package tests pass with the race detector.
 - [ ] Full `rulebooks/dnd5e` tests and lint pass.
 - [ ] `git diff --check`, Markdown link sanity, and `make pre-commit` pass (or a
-      concrete environment blocker is reported).
+      known repository or concrete environment blocker is reported).
 - [ ] Diff contains no package move, new module, unrelated behavior, or local
       `replace` directive.

--- a/docs/how-to/add-a-dnd5e-monster.md
+++ b/docs/how-to/add-a-dnd5e-monster.md
@@ -176,7 +176,7 @@ change set is:
 |---|---|
 | `rulebooks/dnd5e/refs/monsters.go` | Add the unexported singleton ref and the `refs.Monsters.ExampleBeast()` method. Use lowercase hyphenated ref IDs. |
 | `rulebooks/dnd5e/refs/refs_test.go` | Assert the new ref's module, type, and ID (add a monster namespace table if needed). |
-| `rulebooks/dnd5e/monster/monsters/example_beast.go` | Add `NewExampleBeast(id string) *monster.Monster`, source comment, supported stats/actions, and speed. |
+| `rulebooks/dnd5e/monster/monsters/example_beast.go` | Add `NewExampleBeast(id string) *monster.Monster`, an adaptation/change comment per the provenance section, supported stats/actions, and speed. |
 | `rulebooks/dnd5e/monster/monsters/example_beast_test.go` | Assert ID, ref, name, stats, ability scores, speed, action IDs/types, and any supported attached trait data. |
 | `rulebooks/dnd5e/monster/monsters/registry.go` | Map the full `refs.Monsters.ExampleBeast().String()` to the constructor. |
 | `rulebooks/dnd5e/monster/monsters/registry_test.go` | Add the ref to the expected registry list; the existing test proves ref → constructor → same ref. |

--- a/docs/how-to/add-a-dnd5e-monster.md
+++ b/docs/how-to/add-a-dnd5e-monster.md
@@ -168,7 +168,11 @@ code after taking the separately scoped new-mechanic lane.
 
 ## 4. Follow the canonical simple fixture
 
-Use the existing one-action bandit as the worked pattern:
+Use the existing one-action bandit as the worked **structural** pattern. Do
+not copy its distance literals: the older factories use feet-shaped values such
+as `Reach: 5` and `RangeNormal: 80`, while the current generic action configs
+and `PerceptionData.Distance` interpret reach/ranges as hex counts. New content
+must use current units (5 feet = 1 hex) and pin them in tests.
 
 - factory: [`monster/monsters/bandit.go`](../../rulebooks/dnd5e/monster/monsters/bandit.go)
   (`NewBanditMelee` is the smallest example);

--- a/docs/how-to/add-a-dnd5e-monster.md
+++ b/docs/how-to/add-a-dnd5e-monster.md
@@ -1,0 +1,299 @@
+---
+name: add a D&D 5e monster
+description: Human + agent contract for legal, supported monster content and its current factory/registry/round-trip path
+updated: 2026-08-10
+---
+
+# Add a D&D 5e monster
+
+This is the recommended first rulebook contribution **when every rule clause can
+be composed from behavior that already ships**. It is an operator contract for a
+human supervising an agent, not permission to translate an arbitrary stat block
+and hope the engine understands it.
+
+Read the [D&D 5e rulebook mental model](../../rulebooks/dnd5e/README.md) and the
+[nearest monster guide](../../rulebooks/dnd5e/monster/README.md) first.
+
+## Human + agent contract
+
+### The human provides and approves
+
+- the creature concept and allowed source;
+- the source version, URL or bibliographic reference, license, attribution, and
+  whether the content was adapted;
+- the exact clauses that must be represented (not merely its name and headline
+  statistics);
+- the decision to stop when a clause needs new mechanics;
+- final review that the result is faithful without including closed text.
+
+### The agent must
+
+- inspect current code and tests before describing a capability;
+- make a clause-by-clause support inventory and show it to the human;
+- use the current paths in this guide, not a proposed package layout;
+- never silently omit, approximate, or claim support for an unsupported clause;
+- keep a content-only change separate from new mechanic behavior;
+- add construction, registry, and applicable serialization/load tests;
+- report the source, changes, commands, and limitations in the PR.
+
+If provenance is unclear or any required rule clause is unsupported, the agent
+stops. “The source is on a wiki/API” and “a similarly named field exists” are
+not sufficient evidence.
+
+## 1. Establish provenance before writing code
+
+Allowed inputs are:
+
+1. **Original content** written by the contributor, with no copied protected
+   expression or closed stat block.
+2. **Content under a license compatible with this repository's use**, with all
+   required attribution and change notices preserved. The primary official
+   source for 2014 D&D 5e open content is the
+   [System Reference Document 5.1 PDF](https://media.wizards.com/2023/downloads/dnd/SRD_CC_v5.1.pdf),
+   released under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+Do **not** copy monster statistics, descriptive text, abilities, or other clauses
+from a closed Monster Manual or another unlicensed book. A monster also appearing
+in the SRD does not make the book's additional wording or clauses open: use the
+SRD version only. Do not treat a third-party API, wiki, video, search result, or
+model memory as the legal source unless its own provenance and license are
+verified.
+
+For adapted SRD 5.1 content, preserve an attribution record in the PR and add a
+short source comment next to the factory when values are derived from it. At a
+minimum record:
+
+```text
+Source: System Reference Document 5.1 by Wizards of the Coast LLC
+Source URL: https://media.wizards.com/2023/downloads/dnd/SRD_CC_v5.1.pdf
+License: CC BY 4.0 — https://creativecommons.org/licenses/by/4.0/
+Changes: <identify renaming, omitted clauses, or other adaptation>
+```
+
+This is a minimum repository guardrail, not legal advice. If the source's terms
+cannot be satisfied confidently, use original content or stop for human review.
+
+## 2. Choose the lane clause by clause
+
+Make a table before editing:
+
+| Source clause | Current implementation evidence | Lane | Test |
+|---|---|---|---|
+| e.g. one melee attack | `monster/actions/melee.go` + loader | content composition | factory + action round trip |
+| e.g. “on hit, target is grappled” | no current action/rule path | new mechanic — stop | separately scoped rule test |
+
+### Content-composition lane
+
+A content-only monster can currently compose these verified surfaces:
+
+- canonical identity through `refs.Monsters`;
+- `monster.Config`: ID, name, ref, HP/max HP, AC, six ability scores, and an
+  optional proficiency bonus (zero defaults to 2);
+- walking/flying/swimming/climbing/burrowing speed through `SetSpeed`;
+- generic melee, ranged, multiattack, and bite action objects in
+  `monster/actions`, subject to the limitations below;
+- targeting through `SetTargeting`: closest, lowest HP, or lowest AC;
+- immunity and vulnerability trait JSON through current `monstertraits`
+  helpers, with load/apply/round-trip tests.
+
+A **simple first fixture** should use one generic melee or ranged attack, no
+special trait text, and default closest targeting. This keeps the contribution
+about content composition rather than inventing rule semantics.
+
+### Supported data is not the same as supported clause behavior
+
+Be explicit about current limitations:
+
+- `monster.Data` has senses and proficiency fields, but the built-in factory
+  surface has no setters for them. It also has `Features` and `Inventory`
+  fields that the current base load/`ToData` path does not hydrate/preserve as
+  complete runtime behavior. Do not add such clauses in a factory-only PR.
+- CR, XP, size, creature type, alignment, languages, saving-throw
+  proficiencies, legendary/lair actions, recharge, spellcasting, and encounter
+  difficulty are not part of the current built-in factory contract.
+- generic melee/ranged actions publish attack events. The top-level encounter
+  module resolves their snapshot attack bonus/damage through its resolver;
+  the actions are not standalone hit-and-damage functions.
+- ranged normal-vs-long range disadvantage is not implemented by the generic
+  ranged action; it only gates against long range.
+- `BiteConfig.KnockdownDC` serializes, but knockdown-on-hit is not implemented.
+- Pack Tactics currently subscribes as a no-op; ally adjacency does not grant
+  advantage.
+- Undead Fortitude currently rolls but does not change HP and cannot enforce
+  its critical-hit exception.
+- comments in some existing factories mention Pack Tactics or Undead Fortitude
+  without attaching a completed behavior. A comment is not capability evidence.
+
+Do not “support” a source by dropping one of its material clauses. Either use an
+original/simple creature whose contract fits the current engine, or take the
+new-mechanic lane.
+
+### New-mechanic stop/scope lane
+
+When any required clause is unsupported:
+
+1. stop the monster content edit;
+2. open or confirm a separate issue and board item for the mechanic;
+3. define the narrowest rule owner, inputs/outputs, event-chain behavior,
+   persistence/reload consequence, and a real-path rule test;
+4. implement and ship the mechanic in its own reviewed change;
+5. return to the content contribution only after the published/current rulebook
+   surface can express the whole clause.
+
+Do not put encounter composition into the monster factory and do not make the
+host interpret a rule. If encounter selection, population, placement, or CR
+budgeting is the missing feature, scope it at the composition layer rather than
+pretending it is a stat-block behavior.
+
+## 3. Use the current files
+
+For a creature named `Example Beast` with slug `example-beast`, the current
+change set is:
+
+| File | Required edit |
+|---|---|
+| `rulebooks/dnd5e/refs/monsters.go` | Add the unexported singleton ref and the `refs.Monsters.ExampleBeast()` method. Use lowercase hyphenated ref IDs. |
+| `rulebooks/dnd5e/refs/refs_test.go` | Assert the new ref's module, type, and ID (add a monster namespace table if needed). |
+| `rulebooks/dnd5e/monster/monsters/example_beast.go` | Add `NewExampleBeast(id string) *monster.Monster`, source comment, supported stats/actions, and speed. |
+| `rulebooks/dnd5e/monster/monsters/example_beast_test.go` | Assert ID, ref, name, stats, ability scores, speed, action IDs/types, and any supported attached trait data. |
+| `rulebooks/dnd5e/monster/monsters/registry.go` | Map the full `refs.Monsters.ExampleBeast().String()` to the constructor. |
+| `rulebooks/dnd5e/monster/monsters/registry_test.go` | Add the ref to the expected registry list; the existing test proves ref → constructor → same ref. |
+
+Do not create `rulebooks/dnd5e/monsters` for this task. That flatter location is
+a proposed follow-up only. Do not add a `go.mod`: all of the paths above are
+packages inside the existing `rulebooks/dnd5e` module.
+
+Only touch `monster/actions`, `monstertraits`, their refs/loaders, or encounter
+code after taking the separately scoped new-mechanic lane.
+
+## 4. Follow the canonical simple fixture
+
+Use the existing one-action bandit as the worked pattern:
+
+- factory: [`monster/monsters/bandit.go`](../../rulebooks/dnd5e/monster/monsters/bandit.go)
+  (`NewBanditMelee` is the smallest example);
+- direct assertions: [`bandit_test.go`](../../rulebooks/dnd5e/monster/monsters/bandit_test.go);
+- discoverability: [`registry.go`](../../rulebooks/dnd5e/monster/monsters/registry.go);
+- registry correctness: [`registry_test.go`](../../rulebooks/dnd5e/monster/monsters/registry_test.go).
+
+The minimum shape is:
+
+```go
+func NewExampleBeast(id string) *monster.Monster {
+    m := monster.New(monster.Config{
+        ID:            id,
+        Name:          "Example Beast",
+        Ref:           refs.Monsters.ExampleBeast(),
+        HP:            9,
+        AC:            12,
+        AbilityScores: shared.AbilityScores{
+            abilities.STR: 10, abilities.DEX: 12, abilities.CON: 11,
+            abilities.INT: 3, abilities.WIS: 10, abilities.CHA: 6,
+        },
+    })
+    m.AddAction(actions.NewMeleeAction(actions.MeleeConfig{
+        Name: "claw", AttackBonus: 3, DamageDice: "1d4+1",
+        Reach: 1, DamageType: damage.Slashing,
+    }))
+    m.SetSpeed(monster.SpeedData{Walk: 30})
+    return m
+}
+```
+
+The values above are an illustrative original fixture, not a published D&D
+stat block. Verify dice notation, range units, and damage vocabulary against
+current action tests. In these action configs, reach/ranges are hex counts even
+though `SpeedData` is feet; existing older comments and values are not uniformly
+reliable, so the new test must pin the intended current behavior.
+
+### Prove the full applicable round trip
+
+A no-trait fixture still needs to prove action hydration:
+
+```text
+factory
+  → ToData
+  → JSON marshal/unmarshal (when persistence is claimed)
+  → monster.LoadFromData(ctx, data, bus)
+  → actions.LoadMonsterActions(loaded, data.Actions)
+  → monstertraits.LoadMonsterConditions(...) when conditions exist
+  → loaded.ToData
+```
+
+Assert that ID/ref, current and max HP, AC, ability scores, speed, targeting,
+action ref/config, and supported trait JSON survive as applicable. Use a real
+event bus and clean up the loaded monster. For a trait, assert its actual chain
+behavior as well as JSON presence; serialization alone does not prove a rule.
+
+The encounter hydration cascade already performs these loading steps, but a
+rulebook content test should keep the factory contract understandable without
+requiring a full encounter fixture. If the contribution is also intended for
+authored dungeon specs, the registry test is mandatory because dungeonspec
+validation calls `monsters.ByRef`.
+
+## 5. Validate
+
+Run from the repository root unless the command changes directory:
+
+```bash
+# Focused rulebook packages touched by a simple monster
+cd rulebooks/dnd5e
+go test -race ./refs ./monster ./monster/actions ./monster/monsters ./monstertraits
+
+# Full owning module
+go test -race ./...
+golangci-lint run ./...
+
+# Return to repository root for repository gates
+cd ../..
+git diff --check
+make pre-commit
+```
+
+`make pre-commit` currently exercises Core and Events; it does not replace the
+D&D 5e module commands above. The installed Git hook exits successfully for a
+documentation-only commit and checks changed Go packages for code changes.
+
+Also open every changed Markdown link or run the repository-relative link check
+used by the PR. There is currently no dedicated Markdown/link target in the
+Makefile, so do not report one as if it existed.
+
+## Done checklist
+
+### Provenance
+
+- [ ] Human approved an original or permissively licensed source.
+- [ ] PR records source, URL/reference, license, attribution, and adaptations.
+- [ ] No closed Monster Manual or unverified aggregator content was copied.
+
+### Capability and scope
+
+- [ ] Every source clause appears in the support inventory.
+- [ ] Every included clause has current code and real-path test evidence.
+- [ ] Unsupported clauses stopped or moved to separately scoped mechanic work;
+      none were silently omitted or described as shipped.
+- [ ] Factory contains definition only; rule resolution and encounter
+      composition remain with their current owners.
+
+### Current integration
+
+- [ ] Canonical ref and ref test exist.
+- [ ] Current `monster/monsters` factory and focused test exist.
+- [ ] Registry and expected registry list include the ref and construct the
+      matching ref.
+- [ ] Factory `ToData` preserves the intended definition.
+- [ ] Base load plus action load (and condition load/apply when applicable)
+      reconstructs the runtime monster.
+- [ ] `ToData` after load preserves applicable ID/ref, mutable HP, stats, speed,
+      targeting, actions, and supported traits.
+- [ ] An intended authored encounter path can resolve the ref through
+      `monsters.ByRef`; no future `dnd5e/monsters` path is assumed.
+
+### Verification
+
+- [ ] Focused package tests pass with the race detector.
+- [ ] Full `rulebooks/dnd5e` tests and lint pass.
+- [ ] `git diff --check`, Markdown link sanity, and `make pre-commit` pass (or a
+      concrete environment blocker is reported).
+- [ ] Diff contains no package move, new module, unrelated behavior, or local
+      `replace` directive.

--- a/docs/how-to/add-a-rulebook-entry.md
+++ b/docs/how-to/add-a-rulebook-entry.md
@@ -1,12 +1,12 @@
 ---
 name: how to add a rulebook entry
-description: Adding static D&D 5e data — background grants, race grants, spell data, monster stats
-updated: 2026-05-02
+description: Entry points for D&D 5e grants, spells, and monster content
+updated: 2026-08-10
 ---
 
 # How to add a rulebook entry
 
-Static data (background proficiencies, race languages, spell damage tables, monster stat blocks) lives in `rulebooks/dnd5e/` data-only packages. These packages have constants and data functions, no game logic.
+D&D 5e content lives in owning packages under `rulebooks/dnd5e/`. Some entries are simple data mappings; others, especially monsters and spells, compose runtime rule behavior and persistence loaders. Verify the owning package and its tests instead of assuming an entry is data-only.
 
 ## Adding a background grant
 
@@ -50,27 +50,11 @@ Without this test, a wrong skill assignment in the switch goes undetected until 
 
 Edit `rulebooks/dnd5e/races/grants.go` — same pattern as backgrounds. Add a test in `races/grants_test.go`.
 
-## Adding a monster stat block
+## Adding a monster
 
-Monster data lives in `rulebooks/dnd5e/monster/`. Each monster type is a function that returns a `*monster.Data`:
+Use the dedicated [Add a D&D 5e monster](add-a-dnd5e-monster.md) contract. The current path is a runtime factory in `rulebooks/dnd5e/monster/monsters/`, plus a canonical ref, registry entry, focused tests, and the applicable multi-step load/round-trip proof. Factories return `*monster.Monster`, not `*monster.Data`.
 
-```go
-// monster/goblin.go
-func NewGoblin() *Data {
-    return &Data{
-        Name:       "Goblin",
-        CR:         0.25,
-        HitPoints:  7,
-        ArmorClass: 15,
-        Speed:      30,
-        // ... abilities, attacks, traits
-    }
-}
-```
-
-Add the monster to the monster registry (wherever `GetMonster(type)` is implemented).
-
-Write a test that asserts the stat block values match the Monster Manual entry. This is the source of truth — once merged, rpg-api will use these values in all encounters.
+The guide also enforces provenance: do not copy closed Monster Manual content. A clause that the current action/trait/resolution paths cannot express requires separately scoped mechanic work; do not silently omit it.
 
 ## Adding a spell
 

--- a/docs/how-to/run-tests.md
+++ b/docs/how-to/run-tests.md
@@ -1,101 +1,115 @@
 ---
 name: how to run tests
-description: Per-module test commands, known failures, pre-commit targets
-updated: 2026-05-04
+description: Per-module, full-repository, lint, and pre-commit commands for the multi-module repository
+updated: 2026-08-10
 ---
 
 # How to run tests
 
-rpg-toolkit is multi-module. Each module must be tested independently — there is no workspace-level `go test ./...` that covers all modules at once.
+RPG Toolkit has 22 independent Go module roots and no root `go.mod`. A root-level
+`go test ./...` is therefore not a repository test. Run the owning module first,
+then use the Makefile's module discovery when a full sweep is required.
 
-## Per-module test command
+## Owning module
+
+From the repository root:
 
 ```bash
-# From the module directory
-cd /home/kirk/personal/rpg-toolkit/<module>
+cd rulebooks/dnd5e       # replace with the module you changed
 go test -race ./...
+golangci-lint run ./...
 ```
 
-### All modules with known-passing tests (as of 2026-05-02)
+For a D&D 5e monster contribution, use the more focused commands and round-trip
+acceptance in [Add a D&D 5e monster](add-a-dnd5e-monster.md) before the full
+rulebook command.
+
+Other examples:
 
 ```bash
-cd /home/kirk/personal/rpg-toolkit/core && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/events && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/dice && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/rpgerr && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/game && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/mechanics/effects && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/mechanics/resources && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/mechanics/features && go test -race ./...  # "no test files" -- not a failure
-cd /home/kirk/personal/rpg-toolkit/mechanics/proficiency && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/mechanics/spells && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/tools/spatial && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/tools/environments && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/tools/selectables && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/tools/spawn && go test -race ./...
-cd /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e && go test -race ./...
+cd core && go test -race ./...
+cd events && go test -race ./...
+cd encounter && go test -race ./...
+cd tools/spatial && go test -race ./...
+cd play/clock && go test -race ./...
 ```
 
-### Modules with known issues
+Each `cd` above starts from the repository root; run them as separate commands or
+return to the root between them.
+
+## All modules
+
+The Makefile discovers every tracked `go.mod`:
 
 ```bash
-# mechanics/conditions — runs but emits go.mod warning
-cd /home/kirk/personal/rpg-toolkit/mechanics/conditions && go test ./...
-# Emits: go: updates to go.mod needed (before printing test results)
-# Tests pass. CI will fail on the go.mod diff.
-# Tracked: issue #613
+make test-all       # go test -race ./... in every module
+make lint-all       # golangci-lint in every module
+make fmt-all        # writes formatting changes across all Go source
+make mod-tidy       # writes dependency changes in every module
 ```
 
-## Makefile targets
+Use the writing targets (`fmt-all`, `mod-tidy`) deliberately and inspect the
+diff. A scoped change should not commit unrelated module churn.
+
+## D&D 5e integration tests
+
+From `rulebooks/dnd5e`:
 
 ```bash
-# pre-commit: fmt + tidy + lint + test for core + events only
-make pre-commit
-
-# test all modules (uses find to locate all go.mod files)
-make test-all
-
-# lint all modules
-make lint-all
-
-# format all modules
-make fmt-all
-```
-
-Note: `make pre-commit` only covers `core` and `events`. For modules outside those two, run per-module commands before committing.
-
-## Integration tests (dnd5e)
-
-```bash
-cd /home/kirk/personal/rpg-toolkit/rulebooks/dnd5e
 go test -race ./integration/...
 ```
 
-This runs the full Barbarian/Fighter/Monk/Rogue encounter scenarios. These are the most valuable tests in the codebase — they exercise the complete chain from character finalization through combat resolution.
+These tests exercise complete rulebook flows for the currently covered classes.
+They do not replace package-level tests for a new rule or content loader.
 
-## Linting
+## Pre-commit gates
+
+Run the required repository target from the root:
 
 ```bash
-# Per module
-cd /home/kirk/personal/rpg-toolkit/<module>
-golangci-lint run ./...
-
-# All modules (Makefile)
-make lint-all
+make pre-commit
 ```
 
-## go mod tidy check
+The target currently formats, tidies, lints, and tests **Core and Events only**;
+it does not validate all modules. Always run owning-module tests/lint too.
 
-When adding or changing dependencies in any module:
+There is a known main-branch defect in its Core coverage extraction
+([#769](https://github.com/KirkDiggler/rpg-toolkit/issues/769)): the target can
+leak `go test` package output into the numeric `bc` comparison and fail even when
+tests/lint pass. Record that exact failure and the successful owning-module
+evidence; do not bypass hooks or claim the target passed.
+
+The installed `.githooks/pre-commit` script is different from the Make target.
+It inspects staged `.go` files, discovers their owning modules, and checks only
+those changed packages. With no staged Go files (for example, a documentation-
+only commit), it exits successfully after reporting that fact.
+
+## Formatting, dependency, and diff checks
+
+For a changed Go module:
+
 ```bash
-cd /home/kirk/personal/rpg-toolkit/<module>
+cd <module>
+gofmt -w <changed-go-files>
 go mod tidy
+git diff --exit-code -- go.mod go.sum   # omit --exit-code if dependency changes are intentional
 ```
 
-If the command changes `go.mod` or `go.sum`, commit those changes. CI runs `go mod tidy` and fails if the diff is non-empty.
+From the repository root:
 
-## Known CI behavior
+```bash
+git diff --check
+```
 
-- `make pre-commit` passes today for core + events.
-- `mechanics/conditions`, `mechanics/spells` tests pass locally but CI fails because `go mod tidy` would change their go.mod (replace directives present, issue #613).
-- `items` module tests now compile and pass (resolved per issue #612).
+Never commit a local `replace` directive. See
+[Fix `go.mod` replace directives](fix-go-mod-replace-directives.md).
+
+## Documentation checks
+
+There is currently no dedicated Markdown or link-check Make target. For a docs
+change:
+
+- run `git diff --check`;
+- resolve every repository-relative link from the Markdown file containing it;
+- check any new external URLs;
+- report the method used rather than naming a nonexistent repository check.

--- a/docs/ideas/monster-behavior/design-monster-structure.md
+++ b/docs/ideas/monster-behavior/design-monster-structure.md
@@ -1,5 +1,11 @@
 # Monster Structure Design
 
+> **Historical design note — not current API documentation.** This captured the
+> direction before the present implementation. Some concepts shipped, but fields,
+> refs, loaders, and examples below differ from current code and may not compile.
+> Start with the [current monster README](../../../rulebooks/dnd5e/monster/README.md)
+> and verify behavior in code/tests.
+
 Following the character pattern: Data struct for persistence, LoadFromData to wire to bus.
 
 ---

--- a/docs/plans/2025-12-15-monster-additions-design.md
+++ b/docs/plans/2025-12-15-monster-additions-design.md
@@ -1,5 +1,11 @@
 # Monster Additions Design
 
+> **Historical implementation plan — not current contribution instructions.**
+> Parts of this roster and package shape shipped, but several described clauses
+> (including Pack Tactics effects, bite knockdown, and complete Undead Fortitude)
+> are not implemented behavior today. Preserve the plan as history; use the
+> [current monster guide](../how-to/add-a-dnd5e-monster.md) for new work.
+
 **Date:** 2025-12-15
 **Status:** Approved
 **Related Issue:** [#425 - Monster Additions: Skeleton and Boss stat blocks](https://github.com/KirkDiggler/rpg-toolkit/issues/425)

--- a/docs/plans/2026-01-06-monster-pathfinding.md
+++ b/docs/plans/2026-01-06-monster-pathfinding.md
@@ -1,5 +1,10 @@
 # Monster Pathfinding Implementation Plan
 
+> **Historical implementation plan — do not execute these steps now.** A* is
+> shipped in `tools/spatial`, and `monster.TakeTurn` calls that implementation;
+> the proposed monster-local files and commands below are not the current API.
+> See the [current monster README](../../rulebooks/dnd5e/monster/README.md).
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Replace greedy monster movement with A* pathfinding that navigates around walls and obstacles.

--- a/docs/plans/2026-01-06-monster-pathfinding.md
+++ b/docs/plans/2026-01-06-monster-pathfinding.md
@@ -5,7 +5,9 @@
 > the proposed monster-local files and commands below are not the current API.
 > See the [current monster README](../../rulebooks/dnd5e/monster/README.md).
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Legacy execution note:** The original plan required an agent-specific
+> execution skill. That instruction remains available in git history but is
+> intentionally not actionable in this historical document.
 
 **Goal:** Replace greedy monster movement with A* pathfinding that navigates around walls and obstacles.
 

--- a/rulebooks/dnd5e/README.md
+++ b/rulebooks/dnd5e/README.md
@@ -1,308 +1,124 @@
-# D&D 5e Rulebook
+# D&D 5e rulebook
 
-This package implements Dungeons & Dragons 5th Edition rules using the rpg-toolkit infrastructure.
+`rulebooks/dnd5e` is one Go module:
 
-## Overview
-
-The D&D 5e rulebook provides:
-- Character creation with the builder pattern
-- Rich domain models with game mechanics (Attack, SaveThrow, etc.)
-- Data structures for persistence
-- Validation of D&D 5e rules
-- Clear separation between game logic and storage
-
-## Package Structure
-
-The D&D 5e rulebook is organized into bounded contexts:
-
-```
-dnd5e/
-├── character/     # Character creation, persistence, validation
-├── features/      # Character features (rage, second wind, etc.)
-├── combat/        # Attack rolls, damage, initiative
-├── magic/         # Spells, spell slots, casting mechanics
-├── equipment/     # Items, inventory, attunement
-├── rules/         # Core calculations, modifiers
-├── shared/        # Shared types (AbilityScores, etc.)
-└── dnd5e.go       # Package facade for easy imports
+```text
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e
 ```
 
-### Usage
+It implements D&D 5e rules and content. It does not store game state or know
+about a particular database, API, proto, or UI. A host supplies IDs, loads
+rulebook-owned data, calls rulebook behavior, and stores the resulting data.
 
-You can import the entire package:
-```go
-import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e"
+## Recommended first contribution
 
-// Use the facade
-builder, err := dnd5e.NewCharacterBuilder("draft-123")
-char := &dnd5e.Character{}
+Add a simple monster whose entire stat block can be composed from behavior that
+already exists. The [human + agent monster guide](../../docs/how-to/add-a-dnd5e-monster.md)
+contains the provenance gate, supported-capability audit, exact files, tests,
+and round-trip checklist.
+
+Do not copy closed Monster Manual text or statistics. SRD 5.1 content may be
+used under its CC BY 4.0 terms with attribution; original content is also
+welcome. The guide has the full source contract.
+
+## The rulebook mental model
+
+Follow one fact through these layers:
+
+```text
+ref/key → definition or factory → runtime rule behavior → Data/JSON → host storage
+                                      ↑
+                               event bus / rule chains
 ```
 
-Or import specific contexts:
+1. **Refs are boundary keys.** `refs.Monsters.Bandit()` identifies content as
+   `dnd5e:monsters:bandit`. Hosts pass keys; they do not reproduce the rule.
+2. **Definitions compose existing rules.** A monster factory chooses identity,
+   stats, supported actions, supported traits, speed, and targeting. Character,
+   class, weapon, spell, and other packages follow their own composition
+   patterns.
+3. **Runtime types own behavior.** Packages such as `combat`, `character`,
+   `conditions`, `features`, `monster`, and `monstertraits` implement rules and
+   subscribe to or publish on the event bus.
+4. **Data is the persistence boundary.** Stateful runtime objects expose
+   `ToData` (or `ToJSON` for polymorphic conditions/features); rulebook loaders
+   reconstruct behavior and subscriptions. The host persists the data but does
+   not interpret it.
+5. **Composition is above rule resolution.** The top-level `encounter` module
+   currently composes D&D 5e monster decisions, combat resolution, spatial
+   state, and encounter events. It is D&D-5e-coupled today.
+
+For monsters, loading is currently multi-step: `monster.LoadFromData` creates
+and subscribes the base runtime monster, `monster/actions.LoadMonsterActions`
+restores its action implementations, and
+`monstertraits.LoadMonsterConditions` loads and applies persisted traits. The
+`encounter.LoadFromData` hydration cascade performs all three. Calling only
+`monster.LoadFromData` does **not** restore a complete factory-created monster.
+
+## Current package map
+
+The module contains many packages. Start with the nearest package rather than
+trying to learn all of them.
+
+| Area | Current packages | What they own |
+|---|---|---|
+| Boundary vocabulary | `refs`, `abilities`, `damage`, `skills`, `languages`, `weapons`, `armor` | Typed identifiers and rulebook vocabulary |
+| Characters | `character`, `character/choices`, `class`, `classes`, `race`, `races`, `backgrounds`, `packs`, `equipment` | Character authoring, grants, equipment, runtime state, and persistence |
+| Rules | `actions`, `combat`, `combatabilities`, `checks`, `saves`, `initiative`, `features`, `conditions`, `fightingstyles`, `resources`, `spells` | D&D-specific resolution and behavior |
+| Monsters | `monster`, `monster/actions`, `monster/monsters`, `monstertraits` | Runtime/data model, reusable actions, built-in factories/registry, and trait behaviors |
+| Integration/composition helpers | `events`, `gamectx`, `dungeon`, `integration` | D&D event vocabulary, runtime lookup context, dungeon content, and end-to-end rule tests |
+
+The root `dnd5e` package is a small facade containing aliases for selected race,
+class, and shared character-creation types. It is **not** a facade for the whole
+rulebook. Import the owning subpackage directly.
+
+There is no `rulebooks/dnd5e/monsters` package today. Built-in content currently
+lives at `rulebooks/dnd5e/monster/monsters` inside this same module. A possible
+cleanup is recorded as a proposed follow-up in the
+[nearest monster README](monster/README.md); current instructions do not depend
+on it.
+
+## Install
+
+Because this repository is multi-module, install this module directly:
+
+```bash
+go get github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e@latest
+```
+
+Import the package that owns the behavior:
+
 ```go
 import (
-    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
-    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+    "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
+
+constructor, ok := monsters.ByRef(refs.Monsters.Bandit().String())
 ```
 
-## Key Concepts
+No root toolkit package needs to be installed, and this directory must not gain
+another `go.mod` for each content family.
 
-### Features & Conditions System
+## Contributor routes
 
-Character features and conditions use an event-driven architecture for clean separation:
+- [Add a D&D 5e monster](../../docs/how-to/add-a-dnd5e-monster.md)
+- [Monster package guide](monster/README.md)
+- [Add a mechanic](../../docs/how-to/add-a-mechanic.md)
+- [Add another rulebook entry](../../docs/how-to/add-a-rulebook-entry.md)
+- [Rulebook architecture component](../../docs/architecture/components/rulebook-dnd5e.md)
+- [Data model and round trips](../../docs/architecture/data-model.md)
+- [Run tests](../../docs/how-to/run-tests.md)
 
-#### Features
-Features (rage, second wind, action surge) handle activation and resource consumption:
-- Load from JSON configuration for flexibility
-- Check activation requirements (uses remaining, prerequisites)
-- Publish condition events when activated
-- Don't track ongoing state - that's the condition's job
+## Validate this module
 
-#### Conditions
-Conditions are self-contained effects that manage their own lifecycle:
-- Applied via events (from features, spells, items, environment)
-- Subscribe to relevant game events (attacks, damage, round end)
-- Apply modifiers and effects during their lifetime
-- Remove themselves when their duration ends or conditions are met
+From `rulebooks/dnd5e`:
 
-#### The Flow
-```go
-// 1. Load and activate a feature
-featureJSON := `{
-    "ref": "dnd5e:features:rage",
-    "id": "barbarian-rage",
-    "data": {"uses": 3, "level": 5}
-}`
-rage, _ := features.LoadJSON([]byte(featureJSON), eventBus)
-
-// 2. Feature publishes condition event
-rage.Activate(ctx, barbarian, features.FeatureInput{})
-// → Publishes: ConditionAppliedEvent{Target: "barbarian", Type: "raging"}
-
-// 3. Character receives and applies condition
-// Character.OnConditionApplied() → loads RagingCondition → calls Apply()
-
-// 4. Condition manages everything
-// RagingCondition subscribes to attacks, damage, rounds
-// Adds damage bonus, applies resistance, tracks duration
-// Removes itself when rage ends
+```bash
+go test -race ./...
+golangci-lint run ./...
 ```
 
-Key benefits:
-- **Clean separation**: Features, conditions, and characters each have one job
-- **Event-driven**: No direct coupling between components
-- **Self-contained**: Each condition knows its complete ruleset
-- **Persistence-friendly**: Conditions save/load with character data
-
-See [features/README.md](features/README.md) for detailed documentation.
-
-### Character Data vs Game Data
-
-The rulebook separates character state from game reference data:
-
-1. **Character** - The runtime character with all capabilities "baked in"
-   - No references to race/class objects
-   - Everything extracted during creation
-   - Tracks current state (HP, conditions, effects)
-
-2. **Game Data** (RaceData, ClassData) - Reference data for character creation
-   - Only needed during character creation
-   - Defines available choices and features
-   - Not needed during gameplay
-
-### Conditions and Effects
-
-Characters track their current state through typed conditions and effects:
-
-```go
-// Apply conditions
-character.AddCondition(conditions.Condition{
-    Type:   conditions.Poisoned,
-    Source: "giant_spider",
-})
-
-// Apply spell effects
-character.AddEffect(effects.NewBlessEffect("cleric_spell"))
-
-// Effects modify calculations
-ac := character.AC() // Includes any AC bonuses from effects
-
-// Everything persists automatically
-data := character.ToData() // Includes conditions and effects
-```
-
-### During Gameplay
-
-```go
-// Load character for session
-character, _ := LoadCharacterFromData(savedData, raceData, classData, backgroundData)
-
-// During combat...
-character.AddEffect(effects.NewRageEffect("barbarian_rage"))
-character.AddCondition(conditions.Grappled)
-
-// Each character tracks their own state
-char1.AddEffect(effects.NewBlessEffect("cleric_123"))
-char2.AddEffect(effects.NewBlessEffect("cleric_123"))
-char3.AddEffect(effects.NewBlessEffect("cleric_123"))
-
-// Save state after changes
-save(char1.ToData()) // Has bless
-save(char2.ToData()) // Has bless
-save(char3.ToData()) // Has bless
-```
-
-### Character Creation
-
-Two ways to create characters:
-
-#### Simple Direct Creation
-
-```go
-// Load your game data
-raceData := loadRaceData("human")
-classData := loadClassData("fighter")
-backgroundData := loadBackgroundData("soldier")
-
-// Create character directly
-character, err := character.NewFromCreationData(character.CreationData{
-    ID:             "char-ragnar-001", // Game service provides ID
-    Name:           "Ragnar",
-    RaceData:       raceData,
-    ClassData:      classData,
-    BackgroundData: backgroundData,
-    AbilityScores: shared.AbilityScores{
-        Strength: 15, Dexterity: 14, Constitution: 13,
-        Intelligence: 12, Wisdom: 10, Charisma: 8,
-    },
-    Choices: map[string]any{
-        "skills": []string{"athletics", "intimidation"},
-        "language": "orcish",
-    },
-})
-
-// Save the character
-data := character.ToData()
-saveToDatabase(data)
-```
-
-#### Builder Pattern (for multi-step UIs)
-
-```go
-// Create builder
-builder, err := NewCharacterBuilder("draft-123")
-
-// Load your game data from wherever (API, files, etc.)
-raceData := loadRaceData("human")     // You implement this
-classData := loadClassData("wizard")   // You implement this
-backgroundData := loadBackgroundData("sage") // You implement this
-
-// Set character details with the data
-builder.SetName("Gandalf")
-builder.SetRaceData(raceData, "")     // Pass race data, optional subrace ID
-builder.SetClassData(classData)        // Pass class data
-builder.SetBackgroundData(backgroundData) // Pass background data
-
-// Set ability scores
-builder.SetAbilityScores(AbilityScores{
-    Strength: 10,
-    Dexterity: 14,
-    Constitution: 13,
-    Intelligence: 18,
-    Wisdom: 15,
-    Charisma: 12,
-})
-
-// Select skills from available options
-builder.SelectSkills([]string{"arcana", "history"})
-
-// Check progress
-progress := builder.Progress()
-fmt.Printf("%.0f%% complete\n", progress.PercentComplete)
-
-// Build when ready
-if progress.CanBuild {
-    character, err := builder.Build()
-    if err == nil {
-        // Convert to data for persistence
-        charData := character.ToData()
-        saveToDatabase(charData) // You implement this
-    }
-}
-
-// Or save draft to continue later
-draftData := builder.ToData()
-saveDraft(draftData) // You implement this
-
-// Later, load and continue
-builder2, err := LoadDraft(draftData)
-```
-
-### Data Contract
-
-The rulebook defines what data needs persisting:
-
-- `CharacterData` - Everything needed to recreate a character
-- `CharacterDraftData` - In-progress character creation state
-- Choice tracking - Player selections during creation
-- Conditions and resources - Current character state
-
-### Integration with Game Services
-
-Game services (like rpg-api) use this rulebook by:
-
-1. Storing the data structures we define
-2. Using the builder for character creation
-3. Loading characters with a DataLoader
-4. Calling game mechanics methods
-
-```go
-// In your game service
-type Repository struct {
-    db Database
-}
-
-func (r *Repository) SaveCharacter(ctx context.Context, char *dnd5e.Character) error {
-    data := char.ToData()
-    return r.db.Save("character", data)
-}
-
-func (r *Repository) LoadCharacter(ctx context.Context, id string) (*dnd5e.Character, error) {
-    var data dnd5e.CharacterData
-    if err := r.db.Load("character", id, &data); err != nil {
-        return nil, err
-    }
-    return dnd5e.LoadCharacter(data, r.loader)
-}
-```
-
-## Current Status
-
-### Completed
-- ✅ Character creation with builder pattern
-- ✅ Features system with LoadJSON pattern
-- ✅ Rage feature with event-driven effects
-- ✅ Type-safe modifiers and events
-- ✅ Thread-safe feature implementation
-- ✅ Initiative tracking system
-
-### In Progress
-- 🚧 Additional features (second wind, action surge)
-- 🚧 Turn/round tracking for durations
-
-### Future Enhancements
-- [ ] Complete choice compilation logic
-- [ ] Add spell casting mechanics
-- [ ] Implement remaining combat actions
-- [ ] Expand conditions and effects system
-- [ ] Support for multiclassing
-- [ ] Magic item attunement
-- [ ] Feat selection
-
-## Design Principles
-
-1. **Game logic lives here** - Not in the API service
-2. **Data/Domain separation** - Clear boundaries for persistence
-3. **Validation is game rules** - We enforce D&D 5e rules
-4. **No persistence logic** - We define what to store, not how
+A content contribution should also run the focused commands in its nearest
+how-to. The code and tests are the final behavior truth; architecture docs,
+plans, and examples can lag.

--- a/rulebooks/dnd5e/monster/README.md
+++ b/rulebooks/dnd5e/monster/README.md
@@ -118,10 +118,13 @@ must perform the extra action and trait steps. A test that calls only
 ## Supported first contribution
 
 Use [`monster/monsters/bandit.go`](monsters/bandit.go) and
-[`bandit_test.go`](monsters/bandit_test.go) as the canonical simple fixture:
-one factory, one supported generic attack, no special trait clause, explicit
-speed, and direct stat/action assertions. Also follow
-[`registry.go`](monsters/registry.go) and
+[`bandit_test.go`](monsters/bandit_test.go) as the canonical simple **structural**
+fixture: one factory, one supported generic attack, no special trait clause,
+explicit speed, and direct stat/action assertions. Do not copy its older
+distance literals: values such as `Reach: 5` and `RangeNormal: 80` are
+feet-shaped, while current action configs and `PerceivedEntity.Distance` use
+hex counts (5 feet = 1 hex). New content must use and test current units.
+Also follow [`registry.go`](monsters/registry.go) and
 [`registry_test.go`](monsters/registry_test.go), which prove that each registered
 ref constructs a monster carrying the same ref.
 

--- a/rulebooks/dnd5e/monster/README.md
+++ b/rulebooks/dnd5e/monster/README.md
@@ -1,0 +1,153 @@
+# D&D 5e monsters: current guide
+
+This directory is the nearest orientation point for current monster work. It is
+inside the single `rulebooks/dnd5e` Go module.
+
+## Current packages
+
+| Import path suffix | Current responsibility |
+|---|---|
+| `monster` | `Monster` runtime type, `Data`, action/perception contracts, targeting, `TakeTurn`, base `LoadFromData` / `ToData`; also the older `NewGoblin` factory |
+| `monster/actions` | Loadable generic melee, ranged, multiattack, and bite action implementations plus the action loader |
+| `monster/monsters` | Built-in stat factories and the canonical-ref-to-constructor registry |
+| `monstertraits` | Loadable condition-style monster traits (separate sibling package to avoid import cycles) |
+| `refs` | Canonical monster, monster-action, and monster-trait refs |
+
+In Go import terms, `monster/actions` and `monster/monsters` are subpackages,
+not symbols exposed through package `monster`; callers import them directly.
+
+## Four responsibilities that must not be collapsed
+
+```text
+definition         tactics / decision          rules resolution        encounter composition
+factory + ref  →  Monster.TakeTurn        →  combat resolver      →  encounter.NPCAct
+stat/action data    scores + target strategy    hit/damage verdicts     state, movement, events
+```
+
+### 1. Definition
+
+A built-in factory in `monster/monsters` composes a runtime `*monster.Monster`
+from current capabilities. It gives the creature a canonical ref, stats,
+actions, speed, optional supported trait JSON, and optional targeting. The
+registry maps the full ref string to that constructor so authored encounter
+content can resolve it.
+
+A definition should contain no storage or encounter orchestration.
+
+### 2. Tactics / decision
+
+The shipped decider is `(*monster.Monster).TakeTurn`; there is no separate,
+usable behavior-tree or tactics module today. `TakeTurn` currently:
+
+- chooses a target using `TargetClosest`, `TargetLowestHP`, or `TargetLowestAC`
+  (`TargetingUnspecified` behaves like closest at decision time);
+- uses `tools/spatial.NewSimplePathFinder` to move toward that same target,
+  respecting blocked cells and an optional traversal predicate;
+- scores affordable `MonsterAction`s, chooses the highest score, selects a
+  target appropriate to the action type, activates it, and consumes the
+  matching action-economy slot;
+- returns the movement path and attempted-action records.
+
+Action scoring and target selection are intentionally simple. The top-level
+`behavior/` directory contains only a design stub, not a Go module or shipped
+behavior framework.
+
+### 3. Rules resolution
+
+The generic melee/ranged/bite actions validate range and publish a D&D 5e
+`AttackEvent`. They do not themselves roll the complete attack and apply damage.
+The current top-level encounter SDK captures that event and delegates hit/damage
+to its wired `CombatResolver`.
+
+Do not infer behavior from a config field alone:
+
+- melee/ranged attack bonus, damage dice, and damage type serialize and are used
+  by current encounter seeding snapshots, but the action's `Activate` method is
+  event publication, not standalone damage resolution;
+- `BiteConfig.KnockdownDC` round-trips, but bite knockdown is explicitly not
+  implemented;
+- ranged activation enforces long range, but normal-range/long-range
+  disadvantage behavior is not implemented there;
+- `PackTactics` loads and subscribes but its ally-adjacency modifier is a no-op;
+- `UndeadFortitude` rolls a save but does not restore/mutate HP, and it cannot
+  detect critical hits from the current event;
+- a factory comment saying a monster “has” one of those traits does not attach
+  or complete the behavior. Verify `AddTraitData` and the trait implementation.
+
+Immunity and vulnerability traits do have chain modifier implementations and
+are attached by factories that call their `Must...JSON` helpers. Every new
+clause still needs a focused test on the real event path.
+
+### 4. Encounter composition
+
+The current top-level `encounter` module is D&D-5e-coupled. `NPCAct` builds
+perception and action economy, calls the shipped `TakeTurn`, applies movement,
+captures rulebook attack/condition events, resolves attacks through the
+encounter's resolver, updates encounter state, and publishes encounter events.
+It also requires a rehydratable monster JSON blob; the old scripted fallback is
+not a supported path.
+
+Monster definitions should not reach into encounter composition. Encounter
+selection, group size, placement, difficulty budgeting, room theme, and spawn
+frequency are separate authoring/composition concerns.
+
+## Construction and loading are not the same operation
+
+A factory returns a ready-to-serialize runtime monster:
+
+```text
+monster/monsters constructor → *monster.Monster → ToData / JSON
+```
+
+Reload currently has multiple explicit steps because importing action or trait
+loaders from package `monster` would create cycles:
+
+```text
+monster.LoadFromData(ctx, data, bus)             # base state + monster subscriptions
+actions.LoadMonsterActions(mon, data.Actions)    # runtime action implementations
+monstertraits.LoadMonsterConditions(             # trait JSON → Apply on bus → attach
+    ctx, mon, data.Conditions, bus, roller,
+)
+```
+
+The encounter's `LoadFromData` hydration cascade performs all three and later
+writes held combatants back through `ToData`. Outside the encounter, the caller
+must perform the extra action and trait steps. A test that calls only
+`monster.LoadFromData` has not proven a full monster round trip.
+
+## Supported first contribution
+
+Use [`monster/monsters/bandit.go`](monsters/bandit.go) and
+[`bandit_test.go`](monsters/bandit_test.go) as the canonical simple fixture:
+one factory, one supported generic attack, no special trait clause, explicit
+speed, and direct stat/action assertions. Also follow
+[`registry.go`](monsters/registry.go) and
+[`registry_test.go`](monsters/registry_test.go), which prove that each registered
+ref constructs a monster carrying the same ref.
+
+The full operator contract, source rules, exact file checklist, and round-trip
+acceptance are in [Add a D&D 5e monster](../../../docs/how-to/add-a-dnd5e-monster.md).
+
+## Historical and proposed documents
+
+These are context, not current instructions:
+
+- [Monster structure design](../../../docs/ideas/monster-behavior/design-monster-structure.md)
+  is a historical design note; several snippets differ from shipped APIs.
+- [Monster additions design](../../../docs/plans/2025-12-15-monster-additions-design.md)
+  is an implementation-era plan; some roster entries shipped while some stated
+  clauses remain unsupported.
+- [Monster pathfinding plan](../../../docs/plans/2026-01-06-monster-pathfinding.md)
+  is historical; shipped A* now lives in `tools/spatial` and `TakeTurn` uses it.
+
+### Proposed follow-up: flatten built-in content by one package
+
+A desired future information architecture is
+`rulebooks/dnd5e/monsters` as an immediate package inside the existing
+`rulebooks/dnd5e` module. It would move the built-in factories/registry out of
+`monster/monsters` while leaving runtime types in `monster`.
+
+This is **not the current path**, has not been implemented here, and must not get
+its own `go.mod`. It requires a separately reviewed migration with import and
+consumer updates. Until that lands, add content to the current paths documented
+above.


### PR DESCRIPTION
## Summary
- replace the stale portfolio-style root README with a truthful 22-module landing page and progressive-disclosure routes
- document the current D&D 5e and monster package mental model, including definition → decision → resolution → encounter composition and the multi-step monster load path
- add a human+agent monster contribution contract covering provenance, closed-content guardrails, supported-vs-unsupported clauses, exact files, a simple fixture, validation, and round-trip done criteria
- correct directly contradictory navigation/how-to/component pointers and mark historical monster behavior/planning documents as non-current
- record `rulebooks/dnd5e/monsters` only as a proposed same-module follow-up; no package/module move or behavior change is included

## Key decisions
- #885 remains a distinct encounter-module-guidance task; this PR closes the repository/rulebook/monster onboarding issue #919 instead
- `monster/monsters/bandit.go` is the current simple contribution fixture
- Pack Tactics, bite knockdown, and complete Undead Fortitude are called out as unsupported rather than inferred from config fields/comments
- SRD 5.1 under CC BY 4.0 or original content is allowed with provenance/attribution; closed Monster Manual content is not

## Validation
- `go test -race ./refs ./monster ./monster/actions ./monster/monsters ./monstertraits` (from `rulebooks/dnd5e`) — PASS
- `go test -race ./...` (from `rulebooks/dnd5e`) — PASS
- `golangci-lint run ./...` (from `rulebooks/dnd5e`) — PASS, 0 issues
- changed-Markdown repository-relative link check — PASS, 80 links across 12 files
- new external URL checks — PASS, HTTP 200 for the SRD PDF, exact SRD resource/legalcode URLs, and linked issues
- `git diff --check` — PASS
- `make pre-commit` — known main-branch blocker #769: Core tests/lint pass, then coverage extraction leaks package output into `bc`, emits syntax errors, and prints 76.5% under the configured threshold; documented in `docs/how-to/run-tests.md`

Closes #919

— asset-pipeline agent, on behalf of KirkDiggler