### PR TITLE
docs(combat): architecture overview + ADR-0036 (additional damage & selective crits)

### DIFF
--- a/docs/adr/0036-additional-damage-selective-crit.md
+++ b/docs/adr/0036-additional-damage-selective-crit.md
@@ -57,54 +57,52 @@ encounter/  (SDK)           AttackInput{AttackerDamageDice, AttackerDamageType, 
 ### The attack damage flow
 
 ```mermaid
-%%{init: {'flowchart': {'useMaxWidth': false, 'htmlLabels': true}}}%%
-flowchart LR
-    AI["combat.AttackInput<br/>Weapon (Damage='1d8', DamageType=bludgeoning)<br/>Roller, EventBus, AttackerID, TargetID<br/>v1: AdditionalDamage []DamageComponentSpec"]
-
-    subgraph P1["attack_phases.go - ResolveAttackHit, phase 1"]
-        direction TB
+flowchart TD
+    subgraph P1["phase 1 - ResolveAttackHit (attack_phases.go)"]
+        direction LR
+        AI["AttackInput<br/>Weapon (1d8 bludgeoning),<br/>Roller, EventBus, IDs<br/>v1: AdditionalDamage []DamageComponentSpec"]
         R1["roll d20 -> AttackRoll"]
-        AC["AttackChain staged: advantage, pack tactics, improved-crit threshold"]
-        CTX["AttackContext{AttackRoll, AbilityMod, AbilityUsed,<br/>CriticalThreshold, Weapon, IsMelee}<br/>v1: + AdditionalDamage"]
-        R1 --> AC --> CTX
+        AC["AttackChain: advantage,<br/>pack tactics, crit threshold"]
+        CTX["AttackContext{AttackRoll, AbilityMod,<br/>CriticalThreshold, Weapon, IsMelee}<br/>v1: + AdditionalDamage"]
+        AI --> R1 --> AC --> CTX
     end
 
     WIN["reaction window - Shield, Protection"]
 
-    subgraph P2["attack_phases.go - ApplyAttackOutcome, phase 2"]
-        direction TB
-        HIT["hit? crit?  roll vs effectiveAC, crit if >= threshold"]
-        ROLL["parse Weapon.Damage -> dice.Pool<br/>roll pool crit?2:1 -> weaponComponent<br/>(DamageComponent: dice rolls, IsCritical=crit)"]
-        ABIL["abilityComponent (FlatBonus=AbilityMod, never doubled)"]
-        ADD["v1: each AdditionalDamage spec<br/>parse Dice -> pool, roll ONCE<br/>-> DamageComponent{Type, IsCritical=false}"]
+    subgraph P2["phase 2 - ApplyAttackOutcome (attack_phases.go)"]
+        direction LR
+        HIT["hit? crit? vs effectiveAC"]
+        ROLL["parse Weapon.Damage -> Pool<br/>roll crit?2:1 -> weaponComponent"]
+        ABIL["abilityComponent<br/>FlatBonus=AbilityMod, never doubled"]
+        ADD["v1: each AdditionalDamage spec<br/>roll ONCE -> DamageComponent<br/>{Type, IsCritical=false}"]
         HIT --> ROLL --> ABIL --> ADD
     end
 
-    subgraph CH["combat/damage.go - ResolveDamage, the chain"]
-        direction TB
-        CE["DamageChainEvent{Components: weapon, ability, additional...}"]
-        ST["staged chain Base->Features->Conditions->Equipment->Final<br/>conditions add/modify components:<br/>rage, sneak attack (crit-eligible dice), GWF reroll,<br/>resistance x0.5, vulnerability x2, immunity x0"]
-        CALC["calculateFinalDamage: group by Type, apply multipliers<br/>-> []DamageInstanceInput{Amount int, Type}  dice become INTS here"]
+    subgraph CH["ResolveDamage - the chain (combat/damage.go)"]
+        direction LR
+        CE["DamageChainEvent{Components:<br/>weapon, ability, additional}"]
+        ST["staged chain Base->Features-><br/>Conditions->Equipment->Final<br/>rage, sneak attack, GWF reroll,<br/>resist x0.5, vuln x2, immune x0"]
+        CALC["calculateFinalDamage: group by Type,<br/>apply multipliers -><br/>[]DamageInstanceInput{int}  dice->INTS"]
         TOTAL["TotalDamage + FinalComponents"]
         CE --> ST --> CALC --> TOTAL
     end
 
-    subgraph OUT["ApplyAttackOutcome returns + notifies"]
-        direction TB
-        AR["AttackResult{TotalDamage, Critical, Breakdown.Components}"]
+    subgraph OUT["returns + notifies"]
+        direction LR
+        AR["AttackResult{TotalDamage, Critical,<br/>Breakdown.Components}"]
         DRE["publish DamageReceivedEvent"]
         AR --> DRE
     end
 
-    subgraph DOWN["DOWNSTREAM - rpg-api / encounter SDK, not rpg-toolkit combat"]
-        direction TB
+    subgraph DOWN["DOWNSTREAM - rpg-api / encounter SDK"]
+        direction LR
         HP["Target.ApplyDamage -> HP mutation"]
         DDE["encounter DamageDealtEvent{Components}"]
         HP --> DDE
     end
 
-    AI --> R1
-    CTX --> WIN --> HIT
+    CTX --> WIN
+    WIN --> HIT
     ADD --> CE
     TOTAL --> AR
     DRE --> HP

--- a/docs/adr/0036-additional-damage-selective-crit.md
+++ b/docs/adr/0036-additional-damage-selective-crit.md
@@ -1,0 +1,235 @@
+# ADR-0036: Additional Damage and Selective Critical Hits
+
+Date: 2026-01-20
+
+## Status
+
+Proposed
+
+Companion to [ADR-0026: Damage Application via Event Chain](0026-damage-application-via-event-chain.md).
+
+## Context
+
+Monster attacks in D&D 5e frequently deal more than one type of damage on a
+single hit — a weapon's physical damage plus an elemental or magical rider. The
+canonical example is the ooze's pseudopod: **bludgeoning + acid**.
+
+The toolkit does not model this today. An attack carries exactly one damage
+pool: `weapons.Weapon` has a single `Damage` dice string and a single
+`DamageType`. Bonus damage of other types can only enter as `DamageComponent`s
+added by *conditions* on the damage chain (sneak attack, rage, etc.) — there is
+no way to say "this attack *intrinsically* deals slashing + fire."
+
+The second half of the problem is the critical hit. Today, crit doubling is
+**pool-level, not component-level**: `ApplyAttackOutcome` calls
+`rollDamageDice(pool, roller, 2)` on the weapon's one pool. There is no
+per-component notion of "this pool doubles on a crit, that one does not." The
+`IsCritical` flag exists on `DamageComponent` but is *set* by whoever adds the
+component; nothing *consults* it during doubling.
+
+For the ooze we want the rule many tables play (and the DMG optional rule):
+**the physical/weapon dice double on a crit, the rider does not.** RAW 5e
+doubles all damage dice; this ADR deliberately adopts the variant, because it is
+the behavior the game wants and it keeps the common "weapon + elemental rider"
+monster pattern cheap to express.
+
+### Where the pieces live today
+
+```
+dice/                      dice.Pool, dice.ParseNotation("1d8" -> Pool), dice.Roller
+events/                    EventBus, StagedChain
+core/                      Ref, Entity
+rulebooks/dnd5e/
+  damage/                  Type (bludgeoning, acid, ...) - IsPhysical/IsElemental
+  weapons/                 Weapon{Damage string, DamageType, Properties[]WeaponProperty}
+  events/                  DamageComponent{FinalDiceRolls, FlatBonus, DamageType,
+                                    IsCritical, Multiplier}  <- RICH carrier (attacks)
+                            DamageChainEvent, AttackChainEvent, DamageReceivedEvent
+  combat/                  AttackInput, AttackContext, ResolveAttackHit, ApplyAttackOutcome
+                            ResolveDamage, DealDamage, DealDamageInput
+                            DamageInstanceInput{Amount int, Type}  <- SIMPLE carrier (spells/cond)
+                            calculateFinalDamage, stages (Base/Features/Conditions/Equipment/Final)
+  monster/                 MonsterAction, MeleeConfig{DamageDice, DamageType} -> publishes AttackEvent
+encounter/  (SDK)           AttackInput{AttackerDamageDice, AttackerDamageType, Attacker, Defender},
+                            CombatResolver.ResolveAttack, DamageDealtEvent
+```
+
+### The attack damage flow
+
+```mermaid
+flowchart TD
+    AI["combat.AttackInput<br/>Weapon (Damage='1d8', DamageType=bludgeoning)<br/>Roller, EventBus, AttackerID, TargetID<br/>v1: AdditionalDamage []DamageComponentSpec"]
+
+    subgraph P1["attack_phases.go - ResolveAttackHit, phase 1"]
+        R1["roll d20 -> AttackRoll"]
+        AC["AttackChain staged: advantage, pack tactics, improved-crit threshold"]
+        CTX["AttackContext{AttackRoll, AbilityMod, AbilityUsed,<br/>CriticalThreshold, Weapon, IsMelee}<br/>v1: + AdditionalDamage"]
+        R1 --> AC --> CTX
+    end
+
+    WIN["reaction window - Shield, Protection"]
+
+    subgraph P2["attack_phases.go - ApplyAttackOutcome, phase 2"]
+        HIT["hit? crit?  roll vs effectiveAC, crit if >= threshold"]
+        ROLL["parse Weapon.Damage -> dice.Pool<br/>roll pool crit?2:1 -> weaponComponent<br/>(DamageComponent: dice rolls, IsCritical=crit)"]
+        ABIL["abilityComponent (FlatBonus=AbilityMod, never doubled)"]
+        ADD["v1: each AdditionalDamage spec<br/>parse Dice -> pool, roll ONCE<br/>-> DamageComponent{Type, IsCritical=false}"]
+        HIT --> ROLL --> ABIL --> ADD
+    end
+
+    subgraph CH["combat/damage.go - ResolveDamage, the chain"]
+        CE["DamageChainEvent{Components: weapon, ability, additional...}"]
+        ST["staged chain Base->Features->Conditions->Equipment->Final<br/>conditions add/modify components:<br/>rage, sneak attack (crit-eligible dice), GWF reroll,<br/>resistance x0.5, vulnerability x2, immunity x0"]
+        CALC["calculateFinalDamage: group by Type, apply multipliers<br/>-> []DamageInstanceInput{Amount int, Type}  dice become INTS here"]
+        TOTAL["TotalDamage + FinalComponents"]
+        CE --> ST --> CALC --> TOTAL
+    end
+
+    subgraph OUT["ApplyAttackOutcome returns + notifies"]
+        AR["AttackResult{TotalDamage, Critical, Breakdown.Components}"]
+        DRE["publish DamageReceivedEvent"]
+        AR --> DRE
+    end
+
+    subgraph DOWN["DOWNSTREAM - rpg-api / encounter SDK, not rpg-toolkit combat"]
+        HP["Target.ApplyDamage -> HP mutation"]
+        DDE["encounter DamageDealtEvent{Components}"]
+        HP --> DDE
+    end
+
+    AI --> R1
+    CTX --> WIN --> HIT
+    ADD --> CE
+    TOTAL --> AR
+    DRE --> HP
+```
+
+Three observations that drove this decision:
+
+1. **Dice strings only live at the very top.** `Weapon.Damage` is `"1d8"`;
+   `dice.ParseNotation` turns it into a `dice.Pool`, which `ApplyAttackOutcome`
+   rolls into `[]int` stored in `DamageComponent.FinalDiceRolls`. The chain keeps
+   dice rolls around (for rerolls like GWF and for the combat log). Only
+   `calculateFinalDamage` sums them into `DamageInstanceInput.Amount int`. So
+   "damage is already an int" is true at the *spells/conditions* entry
+   (`DealDamage.Instances`) — **not** at the attack entry. Attacks carry dice
+   rolls as `DamageComponent` until the last step. Additional damage is
+   dice-based, so it must produce `DamageComponent`s and plug into the attack
+   path, not the int path.
+
+2. **Two carriers, one chain.** `DamageInstanceInput{Amount int}` is the simple
+   path (spells, conditions, environment — the total is already known).
+   `DamageComponent{FinalDiceRolls, FlatBonus, …}` is the rich path (attacks —
+   dice are involved). Both converge on `ResolveDamage`. The existing chain and
+   `calculateFinalDamage` already group components by damage type and apply
+   per-type multipliers, so a second intrinsic damage type needs no new
+   resistance/vulnerability machinery — acid resistance will still halve the
+   acid component for free.
+
+3. **Crit doubling is the one spot that is pool-level.** Everything downstream
+   of `ApplyAttackOutcome` is already component-aware; the only change needed
+   for selective crit is in `ApplyAttackOutcome` itself, where additional
+   components are rolled once regardless of crit.
+
+## Decision
+
+Add an optional `AdditionalDamage []DamageComponentSpec` to the attack path.
+The weapon's own pool remains the primary damage and keeps its existing crit
+semantics (rolled twice on a crit). Each additional damage spec is rolled
+**once** and is **never doubled on a critical hit**. All components — weapon,
+ability, and additional — feed `ResolveDamage` exactly as today.
+
+### v1 type (in `rulebooks/dnd5e/combat/`, next to `AttackInput`)
+
+```go
+// DamageComponentSpec is one intrinsic rider damage pool an attack deals on
+// a hit. It is rolled once and never doubled on a critical hit.
+type DamageComponentSpec struct {
+    Dice string      // "1d6"
+    Type damage.Type // damage.Acid
+}
+```
+
+### Threading
+
+- `AttackInput.AdditionalDamage []DamageComponentSpec` (nil/empty = today's
+  behavior; every existing test stays green).
+- `ResolveAttackHit` copies it onto `AttackContext`.
+- `ApplyAttackOutcome`, after building the weapon and ability components, for
+  each spec: `dice.ParseNotation(spec.Dice)` → roll once → emit a
+  `DamageComponent{Source: …, DamageType: spec.Type, IsCritical: false, …}`.
+
+No change to `ResolveDamage`, the damage chain, or `calculateFinalDamage` —
+resistance/vulnerability/immunity already operate per damage type.
+
+### The ooze, expressed
+
+Pseudopod = weapon pool `1d8 bludgeoning` (crit-eligible, as today) +
+`AdditionalDamage: [{Dice: "1d6", Type: damage.Acid}]` (never crits). On a crit:
+2× bludgeoning dice, 1× acid dice. On a normal hit: 1× each.
+
+### Property abstraction is deliberately deferred
+
+A general "damage properties" model (mirroring `weapons.WeaponProperty`) is the
+natural evolution — crit eligibility would become one `DamageProperty` among
+many. We are **not** building it in v1. v1 has exactly one behavior ("additional
+damage does not double on a crit"); a property enum with a single value is
+speculative structure. The `DamageProperty` enum will be extracted the moment a
+second property appears (e.g. "this additional damage *can* crit," or "this
+damage ignores resistance"). This is the intended "embrace the refactor" path:
+ship the simplest model that solves the ooze, then refactor upward when a second
+case demands it.
+
+## Consequences
+
+### Positive
+- Solves the ooze and the large majority of "weapon + elemental/magical rider"
+  monster stat blocks in one small, backwards-compatible change.
+- The change is localized to `ApplyAttackOutcome` and one new type; the damage
+  chain and resistance/vulnerability logic are untouched (already correct).
+- Fully testable inside `rpg-toolkit` at the combat layer, independent of
+  rpg-api plumbing.
+- Leaves the composable "damage recipe" / property model as a clean future
+  refactor rather than forcing it prematurely.
+
+### Negative
+- Does not cover the rare case where additional damage *should* crit (e.g. a
+  flametongue's fire under strict RAW). Sneak attack is unaffected — it is
+  already a condition on the damage chain, not intrinsic attack damage.
+- "Additional never crits" is a variant rule, not RAW. Adopted deliberately; if
+  the game later wants RAW crit doubling for a specific source, that is the
+  trigger to introduce `DamageProperty`.
+- End-to-end exercise for a real monster in a live encounter requires follow-on
+  rpg-api resolver plumbing to populate `AttackInput.AdditionalDamage` from a
+  monster action. The crit behavior itself is proven at the combat layer first.
+
+### Neutral
+- `MeleeConfig`/`BiteConfig`/`RangedConfig` gaining an `AdditionalDamage` field,
+  and a `NewOoze()` monster definition, are natural follow-on steps once the
+  combat-core behavior is solid. They are authoring convenience, not part of the
+  crit decision.
+- No change to the lower toolkit layers. A generic "damage builder" in
+  `tools/` or `mechanics/` is explicitly deferred until a second rulebook or a
+  second consumer makes the unknowns concrete.
+
+## Example
+
+### Test shape (TDD — tests written first, implementation follows)
+
+In `rulebooks/dnd5e/combat/`, driven through `ApplyAttackOutcome` with a rigged
+`mockRoller` and stub combatants (the existing `AttackPhasesTestSuite` seam):
+
+1. Single-pool crit → weapon dice rolled twice (regression guard; passes before
+   any change).
+2. Ooze: bludgeoning main + acid additional, crit → bludgeoning ×2, acid ×1.
+3. Same ooze, non-crit → both ×1.
+4. On a crit, `result.Breakdown.Components` shows bludgeoning `IsCritical: true`
+   and acid `IsCritical: false`, so the combat log / animation can narrate the
+   difference.
+
+### Open design choice (ratified)
+
+The weapon's primary pool stays **implicitly crit-eligible** (backwards
+compatible). Making every pool — including the primary — go through the spec
+list from day one is a larger blast radius across the weapons catalog for no v1
+benefit, and is left for the composable-recipe refactor.

--- a/docs/adr/0036-additional-damage-selective-crit.md
+++ b/docs/adr/0036-additional-damage-selective-crit.md
@@ -57,10 +57,12 @@ encounter/  (SDK)           AttackInput{AttackerDamageDice, AttackerDamageType, 
 ### The attack damage flow
 
 ```mermaid
-flowchart TD
+%%{init: {'flowchart': {'useMaxWidth': false, 'htmlLabels': true}}}%%
+flowchart LR
     AI["combat.AttackInput<br/>Weapon (Damage='1d8', DamageType=bludgeoning)<br/>Roller, EventBus, AttackerID, TargetID<br/>v1: AdditionalDamage []DamageComponentSpec"]
 
     subgraph P1["attack_phases.go - ResolveAttackHit, phase 1"]
+        direction TB
         R1["roll d20 -> AttackRoll"]
         AC["AttackChain staged: advantage, pack tactics, improved-crit threshold"]
         CTX["AttackContext{AttackRoll, AbilityMod, AbilityUsed,<br/>CriticalThreshold, Weapon, IsMelee}<br/>v1: + AdditionalDamage"]
@@ -70,6 +72,7 @@ flowchart TD
     WIN["reaction window - Shield, Protection"]
 
     subgraph P2["attack_phases.go - ApplyAttackOutcome, phase 2"]
+        direction TB
         HIT["hit? crit?  roll vs effectiveAC, crit if >= threshold"]
         ROLL["parse Weapon.Damage -> dice.Pool<br/>roll pool crit?2:1 -> weaponComponent<br/>(DamageComponent: dice rolls, IsCritical=crit)"]
         ABIL["abilityComponent (FlatBonus=AbilityMod, never doubled)"]
@@ -78,6 +81,7 @@ flowchart TD
     end
 
     subgraph CH["combat/damage.go - ResolveDamage, the chain"]
+        direction TB
         CE["DamageChainEvent{Components: weapon, ability, additional...}"]
         ST["staged chain Base->Features->Conditions->Equipment->Final<br/>conditions add/modify components:<br/>rage, sneak attack (crit-eligible dice), GWF reroll,<br/>resistance x0.5, vulnerability x2, immunity x0"]
         CALC["calculateFinalDamage: group by Type, apply multipliers<br/>-> []DamageInstanceInput{Amount int, Type}  dice become INTS here"]
@@ -86,12 +90,14 @@ flowchart TD
     end
 
     subgraph OUT["ApplyAttackOutcome returns + notifies"]
+        direction TB
         AR["AttackResult{TotalDamage, Critical, Breakdown.Components}"]
         DRE["publish DamageReceivedEvent"]
         AR --> DRE
     end
 
     subgraph DOWN["DOWNSTREAM - rpg-api / encounter SDK, not rpg-toolkit combat"]
+        direction TB
         HP["Target.ApplyDamage -> HP mutation"]
         DDE["encounter DamageDealtEvent{Components}"]
         HP --> DDE
@@ -168,17 +174,12 @@ Pseudopod = weapon pool `1d8 bludgeoning` (crit-eligible, as today) +
 `AdditionalDamage: [{Dice: "1d6", Type: damage.Acid}]` (never crits). On a crit:
 2× bludgeoning dice, 1× acid dice. On a normal hit: 1× each.
 
-### Property abstraction is deliberately deferred
+### Primary damage pool
 
-A general "damage properties" model (mirroring `weapons.WeaponProperty`) is the
-natural evolution — crit eligibility would become one `DamageProperty` among
-many. We are **not** building it in v1. v1 has exactly one behavior ("additional
-damage does not double on a crit"); a property enum with a single value is
-speculative structure. The `DamageProperty` enum will be extracted the moment a
-second property appears (e.g. "this additional damage *can* crit," or "this
-damage ignores resistance"). This is the intended "embrace the refactor" path:
-ship the simplest model that solves the ooze, then refactor upward when a second
-case demands it.
+The weapon's own pool stays **implicitly crit-eligible** (backwards compatible).
+Additional damage is the only place the "never crits" rule applies; making every
+pool — including the primary — go through the spec list from day one would be a
+larger blast radius across the weapons catalog for no v1 benefit.
 
 ## Consequences
 
@@ -189,16 +190,12 @@ case demands it.
   chain and resistance/vulnerability logic are untouched (already correct).
 - Fully testable inside `rpg-toolkit` at the combat layer, independent of
   rpg-api plumbing.
-- Leaves the composable "damage recipe" / property model as a clean future
-  refactor rather than forcing it prematurely.
 
 ### Negative
 - Does not cover the rare case where additional damage *should* crit (e.g. a
   flametongue's fire under strict RAW). Sneak attack is unaffected — it is
   already a condition on the damage chain, not intrinsic attack damage.
-- "Additional never crits" is a variant rule, not RAW. Adopted deliberately; if
-  the game later wants RAW crit doubling for a specific source, that is the
-  trigger to introduce `DamageProperty`.
+- "Additional never crits" is a variant rule, not RAW, adopted deliberately.
 - End-to-end exercise for a real monster in a live encounter requires follow-on
   rpg-api resolver plumbing to populate `AttackInput.AdditionalDamage` from a
   monster action. The crit behavior itself is proven at the combat layer first.
@@ -226,10 +223,3 @@ In `rulebooks/dnd5e/combat/`, driven through `ApplyAttackOutcome` with a rigged
 4. On a crit, `result.Breakdown.Components` shows bludgeoning `IsCritical: true`
    and acid `IsCritical: false`, so the combat log / animation can narrate the
    difference.
-
-### Open design choice (ratified)
-
-The weapon's primary pool stays **implicitly crit-eligible** (backwards
-compatible). Making every pool — including the primary — go through the spec
-list from day one is a larger blast radius across the weapons catalog for no v1
-benefit, and is left for the composable-recipe refactor.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ Each ADR follows this structure:
 - [ADR-0005: Effect Composition](0005-effect-composition.md) - Design for composable effects system
 - [ADR-0006: Feature Management Pattern](0006-feature-management-pattern.md) - Hybrid approach for feature management
 - [ADR-0007: Generic Restoration Triggers](0007-generic-restoration-triggers.md) - Generic trigger system for resource restoration
+- [ADR-0036: Additional Damage and Selective Critical Hits](0036-additional-damage-selective-crit.md) - Multi-damage-type attacks where only the weapon pool doubles on a crit (companion to ADR-0026)
 
 ## Creating a New ADR
 

--- a/rulebooks/dnd5e/combat/architecture-overview.md
+++ b/rulebooks/dnd5e/combat/architecture-overview.md
@@ -51,54 +51,52 @@ encounter/  (SDK)           AttackInput{AttackerDamageDice, AttackerDamageType, 
 ## The attack damage flow
 
 ```mermaid
-%%{init: {'flowchart': {'useMaxWidth': false, 'htmlLabels': true}}}%%
-flowchart LR
-    AI["combat.AttackInput<br/>Weapon (Damage='1d8', DamageType=bludgeoning)<br/>Roller, EventBus, AttackerID, TargetID<br/>v1: AdditionalDamage []DamageComponentSpec"]
-
-    subgraph P1["attack_phases.go - ResolveAttackHit, phase 1"]
-        direction TB
+flowchart TD
+    subgraph P1["phase 1 - ResolveAttackHit (attack_phases.go)"]
+        direction LR
+        AI["AttackInput<br/>Weapon (1d8 bludgeoning),<br/>Roller, EventBus, IDs<br/>v1: AdditionalDamage []DamageComponentSpec"]
         R1["roll d20 -> AttackRoll"]
-        AC["AttackChain staged: advantage, pack tactics, improved-crit threshold"]
-        CTX["AttackContext{AttackRoll, AbilityMod, AbilityUsed,<br/>CriticalThreshold, Weapon, IsMelee}<br/>v1: + AdditionalDamage"]
-        R1 --> AC --> CTX
+        AC["AttackChain: advantage,<br/>pack tactics, crit threshold"]
+        CTX["AttackContext{AttackRoll, AbilityMod,<br/>CriticalThreshold, Weapon, IsMelee}<br/>v1: + AdditionalDamage"]
+        AI --> R1 --> AC --> CTX
     end
 
     WIN["reaction window - Shield, Protection"]
 
-    subgraph P2["attack_phases.go - ApplyAttackOutcome, phase 2"]
-        direction TB
-        HIT["hit? crit?  roll vs effectiveAC, crit if >= threshold"]
-        ROLL["parse Weapon.Damage -> dice.Pool<br/>roll pool crit?2:1 -> weaponComponent<br/>(DamageComponent: dice rolls, IsCritical=crit)"]
-        ABIL["abilityComponent (FlatBonus=AbilityMod, never doubled)"]
-        ADD["v1: each AdditionalDamage spec<br/>parse Dice -> pool, roll ONCE<br/>-> DamageComponent{Type, IsCritical=false}"]
+    subgraph P2["phase 2 - ApplyAttackOutcome (attack_phases.go)"]
+        direction LR
+        HIT["hit? crit? vs effectiveAC"]
+        ROLL["parse Weapon.Damage -> Pool<br/>roll crit?2:1 -> weaponComponent"]
+        ABIL["abilityComponent<br/>FlatBonus=AbilityMod, never doubled"]
+        ADD["v1: each AdditionalDamage spec<br/>roll ONCE -> DamageComponent<br/>{Type, IsCritical=false}"]
         HIT --> ROLL --> ABIL --> ADD
     end
 
-    subgraph CH["combat/damage.go - ResolveDamage, the chain"]
-        direction TB
-        CE["DamageChainEvent{Components: weapon, ability, additional...}"]
-        ST["staged chain Base->Features->Conditions->Equipment->Final<br/>conditions add/modify components:<br/>rage, sneak attack (crit-eligible dice), GWF reroll,<br/>resistance x0.5, vulnerability x2, immunity x0"]
-        CALC["calculateFinalDamage: group by Type, apply multipliers<br/>-> []DamageInstanceInput{Amount int, Type}  dice become INTS here"]
+    subgraph CH["ResolveDamage - the chain (combat/damage.go)"]
+        direction LR
+        CE["DamageChainEvent{Components:<br/>weapon, ability, additional}"]
+        ST["staged chain Base->Features-><br/>Conditions->Equipment->Final<br/>rage, sneak attack, GWF reroll,<br/>resist x0.5, vuln x2, immune x0"]
+        CALC["calculateFinalDamage: group by Type,<br/>apply multipliers -><br/>[]DamageInstanceInput{int}  dice->INTS"]
         TOTAL["TotalDamage + FinalComponents"]
         CE --> ST --> CALC --> TOTAL
     end
 
-    subgraph OUT["ApplyAttackOutcome returns + notifies"]
-        direction TB
-        AR["AttackResult{TotalDamage, Critical, Breakdown.Components}"]
+    subgraph OUT["returns + notifies"]
+        direction LR
+        AR["AttackResult{TotalDamage, Critical,<br/>Breakdown.Components}"]
         DRE["publish DamageReceivedEvent"]
         AR --> DRE
     end
 
-    subgraph DOWN["DOWNSTREAM - rpg-api / encounter SDK, not rpg-toolkit combat"]
-        direction TB
+    subgraph DOWN["DOWNSTREAM - rpg-api / encounter SDK"]
+        direction LR
         HP["Target.ApplyDamage -> HP mutation"]
         DDE["encounter DamageDealtEvent{Components}"]
         HP --> DDE
     end
 
-    AI --> R1
-    CTX --> WIN --> HIT
+    CTX --> WIN
+    WIN --> HIT
     ADD --> CE
     TOTAL --> AR
     DRE --> HP

--- a/rulebooks/dnd5e/combat/architecture-overview.md
+++ b/rulebooks/dnd5e/combat/architecture-overview.md
@@ -1,0 +1,176 @@
+# Combat Architecture Overview
+
+This is the living reference for anyone working in `rulebooks/dnd5e/combat/`.
+It explains how an attack flows from input to applied damage and where each
+type lives. It is *not* a decision record — for the decisions behind the damage
+chain see [ADR-0026](../../../docs/adr/0026-damage-application-via-event-chain.md),
+and for the additional-damage / selective-crit extension see
+[ADR-0036](../../../docs/adr/0036-additional-damage-selective-crit.md).
+
+## The two-phase attack resolution
+
+An attack is resolved in two discrete phases so that reactions (Shield,
+Protection, opportunity-attack prompts) can fire *between* the hit decision and
+the damage roll:
+
+1. **`ResolveAttackHit`** (phase 1) — rolls the d20, runs the `AttackChain` for
+   modifiers (advantage, pack tactics, improved-crit threshold), and produces an
+   `AttackContext`. Nothing is damaged yet.
+2. **Reaction window** — the host offers reactions to the defender; chosen
+   `ReactionModifier`s (e.g. Shield's +8 AC) are passed to phase 2.
+3. **`ApplyAttackOutcome`** (phase 2) — re-evaluates hit/crit against the
+   effective AC, rolls damage, runs the damage chain, and returns the result.
+   It publishes `DamageReceivedEvent` but does **not** mutate HP — HP mutation
+   is the encounter SDK's job (see "How to trace a monster attack" below).
+
+`ResolveAttack` is a backwards-compatible wrapper that runs both phases with no
+reactions. New callers that need reaction windows should call the two phases
+directly.
+
+## Where the types live
+
+```
+dice/                      dice.Pool, dice.ParseNotation("1d8" -> Pool), dice.Roller
+events/                    EventBus, StagedChain
+core/                      Ref, Entity
+rulebooks/dnd5e/
+  damage/                  Type (bludgeoning, acid, ...) · IsPhysical/IsElemental
+  weapons/                 Weapon{Damage string, DamageType, Properties[]WeaponProperty}
+  events/                  DamageComponent{FinalDiceRolls, FlatBonus, DamageType,
+                                    IsCritical, Multiplier}  <- RICH carrier (attacks)
+                            DamageChainEvent, AttackChainEvent, DamageReceivedEvent
+  combat/                  AttackInput, AttackContext, ResolveAttackHit, ApplyAttackOutcome
+                            ResolveDamage, DealDamage, DealDamageInput
+                            DamageInstanceInput{Amount int, Type}  <- SIMPLE carrier (spells/cond)
+                            calculateFinalDamage, stages (Base/Features/Conditions/Equipment/Final)
+  monster/                 MonsterAction, MeleeConfig{DamageDice, DamageType} -> publishes AttackEvent
+encounter/  (SDK)           AttackInput{AttackerDamageDice, AttackerDamageType, Attacker, Defender},
+                            CombatResolver.ResolveAttack, DamageDealtEvent
+```
+
+## The attack damage flow
+
+```mermaid
+%%{init: {'flowchart': {'useMaxWidth': false, 'htmlLabels': true}}}%%
+flowchart LR
+    AI["combat.AttackInput<br/>Weapon (Damage='1d8', DamageType=bludgeoning)<br/>Roller, EventBus, AttackerID, TargetID<br/>v1: AdditionalDamage []DamageComponentSpec"]
+
+    subgraph P1["attack_phases.go - ResolveAttackHit, phase 1"]
+        direction TB
+        R1["roll d20 -> AttackRoll"]
+        AC["AttackChain staged: advantage, pack tactics, improved-crit threshold"]
+        CTX["AttackContext{AttackRoll, AbilityMod, AbilityUsed,<br/>CriticalThreshold, Weapon, IsMelee}<br/>v1: + AdditionalDamage"]
+        R1 --> AC --> CTX
+    end
+
+    WIN["reaction window - Shield, Protection"]
+
+    subgraph P2["attack_phases.go - ApplyAttackOutcome, phase 2"]
+        direction TB
+        HIT["hit? crit?  roll vs effectiveAC, crit if >= threshold"]
+        ROLL["parse Weapon.Damage -> dice.Pool<br/>roll pool crit?2:1 -> weaponComponent<br/>(DamageComponent: dice rolls, IsCritical=crit)"]
+        ABIL["abilityComponent (FlatBonus=AbilityMod, never doubled)"]
+        ADD["v1: each AdditionalDamage spec<br/>parse Dice -> pool, roll ONCE<br/>-> DamageComponent{Type, IsCritical=false}"]
+        HIT --> ROLL --> ABIL --> ADD
+    end
+
+    subgraph CH["combat/damage.go - ResolveDamage, the chain"]
+        direction TB
+        CE["DamageChainEvent{Components: weapon, ability, additional...}"]
+        ST["staged chain Base->Features->Conditions->Equipment->Final<br/>conditions add/modify components:<br/>rage, sneak attack (crit-eligible dice), GWF reroll,<br/>resistance x0.5, vulnerability x2, immunity x0"]
+        CALC["calculateFinalDamage: group by Type, apply multipliers<br/>-> []DamageInstanceInput{Amount int, Type}  dice become INTS here"]
+        TOTAL["TotalDamage + FinalComponents"]
+        CE --> ST --> CALC --> TOTAL
+    end
+
+    subgraph OUT["ApplyAttackOutcome returns + notifies"]
+        direction TB
+        AR["AttackResult{TotalDamage, Critical, Breakdown.Components}"]
+        DRE["publish DamageReceivedEvent"]
+        AR --> DRE
+    end
+
+    subgraph DOWN["DOWNSTREAM - rpg-api / encounter SDK, not rpg-toolkit combat"]
+        direction TB
+        HP["Target.ApplyDamage -> HP mutation"]
+        DDE["encounter DamageDealtEvent{Components}"]
+        HP --> DDE
+    end
+
+    AI --> R1
+    CTX --> WIN --> HIT
+    ADD --> CE
+    TOTAL --> AR
+    DRE --> HP
+```
+
+## Three things to internalize
+
+1. **Dice strings only live at the very top.** `Weapon.Damage` is `"1d8"`;
+   `dice.ParseNotation` turns it into a `dice.Pool`, which `ApplyAttackOutcome`
+   rolls into `[]int` stored in `DamageComponent.FinalDiceRolls`. The chain keeps
+   dice rolls around (for rerolls like Great Weapon Fighting and for the combat
+   log). Only `calculateFinalDamage` sums them into `DamageInstanceInput.Amount
+   int`. So "damage is already an int" is true at the *spells/conditions* entry
+   (`DealDamage.Instances`) — **not** at the attack entry. Attacks carry dice
+   rolls as `DamageComponent` until the last step. If you are adding
+   dice-based damage to an attack, produce `DamageComponent`s, not
+   `DamageInstanceInput` ints.
+
+2. **Two carriers, one chain.** `DamageInstanceInput{Amount int, Type}` is the
+   simple path (spells, conditions, environment — the total is already known).
+   `DamageComponent{FinalDiceRolls, FlatBonus, …}` is the rich path (attacks —
+   dice are involved). Both converge on `ResolveDamage`. The chain and
+   `calculateFinalDamage` already group components by damage type and apply
+   per-type multipliers, so adding a second intrinsic damage type needs **no**
+   new resistance/vulnerability machinery — acid resistance will still halve the
+   acid component for free.
+
+3. **Crit doubling is the one pool-level spot.** Everything downstream of
+   `ApplyAttackOutcome` is already component-aware. The only place that treats
+   damage as a single pool is `ApplyAttackOutcome` itself, where
+   `rollDamageDice(pool, roller, 2)` rolls the weapon's one pool twice on a crit.
+   This is why selective crit (some pools double, some don't) is a change to
+   `ApplyAttackOutcome` only.
+
+## How to trace a monster attack
+
+A monster action in `rulebooks/dnd5e/monster/actions/` does **not** resolve
+damage — it publishes a dnd5e `AttackEvent{AttackerID, TargetID, WeaponRef,
+IsMelee}`. The resolution path is:
+
+1. The rpg-api `CombatResolver` receives the encounter-SDK `AttackInput`
+   (carrying `AttackerDamageDice`/`AttackerDamageType` snapshots plus the
+   hydrated `Attacker`/`Defender` combatants) and translates it into the
+   rulebook `combat.AttackInput{Weapon, EventBus, Roller, …}`.
+2. `combat.ResolveAttackHit` (phase 1) → `AttackContext`.
+3. Reaction window (the host prompts the defender).
+4. `combat.ApplyAttackOutcome` (phase 2) → `AttackResult` and publishes
+   `DamageReceivedEvent`.
+5. The encounter SDK applies HP via `Target.ApplyDamage` and emits the
+   encounter-level `DamageDealtEvent` (with the full `Components` breakdown).
+
+Steps 2, 4, and the `DamageReceivedEvent` publish are in this package. Steps 1
+and 5 are in rpg-api / the encounter SDK. When debugging "why did this monster
+deal the wrong damage," the answer is almost always in `ApplyAttackOutcome`
+(phase 2) or a condition subscribed to the damage chain — not in the monster
+action that published the event.
+
+## v1 extension: additional damage
+
+ADR-0036 adds an optional `AdditionalDamage []DamageComponentSpec` to
+`AttackInput`, threaded onto `AttackContext` and consumed by
+`ApplyAttackOutcome`. Each spec is a dice pool of a single damage type, rolled
+**once** and **never doubled on a critical hit** — the rule the ooze's pseudopod
+needs (bludgeoning crits, acid does not). The weapon's own pool keeps its
+existing crit semantics. The damage chain and `calculateFinalDamage` are
+unchanged; resistance/vulnerability still apply per type as today.
+
+```go
+// DamageComponentSpec is one intrinsic rider damage pool an attack deals on
+// a hit. It is rolled once and never doubled on a critical hit.
+type DamageComponentSpec struct {
+    Dice string      // "1d6"
+    Type damage.Type // damage.Acid
+}
+```


### PR DESCRIPTION
## What

Captures the architecture of attack/damage resolution in
`rulebooks/dnd5e/combat/` and records the design decision for the upcoming
additional-damage / selective-critical-hit work. **Docs-only — no code or
behavior change.**

## Why

The combat package's damage flow is non-obvious: monster actions only publish an
`AttackEvent`, crit doubling is pool-level in `ApplyAttackOutcome`, and there
are two damage carriers (`DamageComponent` rich vs `DamageInstanceInput` int)
converging on one chain. Anyone working in `combat/` currently has to
reverse-engineer this. This adds a living reference so the next person doesn't
have to.

It also pins down the design for multi-damage-type monster attacks — the ooze's
pseudopod (bludgeoning + acid), where only the bludgeoning doubles on a crit —
before writing the code.

## Changes

- `rulebooks/dnd5e/combat/architecture-overview.md` (new) — the living
  reference: the two-phase resolution, the layered type map, the attack-damage
  flow diagram, the three things to internalize (dice→int transition, two
  carriers / one chain, crit doubling is the one pool-level spot), and a
  monster-attack trace.
- `docs/adr/0036-additional-damage-selective-crit.md` (new) — the decision
  record, companion to ADR-0026. v1 adds `AdditionalDamage []DamageComponentSpec`
  to the attack path; additional damage is rolled once and never doubled on a
  crit. The damage chain and resistance/vulnerability logic are unchanged.
- `docs/adr/README.md` — index pointer to ADR-0036.

## Diagram

The flow is rendered as a multi-row diagram (five phases stacked vertically,
each a left-to-right row) so it fits editors that do not wrap.

## Not in this PR

The implementation — the `DamageComponentSpec` type, the
`AttackInput`/`AttackContext` threading, the per-component crit loop in
`ApplyAttackOutcome`, and the `NewOoze()` monster definition — is deliberately
**not** included. This PR captures the design first; the code follows on this
same branch in subsequent commits, TDD-style (tests first).

— asset-pipeline agent, on behalf of KirkDiggler
