### PR TITLE
feat(rulebooks/dnd5e/encounter): world anchoring — rooms in dungeon-absolute space, coherence as law (#929)

### DIFF
--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -50,6 +50,37 @@ type AtlasRoom struct {
 	// dungeon-absolute space. Reported separately from Cells so a host
 	// can render them distinctly (#929 T3 ruling 1).
 	Occluders []spatial.Position
+
+	// Boundaries is the room's walls/barriers (RoomInput.Boundaries),
+	// with both endpoints projected into dungeon-absolute space (#929
+	// hardening round A). Boundaries are real map geometry — registered
+	// on the spatial room, affecting sight and movement, persisted in
+	// the blob — so a host rendering the static map gets them from Atlas
+	// like every other construction-truth fact, instead of reaching into
+	// ToData().Field.Rooms[].Boundaries and hand-projecting both
+	// endpoints through Origin itself: exactly the arithmetic this
+	// bridge exists to centralize. In declaration order (RoomInput's own
+	// order, the same construction-truth ordering Occluders already
+	// uses above) — deterministic given a fixed input (C8), though not
+	// independently sorted the way Rooms/Doorways are.
+	Boundaries []AtlasBoundary
+}
+
+// AtlasBoundary is one wall or barrier crossing, with both endpoints
+// projected into dungeon-absolute space (#929 hardening round A;
+// spatial.Boundary's doc comment for the room-local fields this mirrors).
+type AtlasBoundary struct {
+	// From is one endpoint of the crossing, in dungeon-absolute space.
+	From spatial.Position
+
+	// To is the other endpoint of the crossing, in dungeon-absolute space.
+	To spatial.Position
+
+	// BlocksMovement reports whether an entity may cross this boundary.
+	BlocksMovement bool
+
+	// BlocksLineOfSight reports whether line of sight may cross this boundary.
+	BlocksLineOfSight bool
 }
 
 // AtlasDoorway is one connection's absolute endpoint pair.
@@ -112,8 +143,10 @@ type LocateOutput struct {
 //
 // Deterministic (C8): Rooms sorted by room ID, Doorways sorted by
 // connection ID, each room's Cells in grid-iteration order (atlasCells'
-// Q-outer/R-inner nesting). Copy-out: every returned slice is freshly
-// allocated per call; mutating the result never reaches internal state.
+// Q-outer/R-inner nesting), each room's Boundaries in declaration order
+// (RoomInput's own order, same as Occluders — #929 hardening round A).
+// Copy-out: every returned slice is freshly allocated per call; mutating
+// the result never reaches internal state.
 //
 // Cost: O(total cells across all rooms) by contract — Atlas enumerates
 // every cell of every room, via a make() sized exactly Width*Height per
@@ -129,6 +162,22 @@ type LocateOutput struct {
 // carries the two integers that produce it in a few hundred bytes — not
 // impractically, trivially. Reject-never-crash is module law
 // (LoadEncounter's doc comment); this was the trust boundary.
+//
+// Bounded is not the same as cheap (#929 hardening round I): at the
+// field budget — four 1024×1024 rooms, a legal field whose persisted
+// blob is well under a kilobyte (measured: 573 bytes) — a single Atlas()
+// call allocates on the order of 128 MB (measured via runtime.MemStats'
+// TotalAlloc delta: ~134 MB, i.e. exactly maxFieldCells cells at 16
+// bytes each, doubled by atlasCells' local enumeration plus its
+// Origin-projected copy) and takes tens of milliseconds (measured:
+// ~60-65ms cold, ~45-50ms on a repeat call), REPEATABLY — every call
+// redoes the same work, nothing is memoized internally. Hosts that call
+// Atlas() per request rather than per encounter will feel this; cache
+// the returned Atlas per encounter instead. Caching is trivially safe
+// here specifically because Atlas is pure construction-truth (ruling 3
+// above) — no live state can make a cached snapshot stale; only a
+// reload (LoadEncounter, which returns a new *Encounter) requires a
+// fresh call.
 //
 // Occluders are map data, not entities: every occluder cell is also an
 // AtlasRoom.Cells entry (AtlasRoom.Occluders is a SUBSET of
@@ -161,14 +210,25 @@ func (e *Encounter) Atlas() (Atlas, error) {
 			occluders[j] = o.Add(ri.Origin)
 		}
 
+		boundaries := make([]AtlasBoundary, len(ri.Boundaries))
+		for j, b := range ri.Boundaries {
+			boundaries[j] = AtlasBoundary{
+				From:              b.From.Add(ri.Origin),
+				To:                b.To.Add(ri.Origin),
+				BlocksMovement:    b.BlocksMovement,
+				BlocksLineOfSight: b.BlocksLineOfSight,
+			}
+		}
+
 		rooms[i] = AtlasRoom{
-			ID:        ri.ID,
-			Grid:      ri.Grid,
-			Origin:    ri.Origin,
-			Width:     ri.Width,
-			Height:    ri.Height,
-			Cells:     cells,
-			Occluders: occluders,
+			ID:         ri.ID,
+			Grid:       ri.Grid,
+			Origin:     ri.Origin,
+			Width:      ri.Width,
+			Height:     ri.Height,
+			Cells:      cells,
+			Occluders:  occluders,
+			Boundaries: boundaries,
 		}
 	}
 	// LOAD-BEARING: fieldInput is never sorted anywhere else — this sort is
@@ -215,12 +275,18 @@ func (e *Encounter) Absolute(in *AbsoluteInput) (*AbsoluteOutput, error) {
 		return nil, fmt.Errorf("absolute: %w", ErrNilInput)
 	}
 
-	ri, ok := e.roomInput(in.Room)
+	// The orchestrator's own constructed Grid, not a fresh buildRoomGrid
+	// call (#929 hardening round G) — same idiom moveMember/Join already
+	// use. A room's Grid is immutable for the Encounter's lifetime (no
+	// verb ever changes Width/Height/family after construction), so this
+	// is behavior-identical to rebuilding one from ri.Grid/Width/Height,
+	// just without reconstructing it on every call on a host's per-frame
+	// path.
+	room, ok := e.orchestrator.GetRoom(in.Room)
 	if !ok {
 		return nil, fmt.Errorf("absolute: unknown room %q: %w", in.Room, ErrNoField)
 	}
-
-	grid := buildRoomGrid(ri.Grid, ri.Width, ri.Height)
+	grid := room.GetGrid()
 	if !grid.IsValidPosition(in.Position) {
 		return nil, fmt.Errorf("absolute: position out of bounds: %w", ErrBadPlacement)
 	}
@@ -228,6 +294,10 @@ func (e *Encounter) Absolute(in *AbsoluteInput) (*AbsoluteOutput, error) {
 		return nil, fmt.Errorf("absolute: position is not an integral axial cell: %w", ErrBadPlacement)
 	}
 
+	// Origin lives ONLY in construction-truth (RoomInput), never on the
+	// spatial room itself — orchestrator already confirmed this room
+	// exists above, so no second existence check here.
+	ri, _ := e.roomInput(in.Room)
 	return &AbsoluteOutput{Position: in.Position.Add(ri.Origin)}, nil
 }
 
@@ -256,6 +326,18 @@ func (e *Encounter) Absolute(in *AbsoluteInput) (*AbsoluteOutput, error) {
 // as it would an empty one (#929 T3 ruling 1) — occlusion is
 // walkability, not ownership, and this function never consults
 // occluders.
+//
+// WARNING — the Locate→Move trap (#929 hardening round B): composing
+// Locate then Move is a natural host pattern ("where does this absolute
+// position land, then move the member there"), but Move is SAME-ROOM
+// ONLY — it applies LocateOutput.Position inside the member's OWN
+// current room, never inside LocateOutput.Room. If the member's current
+// room differs from LocateOutput.Room, Move silently misplaces the
+// member instead of erroring (Move's own doc comment has the concrete
+// example). Callers MUST compare LocateOutput.Room against the member's
+// current room before calling Move with LocateOutput.Position; use
+// Traverse when they differ. Doc-only for v0.3 — see Move's doc comment
+// for why the real fix is a follow-up, not made here.
 func (e *Encounter) Locate(in *LocateInput) (*LocateOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("locate: %w", ErrNilInput)
@@ -263,7 +345,18 @@ func (e *Encounter) Locate(in *LocateInput) (*LocateOutput, error) {
 
 	for _, ri := range e.fieldInput {
 		local := in.Position.Subtract(ri.Origin)
-		grid := buildRoomGrid(ri.Grid, ri.Width, ri.Height)
+		// The orchestrator's own constructed Grid, not a fresh
+		// buildRoomGrid call per room per call (#929 hardening round G)
+		// — Locate was the worst offender, rebuilding a Grid for every
+		// room on every call. fieldInput and the orchestrator's room set
+		// stay in sync by construction (every room added to one is
+		// added to the other, and neither changes after construction),
+		// so a lookup miss here is unreachable, not a real defect class.
+		room, ok := e.orchestrator.GetRoom(ri.ID)
+		if !ok {
+			continue
+		}
+		grid := room.GetGrid()
 		if !grid.IsValidPosition(local) {
 			continue
 		}

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -116,11 +116,34 @@ type LocateOutput struct {
 // allocated per call; mutating the result never reaches internal state.
 //
 // Cost: O(total cells across all rooms) by contract — Atlas enumerates
-// every cell of every room. A legal-but-absurd room near maxRoomSpan
-// (1<<30) would allocate enormously; that is the caller's contract, not
-// guarded here. The wire cannot practically carry such a field today
-// (RoomData round-trips through JSON), so this only matters for a caller
-// that constructs an Encounter directly and then asks for its Atlas.
+// every cell of every room, via a make() sized exactly Width*Height per
+// room (atlasCells). This is BOUNDED, not merely documented:
+// maxRoomCells/maxFieldCells (encounter.go) reject an oversized room or
+// field at room legality — the shared path both NewEncounter and
+// LoadEncounter route through — before an Encounter exists to call Atlas
+// on. Before that bound existed, this comment claimed a legal-but-absurd
+// room would merely "allocate enormously" and that the wire "cannot
+// practically carry" one — both wrong (#929 T3 Opus round F1): a
+// 2^30 x 2^30 room, legal under maxRoomSpan's per-axis check alone,
+// PANICS atlasCells' make() (a 2^60-capacity argument), and the wire
+// carries the two integers that produce it in 394 bytes — not
+// impractically, trivially. Reject-never-crash is module law
+// (LoadEncounter's doc comment); this was the trust boundary.
+//
+// Occluders are map data, not entities: every occluder cell is also a
+// Cells entry (Occluders is a SUBSET of Cells —
+// TestAtlasRoomCellsAndOccludersAreAbsolute), which is why occluders must
+// be integral in every family (encounter.go's occluder-integrality
+// check, #929 T3 Opus round F2). A MEMBER's position is different in
+// kind — an entity's position, not a map cell — and on a
+// fractional-tolerant square grid it may sit anywhere in a room's
+// continuous span, coinciding with no integer cell in Cells at all; hex
+// forbids fractional member positions entirely
+// (isIntegralAxialPosition), so this only affects square hosts (#929 T3
+// Opus round F4). The asymmetry — occluders must be integral, member
+// positions may be fractional — is deliberate: one is floor/blockage
+// data Atlas enumerates, the other is a live position Atlas never
+// touches.
 func (e *Encounter) Atlas() (Atlas, error) {
 	roomsByID := make(map[string]RoomInput, len(e.fieldInput))
 	rooms := make([]AtlasRoom, len(e.fieldInput))
@@ -210,10 +233,22 @@ func (e *Encounter) Absolute(in *AbsoluteInput) (*AbsoluteOutput, error) {
 
 // Locate is the reverse bridge: resolves a dungeon-absolute position to
 // its owning room and the equivalent room-local position. W2 (rooms
-// never overlap) plus integral origins make ownership unambiguous even
-// for a fractional square point (#929 T3 ruling 2 — the half-open
-// interval argument): at most one room's bounds check can ever pass, so
-// iteration order does not matter.
+// never overlap) plus integral origins make ownership uniqueness EXACT
+// in real (infinite-precision) arithmetic — and exact in float64 too,
+// for INTEGRAL cells specifically, since integers stay exact to 2^53,
+// far past maxAnchorCoord (1<<30). For a FRACTIONAL square position the
+// round trip is only approximate: near an extreme anchor (close to
+// maxAnchorCoord), a fraction within roughly one float64 ULP of a room
+// edge (~2.4e-7 at that magnitude) can round to the WRONG room — a
+// float64 precision limit, not a logic bug, and not chased further here
+// (#929 T3 Opus round F3 — an earlier version of this comment
+// overclaimed exactness for the fractional case too). The guarantee
+// this module DOES make and pins with a test:
+// TestLocateAbsoluteRoundTripExactAtExtremeOrigin proves an INTEGRAL
+// round trip is exact even at extreme origins (±(2^30−8)). At most one
+// room's bounds check can pass for a given input, so iteration order
+// never matters — that part holds unconditionally, independent of the
+// precision caveat above.
 //
 // Returns ErrNilInput for a nil input, and ErrBadPlacement if no room
 // owns the position — void is not floor. Occluded cells ARE owned:
@@ -270,6 +305,16 @@ func atlasCells(shape spatial.GridShape, width, height int) []spatial.Position {
 	qMin, qMax := axisBounds(shape, width)
 	rMin, rMax := axisBounds(shape, height)
 
+	// SAFE: (qMax-qMin+1)*(rMax-rMin+1) always equals width*height (both
+	// families — this function's doc comment), and width*height is
+	// bounded by maxRoomCells at room legality (encounter.go) BEFORE any
+	// RoomInput reaches here — the only path to a RoomInput is
+	// buildValidRoomGrids, which every construction seam routes through.
+	// No redundant check here (#929 T3 Opus round F1 ruling): a future
+	// editor who relaxes maxRoomCells without reading this comment
+	// reintroduces the panic this bound exists to prevent — the
+	// doorway-sort lesson, applied to an allocation instead of an
+	// ordering invariant.
 	cells := make([]spatial.Position, 0, (qMax-qMin+1)*(rMax-rMin+1))
 	for q := qMin; q <= qMax; q++ {
 		for r := rMin; r <= rMax; r++ {

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -126,19 +126,19 @@ type LocateOutput struct {
 // practically carry" one — both wrong (#929 T3 Opus round F1): a
 // 2^30 x 2^30 room, legal under maxRoomSpan's per-axis check alone,
 // PANICS atlasCells' make() (a 2^60-capacity argument), and the wire
-// carries the two integers that produce it in 394 bytes — not
+// carries the two integers that produce it in a few hundred bytes — not
 // impractically, trivially. Reject-never-crash is module law
 // (LoadEncounter's doc comment); this was the trust boundary.
 //
-// Occluders are map data, not entities: every occluder cell is also a
-// Cells entry (Occluders is a SUBSET of Cells —
-// TestAtlasRoomCellsAndOccludersAreAbsolute), which is why occluders must
-// be integral in every family (encounter.go's occluder-integrality
-// check, #929 T3 Opus round F2). A MEMBER's position is different in
-// kind — an entity's position, not a map cell — and on a
-// fractional-tolerant square grid it may sit anywhere in a room's
-// continuous span, coinciding with no integer cell in Cells at all; hex
-// forbids fractional member positions entirely
+// Occluders are map data, not entities: every occluder cell is also an
+// AtlasRoom.Cells entry (AtlasRoom.Occluders is a SUBSET of
+// AtlasRoom.Cells — TestAtlasRoomCellsAndOccludersAreAbsolute), which is
+// why occluders must be integral in every family (encounter.go's
+// occluder-integrality check, #929 T3 Opus round F2). A MEMBER's
+// position is different in kind — an entity's position, not a map cell
+// — and on a fractional-tolerant square grid it may sit anywhere in a
+// room's continuous span, coinciding with no integer cell in
+// AtlasRoom.Cells at all; hex forbids fractional member positions entirely
 // (isIntegralAxialPosition), so this only affects square hosts (#929 T3
 // Opus round F4). The asymmetry — occluders must be integral, member
 // positions may be fractional — is deliberate: one is floor/blockage
@@ -291,8 +291,8 @@ func (e *Encounter) roomInput(id string) (RoomInput, bool) {
 
 // atlasCells re-derives a room's local, integral cell coordinates for
 // Atlas. T1 deleted the original enumeration helper (roomLocalCells)
-// when W2 went interval-based (roomAbsoluteBounds' doc comment) — this
-// is a fresh implementation, not a resurrection, proven against
+// when W2 went interval-based (axisBounds' doc comment, encounter.go) —
+// this is a fresh implementation, not a resurrection, proven against
 // spatial's own IsValidPosition by TestAtlasCellsMatchIsValidPosition
 // (#929 T3 ruling 4).
 //
@@ -306,7 +306,7 @@ func atlasCells(shape spatial.GridShape, width, height int) []spatial.Position {
 	rMin, rMax := axisBounds(shape, height)
 
 	// SAFE: (qMax-qMin+1)*(rMax-rMin+1) always equals width*height (both
-	// families — this function's doc comment), and width*height is
+	// families — axisBounds' doc comment, encounter.go), and width*height is
 	// bounded by maxRoomCells at room legality (encounter.go) BEFORE any
 	// RoomInput reaches here — the only path to a RoomInput is
 	// buildValidRoomGrids, which every construction seam routes through.

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -1,0 +1,268 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// Atlas is a deterministic, construction-time snapshot of the field
+// projected into dungeon-absolute space: every room's absolute cell set
+// and occluders, and every connection's absolute doorway pair (#929 T3 —
+// the read surface promised by RoomInput.Origin's doc comment).
+type Atlas struct {
+	// Rooms is every room's absolute footprint, sorted by room ID (C8).
+	Rooms []AtlasRoom
+
+	// Doorways is every connection's absolute endpoint pair, sorted by
+	// connection ID (C8).
+	Doorways []AtlasDoorway
+}
+
+// AtlasRoom is one room's absolute-space footprint.
+type AtlasRoom struct {
+	// ID is the room's identifier.
+	ID string
+
+	// Grid is the room's coordinate family (GridShapeSquare or GridShapeHex).
+	Grid spatial.GridShape
+
+	// Origin is the room's dungeon-absolute anchor (RoomInput.Origin).
+	Origin spatial.Position
+
+	// Width is the room's horizontal dimension.
+	Width int
+
+	// Height is the room's vertical dimension.
+	Height int
+
+	// Cells is every cell of the room, in dungeon-absolute space, in
+	// grid-iteration order (atlasCells) — always populated regardless of
+	// occupancy or occlusion: occlusion is walkability, not ownership
+	// (#929 T3 ruling 1).
+	Cells []spatial.Position
+
+	// Occluders is the room's line-of-sight-blocking cells, in
+	// dungeon-absolute space. Reported separately from Cells so a host
+	// can render them distinctly (#929 T3 ruling 1).
+	Occluders []spatial.Position
+}
+
+// AtlasDoorway is one connection's absolute endpoint pair.
+type AtlasDoorway struct {
+	// Connection is the connection's identifier.
+	Connection string
+
+	// From is the source room ID.
+	From string
+
+	// FromCell is the connection's endpoint in From, in dungeon-absolute space.
+	FromCell spatial.Position
+
+	// To is the destination room ID.
+	To string
+
+	// ToCell is the connection's endpoint in To, in dungeon-absolute space.
+	ToCell spatial.Position
+}
+
+// AbsoluteInput names a room-local position to project into
+// dungeon-absolute space.
+type AbsoluteInput struct {
+	// Room is the room the position is local to.
+	Room string
+
+	// Position is the room-local position to project.
+	Position spatial.Position
+}
+
+// AbsoluteOutput is a position projected into dungeon-absolute space.
+type AbsoluteOutput struct {
+	// Position is the dungeon-absolute position.
+	Position spatial.Position
+}
+
+// LocateInput names a dungeon-absolute position to resolve to its
+// owning room.
+type LocateInput struct {
+	// Position is the dungeon-absolute position to resolve.
+	Position spatial.Position
+}
+
+// LocateOutput is a dungeon-absolute position resolved to its owning
+// room and the equivalent room-local position.
+type LocateOutput struct {
+	// Room is the owning room's ID.
+	Room string
+
+	// Position is the room-local position.
+	Position spatial.Position
+}
+
+// Atlas returns a deterministic, construction-time snapshot of the field
+// projected into dungeon-absolute space. Computed ONLY from construction
+// data — fieldInput and connectionsInput, the same snapshot ToData
+// persists — never from live member placement or clock state, so
+// placing/moving a member or Pumping a tick never changes it (#929 T3
+// ruling 3).
+//
+// Deterministic (C8): Rooms sorted by room ID, Doorways sorted by
+// connection ID, each room's Cells in grid-iteration order (atlasCells'
+// Q-outer/R-inner nesting). Copy-out: every returned slice is freshly
+// allocated per call; mutating the result never reaches internal state.
+//
+// Cost: O(total cells across all rooms) by contract — Atlas enumerates
+// every cell of every room. A legal-but-absurd room near maxRoomSpan
+// (1<<30) would allocate enormously; that is the caller's contract, not
+// guarded here. The wire cannot practically carry such a field today
+// (RoomData round-trips through JSON), so this only matters for a caller
+// that constructs an Encounter directly and then asks for its Atlas.
+func (e *Encounter) Atlas() (Atlas, error) {
+	roomsByID := make(map[string]RoomInput, len(e.fieldInput))
+	rooms := make([]AtlasRoom, len(e.fieldInput))
+	for i, ri := range e.fieldInput {
+		roomsByID[ri.ID] = ri
+
+		local := atlasCells(ri.Grid, ri.Width, ri.Height)
+		cells := make([]spatial.Position, len(local))
+		for j, c := range local {
+			cells[j] = c.Add(ri.Origin)
+		}
+
+		occluders := make([]spatial.Position, len(ri.Occluders))
+		for j, o := range ri.Occluders {
+			occluders[j] = o.Add(ri.Origin)
+		}
+
+		rooms[i] = AtlasRoom{
+			ID:        ri.ID,
+			Grid:      ri.Grid,
+			Origin:    ri.Origin,
+			Width:     ri.Width,
+			Height:    ri.Height,
+			Cells:     cells,
+			Occluders: occluders,
+		}
+	}
+	sort.Slice(rooms, func(i, j int) bool { return rooms[i].ID < rooms[j].ID })
+
+	doorways := make([]AtlasDoorway, len(e.connectionsInput))
+	for i, ci := range e.connectionsInput {
+		doorways[i] = AtlasDoorway{
+			Connection: ci.ID,
+			From:       ci.From,
+			FromCell:   ci.FromPosition.Add(roomsByID[ci.From].Origin),
+			To:         ci.To,
+			ToCell:     ci.ToPosition.Add(roomsByID[ci.To].Origin),
+		}
+	}
+	sort.Slice(doorways, func(i, j int) bool { return doorways[i].Connection < doorways[j].Connection })
+
+	return Atlas{Rooms: rooms, Doorways: doorways}, nil
+}
+
+// Absolute projects a room-local position into dungeon-absolute space.
+// Legal for ANY in-bounds position, whether occupied, occluded, or
+// empty — hosts project percept ghosts at cells nobody stands on (#929
+// T3 ruling 1); it never consults members or occluders.
+//
+// Returns ErrNilInput for a nil input, ErrNoField for a room ID that
+// names no room in this field (the same room-list defect vocabulary
+// Setup/Load reject with — #929 T3 ruling), and ErrBadPlacement if
+// Position is out of the room's bounds or (hex only) not an integral
+// axial cell — the bridge refuses to project fiction.
+func (e *Encounter) Absolute(in *AbsoluteInput) (*AbsoluteOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("absolute: %w", ErrNilInput)
+	}
+
+	ri, ok := e.roomInput(in.Room)
+	if !ok {
+		return nil, fmt.Errorf("absolute: unknown room %q: %w", in.Room, ErrNoField)
+	}
+
+	grid := buildRoomGrid(ri.Grid, ri.Width, ri.Height)
+	if !grid.IsValidPosition(in.Position) {
+		return nil, fmt.Errorf("absolute: position out of bounds: %w", ErrBadPlacement)
+	}
+	if !isIntegralAxialPosition(grid, in.Position) {
+		return nil, fmt.Errorf("absolute: position is not an integral axial cell: %w", ErrBadPlacement)
+	}
+
+	return &AbsoluteOutput{Position: in.Position.Add(ri.Origin)}, nil
+}
+
+// Locate is the reverse bridge: resolves a dungeon-absolute position to
+// its owning room and the equivalent room-local position. W2 (rooms
+// never overlap) plus integral origins make ownership unambiguous even
+// for a fractional square point (#929 T3 ruling 2 — the half-open
+// interval argument): at most one room's bounds check can ever pass, so
+// iteration order does not matter.
+//
+// Returns ErrNilInput for a nil input, and ErrBadPlacement if no room
+// owns the position — void is not floor. Occluded cells ARE owned:
+// Locate returns the owning room for a cell an occluder sits on exactly
+// as it would an empty one (#929 T3 ruling 1) — occlusion is
+// walkability, not ownership, and this function never consults
+// occluders.
+func (e *Encounter) Locate(in *LocateInput) (*LocateOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("locate: %w", ErrNilInput)
+	}
+
+	for _, ri := range e.fieldInput {
+		local := in.Position.Subtract(ri.Origin)
+		grid := buildRoomGrid(ri.Grid, ri.Width, ri.Height)
+		if !grid.IsValidPosition(local) {
+			continue
+		}
+		if !isIntegralAxialPosition(grid, local) {
+			continue
+		}
+		return &LocateOutput{Room: ri.ID, Position: local}, nil
+	}
+
+	return nil, fmt.Errorf("locate: position owned by no room: %w", ErrBadPlacement)
+}
+
+// roomInput looks up a room's construction-truth RoomInput by ID —
+// shared by Absolute and Locate, both of which need Origin (only ever
+// stored here, never on the spatial room itself) alongside grid shape
+// and dimensions.
+func (e *Encounter) roomInput(id string) (RoomInput, bool) {
+	for _, ri := range e.fieldInput {
+		if ri.ID == id {
+			return ri, true
+		}
+	}
+	return RoomInput{}, false
+}
+
+// atlasCells re-derives a room's local, integral cell coordinates for
+// Atlas. T1 deleted the original enumeration helper (roomLocalCells)
+// when W2 went interval-based (roomAbsoluteBounds' doc comment) — this
+// is a fresh implementation, not a resurrection, proven against
+// spatial's own IsValidPosition by TestAtlasCellsMatchIsValidPosition
+// (#929 T3 ruling 4).
+//
+// Built on axisBounds (encounter.go), the same min/max primitive W2
+// already trusts: enumerates every integer in
+// [axisBounds(shape,width).min, axisBounds(shape,width).max] crossed
+// with [axisBounds(shape,height).min, axisBounds(shape,height).max], Q
+// (X) outer, R (Y) inner — deterministic, grid-iteration order.
+func atlasCells(shape spatial.GridShape, width, height int) []spatial.Position {
+	qMin, qMax := axisBounds(shape, width)
+	rMin, rMax := axisBounds(shape, height)
+
+	cells := make([]spatial.Position, 0, (qMax-qMin+1)*(rMax-rMin+1))
+	for q := qMin; q <= qMax; q++ {
+		for r := rMin; r <= rMax; r++ {
+			cells = append(cells, spatial.Position{X: float64(q), Y: float64(r)})
+		}
+	}
+	return cells
+}

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -148,6 +148,8 @@ func (e *Encounter) Atlas() (Atlas, error) {
 			Occluders: occluders,
 		}
 	}
+	// LOAD-BEARING: fieldInput is never sorted anywhere else — this sort is
+	// the only thing establishing C8 order for Rooms.
 	sort.Slice(rooms, func(i, j int) bool { return rooms[i].ID < rooms[j].ID })
 
 	doorways := make([]AtlasDoorway, len(e.connectionsInput))
@@ -160,6 +162,16 @@ func (e *Encounter) Atlas() (Atlas, error) {
 			ToCell:     ci.ToPosition.Add(roomsByID[ci.To].Origin),
 		}
 	}
+	// Currently redundant — e.connectionsInput is already sorted by ID at
+	// both NewEncounter and LoadEncounter (encounter.go, data.go) before
+	// Atlas ever runs — but kept anyway so Atlas's own C8 determinism is
+	// self-contained rather than coupled to an invariant maintained in two
+	// OTHER files. Unlike the Rooms sort above (load-bearing: fieldInput is
+	// never pre-sorted), a future editor deleting this "redundant" sort
+	// would find no failing test today — exactly the trap this comment
+	// exists to prevent (#929 T3 fix round item 4; mutation evidence: the
+	// mutant that removes this line is unobservable through the public API
+	// on any normally-constructed encounter).
 	sort.Slice(doorways, func(i, j int) bool { return doorways[i].Connection < doorways[j].Connection })
 
 	return Atlas{Rooms: rooms, Doorways: doorways}, nil

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -20,14 +20,24 @@ import (
 // so a missing/removed sort is observable through the public API. Every
 // room has a distinct, nonzero-on-both-axes Origin (r1: (-50,7), r2:
 // (-46,6)) so a sign-flipped bridge (Subtract instead of Add, or vice
-// versa) produces a wrong, non-accidental-match absolute value.
+// versa) produces a wrong, non-accidental-match absolute value. atlas-r1
+// also carries one boundary (#929 hardening round A) so AtlasRoom.Boundaries
+// projection, copy-out, reload survival, and live-state independence are
+// all exercised by the same tests that already cover Cells/Occluders.
 func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
 				{ID: "atlas-r1", Width: 4, Height: 3, Origin: spatial.Position{X: -50, Y: 7},
-					Occluders: []spatial.Position{{X: 1, Y: 1}}},
+					Occluders: []spatial.Position{{X: 1, Y: 1}},
+					// (0,2)-(1,2): the far row from atlas-p1's Y=0 move path
+					// below (TestAtlasUnaffectedByLiveState moves it (0,0) to
+					// (3,0)) — a movement-blocking boundary on that row would
+					// reject the very move this fixture is also used to pin.
+					Boundaries: []spatial.Boundary{
+						{From: spatial.Position{X: 0, Y: 2}, To: spatial.Position{X: 1, Y: 2}, BlocksMovement: true, BlocksLineOfSight: true},
+					}},
 				{ID: "atlas-r4", Width: 6, Height: 5, Origin: spatial.Position{X: 9954, Y: 6}},
 				{ID: "atlas-r2", Width: 6, Height: 5, Origin: spatial.Position{X: -46, Y: 6}},
 			},
@@ -176,7 +186,10 @@ func (s *EncounterTestSuite) TestAtlasDeterministicOrdering() {
 // TestAtlasRoomCellsAndOccludersAreAbsolute pins exact absolute values —
 // local cell + Origin, element-wise — and would die under a sign-flipped
 // Add-vs-Subtract mutant inside Atlas itself (distinct from the same
-// mutant inside Absolute/Locate, pinned separately).
+// mutant inside Absolute/Locate, pinned separately). Also pins
+// AtlasBoundary's absolute projection (#929 hardening round A): both
+// endpoints offset by Origin, independently — a mutant that projects only
+// From, or swaps From/To, changes one or both expected values here.
 func (s *EncounterTestSuite) TestAtlasRoomCellsAndOccludersAreAbsolute() {
 	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
 	s.Require().NoError(err)
@@ -203,6 +216,12 @@ func (s *EncounterTestSuite) TestAtlasRoomCellsAndOccludersAreAbsolute() {
 	// walkability, not ownership). This is the property hosts actually
 	// render by: floor from Cells, blockage layered from Occluders.
 	s.Require().Contains(r1.Cells, spatial.Position{X: -49, Y: 8}, "an occluded cell is still floor — it must appear in Cells too")
+
+	// #929 hardening round A: local (0,0)-(1,0) projected through Origin
+	// (-50,7) — BOTH endpoints offset, flags carried through unchanged.
+	s.Require().Equal([]encounter.AtlasBoundary{
+		{From: spatial.Position{X: -50, Y: 9}, To: spatial.Position{X: -49, Y: 9}, BlocksMovement: true, BlocksLineOfSight: true},
+	}, r1.Boundaries, "boundary endpoints must each be offset by Origin, flags preserved")
 }
 
 // TestAtlasDoorwaysAreAbsolute pins exact FromCell/ToCell values, each
@@ -267,6 +286,11 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 		for j := range atlas1.Rooms[i].Occluders {
 			atlas1.Rooms[i].Occluders[j] = spatial.Position{X: -999, Y: -999}
 		}
+		for j := range atlas1.Rooms[i].Boundaries {
+			atlas1.Rooms[i].Boundaries[j] = encounter.AtlasBoundary{
+				From: spatial.Position{X: -999, Y: -999}, To: spatial.Position{X: -999, Y: -999},
+			}
+		}
 	}
 	for i := range atlas1.Doorways {
 		atlas1.Doorways[i].FromCell = spatial.Position{X: -999, Y: -999}
@@ -288,6 +312,9 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 		"mutating the first snapshot's Cells must not corrupt internal state")
 	s.Require().Equal(spatial.Position{X: -47, Y: 8}, atlas2.Doorways[0].FromCell,
 		"mutating the first snapshot's Doorways must not corrupt internal state")
+	s.Require().Equal([]encounter.AtlasBoundary{
+		{From: spatial.Position{X: -50, Y: 9}, To: spatial.Position{X: -49, Y: 9}, BlocksMovement: true, BlocksLineOfSight: true},
+	}, r1.Boundaries, "mutating the first snapshot's Boundaries must not corrupt internal state (#929 hardening round A)")
 }
 
 // TestAtlasIdenticalAfterReload pins the wave's reload-behavior-identity

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -321,8 +321,19 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 // property (established at T2 for traversal — TestReloadedAnchoredEncounterAcceptsSameTraverse
 // in data_test.go) for Atlas specifically: an anchored multi-room
 // encounter's Atlas, captured before ToData/LoadEncounter and again after,
-// must be deep-equal — including Cells ordering, not just set membership
-// (#929 T3 fix round item 2).
+// must be deep-equal (#929 T3 fix round item 2).
+//
+// This proves Cells ordering is DETERMINISTIC across a reload — not that
+// the order is any PARTICULAR order (#929 hardening round, test-gap
+// closure item 2 — corrects this comment's earlier "including Cells
+// ordering" claim, which overclaimed what a same-enumerator comparison
+// can show): both atlas1 and atlas2 are produced by calling the exact
+// SAME atlasCells enumerator, so a mutant that reordered atlasCells
+// itself (e.g. swapping its Q-outer/R-inner nesting to R-outer/Q-inner)
+// would reorder BOTH calls identically and still pass here. The exact,
+// intended order is pinned separately, against a hand-computed fixture
+// independent of atlasCells' own implementation, by
+// TestAtlasCellsExactOrder.
 func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 	enc1, err := encounter.NewEncounter(validAtlasOrderingSetup())
 	s.Require().NoError(err)
@@ -337,7 +348,32 @@ func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 	atlas2, err := enc2.Atlas()
 	s.Require().NoError(err)
 
-	s.Require().Equal(atlas1, atlas2, "Atlas must be identical after a ToData/LoadEncounter round trip, including Cells ordering")
+	s.Require().Equal(atlas1, atlas2, "Atlas must be identical after a ToData/LoadEncounter round trip — deterministic, though this alone cannot prove the order is the INTENDED one (see TestAtlasCellsExactOrder)")
+}
+
+// TestAtlasCellsExactOrder pins atlasCells' Q-outer/R-inner nesting order
+// exactly, against a fixture independent of atlasCells' own
+// implementation (#929 hardening round, test-gap closure item 2):
+// TestAtlasCellsMatchIsValidPosition only proves SET membership (both
+// sides are compared as maps), and TestAtlasIdenticalAfterReload only
+// proves the SAME enumerator is deterministic across two calls — neither
+// can catch a reordering that both calls agree on, such as swapping
+// atlasCells' outer/inner loop nesting. A small, hand-computed 2x3
+// square room (Origin zero, so absolute == local) makes the full
+// expected order easy to verify by inspection: Q outer over X∈[0,1], R
+// inner over Y∈[0,2].
+func (s *EncounterTestSuite) TestAtlasCellsExactOrder() {
+	enc, err := encounter.NewEncounter(singleRoomSetup(spatial.GridShapeSquare, 2, 3))
+	s.Require().NoError(err)
+
+	atlas, err := enc.Atlas()
+	s.Require().NoError(err)
+	s.Require().Len(atlas.Rooms, 1)
+
+	s.Require().Equal([]spatial.Position{
+		{X: 0, Y: 0}, {X: 0, Y: 1}, {X: 0, Y: 2},
+		{X: 1, Y: 0}, {X: 1, Y: 1}, {X: 1, Y: 2},
+	}, atlas.Rooms[0].Cells, "atlasCells must iterate Q (X) outer, R (Y) inner, in exactly this order")
 }
 
 // TestLocateAbsoluteRoundTripHex pins the round-trip law over EVERY

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -387,6 +387,37 @@ func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripFractionalSquare() {
 	s.Require().Equal(local, loc.Position)
 }
 
+// TestLocateAbsoluteRoundTripExactAtExtremeOrigin pins the guarantee this
+// module actually makes (#929 T3 Opus round F3, Locate's corrected doc
+// comment): an INTEGRAL round trip is exact even at an extreme anchor —
+// Origin at ±(2^30−8), just inside maxAnchorCoord (1<<30). Unlike the
+// fractional case (approximate near an extreme anchor, within one
+// float64 ULP of a room edge — not chased in code), an integral position
+// stays exact because integers round-trip exactly to 2^53, far past
+// this magnitude.
+func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripExactAtExtremeOrigin() {
+	const extreme = (1 << 30) - 8
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "extreme", Width: 10, Height: 10, Origin: spatial.Position{X: extreme, Y: -extreme}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	local := spatial.Position{X: 3, Y: 7}
+	abs, err := enc.Absolute(&encounter.AbsoluteInput{Room: "extreme", Position: local})
+	s.Require().NoError(err)
+	s.Require().Equal(spatial.Position{X: extreme + 3, Y: -extreme + 7}, abs.Position)
+
+	loc, err := enc.Locate(&encounter.LocateInput{Position: abs.Position})
+	s.Require().NoError(err)
+	s.Require().Equal("extreme", loc.Room)
+	s.Require().Equal(local, loc.Position, "an integral round trip at an extreme anchor must be EXACT, not off by a ULP")
+}
+
 // TestLocateOwnershipAtKissingDoorway pins the case that makes W2's
 // uniqueness meaningful: each doorway cell — immediately adjacent to a
 // cell in the OTHER room — must locate to its OWN room, not its

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -47,6 +47,26 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 	}
 }
 
+// validAtlasVoidGapSetup is two square rooms close together but NOT
+// touching — a genuine 3-cell void gap between them (gap-a absolute
+// X∈[0,2], gap-b absolute X∈[6,8], same Y band) — the realistic shape of
+// "void is not floor": a corridor-width gap between two nearby rooms, not
+// a point off in empty space (#929 T3 fix round item 5).
+func validAtlasVoidGapSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "gap-a", Width: 3, Height: 3, Origin: spatial.Position{X: 0, Y: 0}},
+				{ID: "gap-b", Width: 3, Height: 3, Origin: spatial.Position{X: 6, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "gap-a", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
 // singleRoomSetup builds a minimal one-room encounter for the enumeration
 // property test — Origin zero, so a room's Atlas Cells equal its local
 // cells exactly, letting the test compare against spatial's own
@@ -177,6 +197,12 @@ func (s *EncounterTestSuite) TestAtlasRoomCellsAndOccludersAreAbsolute() {
 	s.Require().Contains(r1.Cells, spatial.Position{X: -50, Y: 7}, "local (0,0) projected through Origin")
 	s.Require().Contains(r1.Cells, spatial.Position{X: -47, Y: 9}, "local (3,2), the far corner, projected through Origin")
 	s.Require().Equal([]spatial.Position{{X: -49, Y: 8}}, r1.Occluders, "occluder must be offset by Origin too")
+
+	// #929 T3 fix round item 3: an occluder's cell is floor AND blockage —
+	// it must appear in BOTH Cells and Occluders (ruling 1: occlusion is
+	// walkability, not ownership). This is the property hosts actually
+	// render by: floor from Cells, blockage layered from Occluders.
+	s.Require().Contains(r1.Cells, spatial.Position{X: -49, Y: 8}, "an occluded cell is still floor — it must appear in Cells too")
 }
 
 // TestAtlasDoorwaysAreAbsolute pins exact FromCell/ToCell values, each
@@ -264,6 +290,29 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 		"mutating the first snapshot's Doorways must not corrupt internal state")
 }
 
+// TestAtlasIdenticalAfterReload pins the wave's reload-behavior-identity
+// property (established at T2 for traversal — TestReloadedAnchoredEncounterAcceptsSameTraverse
+// in data_test.go) for Atlas specifically: an anchored multi-room
+// encounter's Atlas, captured before ToData/LoadEncounter and again after,
+// must be deep-equal — including Cells ordering, not just set membership
+// (#929 T3 fix round item 2).
+func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
+	enc1, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	atlas1, err := enc1.Atlas()
+	s.Require().NoError(err)
+
+	data := enc1.ToData()
+	enc2, err := encounter.LoadEncounter(data, nil)
+	s.Require().NoError(err)
+
+	atlas2, err := enc2.Atlas()
+	s.Require().NoError(err)
+
+	s.Require().Equal(atlas1, atlas2, "Atlas must be identical after a ToData/LoadEncounter round trip, including Cells ordering")
+}
+
 // TestLocateAbsoluteRoundTripHex pins the round-trip law over EVERY
 // in-bounds cell of BOTH rooms in the canonical asymmetric hex fixture:
 // Locate(Absolute(r,p)) == (r,p).
@@ -280,6 +329,36 @@ func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripHex() {
 	}
 	for _, room := range rooms {
 		for _, local := range bruteForceLocalCells(spatial.GridShapeHex, room.width, room.height) {
+			abs, err := enc.Absolute(&encounter.AbsoluteInput{Room: room.id, Position: local})
+			s.Require().NoError(err, "room %s cell %v", room.id, local)
+
+			loc, err := enc.Locate(&encounter.LocateInput{Position: abs.Position})
+			s.Require().NoError(err, "room %s cell %v absolute %v", room.id, local, abs.Position)
+			s.Require().Equal(room.id, loc.Room, "round trip must return to the same room")
+			s.Require().Equal(local, loc.Position, "round trip must return to the same local position")
+		}
+	}
+}
+
+// TestLocateAbsoluteRoundTripSquare mirrors TestLocateAbsoluteRoundTripHex's
+// structure for the square family: the round-trip law over EVERY in-bounds
+// INTEGER cell of BOTH rooms in the kissing pair (atlas-r1/atlas-r2) from
+// validAtlasOrderingSetup — the design's promise applies to every room, not
+// just hex (#929 T3 fix round item 1). The fractional case is pinned
+// separately by TestLocateAbsoluteRoundTripFractionalSquare.
+func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripSquare() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	rooms := []struct {
+		id            string
+		width, height int
+	}{
+		{"atlas-r1", 4, 3},
+		{"atlas-r2", 6, 5},
+	}
+	for _, room := range rooms {
+		for _, local := range bruteForceLocalCells(spatial.GridShapeSquare, room.width, room.height) {
 			abs, err := enc.Absolute(&encounter.AbsoluteInput{Room: room.id, Position: local})
 			s.Require().NoError(err, "room %s cell %v", room.id, local)
 
@@ -401,6 +480,16 @@ func (s *EncounterTestSuite) TestLocateRejections() {
 		enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
 		s.Require().NoError(err)
 		_, err = enc.Locate(&encounter.LocateInput{Position: spatial.Position{X: 99999, Y: 99999}})
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().Contains(err.Error(), "owned by no room")
+	})
+
+	s.Run("void position in the gap between two nearby non-touching rooms", func() {
+		// The realistic shape of the law, not just a far-away point: (4,1)
+		// sits in gap-a/gap-b's 3-cell corridor gap, close to both rooms.
+		enc, err := encounter.NewEncounter(validAtlasVoidGapSetup())
+		s.Require().NoError(err)
+		_, err = enc.Locate(&encounter.LocateInput{Position: spatial.Position{X: 4, Y: 1}})
 		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
 		s.Require().Contains(err.Error(), "owned by no room")
 	})

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -1,0 +1,417 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// validAtlasOrderingSetup is the asymmetric fixture for #929 T3: two
+// independent, far-apart kissing room pairs (atlas-r1/atlas-r2 near the
+// absolute origin, atlas-r3/atlas-r4 shifted +10000 on X so W2 is
+// trivially satisfied between the pairs), declared with BOTH rooms and
+// connections out of ID order (Rooms: r3,r1,r4,r2 — sorted order is
+// r1,r2,r3,r4; Connections: connB,connA — sorted order is connA,connB),
+// so a missing/removed sort is observable through the public API. Every
+// room has a distinct, nonzero-on-both-axes Origin (r1: (-50,7), r2:
+// (-46,6)) so a sign-flipped bridge (Subtract instead of Add, or vice
+// versa) produces a wrong, non-accidental-match absolute value.
+func validAtlasOrderingSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
+				{ID: "atlas-r1", Width: 4, Height: 3, Origin: spatial.Position{X: -50, Y: 7},
+					Occluders: []spatial.Position{{X: 1, Y: 1}}},
+				{ID: "atlas-r4", Width: 6, Height: 5, Origin: spatial.Position{X: 9954, Y: 6}},
+				{ID: "atlas-r2", Width: 6, Height: 5, Origin: spatial.Position{X: -46, Y: 6}},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "atlas-connB", From: "atlas-r3", To: "atlas-r4",
+					FromPosition: spatial.Position{X: 3, Y: 1},
+					ToPosition:   spatial.Position{X: 0, Y: 2}},
+				{ID: "atlas-connA", From: "atlas-r1", To: "atlas-r2",
+					FromPosition: spatial.Position{X: 3, Y: 1},
+					ToPosition:   spatial.Position{X: 0, Y: 2}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "atlas-p1", Kind: encounter.KindPlayer, Room: "atlas-r1", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
+// singleRoomSetup builds a minimal one-room encounter for the enumeration
+// property test — Origin zero, so a room's Atlas Cells equal its local
+// cells exactly, letting the test compare against spatial's own
+// IsValidPosition without any Origin arithmetic in the way.
+func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "solo", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
+// bruteForceLocalCells independently enumerates a room's valid integer
+// local cells using ONLY spatial's public API (NewSquareGrid/
+// NewAxialHexGrid + IsValidPosition) — no dependency on this module's
+// own enumeration, so it is a genuine independent oracle for
+// TestAtlasCellsMatchIsValidPosition (#929 T3 ruling 4).
+func bruteForceLocalCells(shape spatial.GridShape, width, height int) []spatial.Position {
+	var grid spatial.Grid
+	if shape == spatial.GridShapeHex {
+		grid = spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: float64(width), SpanHeight: float64(height)})
+	} else {
+		grid = spatial.NewSquareGrid(spatial.SquareGridConfig{Width: float64(width), Height: float64(height)})
+	}
+
+	pad := width + height + 4 // generous — bigger than any valid span in either family
+	var cells []spatial.Position
+	for x := -pad; x <= pad; x++ {
+		for y := -pad; y <= pad; y++ {
+			pos := spatial.Position{X: float64(x), Y: float64(y)}
+			if grid.IsValidPosition(pos) {
+				cells = append(cells, pos)
+			}
+		}
+	}
+	return cells
+}
+
+// TestAtlasCellsMatchIsValidPosition is the ruling-4 property test: for a
+// spread of dimension parities (odd, even, and 1xN thin rooms) across
+// both grid families, Atlas's room Cells (Origin zero, so absolute ==
+// local) must be EXACTLY the set spatial's own IsValidPosition accepts —
+// not a subset, not a superset. A one-cell span drift in the enumerator
+// fails this for some parity in the spread.
+func (s *EncounterTestSuite) TestAtlasCellsMatchIsValidPosition() {
+	dims := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	shapes := map[string]spatial.GridShape{"square": spatial.GridShapeSquare, "hex": spatial.GridShapeHex}
+
+	for shapeName, shape := range shapes {
+		for _, w := range dims {
+			for _, h := range dims {
+				s.Run(fmt.Sprintf("%s-%dx%d", shapeName, w, h), func() {
+					enc, err := encounter.NewEncounter(singleRoomSetup(shape, w, h))
+					s.Require().NoError(err)
+
+					atlas, err := enc.Atlas()
+					s.Require().NoError(err)
+					s.Require().Len(atlas.Rooms, 1)
+
+					got := make(map[spatial.Position]bool, len(atlas.Rooms[0].Cells))
+					for _, c := range atlas.Rooms[0].Cells {
+						got[c] = true
+					}
+
+					want := make(map[spatial.Position]bool)
+					for _, c := range bruteForceLocalCells(shape, w, h) {
+						want[c] = true
+					}
+
+					s.Require().Equal(want, got,
+						"atlasCells must agree exactly with spatial's own IsValidPosition")
+				})
+			}
+		}
+	}
+}
+
+// TestAtlasDeterministicOrdering pins C8: Rooms sorted by room ID and
+// Doorways sorted by connection ID, regardless of declaration order —
+// validAtlasOrderingSetup declares both scrambled.
+func (s *EncounterTestSuite) TestAtlasDeterministicOrdering() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	atlas, err := enc.Atlas()
+	s.Require().NoError(err)
+
+	gotRoomIDs := make([]string, len(atlas.Rooms))
+	for i, r := range atlas.Rooms {
+		gotRoomIDs[i] = r.ID
+	}
+	s.Require().Equal([]string{"atlas-r1", "atlas-r2", "atlas-r3", "atlas-r4"}, gotRoomIDs,
+		"Rooms must be sorted by ID regardless of declaration order")
+
+	gotConnIDs := make([]string, len(atlas.Doorways))
+	for i, d := range atlas.Doorways {
+		gotConnIDs[i] = d.Connection
+	}
+	s.Require().Equal([]string{"atlas-connA", "atlas-connB"}, gotConnIDs,
+		"Doorways must be sorted by connection ID regardless of declaration order")
+}
+
+// TestAtlasRoomCellsAndOccludersAreAbsolute pins exact absolute values —
+// local cell + Origin, element-wise — and would die under a sign-flipped
+// Add-vs-Subtract mutant inside Atlas itself (distinct from the same
+// mutant inside Absolute/Locate, pinned separately).
+func (s *EncounterTestSuite) TestAtlasRoomCellsAndOccludersAreAbsolute() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	atlas, err := enc.Atlas()
+	s.Require().NoError(err)
+
+	var r1 encounter.AtlasRoom
+	found := false
+	for _, r := range atlas.Rooms {
+		if r.ID == "atlas-r1" {
+			r1 = r
+			found = true
+		}
+	}
+	s.Require().True(found, "atlas-r1 must be present")
+
+	s.Require().Contains(r1.Cells, spatial.Position{X: -50, Y: 7}, "local (0,0) projected through Origin")
+	s.Require().Contains(r1.Cells, spatial.Position{X: -47, Y: 9}, "local (3,2), the far corner, projected through Origin")
+	s.Require().Equal([]spatial.Position{{X: -49, Y: 8}}, r1.Occluders, "occluder must be offset by Origin too")
+}
+
+// TestAtlasDoorwaysAreAbsolute pins exact FromCell/ToCell values, each
+// offset by its OWN room's Origin (asymmetric: atlas-r1 and atlas-r2
+// have different, nonzero origins) — dies under a sign flip or a
+// wrong-room-Origin cross-wiring mutant.
+func (s *EncounterTestSuite) TestAtlasDoorwaysAreAbsolute() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	atlas, err := enc.Atlas()
+	s.Require().NoError(err)
+	s.Require().Len(atlas.Doorways, 2)
+
+	connA := atlas.Doorways[0] // sorted: connA precedes connB
+	s.Require().Equal("atlas-connA", connA.Connection)
+	s.Require().Equal("atlas-r1", connA.From)
+	s.Require().Equal(spatial.Position{X: -47, Y: 8}, connA.FromCell)
+	s.Require().Equal("atlas-r2", connA.To)
+	s.Require().Equal(spatial.Position{X: -46, Y: 8}, connA.ToCell)
+}
+
+// TestAtlasUnaffectedByLiveState pins ruling 3: Atlas is construction
+// truth, never live truth. Placing (already done by Setup), moving a
+// member, and pumping a clock tick must never change it.
+func (s *EncounterTestSuite) TestAtlasUnaffectedByLiveState() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	before, err := enc.Atlas()
+	s.Require().NoError(err)
+
+	_, err = enc.Move(&encounter.MoveInput{Member: "atlas-p1", To: spatial.Position{X: 3, Y: 0}})
+	s.Require().NoError(err)
+
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	after, err := enc.Atlas()
+	s.Require().NoError(err)
+
+	s.Require().Equal(before, after,
+		"Atlas must be computed from construction data only — live member placement and clock state must never leak in")
+}
+
+// TestAtlasCopyOutImmunity mutates every slice a returned Atlas exposes
+// and re-fetches — the second Atlas must be unaffected, proving nothing
+// aliases internal storage (MUTATION-PROOF: verified by temporarily
+// aliasing Occluders directly to fieldInput and observing this fail,
+// per #929 T3 mutation-evidence protocol).
+func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	atlas1, err := enc.Atlas()
+	s.Require().NoError(err)
+
+	for i := range atlas1.Rooms {
+		for j := range atlas1.Rooms[i].Cells {
+			atlas1.Rooms[i].Cells[j] = spatial.Position{X: -999, Y: -999}
+		}
+		for j := range atlas1.Rooms[i].Occluders {
+			atlas1.Rooms[i].Occluders[j] = spatial.Position{X: -999, Y: -999}
+		}
+	}
+	for i := range atlas1.Doorways {
+		atlas1.Doorways[i].FromCell = spatial.Position{X: -999, Y: -999}
+		atlas1.Doorways[i].ToCell = spatial.Position{X: -999, Y: -999}
+	}
+
+	atlas2, err := enc.Atlas()
+	s.Require().NoError(err)
+
+	var r1 encounter.AtlasRoom
+	for _, r := range atlas2.Rooms {
+		if r.ID == "atlas-r1" {
+			r1 = r
+		}
+	}
+	s.Require().Equal([]spatial.Position{{X: -49, Y: 8}}, r1.Occluders,
+		"mutating the first snapshot's Occluders must not corrupt internal state")
+	s.Require().Contains(r1.Cells, spatial.Position{X: -50, Y: 7},
+		"mutating the first snapshot's Cells must not corrupt internal state")
+	s.Require().Equal(spatial.Position{X: -47, Y: 8}, atlas2.Doorways[0].FromCell,
+		"mutating the first snapshot's Doorways must not corrupt internal state")
+}
+
+// TestLocateAbsoluteRoundTripHex pins the round-trip law over EVERY
+// in-bounds cell of BOTH rooms in the canonical asymmetric hex fixture:
+// Locate(Absolute(r,p)) == (r,p).
+func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripHex() {
+	enc, err := encounter.NewEncounter(validAnchoredHexSetup())
+	s.Require().NoError(err)
+
+	rooms := []struct {
+		id            string
+		width, height int
+	}{
+		{"hex-big", 10, 4},
+		{"hex-small", 3, 9},
+	}
+	for _, room := range rooms {
+		for _, local := range bruteForceLocalCells(spatial.GridShapeHex, room.width, room.height) {
+			abs, err := enc.Absolute(&encounter.AbsoluteInput{Room: room.id, Position: local})
+			s.Require().NoError(err, "room %s cell %v", room.id, local)
+
+			loc, err := enc.Locate(&encounter.LocateInput{Position: abs.Position})
+			s.Require().NoError(err, "room %s cell %v absolute %v", room.id, local, abs.Position)
+			s.Require().Equal(room.id, loc.Room, "round trip must return to the same room")
+			s.Require().Equal(local, loc.Position, "round trip must return to the same local position")
+		}
+	}
+}
+
+// TestLocateAbsoluteRoundTripFractionalSquare pins ruling 2: a fractional
+// SQUARE position is legal and round-trips exactly, subtract-then-bounds.
+func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripFractionalSquare() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	local := spatial.Position{X: 1.5, Y: 0.5}
+	abs, err := enc.Absolute(&encounter.AbsoluteInput{Room: "atlas-r1", Position: local})
+	s.Require().NoError(err)
+	s.Require().Equal(spatial.Position{X: -48.5, Y: 7.5}, abs.Position)
+
+	loc, err := enc.Locate(&encounter.LocateInput{Position: abs.Position})
+	s.Require().NoError(err)
+	s.Require().Equal("atlas-r1", loc.Room)
+	s.Require().Equal(local, loc.Position)
+}
+
+// TestLocateOwnershipAtKissingDoorway pins the case that makes W2's
+// uniqueness meaningful: each doorway cell — immediately adjacent to a
+// cell in the OTHER room — must locate to its OWN room, not its
+// neighbor's.
+func (s *EncounterTestSuite) TestLocateOwnershipAtKissingDoorway() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	fromAbs, err := enc.Absolute(&encounter.AbsoluteInput{Room: "atlas-r1", Position: spatial.Position{X: 3, Y: 1}})
+	s.Require().NoError(err)
+	toAbs, err := enc.Absolute(&encounter.AbsoluteInput{Room: "atlas-r2", Position: spatial.Position{X: 0, Y: 2}})
+	s.Require().NoError(err)
+
+	fromLoc, err := enc.Locate(&encounter.LocateInput{Position: fromAbs.Position})
+	s.Require().NoError(err)
+	s.Require().Equal("atlas-r1", fromLoc.Room, "the doorway cell in atlas-r1 must locate to atlas-r1, not atlas-r2")
+
+	toLoc, err := enc.Locate(&encounter.LocateInput{Position: toAbs.Position})
+	s.Require().NoError(err)
+	s.Require().Equal("atlas-r2", toLoc.Room, "the doorway cell in atlas-r2 must locate to atlas-r2, not atlas-r1")
+}
+
+// TestAbsoluteLegalOnOccludedCell and TestLocateOwnsOccludedCell pin
+// ruling 1: occlusion is walkability, not ownership — both bridges treat
+// an occluded cell exactly like an empty one.
+func (s *EncounterTestSuite) TestAbsoluteLegalOnOccludedCell() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	out, err := enc.Absolute(&encounter.AbsoluteInput{Room: "atlas-r1", Position: spatial.Position{X: 1, Y: 1}})
+	s.Require().NoError(err, "an occluder must not bar Absolute from projecting the cell")
+	s.Require().Equal(spatial.Position{X: -49, Y: 8}, out.Position)
+}
+
+// TestLocateOwnsOccludedCell is the Locate-side sibling of
+// TestAbsoluteLegalOnOccludedCell.
+func (s *EncounterTestSuite) TestLocateOwnsOccludedCell() {
+	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+	s.Require().NoError(err)
+
+	loc, err := enc.Locate(&encounter.LocateInput{Position: spatial.Position{X: -49, Y: 8}})
+	s.Require().NoError(err, "an occluder must not bar Locate from resolving the cell's owner")
+	s.Require().Equal("atlas-r1", loc.Room)
+	s.Require().Equal(spatial.Position{X: 1, Y: 1}, loc.Position)
+}
+
+// TestAbsoluteRejections pins Absolute's R5 rejection classes.
+func (s *EncounterTestSuite) TestAbsoluteRejections() {
+	s.Run("nil input", func() {
+		enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+		s.Require().NoError(err)
+		_, err = enc.Absolute(nil)
+		s.Require().ErrorIs(err, encounter.ErrNilInput)
+	})
+
+	s.Run("unknown room", func() {
+		enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+		s.Require().NoError(err)
+		_, err = enc.Absolute(&encounter.AbsoluteInput{Room: "nowhere", Position: spatial.Position{X: 0, Y: 0}})
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Require().Contains(err.Error(), `unknown room "nowhere"`)
+	})
+
+	s.Run("out of bounds", func() {
+		enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+		s.Require().NoError(err)
+		_, err = enc.Absolute(&encounter.AbsoluteInput{Room: "atlas-r1", Position: spatial.Position{X: 100, Y: 100}})
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().Contains(err.Error(), "out of bounds")
+	})
+
+	s.Run("hex fractional position", func() {
+		enc, err := encounter.NewEncounter(validAnchoredHexSetup())
+		s.Require().NoError(err)
+		_, err = enc.Absolute(&encounter.AbsoluteInput{Room: "hex-big", Position: spatial.Position{X: 0.5, Y: 0}})
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().Contains(err.Error(), "not an integral axial cell")
+	})
+}
+
+// TestLocateRejections pins Locate's R5 rejection classes.
+func (s *EncounterTestSuite) TestLocateRejections() {
+	s.Run("nil input", func() {
+		enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+		s.Require().NoError(err)
+		_, err = enc.Locate(nil)
+		s.Require().ErrorIs(err, encounter.ErrNilInput)
+	})
+
+	s.Run("void position owned by no room", func() {
+		enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
+		s.Require().NoError(err)
+		_, err = enc.Locate(&encounter.LocateInput{Position: spatial.Position{X: 99999, Y: 99999}})
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().Contains(err.Error(), "owned by no room")
+	})
+
+	s.Run("fractional hex absolute position resolves to no room", func() {
+		// (0.5,0) is not a real cell of any hex room — must be void, not
+		// silently truncated into hex-big's ownership.
+		enc, err := encounter.NewEncounter(validAnchoredHexSetup())
+		s.Require().NoError(err)
+		_, err = enc.Locate(&encounter.LocateInput{Position: spatial.Position{X: 0.5, Y: 0}})
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().Contains(err.Error(), "owned by no room")
+	})
+}

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -52,7 +52,11 @@ func TestVaultChase(t *testing.T) {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: corridorRoom, Width: 10, Height: 10},
-				{ID: vaultRoom, Width: 10, Height: 10},
+				// Anchored immediately east of the corridor (#929 T1): the
+				// gate's endpoints (9,5) and (0,5)+(10,0)=(10,5) are
+				// Chebyshev-adjacent (W3), and the rooms' absolute
+				// footprints (x:[0,9] vs x:[10,19]) stay disjoint (W2).
+				{ID: vaultRoom, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{gate},
 		},

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -6,13 +6,16 @@
 // server, no rpg-api, no Discord activity involved. It sets up the
 // tomb-watch crypt (two players, a patrolling goblin, a pillar), a
 // passage in its unclaimed corner leading to a second room — the
-// ossuary — and hands you the verbs. Every action renders the WORLD
-// TRUTH beside each asked-for player's BELIEFS, scoped to whichever
-// room that player currently stands in — capitals are current
-// sightings, lowercase are ghosts at last-seen — which is the intel
-// model made visible: move behind the pillar and watch yourself become
-// a memory, or step through the passage and watch the crypt itself
-// fade to nothing (T3 — sight never crosses a connection).
+// ossuary, anchored immediately east of the crypt (#929, W2/W3) — and
+// hands you the verbs. Every action renders the WORLD TRUTH beside each
+// asked-for player's BELIEFS, scoped to whichever room that player
+// currently stands in — capitals are current sightings, lowercase are
+// ghosts at last-seen — which is the intel model made visible: move
+// behind the pillar and watch yourself become a memory, or step through
+// the passage and watch the crypt itself fade to nothing (T3 — sight
+// never crosses a connection). The atlas command makes the OTHER half
+// visible: the two rooms placed in one continuous absolute space, the
+// passage's kissing pair made concrete (#929 T5).
 //
 // Run from the module directory:
 //
@@ -20,7 +23,7 @@
 //
 // Commands: move <name> <x> <y> | traverse <name> <connection> | pump |
 // view <name> | story <name> | join <name> <x> <y> | exit <name> |
-// end withdrew | save <file> | load <file> | status | help | quit
+// end withdrew | save <file> | load <file> | atlas | status | help | quit
 package main
 
 import (
@@ -77,7 +80,18 @@ func newCrypt() (*encounter.Encounter, error) {
 					Occluders: []spatial.Position{{X: 6, Y: 6}, {X: 5, Y: 6}},
 				},
 				{
+					// Anchored immediately east of the crypt (#929): the
+					// passage's endpoints, crypt (11,0) and ossuary local
+					// (0,0)+Origin(12,0)=(12,0), are Chebyshev-adjacent
+					// (W3), and the rooms' absolute footprints — crypt
+					// x:[0,11], ossuary x:[12,19] — stay disjoint (W2).
+					// Before this Origin existed, both rooms defaulted to
+					// (0,0) and W2 rejected the field outright — the
+					// workbench crashed on startup (`setup: newencounter:
+					// room "crypt" and room "ossuary" overlap at absolute
+					// cell (0, 0): no field`) until this fix.
 					ID: ossuaryID, Width: ossuaryW, Height: ossuaryH,
+					Origin:    spatial.Position{X: 12, Y: 0},
 					Occluders: []spatial.Position{{X: 4, Y: 3}},
 				},
 			},
@@ -245,6 +259,54 @@ func printStatus(enc *encounter.Encounter) {
 	}
 }
 
+// atlasDistanceGrid returns a throwaway grid of the given family, valid
+// ONLY as a Distance calculator over ABSOLUTE positions — Distance
+// depends solely on the two positions passed to it, never on the grid's
+// own bounds (SquareGrid.Distance and AxialHexGrid.Distance's own
+// implementations), so any instance of the right family computes the
+// correct distance between two dungeon-absolute doorway cells (#929 T5).
+func atlasDistanceGrid(family spatial.GridShape) spatial.Grid {
+	if family == spatial.GridShapeHex {
+		return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 100000, SpanHeight: 100000})
+	}
+	return spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 100000, Height: 100000})
+}
+
+// printAtlas renders the dungeon in world space (#929 T5): every room
+// placed at its absolute footprint, and every doorway's kissing pair —
+// the two absolute cells a connection joins, and the distance between
+// them (always 1 for anything the composition actually constructed; W3
+// guarantees it) — made visible. This is the one property the web
+// client renders by: the room boundary is invisible in world space.
+func printAtlas(enc *encounter.Encounter) {
+	atlas, err := enc.Atlas()
+	if err != nil {
+		fmt.Println("  atlas:", err)
+		return
+	}
+	fmt.Println("  ATLAS — the dungeon in absolute space")
+	for _, r := range atlas.Rooms {
+		qMin, qMax, rMin, rMax := r.Cells[0].X, r.Cells[0].X, r.Cells[0].Y, r.Cells[0].Y
+		for _, c := range r.Cells {
+			qMin, qMax = min(qMin, c.X), max(qMax, c.X)
+			rMin, rMax = min(rMin, c.Y), max(rMax, c.Y)
+		}
+		fmt.Printf("    room %-10s origin (%g,%g)  %dx%d  absolute x:[%g,%g] y:[%g,%g]\n",
+			r.ID, r.Origin.X, r.Origin.Y, r.Width, r.Height, qMin, qMax, rMin, rMax)
+	}
+	for _, d := range atlas.Doorways {
+		var family spatial.GridShape
+		for _, r := range atlas.Rooms {
+			if r.ID == d.From {
+				family = r.Grid
+			}
+		}
+		dist := atlasDistanceGrid(family).Distance(d.FromCell, d.ToCell)
+		fmt.Printf("    doorway %-10s %s(%g,%g) absolute -- %s(%g,%g) absolute  distance %g — they kiss\n",
+			d.Connection, d.From, d.FromCell.X, d.FromCell.Y, d.To, d.ToCell.X, d.ToCell.Y, dist)
+	}
+}
+
 const legend = `  @ you   A/B/C capitals: seen NOW   a/b/g lowercase: ghost at last-seen
   # pillar/sarcophagus   > the stairs down (reach them and the encounter closes)
   connection "passage": crypt (11,0) <-> ossuary (0,0) — stand on the
@@ -259,6 +321,8 @@ const commands = `  move <name> <x> <y>   walk (the world holds still — you pu
   exit <name>           a player heads back to town (carry-forward prints)
   end withdrew          the party calls the delve off (External ending)
   save <file> / load <file>   the ONE aggregate blob, round-tripped
+  atlas                 the dungeon in absolute space — rooms placed by
+                        origin, every doorway's kissing pair made visible
   status | help | quit`
 
 func main() {
@@ -291,6 +355,8 @@ func main() {
 			fmt.Println(commands)
 		case "status":
 			printStatus(enc)
+		case "atlas":
+			printAtlas(enc)
 		case "view":
 			if len(args) == 2 {
 				showView(enc, core.EntityID(args[1]))

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -75,9 +75,11 @@ func goblinPatrol() *patrol {
 // newCrypt (#929 T5 trailing) so main_test.go can construct it directly:
 // the demo fixture is now smoke-tested by `go test`, not just by a human
 // running the binary. This is exactly what closes the gap the workbench's
-// own startup regression exposed (see this file's package doc comment) —
-// a future W-law addition that invalidates this fixture now fails CI
-// instead of surfacing only when someone launches the workbench by hand.
+// own startup regression exposed (the ossuary room's Origin comment
+// below, and TestDungeonSetupConstructs' own doc comment in
+// main_test.go, both tell the story) — a future W-law addition that
+// invalidates this fixture now fails CI instead of surfacing only when
+// someone launches the workbench by hand.
 func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -71,8 +71,15 @@ func goblinPatrol() *patrol {
 	}}
 }
 
-func newCrypt() (*encounter.Encounter, error) {
-	return encounter.NewEncounter(&encounter.SetupInput{
+// dungeonSetup builds the tomb-watch crypt's SetupInput — split out from
+// newCrypt (#929 T5 trailing) so main_test.go can construct it directly:
+// the demo fixture is now smoke-tested by `go test`, not just by a human
+// running the binary. This is exactly what closes the gap the workbench's
+// own startup regression exposed (see this file's package doc comment) —
+// a future W-law addition that invalidates this fixture now fails CI
+// instead of surfacing only when someone launches the workbench by hand.
+func dungeonSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{
@@ -114,7 +121,11 @@ func newCrypt() (*encounter.Encounter, error) {
 				Room: cryptID, Position: spatial.Position{X: 11, Y: 11}}},
 			{Key: "withdrew", Trigger: encounter.TriggerExternal{}},
 		},
-	})
+	}
+}
+
+func newCrypt() (*encounter.Encounter, error) {
+	return encounter.NewEncounter(dungeonSetup())
 }
 
 // roomByID finds a room's data by ID — nil if the field has no such

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main_test.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// TestDungeonSetupConstructs is a smoke test, not a second scene (#929 T5
+// trailing): it makes the workbench's demo fixture constructible BY TEST,
+// so CI already covers it. Before this existed, the fixture crashed the
+// workbench on startup for some span of this wave (both rooms defaulted
+// to Origin (0,0), which W2 rejects as overlapping) and nothing caught
+// it — six review passes read the library and never ran the binary. A
+// future W-law addition that invalidates this fixture now fails this
+// test instead of surfacing only when a human launches the workbench.
+func TestDungeonSetupConstructs(t *testing.T) {
+	enc, err := encounter.NewEncounter(dungeonSetup())
+	if err != nil {
+		t.Fatalf("the demo dungeon must construct: %v", err)
+	}
+
+	if _, err := enc.Atlas(); err != nil {
+		t.Fatalf("the demo dungeon's Atlas must resolve: %v", err)
+	}
+}

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -1,0 +1,296 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// continuityGrid returns a throwaway grid of the given family, valid ONLY
+// as a Distance calculator over ABSOLUTE positions — Distance depends
+// only on the two positions passed to it, never on the grid's own bounds
+// (SquareGrid.Distance and AxialHexGrid.Distance's own implementations),
+// so any instance of the right family computes the correct distance
+// between two dungeon-absolute positions regardless of which room's
+// config built it. #929 T4: this is what lets a scene assert continuity
+// in absolute space without needing a specific room's live Grid.
+func continuityGrid(family spatial.GridShape) spatial.Grid {
+	if family == spatial.GridShapeHex {
+		return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 100000, SpanHeight: 100000})
+	}
+	return spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 100000, Height: 100000})
+}
+
+// continuityViolation returns the index i such that positions[i] and
+// positions[i+1] are MORE than maxDist apart, or -1 if every consecutive
+// pair is within maxDist — the localization primitive the discriminating
+// probe (#929 T4) needs: not just "did continuity break" but "exactly
+// where."
+func continuityViolation(family spatial.GridShape, positions []spatial.Position, maxDist float64) int {
+	grid := continuityGrid(family)
+	for i := 0; i < len(positions)-1; i++ {
+		if grid.Distance(positions[i], positions[i+1]) > maxDist {
+			return i
+		}
+	}
+	return -1
+}
+
+// vaultChaseHexGate is the connection shared by every hex vault-chase
+// fixture in this file (the main scene and the hostile probe) — kept as
+// its own value so the probe can shift ONLY the vault's Origin without
+// re-deriving the gate.
+func vaultChaseHexGate() encounter.ConnectionInput {
+	return encounter.ConnectionInput{
+		ID: "gate", From: "corridor", To: "vault",
+		FromPosition: spatial.Position{X: 4, Y: 1},
+		ToPosition:   spatial.Position{X: -5, Y: -2},
+	}
+}
+
+// vaultChaseHexSetup is the hex-family sibling of chase_test.go's
+// TestVaultChase fixture (#929 T4 — "the vault-chase fixture/story, or a
+// sibling of it, in the game's family"): the SAME shape — a corridor and
+// a vault joined by one gate, a pursuit decider, a sanctuary ending in
+// the far room — re-derived for hex. vaultOrigin is a parameter so the
+// discriminating probe (below) can build a hostile, shifted-origin
+// variant without duplicating this fixture.
+//
+// Geometry: corridor is 10x10 hex at Origin (0,0) — Q,R both in [-5,4].
+// The valid vault Origin is (10,3): vault's Q-range ([5,14]) is fully
+// disjoint from corridor's ([-5,4]) regardless of R (W2), and the gate's
+// endpoints — corridor (4,1) [Q-max edge] and vault local (-5,-2)
+// [Q-min edge] — land on absolute (4,1) and (5,1): cube distance 1, a
+// genuine axial neighbor via the standard (+1,0) offset, not a formula
+// quirk (W3).
+func vaultChaseHexSetup(vaultOrigin spatial.Position) *encounter.SetupInput {
+	gate := vaultChaseHexGate()
+	pursuit := &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice}
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
+				{ID: "vault", Width: 10, Height: 10, Grid: spatial.GridShapeHex, Origin: vaultOrigin},
+			},
+			Connections: []encounter.ConnectionInput{gate},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: "corridor", Position: spatial.Position{X: 1, Y: 1}},
+			// One hex-step from the gate's corridor-side endpoint (4,1) via
+			// the (0,+1) offset — close enough that the pursuit decider's
+			// "jump to last-seen position" IS a genuine single-step move,
+			// not a room-spanning teleport (#929 T4: every recorded beat in
+			// this scene, not just the doorway, is a real single-cell hop).
+			{ID: goblin, Kind: encounter.KindMonster, Room: "corridor",
+				Position: spatial.Position{X: 4, Y: 0}, Decider: pursuit},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "sanctuary", Trigger: encounter.TriggerReachedPosition{
+				Room: "vault", Position: spatial.Position{X: -2, Y: -2}}},
+		},
+	}
+}
+
+// continuityProjector accumulates a human-readable, exact transcript and
+// a plain position path as a story unfolds, projecting every room-local
+// position through Absolute — the wave's payoff pin's own instrument.
+type continuityProjector struct {
+	t          *testing.T
+	enc        *encounter.Encounter
+	transcript []string
+}
+
+func newContinuityProjector(t *testing.T, enc *encounter.Encounter) *continuityProjector {
+	return &continuityProjector{t: t, enc: enc}
+}
+
+// useEncounter repoints the projector at a reloaded Encounter — the
+// transcript keeps accumulating in the SAME slice across the swap, so a
+// reload mid-story never splits the pinned transcript in two.
+func (p *continuityProjector) useEncounter(enc *encounter.Encounter) {
+	p.enc = enc
+}
+
+// project projects one room-local position through Absolute, records it
+// in the human-readable transcript, and returns the absolute position for
+// the caller's own path-continuity bookkeeping.
+func (p *continuityProjector) project(member, verb, room string, pos spatial.Position) spatial.Position {
+	p.t.Helper()
+	out, err := p.enc.Absolute(&encounter.AbsoluteInput{Room: room, Position: pos})
+	require.NoError(p.t, err, "%s %s: Absolute must accept this legal in-bounds position", member, verb)
+	p.transcript = append(p.transcript, fmt.Sprintf("%s %s: %s(%g,%g) -> absolute(%g,%g)",
+		member, verb, room, pos.X, pos.Y, out.Position.X, out.Position.Y))
+	return out.Position
+}
+
+// TestVaultChaseAbsoluteContinuity is the wave's payoff scene (#929 T4):
+// W2 + W3 + the local/absolute bridge, proven as ONE property — a
+// member's path, projected into dungeon-absolute space, is continuous
+// across a doorway exactly as it is within a room. This is the hex
+// sibling of chase_test.go's TestVaultChase (untouched, still
+// byte-identical); the story shape is deliberately the same (corridor,
+// vault, one gate, a pursuit decider, sanctuary in the far room, a
+// mid-chase reload) so the two scenes read as siblings, not vignettes.
+//
+// Every recorded position — including the goblin's — is a genuine
+// single-hex-step from the one before it (the fixture is built for
+// this: see vaultChaseHexSetup's doc comment), so the continuity claim
+// holds over the WHOLE transcript, not just at the doorway; the doorway
+// step is then asserted to be distance EXACTLY 1, same as every other
+// step — the kiss made visible, indistinguishable by inspection from an
+// ordinary move.
+func TestVaultChaseAbsoluteContinuity(t *testing.T) {
+	enc, err := encounter.NewEncounter(vaultChaseHexSetup(spatial.Position{X: 10, Y: 3}))
+	require.NoError(t, err, "the hex vault assembles")
+
+	proj := newContinuityProjector(t, enc)
+	var alicePath, goblinPath []spatial.Position
+
+	// ---- Beat 1: starting placements, mutual sight ----------------------
+	alicePath = append(alicePath, proj.project(string(alice), "start", "corridor", spatial.Position{X: 1, Y: 1}))
+	goblinPath = append(goblinPath, proj.project(string(goblin), "start", "corridor", spatial.Position{X: 4, Y: 0}))
+
+	st, _ := seen(t, enc, alice, goblin)
+	require.Equal(t, intel.Current, st, "beat 1: alice sees the goblin across the open corridor")
+	st, _ = seen(t, enc, goblin, alice)
+	require.Equal(t, intel.Current, st, "beat 1: and the goblin sees her back")
+
+	// ---- Beat 2: alice steps toward the gate, one hex at a time ----------
+	for _, to := range []spatial.Position{{X: 2, Y: 1}, {X: 3, Y: 1}, {X: 4, Y: 1}} {
+		_, err = enc.Move(&encounter.MoveInput{Member: alice, To: to})
+		require.NoError(t, err, "alice steps toward the gate")
+		alicePath = append(alicePath, proj.project(string(alice), "move", "corridor", to))
+	}
+
+	travOut, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "gate"})
+	require.NoError(t, err, "alice slips through the gate")
+	require.Equal(t, "vault", travOut.Traversed.ToRoom)
+	require.Equal(t, spatial.Position{X: -5, Y: -2}, travOut.Traversed.To)
+	// The departure cell was already recorded as alicePath's last entry
+	// (Traversed.From equals the (4,1) move above — same room, same
+	// cell); only the arrival cell is new.
+	require.Equal(t, spatial.Position{X: 4, Y: 1}, travOut.Traversed.From, "the departure cell matches the last recorded move")
+	alicePath = append(alicePath, proj.project(string(alice), "arrive via gate", "vault", travOut.Traversed.To))
+
+	// The ghost forms at the threshold, in the CORRIDOR — the goblin's
+	// last sight of her, not the vault it has never seen.
+	st, p := seen(t, enc, goblin, alice)
+	require.Equal(t, intel.Held, st, "beat 2: the goblin's sight of alice fades — she left the room")
+	require.Equal(t, "corridor", p.Room)
+	require.Equal(t, 4.0, p.X)
+	require.Equal(t, 1.0, p.Y)
+
+	// She takes one more step deeper into the vault before the pause.
+	_, err = enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: -4, Y: -2}})
+	require.NoError(t, err, "alice steps deeper into the vault")
+	alicePath = append(alicePath, proj.project(string(alice), "move", "vault", spatial.Position{X: -4, Y: -2}))
+
+	// ---- Beat 3: the pause (pause is free) --------------------------------
+	// The projected path must survive the reload — the SAME claim T3 pinned
+	// for Atlas (TestAtlasIdenticalAfterReload), now exercised as a live
+	// path a host is actively rendering, not just a static snapshot.
+	beforeReload := alicePath[len(alicePath)-1]
+	data := enc.ToData()
+	enc2, err := encounter.LoadEncounter(data, map[encounter.MemberID]encounter.Decider{
+		goblin: &pursuitDecider{connections: []encounter.ConnectionInput{vaultChaseHexGate()}, target: alice},
+	})
+	require.NoError(t, err, "the suspended chase crosses a process boundary")
+	enc = enc2
+	proj.useEncounter(enc) // SAME projector, reloaded enc — the transcript keeps accumulating
+
+	st, p = seen(t, enc, goblin, alice)
+	require.Equal(t, intel.Held, st, "beat 3: the ghost survived the reload")
+	require.Equal(t, "corridor", p.Room)
+
+	// Re-project alice's CURRENT position on the reloaded encounter — it
+	// must be identical to her last pre-reload position (distance 0,
+	// trivially continuous): a reload never moves anyone.
+	afterReload := proj.project(string(alice), "reload checkpoint", "vault", spatial.Position{X: -4, Y: -2})
+	require.Equal(t, beforeReload, afterReload, "beat 3: the projected position is unchanged by the reload")
+
+	// ---- Beat 4: the pursuit crosses too ----------------------------------
+	pumpOut1, err := enc.Pump(&encounter.PumpInput{})
+	require.NoError(t, err, "beat 4: the pursuit resumes")
+	require.Len(t, pumpOut1.MonsterMoves, 1, "beat 4: the goblin steps toward the threshold")
+	require.Equal(t, spatial.Position{X: 4, Y: 1}, pumpOut1.MonsterMoves[0].To)
+	goblinPath = append(goblinPath, proj.project(string(goblin), "move", "corridor", pumpOut1.MonsterMoves[0].To))
+
+	pumpOut2, err := enc.Pump(&encounter.PumpInput{})
+	require.NoError(t, err, "beat 4: the goblin follows her through")
+	require.Len(t, pumpOut2.MonsterTraverses, 1, "beat 4: the goblin traverses the gate")
+	require.Equal(t, "vault", pumpOut2.MonsterTraverses[0].ToRoom)
+	require.Equal(t, spatial.Position{X: -5, Y: -2}, pumpOut2.MonsterTraverses[0].To)
+	goblinPath = append(goblinPath, proj.project(string(goblin), "arrive via gate", "vault", pumpOut2.MonsterTraverses[0].To))
+
+	// ---- Beat 5: sanctuary ------------------------------------------------
+	for _, to := range []spatial.Position{{X: -3, Y: -2}, {X: -2, Y: -2}} {
+		moveOut, mErr := enc.Move(&encounter.MoveInput{Member: alice, To: to})
+		require.NoError(t, mErr, "alice steps toward sanctuary")
+		alicePath = append(alicePath, proj.project(string(alice), "move", "vault", to))
+		if to == (spatial.Position{X: -2, Y: -2}) {
+			require.NotNil(t, moveOut.Outcome, "the ending fires on arrival")
+			require.Equal(t, "sanctuary", moveOut.Outcome.Ending)
+
+			var aliceOutcome, goblinOutcome encounter.MemberOutcome
+			for _, m := range moveOut.Outcome.Members {
+				switch m.ID {
+				case alice:
+					aliceOutcome = m
+				case goblin:
+					goblinOutcome = m
+				}
+			}
+			// The final ending position, projected too (#929 T4): it must
+			// agree with the live path's own last recorded entries.
+			outAlice := proj.project(string(alice), "outcome", aliceOutcome.Room, aliceOutcome.Position)
+			outGoblin := proj.project(string(goblin), "outcome", goblinOutcome.Room, goblinOutcome.Position)
+			require.Equal(t, alicePath[len(alicePath)-1], outAlice, "the outcome's alice position matches her live projected path")
+			require.Equal(t, goblinPath[len(goblinPath)-1], outGoblin, "the outcome's goblin position matches its live projected path")
+		}
+	}
+
+	// ---- The continuity claim, proven -------------------------------------
+	// Every consecutive pair in BOTH paths is at most one step apart — the
+	// whole transcript is a genuine walk, not a sequence of jumps.
+	require.Equal(t, -1, continuityViolation(spatial.GridShapeHex, alicePath, 1),
+		"alice's absolute-space path must be continuous throughout, including the outcome projection")
+	require.Equal(t, -1, continuityViolation(spatial.GridShapeHex, goblinPath, 1),
+		"the goblin's absolute-space path must be continuous throughout, including the outcome projection")
+
+	// The doorway step, specifically: distance EXACTLY 1, not 0, not 2 —
+	// the room boundary is invisible in world space.
+	grid := continuityGrid(spatial.GridShapeHex)
+	require.Equal(t, 1.0, grid.Distance(alicePath[3], alicePath[4]), "alice's doorway crossing is distance exactly 1")
+	require.Equal(t, 1.0, grid.Distance(goblinPath[0], goblinPath[1]), "the goblin's doorway crossing is distance exactly 1")
+
+	// ---- The transcript, pinned exactly ------------------------------------
+	// Human-readable in the house style, doubling as documentation of what
+	// the host actually sees — the doorway rows (both "arrive via gate"
+	// entries) read exactly like an ordinary move, by design: the room
+	// boundary is invisible in world space.
+	require.Equal(t, []string{
+		"alice start: corridor(1,1) -> absolute(1,1)",
+		"goblin start: corridor(4,0) -> absolute(4,0)",
+		"alice move: corridor(2,1) -> absolute(2,1)",
+		"alice move: corridor(3,1) -> absolute(3,1)",
+		"alice move: corridor(4,1) -> absolute(4,1)",
+		"alice arrive via gate: vault(-5,-2) -> absolute(5,1)",
+		"alice move: vault(-4,-2) -> absolute(6,1)",
+		"alice reload checkpoint: vault(-4,-2) -> absolute(6,1)",
+		"goblin move: corridor(4,1) -> absolute(4,1)",
+		"goblin arrive via gate: vault(-5,-2) -> absolute(5,1)",
+		"alice move: vault(-3,-2) -> absolute(7,1)",
+		"alice move: vault(-2,-2) -> absolute(8,1)",
+		"alice outcome: vault(-2,-2) -> absolute(8,1)",
+		"goblin outcome: vault(-5,-2) -> absolute(5,1)",
+	}, proj.transcript, "the story IS the projected continuity, told in order")
+}

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -32,9 +32,16 @@ func continuityGrid(family spatial.GridShape) spatial.Grid {
 
 // continuityViolation returns the index i such that positions[i] and
 // positions[i+1] are MORE than maxDist apart, or -1 if every consecutive
-// pair is within maxDist — the localization primitive the discriminating
-// probe (#929 T4) needs: not just "did continuity break" but "exactly
-// where."
+// pair is within maxDist. Written to localize a hostile probe run
+// manually during T4 (a field built with W3 deliberately disabled, to
+// confirm this function actually detects a break) and then deleted, not
+// committed — a discontinuous field is unconstructible through the
+// public API precisely BECAUSE W3 rejects it (#929 hardening round,
+// test-gap closure item 7 — this is a strong property of the module,
+// not merely an untested corner). The index return stays regardless: it
+// makes a REAL assertion failure in this file diagnosable — which step
+// broke, not just that one did — independent of that probe's own
+// history.
 func continuityViolation(family spatial.GridShape, positions []spatial.Position, maxDist float64) int {
 	grid := continuityGrid(family)
 	for i := 0; i < len(positions)-1; i++ {
@@ -45,10 +52,12 @@ func continuityViolation(family spatial.GridShape, positions []spatial.Position,
 	return -1
 }
 
-// vaultChaseHexGate is the connection shared by every hex vault-chase
-// fixture in this file (the main scene and the hostile probe) — kept as
-// its own value so the probe can shift ONLY the vault's Origin without
-// re-deriving the gate.
+// vaultChaseHexGate is the connection shared by the two places this file
+// builds the hex vault-chase decider — vaultChaseHexSetup's initial
+// construction (below) and TestVaultChaseAbsoluteContinuity's mid-chase
+// reload, which re-attaches a decider carrying the identical topology —
+// kept as its own value so both share the exact same gate without
+// re-deriving it.
 func vaultChaseHexGate() encounter.ConnectionInput {
 	return encounter.ConnectionInput{
 		ID: "gate", From: "corridor", To: "vault",
@@ -61,25 +70,30 @@ func vaultChaseHexGate() encounter.ConnectionInput {
 // TestVaultChase fixture (#929 T4 — "the vault-chase fixture/story, or a
 // sibling of it, in the game's family"): the SAME shape — a corridor and
 // a vault joined by one gate, a pursuit decider, a sanctuary ending in
-// the far room — re-derived for hex. vaultOrigin is a parameter so the
-// discriminating probe (below) can build a hostile, shifted-origin
-// variant without duplicating this fixture.
+// the far room — re-derived for hex. The vault's Origin used to be a
+// parameter so a hostile, shifted-origin variant could be built for a
+// discriminating probe without duplicating this fixture — that probe
+// was run manually during T4 and deleted, never committed (#929
+// hardening round, test-gap closure item 7: the parameter had exactly
+// one call site, always passing the same value below, so it was dead),
+// leaving the vault's Origin fixed at the one geometry this scene ever
+// actually uses.
 //
 // Geometry: corridor is 10x10 hex at Origin (0,0) — Q,R both in [-5,4].
-// The valid vault Origin is (10,3): vault's Q-range ([5,14]) is fully
+// The vault's Origin is (10,3): vault's Q-range ([5,14]) is fully
 // disjoint from corridor's ([-5,4]) regardless of R (W2), and the gate's
 // endpoints — corridor (4,1) [Q-max edge] and vault local (-5,-2)
 // [Q-min edge] — land on absolute (4,1) and (5,1): cube distance 1, a
 // genuine axial neighbor via the standard (+1,0) offset, not a formula
 // quirk (W3).
-func vaultChaseHexSetup(vaultOrigin spatial.Position) *encounter.SetupInput {
+func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()
 	pursuit := &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice}
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
-				{ID: "vault", Width: 10, Height: 10, Grid: spatial.GridShapeHex, Origin: vaultOrigin},
+				{ID: "vault", Width: 10, Height: 10, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: 3}},
 			},
 			Connections: []encounter.ConnectionInput{gate},
 		},
@@ -153,7 +167,7 @@ func (p *continuityProjector) project(member, verb, room string, pos spatial.Pos
 // step — the kiss made visible, indistinguishable by inspection from an
 // ordinary move.
 func TestVaultChaseAbsoluteContinuity(t *testing.T) {
-	enc, err := encounter.NewEncounter(vaultChaseHexSetup(spatial.Position{X: 10, Y: 3}))
+	enc, err := encounter.NewEncounter(vaultChaseHexSetup())
 	require.NoError(t, err, "the hex vault assembles")
 
 	proj := newContinuityProjector(t, enc)

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -136,10 +136,14 @@ func (p *continuityProjector) project(member, verb, room string, pos spatial.Pos
 // W2 + W3 + the local/absolute bridge, proven as ONE property — a
 // member's path, projected into dungeon-absolute space, is continuous
 // across a doorway exactly as it is within a room. This is the hex
-// sibling of chase_test.go's TestVaultChase (untouched, still
-// byte-identical); the story shape is deliberately the same (corridor,
-// vault, one gate, a pursuit decider, sanctuary in the far room, a
-// mid-chase reload) so the two scenes read as siblings, not vignettes.
+// sibling of chase_test.go's TestVaultChase — its TRANSCRIPT (the beats,
+// positions, and assertions the story makes) is unchanged, though T1
+// touched the file itself to give vaultRoom an explicit Origin (W2
+// requires it; #929 hardening round H corrects an earlier claim of
+// byte-identical that no longer held once that Origin was added). The
+// story shape is deliberately the same (corridor, vault, one gate, a
+// pursuit decider, sanctuary in the far room, a mid-chase reload) so the
+// two scenes read as siblings, not vignettes.
 //
 // Every recorded position — including the goblin's — is a genuine
 // single-hex-step from the one before it (the fixture is built for

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -344,31 +344,6 @@ func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
 // and members are re-placed at persisted positions.
-
-// endingTriggerFromData converts one persisted ending's Kind/Room/Position/
-// Member into its runtime Trigger. Shared by two call sites in
-// LoadEncounter — the ending-trigger validation (which needs it early,
-// right after roomGrids exists, so validateEndingTriggers has something
-// to check) and the later "Restore declared endings" construction (which
-// needs it again, once construction is safe to begin, R5) — ONE
-// conversion, not two copies of the same switch (#929 T3 Opus round F5).
-// ed.Kind is already guaranteed to be "reached_position" or "external" by
-// the key/kind checks earlier in LoadEncounter, and a "reached_position"
-// ed.Position is already guaranteed non-nil there too — both preconditions
-// checked before this is ever called, so no error return is needed here.
-func endingTriggerFromData(ed EndingData) Trigger {
-	switch ed.Kind {
-	case "reached_position":
-		return TriggerReachedPosition{
-			Room:     ed.Room,
-			Position: spatial.Position{X: ed.Position.X, Y: ed.Position.Y},
-			Member:   ed.Member,
-		}
-	case "external":
-		return TriggerExternal{}
-	}
-	return nil
-}
 func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounter, error) {
 	// R5: Validate everything before constructing
 	// No rooms
@@ -694,6 +669,31 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 	sort.Slice(e.connectionsInput, func(i, j int) bool { return e.connectionsInput[i].ID < e.connectionsInput[j].ID })
 
 	return e, nil
+}
+
+// endingTriggerFromData converts one persisted ending's Kind/Room/Position/
+// Member into its runtime Trigger. Shared by two call sites in
+// LoadEncounter above — the ending-trigger validation (which needs it
+// early, right after roomGrids exists, so validateEndingTriggers has
+// something to check) and the "Restore declared endings" construction
+// (which needs it again, once construction is safe to begin, R5) — ONE
+// conversion, not two copies of the same switch (#929 T3 Opus round F5).
+// ed.Kind is already guaranteed to be "reached_position" or "external" by
+// the key/kind checks earlier in LoadEncounter, and a "reached_position"
+// ed.Position is already guaranteed non-nil there too — both preconditions
+// checked before this is ever called, so no error return is needed here.
+func endingTriggerFromData(ed EndingData) Trigger {
+	switch ed.Kind {
+	case "reached_position":
+		return TriggerReachedPosition{
+			Room:     ed.Room,
+			Position: spatial.Position{X: ed.Position.X, Y: ed.Position.Y},
+			Member:   ed.Member,
+		}
+	case "external":
+		return TriggerExternal{}
+	}
+	return nil
 }
 
 // convertRoomDataToRoomInput converts RoomData to RoomInput, both for the

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -273,9 +273,13 @@ func (e *Encounter) ToData() EncounterData {
 // goldens keep omitting the field entirely. No GridShapeGridless case
 // (#929 T2 second review round: deleted — write-only wire value at this
 // point, since no RoomInput this function is ever called with can hold
-// GridShapeGridless — buildValidRoomGrids rejects it at both Setup and
-// Load, per gridDataToShape's own doc comment, well before a room is
-// ever stored in fieldInput and later handed to ToData). The default
+// GridShapeGridless. At Setup, buildValidRoomGrids' shape-legality switch
+// rejects it explicitly (encounter.go's doc comment on that switch); at
+// Load it never even reaches that switch — gridDataToShape below rejects
+// a stored "gridless" string at the wire layer, before a RoomInput ever
+// exists, closing the load-side hole T1 left open — see gridDataToShape's
+// own doc comment. Either way, a room is never stored in fieldInput and
+// later handed to ToData while holding GridShapeGridless). The default
 // case already returns "" for it, same as any other unreachable value.
 func gridShapeToData(shape spatial.GridShape) string {
 	switch shape {
@@ -311,24 +315,33 @@ func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 }
 
 // LoadEncounter reconstructs an Encounter from persistent data and re-attached deciders.
-// Validation order (R5 — validate all before constructing): nil-equivalent empty Data,
-// no rooms, no endings, empty/reserved ending keys (and kind/reached_position checks),
-// undeclared outcome ending; THEN, per room list, a wire-only ID pre-pass (empty/duplicate
-// room ID — #929 T2 second review round, so a later presence error can never misname an
-// empty/ambiguous ID), grid-shape resolution (unrecognized-or-no-longer-supported string)
-// and origin presence (W5) per room; THEN room-list defects via the SAME
-// buildValidRoomGrids Setup uses: shape legality, non-integral occluder position in any
-// family (#929 T3 Opus round F2), W1 (one grid family per field), room legality
-// (non-positive/oversized/over-cell-budget dimensions, out-of-bounds origin —
-// maxRoomSpan/maxAnchorCoord/maxRoomCells/maxFieldCells), origin legality
-// (non-representable origin, every family), W2 (rooms never overlap); THEN, per
-// connection list, the SAME wire-only ID pre-pass and endpoint presence, then connection
-// defects via validateConnectionInputs: unknown or self-referencing room, endpoint out of
-// bounds or on an occluder, W3 (non-kissing doorway); THEN duplicate member IDs, member's
-// room not in field, member position out of bounds or non-integral (hex), ending trigger
-// validity (unknown room or unreachable position on a TriggerReachedPosition — #929 T3
-// Opus round F5, the SAME validateEndingTriggers Setup uses), outcome member room/bounds
-// checks, everMembers missing a current member.
+// Validation order (R5 — validate all before constructing): no rooms, no endings,
+// empty/reserved ending keys (and kind/reached_position checks), undeclared outcome
+// ending; THEN, per room list, a wire-only ID pre-pass (empty/duplicate room ID — #929 T2
+// second review round, so a later presence error can never misname an empty/ambiguous
+// ID), grid-shape resolution (unrecognized-or-no-longer-supported string) and origin
+// presence (W5) per room; THEN room-list defects via the SAME buildValidRoomGrids Setup
+// uses: shape legality, non-integral occluder position in any family (#929 T3 Opus round
+// F2), W1 (one grid family per field), room legality (non-positive/oversized/over-cell-
+// budget dimensions, out-of-bounds origin — maxRoomSpan/maxAnchorCoord/maxRoomCells/
+// maxFieldCells), origin legality (non-representable origin, every family), W2 (rooms
+// never overlap); THEN, per connection list, the SAME wire-only ID pre-pass and endpoint
+// presence, then connection defects via validateConnectionInputs: unknown or
+// self-referencing room, endpoint out of bounds, non-integral (hex), or on an occluder,
+// W3 (non-kissing doorway); THEN empty or duplicate member IDs, member's room not in
+// field, member position out of bounds or non-integral (hex), ending trigger validity
+// (unknown room or unreachable position on a TriggerReachedPosition — #929 T3 Opus round
+// F5, the SAME validateEndingTriggers Setup uses), an abandoned outcome with members
+// still present, outcome member room/bounds checks, everMembers missing a current
+// member.
+//
+// One check runs OUTSIDE this up-front pass, later, during member re-placement and
+// decider re-attachment (construction has already begun by then): a player member
+// naming a Decider in the reattachment map (design law C2, enforced identically at
+// Setup, Join, and here). This is not an R5 violation — nothing external is mutated,
+// and the partially-built Encounter is discarded on this error like any other — but it
+// is a real ordering asymmetry against the up-front list above; a future cleanup could
+// hoist it into the member validation loop instead.
 //
 // #929 T2: the room-list and connection validation is deliberately the SAME Setup
 // runs, not a parallel reimplementation — Setup and Load diverging on the W-laws was

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -344,6 +344,31 @@ func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
 // and members are re-placed at persisted positions.
+
+// endingTriggerFromData converts one persisted ending's Kind/Room/Position/
+// Member into its runtime Trigger. Shared by two call sites in
+// LoadEncounter — the ending-trigger validation (which needs it early,
+// right after roomGrids exists, so validateEndingTriggers has something
+// to check) and the later "Restore declared endings" construction (which
+// needs it again, once construction is safe to begin, R5) — ONE
+// conversion, not two copies of the same switch (#929 T3 Opus round F5).
+// ed.Kind is already guaranteed to be "reached_position" or "external" by
+// the key/kind checks earlier in LoadEncounter, and a "reached_position"
+// ed.Position is already guaranteed non-nil there too — both preconditions
+// checked before this is ever called, so no error return is needed here.
+func endingTriggerFromData(ed EndingData) Trigger {
+	switch ed.Kind {
+	case "reached_position":
+		return TriggerReachedPosition{
+			Room:     ed.Room,
+			Position: spatial.Position{X: ed.Position.X, Y: ed.Position.Y},
+			Member:   ed.Member,
+		}
+	case "external":
+		return TriggerExternal{}
+	}
+	return nil
+}
 func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounter, error) {
 	// R5: Validate everything before constructing
 	// No rooms
@@ -446,6 +471,20 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		if !isIntegralAxialPosition(roomGrids[m.Room], spatial.Position{X: m.Position.X, Y: m.Position.Y}) {
 			return nil, fmt.Errorf("load encounter: member %q position is not an integral axial cell: %w", m.ID, ErrInvalidData)
 		}
+	}
+
+	// A TriggerReachedPosition ending must name a real room and reachable
+	// position — the SAME shared validator Setup uses (#929 T3 Opus round
+	// F5; validateEndingTriggers' doc comment), fed the wire endings
+	// resolved to their runtime Trigger via endingTriggerFromData — the
+	// SAME conversion the "Restore declared endings" construction below
+	// reuses, so the switch on ed.Kind exists exactly once, not twice.
+	endingInputsForValidation := make([]EndingInput, len(data.Endings))
+	for i, ed := range data.Endings {
+		endingInputsForValidation[i] = EndingInput{Key: ed.Key, Trigger: endingTriggerFromData(ed)}
+	}
+	if err := validateEndingTriggers(endingInputsForValidation, roomGrids); err != nil {
+		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
 
 	// Outcome members must reference rooms that exist with in-bounds
@@ -619,20 +658,10 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		e.everMembers[em] = true
 	}
 
-	// Restore declared endings
+	// Restore declared endings — endingTriggerFromData is the SAME
+	// conversion the ending-trigger validation above already ran.
 	for _, ed := range data.Endings {
-		var trigger Trigger
-		switch ed.Kind {
-		case "reached_position":
-			trigger = TriggerReachedPosition{
-				Room:     ed.Room,
-				Position: spatial.Position{X: ed.Position.X, Y: ed.Position.Y},
-				Member:   ed.Member,
-			}
-		case "external":
-			trigger = TriggerExternal{}
-		}
-		e.endings = append(e.endings, declaredEnding{key: ed.Key, trigger: trigger})
+		e.endings = append(e.endings, declaredEnding{key: ed.Key, trigger: endingTriggerFromData(ed)})
 	}
 
 	// Restore outcome if present

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -270,13 +270,17 @@ func (e *Encounter) ToData() EncounterData {
 // string form, reusing spatial's own GridType* constants
 // (tools/spatial/data.go) so the wire vocabulary matches spatial's own
 // persistence. Square (the zero value) maps to "" so byte-compat
-// goldens keep omitting the field entirely.
+// goldens keep omitting the field entirely. No GridShapeGridless case
+// (#929 T2 second review round: deleted — write-only wire value at this
+// point, since no RoomInput this function is ever called with can hold
+// GridShapeGridless — buildValidRoomGrids rejects it at both Setup and
+// Load, per gridDataToShape's own doc comment, well before a room is
+// ever stored in fieldInput and later handed to ToData). The default
+// case already returns "" for it, same as any other unreachable value.
 func gridShapeToData(shape spatial.GridShape) string {
 	switch shape {
 	case spatial.GridShapeHex:
 		return spatial.GridTypeHex
-	case spatial.GridShapeGridless:
-		return spatial.GridTypeGridless
 	default:
 		return ""
 	}
@@ -309,25 +313,33 @@ func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 // LoadEncounter reconstructs an Encounter from persistent data and re-attached deciders.
 // Validation order (R5 — validate all before constructing): nil-equivalent empty Data,
 // no rooms, no endings, empty/reserved ending keys (and kind/reached_position checks),
-// undeclared outcome ending, room defects (empty/duplicate ID, unrecognized-or-no-longer-
-// supported grid shape, missing origin — W5 presence), then room-list and connection
-// defects via the SAME buildValidRoomGrids/validateConnectionInputs Setup uses: W1 (one
-// grid family per field), non-positive dimensions, non-representable/non-integral origin
-// (every family), W2 (rooms never overlap), and connection defects (empty/duplicate ID,
-// missing room, self-connection, missing endpoint, endpoint out of bounds or on an
-// occluder, W3 non-kissing doorway) — then duplicate member IDs, member's room not in
-// field, member position out of bounds, outcome member room/bounds checks, everMembers
-// missing a current member.
+// undeclared outcome ending; THEN, per room list, a wire-only ID pre-pass (empty/duplicate
+// room ID — #929 T2 second review round, so a later presence error can never misname an
+// empty/ambiguous ID), grid-shape resolution (unrecognized-or-no-longer-supported string)
+// and origin presence (W5) per room; THEN room-list defects via the SAME
+// buildValidRoomGrids Setup uses: W1 (one grid family per field), room legality
+// (non-positive or oversized dimensions, out-of-bounds origin — maxRoomSpan/
+// maxAnchorCoord), origin legality (non-representable origin, every family), W2 (rooms
+// never overlap); THEN, per connection list, the SAME wire-only ID pre-pass and endpoint
+// presence, then connection defects via validateConnectionInputs: unknown or
+// self-referencing room, endpoint out of bounds or on an occluder, W3 (non-kissing
+// doorway); THEN duplicate member IDs, member's room not in field, member position out of
+// bounds, outcome member room/bounds checks, everMembers missing a current member.
 //
-// #929 T2: this is deliberately the SAME validation Setup runs, not a parallel
-// reimplementation — Setup and Load diverging on the W-laws was flagged explicitly in
-// T1 review as a drift risk. RoomData/ConnectionData convert to RoomInput/ConnectionInput
-// FIRST (resolving the grid string and checking Origin/endpoint presence — concerns that
-// only exist at the wire layer, since RoomInput.Grid is already typed and
-// RoomInput.Origin is already a value, not a pointer), then the converted slices are
-// handed to buildValidRoomGrids/validateConnectionInputs verbatim; every error they
-// return is wrapped once more with ErrInvalidData (multi-%w, this module's established
-// load-error style — the underlying error already carries ErrNoField/ErrBadConnection).
+// #929 T2: the room-list and connection validation is deliberately the SAME Setup
+// runs, not a parallel reimplementation — Setup and Load diverging on the W-laws was
+// flagged explicitly in T1 review as a drift risk. RoomData/ConnectionData convert to
+// RoomInput/ConnectionInput FIRST (the ID pre-pass, grid-string resolution, and
+// Origin/endpoint presence checks above — concerns that only exist at the wire layer,
+// since RoomInput.Grid is already typed and RoomInput.Origin is already a value, not a
+// pointer), then the converted slices are handed to
+// buildValidRoomGrids/validateConnectionInputs verbatim; every error they return is
+// wrapped once more with ErrInvalidData (multi-%w, this module's established load-error
+// style — the underlying error already carries ErrNoField/ErrBadConnection). Neither
+// shared validator's own error messages carry a verb prefix (#929 T2 second review
+// round — buildValidRoomGrids' doc comment), so this wrap is the ONLY place "load
+// encounter:" enters those messages — NewEncounter wraps the identical unprefixed
+// errors with "newencounter:" instead, at its own call sites.
 //
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
@@ -659,15 +671,38 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 // SAME room-list validation Setup uses (buildValidRoomGrids — see
 // LoadEncounter's doc comment) and for later storage. This is the ONLY
 // place LoadEncounter resolves the wire-only concerns that don't exist on
-// RoomInput itself: the Grid string (rejecting an unrecognized value,
-// including the no-longer-supported "gridless" — gridDataToShape's doc
-// comment) and Origin's W5 presence requirement (a nil pointer means the
-// field was absent from the blob, distinct from a declared zero — RoomData's
-// doc comment). Both reject with ErrNoField, matching the room-list defect
-// vocabulary buildValidRoomGrids itself uses for every OTHER room-list
-// defect, so a caller inspecting the error chain sees one consistent
-// sentinel regardless of which check fired.
+// RoomInput itself: ID presence/uniqueness (a cheap pre-pass, #929 T2
+// second review round — see below), the Grid string (rejecting an
+// unrecognized value, including the no-longer-supported "gridless" —
+// gridDataToShape's doc comment), and Origin's W5 presence requirement (a
+// nil pointer means the field was absent from the blob, distinct from a
+// declared zero — RoomData's doc comment). All reject with ErrNoField,
+// matching the room-list defect vocabulary buildValidRoomGrids itself uses
+// for every OTHER room-list defect, so a caller inspecting the error chain
+// sees one consistent sentinel regardless of which check fired.
+//
+// The ID pre-pass runs as its OWN first pass over the raw wire IDs, before
+// any other conversion: without it, an empty or duplicate room ID could
+// reach the Grid/Origin checks below and produce a message naming that
+// same empty or ambiguous ID — e.g. `room "" missing origin` — instead of
+// the actual defect (the ID itself). buildValidRoomGrids ALSO checks
+// ID empty/duplicate, but only after every room in the list has already
+// survived conversion — too late to prevent THIS symptom. The pre-pass is
+// intentionally redundant with that later check for a room list that
+// passes it: its only job is to guarantee an ID-defective room never
+// reaches a presence error that would misname it.
 func convertRoomDataToRoomInput(rooms []RoomData) ([]RoomInput, error) {
+	seenIDs := make(map[string]bool, len(rooms))
+	for _, rd := range rooms {
+		if rd.ID == "" {
+			return nil, fmt.Errorf("room has empty id: %w", ErrNoField)
+		}
+		if seenIDs[rd.ID] {
+			return nil, fmt.Errorf("duplicate room %q: %w", rd.ID, ErrNoField)
+		}
+		seenIDs[rd.ID] = true
+	}
+
 	result := make([]RoomInput, len(rooms))
 	for i, rd := range rooms {
 		shape, ok := gridDataToShape(rd.Grid)
@@ -710,12 +745,26 @@ func convertRoomDataToRoomInput(rooms []RoomData) ([]RoomInput, error) {
 // ConnectionInput, both for the SAME connection validation Setup uses
 // (validateConnectionInputs — see LoadEncounter's doc comment) and for
 // later storage. This is the ONLY place LoadEncounter resolves the
-// wire-only endpoint-presence concern that doesn't exist on ConnectionInput
-// itself: a nil FromPosition/ToPosition pointer means the field was absent
-// from the blob (not merely zero-valued) — ConnectionData's doc comment.
-// Rejects with ErrBadConnection, matching validateConnectionInputs' own
-// vocabulary for every other connection defect.
+// wire-only concerns that don't exist on ConnectionInput itself: ID
+// presence/uniqueness (a cheap pre-pass, #929 T2 second review round — same
+// reasoning as convertRoomDataToRoomInput's own pre-pass, so an endpoint-
+// presence error can never misname an empty/ambiguous connection ID) and a
+// nil FromPosition/ToPosition pointer, meaning the field was absent from
+// the blob, not merely zero-valued (ConnectionData's doc comment). Rejects
+// with ErrBadConnection, matching validateConnectionInputs' own vocabulary
+// for every other connection defect.
 func convertConnectionDataToConnectionInput(conns []ConnectionData) ([]ConnectionInput, error) {
+	seenIDs := make(map[string]bool, len(conns))
+	for _, cd := range conns {
+		if cd.ID == "" {
+			return nil, fmt.Errorf("connection has empty id: %w", ErrBadConnection)
+		}
+		if seenIDs[cd.ID] {
+			return nil, fmt.Errorf("duplicate connection %q: %w", cd.ID, ErrBadConnection)
+		}
+		seenIDs[cd.ID] = true
+	}
+
 	result := make([]ConnectionInput, len(conns))
 	for i, cd := range conns {
 		if cd.FromPosition == nil {

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -316,13 +316,15 @@ func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 
 // LoadEncounter reconstructs an Encounter from persistent data and re-attached deciders.
 // Validation order (R5 — validate all before constructing): no rooms, no endings,
-// empty/reserved ending keys (and kind/reached_position checks), undeclared outcome
+// empty/reserved ending keys, duplicate ending keys (#929 hardening round E, mirroring
+// NewEncounter's identical check), kind/reached_position checks, undeclared outcome
 // ending; THEN, per room list, a wire-only ID pre-pass (empty/duplicate room ID — #929 T2
 // second review round, so a later presence error can never misname an empty/ambiguous
 // ID), grid-shape resolution (unrecognized-or-no-longer-supported string) and origin
 // presence (W5) per room; THEN room-list defects via the SAME buildValidRoomGrids Setup
-// uses: shape legality, non-integral occluder position in any family (#929 T3 Opus round
-// F2), W1 (one grid family per field), room legality (non-positive/oversized/over-cell-
+// uses: shape legality, non-integral or duplicate occluder position in any family (#929
+// T3 Opus round F2; duplicate — #929 hardening round D), W1 (one grid family per field),
+// room legality (non-positive/oversized/over-cell-
 // budget dimensions, out-of-bounds origin — maxRoomSpan/maxAnchorCoord/maxRoomCells/
 // maxFieldCells), origin legality (non-representable origin, every family), W2 (rooms
 // never overlap); THEN, per connection list, the SAME wire-only ID pre-pass and endpoint
@@ -373,21 +375,28 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		return nil, fmt.Errorf("load encounter: bad endings: %w: %w", ErrInvalidData, ErrNoEnding)
 	}
 
-	// Validate ending keys and kinds
+	// Validate ending keys and kinds: empty/reserved, duplicate (#929
+	// hardening round E — the SAME liveness hole NewEncounter's
+	// identical check closes, mirrored at Load), and kind.
+	seenEndingKeys := make(map[string]bool, len(data.Endings))
 	for _, ed := range data.Endings {
 		if ed.Key == "" || ed.Key == "abandoned" {
 			return nil, fmt.Errorf("load encounter: bad endings: %w: %w", ErrInvalidData, ErrNoEnding)
 		}
+		if seenEndingKeys[ed.Key] {
+			return nil, fmt.Errorf("load encounter: duplicate ending %q: %w: %w", ed.Key, ErrInvalidData, ErrNoEnding)
+		}
+		seenEndingKeys[ed.Key] = true
 
 		if ed.Kind != "reached_position" && ed.Kind != "external" {
-			return nil, fmt.Errorf("load encounter: unknown ending kind %q: %w", ed.Kind, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: unknown ending kind %q: %w: %w", ed.Kind, ErrInvalidData, ErrNoEnding)
 		}
 
 		// A reached_position ending without a position would panic at
 		// construction — LoadEncounter is the trust boundary for
 		// persisted bytes and must reject, never crash (T6 review M2).
 		if ed.Kind == "reached_position" && (ed.Position == nil || ed.Room == "") {
-			return nil, fmt.Errorf("load encounter: ending %q reached_position without room/position: %w", ed.Key, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: ending %q reached_position without room/position: %w: %w", ed.Key, ErrInvalidData, ErrNoEnding)
 		}
 	}
 
@@ -405,7 +414,7 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("load encounter: outcome ending %q not declared: %w", data.Outcome.Ending, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: outcome ending %q not declared: %w: %w", data.Outcome.Ending, ErrInvalidData, ErrNoEnding)
 		}
 	}
 
@@ -441,27 +450,27 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 	for _, m := range data.Members {
 		// Empty member IDs are unreachable (Setup and Join both reject).
 		if m.ID == "" {
-			return nil, fmt.Errorf("load encounter: empty member id: %w", ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: empty member id: %w: %w", ErrInvalidData, ErrNoMember)
 		}
 		if seenIDs[m.ID] {
-			return nil, fmt.Errorf("load encounter: duplicate member %q: %w", m.ID, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: duplicate member %q: %w: %w", m.ID, ErrInvalidData, ErrNoMember)
 		}
 		seenIDs[m.ID] = true
 
 		if _, ok := roomGrids[m.Room]; !ok {
-			return nil, fmt.Errorf("load encounter: member %q room %q not in field: %w", m.ID, m.Room, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: member %q room %q not in field: %w: %w", m.ID, m.Room, ErrInvalidData, ErrBadPlacement)
 		}
 
 		// Validate position in bounds — grid-deferred: the room's own
 		// constructed Grid decides validity (see roomGrids above).
 		if !roomGrids[m.Room].IsValidPosition(spatial.Position{X: m.Position.X, Y: m.Position.Y}) {
-			return nil, fmt.Errorf("load encounter: member %q position out of bounds: %w", m.ID, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: member %q position out of bounds: %w: %w", m.ID, ErrInvalidData, ErrBadPlacement)
 		}
 
 		// Hex rooms require integral axial member positions (interim
 		// tools/spatial#926 enforcement — see isIntegralAxialPosition).
 		if !isIntegralAxialPosition(roomGrids[m.Room], spatial.Position{X: m.Position.X, Y: m.Position.Y}) {
-			return nil, fmt.Errorf("load encounter: member %q position is not an integral axial cell: %w", m.ID, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: member %q position is not an integral axial cell: %w: %w", m.ID, ErrInvalidData, ErrBadPlacement)
 		}
 	}
 
@@ -485,15 +494,15 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 	// present is unreachable (abandonment means the membership emptied).
 	if data.Outcome != nil {
 		if data.Outcome.Ending == "abandoned" && len(data.Members) > 0 {
-			return nil, fmt.Errorf("load encounter: abandoned outcome with members present: %w", ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: abandoned outcome with members present: %w: %w", ErrInvalidData, ErrNoMember)
 		}
 		for _, om := range data.Outcome.Members {
 			_, ok := roomGrids[om.Room]
 			if !ok {
-				return nil, fmt.Errorf("load encounter: outcome member %q room %q not in field: %w", om.ID, om.Room, ErrInvalidData)
+				return nil, fmt.Errorf("load encounter: outcome member %q room %q not in field: %w: %w", om.ID, om.Room, ErrInvalidData, ErrBadPlacement)
 			}
 			if !roomGrids[om.Room].IsValidPosition(spatial.Position{X: om.Position.X, Y: om.Position.Y}) {
-				return nil, fmt.Errorf("load encounter: outcome member %q position out of bounds: %w", om.ID, ErrInvalidData)
+				return nil, fmt.Errorf("load encounter: outcome member %q position out of bounds: %w: %w", om.ID, ErrInvalidData, ErrBadPlacement)
 			}
 		}
 	}
@@ -508,7 +517,7 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("load encounter: member %q missing from ever_members: %w", m.ID, ErrInvalidData)
+			return nil, fmt.Errorf("load encounter: member %q missing from ever_members: %w: %w", m.ID, ErrInvalidData, ErrNoMember)
 		}
 	}
 
@@ -551,7 +560,7 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 	// spatial-typed) rather than re-deriving from data.Field — the same
 	// construction shape NewEncounter's own room-construction loop uses.
 	spatialRoomMap := make(map[string]*spatial.BasicRoom)
-	for _, ri := range roomInputs {
+	for roomIdx, ri := range roomInputs {
 		room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
 			ID:   ri.ID,
 			Type: "room",
@@ -563,9 +572,12 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		}
 		spatialRoomMap[ri.ID] = room
 
-		// Add occluders as blocking entities
-		for _, pos := range ri.Occluders {
-			occluder := &occluderEntity{id: fmt.Sprintf("occluder-%s-%d-%d", ri.ID, int(pos.X), int(pos.Y))}
+		// Add occluders as blocking entities. Index-based ID, not
+		// room-ID-plus-coordinate concatenation (#929 hardening round
+		// C — see NewEncounter's identical loop for the collision this
+		// avoids; this is the SAME fix, mirrored at the Load seam).
+		for occIdx, pos := range ri.Occluders {
+			occluder := &occluderEntity{id: fmt.Sprintf("occluder-%d-%d", roomIdx, occIdx)}
 			_, err = e.orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
 				RoomID:   spatial.RoomID(ri.ID),
 				Entity:   occluder,

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -51,19 +51,22 @@ type FieldData struct {
 	Connections []ConnectionData `json:"connections,omitempty"`
 }
 
-// RoomData persists construction inputs. As of #929 T1 this does NOT
-// mirror RoomInput exactly: RoomInput gained an Origin field for Setup-time
-// W-law validation (RoomInput.Origin's doc comment in field.go), but Origin
-// is not yet persisted here — an encounter's absolute anchoring does not
-// survive a ToData/LoadEncounter round trip in this wave. Origin
-// persistence (and Load-side enforcement of the W-laws generally) lands
-// in T2, alongside a grid-string rejection for stored "gridless" values.
-// Grid is persisted as spatial's own GridType string ("hex" or
-// "gridless" — tools/spatial's GridTypeHex/GridTypeGridless), not the
-// GridShape iota: the iota is an in-process enumeration order, not a
-// wire contract, and would silently reinterpret old blobs if spatial
-// ever reordered it. Grid omits when empty (the square zero value) so
-// pre-v0.2 blobs and square-only encounters keep byte-identical output.
+// RoomData mirrors RoomInput exactly to persist construction inputs — true
+// again as of #929 T2 (a T1-era comment here briefly said otherwise, while
+// Origin was Setup-only). Origin is REQUIRED at load (W5): a nil pointer
+// means the field was absent from the blob (distinct from a declared
+// zero) and is rejected with ErrInvalidData naming the room — a missing
+// anchor must never silently default to (0,0), a legal position that
+// would invent placement, mirroring ConnectionData's FromPosition/ToPosition
+// precedent. ToData ALWAYS writes Origin, even the zero value (no
+// omitempty) — a declared (0,0) persists as an explicit "origin":{"x":0,"y":0},
+// never as absence, so presence itself is meaningful at load.
+// Grid is persisted as spatial's own GridType string ("hex" — tools/spatial's
+// GridTypeHex; "gridless" is a v0.2-era value no longer accepted at load,
+// #929 T2), not the GridShape iota: the iota is an in-process enumeration
+// order, not a wire contract, and would silently reinterpret old blobs if
+// spatial ever reordered it. Grid omits when empty (the square zero value)
+// so pre-v0.2 blobs and square-only encounters keep byte-identical output.
 type RoomData struct {
 	ID         string         `json:"id"`
 	Width      int            `json:"width"`
@@ -71,6 +74,7 @@ type RoomData struct {
 	Grid       string         `json:"grid,omitempty"`
 	Occluders  []PositionData `json:"occluders,omitempty"`
 	Boundaries []BoundaryData `json:"boundaries,omitempty"`
+	Origin     *PositionData  `json:"origin"`
 }
 
 // PositionData is the persistent representation of spatial.Position.
@@ -200,6 +204,11 @@ func (e *Encounter) ToData() EncounterData {
 			Grid:       gridShapeToData(ri.Grid),
 			Occluders:  make([]PositionData, len(ri.Occluders)),
 			Boundaries: make([]BoundaryData, len(ri.Boundaries)),
+			// Always a fresh pointer, always written — even the zero value
+			// (no omitempty, RoomData's own doc comment) — so a declared
+			// origin (0,0) round-trips as explicit presence, not absence,
+			// and two ToData calls never alias the same PositionData.
+			Origin: &PositionData{X: ri.Origin.X, Y: ri.Origin.Y},
 		}
 
 		for j, occ := range ri.Occluders {
@@ -279,14 +288,19 @@ func gridShapeToData(shape spatial.GridShape) string {
 // it defensively for hand-authored fixtures. An unrecognized string
 // returns ok=false so the caller can reject with a fragment naming
 // the bad value, rather than silently defaulting to square.
+//
+// "gridless" is deliberately NOT recognized (#929 T2): it was a v0.2
+// value, dropped from the shape-legality-valid set in T1 (RoomInput.Grid's
+// doc comment) — Setup has rejected it since T1, and a stored "gridless"
+// string now falls through to the same ok=false rejection any other
+// unrecognized string gets, closing the load-side hole T1 left open
+// (a stored "gridless" blob loaded successfully until this change).
 func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 	switch s {
 	case "", spatial.GridTypeSquare:
 		return spatial.GridShapeSquare, true
 	case spatial.GridTypeHex:
 		return spatial.GridShapeHex, true
-	case spatial.GridTypeGridless:
-		return spatial.GridShapeGridless, true
 	default:
 		return spatial.GridShapeSquare, false
 	}
@@ -295,11 +309,26 @@ func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 // LoadEncounter reconstructs an Encounter from persistent data and re-attached deciders.
 // Validation order (R5 — validate all before constructing): nil-equivalent empty Data,
 // no rooms, no endings, empty/reserved ending keys (and kind/reached_position checks),
-// undeclared outcome ending, room defects (empty/duplicate ID, unrecognized grid shape),
-// connection defects (empty/duplicate ID, missing room, self-connection, endpoint out of
-// bounds or on an occluder), duplicate member IDs, member's room not in field, member
-// position out of bounds, outcome member room/bounds checks, everMembers missing a
-// current member.
+// undeclared outcome ending, room defects (empty/duplicate ID, unrecognized-or-no-longer-
+// supported grid shape, missing origin — W5 presence), then room-list and connection
+// defects via the SAME buildValidRoomGrids/validateConnectionInputs Setup uses: W1 (one
+// grid family per field), non-positive dimensions, non-representable/non-integral origin
+// (every family), W2 (rooms never overlap), and connection defects (empty/duplicate ID,
+// missing room, self-connection, missing endpoint, endpoint out of bounds or on an
+// occluder, W3 non-kissing doorway) — then duplicate member IDs, member's room not in
+// field, member position out of bounds, outcome member room/bounds checks, everMembers
+// missing a current member.
+//
+// #929 T2: this is deliberately the SAME validation Setup runs, not a parallel
+// reimplementation — Setup and Load diverging on the W-laws was flagged explicitly in
+// T1 review as a drift risk. RoomData/ConnectionData convert to RoomInput/ConnectionInput
+// FIRST (resolving the grid string and checking Origin/endpoint presence — concerns that
+// only exist at the wire layer, since RoomInput.Grid is already typed and
+// RoomInput.Origin is already a value, not a pointer), then the converted slices are
+// handed to buildValidRoomGrids/validateConnectionInputs verbatim; every error they
+// return is wrapped once more with ErrInvalidData (multi-%w, this module's established
+// load-error style — the underlying error already carries ErrNoField/ErrBadConnection).
+//
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
 // and members are re-placed at persisted positions.
@@ -351,107 +380,31 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		}
 	}
 
-	// Validate rooms: unique non-empty IDs, recognized grid shape (deferred
-	// from Opus T1 review — empty/duplicate room IDs previously went
-	// unvalidated, and connections resolved via last-wins map insertion).
-	// Reuses ErrNoField: a malformed room list is as unusable as an empty
-	// one. roomGrids holds each room's constructed Grid so downstream bounds
-	// checks (connections, members, outcome members) ask the SAME grid the
-	// room will actually be built with — a hardcoded rectangle check would
-	// silently diverge from GridlessRoom's inclusive upper bound
-	// (tools/spatial/gridless.go: IsValidPosition uses x <= Width, not
-	// x < Width like Square/Hex).
-	roomMap := make(map[string]bool)
-	roomsByID := make(map[string]RoomData)
-	roomGrids := make(map[string]spatial.Grid, len(data.Field.Rooms))
-	for _, r := range data.Field.Rooms {
-		if r.ID == "" {
-			return nil, fmt.Errorf("load encounter: room has empty id: %w: %w", ErrInvalidData, ErrNoField)
-		}
-		if roomMap[r.ID] {
-			return nil, fmt.Errorf("load encounter: duplicate room %q: %w: %w", r.ID, ErrInvalidData, ErrNoField)
-		}
-		shape, ok := gridDataToShape(r.Grid)
-		if !ok {
-			return nil, fmt.Errorf("load encounter: room %q has unknown grid shape %q: %w: %w", r.ID, r.Grid, ErrInvalidData, ErrNoField)
-		}
-		roomMap[r.ID] = true
-		roomsByID[r.ID] = r
-		roomGrids[r.ID] = buildRoomGrid(shape, r.Width, r.Height)
-
-		// Hex rooms require integral axial occluder positions (interim
-		// tools/spatial#926 enforcement — see isIntegralAxialPosition).
-		for _, occ := range r.Occluders {
-			pos := spatial.Position{X: occ.X, Y: occ.Y}
-			if !isIntegralAxialPosition(roomGrids[r.ID], pos) {
-				return nil, fmt.Errorf("load encounter: room %q occluder (%g,%g) is not an integral axial cell: %w: %w", r.ID, occ.X, occ.Y, ErrInvalidData, ErrNoField)
-			}
-		}
+	// Convert the wire representation to RoomInput/ConnectionInput — the
+	// ONLY load-specific pre-validation left (grid-string resolution, W5
+	// origin presence, connection endpoint presence: concerns that exist
+	// only because the wire form uses strings and pointers where the
+	// construction form uses typed values) — then hand off to the SAME
+	// room-list and connection validation Setup uses (see this function's
+	// doc comment). Every remaining room-list/connection defect class
+	// (shape legality, W1, room legality, origin legality, W2, W3, and the
+	// existing bounds/occluder/self-connection checks) is enforced by
+	// buildValidRoomGrids/validateConnectionInputs, not duplicated here.
+	roomInputs, err := convertRoomDataToRoomInput(data.Field.Rooms)
+	if err != nil {
+		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
+	}
+	roomGrids, err := buildValidRoomGrids(roomInputs)
+	if err != nil {
+		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
 
-	// Validate connections: unique non-empty IDs, endpoints resolve to
-	// distinct declared rooms, and endpoints lie within their room's
-	// bounds (per the room's own grid) and off any occluder.
-	// ErrBadConnection rides alongside ErrInvalidData so connection defects
-	// are discriminable from other load rejections.
-	seenConnectionIDs := make(map[string]bool, len(data.Field.Connections))
-	for _, c := range data.Field.Connections {
-		if c.ID == "" {
-			return nil, fmt.Errorf("load encounter: connection has empty id: %w: %w", ErrInvalidData, ErrBadConnection)
-		}
-		if seenConnectionIDs[c.ID] {
-			return nil, fmt.Errorf("load encounter: duplicate connection %q: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-		}
-		seenConnectionIDs[c.ID] = true
-
-		fromRoom, ok := roomsByID[c.From]
-		if !ok {
-			return nil, fmt.Errorf("load encounter: connection %q references missing room %q: %w: %w", c.ID, c.From, ErrInvalidData, ErrBadConnection)
-		}
-		toRoom, ok := roomsByID[c.To]
-		if !ok {
-			return nil, fmt.Errorf("load encounter: connection %q references missing room %q: %w: %w", c.ID, c.To, ErrInvalidData, ErrBadConnection)
-		}
-		if c.From == c.To {
-			return nil, fmt.Errorf("load encounter: connection %q connects room %q to itself: %w: %w", c.ID, c.From, ErrInvalidData, ErrBadConnection)
-		}
-
-		// Both endpoints are required — ToData always populates them, so
-		// a nil pointer here means the field was absent from the blob
-		// (not merely zero-valued). Without this check a missing endpoint
-		// would unmarshal to a nil *PositionData and panic below; worse,
-		// if the field type were still a value struct, it would silently
-		// default to (0,0), a legal cell that invents topology.
-		if c.FromPosition == nil {
-			return nil, fmt.Errorf("load encounter: connection %q missing from_position: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-		}
-		if c.ToPosition == nil {
-			return nil, fmt.Errorf("load encounter: connection %q missing to_position: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-		}
-
-		if !roomGrids[c.From].IsValidPosition(spatial.Position{X: c.FromPosition.X, Y: c.FromPosition.Y}) {
-			return nil, fmt.Errorf("load encounter: connection %q from-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-		}
-		if !isIntegralAxialPosition(roomGrids[c.From], spatial.Position{X: c.FromPosition.X, Y: c.FromPosition.Y}) {
-			return nil, fmt.Errorf("load encounter: connection %q from-position is not an integral axial cell: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-		}
-		if !roomGrids[c.To].IsValidPosition(spatial.Position{X: c.ToPosition.X, Y: c.ToPosition.Y}) {
-			return nil, fmt.Errorf("load encounter: connection %q to-position out of bounds: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-		}
-		if !isIntegralAxialPosition(roomGrids[c.To], spatial.Position{X: c.ToPosition.X, Y: c.ToPosition.Y}) {
-			return nil, fmt.Errorf("load encounter: connection %q to-position is not an integral axial cell: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-		}
-
-		for _, occ := range fromRoom.Occluders {
-			if occ.X == c.FromPosition.X && occ.Y == c.FromPosition.Y {
-				return nil, fmt.Errorf("load encounter: connection %q from-position on occluder: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-			}
-		}
-		for _, occ := range toRoom.Occluders {
-			if occ.X == c.ToPosition.X && occ.Y == c.ToPosition.Y {
-				return nil, fmt.Errorf("load encounter: connection %q to-position on occluder: %w: %w", c.ID, ErrInvalidData, ErrBadConnection)
-			}
-		}
+	connectionInputs, err := convertConnectionDataToConnectionInput(data.Field.Connections)
+	if err != nil {
+		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
+	}
+	if err = validateConnectionInputs(roomInputs, roomGrids, connectionInputs); err != nil {
+		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
 
 	// Validate members: no duplicates, rooms exist, positions in bounds
@@ -466,7 +419,7 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		}
 		seenIDs[m.ID] = true
 
-		if !roomMap[m.Room] {
+		if _, ok := roomGrids[m.Room]; !ok {
 			return nil, fmt.Errorf("load encounter: member %q room %q not in field: %w", m.ID, m.Room, ErrInvalidData)
 		}
 
@@ -492,7 +445,7 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 			return nil, fmt.Errorf("load encounter: abandoned outcome with members present: %w", ErrInvalidData)
 		}
 		for _, om := range data.Outcome.Members {
-			_, ok := roomsByID[om.Room]
+			_, ok := roomGrids[om.Room]
 			if !ok {
 				return nil, fmt.Errorf("load encounter: outcome member %q room %q not in field: %w", om.ID, om.Room, ErrInvalidData)
 			}
@@ -551,8 +504,11 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 
 	// Create all rooms, reusing each room's already-constructed Grid
 	// (roomGrids, built above) so validation and placement agree exactly.
+	// Iterates roomInputs/connectionInputs (already validated, already
+	// spatial-typed) rather than re-deriving from data.Field — the same
+	// construction shape NewEncounter's own room-construction loop uses.
 	spatialRoomMap := make(map[string]*spatial.BasicRoom)
-	for _, ri := range data.Field.Rooms {
+	for _, ri := range roomInputs {
 		room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
 			ID:   ri.ID,
 			Type: "room",
@@ -570,7 +526,7 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 			_, err = e.orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
 				RoomID:   spatial.RoomID(ri.ID),
 				Entity:   occluder,
-				Position: spatial.Position{X: pos.X, Y: pos.Y},
+				Position: pos,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("load encounter occluder placement: %w: %w: %w", ErrInvalidData, ErrBadPlacement, err)
@@ -579,16 +535,10 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 
 		// Add boundaries
 		for _, b := range ri.Boundaries {
-			boundary := spatial.Boundary{
-				From:              spatial.Position{X: b.From.X, Y: b.From.Y},
-				To:                spatial.Position{X: b.To.X, Y: b.To.Y},
-				BlocksMovement:    b.BlocksMovement,
-				BlocksLineOfSight: b.BlocksLineOfSight,
-			}
 			boundaryRoom := spatialRoomMap[ri.ID]
 			if boundaryRoom != nil {
 				if br, ok := interface{}(boundaryRoom).(spatial.BoundaryAwareRoom); ok {
-					err = br.RegisterBoundary(boundary)
+					err = br.RegisterBoundary(b)
 					if err != nil {
 						return nil, fmt.Errorf("load encounter boundary: %w: %w: %w", ErrInvalidData, ErrBadPlacement, err)
 					}
@@ -598,7 +548,7 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 	}
 
 	// Add connections
-	for _, ci := range data.Field.Connections {
+	for _, ci := range connectionInputs {
 		door := spatial.CreateDoorConnection(ci.ID, ci.From, ci.To, 1.0)
 		err = e.orchestrator.AddConnection(door)
 		if err != nil {
@@ -690,22 +640,44 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 		e.outcome = outcome
 	}
 
-	// Store field and connections inputs for future ToData calls. Connections
-	// are kept sorted by ID (C8 determinism — order is observable in ToData).
-	e.fieldInput = convertRoomDataToRoomInput(data.Field.Rooms)
-	e.connectionsInput = convertConnectionDataToConnectionInput(data.Field.Connections)
+	// Store field and connections inputs for future ToData calls — the
+	// SAME roomInputs/connectionInputs already built (and validated)
+	// above, not re-converted: both were freshly allocated from data by
+	// convertRoomDataToRoomInput/convertConnectionDataToConnectionInput,
+	// never aliasing the caller's data (T6 review M4's alias-immunity
+	// requirement, pinned at this seam by TestAliasImmunityLoadEncounter).
+	// Connections are kept sorted by ID (C8 determinism — order is
+	// observable in ToData).
+	e.fieldInput = roomInputs
+	e.connectionsInput = connectionInputs
 	sort.Slice(e.connectionsInput, func(i, j int) bool { return e.connectionsInput[i].ID < e.connectionsInput[j].ID })
 
 	return e, nil
 }
 
-// convertRoomDataToRoomInput converts RoomData back to RoomInput for storage.
-func convertRoomDataToRoomInput(rooms []RoomData) []RoomInput {
+// convertRoomDataToRoomInput converts RoomData to RoomInput, both for the
+// SAME room-list validation Setup uses (buildValidRoomGrids — see
+// LoadEncounter's doc comment) and for later storage. This is the ONLY
+// place LoadEncounter resolves the wire-only concerns that don't exist on
+// RoomInput itself: the Grid string (rejecting an unrecognized value,
+// including the no-longer-supported "gridless" — gridDataToShape's doc
+// comment) and Origin's W5 presence requirement (a nil pointer means the
+// field was absent from the blob, distinct from a declared zero — RoomData's
+// doc comment). Both reject with ErrNoField, matching the room-list defect
+// vocabulary buildValidRoomGrids itself uses for every OTHER room-list
+// defect, so a caller inspecting the error chain sees one consistent
+// sentinel regardless of which check fired.
+func convertRoomDataToRoomInput(rooms []RoomData) ([]RoomInput, error) {
 	result := make([]RoomInput, len(rooms))
 	for i, rd := range rooms {
-		// gridDataToShape's ok is ignored: LoadEncounter has already
-		// validated every room's Grid string before this conversion runs.
-		shape, _ := gridDataToShape(rd.Grid)
+		shape, ok := gridDataToShape(rd.Grid)
+		if !ok {
+			return nil, fmt.Errorf("room %q has unknown grid shape %q: %w", rd.ID, rd.Grid, ErrNoField)
+		}
+		if rd.Origin == nil {
+			return nil, fmt.Errorf("room %q missing origin: %w", rd.ID, ErrNoField)
+		}
+
 		ri := RoomInput{
 			ID:         rd.ID,
 			Width:      rd.Width,
@@ -713,6 +685,7 @@ func convertRoomDataToRoomInput(rooms []RoomData) []RoomInput {
 			Grid:       shape,
 			Occluders:  make([]spatial.Position, len(rd.Occluders)),
 			Boundaries: make([]spatial.Boundary, len(rd.Boundaries)),
+			Origin:     spatial.Position{X: rd.Origin.X, Y: rd.Origin.Y},
 		}
 
 		for j, pd := range rd.Occluders {
@@ -730,13 +703,27 @@ func convertRoomDataToRoomInput(rooms []RoomData) []RoomInput {
 
 		result[i] = ri
 	}
-	return result
+	return result, nil
 }
 
-// convertConnectionDataToConnectionInput converts ConnectionData back to ConnectionInput for storage.
-func convertConnectionDataToConnectionInput(conns []ConnectionData) []ConnectionInput {
+// convertConnectionDataToConnectionInput converts ConnectionData to
+// ConnectionInput, both for the SAME connection validation Setup uses
+// (validateConnectionInputs — see LoadEncounter's doc comment) and for
+// later storage. This is the ONLY place LoadEncounter resolves the
+// wire-only endpoint-presence concern that doesn't exist on ConnectionInput
+// itself: a nil FromPosition/ToPosition pointer means the field was absent
+// from the blob (not merely zero-valued) — ConnectionData's doc comment.
+// Rejects with ErrBadConnection, matching validateConnectionInputs' own
+// vocabulary for every other connection defect.
+func convertConnectionDataToConnectionInput(conns []ConnectionData) ([]ConnectionInput, error) {
 	result := make([]ConnectionInput, len(conns))
 	for i, cd := range conns {
+		if cd.FromPosition == nil {
+			return nil, fmt.Errorf("connection %q missing from_position: %w", cd.ID, ErrBadConnection)
+		}
+		if cd.ToPosition == nil {
+			return nil, fmt.Errorf("connection %q missing to_position: %w", cd.ID, ErrBadConnection)
+		}
 		result[i] = ConnectionInput{
 			ID:           cd.ID,
 			From:         cd.From,
@@ -745,5 +732,5 @@ func convertConnectionDataToConnectionInput(conns []ConnectionData) []Connection
 			ToPosition:   spatial.Position{X: cd.ToPosition.X, Y: cd.ToPosition.Y},
 		}
 	}
-	return result
+	return result, nil
 }

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -317,14 +317,18 @@ func gridDataToShape(s string) (shape spatial.GridShape, ok bool) {
 // room ID — #929 T2 second review round, so a later presence error can never misname an
 // empty/ambiguous ID), grid-shape resolution (unrecognized-or-no-longer-supported string)
 // and origin presence (W5) per room; THEN room-list defects via the SAME
-// buildValidRoomGrids Setup uses: W1 (one grid family per field), room legality
-// (non-positive or oversized dimensions, out-of-bounds origin — maxRoomSpan/
-// maxAnchorCoord), origin legality (non-representable origin, every family), W2 (rooms
-// never overlap); THEN, per connection list, the SAME wire-only ID pre-pass and endpoint
-// presence, then connection defects via validateConnectionInputs: unknown or
-// self-referencing room, endpoint out of bounds or on an occluder, W3 (non-kissing
-// doorway); THEN duplicate member IDs, member's room not in field, member position out of
-// bounds, outcome member room/bounds checks, everMembers missing a current member.
+// buildValidRoomGrids Setup uses: shape legality, non-integral occluder position in any
+// family (#929 T3 Opus round F2), W1 (one grid family per field), room legality
+// (non-positive/oversized/over-cell-budget dimensions, out-of-bounds origin —
+// maxRoomSpan/maxAnchorCoord/maxRoomCells/maxFieldCells), origin legality
+// (non-representable origin, every family), W2 (rooms never overlap); THEN, per
+// connection list, the SAME wire-only ID pre-pass and endpoint presence, then connection
+// defects via validateConnectionInputs: unknown or self-referencing room, endpoint out of
+// bounds or on an occluder, W3 (non-kissing doorway); THEN duplicate member IDs, member's
+// room not in field, member position out of bounds or non-integral (hex), ending trigger
+// validity (unknown room or unreachable position on a TriggerReachedPosition — #929 T3
+// Opus round F5, the SAME validateEndingTriggers Setup uses), outcome member room/bounds
+// checks, everMembers missing a current member.
 //
 // #929 T2: the room-list and connection validation is deliberately the SAME Setup
 // runs, not a parallel reimplementation — Setup and Load diverging on the W-laws was

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -51,7 +51,13 @@ type FieldData struct {
 	Connections []ConnectionData `json:"connections,omitempty"`
 }
 
-// RoomData mirrors RoomInput exactly to persist construction inputs.
+// RoomData persists construction inputs. As of #929 T1 this does NOT
+// mirror RoomInput exactly: RoomInput gained an Origin field for Setup-time
+// W-law validation (RoomInput.Origin's doc comment in field.go), but Origin
+// is not yet persisted here — an encounter's absolute anchoring does not
+// survive a ToData/LoadEncounter round trip in this wave. Origin
+// persistence (and Load-side enforcement of the W-laws generally) lands
+// in T2, alongside a grid-string rejection for stored "gridless" values.
 // Grid is persisted as spatial's own GridType string ("hex" or
 // "gridless" — tools/spatial's GridTypeHex/GridTypeGridless), not the
 // GridShape iota: the iota is an in-process enumeration order, not a

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -1852,11 +1852,31 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 		{"origin legality: fractional hex origin", func(d *encounter.EncounterData) {
 			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 6.5, Y: -5}
 		}, encounter.ErrNoField, "not a representable integral cell"},
+		{"origin legality: NaN origin", func(d *encounter.EncounterData) {
+			// #929 hardening round, test-gap closure item 4: NaN had ZERO
+			// coverage anywhere in the suite before this. Unlike Inf below,
+			// NaN does NOT get caught by room legality's magnitude check —
+			// math.Abs(NaN) is NaN, and every comparison against NaN
+			// (including >) is false, so a NaN origin silently slips PAST
+			// `math.Abs(r.Origin.X) > maxAnchorCoord` uncaught, and is only
+			// rejected later, by origin legality's isRepresentableInteger
+			// (which explicitly tests IsNaN). The fragment asserts THAT
+			// message specifically, proving the ordering, not just that
+			// SOME check eventually rejects it.
+			d.Field.Rooms[1].Origin = &encounter.PositionData{X: math.NaN(), Y: -5}
+		}, encounter.ErrNoField, "not a representable integral cell"},
 		{"room legality: infinite origin", func(d *encounter.EncounterData) {
 			// #929 T2 second review round: caught by maxAnchorCoord's bound
 			// in room legality — Inf is never <= a finite bound — before
 			// origin legality's representability check ever runs.
 			d.Field.Rooms[1].Origin = &encounter.PositionData{X: math.Inf(1), Y: -5}
+		}, encounter.ErrNoField, "exceeds max anchor coordinate"},
+		{"room legality: negative infinite origin", func(d *encounter.EncounterData) {
+			// #929 hardening round, test-gap closure item 4: the row above
+			// only ever tried +Inf; -Inf takes the SAME path (math.Abs(-Inf)
+			// is +Inf, and +Inf > any finite bound is true) but had never
+			// actually been exercised.
+			d.Field.Rooms[1].Origin = &encounter.PositionData{X: math.Inf(-1), Y: -5}
 		}, encounter.ErrNoField, "exceeds max anchor coordinate"},
 		{"room legality: origin exceeds max anchor coordinate (1e19)", func(d *encounter.EncounterData) {
 			// #929 T2 second review round: 1e19 is both non-representable
@@ -1883,6 +1903,19 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 			// — this must fail on adjacency, not on the earlier bounds check.
 			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 1, Y: 4}
 		}, encounter.ErrBadConnection, "not adjacent"},
+		{"W3: hex axial (1,1) delta is NOT adjacent (cube distance 2)", func(d *encounter.EncounterData) {
+			// Load-seam mirror of encounter_test.go's TestSetupAnchoring
+			// row of the same name (#929 hardening round, test-gap closure
+			// item 6): both existing Load W3 rows above sit at cube/
+			// Chebyshev distance 3 either way ("endpoints do not kiss") —
+			// neither discriminates a Chebyshev-on-axial mutant (which
+			// would wrongly accept max(|ΔQ|,|ΔR|)=1 as adjacent) from the
+			// correct cube-distance formula. hex-small's Origin shifts
+			// from (6,-5) to (6,-3): the gate's endpoints, once anchored,
+			// differ by axial (ΔQ=1,ΔR=1) — cube distance (1+1+2)/2=2, NOT
+			// 1 — while still disjoint from hex-big (W2 passes).
+			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 6, Y: -3}
+		}, encounter.ErrBadConnection, "distance 2"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -1929,6 +1962,106 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Require().Contains(err.Error(), `room "r-a" and room "r-c" overlap at absolute cell (2, 2)`)
+}
+
+// TestLoadAnchoringSquareOriginRejected is the Load-seam counterpart to
+// encounter_test.go's TestSetupAnchoringSquareOriginRejected (#929
+// hardening round, test-gap closure item 6): TestLoadAnchoring's
+// "origin legality: fractional hex origin" row exercises this same
+// check, but only ever against a HEX room — Load-seam coverage of
+// origin legality was hex-shaped, leaving the square-family case to
+// shared-code reasoning alone. Same geometry as the Setup sibling: a
+// single 5x5 SQUARE room at Origin (0.5,1.5).
+func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0.5, Y: 1.5}},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 1, Y: 1}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "not a representable integral cell")
+}
+
+// TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap is the
+// Load-seam counterpart to encounter_test.go's
+// TestSetupAnchoringHugeOriginRejectedNotFalseOverlap (#929 hardening
+// round, test-gap closure item 6): TestLoadAnchoring's "room legality:
+// origin exceeds max anchor coordinate (1e19)" row mutates ONLY
+// hex-small's Origin within the shared hex base fixture — Load-seam
+// coverage of the maxAnchorCoord bound, like origin legality above, was
+// hex-shaped. Same geometry as the Setup sibling: two 5x5 SQUARE rooms
+// at Origins 1e19 and 2e19 — nowhere near each other in real space, but
+// which would truncate to the SAME implementation-defined int64 value
+// without this bound, producing a false W2 overlap verdict.
+func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 1e19, Y: 0}},
+				{ID: "r2", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 2e19, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 1, Y: 1}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceeds max anchor coordinate",
+		"must reject at room legality, not fall through to a W2 overlap verdict on garbage-truncated positions")
+	s.Require().NotContains(err.Error(), "overlap at absolute cell",
+		"the old bug produced a W2 overlap message here — this must NOT be that")
+}
+
+// TestLoadAnchoringFractionalSquareEndpointSubUnitDistance is the
+// Load-seam counterpart to encounter_test.go's
+// TestSetupAnchoringFractionalSquareEndpointSubUnitDistance (#929
+// hardening round, test-gap closure item 6): W3's strict `dist != 1`
+// comparison — as opposed to a `> 1` mutant that would wrongly accept a
+// sub-1 gap as "close enough" — had no Load-seam coverage at all. Same
+// geometry as the Setup sibling: r1 is 3x3 at the zero-value Origin; r2
+// is 3x3 at Origin (3,0), immediately east — fully disjoint (r1 absolute
+// x:[0,2], r2 absolute x:[3,5]). FromPosition (2.5,1), a legal
+// fractional cell in r1, projects to absolute (2.5,1) — only 0.5
+// Chebyshev distance from ToPosition (0,1)'s absolute (3,1).
+func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "r2", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 3, Y: 0}},
+			},
+			Connections: []encounter.ConnectionData{{
+				ID: "gate", From: "r1", To: "r2",
+				FromPosition: &encounter.PositionData{X: 2.5, Y: 1},
+				ToPosition:   &encounter.PositionData{X: 0, Y: 1},
+			}},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 0, Y: 0}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrBadConnection)
+	s.Require().Contains(err.Error(), "distance 0.5")
 }
 
 // TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint is the Load-seam
@@ -1979,11 +2112,35 @@ func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 	s.Require().Contains(err.Error(), "exceeding max room cells")
 }
 
+// TestLoadOversizedRoomHeightRejected is the Load-seam counterpart to
+// encounter_test.go's TestSetupOversizedRoomHeightRejected — same
+// reasoning, same fixture (#929 hardening round, test-gap closure item
+// 3): maxRoomSpan's Height clause was unpinned at both seams.
+func (s *DataTestSuite) TestLoadOversizedRoomHeightRejected() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "tall", Width: 5, Height: (1 << 30) + 1, Origin: &encounter.PositionData{X: 0, Y: 0}},
+			},
+		},
+		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceed max room span",
+		"a Height-only oversize must reject at room-span legality, not fall through to a different check with a different message")
+}
+
 // TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms is the Load-seam
 // counterpart to encounter_test.go's
-// TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms.
+// TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms — SIX rooms, not
+// five, and the exact true-total number asserted, for the same reason
+// (that test's doc comment): #929 hardening round, test-gap closure
+// item 1.
 func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
-	rooms := make([]encounter.RoomData, 5)
+	rooms := make([]encounter.RoomData, 6)
 	for i := range rooms {
 		rooms[i] = encounter.RoomData{
 			ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024,
@@ -1998,6 +2155,8 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "field has 6291456 total cells across all rooms",
+		"must name the TRUE total over all six rooms, not a running total that stopped short at a mid-loop room")
 	s.Require().Contains(err.Error(), "exceeding max field cells")
 }
 
@@ -2142,6 +2301,38 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	s.Require().NoError(err, "the reloaded encounter accepts the SAME traverse")
 	s.Equal(out1.Traversed.ToRoom, out2.Traversed.ToRoom)
 	s.Equal(out1.Traversed.To, out2.Traversed.To)
+}
+
+// TestLoadAnchoringSquareEndpointNotAdjacentDistance2 is the Load-seam
+// counterpart to encounter_test.go's
+// TestSetupAnchoringSquareEndpointNotAdjacentDistance2 — same geometry
+// (#929 hardening round, test-gap closure item 5): square-family W3
+// non-adjacency at a genuine distance (2), not the sub-unit case, had no
+// coverage at either seam.
+func (s *DataTestSuite) TestLoadAnchoringSquareEndpointNotAdjacentDistance2() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "r2", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 4, Y: 0}},
+			},
+			Connections: []encounter.ConnectionData{{
+				ID: "gate", From: "r1", To: "r2",
+				FromPosition: &encounter.PositionData{X: 2, Y: 1},
+				ToPosition:   &encounter.PositionData{X: 0, Y: 1},
+			}},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 0, Y: 0}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrBadConnection)
+	s.Require().Contains(err.Error(), "not adjacent")
 }
 
 // TestLoadRejectsHostileNonKissingBlob pins W3 against a HAND-EDITED wire

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -103,18 +103,27 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 // the round-trip — most notably in convertConnectionDataToConnectionInput,
 // which only ever sees pre-sorted, already-round-tripped ToData output in
 // other tests — would change the observed values, not just their order.
+//
+// #929 T1: r2's Origin (5,0) anchors it immediately east of r1 (5x5 each,
+// so r1's absolute footprint is x:[0,4],y:[0,4] and r2's is x:[5,9],y:[0,4]
+// — disjoint, W2). All three doors sit on r1's east edge (x=4) and r2's
+// west edge (local x=0, absolute x=5), one per row, so every one
+// independently satisfies W3 (Chebyshev distance 1, dx=1/dy=0) under this
+// SAME shared origin — the original fixture's three endpoint pairs had
+// three different relative offsets and could not all kiss under any single
+// origin simultaneously.
 func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
-				{ID: "r2", Width: 5, Height: 5},
+				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: 0}},
 			},
 			// Declared out of ID order — persistence must not echo this order.
 			Connections: []encounter.ConnectionInput{
-				{ID: "z-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 0, Y: 3}, ToPosition: spatial.Position{X: 2, Y: 1}},
-				{ID: "a-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 1, Y: 4}, ToPosition: spatial.Position{X: 3, Y: 2}},
-				{ID: "m-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 2, Y: 0}, ToPosition: spatial.Position{X: 4, Y: 3}},
+				{ID: "z-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 4, Y: 1}, ToPosition: spatial.Position{X: 0, Y: 1}},
+				{ID: "a-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 4, Y: 2}, ToPosition: spatial.Position{X: 0, Y: 2}},
+				{ID: "m-door", From: "r1", To: "r2", FromPosition: spatial.Position{X: 4, Y: 3}, ToPosition: spatial.Position{X: 0, Y: 3}},
 			},
 		},
 		Members: []encounter.MemberInput{
@@ -128,9 +137,9 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 
 	data1 := enc1.ToData()
 	expected := []encounter.ConnectionData{
-		{ID: "a-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 1, Y: 4}, ToPosition: &encounter.PositionData{X: 3, Y: 2}},
-		{ID: "m-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 2, Y: 0}, ToPosition: &encounter.PositionData{X: 4, Y: 3}},
-		{ID: "z-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 0, Y: 3}, ToPosition: &encounter.PositionData{X: 2, Y: 1}},
+		{ID: "a-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 2}, ToPosition: &encounter.PositionData{X: 0, Y: 2}},
+		{ID: "m-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 3}, ToPosition: &encounter.PositionData{X: 0, Y: 3}},
+		{ID: "z-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 1}, ToPosition: &encounter.PositionData{X: 0, Y: 1}},
 	}
 	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
 
@@ -219,15 +228,24 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 // source (the encounter deep-copies the field description). Also covers
 // connections: mutating the caller's ConnectionInput slice (and its
 // endpoint positions) after NewEncounter must not affect the encounter.
+//
+// #929 T1: door1's FromPosition moved to r1's top-right corner (4,0) — an
+// interior cell like the original (1,0)'s neighbor set never fully escapes
+// r1's own footprint diagonally, but a corner's does. r2's Origin (5,-1)
+// anchors it diagonally past that corner: absolute FromPosition (4,0) and
+// absolute ToPosition local(0,0)+(5,-1)=(5,-1) are Chebyshev-adjacent
+// (distance 1, a diagonal kiss), while r1's absolute footprint
+// (x:[0,4],y:[0,4]) and r2's (x:[5,9],y:[-1,3]) share no x value at all,
+// so they stay disjoint (W2) regardless of y.
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}}},
-				{ID: "r2", Width: 5, Height: 5},
+				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: -1}},
 			},
 			Connections: []encounter.ConnectionInput{
-				{ID: "door1", From: "r1", To: "r2", FromPosition: spatial.Position{X: 1, Y: 0}, ToPosition: spatial.Position{X: 0, Y: 0}},
+				{ID: "door1", From: "r1", To: "r2", FromPosition: spatial.Position{X: 4, Y: 0}, ToPosition: spatial.Position{X: 0, Y: 0}},
 			},
 		},
 		Members: []encounter.MemberInput{
@@ -255,7 +273,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	s.Require().Len(data.Field.Connections, 1)
 	s.Equal("door1", data.Field.Connections[0].ID, "the snapshot must not see the caller's vandalism")
 	s.Equal("r1", data.Field.Connections[0].From)
-	s.Equal(&encounter.PositionData{X: 1, Y: 0}, data.Field.Connections[0].FromPosition)
+	s.Equal(&encounter.PositionData{X: 4, Y: 0}, data.Field.Connections[0].FromPosition)
 	s.Equal(&encounter.PositionData{X: 0, Y: 0}, data.Field.Connections[0].ToPosition)
 
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -1312,6 +1312,65 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
+// TestLoadOccluderIDCrossRoomCollisionAccepted is the Load-seam counterpart
+// to encounter_test.go's TestSetupOccluderIDCrossRoomCollisionAccepted
+// (#929 hardening round C).
+func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridTypeHex,
+					Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{{X: -5, Y: 4}}},
+				{ID: "r-", Width: 12, Height: 10, Grid: spatial.GridTypeHex,
+					Origin: &encounter.PositionData{X: 1000, Y: 0}, Occluders: []encounter.PositionData{{X: 5, Y: 4}}},
+			},
+		},
+		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide at Load either`)
+}
+
+// TestLoadDuplicateOccluderRejected is the Load-seam counterpart to
+// encounter_test.go's TestSetupDuplicateOccluderRejected (#929 hardening
+// round D).
+func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0},
+					Occluders: []encounter.PositionData{{X: 3, Y: 3}, {X: 3, Y: 3}}},
+			},
+		},
+		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "duplicate occluder")
+}
+
+// TestLoadDuplicateEndingKeyRejected is the Load-seam counterpart to
+// encounter_test.go's TestSetupDuplicateEndingKeyRejected (#929
+// hardening round E).
+func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
+		},
+		Endings: []encounter.EndingData{
+			{Key: "dup", Kind: "reached_position", Room: "hall", Position: &encounter.PositionData{X: 4, Y: 4}},
+			{Key: "dup", Kind: "external"},
+		},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoEnding)
+	s.Require().Contains(err.Error(), "duplicate ending")
+}
+
 // TestLoadRejections: every unreachable state rejects with ErrInvalidData
 // AND the check that fired is the one the case targets. Connection rows
 // also assert ErrBadConnection (via alsoErr) and, where a room name is
@@ -1329,18 +1388,18 @@ func (s *DataTestSuite) TestLoadRejections() {
 		{"no endings", func(d *encounter.EncounterData) { d.Endings = nil }, "bad endings", nil},
 		{"empty ending key", func(d *encounter.EncounterData) { d.Endings[0].Key = "" }, "bad endings", nil},
 		{"reserved ending key", func(d *encounter.EncounterData) { d.Endings[0].Key = "abandoned" }, "bad endings", nil},
-		{"unknown ending kind", func(d *encounter.EncounterData) { d.Endings[0].Kind = "psychic" }, "unknown ending kind", nil},
+		{"unknown ending kind", func(d *encounter.EncounterData) { d.Endings[0].Kind = "psychic" }, "unknown ending kind", encounter.ErrNoEnding},
 		{"reached_position without position", func(d *encounter.EncounterData) {
 			d.Endings[0] = encounter.EndingData{Key: "done", Kind: "reached_position", Room: "r1"}
-		}, "without room/position", nil},
-		{"empty member id", func(d *encounter.EncounterData) { d.Members[0].ID = "" }, "empty member id", nil},
+		}, "without room/position", encounter.ErrNoEnding},
+		{"empty member id", func(d *encounter.EncounterData) { d.Members[0].ID = "" }, "empty member id", encounter.ErrNoMember},
 		{"duplicate member ids", func(d *encounter.EncounterData) {
 			d.Members = append(d.Members, d.Members[0])
-		}, "duplicate member", nil},
-		{"member room not in field", func(d *encounter.EncounterData) { d.Members[0].Room = "nowhere" }, "not in field", nil},
+		}, "duplicate member", encounter.ErrNoMember},
+		{"member room not in field", func(d *encounter.EncounterData) { d.Members[0].Room = "nowhere" }, "not in field", encounter.ErrBadPlacement},
 		{"member out of bounds", func(d *encounter.EncounterData) {
 			d.Members[0].Position = encounter.PositionData{X: 99, Y: 99}
-		}, "out of bounds", nil},
+		}, "out of bounds", encounter.ErrBadPlacement},
 		{"connection missing room", func(d *encounter.EncounterData) {
 			// FromPosition/ToPosition present (any value) so the ONLY
 			// defect this fixture carries is the unknown "to" room — #929
@@ -1399,21 +1458,21 @@ func (s *DataTestSuite) TestLoadRejections() {
 		}, "missing to_position", encounter.ErrBadConnection},
 		{"outcome undeclared ending", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "never-declared"}
-		}, "outcome", nil},
+		}, "outcome", encounter.ErrNoEnding},
 		{"abandoned outcome with members present", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "abandoned"}
-		}, "abandoned outcome with members", nil},
+		}, "abandoned outcome with members", encounter.ErrNoMember},
 		{"outcome member room missing", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
 				{ID: "ghost", Room: "nowhere", Position: encounter.PositionData{X: 1, Y: 1}}}}
-		}, "outcome member", nil},
+		}, "outcome member", encounter.ErrBadPlacement},
 		{"outcome member out of bounds", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
 				{ID: "p1", Room: "r1", Position: encounter.PositionData{X: 999, Y: 999}}}}
-		}, "out of bounds", nil},
+		}, "out of bounds", encounter.ErrBadPlacement},
 		{"ever_members missing current member", func(d *encounter.EncounterData) {
 			d.EverMembers = nil
-		}, "ever_members", nil},
+		}, "ever_members", encounter.ErrNoMember},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -25,35 +25,46 @@ type DataTestSuite struct {
 // External ending, intel-free monsters in a second room, and non-zero
 // clock/At fields. Eleven tag renames survived the small goldens
 // because omitempty hid these fields (T6 review).
+//
+// #929 T1 follow-up: rewritten all-hex (both crypt and hall) — hex is the
+// game's shipped family, so the rich golden should exercise it, not
+// square+hex mixed (W1 forbids that field shape outright now — see
+// TestSetupAnchoring's W1 row). The square case's own exact-byte pin lives
+// in TestGoldenJSONOpen/TestGoldenJSONClosed ("grid" key absent for the
+// zero value) — unaffected by this rewrite. Every position below is
+// re-derived for crypt's (Width=8,Height=8 => Q,R valid [-4,4)) and hall's
+// (Width=6,Height=6 => Q,R valid [-3,3)) origin-centered spans: crypt's
+// occluder, boundary (still an axial-neighbor pair, ΔR=1), member p1, and
+// the "guarded" ending's position are distinct in-bounds cells; door1's
+// endpoints are each room's own boundary cell (an interior cell can never
+// kiss anything) — FromPosition (3,0) is crypt's max-Q edge, ToPosition
+// (-3,0) is hall's min-Q edge, still NEGATIVE-axial on purpose (the
+// ordinary case for an origin-centered hex room). hall's Origin (7,0)
+// anchors it immediately east of crypt: absolute (4,0) and (3,0) are
+// cube-distance 1 (W3), and hall's absolute Q span ([4,9]) shares no Q
+// value with crypt's ([-4,3]), so the rooms stay disjoint (W2).
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
-				{ID: "crypt", Width: 8, Height: 8,
-					Occluders:  []spatial.Position{{X: 4, Y: 4}},
-					Boundaries: []spatial.Boundary{{From: spatial.Position{X: 2, Y: 2}, To: spatial.Position{X: 2, Y: 3}, BlocksMovement: true, BlocksLineOfSight: true}},
+				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
+					Occluders:  []spatial.Position{{X: 1, Y: 2}},
+					Boundaries: []spatial.Boundary{{From: spatial.Position{X: -2, Y: -2}, To: spatial.Position{X: -2, Y: -1}, BlocksMovement: true, BlocksLineOfSight: true}},
 				},
-				// hall is axial hex (Width=6,Height=6 => Q,R valid in
-				// [-3,3)): door1's arrival endpoint sits at a NEGATIVE
-				// axial coordinate on purpose — the ordinary case for an
-				// origin-centered hex room, and a fixture proving
-				// endpoints validate there at both seams (Setup here,
-				// Load in TestConnectionEndpointBoundsBoundariesLoad's
-				// hex sibling).
-				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex},
+				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 7, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "door1", From: "crypt", To: "hall",
-				FromPosition: spatial.Position{X: 0, Y: 6},
-				ToPosition:   spatial.Position{X: -1, Y: -1},
+				FromPosition: spatial.Position{X: 3, Y: 0},
+				ToPosition:   spatial.Position{X: -3, Y: 0},
 			}},
 		},
 		Members: []encounter.MemberInput{
-			{ID: "p1", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 0, Y: 0}},
 			{ID: "g1", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 0, Y: 0}, Decider: &testDecider{intent: encounter.IntentHold{}}},
 		},
 		Endings: []encounter.EndingInput{
-			{Key: "guarded", Trigger: encounter.TriggerReachedPosition{Room: "crypt", Position: spatial.Position{X: 7, Y: 7}, Member: core.EntityID("p1")}},
+			{Key: "guarded", Trigger: encounter.TriggerReachedPosition{Room: "crypt", Position: spatial.Position{X: 3, Y: 3}, Member: core.EntityID("p1")}},
 			{Key: "leave", Trigger: encounter.TriggerExternal{}},
 		},
 	})
@@ -63,7 +74,10 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 
 	bs, err := json.Marshal(enc.ToData())
 	s.Require().NoError(err)
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"occluders":[{"x":4,"y":4}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":"hex"}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":0,"y":6},"to_position":{"x":-1,"y":-1}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":0,"y":0}},{"id":"p1","kind":"player","room":"crypt","position":{"x":1,"y":1}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":7,"y":7},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
+	// Note: hall's Origin (7,0) is NOT reflected below — RoomData does not
+	// persist Origin yet (Task 2's scope; this task validates it at Setup
+	// only). T2 will regenerate this golden again once RoomData gains it.
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":"hex"}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":0,"y":0}},{"id":"p1","kind":"player","room":"crypt","position":{"x":0,"y":0}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
 	s.Equal(expected, string(bs))
 }
 
@@ -192,35 +206,70 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 // TestRoomGridShapeSurvivesReload pins connection persistence's newest
 // field (#922 T1.5): a room's declared Grid shape round-trips through
 // ToData -> LoadEncounter -> ToData intact, for both the square zero value
-// and a non-zero shape (hex), in the same encounter.
+// and a non-zero shape (hex).
+//
+// #929 T1 follow-up: originally both shapes lived in ONE encounter (two
+// rooms, one square, one hex). W1 ("one geometry per field" — see
+// TestSetupAnchoring's W1 row) now makes that field itself a defect, not
+// just an inconvenience — a mixed-family field has no coherent absolute
+// space to validate at all, so this is correctly impossible, not a
+// regression to work around. Split into two single-room encounters, one
+// per family; each still proves its own shape survives a full
+// ToData -> LoadEncounter -> ToData round trip.
 func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
-	setup := &encounter.SetupInput{
-		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{
-				{ID: "square-room", Width: 5, Height: 5},
-				{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
+	s.Run("square", func() {
+		setup := &encounter.SetupInput{
+			Field: encounter.FieldInput{
+				Rooms: []encounter.RoomInput{
+					{ID: "square-room", Width: 5, Height: 5},
+				},
 			},
-		},
-		Members: []encounter.MemberInput{
-			{ID: "p1", Kind: encounter.KindPlayer, Room: "square-room", Position: spatial.Position{X: 1, Y: 1}},
-		},
-		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
-	}
+			Members: []encounter.MemberInput{
+				{ID: "p1", Kind: encounter.KindPlayer, Room: "square-room", Position: spatial.Position{X: 1, Y: 1}},
+			},
+			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		}
 
-	enc1, err := encounter.NewEncounter(setup)
-	s.Require().NoError(err)
+		enc1, err := encounter.NewEncounter(setup)
+		s.Require().NoError(err)
 
-	data1 := enc1.ToData()
-	s.Require().Len(data1.Field.Rooms, 2)
-	s.Equal("", data1.Field.Rooms[0].Grid, "square is the zero value — omitted, not the literal \"square\"")
-	s.Equal(spatial.GridTypeHex, data1.Field.Rooms[1].Grid)
+		data1 := enc1.ToData()
+		s.Require().Len(data1.Field.Rooms, 1)
+		s.Equal("", data1.Field.Rooms[0].Grid, "square is the zero value — omitted, not the literal \"square\"")
 
-	enc2, err := encounter.LoadEncounter(data1, nil)
-	s.Require().NoError(err)
+		enc2, err := encounter.LoadEncounter(data1, nil)
+		s.Require().NoError(err)
 
-	data2 := enc2.ToData()
-	s.Equal("", data2.Field.Rooms[0].Grid, "grid shape must survive a second round-trip")
-	s.Equal(spatial.GridTypeHex, data2.Field.Rooms[1].Grid, "grid shape must survive a second round-trip")
+		data2 := enc2.ToData()
+		s.Equal("", data2.Field.Rooms[0].Grid, "grid shape must survive a second round-trip")
+	})
+
+	s.Run("hex", func() {
+		setup := &encounter.SetupInput{
+			Field: encounter.FieldInput{
+				Rooms: []encounter.RoomInput{
+					{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
+				},
+			},
+			Members: []encounter.MemberInput{
+				{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-room", Position: spatial.Position{X: 1, Y: 1}},
+			},
+			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		}
+
+		enc1, err := encounter.NewEncounter(setup)
+		s.Require().NoError(err)
+
+		data1 := enc1.ToData()
+		s.Require().Len(data1.Field.Rooms, 1)
+		s.Equal(spatial.GridTypeHex, data1.Field.Rooms[0].Grid)
+
+		enc2, err := encounter.LoadEncounter(data1, nil)
+		s.Require().NoError(err)
+
+		data2 := enc2.ToData()
+		s.Equal(spatial.GridTypeHex, data2.Field.Rooms[0].Grid, "grid shape must survive a second round-trip")
+	})
 }
 
 // TestSetupInputNotAliased pins T6 review M4: a caller that edits its

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -52,15 +52,31 @@ type DataTestSuite struct {
 // proof for negative anchors this wave's persistence work needs (a
 // declared origin round-trips as an explicit, signed value, not just a
 // non-negative one).
+//
+// #929 T2 second review round: re-translated AGAIN, by (0,+7) on top of
+// the above, to (crypt (-10,7), hall (-3,7)) — transposition hardening.
+// Both prior shifts kept Y=0 for both rooms, so an X/Y transposition bug
+// anywhere in the ToData/marshal path (an M7/M8-class mutant) had a real
+// chance of surviving undetected here: with Y=0, a transposed (-10,0)
+// would marshal as (0,-10) — a DIFFERENT byte string, so that specific
+// case was already caught — but any bug that transposed X/Y AFTER first
+// somehow losing or ignoring one axis could still slip through a
+// fixture where one axis is always zero. With BOTH X and Y now nonzero
+// and DISTINCT for both rooms (crypt: -10≠7; hall: -3≠7), no such gap
+// remains: any X/Y transposition changes the bytes unambiguously. This
+// shift is STILL a uniform translation of the whole field (adding (0,7)
+// to both rooms alike), so every W2/W3 relationship from the comment
+// above is preserved exactly — translation invariance holds regardless
+// of the shift vector's own shape.
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
-				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 0},
+				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
 					Occluders:  []spatial.Position{{X: 1, Y: 2}},
 					Boundaries: []spatial.Boundary{{From: spatial.Position{X: -2, Y: -2}, To: spatial.Position{X: -2, Y: -1}, BlocksMovement: true, BlocksLineOfSight: true}},
 				},
-				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -3, Y: 0}},
+				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -3, Y: 7}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "door1", From: "crypt", To: "hall",
@@ -86,7 +102,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// Exact-string pin: every room now carries "origin" (#929 T2), always
 	// present (no omitempty — RoomData's doc comment) — crypt's and hall's
 	// are both negative-axial, the wire-shape proof this golden exists for.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":0}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":0}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":0,"y":0}},{"id":"p1","kind":"player","room":"crypt","position":{"x":0,"y":0}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":0,"y":0}},{"id":"p1","kind":"player","room":"crypt","position":{"x":0,"y":0}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
 	s.Equal(expected, string(bs))
 }
 
@@ -809,6 +825,15 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		enc, err := encounter.NewEncounter(setup)
 		s.Require().NoError(err)
 
+		// Advance the clock BEFORE closing (#929 T2 second review round —
+		// golden law: every omitempty field must be exercised at least
+		// once; OutcomeData.At omits at tick 0, so a golden that closes
+		// immediately can never prove `at` actually persists a non-zero
+		// value). One Pump advances the world tick to 1, adding its own
+		// "clock" beat to the log ahead of the closing move.
+		_, err = enc.Pump(&encounter.PumpInput{})
+		s.Require().NoError(err)
+
 		// Close the encounter
 		_, err = enc.Move(&encounter.MoveInput{
 			Member: "p1",
@@ -821,9 +846,11 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		s.Require().NoError(err)
 
 		// Exact-string pin of the closed shape: outcome present with the
-		// fired ending and final member placements; the story carries
-		// both beats (opening + the closing move).
-		expectedJSON := `{"outcome":{"ending":"done","members":[{"id":"p1","room":"room1","position":{"x":0,"y":0}}]},"clock":{},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"]}`
+		// fired ending (AT A NON-ZERO TICK — "at":1, the field this golden
+		// exists to exercise) and final member placements; the story
+		// carries all three beats (opening + the pump's tick + the
+		// closing move).
+		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","room":"room1","position":{"x":0,"y":0}}]},"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"]}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -1505,6 +1532,31 @@ func (s *DataTestSuite) TestLoadRoomValidation() {
 	}
 }
 
+// TestLoadRoomEmptyIDReportsIDDefectNotOrigin pins F3 (#929 T2 second
+// review round): a room with BOTH an empty ID AND a nil origin must report
+// the ID defect ("room has empty id"), never a presence error that names
+// the empty ID. Before this fix, convertRoomDataToRoomInput's per-room
+// conversion loop checked Origin presence directly (ID validity was only
+// ever checked LATER, by buildValidRoomGrids, after conversion had already
+// succeeded) — so this exact fixture produced `room "" missing origin`,
+// naming a room by an ID that was itself the real defect. The wire-only ID
+// pre-pass (empty/duplicate) now runs as its own first pass over ALL rooms,
+// before any other conversion, so an ID-defective room can never reach a
+// presence check at all.
+func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
+	data := validEncounterData()
+	data.Field.Rooms[0].ID = ""
+	data.Field.Rooms[0].Origin = nil
+
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "room has empty id")
+	s.Require().NotContains(err.Error(), "missing origin",
+		"the ID defect must be reported — a presence error here would misname the room")
+}
+
 // connHexRoomData returns a fresh EncounterData with one 4x3 hex room and a
 // member at pos — the Load-seam counterpart to encounter_test.go's
 // TestHexRoomBounds. Width=4, Height=3 => Q valid in [-2,2), R valid in
@@ -1705,12 +1757,17 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 		{"origin legality: fractional hex origin", func(d *encounter.EncounterData) {
 			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 6.5, Y: -5}
 		}, encounter.ErrNoField, "not a representable integral cell"},
-		{"origin legality: infinite origin", func(d *encounter.EncounterData) {
+		{"room legality: infinite origin", func(d *encounter.EncounterData) {
+			// #929 T2 second review round: caught by maxAnchorCoord's bound
+			// in room legality — Inf is never <= a finite bound — before
+			// origin legality's representability check ever runs.
 			d.Field.Rooms[1].Origin = &encounter.PositionData{X: math.Inf(1), Y: -5}
-		}, encounter.ErrNoField, "not a representable integral cell"},
-		{"origin legality: origin exceeds int64 precision (1e19)", func(d *encounter.EncounterData) {
+		}, encounter.ErrNoField, "exceeds max anchor coordinate"},
+		{"room legality: origin exceeds max anchor coordinate (1e19)", func(d *encounter.EncounterData) {
+			// #929 T2 second review round: 1e19 is both non-representable
+			// AND out of bounds — the bound fires first, in room legality.
 			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 1e19, Y: -5}
-		}, encounter.ErrNoField, "not a representable integral cell"},
+		}, encounter.ErrNoField, "exceeds max anchor coordinate"},
 		{"W5: nil origin — absent, not a declared zero", func(d *encounter.EncounterData) {
 			d.Field.Rooms[1].Origin = nil
 		}, encounter.ErrNoField, `room "hex-small" missing origin`},
@@ -1777,6 +1834,32 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Require().Contains(err.Error(), `room "r-a" and room "r-c" overlap at absolute cell (2, 2)`)
+}
+
+// TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint is the Load-seam
+// counterpart to encounter_test.go's
+// TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint — same geometry,
+// same maxRoomSpan bound, unified path (see LoadEncounter's doc comment).
+func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r1", Width: 1000, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "r2", Width: math.MaxInt, Height: 5, Origin: &encounter.PositionData{X: 999, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 1, Y: 1}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceed max room span")
+	s.Require().NotContains(err.Error(), "overlap at absolute cell")
 }
 
 // TestOriginRoundTripByteIdentical pins W5's round-trip law: origins

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 
@@ -1280,6 +1281,19 @@ func validEncounterDataWithConnection() encounter.EncounterData {
 	return d
 }
 
+// TestLoadSquareOccluderFractionalRejected is the Load-seam counterpart to
+// encounter_test.go's TestSetupSquareOccluderFractionalRejected (#929 T3
+// Opus round F2).
+func (s *DataTestSuite) TestLoadSquareOccluderFractionalRejected() {
+	data := validEncounterDataWithConnection()
+	data.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "not a representable integral cell")
+}
+
 // TestLoadRejections: every unreachable state rejects with ErrInvalidData
 // AND the check that fired is the one the case targets. Connection rows
 // also assert ErrBadConnection (via alsoErr) and, where a room name is
@@ -1670,22 +1684,26 @@ func validHexAxialData() encounter.EncounterData {
 // encounter_test.go's TestSetupHexIntegralAxial.
 func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 	cases := []struct {
-		name    string
-		mutate  func(d *encounter.EncounterData)
-		alsoErr error
+		name     string
+		mutate   func(d *encounter.EncounterData)
+		alsoErr  error
+		fragment string
 	}{
 		{"member position fractional", func(d *encounter.EncounterData) {
 			d.Members[0].Position = encounter.PositionData{X: 0.5, Y: 0}
-		}, nil},
+		}, nil, "not an integral axial cell"},
 		{"connection from-position fractional", func(d *encounter.EncounterData) {
 			d.Field.Connections[0].FromPosition = &encounter.PositionData{X: 1.5, Y: 1}
-		}, encounter.ErrBadConnection},
+		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"connection to-position fractional", func(d *encounter.EncounterData) {
 			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: -1.5, Y: -1}
-		}, encounter.ErrBadConnection},
+		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"occluder position fractional", func(d *encounter.EncounterData) {
+			// #929 T3 Opus round F2: occluder integrality is now universal
+			// (isIntegralPosition), not hex-only — see the Setup-seam
+			// counterpart in encounter_test.go's TestSetupHexIntegralAxial.
 			d.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
-		}, encounter.ErrNoField},
+		}, encounter.ErrNoField, "not a representable integral cell"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -1697,7 +1715,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 			if tc.alsoErr != nil {
 				s.Require().ErrorIs(err, tc.alsoErr, tc.name)
 			}
-			s.Require().Contains(err.Error(), "not an integral axial cell",
+			s.Require().Contains(err.Error(), tc.fragment,
 				"the check that fired must be the one this case targets")
 		})
 	}
@@ -1860,6 +1878,114 @@ func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint()
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Require().Contains(err.Error(), "exceed max room span")
 	s.Require().NotContains(err.Error(), "overlap at absolute cell")
+}
+
+// TestLoadRoomCellBudgetRejectsPanicReproduction is the Load-seam
+// counterpart to encounter_test.go's TestSetupRoomCellBudgetRejectsPanicReproduction
+// (#929 T3 Opus round F1): the exact 2^30 x 2^30 reproduction, but as a
+// hand-built persisted blob — LoadEncounter is the trust boundary for
+// bytes nobody validated at declaration time, so this is the more
+// important of the two reproductions to pin.
+func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "huge", Width: 1 << 30, Height: 1 << 30, Origin: &encounter.PositionData{X: 0, Y: 0}},
+			},
+		},
+		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err, "a 2^30 x 2^30 room from a persisted blob must REJECT, not panic")
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceeding max room cells")
+}
+
+// TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms is the Load-seam
+// counterpart to encounter_test.go's
+// TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms.
+func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
+	rooms := make([]encounter.RoomData, 5)
+	for i := range rooms {
+		rooms[i] = encounter.RoomData{
+			ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024,
+			Origin: &encounter.PositionData{X: 0, Y: 0},
+		}
+	}
+	data := encounter.EncounterData{
+		Field:   encounter.FieldData{Rooms: rooms},
+		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceeding max field cells")
+}
+
+// validEndingTriggerData is the Load-seam counterpart to
+// encounter_test.go's validEndingTriggerSetup.
+func validEndingTriggerData() encounter.EncounterData {
+	return encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
+		},
+		Endings: []encounter.EndingData{
+			{Key: "reach", Kind: "reached_position", Room: "hall", Position: &encounter.PositionData{X: 3, Y: 3}},
+		},
+	}
+}
+
+// TestLoadEndingTriggerValidation is the Load-seam counterpart to
+// encounter_test.go's TestSetupEndingTriggerValidation (#929 T3 Opus
+// round F5).
+func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
+	cases := []struct {
+		name     string
+		mutate   func(d *encounter.EncounterData)
+		fragment string
+	}{
+		{"unknown room", func(d *encounter.EncounterData) {
+			d.Endings[0].Room = "nowhere"
+		}, "unknown room"},
+		{"out of bounds position", func(d *encounter.EncounterData) {
+			d.Endings[0].Position = &encounter.PositionData{X: 100, Y: 100}
+		}, "out of bounds"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			data := validEndingTriggerData()
+			tc.mutate(&data)
+			_, err := encounter.LoadEncounter(data, nil)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrNoEnding, tc.name)
+			s.Require().Contains(err.Error(), tc.fragment,
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	_, err := encounter.LoadEncounter(validEndingTriggerData(), nil)
+	s.Require().NoError(err, "a trigger naming a real room and in-bounds position must validate")
+}
+
+// TestLoadEndingTriggerHexNonIntegralRejected is the Load-seam counterpart
+// to encounter_test.go's TestSetupEndingTriggerHexNonIntegralRejected.
+func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}}},
+		},
+		Endings: []encounter.EndingData{
+			{Key: "reach", Kind: "reached_position", Room: "hall", Position: &encounter.PositionData{X: 1.5, Y: 0}},
+		},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoEnding)
+	s.Require().Contains(err.Error(), "not an integral axial cell")
 }
 
 // TestOriginRoundTripByteIdentical pins W5's round-trip law: origins

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -1294,6 +1294,24 @@ func (s *DataTestSuite) TestLoadSquareOccluderFractionalRejected() {
 	s.Require().Contains(err.Error(), "not a representable integral cell")
 }
 
+// TestLoadOccluderOnBoundaryCellAccepted is the Load-seam counterpart to
+// encounter_test.go's TestSetupOccluderOnBoundaryCellAccepted (#929 T3
+// trailing round N2).
+func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{
+					{X: 0, Y: 2}, {X: 4, Y: 2}, {X: 2, Y: 0}, {X: 2, Y: 4}, {X: 0, Y: 0}, {X: 4, Y: 4},
+				}},
+			},
+		},
+		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal at Load too")
+}
+
 // TestLoadRejections: every unreachable state rejects with ErrInvalidData
 // AND the check that fired is the one the case targets. Connection rows
 // also assert ErrBadConnection (via alsoErr) and, where a room name is

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -4,8 +4,10 @@
 package encounter_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -39,19 +41,26 @@ type DataTestSuite struct {
 // endpoints are each room's own boundary cell (an interior cell can never
 // kiss anything) — FromPosition (3,0) is crypt's max-Q edge, ToPosition
 // (-3,0) is hall's min-Q edge, still NEGATIVE-axial on purpose (the
-// ordinary case for an origin-centered hex room). hall's Origin (7,0)
-// anchors it immediately east of crypt: absolute (4,0) and (3,0) are
-// cube-distance 1 (W3), and hall's absolute Q span ([4,9]) shares no Q
-// value with crypt's ([-4,3]), so the rooms stay disjoint (W2).
+// ordinary case for an origin-centered hex room).
+//
+// #929 T2: both Origins shifted by (-10,0) from the T1 follow-up's
+// (crypt (0,0), hall (7,0)) to (crypt (-10,0), hall (-3,0)) — a uniform
+// translation of the whole field preserves every W2/W3 relationship
+// (absolute (4,0)/(-6,0) are still cube-distance 1; the rooms' absolute
+// Q spans [-14,-7] and [-6,-1] still share no Q value) while making BOTH
+// origins negative-axial, so the rich golden's bytes are the wire-shape
+// proof for negative anchors this wave's persistence work needs (a
+// declared origin round-trips as an explicit, signed value, not just a
+// non-negative one).
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
-				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
+				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 0},
 					Occluders:  []spatial.Position{{X: 1, Y: 2}},
 					Boundaries: []spatial.Boundary{{From: spatial.Position{X: -2, Y: -2}, To: spatial.Position{X: -2, Y: -1}, BlocksMovement: true, BlocksLineOfSight: true}},
 				},
-				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 7, Y: 0}},
+				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -3, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "door1", From: "crypt", To: "hall",
@@ -74,10 +83,10 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 
 	bs, err := json.Marshal(enc.ToData())
 	s.Require().NoError(err)
-	// Note: hall's Origin (7,0) is NOT reflected below — RoomData does not
-	// persist Origin yet (Task 2's scope; this task validates it at Setup
-	// only). T2 will regenerate this golden again once RoomData gains it.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}]},{"id":"hall","width":6,"height":6,"grid":"hex"}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":0,"y":0}},{"id":"p1","kind":"player","room":"crypt","position":{"x":0,"y":0}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
+	// Exact-string pin: every room now carries "origin" (#929 T2), always
+	// present (no omitempty — RoomData's doc comment) — crypt's and hall's
+	// are both negative-axial, the wire-shape proof this golden exists for.
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":0}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":0}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","room":"hall","position":{"x":0,"y":0}},{"id":"p1","kind":"player","room":"crypt","position":{"x":0,"y":0}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"]}`
 	s.Equal(expected, string(bs))
 }
 
@@ -172,18 +181,24 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 // is never exercised on genuinely unsorted input elsewhere in this suite.
 // This hand-authors an EncounterData directly, bypassing NewEncounter/ToData
 // entirely, with connections declared out of ID order.
+// #929 T2: r2's Origin (5,0) anchors it immediately east of r1 (5x5 each),
+// matching TestConnectionsSurviveReload's geometry exactly — all three
+// doors sit on r1's east edge (x=4) and r2's west edge (local x=0), one
+// per row, so every one independently satisfies W3 under this SAME shared
+// origin (this test only cares about sort order, not which door owns
+// which row).
 func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "r1", Width: 5, Height: 5},
-				{ID: "r2", Width: 5, Height: 5},
+				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "r2", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 5, Y: 0}},
 			},
 			// Hand-authored out of ID order — NOT produced by ToData.
 			Connections: []encounter.ConnectionData{
-				{ID: "z-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 0, Y: 0}, ToPosition: &encounter.PositionData{X: 1, Y: 1}},
-				{ID: "a-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 2, Y: 0}, ToPosition: &encounter.PositionData{X: 3, Y: 1}},
-				{ID: "m-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 0}, ToPosition: &encounter.PositionData{X: 0, Y: 4}},
+				{ID: "z-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 1}, ToPosition: &encounter.PositionData{X: 0, Y: 1}},
+				{ID: "a-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 2}, ToPosition: &encounter.PositionData{X: 0, Y: 2}},
+				{ID: "m-door", From: "r1", To: "r2", FromPosition: &encounter.PositionData{X: 4, Y: 3}, ToPosition: &encounter.PositionData{X: 0, Y: 3}},
 			},
 		},
 		Members: []encounter.MemberData{
@@ -754,7 +769,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 		// renamed tag fails this where a decoded comparison would not.
 		// (log carries the opening beat: a fresh encounter is born with
 		// its first story entry; clock/intel marshal {} per leaf laws.)
-		expectedJSON := `{"clock":{},"intel":{},"log":{"next_seq":2,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":2,"y":2}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"]}`
+		expectedJSON := `{"clock":{},"intel":{},"log":{"next_seq":2,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":2,"y":2}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"]}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -808,7 +823,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		// Exact-string pin of the closed shape: outcome present with the
 		// fired ending and final member placements; the story carries
 		// both beats (opening + the closing move).
-		expectedJSON := `{"outcome":{"ending":"done","members":[{"id":"p1","room":"room1","position":{"x":0,"y":0}}]},"clock":{},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"]}`
+		expectedJSON := `{"outcome":{"ending":"done","members":[{"id":"p1","room":"room1","position":{"x":0,"y":0}}]},"clock":{},"intel":{},"log":{"next_seq":3,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"]}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -860,6 +875,12 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 		if len(data1.Endings) > 0 {
 			data1.Endings[0].Key = "mutated"
 		}
+		// #929 T2: Origin is a pointer (RoomData's doc comment — presence
+		// itself is meaningful, so it can't be a value type) — mutating
+		// THROUGH it must not reach a later call's own fresh pointer.
+		s.Require().NotEmpty(data1.Field.Rooms)
+		s.Require().NotNil(data1.Field.Rooms[0].Origin)
+		data1.Field.Rooms[0].Origin.X = 999
 
 		// Get data again
 		data2 := enc.ToData()
@@ -868,6 +889,9 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 		s.NotEqual("mutated", data2.Members[0].ID)
 		s.NotEqual("mutated", data2.EverMembers[0])
 		s.NotEqual("mutated", data2.Endings[0].Key)
+		s.Require().NotNil(data2.Field.Rooms[0].Origin)
+		s.NotEqual(999.0, data2.Field.Rooms[0].Origin.X,
+			"ToData must return a FRESH Origin pointer each call, not alias the same PositionData across calls")
 	})
 }
 
@@ -1183,7 +1207,9 @@ func (d *testDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 
 func validEncounterData() encounter.EncounterData {
 	return encounter.EncounterData{
-		Field: encounter.FieldData{Rooms: []encounter.RoomData{{ID: "r1", Width: 5, Height: 5}}},
+		Field: encounter.FieldData{Rooms: []encounter.RoomData{
+			{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
+		}},
 		Members: []encounter.MemberData{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: encounter.PositionData{X: 1, Y: 1}},
 		},
@@ -1196,25 +1222,33 @@ func validEncounterData() encounter.EncounterData {
 // DELIBERATELY mismatched room (r1 resized to 10x4, r2 added at 3x9) and one
 // fully valid connection between them — the base for the connection defect
 // rows below (one-defect discipline: each row breaks exactly one thing about
-// this otherwise-valid connection). FromPosition{7,1} is valid ONLY in r1
-// and ToPosition{1,7} valid ONLY in r2: same-sized rooms and equal From/To
+// this otherwise-valid connection). FromPosition{9,1} is valid ONLY in r1
+// and ToPosition{0,7} valid ONLY in r2: same-sized rooms and equal From/To
 // positions would make a check that validates an endpoint against the WRONG
 // room (or a From/To transposition in convertConnectionDataToConnectionInput)
 // invisible. r1 carries an occluder at (2,2) and r2 an occluder at (1,3), so
 // both the from- and to-side "endpoint on occluder" rows have something to hit.
+//
+// #929 T2: mirrors encounter_test.go's validConnSetup exactly (its own
+// comment explains the geometry in full) — FromPosition sits on r1's own
+// right-edge boundary (an interior cell can never kiss anything), r2's
+// Origin (10,-6) anchors it so absolute FromPosition (9,1) and absolute
+// ToPosition (10,7... local(0,7)+Origin(10,-6)=(10,1)) are Chebyshev-
+// adjacent (W3), while r1's absolute footprint (x:[0,9],y:[0,3]) and r2's
+// (x:[10,12],y:[-6,2]) share no x value at all, so they stay disjoint (W2).
 func validEncounterDataWithConnection() encounter.EncounterData {
 	d := validEncounterData()
 	d.Field.Rooms[0].Width = 10
 	d.Field.Rooms[0].Height = 4
 	d.Field.Rooms[0].Occluders = []encounter.PositionData{{X: 2, Y: 2}}
 	d.Field.Rooms = append(d.Field.Rooms, encounter.RoomData{
-		ID: "r2", Width: 3, Height: 9,
+		ID: "r2", Width: 3, Height: 9, Origin: &encounter.PositionData{X: 10, Y: -6},
 		Occluders: []encounter.PositionData{{X: 1, Y: 3}},
 	})
 	d.Field.Connections = []encounter.ConnectionData{
 		{ID: "c1", From: "r1", To: "r2",
-			FromPosition: &encounter.PositionData{X: 7, Y: 1},
-			ToPosition:   &encounter.PositionData{X: 1, Y: 7}},
+			FromPosition: &encounter.PositionData{X: 9, Y: 1},
+			ToPosition:   &encounter.PositionData{X: 0, Y: 7}},
 	}
 	return d
 }
@@ -1249,8 +1283,14 @@ func (s *DataTestSuite) TestLoadRejections() {
 			d.Members[0].Position = encounter.PositionData{X: 99, Y: 99}
 		}, "out of bounds", nil},
 		{"connection missing room", func(d *encounter.EncounterData) {
-			d.Field.Connections = []encounter.ConnectionData{{ID: "c1", From: "r1", To: "nowhere"}}
-		}, `missing room "nowhere"`, encounter.ErrBadConnection},
+			// FromPosition/ToPosition present (any value) so the ONLY
+			// defect this fixture carries is the unknown "to" room — #929
+			// T2: endpoint presence is now checked during conversion,
+			// before room-existence, so a nil endpoint here would mask
+			// this row's own target defect behind "missing from_position".
+			d.Field.Connections = []encounter.ConnectionData{{ID: "c1", From: "r1", To: "nowhere",
+				FromPosition: &encounter.PositionData{X: 1, Y: 1}, ToPosition: &encounter.PositionData{X: 1, Y: 1}}}
+		}, `unknown room "nowhere"`, encounter.ErrBadConnection},
 		{"connection empty id", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].ID = ""
@@ -1262,11 +1302,11 @@ func (s *DataTestSuite) TestLoadRejections() {
 		{"connection unknown from room", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].From = "nowhere"
-		}, `missing room "nowhere"`, encounter.ErrBadConnection},
+		}, `unknown room "nowhere"`, encounter.ErrBadConnection},
 		{"connection unknown to room", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].To = "nowhere"
-		}, `missing room "nowhere"`, encounter.ErrBadConnection},
+		}, `unknown room "nowhere"`, encounter.ErrBadConnection},
 		{"connection self-connection", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].To = "r1"
@@ -1336,8 +1376,8 @@ func (s *DataTestSuite) TestLoadRejections() {
 	_, err := encounter.LoadEncounter(validEncounterData(), nil)
 	s.Require().NoError(err, "the valid base fixture must load")
 
-	// The valid CONNECTION base must also load. Since FromPosition{7,1} is
-	// valid ONLY in r1 and ToPosition{1,7} valid ONLY in r2, this positive
+	// The valid CONNECTION base must also load. Since FromPosition{9,1} is
+	// valid ONLY in r1 and ToPosition{0,7} valid ONLY in r2, this positive
 	// control pins that each endpoint is checked against ITS OWN room (a
 	// check wired to the wrong room would reject this valid connection),
 	// and that endpoints survive Load unswapped (a From/To transposition
@@ -1348,9 +1388,9 @@ func (s *DataTestSuite) TestLoadRejections() {
 	s.Require().NoError(err, "the valid connection base fixture must load")
 	connData := connEnc.ToData()
 	s.Require().Len(connData.Field.Connections, 1)
-	s.Equal(&encounter.PositionData{X: 7, Y: 1}, connData.Field.Connections[0].FromPosition,
+	s.Equal(&encounter.PositionData{X: 9, Y: 1}, connData.Field.Connections[0].FromPosition,
 		"from-position must survive Load unswapped")
-	s.Equal(&encounter.PositionData{X: 1, Y: 7}, connData.Field.Connections[0].ToPosition,
+	s.Equal(&encounter.PositionData{X: 0, Y: 7}, connData.Field.Connections[0].ToPosition,
 		"to-position must survive Load unswapped")
 }
 
@@ -1358,12 +1398,18 @@ func (s *DataTestSuite) TestLoadRejections() {
 // coordinates 0..3 x 0..2) and one connection — the Load-seam counterpart to
 // encounter_test.go's connBoundsSetup, pinning the square grid's strictly-
 // less-than bounds semantics at Load independent of any cross-room concern.
+//
+// #929 T2: r2's Origin (4,3) mirrors connBoundsSetup exactly — its own
+// comment explains the diagonal-kiss/disjointness geometry (positive
+// control FromPosition (3,2), r1's own bottom-right corner, kisses
+// ToPosition (0,0)+Origin(4,3)=(4,3) at Chebyshev distance 1; the rooms'
+// absolute footprints x:[0,3] vs x:[4,7] share no x value).
 func connBoundsData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "r1", Width: 4, Height: 3},
-				{ID: "r2", Width: 4, Height: 3},
+				{ID: "r1", Width: 4, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "r2", Width: 4, Height: 3, Origin: &encounter.PositionData{X: 4, Y: 3}},
 			},
 			Connections: []encounter.ConnectionData{
 				{ID: "c1", From: "r1", To: "r2",
@@ -1467,7 +1513,7 @@ func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeHex},
+				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
 		},
 		Members: []encounter.MemberData{
@@ -1513,21 +1559,26 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 
 // TestHexConnectionEndpointNegativeAxialLoad is the Load-seam counterpart
 // to encounter_test.go's TestHexConnectionEndpointNegativeAxial.
+// #929 T2: mirrors encounter_test.go's TestHexConnectionEndpointNegativeAxial
+// exactly (its own comment explains the geometry) — both rooms are hex now,
+// not square+hex (W1 forbids mixing families in one field — see
+// TestSetupAnchoring's W1 row on the Setup side). hex-b's negative-axial
+// corner (-3,-3) is still what gives this test its name.
 func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "square-room", Width: 10, Height: 10},
-				{ID: "hex-room", Width: 6, Height: 6, Grid: spatial.GridTypeHex},
+				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 7}},
 			},
 			Connections: []encounter.ConnectionData{{
-				ID: "gate", From: "square-room", To: "hex-room",
-				FromPosition: &encounter.PositionData{X: 9, Y: 9},
-				ToPosition:   &encounter.PositionData{X: -2, Y: -2},
+				ID: "gate", From: "hex-a", To: "hex-b",
+				FromPosition: &encounter.PositionData{X: 4, Y: 4},
+				ToPosition:   &encounter.PositionData{X: -3, Y: -3},
 			}},
 		},
 		Members: []encounter.MemberData{
-			{ID: "p1", Kind: encounter.KindPlayer, Room: "square-room", Position: encounter.PositionData{X: 1, Y: 1}},
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-a", Position: encounter.PositionData{X: 1, Y: 1}},
 		},
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
@@ -1538,20 +1589,21 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 
 // validHexAxialData returns a fresh EncounterData with two hex rooms
 // joined by one connection, a member, and an occluder — the Load-seam
-// counterpart to encounter_test.go's validHexAxialSetup. Every position
-// is integral axial, including a negative one (gate.ToPosition).
+// counterpart to encounter_test.go's validHexAxialSetup, mirrored exactly
+// (its own comment explains the geometry). Every position is integral
+// axial, including a negative one (gate.ToPosition).
 func validHexAxialData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex,
+				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0},
 					Occluders: []encounter.PositionData{{X: 2, Y: 2}}},
-				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridTypeHex},
+				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 1}},
 			},
 			Connections: []encounter.ConnectionData{{
 				ID: "gate", From: "hex-a", To: "hex-b",
-				FromPosition: &encounter.PositionData{X: 1, Y: 1},
-				ToPosition:   &encounter.PositionData{X: -1, Y: -1},
+				FromPosition: &encounter.PositionData{X: 3, Y: 0},
+				ToPosition:   &encounter.PositionData{X: -4, Y: -1},
 			}},
 		},
 		Members: []encounter.MemberData{
@@ -1602,6 +1654,240 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 	s.Require().NoError(err, "integral axial positions, including negative ones, must be accepted")
 }
 
+// ============================================================
+// #929 T2 — Load-side W-laws: the SAME laws encounter_test.go's
+// TestSetupAnchoring pins at Setup, now pinned at Load too (unified via
+// buildValidRoomGrids/validateConnectionInputs — LoadEncounter's doc
+// comment in data.go).
+// ============================================================
+
+// validAnchoredHexData mirrors encounter_test.go's validAnchoredHexSetup
+// exactly (its own comment explains the geometry in full: hex-big 10x4 at
+// the zero-value Origin, hex-small 3x9 at the NEGATIVE-axial Origin
+// (6,-5), an off-axis kissing doorway, disjoint absolute Q spans).
+func validAnchoredHexData() encounter.EncounterData {
+	return encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 6, Y: -5}},
+			},
+			Connections: []encounter.ConnectionData{{
+				ID: "gate", From: "hex-big", To: "hex-small",
+				FromPosition: &encounter.PositionData{X: 4, Y: 0},
+				ToPosition:   &encounter.PositionData{X: -1, Y: 4},
+			}},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-big", Position: encounter.PositionData{X: 0, Y: 0}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+}
+
+// TestLoadAnchoring pins the Load-seam one-defect rows for W1 (mixed grid
+// families), origin legality (non-integral, infinite, and non-representable
+// — isRepresentableInteger, encounter.go), W5 (nil origin presence, naming
+// the room), room legality (non-positive dimensions, both axes), and W3
+// (endpoints that don't kiss) — each breaking exactly ONE thing about
+// validAnchoredHexData's otherwise-valid base.
+func (s *DataTestSuite) TestLoadAnchoring() {
+	cases := []struct {
+		name     string
+		mutate   func(d *encounter.EncounterData)
+		alsoErr  error
+		fragment string
+	}{
+		{"W1: mixed grid families", func(d *encounter.EncounterData) {
+			d.Field.Rooms[1].Grid = ""
+		}, encounter.ErrNoField, "declare different grid families"},
+		{"origin legality: fractional hex origin", func(d *encounter.EncounterData) {
+			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 6.5, Y: -5}
+		}, encounter.ErrNoField, "not a representable integral cell"},
+		{"origin legality: infinite origin", func(d *encounter.EncounterData) {
+			d.Field.Rooms[1].Origin = &encounter.PositionData{X: math.Inf(1), Y: -5}
+		}, encounter.ErrNoField, "not a representable integral cell"},
+		{"origin legality: origin exceeds int64 precision (1e19)", func(d *encounter.EncounterData) {
+			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 1e19, Y: -5}
+		}, encounter.ErrNoField, "not a representable integral cell"},
+		{"W5: nil origin — absent, not a declared zero", func(d *encounter.EncounterData) {
+			d.Field.Rooms[1].Origin = nil
+		}, encounter.ErrNoField, `room "hex-small" missing origin`},
+		{"room legality: zero width", func(d *encounter.EncounterData) {
+			d.Field.Rooms[0].Width = 0
+		}, encounter.ErrNoField, "non-positive dimensions"},
+		{"room legality: zero height", func(d *encounter.EncounterData) {
+			d.Field.Rooms[0].Height = 0
+		}, encounter.ErrNoField, "non-positive dimensions"},
+		{"room legality: negative width", func(d *encounter.EncounterData) {
+			d.Field.Rooms[0].Width = -1
+		}, encounter.ErrNoField, "non-positive dimensions"},
+		{"room legality: negative height", func(d *encounter.EncounterData) {
+			d.Field.Rooms[0].Height = -1
+		}, encounter.ErrNoField, "non-positive dimensions"},
+		{"W3: endpoints do not kiss", func(d *encounter.EncounterData) {
+			// (1,4) is still a legal LOCAL cell in hex-small (max Q, max R)
+			// — this must fail on adjacency, not on the earlier bounds check.
+			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 1, Y: 4}
+		}, encounter.ErrBadConnection, "not adjacent"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			data := validAnchoredHexData()
+			tc.mutate(&data)
+			_, err := encounter.LoadEncounter(data, nil)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
+			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
+			s.Require().Contains(err.Error(), tc.fragment,
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	// The valid base itself must load — the one-defect discipline only
+	// means something if zero defects pass.
+	_, err := encounter.LoadEncounter(validAnchoredHexData(), nil)
+	s.Require().NoError(err, "the valid anchored base fixture must load")
+}
+
+// TestLoadAnchoringOverlapNonAdjacentPair is the Load-seam counterpart to
+// encounter_test.go's TestSetupAnchoringOverlapNonAdjacentPair — the TRUE
+// one-defect W2 row (no connection involved at all): three square rooms,
+// only the non-adjacent-in-slice (r-a, r-c) pair overlaps, witness (2,2).
+// See that test's comment for why this specifically kills a W2
+// adjacent-pairs-only mutant where W1's equivalent does not.
+func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
+	data := encounter.EncounterData{
+		Field: encounter.FieldData{
+			Rooms: []encounter.RoomData{
+				{ID: "r-a", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
+				{ID: "r-b", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 20, Y: 20}},
+				{ID: "r-c", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 2, Y: 2}},
+			},
+		},
+		Members: []encounter.MemberData{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r-a", Position: encounter.PositionData{X: 1, Y: 1}},
+		},
+		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
+		EverMembers: []encounter.MemberID{"p1"},
+	}
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), `room "r-a" and room "r-c" overlap at absolute cell (2, 2)`)
+}
+
+// TestOriginRoundTripByteIdentical pins W5's round-trip law: origins
+// survive ToData -> LoadEncounter -> ToData byte-identically, including a
+// NEGATIVE-axial one (hex-small's Origin, validAnchoredHexData) — not just
+// structurally equal but literally the same bytes, since a byte-level pin
+// catches a tag or field-order regression a decoded-struct comparison
+// would not.
+func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
+	enc1, err := encounter.LoadEncounter(validAnchoredHexData(), nil)
+	s.Require().NoError(err)
+	data1 := enc1.ToData()
+	bs1, err := json.Marshal(data1.Field)
+	s.Require().NoError(err)
+
+	enc2, err := encounter.LoadEncounter(data1, nil)
+	s.Require().NoError(err)
+	data2 := enc2.ToData()
+	bs2, err := json.Marshal(data2.Field)
+	s.Require().NoError(err)
+
+	s.Equal(string(bs1), string(bs2), "origins (including hex-small's negative-axial one) must survive a second round trip byte-identically")
+	s.Contains(string(bs1), `"origin":{"x":6,"y":-5}`, "the negative-axial origin must be present, not truncated or dropped")
+}
+
+// TestReloadedAnchoredEncounterAcceptsSameTraverse pins behavior-identity
+// after reload for an anchored multi-room encounter (#929 T2 round-trip
+// requirement): a member traverses a kissing doorway on the ORIGINAL
+// encounter; a FRESH member placed at the same threshold on the RELOADED
+// encounter traverses the same connection and lands in the same room at
+// the same local position — the reload changed nothing observable about
+// how the field behaves, even though the field now carries persisted
+// Origins it didn't in v0.2.
+func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
+				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "hex-big", To: "hex-small",
+				FromPosition: spatial.Position{X: 4, Y: 0},
+				ToPosition:   spatial.Position{X: -1, Y: 4},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-big", Position: spatial.Position{X: 4, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+	enc1, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err)
+
+	out1, err := enc1.Traverse(&encounter.TraverseInput{Member: "p1", Connection: "gate"})
+	s.Require().NoError(err, "the original encounter accepts the traverse")
+	s.Equal("hex-small", out1.Traversed.ToRoom)
+	s.Equal(spatial.Position{X: -1, Y: 4}, out1.Traversed.To)
+
+	// Reload from BEFORE the traverse (so a fresh member can repeat it) —
+	// the round-trip law under test is "the FIELD behaves identically",
+	// not "the same member can traverse twice".
+	dataPreTraverse := enc1.ToData()
+	// p1 already moved on enc1; roll dataPreTraverse's member back to the
+	// threshold so the reloaded encounter's own member reenacts the same
+	// traverse enc1 just proved.
+	for i, m := range dataPreTraverse.Members {
+		if m.ID == "p1" {
+			dataPreTraverse.Members[i].Room = "hex-big"
+			dataPreTraverse.Members[i].Position = encounter.PositionData{X: 4, Y: 0}
+		}
+	}
+	enc2, err := encounter.LoadEncounter(dataPreTraverse, nil)
+	s.Require().NoError(err)
+
+	out2, err := enc2.Traverse(&encounter.TraverseInput{Member: "p1", Connection: "gate"})
+	s.Require().NoError(err, "the reloaded encounter accepts the SAME traverse")
+	s.Equal(out1.Traversed.ToRoom, out2.Traversed.ToRoom)
+	s.Equal(out1.Traversed.To, out2.Traversed.To)
+}
+
+// TestLoadRejectsHostileNonKissingBlob pins W3 against a HAND-EDITED wire
+// blob, not a Go-struct mutation (the hostile-blob standard, #929 T2
+// mutation evidence): marshal a genuinely valid encounter, edit the JSON
+// BYTES directly to move one connection endpoint off its kissing cell, and
+// confirm LoadEncounter still rejects it — proving the check runs against
+// whatever bytes actually arrive over the wire, not just against values a
+// well-behaved Go caller would ever construct.
+func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
+	valid := validAnchoredHexData()
+	bs, err := json.Marshal(valid)
+	s.Require().NoError(err)
+
+	// gate.ToPosition is {"x":-1,"y":4} in the valid blob (hex-small's own
+	// max-Q/max-R corner, kissing hex-big's (4,0)). Move it to hex-small's
+	// OTHER corner (1,4) — still a legal LOCAL cell, but cube distance 2
+	// from the absolute anchor, same defect TestLoadAnchoring's "W3" row
+	// pins via a struct mutation — this pins it via raw bytes instead.
+	hostile := bytes.Replace(bs, []byte(`"to_position":{"x":-1,"y":4}`), []byte(`"to_position":{"x":1,"y":4}`), 1)
+	s.Require().NotEqual(bs, hostile, "the byte replacement must actually have matched something")
+
+	var data encounter.EncounterData
+	s.Require().NoError(json.Unmarshal(hostile, &data))
+
+	_, err = encounter.LoadEncounter(data, nil)
+	s.Require().Error(err, "a hand-edited blob with a non-kissing doorway must reject")
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	s.Require().ErrorIs(err, encounter.ErrBadConnection)
+	s.Require().Contains(err.Error(), "not adjacent")
+}
+
 // connGridlessRoomData returns a fresh EncounterData with one 4x3 gridless
 // room and a member at pos — the Load-seam counterpart to
 // encounter_test.go's TestGridlessRoomInclusiveBounds.
@@ -1609,7 +1895,7 @@ func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
 			Rooms: []encounter.RoomData{
-				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeGridless},
+				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeGridless, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
 		},
 		Members: []encounter.MemberData{
@@ -1620,21 +1906,28 @@ func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 	}
 }
 
-// TestGridlessRoomInclusiveBoundsLoad is the Load-seam counterpart to
-// encounter_test.go's TestGridlessRoomInclusiveBounds — see that test's
-// comment for why this is the sharpest available proof that bounds checks
-// ask the room's own constructed grid rather than a hardcoded rectangle.
+// TestGridlessRoomInclusiveBoundsLoad was the Load-seam counterpart to
+// encounter_test.go's TestGridlessRoomInclusiveBounds, pinning gridless's
+// old inclusive-bounds semantics. #929 T2 (mirroring the Setup-side
+// rewrite): a stored "gridless" grid string no longer loads at all —
+// gridDataToShape's doc comment — so this now pins THAT rejection instead,
+// regardless of the member position within it.
 func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
-	s.Run("position exactly at Width is accepted (inclusive upper bound)", func() {
+	s.Run("gridless grid string rejected regardless of member position", func() {
 		_, err := encounter.LoadEncounter(connGridlessRoomData(encounter.PositionData{X: 4, Y: 0}), nil)
-		s.Require().NoError(err, "gridless rooms accept x == Width; a rectangle-math fallback would reject this")
+		s.Require().Error(err, `a stored "gridless" grid string no longer loads`)
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Require().Contains(err.Error(), "unknown grid shape",
+			"the check that fired must be shape resolution, not a downstream placement check")
 	})
 
-	s.Run("position negative is still rejected", func() {
+	s.Run("still rejected for a position that would also be out of bounds", func() {
 		_, err := encounter.LoadEncounter(connGridlessRoomData(encounter.PositionData{X: -1, Y: 0}), nil)
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
-		s.Require().Contains(err.Error(), "out of bounds")
+		s.Require().ErrorIs(err, encounter.ErrNoField,
+			"shape resolution fires before any placement check ever sees this position")
 	})
 }
 

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -26,8 +26,12 @@
 //   - W4 (projection is a read) — rules and verbs stay room-local; absolute
 //     coordinates appear only in query outputs (Atlas, Absolute, Locate),
 //     never in a rule's own logic.
-//   - W5 (anchors are construction data) — Origin is validated identically
-//     at Setup and Load, never derived or inferred.
+//   - W5 (anchors are construction data) — Origin's LEGALITY (bounds,
+//     integrality) is validated identically at Setup and Load, never
+//     derived or inferred; PRESENCE is structurally Load-only — Origin is
+//     a plain value at Setup (RoomInput) but a pointer at Load
+//     (RoomData), so only Load can distinguish a missing Origin from a
+//     declared zero one.
 //
 // Room and field size are allocation-bounded (a legal-but-absurd room or
 // field could otherwise demand an allocation Atlas cannot safely make);

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -13,4 +13,23 @@
 // Design contract: docs/ideas/encounter/design.md (composition laws C1–C8).
 // This is not a play/ leaf: the module composes published pieces and exposes
 // one aggregate persistence pair at the host seam.
+//
+// v0.3 anchors every room in one dungeon-absolute space (docs/ideas/
+// encounter-anchoring/design.md), governed by five more laws:
+//
+//   - W1 (one geometry per field) — every room in a field shares the same
+//     grid family; a mixed field has no coherent absolute space.
+//   - W2 (rooms never overlap) — distinct rooms' absolute footprints are
+//     disjoint; touching is legal, sharing a cell is not.
+//   - W3 (doorways kiss) — a connection's two endpoints, once anchored to
+//     their rooms' origins, are adjacent absolute cells.
+//   - W4 (projection is a read) — rules and verbs stay room-local; absolute
+//     coordinates appear only in query outputs (Atlas, Absolute, Locate),
+//     never in a rule's own logic.
+//   - W5 (anchors are construction data) — Origin is validated identically
+//     at Setup and Load, never derived or inferred.
+//
+// Room and field size are allocation-bounded (a legal-but-absurd room or
+// field could otherwise demand an allocation Atlas cannot safely make);
+// see maxRoomCells/maxFieldCells for the exact figures and why.
 package encounter

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -25,14 +25,15 @@ type SightPayload struct {
 	Y    float64 `json:"y"`
 }
 
-// Encounter is the aggregate encounter composition: members, field, clock,
-// intel, and record. Construct via NewEncounter; zero value unusable.
 // declaredEnding pairs an ending key with its trigger, in Setup order.
 type declaredEnding struct {
 	key     string
 	trigger Trigger
 }
 
+// Encounter is the aggregate encounter composition: members, field, clock,
+// intel, and record. Construct via NewEncounter or LoadEncounter; the zero
+// value is unusable.
 type Encounter struct {
 	orchestrator *spatial.BasicRoomOrchestrator
 	clock        *clock.Tick
@@ -80,13 +81,19 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 // gridDataToShape BEFORE this is ever called (gridDataToShape's doc
 // comment — a stored "gridless" or otherwise unrecognized string is
 // rejected there, at the string layer), and Setup's buildValidRoomGrids
-// rejects gridless and any unrecognized value before calling this too —
-// so the switch's default (square, for an unrecognized value) is
-// unreachable from EITHER path and exists only so a caller that somehow
-// bypasses both validators degrades to square rather than panicking.
-// GridShapeGridless itself has no case here at all as of T2: gridless
-// left the composition in T1 (shape legality) and now has no reachable
-// caller anywhere in this module, Setup or Load.
+// rejects gridless and any unrecognized value before calling this too.
+// The switch's default case covers TWO things, only one of which is
+// unreachable: it IS the normal, constantly-exercised path for every
+// square room (GridShapeSquare is the zero value, so it falls to
+// default rather than needing its own case) — that part is reachable on
+// every square-family construction. Only the OTHER thing default
+// covers — an unrecognized shape value degrading to square instead of
+// panicking — is unreachable from either validated path, and exists
+// only so a caller that somehow bypasses both validators degrades
+// gracefully rather than panicking. GridShapeGridless itself has no
+// case here at all as of T2: gridless left the composition in T1 (shape
+// legality) and now has no reachable caller anywhere in this module,
+// Setup or Load.
 //
 // Hex rooms build spatial.AxialHexGrid, NOT spatial.HexGrid: the wire (and
 // Platform's pathing) speaks cube coordinates natively, and axial (Q, R,
@@ -115,12 +122,19 @@ func buildRoomGrid(shape spatial.GridShape, width, height int) spatial.Grid {
 // position like (0.5, 0.5) would otherwise persist as a distinct
 // position that behaves exactly like (0,0) — an invisible collision with
 // an unrelated, legitimately-placed cell. Applies ONLY to hex rooms:
-// square stays fractional-tolerant as today, and gridless is continuous
-// by design — call this next to every grid-deferred IsValidPosition
-// check (or, where no such check exists at a seam, next to where the
-// position first enters) so every externally supplied hex-room position
-// is covered: member/Move/Join positions, connection endpoints, and
-// occluders.
+// square stays fractional-tolerant by design (RoomInput.Grid's doc
+// comment) — call this next to every grid-deferred IsValidPosition check
+// (or, where no such check exists at a seam, next to where the position
+// first enters) so every externally supplied hex-room position is
+// covered: member positions at Setup and Load (NewEncounter,
+// LoadEncounter), Move's target (moveMember), Join's position,
+// connection endpoints (validateConnectionInputs, shared by both
+// construction seams), a TriggerReachedPosition ending's target
+// (validateEndingTriggers, #929 T3 Opus round F5), and the two
+// local/absolute bridges' own positions (Absolute, Locate, #929 T3).
+// Occluder positions do NOT go through this — they use the universal
+// isIntegralPosition instead, every family, not just hex (#929 T3 Opus
+// round F2; isIntegralPosition's own doc comment).
 func isIntegralAxialPosition(grid spatial.Grid, pos spatial.Position) bool {
 	if grid.GetShape() != spatial.GridShapeHex {
 		return true
@@ -193,7 +207,7 @@ const (
 
 // maxRoomCells bounds a single room's total cell count (Width*Height —
 // EQUAL for both grid families: axisBounds' span always equals the
-// dimension itself, every parity, hex included — see atlasCells' doc
+// dimension itself, every parity, hex included — see axisBounds' doc
 // comment), and maxFieldCells bounds the SUM of every room's cell count
 // across one field. ALLOCATION-SAFETY bounds for Atlas, distinct in
 // PURPOSE from maxRoomSpan/maxAnchorCoord above (coordinate-OVERFLOW
@@ -203,38 +217,47 @@ const (
 // each) multiply to up to 1<<60 — the amplification is exactly what
 // makes a SEPARATE bound necessary: a 2^30 x 2^30 room passes
 // maxRoomSpan's per-axis check cleanly but PANICS atlasCells' make()
-// (a 2^60-capacity argument), reachable from a 394-byte persisted blob —
-// two integers, no bulk data (#929 T3 Opus round F1). Enforced HERE, in
-// room legality — the shared path both NewEncounter and LoadEncounter
-// route through — not inside Atlas itself: see the comment at
-// atlasCells' allocation site (atlas.go) for why no redundant check
-// lives there.
+// (a 2^60-capacity argument), reachable from a persisted blob a few
+// hundred bytes long — two integers, no bulk data (#929 T3 Opus round
+// F1). Enforced HERE, in room legality — the shared path both
+// NewEncounter and LoadEncounter route through — not inside Atlas
+// itself: see the comment at atlasCells' allocation site (atlas.go) for
+// why no redundant check lives there.
 const (
 	maxRoomCells  = 1 << 20
 	maxFieldCells = 1 << 22
 )
 
 // buildValidRoomGrids rejects room defects before construction (R5
-// atomicity — no observable state until Setup succeeds), in this order per
-// defect class (docs/ideas/encounter-anchoring/design.md's Validation
-// section, Opus-round amendment): empty or duplicate room ID; an
-// unrecognized or no-longer-supported grid shape; non-integral occluder
-// positions in EVERY family, not just hex (#929 T3 Opus round F2 — see
-// isIntegralPosition; the occluder loop below); W1 (one grid family per
-// field — validateGridFamilies); room legality (non-positive OR oversized
+// atomicity — no observable state until Setup succeeds). The first three
+// defect classes — empty or duplicate room ID, an unrecognized or
+// no-longer-supported grid shape, and non-integral occluder positions in
+// EVERY family, not just hex (#929 T3 Opus round F2 — see
+// isIntegralPosition; the occluder loop below) — are checked inside ONE
+// per-room loop, not as three separate global passes: for a GIVEN room,
+// that room's own ID defect wins before its shape defect, which wins
+// before its occluder defect, but WHICH ROOM's defect is reported first
+// depends on slice order, not defect-class priority — a field with an
+// unrecognized shape on room A and an empty ID on room B (A listed
+// first) reports A's shape defect, not B's empty ID, even though ID is
+// listed first in this prose. Every defect class AFTER those three (W1
+// onward) genuinely IS a separate pass over every room, run in the order
+// named here (docs/ideas/encounter-anchoring/design.md's Validation
+// section, Opus-round amendment): W1 (one grid family per field —
+// validateGridFamilies); room legality (non-positive OR oversized
 // Width/Height, a per-room cell count exceeding maxRoomCells, AND an
 // out-of-bounds Origin — checked per room in one pass; ONLY AFTER every
 // room clears that pass does a separate, final check compare the summed
 // cell count against maxFieldCells, so its error names the TRUE total
 // over every room, not a partial sum from wherever the loop happened to
-// stop — #929 T3 trailing round N3); a negative dimension used to panic
+// stop — #929 T3 trailing round N3). A negative dimension used to panic
 // NewEncounter via a negative-capacity make() in the since-deleted
-// enumeration path, an unbounded dimension or origin can overflow int64
-// arithmetic downstream (maxRoomSpan/maxAnchorCoord), and an oversized
+// enumeration path; an unbounded dimension or origin can overflow int64
+// arithmetic downstream (maxRoomSpan/maxAnchorCoord); and an oversized
 // CELL COUNT — legal per-axis but catastrophic multiplied — panics
 // Atlas's own allocation instead (maxRoomCells/maxFieldCells, #929 T3
-// Opus round F1); a panic or a
-// silent overflow is not a rejection); origin legality (non-representable
+// Opus round F1). In every one of those three cases, a panic or a silent
+// overflow is not a rejection. Then origin legality (non-representable
 // Origin, for EVERY family now, not just hex — a fractional origin
 // defeats W2's disjointness promise for ANY grid, not only hex: see
 // isIntegralPosition); and W2 (rooms never overlap in absolute space —
@@ -290,8 +313,8 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		// Occluders must be integral in EVERY family, not just hex (#929 T3
 		// Opus round F2 — the identical square-vs-hex asymmetry T1 already
 		// fixed for Origin: see isIntegralPosition's doc comment). Two
-		// reinforcing reasons: (1) Atlas.Occluders must be a subset of
-		// Atlas.Cells (Cells only enumerates INTEGER cells — atlasCells'
+		// reinforcing reasons: (1) AtlasRoom.Occluders must be a subset of
+		// AtlasRoom.Cells (Cells only enumerates INTEGER cells — atlasCells'
 		// doc comment), so a fractional occluder would appear in Occluders
 		// while absent from Cells, breaking the host contract "floor from
 		// Cells, blockage from Occluders"; (2) the occluder entity ID built
@@ -509,7 +532,8 @@ func validateRoomsDisjoint(rooms []RoomInput) error {
 // (R5 atomicity — no observable state until Setup succeeds): empty or
 // duplicate ID, an unknown or self-referencing room, an endpoint outside
 // its room's bounds (per that room's own constructed Grid, from roomGrids —
-// see buildValidRoomGrids) or on an occluder position, and (W3) endpoints
+// see buildValidRoomGrids) or non-integral (hex rooms only — see
+// isIntegralAxialPosition) or on an occluder position, and (W3) endpoints
 // that do not kiss — are not adjacent absolute cells once each is anchored
 // to its own room's Origin. Error messages carry NO verb prefix — shared
 // with LoadEncounter, same reasoning as buildValidRoomGrids' doc comment.
@@ -631,14 +655,18 @@ func validateEndingTriggers(endings []EndingInput, roomGrids map[string]spatial.
 
 // NewEncounter constructs and initializes an encounter from SetupInput.
 // Validation order (first failure wins, R5 atomicity): nil input, no rooms,
-// no endings, reserved ending key, empty member ID, duplicate member IDs,
-// room defects (empty/duplicate ID, unrecognized or no-longer-supported
-// grid shape, non-integral occluder position in any family, W1 mixed grid
-// families, non-positive/oversized/over-cell-budget dimensions, non-integral
-// origin, W2 overlapping absolute footprints), connection defects
-// (empty/duplicate ID, unknown room, self-connection, endpoint out of
-// bounds or on an occluder, W3 endpoints not adjacent once anchored),
-// member position integrality, ending trigger validity (unknown room or
+// no endings, empty-or-reserved ending key, empty member ID, duplicate
+// member IDs, a player member carrying a Decider (design law C2 — runs in
+// the SAME member-ID loop, before room defects; Join's own doc comment
+// lists this check too, at its own seam), room defects (empty/duplicate
+// ID, unrecognized or no-longer-supported grid shape, non-integral
+// occluder position in any family, W1 mixed grid families,
+// non-positive/oversized/over-cell-budget dimensions, an out-of-bounds
+// Origin (maxAnchorCoord) or a non-representable one, W2 overlapping
+// absolute footprints), connection defects (empty/duplicate ID, unknown
+// room, self-connection, endpoint out of bounds, non-integral (hex), or
+// on an occluder, W3 endpoints not adjacent once anchored), member
+// position integrality, ending trigger validity (unknown room or
 // unreachable position on a TriggerReachedPosition — #929 T3 Opus round
 // F5), spatial placement errors.
 func NewEncounter(in *SetupInput) (*Encounter, error) {

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -169,33 +169,69 @@ func isRepresentableInteger(v float64) bool {
 	return float64(int(v)) == v
 }
 
+// maxRoomSpan bounds RoomInput.Width/Height, and maxAnchorCoord bounds
+// |Origin.X| and |Origin.Y| — pure integer-overflow defense (#929 T2
+// second review round), not a gameplay limit: no real dungeon room is
+// ever within six orders of magnitude of 1<<30 (~1.07 billion). Without
+// this bound, roomAbsoluteBounds' interval-sum arithmetic
+// (axisBounds' local max + Origin) can silently wrap int64: two
+// same-shaped rooms with huge Width and an Origin offset chosen so their
+// TRUE (infinite-precision) footprints genuinely overlap can wrap to a
+// witness sum that reads as disjoint, producing a FALSE "no overlap" W2
+// verdict through the public API (see the mutation-evidence fixture in
+// encounter_test.go — TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint's
+// comment walks through the exact wraparound). Both constants are set to the SAME
+// value deliberately: with every Width/Height/Origin bounded by
+// maxRoomSpan/maxAnchorCoord, the largest possible interval sum
+// (maxAnchorCoord + maxRoomSpan) is ~2<<30, leaving over 30 bits of
+// headroom before int64 overflow even in the most adversarial legal
+// input.
+const (
+	maxRoomSpan    = 1 << 30
+	maxAnchorCoord = 1 << 30
+)
+
 // buildValidRoomGrids rejects room defects before construction (R5
 // atomicity — no observable state until Setup succeeds), in this order per
 // defect class (docs/ideas/encounter-anchoring/design.md's Validation
 // section, Opus-round amendment): empty or duplicate room ID; an
 // unrecognized or no-longer-supported grid shape; non-integral hex
 // occluder positions; W1 (one grid family per field — validateGridFamilies);
-// non-positive Width/Height (room legality — a negative dimension used to
-// panic NewEncounter via a negative-capacity make() in the since-deleted
-// enumeration path; a panic is not a rejection); non-integral Origin, for
-// EVERY family now, not just hex (origin legality — a fractional origin
-// defeats W2's disjointness promise for ANY grid, not only hex: see
-// isIntegralPosition); and W2 (rooms never overlap in absolute space —
-// validateRoomsDisjoint). On success, returns each room's constructed Grid
-// keyed by room ID — reused both for downstream bounds checks (connections,
-// and transitively member placement via spatial's own PlaceEntity) and
-// later in NewEncounter's room-construction loop, so a room's shape is
-// built exactly once and every consumer asks the SAME grid. Reuses
-// ErrNoField — a malformed room list is as unusable as an empty one.
+// room legality (non-positive OR oversized Width/Height, AND an
+// out-of-bounds Origin — a negative dimension used to panic NewEncounter
+// via a negative-capacity make() in the since-deleted enumeration path,
+// and an unbounded dimension or origin can overflow int64 arithmetic
+// downstream, see maxRoomSpan/maxAnchorCoord — a panic or a silent
+// overflow is not a rejection); origin legality (non-representable Origin,
+// for EVERY family now, not just hex — a fractional origin defeats W2's
+// disjointness promise for ANY grid, not only hex: see isIntegralPosition);
+// and W2 (rooms never overlap in absolute space — validateRoomsDisjoint). On
+// success, returns each
+// room's constructed Grid keyed by room ID — reused both for downstream
+// bounds checks (connections, and transitively member placement via
+// spatial's own PlaceEntity) and later in NewEncounter's room-construction
+// loop, so a room's shape is built exactly once and every consumer asks the
+// SAME grid. Reuses ErrNoField — a malformed room list is as unusable as an
+// empty one.
+//
+// Error messages here carry NO verb prefix (#929 T2 second review round —
+// this and validateGridFamilies/validateRoomsDisjoint/validateConnectionInputs
+// are shared between NewEncounter and LoadEncounter, and a message baked
+// with "newencounter:" leaked into Load's own errors, e.g. "load encounter:
+// invalid encounter data: newencounter: room ... has empty id"). Each
+// caller wraps its OWN verb at the call site instead — NewEncounter wraps
+// "newencounter: %w", LoadEncounter wraps "load encounter: %w: %w" with
+// ErrInvalidData — so the SAME validator produces a message honest about
+// which seam actually rejected it.
 func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 	seenIDs := make(map[string]bool, len(rooms))
 	grids := make(map[string]spatial.Grid, len(rooms))
 	for _, r := range rooms {
 		if r.ID == "" {
-			return nil, fmt.Errorf("newencounter: room has empty id: %w", ErrNoField)
+			return nil, fmt.Errorf("room has empty id: %w", ErrNoField)
 		}
 		if seenIDs[r.ID] {
-			return nil, fmt.Errorf("newencounter: duplicate room %q: %w", r.ID, ErrNoField)
+			return nil, fmt.Errorf("duplicate room %q: %w", r.ID, ErrNoField)
 		}
 		seenIDs[r.ID] = true
 
@@ -213,9 +249,9 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		switch r.Grid {
 		case spatial.GridShapeSquare, spatial.GridShapeHex:
 		case spatial.GridShapeGridless:
-			return nil, fmt.Errorf("newencounter: room %q declares gridless grid shape, no longer supported: %w", r.ID, ErrNoField)
+			return nil, fmt.Errorf("room %q declares gridless grid shape, no longer supported: %w", r.ID, ErrNoField)
 		default:
-			return nil, fmt.Errorf("newencounter: room %q has unknown grid shape %d: %w", r.ID, r.Grid, ErrNoField)
+			return nil, fmt.Errorf("room %q has unknown grid shape %d: %w", r.ID, r.Grid, ErrNoField)
 		}
 		grids[r.ID] = buildRoomGrid(r.Grid, r.Width, r.Height)
 
@@ -223,7 +259,7 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		// tools/spatial#926 enforcement — see isIntegralAxialPosition).
 		for _, occ := range r.Occluders {
 			if !isIntegralAxialPosition(grids[r.ID], occ) {
-				return nil, fmt.Errorf("newencounter: room %q occluder (%g,%g) is not an integral axial cell: %w", r.ID, occ.X, occ.Y, ErrNoField)
+				return nil, fmt.Errorf("room %q occluder (%g,%g) is not an integral axial cell: %w", r.ID, occ.X, occ.Y, ErrNoField)
 			}
 		}
 	}
@@ -235,29 +271,51 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		return nil, err
 	}
 
-	// Room legality: non-positive Width or Height is a defect, not a
-	// silent no-op (#929 T1 Opus round: Width:-1 previously reached
+	// Room legality: non-positive OR oversized Width/Height is a defect,
+	// not a silent no-op (#929 T1 Opus round: Width:-1 previously reached
 	// buildRoomGrid and, downstream, a negative-capacity make() in the
-	// enumeration W2 used before this same round replaced it with interval
-	// math — a panic, not a rejection, either way an unvalidated dimension
-	// has no business reaching construction). Runs after W1 (a mixed-family
-	// field with a bad dimension reports the family mismatch first) and
-	// before origin legality/W2 (both need real dimensions to reason about).
+	// enumeration W2 used before that same round replaced it with interval
+	// math — a panic, not a rejection). The upper bound (maxRoomSpan, #929
+	// T2 second review round) is separate, newer defense: an UNBOUNDED
+	// dimension doesn't panic, but can silently overflow int64 in
+	// roomAbsoluteBounds' interval-sum arithmetic, producing a false "no
+	// overlap" W2 verdict instead of a crash — see maxRoomSpan's doc
+	// comment and TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint's
+	// mutation evidence. |Origin.X|/|Origin.Y| <= maxAnchorCoord is the
+	// SAME overflow defense applied to the other operand of that same
+	// interval-sum arithmetic, co-located here rather than in origin
+	// legality below (#929 T2 second review round: this tightens
+	// isRepresentableInteger's effective envelope — an origin like 1e19,
+	// or ±Inf, is caught HERE, by the bound, before origin legality's
+	// representability check ever runs; Inf is never <= a finite bound).
+	// Runs after W1 (a mixed-family field with a bad dimension/origin
+	// reports the family mismatch first) and before origin legality/W2
+	// (both need real, bounded dimensions and origins to reason about).
 	for _, r := range rooms {
 		if r.Width <= 0 || r.Height <= 0 {
-			return nil, fmt.Errorf("newencounter: room %q has non-positive dimensions (%d x %d): %w", r.ID, r.Width, r.Height, ErrNoField)
+			return nil, fmt.Errorf("room %q has non-positive dimensions (%d x %d): %w", r.ID, r.Width, r.Height, ErrNoField)
+		}
+		if r.Width > maxRoomSpan || r.Height > maxRoomSpan {
+			return nil, fmt.Errorf("room %q dimensions (%d x %d) exceed max room span %d: %w", r.ID, r.Width, r.Height, maxRoomSpan, ErrNoField)
+		}
+		if math.Abs(r.Origin.X) > maxAnchorCoord || math.Abs(r.Origin.Y) > maxAnchorCoord {
+			return nil, fmt.Errorf("room %q origin (%g,%g) exceeds max anchor coordinate %d: %w", r.ID, r.Origin.X, r.Origin.Y, maxAnchorCoord, ErrNoField)
 		}
 	}
 
-	// Origin legality: every room's Origin must be integral, for EVERY
-	// grid family (#929 T1 Opus round: originally hex-only, extended
-	// here — see isIntegralPosition for why a fractional SQUARE origin is
-	// equally a defect). Runs after W1 and room legality so a mixed-family
-	// or malformed-dimension field reports THAT defect first, not an
-	// origin defect on a room whose shape or size is already wrong.
+	// Origin legality: every room's Origin must be a representable integer
+	// (isRepresentableInteger — rejects fractional, NaN, and any magnitude
+	// past int64's usable precision; ±Inf and magnitudes past
+	// maxAnchorCoord are already caught above, in room legality). Applies
+	// for EVERY grid family (#929 T1 Opus round: originally hex-only,
+	// extended here — see isIntegralPosition for why a fractional SQUARE
+	// origin is equally a defect). Runs after W1 and room legality so a
+	// mixed-family or malformed-dimension/origin field reports THAT defect
+	// first, not a representability defect on a room whose shape, size,
+	// or anchor bound is already wrong.
 	for _, r := range rooms {
 		if !isIntegralPosition(r.Origin) {
-			return nil, fmt.Errorf("newencounter: room %q origin (%g,%g) is not a representable integral cell: %w", r.ID, r.Origin.X, r.Origin.Y, ErrNoField)
+			return nil, fmt.Errorf("room %q origin (%g,%g) is not a representable integral cell: %w", r.ID, r.Origin.X, r.Origin.Y, ErrNoField)
 		}
 	}
 
@@ -306,7 +364,7 @@ func validateGridFamilies(rooms []RoomInput) error {
 	for i := 0; i < len(rooms); i++ {
 		for j := i + 1; j < len(rooms); j++ {
 			if rooms[i].Grid != rooms[j].Grid {
-				return fmt.Errorf("newencounter: room %q (%s) and room %q (%s) declare different grid families: %w",
+				return fmt.Errorf("room %q (%s) and room %q (%s) declare different grid families: %w",
 					rooms[i].ID, gridShapeName(rooms[i].Grid), rooms[j].ID, gridShapeName(rooms[j].Grid), ErrNoField)
 			}
 		}
@@ -378,7 +436,7 @@ func validateRoomsDisjoint(rooms []RoomInput) error {
 					X: float64(max(bs[i].qMin, bs[j].qMin)),
 					Y: float64(max(bs[i].rMin, bs[j].rMin)),
 				}
-				return fmt.Errorf("newencounter: room %q and room %q overlap at absolute cell %s: %w",
+				return fmt.Errorf("room %q and room %q overlap at absolute cell %s: %w",
 					rooms[i].ID, rooms[j].ID, witness, ErrNoField)
 			}
 		}
@@ -392,7 +450,8 @@ func validateRoomsDisjoint(rooms []RoomInput) error {
 // its room's bounds (per that room's own constructed Grid, from roomGrids —
 // see buildValidRoomGrids) or on an occluder position, and (W3) endpoints
 // that do not kiss — are not adjacent absolute cells once each is anchored
-// to its own room's Origin.
+// to its own room's Origin. Error messages carry NO verb prefix — shared
+// with LoadEncounter, same reasoning as buildValidRoomGrids' doc comment.
 func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Grid, connections []ConnectionInput) error {
 	roomsByID := make(map[string]RoomInput, len(rooms))
 	for _, r := range rooms {
@@ -402,46 +461,46 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 	seenIDs := make(map[string]bool, len(connections))
 	for _, c := range connections {
 		if c.ID == "" {
-			return fmt.Errorf("newencounter: connection has empty id: %w", ErrBadConnection)
+			return fmt.Errorf("connection has empty id: %w", ErrBadConnection)
 		}
 		if seenIDs[c.ID] {
-			return fmt.Errorf("newencounter: duplicate connection %q: %w", c.ID, ErrBadConnection)
+			return fmt.Errorf("duplicate connection %q: %w", c.ID, ErrBadConnection)
 		}
 		seenIDs[c.ID] = true
 
 		fromRoom, ok := roomsByID[c.From]
 		if !ok {
-			return fmt.Errorf("newencounter: connection %q references unknown room %q: %w", c.ID, c.From, ErrBadConnection)
+			return fmt.Errorf("connection %q references unknown room %q: %w", c.ID, c.From, ErrBadConnection)
 		}
 		toRoom, ok := roomsByID[c.To]
 		if !ok {
-			return fmt.Errorf("newencounter: connection %q references unknown room %q: %w", c.ID, c.To, ErrBadConnection)
+			return fmt.Errorf("connection %q references unknown room %q: %w", c.ID, c.To, ErrBadConnection)
 		}
 		if c.From == c.To {
-			return fmt.Errorf("newencounter: connection %q connects room %q to itself: %w", c.ID, c.From, ErrBadConnection)
+			return fmt.Errorf("connection %q connects room %q to itself: %w", c.ID, c.From, ErrBadConnection)
 		}
 
 		if !roomGrids[c.From].IsValidPosition(c.FromPosition) {
-			return fmt.Errorf("newencounter: connection %q from-position out of bounds: %w", c.ID, ErrBadConnection)
+			return fmt.Errorf("connection %q from-position out of bounds: %w", c.ID, ErrBadConnection)
 		}
 		if !isIntegralAxialPosition(roomGrids[c.From], c.FromPosition) {
-			return fmt.Errorf("newencounter: connection %q from-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
+			return fmt.Errorf("connection %q from-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
 		}
 		if !roomGrids[c.To].IsValidPosition(c.ToPosition) {
-			return fmt.Errorf("newencounter: connection %q to-position out of bounds: %w", c.ID, ErrBadConnection)
+			return fmt.Errorf("connection %q to-position out of bounds: %w", c.ID, ErrBadConnection)
 		}
 		if !isIntegralAxialPosition(roomGrids[c.To], c.ToPosition) {
-			return fmt.Errorf("newencounter: connection %q to-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
+			return fmt.Errorf("connection %q to-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
 		}
 
 		for _, occ := range fromRoom.Occluders {
 			if occ.X == c.FromPosition.X && occ.Y == c.FromPosition.Y {
-				return fmt.Errorf("newencounter: connection %q from-position on occluder: %w", c.ID, ErrBadConnection)
+				return fmt.Errorf("connection %q from-position on occluder: %w", c.ID, ErrBadConnection)
 			}
 		}
 		for _, occ := range toRoom.Occluders {
 			if occ.X == c.ToPosition.X && occ.Y == c.ToPosition.Y {
-				return fmt.Errorf("newencounter: connection %q to-position on occluder: %w", c.ID, ErrBadConnection)
+				return fmt.Errorf("connection %q to-position on occluder: %w", c.ID, ErrBadConnection)
 			}
 		}
 
@@ -470,7 +529,7 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 		// wrongly claimed sub-1 distances were unfalsifiable and left the
 		// strict form unpinned).
 		if dist := roomGrids[c.From].Distance(fromAbs, toAbs); dist != 1 {
-			return fmt.Errorf("newencounter: connection %q endpoints %s and %s are not adjacent (distance %g): %w",
+			return fmt.Errorf("connection %q endpoints %s and %s are not adjacent (distance %g): %w",
 				c.ID, fromAbs, toAbs, dist, ErrBadConnection)
 		}
 	}
@@ -529,14 +588,14 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// room's shape is built exactly once.
 	roomGrids, err := buildValidRoomGrids(in.Field.Rooms)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("newencounter: %w", err)
 	}
 
 	// Check connections: unique non-empty IDs, endpoints resolve to distinct
 	// declared rooms, endpoints in bounds (per the room's own grid) and off
 	// any occluder.
 	if err = validateConnectionInputs(in.Field.Rooms, roomGrids, in.Field.Connections); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("newencounter: %w", err)
 	}
 
 	// Hex rooms require integral axial member positions (interim

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -75,16 +75,18 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 }
 
 // buildRoomGrid constructs the spatial Grid for a room's declared shape.
-// From Setup (buildValidRoomGrids), only GridShapeSquare and GridShapeHex
-// ever reach here — shape legality rejects gridless and any unrecognized
-// value before this is called, so the GridShapeGridless case and the
-// switch's default (square, for an unrecognized value) are both
-// unreachable from that path. Neither is dead code overall, though:
-// LoadEncounter (data.go) still calls this directly and still routes a
-// stored "gridless" grid string through the GridShapeGridless case — T2
-// removes that branch once Load-side rejection of gridless lands alongside
-// Origin persistence. Until then this stays a three-shape switch, one
-// path reachable only from Load.
+// Only GridShapeSquare and GridShapeHex ever reach here now (#929 T2):
+// LoadEncounter converts its wire-only grid string to a GridShape via
+// gridDataToShape BEFORE this is ever called (gridDataToShape's doc
+// comment — a stored "gridless" or otherwise unrecognized string is
+// rejected there, at the string layer), and Setup's buildValidRoomGrids
+// rejects gridless and any unrecognized value before calling this too —
+// so the switch's default (square, for an unrecognized value) is
+// unreachable from EITHER path and exists only so a caller that somehow
+// bypasses both validators degrades to square rather than panicking.
+// GridShapeGridless itself has no case here at all as of T2: gridless
+// left the composition in T1 (shape legality) and now has no reachable
+// caller anywhere in this module, Setup or Load.
 //
 // Hex rooms build spatial.AxialHexGrid, NOT spatial.HexGrid: the wire (and
 // Platform's pathing) speaks cube coordinates natively, and axial (Q, R,
@@ -99,8 +101,6 @@ func buildRoomGrid(shape spatial.GridShape, width, height int) spatial.Grid {
 	switch shape {
 	case spatial.GridShapeHex:
 		return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: float64(width), SpanHeight: float64(height)})
-	case spatial.GridShapeGridless:
-		return spatial.NewGridlessRoom(spatial.GridlessConfig{Width: float64(width), Height: float64(height)})
 	default:
 		return spatial.NewSquareGrid(spatial.SquareGridConfig{Width: float64(width), Height: float64(height)})
 	}
@@ -203,11 +203,13 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		// wire cannot carry a continuous room's absolute projection — so it
 		// is rejected explicitly, distinct from a genuinely unrecognized
 		// value. Square and hex are the only surviving families; W1 below
-		// compares them. This branch is unreachable from Setup as of this
-		// wave (every room here has already survived it), but LoadEncounter
-		// (data.go) still routes a stored "gridless" grid string through
-		// buildRoomGrid's own gridless case — Load-side rejection of it is
-		// T2's job, alongside persisting Origin.
+		// compares them. This branch is reachable only from a direct Go-level
+		// caller of NewEncounter that still constructs a GridShapeGridless
+		// RoomInput (#929 T2: LoadEncounter no longer reaches this case at
+		// all — a stored "gridless" grid string is rejected earlier, at the
+		// string layer, by gridDataToShape before a RoomInput ever exists —
+		// see this switch's Load-seam counterpart in that function's doc
+		// comment).
 		switch r.Grid {
 		case spatial.GridShapeSquare, spatial.GridShapeHex:
 		case spatial.GridShapeGridless:

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -222,14 +222,18 @@ const (
 // positions in EVERY family, not just hex (#929 T3 Opus round F2 — see
 // isIntegralPosition; the occluder loop below); W1 (one grid family per
 // field — validateGridFamilies); room legality (non-positive OR oversized
-// Width/Height, a cell count exceeding maxRoomCells or pushing the
-// field's running total past maxFieldCells, AND an out-of-bounds Origin —
-// a negative dimension used to panic NewEncounter via a negative-capacity
-// make() in the since-deleted enumeration path, an unbounded dimension or
-// origin can overflow int64 arithmetic downstream (maxRoomSpan/
-// maxAnchorCoord), and an oversized CELL COUNT — legal per-axis but
-// catastrophic multiplied — panics Atlas's own allocation instead
-// (maxRoomCells/maxFieldCells, #929 T3 Opus round F1); a panic or a
+// Width/Height, a per-room cell count exceeding maxRoomCells, AND an
+// out-of-bounds Origin — checked per room in one pass; ONLY AFTER every
+// room clears that pass does a separate, final check compare the summed
+// cell count against maxFieldCells, so its error names the TRUE total
+// over every room, not a partial sum from wherever the loop happened to
+// stop — #929 T3 trailing round N3); a negative dimension used to panic
+// NewEncounter via a negative-capacity make() in the since-deleted
+// enumeration path, an unbounded dimension or origin can overflow int64
+// arithmetic downstream (maxRoomSpan/maxAnchorCoord), and an oversized
+// CELL COUNT — legal per-axis but catastrophic multiplied — panics
+// Atlas's own allocation instead (maxRoomCells/maxFieldCells, #929 T3
+// Opus round F1); a panic or a
 // silent overflow is not a rejection); origin legality (non-representable
 // Origin, for EVERY family now, not just hex — a fractional origin
 // defeats W2's disjointness promise for ANY grid, not only hex: see
@@ -346,13 +350,18 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		if cellCount > maxRoomCells {
 			return nil, fmt.Errorf("room %q has %d cells (%d x %d), exceeding max room cells %d: %w", r.ID, cellCount, r.Width, r.Height, maxRoomCells, ErrNoField)
 		}
+		// Accumulated, not checked yet — checked once below, against the
+		// TRUE final sum over every room (#929 T3 trailing round N3): a
+		// mid-loop check here would report a partial running total on
+		// whichever room happened to tip it over, undercounting the real
+		// field total whenever rooms remained after it in the list.
 		totalCells += cellCount
-		if totalCells > maxFieldCells {
-			return nil, fmt.Errorf("field has %d total cells across all rooms, exceeding max field cells %d: %w", totalCells, maxFieldCells, ErrNoField)
-		}
 		if math.Abs(r.Origin.X) > maxAnchorCoord || math.Abs(r.Origin.Y) > maxAnchorCoord {
 			return nil, fmt.Errorf("room %q origin (%g,%g) exceeds max anchor coordinate %d: %w", r.ID, r.Origin.X, r.Origin.Y, maxAnchorCoord, ErrNoField)
 		}
+	}
+	if totalCells > maxFieldCells {
+		return nil, fmt.Errorf("field has %d total cells across all rooms, exceeding max field cells %d: %w", totalCells, maxFieldCells, ErrNoField)
 	}
 
 	// Origin legality: every room's Origin must be a representable integer
@@ -872,8 +881,6 @@ func (e *Encounter) View(in *ViewInput) ([]intel.Holding, error) {
 	return holdings, nil
 }
 
-// Members returns the current member roster in stable order.
-
 // buildMemberOutcomes snapshots every current member's placement in
 // sorted-ID order — deterministic output for outcomes and persistence
 // (map iteration here was a latent nondeterminism, T6 review M1).
@@ -899,6 +906,7 @@ func (e *Encounter) buildMemberOutcomes() []MemberOutcome {
 	return outcomes
 }
 
+// Members returns the current member roster in stable order.
 func (e *Encounter) Members() ([]Member, error) {
 	// Sort by ID for stability
 	ids := make([]MemberID, 0, len(e.members))

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -229,14 +229,15 @@ const (
 )
 
 // buildValidRoomGrids rejects room defects before construction (R5
-// atomicity — no observable state until Setup succeeds). The first three
+// atomicity — no observable state until Setup succeeds). The first four
 // defect classes — empty or duplicate room ID, an unrecognized or
-// no-longer-supported grid shape, and non-integral occluder positions in
-// EVERY family, not just hex (#929 T3 Opus round F2 — see
+// no-longer-supported grid shape, non-integral occluder positions in
+// EVERY family, not just hex (#929 T3 Opus round F2), and a duplicate
+// occluder position within one room (#929 hardening round D — see
 // isIntegralPosition; the occluder loop below) — are checked inside ONE
-// per-room loop, not as three separate global passes: for a GIVEN room,
+// per-room loop, not as four separate global passes: for a GIVEN room,
 // that room's own ID defect wins before its shape defect, which wins
-// before its occluder defect, but WHICH ROOM's defect is reported first
+// before its occluder defects, but WHICH ROOM's defect is reported first
 // depends on slice order, not defect-class priority — a field with an
 // unrecognized shape on room A and an empty ID on room B (A listed
 // first) reports A's shape defect, not B's empty ID, even though ID is
@@ -312,21 +313,50 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 
 		// Occluders must be integral in EVERY family, not just hex (#929 T3
 		// Opus round F2 — the identical square-vs-hex asymmetry T1 already
-		// fixed for Origin: see isIntegralPosition's doc comment). Two
-		// reinforcing reasons: (1) AtlasRoom.Occluders must be a subset of
-		// AtlasRoom.Cells (Cells only enumerates INTEGER cells — atlasCells'
-		// doc comment), so a fractional occluder would appear in Occluders
-		// while absent from Cells, breaking the host contract "floor from
-		// Cells, blockage from Occluders"; (2) the occluder entity ID built
-		// below (occluder-<room>-<int(X)>-<int(Y)>) truncates to int — that
-		// ID scheme is only collision-safe while occluders are integral
-		// (two fractional occluders like (1.4,1) and (1.6,1) would both
-		// truncate to the SAME id). isIntegralPosition, not
-		// isIntegralAxialPosition — universal, not hex-only.
+		// fixed for Origin: see isIntegralPosition's doc comment):
+		// AtlasRoom.Occluders must be a subset of AtlasRoom.Cells (Cells
+		// only enumerates INTEGER cells — atlasCells' doc comment), so a
+		// fractional occluder would appear in Occluders while absent from
+		// Cells, breaking the host contract "floor from Cells, blockage
+		// from Occluders". isIntegralPosition, not isIntegralAxialPosition
+		// — universal, not hex-only.
+		//
+		// This is the ONLY reason left, as of #929 hardening round C: an
+		// earlier version of this comment ALSO cited the occluder entity
+		// ID (built below) truncating fractional coordinates to int as a
+		// second, "reinforcing" reason — that claim was itself wrong in a
+		// way integrality could never have fixed: truncation makes
+		// coordinate-based IDs collide only WITHIN one room's own
+		// occluders, but the old ID scheme concatenated the ROOM ID too
+		// (occluder-<room>-<int(X)>-<int(Y)>), and room IDs are arbitrary,
+		// unrestricted strings — "r" with occluder (-5,4) and "r-" with
+		// occluder (5,4) both produced "occluder-r--5-4" regardless of
+		// integrality, a genuine CROSS-room collision on a legal field.
+		// The entity ID is index-based now (room's declaration index,
+		// occluder's index within it — see the occluder-placement loop
+		// below), which can never collide on ANY input, integral or not.
+		// Duplicate occluder positions are a room-list defect too (#929
+		// hardening round D), not something left to spatial's own voice:
+		// before the occluder entity ID went index-based (hardening round
+		// C), a duplicate coordinate happened to collide on the OLD
+		// coordinate-derived ID and got rejected as "entity ... already
+		// indexed" — spatial's vocabulary, not ours, and an accident of
+		// that ID scheme, not a real "no duplicate cells" rule (spatial
+		// freely allows two DIFFERENT entities to share a position). The
+		// index-based ID fixed the cross-room collision but also
+		// silently REMOVED that accidental duplicate-catch — two
+		// occluders at the same cell now place without error. Caught
+		// explicitly here instead: same room-list defect vocabulary
+		// every other room check uses.
+		seenOccluders := make(map[spatial.Position]bool, len(r.Occluders))
 		for _, occ := range r.Occluders {
 			if !isIntegralPosition(occ) {
 				return nil, fmt.Errorf("room %q occluder (%g,%g) is not a representable integral cell: %w", r.ID, occ.X, occ.Y, ErrNoField)
 			}
+			if seenOccluders[occ] {
+				return nil, fmt.Errorf("room %q has duplicate occluder (%g,%g): %w", r.ID, occ.X, occ.Y, ErrNoField)
+			}
+			seenOccluders[occ] = true
 		}
 	}
 
@@ -655,12 +685,13 @@ func validateEndingTriggers(endings []EndingInput, roomGrids map[string]spatial.
 
 // NewEncounter constructs and initializes an encounter from SetupInput.
 // Validation order (first failure wins, R5 atomicity): nil input, no rooms,
-// no endings, empty-or-reserved ending key, empty member ID, duplicate
-// member IDs, a player member carrying a Decider (design law C2 — runs in
+// no endings, empty-or-reserved ending key, duplicate ending key (#929
+// hardening round E), empty member ID, duplicate member IDs, a player
+// member carrying a Decider (design law C2 — runs in
 // the SAME member-ID loop, before room defects; Join's own doc comment
 // lists this check too, at its own seam), room defects (empty/duplicate
-// ID, unrecognized or no-longer-supported grid shape, non-integral
-// occluder position in any family, W1 mixed grid families,
+// ID, unrecognized or no-longer-supported grid shape, non-integral or
+// duplicate occluder position in any family, W1 mixed grid families,
 // non-positive/oversized/over-cell-budget dimensions, an out-of-bounds
 // Origin (maxAnchorCoord) or a non-representable one, W2 overlapping
 // absolute footprints), connection defects (empty/duplicate ID, unknown
@@ -683,11 +714,22 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		return nil, fmt.Errorf("newencounter: %w", ErrNoEnding)
 	}
 
-	// Check ending keys
+	// Check ending keys: empty/reserved, and duplicate (#929 hardening
+	// round E — two endings sharing a key both used to load; End scans
+	// in declaration order, so a reached_position twin declared FIRST
+	// permanently shadowed a same-keyed external ending declared after
+	// it, the exact liveness hole ErrNoEnding's doc comment already
+	// names for zero endings and unreachable triggers, now closed for
+	// this class too).
+	seenEndingKeys := make(map[string]bool, len(in.Endings))
 	for _, ending := range in.Endings {
 		if ending.Key == "" || ending.Key == "abandoned" {
 			return nil, fmt.Errorf("newencounter: %w", ErrNoEnding)
 		}
+		if seenEndingKeys[ending.Key] {
+			return nil, fmt.Errorf("newencounter: duplicate ending %q: %w", ending.Key, ErrNoEnding)
+		}
+		seenEndingKeys[ending.Key] = true
 	}
 
 	// Check member IDs: empty or duplicate; validate deciders
@@ -783,7 +825,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// Create all rooms, reusing each room's already-constructed Grid
 	// (roomGrids, built above) so validation and placement agree exactly.
 	roomMap := make(map[string]*spatial.BasicRoom)
-	for _, ri := range in.Field.Rooms {
+	for roomIdx, ri := range in.Field.Rooms {
 		room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
 			ID:   ri.ID,
 			Type: "room",
@@ -795,9 +837,20 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		}
 		roomMap[ri.ID] = room
 
-		// Add occluders as blocking entities
-		for _, pos := range ri.Occluders {
-			occluder := &occluderEntity{id: fmt.Sprintf("occluder-%s-%d-%d", ri.ID, int(pos.X), int(pos.Y))}
+		// Add occluders as blocking entities. ID is index-based
+		// (room's own declaration index, occluder's index within that
+		// room), not room-ID-plus-coordinate string concatenation (#929
+		// hardening round C): room IDs are arbitrary, unrestricted
+		// strings, so "r" with occluder (-5,4) and "r-" with occluder
+		// (5,4) both produced "occluder-r--5-4" under the old scheme —
+		// a genuine cross-room collision on a W1/W2/W3-legal field,
+		// rejected by the orchestrator naming the wrong room. A pair of
+		// slice indices can never collide regardless of what characters
+		// appear in either ID. This ID is purely an internal spatial
+		// bookkeeping key — never surfaced to any caller — so index
+		// stability across a single construction call is all it needs.
+		for occIdx, pos := range ri.Occluders {
+			occluder := &occluderEntity{id: fmt.Sprintf("occluder-%d-%d", roomIdx, occIdx)}
 			_, err = e.orchestrator.PlaceEntity(&spatial.PlaceEntityInput{
 				RoomID:   spatial.RoomID(ri.ID),
 				Entity:   occluder,
@@ -1050,6 +1103,24 @@ func (e *Encounter) moveMember(member *Member, to spatial.Position) (spatial.Pos
 // Validation order (R5 atomicity): nil input → empty member → closed →
 // not a member → spatial move rejection. On success, refreshes sight for all members,
 // records beat, and evaluates ReachedPosition endings.
+//
+// WARNING — the Locate→Move trap (#929 hardening round B): Move is
+// SAME-ROOM ONLY. It interprets MoveInput.Position as local coordinates
+// within the member's OWN current room — never the room Locate resolved.
+// Composing Locate then Move (a natural host pattern: "where does this
+// absolute position land, then move the member there") silently
+// misplaces the member whenever LocateOutput.Room differs from the
+// member's current room: Move does not know or check where Locate's
+// answer came from, so it applies LocateOutput.Position as-is inside the
+// member's own room instead — e.g. an intended absolute target of (8,2)
+// in the OTHER room actually landing the member at local (2,2) in their
+// OWN room, no error. Callers MUST compare LocateOutput.Room against the
+// member's current room before feeding LocateOutput.Position to Move
+// (or Absolute's input, symmetrically); when they differ, use Traverse
+// instead — it is the cross-room verb. This is a doc-only ruling for
+// v0.3: the real fix is a verb input that carries the intended room and
+// rejects a mismatch, an API change filed as a follow-up rather than
+// made at the end of this wave.
 func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	// Validation order
 	if in == nil {

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -124,8 +124,11 @@ func isIntegralAxialPosition(grid spatial.Grid, pos spatial.Position) bool {
 
 // buildValidRoomGrids rejects room defects before construction (R5
 // atomicity — no observable state until Setup succeeds): empty or
-// duplicate room ID, and an unrecognized grid shape. On success, returns
-// each room's constructed Grid keyed by room ID — reused both for
+// duplicate room ID, an unrecognized or no-longer-supported grid shape,
+// non-integral hex occluder/origin positions, and the field-wide W-laws W1
+// (one grid family per field) and W2 (rooms never overlap in absolute
+// space) — see validateGridFamilies and validateRoomsDisjoint. On success,
+// returns each room's constructed Grid keyed by room ID — reused both for
 // downstream bounds checks (connections, and transitively member
 // placement via spatial's own PlaceEntity) and later in NewEncounter's
 // room-construction loop, so a room's shape is built exactly once and
@@ -146,8 +149,15 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		}
 		seenIDs[r.ID] = true
 
+		// Shape legality: gridless leaves the composition as of v0.3 — the
+		// wire cannot carry a continuous room's absolute projection — so it
+		// is rejected explicitly, distinct from a genuinely unrecognized
+		// value. Square and hex are the only surviving families; W1 below
+		// compares them.
 		switch r.Grid {
-		case spatial.GridShapeSquare, spatial.GridShapeHex, spatial.GridShapeGridless:
+		case spatial.GridShapeSquare, spatial.GridShapeHex:
+		case spatial.GridShapeGridless:
+			return nil, fmt.Errorf("newencounter: room %q declares gridless grid shape, no longer supported: %w", r.ID, ErrNoField)
 		default:
 			return nil, fmt.Errorf("newencounter: room %q has unknown grid shape %d: %w", r.ID, r.Grid, ErrNoField)
 		}
@@ -161,14 +171,150 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 			}
 		}
 	}
+
+	// W1 — one geometry per field: every room in this field must share the
+	// same grid family. Runs only after every room has individually passed
+	// shape legality above, so only square/hex remain here.
+	if err := validateGridFamilies(rooms); err != nil {
+		return nil, err
+	}
+
+	// Origin legality: hex rooms require integral axial origins — same
+	// interim tools/spatial#926 enforcement as occluders above, extended to
+	// Origin (RoomInput.Origin's doc comment). Runs after W1 so a
+	// mixed-family field reports the family mismatch, not an origin defect
+	// on a room whose shape is already wrong.
+	for _, r := range rooms {
+		if !isIntegralAxialPosition(grids[r.ID], r.Origin) {
+			return nil, fmt.Errorf("newencounter: room %q origin (%g,%g) is not an integral axial cell: %w", r.ID, r.Origin.X, r.Origin.Y, ErrNoField)
+		}
+	}
+
+	// W2 — rooms never overlap: distinct rooms' absolute cell sets (local
+	// cell + Origin) must be disjoint. Zero-value origins are legal on
+	// their own; a multi-room field that leaves every Origin defaulted
+	// collides every room at (0,0) and is rejected HERE — there is no
+	// separate "origin required" check (RoomInput.Origin's doc comment).
+	if err := validateRoomsDisjoint(rooms); err != nil {
+		return nil, err
+	}
+
 	return grids, nil
+}
+
+// gridShapeName renders a GridShape for W1's mixed-family defect message.
+// Called only on values that have already passed shape legality above, so
+// square and hex are the only cases exercised in practice; the default
+// exists so an unvalidated caller still gets a readable message instead of
+// a bare integer.
+func gridShapeName(shape spatial.GridShape) string {
+	switch shape {
+	case spatial.GridShapeSquare:
+		return "square"
+	case spatial.GridShapeHex:
+		return "hex"
+	default:
+		return fmt.Sprintf("shape(%d)", shape)
+	}
+}
+
+// validateGridFamilies rejects a field whose rooms declare more than one
+// grid family (W1 — one geometry per field). Local→absolute is element-wise
+// addition (RoomInput.Origin's doc comment): a hex room's axial Q/R and a
+// square room's Cartesian X/Y cannot be added together and mean anything, so
+// a mixed field has no coherent absolute space at all — this must reject
+// before W2/W3 ever try to build one. Compares ALL pairs semantically, not
+// just adjacent-in-slice: a three-room field ordered square, hex, square
+// must still be caught even though both adjacent pairs (0,1) and (1,2)
+// already mismatch on their own — see #929 T1 mutation notes for why an
+// adjacent-only comparison cannot be distinguished from this by any fixture
+// once only two families survive shape legality (equality over a two-value
+// domain is transitive), and why full pairwise comparison is still the
+// correct, future-proof implementation.
+func validateGridFamilies(rooms []RoomInput) error {
+	for i := 0; i < len(rooms); i++ {
+		for j := i + 1; j < len(rooms); j++ {
+			if rooms[i].Grid != rooms[j].Grid {
+				return fmt.Errorf("newencounter: room %q (%s) and room %q (%s) declare different grid families: %w",
+					rooms[i].ID, gridShapeName(rooms[i].Grid), rooms[j].ID, gridShapeName(rooms[j].Grid), ErrNoField)
+			}
+		}
+	}
+	return nil
+}
+
+// roomLocalCells enumerates a room's local, integral cell coordinates — W2's
+// building block for each room's absolute footprint (see
+// validateRoomsDisjoint). Square cells fill the [0,Width) x [0,Height)
+// rectangle SquareGrid.IsValidPosition itself checks. Hex cells fill
+// AxialHexGrid's origin-centered span (tools/spatial/hex_grid.go,
+// AxialHexGridConfig's doc comment): Q integral in [-Width/2, Width/2), R
+// integral in [-Height/2, Height/2) — the SAME half-width/half-height
+// arithmetic AxialHexGrid.IsValidPosition itself uses, not guessed. Callers
+// have already rejected gridless (shape legality) and mixed families (W1),
+// so shape here is always square or hex.
+func roomLocalCells(shape spatial.GridShape, width, height int) []spatial.Position {
+	cells := make([]spatial.Position, 0, width*height)
+	if shape == spatial.GridShapeHex {
+		halfW := float64(width) / 2
+		halfH := float64(height) / 2
+		qMin := int(math.Ceil(-halfW))
+		rMin := int(math.Ceil(-halfH))
+		for q := qMin; float64(q) < halfW; q++ {
+			for r := rMin; float64(r) < halfH; r++ {
+				cells = append(cells, spatial.Position{X: float64(q), Y: float64(r)})
+			}
+		}
+		return cells
+	}
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			cells = append(cells, spatial.Position{X: float64(x), Y: float64(y)})
+		}
+	}
+	return cells
+}
+
+// validateRoomsDisjoint rejects a field whose rooms' absolute footprints
+// share a cell (W2 — rooms never overlap): absolute = local cell + Origin,
+// element-wise (RoomInput.Origin's doc comment). Touching — adjacent cells,
+// no shared cell — is legal; this rejects ONLY a shared cell. For each pair,
+// iterates room j's local cells in their generation order (deterministic —
+// see roomLocalCells) against room i's prebuilt absolute set, so the
+// reported witness is the first shared cell in that fixed order, not
+// map-iteration order.
+func validateRoomsDisjoint(rooms []RoomInput) error {
+	localCells := make([][]spatial.Position, len(rooms))
+	absSets := make([]map[spatial.Position]bool, len(rooms))
+	for i, r := range rooms {
+		localCells[i] = roomLocalCells(r.Grid, r.Width, r.Height)
+		set := make(map[spatial.Position]bool, len(localCells[i]))
+		for _, cell := range localCells[i] {
+			set[cell.Add(r.Origin)] = true
+		}
+		absSets[i] = set
+	}
+	for i := 0; i < len(rooms); i++ {
+		for j := i + 1; j < len(rooms); j++ {
+			for _, cell := range localCells[j] {
+				abs := cell.Add(rooms[j].Origin)
+				if absSets[i][abs] {
+					return fmt.Errorf("newencounter: room %q and room %q overlap at absolute cell %s: %w",
+						rooms[i].ID, rooms[j].ID, abs, ErrNoField)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // validateConnectionInputs rejects connection defects before construction
 // (R5 atomicity — no observable state until Setup succeeds): empty or
-// duplicate ID, an unknown or self-referencing room, and an endpoint outside
+// duplicate ID, an unknown or self-referencing room, an endpoint outside
 // its room's bounds (per that room's own constructed Grid, from roomGrids —
-// see buildValidRoomGrids) or on an occluder position.
+// see buildValidRoomGrids) or on an occluder position, and (W3) endpoints
+// that do not kiss — are not adjacent absolute cells once each is anchored
+// to its own room's Origin.
 func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Grid, connections []ConnectionInput) error {
 	roomsByID := make(map[string]RoomInput, len(rooms))
 	for _, r := range rooms {
@@ -220,6 +366,21 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 				return fmt.Errorf("newencounter: connection %q to-position on occluder: %w", c.ID, ErrBadConnection)
 			}
 		}
+
+		// W3 — doorways kiss: once each endpoint is anchored to its own
+		// room's Origin, the two absolute cells must be adjacent — cube
+		// distance 1 for hex, Chebyshev distance 1 for square. W1
+		// guarantees both rooms in a valid field share one grid family, so
+		// either room's own Grid.Distance already implements the correct
+		// formula (AxialHexGrid: cube distance; SquareGrid: Chebyshev) —
+		// using the from-room's is an arbitrary but consistent choice, not
+		// a hand-rolled formula that could silently diverge from spatial's.
+		fromAbs := c.FromPosition.Add(fromRoom.Origin)
+		toAbs := c.ToPosition.Add(toRoom.Origin)
+		if dist := roomGrids[c.From].Distance(fromAbs, toAbs); dist != 1 {
+			return fmt.Errorf("newencounter: connection %q endpoints %s and %s are not adjacent (distance %g): %w",
+				c.ID, fromAbs, toAbs, dist, ErrBadConnection)
+		}
 	}
 	return nil
 }
@@ -227,9 +388,11 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 // NewEncounter constructs and initializes an encounter from SetupInput.
 // Validation order (first failure wins, R5 atomicity): nil input, no rooms,
 // no endings, reserved ending key, empty member ID, duplicate member IDs,
-// room defects (empty/duplicate ID, unrecognized grid shape), connection
-// defects (empty/duplicate ID, unknown room, self-connection, endpoint out
-// of bounds or on an occluder), spatial placement errors.
+// room defects (empty/duplicate ID, unrecognized or no-longer-supported
+// grid shape, W1 mixed grid families, non-integral hex origin, W2
+// overlapping absolute footprints), connection defects (empty/duplicate ID,
+// unknown room, self-connection, endpoint out of bounds or on an occluder,
+// W3 endpoints not adjacent once anchored), spatial placement errors.
 func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// Validation order: nil, no rooms, no endings, reserved ending, empty ID, duplicates
 	if in == nil {

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -128,20 +128,45 @@ func isIntegralAxialPosition(grid spatial.Grid, pos spatial.Position) bool {
 	return pos.X == math.Trunc(pos.X) && pos.Y == math.Trunc(pos.Y)
 }
 
-// isIntegralPosition reports whether pos has integral X and Y, with no
-// grid-shape exception — the universal origin-legality check (#929 T1
-// Opus round finding): unlike isIntegralAxialPosition, a fractional
-// SQUARE origin is also a defect, not just a fractional hex one. W2's
-// disjointness promise (RoomInput.Origin's doc comment) is only sound
-// over an INTEGER cell lattice: two 5x5 square rooms anchored at (0,0)
-// and (0.5,0.5) have disjoint integer cell sets (W2 as enumerated would
-// accept them) while their continuous footprints interpenetrate roughly
-// 81% of each room's area, and a Chebyshev-0 "doorway" (a connection
-// whose two endpoints land on literally the same fractional point) would
-// still measure as adjacent. Every room's Origin must land on a whole
-// coordinate, for every family, before W2 ever runs.
+// isIntegralPosition reports whether pos has X and Y that are each a
+// REPRESENTABLE integer, with no grid-shape exception — the universal
+// origin-legality check (#929 T1 Opus round finding): unlike
+// isIntegralAxialPosition, a fractional SQUARE origin is also a defect,
+// not just a fractional hex one. W2's disjointness promise (RoomInput.Origin's
+// doc comment) is only sound over an INTEGER cell lattice: two 5x5 square
+// rooms anchored at (0,0) and (0.5,0.5) have disjoint integer cell sets
+// (W2 as enumerated would accept them) while their continuous footprints
+// interpenetrate roughly 81% of each room's area, and a Chebyshev-0
+// "doorway" (a connection whose two endpoints land on literally the same
+// fractional point) would still measure as adjacent.
+//
+// "Representable" is doing real work here, not just "integral" (#929 T1
+// SECOND Opus round finding): pos.X == math.Trunc(pos.X) alone passes for
+// +Inf/-Inf (Trunc of infinity is infinity) and for any float64 whose
+// magnitude exceeds int64's range, where roomAbsoluteBounds' int()
+// conversion is Go-spec implementation-defined and silently produces
+// garbage — e.g. two 5x5 rooms anchored at X=1e19 and X=2e19 both passed
+// the OLD check (both "integral" by Trunc), then both truncated to the
+// SAME implementation-defined int64 value, producing a false W2 overlap
+// verdict through the public API for rooms that were never near each
+// other, and +Inf was accepted as an anchor outright. Rejecting ±Inf/NaN
+// explicitly and requiring an EXACT round trip through int() and back
+// closes both holes — see isRepresentableInteger.
 func isIntegralPosition(pos spatial.Position) bool {
-	return pos.X == math.Trunc(pos.X) && pos.Y == math.Trunc(pos.Y)
+	return isRepresentableInteger(pos.X) && isRepresentableInteger(pos.Y)
+}
+
+// isRepresentableInteger reports whether v is finite, not NaN, and an
+// EXACT integer once round-tripped through int() and back — see
+// isIntegralPosition for why "integral by Trunc" alone is not enough.
+// float64(int(v)) == v also subsumes the plain fractional check: Go's
+// float-to-int conversion truncates toward zero, so a fractional v never
+// round-trips either, without a separate math.Trunc comparison.
+func isRepresentableInteger(v float64) bool {
+	if math.IsInf(v, 0) || math.IsNaN(v) {
+		return false
+	}
+	return float64(int(v)) == v
 }
 
 // buildValidRoomGrids rejects room defects before construction (R5
@@ -230,7 +255,7 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 	// origin defect on a room whose shape or size is already wrong.
 	for _, r := range rooms {
 		if !isIntegralPosition(r.Origin) {
-			return nil, fmt.Errorf("newencounter: room %q origin (%g,%g) is not an integral cell: %w", r.ID, r.Origin.X, r.Origin.Y, ErrNoField)
+			return nil, fmt.Errorf("newencounter: room %q origin (%g,%g) is not a representable integral cell: %w", r.ID, r.Origin.X, r.Origin.Y, ErrNoField)
 		}
 	}
 
@@ -428,13 +453,20 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 		// a hand-rolled formula that could silently diverge from spatial's.
 		fromAbs := c.FromPosition.Add(fromRoom.Origin)
 		toAbs := c.ToPosition.Add(toRoom.Origin)
-		// Strict != 1, not > 1: distance 0 (coincident endpoints) is
-		// unreachable once origin legality requires integral origins for
-		// every family and W2 requires disjoint room footprints (a shared
-		// or coincident absolute cell is exactly what W2 already rejects
-		// before this ever runs) — kept strict anyway as defense-in-depth,
-		// deliberately UNPINNED by a dedicated test, since no fixture can
-		// falsify it (#929 T1 Opus round).
+		// Strict != 1, not > 1: origin legality's integrality requirement
+		// (every family) only constrains ORIGINS, not endpoints — square
+		// endpoints stay fractional-tolerant by design (RoomInput.Grid's
+		// doc comment), so a fractional FromPosition/ToPosition can land
+		// LESS than 1 unit from another room's boundary even with fully
+		// integral, disjoint room origins: e.g. a 3x3 room at Origin (0,0)
+		// and a 3x3 room at Origin (3,0), FromPosition (2.5,1) (absolute
+		// (2.5,1)), ToPosition (0,1) (absolute (3,1)) — Chebyshev distance
+		// 0.5. A `> 1` comparison would wrongly ACCEPT that as "close
+		// enough"; `!= 1` correctly rejects it. This IS pinned — see
+		// TestSetupAnchoringFractionalSquareEndpointSubUnitDistance (#929
+		// T1 second Opus round: an earlier version of this comment
+		// wrongly claimed sub-1 distances were unfalsifiable and left the
+		// strict form unpinned).
 		if dist := roomGrids[c.From].Distance(fromAbs, toAbs); dist != 1 {
 			return fmt.Errorf("newencounter: connection %q endpoints %s and %s are not adjacent (distance %g): %w",
 				c.ID, fromAbs, toAbs, dist, ErrBadConnection)

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -75,10 +75,16 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 }
 
 // buildRoomGrid constructs the spatial Grid for a room's declared shape.
-// Called only after validation has confirmed Grid is one of the three known
-// GridShape values; the switch's default (square) is therefore unreachable
-// in practice and exists only so an unvalidated caller degrades gracefully
-// rather than panicking.
+// From Setup (buildValidRoomGrids), only GridShapeSquare and GridShapeHex
+// ever reach here — shape legality rejects gridless and any unrecognized
+// value before this is called, so the GridShapeGridless case and the
+// switch's default (square, for an unrecognized value) are both
+// unreachable from that path. Neither is dead code overall, though:
+// LoadEncounter (data.go) still calls this directly and still routes a
+// stored "gridless" grid string through the GridShapeGridless case — T2
+// removes that branch once Load-side rejection of gridless lands alongside
+// Origin persistence. Until then this stays a three-shape switch, one
+// path reachable only from Load.
 //
 // Hex rooms build spatial.AxialHexGrid, NOT spatial.HexGrid: the wire (and
 // Platform's pathing) speaks cube coordinates natively, and axial (Q, R,
@@ -122,21 +128,40 @@ func isIntegralAxialPosition(grid spatial.Grid, pos spatial.Position) bool {
 	return pos.X == math.Trunc(pos.X) && pos.Y == math.Trunc(pos.Y)
 }
 
+// isIntegralPosition reports whether pos has integral X and Y, with no
+// grid-shape exception — the universal origin-legality check (#929 T1
+// Opus round finding): unlike isIntegralAxialPosition, a fractional
+// SQUARE origin is also a defect, not just a fractional hex one. W2's
+// disjointness promise (RoomInput.Origin's doc comment) is only sound
+// over an INTEGER cell lattice: two 5x5 square rooms anchored at (0,0)
+// and (0.5,0.5) have disjoint integer cell sets (W2 as enumerated would
+// accept them) while their continuous footprints interpenetrate roughly
+// 81% of each room's area, and a Chebyshev-0 "doorway" (a connection
+// whose two endpoints land on literally the same fractional point) would
+// still measure as adjacent. Every room's Origin must land on a whole
+// coordinate, for every family, before W2 ever runs.
+func isIntegralPosition(pos spatial.Position) bool {
+	return pos.X == math.Trunc(pos.X) && pos.Y == math.Trunc(pos.Y)
+}
+
 // buildValidRoomGrids rejects room defects before construction (R5
-// atomicity — no observable state until Setup succeeds): empty or
-// duplicate room ID, an unrecognized or no-longer-supported grid shape,
-// non-integral hex occluder/origin positions, and the field-wide W-laws W1
-// (one grid family per field) and W2 (rooms never overlap in absolute
-// space) — see validateGridFamilies and validateRoomsDisjoint. On success,
-// returns each room's constructed Grid keyed by room ID — reused both for
-// downstream bounds checks (connections, and transitively member
-// placement via spatial's own PlaceEntity) and later in NewEncounter's
-// room-construction loop, so a room's shape is built exactly once and
-// every consumer asks the SAME grid. A hardcoded rectangle bounds check
-// would silently diverge from GridlessRoom's inclusive upper bound
-// (tools/spatial/gridless.go: IsValidPosition uses x <= Width, not
-// x < Width like Square/Hex). Reuses ErrNoField — a malformed room list
-// is as unusable as an empty one.
+// atomicity — no observable state until Setup succeeds), in this order per
+// defect class (docs/ideas/encounter-anchoring/design.md's Validation
+// section, Opus-round amendment): empty or duplicate room ID; an
+// unrecognized or no-longer-supported grid shape; non-integral hex
+// occluder positions; W1 (one grid family per field — validateGridFamilies);
+// non-positive Width/Height (room legality — a negative dimension used to
+// panic NewEncounter via a negative-capacity make() in the since-deleted
+// enumeration path; a panic is not a rejection); non-integral Origin, for
+// EVERY family now, not just hex (origin legality — a fractional origin
+// defeats W2's disjointness promise for ANY grid, not only hex: see
+// isIntegralPosition); and W2 (rooms never overlap in absolute space —
+// validateRoomsDisjoint). On success, returns each room's constructed Grid
+// keyed by room ID — reused both for downstream bounds checks (connections,
+// and transitively member placement via spatial's own PlaceEntity) and
+// later in NewEncounter's room-construction loop, so a room's shape is
+// built exactly once and every consumer asks the SAME grid. Reuses
+// ErrNoField — a malformed room list is as unusable as an empty one.
 func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 	seenIDs := make(map[string]bool, len(rooms))
 	grids := make(map[string]spatial.Grid, len(rooms))
@@ -153,7 +178,11 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		// wire cannot carry a continuous room's absolute projection — so it
 		// is rejected explicitly, distinct from a genuinely unrecognized
 		// value. Square and hex are the only surviving families; W1 below
-		// compares them.
+		// compares them. This branch is unreachable from Setup as of this
+		// wave (every room here has already survived it), but LoadEncounter
+		// (data.go) still routes a stored "gridless" grid string through
+		// buildRoomGrid's own gridless case — Load-side rejection of it is
+		// T2's job, alongside persisting Origin.
 		switch r.Grid {
 		case spatial.GridShapeSquare, spatial.GridShapeHex:
 		case spatial.GridShapeGridless:
@@ -179,14 +208,29 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		return nil, err
 	}
 
-	// Origin legality: hex rooms require integral axial origins — same
-	// interim tools/spatial#926 enforcement as occluders above, extended to
-	// Origin (RoomInput.Origin's doc comment). Runs after W1 so a
-	// mixed-family field reports the family mismatch, not an origin defect
-	// on a room whose shape is already wrong.
+	// Room legality: non-positive Width or Height is a defect, not a
+	// silent no-op (#929 T1 Opus round: Width:-1 previously reached
+	// buildRoomGrid and, downstream, a negative-capacity make() in the
+	// enumeration W2 used before this same round replaced it with interval
+	// math — a panic, not a rejection, either way an unvalidated dimension
+	// has no business reaching construction). Runs after W1 (a mixed-family
+	// field with a bad dimension reports the family mismatch first) and
+	// before origin legality/W2 (both need real dimensions to reason about).
 	for _, r := range rooms {
-		if !isIntegralAxialPosition(grids[r.ID], r.Origin) {
-			return nil, fmt.Errorf("newencounter: room %q origin (%g,%g) is not an integral axial cell: %w", r.ID, r.Origin.X, r.Origin.Y, ErrNoField)
+		if r.Width <= 0 || r.Height <= 0 {
+			return nil, fmt.Errorf("newencounter: room %q has non-positive dimensions (%d x %d): %w", r.ID, r.Width, r.Height, ErrNoField)
+		}
+	}
+
+	// Origin legality: every room's Origin must be integral, for EVERY
+	// grid family (#929 T1 Opus round: originally hex-only, extended
+	// here — see isIntegralPosition for why a fractional SQUARE origin is
+	// equally a defect). Runs after W1 and room legality so a mixed-family
+	// or malformed-dimension field reports THAT defect first, not an
+	// origin defect on a room whose shape or size is already wrong.
+	for _, r := range rooms {
+		if !isIntegralPosition(r.Origin) {
+			return nil, fmt.Errorf("newencounter: room %q origin (%g,%g) is not an integral cell: %w", r.ID, r.Origin.X, r.Origin.Y, ErrNoField)
 		}
 	}
 
@@ -243,65 +287,72 @@ func validateGridFamilies(rooms []RoomInput) error {
 	return nil
 }
 
-// roomLocalCells enumerates a room's local, integral cell coordinates — W2's
-// building block for each room's absolute footprint (see
-// validateRoomsDisjoint). Square cells fill the [0,Width) x [0,Height)
-// rectangle SquareGrid.IsValidPosition itself checks. Hex cells fill
-// AxialHexGrid's origin-centered span (tools/spatial/hex_grid.go,
-// AxialHexGridConfig's doc comment): Q integral in [-Width/2, Width/2), R
-// integral in [-Height/2, Height/2) — the SAME half-width/half-height
-// arithmetic AxialHexGrid.IsValidPosition itself uses, not guessed. Callers
-// have already rejected gridless (shape legality) and mixed families (W1),
-// so shape here is always square or hex.
-func roomLocalCells(shape spatial.GridShape, width, height int) []spatial.Position {
-	cells := make([]spatial.Position, 0, width*height)
+// axisBounds returns a room's LOCAL integer [min,max] cell bounds along one
+// axis, for a dimension `dim` (Width for Q/X, Height for R/Y) — W2's
+// building block (see roomAbsoluteBounds), replacing an earlier
+// enumeration-based approach (#929 T1 Opus round: enumerating a 1000x1000
+// room's ~1M cells to check overlap measured 1.35s/205MB per NewEncounter
+// call, and a negative dimension's negative-capacity make() there is what
+// used to panic — see buildValidRoomGrids' room-legality check). Square's
+// bound is the one-sided [0,dim) rectangle SquareGrid.IsValidPosition
+// itself checks, i.e. integer max = dim-1. Hex's bound is AxialHexGrid's
+// origin-centered half-open span (tools/spatial/hex_grid.go,
+// AxialHexGridConfig's doc comment) reduced to its integer min/max: half =
+// dim/2; min = ceil(-half); max = ceil(half)-1. Both formulas are the SAME
+// half-width/half-height arithmetic AxialHexGrid.IsValidPosition itself
+// uses, not guessed, and both hold for dim odd or even (verified against
+// roomLocalCells' enumeration, since deleted, before this replaced it —
+// e.g. dim=3: half=1.5, min=-1, max=1, three integers; dim=4: half=2.0,
+// min=-2, max=1, four integers).
+func axisBounds(shape spatial.GridShape, dim int) (min, max int) {
 	if shape == spatial.GridShapeHex {
-		halfW := float64(width) / 2
-		halfH := float64(height) / 2
-		qMin := int(math.Ceil(-halfW))
-		rMin := int(math.Ceil(-halfH))
-		for q := qMin; float64(q) < halfW; q++ {
-			for r := rMin; float64(r) < halfH; r++ {
-				cells = append(cells, spatial.Position{X: float64(q), Y: float64(r)})
-			}
-		}
-		return cells
+		half := float64(dim) / 2
+		return int(math.Ceil(-half)), int(math.Ceil(half)) - 1
 	}
-	for x := 0; x < width; x++ {
-		for y := 0; y < height; y++ {
-			cells = append(cells, spatial.Position{X: float64(x), Y: float64(y)})
-		}
-	}
-	return cells
+	return 0, dim - 1
+}
+
+// roomAbsoluteBounds returns a room's absolute-space bounding box: its
+// local integer cell bounds (axisBounds), offset by Origin, per axis.
+// Requires Origin to already be integral (buildValidRoomGrids' origin
+// legality runs before W2) — the int() truncation here is exact, not
+// lossy, for every Origin this is ever called with.
+func roomAbsoluteBounds(r RoomInput) (qMin, qMax, rMin, rMax int) {
+	localQMin, localQMax := axisBounds(r.Grid, r.Width)
+	localRMin, localRMax := axisBounds(r.Grid, r.Height)
+	oq, or := int(r.Origin.X), int(r.Origin.Y)
+	return localQMin + oq, localQMax + oq, localRMin + or, localRMax + or
 }
 
 // validateRoomsDisjoint rejects a field whose rooms' absolute footprints
 // share a cell (W2 — rooms never overlap): absolute = local cell + Origin,
 // element-wise (RoomInput.Origin's doc comment). Touching — adjacent cells,
-// no shared cell — is legal; this rejects ONLY a shared cell. For each pair,
-// iterates room j's local cells in their generation order (deterministic —
-// see roomLocalCells) against room i's prebuilt absolute set, so the
-// reported witness is the first shared cell in that fixed order, not
-// map-iteration order.
+// no shared cell — is legal; this rejects ONLY a shared cell. Both grid
+// families are solid rectangles in their OWN coordinate system (a hex
+// room's Q,R span is a rhombus embedded in 2D axial space, but each axis
+// is independently an interval, exactly like square's X,Y), so two rooms'
+// footprints overlap iff BOTH axes' intervals intersect — no enumeration:
+// O(1) per room pair, not O(cells). The witness cell, when rejecting, is
+// the component-wise max of the two rooms' interval mins — the
+// lexicographically-first cell both footprints necessarily contain,
+// deterministic regardless of iteration order.
 func validateRoomsDisjoint(rooms []RoomInput) error {
-	localCells := make([][]spatial.Position, len(rooms))
-	absSets := make([]map[spatial.Position]bool, len(rooms))
+	type bounds struct{ qMin, qMax, rMin, rMax int }
+	bs := make([]bounds, len(rooms))
 	for i, r := range rooms {
-		localCells[i] = roomLocalCells(r.Grid, r.Width, r.Height)
-		set := make(map[spatial.Position]bool, len(localCells[i]))
-		for _, cell := range localCells[i] {
-			set[cell.Add(r.Origin)] = true
-		}
-		absSets[i] = set
+		bs[i].qMin, bs[i].qMax, bs[i].rMin, bs[i].rMax = roomAbsoluteBounds(r)
 	}
 	for i := 0; i < len(rooms); i++ {
 		for j := i + 1; j < len(rooms); j++ {
-			for _, cell := range localCells[j] {
-				abs := cell.Add(rooms[j].Origin)
-				if absSets[i][abs] {
-					return fmt.Errorf("newencounter: room %q and room %q overlap at absolute cell %s: %w",
-						rooms[i].ID, rooms[j].ID, abs, ErrNoField)
+			qOverlap := bs[i].qMin <= bs[j].qMax && bs[j].qMin <= bs[i].qMax
+			rOverlap := bs[i].rMin <= bs[j].rMax && bs[j].rMin <= bs[i].rMax
+			if qOverlap && rOverlap {
+				witness := spatial.Position{
+					X: float64(max(bs[i].qMin, bs[j].qMin)),
+					Y: float64(max(bs[i].rMin, bs[j].rMin)),
 				}
+				return fmt.Errorf("newencounter: room %q and room %q overlap at absolute cell %s: %w",
+					rooms[i].ID, rooms[j].ID, witness, ErrNoField)
 			}
 		}
 	}
@@ -377,6 +428,13 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 		// a hand-rolled formula that could silently diverge from spatial's.
 		fromAbs := c.FromPosition.Add(fromRoom.Origin)
 		toAbs := c.ToPosition.Add(toRoom.Origin)
+		// Strict != 1, not > 1: distance 0 (coincident endpoints) is
+		// unreachable once origin legality requires integral origins for
+		// every family and W2 requires disjoint room footprints (a shared
+		// or coincident absolute cell is exactly what W2 already rejects
+		// before this ever runs) — kept strict anyway as defense-in-depth,
+		// deliberately UNPINNED by a dedicated test, since no fixture can
+		// falsify it (#929 T1 Opus round).
 		if dist := roomGrids[c.From].Distance(fromAbs, toAbs); dist != 1 {
 			return fmt.Errorf("newencounter: connection %q endpoints %s and %s are not adjacent (distance %g): %w",
 				c.ID, fromAbs, toAbs, dist, ErrBadConnection)

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -191,22 +191,50 @@ const (
 	maxAnchorCoord = 1 << 30
 )
 
+// maxRoomCells bounds a single room's total cell count (Width*Height —
+// EQUAL for both grid families: axisBounds' span always equals the
+// dimension itself, every parity, hex included — see atlasCells' doc
+// comment), and maxFieldCells bounds the SUM of every room's cell count
+// across one field. ALLOCATION-SAFETY bounds for Atlas, distinct in
+// PURPOSE from maxRoomSpan/maxAnchorCoord above (coordinate-OVERFLOW
+// defense): Atlas materializes every cell of every room by contract
+// (Atlas's doc comment), via a make() sized exactly Width*Height per
+// room. Two individually-legal integers under maxRoomSpan (up to 1<<30
+// each) multiply to up to 1<<60 — the amplification is exactly what
+// makes a SEPARATE bound necessary: a 2^30 x 2^30 room passes
+// maxRoomSpan's per-axis check cleanly but PANICS atlasCells' make()
+// (a 2^60-capacity argument), reachable from a 394-byte persisted blob —
+// two integers, no bulk data (#929 T3 Opus round F1). Enforced HERE, in
+// room legality — the shared path both NewEncounter and LoadEncounter
+// route through — not inside Atlas itself: see the comment at
+// atlasCells' allocation site (atlas.go) for why no redundant check
+// lives there.
+const (
+	maxRoomCells  = 1 << 20
+	maxFieldCells = 1 << 22
+)
+
 // buildValidRoomGrids rejects room defects before construction (R5
 // atomicity — no observable state until Setup succeeds), in this order per
 // defect class (docs/ideas/encounter-anchoring/design.md's Validation
 // section, Opus-round amendment): empty or duplicate room ID; an
-// unrecognized or no-longer-supported grid shape; non-integral hex
-// occluder positions; W1 (one grid family per field — validateGridFamilies);
-// room legality (non-positive OR oversized Width/Height, AND an
-// out-of-bounds Origin — a negative dimension used to panic NewEncounter
-// via a negative-capacity make() in the since-deleted enumeration path,
-// and an unbounded dimension or origin can overflow int64 arithmetic
-// downstream, see maxRoomSpan/maxAnchorCoord — a panic or a silent
-// overflow is not a rejection); origin legality (non-representable Origin,
-// for EVERY family now, not just hex — a fractional origin defeats W2's
-// disjointness promise for ANY grid, not only hex: see isIntegralPosition);
-// and W2 (rooms never overlap in absolute space — validateRoomsDisjoint). On
-// success, returns each
+// unrecognized or no-longer-supported grid shape; non-integral occluder
+// positions in EVERY family, not just hex (#929 T3 Opus round F2 — see
+// isIntegralPosition; the occluder loop below); W1 (one grid family per
+// field — validateGridFamilies); room legality (non-positive OR oversized
+// Width/Height, a cell count exceeding maxRoomCells or pushing the
+// field's running total past maxFieldCells, AND an out-of-bounds Origin —
+// a negative dimension used to panic NewEncounter via a negative-capacity
+// make() in the since-deleted enumeration path, an unbounded dimension or
+// origin can overflow int64 arithmetic downstream (maxRoomSpan/
+// maxAnchorCoord), and an oversized CELL COUNT — legal per-axis but
+// catastrophic multiplied — panics Atlas's own allocation instead
+// (maxRoomCells/maxFieldCells, #929 T3 Opus round F1); a panic or a
+// silent overflow is not a rejection); origin legality (non-representable
+// Origin, for EVERY family now, not just hex — a fractional origin
+// defeats W2's disjointness promise for ANY grid, not only hex: see
+// isIntegralPosition); and W2 (rooms never overlap in absolute space —
+// validateRoomsDisjoint). On success, returns each
 // room's constructed Grid keyed by room ID — reused both for downstream
 // bounds checks (connections, and transitively member placement via
 // spatial's own PlaceEntity) and later in NewEncounter's room-construction
@@ -255,11 +283,22 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		}
 		grids[r.ID] = buildRoomGrid(r.Grid, r.Width, r.Height)
 
-		// Hex rooms require integral axial occluder positions (interim
-		// tools/spatial#926 enforcement — see isIntegralAxialPosition).
+		// Occluders must be integral in EVERY family, not just hex (#929 T3
+		// Opus round F2 — the identical square-vs-hex asymmetry T1 already
+		// fixed for Origin: see isIntegralPosition's doc comment). Two
+		// reinforcing reasons: (1) Atlas.Occluders must be a subset of
+		// Atlas.Cells (Cells only enumerates INTEGER cells — atlasCells'
+		// doc comment), so a fractional occluder would appear in Occluders
+		// while absent from Cells, breaking the host contract "floor from
+		// Cells, blockage from Occluders"; (2) the occluder entity ID built
+		// below (occluder-<room>-<int(X)>-<int(Y)>) truncates to int — that
+		// ID scheme is only collision-safe while occluders are integral
+		// (two fractional occluders like (1.4,1) and (1.6,1) would both
+		// truncate to the SAME id). isIntegralPosition, not
+		// isIntegralAxialPosition — universal, not hex-only.
 		for _, occ := range r.Occluders {
-			if !isIntegralAxialPosition(grids[r.ID], occ) {
-				return nil, fmt.Errorf("room %q occluder (%g,%g) is not an integral axial cell: %w", r.ID, occ.X, occ.Y, ErrNoField)
+			if !isIntegralPosition(occ) {
+				return nil, fmt.Errorf("room %q occluder (%g,%g) is not a representable integral cell: %w", r.ID, occ.X, occ.Y, ErrNoField)
 			}
 		}
 	}
@@ -291,12 +330,25 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 	// Runs after W1 (a mixed-family field with a bad dimension/origin
 	// reports the family mismatch first) and before origin legality/W2
 	// (both need real, bounded dimensions and origins to reason about).
+	var totalCells int64
 	for _, r := range rooms {
 		if r.Width <= 0 || r.Height <= 0 {
 			return nil, fmt.Errorf("room %q has non-positive dimensions (%d x %d): %w", r.ID, r.Width, r.Height, ErrNoField)
 		}
 		if r.Width > maxRoomSpan || r.Height > maxRoomSpan {
 			return nil, fmt.Errorf("room %q dimensions (%d x %d) exceed max room span %d: %w", r.ID, r.Width, r.Height, maxRoomSpan, ErrNoField)
+		}
+		// Allocation safety (#929 T3 Opus round F1), separate from the span
+		// check above: Width and Height can each be legal under
+		// maxRoomSpan yet multiply to a cell count Atlas cannot safely
+		// allocate — see maxRoomCells/maxFieldCells's doc comment.
+		cellCount := int64(r.Width) * int64(r.Height)
+		if cellCount > maxRoomCells {
+			return nil, fmt.Errorf("room %q has %d cells (%d x %d), exceeding max room cells %d: %w", r.ID, cellCount, r.Width, r.Height, maxRoomCells, ErrNoField)
+		}
+		totalCells += cellCount
+		if totalCells > maxFieldCells {
+			return nil, fmt.Errorf("field has %d total cells across all rooms, exceeding max field cells %d: %w", totalCells, maxFieldCells, ErrNoField)
 		}
 		if math.Abs(r.Origin.X) > maxAnchorCoord || math.Abs(r.Origin.Y) > maxAnchorCoord {
 			return nil, fmt.Errorf("room %q origin (%g,%g) exceeds max anchor coordinate %d: %w", r.ID, r.Origin.X, r.Origin.Y, maxAnchorCoord, ErrNoField)
@@ -536,14 +588,50 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 	return nil
 }
 
+// validateEndingTriggers rejects a TriggerReachedPosition ending whose Room
+// or Position is malformed: an ending that names no real room, or a
+// position that can never be reached, can never fire — "an encounter that
+// cannot end is a liveness hole" (ErrNoEnding's doc comment) applies to a
+// single dead ending exactly as it does to zero endings (#929 T3 Opus round
+// F5). TriggerExternal endings carry no spatial data and are skipped.
+//
+// Checked identically at Setup and Load — the SAME shared-validator
+// pattern established for room-list/connection validation (buildValidRoomGrids'
+// doc comment): unknown room, out-of-bounds position, or (hex only)
+// non-integral position all reject with ErrNoEnding, no verb prefix — each
+// caller wraps its own at the call site.
+func validateEndingTriggers(endings []EndingInput, roomGrids map[string]spatial.Grid) error {
+	for _, ei := range endings {
+		trigger, ok := ei.Trigger.(TriggerReachedPosition)
+		if !ok {
+			continue
+		}
+		grid, ok := roomGrids[trigger.Room]
+		if !ok {
+			return fmt.Errorf("ending %q trigger names unknown room %q: %w", ei.Key, trigger.Room, ErrNoEnding)
+		}
+		if !grid.IsValidPosition(trigger.Position) {
+			return fmt.Errorf("ending %q trigger position is out of bounds: %w", ei.Key, ErrNoEnding)
+		}
+		if !isIntegralAxialPosition(grid, trigger.Position) {
+			return fmt.Errorf("ending %q trigger position is not an integral axial cell: %w", ei.Key, ErrNoEnding)
+		}
+	}
+	return nil
+}
+
 // NewEncounter constructs and initializes an encounter from SetupInput.
 // Validation order (first failure wins, R5 atomicity): nil input, no rooms,
 // no endings, reserved ending key, empty member ID, duplicate member IDs,
 // room defects (empty/duplicate ID, unrecognized or no-longer-supported
-// grid shape, W1 mixed grid families, non-integral hex origin, W2
-// overlapping absolute footprints), connection defects (empty/duplicate ID,
-// unknown room, self-connection, endpoint out of bounds or on an occluder,
-// W3 endpoints not adjacent once anchored), spatial placement errors.
+// grid shape, non-integral occluder position in any family, W1 mixed grid
+// families, non-positive/oversized/over-cell-budget dimensions, non-integral
+// origin, W2 overlapping absolute footprints), connection defects
+// (empty/duplicate ID, unknown room, self-connection, endpoint out of
+// bounds or on an occluder, W3 endpoints not adjacent once anchored),
+// member position integrality, ending trigger validity (unknown room or
+// unreachable position on a TriggerReachedPosition — #929 T3 Opus round
+// F5), spatial placement errors.
 func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// Validation order: nil, no rooms, no endings, reserved ending, empty ID, duplicates
 	if in == nil {
@@ -609,6 +697,12 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		if grid, ok := roomGrids[mi.Room]; ok && !isIntegralAxialPosition(grid, mi.Position) {
 			return nil, fmt.Errorf("newencounter: member %q position is not an integral axial cell: %w", mi.ID, ErrBadPlacement)
 		}
+	}
+
+	// A TriggerReachedPosition ending must name a real room and reachable
+	// position (#929 T3 Opus round F5) — see validateEndingTriggers.
+	if err := validateEndingTriggers(in.Endings, roomGrids); err != nil {
+		return nil, fmt.Errorf("newencounter: %w", err)
 	}
 
 	// Connections are stored sorted by ID (C8 determinism — order is

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -911,20 +911,28 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 		{"origin legality: fractional hex origin", func(in *encounter.SetupInput) {
 			in.Field.Rooms[1].Origin = spatial.Position{X: 6.5, Y: -5}
 		}, encounter.ErrNoField, "not a representable integral cell"},
-		{"origin legality: infinite origin", func(in *encounter.SetupInput) {
+		{"room legality: infinite origin", func(in *encounter.SetupInput) {
 			// #929 T1 second Opus round: math.Trunc(+Inf) is +Inf, so the
 			// old pos.X == math.Trunc(pos.X) check accepted this outright.
+			// #929 T2 second review round: now caught even earlier, by
+			// maxAnchorCoord's bound in room legality — Inf is never <= a
+			// finite bound, so this never even reaches the representability
+			// check origin legality runs afterward.
 			in.Field.Rooms[1].Origin = spatial.Position{X: math.Inf(1), Y: -5}
-		}, encounter.ErrNoField, "not a representable integral cell"},
-		{"origin legality: origin exceeds int64 precision (1e19)", func(in *encounter.SetupInput) {
+		}, encounter.ErrNoField, "exceeds max anchor coordinate"},
+		{"room legality: origin exceeds max anchor coordinate (1e19)", func(in *encounter.SetupInput) {
 			// #929 T1 second Opus round: 1e19 is "integral" by Trunc (it has
 			// no fractional part as a float64) but exceeds int64's range —
 			// roomAbsoluteBounds' int() conversion on a value like this is
 			// Go-spec implementation-defined, not a real cell. See
 			// TestSetupAnchoringHugeOriginRejectedNotFalseOverlap for the
 			// two-room construction that used to produce a wrong verdict.
+			// #929 T2 second review round: now caught by maxAnchorCoord's
+			// bound in room legality, before origin legality's
+			// representability check ever runs (1e19 is both non-representable
+			// AND out of bounds — the bound fires first).
 			in.Field.Rooms[1].Origin = spatial.Position{X: 1e19, Y: -5}
-		}, encounter.ErrNoField, "not a representable integral cell"},
+		}, encounter.ErrNoField, "exceeds max anchor coordinate"},
 		{"ordering: W2 wins over a co-occurring W3 defect", func(in *encounter.SetupInput) {
 			in.Field.Rooms[1].Origin = spatial.Position{X: 0, Y: 0}
 		}, encounter.ErrNoField, "overlap at absolute cell"},
@@ -1160,8 +1168,10 @@ func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDi
 // legality, then BOTH got truncated by roomAbsoluteBounds' int() to the
 // SAME implementation-defined int64 value, producing a FALSE W2 overlap
 // verdict through the public API. This pins that such an origin now
-// rejects at ORIGIN LEGALITY instead — before W2 ever sees it, and
-// specifically NOT with a W2 "overlap" message.
+// rejects at ROOM LEGALITY instead (#929 T2 second review round:
+// maxAnchorCoord's bound now fires before origin legality's representability
+// check even runs — 1e19 is both non-representable AND out of bounds) —
+// before W2 ever sees it, and specifically NOT with a W2 "overlap" message.
 func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{
@@ -1177,10 +1187,44 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 	})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
-	s.Require().Contains(err.Error(), "not a representable integral cell",
-		"must reject at origin legality, not fall through to a W2 overlap verdict on garbage-truncated positions")
+	s.Require().Contains(err.Error(), "exceeds max anchor coordinate",
+		"must reject at room legality, not fall through to a W2 overlap verdict on garbage-truncated positions")
 	s.Require().NotContains(err.Error(), "overlap at absolute cell",
 		"the old bug produced a W2 overlap message here — this must NOT be that")
+}
+
+// TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint pins maxRoomSpan
+// (#929 T2 second review round — see its doc comment): before this bound,
+// an unbounded Width could overflow roomAbsoluteBounds' interval-sum
+// arithmetic. r1 is 1000 wide at the zero-value Origin (absolute Q span
+// [0,999]); r2 is math.MaxInt wide, anchored at (999,0) — TRUE
+// (infinite-precision) math says these overlap by exactly one column, at
+// Q=999 (r2's own left edge sits exactly on r1's own right edge). But
+// r2's absolute qMax is 999 + math.MaxInt - 1, which OVERFLOWS int64 and
+// wraps to a large NEGATIVE number — see this test's own mutation-evidence
+// entry in the T2 second-round report for the exact wrapped value and the
+// resulting false "disjoint" verdict WITHOUT this bound. WITH it, r2's
+// Width alone is already rejected — oversized, not evaluated for overlap
+// at all.
+func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 1000, Height: 5},
+				{ID: "r2", Width: math.MaxInt, Height: 5, Origin: spatial.Position{X: 999, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceed max room span",
+		"must reject at room legality for being oversized, before overlap is ever evaluated")
+	s.Require().NotContains(err.Error(), "overlap at absolute cell",
+		"without the bound, this exact fixture used to wrongly VALIDATE via a false-disjoint W2 verdict — see the mutation evidence")
 }
 
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -607,21 +607,30 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 // a positive one, via the same grid-deferred bounds check members use.
 // Load-seam counterpart: TestHexConnectionEndpointNegativeAxialLoad in
 // data_test.go.
+//
+// #929 T1 follow-up: both rooms are hex (W1 forbids mixing families in one
+// field — see TestSetupAnchoring's W1 row) rather than the original
+// square+hex pairing. hex-a is 10x10 (Q,R valid [-5,5)); hex-b is 6x6 (Q,R
+// valid [-3,3)), anchored at (8,7) so its NEGATIVE-axial corner (-3,-3) —
+// the coordinate that gives this test its name — sits immediately east of
+// hex-a's own (4,4) corner: absolute (5,4) is a cube-distance-1 neighbor of
+// (4,4) (W3), and hex-b's absolute Q span ([5,10]) shares no Q value with
+// hex-a's ([-5,4]), so the rooms stay disjoint (W2) regardless of R.
 func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
-				{ID: "square-room", Width: 10, Height: 10},
-				{ID: "hex-room", Width: 6, Height: 6, Grid: spatial.GridShapeHex},
+				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
+				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 7}},
 			},
 			Connections: []encounter.ConnectionInput{{
-				ID: "gate", From: "square-room", To: "hex-room",
-				FromPosition: spatial.Position{X: 9, Y: 9},
-				ToPosition:   spatial.Position{X: -2, Y: -2},
+				ID: "gate", From: "hex-a", To: "hex-b",
+				FromPosition: spatial.Position{X: 4, Y: 4},
+				ToPosition:   spatial.Position{X: -3, Y: -3},
 			}},
 		},
 		Members: []encounter.MemberInput{
-			{ID: "p1", Kind: encounter.KindPlayer, Room: "square-room", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-a", Position: spatial.Position{X: 1, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -395,6 +395,74 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal")
 }
 
+// TestSetupOccluderIDCrossRoomCollisionAccepted pins the hardening round's
+// fix (#929 item C): the occluder entity ID used to concatenate room ID
+// and truncated coordinates (occluder-<room>-<int(X)>-<int(Y)>), so room
+// "r" with occluder (-5,4) and room "r-" with occluder (5,4) both produced
+// "occluder-r--5-4" — a genuine cross-room ID collision on a field that is
+// otherwise entirely legal under W1/W2/W3. The ID is index-based now, so
+// this exact colliding pair must construct without error.
+func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
+					Occluders: []spatial.Position{{X: -5, Y: 4}}},
+				{ID: "r-", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
+					Origin: spatial.Position{X: 1000, Y: 0}, Occluders: []spatial.Position{{X: 5, Y: 4}}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+	_, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide`)
+}
+
+// TestSetupDuplicateOccluderRejected pins the hardening round's item D:
+// two occluders at the SAME cell used to escape module validation
+// entirely and reject only in spatial's own voice ("entity ... already
+// indexed") as an accident of the old coordinate-derived entity ID —
+// see TestSetupOccluderIDCrossRoomCollisionAccepted's fix, which
+// switched to an index-based ID and, as a side effect, removed even
+// that accidental catch. Rejected explicitly now, in the module's own
+// room-list defect vocabulary.
+func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}, {X: 3, Y: 3}}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+	_, err := encounter.NewEncounter(setup)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "duplicate occluder")
+}
+
+// TestSetupDuplicateEndingKeyRejected pins hardening round item E: two
+// endings sharing a key both used to construct — a genuine liveness
+// hole, since End scans in declaration order and a reached_position
+// twin declared first permanently shadows a same-keyed external ending
+// declared after it (probed: End("dup") failed "is not External"
+// forever, the external ending having no other way to fire).
+func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "dup", Trigger: encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 4, Y: 4}}},
+			{Key: "dup", Trigger: encounter.TriggerExternal{}},
+		},
+	}
+	_, err := encounter.NewEncounter(setup)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoEnding)
+	s.Require().Contains(err.Error(), "duplicate ending")
+}
+
 // TestSetupConnectionValidation mirrors TestLoadRejections' connection
 // defect classes at the Setup seam: each case breaks exactly one thing
 // about an otherwise-valid connection and must reject with ErrBadConnection.

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -313,23 +313,33 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 // validConnSetup returns a fresh SetupInput with two DELIBERATELY
 // mismatched rooms — r1 is 10x4 (occluder at (2,2)), r2 is 3x9 (occluder
 // at (1,3)) — and one fully valid connection between them, with
-// FromPosition{7,1} valid ONLY in r1 and ToPosition{1,7} valid ONLY in r2.
+// FromPosition{9,1} valid ONLY in r1 and ToPosition{0,7} valid ONLY in r2.
 // Same-sized rooms and equal From/To positions would make a check that
 // validates an endpoint against the WRONG room (or a Load-side From/To
 // transposition) invisible: this is the base for
 // TestSetupConnectionValidation's one-defect rows, mirroring the same
 // defect classes rejected at Load (TestLoadRejections).
+//
+// #929 T1: the endpoints sit on each room's OWN boundary (r1's rightmost
+// column, r2's leftmost column) — a connection can only ever kiss (W3)
+// through a room's boundary cell, never an interior one (every neighbor of
+// an interior cell is still inside that room's own footprint). r2's Origin
+// (10,-6) puts its leftmost column at absolute x=10, immediately east of
+// r1's rightmost column (absolute x=9, since r1's Origin is the zero
+// value) — Chebyshev-adjacent (W3) — while r1's absolute footprint
+// (x:[0,9], y:[0,3]) and r2's (x:[10,12], y:[-6,2]) share no x value at
+// all, so they stay disjoint (W2) regardless of their y overlap.
 func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
-				{ID: "r2", Width: 3, Height: 9, Occluders: []spatial.Position{{X: 1, Y: 3}}},
+				{ID: "r2", Width: 3, Height: 9, Origin: spatial.Position{X: 10, Y: -6}, Occluders: []spatial.Position{{X: 1, Y: 3}}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "c1", From: "r1", To: "r2",
-					FromPosition: spatial.Position{X: 7, Y: 1},
-					ToPosition:   spatial.Position{X: 1, Y: 7}},
+					FromPosition: spatial.Position{X: 9, Y: 1},
+					ToPosition:   spatial.Position{X: 0, Y: 7}},
 			},
 		},
 		Members: []encounter.MemberInput{
@@ -391,17 +401,17 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 	}
 
 	// The valid base itself must construct — the one-defect discipline only
-	// means something if zero defects pass. Since FromPosition{7,1} is valid
-	// ONLY in r1 and ToPosition{1,7} valid ONLY in r2, this positive control
+	// means something if zero defects pass. Since FromPosition{9,1} is valid
+	// ONLY in r1 and ToPosition{0,7} valid ONLY in r2, this positive control
 	// also pins that each endpoint is checked against ITS OWN room: a check
 	// wired to the wrong room would reject this valid connection.
 	enc, err := encounter.NewEncounter(validConnSetup())
 	s.Require().NoError(err, "the valid base fixture must construct")
 	data := enc.ToData()
 	s.Require().Len(data.Field.Connections, 1)
-	s.Equal(&encounter.PositionData{X: 7, Y: 1}, data.Field.Connections[0].FromPosition,
+	s.Equal(&encounter.PositionData{X: 9, Y: 1}, data.Field.Connections[0].FromPosition,
 		"from-position must survive unswapped")
-	s.Equal(&encounter.PositionData{X: 1, Y: 7}, data.Field.Connections[0].ToPosition,
+	s.Equal(&encounter.PositionData{X: 0, Y: 7}, data.Field.Connections[0].ToPosition,
 		"to-position must survive unswapped")
 }
 
@@ -409,13 +419,18 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 // coordinates 0..3 x 0..2) and an r2 large enough to always hold the
 // connection's fixed ToPosition — used to pin the square grid's strictly-
 // less-than bounds semantics against FromPosition in r1, independent of any
-// cross-room concern (that's validConnSetup's job).
+// cross-room concern (that's validConnSetup's job). r2's Origin (4,3)
+// anchors it diagonally past r1's bottom-right corner (#929 T1): the
+// positive control's FromPosition (3,2) — r1's own bottom-right corner —
+// and ToPosition (0,0)+(4,3)=(4,3) are Chebyshev-adjacent (a diagonal kiss,
+// distance 1), while the rooms' absolute footprints (x:[0,3] vs x:[4,7])
+// share no x value and so stay disjoint (W2) regardless of y.
 func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 4, Height: 3},
-				{ID: "r2", Width: 4, Height: 3},
+				{ID: "r2", Width: 4, Height: 3, Origin: spatial.Position{X: 4, Y: 3}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "c1", From: "r1", To: "r2",
@@ -619,18 +634,28 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 // TestSetupHexIntegralAxial's one-defect rows: interim tools/spatial#926
 // enforcement (isIntegralAxialPosition) rejects a fractional X or Y at
 // any of these positions in a hex room.
+//
+// #929 T1: both rooms are Width=8,Height=8, so each has valid axial Q,R in
+// [-4,4) (i.e. -4..3). gate.FromPosition sits at hex-a's own Q=3 boundary
+// (an interior cell like the original (1,1) can never kiss anything — every
+// neighbor of an interior cell is still inside that room's own footprint).
+// hex-b's Origin (8,1) anchors it immediately past that boundary: absolute
+// FromPosition (3,0) and absolute ToPosition local(-4,-1)+(8,1)=(4,0) are
+// cube-distance 1 (W3), while hex-b's absolute Q span ([4,11]) shares no Q
+// value with hex-a's ([-4,3]), so the two rooms stay disjoint (W2)
+// regardless of R.
 func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
 					Occluders: []spatial.Position{{X: 2, Y: 2}}},
-				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridShapeHex},
+				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 1}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "hex-a", To: "hex-b",
-				FromPosition: spatial.Position{X: 1, Y: 1},
-				ToPosition:   spatial.Position{X: -1, Y: -1},
+				FromPosition: spatial.Position{X: 3, Y: 0},
+				ToPosition:   spatial.Position{X: -4, Y: -1},
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -678,7 +703,7 @@ func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 	}
 
 	// Positive control: the valid base — integral throughout, including
-	// a NEGATIVE axial position (gate.ToPosition at (-1,-1)) — constructs.
+	// a NEGATIVE axial position (gate.ToPosition at (-4,-1)) — constructs.
 	_, err := encounter.NewEncounter(validHexAxialSetup())
 	s.Require().NoError(err, "integral axial positions, including negative ones, must be accepted")
 }
@@ -741,17 +766,17 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	})
 }
 
-// TestGridlessRoomInclusiveBounds pins gridless's own divergence from the
-// rectangle math this task deletes: GridlessRoom.IsValidPosition
-// (tools/spatial/gridless.go:33-36) uses an INCLUSIVE upper bound
-// (x <= Width), unlike SquareGrid's exclusive (x < Width). A position
-// exactly AT Width — rejected for square — is a sharp, independent proof
-// that bounds checks ask the room's OWN constructed grid rather than a
-// hardcoded rectangle: a "grid shape ignored, always builds square" mutant
-// would reject this position; the correct code accepts it. (AxialHexGrid
-// diverges from square too, but via origin-centered bounds and legal
-// negative coordinates, not an inclusive upper bound — see
-// TestHexRoomBounds.)
+// TestGridlessRoomInclusiveBounds pinned gridless's own divergence from the
+// rectangle math a prior task deleted (GridlessRoom.IsValidPosition's
+// inclusive upper bound, x <= Width, vs SquareGrid's exclusive x < Width).
+// #929 T1 (shape legality, W1) retires that coverage: gridless leaves the
+// composition entirely as of v0.3 — the wire cannot carry a continuous
+// room's absolute projection — so a declared GridShapeGridless room is now
+// a room-list defect at Setup, full stop, regardless of any position within
+// it. This test is repurposed to pin THAT rejection instead of gridless's
+// old bounds semantics (AxialHexGrid's own divergence from square — origin-
+// centered bounds, legal negative coordinates — is still covered by
+// TestHexRoomBounds).
 func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 	gridlessSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
@@ -767,16 +792,191 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 		}
 	}
 
-	s.Run("position exactly at Width is accepted (inclusive upper bound)", func() {
+	s.Run("gridless room rejected regardless of member position", func() {
 		_, err := encounter.NewEncounter(gridlessSetup(spatial.Position{X: 4, Y: 0}))
-		s.Require().NoError(err, "gridless rooms accept x == Width; a rectangle-math fallback would reject this")
+		s.Require().Error(err, "gridless leaves the composition as of v0.3 — no position can rescue it")
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Require().Contains(err.Error(), "gridless grid shape, no longer supported",
+			"the check that fired must be shape legality, not a downstream placement check")
 	})
 
-	s.Run("position negative is still rejected", func() {
+	s.Run("still rejected for a position that would also be out of bounds", func() {
 		_, err := encounter.NewEncounter(gridlessSetup(spatial.Position{X: -1, Y: 0}))
 		s.Require().Error(err)
-		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Require().ErrorIs(err, encounter.ErrNoField,
+			"shape legality fires before any placement check ever sees this position")
 	})
+}
+
+// ============================================================
+// #929 T1 — anchoring: RoomInput.Origin, W1 (one geometry per field), W2
+// (rooms never overlap), W3 (doorways kiss). Shape legality's own
+// rejection (GridShapeGridless) is pinned above by
+// TestGridlessRoomInclusiveBounds — repurposed for exactly this law.
+// ============================================================
+
+// validAnchoredHexSetup returns THE core fixture for the W-law tests below:
+// two hex rooms, asymmetric in every dimension (T1 review lesson —
+// symmetric fixtures hide cross-wiring mutants: a prior wave's full sweep
+// missed four of them this way). hex-big is 10x4 (Q valid [-5,4), R valid
+// [-2,2)) at the zero-value Origin; hex-small is 3x9 (Q valid [-1,2), R
+// valid [-4,5)) anchored at (6,-5) — a NEGATIVE-axial origin, on purpose.
+//
+// The connection's endpoints are each their own room's OWN boundary cell —
+// an interior cell can never kiss anything, since every neighbor of an
+// interior cell is still inside that room's own footprint — and are
+// computed, not guessed, from the span arithmetic above: FromPosition
+// (4,0) is hex-big's max-Q boundary; ToPosition (-1,4) is hex-small's
+// min-Q/max-R corner. Anchored, their absolute cells are (4,0) and (5,-1):
+// ΔQ=1, ΔR=-1, ΔS=0, cube distance (1+1+0)/2 = 1 — adjacent, and
+// deliberately OFF-AXIS (both ΔQ and ΔR nonzero) so a Manhattan-distance
+// mutant (|ΔQ|+|ΔR|=2) would wrongly reject this valid base — see
+// TestAnchoringMutationEvidence.
+//
+// hex-big's absolute Q span is [-5,4]; hex-small's is local[-1,1]+6=[5,7]:
+// the two share NO Q value at all, so W2 holds regardless of R — the
+// rooms are disjoint, touching only through the one declared doorway.
+func validAnchoredHexSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
+				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "hex-big", To: "hex-small",
+				FromPosition: spatial.Position{X: 4, Y: 0},
+				ToPosition:   spatial.Position{X: -1, Y: 4},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-big", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+}
+
+// TestSetupAnchoring pins the one-defect rows for W1 (mixed grid families),
+// origin legality (non-integral hex origin), W2 (overlapping footprints),
+// and W3 (endpoints that don't kiss) — each breaking exactly ONE thing
+// about validAnchoredHexSetup's otherwise-valid base, rejecting with the
+// sentinel and message fragment its own law uses.
+func (s *EncounterTestSuite) TestSetupAnchoring() {
+	cases := []struct {
+		name     string
+		mutate   func(in *encounter.SetupInput)
+		alsoErr  error
+		fragment string
+	}{
+		{"W1: mixed grid families", func(in *encounter.SetupInput) {
+			in.Field.Rooms[1].Grid = spatial.GridShapeSquare
+		}, encounter.ErrNoField, "declare different grid families"},
+		{"origin legality: fractional hex origin", func(in *encounter.SetupInput) {
+			in.Field.Rooms[1].Origin = spatial.Position{X: 6.5, Y: -5}
+		}, encounter.ErrNoField, "not an integral axial cell"},
+		{"W2: overlapping footprints", func(in *encounter.SetupInput) {
+			in.Field.Rooms[1].Origin = spatial.Position{X: 0, Y: 0}
+		}, encounter.ErrNoField, "overlap at absolute cell"},
+		{"W3: endpoints do not kiss", func(in *encounter.SetupInput) {
+			// (1,4) is still a legal LOCAL cell in hex-small (max Q, max R)
+			// — this must fail on adjacency, not on the earlier bounds check.
+			in.Field.Connections[0].ToPosition = spatial.Position{X: 1, Y: 4}
+		}, encounter.ErrBadConnection, "not adjacent"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			setup := validAnchoredHexSetup()
+			tc.mutate(setup)
+			_, err := encounter.NewEncounter(setup)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
+			s.Require().Contains(err.Error(), tc.fragment,
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	// The valid base itself must construct — the one-defect discipline only
+	// means something if zero defects pass. This ALSO doubles as the
+	// "touching but not overlapping" sibling proof (W2 rejects overlap,
+	// not contact): hex-big and hex-small touch at exactly the gate's two
+	// cells and nowhere else, yet still validate.
+	_, err := encounter.NewEncounter(validAnchoredHexSetup())
+	s.Require().NoError(err, "the valid base fixture — asymmetric, negative-anchored, off-axis kissing — must construct")
+}
+
+// TestSetupAnchoringSquareDiagonalKiss pins W3's Chebyshev adjacency for
+// the square family, specifically a DIAGONAL kiss (Chebyshev distance 1
+// includes diagonals, unlike a 4-directional adjacency check): sq-a and
+// sq-b sit corner-to-corner, touching at exactly one point and sharing no
+// cell (also the square-family sibling proof that W2 rejects overlap, not
+// contact — TestSetupAnchoring's hex base already proves it once, this
+// proves it independently for square's own distance formula).
+func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "sq-a", Width: 5, Height: 5},
+				{ID: "sq-b", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: 5}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "corner-gate", From: "sq-a", To: "sq-b",
+				FromPosition: spatial.Position{X: 4, Y: 4},
+				ToPosition:   spatial.Position{X: 0, Y: 0},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "sq-a", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+	_, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err, "a diagonal (Chebyshev distance 1) kiss must be accepted, not just a 4-directional one")
+}
+
+// TestSetupAnchoringSquareOriginUnconstrained pins that origin legality
+// (isIntegralAxialPosition) is a hex-only rule: a square room's Origin may
+// be fractional — square has always been fractional-tolerant (RoomInput.Grid's
+// doc comment) and Origin is no exception, unlike a hex room's (see
+// TestSetupAnchoring's "origin legality" row).
+func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginUnconstrained() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0.5, Y: 1.5}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err, "a fractional Origin on a square room is not a defect")
+}
+
+// TestSetupAnchoringW1BothDirections pins W1's message names BOTH rooms and
+// BOTH families regardless of which room is square and which is hex —
+// mutating a two-hex-room field's SECOND room mirrors
+// TestSetupAnchoring's row, which mutates via the same slice index; this
+// covers the field declared the other way around (hex declared first,
+// square second) to guard against a comparison that only checks one
+// direction.
+func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "square-first", Width: 5, Height: 5},
+				{ID: "hex-second", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "square-first", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), `room "square-first" (square)`)
+	s.Require().Contains(err.Error(), `room "hex-second" (hex)`)
 }
 
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {
@@ -1521,7 +1721,11 @@ func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Enco
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				// Anchored immediately east of room-a (#929 T1): door1's
+				// endpoints (9,5) and (0,5)+(10,0)=(10,5) are
+				// Chebyshev-adjacent (W3); the rooms' absolute footprints
+				// (x:[0,9] vs x:[10,19]) stay disjoint (W2).
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "door1", From: "room-a", To: "room-b",
@@ -1588,8 +1792,13 @@ func (s *EncounterTestSuite) TestTraverseValidation() {
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-a", Width: 10, Height: 10},
-					{ID: "room-b", Width: 10, Height: 10},
-					{ID: "room-c", Width: 10, Height: 10},
+					// Anchored east of room-a so door1's endpoints kiss (#929
+					// T1) — see newTwoRoomEncounterWithConnection's comment.
+					{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
+					// room-c touches neither: anchored south of room-a,
+					// disjoint from both (W2) and irrelevant to door1 (W3
+					// only constrains door1's own two rooms).
+					{ID: "room-c", Width: 10, Height: 10, Origin: spatial.Position{X: 0, Y: 10}},
 				},
 				Connections: []encounter.ConnectionInput{
 					{ID: "door1", From: "room-a", To: "room-b",
@@ -1763,7 +1972,7 @@ func (s *EncounterTestSuite) TestTraverseEndingFiresOnArrival() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "door1", From: "room-a", To: "room-b",
@@ -1804,7 +2013,7 @@ func (s *EncounterTestSuite) TestTraverseMonsterOnUnfilteredEndingDoesNotClose()
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "door1", From: "room-a", To: "room-b",

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -367,6 +367,34 @@ func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
 	s.Require().Contains(err.Error(), "not a representable integral cell")
 }
 
+// TestSetupOccluderOnBoundaryCellAccepted pins N2's over-tightening sweep
+// (#929 T3 trailing round): every occluder in every EXISTING fixture sits
+// on an interior cell, so a mutant that rejected a boundary-cell occluder
+// (plausible: "occluders should be interior only") survived the suite
+// with zero failures until this row was added. Occluders block line of
+// sight (field.go's doc comment), not placement — a boundary cell,
+// including a corner, is exactly as legal an occluder position as an
+// interior one.
+func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{
+					{X: 0, Y: 2}, // left edge
+					{X: 4, Y: 2}, // right edge
+					{X: 2, Y: 0}, // top edge
+					{X: 2, Y: 4}, // bottom edge
+					{X: 0, Y: 0}, // corner
+					{X: 4, Y: 4}, // corner
+				}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+	_, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal")
+}
+
 // TestSetupConnectionValidation mirrors TestLoadRejections' connection
 // defect classes at the Setup seam: each case breaks exactly one thing
 // about an otherwise-valid connection and must reject with ErrBadConnection.
@@ -1353,6 +1381,91 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
 	s.Require().Contains(err.Error(), "not an integral axial cell")
+}
+
+// validTriggerAcceptanceFieldSetup is the rich SQUARE-family fixture for
+// TestSetupEndingTriggerMustAccept (#929 T3 trailing round N2): a kissing
+// pair (hall/vault, connected, hall carries an occluder) plus an isolated
+// room (annex, no connection at all) — exercising every must-accept shape
+// a TriggerReachedPosition can legally target. A rejection-only test
+// suite proves a validator rejects; this fixture is what proves it does
+// NOT over-reach.
+func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
+				{ID: "vault", Width: 4, Height: 4, Origin: spatial.Position{X: 5, Y: 0}},
+				{ID: "annex", Width: 3, Height: 3, Origin: spatial.Position{X: 1000, Y: 1000}},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "gate", From: "hall", To: "vault",
+					FromPosition: spatial.Position{X: 4, Y: 2},
+					ToPosition:   spatial.Position{X: 0, Y: 2}},
+			},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 0, Y: 0}}},
+		},
+	}
+}
+
+// TestSetupEndingTriggerMustAccept pins N2 (#929 T3 trailing round): a
+// one-defect rejection table only proves a validator rejects what it
+// should; only a rich positive control proves it does not ALSO reject
+// what it shouldn't. Each row targets a specific over-tightening
+// hypothesis Opus's mutants tested and found undefended: occluded cells,
+// doorway endpoints on EITHER side, fractional square positions, a room
+// with zero connections, local (0,0), and a room's far corner. Each row
+// also survives a ToData/LoadEncounter round trip — the SAME shape must
+// validate identically at both seams.
+func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
+	cases := []struct {
+		name    string
+		trigger encounter.TriggerReachedPosition
+	}{
+		{"occluded cell", encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 2, Y: 2}}},
+		{"doorway endpoint, from-room side", encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 4, Y: 2}}},
+		{"doorway endpoint, to-room side", encounter.TriggerReachedPosition{Room: "vault", Position: spatial.Position{X: 0, Y: 2}}},
+		{"fractional square position", encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 1.5, Y: 1.5}}},
+		{"room with no connection", encounter.TriggerReachedPosition{Room: "annex", Position: spatial.Position{X: 1, Y: 1}}},
+		{"local (0,0)", encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 0, Y: 0}}},
+		{"far corner", encounter.TriggerReachedPosition{Room: "vault", Position: spatial.Position{X: 3, Y: 3}}},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			setup := validTriggerAcceptanceFieldSetup()
+			setup.Endings[0].Trigger = tc.trigger
+			enc, err := encounter.NewEncounter(setup)
+			s.Require().NoError(err, tc.name)
+
+			data := enc.ToData()
+			_, err = encounter.LoadEncounter(data, nil)
+			s.Require().NoError(err, "%s must survive a ToData/LoadEncounter round trip", tc.name)
+		})
+	}
+}
+
+// TestSetupEndingTriggerHexNegativeAxialMustAccept is
+// TestSetupEndingTriggerMustAccept's hex-specific sibling (W1 forbids
+// mixing families in one fixture): hex rooms are ORIGIN-CENTERED, so a
+// negative Q/R trigger position is the NORMAL case for roughly half of
+// any room, not an edge case — the realistic hazard N2 names explicitly.
+func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "crypt", Position: spatial.Position{X: -2, Y: -2}}},
+		},
+	}
+	enc, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err, "a negative-axial hex trigger position is the NORMAL case, not an edge case")
+
+	data := enc.ToData()
+	_, err = encounter.LoadEncounter(data, nil)
+	s.Require().NoError(err, "must survive a ToData/LoadEncounter round trip")
 }
 
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -1122,6 +1122,40 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	s.Require().NoError(err, "a diagonal (Chebyshev distance 1) kiss must be accepted, not just a 4-directional one")
 }
 
+// TestSetupAnchoringSquareEndpointNotAdjacentDistance2 pins W3's
+// square-family rejection at a genuine, non-sub-unit distance (#929
+// hardening round, test-gap closure item 5): the only existing
+// square-family W3 non-adjacency coverage before this was the sub-unit
+// 0.5 case (TestSetupAnchoringFractionalSquareEndpointSubUnitDistance);
+// the two "not adjacent"/"distance 2" rows in TestSetupAnchoring's table
+// are hex-only. r1 is 3x3 at the zero-value Origin (absolute x:[0,2]);
+// r2 is 3x3 at Origin (4,0) (absolute x:[4,6]) — a genuine one-column
+// void gap at x=3, so W2 passes (footprints disjoint, not overlapping).
+// FromPosition (2,1) in r1 projects to absolute (2,1); ToPosition (0,1)
+// in r2 projects to absolute (4,1) — Chebyshev distance 2, not 1.
+func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance2() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 3, Height: 3},
+				{ID: "r2", Width: 3, Height: 3, Origin: spatial.Position{X: 4, Y: 0}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "r1", To: "r2",
+				FromPosition: spatial.Position{X: 2, Y: 1},
+				ToPosition:   spatial.Position{X: 0, Y: 1},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrBadConnection)
+	s.Require().Contains(err.Error(), "not adjacent")
+}
+
 // TestSetupAnchoringSquareOriginRejected pins that origin legality
 // (isIntegralPosition) applies to EVERY grid family, square included, not
 // just hex. #929 T1 Opus round finding: this test used to assert the
@@ -1148,6 +1182,52 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Require().Contains(err.Error(), "not a representable integral cell")
+}
+
+// TestSetupAnchoringNaNOriginRejected pins a genuinely subtle ordering
+// (#929 hardening round, test-gap closure item 4 — NaN and -Inf had ZERO
+// coverage anywhere in the suite before this): room legality's magnitude
+// check is `math.Abs(r.Origin.X) > maxAnchorCoord`, and for X = NaN,
+// math.Abs(NaN) is NaN, and EVERY comparison against NaN (including >)
+// is false in IEEE 754 — so a NaN origin silently SLIPS PAST room
+// legality's magnitude check, uncaught, and is rejected only later, by
+// the SEPARATE origin-legality loop (isIntegralPosition ->
+// isRepresentableInteger, which explicitly tests IsNaN). Verified by
+// probe before writing this assertion. The fragment below asserts the
+// origin-legality message SPECIFICALLY (not just ErrNoField) so a future
+// reorder that changes which check catches NaN fails loudly here,
+// instead of this test silently continuing to pass against a different
+// message.
+func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "not a representable integral cell",
+		"a NaN origin must be caught by origin legality, since room legality's Abs(NaN) > bound comparison is always false")
+}
+
+// TestSetupAnchoringNegativeInfinityOriginRejected is NaN's sibling case
+// (#929 hardening round, test-gap closure item 4), with the OPPOSITE
+// ordering: math.Abs(-Inf) is +Inf, and +Inf > maxAnchorCoord (any
+// finite bound) IS true — so -Inf does NOT slip past room legality's
+// magnitude check the way NaN does; it is caught there, first, with
+// room legality's OWN message.
+func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceeds max anchor coordinate",
+		"-Inf must be caught by room legality's magnitude check, unlike NaN — Abs(-Inf) > bound is true")
 }
 
 // TestSetupAnchoringW1BothDirections pins W1's message names BOTH rooms and
@@ -1366,13 +1446,76 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 	s.Require().Contains(err.Error(), "exceeding max room cells")
 }
 
+// TestSetupRoomCellBudgetRejectsPanicReproductionHex is the hex-family
+// sibling of TestSetupRoomCellBudgetRejectsPanicReproduction (#929
+// hardening round, test-gap closure item 3): maxRoomCells' doc comment
+// claims the bound is family-agnostic ("EQUAL for both grid families...
+// hex included"), but every existing budget fixture — this one's square
+// sibling, and TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms —
+// only ever declares a square room (Grid left unset, defaulting to
+// GridShapeSquare). This pins the SAME 2^30 x 2^30 reproduction against
+// an EXPLICIT hex room.
+func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err, "a 2^30 x 2^30 HEX room must REJECT too — the bound is family-agnostic")
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceeding max room cells")
+}
+
+// TestSetupOversizedRoomHeightRejected pins maxRoomSpan's Height clause
+// independently of Width (#929 hardening round, test-gap closure item
+// 3): TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint only grows
+// Width (r2 is math.MaxInt WIDE, Height a legal 5), and
+// TestSetupRoomCellBudgetRejectsPanicReproduction grows Width and Height
+// EQUALLY (1<<30 each) — neither can discriminate the
+// `|| r.Height > maxRoomSpan` half of the check from the Width half;
+// deleting either clause alone leaves the whole suite green. This
+// fixture grows ONLY Height (Width stays a legal 5) just past the bound
+// (1<<30 + 1). With the clause present, this rejects at room-span
+// legality with "exceed max room span". Without it (the mutant), the
+// oversized Height is NOT unobserved — it still rejects, just later and
+// with a DIFFERENT message: cellCount = 5*((1<<30)+1) comfortably
+// exceeds maxRoomCells, so a deleted Height-span clause falls through to
+// the cell-budget check instead. The message assertion below is what
+// actually catches the mutant — a bare Error()/ErrorIs(ErrNoField)
+// check alone would not.
+func (s *EncounterTestSuite) TestSetupOversizedRoomHeightRejected() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceed max room span",
+		"a Height-only oversize must reject at room-span legality, not fall through to a different check with a different message")
+}
+
 // TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms pins F1's field-total
-// bound: five 1024x1024 rooms are each EXACTLY at maxRoomCells (1<<20,
-// individually legal — the per-room check passes) but their SUM (5<<20)
+// bound: SIX 1024x1024 rooms are each EXACTLY at maxRoomCells (1<<20,
+// individually legal — the per-room check passes) but their SUM (6<<20)
 // exceeds maxFieldCells (4<<20) — amplification across rooms, not within
-// one, the OTHER half of F1's reproduction.
+// one, the OTHER half of F1's reproduction. SIX rooms, not five (#929
+// hardening round, test-gap closure item 1): with only five, rooms 1-4
+// sum to EXACTLY maxFieldCells (4<<20) — not yet exceeding it — so the
+// budget is first exceeded at the fifth and LAST room, and the N3 fix
+// (accumulate the TRUE total over every room before checking once, so a
+// future room in the list is never silently dropped from the count) is
+// unpinnable: a reverted mid-loop check that returns as soon as the
+// RUNNING total exceeds the budget would trip at that same last room and
+// report the identical number, since there is no room AFTER it to be
+// dropped from the count. A sixth room makes the two diverge: a mid-loop
+// check trips at room 5 (running total 5<<20 = 5242880, room 6 never
+// even summed), while the true-total fix processes all six and reports
+// 6<<20 = 6291456 — the exact number asserted below.
 func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms() {
-	rooms := make([]encounter.RoomInput, 5)
+	rooms := make([]encounter.RoomInput, 6)
 	for i := range rooms {
 		rooms[i] = encounter.RoomInput{ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024}
 	}
@@ -1382,6 +1525,8 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 	})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "field has 6291456 total cells across all rooms",
+		"must name the TRUE total over all six rooms, not a running total that stopped short at a mid-loop room")
 	s.Require().Contains(err.Error(), "exceeding max field cells")
 }
 

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -1249,13 +1249,16 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 // arithmetic. r1 is 1000 wide at the zero-value Origin (absolute Q span
 // [0,999]); r2 is math.MaxInt wide, anchored at (999,0) — TRUE
 // (infinite-precision) math says these overlap by exactly one column, at
-// Q=999 (r2's own left edge sits exactly on r1's own right edge). But
-// r2's absolute qMax is 999 + math.MaxInt - 1, which OVERFLOWS int64 and
-// wraps to a large NEGATIVE number — see this test's own mutation-evidence
-// entry in the T2 second-round report for the exact wrapped value and the
-// resulting false "disjoint" verdict WITHOUT this bound. WITH it, r2's
-// Width alone is already rejected — oversized, not evaluated for overlap
-// at all.
+// Q=999 (r2's own left edge sits exactly on r1's own right edge). r2's
+// absolute qMax is axisBounds(math.MaxInt).max + 999 = (math.MaxInt-1) +
+// 999, which OVERFLOWS int64 and wraps to -9223372036854774811 (verified
+// by running the exact interval-sum arithmetic standalone, not hand
+// computed): with r2's qMin at 999 and its qMax wrapped to that large
+// NEGATIVE number, validateRoomsDisjoint's overlap check
+// (bs[i].qMin <= bs[j].qMax && bs[j].qMin <= bs[i].qMax) sees
+// 0 <= -9223372036854774811 as false and wrongly reports the rooms
+// disjoint — WITHOUT this bound. WITH it, r2's Width alone is already
+// rejected — oversized, not evaluated for overlap at all.
 func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -511,6 +511,12 @@ func validRoomSetup() *encounter.SetupInput {
 // (#922 T1.5, deferred from the Opus T1 review): empty room ID, duplicate
 // room ID, and an unrecognized grid shape all reject with ErrNoField — a
 // malformed room list is as unusable as an empty one.
+//
+// #929 T1 Opus round: also pins room legality (non-positive Width/Height),
+// both zero AND negative for each dimension — the blocker this closes:
+// Width:-1 previously reached a negative-capacity make() in W2's
+// enumeration path (since replaced by interval math) and PANICKED
+// NewEncounter instead of rejecting it (R5: a panic is not a rejection).
 func (s *EncounterTestSuite) TestSetupRoomValidation() {
 	cases := []struct {
 		name     string
@@ -526,6 +532,18 @@ func (s *EncounterTestSuite) TestSetupRoomValidation() {
 		{"room has unknown grid shape", func(in *encounter.SetupInput) {
 			in.Field.Rooms[0].Grid = spatial.GridShape(99)
 		}, "unknown grid shape"},
+		{"room has zero width", func(in *encounter.SetupInput) {
+			in.Field.Rooms[0].Width = 0
+		}, "non-positive dimensions"},
+		{"room has zero height", func(in *encounter.SetupInput) {
+			in.Field.Rooms[0].Height = 0
+		}, "non-positive dimensions"},
+		{"room has negative width", func(in *encounter.SetupInput) {
+			in.Field.Rooms[0].Width = -1
+		}, "non-positive dimensions"},
+		{"room has negative height", func(in *encounter.SetupInput) {
+			in.Field.Rooms[0].Height = -1
+		}, "non-positive dimensions"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -866,10 +884,19 @@ func validAnchoredHexSetup() *encounter.SetupInput {
 }
 
 // TestSetupAnchoring pins the one-defect rows for W1 (mixed grid families),
-// origin legality (non-integral hex origin), W2 (overlapping footprints),
-// and W3 (endpoints that don't kiss) — each breaking exactly ONE thing
-// about validAnchoredHexSetup's otherwise-valid base, rejecting with the
-// sentinel and message fragment its own law uses.
+// origin legality (non-integral origin), and W3 (endpoints that don't
+// kiss) — each breaking exactly ONE thing about validAnchoredHexSetup's
+// otherwise-valid base, rejecting with the sentinel and message fragment
+// its own law uses.
+//
+// The "W2" row below is honestly an ORDERING pin, not a one-defect row
+// (#929 T1 Opus round correction): zeroing hex-small's Origin makes it
+// collide with hex-big at (0,0) (a genuine W2 defect) but ALSO detaches
+// the gate's endpoints from their designed kiss (a W3 defect too, at the
+// mutated Origin) — W2 wins only because it runs before W3 in
+// buildValidRoomGrids' order. TestSetupAnchoringOverlapNonAdjacentPair is
+// the true one-defect W2 row: three rooms, only a non-adjacent-in-slice
+// pair overlaps, no connection involved at all.
 func (s *EncounterTestSuite) TestSetupAnchoring() {
 	cases := []struct {
 		name     string
@@ -882,8 +909,8 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 		}, encounter.ErrNoField, "declare different grid families"},
 		{"origin legality: fractional hex origin", func(in *encounter.SetupInput) {
 			in.Field.Rooms[1].Origin = spatial.Position{X: 6.5, Y: -5}
-		}, encounter.ErrNoField, "not an integral axial cell"},
-		{"W2: overlapping footprints", func(in *encounter.SetupInput) {
+		}, encounter.ErrNoField, "not an integral cell"},
+		{"ordering: W2 wins over a co-occurring W3 defect", func(in *encounter.SetupInput) {
 			in.Field.Rooms[1].Origin = spatial.Position{X: 0, Y: 0}
 		}, encounter.ErrNoField, "overlap at absolute cell"},
 		{"W3: endpoints do not kiss", func(in *encounter.SetupInput) {
@@ -891,6 +918,18 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 			// — this must fail on adjacency, not on the earlier bounds check.
 			in.Field.Connections[0].ToPosition = spatial.Position{X: 1, Y: 4}
 		}, encounter.ErrBadConnection, "not adjacent"},
+		{"W3: hex axial (1,1) delta is NOT adjacent (cube distance 2)", func(in *encounter.SetupInput) {
+			// hex-small's Origin shifts by (0,+2) from the valid base's
+			// (6,-5) to (6,-3): the gate's endpoints, once anchored, now
+			// differ by axial (ΔQ=1,ΔR=1) — cube distance (1+1+2)/2=2, NOT
+			// 1. A "Chebyshev-on-axial" mutant (max(|ΔQ|,|ΔR|)=1) would
+			// wrongly ACCEPT this as adjacent — see the mutation evidence
+			// table in the #929 T1 fix-round report. Still disjoint from
+			// hex-big (W2 passes): hex-small's absolute Q span becomes
+			// local[-1,1]+6=[5,7], still sharing no Q value with hex-big's
+			// [-5,4], so this is a genuine W3-only defect.
+			in.Field.Rooms[1].Origin = spatial.Position{X: 6, Y: -3}
+		}, encounter.ErrBadConnection, "distance 2"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -942,12 +981,18 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	s.Require().NoError(err, "a diagonal (Chebyshev distance 1) kiss must be accepted, not just a 4-directional one")
 }
 
-// TestSetupAnchoringSquareOriginUnconstrained pins that origin legality
-// (isIntegralAxialPosition) is a hex-only rule: a square room's Origin may
-// be fractional — square has always been fractional-tolerant (RoomInput.Grid's
-// doc comment) and Origin is no exception, unlike a hex room's (see
-// TestSetupAnchoring's "origin legality" row).
-func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginUnconstrained() {
+// TestSetupAnchoringSquareOriginRejected pins that origin legality
+// (isIntegralPosition) applies to EVERY grid family, square included, not
+// just hex. #929 T1 Opus round finding: this test used to assert the
+// OPPOSITE — that a fractional square origin was fine — and in doing so
+// blessed a real hole in W2's disjointness promise. Two 5x5 square rooms
+// anchored at (0,0) and (0.5,0.5) have disjoint INTEGER cell sets (an
+// enumeration-based W2 check, since replaced, would have accepted them)
+// while their continuous footprints interpenetrate roughly 81% of each
+// room's area, and a Chebyshev-0 "doorway" (two endpoints landing on the
+// same fractional point) would still measure as adjacent. This is now the
+// rejection pin that closes that hole.
+func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
@@ -959,7 +1004,9 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginUnconstrained() {
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
-	s.Require().NoError(err, "a fractional Origin on a square room is not a defect")
+	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "not an integral cell")
 }
 
 // TestSetupAnchoringW1BothDirections pins W1's message names BOTH rooms and
@@ -986,6 +1033,73 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Require().Contains(err.Error(), `room "square-first" (square)`)
 	s.Require().Contains(err.Error(), `room "hex-second" (hex)`)
+}
+
+// TestSetupAnchoringOverlapNonAdjacentPair is fixture 3b (#929 T1 Opus
+// round mutation evidence): three square rooms — r-a at the zero-value
+// Origin, r-b anchored far away at (20,20), r-c anchored at (2,2) — where
+// ONLY the (r-a, r-c) pair overlaps. r-a and r-b don't (adjacent pair
+// 0,1); r-b and r-c don't (adjacent pair 1,2); only r-a and r-c do
+// (non-adjacent pair 0,2). This is the TRUE one-defect W2 row — no
+// connection involved at all, unlike TestSetupAnchoring's "ordering" row
+// — and it kills a mutant that reduces W2's pairwise loop to adjacent-in-
+// slice-only comparison (j := i+1; j < i+2). Unlike W1's equivalent
+// mutant (provably unobservable over a two-value domain — see
+// validateGridFamilies' doc comment), overlap is NOT a transitive
+// relation over three arbitrarily-positioned rooms, so this fixture
+// genuinely distinguishes full pairwise from adjacent-only comparison.
+// Witness cell (2,2) is the component-wise max of r-a's and r-c's
+// interval mins.
+func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r-a", Width: 5, Height: 5},
+				{ID: "r-b", Width: 5, Height: 5, Origin: spatial.Position{X: 20, Y: 20}},
+				{ID: "r-c", Width: 5, Height: 5, Origin: spatial.Position{X: 2, Y: 2}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r-a", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), `room "r-a" and room "r-c" overlap at absolute cell (2, 2)`)
+}
+
+// TestSetupAnchoringRSpanSeparation is fixture 3c (#929 T1 Opus round
+// mutation evidence): two 4x4 hex rooms with IDENTICAL Q ranges — hex-r-b
+// is anchored at (0,4), directly south of hex-r-a, not east — disjoint
+// along R alone despite the shared Q span. This must ACCEPT (proving W2's
+// interval check doesn't need Q separation specifically) and kills an
+// R-span boundary-arithmetic drift mutant in axisBounds: dropping the hex
+// max formula's "-1" widens hex-r-a's R span from [-2,1] to [-2,2], which
+// falsely overlaps these rooms at R=2 (hex-r-b's R span is [2,5]) — see
+// the mutation evidence table. Its doorway also kisses: FromPosition
+// (0,1) is hex-r-a's own max-R boundary; ToPosition (0,-2) is hex-r-b's
+// own min-R boundary; anchored, absolute (0,1) and (0,2) are cube-distance
+// 1.
+func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
+				{ID: "hex-r-b", Width: 4, Height: 4, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 0, Y: 4}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "hex-r-a", To: "hex-r-b",
+				FromPosition: spatial.Position{X: 0, Y: 1},
+				ToPosition:   spatial.Position{X: 0, Y: -2},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-r-a", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err, "rooms separated along R alone, with identical Q ranges, must still be accepted as disjoint")
 }
 
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -6,6 +6,7 @@ package encounter_test
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -909,7 +910,21 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 		}, encounter.ErrNoField, "declare different grid families"},
 		{"origin legality: fractional hex origin", func(in *encounter.SetupInput) {
 			in.Field.Rooms[1].Origin = spatial.Position{X: 6.5, Y: -5}
-		}, encounter.ErrNoField, "not an integral cell"},
+		}, encounter.ErrNoField, "not a representable integral cell"},
+		{"origin legality: infinite origin", func(in *encounter.SetupInput) {
+			// #929 T1 second Opus round: math.Trunc(+Inf) is +Inf, so the
+			// old pos.X == math.Trunc(pos.X) check accepted this outright.
+			in.Field.Rooms[1].Origin = spatial.Position{X: math.Inf(1), Y: -5}
+		}, encounter.ErrNoField, "not a representable integral cell"},
+		{"origin legality: origin exceeds int64 precision (1e19)", func(in *encounter.SetupInput) {
+			// #929 T1 second Opus round: 1e19 is "integral" by Trunc (it has
+			// no fractional part as a float64) but exceeds int64's range —
+			// roomAbsoluteBounds' int() conversion on a value like this is
+			// Go-spec implementation-defined, not a real cell. See
+			// TestSetupAnchoringHugeOriginRejectedNotFalseOverlap for the
+			// two-room construction that used to produce a wrong verdict.
+			in.Field.Rooms[1].Origin = spatial.Position{X: 1e19, Y: -5}
+		}, encounter.ErrNoField, "not a representable integral cell"},
 		{"ordering: W2 wins over a co-occurring W3 defect", func(in *encounter.SetupInput) {
 			in.Field.Rooms[1].Origin = spatial.Position{X: 0, Y: 0}
 		}, encounter.ErrNoField, "overlap at absolute cell"},
@@ -1006,7 +1021,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	})
 	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
 	s.Require().ErrorIs(err, encounter.ErrNoField)
-	s.Require().Contains(err.Error(), "not an integral cell")
+	s.Require().Contains(err.Error(), "not a representable integral cell")
 }
 
 // TestSetupAnchoringW1BothDirections pins W1's message names BOTH rooms and
@@ -1100,6 +1115,72 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
 	s.Require().NoError(err, "rooms separated along R alone, with identical Q ranges, must still be accepted as disjoint")
+}
+
+// TestSetupAnchoringFractionalSquareEndpointSubUnitDistance pins W3's
+// strict `dist != 1` comparison (#929 T1 second Opus round: an earlier
+// comment on that check wrongly claimed sub-1 distances were unfalsifiable
+// post-origin-legality — origin legality only constrains ORIGINS, not
+// connection endpoints, and square endpoints stay fractional-tolerant by
+// design, RoomInput.Grid's doc comment). r1 is 3x3 at the zero-value
+// Origin; r2 is 3x3 at Origin (3,0), immediately east — fully disjoint (r1
+// absolute x:[0,2], r2 absolute x:[3,5]), both origins integral. Yet
+// FromPosition (2.5,1), a legal fractional cell in r1, projects to
+// absolute (2.5,1) — only 0.5 Chebyshev distance from ToPosition (0,1)'s
+// absolute (3,1). A `> 1` mutant would wrongly ACCEPT a 0.5-unit gap as
+// "close enough"; the strict `!= 1` correctly rejects it.
+func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDistance() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 3, Height: 3},
+				{ID: "r2", Width: 3, Height: 3, Origin: spatial.Position{X: 3, Y: 0}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "r1", To: "r2",
+				FromPosition: spatial.Position{X: 2.5, Y: 1},
+				ToPosition:   spatial.Position{X: 0, Y: 1},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrBadConnection)
+	s.Require().Contains(err.Error(), "distance 0.5")
+}
+
+// TestSetupAnchoringHugeOriginRejectedNotFalseOverlap pins the fix for the
+// second Opus round's headline finding: before this fix, isIntegralPosition's
+// pos.X == math.Trunc(pos.X) check accepted any float64 past int64's usable
+// precision as "integral" (Trunc is a no-op there), so two rooms anchored
+// at X=1e19 and X=2e19 — nowhere near each other — both passed origin
+// legality, then BOTH got truncated by roomAbsoluteBounds' int() to the
+// SAME implementation-defined int64 value, producing a FALSE W2 overlap
+// verdict through the public API. This pins that such an origin now
+// rejects at ORIGIN LEGALITY instead — before W2 ever sees it, and
+// specifically NOT with a W2 "overlap" message.
+func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 1e19, Y: 0}},
+				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 2e19, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "not a representable integral cell",
+		"must reject at origin legality, not fall through to a W2 overlap verdict on garbage-truncated positions")
+	s.Require().NotContains(err.Error(), "overlap at absolute cell",
+		"the old bug produced a W2 overlap message here — this must NOT be that")
 }
 
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -6,6 +6,7 @@ package encounter_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 
@@ -348,6 +349,22 @@ func validConnSetup() *encounter.SetupInput {
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	}
+}
+
+// TestSetupSquareOccluderFractionalRejected pins F2 (#929 T3 Opus round):
+// occluder integrality is universal now, not hex-only — a fractional
+// occluder on a SQUARE room (previously accepted outright, before this
+// fix) must reject exactly like a fractional hex one
+// (TestSetupHexIntegralAxial's sibling row), with the universal
+// isRepresentableInteger message, not the hex-specific one. One-defect:
+// validConnSetup's r1.Occluders[0] is the ONLY thing mutated.
+func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
+	setup := validConnSetup()
+	setup.Field.Rooms[0].Occluders[0] = spatial.Position{X: 2.5, Y: 2}
+	_, err := encounter.NewEncounter(setup)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "not a representable integral cell")
 }
 
 // TestSetupConnectionValidation mirrors TestLoadRejections' connection
@@ -701,22 +718,27 @@ func validHexAxialSetup() *encounter.SetupInput {
 // TestLoadHexIntegralAxial in data_test.go.
 func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 	cases := []struct {
-		name    string
-		mutate  func(in *encounter.SetupInput)
-		alsoErr error
+		name     string
+		mutate   func(in *encounter.SetupInput)
+		alsoErr  error
+		fragment string
 	}{
 		{"member position fractional", func(in *encounter.SetupInput) {
 			in.Members[0].Position = spatial.Position{X: 0.5, Y: 0}
-		}, encounter.ErrBadPlacement},
+		}, encounter.ErrBadPlacement, "not an integral axial cell"},
 		{"connection from-position fractional", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].FromPosition = spatial.Position{X: 1.5, Y: 1}
-		}, encounter.ErrBadConnection},
+		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"connection to-position fractional", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].ToPosition = spatial.Position{X: -1.5, Y: -1}
-		}, encounter.ErrBadConnection},
+		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"occluder position fractional", func(in *encounter.SetupInput) {
+			// #929 T3 Opus round F2: occluder integrality is now universal
+			// (isIntegralPosition), not hex-only (isIntegralAxialPosition) —
+			// the message matches Origin's ("not a representable integral
+			// cell"), not the hex-specific connection/member wording.
 			in.Field.Rooms[0].Occluders[0] = spatial.Position{X: 2.5, Y: 2}
-		}, encounter.ErrNoField},
+		}, encounter.ErrNoField, "not a representable integral cell"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -725,7 +747,7 @@ func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 			_, err := encounter.NewEncounter(setup)
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
-			s.Require().Contains(err.Error(), "not an integral axial cell",
+			s.Require().Contains(err.Error(), tc.fragment,
 				"the check that fired must be the one this case targets")
 		})
 	}
@@ -1225,6 +1247,112 @@ func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisj
 		"must reject at room legality for being oversized, before overlap is ever evaluated")
 	s.Require().NotContains(err.Error(), "overlap at absolute cell",
 		"without the bound, this exact fixture used to wrongly VALIDATE via a false-disjoint W2 verdict — see the mutation evidence")
+}
+
+// TestSetupRoomCellBudgetRejectsPanicReproduction pins F1 (#929 T3 Opus
+// round, HIGH): a 2^30 x 2^30 room is individually LEGAL under
+// maxRoomSpan's per-axis check (each dimension equals, not exceeds, the
+// bound) but its cell count (2^60) panics Atlas's allocation — the exact
+// reproduction Opus found, reachable from a tiny SetupInput. Must REJECT
+// with maxRoomCells' message, never construct.
+func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err, "a 2^30 x 2^30 room must REJECT, not panic Atlas's allocation")
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceeding max room cells")
+}
+
+// TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms pins F1's field-total
+// bound: five 1024x1024 rooms are each EXACTLY at maxRoomCells (1<<20,
+// individually legal — the per-room check passes) but their SUM (5<<20)
+// exceeds maxFieldCells (4<<20) — amplification across rooms, not within
+// one, the OTHER half of F1's reproduction.
+func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRooms() {
+	rooms := make([]encounter.RoomInput, 5)
+	for i := range rooms {
+		rooms[i] = encounter.RoomInput{ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024}
+	}
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field:   encounter.FieldInput{Rooms: rooms},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Require().Contains(err.Error(), "exceeding max field cells")
+}
+
+// validEndingTriggerSetup is the base fixture for TestSetupEndingTriggerValidation:
+// a single square room with a TriggerReachedPosition ending naming a real,
+// in-bounds room/position — the valid base each case breaks exactly one
+// thing about (#929 T3 Opus round F5).
+func validEndingTriggerSetup() *encounter.SetupInput {
+	return &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 3, Y: 3}}},
+		},
+	}
+}
+
+// TestSetupEndingTriggerValidation pins F5 (#929 T3 Opus round): a
+// TriggerReachedPosition ending that names no real room, or a position
+// that can never be reached, is a declaration defect — "an encounter that
+// cannot end is a liveness hole" (ErrNoEnding's doc comment) — not a
+// silently-accepted dead ending.
+func (s *EncounterTestSuite) TestSetupEndingTriggerValidation() {
+	cases := []struct {
+		name     string
+		mutate   func(in *encounter.SetupInput)
+		fragment string
+	}{
+		{"unknown room", func(in *encounter.SetupInput) {
+			in.Endings[0].Trigger = encounter.TriggerReachedPosition{Room: "nowhere", Position: spatial.Position{X: 3, Y: 3}}
+		}, "unknown room"},
+		{"out of bounds position", func(in *encounter.SetupInput) {
+			in.Endings[0].Trigger = encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 100, Y: 100}}
+		}, "out of bounds"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			setup := validEndingTriggerSetup()
+			tc.mutate(setup)
+			_, err := encounter.NewEncounter(setup)
+			s.Require().Error(err, tc.name)
+			s.Require().ErrorIs(err, encounter.ErrNoEnding, tc.name)
+			s.Require().Contains(err.Error(), tc.fragment,
+				"the check that fired must be the one this case targets")
+		})
+	}
+
+	// The valid base itself must construct.
+	_, err := encounter.NewEncounter(validEndingTriggerSetup())
+	s.Require().NoError(err, "a trigger naming a real room and in-bounds position must validate")
+}
+
+// TestSetupEndingTriggerHexNonIntegralRejected is TestSetupEndingTriggerValidation's
+// hex-specific sibling: a fractional axial trigger position rejects
+// exactly like a fractional connection/member position does (#929 T3
+// Opus round F5).
+func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
+	setup := &encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 1.5, Y: 0}}},
+		},
+	}
+	_, err := encounter.NewEncounter(setup)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, encounter.ErrNoEnding)
+	s.Require().Contains(err.Error(), "not an integral axial cell")
 }
 
 func (s *EncounterTestSuite) TestSetupOpeningBeat() {

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -26,9 +26,12 @@ var (
 	ErrClosed = errors.New("encounter closed")
 
 	// ErrNoField is returned when Setup is called without rooms, or when a
-	// declared room is itself defective — empty or duplicate ID,
-	// unrecognized or no-longer-supported grid shape (checked at both Setup
-	// and Load), non-positive Width/Height, or a non-integral Origin (EVERY
+	// declared room is itself defective — empty or duplicate ID, an
+	// unrecognized grid shape value (checked at both Setup and Load), a
+	// no-longer-supported grid shape (gridless; Setup-only as of this
+	// wave — a stored "gridless" grid string still LOADS today, per
+	// RoomData's own doc comment in data.go; Load-side rejection of it is
+	// T2's job), non-positive Width/Height, or a non-integral Origin (EVERY
 	// grid family, not just hex) — or the room list as a whole is
 	// incoherent (W1: more than one grid family in one field; W2: two
 	// rooms' absolute footprints overlap) — a malformed room list is as

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -28,18 +28,28 @@ var (
 	// ErrNoField is returned when Setup is called without rooms, or when a
 	// declared room is itself defective — empty or duplicate ID, an
 	// unrecognized-or-no-longer-supported grid shape value (gridless
-	// included — RoomData's doc comment in data.go), non-positive
-	// Width/Height, or a non-integral Origin (EVERY grid family, not just
-	// hex) — or the room list as a whole is incoherent (W1: more than one
-	// grid family in one field; W2: two rooms' absolute footprints
-	// overlap) — a malformed room list is as unusable as an empty one.
+	// included — RoomData's doc comment in data.go), non-positive OR
+	// oversized Width/Height (maxRoomSpan), an out-of-bounds Origin
+	// (maxAnchorCoord) or a non-representable one (non-integral, ±Inf,
+	// NaN — EVERY grid family, not just hex), or — Load-only, since
+	// RoomInput.Origin is a plain value and can't be absent the way
+	// RoomData.Origin's pointer can — a MISSING Origin (W5 presence: a nil
+	// pointer means the field was absent from the blob, distinct from a
+	// declared zero — RoomData's doc comment in data.go) — or the room
+	// list as a whole is incoherent (W1: more than one grid family in one
+	// field; W2: two rooms' absolute footprints overlap) — a malformed
+	// room list is as unusable as an empty one.
 	//
 	// Checked identically at Setup and Load (#929 T2): LoadEncounter routes
 	// room-list validation through the SAME buildValidRoomGrids Setup uses
 	// (LoadEncounter's doc comment in data.go), so W1, room-dimension
 	// legality, origin legality, and W2 reject a persisted blob exactly as
 	// they would a live SetupInput — Setup and Load can no longer drift on
-	// these checks by construction, not just by convention.
+	// these checks by construction, not just by convention. The shared
+	// validator's own error messages carry no verb prefix — NewEncounter
+	// and LoadEncounter each wrap their own ("newencounter:" / "load
+	// encounter:") at their own call sites (#929 T2 second review round;
+	// buildValidRoomGrids' doc comment).
 	ErrNoField = errors.New("no field")
 
 	// ErrBadPlacement is returned when a placement fails spatial validation.

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -11,11 +11,17 @@ var (
 	ErrNilInput = errors.New("nil input")
 
 	// ErrNoMember is returned when an input contains an empty or
-	// duplicate member ID (Setup, Join), a member is declared a player
-	// while carrying a Decider — design law C2 — at any of the three
-	// seams that accept one (NewEncounter, LoadEncounter, Join), Join
-	// names a member ID already in the encounter, Exit is called with an
-	// empty member ID, or Story's audience never joined.
+	// duplicate member ID (Setup, Join, and Load — Load's identical
+	// checks used to carry only ErrInvalidData, #929 hardening round F),
+	// a member is declared a player while carrying a Decider — design
+	// law C2 — at any of the three seams that accept one (NewEncounter,
+	// LoadEncounter, Join), Join names a member ID already in the
+	// encounter, Exit is called with an empty member ID, Story's
+	// audience never joined, or — Load-only, since these are persisted-
+	// state coherence checks with no Setup analogue — a persisted
+	// abandoned outcome with non-empty membership (abandonment means the
+	// membership emptied) or a current member missing from EverMembers
+	// (#929 hardening round F).
 	ErrNoMember = errors.New("empty member id")
 
 	// ErrNotMember is returned when an entity is not a member of this encounter.
@@ -23,13 +29,22 @@ var (
 
 	// ErrNoEnding is returned when Setup or Load is called with zero
 	// endings, a declared ending's key is empty or the reserved
-	// "abandoned", End is called with an undeclared key or one whose
-	// Trigger is not TriggerExternal, or a TriggerReachedPosition ending
-	// names an unknown room or an unreachable position (#929 T3 Opus
-	// round F5, checked identically at Setup and Load — see
-	// validateEndingTriggers). An encounter that cannot end — whether it
-	// declares zero endings or one that can never fire — is a liveness
-	// hole.
+	// "abandoned", a declared ending's key duplicates an earlier one in
+	// the same input (#929 hardening round E — an unvalidated duplicate
+	// lets declaration order silently shadow a later ending, e.g. a
+	// reached_position twin permanently hiding an external ending), End
+	// is called with an undeclared key or one whose Trigger is not
+	// TriggerExternal, or a TriggerReachedPosition ending names an
+	// unknown room or an unreachable position (#929 T3 Opus round F5,
+	// checked identically at Setup and Load — see
+	// validateEndingTriggers), or — Load-only, since these are wire-
+	// format/persisted-state concerns with no Setup analogue —
+	// EndingData names an unrecognized Kind string, a reached_position
+	// EndingData is missing its Room or Position, or a persisted Outcome
+	// names an ending key that was never declared (these three used to
+	// carry only ErrInvalidData, #929 hardening round F). An encounter
+	// that cannot end — whether it declares zero endings or one that can
+	// never fire — is a liveness hole.
 	ErrNoEnding = errors.New("no such ending")
 
 	// ErrClosed is returned when a mutating verb (action, event, exit, etc.)
@@ -41,7 +56,11 @@ var (
 	// unrecognized-or-no-longer-supported grid shape value (gridless
 	// included — RoomData's doc comment in data.go), a non-integral
 	// occluder position in ANY family, not just hex (#929 T3 Opus round
-	// F2), non-positive OR oversized Width/Height (maxRoomSpan), a
+	// F2), a duplicate occluder position within one room (#929 hardening
+	// round D — previously escaped module validation and rejected only
+	// in spatial's own voice, an accident of the pre-index-based
+	// occluder entity ID), non-positive OR oversized Width/Height
+	// (maxRoomSpan), a
 	// per-room or field-total cell count exceeding maxRoomCells/
 	// maxFieldCells (allocation safety for Atlas — #929 T3 Opus round F1),
 	// an out-of-bounds Origin (maxAnchorCoord) or a non-representable one
@@ -82,7 +101,11 @@ var (
 	// moveMember's own bounds/integrality checks, Traverse's threshold
 	// check, Pump's snapshot lookups, Join's/Exit's own lookups) reject
 	// before ever reaching spatial, with nothing beneath ErrBadPlacement
-	// to wrap.
+	// to wrap. Also covers LoadEncounter's member and outcome-member
+	// checks — room lookup miss, out-of-bounds position, non-integral
+	// (hex) position — which mirror NewEncounter's identical member
+	// checks and used to carry only ErrInvalidData (#929 hardening
+	// round F).
 	ErrBadPlacement = errors.New("bad placement")
 
 	// ErrBadConnection is returned when a connection's ID is empty or

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -10,16 +10,23 @@ var (
 	// Indicates a caller defect.
 	ErrNilInput = errors.New("nil input")
 
-	// ErrNoMember is returned when an input contains an empty member ID.
+	// ErrNoMember is returned when an input contains an empty or
+	// duplicate member ID (Setup, Join), a member is declared a player
+	// while carrying a Decider — design law C2 — at any of the three
+	// seams that accept one (NewEncounter, LoadEncounter, Join), Join
+	// names a member ID already in the encounter, Exit is called with an
+	// empty member ID, or Story's audience never joined.
 	ErrNoMember = errors.New("empty member id")
 
 	// ErrNotMember is returned when an entity is not a member of this encounter.
 	ErrNotMember = errors.New("not a member")
 
-	// ErrNoEnding is returned when Setup is called with zero endings, End
-	// is called with an undeclared key, or a TriggerReachedPosition
-	// ending names an unknown room or an unreachable position (#929 T3
-	// Opus round F5, checked identically at Setup and Load — see
+	// ErrNoEnding is returned when Setup or Load is called with zero
+	// endings, a declared ending's key is empty or the reserved
+	// "abandoned", End is called with an undeclared key or one whose
+	// Trigger is not TriggerExternal, or a TriggerReachedPosition ending
+	// names an unknown room or an unreachable position (#929 T3 Opus
+	// round F5, checked identically at Setup and Load — see
 	// validateEndingTriggers). An encounter that cannot end — whether it
 	// declares zero endings or one that can never fire — is a liveness
 	// hole.
@@ -64,18 +71,32 @@ var (
 	// ErrNoConnection's split from ErrBadConnection below.
 	ErrNoField = errors.New("no field")
 
-	// ErrBadPlacement is returned when a placement fails spatial validation.
-	// Wraps the underlying spatial error.
+	// ErrBadPlacement is returned when a placement or position is bad in
+	// a way runtime spatial state can catch (not declaration-time
+	// validation — that's ErrNoField/ErrBadConnection): a room or entity
+	// lookup miss, a position out of bounds or (hex) non-integral, a
+	// member not standing at a connection's threshold, or an actual
+	// underlying spatial-package call (AddRoom, PlaceEntity,
+	// TransitionEntity, RemoveEntity) failing. Only the LAST class wraps
+	// an underlying spatial error — most call sites (Absolute, Locate,
+	// moveMember's own bounds/integrality checks, Traverse's threshold
+	// check, Pump's snapshot lookups, Join's/Exit's own lookups) reject
+	// before ever reaching spatial, with nothing beneath ErrBadPlacement
+	// to wrap.
 	ErrBadPlacement = errors.New("bad placement")
 
 	// ErrBadConnection is returned when a connection's ID is empty or
-	// duplicated, its From/To names an unknown room or itself, or an
-	// endpoint lies outside its room's bounds or on an occluder position —
-	// or (W3) its two endpoints, once anchored to their rooms' Origin, are
-	// not adjacent absolute cells. Checked identically at Setup and Load
-	// (#929 T2 — see ErrNoField's doc comment): LoadEncounter routes
-	// connection validation through the SAME validateConnectionInputs
-	// Setup uses.
+	// duplicated, its From/To names an unknown room or itself, an
+	// endpoint lies outside its room's bounds, is non-integral (hex
+	// rooms only), or sits on an occluder position — or (W3) its two
+	// endpoints, once anchored to their rooms' Origin, are not adjacent
+	// absolute cells — or, Load-only, since ConnectionInput's endpoints
+	// are plain values and can't be absent the way ConnectionData's
+	// pointers can, a MISSING FromPosition or ToPosition (the connection
+	// analogue of ErrNoField's missing-Origin case). Checked identically
+	// at Setup and Load (#929 T2 — see ErrNoField's doc comment):
+	// LoadEncounter routes connection validation through the SAME
+	// validateConnectionInputs Setup uses.
 	ErrBadConnection = errors.New("bad connection")
 
 	// ErrNoConnection is returned by Traverse when the given connection ID

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -50,6 +50,11 @@ var (
 	// and LoadEncounter each wrap their own ("newencounter:" / "load
 	// encounter:") at their own call sites (#929 T2 second review round;
 	// buildValidRoomGrids' doc comment).
+	//
+	// Also returned by Absolute (#929 T3) when the named room does not
+	// exist in this field — a runtime lookup miss reusing the room-list
+	// defect vocabulary rather than a dedicated sentinel, unlike
+	// ErrNoConnection's split from ErrBadConnection below.
 	ErrNoField = errors.New("no field")
 
 	// ErrBadPlacement is returned when a placement fails spatial validation.

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -27,23 +27,19 @@ var (
 
 	// ErrNoField is returned when Setup is called without rooms, or when a
 	// declared room is itself defective — empty or duplicate ID, an
-	// unrecognized grid shape value (checked at both Setup and Load), a
-	// no-longer-supported grid shape (gridless; Setup-only as of this
-	// wave — a stored "gridless" grid string still LOADS today, per
-	// RoomData's own doc comment in data.go; Load-side rejection of it is
-	// T2's job), non-positive Width/Height, or a non-integral Origin (EVERY
-	// grid family, not just hex) — or the room list as a whole is
-	// incoherent (W1: more than one grid family in one field; W2: two
-	// rooms' absolute footprints overlap) — a malformed room list is as
-	// unusable as an empty one.
+	// unrecognized-or-no-longer-supported grid shape value (gridless
+	// included — RoomData's doc comment in data.go), non-positive
+	// Width/Height, or a non-integral Origin (EVERY grid family, not just
+	// hex) — or the room list as a whole is incoherent (W1: more than one
+	// grid family in one field; W2: two rooms' absolute footprints
+	// overlap) — a malformed room list is as unusable as an empty one.
 	//
-	// W1, room-dimension legality, origin legality, and W2 are SETUP-ONLY
-	// as of this wave: LoadEncounter (data.go) predates them and does not
-	// yet enforce any of the four. Load-side enforcement of the W-laws
-	// lands with persistence in T2 (RoomInput.Origin's doc comment) —
-	// until then, a hand-authored or previously-persisted blob can carry a
-	// mixed-family field, a non-positive dimension, or an overlapping pair
-	// through Load unrejected.
+	// Checked identically at Setup and Load (#929 T2): LoadEncounter routes
+	// room-list validation through the SAME buildValidRoomGrids Setup uses
+	// (LoadEncounter's doc comment in data.go), so W1, room-dimension
+	// legality, origin legality, and W2 reject a persisted blob exactly as
+	// they would a live SetupInput — Setup and Load can no longer drift on
+	// these checks by construction, not just by convention.
 	ErrNoField = errors.New("no field")
 
 	// ErrBadPlacement is returned when a placement fails spatial validation.
@@ -53,10 +49,11 @@ var (
 	// ErrBadConnection is returned when a connection's ID is empty or
 	// duplicated, its From/To names an unknown room or itself, or an
 	// endpoint lies outside its room's bounds or on an occluder position —
-	// all checked at both Setup and Load — or (W3) its two endpoints, once
-	// anchored to their rooms' Origin, are not adjacent absolute cells.
-	// W3 is SETUP-ONLY as of this wave (see ErrNoField's doc comment);
-	// Load-side enforcement lands with persistence in T2.
+	// or (W3) its two endpoints, once anchored to their rooms' Origin, are
+	// not adjacent absolute cells. Checked identically at Setup and Load
+	// (#929 T2 — see ErrNoField's doc comment): LoadEncounter routes
+	// connection validation through the SAME validateConnectionInputs
+	// Setup uses.
 	ErrBadConnection = errors.New("bad connection")
 
 	// ErrNoConnection is returned by Traverse when the given connection ID

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -26,12 +26,21 @@ var (
 	ErrClosed = errors.New("encounter closed")
 
 	// ErrNoField is returned when Setup is called without rooms, or when a
-	// declared room is itself defective (empty or duplicate ID, unrecognized
-	// or no-longer-supported grid shape, non-integral hex origin) or the
-	// room list as a whole is incoherent (W1: more than one grid family in
-	// one field; W2: two rooms' absolute footprints overlap) — a malformed
-	// room list is as unusable as an empty one. Returned at both Setup and
-	// Load.
+	// declared room is itself defective — empty or duplicate ID,
+	// unrecognized or no-longer-supported grid shape (checked at both Setup
+	// and Load), non-positive Width/Height, or a non-integral Origin (EVERY
+	// grid family, not just hex) — or the room list as a whole is
+	// incoherent (W1: more than one grid family in one field; W2: two
+	// rooms' absolute footprints overlap) — a malformed room list is as
+	// unusable as an empty one.
+	//
+	// W1, room-dimension legality, origin legality, and W2 are SETUP-ONLY
+	// as of this wave: LoadEncounter (data.go) predates them and does not
+	// yet enforce any of the four. Load-side enforcement of the W-laws
+	// lands with persistence in T2 (RoomInput.Origin's doc comment) —
+	// until then, a hand-authored or previously-persisted blob can carry a
+	// mixed-family field, a non-positive dimension, or an overlapping pair
+	// through Load unrejected.
 	ErrNoField = errors.New("no field")
 
 	// ErrBadPlacement is returned when a placement fails spatial validation.
@@ -39,11 +48,12 @@ var (
 	ErrBadPlacement = errors.New("bad placement")
 
 	// ErrBadConnection is returned when a connection's ID is empty or
-	// duplicated, its From/To names an unknown room or itself, an endpoint
-	// lies outside its room's bounds or on an occluder position, or (W3)
-	// its two endpoints, once anchored to their rooms' Origin, are not
-	// adjacent absolute cells. Returned at both Setup and Load — a
-	// declaration-time defect.
+	// duplicated, its From/To names an unknown room or itself, or an
+	// endpoint lies outside its room's bounds or on an occluder position —
+	// all checked at both Setup and Load — or (W3) its two endpoints, once
+	// anchored to their rooms' Origin, are not adjacent absolute cells.
+	// W3 is SETUP-ONLY as of this wave (see ErrNoField's doc comment);
+	// Load-side enforcement lands with persistence in T2.
 	ErrBadConnection = errors.New("bad connection")
 
 	// ErrNoConnection is returned by Traverse when the given connection ID

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -27,8 +27,11 @@ var (
 
 	// ErrNoField is returned when Setup is called without rooms, or when a
 	// declared room is itself defective (empty or duplicate ID, unrecognized
-	// grid shape) — a malformed room list is as unusable as an empty one.
-	// Returned at both Setup and Load.
+	// or no-longer-supported grid shape, non-integral hex origin) or the
+	// room list as a whole is incoherent (W1: more than one grid family in
+	// one field; W2: two rooms' absolute footprints overlap) — a malformed
+	// room list is as unusable as an empty one. Returned at both Setup and
+	// Load.
 	ErrNoField = errors.New("no field")
 
 	// ErrBadPlacement is returned when a placement fails spatial validation.
@@ -36,9 +39,11 @@ var (
 	ErrBadPlacement = errors.New("bad placement")
 
 	// ErrBadConnection is returned when a connection's ID is empty or
-	// duplicated, its From/To names an unknown room or itself, or an
-	// endpoint lies outside its room's bounds or on an occluder position.
-	// Returned at both Setup and Load — a declaration-time defect.
+	// duplicated, its From/To names an unknown room or itself, an endpoint
+	// lies outside its room's bounds or on an occluder position, or (W3)
+	// its two endpoints, once anchored to their rooms' Origin, are not
+	// adjacent absolute cells. Returned at both Setup and Load — a
+	// declaration-time defect.
 	ErrBadConnection = errors.New("bad connection")
 
 	// ErrNoConnection is returned by Traverse when the given connection ID

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -16,9 +16,13 @@ var (
 	// ErrNotMember is returned when an entity is not a member of this encounter.
 	ErrNotMember = errors.New("not a member")
 
-	// ErrNoEnding is returned when Setup is called with zero endings, or End
-	// is called with an undeclared key. An encounter that cannot end is a
-	// liveness hole.
+	// ErrNoEnding is returned when Setup is called with zero endings, End
+	// is called with an undeclared key, or a TriggerReachedPosition
+	// ending names an unknown room or an unreachable position (#929 T3
+	// Opus round F5, checked identically at Setup and Load — see
+	// validateEndingTriggers). An encounter that cannot end — whether it
+	// declares zero endings or one that can never fire — is a liveness
+	// hole.
 	ErrNoEnding = errors.New("no such ending")
 
 	// ErrClosed is returned when a mutating verb (action, event, exit, etc.)
@@ -28,17 +32,20 @@ var (
 	// ErrNoField is returned when Setup is called without rooms, or when a
 	// declared room is itself defective — empty or duplicate ID, an
 	// unrecognized-or-no-longer-supported grid shape value (gridless
-	// included — RoomData's doc comment in data.go), non-positive OR
-	// oversized Width/Height (maxRoomSpan), an out-of-bounds Origin
-	// (maxAnchorCoord) or a non-representable one (non-integral, ±Inf,
-	// NaN — EVERY grid family, not just hex), or — Load-only, since
-	// RoomInput.Origin is a plain value and can't be absent the way
-	// RoomData.Origin's pointer can — a MISSING Origin (W5 presence: a nil
-	// pointer means the field was absent from the blob, distinct from a
-	// declared zero — RoomData's doc comment in data.go) — or the room
-	// list as a whole is incoherent (W1: more than one grid family in one
-	// field; W2: two rooms' absolute footprints overlap) — a malformed
-	// room list is as unusable as an empty one.
+	// included — RoomData's doc comment in data.go), a non-integral
+	// occluder position in ANY family, not just hex (#929 T3 Opus round
+	// F2), non-positive OR oversized Width/Height (maxRoomSpan), a
+	// per-room or field-total cell count exceeding maxRoomCells/
+	// maxFieldCells (allocation safety for Atlas — #929 T3 Opus round F1),
+	// an out-of-bounds Origin (maxAnchorCoord) or a non-representable one
+	// (non-integral, ±Inf, NaN — EVERY grid family, not just hex), or —
+	// Load-only, since RoomInput.Origin is a plain value and can't be
+	// absent the way RoomData.Origin's pointer can — a MISSING Origin (W5
+	// presence: a nil pointer means the field was absent from the blob,
+	// distinct from a declared zero — RoomData's doc comment in data.go)
+	// — or the room list as a whole is incoherent (W1: more than one grid
+	// family in one field; W2: two rooms' absolute footprints overlap) —
+	// a malformed room list is as unusable as an empty one.
 	//
 	// Checked identically at Setup and Load (#929 T2): LoadEncounter routes
 	// room-list validation through the SAME buildValidRoomGrids Setup uses

--- a/rulebooks/dnd5e/encounter/errors_test.go
+++ b/rulebooks/dnd5e/encounter/errors_test.go
@@ -20,6 +20,8 @@ func TestSentinelsAreDistinct(t *testing.T) {
 		encounter.ErrClosed,
 		encounter.ErrNoField,
 		encounter.ErrBadPlacement,
+		encounter.ErrBadConnection,
+		encounter.ErrNoConnection,
 		encounter.ErrInvalidData,
 	}
 

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// Example_theDungeon is the anchoring wave's signature scene (#929 T5) —
+// sibling to Example_theTraverse, which shows the SAME kind of doorway
+// crossing through percepts (what a MEMBER believes). This one shows what
+// a HOST renders: every position projected into dungeon-absolute space
+// via Absolute, so the room boundary that Example_theTraverse's story
+// crosses becomes visible as exactly what it is — one continuous space,
+// not two local coordinate systems glued together. The Output block
+// below is verified by go test, so this narration can never drift from
+// what Absolute actually returns.
+func Example_theDungeon() {
+	gate := encounter.ConnectionInput{
+		ID: "gate", From: "hall", To: "vault",
+		FromPosition: spatial.Position{X: 7, Y: 4},
+		ToPosition:   spatial.Position{X: 0, Y: 4},
+	}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hall", Width: 8, Height: 8},
+				// Anchored immediately east of the hall (#929 T1): the
+				// gate's endpoints (7,4) and (0,4)+(8,0)=(8,4) are
+				// Chebyshev-adjacent (W3), and the rooms' absolute
+				// footprints (x:[0,7] vs x:[8,15]) stay disjoint (W2).
+				{ID: "vault", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},
+			},
+			Connections: []encounter.ConnectionInput{gate},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 7, Y: 4}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "done", Trigger: encounter.TriggerExternal{}},
+		},
+	})
+	if err != nil {
+		fmt.Println("setup:", err)
+		return
+	}
+
+	// tellAbsolute is what a host does with a member's room-local
+	// position before handing it to a renderer: project it, once,
+	// through the bridge — never re-derive world coordinates by hand.
+	tellAbsolute := func(room string, pos spatial.Position) {
+		out, err := enc.Absolute(&encounter.AbsoluteInput{Room: room, Position: pos})
+		if err != nil {
+			fmt.Println("absolute:", err)
+			return
+		}
+		fmt.Printf("alice: %s local(%g,%g) -- dungeon-absolute(%g,%g)\n", room, pos.X, pos.Y, out.Position.X, out.Position.Y)
+	}
+
+	fmt.Println("-- alice, at the threshold --")
+	tellAbsolute("hall", spatial.Position{X: 7, Y: 4})
+
+	fmt.Println("-- she crosses the gate --")
+	travOut, err := enc.Traverse(&encounter.TraverseInput{Member: "alice", Connection: "gate"})
+	if err != nil {
+		fmt.Println("traverse:", err)
+		return
+	}
+	tellAbsolute(travOut.Traversed.ToRoom, travOut.Traversed.To)
+
+	// Output:
+	// -- alice, at the threshold --
+	// alice: hall local(7,4) -- dungeon-absolute(7,4)
+	// -- she crosses the gate --
+	// alice: vault local(0,4) -- dungeon-absolute(8,4)
+}

--- a/rulebooks/dnd5e/encounter/example_traverse_test.go
+++ b/rulebooks/dnd5e/encounter/example_traverse_test.go
@@ -31,7 +31,11 @@ func Example_theTraverse() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},
-				{ID: "vault", Width: 8, Height: 8},
+				// Anchored immediately east of the hall (#929 T1): the
+				// gate's endpoints (7,4) and (0,4)+(8,0)=(8,4) are
+				// Chebyshev-adjacent (W3), and the rooms' absolute
+				// footprints (x:[0,7] vs x:[8,15]) stay disjoint (W2).
+				{ID: "vault", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{gate},
 		},

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -84,14 +84,17 @@ type RoomInput struct {
 	// area — a fractional origin defeats the very disjointness this field
 	// exists to guarantee, not just a hex-specific edge case.
 	//
-	// Setup validates every field against the W-laws: W1 (one grid family
-	// per field), W2 (rooms never overlap in absolute space), and W3
-	// (every connection's endpoints are adjacent absolute cells). Rules
-	// and verbs (Move, View, Traverse, ...) stay room-local — absolute
-	// coordinates only ever appear in query OUTPUTS: Atlas, Absolute, and
-	// Locate project through Origin (W4 — "projection is a read", #929
-	// T3), never a rule's own logic. Origin also round-trips through
-	// persistence (RoomData.Origin, #929 T2).
+	// Both construction seams — Setup and Load — validate every field
+	// against the W-laws identically (#929 T2: LoadEncounter routes
+	// through the SAME shared validators Setup uses, not a parallel
+	// reimplementation): W1 (one grid family per field), W2 (rooms never
+	// overlap in absolute space), and W3 (every connection's endpoints
+	// are adjacent absolute cells). Rules and verbs (Move, View,
+	// Traverse, ...) stay room-local — absolute coordinates only ever
+	// appear in query OUTPUTS: Atlas, Absolute, and Locate project
+	// through Origin (W4 — "projection is a read", #929 T3), never a
+	// rule's own logic. Origin also round-trips through persistence
+	// (RoomData.Origin, #929 T2).
 	Origin spatial.Position
 }
 

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -61,6 +61,22 @@ type RoomInput struct {
 
 	// Boundaries define walls or barriers between adjacent cells.
 	Boundaries []spatial.Boundary
+
+	// Origin is this room's dungeon-absolute anchor: local (0,0) maps to
+	// Origin in the field's shared absolute space. Local→absolute is
+	// element-wise addition (local cell + Origin) — for hex rooms this is
+	// ordinary axial cube arithmetic (axial+axial is valid cube math), not
+	// a special case. The zero value anchors a room at the absolute
+	// origin, which is legal on its own; in a multi-room field, leaving
+	// every Origin at its zero value collides every room at (0,0) and is
+	// rejected by W2 (see NewEncounter) — there is no separate
+	// "origin required" check. Setup validates every field against the
+	// W-laws: W1 (one grid family per field), W2 (rooms never overlap in
+	// absolute space), and W3 (every connection's endpoints are adjacent
+	// absolute cells). Rules and queries stay room-local in this wave —
+	// Origin exists for layout coherence at Setup, not yet for movement,
+	// sight, or persistence.
+	Origin spatial.Position
 }
 
 // ConnectionInput describes a connection between two rooms: a bidirectional

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -35,16 +35,19 @@ type RoomInput struct {
 	Height int
 
 	// Grid selects the room's coordinate system: GridShapeSquare (the zero
-	// value — Width x Height cells, origin (0,0), Chebyshev distance),
-	// GridShapeHex, or GridShapeGridless (continuous positions within
-	// Width x Height, origin (0,0)). The zero value keeps every
-	// pre-existing room square, so v0.1 persisted blobs without this
-	// field unmarshal to square unchanged.
+	// value — Width x Height cells, origin (0,0), Chebyshev distance) or
+	// GridShapeHex — the only two families Setup and Load accept as of
+	// #929 T1/T2. GridShapeGridless still exists as a spatial.GridShape
+	// value but is rejected outright (shape legality — buildValidRoomGrids'
+	// doc comment in encounter.go): gridless left the composition in v0.3,
+	// the wire cannot carry a continuous room's absolute projection. The
+	// zero value keeps every pre-existing room square, so v0.1 persisted
+	// blobs without this field unmarshal to square unchanged.
 	//
 	// GridShapeHex rooms speak AXIAL cube coordinates (tools/spatial's
 	// AxialHexGrid), not offset: Position.X is Q, Position.Y is R, and S
 	// = -(Q+R) is derived. Bounds are ORIGIN-CENTERED spans, unlike
-	// square/gridless — Q is valid in [-Width/2, Width/2) and R in
+	// square — Q is valid in [-Width/2, Width/2) and R in
 	// [-Height/2, Height/2), so negative coordinates are legal and
 	// expected, not a defect. Distance, adjacency, and line of sight in a
 	// hex room run true cube hex math via spatial. This is a deliberate

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -70,12 +70,22 @@ type RoomInput struct {
 	// origin, which is legal on its own; in a multi-room field, leaving
 	// every Origin at its zero value collides every room at (0,0) and is
 	// rejected by W2 (see NewEncounter) — there is no separate
-	// "origin required" check. Setup validates every field against the
-	// W-laws: W1 (one grid family per field), W2 (rooms never overlap in
-	// absolute space), and W3 (every connection's endpoints are adjacent
-	// absolute cells). Rules and queries stay room-local in this wave —
-	// Origin exists for layout coherence at Setup, not yet for movement,
-	// sight, or persistence.
+	// "origin required" check.
+	//
+	// Origin must be an INTEGRAL cell (X and Y both whole numbers) for
+	// EVERY grid family, square included — not just hex. W2's "rooms never
+	// overlap" promise is only sound over an integer cell lattice: two 5x5
+	// SQUARE rooms anchored at (0,0) and (0.5,0.5) have disjoint integer
+	// cell sets (a naive per-cell W2 check would accept them) while their
+	// continuous footprints interpenetrate roughly 81% of each room's
+	// area — a fractional origin defeats the very disjointness this field
+	// exists to guarantee, not just a hex-specific edge case.
+	//
+	// Setup validates every field against the W-laws: W1 (one grid family
+	// per field), W2 (rooms never overlap in absolute space), and W3
+	// (every connection's endpoints are adjacent absolute cells). Rules
+	// and queries stay room-local in this wave — Origin exists for layout
+	// coherence at Setup, not yet for movement, sight, or persistence.
 	Origin spatial.Position
 }
 

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -87,8 +87,11 @@ type RoomInput struct {
 	// Setup validates every field against the W-laws: W1 (one grid family
 	// per field), W2 (rooms never overlap in absolute space), and W3
 	// (every connection's endpoints are adjacent absolute cells). Rules
-	// and queries stay room-local in this wave — Origin exists for layout
-	// coherence at Setup, not yet for movement, sight, or persistence.
+	// and verbs (Move, View, Traverse, ...) stay room-local — absolute
+	// coordinates only ever appear in query OUTPUTS: Atlas, Absolute, and
+	// Locate project through Origin (W4 — "projection is a read", #929
+	// T3), never a rule's own logic. Origin also round-trips through
+	// persistence (RoomData.Origin, #929 T2).
 	Origin spatial.Position
 }
 

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -968,7 +968,11 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 
 // twoRoomDoor is the standard fixture connection for the Pump/traverse
 // tests below: room-a to room-b, DELIBERATELY asymmetric endpoints (T1
-// review lesson) so a from/to mix-up would be observable.
+// review lesson) so a from/to mix-up would be observable. room-b's Origin
+// (see the room-a/room-b RoomInput literals below) sits it immediately to
+// room-a's east — (9,5) and (0,5)+(10,0)=(10,5) are Chebyshev-adjacent
+// (distance 1), satisfying W3, while the rooms' absolute footprints
+// (x:[0,9] vs x:[10,19]) stay disjoint, satisfying W2 (#929 T1).
 var twoRoomDoor = encounter.ConnectionInput{
 	ID: "door1", From: "room-a", To: "room-b",
 	FromPosition: spatial.Position{X: 9, Y: 5},
@@ -988,7 +992,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 		},
 		Members: []encounter.MemberInput{
@@ -1028,7 +1032,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseSuccess() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{twoRoomDoor},
 		},
@@ -1073,7 +1077,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{twoRoomDoor},
 		},
@@ -1127,7 +1131,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseUnknownConnectionDoesNotAbort() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{twoRoomDoor},
 		},
@@ -1178,7 +1182,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{twoRoomDoor},
 		},
@@ -1221,7 +1225,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{twoRoomDoor},
 		},
@@ -1321,7 +1325,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
-				{ID: "room-b", Width: 10, Height: 10},
+				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{twoRoomDoor},
 		},


### PR DESCRIPTION
## What

Encounter **v0.3.0 — world anchoring**. Every room is anchored in dungeon-absolute space, layout coherence is load-rejectable law, and the composition serves the map instead of making hosts compute it. Design triplet: #930 (merges as ratification). Closes #929.

This graduates rpg-api's `internal/components/dungeon` coordinate prototype (rpg-api#471, graduation planned in #479) into the module that can actually validate it. The prototype's lessons carry verbatim — distinct local/absolute spaces, an origins-map layout, one legal bridge, no ad-hoc coordinate math at call sites. What it could never do, because it couldn't see connections, is now law.

## The laws

- **W1 — one geometry per field.** All rooms share a grid family; absolute space inherits it. (Gridless left the composition this wave: the wire cannot carry it, and it was the sole source of special cases in W2/W3/Atlas.)
- **W2 — rooms never overlap.** Absolute cell sets are disjoint. This subsumes "origins required" — a multi-room field that defaults its origins collides at (0,0) and rejects with no dedicated rule.
- **W3 — doorways kiss.** A connection's two endpoints project to *adjacent* absolute cells. A traversal is therefore one ordinary step in world space, and the client never learns rooms exist.
- **W4 — projection is a read.** `Atlas()` serves the static map; `Absolute()`/`Locate()` bridge live positions. Rules, verbs, percepts, and deciders stay room-local — T3 and C2 untouched.
- **W5 — anchors are construction data.** Origins persist, and are validated identically at Setup and Load.

## The payoff, as a test

`TestVaultChaseAbsoluteContinuity` projects an entire hex pursuit through the bridge — placements, moves, both doorway crossings, a mid-story reload, the pursuit, the ending — and asserts the world-space path is **continuous across all 14 rows**, with each doorway crossing at distance **exactly 1**. In the pinned transcript the doorway rows are indistinguishable from ordinary moves, which is precisely the property the web client renders by.

Its discrimination is proven by localization, not by mere failure: with W3 disabled and one origin shifted a single cell, the continuity check breaks at *exactly* the doorway pair while the preceding corridor steps stay continuous.

## Surface added

| Query | Purpose |
|---|---|
| `Atlas() (Atlas, error)` | The static world map: rooms with absolute cells, occluders and boundaries, plus doorway kissing pairs. Construction-truth — unchanged by moves, pumps, joins, exits, or close. Cache it per encounter; at the field budget one call costs ~128 MB. |
| `Absolute(*AbsoluteInput)` | room-local → dungeon-absolute. Legal for any in-bounds position: occupied, occluded, or empty. |
| `Locate(*LocateInput)` | dungeon-absolute → (room, room-local). The host's inbound path, since wire targets arrive absolute. Well-defined *because* of W2. |

`RoomInput.Origin` and `RoomData.Origin` (presence-required at load) complete the set.

## What the review rounds found

Six review passes (three sonnet, three Opus) across the five tasks. The defects worth naming, all closed pre-merge:

- **Two wrong-verdict integer overflows reachable through the public API.** Origins past 2^63 collapsed to int64-min bounds, so two rooms 1e19 apart were rejected as *overlapping*; separately, unbounded `Width`/`Height` wrapped the interval sums so two rooms overlapping over ~9.2e18 cells were accepted as *disjoint*. Both closed with bounded world coordinates.
- **A panic reachable from a few hundred bytes of persisted data.** A 2^30 × 2^30 room passed the span check and `Atlas()` died allocating a 2^60 slice — on a function that returns an error it never used. Closed with allocation-safety bounds at room legality, so a broken-by-construction encounter cannot persist at all.
- **W2 was unsound under fractional square origins**: two rooms could interpenetrate over ~81% of their area while their integer cell sets stayed disjoint. Origin integrality is now universal, not hex-only. The same asymmetry was later found and fixed for occluders, where it broke `Occluders ⊆ Cells` — the contract hosts render by.
- **Three fixture-blindness gaps** where correct code had no test that could catch its own regression: a Chebyshev-on-axial substitution passed every hex fixture (none used the axial (1,1) case where the formulas diverge), W2 weakened to adjacent-pairs-only survived, and the hex R-span boundary was unobservable because every fixture separated on Q.
- **The Setup/Load seam is now structurally unified**, not merely consistent: Load routes through the same validators Setup uses, and a single mutation to a shared validator kills pins on *both* seams.

New family standard minted here — **over-tightening defense**: a one-defect rejection table proves a validator *rejects*; only a rich positive control proves it doesn't *over-reach*. Four plausible "hardening" changes to the new trigger validator would have passed CI while breaking legitimate hex encounters (negative axial coordinates are the *normal* case for origin-centered rooms). Must-accept rows now defend the legal edges.

## Verification

- **599 tests**, green; `-race` clean and stable under repeated runs; lint 0 issues; gofmt/tidy clean.
- **`gorelease -base=v0.2.0` → `Suggested version: v0.3.0`** (all changes listed compatible: three methods, six types, two struct fields).
- `./scripts/verify.sh rulebooks/dnd5e/encounter` re-proves every transcript, including the new `Example_theDungeon`, which shows the same member at `hall local(7,4) → dungeon-absolute(7,4)` and, after crossing, `vault local(0,4) → dungeon-absolute(8,4)`.
- The workbench gains an `atlas` command that prints the dungeon in world space with each doorway's kissing pair and its computed distance.

One regression found late and worth recording: the workbench binary had been failing to start since T1 (its second room never got an origin, so W2 correctly rejected the field) — invisible because nothing in CI ran it. Fixed, and its fixture is now covered by a test so the class can't hide again.

## For rpg-api

The wiring issue (rpg-api#793) targets this tag for the map surface. `internal/components/dungeon`'s coordinate machinery retires when that lands; `Absolute`/`Locate` are its heirs, living where coherence is guaranteed rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler
