### PR TITLE
docs(ideas): encounter transitions triplet — room-to-room traversal (v0.2 wave)

### DIFF
--- a/docs/ideas/encounter-transitions/brainstorm.md
+++ b/docs/ideas/encounter-transitions/brainstorm.md
@@ -1,0 +1,93 @@
+# Encounter transitions — brainstorm (wave 2 of the free-roam composition)
+
+Issue: #922. Builds on `docs/ideas/encounter/` (wave 1, shipped as
+`rulebooks/dnd5e/encounter/v0.1.0`, PR #921). Ratified conversationally
+with Kirk on 2026-08-10; this document records the decisions and his
+words that shaped them.
+
+## The forcing question
+
+rpg-api#793 wires the composition into the game as a coexisting
+encounter type. The wire speaks one dungeon-absolute space — a
+deliberate choice: *"we left that per room because it put load on the
+web to connect and build dungeons from separate rooms."* And movement
+crosses rooms: *"pathing goes from room to room."* The composition's
+`Move` is same-room by documented v1 constraint, and wave 1's
+`ConnectionInput{ID, From, To}` is declared but inert. Multi-room free
+roam blocks on giving that topology teeth.
+
+## Decisions
+
+### 1. The composition owns the topology (confirmed, not new)
+
+Wave 1 already put connections in `FieldInput`; v0.2 makes them do
+something. The alternative — an adapter-only `Transfer` verb where
+rpg-api decides what's traversable — was rejected because deciders live
+at the composition level: if the composition doesn't know rooms
+connect, **a monster can never chase a player through a doorway**.
+Pursuit would die at every room boundary, capping monster behavior at
+single-room forever and quietly moving rules truth (what is
+traversable) out of the rulebook.
+
+### 2. Openings only — no door state
+
+Kirk: *"our freeroam can open doors and it can actually be simplified
+if that helps us. we can get there when we get there."* The live game's
+door interaction is explicitly not a parity requirement. Connections in
+v0.2 are always-open openings. Door state (open/closed/locked,
+Interact semantics, probably interrupt windows) is a later wave.
+
+### 3. Sight stays room-scoped
+
+Connections do not transmit line of sight in this version. Crossing a
+boundary is how you learn what's there — good dungeon-crawl texture,
+and it keeps v0.2 from inheriting surprise cross-room occlusion math.
+Cross-room LoS becomes its own considered feature later, not a freebie.
+
+### 4. Traversal is an explicit verb, not Move magic
+
+`Move` stays same-room and honest. A new `Traverse` verb crosses a
+connection: the member must be standing at one endpoint; they arrive at
+the other. The server already owns pathing in the absolute space, so a
+cross-room path decomposes at the adapter into move → traverse → move.
+Implicit auto-transition on `Move` was rejected as unfalsifiable magic:
+the explicit verb gives a pinnable beat and a crisp precondition.
+
+### 5. Deciders learn where they stand (resolving the wave-1 gap)
+
+`Decide(view []intel.Holding)` has no self-placement — flagged at
+wave-1 ratification as the View own-placement gap. It bites for real
+now: a decider cannot pick a doorway without knowing which room it is
+in. v0.2 resolves the gap in the direction the wave-1 design originally
+promised: the decider receives a snapshot of its own room + position
+alongside its holdings. Static field topology is not secret — deciders
+may be constructed knowing the map; what they must never receive is
+other members' live truth (C2 stands).
+
+### 6. Intent vocabulary grows `IntentTraverse`
+
+Pursuit through an opening is a decision like any other: decided in
+phase 1, executed in phase 2, atomic under R5. A goblin that saw you
+slip into the hall holds a ghost whose payload names the room — it can
+choose the connection that leads there.
+
+### 7. No dungeon-builder coupling
+
+Kirk: dungeon builder *"spec 0.4 is not verified and 0.3 is not really
+playable."* The composition's authoring surface stays `SetupInput`;
+rpg-api's wave-1 dungeon keys use a minimal direct spec. Nothing here
+consumes or emits the dungeon-builder pipeline.
+
+### 8. Version and compatibility
+
+`v0.2.0`, additive in spirit. Two honest compat notes, both acceptable
+at zero external consumers (rpg-api is not wired yet): connection
+validation tightens (endpoints become required), and the `Decider`
+interface signature changes. Both are called out in the design.
+
+## Shelved (future us answers better than today us)
+
+- Door state, locks, and their Interact/interrupt semantics.
+- Cross-room line of sight through openings.
+- One-way or conditional connections (chutes, portcullises).
+- Combat chaining at a doorway (rides #916).

--- a/docs/ideas/encounter-transitions/brainstorm.md
+++ b/docs/ideas/encounter-transitions/brainstorm.md
@@ -78,7 +78,20 @@ playable."* The composition's authoring surface stays `SetupInput`;
 rpg-api's wave-1 dungeon keys use a minimal direct spec. Nothing here
 consumes or emits the dungeon-builder pipeline.
 
-### 8. Version and compatibility
+### 8. Rooms choose their grid (added 2026-08-11, Platform pushback)
+
+Platform flagged the composition's square-grid usage against the
+hex-cube wire. The truth: spatial underneath is the same hex engine
+the old module ships to the wire (`GridShape`, `NewHexGrid`, cube
+coordinates, all LoS/adjacency behind the Grid interface); the
+composition merely *chose* square at its two grid-construction sites.
+v0.2 makes the choice per-room: `RoomInput` gains a `GridShape`
+(zero value = square, fully compatible), and in-bounds validation
+defers to the grid's own validity check instead of rectangle math.
+Rooms constructed hex make the wire projection identity rather than a
+lossy square→hex remap.
+
+### 9. Version and compatibility
 
 `v0.2.0`, additive in spirit. Two honest compat notes, both acceptable
 at zero external consumers (rpg-api is not wired yet): connection

--- a/docs/ideas/encounter-transitions/design.md
+++ b/docs/ideas/encounter-transitions/design.md
@@ -27,6 +27,17 @@ discipline.
 ## Type changes
 
 ```go
+// RoomInput gains a grid choice. Zero value is GridShapeSquare —
+// existing setups, tests, and goldens are untouched. Hex rooms make
+// the dungeon-absolute hex wire projection an identity mapping.
+type RoomInput struct {
+	// ... existing fields ...
+	Grid spatial.GridShape // square (default) | hex | gridless
+}
+// In-bounds validation (member placement, connection endpoints,
+// movement targets) defers to the constructed grid's own validity
+// check; the module owns no rectangle math of its own.
+
 // ConnectionInput gains endpoints (BREAKING for stored v0.1 data that
 // declared connections — none exists; rpg-api is not wired yet).
 type ConnectionInput struct {

--- a/docs/ideas/encounter-transitions/design.md
+++ b/docs/ideas/encounter-transitions/design.md
@@ -136,6 +136,20 @@ required at load** (nil → ErrInvalidData+ErrBadConnection naming the
 side) — a missing endpoint must reject, not silently become the legal
 cell (0,0). This is what makes compat note 1 above genuinely true.
 
+Coordinate-model amendment (Kirk, 2026-08-11, ratified): **hex rooms
+speak axial/cube, not offset.** `buildRoomGrid` constructs spatial's
+`AxialHexGrid` — Position.X/Y are axial Q/R (S = -(Q+R) derived);
+bounds are origin-centered spans (negative coordinates legal), unlike
+square/gridless's (0,0)-origin rectangles; distance/adjacency/LoS run
+the pure cube formulas. Why: the wire and server pathing already speak
+cube — axial is cube's lossless 2D projection, so the projection at
+the seam is an identity, where the previously-chosen offset HexGrid
+would have forced a parity-dependent conversion (the exact confusion
+Platform flagged). Side effect: hex validity now diverges from
+square's, so the hex tests independently kill the build-square-always
+mutant (superseding the earlier "only gridless discriminates"
+finding).
+
 ## Acceptance criteria
 
 - A two-room field with one opening validates, round-trips, and

--- a/docs/ideas/encounter-transitions/design.md
+++ b/docs/ideas/encounter-transitions/design.md
@@ -82,7 +82,7 @@ type IntentTraverse struct {
 |---|---|
 | `Traverse(*TraverseInput) (*TraverseOutput, error)` | NEW. Precondition per T2. Refreshes percepts in **both** rooms (departure and arrival are observable absences/appearances). Appends a `traversed` beat. Runs ending evaluation at the arrival position. Rejects on `ErrClosed`, `ErrNilInput`, `ErrNoMember`, `ErrNoConnection`, `ErrBadPlacement`. |
 | `Move` | Unchanged, still same-room; its doc comment stays honest about that. |
-| `Pump` | Phase 2 executes `IntentTraverse` with the same T2 precondition; a decider intent that fails precondition aborts the pump atomically (R5), exactly like a failed `IntentMoveTo`. |
+| `Pump` | Phase 2 executes `IntentTraverse` with the same T2 precondition. Failure contract (corrected during Task 3 to match the module's shipped v0.1 semantics): a phase-1 decider ERROR aborts the pump atomically (R5 — clock untouched, no beats, nothing executed); a phase-2 EXECUTION failure (illegal position, unknown connection) is silently skipped — the pump completes, and that action is simply absent from output and beats — exactly like a failed `IntentMoveTo` has always behaved. |
 | `View`, `Story`, `Join`, `Exit`, `End`, `ToData`/`LoadEncounter` | Unchanged surfaces; behavior notes below. |
 
 New sentinel: `ErrNoConnection` (unknown connection ID), wrapped

--- a/docs/ideas/encounter-transitions/design.md
+++ b/docs/ideas/encounter-transitions/design.md
@@ -127,6 +127,15 @@ map it was built with.
 
 `gorelease` gate stays in CI; tag `rulebooks/dnd5e/encounter/v0.2.0`.
 
+Wire-shape amendments (Copilot round on PR #924, ratified): the blob
+persists grid shape as a **string** using spatial's own serialization
+vocabulary (`GridTypeHex`/`GridTypeGridless`; empty = square), never
+the iota integer — constant reordering must not reinterpret stored
+data. Connection endpoints persist as pointers with **presence
+required at load** (nil → ErrInvalidData+ErrBadConnection naming the
+side) — a missing endpoint must reject, not silently become the legal
+cell (0,0). This is what makes compat note 1 above genuinely true.
+
 ## Acceptance criteria
 
 - A two-room field with one opening validates, round-trips, and

--- a/docs/ideas/encounter-transitions/design.md
+++ b/docs/ideas/encounter-transitions/design.md
@@ -1,0 +1,141 @@
+# Encounter transitions — design (v0.2.0)
+
+Amends the wave-1 design (`docs/ideas/encounter/design.md`). Everything
+not named here carries over unchanged: laws C1–C8, the verb/query
+surfaces, persistence-at-the-seam, family signature law, R8/R9
+discipline.
+
+## New laws
+
+- **T1 — connections are open.** A connection is a bidirectional
+  opening between two rooms with exactly one endpoint cell in each. No
+  state, no locks, no Interact. Door state is a future wave.
+- **T2 — traversal is standing at the threshold.** `Traverse` requires
+  the member's position to equal the connection's endpoint in the
+  member's current room; the member arrives at the far endpoint in the
+  other room. Anything else is `ErrBadPlacement`.
+- **T3 — sight never crosses a connection.** Percept computation
+  remains room-scoped. An opening is not a window.
+- **T4 — traversal is an activity, not time.** Like `Move`, `Traverse`
+  never advances the clock. Only `Pump` advances the clock.
+- **T5 — deciders know self, holdings, and the map; never live truth.**
+  The decide phase receives the decider's own room + position and its
+  holdings. Static topology may be given to a decider at construction.
+  C2 stands: nothing about other members' current state ever reaches a
+  decider except through its own holdings.
+
+## Type changes
+
+```go
+// ConnectionInput gains endpoints (BREAKING for stored v0.1 data that
+// declared connections — none exists; rpg-api is not wired yet).
+type ConnectionInput struct {
+	ID string
+	From string                 // room ID
+	FromPosition spatial.Position // endpoint cell in From
+	To string                   // room ID
+	ToPosition spatial.Position   // endpoint cell in To
+}
+
+// TraverseInput follows the family signature law.
+type TraverseInput struct {
+	Member     MemberID
+	Connection string // ConnectionInput.ID
+}
+
+// TraverseOutput mirrors MoveOutput: deltas, never published; Outcome
+// present iff the arrival closed the encounter.
+type TraverseOutput struct { /* same shape family as MoveOutput */ }
+
+// Snapshot is what a decider decides from. Replaces the bare holdings
+// slice (interface change; zero external implementors).
+type Snapshot struct {
+	Room     string
+	Position spatial.Position
+	Holdings []intel.Holding
+}
+
+type Decider interface {
+	Decide(snap Snapshot) (Intent, error)
+}
+
+// IntentTraverse joins IntentMoveTo and IntentHold.
+type IntentTraverse struct {
+	Connection string
+}
+```
+
+## Verb surface
+
+| Verb | Change |
+|---|---|
+| `Traverse(*TraverseInput) (*TraverseOutput, error)` | NEW. Precondition per T2. Refreshes percepts in **both** rooms (departure and arrival are observable absences/appearances). Appends a `traversed` beat. Runs ending evaluation at the arrival position. Rejects on `ErrClosed`, `ErrNilInput`, `ErrNoMember`, `ErrNoConnection`, `ErrBadPlacement`. |
+| `Move` | Unchanged, still same-room; its doc comment stays honest about that. |
+| `Pump` | Phase 2 executes `IntentTraverse` with the same T2 precondition; a decider intent that fails precondition aborts the pump atomically (R5), exactly like a failed `IntentMoveTo`. |
+| `View`, `Story`, `Join`, `Exit`, `End`, `ToData`/`LoadEncounter` | Unchanged surfaces; behavior notes below. |
+
+New sentinel: `ErrNoConnection` (unknown connection ID), wrapped
+multi-`%w` like the family's other sentinels and pinned by `errors.Is`.
+
+## Validation (Setup and Load — same rules, one-defect fixtures)
+
+Reject when: duplicate connection ID; `From`/`To` names an unknown
+room; `From == To` (self-connection); an endpoint out of the room's
+bounds; an endpoint on an occluder. Load-side violations wrap
+`ErrInvalidData` multi-`%w` with discriminating message fragments, in
+the wave-1 `validEncounterData()` one-defect table style. Every new
+field appears in the rich golden (`TestGoldenJSONRich` grows
+connections with both endpoints).
+
+## Persistence
+
+`FieldData` already persists construction inputs; connections gain
+their endpoint fields in the blob. Reload pins: a member who traversed
+reloads in the **new** room (construct-path reload preserves member
+room, not connection history); ordered iteration stays deterministic
+(C8 — connections sorted by ID wherever order is observable).
+
+## Decider flow (the point of the wave)
+
+A goblin standing in the crypt saw alice slip through the north opening
+last tick. Its holdings contain a ghost whose `SightPayload.Room` says
+`hall`. Constructed with the map, it knows `north-door` leads there. It
+decides `IntentTraverse{Connection: "north-door"}`; phase 2 executes;
+its percepts refresh in the hall; the chase is on. This must exist as
+an integration pin (the wave's vandalDecider analogue): decider crosses
+a room boundary in pursuit of a ghost, using only self + holdings + the
+map it was built with.
+
+## Compatibility notes (honest, both acceptable at zero consumers)
+
+1. Stored v0.1 blobs that declared connections fail v0.2 load
+   (endpoints required). No such blobs exist outside this repo's own
+   fixtures.
+2. `Decider` implementors must adopt `Snapshot`. The only implementors
+   live in this module's tests and workbench.
+
+`gorelease` gate stays in CI; tag `rulebooks/dnd5e/encounter/v0.2.0`.
+
+## Acceptance criteria
+
+- A two-room field with one opening validates, round-trips, and
+  rejects each defect class individually with the pinned fragment.
+- A player at the threshold traverses; away from it, `ErrBadPlacement`;
+  unknown connection, `ErrNoConnection`; after close, `ErrClosed` (the
+  sweep grows `Traverse`).
+- Traversal triggers ending evaluation: arriving on a
+  `TriggerReachedPosition` cell in the destination room closes the
+  encounter with the declared key.
+- A decider-driven monster pursues a ghost through an opening
+  (integration pin above); the pump stays atomic when a traverse
+  intent's precondition fails.
+- Percepts: departure room observers lose Current status on the
+  traverser (ghost forms at the threshold); arrival room observers gain
+  Current; sight does not cross the opening in either direction (T3
+  pin: observer adjacent to an endpoint sees nothing in the far room).
+- Scene test tells one continuous story ending in a cross-room event;
+  the wave-1 tombwatch scene and its archived transcript stay
+  untouched.
+- The module Example gains (or a sibling Example adds) a pinned
+  transcript showing a traversal beat; `./scripts/verify.sh
+  rulebooks/dnd5e/encounter` prints it.

--- a/docs/ideas/encounter-transitions/plan.md
+++ b/docs/ideas/encounter-transitions/plan.md
@@ -74,3 +74,55 @@ rulebooks/dnd5e/encounter` green; `gorelease` gate green; module tag
 Per-task combined review (sonnet), Opus persistence/deep review on
 Tasks 1 and 3 (the seam and the interface change), director checklist
 before each commit. Execution addenda appended here as tasks land.
+
+---
+
+## Execution addenda
+
+**Task 1 (commits ae803ce, 01eb760, 4194d4d) — COMPLETE.** Endpoints +
+nine-defect validation both seams + sorted persistence. Sonnet review
+found five mutation gaps (To-side bounds/occluder and From-room checks
+unpinned at both seams; weak fragment on the pre-existing To-room row;
+ErrBadConnection unasserted at Load) — closed with per-mutant kill
+evidence. Opus deep pass found the fixtures symmetric two ways (rooms
+same-sized → endpoint-vs-wrong-room cross-wiring invisible; reload
+endpoints equal → Load-direction transposition invisible): one
+deliberately asymmetric fixture (10x4 / 3x9, endpoints {7,1}/{1,7})
+killed all four survivors. Also fixed: duplicate-member message
+falsely read "empty member id" (pre-existing); orphaned NewEncounter
+doc comment. New standard minted: **connection fixtures must be
+asymmetric in room dimensions AND endpoints** so cross-wiring and
+transposition mutants stay observable. 29 mutants accounted.
+
+**Task 1.5 (commit baec468) — COMPLETE, added mid-wave.** Platform
+pushback on rpg-api#793 (hex) answered by making the grid choice
+per-room: `RoomInput.Grid spatial.GridShape` (zero value square, byte-
+stable goldens), both construction sites routed, rectangle math
+deleted in favor of grid-deferred validity, room-ID validation added
+(empty/duplicate — the Opus-found hole). Honest-signal finding worth
+keeping: spatial's bounded HexGrid validity formula is numerically
+IDENTICAL to square's (offset coordinates), so hex bounds tests cannot
+prove shape routing — the GRIDLESS inclusive upper bound is the
+discriminating signal, and the build-square-always mutant is pinned by
+the gridless tests. Review: APPROVED, 14 hostile-blob probes (no
+panics; unknown-room checks all precede grid-map indexing).
+
+**Task 2 (commits f7ff0ce, e9f2a95) — COMPLETE.** The Traverse verb:
+own prechecks carry the contract (new ErrNoConnection sentinel;
+ErrBadPlacement off-threshold), spatial's TransitionEntity+PlaceEntity
+execute it (revised from RemoveEntity+PlaceEntity after research:
+TransitionEntity applies the same registry-lesson cleanup AND its
+indexed-room backstop independently catches wiring bugs the module's
+own checks structurally cannot — proven by a FromRoom/ToRoom-swap
+mutant failing 9 tests). One global refreshSight covers both rooms
+(each observer scopes to their own room) — verified by three
+exclusion mutants. Review: APPROVED. R5 analysis: the transition→place
+limbo window is unreachable under four invariants (immutable rooms,
+non-blocking members, grid-validated endpoints, permanently-passable
+door connections), proven by chained-precondition argument AND a
+forced-failure probe (consequence if ever opened: member recorded in a
+room she is not spatially present in; graceful ErrBadPlacement, no
+panic). Debt: an invariant comment at the shared seam (Task 3 item 0);
+ending-evaluation loop now duplicated 3-4x file-wide (pre-existing,
+refactor candidate); beat-audience narrowing mutant unpinned file-wide
+(pre-existing).

--- a/docs/ideas/encounter-transitions/plan.md
+++ b/docs/ideas/encounter-transitions/plan.md
@@ -126,3 +126,58 @@ panic). Debt: an invariant comment at the shared seam (Task 3 item 0);
 ending-evaluation loop now duplicated 3-4x file-wide (pre-existing,
 refactor candidate); beat-audience narrowing mutant unpinned file-wide
 (pre-existing).
+
+**Task 3 (commits 4236390, f869e81) — COMPLETE.** Snapshot{Room,
+Position, Holdings} replaces the bare holdings slice (the wave-1
+own-placement gap, resolved); IntentTraverse executes through a helper
+shared with the Traverse verb. REAL latent bug found during the
+restructure: Pump's planned list stored member VALUE COPIES — harmless
+while only same-room moves existed, state corruption once traverses
+mutate member.Room — fixed with live-pointer lookups and pinned by
+reintroduction-mutant. Design correction ratified: Pump's shipped
+failure contract is decider-error-aborts (phase 1) / execution-
+failure-skips (phase 2) — the triplet's original "aborts atomically"
+claim was wrong about v0.1 and is amended. Sonnet round: APPROVED, two
+minors (mid-pump closure coherent-but-unpinned → TestPumpFullTickThen
+EvaluateAcrossTraverse, whose falsifiable signal is the second
+monster's POST-move outcome position; sibling-rigor gap on the
+unknown-connection skip test → phantom-beat mutant now dies).
+
+**Task 4 (commit 736db19) — COMPLETE.** The vault chase: corridor +
+vault + "gate", one continuous scene — sight, the slip, the ghost
+pinned symmetrically at the true last-seen threshold, mid-chase
+save/reload with a fresh decider re-attached, pursuit walk + the
+goblin's OWN traverse decision, Current reacquired same-pump, ending
+with full-position Outcome, archive sweep grown to Traverse, exact
+nine-beat transcript pin (predicted from code before first run;
+liveness proven by beat-rename mutant in review).
+
+**Opus deep pass (T3+T4 combined; first attempt stalled mid-stream on
+an API error and was replaced) — APPROVED, three minors, all closed in
+fefbbcb:** (1) reentrant contract-violating decider could nil-panic
+phase 2 → nil-guard + TestPumpSurvivesReentrantSelfExitingDecider
+(reject-never-crash upheld); (2) the endings field comment overstated
+first-declared-wins — the true, now-PINNED law: decision order
+dominates across actions in one pump, declaration order tiebreaks
+within one action (loop-nesting mutant flips only the cross-ordering
+subtest); (3) chase sweep's Traverse entry made valid-if-open (goblin,
+who ends on the vault endpoint, replaces alice). Also proven: percept
+simultaneity (refreshSight once, end-of-tick, both rooms final
+positions); phase-1 purity on the early-error path (byte-identical
+ToData); member.Room-vs-spatial divergence UNREPRESENTABLE (both
+derive from the one persisted room field); PumpOutput aliasing
+impossible. Observation recorded, pre-existing, wave-1 follow-up:
+intel Refreshed delta ORDERING is nondeterministic across runs (4
+orderings / 200 runs) but never reaches blobs or transcripts (1 blob,
+1 transcript / 200 runs).
+
+**Task 5 (commits fefbbcb, 44371c4) — COMPLETE.** Example_theTraverse
+with pinned transcript; workbench gains the ossuary + a traverse
+command with room-aware world/belief grids; verify.sh green (259
+tests); `gorelease -base v0.1.0` verdict matches the design exactly —
+one intentional incompatible change (Decider.Decide signature), all
+else additive, suggested version v0.2.0.
+
+**Wave complete: PR #924, eleven commits, 259 subtests.** Awaiting
+merge + tag `rulebooks/dnd5e/encounter/v0.2.0` (Platform's dependency
+signal on rpg-api#793).

--- a/docs/ideas/encounter-transitions/plan.md
+++ b/docs/ideas/encounter-transitions/plan.md
@@ -208,3 +208,21 @@ invalid under centered spans — the correction doubles as a negative-
 axial proof); the build-square-always mutant now dies via hex tests
 directly, superseding the "only gridless discriminates" finding. 269
 tests; gorelease verdict unchanged (v0.2.0).
+
+**Platform round (commit f8f3a29) — COMPLETE.** Platform review found
+two real boundary defects, both reproduced with probes: (1) a map-
+present NIL decider passed LoadEncounter and panicked the first Pump —
+nil entry now ≡ absent (the Setup/Join optional posture; Join's nil-
+holds behavior gained its missing pin), regression tests incl. the
+mixed nil+real map; (2) fractional axial positions (Position is
+float64) were accepted by spatial's AxialHexGrid bounds check while
+all cube math truncates — (0.5,0.5) persisted as a distinct hex
+position behaving as (0,0), silently breaking the axial↔cube
+identity. Semantic-owner fix filed as toolkit#926 (spatial ingress);
+interim: the composition enforces integral axial at every seam a hex
+position enters (Setup/Load members, endpoints both sides, occluders,
+Move targets — the path Pump shares, so fractional decider intents
+fall under the phase-2 silent-skip contract for free — and Join),
+hex-only (square fractional-tolerant, gridless continuous by design),
+each seam's existing defect family, all rows mutant-verified. 288
+tests; gorelease verdict unchanged (v0.2.0).

--- a/docs/ideas/encounter-transitions/plan.md
+++ b/docs/ideas/encounter-transitions/plan.md
@@ -195,3 +195,16 @@ blobs fail v0.2 load" claim was unenforced → endpoints are now
 verified), making the compat claim true. 261 tests; gorelease verdict
 unchanged (v0.2.0, one ratified incompatible change). Copilot replies
 posted on both threads.
+
+**Axial round (commit 41412f5, Kirk-directed) — COMPLETE.** Kirk
+caught the coordinate-model confusion at its root: T1.5 had wired
+spatial's bounded OFFSET HexGrid; the wire and Platform's pathing
+speak CUBE. Hex rooms now construct AxialHexGrid — X/Y are axial Q/R,
+true cube math for distance/LoS, origin-centered spans with legal
+negative coordinates, identity wire projection. Test matrix rewritten
+both seams (negative-Q accepted — the flip; ±Width/2 boundary
+semantics); golden's hex fixture corrected (its old endpoint was
+invalid under centered spans — the correction doubles as a negative-
+axial proof); the build-square-always mutant now dies via hex tests
+directly, superseding the "only gridless discriminates" finding. 269
+tests; gorelease verdict unchanged (v0.2.0).

--- a/docs/ideas/encounter-transitions/plan.md
+++ b/docs/ideas/encounter-transitions/plan.md
@@ -22,6 +22,17 @@ fields; one-defect rejection table rows + fragments; rich golden grows
 a connection with both endpoints; `deepCopyRoomInputs`-style aliasing
 protection extended to connections; reload pin for connection survival.
 
+## Task 1.5 — rooms choose their grid
+
+`RoomInput.Grid spatial.GridShape` (zero value square) routed into
+both grid-construction sites (Setup and load path); persisted in
+`FieldData`; rich golden grows a hex room; in-bounds validation
+(members, connection endpoints, move targets) refactored to defer to
+the grid's `IsValidPosition` — delete the module's own rectangle math.
+Tests: hex room constructs, validates a legal hex position, rejects an
+illegal one at both seams; square defaults byte-stable (existing
+goldens unchanged); reload preserves grid shape.
+
 ## Task 2 — the Traverse verb
 
 `TraverseInput`/`TraverseOutput`, `ErrNoConnection` sentinel wired

--- a/docs/ideas/encounter-transitions/plan.md
+++ b/docs/ideas/encounter-transitions/plan.md
@@ -181,3 +181,17 @@ else additive, suggested version v0.2.0.
 **Wave complete: PR #924, eleven commits, 259 subtests.** Awaiting
 merge + tag `rulebooks/dnd5e/encounter/v0.2.0` (Platform's dependency
 signal on rpg-api#793).
+
+**Copilot round (commit 095e6f5) — COMPLETE.** Both findings verified
+real and fixed pre-tag while the wire shape was still free: (1) grid
+persisted as the iota INTEGER — brittle against constant reordering
+and inconsistent with spatial's own string serialization → RoomData.
+Grid is now a string reusing spatial's GridType* constants (empty =
+square; goldens byte-stable; unknown strings rejected, mutant-
+verified); (2) missing connection endpoints silently unmarshaled to
+the LEGAL cell (0,0) — invented topology, and the design's "v0.1
+blobs fail v0.2 load" claim was unenforced → endpoints are now
+*PositionData with presence required (two one-defect rows, mutant-
+verified), making the compat claim true. 261 tests; gorelease verdict
+unchanged (v0.2.0, one ratified incompatible change). Copilot replies
+posted on both threads.

--- a/docs/ideas/encounter-transitions/plan.md
+++ b/docs/ideas/encounter-transitions/plan.md
@@ -1,0 +1,65 @@
+# Encounter transitions — plan (v0.2.0)
+
+Five tasks, one in-flight PR for the module (house rule). Each task is
+dispatched with the standing brief standards from wave 1
+(`docs/ideas/encounter/plan.md`), which remain binding:
+
+- Rejection fixtures are valid-except-exactly-one-defect with
+  discriminating message fragments asserted.
+- Golden JSON exercises every `omitempty` field (rich golden).
+- Mutation pins use compiling mutants only (build before judging).
+- Scene tests are ONE continuous story.
+- Lint is judged by exit code, `gofmt -l` checked explicitly — pipes
+  hide failures.
+- Deltas returned, never published; no randomness; sorted iteration
+  anywhere order is observable.
+
+## Task 1 — connections grow endpoints
+
+`ConnectionInput` gains `FromPosition`/`ToPosition`; Setup + Load
+validation per the design's defect list; `FieldData` persists the new
+fields; one-defect rejection table rows + fragments; rich golden grows
+a connection with both endpoints; `deepCopyRoomInputs`-style aliasing
+protection extended to connections; reload pin for connection survival.
+
+## Task 2 — the Traverse verb
+
+`TraverseInput`/`TraverseOutput`, `ErrNoConnection` sentinel wired
+multi-`%w`; T2 precondition; percept refresh in both rooms; `traversed`
+beat; ending evaluation at arrival; `ErrClosed` sweep grows the verb.
+Tests: threshold success, off-threshold `ErrBadPlacement`, unknown
+connection, both-directions traversal (T1 bidirectionality), arrival
+onto an ending cell closes with the declared key, T3 pin (observer at
+an endpoint sees nothing in the far room), beat pinned via Story.
+
+## Task 3 — deciders learn where they stand
+
+`Snapshot{Room, Position, Holdings}`; `Decider.Decide(Snapshot)`;
+migrate in-repo implementors (tests, workbench); `IntentTraverse`;
+Pump phase-2 execution with atomic abort on failed precondition (R5
+pin: clock not advanced, no beats, no partial moves — read the clock).
+Integration pin: pursuit decider crosses a room boundary chasing a
+ghost using only snapshot + holdings + construction-time map.
+
+## Task 4 — the scene
+
+New scene test (sibling to tombwatch, which stays untouched with its
+archived transcript): a two-room chase told as one continuous story —
+sight, the slip through the opening, the ghost at the threshold, the
+pursuit traverse, save/reload mid-chase (decider re-attached, room
+survives), the ending in the far room, the archive sweep including
+`Traverse`.
+
+## Task 5 — transcript, workbench, gate
+
+Example with pinned `// Output:` showing a traversal beat (new sibling
+Example; the wave-1 Example stays byte-identical). Workbench gains the
+second room + `traverse` command. `./scripts/verify.sh
+rulebooks/dnd5e/encounter` green; `gorelease` gate green; module tag
+`rulebooks/dnd5e/encounter/v0.2.0` after merge.
+
+## Review cadence
+
+Per-task combined review (sonnet), Opus persistence/deep review on
+Tasks 1 and 3 (the seam and the interface change), director checklist
+before each commit. Execution addenda appended here as tasks land.


### PR DESCRIPTION
Refs #922. Wave 2 of the free-roam composition (`docs/ideas/encounter/` was wave 1, shipped as v0.1.0 via #921).

The triplet ratifies, in Kirk's words from the 2026-08-10 session:

- **The composition owns the topology** — wave 1's declared-but-inert `ConnectionInput` gains endpoints and a `Traverse` verb, because deciders live at the composition level: without it, a monster can never chase a player through a doorway.
- **Openings only** — "our freeroam can open doors and it can actually be simplified if that helps us. we can get there when we get there." No door state, no locks.
- **Sight stays room-scoped** — an opening is not a window; cross-room LoS is a future considered feature.
- **Deciders learn where they stand** — `Decide` receives a `Snapshot{Room, Position, Holdings}`, resolving the View own-placement gap flagged at wave-1 ratification, plus `IntentTraverse` executed atomically by `Pump`.
- **No dungeon-builder coupling** — spec 0.4 unverified / 0.3 not playable; the authoring surface stays `SetupInput`.

Downstream: rpg-api#793 (Platform) wires the composition into the local dev loop and depends on this wave for multi-room. This PR stays open through implementation and merges as ratification, per house process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler
