### PR TITLE
docs(ideas): session SDK — scenes, brainstorm, and design (#935)

### DIFF
--- a/docs/ideas/session-sdk/brainstorm.md
+++ b/docs/ideas/session-sdk/brainstorm.md
@@ -1,0 +1,254 @@
+# Session SDK — brainstorm
+
+**Status:** open question space. Nothing here is ratified. Kirk's rulings are
+marked **RULED**; everything else is a lean or an open.
+
+**Origin:** this started as a scoping question on
+[#916](https://github.com/KirkDiggler/rpg-toolkit/issues/916) (suspendable
+movement + opportunity-attack-with-option) and turned into something larger the
+moment we asked who the customer is. #916 survives as a behavior inside this,
+not as a wave of its own.
+
+---
+
+## How we got here
+
+The question was where a suspendable movement resolution should live: the old
+`rulebooks/dnd5e/combat` stack, the new `rulebooks/dnd5e/encounter`
+composition, or a standalone phase-machine module.
+
+Four findings moved the answer, in order:
+
+1. **`encounter.Move` is a single hop, not a walk.** It calls
+   `orchestrator.MoveEntity` once with a destination — no path, no steps, no
+   distance limit. The old stack's `combat.MoveEntity` *does* walk cell by cell.
+   An opportunity attack is a property of the path, so somebody has to walk it.
+
+2. **Walls are real, and they were already there.** `spatial.Boundary` is an
+   undirected crossing between adjacent cells with separate `BlocksMovement`
+   and `BlocksLineOfSight` flags; the composition registers them and Atlas
+   projects both endpoints into absolute space. A doorway is simply a crossing
+   that isn't blocked — which is exactly why a monster standing in one can see
+   into both rooms, and why an arrow crosses it.
+
+   Therefore **T3 ("sight never crosses a connection") is not geometry.** It is
+   a room-scoped shortcut written when rooms were islands, sitting on top of a
+   crossing-based model that does not care which room a cell belongs to.
+   Anchoring made it obsolete. Retiring it is a perception wave: field-level
+   line of sight computed over Atlas, which is the only thing in the system
+   that sees every room at once. Spatial cannot own it — its boundaries are
+   registered *within* a room, and a doorway crossing spans two.
+
+3. **The composition has no entities.** `Member` is `{ID, Kind, Room}`. No hit
+   points, no sheet, no conditions, no damage, no attack. So
+   opportunity-attack-with-option — #916's headline — cannot be built there
+   today: the window would open, the player would answer "I swing," and there
+   is nothing to swing with.
+
+4. **The customer's loop is the actual design constraint.** rpg-api wants:
+   load data (encounter, monsters, players), load it into the encounter, take
+   actions, get data back, save. Measured against that loop, step two is
+   missing entirely.
+
+---
+
+## The shape
+
+**RULED — the encounter is the world; an SDK above it is the table.**
+
+The encounter stays what it is: geometry, placement, perception, story,
+endings. No entities, no bus, no combat. Its aggregate discipline (one
+`ToData`, reject-never-crash, W1–W5 validated identically at both seams) is
+worth protecting, and stuffing character sheets into it is what would dilute
+it.
+
+Above it sits a **session manager** that holds what isn't the world: the roster
+of live entities, the bus they attach to, the resolution pipeline, and
+interrupt custody.
+
+**RULED — it is a composer of composers, in the AWS-SDK sense.** Not one client
+with eighty methods. Encounter is its own thing; players are their own thing.
+The manager owns wiring and lifetime, never domain logic — the same trick the
+encounter already pulls with clock, intel, record, and spatial. **When combat
+gets heavy inside it, combat becomes its own package** with its own laws and
+tests, and the manager just ensures it plays nicely with the supporting cast.
+
+### What this buys immediately
+
+Path movement stops being an encounter feature — the manager walks a path by
+calling `encounter.Move` one cell at a time. The single-hop `Move` was the
+right primitive all along.
+
+Two things then come free, with no new encounter code:
+
+- **Sight-per-step.** `Move` already refreshes sight and returns deltas on
+  every call, so walking a path yields "Alice just saw the ogre" at step three.
+- **Endings mid-path.** `Move` already evaluates `ReachedPosition` and returns
+  an outcome; the manager sees it and stops walking. Reaching the exit on step
+  three means steps four and five correctly never happen.
+
+---
+
+## The customer contract
+
+**RULED — repositories, implemented by the game server, trading in data.**
+
+```go
+mgr, err := session.NewManager(&session.Config{
+    Characters: charRepo,   // GetCharacter / SaveCharacter
+    Encounters: encRepo,    // GetEncounter / SaveEncounter
+    Monsters:   monRepo,
+})  // refuses to construct without everything it needs
+
+out, err := mgr.Move(ctx, &session.MoveInput{
+    Encounter: "enc-123", Member: "alice", Path: path,
+})
+// out.Pending != nil  →  alice owes an answer
+
+out, err := mgr.Answer(ctx, &session.AnswerInput{...})
+```
+
+`GetCharacter` returns `character.Data`; the manager hydrates. The game server
+stays dumb storage and reconstitution stays in the toolkit, where the laws are.
+**RULED — same seam as everywhere else.**
+
+**RULED — stateless per call.** We are turn-based, and this simplifies a lot.
+Each verb loads what it needs, acts, saves, and drops everything. The bus and
+the live entities exist only for the duration of one call: conditions attach,
+do their work, and go away, with durable state living in the character blob
+where it belongs. No stale in-memory state, no sticky sessions, horizontal
+scaling for free.
+
+The consequence worth stating plainly: **rpg-api never holds a domain object.**
+They implement two or three interfaces once and then call verbs with IDs. That
+is strictly simpler than today, where they hold the encounter and juggle its
+blob.
+
+It also makes suspension nearly invisible to them. Load → walk → freeze → save
+happens inside one call; the answer arrives days later as another call that
+loads, resumes, and saves. From outside, a verb returned `Pending` and later
+didn't.
+
+**RULED — atomicity gets no hard decision yet, only observable failure.** Every
+verb reports what it persisted and what it didn't; a partial save is an error
+that names the pieces rather than a silent shrug. The elegant answer will show
+itself once real use cases exist. (The shape it might take: a `WithTx`-style
+port the server implements however its database wants, and an in-memory test
+implementation no-ops.)
+
+---
+
+## Strategy: wrap first, replace behind it
+
+**RULED — put the existing combat/encounter implementation behind the SDK.**
+rpg-api migrates once, mapping to existing functionality internally, and from
+then on only ever updates their version of the SDK while we replace the insides
+wave by wave.
+
+Two disciplines decide whether that promise survives contact:
+
+- **The surface comes from use cases, not from the old stack.** The failure
+  mode is a wrapper shaped like the thing it wraps — rename a result type, ship
+  it, and the old shape is the public contract forever. Test: write the
+  acceptance scenes purely as SDK calls *before* opening the old code. If they
+  can be written without consulting what exists, the surface is honest and the
+  mapping underneath is labor.
+- **No inner type appears in an SDK signature.** Not `encounter.MoveOutput`,
+  not `combat.MoveEntityResult`. The moment one leaks, replacing that module
+  becomes a breaking change and the version-bump promise is dead. Stable value
+  types (`spatial.Position`) may pass through; results and aggregates may not.
+- **`gorelease` gate from day one**, so "rpg-api only bumps a version" is CI
+  rather than intention. Every internal replacement wave must come back
+  *compatible* or it doesn't ship.
+
+---
+
+## Three mechanisms, not one
+
+The bus argument resolved by splitting what rage actually does:
+
+| Job | Mechanism | Example |
+|---|---|---|
+| Modify a value during resolution | **chain** (`core/chain`), ordered pipeline | rage adds damage, grants resistance |
+| React to a fact that already happened | **bus**, publish/observe | "was I hit? extend the rage"; "turn ended, decrement"; the curse that watches for a priest and removes itself |
+| Stop the world and ask a human | **checkpoint**, enumerated, suspension returned as a value | opportunity attack; Shield |
+
+Journey 052's rule was never "no bus" — it was **control flow never rides the
+bus.** Rage modifying damage is not control flow. Rage extending itself is not
+control flow. Suspension is.
+
+The checkpoint is enumerated rather than published for one reason: a suspension
+must resume identically after a process restart. If two effects fire on the
+same step, subscription order is whatever the loader happened to re-establish;
+enumeration order is a function of persisted data. C8 dies under the first and
+holds under the second.
+
+**Things live where they are from** — this is preserved, and it is what killed
+an earlier proposal for a central watcher registry the encounter would
+maintain. Rage lives on the character. A trap's position is map content; its
+behavior lives with the trap. The manager walks to them; it does not track
+them.
+
+**RULED — the trap is not an interrupt.** It does its thing. So a checkpoint
+has four outcomes and only the last suspends: do nothing, halt the movement,
+resolve something (damage, a stun), or ask someone. The shape must support the
+trap without the trap being a question. (A *stun* or otherwise disabling trap
+may reopen this — parked.)
+
+---
+
+## Scope beyond the encounter
+
+**Character creation moves here.** Later: a quest-like thing, a town to shop
+in. The encounter is one phase of something longer, which is why the unit is a
+*session* rather than a fight.
+
+---
+
+## Open questions
+
+1. **Naming and scope of the unit.** `session` fits the breadth (create a
+   character, shop, quest, fight). Every verb sketched so far is scoped by
+   encounter ID, which reads more like a stateless service than a session. If
+   party-level state (downtime, travel, a campaign clock) is coming, the thing
+   that owns it may deserve the name.
+2. **Does the manager own resolution, or only orchestrate it?** If it walks
+   steps and consults entities, chains and attack resolution live there — and
+   `rulebooks/dnd5e/combat` becomes something it calls rather than something
+   the encounter grows. Lean: yes, and this is where "what does ideal
+   composable combat look like" gets asked, since it is the first place with
+   both a world and entities in the same room.
+3. **Reaction economy.** With the world frozen, "one reaction per round" needs
+   a round, and free-roam has a clock instead.
+4. **Cross-doorway threat.** Absolute geometry makes the two endpoint cells
+   adjacent, so a monster in the vault threatens a player in the corridor —
+   while T3 says neither can see the other. Being attacked unseen is fine in
+   5e; *taking* an opportunity attack on something unseen is not. Blocked on
+   the perception wave that retires T3.
+5. **"Hidden."** A perception check unhides a trap for one character and not
+   another, which is exactly intel's per-observer holdings model. Not yet
+   designed.
+6. **First acceptance scene.** Lean: the interrupt born from perception —
+   Alice walks a path, step three refreshes her sight, the ogre comes into
+   view, the world freezes, she is asked *continue or stop*, we persist
+   mid-path, restart the process, and she answers minutes later. It needs no
+   combat, and rpg-api cannot generate that pause itself because only the
+   world model knows what she just saw.
+
+---
+
+## What this does to #916
+
+#916 as written cannot ship: its headline (opportunity-attack-with-option)
+needs entities the composition does not have, and its framing ("retires the
+`ReactionTriggerEvent` workaround") assumed we would be editing the old stack.
+The interrupt spine becomes a property of how the session manager resolves,
+not a feature bolted onto the encounter.
+
+The lesson that keeps the reordering honest: **build resolution as a
+re-enterable phase machine from the first line of combat code** — explicit
+phase index, no Go stack held across a wait, in-between state serializable —
+even in the wave where nothing suspends yet. `ReactionTriggerEvent` happened
+because attack resolution was a straight-line function, not because reactions
+came late. Get that right and waves can be ordered by customer need instead of
+by architectural fear.

--- a/docs/ideas/session-sdk/brainstorm.md
+++ b/docs/ideas/session-sdk/brainstorm.md
@@ -96,8 +96,8 @@ Two things then come free, with no new encounter code:
 ```go
 mgr, err := session.NewManager(&session.Config{
     Characters: charRepo,   // GetCharacter / SaveCharacter
-    Encounters: encRepo,    // GetEncounter / SaveEncounter
-    Monsters:   monRepo,
+    Encounters: encRepo,    // superseded — see design.md
+    Monsters:   monRepo,    // superseded — see design.md
 })  // refuses to construct without everything it needs
 
 out, err := mgr.Move(ctx, &session.MoveInput{

--- a/docs/ideas/session-sdk/brainstorm.md
+++ b/docs/ideas/session-sdk/brainstorm.md
@@ -95,7 +95,7 @@ Two things then come free, with no new encounter code:
 
 ```go
 mgr, err := session.NewManager(&session.Config{
-    Characters: charRepo,   // GetCharacter / SaveCharacter
+    Characters: charRepo,   // superseded — see design.md
     Encounters: encRepo,    // superseded — see design.md
     Monsters:   monRepo,    // superseded — see design.md
 })  // refuses to construct without everything it needs
@@ -133,8 +133,8 @@ didn't.
 verb reports what it persisted and what it didn't; a partial save is an error
 that names the pieces rather than a silent shrug. The elegant answer will show
 itself once real use cases exist. (The shape it might take: a `WithTx`-style
-port the server implements however its database wants, and an in-memory test
-implementation no-ops.)
+interface the server implements however its database wants, and an in-memory
+test implementation no-ops.)
 
 ---
 

--- a/docs/ideas/session-sdk/brainstorm.md
+++ b/docs/ideas/session-sdk/brainstorm.md
@@ -180,7 +180,9 @@ control flow. Suspension is.
 The checkpoint is enumerated rather than published for one reason: a suspension
 must resume identically after a process restart. If two effects fire on the
 same step, subscription order is whatever the loader happened to re-establish;
-enumeration order is a function of persisted data. C8 dies under the first and
+enumeration order is a function of persisted data. C8 — the encounter
+composition's determinism law, that identical inputs yield identical outputs and
+byte-identical blobs — dies under the first and
 holds under the second.
 
 **Things live where they are from** — this is preserved, and it is what killed

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -92,13 +92,34 @@ relational database. It is a constraint on *us*, not a claim about the server.
 and emphatically not one repository that saves everything.
 
 ```go
-type CharacterRepository interface { /* character.Data           */ }
-type EncounterRepository interface { /* encounter.EncounterData  */ }
-type MonsterRepository   interface { /* monster instance data    */ }
-type SessionRepository   interface { /* SessionData — only       */ }
+type CharacterRepository interface { /* character.Data          — player characters   */ }
+type NPCRepository       interface { /* npc.Data                — monster is one type */ }
+type EncounterRepository interface { /* encounter.EncounterData — the world           */ }
+type SessionRepository   interface { /* SessionData             — windows + frozen    */ }
 ```
 
 Each is get-by-id and put-by-id over exactly one shape.
+
+**RULED — an NPC is an entity, not encounter furniture.** An earlier draft had
+monster instances living inside the session blob, which made a monster a
+different *kind of thing* from a character for no reason the domain supports.
+An NPC has its own shape and its own durable data, exactly like a character —
+so a wounded ogre that flees stays wounded, and a recurring villain who
+remembers the last fight is free rather than a special case.
+
+The composition already anticipates this: `Member` is `{ID, Kind, Room}`, and
+`Kind` is precisely the discriminator the manager uses to decide which
+repository an ID resolves against. Monster is one NPC type; shopkeepers, quest
+givers, and the priest a curse is watching for are others, and they outlive any
+single session regardless.
+
+**OPEN — the lifecycle of ephemeral NPCs.** A dungeon run spawns a dozen ogres,
+each now a durable record, and something must clean up. Leaning: the server's
+business, since a Redis TTL is the natural answer and this is a storage concern
+rather than a rules one. But the SDK may need to *signal* that an NPC is spent
+(died; session ended) rather than leaving the server to infer it — and "port
+method" versus "server policy" are different enough answers to want deciding
+before the first tag.
 
 The line is *composition versus reference*. Clock, intel, and record are **parts
 of** an encounter — no independent lifetime, no meaning apart from it — so they

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -1,8 +1,14 @@
 # Session SDK — design
 
-**Status:** proposed, not ratified. Derived from `scenes.md`, which was written
-before opening the old code. Where this document and the scenes disagree, the
-scenes win — they are the contract; this is the shape that serves them.
+**Status:** ratified through wave 1. Waves 0 and 1 shipped
+(`encounter/v0.4.0`, `session/v0.1.0`); waves 2–5 remain the plan of record.
+Where implementation corrected the design, this document carries the correction
+*and the reason* rather than a quiet rewrite — those reasons are the most
+reusable thing here.
+
+Derived from `scenes.md`, which was written before opening the old code. Where
+this document and the scenes disagree, the scenes win — they are the contract;
+this is the shape that serves them.
 
 **Module:** `rulebooks/dnd5e/session`, its own Go module with its own `go.mod`,
 its own semver, and its own `gorelease` gate from the first tag.
@@ -21,7 +27,7 @@ here rather than in the module that owns that rule, this document has been
 violated.
 
 ```
-        rpg-api  ──implements──▶  ports (Get/Save)
+        rpg-api  ──implements──▶  repositories (Get/Save)
            │
            └──calls──▶  session.Manager
                              │
@@ -36,7 +42,7 @@ violated.
 
 ## What it is not
 
-- **Storage.** The server owns that, behind ports.
+- **Storage.** The server owns that, behind repositories.
 - **Authoring.** Encounters, maps, and monster definitions come from content
   pipelines, not from here.
 - **Transport.** gRPC, protos, and streams are rpg-api's.
@@ -56,7 +62,7 @@ SDK-owned types and stable value types (`spatial.Position`) only. Never
 `encounter.MoveOutput`, never a combat result. The instant one leaks, replacing
 that module becomes a breaking change and the version-bump promise is void.
 
-**S3 — Repositories trade in data.** Ports accept and return persistence
+**S3 — Repositories trade in data.** They accept and return persistence
 shapes. Hydration happens inside, where the laws are. The server stays dumb
 storage.
 
@@ -80,9 +86,18 @@ it needs. No lazy discovery at call time, no nil-panic three verbs later.
 
 ---
 
-## Ports
+## Repositories
 
-**S12 — Ports are key-value.** Every operation is get-by-id or put-by-id. No
+**They are called repositories, not ports and not adapters** — a naming
+correction Kirk made before the first tag, and worth recording because it is the
+kind of thing that gets re-litigated. "Port" reads as a TCP port or as porting
+software, and carries hexagonal-architecture baggage nobody here signed up for.
+"Adapter" is worse: an adapter sits *between* two parties that cannot speak
+directly, and there is no such gap here — the game server implements our
+interface and calls us. What these things do is fetch and store records by
+identity. That is a repository, so that is the word.
+
+**S12 — Repositories are key-value.** Every operation is get-by-id or put-by-id. No
 queries, no scans, no joins, no sorts. The SDK never asks storage a question it
 cannot answer with a key. This is what keeps Redis (the game's actual store)
 viable forever and makes it structurally impossible to back into requiring a
@@ -99,12 +114,12 @@ type CharacterRepository interface { /* character.Data — arrives with entities
 
 **`CharacterRepository` is deferred to the entities wave, not defined up front**
 — a correction the implementation forced. `character` is a package *inside* the
-large `rulebooks/dnd5e` module, so declaring the port early would take a
-permanent dependency on combat, conditions, and spells to satisfy a port that
+large `rulebooks/dnd5e` module, so declaring it early would take a permanent
+dependency on combat, conditions, and spells to satisfy a repository that
 nothing calls until entities exist; the free-roam verbs need only member IDs.
 The same asymmetric-reversibility rule that governs `NPCRepository` applies:
 adding a `Config` field later is compatible, removing one a host has already
-implemented is not. Ports are introduced when something calls them.
+implemented is not. Repositories are introduced when something calls them.
 
 Each is get-by-id and put-by-id over exactly one shape.
 
@@ -134,13 +149,13 @@ validate. `SessionData` is ours, so the eventual migration is confined to this
 module.
 
 The reason to start here rather than with the repo is **asymmetric
-reversibility**. Adding a port to `Config` later is a compatible change: a new
-optional field, implemented when it is needed. *Removing* one is not — the
-server has already written that implementation. So the cheap direction is to
-ship without `NPCRepository` and add it the day a durable NPC exists (a
-shopkeeper, a quest giver, a recurring villain who remembers being wounded).
-Shipping the port in the migration wave and then deciding NPCs were
-session-scoped would leave us carrying a port nobody uses.
+reversibility**. Adding a repository to `Config` later is a compatible change: a
+new field, implemented when it is needed. *Removing* one is not — the server has
+already written that implementation. So the cheap direction is to ship without
+`NPCRepository` and add it the day a durable NPC exists (a shopkeeper, a quest
+giver, a recurring villain who remembers being wounded). Shipping it in the
+migration wave and then deciding NPCs were session-scoped would leave us
+carrying a repository nobody uses.
 
 **Rejected: delete-on-death.** It loses the corpse. Players loot bodies, and
 "the ogre is dead but still lying there" is a state a session should be able to
@@ -158,11 +173,11 @@ Two things follow, and both were lost by an earlier draft that made
 
 - **Storage strategy becomes per-type and stays the server's business.** An
   encounter that lives in memory on a live server and checkpoints periodically
-  is invisible to the SDK — which is exactly what a port boundary is for, and a
-  good fit, since a path walk should not round-trip Redis per step. A wrapper
-  would have welded the encounter's storage to the session's permanently. S1 is
-  unaffected: the *manager* holds no state; what sits behind a port is not the
-  manager's concern.
+  is invisible to the SDK — which is exactly what the repository boundary is
+  for, and a good fit, since a path walk should not round-trip Redis per step. A
+  wrapper would have welded the encounter's storage to the session's
+  permanently. S1 is unaffected: the *manager* holds no state; what sits behind a
+  repository is not the manager's concern.
 - **Writes stay proportional to what changed.** Opening an interrupt window
   writes a small session blob rather than rewriting every room, connection, and
   member of the tomb. Within a single verb it is one load and one save
@@ -173,7 +188,7 @@ a decision explicitly deferred (see *Observable failure*), and paid for it in
 composability. Repo-per-type accepts multi-blob writes and reports their
 failures instead.
 
-There is deliberately **no content port.** Authored content — the tomb, a
+There is deliberately **no content repository.** Authored content — the tomb, a
 monster template — is handed in as a parameter at the moment it is needed,
 because the server already knows where its own content lives and that lookup
 happens once per session rather than once per verb:
@@ -186,18 +201,18 @@ mgr.StartSession(ctx, &StartSessionInput{
 ```
 
 If content-fetching becomes real (item catalogs when shopping lands), it can
-arrive later as an optional capability without breaking anything.
+arrive later as an added `Config` field without breaking anything.
 
-Note the deliberate exception to S2: **port signatures reference the inner
+Note the deliberate exception to S2: **repository signatures reference the inner
 modules' `Data` types**, because the server persists exactly those bytes. This
 is the one place inner types are legal, and it is why they are `Data` types —
 persistence shapes are the slowest-changing surface we own, and they already
 carry a compatibility discipline. Domain types stay hidden.
 
-`NotFound` must be distinguishable. Ports return a sentinel the manager can
-test, so "no such session" is a clean rejection rather than a mystery.
+`NotFound` must be distinguishable. Repositories return a sentinel the manager
+can test, so "no such session" is a clean rejection rather than a mystery.
 
-### The log wants bounding, not a port
+### The log wants bounding, not a repository
 
 `record.LogData` lives inside `EncounterData` and **is never trimmed** — there
 are zero calls to `TrimBefore` anywhere in the composition. So the log grows for
@@ -246,16 +261,22 @@ alongside it. It is small and self-contained enough to ship on its own.
 
 ```go
 mgr, err := session.NewManager(&session.Config{
-    Characters: charRepo,
-    Encounters: encRepo,
-    Sessions:   sessRepo,
-    Events:     stream,   // optional capability
+    Sessions:   sessRepo,  // SessionData
+    Encounters: encRepo,   // encounter.EncounterData
+    Events:     stream,    // required — see "The event stream"
 })
 ```
 
-Missing a required port fails construction with an error naming it (S8). Which
-ports are required is a function of which capabilities the config declares —
-the open question in `scenes.md` about capability configs lands here.
+**Everything in `Config` is required.** Missing any component fails construction
+with an error naming it (S8), checked in a fixed order so the first complaint is
+deterministic. `CharacterRepository` is absent because nothing calls it yet, not
+because it is optional.
+
+This settles the capability-config question `scenes.md` left open, and settles it
+by deleting it: there are no optional components, so `Config` never became
+capability-shaped. A host that genuinely wants no fan-out passes the
+`DiscardEvents` stream we ship — an explicit choice at a call site rather than an
+absence the manager has to tolerate everywhere downstream.
 
 ---
 
@@ -355,9 +376,14 @@ type SessionData struct {
     Encounter string               `json:"encounter"` // by ID
     Windows   interrupt.LedgerData `json:"windows"`
     Frozen    []byte               `json:"frozen,omitempty"`
-    NPCs      []npc.Data           `json:"npcs,omitempty"` // session-scoped; see Ports
+    NPCs      []npc.Data           `json:"npcs,omitempty"` // session-scoped; see Repositories
 }
 ```
+
+**Shipped so far: `ID` and `Encounter` only.** `Windows` and `Frozen` arrive
+with the interrupt spine (wave 2), `NPCs` with entities (wave 3) — each added
+the wave that first writes to it, since a persisted field nothing populates is a
+shape we would be committed to before learning whether it is right.
 
 Small, and written only when session state actually changes. The encounter
 never learns what an interrupt window is; the session module validates session
@@ -418,7 +444,8 @@ type Entry struct {
 
 Ordering, gap detection, a causality token, delivery scoping, filterable
 metadata, content. The composition appends one for every state change. There is
-no stream to build — only a delivery port to attach to the log we already write.
+no stream to build — only a delivery interface to attach to the log we already
+write.
 
 ### Why it cannot live above us
 
@@ -460,7 +487,7 @@ respect to the game. That is deliberately left as the composition's problem —
 and it is the layering working, since scoping audiences there fixes the stream
 here for free.
 
-### Port
+### The interface
 
 ```go
 type EventStream interface {
@@ -468,10 +495,25 @@ type EventStream interface {
 }
 ```
 
-Optional capability: a single-player setup, a test, or a headless simulation
-constructs without one and simply produces no stream. This is the first case
-that makes `Config` capability-shaped rather than all-required, which settles
-the port-granularity open question in `scenes.md`.
+**RULED — the stream is required, not optional.** An earlier draft of this
+document had it as an opt-in multiplayer capability. That was wrong twice over,
+and Kirk caught it before the first tag.
+
+Wrong on the game: a verb's return value carries what *that caller* needs to
+know, and it structurally cannot carry what happened to everyone else. Single-
+player and multiplayer alike render from the stream — it is the live channel, not
+a fan-out feature bolted onto one. A single-player client with no stream sees its
+own moves and nothing the world does back.
+
+Wrong on the timing, which is the more general lesson: **this package is being
+introduced here.** No host has implemented `Config` yet, so requiring the stream
+today costs exactly nothing. Requiring it in v0.3.0 would break every host that
+took us up on the option. Loosening a rule later is compatible; tightening it is
+not — so a rule we are even slightly inclined toward belongs in the first tag,
+where the reversible direction is still available. This is the same asymmetry
+that deferred `CharacterRepository`, pointing the other way.
+
+A host that truly wants no fan-out passes `DiscardEvents`, which we ship.
 
 `Event` is an **SDK-owned envelope**, not `record.Entry` re-exported — settled
 by the proto mapping, and forced independently by S11. See "Shaped for the
@@ -530,8 +572,8 @@ None of this is customer-visible; all of it can change under a compatible tag.
 
 ## Open questions carried forward
 
-From `scenes.md`, unresolved and listed here so they are not lost: port
-granularity under capability configs; whether monsters are authored into an
+From `scenes.md`, unresolved and listed here so they are not lost: whether
+monsters are authored into an
 encounter or joined by the server; how itemized an attack result should be;
 reaction economy without rounds; whether monsters answer their own windows
 synchronously; and where the manager's durable state lives.

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -82,8 +82,14 @@ it needs. No lazy discovery at call time, no nil-panic three verbs later.
 
 ## Ports
 
-One interface per aggregate, so a server that has no monsters yet can still
-construct a character-creation-only manager.
+**S12 — Ports are key-value.** Every operation is get-by-id or put-by-id. No
+queries, no scans, no joins, no sorts. The SDK never asks storage a question it
+cannot answer with a key. This is what keeps Redis (the game's actual store)
+viable forever and makes it structurally impossible to back into requiring a
+relational database. It is a constraint on *us*, not a claim about the server.
+
+The split follows a real line in the domain: **characters outlive sessions;
+everything else in an encounter does not.**
 
 ```go
 type CharacterRepository interface {
@@ -91,13 +97,31 @@ type CharacterRepository interface {
     SaveCharacter(ctx context.Context, data *character.Data) error
 }
 
-type EncounterRepository interface {
-    GetEncounter(ctx context.Context, id string) (*encounter.EncounterData, error)
-    SaveEncounter(ctx context.Context, id string, data *encounter.EncounterData) error
+type SessionRepository interface {
+    GetSession(ctx context.Context, id string) (*SessionData, error)
+    SaveSession(ctx context.Context, data *SessionData) error
 }
-
-type MonsterRepository interface { /* symmetric */ }
 ```
+
+Alice's sheet is durable player property — it exists between runs and it is
+hers. The encounter state, the open windows, the frozen path, and the monster
+instances are all session-scoped: an ogre's remaining hit points mean nothing
+once the run ends.
+
+There is deliberately **no content port.** Authored content — the tomb, a
+monster template — is handed in as a parameter at the moment it is needed,
+because the server already knows where its own content lives and that lookup
+happens once per session rather than once per verb:
+
+```go
+mgr.StartSession(ctx, &StartSessionInput{
+    Session:   "sess-123",
+    Encounter: authoredTomb,
+})
+```
+
+If content-fetching becomes real (item catalogs when shopping lands), it can
+arrive later as an optional capability without breaking anything.
 
 Note the deliberate exception to S2: **port signatures reference the inner
 modules' `Data` types**, because the server persists exactly those bytes. This
@@ -106,7 +130,12 @@ persistence shapes are the slowest-changing surface we own, and they already
 carry a compatibility discipline. Domain types stay hidden.
 
 `NotFound` must be distinguishable. Ports return a sentinel the manager can
-test, so "no such encounter" is a clean rejection rather than a mystery.
+test, so "no such session" is a clean rejection rather than a mystery.
+
+**OPEN:** monster instances are assumed session-scoped, living inside
+`SessionData`, with templates handed in at spawn. If monsters must persist
+across sessions, that is a third repository and is much cheaper to decide now
+than to discover.
 
 ---
 
@@ -115,8 +144,8 @@ test, so "no such encounter" is a clean rejection rather than a mystery.
 ```go
 mgr, err := session.NewManager(&session.Config{
     Characters: charRepo,
-    Monsters:   monRepo,
-    Encounters: encRepo,
+    Sessions:   sessRepo,
+    Events:     stream,   // optional capability
 })
 ```
 
@@ -208,15 +237,35 @@ a window is open; any verb at all on a closed encounter.
 
 ## Persistence
 
-The manager's own durable state — the interrupt ledger and the frozen
-resolution bytes — needs a home. It rides in the **encounter's** blob rather
-than a third one, because its lifetime is exactly the encounter's and because
-a save that spans two blobs is a save that can half-fail.
+**RULED — `SessionData` wraps; the encounter stays pure.**
 
-**OPEN:** this means the encounter's `EncounterData` grows a field for state it
-does not interpret. That is a real cost against the aggregate purity we spent a
-wave hardening, and the alternative — a `SessionData` blob of our own — trades
-it for a second thing to keep consistent. Decide before the first tag.
+The manager's durable state — open interrupt windows and the frozen resolution
+— composes the encounter's blob rather than invading it. This is the same
+fractal one turn further out: `EncounterData` is already a wrapper carrying
+`clock.TickData`, `intel.Data`, and `record.LogData` alongside its own fields.
+
+```go
+type SessionData struct {
+    Encounter encounter.EncounterData `json:"encounter"`
+    Windows   interrupt.LedgerData    `json:"windows"`
+    Frozen    []byte                  `json:"frozen,omitempty"`
+    // monster instances — see the port OPEN above
+}
+```
+
+One blob, one save, atomic. The encounter never learns what a window is. The
+session module validates session state; the encounter validates encounter
+state; each keeps its own laws, and neither can be broken by the other's
+mistakes. The alternatives both cost something real: growing `EncounterData`
+with a field it cannot interpret would spend the aggregate purity we hardened
+last wave, and a second blob would hand us two things to keep consistent —
+which is exactly the partial-save problem we are deliberately not solving yet.
+
+This also clarifies something the scenes were vague about: **an authored
+encounter and a live session are different things.** The tomb is content — a
+bare `EncounterData`. Starting a session wraps a copy of it in a fresh
+`SessionData`. Content is read once and never written; session state is read
+and written every verb.
 
 ### Observable failure
 
@@ -299,11 +348,25 @@ constructs without one and simply produces no stream. This is the first case
 that makes `Config` capability-shaped rather than all-required, which settles
 the port-granularity open question in `scenes.md`.
 
-**OPEN:** whether `Event` is `record.Entry` re-exported (S2 says no inner
-types, but this is arguably a persistence-adjacent shape like the `Data` types)
-or an SDK-owned envelope translated on the way out. Leaning SDK-owned, because
-the per-audience projection in S11 means the thing on the wire is not the thing
-in the log.
+`Event` is an **SDK-owned envelope**, not `record.Entry` re-exported — settled
+by the proto mapping, and forced independently by S11. See "Shaped for the
+wire" below.
+
+## Shaped for the wire
+
+The rulebook has a corresponding proto that the game server implements, so SDK
+output types are **proto-shaped by construction**: flat structs, explicit
+enumerated kinds, nothing polymorphic, no interface-valued fields, no `any`.
+
+Two consequences worth stating because they are easy to get wrong once and
+never fix:
+
+- **`Event` is an SDK-owned envelope**, not `record.Entry` re-exported. S2 wanted
+  that anyway, and S11 forces it regardless: with per-audience projection, the
+  thing on the wire is genuinely not the thing in the log.
+- **`Option` carries a stable machine-readable kind**, not a free-form string
+  the client pattern-matches. It is the field clients branch on, so it is the
+  field that must never be prose.
 
 ## Compatibility
 

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -150,13 +150,38 @@ carry a compatibility discipline. Domain types stay hidden.
 `NotFound` must be distinguishable. Ports return a sentinel the manager can
 test, so "no such session" is a clean rejection rather than a mystery.
 
-**OPEN — the growing log.** `record.LogData` lives *inside* `EncounterData` and
-grows forever, so every encounter save today rewrites the whole story from its
-first beat. It is the one piece whose access pattern is genuinely different —
-append-only, never mutated — and it is also the thing we decided *is* the event
-stream. Shipped in v0.3 and not proposed for rework here; noted because the
-argument for an append-shaped port of its own is the same argument S13 makes,
-and its payoff grows with session length.
+### The log wants bounding, not a port
+
+`record.LogData` lives inside `EncounterData` and **is never trimmed** — there
+are zero calls to `TrimBefore` anywhere in the composition. So the log grows for
+the life of an encounter and every save rewrites the whole story from its first
+beat.
+
+The fix is a retention policy, not a new persistence shape. The machinery is
+already there and already safe: `TrimBefore` exists, `Seq` is explicitly never
+renumbered by it, and queries take a `FromSeq` lower bound — so sequence numbers
+stay stable across a trim, which is exactly what a reconnecting client needs.
+The write surface is already append-only: `Append` plus `TrimBefore`, entries
+never mutated.
+
+**Retention size is a multiplayer-reconnect decision, not a storage decision.**
+Under S10 a client that misses events re-queries `Story` from its last sequence;
+if it has been disconnected longer than the retention window, that delta is gone
+and it must full-resync instead. That is a fine fallback — but it means the
+question is "how long can a phone be in a tunnel and still rejoin cheaply,"
+*not* "how much history do we want to keep." Size it from the first and the
+storage cost falls out; size it from the second and the reconnect behaviour is
+discovered by accident.
+
+Two consequences:
+
+- Retention belongs to the encounter as construction config, applied on append,
+  so it stays self-contained rather than something the manager must remember.
+- `Story` must answer a request for a trimmed sequence with an explicit
+  "that range is gone, resync" signal, never a short answer that looks complete.
+
+**OPEN:** the retention window itself, and whether this lands as an encounter
+change ahead of the SDK or alongside it.
 
 ---
 

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -230,6 +230,7 @@ alongside it. It is small and self-contained enough to ship on its own.
 ```go
 mgr, err := session.NewManager(&session.Config{
     Characters: charRepo,
+    Encounters: encRepo,
     Sessions:   sessRepo,
     Events:     stream,   // optional capability
 })

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -180,8 +180,18 @@ Two consequences:
 - `Story` must answer a request for a trimmed sequence with an explicit
   "that range is gone, resync" signal, never a short answer that looks complete.
 
-**OPEN:** the retention window itself, and whether this lands as an encounter
-change ahead of the SDK or alongside it.
+**RULED — retention is configurable, and the default starts extremely small.**
+
+Small is not a storage economy here; it is a test strategy. A generous window
+means the resync path almost never runs, so it stays unexercised until the one
+player whose train enters a tunnel finds the bug in it. A tiny window makes
+**full resync the common path** — it fires in every dev session, every scene
+test, every manual playthrough — so the expensive branch is the well-trodden
+one and the cheap delta becomes the optimisation rather than the assumption.
+Raise it later from evidence; never start high and hope.
+
+**OPEN:** whether this lands as an encounter change ahead of the SDK or
+alongside it. It is small and self-contained enough to ship on its own.
 
 ---
 

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -1,0 +1,280 @@
+# Session SDK — design
+
+**Status:** proposed, not ratified. Derived from `scenes.md`, which was written
+before opening the old code. Where this document and the scenes disagree, the
+scenes win — they are the contract; this is the shape that serves them.
+
+**Module:** `rulebooks/dnd5e/session`, its own Go module with its own `go.mod`,
+its own semver, and its own `gorelease` gate from the first tag.
+
+---
+
+## What it is
+
+The **session manager** is the game server's single point of contact with the
+toolkit. It composes composers: the encounter (which itself composes clock,
+intel, record, and spatial), characters, monsters, and — when combat gets heavy
+enough to deserve it — a combat package of its own.
+
+It holds wiring and lifetime. It holds no domain logic. The moment a rule lives
+here rather than in the module that owns that rule, this document has been
+violated.
+
+```
+        rpg-api  ──implements──▶  ports (Get/Save)
+           │
+           └──calls──▶  session.Manager
+                             │
+                    ┌────────┼────────────┬─────────────┐
+                    ▼        ▼            ▼             ▼
+                encounter  character   monster      combat
+                    │                                (later)
+          ┌─────────┼─────────┬────────┐
+          ▼         ▼         ▼        ▼
+        clock     intel    record   spatial
+```
+
+## What it is not
+
+- **Storage.** The server owns that, behind ports.
+- **Authoring.** Encounters, maps, and monster definitions come from content
+  pipelines, not from here.
+- **Transport.** gRPC, protos, and streams are rpg-api's.
+- **Presentation.** It returns facts rich enough to narrate; it never narrates.
+
+---
+
+## Laws
+
+**S1 — The manager holds no domain state.** Every verb loads what it needs,
+acts, saves, and drops everything. No caches, no handles, no live sessions. The
+game is turn-based; this costs little and buys horizontal scaling, no sticky
+sessions, and the elimination of every stale-in-memory-state bug class.
+
+**S2 — No inner type crosses the boundary.** SDK signatures reference
+SDK-owned types and stable value types (`spatial.Position`) only. Never
+`encounter.MoveOutput`, never a combat result. The instant one leaks, replacing
+that module becomes a breaking change and the version-bump promise is void.
+
+**S3 — Repositories trade in data.** Ports accept and return persistence
+shapes. Hydration happens inside, where the laws are. The server stays dumb
+storage.
+
+**S4 — Every verb is load → act → save → return.** No setup call, no teardown,
+no caller-visible ordering. A verb is complete when it returns.
+
+**S5 — `Pending` is the only suspension vocabulary.** Every pause — perception,
+reaction, whatever comes later — surfaces in one shape and resolves through one
+`Answer`. A caller cannot tell from the shape of its code what stopped the
+world.
+
+**S6 — Failure names its pieces.** A partial save is an error that says what
+landed and what didn't. Never a silent shrug, never a bare wrapped error.
+
+**S7 — A frozen resolution is data.** It survives a process restart because it
+was never anything else. No goroutine parked, no stack held, no handle to
+reclaim.
+
+**S8 — Construction is total.** The manager refuses to exist without everything
+it needs. No lazy discovery at call time, no nil-panic three verbs later.
+
+---
+
+## Ports
+
+One interface per aggregate, so a server that has no monsters yet can still
+construct a character-creation-only manager.
+
+```go
+type CharacterRepository interface {
+    GetCharacter(ctx context.Context, id string) (*character.Data, error)
+    SaveCharacter(ctx context.Context, data *character.Data) error
+}
+
+type EncounterRepository interface {
+    GetEncounter(ctx context.Context, id string) (*encounter.EncounterData, error)
+    SaveEncounter(ctx context.Context, id string, data *encounter.EncounterData) error
+}
+
+type MonsterRepository interface { /* symmetric */ }
+```
+
+Note the deliberate exception to S2: **port signatures reference the inner
+modules' `Data` types**, because the server persists exactly those bytes. This
+is the one place inner types are legal, and it is why they are `Data` types —
+persistence shapes are the slowest-changing surface we own, and they already
+carry a compatibility discipline. Domain types stay hidden.
+
+`NotFound` must be distinguishable. Ports return a sentinel the manager can
+test, so "no such encounter" is a clean rejection rather than a mystery.
+
+---
+
+## Construction
+
+```go
+mgr, err := session.NewManager(&session.Config{
+    Characters: charRepo,
+    Monsters:   monRepo,
+    Encounters: encRepo,
+})
+```
+
+Missing a required port fails construction with an error naming it (S8). Which
+ports are required is a function of which capabilities the config declares —
+the open question in `scenes.md` about capability configs lands here.
+
+---
+
+## The verb surface
+
+Every verb takes a typed `*XInput` and returns a typed `*XOutput` plus `error`
+— the house pattern, so fields can be added compatibly forever.
+
+| Verb | Purpose |
+|---|---|
+| `Join` | Load an entity into an encounter at a placement |
+| `Move` | Walk a member along a path |
+| `Traverse` | Cross a connection |
+| `Answer` | Resolve an open window |
+| `Pending` | What windows are open, and who owes them |
+| `View` | What a member can perceive |
+| `Story` | What has happened |
+| `Status` | Open or closed, and the outcome |
+| `Atlas` | The static world map |
+| `Exit` / `End` | Leave, or close the encounter |
+| `Attack` | *(combat wave)* |
+| `CreateCharacter` | *(later — the verb that proves this is a session)* |
+
+Read verbs still load and save nothing, but they are still `load → act →
+return`: S1 holds, S4's save step is simply empty.
+
+### Movement takes a path
+
+```go
+type MoveInput struct {
+    Encounter string
+    Member    string
+    Path      []spatial.Position
+}
+
+type MoveOutput struct {
+    Steps      []Step     // what actually happened, in order
+    Discovered []Sighting // per observer
+    Pending    *Pending   // non-nil ⇒ the world is frozen
+    Outcome    *Outcome   // non-nil ⇒ the encounter closed
+    Saved      SaveReport
+}
+```
+
+`len(Steps) < len(Path)` is the primary signal, and it is deliberately not an
+error: the walk stopped because something happened, and what happened is in
+`Pending` or `Outcome`. A one-cell path is a legal degenerate case — that is
+how the game moves today, and it is why the encounter's single-hop `Move`
+primitive stays exactly as it is.
+
+### Suspension
+
+```go
+type Pending struct {
+    Window   string   // opaque; stable across a restart
+    Audience string   // who owes the answer
+    Options  []Option // what they may choose
+    Prompt   Prompt   // enough to render the moment
+}
+
+type AnswerInput struct {
+    Encounter string
+    Window    string
+    Audience  string // must match; answering someone else's window is a rejection
+    Option    string
+}
+```
+
+`Prompt` carries *what the player is looking at*, never *why the resolution
+stopped*. That asymmetry is what lets checkpoint kinds be added forever without
+the customer noticing (S5).
+
+**While a window is open, every other verb on that encounter rejects.** The
+world is frozen — Kirk's ruling — and that is enforced, not merely intended.
+
+### Rejections that must hold
+
+Answering a closed window; answering with an unoffered option; answering
+someone else's window; any verb other than `Answer`/`Pending`/read verbs while
+a window is open; any verb at all on a closed encounter.
+
+---
+
+## Persistence
+
+The manager's own durable state — the interrupt ledger and the frozen
+resolution bytes — needs a home. It rides in the **encounter's** blob rather
+than a third one, because its lifetime is exactly the encounter's and because
+a save that spans two blobs is a save that can half-fail.
+
+**OPEN:** this means the encounter's `EncounterData` grows a field for state it
+does not interpret. That is a real cost against the aggregate purity we spent a
+wave hardening, and the alternative — a `SessionData` blob of our own — trades
+it for a second thing to keep consistent. Decide before the first tag.
+
+### Observable failure
+
+```go
+type SaveReport struct {
+    Written []string // aggregate IDs that landed
+    Failed  []string // aggregate IDs that did not
+}
+```
+
+A partial save returns an error *and* a populated report (S6). No transaction
+decision yet — Kirk's call — but the evidence accumulates from the first wave
+instead of arriving as a bug report from a player whose monster came back to
+life.
+
+---
+
+## Compatibility
+
+`gorelease` gates every release from the first tag, so "rpg-api only bumps a
+version" is CI rather than intention. Every internal replacement wave must come
+back **compatible** or it does not ship.
+
+This is what the strangler strategy is buying and it is worth stating as a
+falsifiable claim: *after the migration wave, no subsequent wave changes any
+rpg-api source file.* If one does, S2 was violated somewhere and the violation
+is findable.
+
+---
+
+## Inside the boundary
+
+None of this is customer-visible; all of it can change under a compatible tag.
+
+- **Chains** (`core/chain`) carry modification during resolution — rage's bonus
+  damage, resistance, a fighting style.
+- **The bus** carries observation — "was I hit?", "turn ended", the curse
+  watching for a priest. Attached for the duration of one verb, since entities
+  are loaded per call (S1). Journey 052's rule holds: control flow never rides
+  it.
+- **Checkpoints** are the only place a suspension is born. Enumerated in an
+  order that is a function of persisted data, never of subscription order,
+  because a resumed resolution must resume identically (C8).
+- **Resolution is a re-enterable phase machine from the first line of combat
+  code** — explicit phase index, no Go stack held across a wait, in-between
+  state serializable — even in waves where nothing suspends. `ReactionTrigger`
+  happened because attack resolution was a straight-line function.
+
+---
+
+## Open questions carried forward
+
+From `scenes.md`, unresolved and listed here so they are not lost: port
+granularity under capability configs; whether monsters are authored into an
+encounter or joined by the server; how itemized an attack result should be;
+reaction economy without rounds; whether monsters answer their own windows
+synchronously; and where the manager's durable state lives.
+
+And the naming test, which only a later wave can settle: if every verb turns
+out to need an encounter ID, this is an encounter service and deserves a
+different name.

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -234,6 +234,77 @@ life.
 
 ---
 
+## The event stream
+
+**RULED — the toolkit owns the events; the game server owns the transport.**
+It supplies a stream implementation the way it supplies repositories, and we
+drive it. The multiplayer game communicates through those events.
+
+### It already exists
+
+`record.Entry` is an event envelope and has been since `play/record` v0.1.0:
+
+```go
+type Entry struct {
+    Seq         uint64          // monotonic, gapless, never renumbered
+    At          uint64          // provenance timestamp
+    Correlation string          // groups cause and effects across entries
+    Audience    []core.EntityID // the roster of viewers
+    Tags        map[string]string
+    Payload     []byte
+}
+```
+
+Ordering, gap detection, a causality token, delivery scoping, filterable
+metadata, content. The composition appends one for every state change. There is
+no stream to build — only a delivery port to attach to the log we already write.
+
+### Why it cannot live above us
+
+**Audience is a game rule, not transport.** Who may see an event is a function
+of intel — who perceived what, through which channel, and when. If the game
+server fans events out, it reimplements visibility, and the first bug leaks
+hidden information: the unspotted ogre, the trap Bob failed his check on, the
+fact that someone is being offered a reaction. Those are rules defects wearing
+delivery clothing, surfacing in the layer least equipped to catch them.
+
+### Laws
+
+**S9 — Publish only after the save lands.** Never announce a fact that failed
+to persist. "Announced but didn't happen" becomes structurally impossible.
+
+**S10 — The log is the truth; the stream is an optimization over it.** Because
+`Seq` is gapless, a client that misses an event sees a hole and re-queries
+`Story` from its last known sequence. Publish failure is therefore **not**
+fatal to a verb: it is reported in the output and the client heals itself. For
+a Discord activity on a phone, this is the difference between a robust game and
+a support burden.
+
+**S11 — Events are projected per audience, not merely filtered.** Two viewers of
+the same beat may receive different payloads. The pending-window event is the
+motivating case: the actor's client needs the options; everyone else needs
+"waiting on Alice" *without* them, because options leak — offering an
+opportunity attack reveals that a threatener exists and roughly where.
+
+### Port
+
+```go
+type EventStream interface {
+    Publish(ctx context.Context, events []Event) error
+}
+```
+
+Optional capability: a single-player setup, a test, or a headless simulation
+constructs without one and simply produces no stream. This is the first case
+that makes `Config` capability-shaped rather than all-required, which settles
+the port-granularity open question in `scenes.md`.
+
+**OPEN:** whether `Event` is `record.Entry` re-exported (S2 says no inner
+types, but this is arguably a persistence-adjacent shape like the `Data` types)
+or an SDK-owned envelope translated on the way out. Leaning SDK-owned, because
+the per-audience projection in S11 means the thing on the wire is not the thing
+in the log.
+
 ## Compatibility
 
 `gorelease` gates every release from the first tag, so "rpg-api only bumps a

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -92,34 +92,43 @@ relational database. It is a constraint on *us*, not a claim about the server.
 and emphatically not one repository that saves everything.
 
 ```go
-type CharacterRepository interface { /* character.Data          — player characters   */ }
-type NPCRepository       interface { /* npc.Data                — monster is one type */ }
-type EncounterRepository interface { /* encounter.EncounterData — the world           */ }
-type SessionRepository   interface { /* SessionData             — windows + frozen    */ }
+type CharacterRepository interface { /* character.Data          — player characters */ }
+type EncounterRepository interface { /* encounter.EncounterData — the world         */ }
+type SessionRepository   interface { /* SessionData             — session state     */ }
 ```
 
 Each is get-by-id and put-by-id over exactly one shape.
 
-**RULED — an NPC is an entity, not encounter furniture.** An earlier draft had
-monster instances living inside the session blob, which made a monster a
-different *kind of thing* from a character for no reason the domain supports.
-An NPC has its own shape and its own durable data, exactly like a character —
-so a wounded ogre that flees stays wounded, and a recurring villain who
-remembers the last fight is free rather than a special case.
+**An NPC is a shape.** It has its own data, and `Member.Kind` is already the
+discriminator that says which shape an ID resolves to — the composition
+anticipated this. Monster is one NPC type; shopkeepers, quest givers, and the
+priest a curse is watching for are others.
 
-The composition already anticipates this: `Member` is `{ID, Kind, Room}`, and
-`Kind` is precisely the discriminator the manager uses to decide which
-repository an ID resolves against. Monster is one NPC type; shopkeepers, quest
-givers, and the priest a curse is watching for are others, and they outlive any
-single session regardless.
+**RULED — NPCs live in `SessionData` for now; `NPCRepository` arrives later.**
 
-**OPEN — the lifecycle of ephemeral NPCs.** A dungeon run spawns a dozen ogres,
-each now a durable record, and something must clean up. Leaning: the server's
-business, since a Redis TTL is the natural answer and this is a storage concern
-rather than a rules one. But the SDK may need to *signal* that an NPC is spent
-(died; session ended) rather than leaving the server to infer it — and "port
-method" versus "server policy" are different enough answers to want deciding
-before the first tag.
+The encounter is the life and death of most monsters, and their state after a
+session means nothing. So they are session-scoped: they sit in `SessionData`
+alongside the windows and the frozen resolution, they vanish when the session
+ends, and **there is no cleanup because there is nothing to clean up.**
+
+Not in `EncounterData` — that carries the same purity cost as an interrupt
+window would, an aggregate holding entity state it cannot interpret or
+validate. `SessionData` is ours, so the eventual migration is confined to this
+module.
+
+The reason to start here rather than with the repo is **asymmetric
+reversibility**. Adding a port to `Config` later is a compatible change: a new
+optional field, implemented when it is needed. *Removing* one is not — the
+server has already written that implementation. So the cheap direction is to
+ship without `NPCRepository` and add it the day a durable NPC exists (a
+shopkeeper, a quest giver, a recurring villain who remembers being wounded).
+Shipping the port in the migration wave and then deciding NPCs were
+session-scoped would leave us carrying a port nobody uses.
+
+**Rejected: delete-on-death.** It loses the corpse. Players loot bodies, and
+"the ogre is dead but still lying there" is a state a session should be able to
+hold. Vanishing at session close gives that for free; vanishing at death forces
+a corpse concept to be invented to get it back.
 
 The line is *composition versus reference*. Clock, intel, and record are **parts
 of** an encounter — no independent lifetime, no meaning apart from it — so they
@@ -323,6 +332,7 @@ type SessionData struct {
     Encounter string               `json:"encounter"` // by ID
     Windows   interrupt.LedgerData `json:"windows"`
     Frozen    []byte               `json:"frozen,omitempty"`
+    NPCs      []npc.Data           `json:"npcs,omitempty"` // session-scoped; see Ports
 }
 ```
 

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -447,6 +447,19 @@ motivating case: the actor's client needs the options; everyone else needs
 "waiting on Alice" *without* them, because options leak — offering an
 opportunity attack reveals that a threatener exists and roughly where.
 
+The audience question is answered by *asking the composition*, never by
+re-deriving visibility here. That is the load-bearing half: a second
+implementation of who-may-know, living outside the module that owns perception,
+would eventually disagree with the first, and a disagreement about visibility is
+a leak.
+
+**Implementation note:** the composition currently addresses every beat to every
+member ([toolkit#940](https://github.com/KirkDiggler/rpg-toolkit/issues/940)),
+so today's fan-out is correct with respect to its contract and too generous with
+respect to the game. That is deliberately left as the composition's problem —
+and it is the layering working, since scoping audiences there fixes the stream
+here for free.
+
 ### Port
 
 ```go

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -92,12 +92,29 @@ relational database. It is a constraint on *us*, not a claim about the server.
 and emphatically not one repository that saves everything.
 
 ```go
-type CharacterRepository interface { /* character.Data          — player characters */ }
-type EncounterRepository interface { /* encounter.EncounterData — the world         */ }
-type SessionRepository   interface { /* SessionData             — session state     */ }
+type EncounterRepository interface { /* encounter.EncounterData — the world     */ }
+type SessionRepository   interface { /* SessionData             — session state */ }
+type CharacterRepository interface { /* character.Data — arrives with entities   */ }
 ```
 
+**`CharacterRepository` is deferred to the entities wave, not defined up front**
+— a correction the implementation forced. `character` is a package *inside* the
+large `rulebooks/dnd5e` module, so declaring the port early would take a
+permanent dependency on combat, conditions, and spells to satisfy a port that
+nothing calls until entities exist; the free-roam verbs need only member IDs.
+The same asymmetric-reversibility rule that governs `NPCRepository` applies:
+adding a `Config` field later is compatible, removing one a host has already
+implemented is not. Ports are introduced when something calls them.
+
 Each is get-by-id and put-by-id over exactly one shape.
+
+The save signatures are deliberately not uniform: `SaveSession` takes only the
+data because `SessionData` carries its own `ID`, while `SaveEncounter` takes the
+key separately because `EncounterData` does not. The alternative — inventing an
+ID field on `EncounterData` purely for symmetry, or dropping the one
+`SessionData` already has — would put the identity of a record in two places or
+none. Passing the key exactly when the payload lacks it keeps a single source of
+truth for each.
 
 **An NPC is a shape.** It has its own data, and `Member.Kind` is already the
 discriminator that says which shape an ID resolves to — the composition
@@ -311,7 +328,12 @@ type AnswerInput struct {
 stopped*. That asymmetry is what lets checkpoint kinds be added forever without
 the customer noticing (S5).
 
-**While a window is open, every other verb on that encounter rejects.** The
+**While a window is open, every verb that would change the world rejects.**
+Read verbs — `View`, `Story`, `Status`, `Atlas`, `Pending` — remain available,
+and must: a client cannot render "waiting on Alice" without asking what the
+world looks like, and a freeze that blinded every other player would be a worse
+experience than no freeze at all. What is frozen is *change*, not observation.
+The
 world is frozen — Kirk's ruling — and that is enforced, not merely intended.
 
 ### Rejections that must hold
@@ -483,7 +505,9 @@ None of this is customer-visible; all of it can change under a compatible tag.
   it.
 - **Checkpoints** are the only place a suspension is born. Enumerated in an
   order that is a function of persisted data, never of subscription order,
-  because a resumed resolution must resume identically (C8).
+  because a resumed resolution must resume identically — C8, the encounter
+  composition's determinism law: identical inputs yield identical outputs and
+  byte-identical blobs.
 - **Resolution is a re-enterable phase machine from the first line of combat
   code** — explicit phase index, no Go stack held across a wait, in-between
   state serializable — even in waves where nothing suspends. `ReactionTrigger`

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -88,25 +88,43 @@ cannot answer with a key. This is what keeps Redis (the game's actual store)
 viable forever and makes it structurally impossible to back into requiring a
 relational database. It is a constraint on *us*, not a claim about the server.
 
-The split follows a real line in the domain: **characters outlive sessions;
-everything else in an encounter does not.**
+**S13 — One repository per data type.** Not one repository per aggregate-graph,
+and emphatically not one repository that saves everything.
 
 ```go
-type CharacterRepository interface {
-    GetCharacter(ctx context.Context, id string) (*character.Data, error)
-    SaveCharacter(ctx context.Context, data *character.Data) error
-}
-
-type SessionRepository interface {
-    GetSession(ctx context.Context, id string) (*SessionData, error)
-    SaveSession(ctx context.Context, data *SessionData) error
-}
+type CharacterRepository interface { /* character.Data           */ }
+type EncounterRepository interface { /* encounter.EncounterData  */ }
+type MonsterRepository   interface { /* monster instance data    */ }
+type SessionRepository   interface { /* SessionData — only       */ }
 ```
 
-Alice's sheet is durable player property — it exists between runs and it is
-hers. The encounter state, the open windows, the frozen path, and the monster
-instances are all session-scoped: an ogre's remaining hit points mean nothing
-once the run ends.
+Each is get-by-id and put-by-id over exactly one shape.
+
+The line is *composition versus reference*. Clock, intel, and record are **parts
+of** an encounter — no independent lifetime, no meaning apart from it — so they
+ride inside `EncounterData` and always have. An encounter is not a part of a
+session in that sense; it is something a session *points at*. Wrapping it would
+have confused the two relationships.
+
+Two things follow, and both were lost by an earlier draft that made
+`SessionData` a wrapper:
+
+- **Storage strategy becomes per-type and stays the server's business.** An
+  encounter that lives in memory on a live server and checkpoints periodically
+  is invisible to the SDK — which is exactly what a port boundary is for, and a
+  good fit, since a path walk should not round-trip Redis per step. A wrapper
+  would have welded the encounter's storage to the session's permanently. S1 is
+  unaffected: the *manager* holds no state; what sits behind a port is not the
+  manager's concern.
+- **Writes stay proportional to what changed.** Opening an interrupt window
+  writes a small session blob rather than rewriting every room, connection, and
+  member of the tomb. Within a single verb it is one load and one save
+  regardless of path length (S4); across verbs, this is what keeps that honest.
+
+The earlier wrapper design existed to make a save atomic — which optimised for
+a decision explicitly deferred (see *Observable failure*), and paid for it in
+composability. Repo-per-type accepts multi-blob writes and reports their
+failures instead.
 
 There is deliberately **no content port.** Authored content — the tomb, a
 monster template — is handed in as a parameter at the moment it is needed,
@@ -132,10 +150,13 @@ carry a compatibility discipline. Domain types stay hidden.
 `NotFound` must be distinguishable. Ports return a sentinel the manager can
 test, so "no such session" is a clean rejection rather than a mystery.
 
-**OPEN:** monster instances are assumed session-scoped, living inside
-`SessionData`, with templates handed in at spawn. If monsters must persist
-across sessions, that is a third repository and is much cheaper to decide now
-than to discover.
+**OPEN — the growing log.** `record.LogData` lives *inside* `EncounterData` and
+grows forever, so every encounter save today rewrites the whole story from its
+first beat. It is the one piece whose access pattern is genuinely different —
+append-only, never mutated — and it is also the thing we decided *is* the event
+stream. Shipped in v0.3 and not proposed for rework here; noted because the
+argument for an append-shaped port of its own is the same argument S13 makes,
+and its payoff grows with session length.
 
 ---
 
@@ -237,29 +258,31 @@ a window is open; any verb at all on a closed encounter.
 
 ## Persistence
 
-**RULED — `SessionData` wraps; the encounter stays pure.**
-
-The manager's durable state — open interrupt windows and the frozen resolution
-— composes the encounter's blob rather than invading it. This is the same
-fractal one turn further out: `EncounterData` is already a wrapper carrying
-`clock.TickData`, `intel.Data`, and `record.LogData` alongside its own fields.
+**RULED — `SessionData` holds only session state, and references the encounter
+rather than containing it.**
 
 ```go
 type SessionData struct {
-    Encounter encounter.EncounterData `json:"encounter"`
-    Windows   interrupt.LedgerData    `json:"windows"`
-    Frozen    []byte                  `json:"frozen,omitempty"`
-    // monster instances — see the port OPEN above
+    ID        string               `json:"id"`
+    Encounter string               `json:"encounter"` // by ID
+    Windows   interrupt.LedgerData `json:"windows"`
+    Frozen    []byte               `json:"frozen,omitempty"`
 }
 ```
 
-One blob, one save, atomic. The encounter never learns what a window is. The
-session module validates session state; the encounter validates encounter
-state; each keeps its own laws, and neither can be broken by the other's
-mistakes. The alternatives both cost something real: growing `EncounterData`
-with a field it cannot interpret would spend the aggregate purity we hardened
-last wave, and a second blob would hand us two things to keep consistent —
-which is exactly the partial-save problem we are deliberately not solving yet.
+Small, and written only when session state actually changes. The encounter
+never learns what an interrupt window is; the session module validates session
+state and the encounter validates its own. Each keeps its laws and neither can
+be broken by the other's mistakes — which was the goal all along; the wrapper
+was simply the wrong way to reach it.
+
+**Rejected: growing `EncounterData` with a window field.** It would spend the
+aggregate purity hardened in the anchoring wave on state the encounter cannot
+interpret or validate.
+
+**Rejected: `SessionData` wrapping `EncounterData`.** It bought save atomicity —
+a decision explicitly deferred — at the cost of per-type storage strategy and
+write proportionality (S13).
 
 This also clarifies something the scenes were vague about: **an authored
 encounter and a live session are different things.** The tomb is content — a

--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -136,7 +136,8 @@ including a mid-story process restart. Its negative control: with the checkpoint
 disabled, Alice walks past the ogre without stopping.
 
 *Discipline:* enumeration order at a checkpoint is a function of persisted data,
-never of subscription order (C8) — pinned by a test that reloads and re-resolves
+never of subscription order (C8, the encounter's determinism law) — pinned by a
+test that reloads and re-resolves
 and gets the identical window order.
 
 ---

--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -1,0 +1,202 @@
+# Session SDK — plan
+
+**Design approved by Kirk 2026-08-12.** This cuts it into waves.
+
+**The cutting rule:** anything that shapes a public type goes in wave 1;
+anything purely internal waits. Under the `gorelease` promise the types fixed in
+wave 1 are permanent, so the wave with the most trivial code carries the most
+irreversible decisions. Everything else can be replaced behind them.
+
+**Module:** `rulebooks/dnd5e/session`, own `go.mod`, own semver, `gorelease`
+gate from the first tag.
+
+---
+
+## The waves
+
+| Wave | Ships | Tag | Needs |
+|---|---|---|---|
+| **0** | Encounter log retention | `encounter/v0.4.0` | — |
+| **1** | Shell, free-roam verbs, event stream | `session/v0.1.0` | — |
+| **2** | The interrupt spine, proven by the perception pause | `session/v0.2.0` | 1 |
+| **3** | Entities on the bus — characters, NPCs, conditions | `session/v0.3.0` | 1 |
+| **4** | Combat | `session/v0.4.0` | 2, 3 |
+| **5** | Reactions — opportunity attack (closes #916) | `session/v0.5.0` | 4 |
+
+Waves 0 and 1 are independent and can run in parallel — different modules, and
+the house rule is one in-flight PR per module.
+
+**Wave 1 is drop-in for the current encounter work.** rpg-api imports *zero* of
+the composition today (verified: no reference to `rulebooks/dnd5e/encounter`
+anywhere in it), so adopting the SDK for free-roam costs them nothing they
+already have. Their existing 6,700 lines of old-stack combat orchestration
+migrate at wave 4, when the SDK finally covers what they use — that is when the
+version-bump promise starts.
+
+---
+
+## Wave 0 — encounter log retention
+
+Small, self-contained, and independently shippable. `TrimBefore` already exists
+and `Seq` is explicitly never renumbered by it; the composition simply never
+calls it, so every encounter save rewrites the whole story from its first beat.
+
+**T0.1 — retention config, applied on append.** `NewEncounter`/`LoadEncounter`
+take a retention setting; the log trims after each append. **Default extremely
+small** so full resync is the common path and stays exercised.
+
+**T0.2 — `Story` reports a trimmed range explicitly.** A request below the
+retained floor returns a distinguishable "that range is gone, resync" signal,
+never a short answer that looks complete.
+
+**Pins:** an encounter that appends past the window retains exactly the window;
+`Seq` values are unchanged by trimming; a `FromSeq` below the floor is
+rejected as trimmed rather than silently truncated. Mutation: raise the
+retention bound by one and the retention pin must fail.
+
+---
+
+## Wave 1 — the shell, free-roam, and the event stream
+
+**Goal:** every public type in the SDK exists and is correct. The logic behind
+them is mostly delegation.
+
+**T1.1 — module, `Config`, `NewManager`.** Ports (`Characters`, `Encounters`,
+`Sessions`, optional `Events`), fail-fast construction naming what is missing
+(S8), a distinguishable `NotFound` sentinel, and every port get-by-id /
+put-by-id only (S12).
+*Pins:* construction refuses each required port individually, by name; a config
+with only the optional port missing succeeds.
+
+**T1.2 — `SessionData`, `StartSession`, load/save.** The session aggregate, its
+`ToData`/`LoadSession` discipline, the authored encounter handed in as a
+parameter rather than fetched (no content port).
+*Pins:* round-trip is byte-identical; a hostile hand-edited blob is rejected,
+not crashed (reject-never-crash); an unknown encounter reference is a clean
+rejection.
+
+**T1.3 — read verbs.** `View`, `Story`, `Status`, `Atlas` over SDK-owned output
+types.
+*Pins:* **the S2 boundary test** — a test that fails if any exported signature
+in the package references a type from `encounter`, `combat`, `clock`, `intel`,
+`record`, or `interrupt`. This is the single most valuable test in the wave: it
+is what makes the version-bump promise mechanical rather than aspirational.
+Stable value types (`spatial.Position`) are the allowed exception and the test
+names them explicitly.
+
+**T1.4 — `Join`, `Exit`, `End`, and `SaveReport`.** Multi-repo writes reporting
+what landed and what did not (S6).
+*Pins:* a repo that fails on save produces an error *and* a populated report
+naming both the written and the failed; the verb never reports success on a
+partial write.
+
+**T1.5 — `Move` with a path, and `Traverse`.** The walk loop over the
+composition's single-hop `Move`. Stops on ending, stops on rejection.
+*Pins:* `len(Steps) < len(Path)` when an ending fires mid-path and the
+remaining steps demonstrably never happened (scene 6); a one-cell path is legal;
+a path with a non-adjacent jump is rejected before anything moves (R5
+atomicity).
+
+**T1.6 — the event stream.** SDK-owned `Event` envelope, proto-shaped: flat,
+explicit kinds, nothing polymorphic. Derived from record beats. Published after
+the save lands (S9). Publish failure reported but non-fatal (S10). **Projected
+per audience, not filtered (S11).**
+*Pins:* the scene-7 assertion — one beat, three payloads, and a fourth viewer
+who receives nothing; **an observer's payload never contains the actor's
+options** (the information-leak pin, and the reason this belongs in wave 1); a
+failing stream leaves the verb successful and the report populated; nothing is
+published when the save fails.
+
+**T1.7 — gate.** `gorelease` clean, `./scripts/verify.sh`, the scenes as
+runnable tests, and a workbench command that drives a session end to end.
+
+---
+
+## Wave 2 — the interrupt spine
+
+**The headline, and it needs no combat.** Scene 2 and scene 3: Alice walks, step
+three brings the ogre into view, the world freezes, we persist mid-path, a
+different process answers, she resumes. Every part of that is reachable with the
+composition's existing perception — which is why this lands before entities
+rather than after.
+
+**T2.1 — checkpoints in the walk.** The walk becomes a re-enterable phase
+machine: explicit phase index, no Go stack held across a wait, in-between state
+serializable (S7). Even here, where only one thing can suspend.
+
+**T2.2 — freeze.** Every non-read verb rejects while a window is open, and the
+rejection carries the window and its audience so the caller learns what to do
+from the error.
+
+**T2.3 — pose, persist, resume.** `interrupt.Ledger` in `SessionData`; frozen
+resolution as opaque bytes in `Frozen`.
+
+**T2.4 — the scene, as one continuous story with a pinned transcript**,
+including a mid-story process restart. Its negative control: with the checkpoint
+disabled, Alice walks past the ogre without stopping.
+
+*Discipline:* enumeration order at a checkpoint is a function of persisted data,
+never of subscription order (C8) — pinned by a test that reloads and re-resolves
+and gets the identical window order.
+
+---
+
+## Wave 3 — entities on the bus
+
+Characters and NPCs load through their repositories, conditions attach for the
+duration of a call and detach after (S1), and durable condition state lives in
+the entity's own blob. `Member.Kind` selects the repository. NPCs live in
+`SessionData` and vanish with the session.
+
+The bus carries **observation only** — journey 052's rule, enforced by the fact
+that nothing in this wave can suspend.
+
+---
+
+## Wave 4 — combat
+
+Where the real engineering is, and where "what would the ideal composable combat
+interaction look like — what does it *simplify*?" gets asked rather than
+assumed. Explicitly **not** a port of rpg-api's 6,700 lines; that code is
+evidence about what a game server needs, not a specification.
+
+Chains carry modification during resolution. Resolution is a re-enterable phase
+machine **from its first line**, even though nothing suspends until wave 5 —
+`ReactionTriggerEvent` happened because attack resolution was a straight-line
+function, and this is the one lesson that must not be relearned.
+
+This is the wave rpg-api migrates on.
+
+---
+
+## Wave 5 — reactions
+
+Opportunity attack on the wave-2 spine, closing #916. Reaction economy, and the
+cross-doorway threat question — which is blocked on the perception wave that
+retires T3, and may push that wave ahead of this one.
+
+---
+
+## House disciplines, applying throughout
+
+- Mutation-proof pins from the first task: a pin is not real until it has been
+  shown to **fail** under the exact breakage it guards.
+- One-defect fixtures with discriminating assertions.
+- **Over-tightening defense**: a rejection table proves a validator rejects;
+  only a rich positive control proves it does not over-reach.
+- Scenes as one continuous story with exact pinned transcripts.
+- `gorelease` green on every wave; a wave that reports *incompatible* does not
+  ship without a deliberate, recorded decision.
+- No draft PRs; no `--no-verify`; no force-push; no `nolint`.
+
+## What would make this plan wrong
+
+- **The S2 boundary test proves unwritable or too coarse.** It is the mechanism
+  behind the whole strategy; if it cannot be made precise, the version-bump
+  promise degrades to a convention and wave 1 needs rethinking.
+- **Stateless-per-call proves too slow** once entities load on every verb. The
+  design's answer is that this is the server's problem behind a port (an
+  in-memory checkpointing encounter repository), but that answer is untested.
+- **The perception pause turns out to need entity state** — if "should Alice
+  stop?" depends on anything on her sheet, wave 2 gains a dependency on wave 3
+  and the order flips.

--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -16,8 +16,8 @@ gate from the first tag.
 
 | Wave | Ships | Tag | Needs |
 |---|---|---|---|
-| **0** | Encounter log retention | `encounter/v0.4.0` | — |
-| **1** | Shell, free-roam verbs, event stream | `session/v0.1.0` | — |
+| **0** ✅ | Encounter log retention | `encounter/v0.4.0` | — |
+| **1** ✅ | Shell, free-roam verbs, event stream | `session/v0.1.0` | — |
 | **2** | The interrupt spine, proven by the perception pause | `session/v0.2.0` | 1 |
 | **3** | Entities on the bus — characters, NPCs, conditions | `session/v0.3.0` | 1 |
 | **4** | Combat | `session/v0.4.0` | 2, 3 |
@@ -61,16 +61,16 @@ retention bound by one and the retention pin must fail.
 **Goal:** every public type in the SDK exists and is correct. The logic behind
 them is mostly delegation.
 
-**T1.1 — module, `Config`, `NewManager`.** Ports (`Characters`, `Encounters`,
-`Sessions`, optional `Events`), fail-fast construction naming what is missing
-(S8), a distinguishable `NotFound` sentinel, and every port get-by-id /
-put-by-id only (S12).
-*Pins:* construction refuses each required port individually, by name; a config
-with only the optional port missing succeeds.
+**T1.1 — module, `Config`, `NewManager`.** The repositories (`Sessions`,
+`Encounters`) plus the required `Events` stream, fail-fast construction naming
+what is missing (S8), a distinguishable `NotFound` sentinel, and every
+repository get-by-id / put-by-id only (S12).
+*Pins:* construction refuses each component individually, by name, in a fixed
+order; the full config succeeds.
 
 **T1.2 — `SessionData`, `StartSession`, load/save.** The session aggregate, its
 `ToData`/`LoadSession` discipline, the authored encounter handed in as a
-parameter rather than fetched (no content port).
+parameter rather than fetched (no content repository).
 *Pins:* round-trip is byte-identical; a hostile hand-edited blob is rejected,
 not crashed (reject-never-crash); an unknown encounter reference is a clean
 rejection.
@@ -196,7 +196,7 @@ retires T3, and may push that wave ahead of this one.
   behind the whole strategy; if it cannot be made precise, the version-bump
   promise degrades to a convention and wave 1 needs rethinking.
 - **Stateless-per-call proves too slow** once entities load on every verb. The
-  design's answer is that this is the server's problem behind a port (an
+  design's answer is that this is the server's problem behind a repository (an
   in-memory checkpointing encounter repository), but that answer is untested.
 - **The perception pause turns out to need entity state** — if "should Alice
   stop?" depends on anything on her sheet, wave 2 gains a dependency on wave 3

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -1,0 +1,237 @@
+# Session SDK — acceptance scenes
+
+**Written before opening the old code.** That is the point of this document.
+If these scenes can be written without consulting what exists, the surface is
+shaped by what the game needs; the mapping onto whatever we already have is
+labor, not design. If we had written them the other way around, we would have
+renamed the old stack and called it a boundary.
+
+Every scene is SDK calls and what comes back. No internals appear — not the
+encounter's types, not combat's, not the bus, not a checkpoint. Where the right
+answer isn't obvious, it is marked **OPEN** rather than guessed.
+
+---
+
+## Scene 0 — Standing the manager up
+
+The game server owns storage and nothing else. It implements the ports; the
+manager refuses to exist without them.
+
+```go
+mgr, err := session.NewManager(&session.Config{
+    Characters: charRepo,   // GetCharacter(ctx, id) (*character.Data, error) / SaveCharacter
+    Monsters:   monRepo,
+    Encounters: encRepo,
+})
+```
+
+- Missing any required port → construction fails with a named error. No lazy
+  discovery at call time, no nil-panic three verbs later.
+- Repositories trade in **data**, not domain objects. Reconstitution happens
+  inside, where the laws are.
+
+**OPEN:** whether ports are one interface per aggregate (above) or a single
+`Repository` with many methods. Leaning per-aggregate — a server that has no
+monsters yet can still construct a character-creation-only manager, and the
+config can name which capabilities are present.
+
+---
+
+## Scene 1 — The party enters the tomb
+
+The tomb is authored content that already exists in storage. Entities are
+loaded *into* it.
+
+```go
+out, err := mgr.Join(ctx, &session.JoinInput{
+    Encounter: "enc-123",
+    Entity:    "char:alice",
+    Room:      "hall",
+    Position:  spatial.Position{X: 2, Y: 3},
+})
+```
+
+- The manager reads the encounter, reads Alice, places her, writes both back.
+- `out.Saved` names what was persisted. If Alice saved and the encounter didn't,
+  that is an error naming both — not a silent partial.
+- rpg-api never held Alice. It named her.
+
+Repeat for the rest of the party and for what's already lurking. **OPEN:**
+whether monsters are joined by the server or come with the authored encounter.
+The tomb probably knows its own ogre; a wandering one probably doesn't.
+
+---
+
+## Scene 2 — Alice walks into something
+
+The headline scene, and the one that justifies the whole design: **the pause is
+born from perception.**
+
+```go
+out, err := mgr.Move(ctx, &session.MoveInput{
+    Encounter: "enc-123",
+    Member:    "alice",
+    Path: []spatial.Position{{3,3}, {4,3}, {5,3}, {6,3}},
+})
+```
+
+Alice walks. At step three the hall opens up and the ogre comes into view. The
+world stops.
+
+```go
+out.Steps       // three entries — she got to {5,3}, not {6,3}
+out.Discovered  // per observer: alice now holds the ogre
+out.Pending     // alice owes an answer: continue, or stop here
+out.Saved       // encounter + alice, both written, mid-path
+```
+
+- The remaining step is **not** discarded. It is frozen, and it is in the blob.
+- Nobody else acts. The world is frozen until the answer arrives.
+- rpg-api did not compute the pause and could not have: only the world model
+  knows what she just saw.
+
+**OPEN:** the shape of `Pending`. It has to carry who owes the answer, what the
+choices are, and enough for a client to render the moment — without leaking why
+the resolution stopped.
+
+---
+
+## Scene 3 — Answering tomorrow, from a different process
+
+```go
+// New process. Same storage. Nothing was held in memory anywhere.
+mgr2, _ := session.NewManager(cfg)
+
+p, err := mgr2.Pending(ctx, &session.PendingInput{Encounter: "enc-123"})
+// p[0].Audience == "alice"
+
+out, err := mgr2.Answer(ctx, &session.AnswerInput{
+    Encounter: "enc-123",
+    Window:    p[0].Window,
+    Option:    "stop",
+})
+```
+
+- Alice stops at `{5,3}`. The frozen step is discarded, the window closes,
+  everything saves.
+- Had she answered `continue`, resolution resumes at step four — the *same*
+  resolution, not a new move.
+
+This is the scene that pins the whole discipline: a resolution survives a
+process restart because it was never anything but data.
+
+**Rejections that must hold:** answering a closed window; answering with an
+option that wasn't offered; someone other than Alice answering Alice's window;
+any other verb on this encounter while the window is open.
+
+---
+
+## Scene 4 — Alice swings, and rage does its thing
+
+```go
+out, err := mgr.Attack(ctx, &session.AttackInput{
+    Encounter: "enc-123",
+    Attacker:  "alice",
+    Target:    "ogre-1",
+    With:      "greataxe",
+})
+```
+
+Alice is raging. Nobody told the manager that; it is on her sheet, and it
+attached itself when she was loaded.
+
+```go
+out.Result   // hit, and what it cost the ogre
+out.Effects  // rage's bonus damage, itemized enough to narrate
+out.Saved    // alice, ogre, encounter
+```
+
+- The caller never mentions rage, never queries for it, never applies it.
+- **OPEN:** how much of the resolution is itemized on the way out. A client that
+  wants to say "+2 rage damage" needs the breakdown; a client that just wants a
+  number doesn't. Leaning itemized, because the narration is the product.
+
+---
+
+## Scene 5 — The ogre runs, and Bob gets a choice
+
+```go
+out, err := mgr.Move(ctx, &session.MoveInput{
+    Encounter: "enc-123", Member: "ogre-1", Path: fleeing,
+})
+// out.Pending → bob owes an answer: take the opportunity attack?
+```
+
+Same `Pending`. Same `Answer`. The caller cannot tell from the shape of its
+code that one pause came from perception and the other from a reaction — which
+is the property that lets us add reaction kinds forever without rpg-api
+changing.
+
+```go
+out, err := mgr.Answer(ctx, &session.AnswerInput{
+    Encounter: "enc-123", Window: w, Option: "attack",
+})
+// the attack resolves, then the ogre's remaining movement continues or halts
+```
+
+- Bob's reaction is spent. **OPEN:** what restores it — with the world frozen,
+  "one per round" needs a round, and free-roam has a clock instead.
+- **OPEN:** whether monsters answer their own windows synchronously. Leaning
+  yes, via the decider the composition already has, so an NPC reaction is the
+  degenerate case of the human path rather than a separate mode.
+
+---
+
+## Scene 6 — The encounter ends underfoot
+
+```go
+out, err := mgr.Move(ctx, &session.MoveInput{
+    Encounter: "enc-123", Member: "alice", Path: fiveSteps,
+})
+
+out.Steps    // three
+out.Outcome  // the tomb's exit ending fired at step three
+```
+
+Steps four and five never happened, and the caller learns that from the length
+of `Steps` rather than from an error. Every verb after this rejects: the
+encounter is closed.
+
+---
+
+## Scene 7 — Making a character (later, but shaped now)
+
+Character creation moves behind this SDK eventually. It is out of scope for the
+first waves, but the surface should not make it awkward:
+
+```go
+out, err := mgr.CreateCharacter(ctx, &session.CreateCharacterInput{...})
+```
+
+The reason to write it down now: it is the scene that proves the manager is a
+**session** and not an encounter service. If the verb set only ever makes sense
+with an encounter ID attached, we named the thing wrong.
+
+---
+
+## What these scenes assert about the surface
+
+1. **Every verb is `load → act → save → return`.** No handles, no sessions to
+   keep alive, no order-of-operations for the caller to get wrong.
+2. **`Pending` is the only interrupt vocabulary the customer learns.** One
+   shape, one `Answer`, regardless of what stopped the world.
+3. **Nothing inner is visible.** Add a checkpoint kind, replace the combat
+   engine, retire a workaround — none of it reaches the signature.
+4. **Failure is named, not silent.** Partial saves report which pieces landed.
+5. **`Path`, not a destination.** The caller says where to walk; what actually
+   happened comes back as steps. A one-cell path is a legal degenerate case,
+   which is how the game moves today.
+
+---
+
+## Scenes deliberately not written yet
+
+Town and shopping; quests; downtime and travel; anything party-scoped that
+outlives an encounter. They are coming, and question 1 in the brainstorm — what
+the manager is actually scoped to — will be answered by whichever of them lands
+first.

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -243,6 +243,21 @@ While that call runs, the stream receives:
 Same beat, three payloads. This is why the fan-out cannot live above us: the
 difference between those three is intel, and intel is a rule.
 
+> **Not true yet — [toolkit#940](https://github.com/KirkDiggler/rpg-toolkit/issues/940).**
+> Implementing this scene revealed that the composition addresses *every* beat
+> to *every* member, unconditionally. `record` has per-viewer filtering and
+> `intel` models perception, but the composition never connects them, so Dave
+> currently hears exactly what Bob and Carol hear.
+>
+> It was harmless while the story was a *query* a host could filter. Making it a
+> *push* channel promotes `Audience` from advisory to load-bearing, and turns an
+> untidy default into a fog-of-war leak.
+>
+> The fix belongs in the composition, not here — filtering in the SDK would put
+> a second implementation of visibility outside the module that owns perception,
+> and the first disagreement between them is a leak. The layering holds: when
+> audiences are scoped, this fan-out inherits the fix with no changes at all.
+
 If the publish fails, the verb still succeeds. Every beat carries a gapless
 `Seq`, so a client that missed one notices the hole and re-queries `Story` from
 its last known sequence. The log is the truth; the stream is a fast path.

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -19,8 +19,10 @@ manager refuses to exist without them.
 
 ```go
 mgr, err := session.NewManager(&session.Config{
-    Characters: charRepo,   // GetCharacter / SaveCharacter — outlive sessions
-    Sessions:   sessRepo,   // GetSession   / SaveSession   — the play state
+    Characters: charRepo,   // character.Data
+    Encounters: encRepo,    // encounter.EncounterData
+    Monsters:   monRepo,    // monster instances
+    Sessions:   sessRepo,   // open windows, frozen resolution
     Events:     stream,     // optional: multiplayer fan-out
 })
 ```
@@ -36,9 +38,12 @@ mgr, err := session.NewManager(&session.Config{
 - **No content port.** The authored tomb is handed in at `StartSession`, since
   the server already knows where its content lives and that lookup happens once
   per session rather than once per verb.
-- The split is `Characters` (durable player property, outliving any session)
-  versus `Sessions` (encounter state, open windows, the frozen path, monster
-  instances — all meaningless once the run ends).
+- **One repository per data type**, never one that saves everything. Clock and
+  intel ride inside the encounter because they are *parts of* it; an encounter
+  is something a session *points at*, so it gets its own repo. This keeps each
+  type's storage strategy the server's business — an encounter held in memory
+  on a live server and checkpointed periodically is invisible from here — and
+  keeps writes proportional to what actually changed.
 
 ---
 

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -21,7 +21,7 @@ manager refuses to exist without them.
 mgr, err := session.NewManager(&session.Config{
     Characters: charRepo,   // character.Data
     Encounters: encRepo,    // encounter.EncounterData
-    Monsters:   monRepo,    // monster instances
+    NPCs:       npcRepo,    // npc.Data — monster is one type
     Sessions:   sessRepo,   // open windows, frozen resolution
     Events:     stream,     // optional: multiplayer fan-out
 })
@@ -66,9 +66,11 @@ out, err := mgr.Join(ctx, &session.JoinInput{
   that is an error naming both — not a silent partial.
 - rpg-api never held Alice. It named her.
 
-Repeat for the rest of the party and for what's already lurking. **OPEN:**
-whether monsters are joined by the server or come with the authored encounter.
-The tomb probably knows its own ogre; a wandering one probably doesn't.
+Repeat for the rest of the party and for what's already lurking — an NPC joins
+the same way a character does, since `Member.Kind` is what tells the manager
+which repository the ID resolves against. **OPEN:** whether an encounter's
+resident NPCs are joined by the server or come with the authored content. The
+tomb probably knows its own ogre; a wandering one probably doesn't.
 
 ---
 

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -21,7 +21,7 @@ manager refuses to exist without them.
 mgr, err := session.NewManager(&session.Config{
     Characters: charRepo,   // character.Data
     Encounters: encRepo,    // encounter.EncounterData
-    NPCs:       npcRepo,    // npc.Data — monster is one type
+    // no NPC repo yet — monsters are session-scoped; see design.md
     Sessions:   sessRepo,   // open windows, frozen resolution
     Events:     stream,     // optional: multiplayer fan-out
 })

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -124,6 +124,10 @@ process restart because it was never anything but data.
 option that wasn't offered; someone other than Alice answering Alice's window;
 any other verb on this encounter while the window is open.
 
+That last rejection is how "process pending first" is *enforced* rather than
+advised — and the error carries the open window and its audience, so the caller
+learns what to do from the rejection instead of having to ask a second time.
+
 ---
 
 ## Scene 4 — Alice swings, and rage does its thing
@@ -199,7 +203,38 @@ encounter is closed.
 
 ---
 
-## Scene 7 — Making a character (later, but shaped now)
+## Scene 7 — Everyone else finds out
+
+Four players share the tomb. Alice's move is *her* call, but it is *everyone's*
+event — and what each of them may know about it differs.
+
+```go
+// The server supplied a stream implementation at construction.
+out, err := mgr.Move(ctx, &session.MoveInput{...})
+```
+
+While that call runs, the stream receives:
+
+- **Alice** — she moved, and she now sees the ogre, and she owes an answer with
+  these options.
+- **Bob and Carol**, in the same room — Alice moved, and she has stopped, and we
+  are waiting on her. **Not** her options.
+- **Dave**, two rooms away and unable to see the hall — nothing at all, or at
+  most that the world is paused.
+
+Same beat, three payloads. This is why the fan-out cannot live above us: the
+difference between those three is intel, and intel is a rule.
+
+If the publish fails, the verb still succeeds. Every beat carries a gapless
+`Seq`, so a client that missed one notices the hole and re-queries `Story` from
+its last known sequence. The log is the truth; the stream is a fast path.
+
+**And nothing is ever announced that was not saved.** Publish happens after the
+write lands, so "the client saw it but the database didn't" cannot occur.
+
+---
+
+## Scene 8 — Making a character (later, but shaped now)
 
 Character creation moves behind this SDK eventually. It is out of scope for the
 first waves, but the surface should not make it awkward:
@@ -226,6 +261,10 @@ with an encounter ID attached, we named the thing wrong.
 5. **`Path`, not a destination.** The caller says where to walk; what actually
    happened comes back as steps. A one-cell path is a legal degenerate case,
    which is how the game moves today.
+6. **The return value is for the caller; the stream is for the table.** A verb
+   tells the actor's request what happened; the event stream tells everyone
+   else, each of them only what they may know. Multiplayer is not something
+   the server assembles from return values.
 
 ---
 

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -83,7 +83,7 @@ born from perception.**
 out, err := mgr.Move(ctx, &session.MoveInput{
     Encounter: "enc-123",
     Member:    "alice",
-    Path: []spatial.Position{{3,3}, {4,3}, {5,3}, {6,3}},
+    Path: []spatial.Position{{X: 3, Y: 3}, {X: 4, Y: 3}, {X: 5, Y: 3}, {X: 6, Y: 3}},
 })
 ```
 
@@ -120,6 +120,7 @@ p, err := mgr2.Pending(ctx, &session.PendingInput{Encounter: "enc-123"})
 out, err := mgr2.Answer(ctx, &session.AnswerInput{
     Encounter: "enc-123",
     Window:    p[0].Window,
+    Audience:  "alice",   // must match the window's audience
     Option:    "stop",
 })
 ```
@@ -134,7 +135,12 @@ process restart because it was never anything but data.
 
 **Rejections that must hold:** answering a closed window; answering with an
 option that wasn't offered; someone other than Alice answering Alice's window;
-any other verb on this encounter while the window is open.
+any *world-changing* verb on this encounter while the window is open.
+
+Read verbs stay available while frozen — `View`, `Story`, `Status`, `Atlas`,
+`Pending`. A client cannot render "waiting on Alice" without asking what the
+world looks like, and a freeze that blinded the other three players would be
+worse than no freeze. Change is frozen; observation is not.
 
 That last rejection is how "process pending first" is *enforced* rather than
 advised — and the error carries the open window and its audience, so the caller
@@ -185,7 +191,7 @@ changing.
 
 ```go
 out, err := mgr.Answer(ctx, &session.AnswerInput{
-    Encounter: "enc-123", Window: w, Option: "attack",
+    Encounter: "enc-123", Window: w, Audience: "bob", Option: "attack",
 })
 // the attack resolves, then the ogre's remaining movement continues or halts
 ```

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -19,9 +19,9 @@ manager refuses to exist without them.
 
 ```go
 mgr, err := session.NewManager(&session.Config{
-    Characters: charRepo,   // GetCharacter(ctx, id) (*character.Data, error) / SaveCharacter
-    Monsters:   monRepo,
-    Encounters: encRepo,
+    Characters: charRepo,   // GetCharacter / SaveCharacter — outlive sessions
+    Sessions:   sessRepo,   // GetSession   / SaveSession   — the play state
+    Events:     stream,     // optional: multiplayer fan-out
 })
 ```
 
@@ -30,10 +30,15 @@ mgr, err := session.NewManager(&session.Config{
 - Repositories trade in **data**, not domain objects. Reconstitution happens
   inside, where the laws are.
 
-**OPEN:** whether ports are one interface per aggregate (above) or a single
-`Repository` with many methods. Leaning per-aggregate — a server that has no
-monsters yet can still construct a character-creation-only manager, and the
-config can name which capabilities are present.
+- Every port operation is **get-by-id or put-by-id**. No queries, no scans, no
+  joins. The game's store is Redis and the access patterns are key-value; the
+  SDK must never require more than that.
+- **No content port.** The authored tomb is handed in at `StartSession`, since
+  the server already knows where its content lives and that lookup happens once
+  per session rather than once per verb.
+- The split is `Characters` (durable player property, outliving any session)
+  versus `Sessions` (encounter state, open windows, the frozen path, monster
+  instances — all meaningless once the run ends).
 
 ---
 

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -22,7 +22,7 @@ mgr, err := session.NewManager(&session.Config{
     Characters: charRepo,   // character.Data
     Encounters: encRepo,    // encounter.EncounterData
     // no NPC repo yet — monsters are session-scoped; see design.md
-    Sessions:   sessRepo,   // open windows, frozen resolution
+    Sessions:   sessRepo,   // windows, frozen resolution, session NPCs
     Events:     stream,     // optional: multiplayer fan-out
 })
 ```

--- a/docs/ideas/session-sdk/scenes.md
+++ b/docs/ideas/session-sdk/scenes.md
@@ -14,28 +14,28 @@ answer isn't obvious, it is marked **OPEN** rather than guessed.
 
 ## Scene 0 — Standing the manager up
 
-The game server owns storage and nothing else. It implements the ports; the
-manager refuses to exist without them.
+The game server owns storage and delivery, and nothing else. It implements the
+repositories and the stream; the manager refuses to exist without them.
 
 ```go
 mgr, err := session.NewManager(&session.Config{
-    Characters: charRepo,   // character.Data
-    Encounters: encRepo,    // encounter.EncounterData
-    // no NPC repo yet — monsters are session-scoped; see design.md
     Sessions:   sessRepo,   // windows, frozen resolution, session NPCs
-    Events:     stream,     // optional: multiplayer fan-out
+    Encounters: encRepo,    // encounter.EncounterData
+    Events:     stream,     // required — the live channel, not a multiplayer add-on
+    // no NPC repo yet — monsters are session-scoped; see design.md
+    // no character repo yet — nothing calls it until entities land; see design.md
 })
 ```
 
-- Missing any required port → construction fails with a named error. No lazy
+- Missing any component → construction fails with a named error. No lazy
   discovery at call time, no nil-panic three verbs later.
 - Repositories trade in **data**, not domain objects. Reconstitution happens
   inside, where the laws are.
 
-- Every port operation is **get-by-id or put-by-id**. No queries, no scans, no
-  joins. The game's store is Redis and the access patterns are key-value; the
-  SDK must never require more than that.
-- **No content port.** The authored tomb is handed in at `StartSession`, since
+- Every repository operation is **get-by-id or put-by-id**. No queries, no
+  scans, no joins. The game's store is Redis and the access patterns are
+  key-value; the SDK must never require more than that.
+- **No content repository.** The authored tomb is handed in at `StartSession`, since
   the server already knows where its content lives and that lookup happens once
   per session rather than once per verb.
 - **One repository per data type**, never one that saves everything. Clock and


### PR DESCRIPTION
## What

The design surface for #935 — a `rulebooks/dnd5e/session` manager that gives
rpg-api one interface and puts the existing implementation behind it. Three
docs, no code. This PR is the review surface; it merges as ratification once
the shape is agreed and the first wave lands.

## Read in this order

**`scenes.md` first, if you read only one.** Seven acceptance scenes written as
SDK calls **before anyone opened the old code** — that ordering is the whole
point. A wrapper designed after reading the implementation it wraps is a rename;
one designed from use cases is a boundary. If the scenes are wrong, everything
downstream is.

Three things surfaced only once they were written down:

- **Scene 2 collapses the design into one assertion.** Alice is handed a
  four-step path and `Steps` comes back with three. Not an error, not a flag —
  the length *is* the fact that the world stopped. Freeze, persist, and resume
  all hang off that one honest return value.
- **Scene 5 is scene 2 with different words.** The ogre flees, Bob is asked
  about an opportunity attack, and the caller's code is byte-identical to the
  perception pause. That is the property that lets reaction kinds be added
  forever without rpg-api noticing — and if those two ever need different
  shapes, we have made a mistake worth catching now.
- **Scene 7 is the naming test.** `CreateCharacter` is waves away, but it is
  the scene that tells us whether "session" is right: if every verb only makes
  sense with an encounter ID attached, this is an encounter service and deserves
  a different name.

**`brainstorm.md`** records how we got here, with Kirk's calls marked **RULED**
so future-us can tell them from my leans. It also carries the finding that
**T3 is not geometry** — walls were already real, a doorway is an unblocked
crossing, and "sight never crosses a connection" is a room-scoped shortcut that
anchoring made obsolete. Retiring it is a perception wave over Atlas, which is
the only thing that sees every room at once.

**`design.md`** derives the contract: eight laws, the ports, and the verb
surface.

## The laws

**S1** no domain state held · **S2** no inner type across the boundary · **S3**
repositories trade in data · **S4** every verb is load→act→save→return · **S5**
`Pending` is the only suspension vocabulary · **S6** failure names its pieces ·
**S7** a frozen resolution is data · **S8** construction is total.

S2 has one deliberate exception, called out in the doc: port signatures
reference the inner modules' `Data` types, because those are the bytes the
server persists, and persistence shapes already carry their own compatibility
discipline. Domain types stay hidden.

## The claim this is buying

Stated so it can be falsified: **after the migration wave, no subsequent wave
changes an rpg-api source file.** `gorelease` gates the module from its first
tag, so that is CI rather than intention. If a wave breaks it, S2 was violated
somewhere and the violation is findable.

## Deliberately unresolved

Marked **OPEN** rather than guessed: port granularity under capability configs;
whether monsters are authored into an encounter or joined by the server; the
shape of `Prompt`; how itemized an attack result should be; reaction economy
without rounds; whether monsters answer their own windows synchronously; and
where the manager's durable state lives — riding in the encounter blob costs
the aggregate purity we just spent a wave hardening, a separate blob costs a
second thing to keep consistent. That last one wants deciding before the first
tag.

## Question for review

**#916** cannot ship as written — its headline needs entities the composition
does not have, and its framing assumed we would be editing the old stack.
Re-point it as a child of #935, or close it in favour of waves cut from this
design? Left alone pending your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler
