### PR TITLE
feat(rulebooks/dnd5e/encounter): room-to-room traversal — connections with teeth, hex first-class, pursuing deciders

### DIFF
--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -192,8 +192,13 @@ func TestVaultChase(t *testing.T) {
 		},
 		"Exit": func() error { _, e := enc.Exit(&encounter.ExitInput{Member: alice}); return e },
 		"End":  func() error { _, e := enc.End(&encounter.EndInput{Ending: sanctuaryEnding}); return e },
+		// The goblin, not alice: it ends the scene standing exactly on
+		// the gate's vault-side endpoint (0,5), so this attempt is
+		// valid-if-open — the rejection below is attributable to
+		// ErrClosed alone, not also to alice's position (she is deeper
+		// in the vault, at (8,8), nowhere near either threshold).
 		"Traverse": func() error {
-			_, e := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: gateConnection})
+			_, e := enc.Traverse(&encounter.TraverseInput{Member: goblin, Connection: gateConnection})
 			return e
 		},
 	} {

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -1,0 +1,227 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// TestVaultChase is the wave's second continuous scene (AC2, alongside
+// TestTombWatch — tombwatch itself untouched): ONE flowing story that
+// exercises the connection primitives Waves 1's tomb watch predates —
+// sight across an open room, slipping through a doorway, the ghost that
+// forms at the threshold (not the far side never seen), a mid-chase save/
+// reload, a decider's OWN pursuit traverse, an ending declared in the far
+// room, and an archive sweep that now includes Traverse. Uses seen() and
+// pursuitDecider, shared with tombwatch_test.go and pump_test.go
+// respectively (same package).
+func TestVaultChase(t *testing.T) {
+	// ---- The set -----------------------------------------------------
+	// Two rooms, one gate. DELIBERATELY asymmetric endpoints (T1 review
+	// lesson): FromPosition {9,5} in the corridor, ToPosition {0,5} in
+	// the vault — a from/to mix-up would be observable.
+	const (
+		corridorRoom    = "corridor"
+		vaultRoom       = "vault"
+		gateConnection  = "gate"
+		sanctuaryEnding = "sanctuary"
+	)
+	gate := encounter.ConnectionInput{
+		ID: gateConnection, From: corridorRoom, To: vaultRoom,
+		FromPosition: spatial.Position{X: 9, Y: 5},
+		ToPosition:   spatial.Position{X: 0, Y: 5},
+	}
+
+	// ---- Beat 1: sight -------------------------------------------------
+	// Alice and the goblin share the corridor, in the open — first light
+	// finds them mutually visible. The goblin's pursuitDecider knows the
+	// gate (static topology, given at construction) and its target
+	// (alice); it never reads encounter state directly — Snapshot +
+	// Holdings + its own construction-time config is all it gets (C2).
+	pursuit := &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: corridorRoom, Width: 10, Height: 10},
+				{ID: vaultRoom, Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{gate},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: corridorRoom, Position: spatial.Position{X: 2, Y: 5}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: corridorRoom,
+				Position: spatial.Position{X: 2, Y: 8}, Decider: pursuit},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: sanctuaryEnding, Trigger: encounter.TriggerReachedPosition{
+				Room: vaultRoom, Position: spatial.Position{X: 8, Y: 8}}},
+		},
+	})
+	require.NoError(t, err, "beat 1: the corridor assembles")
+
+	st, _ := seen(t, enc, alice, goblin)
+	require.Equal(t, intel.Current, st, "beat 1: alice sees the goblin across the open corridor")
+	st, _ = seen(t, enc, goblin, alice)
+	require.Equal(t, intel.Current, st, "beat 1: and the goblin sees her back — intel is symmetric")
+
+	// ---- Beat 2: to the threshold, and through it ----------------------
+	// Alice crosses to the gate, then slips through it into the vault.
+	_, err = enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 9, Y: 5}})
+	require.NoError(t, err, "beat 2: alice crosses to the gate")
+
+	travOut, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: gateConnection})
+	require.NoError(t, err, "beat 2: she slips through the gate")
+	require.Equal(t, vaultRoom, travOut.Traversed.ToRoom, "beat 2: she arrives in the vault")
+	require.Equal(t, spatial.Position{X: 0, Y: 5}, travOut.Traversed.To)
+
+	// The ghost forms — for BOTH of them, symmetrically. Note WHERE:
+	// the threshold in the corridor, her last-seen position — not the
+	// vault, which the goblin has never seen at all.
+	st, p := seen(t, enc, goblin, alice)
+	require.Equal(t, intel.Held, st, "beat 2: the goblin's sight of alice fades — she left the room")
+	require.Equal(t, corridorRoom, p.Room, "beat 2: its ghost holds her LAST-SEEN room")
+	require.Equal(t, 9.0, p.X, "beat 2: at the threshold, not the far side it never saw")
+	require.Equal(t, 5.0, p.Y)
+	st, _ = seen(t, enc, alice, goblin)
+	require.Equal(t, intel.Held, st, "beat 2: alice loses the goblin too — symmetric")
+
+	// She doesn't linger at the arrival cell — she moves deeper into the
+	// vault, toward (but not yet at) sanctuary.
+	_, err = enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 4, Y: 5}})
+	require.NoError(t, err, "beat 2: she moves deeper into the vault")
+
+	// ---- Beat 3: the pause (pause is free) ------------------------------
+	// The table closes the Discord activity mid-chase. The host persists
+	// ONE aggregate and rehydrates it later. Deciders are behavior, not
+	// state: the campaign re-attaches a FRESH pursuitDecider at load —
+	// same topology and target, no memory of its own carried over (its
+	// INTEL does — beliefs are state and traveled in the aggregate).
+	data := enc.ToData()
+	enc2, err := encounter.LoadEncounter(data, map[encounter.MemberID]encounter.Decider{
+		goblin: &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice},
+	})
+	require.NoError(t, err, "beat 3: the suspended chase crosses a process boundary")
+	enc = enc2 // the reload IS the encounter now
+
+	st, p = seen(t, enc, goblin, alice)
+	require.Equal(t, intel.Held, st, "beat 3: the ghost survived the reload")
+	require.Equal(t, corridorRoom, p.Room, "beat 3: still at the threshold — loading never re-derives sight")
+	require.Equal(t, 9.0, p.X)
+
+	// ---- Beat 4: the pursuit traverse ------------------------------------
+	// First pump: the goblin, still in the corridor, walks toward the
+	// ghost's last-seen position — the threshold.
+	pumpOut1, err := enc.Pump(&encounter.PumpInput{})
+	require.NoError(t, err, "beat 4: the pursuit resumes")
+	require.Len(t, pumpOut1.MonsterMoves, 1, "beat 4: the goblin walks toward the threshold")
+	require.Equal(t, spatial.Position{X: 9, Y: 5}, pumpOut1.MonsterMoves[0].To)
+	require.Empty(t, pumpOut1.MonsterTraverses, "beat 4: not standing at the threshold yet on this tick's decision")
+
+	// Second pump: now standing exactly on the connection's endpoint, the
+	// goblin's OWN decision crosses it — the same mechanics the Traverse
+	// verb used for alice, reused, not duplicated.
+	pumpOut2, err := enc.Pump(&encounter.PumpInput{})
+	require.NoError(t, err, "beat 4: the goblin follows her through")
+	require.Len(t, pumpOut2.MonsterTraverses, 1, "beat 4: the goblin traverses the gate")
+	require.Equal(t, goblin, pumpOut2.MonsterTraverses[0].Member)
+	require.Equal(t, corridorRoom, pumpOut2.MonsterTraverses[0].FromRoom)
+	require.Equal(t, vaultRoom, pumpOut2.MonsterTraverses[0].ToRoom)
+	require.Equal(t, spatial.Position{X: 0, Y: 5}, pumpOut2.MonsterTraverses[0].To)
+
+	// It's in her room now — this pump's own refreshSight already shows
+	// her Current again, at (4,5), where she stopped in beat 2.
+	st, p = seen(t, enc, goblin, alice)
+	require.Equal(t, intel.Current, st, "beat 4: the goblin holds alice Current again, having crossed the threshold")
+	require.Equal(t, vaultRoom, p.Room)
+	require.Equal(t, 4.0, p.X)
+	require.Equal(t, 5.0, p.Y)
+
+	// ---- Beat 5: sanctuary, in the far room ------------------------------
+	// Alice reaches the shrine before the goblin closes the distance. The
+	// declared ending fires in the VAULT — a room the corridor-side setup
+	// never mentioned directly; the ending only knows the room by name.
+	moveOut, err := enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 8, Y: 8}})
+	require.NoError(t, err, "beat 5: alice reaches sanctuary")
+	require.NotNil(t, moveOut.Outcome, "beat 5: the ending fires in the Move's own output")
+	require.Equal(t, sanctuaryEnding, moveOut.Outcome.Ending)
+	require.Len(t, moveOut.Outcome.Members, 2, "beat 5: alice and the goblin remain")
+
+	var aliceOutcome, goblinOutcome encounter.MemberOutcome
+	for _, m := range moveOut.Outcome.Members {
+		switch m.ID {
+		case alice:
+			aliceOutcome = m
+		case goblin:
+			goblinOutcome = m
+		}
+	}
+	require.Equal(t, vaultRoom, aliceOutcome.Room)
+	require.Equal(t, spatial.Position{X: 8, Y: 8}, aliceOutcome.Position)
+	// The goblin made it across the threshold too — the outcome reflects
+	// where it TRULY stands, in the vault, not its pre-chase corridor spot.
+	require.Equal(t, vaultRoom, goblinOutcome.Room, "beat 5: the outcome reflects the goblin's post-traverse room")
+	require.Equal(t, spatial.Position{X: 0, Y: 5}, goblinOutcome.Position)
+
+	status, err := enc.Status()
+	require.NoError(t, err)
+	require.False(t, status.Open, "beat 5: closed = has an Outcome")
+
+	// ---- Beat 6: the archive sweep, now including Traverse ---------------
+	// A closed encounter rejects every mutating verb — tomb watch pinned
+	// this for Move/Pump/Join/Exit/End; the connections wave adds Traverse
+	// to the same sweep.
+	for name, verb := range map[string]func() error{
+		"Move": func() error {
+			_, e := enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 1, Y: 1}})
+			return e
+		},
+		"Pump": func() error { _, e := enc.Pump(&encounter.PumpInput{}); return e },
+		"Join": func() error {
+			_, e := enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{
+				ID: "late", Kind: encounter.KindPlayer, Room: vaultRoom, Position: spatial.Position{X: 1, Y: 1}}})
+			return e
+		},
+		"Exit": func() error { _, e := enc.Exit(&encounter.ExitInput{Member: alice}); return e },
+		"End":  func() error { _, e := enc.End(&encounter.EndInput{Ending: sanctuaryEnding}); return e },
+		"Traverse": func() error {
+			_, e := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: gateConnection})
+			return e
+		},
+	} {
+		require.ErrorIs(t, verb(), encounter.ErrClosed, "beat 6: %s on a closed encounter", name)
+	}
+
+	// ---- Beat 7: the archive answers ------------------------------------
+	// Closed encounters answer queries forever. Assert the FULL transcript
+	// of beat kinds, in order — the story IS the scene.
+	view, err := enc.View(&encounter.ViewInput{Member: alice})
+	require.NoError(t, err, "beat 7: the archive answers View")
+	require.NotEmpty(t, view)
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: alice})
+	require.NoError(t, err, "beat 7: the archive answers Story")
+	kinds := make([]string, 0, len(story))
+	for _, e := range story {
+		var beat map[string]any
+		require.NoError(t, json.Unmarshal(e.Payload, &beat))
+		kinds = append(kinds, beat["beat"].(string))
+	}
+	require.Equal(t, []string{
+		"scene-opened",  // beat 1
+		"moved",         // beat 2: alice crosses to the gate
+		"traversed",     // beat 2: she slips through
+		"moved",         // beat 2: she moves deeper into the vault
+		"tick", "moved", // beat 4: pump 1, the goblin walks to the threshold
+		"tick", "traversed", // beat 4: pump 2, the goblin follows her through
+		"moved", // beat 5: alice reaches sanctuary
+	}, kinds, "beat 7: the story IS the chase, told in order")
+}

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -4,19 +4,23 @@
 // Command freeroam-workbench drives the free-roam encounter in a
 // terminal — the pre-UI loop (the dungeonspec-workbench tradition): no
 // server, no rpg-api, no Discord activity involved. It sets up the
-// tomb-watch crypt (two players, a patrolling goblin, a pillar) and
-// hands you the verbs. Every action renders the WORLD TRUTH beside
-// each asked-for player's BELIEFS — capitals are current sightings,
-// lowercase are ghosts at last-seen — which is the intel model made
-// visible: move behind the pillar and watch yourself become a memory.
+// tomb-watch crypt (two players, a patrolling goblin, a pillar), a
+// passage in its unclaimed corner leading to a second room — the
+// ossuary — and hands you the verbs. Every action renders the WORLD
+// TRUTH beside each asked-for player's BELIEFS, scoped to whichever
+// room that player currently stands in — capitals are current
+// sightings, lowercase are ghosts at last-seen — which is the intel
+// model made visible: move behind the pillar and watch yourself become
+// a memory, or step through the passage and watch the crypt itself
+// fade to nothing (T3 — sight never crosses a connection).
 //
 // Run from the module directory:
 //
 //	go run ./cmd/freeroam-workbench
 //
-// Commands: move <name> <x> <y> | pump | view <name> | story <name> |
-// join <name> <x> <y> | exit <name> | end withdrew | save <file> |
-// load <file> | status | help | quit
+// Commands: move <name> <x> <y> | traverse <name> <connection> | pump |
+// view <name> | story <name> | join <name> <x> <y> | exit <name> |
+// end withdrew | save <file> | load <file> | status | help | quit
 package main
 
 import (
@@ -37,6 +41,10 @@ import (
 const (
 	cryptID   = "crypt"
 	cryptSize = 12
+	ossuaryID = "ossuary"
+	ossuaryW  = 8
+	ossuaryH  = 6
+	passageID = "passage"
 )
 
 // patrol is the goblin's route brain: a fixed loop of waypoints.
@@ -63,10 +71,23 @@ func goblinPatrol() *patrol {
 func newCrypt() (*encounter.Encounter, error) {
 	return encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{
-				ID: cryptID, Width: cryptSize, Height: cryptSize,
-				Occluders: []spatial.Position{{X: 6, Y: 6}, {X: 5, Y: 6}},
-			}},
+			Rooms: []encounter.RoomInput{
+				{
+					ID: cryptID, Width: cryptSize, Height: cryptSize,
+					Occluders: []spatial.Position{{X: 6, Y: 6}, {X: 5, Y: 6}},
+				},
+				{
+					ID: ossuaryID, Width: ossuaryW, Height: ossuaryH,
+					Occluders: []spatial.Position{{X: 4, Y: 3}},
+				},
+			},
+			Connections: []encounter.ConnectionInput{
+				{
+					ID: passageID, From: cryptID, To: ossuaryID,
+					FromPosition: spatial.Position{X: 11, Y: 0},
+					ToPosition:   spatial.Position{X: 0, Y: 0},
+				},
+			},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: cryptID, Position: spatial.Position{X: 2, Y: 2}},
@@ -82,39 +103,67 @@ func newCrypt() (*encounter.Encounter, error) {
 	})
 }
 
-// worldGrid renders ground truth from the aggregate snapshot — the
-// HOST's view, which is exactly what a game server holds.
-func worldGrid(data encounter.EncounterData) []string {
-	grid := blankGrid()
-	for _, r := range data.Field.Rooms {
-		for _, o := range r.Occluders {
-			set(grid, o.X, o.Y, '#')
+// roomByID finds a room's data by ID — nil if the field has no such
+// room (a defect the caller should treat as "nothing to render").
+func roomByID(data encounter.EncounterData, room string) *encounter.RoomData {
+	for i := range data.Field.Rooms {
+		if data.Field.Rooms[i].ID == room {
+			return &data.Field.Rooms[i]
 		}
 	}
+	return nil
+}
+
+// worldGrid renders ground truth for ONE room from the aggregate
+// snapshot — the HOST's view, which is exactly what a game server
+// holds. Sight is room-scoped (T3), so belief grids are room-scoped
+// too; world truth follows the same shape for a fair side-by-side.
+func worldGrid(data encounter.EncounterData, room string) []string {
+	r := roomByID(data, room)
+	if r == nil {
+		return nil
+	}
+	grid := blankGrid(r.Width, r.Height)
+	for _, o := range r.Occluders {
+		set(grid, o.X, o.Y, '#')
+	}
 	for _, m := range data.Members {
+		if m.Room != room {
+			continue
+		}
 		set(grid, m.Position.X, m.Position.Y, initialOf(string(m.ID), true))
 	}
-	set(grid, 11, 11, '>')
+	if room == cryptID {
+		set(grid, 11, 11, '>')
+	}
 	return grid
 }
 
-// beliefGrid renders one member's intel: what they currently see in
-// capitals, their ghosts in lowercase at last-seen. Their own position
-// comes from world truth (you always know where you stand).
-func beliefGrid(enc *encounter.Encounter, data encounter.EncounterData, who core.EntityID) ([]string, error) {
+// beliefGrid renders one member's intel, scoped to the room they
+// currently stand in: what they currently see in capitals, their
+// ghosts in lowercase at last-seen (a ghost held from a room the
+// member has since left renders nowhere — this grid only shows their
+// present room). Their own position comes from world truth (you
+// always know where you stand).
+func beliefGrid(enc *encounter.Encounter, data encounter.EncounterData, who core.EntityID, room string) ([]string, error) {
 	view, err := enc.View(&encounter.ViewInput{Member: who})
 	if err != nil {
 		return nil, err
 	}
-	grid := blankGrid()
-	for _, r := range data.Field.Rooms {
-		for _, o := range r.Occluders {
-			set(grid, o.X, o.Y, '#')
-		}
+	r := roomByID(data, room)
+	if r == nil {
+		return nil, nil
+	}
+	grid := blankGrid(r.Width, r.Height)
+	for _, o := range r.Occluders {
+		set(grid, o.X, o.Y, '#')
 	}
 	for _, h := range view {
 		var p encounter.SightPayload
 		if err := json.Unmarshal(h.Payload, &p); err != nil {
+			continue
+		}
+		if p.Room != room {
 			continue
 		}
 		set(grid, p.X, p.Y, initialOf(string(h.Subject), h.Status == intel.Current))
@@ -127,10 +176,10 @@ func beliefGrid(enc *encounter.Encounter, data encounter.EncounterData, who core
 	return grid, nil
 }
 
-func blankGrid() []string {
-	rows := make([]string, cryptSize)
+func blankGrid(w, h int) []string {
+	rows := make([]string, h)
 	for y := range rows {
-		rows[y] = strings.Repeat(".", cryptSize)
+		rows[y] = strings.Repeat(".", w)
 	}
 	return rows
 }
@@ -157,7 +206,11 @@ func initialOf(name string, current bool) byte {
 }
 
 func printSideBySide(left, right []string, leftTitle, rightTitle string) {
-	fmt.Printf("  %-*s   %s\n", cryptSize, leftTitle, rightTitle)
+	width := cryptSize
+	if len(left) > 0 {
+		width = len(left[0])
+	}
+	fmt.Printf("  %-*s   %s\n", width, leftTitle, rightTitle)
 	for i := range left {
 		fmt.Printf("  %s   %s\n", left[i], right[i])
 	}
@@ -193,9 +246,12 @@ func printStatus(enc *encounter.Encounter) {
 }
 
 const legend = `  @ you   A/B/C capitals: seen NOW   a/b/g lowercase: ghost at last-seen
-  # pillar   > the stairs down (reach them and the encounter closes)`
+  # pillar/sarcophagus   > the stairs down (reach them and the encounter closes)
+  connection "passage": crypt (11,0) <-> ossuary (0,0) — stand on the
+  threshold and traverse; the view flips to whichever room you're in`
 
 const commands = `  move <name> <x> <y>   walk (the world holds still — you pump it)
+  traverse <name> <connection>   cross a connection from its threshold
   pump                  a tick passes: the goblin patrols, sights refresh
   view <name>           world truth beside <name>'s beliefs
   story <name>          the record, as <name> is allowed to hear it
@@ -250,6 +306,22 @@ func main() {
 			}
 			x, y := num(args[2]), num(args[3])
 			out, err := enc.Move(&encounter.MoveInput{Member: core.EntityID(args[1]), To: spatial.Position{X: x, Y: y}})
+			if err != nil {
+				fmt.Println(" ", err)
+				continue
+			}
+			showView(enc, core.EntityID(args[1]))
+			if out.Outcome != nil {
+				printStatus(enc)
+			}
+		case "traverse":
+			if len(args) != 3 {
+				fmt.Println("  traverse <name> <connection>")
+				continue
+			}
+			out, err := enc.Traverse(&encounter.TraverseInput{
+				Member: core.EntityID(args[1]), Connection: args[2],
+			})
 			if err != nil {
 				fmt.Println(" ", err)
 				continue
@@ -359,12 +431,23 @@ func main() {
 
 func showView(enc *encounter.Encounter, who core.EntityID) {
 	data := enc.ToData()
-	belief, err := beliefGrid(enc, data, who)
+	room := ""
+	for _, m := range data.Members {
+		if m.ID == who {
+			room = m.Room
+		}
+	}
+	if room == "" {
+		fmt.Println(" ", who, "is not a member")
+		return
+	}
+	belief, err := beliefGrid(enc, data, who, room)
 	if err != nil {
 		fmt.Println(" ", err)
 		return
 	}
-	printSideBySide(worldGrid(data), belief, "WORLD TRUTH", fmt.Sprintf("%s BELIEVES", strings.ToUpper(string(who))))
+	title := fmt.Sprintf("WORLD TRUTH (%s)", room)
+	printSideBySide(worldGrid(data, room), belief, title, fmt.Sprintf("%s BELIEVES", strings.ToUpper(string(who))))
 }
 
 func num(s string) float64 {

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -48,7 +48,7 @@ type patrol struct {
 // Decide returns the next waypoint regardless of what the goblin
 // believes — a deliberately dumb decider; the point of the workbench is
 // watching the courier loop, not clever monsters.
-func (p *patrol) Decide(_ []intel.Holding) (encounter.Intent, error) {
+func (p *patrol) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 	target := p.route[p.step%len(p.route)]
 	p.step++
 	return encounter.IntentMoveTo{To: target}, nil

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -240,10 +240,11 @@ func (e *Encounter) ToData() EncounterData {
 
 // LoadEncounter reconstructs an Encounter from persistent data and re-attached deciders.
 // Validation order (R5 — validate all before constructing): nil-equivalent empty Data,
-// no rooms, no endings, duplicate member IDs, member's room not in field, member position
-// out of bounds, empty/reserved ending keys, undeclared outcome ending, connection defects
-// (empty/duplicate ID, missing room, self-connection, endpoint out of bounds or on an
-// occluder), everMembers missing a current member.
+// no rooms, no endings, empty/reserved ending keys (and kind/reached_position checks),
+// undeclared outcome ending, connection defects (empty/duplicate ID, missing room,
+// self-connection, endpoint out of bounds or on an occluder), duplicate member IDs,
+// member's room not in field, member position out of bounds, outcome member room/bounds
+// checks, everMembers missing a current member.
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
 // and members are re-placed at persisted positions.

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -372,6 +372,15 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		roomMap[r.ID] = true
 		roomsByID[r.ID] = r
 		roomGrids[r.ID] = buildRoomGrid(shape, r.Width, r.Height)
+
+		// Hex rooms require integral axial occluder positions (interim
+		// tools/spatial#926 enforcement — see isIntegralAxialPosition).
+		for _, occ := range r.Occluders {
+			pos := spatial.Position{X: occ.X, Y: occ.Y}
+			if !isIntegralAxialPosition(roomGrids[r.ID], pos) {
+				return nil, fmt.Errorf("load encounter: room %q occluder (%g,%g) is not an integral axial cell: %w: %w", r.ID, occ.X, occ.Y, ErrInvalidData, ErrNoField)
+			}
+		}
 	}
 
 	// Validate connections: unique non-empty IDs, endpoints resolve to
@@ -417,8 +426,14 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		if !roomGrids[c.From].IsValidPosition(spatial.Position{X: c.FromPosition.X, Y: c.FromPosition.Y}) {
 			return nil, fmt.Errorf("load encounter: connection %q from-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
 		}
+		if !isIntegralAxialPosition(roomGrids[c.From], spatial.Position{X: c.FromPosition.X, Y: c.FromPosition.Y}) {
+			return nil, fmt.Errorf("load encounter: connection %q from-position is not an integral axial cell: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+		}
 		if !roomGrids[c.To].IsValidPosition(spatial.Position{X: c.ToPosition.X, Y: c.ToPosition.Y}) {
 			return nil, fmt.Errorf("load encounter: connection %q to-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+		}
+		if !isIntegralAxialPosition(roomGrids[c.To], spatial.Position{X: c.ToPosition.X, Y: c.ToPosition.Y}) {
+			return nil, fmt.Errorf("load encounter: connection %q to-position is not an integral axial cell: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
 		}
 
 		for _, occ := range fromRoom.Occluders {
@@ -453,6 +468,12 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		// constructed Grid decides validity (see roomGrids above).
 		if !roomGrids[m.Room].IsValidPosition(spatial.Position{X: m.Position.X, Y: m.Position.Y}) {
 			return nil, fmt.Errorf("load encounter: member %q position out of bounds: %w", m.ID, ErrInvalidData)
+		}
+
+		// Hex rooms require integral axial member positions (interim
+		// tools/spatial#926 enforcement — see isIntegralAxialPosition).
+		if !isIntegralAxialPosition(roomGrids[m.Room], spatial.Position{X: m.Position.X, Y: m.Position.Y}) {
+			return nil, fmt.Errorf("load encounter: member %q position is not an integral axial cell: %w", m.ID, ErrInvalidData)
 		}
 	}
 
@@ -608,9 +629,16 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		e.members[m.ID] = member
 		e.everMembers[m.ID] = true
 
-		// Re-attach decider if present — players cannot carry deciders
-		// (C2, enforced at all three seams: Setup, Join, and load).
-		if d, ok := deciders[m.ID]; ok {
+		// Re-attach decider if present and non-nil — a literal nil entry
+		// in the reattachment map is equivalent to an ABSENT one: a
+		// monster without a decider is legal and simply holds (Setup and
+		// Join already treat a nil MemberInput.Decider this way). Storing
+		// a nil Decider interface here would panic Pump's first Decide
+		// call on that monster (reject-never-crash: LoadEncounter is the
+		// trust boundary for the caller-supplied reattachment map too,
+		// not just the persisted bytes). Players cannot carry deciders
+		// regardless (C2, enforced at all three seams: Setup, Join, load).
+		if d, ok := deciders[m.ID]; ok && d != nil {
 			if m.Kind == KindPlayer {
 				return nil, fmt.Errorf("load encounter: player %s cannot carry a decider: %w: %w", m.ID, ErrInvalidData, ErrNoMember)
 			}

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -76,9 +76,11 @@ type BoundaryData struct {
 
 // ConnectionData is the persistent representation of a connection.
 type ConnectionData struct {
-	ID   string `json:"id"`
-	From string `json:"from"`
-	To   string `json:"to"`
+	ID           string       `json:"id"`
+	From         string       `json:"from"`
+	To           string       `json:"to"`
+	FromPosition PositionData `json:"from_position"`
+	ToPosition   PositionData `json:"to_position"`
 }
 
 // MemberData is the persistent representation of a member's current placement.
@@ -198,7 +200,13 @@ func (e *Encounter) ToData() EncounterData {
 	}
 
 	for i, ci := range e.connectionsInput {
-		fieldData.Connections[i] = ConnectionData(ci)
+		fieldData.Connections[i] = ConnectionData{
+			ID:           ci.ID,
+			From:         ci.From,
+			To:           ci.To,
+			FromPosition: PositionData{X: ci.FromPosition.X, Y: ci.FromPosition.Y},
+			ToPosition:   PositionData{X: ci.ToPosition.X, Y: ci.ToPosition.Y},
+		}
 	}
 
 	// Build outcome if present
@@ -233,8 +241,9 @@ func (e *Encounter) ToData() EncounterData {
 // LoadEncounter reconstructs an Encounter from persistent data and re-attached deciders.
 // Validation order (R5 — validate all before constructing): nil-equivalent empty Data,
 // no rooms, no endings, duplicate member IDs, member's room not in field, member position
-// out of bounds, empty/reserved ending keys, undeclared outcome ending, connection
-// referencing missing room, everMembers missing a current member.
+// out of bounds, empty/reserved ending keys, undeclared outcome ending, connection defects
+// (empty/duplicate ID, missing room, self-connection, endpoint out of bounds or on an
+// occluder), everMembers missing a current member.
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
 // and members are re-placed at persisted positions.
@@ -294,10 +303,49 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		roomsByID[r.ID] = r
 	}
 
-	// Validate connections reference existing rooms
+	// Validate connections: unique non-empty IDs, endpoints resolve to
+	// distinct declared rooms, and endpoints lie within their room's
+	// bounds and off any occluder. ErrBadConnection rides alongside
+	// ErrInvalidData so connection defects are discriminable from other
+	// load rejections.
+	seenConnectionIDs := make(map[string]bool, len(data.Field.Connections))
 	for _, c := range data.Field.Connections {
-		if !roomMap[c.From] || !roomMap[c.To] {
-			return nil, fmt.Errorf("load encounter: connection %q references missing room: %w", c.ID, ErrInvalidData)
+		if c.ID == "" {
+			return nil, fmt.Errorf("load encounter: connection has empty id: %w: %w", ErrInvalidData, ErrBadConnection)
+		}
+		if seenConnectionIDs[c.ID] {
+			return nil, fmt.Errorf("load encounter: duplicate connection %q: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+		}
+		seenConnectionIDs[c.ID] = true
+
+		fromRoom, ok := roomsByID[c.From]
+		if !ok {
+			return nil, fmt.Errorf("load encounter: connection %q references missing room %q: %w: %w", c.ID, c.From, ErrInvalidData, ErrBadConnection)
+		}
+		toRoom, ok := roomsByID[c.To]
+		if !ok {
+			return nil, fmt.Errorf("load encounter: connection %q references missing room %q: %w: %w", c.ID, c.To, ErrInvalidData, ErrBadConnection)
+		}
+		if c.From == c.To {
+			return nil, fmt.Errorf("load encounter: connection %q connects room %q to itself: %w: %w", c.ID, c.From, ErrInvalidData, ErrBadConnection)
+		}
+
+		if !positionInBounds(c.FromPosition.X, c.FromPosition.Y, fromRoom.Width, fromRoom.Height) {
+			return nil, fmt.Errorf("load encounter: connection %q from-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+		}
+		if !positionInBounds(c.ToPosition.X, c.ToPosition.Y, toRoom.Width, toRoom.Height) {
+			return nil, fmt.Errorf("load encounter: connection %q to-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+		}
+
+		for _, occ := range fromRoom.Occluders {
+			if occ.X == c.FromPosition.X && occ.Y == c.FromPosition.Y {
+				return nil, fmt.Errorf("load encounter: connection %q from-position on occluder: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+			}
+		}
+		for _, occ := range toRoom.Occluders {
+			if occ.X == c.ToPosition.X && occ.Y == c.ToPosition.Y {
+				return nil, fmt.Errorf("load encounter: connection %q to-position on occluder: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+			}
 		}
 	}
 
@@ -540,9 +588,11 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		e.outcome = outcome
 	}
 
-	// Store field and connections inputs for future ToData calls
+	// Store field and connections inputs for future ToData calls. Connections
+	// are kept sorted by ID (C8 determinism — order is observable in ToData).
 	e.fieldInput = convertRoomDataToRoomInput(data.Field.Rooms)
 	e.connectionsInput = convertConnectionDataToConnectionInput(data.Field.Connections)
+	sort.Slice(e.connectionsInput, func(i, j int) bool { return e.connectionsInput[i].ID < e.connectionsInput[j].ID })
 
 	return e, nil
 }
@@ -581,7 +631,13 @@ func convertRoomDataToRoomInput(rooms []RoomData) []RoomInput {
 func convertConnectionDataToConnectionInput(conns []ConnectionData) []ConnectionInput {
 	result := make([]ConnectionInput, len(conns))
 	for i, cd := range conns {
-		result[i] = ConnectionInput(cd)
+		result[i] = ConnectionInput{
+			ID:           cd.ID,
+			From:         cd.From,
+			To:           cd.To,
+			FromPosition: spatial.Position{X: cd.FromPosition.X, Y: cd.FromPosition.Y},
+			ToPosition:   spatial.Position{X: cd.ToPosition.X, Y: cd.ToPosition.Y},
+		}
 	}
 	return result
 }

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -52,15 +52,19 @@ type FieldData struct {
 }
 
 // RoomData mirrors RoomInput exactly to persist construction inputs.
-// Grid omits when GridShapeSquare (the zero value) so pre-v0.2 blobs and
-// square-only encounters keep byte-identical output.
+// Grid is persisted as spatial's own GridType string ("hex" or
+// "gridless" — tools/spatial's GridTypeHex/GridTypeGridless), not the
+// GridShape iota: the iota is an in-process enumeration order, not a
+// wire contract, and would silently reinterpret old blobs if spatial
+// ever reordered it. Grid omits when empty (the square zero value) so
+// pre-v0.2 blobs and square-only encounters keep byte-identical output.
 type RoomData struct {
-	ID         string            `json:"id"`
-	Width      int               `json:"width"`
-	Height     int               `json:"height"`
-	Grid       spatial.GridShape `json:"grid,omitempty"`
-	Occluders  []PositionData    `json:"occluders,omitempty"`
-	Boundaries []BoundaryData    `json:"boundaries,omitempty"`
+	ID         string         `json:"id"`
+	Width      int            `json:"width"`
+	Height     int            `json:"height"`
+	Grid       string         `json:"grid,omitempty"`
+	Occluders  []PositionData `json:"occluders,omitempty"`
+	Boundaries []BoundaryData `json:"boundaries,omitempty"`
 }
 
 // PositionData is the persistent representation of spatial.Position.
@@ -78,12 +82,17 @@ type BoundaryData struct {
 }
 
 // ConnectionData is the persistent representation of a connection.
+// FromPosition and ToPosition are required — ToData always populates
+// both; a nil pointer at Load means the field was absent from the
+// blob and is rejected (a connection without both endpoints has no
+// meaning, and a missing endpoint must never silently default to
+// (0,0), a legal cell that would invent topology).
 type ConnectionData struct {
-	ID           string       `json:"id"`
-	From         string       `json:"from"`
-	To           string       `json:"to"`
-	FromPosition PositionData `json:"from_position"`
-	ToPosition   PositionData `json:"to_position"`
+	ID           string        `json:"id"`
+	From         string        `json:"from"`
+	To           string        `json:"to"`
+	FromPosition *PositionData `json:"from_position"`
+	ToPosition   *PositionData `json:"to_position"`
 }
 
 // MemberData is the persistent representation of a member's current placement.
@@ -182,7 +191,7 @@ func (e *Encounter) ToData() EncounterData {
 			ID:         ri.ID,
 			Width:      ri.Width,
 			Height:     ri.Height,
-			Grid:       ri.Grid,
+			Grid:       gridShapeToData(ri.Grid),
 			Occluders:  make([]PositionData, len(ri.Occluders)),
 			Boundaries: make([]BoundaryData, len(ri.Boundaries)),
 		}
@@ -208,8 +217,8 @@ func (e *Encounter) ToData() EncounterData {
 			ID:           ci.ID,
 			From:         ci.From,
 			To:           ci.To,
-			FromPosition: PositionData{X: ci.FromPosition.X, Y: ci.FromPosition.Y},
-			ToPosition:   PositionData{X: ci.ToPosition.X, Y: ci.ToPosition.Y},
+			FromPosition: &PositionData{X: ci.FromPosition.X, Y: ci.FromPosition.Y},
+			ToPosition:   &PositionData{X: ci.ToPosition.X, Y: ci.ToPosition.Y},
 		}
 	}
 
@@ -239,6 +248,41 @@ func (e *Encounter) ToData() EncounterData {
 		Members:     membersData,
 		Endings:     endingsData,
 		EverMembers: everMembersSlice,
+	}
+}
+
+// gridShapeToData maps a room's constructed grid shape to its persisted
+// string form, reusing spatial's own GridType* constants
+// (tools/spatial/data.go) so the wire vocabulary matches spatial's own
+// persistence. Square (the zero value) maps to "" so byte-compat
+// goldens keep omitting the field entirely.
+func gridShapeToData(shape spatial.GridShape) string {
+	switch shape {
+	case spatial.GridShapeHex:
+		return spatial.GridTypeHex
+	case spatial.GridShapeGridless:
+		return spatial.GridTypeGridless
+	default:
+		return ""
+	}
+}
+
+// gridDataToShape is gridShapeToData's inverse, used at Load. Empty
+// string and the literal "square" both mean the zero-value shape —
+// ToData never emits "square" (it omits the field), but Load accepts
+// it defensively for hand-authored fixtures. An unrecognized string
+// returns ok=false so the caller can reject with a fragment naming
+// the bad value, rather than silently defaulting to square.
+func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
+	switch s {
+	case "", spatial.GridTypeSquare:
+		return spatial.GridShapeSquare, true
+	case spatial.GridTypeHex:
+		return spatial.GridShapeHex, true
+	case spatial.GridTypeGridless:
+		return spatial.GridShapeGridless, true
+	default:
+		return spatial.GridShapeSquare, false
 	}
 }
 
@@ -321,14 +365,13 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		if roomMap[r.ID] {
 			return nil, fmt.Errorf("load encounter: duplicate room %q: %w: %w", r.ID, ErrInvalidData, ErrNoField)
 		}
-		switch r.Grid {
-		case spatial.GridShapeSquare, spatial.GridShapeHex, spatial.GridShapeGridless:
-		default:
-			return nil, fmt.Errorf("load encounter: room %q has unknown grid shape %d: %w: %w", r.ID, r.Grid, ErrInvalidData, ErrNoField)
+		shape, ok := gridDataToShape(r.Grid)
+		if !ok {
+			return nil, fmt.Errorf("load encounter: room %q has unknown grid shape %q: %w: %w", r.ID, r.Grid, ErrInvalidData, ErrNoField)
 		}
 		roomMap[r.ID] = true
 		roomsByID[r.ID] = r
-		roomGrids[r.ID] = buildRoomGrid(r.Grid, r.Width, r.Height)
+		roomGrids[r.ID] = buildRoomGrid(shape, r.Width, r.Height)
 	}
 
 	// Validate connections: unique non-empty IDs, endpoints resolve to
@@ -356,6 +399,19 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		}
 		if c.From == c.To {
 			return nil, fmt.Errorf("load encounter: connection %q connects room %q to itself: %w: %w", c.ID, c.From, ErrInvalidData, ErrBadConnection)
+		}
+
+		// Both endpoints are required — ToData always populates them, so
+		// a nil pointer here means the field was absent from the blob
+		// (not merely zero-valued). Without this check a missing endpoint
+		// would unmarshal to a nil *PositionData and panic below; worse,
+		// if the field type were still a value struct, it would silently
+		// default to (0,0), a legal cell that invents topology.
+		if c.FromPosition == nil {
+			return nil, fmt.Errorf("load encounter: connection %q missing from_position: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
+		}
+		if c.ToPosition == nil {
+			return nil, fmt.Errorf("load encounter: connection %q missing to_position: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
 		}
 
 		if !roomGrids[c.From].IsValidPosition(spatial.Position{X: c.FromPosition.X, Y: c.FromPosition.Y}) {
@@ -613,11 +669,14 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 func convertRoomDataToRoomInput(rooms []RoomData) []RoomInput {
 	result := make([]RoomInput, len(rooms))
 	for i, rd := range rooms {
+		// gridDataToShape's ok is ignored: LoadEncounter has already
+		// validated every room's Grid string before this conversion runs.
+		shape, _ := gridDataToShape(rd.Grid)
 		ri := RoomInput{
 			ID:         rd.ID,
 			Width:      rd.Width,
 			Height:     rd.Height,
-			Grid:       rd.Grid,
+			Grid:       shape,
 			Occluders:  make([]spatial.Position, len(rd.Occluders)),
 			Boundaries: make([]spatial.Boundary, len(rd.Boundaries)),
 		}

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -52,12 +52,15 @@ type FieldData struct {
 }
 
 // RoomData mirrors RoomInput exactly to persist construction inputs.
+// Grid omits when GridShapeSquare (the zero value) so pre-v0.2 blobs and
+// square-only encounters keep byte-identical output.
 type RoomData struct {
-	ID         string         `json:"id"`
-	Width      int            `json:"width"`
-	Height     int            `json:"height"`
-	Occluders  []PositionData `json:"occluders,omitempty"`
-	Boundaries []BoundaryData `json:"boundaries,omitempty"`
+	ID         string            `json:"id"`
+	Width      int               `json:"width"`
+	Height     int               `json:"height"`
+	Grid       spatial.GridShape `json:"grid,omitempty"`
+	Occluders  []PositionData    `json:"occluders,omitempty"`
+	Boundaries []BoundaryData    `json:"boundaries,omitempty"`
 }
 
 // PositionData is the persistent representation of spatial.Position.
@@ -179,6 +182,7 @@ func (e *Encounter) ToData() EncounterData {
 			ID:         ri.ID,
 			Width:      ri.Width,
 			Height:     ri.Height,
+			Grid:       ri.Grid,
 			Occluders:  make([]PositionData, len(ri.Occluders)),
 			Boundaries: make([]BoundaryData, len(ri.Boundaries)),
 		}
@@ -241,10 +245,11 @@ func (e *Encounter) ToData() EncounterData {
 // LoadEncounter reconstructs an Encounter from persistent data and re-attached deciders.
 // Validation order (R5 — validate all before constructing): nil-equivalent empty Data,
 // no rooms, no endings, empty/reserved ending keys (and kind/reached_position checks),
-// undeclared outcome ending, connection defects (empty/duplicate ID, missing room,
-// self-connection, endpoint out of bounds or on an occluder), duplicate member IDs,
-// member's room not in field, member position out of bounds, outcome member room/bounds
-// checks, everMembers missing a current member.
+// undeclared outcome ending, room defects (empty/duplicate ID, unrecognized grid shape),
+// connection defects (empty/duplicate ID, missing room, self-connection, endpoint out of
+// bounds or on an occluder), duplicate member IDs, member's room not in field, member
+// position out of bounds, outcome member room/bounds checks, everMembers missing a
+// current member.
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
 // and members are re-placed at persisted positions.
@@ -296,19 +301,41 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		}
 	}
 
-	// Build room map for validation
+	// Validate rooms: unique non-empty IDs, recognized grid shape (deferred
+	// from Opus T1 review — empty/duplicate room IDs previously went
+	// unvalidated, and connections resolved via last-wins map insertion).
+	// Reuses ErrNoField: a malformed room list is as unusable as an empty
+	// one. roomGrids holds each room's constructed Grid so downstream bounds
+	// checks (connections, members, outcome members) ask the SAME grid the
+	// room will actually be built with — a hardcoded rectangle check would
+	// silently diverge from GridlessRoom's inclusive upper bound
+	// (tools/spatial/gridless.go: IsValidPosition uses x <= Width, not
+	// x < Width like Square/Hex).
 	roomMap := make(map[string]bool)
 	roomsByID := make(map[string]RoomData)
+	roomGrids := make(map[string]spatial.Grid, len(data.Field.Rooms))
 	for _, r := range data.Field.Rooms {
+		if r.ID == "" {
+			return nil, fmt.Errorf("load encounter: room has empty id: %w: %w", ErrInvalidData, ErrNoField)
+		}
+		if roomMap[r.ID] {
+			return nil, fmt.Errorf("load encounter: duplicate room %q: %w: %w", r.ID, ErrInvalidData, ErrNoField)
+		}
+		switch r.Grid {
+		case spatial.GridShapeSquare, spatial.GridShapeHex, spatial.GridShapeGridless:
+		default:
+			return nil, fmt.Errorf("load encounter: room %q has unknown grid shape %d: %w: %w", r.ID, r.Grid, ErrInvalidData, ErrNoField)
+		}
 		roomMap[r.ID] = true
 		roomsByID[r.ID] = r
+		roomGrids[r.ID] = buildRoomGrid(r.Grid, r.Width, r.Height)
 	}
 
 	// Validate connections: unique non-empty IDs, endpoints resolve to
 	// distinct declared rooms, and endpoints lie within their room's
-	// bounds and off any occluder. ErrBadConnection rides alongside
-	// ErrInvalidData so connection defects are discriminable from other
-	// load rejections.
+	// bounds (per the room's own grid) and off any occluder.
+	// ErrBadConnection rides alongside ErrInvalidData so connection defects
+	// are discriminable from other load rejections.
 	seenConnectionIDs := make(map[string]bool, len(data.Field.Connections))
 	for _, c := range data.Field.Connections {
 		if c.ID == "" {
@@ -331,10 +358,10 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 			return nil, fmt.Errorf("load encounter: connection %q connects room %q to itself: %w: %w", c.ID, c.From, ErrInvalidData, ErrBadConnection)
 		}
 
-		if !positionInBounds(c.FromPosition.X, c.FromPosition.Y, fromRoom.Width, fromRoom.Height) {
+		if !roomGrids[c.From].IsValidPosition(spatial.Position{X: c.FromPosition.X, Y: c.FromPosition.Y}) {
 			return nil, fmt.Errorf("load encounter: connection %q from-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
 		}
-		if !positionInBounds(c.ToPosition.X, c.ToPosition.Y, toRoom.Width, toRoom.Height) {
+		if !roomGrids[c.To].IsValidPosition(spatial.Position{X: c.ToPosition.X, Y: c.ToPosition.Y}) {
 			return nil, fmt.Errorf("load encounter: connection %q to-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
 		}
 
@@ -366,22 +393,9 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 			return nil, fmt.Errorf("load encounter: member %q room %q not in field: %w", m.ID, m.Room, ErrInvalidData)
 		}
 
-		// Validate position in bounds
-		if m.Position.X < 0 || m.Position.Y < 0 {
-			return nil, fmt.Errorf("load encounter: member %q position out of bounds: %w", m.ID, ErrInvalidData)
-		}
-
-		// Find room and check bounds
-		var roomHeight, roomWidth int
-		for _, r := range data.Field.Rooms {
-			if r.ID == m.Room {
-				roomWidth = r.Width
-				roomHeight = r.Height
-				break
-			}
-		}
-
-		if m.Position.X >= float64(roomWidth) || m.Position.Y >= float64(roomHeight) {
+		// Validate position in bounds — grid-deferred: the room's own
+		// constructed Grid decides validity (see roomGrids above).
+		if !roomGrids[m.Room].IsValidPosition(spatial.Position{X: m.Position.X, Y: m.Position.Y}) {
 			return nil, fmt.Errorf("load encounter: member %q position out of bounds: %w", m.ID, ErrInvalidData)
 		}
 	}
@@ -395,11 +409,11 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 			return nil, fmt.Errorf("load encounter: abandoned outcome with members present: %w", ErrInvalidData)
 		}
 		for _, om := range data.Outcome.Members {
-			r, ok := roomsByID[om.Room]
+			_, ok := roomsByID[om.Room]
 			if !ok {
 				return nil, fmt.Errorf("load encounter: outcome member %q room %q not in field: %w", om.ID, om.Room, ErrInvalidData)
 			}
-			if om.Position.X < 0 || om.Position.Y < 0 || om.Position.X >= float64(r.Width) || om.Position.Y >= float64(r.Height) {
+			if !roomGrids[om.Room].IsValidPosition(spatial.Position{X: om.Position.X, Y: om.Position.Y}) {
 				return nil, fmt.Errorf("load encounter: outcome member %q position out of bounds: %w", om.ID, ErrInvalidData)
 			}
 		}
@@ -452,17 +466,14 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		Layout: spatial.LayoutTypeOrganic,
 	})
 
-	// Create all rooms
+	// Create all rooms, reusing each room's already-constructed Grid
+	// (roomGrids, built above) so validation and placement agree exactly.
 	spatialRoomMap := make(map[string]*spatial.BasicRoom)
 	for _, ri := range data.Field.Rooms {
-		grid := spatial.NewSquareGrid(spatial.SquareGridConfig{
-			Width:  float64(ri.Width),
-			Height: float64(ri.Height),
-		})
 		room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
 			ID:   ri.ID,
 			Type: "room",
-			Grid: grid,
+			Grid: roomGrids[ri.ID],
 		})
 		err = e.orchestrator.AddRoom(room)
 		if err != nil {
@@ -606,6 +617,7 @@ func convertRoomDataToRoomInput(rooms []RoomData) []RoomInput {
 			ID:         rd.ID,
 			Width:      rd.Width,
 			Height:     rd.Height,
+			Grid:       rd.Grid,
 			Occluders:  make([]spatial.Position, len(rd.Occluders)),
 			Boundaries: make([]spatial.Boundary, len(rd.Boundaries)),
 		}

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -1201,8 +1201,8 @@ func (s *DataTestSuite) TestLoadRejections() {
 
 // connBoundsData returns a fresh EncounterData with a 4x3 room r1 (valid
 // coordinates 0..3 x 0..2) and one connection — the Load-seam counterpart to
-// encounter_test.go's connBoundsSetup, pinning positionInBounds' strictly-
-// less-than semantics at Load independent of any cross-room concern.
+// encounter_test.go's connBoundsSetup, pinning the square grid's strictly-
+// less-than bounds semantics at Load independent of any cross-room concern.
 func connBoundsData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -35,7 +35,11 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 				},
 				{ID: "hall", Width: 6, Height: 6},
 			},
-			Connections: []encounter.ConnectionInput{{ID: "door1", From: "crypt", To: "hall"}},
+			Connections: []encounter.ConnectionInput{{
+				ID: "door1", From: "crypt", To: "hall",
+				FromPosition: spatial.Position{X: 0, Y: 6},
+				ToPosition:   spatial.Position{X: 5, Y: 5},
+			}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
@@ -52,7 +56,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 
 	bs, err := json.Marshal(enc.ToData())
 	s.Require().NoError(err)
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6}],"connections":[{"id":"door1","from":"crypt","to":"hall"}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":3,"y":3}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":5,"y":5}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":3,"y":3}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
 	s.Equal(expected, string(bs))
 }
 
@@ -83,14 +87,65 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 		"first-declared wins after reload — a load that scrambles ending order is a C8 violation")
 }
 
+// TestConnectionsSurviveReload pins connection persistence (#922 T1):
+// endpoints round-trip through ToData -> LoadEncounter intact, and
+// connection order is sorted by ID regardless of declaration order (C8
+// determinism — persisted order must not leak the caller's declaration
+// sequence).
+func (s *DataTestSuite) TestConnectionsSurviveReload() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 5, Height: 5},
+				{ID: "r2", Width: 5, Height: 5},
+			},
+			// Declared out of ID order — persistence must not echo this order.
+			Connections: []encounter.ConnectionInput{
+				{ID: "z-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 0, Y: 0}, ToPosition: spatial.Position{X: 0, Y: 0}},
+				{ID: "a-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 1, Y: 0}, ToPosition: spatial.Position{X: 1, Y: 0}},
+				{ID: "m-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 2, Y: 0}, ToPosition: spatial.Position{X: 2, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 4, Y: 4}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+
+	enc1, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err)
+
+	data1 := enc1.ToData()
+	expected := []encounter.ConnectionData{
+		{ID: "a-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 1, Y: 0}, ToPosition: encounter.PositionData{X: 1, Y: 0}},
+		{ID: "m-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 2, Y: 0}, ToPosition: encounter.PositionData{X: 2, Y: 0}},
+		{ID: "z-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 0, Y: 0}, ToPosition: encounter.PositionData{X: 0, Y: 0}},
+	}
+	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
+
+	enc2, err := encounter.LoadEncounter(data1, nil)
+	s.Require().NoError(err)
+
+	data2 := enc2.ToData()
+	s.Equal(expected, data2.Field.Connections, "connections stay sorted and intact across a second round-trip")
+}
+
 // TestSetupInputNotAliased pins T6 review M4: a caller that edits its
 // own SetupInput after construction must not corrupt the persistence
-// source (the encounter deep-copies the field description).
+// source (the encounter deep-copies the field description). Also covers
+// connections: mutating the caller's ConnectionInput slice (and its
+// endpoint positions) after NewEncounter must not affect the encounter.
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
-			{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}}},
-		}},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}}},
+				{ID: "r2", Width: 5, Height: 5},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "door1", From: "r1", To: "r2", FromPosition: spatial.Position{X: 1, Y: 0}, ToPosition: spatial.Position{X: 0, Y: 0}},
+			},
+		},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -102,12 +157,22 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup.Field.Rooms[0].ID = "VANDALIZED"
 	setup.Field.Rooms[0].Width = 999
 	setup.Field.Rooms[0].Occluders[0] = spatial.Position{X: 4, Y: 4}
+	setup.Field.Connections[0].ID = "VANDALIZED"
+	setup.Field.Connections[0].From = "VANDALIZED"
+	setup.Field.Connections[0].FromPosition = spatial.Position{X: 4, Y: 4}
+	setup.Field.Connections[0].ToPosition = spatial.Position{X: 4, Y: 4}
 
 	data := enc.ToData()
-	s.Require().Len(data.Field.Rooms, 1)
+	s.Require().Len(data.Field.Rooms, 2)
 	s.Equal("r1", data.Field.Rooms[0].ID, "the snapshot must not see the caller's vandalism")
 	s.Equal(5, data.Field.Rooms[0].Width)
 	s.Equal(encounter.PositionData{X: 3, Y: 3}, data.Field.Rooms[0].Occluders[0])
+
+	s.Require().Len(data.Field.Connections, 1)
+	s.Equal("door1", data.Field.Connections[0].ID, "the snapshot must not see the caller's vandalism")
+	s.Equal("r1", data.Field.Connections[0].From)
+	s.Equal(encounter.PositionData{X: 1, Y: 0}, data.Field.Connections[0].FromPosition)
+	s.Equal(encounter.PositionData{X: 0, Y: 0}, data.Field.Connections[0].ToPosition)
 
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom
 	// was an encounter that became permanently unsavable).
@@ -906,6 +971,23 @@ func validEncounterData() encounter.EncounterData {
 	}
 }
 
+// validEncounterDataWithConnection extends validEncounterData with a second
+// room (r2) and a fully valid connection between them — the base for the
+// connection defect rows below (one-defect discipline: each row breaks
+// exactly one thing about this otherwise-valid connection). r1 carries an
+// occluder at (2,2) so the "endpoint on occluder" row has something to hit.
+func validEncounterDataWithConnection() encounter.EncounterData {
+	d := validEncounterData()
+	d.Field.Rooms[0].Occluders = []encounter.PositionData{{X: 2, Y: 2}}
+	d.Field.Rooms = append(d.Field.Rooms, encounter.RoomData{ID: "r2", Width: 5, Height: 5})
+	d.Field.Connections = []encounter.ConnectionData{
+		{ID: "c1", From: "r1", To: "r2",
+			FromPosition: encounter.PositionData{X: 0, Y: 0},
+			ToPosition:   encounter.PositionData{X: 0, Y: 0}},
+	}
+	return d
+}
+
 // TestLoadRejections: every unreachable state rejects with
 // ErrInvalidData AND the check that fired is the one the case targets.
 func (s *DataTestSuite) TestLoadRejections() {
@@ -934,6 +1016,26 @@ func (s *DataTestSuite) TestLoadRejections() {
 		{"connection missing room", func(d *encounter.EncounterData) {
 			d.Field.Connections = []encounter.ConnectionData{{ID: "c1", From: "r1", To: "nowhere"}}
 		}, "connection"},
+		{"connection empty id", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].ID = ""
+		}, "empty id"},
+		{"duplicate connection ids", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections = append(d.Field.Connections, d.Field.Connections[0])
+		}, "duplicate connection"},
+		{"connection self-connection", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].To = "r1"
+		}, "itself"},
+		{"connection endpoint out of bounds", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].FromPosition = encounter.PositionData{X: 99, Y: 99}
+		}, "from-position out of bounds"},
+		{"connection endpoint on occluder", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].FromPosition = encounter.PositionData{X: 2, Y: 2}
+		}, "from-position on occluder"},
 		{"outcome undeclared ending", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "never-declared"}
 		}, "outcome"},

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -975,11 +975,15 @@ func validEncounterData() encounter.EncounterData {
 // room (r2) and a fully valid connection between them — the base for the
 // connection defect rows below (one-defect discipline: each row breaks
 // exactly one thing about this otherwise-valid connection). r1 carries an
-// occluder at (2,2) so the "endpoint on occluder" row has something to hit.
+// occluder at (2,2) and r2 an occluder at (3,3), so both the from- and
+// to-side "endpoint on occluder" rows have something to hit.
 func validEncounterDataWithConnection() encounter.EncounterData {
 	d := validEncounterData()
 	d.Field.Rooms[0].Occluders = []encounter.PositionData{{X: 2, Y: 2}}
-	d.Field.Rooms = append(d.Field.Rooms, encounter.RoomData{ID: "r2", Width: 5, Height: 5})
+	d.Field.Rooms = append(d.Field.Rooms, encounter.RoomData{
+		ID: "r2", Width: 5, Height: 5,
+		Occluders: []encounter.PositionData{{X: 3, Y: 3}},
+	})
 	d.Field.Connections = []encounter.ConnectionData{
 		{ID: "c1", From: "r1", To: "r2",
 			FromPosition: encounter.PositionData{X: 0, Y: 0},
@@ -988,71 +992,91 @@ func validEncounterDataWithConnection() encounter.EncounterData {
 	return d
 }
 
-// TestLoadRejections: every unreachable state rejects with
-// ErrInvalidData AND the check that fired is the one the case targets.
+// TestLoadRejections: every unreachable state rejects with ErrInvalidData
+// AND the check that fired is the one the case targets. Connection rows
+// also assert ErrBadConnection (via alsoErr) and, where a room name is
+// involved, quote the missing room in the fragment — a check neutered in
+// favor of the coincidental zero-value-room bounds fallback must not pass.
 func (s *DataTestSuite) TestLoadRejections() {
 	cases := []struct {
 		name     string
 		mutate   func(d *encounter.EncounterData)
 		fragment string
+		alsoErr  error
 	}{
-		{"zero data", func(d *encounter.EncounterData) { *d = encounter.EncounterData{} }, "no rooms"},
-		{"no rooms", func(d *encounter.EncounterData) { d.Field.Rooms = nil; d.Members = nil; d.EverMembers = nil }, "no rooms"},
-		{"no endings", func(d *encounter.EncounterData) { d.Endings = nil }, "bad endings"},
-		{"empty ending key", func(d *encounter.EncounterData) { d.Endings[0].Key = "" }, "bad endings"},
-		{"reserved ending key", func(d *encounter.EncounterData) { d.Endings[0].Key = "abandoned" }, "bad endings"},
-		{"unknown ending kind", func(d *encounter.EncounterData) { d.Endings[0].Kind = "psychic" }, "unknown ending kind"},
+		{"zero data", func(d *encounter.EncounterData) { *d = encounter.EncounterData{} }, "no rooms", nil},
+		{"no rooms", func(d *encounter.EncounterData) { d.Field.Rooms = nil; d.Members = nil; d.EverMembers = nil }, "no rooms", nil},
+		{"no endings", func(d *encounter.EncounterData) { d.Endings = nil }, "bad endings", nil},
+		{"empty ending key", func(d *encounter.EncounterData) { d.Endings[0].Key = "" }, "bad endings", nil},
+		{"reserved ending key", func(d *encounter.EncounterData) { d.Endings[0].Key = "abandoned" }, "bad endings", nil},
+		{"unknown ending kind", func(d *encounter.EncounterData) { d.Endings[0].Kind = "psychic" }, "unknown ending kind", nil},
 		{"reached_position without position", func(d *encounter.EncounterData) {
 			d.Endings[0] = encounter.EndingData{Key: "done", Kind: "reached_position", Room: "r1"}
-		}, "without room/position"},
-		{"empty member id", func(d *encounter.EncounterData) { d.Members[0].ID = "" }, "empty member id"},
+		}, "without room/position", nil},
+		{"empty member id", func(d *encounter.EncounterData) { d.Members[0].ID = "" }, "empty member id", nil},
 		{"duplicate member ids", func(d *encounter.EncounterData) {
 			d.Members = append(d.Members, d.Members[0])
-		}, "duplicate member"},
-		{"member room not in field", func(d *encounter.EncounterData) { d.Members[0].Room = "nowhere" }, "not in field"},
+		}, "duplicate member", nil},
+		{"member room not in field", func(d *encounter.EncounterData) { d.Members[0].Room = "nowhere" }, "not in field", nil},
 		{"member out of bounds", func(d *encounter.EncounterData) {
 			d.Members[0].Position = encounter.PositionData{X: 99, Y: 99}
-		}, "out of bounds"},
+		}, "out of bounds", nil},
 		{"connection missing room", func(d *encounter.EncounterData) {
 			d.Field.Connections = []encounter.ConnectionData{{ID: "c1", From: "r1", To: "nowhere"}}
-		}, "connection"},
+		}, `missing room "nowhere"`, encounter.ErrBadConnection},
 		{"connection empty id", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].ID = ""
-		}, "empty id"},
+		}, "empty id", encounter.ErrBadConnection},
 		{"duplicate connection ids", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections = append(d.Field.Connections, d.Field.Connections[0])
-		}, "duplicate connection"},
+		}, "duplicate connection", encounter.ErrBadConnection},
+		{"connection unknown from room", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].From = "nowhere"
+		}, `missing room "nowhere"`, encounter.ErrBadConnection},
+		{"connection unknown to room", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].To = "nowhere"
+		}, `missing room "nowhere"`, encounter.ErrBadConnection},
 		{"connection self-connection", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].To = "r1"
-		}, "itself"},
-		{"connection endpoint out of bounds", func(d *encounter.EncounterData) {
+		}, "itself", encounter.ErrBadConnection},
+		{"connection from-position out of bounds", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].FromPosition = encounter.PositionData{X: 99, Y: 99}
-		}, "from-position out of bounds"},
-		{"connection endpoint on occluder", func(d *encounter.EncounterData) {
+		}, "from-position out of bounds", encounter.ErrBadConnection},
+		{"connection to-position out of bounds", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].ToPosition = encounter.PositionData{X: 99, Y: 99}
+		}, "to-position out of bounds", encounter.ErrBadConnection},
+		{"connection from-position on occluder", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].FromPosition = encounter.PositionData{X: 2, Y: 2}
-		}, "from-position on occluder"},
+		}, "from-position on occluder", encounter.ErrBadConnection},
+		{"connection to-position on occluder", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].ToPosition = encounter.PositionData{X: 3, Y: 3}
+		}, "to-position on occluder", encounter.ErrBadConnection},
 		{"outcome undeclared ending", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "never-declared"}
-		}, "outcome"},
+		}, "outcome", nil},
 		{"abandoned outcome with members present", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "abandoned"}
-		}, "abandoned outcome with members"},
+		}, "abandoned outcome with members", nil},
 		{"outcome member room missing", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
 				{ID: "ghost", Room: "nowhere", Position: encounter.PositionData{X: 1, Y: 1}}}}
-		}, "outcome member"},
+		}, "outcome member", nil},
 		{"outcome member out of bounds", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
 				{ID: "p1", Room: "r1", Position: encounter.PositionData{X: 999, Y: 999}}}}
-		}, "out of bounds"},
+		}, "out of bounds", nil},
 		{"ever_members missing current member", func(d *encounter.EncounterData) {
 			d.EverMembers = nil
-		}, "ever_members"},
+		}, "ever_members", nil},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -1063,6 +1087,9 @@ func (s *DataTestSuite) TestLoadRejections() {
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().Contains(err.Error(), tc.fragment,
 				"the check that fired must be the one this case targets")
+			if tc.alsoErr != nil {
+				s.Require().ErrorIs(err, tc.alsoErr, tc.name)
+			}
 		})
 	}
 

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -91,7 +91,11 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 // endpoints round-trip through ToData -> LoadEncounter intact, and
 // connection order is sorted by ID regardless of declaration order (C8
 // determinism — persisted order must not leak the caller's declaration
-// sequence).
+// sequence). Every connection's FromPosition != ToPosition (X != Y within
+// each, and neither is the other transposed) so a From/To swap anywhere in
+// the round-trip — most notably in convertConnectionDataToConnectionInput,
+// which only ever sees pre-sorted, already-round-tripped ToData output in
+// other tests — would change the observed values, not just their order.
 func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
 		Field: encounter.FieldInput{
@@ -101,9 +105,9 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 			},
 			// Declared out of ID order — persistence must not echo this order.
 			Connections: []encounter.ConnectionInput{
-				{ID: "z-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 0, Y: 0}, ToPosition: spatial.Position{X: 0, Y: 0}},
-				{ID: "a-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 1, Y: 0}, ToPosition: spatial.Position{X: 1, Y: 0}},
-				{ID: "m-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 2, Y: 0}, ToPosition: spatial.Position{X: 2, Y: 0}},
+				{ID: "z-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 0, Y: 3}, ToPosition: spatial.Position{X: 2, Y: 1}},
+				{ID: "a-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 1, Y: 4}, ToPosition: spatial.Position{X: 3, Y: 2}},
+				{ID: "m-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 2, Y: 0}, ToPosition: spatial.Position{X: 4, Y: 3}},
 			},
 		},
 		Members: []encounter.MemberInput{
@@ -117,9 +121,9 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 
 	data1 := enc1.ToData()
 	expected := []encounter.ConnectionData{
-		{ID: "a-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 1, Y: 0}, ToPosition: encounter.PositionData{X: 1, Y: 0}},
-		{ID: "m-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 2, Y: 0}, ToPosition: encounter.PositionData{X: 2, Y: 0}},
-		{ID: "z-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 0, Y: 0}, ToPosition: encounter.PositionData{X: 0, Y: 0}},
+		{ID: "a-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 1, Y: 4}, ToPosition: encounter.PositionData{X: 3, Y: 2}},
+		{ID: "m-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 2, Y: 0}, ToPosition: encounter.PositionData{X: 4, Y: 3}},
+		{ID: "z-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 0, Y: 3}, ToPosition: encounter.PositionData{X: 2, Y: 1}},
 	}
 	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
 
@@ -128,6 +132,45 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 
 	data2 := enc2.ToData()
 	s.Equal(expected, data2.Field.Connections, "connections stay sorted and intact across a second round-trip")
+}
+
+// TestLoadSortsUnsortedConnections pins LoadEncounter's own sort in
+// isolation (#922 T1 Opus review): every other test's EncounterData either
+// comes from ToData (already sorted by construction, since NewEncounter and
+// LoadEncounter both sort connectionsInput on the way in) or carries a
+// single connection (trivially sorted) — so LoadEncounter's sort.Slice call
+// is never exercised on genuinely unsorted input elsewhere in this suite.
+// This hand-authors an EncounterData directly, bypassing NewEncounter/ToData
+// entirely, with connections declared out of ID order.
+func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 5, Height: 5},
+				{ID: "r2", Width: 5, Height: 5},
+			},
+			// Hand-authored out of ID order — NOT produced by ToData.
+			Connections: []encounter.ConnectionData{
+				{ID: "z-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 0, Y: 0}, ToPosition: encounter.PositionData{X: 1, Y: 1}},
+				{ID: "a-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 2, Y: 0}, ToPosition: encounter.PositionData{X: 3, Y: 1}},
+				{ID: "m-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 4, Y: 0}, ToPosition: encounter.PositionData{X: 0, Y: 4}},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 1, Y: 1}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+
+	enc, err := encounter.LoadEncounter(data, nil)
+	s.Require().NoError(err)
+
+	got := enc.ToData().Field.Connections
+	s.Require().Len(got, 3)
+	gotIDs := []string{got[0].ID, got[1].ID, got[2].ID}
+	s.Equal([]string{"a-door", "m-door", "z-door"}, gotIDs,
+		"LoadEncounter's own sort must run even when the input was never produced by ToData")
 }
 
 // TestSetupInputNotAliased pins T6 review M4: a caller that edits its
@@ -971,23 +1014,29 @@ func validEncounterData() encounter.EncounterData {
 	}
 }
 
-// validEncounterDataWithConnection extends validEncounterData with a second
-// room (r2) and a fully valid connection between them — the base for the
-// connection defect rows below (one-defect discipline: each row breaks
-// exactly one thing about this otherwise-valid connection). r1 carries an
-// occluder at (2,2) and r2 an occluder at (3,3), so both the from- and
-// to-side "endpoint on occluder" rows have something to hit.
+// validEncounterDataWithConnection extends validEncounterData with a second,
+// DELIBERATELY mismatched room (r1 resized to 10x4, r2 added at 3x9) and one
+// fully valid connection between them — the base for the connection defect
+// rows below (one-defect discipline: each row breaks exactly one thing about
+// this otherwise-valid connection). FromPosition{7,1} is valid ONLY in r1
+// and ToPosition{1,7} valid ONLY in r2: same-sized rooms and equal From/To
+// positions would make a check that validates an endpoint against the WRONG
+// room (or a From/To transposition in convertConnectionDataToConnectionInput)
+// invisible. r1 carries an occluder at (2,2) and r2 an occluder at (1,3), so
+// both the from- and to-side "endpoint on occluder" rows have something to hit.
 func validEncounterDataWithConnection() encounter.EncounterData {
 	d := validEncounterData()
+	d.Field.Rooms[0].Width = 10
+	d.Field.Rooms[0].Height = 4
 	d.Field.Rooms[0].Occluders = []encounter.PositionData{{X: 2, Y: 2}}
 	d.Field.Rooms = append(d.Field.Rooms, encounter.RoomData{
-		ID: "r2", Width: 5, Height: 5,
-		Occluders: []encounter.PositionData{{X: 3, Y: 3}},
+		ID: "r2", Width: 3, Height: 9,
+		Occluders: []encounter.PositionData{{X: 1, Y: 3}},
 	})
 	d.Field.Connections = []encounter.ConnectionData{
 		{ID: "c1", From: "r1", To: "r2",
-			FromPosition: encounter.PositionData{X: 0, Y: 0},
-			ToPosition:   encounter.PositionData{X: 0, Y: 0}},
+			FromPosition: encounter.PositionData{X: 7, Y: 1},
+			ToPosition:   encounter.PositionData{X: 1, Y: 7}},
 	}
 	return d
 }
@@ -1058,7 +1107,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 		}, "from-position on occluder", encounter.ErrBadConnection},
 		{"connection to-position on occluder", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
-			d.Field.Connections[0].ToPosition = encounter.PositionData{X: 3, Y: 3}
+			d.Field.Connections[0].ToPosition = encounter.PositionData{X: 1, Y: 3}
 		}, "to-position on occluder", encounter.ErrBadConnection},
 		{"outcome undeclared ending", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "never-declared"}
@@ -1097,6 +1146,94 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(validEncounterData(), nil)
 	s.Require().NoError(err, "the valid base fixture must load")
+
+	// The valid CONNECTION base must also load. Since FromPosition{7,1} is
+	// valid ONLY in r1 and ToPosition{1,7} valid ONLY in r2, this positive
+	// control pins that each endpoint is checked against ITS OWN room (a
+	// check wired to the wrong room would reject this valid connection),
+	// and that endpoints survive Load unswapped (a From/To transposition
+	// in convertConnectionDataToConnectionInput would not error here —
+	// it would silently swap the values — so the values are re-inspected,
+	// not just the absence of an error).
+	connEnc, err := encounter.LoadEncounter(validEncounterDataWithConnection(), nil)
+	s.Require().NoError(err, "the valid connection base fixture must load")
+	connData := connEnc.ToData()
+	s.Require().Len(connData.Field.Connections, 1)
+	s.Equal(encounter.PositionData{X: 7, Y: 1}, connData.Field.Connections[0].FromPosition,
+		"from-position must survive Load unswapped")
+	s.Equal(encounter.PositionData{X: 1, Y: 7}, connData.Field.Connections[0].ToPosition,
+		"to-position must survive Load unswapped")
+}
+
+// connBoundsData returns a fresh EncounterData with a 4x3 room r1 (valid
+// coordinates 0..3 x 0..2) and one connection — the Load-seam counterpart to
+// encounter_test.go's connBoundsSetup, pinning positionInBounds' strictly-
+// less-than semantics at Load independent of any cross-room concern.
+func connBoundsData() encounter.EncounterData {
+	return encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 4, Height: 3},
+				{ID: "r2", Width: 4, Height: 3},
+			},
+			Connections: []encounter.ConnectionData{
+				{ID: "c1", From: "r1", To: "r2",
+					FromPosition: encounter.PositionData{X: 0, Y: 0},
+					ToPosition:   encounter.PositionData{X: 0, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 0, Y: 0}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+}
+
+// TestConnectionEndpointBoundsBoundariesLoad is the Load-seam counterpart to
+// encounter_test.go's TestConnectionEndpointBoundsBoundaries (#922 T1 Opus
+// review, minor M3/M4): a coordinate exactly at the room's Width/Height is
+// out of bounds, a negative coordinate is out of bounds, and Width-1/Height-1
+// — the last valid cell — is accepted.
+func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
+	s.Run("X exactly at width is rejected", func() {
+		data := connBoundsData()
+		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 4, Y: 0}
+		_, err := encounter.LoadEncounter(data, nil)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("Y exactly at height is rejected", func() {
+		data := connBoundsData()
+		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 0, Y: 3}
+		_, err := encounter.LoadEncounter(data, nil)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("negative X is rejected", func() {
+		data := connBoundsData()
+		data.Field.Connections[0].FromPosition = encounter.PositionData{X: -1, Y: 0}
+		_, err := encounter.LoadEncounter(data, nil)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("negative Y is rejected", func() {
+		data := connBoundsData()
+		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 0, Y: -1}
+		_, err := encounter.LoadEncounter(data, nil)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("Width-1,Height-1 is accepted (positive control)", func() {
+		data := connBoundsData()
+		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 3, Y: 2}
+		_, err := encounter.LoadEncounter(data, nil)
+		s.Require().NoError(err, "the last valid cell must be accepted")
+	})
 }
 
 // TestLoadRejectsPlayerWithDecider pins C2 at the third seam: a player

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -33,17 +33,24 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 					Occluders:  []spatial.Position{{X: 4, Y: 4}},
 					Boundaries: []spatial.Boundary{{From: spatial.Position{X: 2, Y: 2}, To: spatial.Position{X: 2, Y: 3}, BlocksMovement: true, BlocksLineOfSight: true}},
 				},
+				// hall is axial hex (Width=6,Height=6 => Q,R valid in
+				// [-3,3)): door1's arrival endpoint sits at a NEGATIVE
+				// axial coordinate on purpose — the ordinary case for an
+				// origin-centered hex room, and a fixture proving
+				// endpoints validate there at both seams (Setup here,
+				// Load in TestConnectionEndpointBoundsBoundariesLoad's
+				// hex sibling).
 				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "door1", From: "crypt", To: "hall",
 				FromPosition: spatial.Position{X: 0, Y: 6},
-				ToPosition:   spatial.Position{X: 5, Y: 5},
+				ToPosition:   spatial.Position{X: -1, Y: -1},
 			}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
-			{ID: "g1", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 3, Y: 3}, Decider: &testDecider{intent: encounter.IntentHold{}}},
+			{ID: "g1", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 0, Y: 0}, Decider: &testDecider{intent: encounter.IntentHold{}}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: "guarded", Trigger: encounter.TriggerReachedPosition{Room: "crypt", Position: spatial.Position{X: 7, Y: 7}, Member: core.EntityID("p1")}},
@@ -56,7 +63,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 
 	bs, err := json.Marshal(enc.ToData())
 	s.Require().NoError(err)
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":"hex"}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":5,"y":5}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":3,"y":3}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":"hex"}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":-1,"y":-1}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":0,"y":0}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
 	s.Equal(expected, string(bs))
 }
 
@@ -1317,8 +1324,8 @@ func (s *DataTestSuite) TestLoadRoomValidation() {
 
 // connHexRoomData returns a fresh EncounterData with one 4x3 hex room and a
 // member at pos — the Load-seam counterpart to encounter_test.go's
-// TestHexRoomBounds. See that test's comment for why hex's accept/reject
-// boundary values are numerically identical to square's.
+// TestHexRoomBounds. Width=4, Height=3 => Q valid in [-2,2), R valid in
+// [-1.5,1.5) (axial, origin-centered — see that test's comment).
 func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
@@ -1337,17 +1344,59 @@ func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 // TestHexRoomBoundsLoad is the Load-seam counterpart to
 // encounter_test.go's TestHexRoomBounds.
 func (s *DataTestSuite) TestHexRoomBoundsLoad() {
-	s.Run("position within hex bounds accepted", func() {
-		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: 3, Y: 2}), nil)
+	s.Run("positive Q, positive R within span accepted", func() {
+		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: 1, Y: 1}), nil)
 		s.Require().NoError(err)
 	})
 
-	s.Run("position at width boundary rejected", func() {
-		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: 4, Y: 0}), nil)
+	s.Run("negative Q within span accepted — rejected under the old offset HexGrid", func() {
+		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: -1, Y: 0}), nil)
+		s.Require().NoError(err, "axial hex rooms are origin-centered; negative Q is ordinary, not a defect")
+	})
+
+	s.Run("Q at exactly +Width/2 rejected (upper bound exclusive)", func() {
+		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: 2, Y: 0}), nil)
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "out of bounds")
 	})
+
+	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
+		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: -2, Y: 0}), nil)
+		s.Require().NoError(err)
+	})
+
+	s.Run("Q beyond -Width/2 rejected", func() {
+		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: -3, Y: 0}), nil)
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
+		s.Require().Contains(err.Error(), "out of bounds")
+	})
+}
+
+// TestHexConnectionEndpointNegativeAxialLoad is the Load-seam counterpart
+// to encounter_test.go's TestHexConnectionEndpointNegativeAxial.
+func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "square-room", Width: 10, Height: 10},
+				{ID: "hex-room", Width: 6, Height: 6, Grid: spatial.GridTypeHex},
+			},
+			Connections: []encounter.ConnectionData{{
+				ID: "gate", From: "square-room", To: "hex-room",
+				FromPosition: &encounter.PositionData{X: 9, Y: 9},
+				ToPosition:   &encounter.PositionData{X: -2, Y: -2},
+			}},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "square-room", Position: encounter.PositionData{X: 1, Y: 1}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
 }
 
 // connGridlessRoomData returns a fresh EncounterData with one 4x3 gridless

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -1023,6 +1023,76 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 	})
 }
 
+// TestDeciderReattachmentNilEntryHolds pins reject-never-crash at the
+// reattachment map itself: a caller-supplied entry that is PRESENT but
+// nil (map[MemberID]Decider{"goblin": nil}, distinct from an ABSENT key —
+// TestDeciderReattachmentWithoutDecider's case) must not panic Pump. A
+// nil entry is equivalent to an absent one: the monster simply holds.
+func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "goblin", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 8, Y: 8},
+				Decider: &testDecider{intent: encounter.IntentHold{}}},
+		},
+		Endings: []encounter.EndingInput{{Key: "stairs", Trigger: encounter.TriggerReachedPosition{
+			Room: "crypt", Position: spatial.Position{X: 0, Y: 0}}}},
+	}
+	enc1, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err)
+	data1 := enc1.ToData()
+
+	enc2, err := encounter.LoadEncounter(data1, map[encounter.MemberID]encounter.Decider{
+		"goblin": nil,
+	})
+	s.Require().NoError(err, "a present-but-nil reattachment entry must load, not reject")
+
+	s.Require().NotPanics(func() {
+		out, pumpErr := enc2.Pump(&encounter.PumpInput{})
+		s.Require().NoError(pumpErr, "the first pump must not panic on a nil-decider monster")
+		s.Empty(out.MonsterMoves, "a nil-decider monster is absent from decisions and beats — it simply holds")
+	})
+}
+
+// TestDeciderReattachmentMixedNilAndReal pins that a nil entry for one
+// monster does not disturb a real decider re-attached for another in the
+// same reattachment map: the real one decides normally, the nil one holds.
+func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "goblin", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 8, Y: 8},
+				Decider: &testDecider{intent: encounter.IntentHold{}}},
+			{ID: "rat", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 2, Y: 8},
+				Decider: &testDecider{intent: encounter.IntentHold{}}},
+		},
+		Endings: []encounter.EndingInput{{Key: "stairs", Trigger: encounter.TriggerReachedPosition{
+			Room: "crypt", Position: spatial.Position{X: 0, Y: 0}}}},
+	}
+	enc1, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err)
+	data1 := enc1.ToData()
+
+	ratDecider := &testDecider{intent: encounter.IntentMoveTo{To: spatial.Position{X: 3, Y: 8}}}
+	enc2, err := encounter.LoadEncounter(data1, map[encounter.MemberID]encounter.Decider{
+		"goblin": nil,
+		"rat":    ratDecider,
+	})
+	s.Require().NoError(err)
+
+	out, err := enc2.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(out.MonsterMoves, 1, "only rat's real decider produces a move")
+	s.Equal(encounter.MemberID("rat"), out.MonsterMoves[0].Member)
+	s.Equal(spatial.Position{X: 3, Y: 8}, out.MonsterMoves[0].To)
+}
+
 // ============================================================================
 // Rejection Tests
 // ============================================================================
@@ -1397,6 +1467,72 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 	}
 	_, err := encounter.LoadEncounter(data, nil)
 	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
+}
+
+// validHexAxialData returns a fresh EncounterData with two hex rooms
+// joined by one connection, a member, and an occluder — the Load-seam
+// counterpart to encounter_test.go's validHexAxialSetup. Every position
+// is integral axial, including a negative one (gate.ToPosition).
+func validHexAxialData() encounter.EncounterData {
+	return encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex,
+					Occluders: []encounter.PositionData{{X: 2, Y: 2}}},
+				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridTypeHex},
+			},
+			Connections: []encounter.ConnectionData{{
+				ID: "gate", From: "hex-a", To: "hex-b",
+				FromPosition: &encounter.PositionData{X: 1, Y: 1},
+				ToPosition:   &encounter.PositionData{X: -1, Y: -1},
+			}},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-a", Position: encounter.PositionData{X: 0, Y: 0}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+}
+
+// TestLoadHexIntegralAxial is the Load-seam counterpart to
+// encounter_test.go's TestSetupHexIntegralAxial.
+func (s *DataTestSuite) TestLoadHexIntegralAxial() {
+	cases := []struct {
+		name    string
+		mutate  func(d *encounter.EncounterData)
+		alsoErr error
+	}{
+		{"member position fractional", func(d *encounter.EncounterData) {
+			d.Members[0].Position = encounter.PositionData{X: 0.5, Y: 0}
+		}, nil},
+		{"connection from-position fractional", func(d *encounter.EncounterData) {
+			d.Field.Connections[0].FromPosition = &encounter.PositionData{X: 1.5, Y: 1}
+		}, encounter.ErrBadConnection},
+		{"connection to-position fractional", func(d *encounter.EncounterData) {
+			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: -1.5, Y: -1}
+		}, encounter.ErrBadConnection},
+		{"occluder position fractional", func(d *encounter.EncounterData) {
+			d.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
+		}, encounter.ErrNoField},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			data := validHexAxialData()
+			tc.mutate(&data)
+			_, err := encounter.LoadEncounter(data, nil)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
+			if tc.alsoErr != nil {
+				s.Require().ErrorIs(err, tc.alsoErr, tc.name)
+			}
+			s.Require().Contains(err.Error(), "not an integral axial cell",
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	_, err := encounter.LoadEncounter(validHexAxialData(), nil)
+	s.Require().NoError(err, "integral axial positions, including negative ones, must be accepted")
 }
 
 // connGridlessRoomData returns a fresh EncounterData with one 4x3 gridless

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -33,7 +33,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 					Occluders:  []spatial.Position{{X: 4, Y: 4}},
 					Boundaries: []spatial.Boundary{{From: spatial.Position{X: 2, Y: 2}, To: spatial.Position{X: 2, Y: 3}, BlocksMovement: true, BlocksLineOfSight: true}},
 				},
-				{ID: "hall", Width: 6, Height: 6},
+				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "door1", From: "crypt", To: "hall",
@@ -56,7 +56,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 
 	bs, err := json.Marshal(enc.ToData())
 	s.Require().NoError(err)
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":5,"y":5}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":3,"y":3}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":1}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":5,"y":5}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":3,"y":3}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
 	s.Equal(expected, string(bs))
 }
 
@@ -171,6 +171,40 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 	gotIDs := []string{got[0].ID, got[1].ID, got[2].ID}
 	s.Equal([]string{"a-door", "m-door", "z-door"}, gotIDs,
 		"LoadEncounter's own sort must run even when the input was never produced by ToData")
+}
+
+// TestRoomGridShapeSurvivesReload pins connection persistence's newest
+// field (#922 T1.5): a room's declared Grid shape round-trips through
+// ToData -> LoadEncounter -> ToData intact, for both the square zero value
+// and a non-zero shape (hex), in the same encounter.
+func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "square-room", Width: 5, Height: 5},
+				{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "square-room", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+
+	enc1, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err)
+
+	data1 := enc1.ToData()
+	s.Require().Len(data1.Field.Rooms, 2)
+	s.Equal(spatial.GridShapeSquare, data1.Field.Rooms[0].Grid, "square is the zero value")
+	s.Equal(spatial.GridShapeHex, data1.Field.Rooms[1].Grid)
+
+	enc2, err := encounter.LoadEncounter(data1, nil)
+	s.Require().NoError(err)
+
+	data2 := enc2.ToData()
+	s.Equal(spatial.GridShapeSquare, data2.Field.Rooms[0].Grid, "grid shape must survive a second round-trip")
+	s.Equal(spatial.GridShapeHex, data2.Field.Rooms[1].Grid, "grid shape must survive a second round-trip")
 }
 
 // TestSetupInputNotAliased pins T6 review M4: a caller that edits its
@@ -1233,6 +1267,111 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 3, Y: 2}
 		_, err := encounter.LoadEncounter(data, nil)
 		s.Require().NoError(err, "the last valid cell must be accepted")
+	})
+}
+
+// TestLoadRoomValidation is the Load-seam counterpart to
+// encounter_test.go's TestSetupRoomValidation (#922 T1.5, deferred from
+// the Opus T1 review): empty room ID, duplicate room ID, and an
+// unrecognized grid shape all reject with ErrInvalidData + ErrNoField.
+func (s *DataTestSuite) TestLoadRoomValidation() {
+	cases := []struct {
+		name     string
+		mutate   func(d *encounter.EncounterData)
+		fragment string
+	}{
+		{"room has empty id", func(d *encounter.EncounterData) {
+			d.Field.Rooms[0].ID = ""
+		}, "room has empty id"},
+		{"duplicate room id", func(d *encounter.EncounterData) {
+			d.Field.Rooms = append(d.Field.Rooms, d.Field.Rooms[0])
+		}, "duplicate room"},
+		{"room has unknown grid shape", func(d *encounter.EncounterData) {
+			d.Field.Rooms[0].Grid = spatial.GridShape(99)
+		}, "unknown grid shape"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			data := validEncounterData()
+			tc.mutate(&data)
+			_, err := encounter.LoadEncounter(data, nil)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrNoField, tc.name)
+			s.Require().Contains(err.Error(), tc.fragment,
+				"the check that fired must be the one this case targets")
+		})
+	}
+}
+
+// connHexRoomData returns a fresh EncounterData with one 4x3 hex room and a
+// member at pos — the Load-seam counterpart to encounter_test.go's
+// TestHexRoomBounds. See that test's comment for why hex's accept/reject
+// boundary values are numerically identical to square's.
+func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
+	return encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: pos},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+}
+
+// TestHexRoomBoundsLoad is the Load-seam counterpart to
+// encounter_test.go's TestHexRoomBounds.
+func (s *DataTestSuite) TestHexRoomBoundsLoad() {
+	s.Run("position within hex bounds accepted", func() {
+		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: 3, Y: 2}), nil)
+		s.Require().NoError(err)
+	})
+
+	s.Run("position at width boundary rejected", func() {
+		_, err := encounter.LoadEncounter(connHexRoomData(encounter.PositionData{X: 4, Y: 0}), nil)
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
+		s.Require().Contains(err.Error(), "out of bounds")
+	})
+}
+
+// connGridlessRoomData returns a fresh EncounterData with one 4x3 gridless
+// room and a member at pos — the Load-seam counterpart to
+// encounter_test.go's TestGridlessRoomInclusiveBounds.
+func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
+	return encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: pos},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+}
+
+// TestGridlessRoomInclusiveBoundsLoad is the Load-seam counterpart to
+// encounter_test.go's TestGridlessRoomInclusiveBounds — see that test's
+// comment for why this is the sharpest available proof that bounds checks
+// ask the room's own constructed grid rather than a hardcoded rectangle.
+func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
+	s.Run("position exactly at Width is accepted (inclusive upper bound)", func() {
+		_, err := encounter.LoadEncounter(connGridlessRoomData(encounter.PositionData{X: 4, Y: 0}), nil)
+		s.Require().NoError(err, "gridless rooms accept x == Width; a rectangle-math fallback would reject this")
+	})
+
+	s.Run("position negative is still rejected", func() {
+		_, err := encounter.LoadEncounter(connGridlessRoomData(encounter.PositionData{X: -1, Y: 0}), nil)
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
+		s.Require().Contains(err.Error(), "out of bounds")
 	})
 }
 

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -56,7 +56,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 
 	bs, err := json.Marshal(enc.ToData())
 	s.Require().NoError(err)
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":1}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":5,"y":5}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":3,"y":3}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":"hex"}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":5,"y":5}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":3,"y":3}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
 	s.Equal(expected, string(bs))
 }
 
@@ -121,9 +121,9 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 
 	data1 := enc1.ToData()
 	expected := []encounter.ConnectionData{
-		{ID: "a-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 1, Y: 4}, ToPosition: encounter.PositionData{X: 3, Y: 2}},
-		{ID: "m-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 2, Y: 0}, ToPosition: encounter.PositionData{X: 4, Y: 3}},
-		{ID: "z-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 0, Y: 3}, ToPosition: encounter.PositionData{X: 2, Y: 1}},
+		{ID: "a-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 1, Y: 4}, ToPosition: &encounter.PositionData{X: 3, Y: 2}},
+		{ID: "m-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 2, Y: 0}, ToPosition: &encounter.PositionData{X: 4, Y: 3}},
+		{ID: "z-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 0, Y: 3}, ToPosition: &encounter.PositionData{X: 2, Y: 1}},
 	}
 	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
 
@@ -151,9 +151,9 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 			},
 			// Hand-authored out of ID order — NOT produced by ToData.
 			Connections: []encounter.ConnectionData{
-				{ID: "z-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 0, Y: 0}, ToPosition: encounter.PositionData{X: 1, Y: 1}},
-				{ID: "a-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 2, Y: 0}, ToPosition: encounter.PositionData{X: 3, Y: 1}},
-				{ID: "m-door", From: "r1", To: "r2", FromPosition: encounter.PositionData{X: 4, Y: 0}, ToPosition: encounter.PositionData{X: 0, Y: 4}},
+				{ID: "z-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 0, Y: 0}, ToPosition: &encounter.PositionData{X: 1, Y: 1}},
+				{ID: "a-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 2, Y: 0}, ToPosition: &encounter.PositionData{X: 3, Y: 1}},
+				{ID: "m-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 0}, ToPosition: &encounter.PositionData{X: 0, Y: 4}},
 			},
 		},
 		Members: []encounter.MemberData{
@@ -196,15 +196,15 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 
 	data1 := enc1.ToData()
 	s.Require().Len(data1.Field.Rooms, 2)
-	s.Equal(spatial.GridShapeSquare, data1.Field.Rooms[0].Grid, "square is the zero value")
-	s.Equal(spatial.GridShapeHex, data1.Field.Rooms[1].Grid)
+	s.Equal("", data1.Field.Rooms[0].Grid, "square is the zero value — omitted, not the literal \"square\"")
+	s.Equal(spatial.GridTypeHex, data1.Field.Rooms[1].Grid)
 
 	enc2, err := encounter.LoadEncounter(data1, nil)
 	s.Require().NoError(err)
 
 	data2 := enc2.ToData()
-	s.Equal(spatial.GridShapeSquare, data2.Field.Rooms[0].Grid, "grid shape must survive a second round-trip")
-	s.Equal(spatial.GridShapeHex, data2.Field.Rooms[1].Grid, "grid shape must survive a second round-trip")
+	s.Equal("", data2.Field.Rooms[0].Grid, "grid shape must survive a second round-trip")
+	s.Equal(spatial.GridTypeHex, data2.Field.Rooms[1].Grid, "grid shape must survive a second round-trip")
 }
 
 // TestSetupInputNotAliased pins T6 review M4: a caller that edits its
@@ -248,8 +248,8 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	s.Require().Len(data.Field.Connections, 1)
 	s.Equal("door1", data.Field.Connections[0].ID, "the snapshot must not see the caller's vandalism")
 	s.Equal("r1", data.Field.Connections[0].From)
-	s.Equal(encounter.PositionData{X: 1, Y: 0}, data.Field.Connections[0].FromPosition)
-	s.Equal(encounter.PositionData{X: 0, Y: 0}, data.Field.Connections[0].ToPosition)
+	s.Equal(&encounter.PositionData{X: 1, Y: 0}, data.Field.Connections[0].FromPosition)
+	s.Equal(&encounter.PositionData{X: 0, Y: 0}, data.Field.Connections[0].ToPosition)
 
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom
 	// was an encounter that became permanently unsavable).
@@ -1069,8 +1069,8 @@ func validEncounterDataWithConnection() encounter.EncounterData {
 	})
 	d.Field.Connections = []encounter.ConnectionData{
 		{ID: "c1", From: "r1", To: "r2",
-			FromPosition: encounter.PositionData{X: 7, Y: 1},
-			ToPosition:   encounter.PositionData{X: 1, Y: 7}},
+			FromPosition: &encounter.PositionData{X: 7, Y: 1},
+			ToPosition:   &encounter.PositionData{X: 1, Y: 7}},
 	}
 	return d
 }
@@ -1129,20 +1129,31 @@ func (s *DataTestSuite) TestLoadRejections() {
 		}, "itself", encounter.ErrBadConnection},
 		{"connection from-position out of bounds", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
-			d.Field.Connections[0].FromPosition = encounter.PositionData{X: 99, Y: 99}
+			d.Field.Connections[0].FromPosition = &encounter.PositionData{X: 99, Y: 99}
 		}, "from-position out of bounds", encounter.ErrBadConnection},
 		{"connection to-position out of bounds", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
-			d.Field.Connections[0].ToPosition = encounter.PositionData{X: 99, Y: 99}
+			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 99, Y: 99}
 		}, "to-position out of bounds", encounter.ErrBadConnection},
 		{"connection from-position on occluder", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
-			d.Field.Connections[0].FromPosition = encounter.PositionData{X: 2, Y: 2}
+			d.Field.Connections[0].FromPosition = &encounter.PositionData{X: 2, Y: 2}
 		}, "from-position on occluder", encounter.ErrBadConnection},
 		{"connection to-position on occluder", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
-			d.Field.Connections[0].ToPosition = encounter.PositionData{X: 1, Y: 3}
+			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 1, Y: 3}
 		}, "to-position on occluder", encounter.ErrBadConnection},
+		{"connection missing from_position", func(d *encounter.EncounterData) {
+			// Deletes the field from the wire path (nil), not a zero-valued
+			// position — a missing endpoint must never silently default to
+			// (0,0), a legal cell that would invent topology.
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].FromPosition = nil
+		}, "missing from_position", encounter.ErrBadConnection},
+		{"connection missing to_position", func(d *encounter.EncounterData) {
+			*d = validEncounterDataWithConnection()
+			d.Field.Connections[0].ToPosition = nil
+		}, "missing to_position", encounter.ErrBadConnection},
 		{"outcome undeclared ending", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "never-declared"}
 		}, "outcome", nil},
@@ -1193,9 +1204,9 @@ func (s *DataTestSuite) TestLoadRejections() {
 	s.Require().NoError(err, "the valid connection base fixture must load")
 	connData := connEnc.ToData()
 	s.Require().Len(connData.Field.Connections, 1)
-	s.Equal(encounter.PositionData{X: 7, Y: 1}, connData.Field.Connections[0].FromPosition,
+	s.Equal(&encounter.PositionData{X: 7, Y: 1}, connData.Field.Connections[0].FromPosition,
 		"from-position must survive Load unswapped")
-	s.Equal(encounter.PositionData{X: 1, Y: 7}, connData.Field.Connections[0].ToPosition,
+	s.Equal(&encounter.PositionData{X: 1, Y: 7}, connData.Field.Connections[0].ToPosition,
 		"to-position must survive Load unswapped")
 }
 
@@ -1212,8 +1223,8 @@ func connBoundsData() encounter.EncounterData {
 			},
 			Connections: []encounter.ConnectionData{
 				{ID: "c1", From: "r1", To: "r2",
-					FromPosition: encounter.PositionData{X: 0, Y: 0},
-					ToPosition:   encounter.PositionData{X: 0, Y: 0}},
+					FromPosition: &encounter.PositionData{X: 0, Y: 0},
+					ToPosition:   &encounter.PositionData{X: 0, Y: 0}},
 			},
 		},
 		Members: []encounter.MemberData{
@@ -1232,7 +1243,7 @@ func connBoundsData() encounter.EncounterData {
 func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 	s.Run("X exactly at width is rejected", func() {
 		data := connBoundsData()
-		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 4, Y: 0}
+		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 4, Y: 0}
 		_, err := encounter.LoadEncounter(data, nil)
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
@@ -1240,7 +1251,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 
 	s.Run("Y exactly at height is rejected", func() {
 		data := connBoundsData()
-		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 0, Y: 3}
+		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: 3}
 		_, err := encounter.LoadEncounter(data, nil)
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
@@ -1248,7 +1259,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 
 	s.Run("negative X is rejected", func() {
 		data := connBoundsData()
-		data.Field.Connections[0].FromPosition = encounter.PositionData{X: -1, Y: 0}
+		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: -1, Y: 0}
 		_, err := encounter.LoadEncounter(data, nil)
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
@@ -1256,7 +1267,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 
 	s.Run("negative Y is rejected", func() {
 		data := connBoundsData()
-		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 0, Y: -1}
+		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: -1}
 		_, err := encounter.LoadEncounter(data, nil)
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
@@ -1264,7 +1275,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 
 	s.Run("Width-1,Height-1 is accepted (positive control)", func() {
 		data := connBoundsData()
-		data.Field.Connections[0].FromPosition = encounter.PositionData{X: 3, Y: 2}
+		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 3, Y: 2}
 		_, err := encounter.LoadEncounter(data, nil)
 		s.Require().NoError(err, "the last valid cell must be accepted")
 	})
@@ -1287,7 +1298,7 @@ func (s *DataTestSuite) TestLoadRoomValidation() {
 			d.Field.Rooms = append(d.Field.Rooms, d.Field.Rooms[0])
 		}, "duplicate room"},
 		{"room has unknown grid shape", func(d *encounter.EncounterData) {
-			d.Field.Rooms[0].Grid = spatial.GridShape(99)
+			d.Field.Rooms[0].Grid = "triangle"
 		}, "unknown grid shape"},
 	}
 	for _, tc := range cases {
@@ -1312,7 +1323,7 @@ func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
+				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeHex},
 			},
 		},
 		Members: []encounter.MemberData{
@@ -1346,7 +1357,7 @@ func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
+				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeGridless},
 			},
 		},
 		Members: []encounter.MemberData{

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -1033,7 +1033,7 @@ type testDecider struct {
 	intent encounter.Intent
 }
 
-func (d *testDecider) Decide(_ []intel.Holding) (encounter.Intent, error) {
+func (d *testDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 	return d.intent, nil
 }
 

--- a/rulebooks/dnd5e/encounter/decider.go
+++ b/rulebooks/dnd5e/encounter/decider.go
@@ -30,15 +30,53 @@ type IntentHold struct{}
 // isIntent marks IntentHold as an Intent.
 func (i IntentHold) isIntent() {}
 
+// IntentTraverse represents a decision to cross a connection into the room
+// on its other side. Preconditions match the Traverse verb exactly: the
+// decider's own Snapshot.Room/Position (see Snapshot) must be standing
+// exactly on one of the named connection's two endpoints. An illegal
+// traverse intent (unknown connection, or not at the threshold) does not
+// abort the pump — it follows the same silent-skip contract Pump already
+// applies to a spatially-rejected IntentMoveTo: no beat, no room/position
+// change for that member, everything else in the pump proceeds normally.
+type IntentTraverse struct {
+	// Connection is the ID of the connection to traverse.
+	Connection string
+}
+
+// isIntent marks IntentTraverse as an Intent.
+func (i IntentTraverse) isIntent() {}
+
+// Snapshot is a decider's complete input: their OWN current placement
+// (room and position) plus their OWN held intel. The anti-wall-hack
+// contract (C2) extends to placement, not just holdings — a decider
+// learns where IT stands, never where any other member stands except
+// through Holdings' sighted percepts. Static field topology (e.g. a
+// connections list, for a pursuit decider that needs to know where the
+// doors are) is NOT part of Snapshot; give it to a decider at
+// construction time instead — Snapshot itself carries only what changes
+// tick to tick.
+type Snapshot struct {
+	// Room is the decider's own current room ID.
+	Room string
+
+	// Position is the decider's own current position within Room.
+	Position spatial.Position
+
+	// Holdings is the decider's own held intel — exactly what HeldBy
+	// returns for this member, nothing more (C2).
+	Holdings []intel.Holding
+}
+
 // Decider is the interface for monster intelligence. A decider receives ONLY
-// its own holdings (the monster's own vision) and returns an Intent representing
-// what the monster wants to do, or an error that aborts the pump atomically.
-// The anti-wall-hack contract is structural: Decide receives exactly what the
-// monster can see (its own observations), nothing more.
+// its own Snapshot (own room, own position, own holdings — never another
+// member's live truth) and returns an Intent representing what the monster
+// wants to do, or an error that aborts the pump atomically. The anti-wall-
+// hack contract is structural: Decide receives exactly what the monster
+// knows about itself and can see, nothing more.
 type Decider interface {
-	// Decide takes the decider's own holdings (what it can see) and returns
-	// an Intent (what to do) or an error that aborts the pump atomically.
-	// If an error is returned, the Pump rolls back completely: the clock is not
-	// advanced, no moves are executed, and no record beats are appended.
-	Decide(view []intel.Holding) (Intent, error)
+	// Decide takes the decider's own Snapshot and returns an Intent (what
+	// to do) or an error that aborts the pump atomically. If an error is
+	// returned, the Pump rolls back completely: the clock is not advanced,
+	// no moves are executed, and no record beats are appended.
+	Decide(snap Snapshot) (Intent, error)
 }

--- a/rulebooks/dnd5e/encounter/decider.go
+++ b/rulebooks/dnd5e/encounter/decider.go
@@ -8,9 +8,11 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
-// Intent represents a decision made by a decider in response to their view.
-// The anti-wall-hack contract: a decider receives ONLY its own holdings,
-// never the full encounter state. Intent is a sealed type (unexported marker method).
+// Intent represents a decision made by a decider in response to their
+// Snapshot. The anti-wall-hack contract: a decider receives ONLY its own
+// Snapshot (own room, own position, own holdings), never the full
+// encounter state or another member's live truth. Intent is a sealed
+// type (unexported marker method).
 type Intent interface {
 	isIntent()
 }

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -666,13 +666,17 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 // not a member → connection not found → endpoint mismatch (wrong room or
 // wrong position, either rejects the same way).
 //
-// The spatial layer genuinely moves the entity between rooms: RemoveEntity
-// from the departure room, then PlaceEntity into the arrival room — the
-// SAME two managed seams Exit and Join already use individually, just
-// composed. This matters: omitting RemoveEntity leaks the entity in the
-// departure room's registry even though it's invisible to Members/View
-// (see TestExitThenRejoinSameID's doc comment — the wave-1 lesson).
-// Composing the two proven seams here means the lesson can't regress.
+// The spatial layer genuinely moves the entity between rooms: spatial's
+// purpose-built TransitionEntity removes from the departure room (the
+// SAME registry cleanup RemoveEntity performs — omitting it leaks the
+// entity in the room's registry even though it's invisible to
+// Members/View; see TestExitThenRejoinSameID's doc comment, the wave-1
+// lesson) and, as a backstop behind our own endpoint check above,
+// independently re-validates against spatial's own bookkeeping that the
+// named connection exists and actually links the two rooms (in either
+// direction — door connections are Reversible). PlaceEntity into the
+// arrival room always follows — TransitionEntity deliberately leaves the
+// entity unplaced.
 //
 // The clock is NOT advanced — traversal is an activity, not time (law T4).
 // Sight refreshes for ALL members in one refreshSight call: since
@@ -742,22 +746,29 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 		return nil, fmt.Errorf("traverse: member %s is not at connection %s's endpoint: %w", in.Member, in.Connection, ErrBadPlacement)
 	}
 
-	// Move the entity between rooms via the two proven managed seams.
-	_, err := e.orchestrator.RemoveEntity(&spatial.RemoveEntityInput{
-		RoomID:   spatial.RoomID(fromRoom),
-		EntityID: core.EntityID(in.Member),
+	// Move the entity between rooms via spatial's purpose-built transition
+	// seam: TransitionEntity removes from the source room (the SAME
+	// registry cleanup RemoveEntity performs — the wave-1 Exit lesson
+	// applies here too) and, as a backstop BEHIND our own checks above,
+	// independently re-validates against spatial's own bookkeeping that
+	// the connection exists, actually links these two rooms (in either
+	// direction, since door connections are Reversible), and the entity
+	// was truly indexed in the departure room. TransitionEntity
+	// deliberately does NOT place the entity — PlaceEntity must always
+	// follow, using the SAME entity value TransitionEntity returned.
+	transitioned, err := e.orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+		EntityID:     core.EntityID(in.Member),
+		FromRoom:     spatial.RoomID(fromRoom),
+		ToRoom:       spatial.RoomID(toRoom),
+		ConnectionID: spatial.ConnectionID(in.Connection),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("traverse remove entity: %w: %w", ErrBadPlacement, err)
+		return nil, fmt.Errorf("traverse transition entity: %w: %w", ErrBadPlacement, err)
 	}
 
-	entity := &memberEntity{
-		id:   string(in.Member),
-		kind: member.Kind,
-	}
 	_, err = e.orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
 		RoomID:   spatial.RoomID(toRoom),
-		Entity:   entity,
+		Entity:   transitioned.Entity,
 		Position: toPos,
 	})
 	if err != nil {

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -40,8 +40,15 @@ type Encounter struct {
 	members      map[MemberID]*Member
 	everMembers  map[MemberID]bool // Track all members who have ever joined (for Story access)
 	deciders     map[MemberID]Decider
-	// endings holds declared endings in Setup order — evaluation is
-	// deterministic, first-declared-wins (law C8).
+	// endings holds declared endings in Setup order. Evaluation is
+	// deterministic (law C8), but NOT globally "first-declared-wins":
+	// for a single action (Move, Traverse, Join) declaration order is
+	// the only axis, so the first matching declared ending does win.
+	// Pump can execute several monsters' actions in one tick, and there
+	// evaluation walks them in DECISION order first — the action
+	// decided earliest wins regardless of which of its matching endings
+	// was declared later; declaration order is only the tiebreak within
+	// one action's own scan. See Pump's ending-evaluation loop.
 	endings []declaredEnding
 	outcome *Outcome
 	// fieldInput and connectionsInput are stored at Setup time for persistence.
@@ -1048,6 +1055,15 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		// otherwise have carried since Setup/Wave-1 (moves never needed
 		// to write back Room, so this distinction was previously latent).
 		member := e.members[p.memberID]
+		if member == nil {
+			// A contract-violating decider removed itself from the
+			// encounter (e.g. called Exit on its own member) during
+			// phase 1's Decide. Its planned action has no live member
+			// to execute against — same silent-skip contract as a
+			// spatially-rejected move: absent from output and beats,
+			// the pump otherwise proceeds normally.
+			continue
+		}
 		switch intent := p.intent.(type) {
 		case IntentMoveTo:
 			// Spatial rejection does not abort the pump; the monster

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -78,10 +78,20 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 // GridShape values; the switch's default (square) is therefore unreachable
 // in practice and exists only so an unvalidated caller degrades gracefully
 // rather than panicking.
+//
+// Hex rooms build spatial.AxialHexGrid, NOT spatial.HexGrid: the wire (and
+// Platform's pathing) speaks cube coordinates natively, and axial (Q, R,
+// with S = -(Q+R) derived) is cube's 2D projection — an IDENTITY mapping to
+// the wire. HexGrid's bounded offset column/row coordinates would force a
+// lossy, orientation-dependent offset<->cube conversion at that seam for no
+// benefit inside the composition, which never renders a grid itself.
+// width/height become AxialHexGridConfig's SpanWidth/SpanHeight — see
+// RoomInput.Grid's doc comment for what that means for a hex room's
+// Position values (origin-centered, negative coordinates legal).
 func buildRoomGrid(shape spatial.GridShape, width, height int) spatial.Grid {
 	switch shape {
 	case spatial.GridShapeHex:
-		return spatial.NewHexGrid(spatial.HexGridConfig{Width: float64(width), Height: float64(height)})
+		return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: float64(width), SpanHeight: float64(height)})
 	case spatial.GridShapeGridless:
 		return spatial.NewGridlessRoom(spatial.GridlessConfig{Width: float64(width), Height: float64(height)})
 	default:

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -51,12 +51,6 @@ type Encounter struct {
 	connectionsInput []ConnectionInput
 }
 
-// NewEncounter constructs and initializes an encounter from SetupInput.
-// Validation order (first failure wins, R5 atomicity): nil input, no rooms,
-// no endings, reserved ending key, empty member ID, duplicate member IDs,
-// connection defects (empty/duplicate ID, unknown room, self-connection,
-// endpoint out of bounds or on an occluder), spatial placement errors.
-
 // deepCopyRoomInputs snapshots the caller's room descriptions — the
 // persistence source must never alias caller-owned slices (T6 review
 // M4: a caller editing its SetupInput after construction silently
@@ -133,6 +127,11 @@ func validateConnectionInputs(rooms []RoomInput, connections []ConnectionInput) 
 	return nil
 }
 
+// NewEncounter constructs and initializes an encounter from SetupInput.
+// Validation order (first failure wins, R5 atomicity): nil input, no rooms,
+// no endings, reserved ending key, empty member ID, duplicate member IDs,
+// connection defects (empty/duplicate ID, unknown room, self-connection,
+// endpoint out of bounds or on an occluder), spatial placement errors.
 func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// Validation order: nil, no rooms, no endings, reserved ending, empty ID, duplicates
 	if in == nil {
@@ -161,7 +160,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 			return nil, fmt.Errorf("newencounter: %w", ErrNoMember)
 		}
 		if seenIDs[m.ID] {
-			return nil, fmt.Errorf("newencounter: %w", ErrNoMember)
+			return nil, fmt.Errorf("newencounter: duplicate member %s: %w", m.ID, ErrNoMember)
 		}
 		seenIDs[m.ID] = true
 

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -658,38 +658,137 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	}, nil
 }
 
-// Traverse moves a member across a connection from their current endpoint to
-// the connection's OTHER endpoint, in the other room. The member must be
-// standing EXACTLY on one of the connection's two endpoints; connections are
-// bidirectional (T1 law), so traversal works in either direction through the
-// same connection. Validation order (R5 atomicity): nil input → closed →
-// not a member → connection not found → endpoint mismatch (wrong room or
-// wrong position, either rejects the same way).
+// traverseResult holds the outcome of a successful cross-room move via
+// traverseMember — shared by the Traverse verb and Pump's IntentTraverse
+// executor.
+type traverseResult struct {
+	fromRoom string
+	fromPos  spatial.Position
+	toRoom   string
+	toPos    spatial.Position
+}
+
+// traverseMember resolves connectionID against this encounter's declared
+// connections, determines direction from member's CURRENT room/position
+// (they must be standing exactly on one of the connection's two
+// endpoints — connections are bidirectional, T1 law), and moves the
+// entity between rooms via spatial's TransitionEntity + PlaceEntity
+// managed seams, mutating member.Room on success. ANY failure (unknown
+// connection, endpoint mismatch, or a spatial rejection) returns before
+// member.Room is touched.
 //
-// The spatial layer genuinely moves the entity between rooms: spatial's
-// purpose-built TransitionEntity removes from the departure room (the
-// SAME registry cleanup RemoveEntity performs — omitting it leaks the
-// entity in the room's registry even though it's invisible to
-// Members/View; see TestExitThenRejoinSameID's doc comment, the wave-1
-// lesson) and, as a backstop behind our own endpoint check above,
-// independently re-validates against spatial's own bookkeeping that the
-// named connection exists and actually links the two rooms (in either
-// direction — door connections are Reversible). PlaceEntity into the
-// arrival room always follows — TransitionEntity deliberately leaves the
-// entity unplaced.
+// Shared by the Traverse verb (which owns the nil/closed/member-lookup
+// guards and propagates this function's error as its own public
+// contract — ErrNoConnection or ErrBadPlacement, already correctly
+// wrapped here) and Pump's phase-2 IntentTraverse executor (which owns
+// Pump's silent-skip-on-failure semantics: ANY error returned here is
+// treated exactly like a spatially-rejected IntentMoveTo — the monster
+// simply fails to act this tick, no abort).
+func (e *Encounter) traverseMember(member *Member, connectionID string) (traverseResult, error) {
+	var conn *ConnectionInput
+	for i := range e.connectionsInput {
+		if e.connectionsInput[i].ID == connectionID {
+			conn = &e.connectionsInput[i]
+			break
+		}
+	}
+	if conn == nil {
+		return traverseResult{}, fmt.Errorf("connection %s not found: %w", connectionID, ErrNoConnection)
+	}
+
+	room, ok := e.orchestrator.GetRoom(member.Room)
+	if !ok {
+		return traverseResult{}, fmt.Errorf("%w", ErrBadPlacement)
+	}
+	fromPos, ok := room.GetEntityPosition(string(member.ID))
+	if !ok {
+		return traverseResult{}, fmt.Errorf("%w", ErrBadPlacement)
+	}
+	fromRoom := member.Room
+
+	// The member must be standing exactly on one of the connection's two
+	// endpoints. Determine direction from WHICH endpoint they're on — the
+	// arrival side is always the connection's OTHER endpoint (never the
+	// one the member is currently standing on).
+	var toRoom string
+	var toPos spatial.Position
+	switch {
+	case fromRoom == conn.From && fromPos.X == conn.FromPosition.X && fromPos.Y == conn.FromPosition.Y:
+		toRoom, toPos = conn.To, conn.ToPosition
+	case fromRoom == conn.To && fromPos.X == conn.ToPosition.X && fromPos.Y == conn.ToPosition.Y:
+		toRoom, toPos = conn.From, conn.FromPosition
+	default:
+		return traverseResult{}, fmt.Errorf("member %s is not at connection %s's endpoint: %w", member.ID, connectionID, ErrBadPlacement)
+	}
+
+	// Move the entity between rooms via spatial's purpose-built transition
+	// seam: TransitionEntity removes from the source room (the SAME
+	// registry cleanup RemoveEntity performs — the wave-1 Exit lesson
+	// applies here too) and, as a backstop behind our own checks above,
+	// independently re-validates against spatial's own bookkeeping that
+	// the connection exists, actually links these two rooms (in either
+	// direction, since door connections are Reversible), and the entity
+	// was truly indexed in the departure room. TransitionEntity
+	// deliberately does NOT place the entity — PlaceEntity must always
+	// follow, using the SAME entity value TransitionEntity returned.
+	transitioned, err := e.orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
+		EntityID:     core.EntityID(member.ID),
+		FromRoom:     spatial.RoomID(fromRoom),
+		ToRoom:       spatial.RoomID(toRoom),
+		ConnectionID: spatial.ConnectionID(connectionID),
+	})
+	if err != nil {
+		return traverseResult{}, fmt.Errorf("transition entity: %w: %w", ErrBadPlacement, err)
+	}
+
+	// LIMBO WINDOW (defensive, currently unreachable): if PlaceEntity below
+	// were to fail after TransitionEntity above already succeeded, the
+	// entity would be removed from every room and placed in none — this
+	// function does not roll back. Four invariants keep that window
+	// unreachable today: (1) rooms are immutable after Setup/Load, so
+	// fromRoom/toRoom always exist; (2) member entities never block
+	// placement (memberEntity.BlocksMovement() is always false), so
+	// occupancy can never reject PlaceEntity; (3) connection endpoints are
+	// grid-validated at both entry seams (Setup and Load), so toPos is
+	// always valid on the arrival room's grid; (4) door connections are
+	// permanently Passable and Reversible (CreateDoorConnection, never
+	// mutated after Setup/Load), so TransitionEntity's own passability and
+	// direction checks always agree with ours. A future change that
+	// violates any one of these must meet this comment as a deliberate
+	// decision point, not a silent atomicity regression.
+	_, err = e.orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID:   spatial.RoomID(toRoom),
+		Entity:   transitioned.Entity,
+		Position: toPos,
+	})
+	if err != nil {
+		return traverseResult{}, fmt.Errorf("place entity: %w: %w", ErrBadPlacement, err)
+	}
+
+	member.Room = toRoom
+
+	return traverseResult{fromRoom: fromRoom, fromPos: fromPos, toRoom: toRoom, toPos: toPos}, nil
+}
+
+// Traverse moves a member across a connection from their current endpoint to
+// the connection's OTHER endpoint, in the other room. Validation order (R5
+// atomicity): nil input → closed → not a member → traverseMember's own
+// checks (connection not found: ErrNoConnection; endpoint mismatch — wrong
+// room or wrong position, either rejects the same way: ErrBadPlacement).
 //
 // The clock is NOT advanced — traversal is an activity, not time (law T4).
 // Sight refreshes for ALL members in one refreshSight call: since
 // refreshSight scopes each observer's percept to members currently in
-// THEIR OWN room, updating member.Room before the refresh is sufficient —
-// departure-room observers naturally stop seeing the traverser (intel's
-// existing complete-percept contract ghosts them at their last-known
-// position, the departure endpoint) and arrival-room observers naturally
-// gain them Current. No per-room special-casing needed, and sight cannot
-// cross the opening in either direction: rooms are separate spatial
-// containers with no shared geometry (spatial ADR-0015), so there is no
-// code path by which an observer's line-of-sight computation — scoped
-// entirely to entities in their own room — could see into the other room.
+// THEIR OWN room, updating member.Room before the refresh (done inside
+// traverseMember) is sufficient — departure-room observers naturally stop
+// seeing the traverser (intel's existing complete-percept contract ghosts
+// them at their last-known position, the departure endpoint) and
+// arrival-room observers naturally gain them Current. No per-room
+// special-casing needed, and sight cannot cross the opening in either
+// direction: rooms are separate spatial containers with no shared
+// geometry (spatial ADR-0015), so there is no code path by which an
+// observer's line-of-sight computation — scoped entirely to entities in
+// their own room — could see into the other room.
 //
 // Ending evaluation mirrors Move exactly, evaluated against the ARRIVAL
 // room/position: unfiltered ReachedPosition triggers fire for player
@@ -710,74 +809,10 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 		return nil, fmt.Errorf("traverse: %w", ErrNotMember)
 	}
 
-	var conn *ConnectionInput
-	for i := range e.connectionsInput {
-		if e.connectionsInput[i].ID == in.Connection {
-			conn = &e.connectionsInput[i]
-			break
-		}
-	}
-	if conn == nil {
-		return nil, fmt.Errorf("traverse: connection %s not found: %w", in.Connection, ErrNoConnection)
-	}
-
-	room, ok := e.orchestrator.GetRoom(member.Room)
-	if !ok {
-		return nil, fmt.Errorf("traverse: %w", ErrBadPlacement)
-	}
-	fromPos, ok := room.GetEntityPosition(string(in.Member))
-	if !ok {
-		return nil, fmt.Errorf("traverse: %w", ErrBadPlacement)
-	}
-	fromRoom := member.Room
-
-	// The member must be standing exactly on one of the connection's two
-	// endpoints. Determine direction from WHICH endpoint they're on — the
-	// arrival side is always the connection's OTHER endpoint (never the
-	// one the member is currently standing on).
-	var toRoom string
-	var toPos spatial.Position
-	switch {
-	case fromRoom == conn.From && fromPos.X == conn.FromPosition.X && fromPos.Y == conn.FromPosition.Y:
-		toRoom, toPos = conn.To, conn.ToPosition
-	case fromRoom == conn.To && fromPos.X == conn.ToPosition.X && fromPos.Y == conn.ToPosition.Y:
-		toRoom, toPos = conn.From, conn.FromPosition
-	default:
-		return nil, fmt.Errorf("traverse: member %s is not at connection %s's endpoint: %w", in.Member, in.Connection, ErrBadPlacement)
-	}
-
-	// Move the entity between rooms via spatial's purpose-built transition
-	// seam: TransitionEntity removes from the source room (the SAME
-	// registry cleanup RemoveEntity performs — the wave-1 Exit lesson
-	// applies here too) and, as a backstop BEHIND our own checks above,
-	// independently re-validates against spatial's own bookkeeping that
-	// the connection exists, actually links these two rooms (in either
-	// direction, since door connections are Reversible), and the entity
-	// was truly indexed in the departure room. TransitionEntity
-	// deliberately does NOT place the entity — PlaceEntity must always
-	// follow, using the SAME entity value TransitionEntity returned.
-	transitioned, err := e.orchestrator.TransitionEntity(&spatial.TransitionEntityInput{
-		EntityID:     core.EntityID(in.Member),
-		FromRoom:     spatial.RoomID(fromRoom),
-		ToRoom:       spatial.RoomID(toRoom),
-		ConnectionID: spatial.ConnectionID(in.Connection),
-	})
+	result, err := e.traverseMember(member, in.Connection)
 	if err != nil {
-		return nil, fmt.Errorf("traverse transition entity: %w: %w", ErrBadPlacement, err)
+		return nil, fmt.Errorf("traverse: %w", err)
 	}
-
-	_, err = e.orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
-		RoomID:   spatial.RoomID(toRoom),
-		Entity:   transitioned.Entity,
-		Position: toPos,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("traverse place entity: %w: %w", ErrBadPlacement, err)
-	}
-
-	// Update the member's room before refreshSight — see the doc comment
-	// above for why this alone is sufficient for correct two-room percepts.
-	member.Room = toRoom
 
 	memberIDs := make([]MemberID, 0, len(e.members))
 	for id := range e.members {
@@ -797,8 +832,8 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 		"beat":       "traversed",
 		"member":     string(in.Member),
 		"connection": in.Connection,
-		"room":       toRoom,
-		"position":   toPos,
+		"room":       result.toRoom,
+		"position":   result.toPos,
 	}
 	beatBytes, _ := json.Marshal(beatPayload)
 
@@ -823,11 +858,11 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 			continue // Not a ReachedPosition trigger
 		}
 
-		if reachedPosTrigger.Room != toRoom {
+		if reachedPosTrigger.Room != result.toRoom {
 			continue // Different room
 		}
 
-		if reachedPosTrigger.Position.X != toPos.X || reachedPosTrigger.Position.Y != toPos.Y {
+		if reachedPosTrigger.Position.X != result.toPos.X || reachedPosTrigger.Position.Y != result.toPos.Y {
 			continue // Different position
 		}
 
@@ -875,10 +910,10 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 			To       spatial.Position
 		}{
 			Member:   in.Member,
-			FromRoom: fromRoom,
-			From:     fromPos,
-			ToRoom:   toRoom,
-			To:       toPos,
+			FromRoom: result.fromRoom,
+			From:     result.fromPos,
+			ToRoom:   result.toRoom,
+			To:       result.toPos,
 		},
 		IntelDeltas: intelDeltas,
 		Seq:         seqNum,
@@ -888,22 +923,29 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 
 // Pump advances the world by one tick: the exploration clock advances,
 // each monster member (in deterministic order) acts on its own intel via Decider,
-// the complete sight refresh happens once, and the story accrues tick and move beats.
-// Errors from a decider abort the pump atomically (R5): no clock advance, no moves,
-// no record entries.
+// the complete sight refresh happens once, and the story accrues tick and
+// move/traverse beats. Errors from a decider abort the pump atomically (R5):
+// no clock advance, no moves, no record entries.
 //
 // Semantics:
 //   - Tick advances by exactly 1 (via clock.Advance with displacement 1).
 //   - Monsters act in deterministic order (stable Members() order, filtered to KindMonster).
-//   - Each decider receives exactly its own holdings (anti-wall-hack contract C2).
-//   - IntentHold means do nothing; IntentMoveTo executes via managed seam.
-//   - A spatial rejection of a monster's move does NOT abort the pump; the monster
-//     simply fails to move. Only a decider error aborts.
+//   - Each decider receives exactly its own Snapshot: own room, own position,
+//     own holdings (anti-wall-hack contract C2 — placement included, not just sight).
+//   - IntentHold means do nothing; IntentMoveTo executes via the same-room managed
+//     seam; IntentTraverse executes via traverseMember (the Traverse verb's own
+//     mechanics, shared — see its doc comment).
+//   - A spatial rejection of a monster's move, or an illegal traverse intent
+//     (unknown connection, or not at the threshold), does NOT abort the pump; the
+//     monster simply fails to act. Only a decider error aborts.
 //   - After all monster actions: ONE refreshSight for all members, ONE tick beat
-//     (stamped with the new clock reading), then move beats in order.
+//     (stamped with the new clock reading), then move/traverse beats in
+//     decision order (the same order monsters were consulted in).
 //   - Ending evaluation fires ReachedPosition triggers (only if the filter matches;
-//     empty filter = players only, not monsters).
-//   - Returns PumpOutput with the new Tick reading, successful moves, deltas, and beats.
+//     empty filter = players only, not monsters) against each action's resulting
+//     room/position, in the same decision order.
+//   - Returns PumpOutput with the new Tick reading, successful moves, successful
+//     traverses, deltas, and beats.
 func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 	// Validation
 	if in == nil {
@@ -924,11 +966,11 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		return nil, fmt.Errorf("pump members: %w", err)
 	}
 
-	type plannedMove struct {
-		member Member
-		to     spatial.Position
+	type plannedAction struct {
+		memberID MemberID
+		intent   Intent
 	}
-	var planned []plannedMove
+	var planned []plannedAction
 
 	for _, m := range allMembers {
 		if m.Kind != KindMonster {
@@ -937,6 +979,19 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		decider, hasDecider := e.deciders[m.ID]
 		if !hasDecider {
 			continue // no decider = hold
+		}
+
+		// The monster's own placement, read fresh from spatial — never
+		// another member's. A decider that received anyone else's room or
+		// position would be a wall hack extended to placement, not just
+		// sight (C2).
+		room, ok := e.orchestrator.GetRoom(m.Room)
+		if !ok {
+			return nil, fmt.Errorf("pump snapshot room: %w", ErrBadPlacement)
+		}
+		ownPos, ok := room.GetEntityPosition(string(m.ID))
+		if !ok {
+			return nil, fmt.Errorf("pump snapshot position: %w", ErrBadPlacement)
 		}
 
 		// The monster's own holdings and nothing else (C2). HeldBy's
@@ -948,13 +1003,14 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 			return nil, fmt.Errorf("pump held_by: %w", err)
 		}
 
-		intent, err := decider.Decide(ownHoldings)
+		intent, err := decider.Decide(Snapshot{Room: m.Room, Position: ownPos, Holdings: ownHoldings})
 		if err != nil {
 			return nil, fmt.Errorf("pump decide: %w", err)
 		}
 
-		if mv, ok := intent.(IntentMoveTo); ok {
-			planned = append(planned, plannedMove{member: m, to: mv.To})
+		switch intent.(type) {
+		case IntentMoveTo, IntentTraverse:
+			planned = append(planned, plannedAction{memberID: m.ID, intent: intent})
 		}
 	}
 
@@ -970,24 +1026,51 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 
 	newTickReading := uint64(e.clock.ToData().HighWater)
 
-	type monsterMove struct {
-		member *Member
-		from   spatial.Position
-		to     spatial.Position
+	// executedAction is built in PLANNED (decision) order regardless of
+	// kind, so beats and ending evaluation below stay in the same
+	// deterministic per-monster order the deciders were consulted in
+	// (C8) — not "all moves then all traverses".
+	type executedAction struct {
+		member     *Member
+		kind       string // "move" or "traverse"
+		connection string // only meaningful for "traverse"
+		fromRoom   string // only meaningful for "traverse"; a move never changes room
+		from       spatial.Position
+		toRoom     string // only meaningful for "traverse"
+		to         spatial.Position
 	}
-	var successfulMoves []monsterMove
+	var executed []executedAction
 
-	for i := range planned {
-		p := planned[i]
-		// Spatial rejection does not abort the pump; the monster simply
-		// fails to move and no beat is recorded for it.
-		fromPos, moveErr := e.moveMember(&p.member, p.to)
-		if moveErr == nil {
-			successfulMoves = append(successfulMoves, monsterMove{
-				member: &planned[i].member,
-				from:   fromPos,
-				to:     p.to,
-			})
+	for _, p := range planned {
+		// The REAL member pointer, not a Members()-derived copy: a
+		// traverse mutates member.Room, and that mutation must reach the
+		// live e.members entry, not a value copy that planned would
+		// otherwise have carried since Setup/Wave-1 (moves never needed
+		// to write back Room, so this distinction was previously latent).
+		member := e.members[p.memberID]
+		switch intent := p.intent.(type) {
+		case IntentMoveTo:
+			// Spatial rejection does not abort the pump; the monster
+			// simply fails to move and no beat is recorded for it.
+			fromPos, moveErr := e.moveMember(member, intent.To)
+			if moveErr == nil {
+				executed = append(executed, executedAction{
+					member: member, kind: "move", from: fromPos, to: intent.To,
+				})
+			}
+		case IntentTraverse:
+			// An illegal traverse (unknown connection, or not at the
+			// threshold) does not abort the pump either — same silent-skip
+			// contract as a spatially-rejected move (see traverseMember's
+			// doc comment).
+			result, travErr := e.traverseMember(member, intent.Connection)
+			if travErr == nil {
+				executed = append(executed, executedAction{
+					member: member, kind: "traverse", connection: intent.Connection,
+					fromRoom: result.fromRoom, from: result.fromPos,
+					toRoom: result.toRoom, to: result.toPos,
+				})
+			}
 		}
 	}
 
@@ -1022,32 +1105,46 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 
 	seqs := []uint64{tickAppendOut.Seq}
 
-	// Then record move beats for each successful move (in order)
-	for _, move := range successfulMoves {
-		moveBeatPayload := map[string]interface{}{
-			"beat":     "moved",
-			"member":   string(move.member.ID),
-			"position": move.to,
+	// Then record a beat for each successful action, in decision order.
+	for _, action := range executed {
+		var beatPayload map[string]interface{}
+		switch action.kind {
+		case "move":
+			beatPayload = map[string]interface{}{
+				"beat":     "moved",
+				"member":   string(action.member.ID),
+				"position": action.to,
+			}
+		case "traverse":
+			beatPayload = map[string]interface{}{
+				"beat":       "traversed",
+				"member":     string(action.member.ID),
+				"connection": action.connection,
+				"room":       action.toRoom,
+				"position":   action.to,
+			}
 		}
-		moveBeatBytes, _ := json.Marshal(moveBeatPayload)
+		beatBytes, _ := json.Marshal(beatPayload)
 
-		moveAppendOut, err := e.story.Append(&record.AppendInput{
+		actionAppendOut, err := e.story.Append(&record.AppendInput{
 			At:       newTickReading,
 			Audience: memberIDs,
 			Tags:     map[string]string{"tag": "movement"},
-			Payload:  moveBeatBytes,
+			Payload:  beatBytes,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("pump append move beat: %w", err)
+			return nil, fmt.Errorf("pump append %s beat: %w", action.kind, err)
 		}
 
-		seqs = append(seqs, moveAppendOut.Seq)
+		seqs = append(seqs, actionAppendOut.Seq)
 	}
 
-	// Evaluate ReachedPosition endings
+	// Evaluate ReachedPosition endings, in decision order. For a
+	// traverse, action.member.Room is already the ARRIVAL room
+	// (traverseMember mutated it); for a move it's unchanged — either
+	// way action.member.Room is correct to check against.
 	var firedOutcome *Outcome
-	for _, move := range successfulMoves {
-		// Check all endings for this position
+	for _, action := range executed {
 		for _, de := range e.endings {
 			endingKey, trigger := de.key, de.trigger
 			reachedPosTrigger, ok := trigger.(TriggerReachedPosition)
@@ -1055,21 +1152,21 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 				continue // Not a ReachedPosition trigger
 			}
 
-			if reachedPosTrigger.Room != move.member.Room {
+			if reachedPosTrigger.Room != action.member.Room {
 				continue // Different room
 			}
 
-			if reachedPosTrigger.Position.X != move.to.X || reachedPosTrigger.Position.Y != move.to.Y {
+			if reachedPosTrigger.Position.X != action.to.X || reachedPosTrigger.Position.Y != action.to.Y {
 				continue // Different position
 			}
 
 			// Check member filter: non-empty = specific member; empty = players only
 			// Monsters should never trigger an unfiltered (empty-filter) ending
 			if reachedPosTrigger.Member == "" {
-				continue // Empty filter means players only, but this moved member is a monster
+				continue // Empty filter means players only, but this member is a monster
 			}
 
-			if reachedPosTrigger.Member != move.member.ID {
+			if reachedPosTrigger.Member != action.member.ID {
 				continue // Member filter doesn't match
 			}
 
@@ -1102,24 +1199,46 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		}
 	}
 
-	// Build the output with successful moves
-	outputMoves := make([]struct {
+	// Build the output, splitting executed actions by kind (each output
+	// slice preserves the SAME relative order it had in executed).
+	var outputMoves []struct {
 		Member MemberID
 		From   spatial.Position
 		To     spatial.Position
-	}, len(successfulMoves))
-	for i, m := range successfulMoves {
-		outputMoves[i].Member = m.member.ID
-		outputMoves[i].From = m.from
-		outputMoves[i].To = m.to
+	}
+	var outputTraverses []struct {
+		Member   MemberID
+		FromRoom string
+		From     spatial.Position
+		ToRoom   string
+		To       spatial.Position
+	}
+	for _, action := range executed {
+		switch action.kind {
+		case "move":
+			outputMoves = append(outputMoves, struct {
+				Member MemberID
+				From   spatial.Position
+				To     spatial.Position
+			}{Member: action.member.ID, From: action.from, To: action.to})
+		case "traverse":
+			outputTraverses = append(outputTraverses, struct {
+				Member   MemberID
+				FromRoom string
+				From     spatial.Position
+				ToRoom   string
+				To       spatial.Position
+			}{Member: action.member.ID, FromRoom: action.fromRoom, From: action.from, ToRoom: action.toRoom, To: action.to})
+		}
 	}
 
 	return &PumpOutput{
-		Tick:         newTickReading,
-		MonsterMoves: outputMoves,
-		IntelDeltas:  intelDeltas,
-		Seqs:         seqs,
-		Outcome:      firedOutcome,
+		Tick:             newTickReading,
+		MonsterMoves:     outputMoves,
+		MonsterTraverses: outputTraverses,
+		IntelDeltas:      intelDeltas,
+		Seqs:             seqs,
+		Outcome:          firedOutcome,
 	}, nil
 }
 

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -6,6 +6,7 @@ package encounter
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -99,6 +100,28 @@ func buildRoomGrid(shape spatial.GridShape, width, height int) spatial.Grid {
 	}
 }
 
+// isIntegralAxialPosition reports whether pos satisfies spatial's
+// implicit integer-cube contract for hex rooms — upholds it at this
+// composition's boundary until tools/spatial#926 enforces it at ingress;
+// becomes redundant defense once the fixed spatial tag is consumed.
+// AxialHexGrid bounds-checks Position.X/Y but does not integrality-check
+// them, and all of its cube math truncates, so a fractional axial
+// position like (0.5, 0.5) would otherwise persist as a distinct
+// position that behaves exactly like (0,0) — an invisible collision with
+// an unrelated, legitimately-placed cell. Applies ONLY to hex rooms:
+// square stays fractional-tolerant as today, and gridless is continuous
+// by design — call this next to every grid-deferred IsValidPosition
+// check (or, where no such check exists at a seam, next to where the
+// position first enters) so every externally supplied hex-room position
+// is covered: member/Move/Join positions, connection endpoints, and
+// occluders.
+func isIntegralAxialPosition(grid spatial.Grid, pos spatial.Position) bool {
+	if grid.GetShape() != spatial.GridShapeHex {
+		return true
+	}
+	return pos.X == math.Trunc(pos.X) && pos.Y == math.Trunc(pos.Y)
+}
+
 // buildValidRoomGrids rejects room defects before construction (R5
 // atomicity — no observable state until Setup succeeds): empty or
 // duplicate room ID, and an unrecognized grid shape. On success, returns
@@ -129,6 +152,14 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 			return nil, fmt.Errorf("newencounter: room %q has unknown grid shape %d: %w", r.ID, r.Grid, ErrNoField)
 		}
 		grids[r.ID] = buildRoomGrid(r.Grid, r.Width, r.Height)
+
+		// Hex rooms require integral axial occluder positions (interim
+		// tools/spatial#926 enforcement — see isIntegralAxialPosition).
+		for _, occ := range r.Occluders {
+			if !isIntegralAxialPosition(grids[r.ID], occ) {
+				return nil, fmt.Errorf("newencounter: room %q occluder (%g,%g) is not an integral axial cell: %w", r.ID, occ.X, occ.Y, ErrNoField)
+			}
+		}
 	}
 	return grids, nil
 }
@@ -169,8 +200,14 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 		if !roomGrids[c.From].IsValidPosition(c.FromPosition) {
 			return fmt.Errorf("newencounter: connection %q from-position out of bounds: %w", c.ID, ErrBadConnection)
 		}
+		if !isIntegralAxialPosition(roomGrids[c.From], c.FromPosition) {
+			return fmt.Errorf("newencounter: connection %q from-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
+		}
 		if !roomGrids[c.To].IsValidPosition(c.ToPosition) {
 			return fmt.Errorf("newencounter: connection %q to-position out of bounds: %w", c.ID, ErrBadConnection)
+		}
+		if !isIntegralAxialPosition(roomGrids[c.To], c.ToPosition) {
+			return fmt.Errorf("newencounter: connection %q to-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
 		}
 
 		for _, occ := range fromRoom.Occluders {
@@ -245,6 +282,19 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// any occluder.
 	if err = validateConnectionInputs(in.Field.Rooms, roomGrids, in.Field.Connections); err != nil {
 		return nil, err
+	}
+
+	// Hex rooms require integral axial member positions (interim
+	// tools/spatial#926 enforcement — see isIntegralAxialPosition). No
+	// existing bounds pre-check covers members at this seam (placement
+	// bounds are enforced by spatial's own PlaceEntity below), so this
+	// runs as its own pass over the grid this member's declared room
+	// resolved to — a member whose room doesn't exist is caught later,
+	// at placement, unrelated to this check.
+	for _, mi := range in.Members {
+		if grid, ok := roomGrids[mi.Room]; ok && !isIntegralAxialPosition(grid, mi.Position) {
+			return nil, fmt.Errorf("newencounter: member %q position is not an integral axial cell: %w", mi.ID, ErrBadPlacement)
+		}
 	}
 
 	// Connections are stored sorted by ID (C8 determinism — order is
@@ -523,6 +573,16 @@ func (e *Encounter) moveMember(member *Member, to spatial.Position) (spatial.Pos
 	currentPos, ok := room.GetEntityPosition(string(member.ID))
 	if !ok {
 		return spatial.Position{}, fmt.Errorf("movemember: %w", ErrBadPlacement)
+	}
+
+	// Hex rooms require integral axial targets (interim tools/spatial#926
+	// enforcement — see isIntegralAxialPosition). This is the SHARED path
+	// for both the Move verb and Pump's IntentMoveTo execution: a
+	// fractional target from either source is rejected here, and Pump's
+	// existing silent-skip contract for a rejected move applies exactly
+	// as it does for an out-of-bounds one — no special case needed there.
+	if !isIntegralAxialPosition(room.GetGrid(), to) {
+		return spatial.Position{}, fmt.Errorf("movemember: target is not an integral axial cell: %w", ErrBadPlacement)
 	}
 
 	// Attempt the spatial move via managed seam using MoveEntity
@@ -1404,6 +1464,14 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 	// Players cannot carry deciders (design law C2)
 	if in.Member.Kind == KindPlayer && in.Member.Decider != nil {
 		return nil, fmt.Errorf("join: player %s cannot carry a decider: %w", in.Member.ID, ErrNoMember)
+	}
+
+	// Hex rooms require integral axial join positions (interim
+	// tools/spatial#926 enforcement — see isIntegralAxialPosition). A
+	// nonexistent room is left to PlaceEntity's own failure below,
+	// unrelated to this check.
+	if room, ok := e.orchestrator.GetRoom(in.Member.Room); ok && !isIntegralAxialPosition(room.GetGrid(), in.Member.Position) {
+		return nil, fmt.Errorf("join: position is not an integral axial cell: %w", ErrBadPlacement)
 	}
 
 	// Place the new member via managed seam

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -658,6 +658,223 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	}, nil
 }
 
+// Traverse moves a member across a connection from their current endpoint to
+// the connection's OTHER endpoint, in the other room. The member must be
+// standing EXACTLY on one of the connection's two endpoints; connections are
+// bidirectional (T1 law), so traversal works in either direction through the
+// same connection. Validation order (R5 atomicity): nil input → closed →
+// not a member → connection not found → endpoint mismatch (wrong room or
+// wrong position, either rejects the same way).
+//
+// The spatial layer genuinely moves the entity between rooms: RemoveEntity
+// from the departure room, then PlaceEntity into the arrival room — the
+// SAME two managed seams Exit and Join already use individually, just
+// composed. This matters: omitting RemoveEntity leaks the entity in the
+// departure room's registry even though it's invisible to Members/View
+// (see TestExitThenRejoinSameID's doc comment — the wave-1 lesson).
+// Composing the two proven seams here means the lesson can't regress.
+//
+// The clock is NOT advanced — traversal is an activity, not time (law T4).
+// Sight refreshes for ALL members in one refreshSight call: since
+// refreshSight scopes each observer's percept to members currently in
+// THEIR OWN room, updating member.Room before the refresh is sufficient —
+// departure-room observers naturally stop seeing the traverser (intel's
+// existing complete-percept contract ghosts them at their last-known
+// position, the departure endpoint) and arrival-room observers naturally
+// gain them Current. No per-room special-casing needed, and sight cannot
+// cross the opening in either direction: rooms are separate spatial
+// containers with no shared geometry (spatial ADR-0015), so there is no
+// code path by which an observer's line-of-sight computation — scoped
+// entirely to entities in their own room — could see into the other room.
+//
+// Ending evaluation mirrors Move exactly, evaluated against the ARRIVAL
+// room/position: unfiltered ReachedPosition triggers fire for player
+// members only; member-filtered triggers fire for the named member
+// regardless of kind.
+func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
+	// Validation order
+	if in == nil {
+		return nil, fmt.Errorf("traverse: %w", ErrNilInput)
+	}
+
+	if e.outcome != nil {
+		return nil, fmt.Errorf("traverse: %w", ErrClosed)
+	}
+
+	member, ok := e.members[in.Member]
+	if !ok {
+		return nil, fmt.Errorf("traverse: %w", ErrNotMember)
+	}
+
+	var conn *ConnectionInput
+	for i := range e.connectionsInput {
+		if e.connectionsInput[i].ID == in.Connection {
+			conn = &e.connectionsInput[i]
+			break
+		}
+	}
+	if conn == nil {
+		return nil, fmt.Errorf("traverse: connection %s not found: %w", in.Connection, ErrNoConnection)
+	}
+
+	room, ok := e.orchestrator.GetRoom(member.Room)
+	if !ok {
+		return nil, fmt.Errorf("traverse: %w", ErrBadPlacement)
+	}
+	fromPos, ok := room.GetEntityPosition(string(in.Member))
+	if !ok {
+		return nil, fmt.Errorf("traverse: %w", ErrBadPlacement)
+	}
+	fromRoom := member.Room
+
+	// The member must be standing exactly on one of the connection's two
+	// endpoints. Determine direction from WHICH endpoint they're on — the
+	// arrival side is always the connection's OTHER endpoint (never the
+	// one the member is currently standing on).
+	var toRoom string
+	var toPos spatial.Position
+	switch {
+	case fromRoom == conn.From && fromPos.X == conn.FromPosition.X && fromPos.Y == conn.FromPosition.Y:
+		toRoom, toPos = conn.To, conn.ToPosition
+	case fromRoom == conn.To && fromPos.X == conn.ToPosition.X && fromPos.Y == conn.ToPosition.Y:
+		toRoom, toPos = conn.From, conn.FromPosition
+	default:
+		return nil, fmt.Errorf("traverse: member %s is not at connection %s's endpoint: %w", in.Member, in.Connection, ErrBadPlacement)
+	}
+
+	// Move the entity between rooms via the two proven managed seams.
+	_, err := e.orchestrator.RemoveEntity(&spatial.RemoveEntityInput{
+		RoomID:   spatial.RoomID(fromRoom),
+		EntityID: core.EntityID(in.Member),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("traverse remove entity: %w: %w", ErrBadPlacement, err)
+	}
+
+	entity := &memberEntity{
+		id:   string(in.Member),
+		kind: member.Kind,
+	}
+	_, err = e.orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
+		RoomID:   spatial.RoomID(toRoom),
+		Entity:   entity,
+		Position: toPos,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("traverse place entity: %w: %w", ErrBadPlacement, err)
+	}
+
+	// Update the member's room before refreshSight — see the doc comment
+	// above for why this alone is sufficient for correct two-room percepts.
+	member.Room = toRoom
+
+	memberIDs := make([]MemberID, 0, len(e.members))
+	for id := range e.members {
+		memberIDs = append(memberIDs, id)
+	}
+	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
+
+	intelDeltas, err := e.refreshSight(memberIDs)
+	if err != nil {
+		return nil, fmt.Errorf("traverse refresh sight: %w", err)
+	}
+
+	// Record the traversal beat. The clock is NOT advanced (law T4).
+	clockReadingInt := e.clock.ToData().HighWater
+	clockReadingForBeat := uint64(clockReadingInt)
+	beatPayload := map[string]interface{}{
+		"beat":       "traversed",
+		"member":     string(in.Member),
+		"connection": in.Connection,
+		"room":       toRoom,
+		"position":   toPos,
+	}
+	beatBytes, _ := json.Marshal(beatPayload)
+
+	appendOut, err := e.story.Append(&record.AppendInput{
+		At:       clockReadingForBeat,
+		Audience: memberIDs,
+		Tags:     map[string]string{"tag": "movement"},
+		Payload:  beatBytes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("traverse append beat: %w", err)
+	}
+
+	seqNum := appendOut.Seq
+
+	// Evaluate ReachedPosition endings against the ARRIVAL room/position.
+	var firedOutcome *Outcome
+	for _, de := range e.endings {
+		endingKey, trigger := de.key, de.trigger
+		reachedPosTrigger, ok := trigger.(TriggerReachedPosition)
+		if !ok {
+			continue // Not a ReachedPosition trigger
+		}
+
+		if reachedPosTrigger.Room != toRoom {
+			continue // Different room
+		}
+
+		if reachedPosTrigger.Position.X != toPos.X || reachedPosTrigger.Position.Y != toPos.Y {
+			continue // Different position
+		}
+
+		// Check member filter: empty = any player member; non-empty = specific member
+		if reachedPosTrigger.Member != "" && reachedPosTrigger.Member != in.Member {
+			continue // Member filter doesn't match
+		}
+
+		// Member filter passes (empty or matches) but we need to check kind
+		if reachedPosTrigger.Member == "" && member.Kind != KindPlayer {
+			continue // Empty filter means players only, but traversing member is not player
+		}
+
+		// Ending fires! Build the outcome with all members' current positions
+		memberOutcomes := e.buildMemberOutcomes()
+
+		e.outcome = &Outcome{
+			Ending:  endingKey,
+			At:      clockReadingForBeat,
+			Members: memberOutcomes,
+		}
+		// Return a deep copy of the outcome (mutation-proof)
+		outcomeMembers := make([]MemberOutcome, len(e.outcome.Members))
+		for i, m := range e.outcome.Members {
+			outcomeMembers[i] = MemberOutcome{
+				ID:       m.ID,
+				Room:     m.Room,
+				Position: m.Position,
+			}
+		}
+		firedOutcome = &Outcome{
+			Ending:  e.outcome.Ending,
+			At:      e.outcome.At,
+			Members: outcomeMembers,
+		}
+		break
+	}
+
+	return &TraverseOutput{
+		Traversed: struct {
+			Member   MemberID
+			FromRoom string
+			From     spatial.Position
+			ToRoom   string
+			To       spatial.Position
+		}{
+			Member:   in.Member,
+			FromRoom: fromRoom,
+			From:     fromPos,
+			ToRoom:   toRoom,
+			To:       toPos,
+		},
+		IntelDeltas: intelDeltas,
+		Seq:         seqNum,
+		Outcome:     firedOutcome,
+	}, nil
+}
+
 // Pump advances the world by one tick: the exploration clock advances,
 // each monster member (in deterministic order) acts on its own intel via Decider,
 // the complete sight refresh happens once, and the story accrues tick and move beats.

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -66,19 +66,62 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 	return out
 }
 
-// positionInBounds reports whether (x, y) lies within a room of the given
-// width and height — the same rule applied to member placement: non-negative
-// and strictly less than each dimension. Shared by connection validation at
-// both Setup and Load.
-func positionInBounds(x, y float64, width, height int) bool {
-	return x >= 0 && y >= 0 && x < float64(width) && y < float64(height)
+// buildRoomGrid constructs the spatial Grid for a room's declared shape.
+// Called only after validation has confirmed Grid is one of the three known
+// GridShape values; the switch's default (square) is therefore unreachable
+// in practice and exists only so an unvalidated caller degrades gracefully
+// rather than panicking.
+func buildRoomGrid(shape spatial.GridShape, width, height int) spatial.Grid {
+	switch shape {
+	case spatial.GridShapeHex:
+		return spatial.NewHexGrid(spatial.HexGridConfig{Width: float64(width), Height: float64(height)})
+	case spatial.GridShapeGridless:
+		return spatial.NewGridlessRoom(spatial.GridlessConfig{Width: float64(width), Height: float64(height)})
+	default:
+		return spatial.NewSquareGrid(spatial.SquareGridConfig{Width: float64(width), Height: float64(height)})
+	}
+}
+
+// buildValidRoomGrids rejects room defects before construction (R5
+// atomicity — no observable state until Setup succeeds): empty or
+// duplicate room ID, and an unrecognized grid shape. On success, returns
+// each room's constructed Grid keyed by room ID — reused both for
+// downstream bounds checks (connections, and transitively member
+// placement via spatial's own PlaceEntity) and later in NewEncounter's
+// room-construction loop, so a room's shape is built exactly once and
+// every consumer asks the SAME grid. A hardcoded rectangle bounds check
+// would silently diverge from GridlessRoom's inclusive upper bound
+// (tools/spatial/gridless.go: IsValidPosition uses x <= Width, not
+// x < Width like Square/Hex). Reuses ErrNoField — a malformed room list
+// is as unusable as an empty one.
+func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
+	seenIDs := make(map[string]bool, len(rooms))
+	grids := make(map[string]spatial.Grid, len(rooms))
+	for _, r := range rooms {
+		if r.ID == "" {
+			return nil, fmt.Errorf("newencounter: room has empty id: %w", ErrNoField)
+		}
+		if seenIDs[r.ID] {
+			return nil, fmt.Errorf("newencounter: duplicate room %q: %w", r.ID, ErrNoField)
+		}
+		seenIDs[r.ID] = true
+
+		switch r.Grid {
+		case spatial.GridShapeSquare, spatial.GridShapeHex, spatial.GridShapeGridless:
+		default:
+			return nil, fmt.Errorf("newencounter: room %q has unknown grid shape %d: %w", r.ID, r.Grid, ErrNoField)
+		}
+		grids[r.ID] = buildRoomGrid(r.Grid, r.Width, r.Height)
+	}
+	return grids, nil
 }
 
 // validateConnectionInputs rejects connection defects before construction
 // (R5 atomicity — no observable state until Setup succeeds): empty or
 // duplicate ID, an unknown or self-referencing room, and an endpoint outside
-// its room's bounds or on an occluder position.
-func validateConnectionInputs(rooms []RoomInput, connections []ConnectionInput) error {
+// its room's bounds (per that room's own constructed Grid, from roomGrids —
+// see buildValidRoomGrids) or on an occluder position.
+func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Grid, connections []ConnectionInput) error {
 	roomsByID := make(map[string]RoomInput, len(rooms))
 	for _, r := range rooms {
 		roomsByID[r.ID] = r
@@ -106,10 +149,10 @@ func validateConnectionInputs(rooms []RoomInput, connections []ConnectionInput) 
 			return fmt.Errorf("newencounter: connection %q connects room %q to itself: %w", c.ID, c.From, ErrBadConnection)
 		}
 
-		if !positionInBounds(c.FromPosition.X, c.FromPosition.Y, fromRoom.Width, fromRoom.Height) {
+		if !roomGrids[c.From].IsValidPosition(c.FromPosition) {
 			return fmt.Errorf("newencounter: connection %q from-position out of bounds: %w", c.ID, ErrBadConnection)
 		}
-		if !positionInBounds(c.ToPosition.X, c.ToPosition.Y, toRoom.Width, toRoom.Height) {
+		if !roomGrids[c.To].IsValidPosition(c.ToPosition) {
 			return fmt.Errorf("newencounter: connection %q to-position out of bounds: %w", c.ID, ErrBadConnection)
 		}
 
@@ -130,8 +173,9 @@ func validateConnectionInputs(rooms []RoomInput, connections []ConnectionInput) 
 // NewEncounter constructs and initializes an encounter from SetupInput.
 // Validation order (first failure wins, R5 atomicity): nil input, no rooms,
 // no endings, reserved ending key, empty member ID, duplicate member IDs,
-// connection defects (empty/duplicate ID, unknown room, self-connection,
-// endpoint out of bounds or on an occluder), spatial placement errors.
+// room defects (empty/duplicate ID, unrecognized grid shape), connection
+// defects (empty/duplicate ID, unknown room, self-connection, endpoint out
+// of bounds or on an occluder), spatial placement errors.
 func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// Validation order: nil, no rooms, no endings, reserved ending, empty ID, duplicates
 	if in == nil {
@@ -170,9 +214,19 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		}
 	}
 
+	// Check rooms: unique non-empty IDs, recognized grid shape. roomGrids
+	// holds each room's constructed Grid, reused below for connection
+	// bounds validation and again in the room-construction loop so a
+	// room's shape is built exactly once.
+	roomGrids, err := buildValidRoomGrids(in.Field.Rooms)
+	if err != nil {
+		return nil, err
+	}
+
 	// Check connections: unique non-empty IDs, endpoints resolve to distinct
-	// declared rooms, endpoints in bounds and off any occluder.
-	if err := validateConnectionInputs(in.Field.Rooms, in.Field.Connections); err != nil {
+	// declared rooms, endpoints in bounds (per the room's own grid) and off
+	// any occluder.
+	if err = validateConnectionInputs(in.Field.Rooms, roomGrids, in.Field.Connections); err != nil {
 		return nil, err
 	}
 
@@ -192,7 +246,6 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	}
 
 	// Build clock and intel
-	var err error
 	e.clock, err = clock.NewTick()
 	if err != nil {
 		return nil, fmt.Errorf("newencounter clock: %w", err)
@@ -215,17 +268,14 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		Layout: spatial.LayoutTypeOrganic,
 	})
 
-	// Create all rooms
+	// Create all rooms, reusing each room's already-constructed Grid
+	// (roomGrids, built above) so validation and placement agree exactly.
 	roomMap := make(map[string]*spatial.BasicRoom)
 	for _, ri := range in.Field.Rooms {
-		grid := spatial.NewSquareGrid(spatial.SquareGridConfig{
-			Width:  float64(ri.Width),
-			Height: float64(ri.Height),
-		})
 		room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
 			ID:   ri.ID,
 			Type: "room",
-			Grid: grid,
+			Grid: roomGrids[ri.ID],
 		})
 		err = e.orchestrator.AddRoom(room)
 		if err != nil {

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -54,7 +54,8 @@ type Encounter struct {
 // NewEncounter constructs and initializes an encounter from SetupInput.
 // Validation order (first failure wins, R5 atomicity): nil input, no rooms,
 // no endings, reserved ending key, empty member ID, duplicate member IDs,
-// spatial placement errors.
+// connection defects (empty/duplicate ID, unknown room, self-connection,
+// endpoint out of bounds or on an occluder), spatial placement errors.
 
 // deepCopyRoomInputs snapshots the caller's room descriptions — the
 // persistence source must never alias caller-owned slices (T6 review
@@ -69,6 +70,67 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 		out[i] = rc
 	}
 	return out
+}
+
+// positionInBounds reports whether (x, y) lies within a room of the given
+// width and height — the same rule applied to member placement: non-negative
+// and strictly less than each dimension. Shared by connection validation at
+// both Setup and Load.
+func positionInBounds(x, y float64, width, height int) bool {
+	return x >= 0 && y >= 0 && x < float64(width) && y < float64(height)
+}
+
+// validateConnectionInputs rejects connection defects before construction
+// (R5 atomicity — no observable state until Setup succeeds): empty or
+// duplicate ID, an unknown or self-referencing room, and an endpoint outside
+// its room's bounds or on an occluder position.
+func validateConnectionInputs(rooms []RoomInput, connections []ConnectionInput) error {
+	roomsByID := make(map[string]RoomInput, len(rooms))
+	for _, r := range rooms {
+		roomsByID[r.ID] = r
+	}
+
+	seenIDs := make(map[string]bool, len(connections))
+	for _, c := range connections {
+		if c.ID == "" {
+			return fmt.Errorf("newencounter: connection has empty id: %w", ErrBadConnection)
+		}
+		if seenIDs[c.ID] {
+			return fmt.Errorf("newencounter: duplicate connection %q: %w", c.ID, ErrBadConnection)
+		}
+		seenIDs[c.ID] = true
+
+		fromRoom, ok := roomsByID[c.From]
+		if !ok {
+			return fmt.Errorf("newencounter: connection %q references unknown room %q: %w", c.ID, c.From, ErrBadConnection)
+		}
+		toRoom, ok := roomsByID[c.To]
+		if !ok {
+			return fmt.Errorf("newencounter: connection %q references unknown room %q: %w", c.ID, c.To, ErrBadConnection)
+		}
+		if c.From == c.To {
+			return fmt.Errorf("newencounter: connection %q connects room %q to itself: %w", c.ID, c.From, ErrBadConnection)
+		}
+
+		if !positionInBounds(c.FromPosition.X, c.FromPosition.Y, fromRoom.Width, fromRoom.Height) {
+			return fmt.Errorf("newencounter: connection %q from-position out of bounds: %w", c.ID, ErrBadConnection)
+		}
+		if !positionInBounds(c.ToPosition.X, c.ToPosition.Y, toRoom.Width, toRoom.Height) {
+			return fmt.Errorf("newencounter: connection %q to-position out of bounds: %w", c.ID, ErrBadConnection)
+		}
+
+		for _, occ := range fromRoom.Occluders {
+			if occ.X == c.FromPosition.X && occ.Y == c.FromPosition.Y {
+				return fmt.Errorf("newencounter: connection %q from-position on occluder: %w", c.ID, ErrBadConnection)
+			}
+		}
+		for _, occ := range toRoom.Occluders {
+			if occ.X == c.ToPosition.X && occ.Y == c.ToPosition.Y {
+				return fmt.Errorf("newencounter: connection %q to-position on occluder: %w", c.ID, ErrBadConnection)
+			}
+		}
+	}
+	return nil
 }
 
 func NewEncounter(in *SetupInput) (*Encounter, error) {
@@ -109,6 +171,17 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		}
 	}
 
+	// Check connections: unique non-empty IDs, endpoints resolve to distinct
+	// declared rooms, endpoints in bounds and off any occluder.
+	if err := validateConnectionInputs(in.Field.Rooms, in.Field.Connections); err != nil {
+		return nil, err
+	}
+
+	// Connections are stored sorted by ID (C8 determinism — order is
+	// observable in ToData).
+	connectionsInput := append([]ConnectionInput(nil), in.Field.Connections...)
+	sort.Slice(connectionsInput, func(i, j int) bool { return connectionsInput[i].ID < connectionsInput[j].ID })
+
 	// After validation passes, construct (R5: no observable state until success)
 	e := &Encounter{
 		members:          make(map[MemberID]*Member),
@@ -116,7 +189,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		deciders:         make(map[MemberID]Decider),
 		endings:          nil,
 		fieldInput:       deepCopyRoomInputs(in.Field.Rooms),
-		connectionsInput: append([]ConnectionInput(nil), in.Field.Connections...),
+		connectionsInput: connectionsInput,
 	}
 
 	// Build clock and intel

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -476,6 +476,134 @@ func (s *EncounterTestSuite) TestConnectionEndpointBoundsBoundaries() {
 	})
 }
 
+// validRoomSetup returns a fresh SetupInput with a single valid square room
+// and one member — the base for TestSetupRoomValidation's one-defect rows.
+func validRoomSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 5, Height: 5},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
+// TestSetupRoomValidation pins room-level defects at the Setup seam
+// (#922 T1.5, deferred from the Opus T1 review): empty room ID, duplicate
+// room ID, and an unrecognized grid shape all reject with ErrNoField — a
+// malformed room list is as unusable as an empty one.
+func (s *EncounterTestSuite) TestSetupRoomValidation() {
+	cases := []struct {
+		name     string
+		mutate   func(in *encounter.SetupInput)
+		fragment string
+	}{
+		{"room has empty id", func(in *encounter.SetupInput) {
+			in.Field.Rooms[0].ID = ""
+		}, "room has empty id"},
+		{"duplicate room id", func(in *encounter.SetupInput) {
+			in.Field.Rooms = append(in.Field.Rooms, in.Field.Rooms[0])
+		}, "duplicate room"},
+		{"room has unknown grid shape", func(in *encounter.SetupInput) {
+			in.Field.Rooms[0].Grid = spatial.GridShape(99)
+		}, "unknown grid shape"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			setup := validRoomSetup()
+			tc.mutate(setup)
+			_, err := encounter.NewEncounter(setup)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrNoField, tc.name)
+			s.Require().Contains(err.Error(), tc.fragment,
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	// The valid base itself must construct — the one-defect discipline only
+	// means something if zero defects pass.
+	_, err := encounter.NewEncounter(validRoomSetup())
+	s.Require().NoError(err, "the valid base fixture must construct")
+}
+
+// TestHexRoomBounds pins that a hex-shaped room's member-placement bounds
+// defer to the room's own constructed Grid rather than hardcoded rectangle
+// math. HexGrid (tools/spatial/hex_grid.go:54-57) — the offset column/row
+// coordinate hex grid this module constructs for GridShapeHex — uses the
+// IDENTICAL non-negative/strictly-less-than-dimension rule as SquareGrid,
+// so a hex room's accept/reject boundary values are numerically the same
+// shape as square's. This test therefore pins that hex construction
+// succeeds and Width/Height correctly bound the constructed grid; it does
+// NOT by itself prove hex (vs. square) construction happened — see
+// TestGridlessRoomInclusiveBounds for a shape whose validity genuinely
+// diverges from the rectangle math this task deletes.
+func (s *EncounterTestSuite) TestHexRoomBounds() {
+	hexSetup := func(pos spatial.Position) *encounter.SetupInput {
+		return &encounter.SetupInput{
+			Field: encounter.FieldInput{
+				Rooms: []encounter.RoomInput{
+					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
+				},
+			},
+			Members: []encounter.MemberInput{
+				{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: pos},
+			},
+			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		}
+	}
+
+	s.Run("position within hex bounds accepted", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 3, Y: 2})) // Width-1, Height-1
+		s.Require().NoError(err)
+	})
+
+	s.Run("position at width boundary rejected", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 4, Y: 0}))
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+	})
+}
+
+// TestGridlessRoomInclusiveBounds pins the one shape whose validity
+// genuinely diverges from the rectangle math this task deletes:
+// GridlessRoom.IsValidPosition (tools/spatial/gridless.go:33-36) uses an
+// INCLUSIVE upper bound (x <= Width), unlike Square/Hex's exclusive
+// (x < Width). A position exactly AT Width — rejected for square/hex — is
+// the sharpest available proof that bounds checks ask the room's OWN
+// constructed grid rather than a hardcoded rectangle: a "grid shape
+// ignored, always builds square" mutant would reject this position; the
+// correct code accepts it.
+func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
+	gridlessSetup := func(pos spatial.Position) *encounter.SetupInput {
+		return &encounter.SetupInput{
+			Field: encounter.FieldInput{
+				Rooms: []encounter.RoomInput{
+					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
+				},
+			},
+			Members: []encounter.MemberInput{
+				{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: pos},
+			},
+			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		}
+	}
+
+	s.Run("position exactly at Width is accepted (inclusive upper bound)", func() {
+		_, err := encounter.NewEncounter(gridlessSetup(spatial.Position{X: 4, Y: 0}))
+		s.Require().NoError(err, "gridless rooms accept x == Width; a rectangle-math fallback would reject this")
+	})
+
+	s.Run("position negative is still rejected", func() {
+		_, err := encounter.NewEncounter(gridlessSetup(spatial.Position{X: -1, Y: 0}))
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+	})
+}
+
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 	s.Run("opening beat reaches all members via Story", func() {
 		// Arrange

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -274,6 +274,8 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		}
 		_, err := encounter.NewEncounter(setup)
 		s.Require().ErrorIs(err, encounter.ErrNoMember)
+		s.Require().Contains(err.Error(), "duplicate member alice",
+			"the duplicate-ID rejection must name the duplicated ID, not echo the empty-ID message")
 	})
 
 	s.Run("atomicity: after error, valid setup works", func() {
@@ -308,22 +310,26 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	})
 }
 
-// validConnSetup returns a fresh SetupInput with two rooms (r1 carries an
-// occluder at (2,2), r2 carries an occluder at (3,3)) and one fully valid
-// connection between them — the base for TestSetupConnectionValidation's
-// one-defect rows, mirroring the same defect classes rejected at Load
-// (TestLoadRejections).
+// validConnSetup returns a fresh SetupInput with two DELIBERATELY
+// mismatched rooms — r1 is 10x4 (occluder at (2,2)), r2 is 3x9 (occluder
+// at (1,3)) — and one fully valid connection between them, with
+// FromPosition{7,1} valid ONLY in r1 and ToPosition{1,7} valid ONLY in r2.
+// Same-sized rooms and equal From/To positions would make a check that
+// validates an endpoint against the WRONG room (or a Load-side From/To
+// transposition) invisible: this is the base for
+// TestSetupConnectionValidation's one-defect rows, mirroring the same
+// defect classes rejected at Load (TestLoadRejections).
 func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
-				{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
-				{ID: "r2", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}}},
+				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
+				{ID: "r2", Width: 3, Height: 9, Occluders: []spatial.Position{{X: 1, Y: 3}}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "c1", From: "r1", To: "r2",
-					FromPosition: spatial.Position{X: 0, Y: 0},
-					ToPosition:   spatial.Position{X: 0, Y: 0}},
+					FromPosition: spatial.Position{X: 7, Y: 1},
+					ToPosition:   spatial.Position{X: 1, Y: 7}},
 			},
 		},
 		Members: []encounter.MemberInput{
@@ -369,7 +375,7 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 			in.Field.Connections[0].FromPosition = spatial.Position{X: 2, Y: 2}
 		}, "from-position on occluder"},
 		{"connection to-position on occluder", func(in *encounter.SetupInput) {
-			in.Field.Connections[0].ToPosition = spatial.Position{X: 3, Y: 3}
+			in.Field.Connections[0].ToPosition = spatial.Position{X: 1, Y: 3}
 		}, "to-position on occluder"},
 	}
 	for _, tc := range cases {
@@ -385,9 +391,89 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 	}
 
 	// The valid base itself must construct — the one-defect discipline only
-	// means something if zero defects pass.
-	_, err := encounter.NewEncounter(validConnSetup())
+	// means something if zero defects pass. Since FromPosition{7,1} is valid
+	// ONLY in r1 and ToPosition{1,7} valid ONLY in r2, this positive control
+	// also pins that each endpoint is checked against ITS OWN room: a check
+	// wired to the wrong room would reject this valid connection.
+	enc, err := encounter.NewEncounter(validConnSetup())
 	s.Require().NoError(err, "the valid base fixture must construct")
+	data := enc.ToData()
+	s.Require().Len(data.Field.Connections, 1)
+	s.Equal(encounter.PositionData{X: 7, Y: 1}, data.Field.Connections[0].FromPosition,
+		"from-position must survive unswapped")
+	s.Equal(encounter.PositionData{X: 1, Y: 7}, data.Field.Connections[0].ToPosition,
+		"to-position must survive unswapped")
+}
+
+// connBoundsSetup returns a fresh SetupInput with a 4x3 room r1 (valid
+// coordinates 0..3 x 0..2) and an r2 large enough to always hold the
+// connection's fixed ToPosition — used to pin positionInBounds' strictly-
+// less-than semantics against FromPosition in r1, independent of any
+// cross-room concern (that's validConnSetup's job).
+func connBoundsSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 4, Height: 3},
+				{ID: "r2", Width: 4, Height: 3},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "c1", From: "r1", To: "r2",
+					FromPosition: spatial.Position{X: 0, Y: 0},
+					ToPosition:   spatial.Position{X: 0, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
+// TestConnectionEndpointBoundsBoundaries pins positionInBounds' strictly-
+// less-than semantics at the Setup seam (#922 T1 Opus review, minor M3/M4):
+// a coordinate exactly at the room's Width/Height is out of bounds (valid
+// range is 0..dimension-1, matching member placement), a negative coordinate
+// is out of bounds, and Width-1/Height-1 — the last valid cell — is accepted.
+func (s *EncounterTestSuite) TestConnectionEndpointBoundsBoundaries() {
+	s.Run("X exactly at width is rejected", func() {
+		setup := connBoundsSetup()
+		setup.Field.Connections[0].FromPosition = spatial.Position{X: 4, Y: 0}
+		_, err := encounter.NewEncounter(setup)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("Y exactly at height is rejected", func() {
+		setup := connBoundsSetup()
+		setup.Field.Connections[0].FromPosition = spatial.Position{X: 0, Y: 3}
+		_, err := encounter.NewEncounter(setup)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("negative X is rejected", func() {
+		setup := connBoundsSetup()
+		setup.Field.Connections[0].FromPosition = spatial.Position{X: -1, Y: 0}
+		_, err := encounter.NewEncounter(setup)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("negative Y is rejected", func() {
+		setup := connBoundsSetup()
+		setup.Field.Connections[0].FromPosition = spatial.Position{X: 0, Y: -1}
+		_, err := encounter.NewEncounter(setup)
+		s.Require().ErrorIs(err, encounter.ErrBadConnection)
+		s.Require().Contains(err.Error(), "from-position out of bounds")
+	})
+
+	s.Run("Width-1,Height-1 is accepted (positive control)", func() {
+		setup := connBoundsSetup()
+		setup.Field.Connections[0].FromPosition = spatial.Position{X: 3, Y: 2}
+		_, err := encounter.NewEncounter(setup)
+		s.Require().NoError(err, "the last valid cell must be accepted")
+	})
 }
 
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -309,15 +309,16 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 }
 
 // validConnSetup returns a fresh SetupInput with two rooms (r1 carries an
-// occluder at (2,2)) and one fully valid connection between them — the base
-// for TestSetupConnectionValidation's one-defect rows, mirroring the same
-// defect classes rejected at Load (TestLoadRejections).
+// occluder at (2,2), r2 carries an occluder at (3,3)) and one fully valid
+// connection between them — the base for TestSetupConnectionValidation's
+// one-defect rows, mirroring the same defect classes rejected at Load
+// (TestLoadRejections).
 func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
-				{ID: "r2", Width: 5, Height: 5},
+				{ID: "r2", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "c1", From: "r1", To: "r2",
@@ -335,6 +336,8 @@ func validConnSetup() *encounter.SetupInput {
 // TestSetupConnectionValidation mirrors TestLoadRejections' connection
 // defect classes at the Setup seam: each case breaks exactly one thing
 // about an otherwise-valid connection and must reject with ErrBadConnection.
+// Fragments name the missing room where applicable — a check neutered in
+// favor of the coincidental zero-value-room bounds fallback must not pass.
 func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 	cases := []struct {
 		name     string
@@ -347,18 +350,27 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 		{"duplicate connection id", func(in *encounter.SetupInput) {
 			in.Field.Connections = append(in.Field.Connections, in.Field.Connections[0])
 		}, "duplicate connection"},
-		{"connection unknown room", func(in *encounter.SetupInput) {
+		{"connection unknown from room", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].From = "nowhere"
+		}, `unknown room "nowhere"`},
+		{"connection unknown to room", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].To = "nowhere"
-		}, "unknown room"},
+		}, `unknown room "nowhere"`},
 		{"connection self-connection", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].To = "r1"
 		}, "itself"},
-		{"connection endpoint out of bounds", func(in *encounter.SetupInput) {
+		{"connection from-position out of bounds", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].FromPosition = spatial.Position{X: 99, Y: 99}
 		}, "from-position out of bounds"},
-		{"connection endpoint on occluder", func(in *encounter.SetupInput) {
+		{"connection to-position out of bounds", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].ToPosition = spatial.Position{X: 99, Y: 99}
+		}, "to-position out of bounds"},
+		{"connection from-position on occluder", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].FromPosition = spatial.Position{X: 2, Y: 2}
 		}, "from-position on occluder"},
+		{"connection to-position on occluder", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].ToPosition = spatial.Position{X: 3, Y: 3}
+		}, "to-position on occluder"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -399,9 +399,9 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 	s.Require().NoError(err, "the valid base fixture must construct")
 	data := enc.ToData()
 	s.Require().Len(data.Field.Connections, 1)
-	s.Equal(encounter.PositionData{X: 7, Y: 1}, data.Field.Connections[0].FromPosition,
+	s.Equal(&encounter.PositionData{X: 7, Y: 1}, data.Field.Connections[0].FromPosition,
 		"from-position must survive unswapped")
-	s.Equal(encounter.PositionData{X: 1, Y: 7}, data.Field.Connections[0].ToPosition,
+	s.Equal(&encounter.PositionData{X: 1, Y: 7}, data.Field.Connections[0].ToPosition,
 		"to-position must survive unswapped")
 }
 

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -29,7 +29,7 @@ const (
 // simpleDecider is a minimal test decider that holds.
 type simpleDecider struct{}
 
-func (s *simpleDecider) Decide(view []intel.Holding) (encounter.Intent, error) {
+func (s *simpleDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 	return encounter.IntentHold{}, nil
 }
 

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -407,8 +407,8 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 
 // connBoundsSetup returns a fresh SetupInput with a 4x3 room r1 (valid
 // coordinates 0..3 x 0..2) and an r2 large enough to always hold the
-// connection's fixed ToPosition — used to pin positionInBounds' strictly-
-// less-than semantics against FromPosition in r1, independent of any
+// connection's fixed ToPosition — used to pin the square grid's strictly-
+// less-than bounds semantics against FromPosition in r1, independent of any
 // cross-room concern (that's validConnSetup's job).
 func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
@@ -430,8 +430,8 @@ func connBoundsSetup() *encounter.SetupInput {
 	}
 }
 
-// TestConnectionEndpointBoundsBoundaries pins positionInBounds' strictly-
-// less-than semantics at the Setup seam (#922 T1 Opus review, minor M3/M4):
+// TestConnectionEndpointBoundsBoundaries pins the square grid's strictly-
+// less-than bounds semantics at the Setup seam (#922 T1 Opus review, minor M3/M4):
 // a coordinate exactly at the room's Width/Height is out of bounds (valid
 // range is 0..dimension-1, matching member placement), a negative coordinate
 // is out of bounds, and Width-1/Height-1 — the last valid cell — is accepted.
@@ -1330,6 +1330,390 @@ func (s *EncounterTestSuite) TestMoveSpatialRejectionAtomic() {
 	s.Require().NoError(err, "alice still moves from her original position")
 }
 
+// Traverse tests (Task 2)
+
+// newTwoRoomEncounterWithConnection returns an encounter with room-a and
+// room-b connected by "door1": FromPosition {9,5} in room-a, ToPosition
+// {0,5} in room-b — DELIBERATELY asymmetric endpoints (T1 review lesson)
+// so a from/to transposition mutant (landing the traverser back at the
+// DEPARTURE endpoint instead of the far one) is observable. alice starts
+// AT room-a's door endpoint, ready to traverse. bob starts adjacent to
+// her in room-a (mutual line of sight, for ghost-at-threshold pins).
+// goblin starts in room-b adjacent to the arrival endpoint (for
+// arrival-Current and T3 pins).
+func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "door1", From: "room-a", To: "room-b",
+					FromPosition: spatial.Position{X: 9, Y: 5},
+					ToPosition:   spatial.Position{X: 0, Y: 5}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: "room-a", Position: spatial.Position{X: 9, Y: 5}},
+			{ID: bob, Kind: encounter.KindPlayer, Room: "room-a", Position: spatial.Position{X: 8, Y: 5}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: "room-b", Position: spatial.Position{X: 1, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "withdrawn", Trigger: encounter.TriggerExternal{}},
+		},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// TestTraverseValidation pins the guard order (nil input, closed, unknown
+// member, unknown connection, endpoint mismatch) and that each rejection
+// uses the correct sentinel.
+func (s *EncounterTestSuite) TestTraverseValidation() {
+	s.Run("nil input returns ErrNilInput", func() {
+		enc := s.newTwoRoomEncounterWithConnection()
+		_, err := enc.Traverse(nil)
+		s.Require().ErrorIs(err, encounter.ErrNilInput)
+	})
+
+	s.Run("closed encounter returns ErrClosed", func() {
+		enc := s.newTwoRoomEncounterWithConnection()
+		_, err := enc.End(&encounter.EndInput{Ending: "withdrawn"})
+		s.Require().NoError(err)
+
+		_, err = enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+		s.Require().ErrorIs(err, encounter.ErrClosed)
+	})
+
+	s.Run("unknown member returns ErrNotMember", func() {
+		enc := s.newTwoRoomEncounterWithConnection()
+		_, err := enc.Traverse(&encounter.TraverseInput{Member: core.EntityID("nobody"), Connection: "door1"})
+		s.Require().ErrorIs(err, encounter.ErrNotMember)
+	})
+
+	s.Run("unknown connection returns ErrNoConnection", func() {
+		enc := s.newTwoRoomEncounterWithConnection()
+		_, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "no-such-door"})
+		s.Require().ErrorIs(err, encounter.ErrNoConnection)
+	})
+
+	s.Run("off-threshold position (right room, wrong cell) returns ErrBadPlacement", func() {
+		enc := s.newTwoRoomEncounterWithConnection()
+		// bob is in room-a (the connection's From room) but not at the door.
+		_, err := enc.Traverse(&encounter.TraverseInput{Member: bob, Connection: "door1"})
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+	})
+
+	s.Run("wrong room (connection doesn't touch it) returns ErrBadPlacement", func() {
+		// alice sits at room-a's door COORDINATES, but in room-c — a room
+		// the connection doesn't touch at all. Proves room membership is
+		// checked, not just coordinate equality.
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Field: encounter.FieldInput{
+				Rooms: []encounter.RoomInput{
+					{ID: "room-a", Width: 10, Height: 10},
+					{ID: "room-b", Width: 10, Height: 10},
+					{ID: "room-c", Width: 10, Height: 10},
+				},
+				Connections: []encounter.ConnectionInput{
+					{ID: "door1", From: "room-a", To: "room-b",
+						FromPosition: spatial.Position{X: 9, Y: 5},
+						ToPosition:   spatial.Position{X: 0, Y: 5}},
+				},
+			},
+			Members: []encounter.MemberInput{
+				{ID: alice, Kind: encounter.KindPlayer, Room: "room-c", Position: spatial.Position{X: 9, Y: 5}},
+			},
+			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		})
+		s.Require().NoError(err)
+
+		_, err = enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+	})
+}
+
+// TestTraverseBothDirections pins the threshold-success path in BOTH
+// directions through the same connection (T1 law: connections are
+// bidirectional), asserting room+position after each hop.
+func (s *EncounterTestSuite) TestTraverseBothDirections() {
+	s.Run("room-a to room-b", func() {
+		enc := s.newTwoRoomEncounterWithConnection()
+		out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+		s.Require().NoError(err)
+		s.Equal(alice, out.Traversed.Member)
+		s.Equal("room-a", out.Traversed.FromRoom)
+		s.Equal(spatial.Position{X: 9, Y: 5}, out.Traversed.From)
+		s.Equal("room-b", out.Traversed.ToRoom)
+		s.Equal(spatial.Position{X: 0, Y: 5}, out.Traversed.To)
+
+		members, err := enc.Members()
+		s.Require().NoError(err)
+		found := false
+		for _, m := range members {
+			if m.ID == alice {
+				s.Equal("room-b", m.Room)
+				found = true
+			}
+		}
+		s.True(found, "alice must still be a member, now in room-b")
+	})
+
+	s.Run("room-b to room-a (bidirectional through the same connection)", func() {
+		enc := s.newTwoRoomEncounterWithConnection()
+		_, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+		s.Require().NoError(err)
+
+		out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+		s.Require().NoError(err)
+		s.Equal("room-b", out.Traversed.FromRoom)
+		s.Equal(spatial.Position{X: 0, Y: 5}, out.Traversed.From)
+		s.Equal("room-a", out.Traversed.ToRoom)
+		s.Equal(spatial.Position{X: 9, Y: 5}, out.Traversed.To)
+
+		members, err := enc.Members()
+		s.Require().NoError(err)
+		for _, m := range members {
+			if m.ID == alice {
+				s.Equal("room-a", m.Room)
+			}
+		}
+	})
+}
+
+// TestTraverseGhostAtThreshold pins that a departure-room observer's
+// holding of the traverser fades to a ghost AT THE DEPARTURE ENDPOINT —
+// their last-observed position — not the (never-seen) arrival position.
+func (s *EncounterTestSuite) TestTraverseGhostAtThreshold() {
+	enc := s.newTwoRoomEncounterWithConnection()
+
+	bobBefore, err := enc.View(&encounter.ViewInput{Member: bob})
+	s.Require().NoError(err)
+	s.Require().Len(bobBefore, 1, "bob must see alice before the traverse (geometry precondition)")
+	s.Equal(intel.Current, bobBefore[0].Status)
+
+	_, err = enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+
+	bobAfter, err := enc.View(&encounter.ViewInput{Member: bob})
+	s.Require().NoError(err)
+	s.Require().Len(bobAfter, 1, "the ghost is HELD, not gone")
+	s.Equal(intel.Held, bobAfter[0].Status, "bob's sight of alice must fade — she left room-a")
+
+	var aliceSeen encounter.SightPayload
+	s.Require().NoError(json.Unmarshal(bobAfter[0].Payload, &aliceSeen))
+	s.Equal("room-a", aliceSeen.Room, "ghost holds alice's LAST-SEEN room")
+	s.Equal(9.0, aliceSeen.X, "ghost holds alice at the DEPARTURE endpoint, not the arrival one")
+	s.Equal(5.0, aliceSeen.Y)
+}
+
+// TestTraverseArrivalCurrent pins that an arrival-room observer gains the
+// traverser as Current at the arrival endpoint.
+func (s *EncounterTestSuite) TestTraverseArrivalCurrent() {
+	enc := s.newTwoRoomEncounterWithConnection()
+
+	_, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+
+	goblinView, err := enc.View(&encounter.ViewInput{Member: goblin})
+	s.Require().NoError(err)
+	s.Require().Len(goblinView, 1)
+	s.Equal(intel.Subject(alice), goblinView[0].Subject)
+	s.Equal(intel.Current, goblinView[0].Status, "goblin must see alice as Current — she arrived in room-b")
+
+	var aliceSeen encounter.SightPayload
+	s.Require().NoError(json.Unmarshal(goblinView[0].Payload, &aliceSeen))
+	s.Equal("room-b", aliceSeen.Room)
+	s.Equal(0.0, aliceSeen.X)
+	s.Equal(5.0, aliceSeen.Y)
+}
+
+// TestTraverseSightNeverCrossesOpening pins law T3: sight never crosses a
+// connection's opening. goblin stands in room-b, adjacent to the arrival
+// endpoint. Before alice traverses — while she's still in room-a, at the
+// connection's OTHER endpoint — goblin must have NO holding of her at
+// all, not even a ghost: rooms are separate spatial containers with no
+// shared geometry (spatial ADR-0015), so there is no code path by which
+// goblin's line-of-sight computation, scoped entirely to room-b, could
+// observe alice in room-a.
+func (s *EncounterTestSuite) TestTraverseSightNeverCrossesOpening() {
+	enc := s.newTwoRoomEncounterWithConnection()
+
+	goblinBefore, err := enc.View(&encounter.ViewInput{Member: goblin})
+	s.Require().NoError(err)
+	s.Empty(goblinBefore, "goblin must not perceive alice through the unopened doorway")
+}
+
+// TestTraverseOwnView pins that after traversing, the traverser's OWN
+// percept reflects arrival-room members Current and departure-room
+// members faded to ghosts — the same complete-percept contract that
+// governs everyone else's view of them.
+func (s *EncounterTestSuite) TestTraverseOwnView() {
+	enc := s.newTwoRoomEncounterWithConnection()
+
+	aliceBefore, err := enc.View(&encounter.ViewInput{Member: alice})
+	s.Require().NoError(err)
+	s.Require().Len(aliceBefore, 1, "alice sees only bob before traversing (goblin is behind the unopened door)")
+	s.Equal(intel.Subject(bob), aliceBefore[0].Subject)
+	s.Equal(intel.Current, aliceBefore[0].Status)
+
+	_, err = enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+
+	aliceAfter, err := enc.View(&encounter.ViewInput{Member: alice})
+	s.Require().NoError(err)
+	s.Require().Len(aliceAfter, 2, "alice now holds both bob (ghosted) and goblin (Current)")
+
+	var bobHolding, goblinHolding *intel.Holding
+	for i := range aliceAfter {
+		switch aliceAfter[i].Subject {
+		case intel.Subject(bob):
+			bobHolding = &aliceAfter[i]
+		case intel.Subject(goblin):
+			goblinHolding = &aliceAfter[i]
+		}
+	}
+	s.Require().NotNil(bobHolding, "alice must still hold bob (ghosted)")
+	s.Equal(intel.Held, bobHolding.Status, "bob fades to a ghost — alice left room-a")
+	s.Require().NotNil(goblinHolding, "alice must now hold goblin (Current)")
+	s.Equal(intel.Current, goblinHolding.Status, "goblin is Current — alice arrived in room-b")
+}
+
+// TestTraverseEndingFiresOnArrival pins that a ReachedPosition ending
+// declared at the connection's far endpoint fires on arrival, exactly
+// like Move firing endings at a movement target.
+func (s *EncounterTestSuite) TestTraverseEndingFiresOnArrival() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "door1", From: "room-a", To: "room-b",
+					FromPosition: spatial.Position{X: 9, Y: 5},
+					ToPosition:   spatial.Position{X: 0, Y: 5}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: "room-a", Position: spatial.Position{X: 9, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "escaped", Trigger: encounter.TriggerReachedPosition{
+				Room: "room-b", Position: spatial.Position{X: 0, Y: 5}}},
+		},
+	})
+	s.Require().NoError(err)
+
+	out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Outcome, "outcome should be set when arriving at the ending position")
+	s.Equal("escaped", out.Outcome.Ending)
+	s.Require().Len(out.Outcome.Members, 1)
+	s.Equal(alice, out.Outcome.Members[0].ID)
+	s.Equal("room-b", out.Outcome.Members[0].Room)
+	s.Equal(spatial.Position{X: 0, Y: 5}, out.Outcome.Members[0].Position)
+
+	status, err := enc.Status()
+	s.Require().NoError(err)
+	s.False(status.Open)
+}
+
+// TestTraverseMonsterOnUnfilteredEndingDoesNotClose pins the players-only
+// rule for unfiltered ReachedPosition endings, carried over verbatim from
+// Move/Pump: a monster traversing onto an unfiltered ending's cell must
+// NOT close the encounter.
+func (s *EncounterTestSuite) TestTraverseMonsterOnUnfilteredEndingDoesNotClose() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "door1", From: "room-a", To: "room-b",
+					FromPosition: spatial.Position{X: 9, Y: 5},
+					ToPosition:   spatial.Position{X: 0, Y: 5}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: goblin, Kind: encounter.KindMonster, Room: "room-a", Position: spatial.Position{X: 9, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{
+			// Unfiltered: empty Member means players only.
+			{Key: "escaped", Trigger: encounter.TriggerReachedPosition{
+				Room: "room-b", Position: spatial.Position{X: 0, Y: 5}, Member: ""}},
+		},
+	})
+	s.Require().NoError(err)
+
+	out, err := enc.Traverse(&encounter.TraverseInput{Member: goblin, Connection: "door1"})
+	s.Require().NoError(err)
+	s.Nil(out.Outcome, "unfiltered ending must not fire for a monster")
+
+	status, err := enc.Status()
+	s.Require().NoError(err)
+	s.True(status.Open, "encounter should remain open")
+}
+
+// TestTraverseBeatPinned pins the traversed beat: tag, payload, and
+// Story reflects it in position (the Move/Exit precedent applied here).
+func (s *EncounterTestSuite) TestTraverseBeatPinned() {
+	enc := s.newTwoRoomEncounterWithConnection()
+	out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: alice})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(story)
+	last := story[len(story)-1]
+	s.Equal(out.Seq, last.Seq, "TraverseOutput.Seq references the traversed beat")
+
+	var beat map[string]any
+	s.Require().NoError(json.Unmarshal(last.Payload, &beat))
+	s.Equal("traversed", beat["beat"])
+	s.Equal(string(alice), beat["member"])
+	s.Equal("door1", beat["connection"])
+}
+
+// TestTraverseClockUnchanged pins law T4: traversal is an activity, not
+// time — the exploration clock does not advance.
+func (s *EncounterTestSuite) TestTraverseClockUnchanged() {
+	enc := s.newTwoRoomEncounterWithConnection()
+	before := enc.ToData().Clock.HighWater
+
+	_, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+
+	after := enc.ToData().Clock.HighWater
+	s.Equal(before, after, "traversal is an activity, not time — the clock must not advance")
+}
+
+// TestTraverseThenJoinVacatedCellThenTraverseBack pins the wave-1 Exit
+// lesson (see TestExitThenRejoinSameID) against Traverse's own
+// remove+place composition: after alice traverses room-a -> room-b, a
+// NEW member can Join at the vacated room-a endpoint cell (proving
+// RemoveEntity truly cleared it, not just hid it from Members/View), and
+// alice can traverse BACK through the same connection (proving
+// PlaceEntity into room-b left no stale index entry either).
+func (s *EncounterTestSuite) TestTraverseThenJoinVacatedCellThenTraverseBack() {
+	enc := s.newTwoRoomEncounterWithConnection()
+
+	_, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+
+	_, err = enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{
+		ID: core.EntityID("charlie"), Kind: encounter.KindPlayer,
+		Room: "room-a", Position: spatial.Position{X: 9, Y: 5},
+	}})
+	s.Require().NoError(err, "the vacated cell must truly be free — no stale registry entry in room-a")
+
+	out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err, "alice must be able to traverse back — no stale registry entry in room-b either")
+	s.Equal("room-a", out.Traversed.ToRoom)
+}
+
 // Membership flow tests (Task 5)
 
 func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
@@ -1882,6 +2266,11 @@ func (s *EncounterTestSuite) TestAllMutatingVerbsReturnErrClosedPostClose() {
 
 		// Pump on closed: ErrClosed
 		_, err = enc.Pump(&encounter.PumpInput{})
+		s.Require().ErrorIs(err, encounter.ErrClosed)
+
+		// Traverse on closed: ErrClosed (checked before connection lookup,
+		// so a nonexistent connection ID still surfaces ErrClosed first)
+		_, err = enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
 		s.Require().ErrorIs(err, encounter.ErrClosed)
 
 		// End on closed: ErrClosed

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -613,6 +613,134 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
 }
 
+// validHexAxialSetup returns a fresh SetupInput with two hex rooms joined
+// by one connection, a member, and an occluder — every position integral
+// axial, including a negative one (gate.ToPosition). The base for
+// TestSetupHexIntegralAxial's one-defect rows: interim tools/spatial#926
+// enforcement (isIntegralAxialPosition) rejects a fractional X or Y at
+// any of these positions in a hex room.
+func validHexAxialSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
+					Occluders: []spatial.Position{{X: 2, Y: 2}}},
+				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridShapeHex},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "hex-a", To: "hex-b",
+				FromPosition: spatial.Position{X: 1, Y: 1},
+				ToPosition:   spatial.Position{X: -1, Y: -1},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-a", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
+// TestSetupHexIntegralAxial pins the interim tools/spatial#926
+// enforcement at the Setup seam: a fractional X or Y is rejected for
+// every position kind a hex room accepts externally — member, both
+// connection endpoints, and an occluder — each with the error class its
+// existing defect family already uses. Load-seam counterpart:
+// TestLoadHexIntegralAxial in data_test.go.
+func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
+	cases := []struct {
+		name    string
+		mutate  func(in *encounter.SetupInput)
+		alsoErr error
+	}{
+		{"member position fractional", func(in *encounter.SetupInput) {
+			in.Members[0].Position = spatial.Position{X: 0.5, Y: 0}
+		}, encounter.ErrBadPlacement},
+		{"connection from-position fractional", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].FromPosition = spatial.Position{X: 1.5, Y: 1}
+		}, encounter.ErrBadConnection},
+		{"connection to-position fractional", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].ToPosition = spatial.Position{X: -1.5, Y: -1}
+		}, encounter.ErrBadConnection},
+		{"occluder position fractional", func(in *encounter.SetupInput) {
+			in.Field.Rooms[0].Occluders[0] = spatial.Position{X: 2.5, Y: 2}
+		}, encounter.ErrNoField},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			setup := validHexAxialSetup()
+			tc.mutate(setup)
+			_, err := encounter.NewEncounter(setup)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
+			s.Require().Contains(err.Error(), "not an integral axial cell",
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	// Positive control: the valid base — integral throughout, including
+	// a NEGATIVE axial position (gate.ToPosition at (-1,-1)) — constructs.
+	_, err := encounter.NewEncounter(validHexAxialSetup())
+	s.Require().NoError(err, "integral axial positions, including negative ones, must be accepted")
+}
+
+// TestMoveHexIntegralAxial is Move's verb-seam counterpart: a fractional
+// target in a hex room is rejected (moveMember is the shared path with
+// Pump's IntentMoveTo, so this also covers decider-driven moves).
+func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-room", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	s.Run("fractional target rejected", func() {
+		_, err := enc.Move(&encounter.MoveInput{Member: "p1", To: spatial.Position{X: 1.5, Y: 0}})
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().Contains(err.Error(), "not an integral axial cell")
+	})
+
+	s.Run("integral negative axial target accepted", func() {
+		_, err := enc.Move(&encounter.MoveInput{Member: "p1", To: spatial.Position{X: -2, Y: -1}})
+		s.Require().NoError(err)
+	})
+}
+
+// TestJoinHexIntegralAxial is Join's verb-seam counterpart.
+func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-room", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	s.Run("fractional position rejected", func() {
+		_, err := enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{
+			ID: "p2", Kind: encounter.KindPlayer, Room: "hex-room", Position: spatial.Position{X: 1, Y: 0.5},
+		}})
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().Contains(err.Error(), "not an integral axial cell")
+	})
+
+	s.Run("integral negative axial position accepted", func() {
+		_, err := enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{
+			ID: "p3", Kind: encounter.KindPlayer, Room: "hex-room", Position: spatial.Position{X: -3, Y: -3},
+		}})
+		s.Require().NoError(err)
+	})
+}
+
 // TestGridlessRoomInclusiveBounds pins gridless's own divergence from the
 // rectangle math this task deletes: GridlessRoom.IsValidPosition
 // (tools/spatial/gridless.go:33-36) uses an INCLUSIVE upper bound

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -532,16 +532,18 @@ func (s *EncounterTestSuite) TestSetupRoomValidation() {
 
 // TestHexRoomBounds pins that a hex-shaped room's member-placement bounds
 // defer to the room's own constructed Grid rather than hardcoded rectangle
-// math. HexGrid (tools/spatial/hex_grid.go:54-57) — the offset column/row
-// coordinate hex grid this module constructs for GridShapeHex — uses the
-// IDENTICAL non-negative/strictly-less-than-dimension rule as SquareGrid,
-// so a hex room's accept/reject boundary values are numerically the same
-// shape as square's. This test therefore pins that hex construction
-// succeeds and Width/Height correctly bound the constructed grid; it does
-// NOT by itself prove hex (vs. square) construction happened — see
-// TestGridlessRoomInclusiveBounds for a shape whose validity genuinely
-// diverges from the rectangle math this task deletes.
+// math — and, since the switch to AxialHexGrid (tools/spatial's origin-
+// centered axial Q/R grid, see RoomInput.Grid's doc comment), that hex
+// validity now genuinely DIVERGES from square's, not just gridless's: a
+// hex room's bounds are centered on the origin ([-Width/2, Width/2) for Q,
+// [-Height/2, Height/2) for R), so NEGATIVE coordinates are legal — a
+// position square would reject outright. This supersedes an earlier
+// finding (when this module built spatial.HexGrid, a bounded offset grid)
+// that hex's accept/reject shape was numerically identical to square's and
+// only gridless could kill a "grid shape ignored, always builds square"
+// mutant; the negative-Q case below now kills that mutant independently.
 func (s *EncounterTestSuite) TestHexRoomBounds() {
+	// Width=4, Height=3 => Q valid in [-2,2), R valid in [-1.5,1.5).
 	hexSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
 			Field: encounter.FieldInput{
@@ -556,27 +558,72 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 		}
 	}
 
-	s.Run("position within hex bounds accepted", func() {
-		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 3, Y: 2})) // Width-1, Height-1
+	s.Run("positive Q, positive R within span accepted", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 1, Y: 1}))
 		s.Require().NoError(err)
 	})
 
-	s.Run("position at width boundary rejected", func() {
-		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 4, Y: 0}))
+	s.Run("negative Q within span accepted — rejected under the old offset HexGrid", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: -1, Y: 0}))
+		s.Require().NoError(err, "axial hex rooms are origin-centered; negative Q is ordinary, not a defect")
+	})
+
+	s.Run("Q at exactly +Width/2 rejected (upper bound exclusive)", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 2, Y: 0}))
+		s.Require().Error(err)
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+	})
+
+	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: -2, Y: 0}))
+		s.Require().NoError(err)
+	})
+
+	s.Run("Q beyond -Width/2 rejected", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: -3, Y: 0}))
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
 	})
 }
 
-// TestGridlessRoomInclusiveBounds pins the one shape whose validity
-// genuinely diverges from the rectangle math this task deletes:
-// GridlessRoom.IsValidPosition (tools/spatial/gridless.go:33-36) uses an
-// INCLUSIVE upper bound (x <= Width), unlike Square/Hex's exclusive
-// (x < Width). A position exactly AT Width — rejected for square/hex — is
-// the sharpest available proof that bounds checks ask the room's OWN
-// constructed grid rather than a hardcoded rectangle: a "grid shape
-// ignored, always builds square" mutant would reject this position; the
-// correct code accepts it.
+// TestHexConnectionEndpointNegativeAxial pins connection endpoints in a
+// hex room at the Setup seam: a negative axial Q/R endpoint — the
+// ordinary case for an origin-centered hex room — validates exactly like
+// a positive one, via the same grid-deferred bounds check members use.
+// Load-seam counterpart: TestHexConnectionEndpointNegativeAxialLoad in
+// data_test.go.
+func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "square-room", Width: 10, Height: 10},
+				{ID: "hex-room", Width: 6, Height: 6, Grid: spatial.GridShapeHex},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "square-room", To: "hex-room",
+				FromPosition: spatial.Position{X: 9, Y: 9},
+				ToPosition:   spatial.Position{X: -2, Y: -2},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "square-room", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
+}
+
+// TestGridlessRoomInclusiveBounds pins gridless's own divergence from the
+// rectangle math this task deletes: GridlessRoom.IsValidPosition
+// (tools/spatial/gridless.go:33-36) uses an INCLUSIVE upper bound
+// (x <= Width), unlike SquareGrid's exclusive (x < Width). A position
+// exactly AT Width — rejected for square — is a sharp, independent proof
+// that bounds checks ask the room's OWN constructed grid rather than a
+// hardcoded rectangle: a "grid shape ignored, always builds square" mutant
+// would reject this position; the correct code accepts it. (AxialHexGrid
+// diverges from square too, but via origin-centered bounds and legal
+// negative coordinates, not an inclusive upper bound — see
+// TestHexRoomBounds.)
 func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 	gridlessSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -308,6 +308,76 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	})
 }
 
+// validConnSetup returns a fresh SetupInput with two rooms (r1 carries an
+// occluder at (2,2)) and one fully valid connection between them — the base
+// for TestSetupConnectionValidation's one-defect rows, mirroring the same
+// defect classes rejected at Load (TestLoadRejections).
+func validConnSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
+				{ID: "r2", Width: 5, Height: 5},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "c1", From: "r1", To: "r2",
+					FromPosition: spatial.Position{X: 0, Y: 0},
+					ToPosition:   spatial.Position{X: 0, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
+// TestSetupConnectionValidation mirrors TestLoadRejections' connection
+// defect classes at the Setup seam: each case breaks exactly one thing
+// about an otherwise-valid connection and must reject with ErrBadConnection.
+func (s *EncounterTestSuite) TestSetupConnectionValidation() {
+	cases := []struct {
+		name     string
+		mutate   func(in *encounter.SetupInput)
+		fragment string
+	}{
+		{"empty connection id", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].ID = ""
+		}, "empty id"},
+		{"duplicate connection id", func(in *encounter.SetupInput) {
+			in.Field.Connections = append(in.Field.Connections, in.Field.Connections[0])
+		}, "duplicate connection"},
+		{"connection unknown room", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].To = "nowhere"
+		}, "unknown room"},
+		{"connection self-connection", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].To = "r1"
+		}, "itself"},
+		{"connection endpoint out of bounds", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].FromPosition = spatial.Position{X: 99, Y: 99}
+		}, "from-position out of bounds"},
+		{"connection endpoint on occluder", func(in *encounter.SetupInput) {
+			in.Field.Connections[0].FromPosition = spatial.Position{X: 2, Y: 2}
+		}, "from-position on occluder"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			setup := validConnSetup()
+			tc.mutate(setup)
+			_, err := encounter.NewEncounter(setup)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrBadConnection, tc.name)
+			s.Require().Contains(err.Error(), tc.fragment,
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	// The valid base itself must construct — the one-defect discipline only
+	// means something if zero defects pass.
+	_, err := encounter.NewEncounter(validConnSetup())
+	s.Require().NoError(err, "the valid base fixture must construct")
+}
+
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 	s.Run("opening beat reaches all members via Story", func() {
 		// Arrange

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -25,7 +25,10 @@ var (
 	// is called on a closed encounter. A closed encounter has an Outcome.
 	ErrClosed = errors.New("encounter closed")
 
-	// ErrNoField is returned when Setup is called without rooms.
+	// ErrNoField is returned when Setup is called without rooms, or when a
+	// declared room is itself defective (empty or duplicate ID, unrecognized
+	// grid shape) — a malformed room list is as unusable as an empty one.
+	// Returned at both Setup and Load.
 	ErrNoField = errors.New("no field")
 
 	// ErrBadPlacement is returned when a placement fails spatial validation.

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -38,8 +38,14 @@ var (
 	// ErrBadConnection is returned when a connection's ID is empty or
 	// duplicated, its From/To names an unknown room or itself, or an
 	// endpoint lies outside its room's bounds or on an occluder position.
-	// Returned at both Setup and Load.
+	// Returned at both Setup and Load — a declaration-time defect.
 	ErrBadConnection = errors.New("bad connection")
+
+	// ErrNoConnection is returned by Traverse when the given connection ID
+	// does not name any connection in this encounter — a runtime lookup
+	// miss, the ErrNotMember analogue for connections. Distinct from
+	// ErrBadConnection, which is a declaration-time defect at Setup/Load.
+	ErrNoConnection = errors.New("no such connection")
 
 	// ErrInvalidData is returned when LoadEncounter rejects the input data.
 	ErrInvalidData = errors.New("invalid encounter data")

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -32,6 +32,12 @@ var (
 	// Wraps the underlying spatial error.
 	ErrBadPlacement = errors.New("bad placement")
 
+	// ErrBadConnection is returned when a connection's ID is empty or
+	// duplicated, its From/To names an unknown room or itself, or an
+	// endpoint lies outside its room's bounds or on an occluder position.
+	// Returned at both Setup and Load.
+	ErrBadConnection = errors.New("bad connection")
+
 	// ErrInvalidData is returned when LoadEncounter rejects the input data.
 	ErrInvalidData = errors.New("invalid encounter data")
 )

--- a/rulebooks/dnd5e/encounter/example_traverse_test.go
+++ b/rulebooks/dnd5e/encounter/example_traverse_test.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// Example_theTraverse plays the connections wave's signature scene — a
+// member crossing a threshold into another room, and a monster's own
+// pursuit following through the same doorway — and PRINTS it. The
+// Output block below is verified by go test, so this narration can
+// never drift from what the composition actually does. Sibling to
+// Example_theTombWatch (sight, the ghost, save/reload, the ending);
+// this one shows what tomb watch predates: the room boundary itself.
+// Reuses tell() from example_tombwatch_test.go (same package).
+func Example_theTraverse() {
+	// Two rooms, one gate: alice starts exactly at the hall's threshold;
+	// the goblin, across the hall, can see her but not yet follow.
+	gate := encounter.ConnectionInput{
+		ID: "gate", From: "hall", To: "vault",
+		FromPosition: spatial.Position{X: 7, Y: 4},
+		ToPosition:   spatial.Position{X: 0, Y: 4},
+	}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hall", Width: 8, Height: 8},
+				{ID: "vault", Width: 8, Height: 8},
+			},
+			Connections: []encounter.ConnectionInput{gate},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 7, Y: 4}},
+			{ID: "goblin", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 4},
+				Decider: &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: "alice"}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "done", Trigger: encounter.TriggerExternal{}},
+		},
+	})
+	if err != nil {
+		fmt.Println("setup:", err)
+		return
+	}
+
+	fmt.Println("-- first light --")
+	tell(enc, "alice", "goblin")
+	tell(enc, "goblin", "alice")
+
+	fmt.Println("-- alice slips through the gate --")
+	if _, err := enc.Traverse(&encounter.TraverseInput{Member: "alice", Connection: "gate"}); err != nil {
+		fmt.Println("traverse:", err)
+		return
+	}
+	tell(enc, "goblin", "alice")
+
+	// Two ticks: the goblin closes the distance to the threshold, then
+	// crosses it — both decided from nothing but its own snapshot and
+	// the ghost it is holding. Sight stays room-scoped the whole way
+	// (T3): the goblin learns nothing new until it is standing in the
+	// vault itself.
+	fmt.Println("-- the goblin gives chase, and follows her through --")
+	if _, err := enc.Pump(&encounter.PumpInput{}); err != nil {
+		fmt.Println("pump:", err)
+		return
+	}
+	if _, err := enc.Pump(&encounter.PumpInput{}); err != nil {
+		fmt.Println("pump:", err)
+		return
+	}
+	tell(enc, "goblin", "alice")
+
+	// Output:
+	// -- first light --
+	// alice sees goblin at (2,4)
+	// goblin sees alice at (7,4)
+	// -- alice slips through the gate --
+	// goblin holds a GHOST of alice at last-seen (7,4)
+	// -- the goblin gives chase, and follows her through --
+	// goblin sees alice at (0,4)
+}

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -41,7 +41,11 @@ type RoomInput struct {
 	Boundaries []spatial.Boundary
 }
 
-// ConnectionInput describes a connection between two rooms.
+// ConnectionInput describes a connection between two rooms: a bidirectional
+// open doorway. FromPosition and ToPosition are the endpoint cells — the
+// position a member must stand on in each room to traverse the connection.
+// Traversal itself is not implemented here; this only declares where the
+// doorway sits.
 type ConnectionInput struct {
 	// ID is the unique connection identifier.
 	ID string
@@ -51,6 +55,12 @@ type ConnectionInput struct {
 
 	// To is the destination room ID.
 	To string
+
+	// FromPosition is the endpoint cell within room From.
+	FromPosition spatial.Position
+
+	// ToPosition is the endpoint cell within room To.
+	ToPosition spatial.Position
 }
 
 // FieldInput describes the layout of rooms and connections.

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -34,6 +34,14 @@ type RoomInput struct {
 	// Height is the room's vertical dimension.
 	Height int
 
+	// Grid selects the room's coordinate system: GridShapeSquare (the zero
+	// value — Width x Height cells, Chebyshev distance), GridShapeHex
+	// (Width x Height offset column/row hex cells — see tools/spatial's
+	// HexGrid), or GridShapeGridless (continuous positions within Width x
+	// Height). The zero value keeps every pre-existing room square, so v0.1
+	// persisted blobs without this field unmarshal to square unchanged.
+	Grid spatial.GridShape
+
 	// Occluders are positions that block line of sight.
 	Occluders []spatial.Position
 

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -35,11 +35,25 @@ type RoomInput struct {
 	Height int
 
 	// Grid selects the room's coordinate system: GridShapeSquare (the zero
-	// value — Width x Height cells, Chebyshev distance), GridShapeHex
-	// (Width x Height offset column/row hex cells — see tools/spatial's
-	// HexGrid), or GridShapeGridless (continuous positions within Width x
-	// Height). The zero value keeps every pre-existing room square, so v0.1
-	// persisted blobs without this field unmarshal to square unchanged.
+	// value — Width x Height cells, origin (0,0), Chebyshev distance),
+	// GridShapeHex, or GridShapeGridless (continuous positions within
+	// Width x Height, origin (0,0)). The zero value keeps every
+	// pre-existing room square, so v0.1 persisted blobs without this
+	// field unmarshal to square unchanged.
+	//
+	// GridShapeHex rooms speak AXIAL cube coordinates (tools/spatial's
+	// AxialHexGrid), not offset: Position.X is Q, Position.Y is R, and S
+	// = -(Q+R) is derived. Bounds are ORIGIN-CENTERED spans, unlike
+	// square/gridless — Q is valid in [-Width/2, Width/2) and R in
+	// [-Height/2, Height/2), so negative coordinates are legal and
+	// expected, not a defect. Distance, adjacency, and line of sight in a
+	// hex room run true cube hex math via spatial. This is a deliberate
+	// choice, not an implementation detail: the wire (and Platform's
+	// pathing) already speaks cube coordinates natively, and axial is
+	// cube's 2D projection — an IDENTITY mapping to the wire. A bounded
+	// offset column/row grid (spatial's HexGrid) would force a lossy,
+	// orientation-dependent offset<->cube conversion at that seam for no
+	// benefit, since the composition never renders a grid itself.
 	Grid spatial.GridShape
 
 	// Occluders are positions that block line of sight.

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -275,18 +275,32 @@ type PumpOutput struct {
 	// Tick is the exploration clock's reading after the advance.
 	Tick uint64
 
-	// MonsterMoves contains the successful moves executed by monsters during this pump.
+	// MonsterMoves contains the successful same-room moves executed by monsters during this pump.
 	MonsterMoves []struct {
 		Member MemberID
 		From   spatial.Position
 		To     spatial.Position
 	}
 
+	// MonsterTraverses contains the successful cross-room traverses executed by
+	// monsters during this pump (IntentTraverse). An illegal traverse intent
+	// (unknown connection, or the monster not at its threshold) does not appear
+	// here — it is silently skipped, matching MonsterMoves' spatial-rejection
+	// contract.
+	MonsterTraverses []struct {
+		Member   MemberID
+		FromRoom string
+		From     spatial.Position
+		ToRoom   string
+		To       spatial.Position
+	}
+
 	// IntelDeltas maps member IDs to their updated percepts after all monster actions
 	// (SurveilOutput deltas from the single refreshSight cycle).
 	IntelDeltas map[MemberID]*intel.SurveilOutput
 
-	// Seqs contains the sequence numbers of the recorded beats (tick beat first, then move beats).
+	// Seqs contains the sequence numbers of the recorded beats (tick beat
+	// first, then move/traverse beats in decision order).
 	Seqs []uint64
 
 	// Outcome is the encounter outcome if an ending fired; nil otherwise.

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -233,6 +233,40 @@ type MoveOutput struct {
 	Outcome *Outcome
 }
 
+// TraverseInput contains the member and connection to traverse. The member
+// must be standing exactly on one of the connection's two endpoints; they
+// arrive at the other.
+type TraverseInput struct {
+	// Member is the ID of the member traversing.
+	Member MemberID
+
+	// Connection is the ID of the connection to traverse.
+	Connection string
+}
+
+// TraverseOutput reports the results of a traversal action.
+type TraverseOutput struct {
+	// Traversed contains the member's ID, departure room/position, and
+	// arrival room/position.
+	Traversed struct {
+		Member   MemberID
+		FromRoom string
+		From     spatial.Position
+		ToRoom   string
+		To       spatial.Position
+	}
+
+	// IntelDeltas maps member IDs to their updated percepts after traversal
+	// (SurveilOutput deltas from the refreshSight cycle, across both rooms).
+	IntelDeltas map[MemberID]*intel.SurveilOutput
+
+	// Seq is the sequence number of the recorded traversal beat.
+	Seq uint64
+
+	// Outcome is the encounter outcome if an ending fired; nil otherwise.
+	Outcome *Outcome
+}
+
 // PumpInput contains no parameters; the pump is parameterless in wave 1.
 type PumpInput struct{}
 

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -29,7 +29,7 @@ type patrolDecider struct {
 	callCount int
 }
 
-func (p *patrolDecider) Decide(view []intel.Holding) (encounter.Intent, error) {
+func (p *patrolDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 	defer func() { p.callCount++ }()
 
 	if len(p.positions) == 0 {
@@ -41,15 +41,17 @@ func (p *patrolDecider) Decide(view []intel.Holding) (encounter.Intent, error) {
 	return encounter.IntentMoveTo{To: target}, nil
 }
 
-// spyDecider records what holdings it was shown and returns a hold decision.
+// spyDecider records the Snapshot it was shown and returns a hold decision.
 type spyDecider struct {
 	capturedView []intel.Holding
+	capturedSnap encounter.Snapshot
 }
 
-func (s *spyDecider) Decide(view []intel.Holding) (encounter.Intent, error) {
+func (s *spyDecider) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
 	// Capture the view (deep copy to persist it)
-	s.capturedView = make([]intel.Holding, len(view))
-	copy(s.capturedView, view)
+	s.capturedView = make([]intel.Holding, len(snap.Holdings))
+	copy(s.capturedView, snap.Holdings)
+	s.capturedSnap = snap
 	return encounter.IntentHold{}, nil
 }
 
@@ -60,7 +62,7 @@ type failOnceDecider struct {
 	calls int
 }
 
-func (f *failOnceDecider) Decide(_ []intel.Holding) (encounter.Intent, error) {
+func (f *failOnceDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 	f.calls++
 	if f.calls == 1 {
 		return nil, errors.New("first call fails")
@@ -73,13 +75,13 @@ type vandalDecider struct {
 	sawAlice bool
 }
 
-func (v *vandalDecider) Decide(view []intel.Holding) (encounter.Intent, error) {
-	for i := range view {
-		if view[i].Subject == "alice" {
+func (v *vandalDecider) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
+	for i := range snap.Holdings {
+		if snap.Holdings[i].Subject == "alice" {
 			v.sawAlice = true
 		}
-		for j := range view[i].Payload {
-			view[i].Payload[j] = 'X'
+		for j := range snap.Holdings[i].Payload {
+			snap.Holdings[i].Payload[j] = 'X'
 		}
 	}
 	return encounter.IntentHold{}, nil
@@ -89,8 +91,83 @@ type errorDecider struct {
 	err error
 }
 
-func (e *errorDecider) Decide(view []intel.Holding) (encounter.Intent, error) {
+func (e *errorDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 	return nil, e.err
+}
+
+// snapshotSpyDecider records every Snapshot it's given, across calls —
+// used to pin that Pump hands each monster its OWN room/position, never
+// another member's (Task 3, item 2).
+type snapshotSpyDecider struct {
+	snapshots []encounter.Snapshot
+}
+
+func (s *snapshotSpyDecider) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
+	s.snapshots = append(s.snapshots, snap)
+	return encounter.IntentHold{}, nil
+}
+
+// onceTraverseDecider intends IntentTraverse{Connection} on its first
+// call, then holds forever after — a minimal fixture for pinning a
+// single traverse attempt's success or failure.
+type onceTraverseDecider struct {
+	connection string
+	called     bool
+}
+
+func (t *onceTraverseDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
+	if t.called {
+		return encounter.IntentHold{}, nil
+	}
+	t.called = true
+	return encounter.IntentTraverse{Connection: t.connection}, nil
+}
+
+// pursuitDecider is constructed with the field's static connection
+// topology and a target subject to chase — it never reads encounter
+// state directly; Snapshot + Holdings + its own construction-time config
+// is all it gets (C2 extended to placement, not just sight). Logic: if it
+// currently holds a percept of the target, and it is standing EXACTLY
+// where that percept places them (its own room and position match), that
+// cell is either a connection endpoint in this room — traverse through
+// it — or nowhere useful — hold. Otherwise, if the percept's room matches
+// its own current room, walk toward the held position. A percept in a
+// DIFFERENT room is out of this simple pursuer's reach (it does not
+// cross-room-pathfind); it holds until circumstances change.
+type pursuitDecider struct {
+	connections []encounter.ConnectionInput
+	target      core.EntityID
+}
+
+func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
+	for _, h := range snap.Holdings {
+		if h.Subject != intel.Subject(p.target) {
+			continue
+		}
+		var seen encounter.SightPayload
+		if err := json.Unmarshal(h.Payload, &seen); err != nil {
+			return nil, err
+		}
+
+		if snap.Room != seen.Room {
+			return encounter.IntentHold{}, nil
+		}
+
+		if snap.Position.X == seen.X && snap.Position.Y == seen.Y {
+			for _, c := range p.connections {
+				if c.From == snap.Room && c.FromPosition.X == snap.Position.X && c.FromPosition.Y == snap.Position.Y {
+					return encounter.IntentTraverse{Connection: c.ID}, nil
+				}
+				if c.To == snap.Room && c.ToPosition.X == snap.Position.X && c.ToPosition.Y == snap.Position.Y {
+					return encounter.IntentTraverse{Connection: c.ID}, nil
+				}
+			}
+			return encounter.IntentHold{}, nil
+		}
+
+		return encounter.IntentMoveTo{To: spatial.Position{X: seen.X, Y: seen.Y}}, nil
+	}
+	return encounter.IntentHold{}, nil
 }
 
 // TestPumpDoesNotConsultExitedMonsterDecider pins Exit's decider
@@ -859,4 +936,327 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		s.Require().Error(err)
 		s.True(errors.Is(err, encounter.ErrNoMember), "player-with-decider wraps ErrNoMember")
 	})
+}
+
+// twoRoomDoor is the standard fixture connection for the Pump/traverse
+// tests below: room-a to room-b, DELIBERATELY asymmetric endpoints (T1
+// review lesson) so a from/to mix-up would be observable.
+var twoRoomDoor = encounter.ConnectionInput{
+	ID: "door1", From: "room-a", To: "room-b",
+	FromPosition: spatial.Position{X: 9, Y: 5},
+	ToPosition:   spatial.Position{X: 0, Y: 5},
+}
+
+// TestPumpSnapshotIsOwnPlacement pins that each monster's Snapshot
+// carries ITS OWN room/position — never another member's (Task 3, item
+// 2). Two monsters in DIFFERENT rooms each get a spy decider; if Pump
+// ever handed either monster the wrong placement, at least one spy's
+// captured snapshot would name a room/position neither monster stands in.
+func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
+	spyA := &snapshotSpyDecider{}
+	spyB := &snapshotSpyDecider{}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: core.EntityID("goblin-a"), Kind: encounter.KindMonster, Room: "room-a",
+				Position: spatial.Position{X: 2, Y: 3}, Decider: spyA},
+			{ID: core.EntityID("goblin-b"), Kind: encounter.KindMonster, Room: "room-b",
+				Position: spatial.Position{X: 7, Y: 8}, Decider: spyB},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Require().Len(spyA.snapshots, 1)
+	s.Equal("room-a", spyA.snapshots[0].Room, "goblin-a's snapshot must name ITS OWN room")
+	s.Equal(spatial.Position{X: 2, Y: 3}, spyA.snapshots[0].Position, "goblin-a's snapshot must be ITS OWN position")
+
+	s.Require().Len(spyB.snapshots, 1)
+	s.Equal("room-b", spyB.snapshots[0].Room, "goblin-b's snapshot must name ITS OWN room")
+	s.Equal(spatial.Position{X: 7, Y: 8}, spyB.snapshots[0].Position, "goblin-b's snapshot must be ITS OWN position")
+}
+
+// TestPumpIntentTraverseSuccess pins that a monster standing at a
+// connection's threshold, deciding IntentTraverse, actually crosses:
+// room changes, the "traversed" beat is recorded, PumpOutput.MonsterTraverses
+// reflects it (and MonsterMoves does not), and the clock still advances
+// by exactly 1 — Pump's own tick is unconditional regardless of what a
+// monster does within it (traversal itself is not time, law T4, but the
+// PUMP is).
+func (s *PumpTestSuite) TestPumpIntentTraverseSuccess() {
+	goblinID := core.EntityID("goblin")
+	decider := &onceTraverseDecider{connection: "door1"}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{twoRoomDoor},
+		},
+		Members: []encounter.MemberInput{
+			{ID: goblinID, Kind: encounter.KindMonster, Room: "room-a",
+				Position: spatial.Position{X: 9, Y: 5}, Decider: decider},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	out, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Equal(uint64(1), out.Tick)
+	s.Require().Len(out.MonsterTraverses, 1)
+	s.Equal(goblinID, out.MonsterTraverses[0].Member)
+	s.Equal("room-a", out.MonsterTraverses[0].FromRoom)
+	s.Equal(spatial.Position{X: 9, Y: 5}, out.MonsterTraverses[0].From)
+	s.Equal("room-b", out.MonsterTraverses[0].ToRoom)
+	s.Equal(spatial.Position{X: 0, Y: 5}, out.MonsterTraverses[0].To)
+	s.Empty(out.MonsterMoves, "this is a traverse, not a move")
+
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	s.Require().Len(members, 1)
+	s.Equal("room-b", members[0].Room)
+}
+
+// TestPumpIntentTraverseIllegalDoesNotAbort pins that an illegal traverse
+// intent (decider names a REAL connection but the monster isn't AT its
+// threshold) follows the SAME silent-skip contract Pump already
+// established for a spatially-rejected IntentMoveTo (traverseMember's own
+// doc comment): the pump does NOT abort — the clock still advances, the
+// tick beat is still recorded, refreshSight still runs — but no
+// "traversed" beat is recorded and the monster's room/position are
+// unchanged.
+func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
+	goblinID := core.EntityID("goblin")
+	decider := &onceTraverseDecider{connection: "door1"}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{twoRoomDoor},
+		},
+		Members: []encounter.MemberInput{
+			// goblin is NOT at the threshold (the threshold is (9,5)).
+			{ID: goblinID, Kind: encounter.KindMonster, Room: "room-a",
+				Position: spatial.Position{X: 3, Y: 3}, Decider: decider},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	beforeClock := enc.ToData().Clock.HighWater
+
+	out, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err, "an illegal traverse intent must not abort the pump")
+
+	afterClock := enc.ToData().Clock.HighWater
+	s.Equal(beforeClock+1, afterClock, "clock still advances — matches IntentMoveTo's spatial-rejection contract")
+	s.Equal(uint64(1), out.Tick)
+	s.Empty(out.MonsterTraverses, "the illegal traverse must not appear as successful")
+	s.Empty(out.MonsterMoves)
+	s.Len(out.Seqs, 1, "exactly the tick beat — no traversed beat for the failure")
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: goblinID, AfterSeq: 0})
+	s.Require().NoError(err)
+	for _, entry := range story {
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		s.NotEqual("traversed", beat["beat"], "no traversed beat for a failed traverse")
+	}
+
+	data := enc.ToData()
+	s.Require().Len(data.Members, 1)
+	s.Equal("room-a", data.Members[0].Room, "the monster never left its room")
+	s.Equal(3.0, data.Members[0].Position.X, "the monster's position is unchanged")
+	s.Equal(3.0, data.Members[0].Position.Y)
+}
+
+// TestPumpIntentTraverseUnknownConnectionDoesNotAbort pins that an
+// IntentTraverse naming an unknown connection (a decider bug) follows the
+// SAME silent-skip contract as an illegal-position traverse:
+// traverseMember's ErrNoConnection is treated identically to its
+// ErrBadPlacement by Pump's phase-2 executor — no abort, no beat, no
+// position change.
+func (s *PumpTestSuite) TestPumpIntentTraverseUnknownConnectionDoesNotAbort() {
+	goblinID := core.EntityID("goblin")
+	decider := &onceTraverseDecider{connection: "no-such-door"}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{twoRoomDoor},
+		},
+		Members: []encounter.MemberInput{
+			{ID: goblinID, Kind: encounter.KindMonster, Room: "room-a",
+				Position: spatial.Position{X: 9, Y: 5}, Decider: decider}, // AT the real door's threshold, but names a fake one
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	beforeClock := enc.ToData().Clock.HighWater
+
+	out, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err, "an unknown-connection traverse intent must not abort the pump")
+
+	afterClock := enc.ToData().Clock.HighWater
+	s.Equal(beforeClock+1, afterClock, "clock still advances")
+	s.Empty(out.MonsterTraverses)
+	s.Len(out.Seqs, 1, "exactly the tick beat")
+
+	data := enc.ToData()
+	s.Require().Len(data.Members, 1)
+	s.Equal("room-a", data.Members[0].Room, "the monster never left its room")
+}
+
+// TestPumpDeciderErrorAbortsEvenWithTraversableTopology extends the
+// existing decider-error-aborts law (TestPumpDeciderErrorAborts) to a
+// pump where a traverse WOULD have been legal — proving the abort
+// contract doesn't depend on which Intent kind the decider would have
+// returned. PHASE 1's decider-error check runs before ANY intent is even
+// inspected, so this must abort exactly like the single-room case.
+func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() {
+	goblinID := core.EntityID("goblin")
+	deciderErr := errors.New("test decider error")
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{twoRoomDoor},
+		},
+		Members: []encounter.MemberInput{
+			// goblin IS at the threshold — a traverse WOULD be legal, but
+			// the decider errors before ever returning an Intent.
+			{ID: goblinID, Kind: encounter.KindMonster, Room: "room-a",
+				Position: spatial.Position{X: 9, Y: 5}, Decider: &errorDecider{err: deciderErr}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	beforeClock := enc.ToData().Clock.HighWater
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().Error(err, "pump should fail with decider error")
+	afterClock := enc.ToData().Clock.HighWater
+	s.Equal(beforeClock, afterClock, "R5: no clock advance on a decider error, even with legal traverse topology available")
+
+	data := enc.ToData()
+	s.Require().Len(data.Members, 1)
+	s.Equal("room-a", data.Members[0].Room, "the monster never moved — R5 atomicity")
+}
+
+// TestPumpPursuitAcrossConnection is the wave's integration pin: a
+// pursuit decider, constructed with ONLY the field's static topology and
+// a target ID — never reading encounter state directly; Snapshot +
+// Holdings + its own construction-time config is all it gets (C2) —
+// chases a player through a doorway. The player starts AT the threshold,
+// the monster sees them; the player traverses away; the monster's ghost
+// of the player holds the LAST-SEEN position — the threshold, in the OLD
+// room; the monster walks to it, then — standing exactly on the
+// connection endpoint — traverses through the SAME connection, arriving
+// in the player's new room, and holds them Current again.
+func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
+	aliceID := core.EntityID("alice")
+	goblinID := core.EntityID("goblin")
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{twoRoomDoor},
+		},
+		Members: []encounter.MemberInput{
+			{ID: aliceID, Kind: encounter.KindPlayer, Room: "room-a", Position: spatial.Position{X: 9, Y: 5}},
+			{ID: goblinID, Kind: encounter.KindMonster, Room: "room-a", Position: spatial.Position{X: 8, Y: 5},
+				Decider: &pursuitDecider{connections: []encounter.ConnectionInput{twoRoomDoor}, target: aliceID}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	// Precondition: goblin sees alice Current (adjacent, no occluders).
+	goblinView, err := enc.View(&encounter.ViewInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Len(goblinView, 1)
+	s.Equal(intel.Current, goblinView[0].Status, "precondition: goblin must see alice before she leaves")
+
+	// Stage 1: alice traverses away, then repositions within room-b so
+	// the monster's eventual arrival isn't a trivial same-cell coincidence.
+	_, err = enc.Traverse(&encounter.TraverseInput{Member: aliceID, Connection: "door1"})
+	s.Require().NoError(err)
+	_, err = enc.Move(&encounter.MoveInput{Member: aliceID, To: spatial.Position{X: 3, Y: 5}})
+	s.Require().NoError(err)
+
+	goblinView, err = enc.View(&encounter.ViewInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Len(goblinView, 1, "the ghost is HELD, not gone")
+	s.Equal(intel.Held, goblinView[0].Status, "alice left the room — goblin's sight of her fades")
+	var ghostSeen encounter.SightPayload
+	s.Require().NoError(json.Unmarshal(goblinView[0].Payload, &ghostSeen))
+	s.Equal("room-a", ghostSeen.Room, "the ghost holds alice's LAST-SEEN room")
+	s.Equal(9.0, ghostSeen.X, "the ghost holds alice at the THRESHOLD, her last-seen position")
+	s.Equal(5.0, ghostSeen.Y)
+
+	// Stage 2: pump — goblin walks toward the ghost's last-seen position.
+	out1, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(out1.MonsterMoves, 1)
+	s.Equal(spatial.Position{X: 9, Y: 5}, out1.MonsterMoves[0].To, "goblin walks to the threshold")
+	s.Empty(out1.MonsterTraverses, "not standing at the threshold at the time this tick decided")
+
+	// Stage 3: pump — goblin, now AT the threshold, traverses.
+	out2, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(out2.MonsterTraverses, 1)
+	s.Equal(goblinID, out2.MonsterTraverses[0].Member)
+	s.Equal("room-a", out2.MonsterTraverses[0].FromRoom)
+	s.Equal("room-b", out2.MonsterTraverses[0].ToRoom)
+	s.Equal(spatial.Position{X: 0, Y: 5}, out2.MonsterTraverses[0].To)
+
+	// The monster arrives in alice's room and, since THIS pump's own
+	// refreshSight ran AFTER the traverse, already holds her Current.
+	goblinView, err = enc.View(&encounter.ViewInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Len(goblinView, 1)
+	s.Equal(intel.Current, goblinView[0].Status, "the monster holds alice Current again, having crossed the threshold")
+	var aliceSeen encounter.SightPayload
+	s.Require().NoError(json.Unmarshal(goblinView[0].Payload, &aliceSeen))
+	s.Equal("room-b", aliceSeen.Room)
+	s.Equal(3.0, aliceSeen.X)
+	s.Equal(5.0, aliceSeen.Y)
+
+	// Also verify via Story that the chase left the expected trail.
+	story, err := enc.Story(&encounter.StoryInput{Audience: goblinID, AfterSeq: 0})
+	s.Require().NoError(err)
+	var sawTraversed bool
+	for _, entry := range story {
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		if beat["beat"] == "traversed" && beat["member"] == string(goblinID) {
+			sawTraversed = true
+		}
+	}
+	s.True(sawTraversed, "the goblin's traversal must appear in the Story")
 }

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -661,6 +661,34 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 	})
 }
 
+// TestPumpJoinedMonsterWithNilDeciderHolds is Join's counterpart to
+// TestPumpMonsterWithNilDecider (Setup) and
+// TestDeciderReattachmentWithoutDecider (Load): a monster that joins with
+// a nil Decider is legal and simply holds — Join already guards this
+// (encounter.go's `if in.Member.Decider != nil`), previously unpinned at
+// this seam.
+func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: endingStairs, Trigger: encounter.TriggerReachedPosition{
+			Room: room1, Position: spatial.Position{X: 9, Y: 9}}}},
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{
+		ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 5, Y: 5},
+		// No Decider.
+	}})
+	s.Require().NoError(err)
+
+	out, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Empty(out.MonsterMoves, "a joined monster with no decider should not move")
+}
+
 func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 	s.Run("pump on closed encounter returns ErrClosed", func() {
 		// Arrange: goblin with patrol that reaches the ending position

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -1368,3 +1368,127 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	_, err = enc.Pump(&encounter.PumpInput{})
 	s.Require().ErrorIs(err, encounter.ErrClosed)
 }
+
+// TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrder pins the
+// honest law: ending evaluation walks EXECUTED ACTIONS in decision
+// order (C8's per-monster ordering), and declaration order is only a
+// tiebreak WITHIN one action's own scan of e.endings — not a global
+// "first-declared-wins" rule. The control lands each monster on its
+// "natural" declared-order slot, where decision order and declaration
+// order happen to agree — easy to misread as declaration order
+// driving the result. The cross scenario keeps decision order fixed
+// but swaps which ending each monster's landing position fires: the
+// SECOND-declared ending wins because it belongs to the FIRST-deciding
+// monster, disproving the declaration-order reading.
+func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrder() {
+	aID := core.EntityID("aaa-goblin") // decides first (Members() sorts by ID)
+	bID := core.EntityID("zzz-goblin") // decides second
+	posA := spatial.Position{X: 2, Y: 2}
+	posB := spatial.Position{X: 8, Y: 8}
+
+	s.Run("control: decision order and declaration order agree", func() {
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+			Members: []encounter.MemberInput{
+				{ID: aID, Kind: encounter.KindMonster, Room: room1,
+					Position: spatial.Position{X: 5, Y: 5}, Decider: &patrolDecider{positions: []spatial.Position{posA}}},
+				{ID: bID, Kind: encounter.KindMonster, Room: room1,
+					Position: spatial.Position{X: 6, Y: 6}, Decider: &patrolDecider{positions: []spatial.Position{posB}}},
+			},
+			Endings: []encounter.EndingInput{
+				// Declared first: fires for aaa-goblin, who decides first.
+				{Key: "first", Trigger: encounter.TriggerReachedPosition{Room: room1, Position: posA, Member: aID}},
+				// Declared second: fires for zzz-goblin, who decides second.
+				{Key: "second", Trigger: encounter.TriggerReachedPosition{Room: room1, Position: posB, Member: bID}},
+			},
+		})
+		s.Require().NoError(err)
+
+		out, err := enc.Pump(&encounter.PumpInput{})
+		s.Require().NoError(err)
+		s.Require().NotNil(out.Outcome)
+		s.Equal("first", out.Outcome.Ending, "aaa-goblin decides first and lands on the first-declared ending")
+	})
+
+	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+			Members: []encounter.MemberInput{
+				// Same decision order (aaa first, zzz second), but now each
+				// monster's landing position fires the OTHER declared ending.
+				{ID: aID, Kind: encounter.KindMonster, Room: room1,
+					Position: spatial.Position{X: 5, Y: 5}, Decider: &patrolDecider{positions: []spatial.Position{posB}}},
+				{ID: bID, Kind: encounter.KindMonster, Room: room1,
+					Position: spatial.Position{X: 6, Y: 6}, Decider: &patrolDecider{positions: []spatial.Position{posA}}},
+			},
+			Endings: []encounter.EndingInput{
+				// Declared first: fires for zzz-goblin (posA), who decides SECOND.
+				{Key: "first", Trigger: encounter.TriggerReachedPosition{Room: room1, Position: posA, Member: bID}},
+				// Declared second: fires for aaa-goblin (posB), who decides FIRST.
+				{Key: "second", Trigger: encounter.TriggerReachedPosition{Room: room1, Position: posB, Member: aID}},
+			},
+		})
+		s.Require().NoError(err)
+
+		out, err := enc.Pump(&encounter.PumpInput{})
+		s.Require().NoError(err)
+		s.Require().NotNil(out.Outcome)
+		s.Equal("second", out.Outcome.Ending,
+			"aaa-goblin decides first and lands on the SECOND-declared ending — "+
+				"decision order wins, not declaration order")
+	})
+}
+
+// reentrantSelfExitDecider violates the decider contract: it calls
+// Exit on its own member from inside Decide, then still returns a
+// move intent. This is a contract-violating decider, not a supported
+// pattern — but the pump must survive it. Set enc after NewEncounter
+// returns (the encounter doesn't exist yet when Members are declared).
+type reentrantSelfExitDecider struct {
+	enc  *encounter.Encounter
+	self core.EntityID
+}
+
+func (r *reentrantSelfExitDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
+	if _, err := r.enc.Exit(&encounter.ExitInput{Member: r.self}); err != nil {
+		return nil, err
+	}
+	return encounter.IntentMoveTo{To: spatial.Position{X: 9, Y: 9}}, nil
+}
+
+// TestPumpSurvivesReentrantSelfExitingDecider pins the phase-1/phase-2
+// seam against a decider that mutates membership mid-decide: phase 1's
+// planned list is keyed by MemberID, and phase 2 looks the live member
+// pointer up fresh from e.members — which the reentrant Exit has
+// already deleted. Without a nil guard at that lookup, phase 2
+// dereferences a nil *Member and panics. The shipped contract treats
+// this exactly like any other phase-2 execution failure: silent skip,
+// nothing else disturbed.
+func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
+	aliceID := core.EntityID("alice")
+	goblinID := core.EntityID("goblin")
+	decider := &reentrantSelfExitDecider{self: goblinID}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Members: []encounter.MemberInput{
+			{ID: aliceID, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: goblinID, Kind: encounter.KindMonster, Room: room1,
+				Position: spatial.Position{X: 4, Y: 4}, Decider: decider},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	decider.enc = enc
+
+	s.Require().NotPanics(func() {
+		out, pumpErr := enc.Pump(&encounter.PumpInput{})
+		s.Require().NoError(pumpErr, "a contract-violating self-exiting decider must not abort the pump")
+		s.Empty(out.MonsterMoves, "the exited monster's planned move has no live member left to execute")
+	})
+
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	s.Require().Len(members, 1, "only alice remains — goblin's self-exit went through")
+	s.Equal(aliceID, members[0].ID)
+}

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -1119,11 +1119,21 @@ func (s *PumpTestSuite) TestPumpIntentTraverseUnknownConnectionDoesNotAbort() {
 	afterClock := enc.ToData().Clock.HighWater
 	s.Equal(beforeClock+1, afterClock, "clock still advances")
 	s.Empty(out.MonsterTraverses)
-	s.Len(out.Seqs, 1, "exactly the tick beat")
+	s.Len(out.Seqs, 1, "exactly the tick beat — no traversed beat for the failure")
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: goblinID, AfterSeq: 0})
+	s.Require().NoError(err)
+	for _, entry := range story {
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		s.NotEqual("traversed", beat["beat"], "no traversed beat for a failed traverse")
+	}
 
 	data := enc.ToData()
 	s.Require().Len(data.Members, 1)
 	s.Equal("room-a", data.Members[0].Room, "the monster never left its room")
+	s.Equal(9.0, data.Members[0].Position.X, "the monster's position is unchanged")
+	s.Equal(5.0, data.Members[0].Position.Y)
 }
 
 // TestPumpDeciderErrorAbortsEvenWithTraversableTopology extends the
@@ -1259,4 +1269,102 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 		}
 	}
 	s.True(sawTraversed, "the goblin's traversal must appear in the Story")
+}
+
+// TestPumpFullTickThenEvaluateAcrossTraverse pins full-tick-then-evaluate
+// as law, now that IntentTraverse raises its stakes (a fired ending
+// during phase-2 execution would otherwise need to REVERT a room
+// mutation, not just a same-room position). Two monsters decide in the
+// SAME pump: "aaa-goblin" (decides first — Members() stable order sorts
+// its ID before "zzz-goblin") traverses onto a FILTERED ending naming
+// it; "zzz-goblin" has an unrelated same-room move queued. The shipped
+// contract (wave-1 loop skeleton, deliberate, reviewer-verified): phase
+// 2 executes BOTH actions and records BOTH beats BEFORE any ending
+// evaluation; evaluation walks executed in decision order, the first
+// match sets the outcome and stops evaluating further endings, but never
+// reverts an already-applied action; Outcome.Members reflects the FULL
+// post-tick state, including zzz-goblin at its NEW position; the next
+// Pump returns ErrClosed.
+func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
+	aID := core.EntityID("aaa-goblin")
+	bID := core.EntityID("zzz-goblin")
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "room-a", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10},
+			},
+			Connections: []encounter.ConnectionInput{twoRoomDoor},
+		},
+		Members: []encounter.MemberInput{
+			// aaa-goblin is AT the threshold, ready to traverse onto the
+			// filtered ending below.
+			{ID: aID, Kind: encounter.KindMonster, Room: "room-a",
+				Position: spatial.Position{X: 9, Y: 5}, Decider: &onceTraverseDecider{connection: "door1"}},
+			// zzz-goblin has an unrelated same-room move queued.
+			{ID: bID, Kind: encounter.KindMonster, Room: "room-a",
+				Position: spatial.Position{X: 3, Y: 3}, Decider: &patrolDecider{positions: []spatial.Position{{X: 4, Y: 4}}}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "escaped", Trigger: encounter.TriggerReachedPosition{
+				Room: "room-b", Position: spatial.Position{X: 0, Y: 5}, Member: aID}},
+		},
+	})
+	s.Require().NoError(err)
+
+	out, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	// Both actions executed and both beats recorded — the closing ending
+	// (fired by aaa-goblin's traverse) did not suppress zzz-goblin's move.
+	s.Require().Len(out.MonsterTraverses, 1)
+	s.Equal(aID, out.MonsterTraverses[0].Member)
+	s.Require().Len(out.MonsterMoves, 1)
+	s.Equal(bID, out.MonsterMoves[0].Member)
+	s.Equal(spatial.Position{X: 4, Y: 4}, out.MonsterMoves[0].To)
+
+	s.Require().NotNil(out.Outcome, "aaa-goblin's traverse must fire the filtered ending")
+	s.Equal("escaped", out.Outcome.Ending)
+	s.Require().Len(out.Outcome.Members, 2)
+
+	var aOutcome, bOutcome encounter.MemberOutcome
+	for _, m := range out.Outcome.Members {
+		switch m.ID {
+		case aID:
+			aOutcome = m
+		case bID:
+			bOutcome = m
+		}
+	}
+	s.Equal("room-b", aOutcome.Room)
+	s.Equal(spatial.Position{X: 0, Y: 5}, aOutcome.Position)
+	// The full-tick-then-evaluate law, made observable: zzz-goblin's
+	// ALREADY-APPLIED move is reflected in the outcome — its NEW
+	// position, not its pre-pump one. A revert-on-close implementation
+	// would show (3,3) here instead.
+	s.Equal("room-a", bOutcome.Room)
+	s.Equal(spatial.Position{X: 4, Y: 4}, bOutcome.Position,
+		"the outcome must reflect zzz-goblin's post-tick position, not its pre-tick one")
+
+	// Both beats actually landed in the Story (not just the output structs).
+	story, err := enc.Story(&encounter.StoryInput{Audience: aID, AfterSeq: 0})
+	s.Require().NoError(err)
+	var sawTraversed, sawMoved bool
+	for _, entry := range story {
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		switch beat["beat"] {
+		case "traversed":
+			sawTraversed = true
+		case "moved":
+			sawMoved = true
+		}
+	}
+	s.True(sawTraversed, "aaa-goblin's traverse beat must be recorded")
+	s.True(sawMoved, "zzz-goblin's move beat must be recorded despite the mid-tick closure")
+
+	// The encounter is closed: the next pump returns ErrClosed.
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().ErrorIs(err, encounter.ErrClosed)
 }


### PR DESCRIPTION
Closes #922. Ratified by the triplet on #923 (design + plan + execution addenda).

Wave 2 of the free-roam composition: the declared room topology gets teeth, and pursuit survives doorways.

## What this delivers

- **Connections gain endpoints** (`ConnectionInput.FromPosition/ToPosition`) with a nine-defect validation matrix at both seams (Setup + Load), sorted persistence, and one-defect rejection fixtures with discriminating fragments. New sentinel `ErrBadConnection` (declaration defects).
- **Rooms choose their grid** — `RoomInput.Grid spatial.GridShape` (zero value square: existing blobs and goldens byte-stable; hex first-class per Platform's ask on rpg-api#793). All bounds validity defers to the constructed grid; the module owns no rectangle math. Room-ID validation added (empty/duplicate).
- **The `Traverse` verb** — a member standing at a connection's endpoint crosses to the far endpoint (bidirectional). Module prechecks carry the error contract (`ErrNoConnection` for runtime lookup miss, `ErrBadPlacement` off-threshold); spatial's `TransitionEntity` + `PlaceEntity` execute it with an independently-verified backstop. Percepts refresh both rooms in one pass; sight never crosses an opening; ending evaluation runs at arrival; the clock is untouched (traversal is an activity, not time).
- **Deciders learn where they stand** — `Decide(Snapshot{Room, Position, Holdings})` (the one intentional breaking change, ratified in the design; zero external consumers) plus `IntentTraverse`, executed by Pump in decision order through a shared helper. A REAL latent bug found and fixed en route: Pump's planned list stored member value copies — fatal once traverses mutate `member.Room` — now live-pointer lookups, with the regression pinned. `PumpOutput.MonsterTraverses` mirrors `MonsterMoves`.
- **The vault chase** — a continuous two-room scene: sight, the slip, the ghost pinned at the true last-seen threshold, mid-chase save/reload with the decider re-attached, the goblin's own decision carrying it through the gate, Current reacquired, the ending, and an exact ordered transcript pin.
- **Verified transcript + workbench**: `Example_theTraverse` with a pinned `// Output:`; the freeroam workbench gains a second room and a `traverse` command with room-aware world/belief grids.

## Review rigor

Every task passed a sonnet combined review; Tasks 1 and 3+4 additionally passed Opus deep passes. All findings closed with per-mutant kill evidence (~50 mutants and hostile-blob probes across the wave). Laws newly pinned: full-tick-then-evaluate closure; ending evaluation is decision-order-across-actions, declaration-order within one action; reject-never-crash extended to contract-violating reentrant deciders. R5 limbo-window analysis: unreachable under four documented invariants (comment at the shared seam).

## Compatibility

`gorelease -base v0.1.0`: one incompatible change (`Decider.Decide` signature — the ratified Snapshot migration), all else additive. Suggested version confirmed: **v0.2.0**.

After merge, tag: `rulebooks/dnd5e/encounter/v0.2.0` — this is Platform's dependency signal on rpg-api#793 (multi-room + hex both real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler
