### PR TITLE
feat(session): the interrupt spine — resolution that stops, persists, and resumes (#943)

### DIFF
--- a/docs/architecture/components/rulebook-dnd5e-session.md
+++ b/docs/architecture/components/rulebook-dnd5e-session.md
@@ -1,8 +1,8 @@
 ---
 name: rulebooks/dnd5e/session module
-description: The game server's single integration surface — a manager composing the encounter behind ports, with inner types held off the boundary so the insides can be replaced without the host changing
-updated: 2026-08-12
-confidence: high — written alongside the implementation (#938 / PR #942); every claim below is pinned by a test in the module
+description: The game server's single integration surface — a manager composing the encounter behind repositories, with inner types held off the boundary so the insides can be replaced without the host changing
+updated: 2026-08-13
+confidence: high — written alongside the implementation (#938, #943); every claim below is pinned by a test in the module
 ---
 
 # rulebooks/dnd5e/session module
@@ -29,8 +29,7 @@ rpg-api ──implements──▶ repositories (Get/Save)
 
 The encounter composition is the **world** — geometry, placement, perception,
 story, endings. This module is the **table**: entity roster, event fan-out,
-resolution, and (from wave 2) interrupt custody. It holds wiring and lifetime,
-never rules.
+resolution, and interrupt custody. It holds wiring and lifetime, never rules.
 
 ## Why it exists
 
@@ -43,7 +42,8 @@ That is a falsifiable claim, and it is gated two ways:
 - **`boundary_test.go`** parses the package's own source and fails if any
   toolkit type is reachable from an exported declaration. Verified against a
   real leak, not a synthetic one; carries a meta-pin so it cannot silently stop
-  biting. Its allow list has two entries, each with a written reason.
+  biting. Its allow list has three entries, each with a written reason — all of
+  them persistence shapes the host already stores, never a domain type.
 - **`gorelease-dnd5e-session`** in `compat.yml` gates every release.
 
 The boundary test has one known blind spot, closed by hand: sentinel errors are
@@ -59,7 +59,8 @@ test asserts the inner ones are unreachable through returned errors.
 | `Move` | Walk a path, cell by cell |
 | `Traverse` | Cross a connection |
 | `End` | Close through a declared external ending |
-| `Atlas` / `Status` / `View` / `Story` | Reads |
+| `Answer` | Resolve an open window and resume what was waiting on it |
+| `Atlas` / `Status` / `View` / `Story` / `Pending` | Reads |
 
 Every verb is **load → act → save → return**. Nothing is cached between calls,
 which is what lets several servers serve one session with no coordination —
@@ -77,14 +78,50 @@ movement that happened is what was asked for up to the point the world changed.
 cube distance 2 but Chebyshev distance 1, and that substitution has shipped as
 a real defect here before.
 
-**Write order is chosen for its failure mode.** World first, then the session
-pointing at it, so a partial failure leaves a collectable orphan rather than a
-session pointing at nothing.
+**Write order is chosen for its failure mode.** The encounter is written first
+and the session second, because the two half-failures are not symmetric.
+World-without-window is a stoppage in which every persisted fact is true;
+window-without-world would resume past cells nobody walked — corruption that
+looks like progress. `SaveReport` names both halves, and resume re-validates
+against the world it actually loads, so even the survivable failure becomes a
+clean rejection rather than a wrong walk.
 
 **The converter layer is isolated in `convert.go`** and guarded structurally:
 every exported field on an inner type must be carried across or listed with a
 reason. A hand-written converter's real failure is silently dropping a field
 when an inner type grows one.
+
+## The interrupt spine
+
+A resolution can stop, persist, and resume — a walk today, anything later.
+
+**The walk is a re-enterable phase machine.** It holds nothing across a
+suspension: an explicit phase index and the path live in a value that is written
+to storage and read back, so a window outlives the process that opened it. A
+straight-line loop could only have suspended by parking a goroutine, and a
+parked goroutine is a resolution that dies with the process.
+
+**Custody is `play/interrupt`'s**, not this module's. It poses windows,
+validates answers, and persists a ledger. This module supplies the phase
+discipline and the projection; `interrupt.LedgerData` crosses the boundary as a
+stored shape, never `interrupt.Window` or `interrupt.Option` in a signature.
+
+**The freeze is structural.** World-changing verbs open through
+`openForChange`, which refuses while a window is open; `Answer` opens through
+`openForWrite`, because a frozen session is what it exists to operate on.
+Forgetting the freeze requires actively choosing the other opener. Read verbs
+stay available — what is frozen is change, not observation — and the rejection
+is a typed `*FrozenError` naming the window and its audience, so a blocked
+caller is not sent hunting for what the error already knew.
+
+**`Prompt` carries the moment, never the mechanism.** No field names which
+checkpoint fired. Clients render what the player sees and branch on
+`OptionKind`, so new checkpoint kinds arrive without any client learning a new
+reason code — which is the whole reason S5 insists on one suspension shape.
+
+**Enumeration is sorted, not iteration-ordered** (C8): what a checkpoint
+enumerates is a function of persisted data, so a reloaded resolution poses its
+windows identically.
 
 ## Known gaps
 
@@ -105,7 +142,14 @@ In each case, fixing it where the rule lives fixes this module for free.
 ## Deferred by design
 
 `CharacterRepository` arrives with entities, not now: `character` lives inside
-the large `rulebooks/dnd5e` module, and declaring the port early would take a
-permanent dependency on combat, conditions, and spells for a port nothing calls.
-Adding a `Config` field later is compatible; removing one a host has implemented
-is not.
+the large `rulebooks/dnd5e` module, and declaring it early would take a
+permanent dependency on combat, conditions, and spells for a repository nothing
+calls. Adding a `Config` field later is compatible; removing one a host has
+implemented is not.
+
+A session-level `Frozen` blob is deferred for the same reason, and the design
+expected one. The frozen resolution rides in the window that suspended it,
+because today one checkpoint opens one window and the state belongs to that
+window. Shared state across several windows of one resolution — plausible when
+reactions land — is an additive field at that point, and inventing it now would
+commit a persisted shape before anything could tell us whether it is right.

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -1,7 +1,8 @@
 # Session SDK — design
 
-**Status:** ratified through wave 1. Waves 0 and 1 shipped
-(`encounter/v0.4.0`, `session/v0.1.0`); waves 2–5 remain the plan of record.
+**Status:** ratified through wave 2. Waves 0, 1 and 2 shipped
+(`encounter/v0.4.0`, `session/v0.1.0`, `session/v0.2.0`); waves 3–5 remain the
+plan of record.
 Where implementation corrected the design, this document carries the correction
 *and the reason* rather than a quiet rewrite — those reasons are the most
 reusable thing here.
@@ -380,10 +381,20 @@ type SessionData struct {
 }
 ```
 
-**Shipped so far: `ID` and `Encounter` only.** `Windows` and `Frozen` arrive
-with the interrupt spine (wave 2), `NPCs` with entities (wave 3) — each added
-the wave that first writes to it, since a persisted field nothing populates is a
-shape we would be committed to before learning whether it is right.
+**Shipped: `ID`, `Encounter`, and `Windows`.** `NPCs` arrives with entities
+(wave 3), added the wave that first writes to it — a persisted field nothing
+populates is a shape we would be committed to before learning whether it is
+right.
+
+**`Frozen` was not needed, and that is worth recording.** This design gave the
+session a `Frozen []byte` beside the ledger. Wave 2 found the field redundant:
+`interrupt.Window` already carries an opaque payload, one checkpoint opens one
+window, and the suspended state belongs to that window rather than to the
+session. Shared state across several windows of one resolution is plausible when
+reactions land — and at that point `Frozen` is an additive field. Adding it now
+would have committed a persisted shape before anything could tell us whether it
+was the right one, which is the same rule that deferred `CharacterRepository`,
+pointing the same way.
 
 Small, and written only when session state actually changes. The encounter
 never learns what an interrupt window is; the session module validates session

--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -18,7 +18,7 @@ gate from the first tag.
 |---|---|---|---|
 | **0** ✅ | Encounter log retention | `encounter/v0.4.0` | — |
 | **1** ✅ | Shell, free-roam verbs, event stream | `session/v0.1.0` | — |
-| **2** | The interrupt spine, proven by the perception pause | `session/v0.2.0` | 1 |
+| **2** ✅ | The interrupt spine, proven by the perception pause | `session/v0.2.0` | 1 |
 | **3** | Entities on the bus — characters, NPCs, conditions | `session/v0.3.0` | 1 |
 | **4** | Combat | `session/v0.4.0` | 2, 3 |
 | **5** | Reactions — opportunity attack (closes #916) | `session/v0.5.0` | 4 |
@@ -129,7 +129,8 @@ rejection carries the window and its audience so the caller learns what to do
 from the error.
 
 **T2.3 — pose, persist, resume.** `interrupt.Ledger` in `SessionData`; frozen
-resolution as opaque bytes in `Frozen`.
+resolution as opaque bytes. *Shipped without the session-level `Frozen` field:
+the payload rides in the window that suspended it — see design.md.*
 
 **T2.4 — the scene, as one continuous story with a pinned transcript**,
 including a mid-story process restart. Its negative control: with the checkpoint

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -345,8 +345,15 @@ hand-written converter actually has (silently dropping a field when an inner
 type grows one). Pins are mutation-proven throughout, including the
 uncomfortable ones: over-tightening kills only the positive controls, and
 "compute the snapshot but never save it" kills six tests because persistence is
-checked through separate reads rather than returned values. One direct
-dependency. `verify.sh` clean at 120 tests, `-race` clean, `gorelease` gated.
+checked through separate reads rather than returned values. `verify.sh` clean at
+120 tests, `-race` clean, `gorelease` gated.
+
+Its dependencies are the composition it wraps (`encounter`), the three `play`
+modules it projects from, `spatial` for coordinates, and — as of v0.2.0 —
+`core`, for the entity-ID type the interrupt ledger's inputs are written in.
+That last one is a direct dependency taken on internally and held off the
+boundary: `core.EntityID` appears in no exported signature, which the boundary
+test enforces.
 
 **Why not higher, judged from where we stood when we built it.** Four things,
 none of which were available to fix at the time:

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -346,7 +346,7 @@ type grows one). Pins are mutation-proven throughout, including the
 uncomfortable ones: over-tightening kills only the positive controls, and
 "compute the snapshot but never save it" kills six tests because persistence is
 checked through separate reads rather than returned values. One direct
-dependency. `verify.sh` clean at 90 tests, `-race` clean, `gorelease` gated.
+dependency. `verify.sh` clean at 120 tests, `-race` clean, `gorelease` gated.
 
 **Why not higher, judged from where we stood when we built it.** Four things,
 none of which were available to fix at the time:

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -330,9 +330,10 @@ reconsider as the count grows.
 
 ### rulebooks/dnd5e/session — A-
 
-The game server's single integration surface (#938 / PR #942, v0.1.0). Ten
-verbs over two ports; the host implements get-by-id and put-by-id and thereafter
-holds no domain object.
+The game server's single integration surface (#938, #943; v0.2.0). Twelve verbs
+over two repositories and an event stream; the host implements get-by-id and
+put-by-id and thereafter holds no domain object. As of v0.2.0 a resolution can
+stop mid-way, persist as data, survive a process restart, and resume.
 
 **What earns the grade.** The boundary is enforced rather than asserted:
 `boundary_test.go` parses the package's own source and fails on any toolkit type
@@ -366,10 +367,30 @@ none of which were available to fix at the time:
    module reads something it does not own, and it fails *silently* — a changed
    payload shape degrades every event to `EventUnknown` with nothing red.
    *Improve by:* #941, after which the kind reads declared metadata.
-4. **The partial-save path is thin.** `SaveReport` supports naming what landed
-   and what did not, but only `StartSession` writes more than one aggregate
-   today, so the machinery is barely exercised. *Improve by:* entities, which
-   bring the second writer — deliberately not by manufacturing a fake one.
+4. **The checkpoint policy is a rule, and it lives here.** "Stop the walk when
+   the walker sees something for the first time" is a judgement about the game,
+   and this module's charter says it owns no rules. It is here because there is
+   no module that owns *when a resolution should pause* — perception owns what
+   is seen, not what that should interrupt. The machinery is right (checkpoints
+   are enumerated, the vocabulary is uniform); the policy is squatting.
+   *Improve by:* naming the owner when the second checkpoint kind arrives — if
+   traps, reactions and perception each want a different rule, the shape of the
+   thing that decides will be visible, and it can move. Inventing that owner now
+   would be guessing at an interface from one example.
+
+**What v0.2.0 fixed.** The partial-save path was called out as thin at v0.1.0 —
+`SaveReport` could name what landed and what did not, but only `StartSession`
+wrote more than one aggregate. A suspending walk now writes two, in an order
+chosen for its failure mode, and both the two-aggregate report and the
+write-proportionality rule (a walk that suspends nothing does not rewrite the
+session) are pinned and mutation-proven. S6 is exercised rather than promised.
+
+**Why still A- and not higher.** The grade held rather than rose: one
+reservation closed and one opened. Every pin in the new surface is
+mutation-proven — fifteen mutants, all killed — and one of them found a test
+that did not pin what it claimed, which was rewritten rather than explained
+away. But the module is still unproven against a real consumer, and it has
+taken on a rule it does not have a home for.
 
 **Not counted against it.** #940 (beats addressed to every member) makes the
 event fan-out over-broad in game terms, but the module is correct with respect

--- a/rulebooks/dnd5e/session/README.md
+++ b/rulebooks/dnd5e/session/README.md
@@ -2,8 +2,8 @@
 
 **Charter: the game server's single point of contact with the toolkit.**
 
-A host implements two repositories and, from then on, holds no domain object at
-all — it names things and calls verbs.
+A host implements two repositories and an event stream and, from then on, holds
+no domain object at all — it names things and calls verbs.
 
 ## What it is
 
@@ -17,7 +17,7 @@ and the fix is to push it down, never to special-case it up.
 
 ## What it is not
 
-- **Storage.** The host owns that, behind ports.
+- **Storage.** The host owns that, behind repositories.
 - **Authoring.** Worlds and monster definitions come from content pipelines.
 - **Transport.** gRPC, protos, and streams belong to the game server.
 - **Presentation.** It returns facts rich enough to narrate; it never narrates.
@@ -44,6 +44,8 @@ declaration, and `gorelease` gates every release.
 | `read.go` | `Atlas`, `Status`, `View`, `Story`, and the shared load path |
 | `write.go` | `Join`, `Exit`, `End`, and the save/publish seam |
 | `move.go` | `Move` (walking a path) and `Traverse` |
+| `suspend.go` | The suspension vocabulary and the walk's phase machine |
+| `answer.go` | `Answer`, `Pending`, and the freeze |
 | `start.go` | `StartSession` |
 | `events.go` | Per-recipient fan-out |
 | `cmd/session-workbench` | Drives a whole session; run it |

--- a/rulebooks/dnd5e/session/answer.go
+++ b/rulebooks/dnd5e/session/answer.go
@@ -36,6 +36,32 @@ func (e *FrozenError) Error() string {
 // while still recovering the details with errors.As.
 func (e *FrozenError) Unwrap() error { return ErrFrozen }
 
+// SaveError reports a failed save along with what did and did not land.
+//
+// It exists because a verb returns no output when it returns an error, so a
+// bare sentinel would strand exactly the information S6 promises: a caller who
+// cannot see the report cannot tell a total failure from a half one, and that
+// is the difference between "retry the verb" and "the world moved but what it
+// owes did not". Match the condition with errors.Is(err, ErrSaveFailed);
+// recover the detail with errors.As.
+type SaveError struct {
+	// Report names the aggregates that landed and those that did not.
+	Report SaveReport
+
+	// Err is the underlying repository failure, still matchable with errors.Is.
+	Err error
+}
+
+// Error describes which save failed.
+func (e *SaveError) Error() string {
+	return fmt.Sprintf("%v (written %v, failed %v)", e.Err, e.Report.Written, e.Report.Failed)
+}
+
+// Unwrap exposes both the ErrSaveFailed sentinel and the repository's own
+// error, so a caller can match either without this type having to guess which
+// one they care about.
+func (e *SaveError) Unwrap() []error { return []error{ErrSaveFailed, e.Err} }
+
 // AnswerInput resolves an open window.
 type AnswerInput struct {
 	// Session is the session holding the window.

--- a/rulebooks/dnd5e/session/answer.go
+++ b/rulebooks/dnd5e/session/answer.go
@@ -1,0 +1,275 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/interrupt"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// FrozenError reports that a verb was refused because a window is open.
+//
+// It names the window and its audience rather than only saying "no", because a
+// caller who is blocked needs to know who to go ask. A bare sentinel would send
+// them to Pending to find out what this error already knew.
+type FrozenError struct {
+	// Window is the open window blocking the verb.
+	Window string
+
+	// Audience is the member who owes the answer.
+	Audience string
+}
+
+// Error describes the open window blocking the verb.
+func (e *FrozenError) Error() string {
+	return fmt.Sprintf("world frozen: window %s awaits %s", e.Window, e.Audience)
+}
+
+// Unwrap returns ErrFrozen so callers can match the condition with errors.Is
+// while still recovering the details with errors.As.
+func (e *FrozenError) Unwrap() error { return ErrFrozen }
+
+// AnswerInput resolves an open window.
+type AnswerInput struct {
+	// Session is the session holding the window.
+	Session string
+
+	// Window is the window being answered, as reported in Pending.Window.
+	Window string
+
+	// Member must be the window's audience. Answering someone else's window is
+	// a rejection.
+	Member string
+
+	// Option is the Token of the chosen option.
+	Option string
+}
+
+// AnswerOutput reports what resuming produced.
+//
+// It covers the resumption only: the steps taken before the world froze were
+// already reported to whoever called Move. The continuous version of the story
+// is the story itself, which Story returns in one unbroken sequence regardless
+// of how many calls it took to produce.
+type AnswerOutput struct {
+	// Steps are the cells entered after resuming, in order. Empty if the answer
+	// stopped the walk.
+	Steps []Step `json:"steps,omitempty"`
+
+	// Discovered is what changed in each observer's perception while resuming.
+	Discovered map[string]Discovery `json:"discovered,omitempty"`
+
+	// Outcome is present if an ending fired underfoot after resuming.
+	Outcome *Outcome `json:"outcome,omitempty"`
+
+	// Pending is present if resuming hit another checkpoint. A walk may
+	// suspend as many times as it has things to notice.
+	Pending *Pending `json:"pending,omitempty"`
+
+	// Saved names what was persisted.
+	Saved SaveReport `json:"saved"`
+
+	// Delivery names what reached the event stream.
+	Delivery DeliveryReport `json:"delivery"`
+}
+
+// PendingInput asks what windows are open in a session.
+type PendingInput struct {
+	// Session is the session to inspect.
+	Session string
+}
+
+// PendingOutput lists the open windows.
+type PendingOutput struct {
+	// Windows are the open windows in the order they were opened. Empty means
+	// the world is running.
+	Windows []Pending `json:"windows,omitempty"`
+}
+
+// Answer resolves an open window and resumes whatever was waiting on it.
+//
+// This is the one verb that reaches a frozen session, because it is the only
+// thing that can unfreeze one. Choosing OptionContinue resumes the suspended
+// resolution from exactly the cell it stopped at; choosing OptionStop abandons
+// what remained. Neither undoes what already happened — a walk that stopped
+// after three steps stopped there, and the member stands where they stood.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoWindowID,
+// ErrNoSession, ErrNoEncounter, ErrNoWindow if the window is not open,
+// ErrNotAudience if the member does not owe it, ErrNotOffered if the choice was
+// not on the menu, ErrInvalidSession if the frozen resolution is unreadable, or
+// ErrSaveFailed with a populated report.
+func (m *Manager) Answer(ctx context.Context, in *AnswerInput) (*AnswerOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("answer: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("answer: %w", ErrNoMemberID)
+	}
+
+	windowID, err := parseWindow(in.Window)
+	if err != nil {
+		return nil, fmt.Errorf("answer: %w", err)
+	}
+
+	// openForWrite, not openForChange: a frozen session is exactly the state
+	// this verb exists to operate on.
+	scope, err := m.openForWrite(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("answer: %w", err)
+	}
+
+	closed, err := scope.ledger.Answer(&interrupt.AnswerInput{
+		Window: windowID,
+		By:     core.EntityID(in.Member),
+		Choice: interrupt.Option(in.Option),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("answer: %w", translateWindow(err))
+	}
+	scope.touched = true
+
+	frozen, err := thaw(closed.Window.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("answer: %w", err)
+	}
+
+	res := &walkResult{}
+	if OptionKind(closed.Choice) == OptionContinue {
+		res, err = m.resume(scope, frozen)
+		if err != nil {
+			return nil, fmt.Errorf("answer: %w", err)
+		}
+	}
+
+	report, delivery, err := m.commit(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("answer: %w", err)
+	}
+
+	return &AnswerOutput{
+		Steps:      res.steps,
+		Discovered: nilIfEmpty(res.discovered),
+		Outcome:    res.outcome,
+		Pending:    res.pending,
+		Saved:      report,
+		Delivery:   delivery,
+	}, nil
+}
+
+// resume re-validates a thawed walk against the world as it actually loaded,
+// then continues it.
+//
+// Re-validation is not paranoia about our own freeze. The window and the world
+// are two stored aggregates, and persist writes them in an order chosen so that
+// the survivable half-failure is "the world moved but the window did not" — so
+// a window can legitimately outlive a save that failed after it. Checking that
+// the remaining path still starts adjacent to where the member actually stands
+// turns that case into a clean rejection instead of a walk that teleports over
+// the cells the failed save swallowed.
+func (m *Manager) resume(scope *writeScope, frozen *frozenResolution) (*walkResult, error) {
+	remaining := frozen.Path[frozen.Index:]
+	if len(remaining) == 0 {
+		return &walkResult{}, nil
+	}
+	if err := validatePath(scope.enc, encounter.MemberID(frozen.Member), remaining); err != nil {
+		return nil, fmt.Errorf("resuming: %w", err)
+	}
+	return m.runWalk(scope, frozen)
+}
+
+// Pending reports the open windows in a session: who owes an answer, what they
+// may choose, and what they are looking at.
+//
+// A read verb, and available while the world is frozen — a client that cannot
+// ask what it is waiting for has no way to render the wait.
+//
+// It reads session state only. The prompt was recorded when the window opened,
+// because a perception delta is a difference at a moment: by the time anyone
+// asks, it has been folded into what the observer knows and cannot be
+// recomputed. Storing what the audience was shown is the only way to show them
+// the same thing twice.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoSession, or ErrInvalidSession.
+func (m *Manager) Pending(ctx context.Context, in *PendingInput) (*PendingOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("pending: %w", ErrNilInput)
+	}
+	if in.Session == "" {
+		return nil, fmt.Errorf("pending: %w", ErrNoSessionID)
+	}
+
+	data, err := m.loadSessionData(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("pending: %w", err)
+	}
+
+	ledger, err := interrupt.LoadLedger(data.Windows)
+	if err != nil {
+		return nil, fmt.Errorf("pending: session %q: %w: %w", in.Session, ErrInvalidSession, err)
+	}
+
+	open, err := ledger.Open()
+	if err != nil {
+		return nil, fmt.Errorf("pending: %w: %w", ErrInvalidSession, err)
+	}
+	if len(open) == 0 {
+		return &PendingOutput{}, nil
+	}
+
+	windows := make([]Pending, 0, len(open))
+	for _, w := range open {
+		frozen, err := thaw(w.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("pending: window %d: %w", w.ID, err)
+		}
+		windows = append(windows, *projectPending(w, frozen.Prompt))
+	}
+	return &PendingOutput{Windows: windows}, nil
+}
+
+// parseWindow converts an SDK window identifier back to a ledger ID.
+//
+// The identifier is documented as opaque, so this is the only place that knows
+// it is currently a decimal number — which is what makes it safe to change into
+// something composite or signed later without touching a caller.
+func parseWindow(id string) (interrupt.WindowID, error) {
+	if id == "" {
+		return 0, ErrNoWindowID
+	}
+	n, err := strconv.ParseUint(id, 10, 64)
+	if err != nil || n == 0 {
+		return 0, fmt.Errorf("%q: %w", id, ErrNoWindowID)
+	}
+	return interrupt.WindowID(n), nil
+}
+
+// translateWindow maps the custody module's sentinels onto this module's.
+//
+// The same reason the boundary test exists: a host that matched on
+// interrupt.ErrNotOpen would be coupled to the module we most want to stay free
+// to replace. Sentinels are not types in a signature, so nothing mechanical
+// would catch that leak — which is exactly why it is done deliberately here.
+func translateWindow(err error) error {
+	switch {
+	case errors.Is(err, interrupt.ErrNotOpen):
+		return fmt.Errorf("%w: %w", ErrNoWindow, err)
+	case errors.Is(err, interrupt.ErrNotAudience):
+		return fmt.Errorf("%w: %w", ErrNotAudience, err)
+	case errors.Is(err, interrupt.ErrNotOffered):
+		return fmt.Errorf("%w: %w", ErrNotOffered, err)
+	case errors.Is(err, interrupt.ErrNoOption):
+		return fmt.Errorf("%w: %w", ErrNotOffered, err)
+	case errors.Is(err, interrupt.ErrNoAudience):
+		return fmt.Errorf("%w: %w", ErrNoMemberID, err)
+	default:
+		return err
+	}
+}

--- a/rulebooks/dnd5e/session/boundary_test.go
+++ b/rulebooks/dnd5e/session/boundary_test.go
@@ -65,6 +65,18 @@ var allowed = map[string]string{
 	// not already expose it to. A *domain* type in a verb input would be a different
 	// matter, and is what this list exists to keep out.
 	"encounter.EncounterData": "persistence shape the host already holds (S3)",
+
+	// The same S3 exception, for the same reason: SessionData is a persistence
+	// shape, and the ledger of open windows is part of what a session *is*.
+	// The host stores these bytes opaquely and never constructs one — it has no
+	// reason to name interrupt.LedgerData in its own code, and every reason to
+	// round-trip it untouched.
+	//
+	// Note what this does NOT admit: interrupt.Window, interrupt.Ledger, or
+	// interrupt.Option appearing in a verb signature. Suspension reaches the
+	// host through SDK-owned Pending and Option types precisely so the custody
+	// module underneath can be replaced. Only the stored shape crosses.
+	"interrupt.LedgerData": "persistence shape the host stores opaquely (S3)",
 }
 
 // TestNoInnerTypeCrossesTheBoundary parses this package's non-test sources and

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -175,6 +175,42 @@ func drive(out *bytes.Buffer) error {
 		crossed.FromRoom, crossed.From.X, crossed.From.Y,
 		crossed.ToRoom, crossed.To.X, crossed.To.Y)
 
+	fmt.Fprintln(out, "\n== something moves in the dark ==")
+	vaultPath := []spatial.Position{{X: 1, Y: 1}, {X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}}
+	probe, err := mgr.Move(ctx, &session.MoveInput{
+		Session: "crypt-run", Member: "alice", Path: vaultPath,
+	})
+	if err != nil {
+		return err
+	}
+	for _, step := range probe.Steps {
+		fmt.Fprintf(out, "   alice enters (%v,%v)\n", step.Position.X, step.Position.Y)
+	}
+	if probe.Pending == nil {
+		return fmt.Errorf("expected the vault to interrupt the walk, got %d/%d steps",
+			len(probe.Steps), len(vaultPath))
+	}
+	fmt.Fprintf(out, "   the world freezes after %d/%d: %s sees %v\n",
+		len(probe.Steps), len(vaultPath), probe.Pending.Audience, probe.Pending.Prompt.Sighted)
+
+	// Everything that would change the world is refused now, and says why.
+	if _, err := mgr.End(ctx, &session.EndInput{
+		Session: "crypt-run", Ending: "withdraw",
+	}); err != nil {
+		fmt.Fprintf(out, "   end refused while frozen: %v\n", err)
+	}
+
+	resumed, err := mgr.Answer(ctx, &session.AnswerInput{
+		Session: "crypt-run", Window: probe.Pending.Window,
+		Member: "alice", Option: string(session.OptionContinue),
+	})
+	if err != nil {
+		return err
+	}
+	for _, step := range resumed.Steps {
+		fmt.Fprintf(out, "   alice presses on to (%v,%v)\n", step.Position.X, step.Position.Y)
+	}
+
 	fmt.Fprintln(out, "\n== bob's story ==")
 	story, err := mgr.Story(ctx, &session.StoryInput{Session: "crypt-run", Member: "bob"})
 	if err != nil {
@@ -212,7 +248,12 @@ func authoredCrypt() (*encounter.EncounterData, error) {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "antechamber", Width: 6, Height: 6},
-				{ID: "vault", Width: 6, Height: 6, Origin: spatial.Position{X: 6, Y: 0}},
+				// The vault is split by rubble with one sightline through it at
+				// y=3, so what waits at (4,3) is invisible until someone lines
+				// up with the gap.
+				{ID: "vault", Width: 6, Height: 6, Origin: spatial.Position{X: 6, Y: 0}, Occluders: []spatial.Position{
+					{X: 2, Y: 0}, {X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 4}, {X: 2, Y: 5},
+				}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "antechamber", To: "vault",
@@ -222,6 +263,7 @@ func authoredCrypt() (*encounter.EncounterData, error) {
 		},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "antechamber", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "wight", Kind: encounter.KindMonster, Room: "vault", Position: spatial.Position{X: 4, Y: 3}},
 		},
 		Endings:   []encounter.EndingInput{{Key: "withdraw", Trigger: encounter.TriggerExternal{}}},
 		Retention: encounter.RetentionUnbounded,

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
@@ -30,8 +30,15 @@ func TestWorkbenchRuns(t *testing.T) {
 		"gate: antechamber (5,1) kisses vault (6,1)", // W3 holds in absolute space
 		"alice enters (5,1)",                         // the walk reached the doorway
 		"antechamber (5,1) → vault (0,1)",            // and crossed it
+
+		// The interrupt spine, end to end. Each of these is a different claim,
+		// and any one of them regressing would leave the others still true:
+		"the world freezes after 3/4: alice sees [wight]",                    // perception suspends a walk mid-path
+		"end refused while frozen: end: world frozen: window 1 awaits alice", // and the refusal names who to go ask
+		"alice presses on to (1,4)",                                          // answering resumes from where it stopped
+
 		`ended by "withdraw"`,
-		"alice in vault at (0,1)", // the crossing persisted through to the ending
+		"alice in vault at (1,4)", // the resumed walk persisted through to the ending
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("workbench output missing %q\nfull output:\n%s", want, got)

--- a/rulebooks/dnd5e/session/data.go
+++ b/rulebooks/dnd5e/session/data.go
@@ -3,6 +3,8 @@
 
 package session
 
+import "github.com/KirkDiggler/rpg-toolkit/play/interrupt"
+
 // SessionData is the persistent representation of a session.
 //
 // It holds only session state. The encounter is referenced by ID rather than
@@ -17,4 +19,18 @@ type SessionData struct {
 
 	// Encounter is the ID of the encounter this session plays in.
 	Encounter string `json:"encounter"`
+
+	// Windows is the ledger of open interrupt windows: who owes an answer,
+	// what they may choose, and the frozen resolution waiting on it.
+	//
+	// It lives here rather than in EncounterData deliberately. An encounter
+	// cannot interpret or validate a suspended walk, so holding one would spend
+	// the aggregate purity hardened in the anchoring wave on state it does not
+	// understand. This struct is ours, so the cost of being wrong is confined
+	// to this module.
+	//
+	// A session written before v0.2.0 has no windows key; it unmarshals to the
+	// zero LedgerData, which LoadLedger reads as an idle ledger. Older sessions
+	// therefore load unchanged rather than needing a migration.
+	Windows interrupt.LedgerData `json:"windows,omitempty"`
 }

--- a/rulebooks/dnd5e/session/doc.go
+++ b/rulebooks/dnd5e/session/doc.go
@@ -28,21 +28,18 @@
 //
 // # What this version does and does not do
 //
-// The laws below describe the whole design, and two of them are commitments
-// rather than descriptions today. Stated as such deliberately: a reader
-// deciding whether to depend on this needs to know which is which, and a
-// package doc that quietly narrates the destination is worse than one that
-// names the waypoint.
+// Every law below is in force and exercised. S5 and S7 were commitments in
+// v0.1.0 — nothing could suspend yet — and are descriptions as of v0.2.0: a
+// walk stops mid-path, freezes as data, survives a process restart, and
+// resumes. The loop did not change shape when they became real, which is why
+// they were stated at the first tag rather than invented at the second.
 //
-// In force now: S1, S2, S3, S4, S6, S8, S12, S13, and the event-stream laws.
-//
-// Not yet exercised: S5 (Pending as suspension vocabulary) and S7 (a frozen
-// resolution is data) — nothing suspends in this version. The only pause a
-// verb can report is an ending, and it is reported by returning fewer steps
-// than were asked for. When resolutions become genuinely suspendable, the
-// caller learns through the same channel: a verb that returns having stopped,
-// plus a field naming who owes an answer. The loop does not change shape,
-// which is why those laws are stated now rather than invented later.
+// What is genuinely absent is scope, not law. Only one thing can suspend a
+// resolution today: a member seeing something for the first time. Characters,
+// NPCs and their conditions arrive with the entities wave; combat and
+// reactions after that. Each is a new checkpoint kind, and a new checkpoint
+// kind is additive by construction — Prompt names what the player is looking
+// at and never why the resolution stopped, so no client learns a reason code.
 //
 // # Laws
 //
@@ -62,14 +59,16 @@
 // S4 — every verb is load, act, save, return.
 //
 // S5 — Pending is the only suspension vocabulary. Every pause, whatever caused
-// it, surfaces in one shape and resolves through one Answer. (Committed, not
-// yet exercised: see above.)
+// it, surfaces in one shape and resolves through one Answer. While a window is
+// open every verb that would change the world is refused; read verbs are not,
+// because what is frozen is change, not observation.
 //
 // S6 — failure names its pieces. A partial save is an error with a populated
 // report, never a silent shrug.
 //
-// S7 — a frozen resolution is data. It survives a process restart because it
-// was never anything else. (Committed, not yet exercised: see above.)
+// S7 — a frozen resolution is data. The walk is a re-enterable phase machine
+// holding nothing across a suspension, so a window survives the process that
+// opened it: the answer may arrive days later, on another machine.
 //
 // S8 — construction is total. The manager refuses to exist without what it
 // needs; there is no lazy discovery at call time.

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -133,6 +133,39 @@ var (
 	// and be permanently unusable.
 	ErrInvalidWorld = errors.New("invalid encounter data")
 
+	// ErrFrozen is returned by every verb that would change the world while an
+	// interrupt window is open. Read verbs are unaffected.
+	//
+	// Errors wrapping this are *FrozenError, which names the window and who
+	// owes it. Match the sentinel with errors.Is to detect the condition; use
+	// errors.As to recover the window and tell the caller what to do about it.
+	ErrFrozen = errors.New("world frozen")
+
+	// ErrNoWindow is returned when a verb names a window that is not open —
+	// unknown, never opened, or already answered. One answer per window.
+	ErrNoWindow = errors.New("no such open window")
+
+	// ErrNotAudience is returned when a member answers a window they do not
+	// owe. Answering for someone else is a rejection, not a courtesy.
+	ErrNotAudience = errors.New("not this window's audience")
+
+	// ErrNotOffered is returned when an answer names a choice the window did
+	// not offer.
+	ErrNotOffered = errors.New("choice not offered")
+
+	// ErrNoWindowID is returned when a verb is given an empty or unparseable
+	// window identifier.
+	ErrNoWindowID = errors.New("bad window id")
+
+	// ErrInvalidSession is returned when stored session state is not a state
+	// this module could have written — a hand-edited or corrupted blob.
+	//
+	// It is deliberately distinct from ErrInvalidWorld. A caller who sees this
+	// knows the encounter is fine and only the session record is suspect, which
+	// is the difference between "the tomb is unreadable" and "an open window
+	// refers to a resolution that cannot be real".
+	ErrInvalidSession = errors.New("invalid session data")
+
 	// ErrSaveFailed is returned when one or more aggregates could not be
 	// persisted. The accompanying SaveReport names which landed and which did
 	// not (S6) — a partial write is never reported as success, and never as an

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -5,6 +5,7 @@ package session_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -122,14 +123,17 @@ func Example_theSession() {
 	//     bob at (1,3)
 }
 
-// Example_thePending shows the shape a suspension will take from the host's
-// side, using the only pause that exists today — an ending.
+// Example_thePending is the host's whole suspension loop, and it is short on
+// purpose.
 //
-// The point is the CALLER'S code, not the mechanism. A verb comes back having
-// done less than it was asked, says so in its own return value, and the host
-// reacts. When resolutions become genuinely suspendable, the caller learns
-// about it through the same channel: a verb that returns having stopped, plus a
-// field saying who owes an answer. Nothing about this loop changes shape.
+// A verb returns having done less than it was asked and says who owes an
+// answer. The host renders that, collects a choice, and hands it back. It never
+// learns what kind of checkpoint fired — it branches on the option kinds it was
+// offered, which is what lets new checkpoint kinds arrive without any client
+// changing.
+//
+// The earlier version of this example simulated the shape with an ending,
+// because nothing could genuinely suspend yet. This is the real thing.
 func Example_thePending() {
 	ctx := context.Background()
 	mgr, err := session.NewManager(&session.Config{
@@ -140,31 +144,61 @@ func Example_thePending() {
 		panic(err)
 	}
 	if _, err := mgr.StartSession(ctx, &session.StartSessionInput{
-		Session: "run", Encounter: "tomb", World: authoredTomb(),
+		Session: "run", Encounter: "tomb", World: ambushWorld(panicFataler{}),
 	}); err != nil {
 		panic(err)
 	}
 
-	path := []spatial.Position{{X: 2, Y: 1}, {X: 3, Y: 1}, {X: 4, Y: 1}, {X: 5, Y: 1}}
-	out, err := mgr.Move(ctx, &session.MoveInput{
-		Session: "run", Member: "alice", Path: path,
-	})
+	path := []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}}
+	out, err := mgr.Move(ctx, &session.MoveInput{Session: "run", Member: "alice", Path: path})
 	if err != nil {
 		panic(err)
 	}
 
-	switch {
-	case out.Outcome != nil:
-		fmt.Printf("stopped after %d/%d: the encounter ended (%s)\n",
-			len(out.Steps), len(path), out.Outcome.Ending)
-	case len(out.Steps) < len(path):
-		fmt.Printf("stopped after %d/%d: something interrupted\n", len(out.Steps), len(path))
-	default:
+	if out.Pending == nil {
 		fmt.Printf("walked all %d cells\n", len(out.Steps))
+		return
 	}
 
+	offered := make([]string, 0, len(out.Pending.Options))
+	for _, opt := range out.Pending.Options {
+		offered = append(offered, string(opt.Kind))
+	}
+	fmt.Printf("stopped after %d/%d: %s sees %v and must choose %v\n",
+		len(out.Steps), len(path), out.Pending.Audience, out.Pending.Prompt.Sighted, offered)
+
+	// Everything that would change the world is refused until she answers, and
+	// the refusal says who to go ask.
+	_, err = mgr.Move(ctx, &session.MoveInput{
+		Session: "run", Member: "alice", Path: []spatial.Position{{X: 2, Y: 4}},
+	})
+	var frozen *session.FrozenError
+	if errors.As(err, &frozen) {
+		fmt.Printf("meanwhile the world is frozen, waiting on %s\n", frozen.Audience)
+	}
+
+	// The answer may arrive from anywhere, at any time — it is just another call.
+	resumed, err := mgr.Answer(ctx, &session.AnswerInput{
+		Session: "run", Window: out.Pending.Window,
+		Member: "alice", Option: string(session.OptionContinue),
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("she presses on, %d cell(s) further\n", len(resumed.Steps))
+
 	// Output:
-	// stopped after 3/4: the encounter ended (stairs)
+	// stopped after 2/3: alice sees [ogre] and must choose [continue stop]
+	// meanwhile the world is frozen, waiting on alice
+	// she presses on, 1 cell(s) further
+}
+
+// panicFataler adapts the test fixtures for use from an Example, which has no
+// *testing.T to fail through.
+type panicFataler struct{}
+
+func (panicFataler) Fatalf(format string, args ...any) {
+	panic(fmt.Sprintf(format, args...))
 }
 
 // authoredTomb is content, not a live encounter: the blob a host would have

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
+	github.com/KirkDiggler/rpg-toolkit/play/interrupt v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -3,6 +3,7 @@ module github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session
 go 1.24
 
 require (
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/interrupt v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
@@ -12,7 +13,6 @@ require (
 )
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.11.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2 // indirect
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0 // indirect
 	github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0 // indirect

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -8,6 +8,8 @@ github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0 h1:uKGivoRcgQW3sQ0I0G5ct0Dk
 github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0/go.mod h1:LRzXoz7Is2z6s4KWtVG6B68uunxJgE5qWdk14EtHlbk=
 github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0 h1:89nU27faMf80JrIJlQeVeYacQIexkgBFzHomvXWyE/I=
 github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0/go.mod h1:BlYgBeigB1mUum7FG8AUxWX32tgBrBLFg4/t//+tSvk=
+github.com/KirkDiggler/rpg-toolkit/play/interrupt v0.1.0 h1:L9ozHqfxKo8Ca/z4EF/juHaDT62b343d43CRwW6kTlY=
+github.com/KirkDiggler/rpg-toolkit/play/interrupt v0.1.0/go.mod h1:IRzIF0Rp4mzlan3SxrRR41drGYsL3DY4p8oM7qRSBag=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q+6k8n0krpcnka+lLyflk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.4.0 h1:27AxCK1/Ypt16fjhALdu1br27j7syvVm3y8s/uylF58=

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -54,6 +54,11 @@ type MoveOutput struct {
 	// walk stopped.
 	Outcome *Outcome `json:"outcome,omitempty"`
 
+	// Pending is present if the walk stopped at a checkpoint and is waiting on
+	// a decision. The world is frozen until it is answered, and the remaining
+	// steps resume from exactly where these left off.
+	Pending *Pending `json:"pending,omitempty"`
+
 	// Saved names what was persisted.
 	Saved SaveReport `json:"saved"`
 
@@ -136,7 +141,7 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", ErrEmptyPath)
 	}
 
-	scope, err := m.openForWrite(ctx, in.Session)
+	scope, err := m.openForChange(ctx, in.Session)
 	if err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
@@ -145,36 +150,13 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	steps := make([]Step, 0, len(in.Path))
-	merged := map[string]Discovery{}
-	var outcome *Outcome
-
-	for _, cell := range in.Path {
-		moved, moveErr := scope.enc.Move(&encounter.MoveInput{
-			Member: encounter.MemberID(in.Member),
-			To:     cell,
-		})
-		if moveErr != nil {
-			// Nothing is saved on a mid-walk rejection. The member has really
-			// moved in memory for the steps already taken, but that encounter
-			// is discarded unsaved, so the persisted world is untouched — the
-			// whole walk fails, rather than leaving the party at an arbitrary
-			// cell nobody chose.
-			return nil, fmt.Errorf("move: step %d of %d: %w",
-				len(steps)+1, len(in.Path), translate(moveErr))
-		}
-
-		steps = append(steps, Step{Position: moved.Moved.To, Seq: moved.Seq})
-		mergeDiscoveries(merged, projectDiscoveries(moved.IntelDeltas))
-
-		if moved.Outcome != nil {
-			// The encounter ended underfoot. Every remaining step is abandoned:
-			// a closed encounter refuses movement anyway, and attempting them
-			// would turn a clean stop into a rejection the caller has to
-			// interpret.
-			outcome = projectOutcome(moved.Outcome)
-			break
-		}
+	res, err := m.runWalk(scope, &frozenResolution{
+		Kind:   kindWalk,
+		Member: in.Member,
+		Path:   in.Path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("move: %w", err)
 	}
 
 	report, delivery, err := m.commit(ctx, scope)
@@ -183,9 +165,10 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 	}
 
 	return &MoveOutput{
-		Steps:      steps,
-		Discovered: nilIfEmpty(merged),
-		Outcome:    outcome,
+		Steps:      res.steps,
+		Discovered: nilIfEmpty(res.discovered),
+		Outcome:    res.outcome,
+		Pending:    res.pending,
 		Saved:      report,
 		Delivery:   delivery,
 	}, nil
@@ -211,7 +194,7 @@ func (m *Manager) Traverse(ctx context.Context, in *TraverseInput) (*TraverseOut
 		return nil, fmt.Errorf("traverse: %w", ErrNoConnection)
 	}
 
-	scope, err := m.openForWrite(ctx, in.Session)
+	scope, err := m.openForChange(ctx, in.Session)
 	if err != nil {
 		return nil, fmt.Errorf("traverse: %w", err)
 	}

--- a/rulebooks/dnd5e/session/suspend.go
+++ b/rulebooks/dnd5e/session/suspend.go
@@ -1,0 +1,290 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/interrupt"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// OptionKind classifies an offered choice in a way a client can branch on.
+//
+// It is an enumerated kind rather than a free-form string because this is the
+// field clients switch on, and a field clients switch on must never be prose.
+// New kinds may be added; existing ones never change meaning.
+type OptionKind string
+
+const (
+	// OptionContinue resumes the suspended resolution from where it stopped.
+	OptionContinue OptionKind = "continue"
+
+	// OptionStop abandons whatever remained of the suspended resolution. What
+	// already happened stays happened — stopping is not undoing.
+	OptionStop OptionKind = "stop"
+)
+
+// Option is one choice offered at an open window.
+type Option struct {
+	// Kind is what this choice means, for a client deciding how to render it.
+	Kind OptionKind `json:"kind"`
+
+	// Token is what to pass back as AnswerInput.Option to select this choice.
+	//
+	// It is separate from Kind so the token can become opaque later — a signed
+	// or scoped value, say — without changing how clients classify choices.
+	Token string `json:"token"`
+}
+
+// Prompt is what the member who owes an answer is looking at.
+//
+// It carries the moment, never the mechanism. There is deliberately no field
+// naming which kind of checkpoint fired: a client renders what is in front of
+// the player and branches on OptionKind, so new checkpoint kinds — a trap
+// underfoot, an offered reaction, something a later wave has not thought of —
+// arrive without any client learning a new reason code.
+type Prompt struct {
+	// Member is who is being asked.
+	Member string `json:"member"`
+
+	// Room is where they stand.
+	Room string `json:"room"`
+
+	// At is the cell they stand in — where the resolution stopped, not where
+	// it was headed.
+	At spatial.Position `json:"at"`
+
+	// Sighted names what just came into view, sorted, if anything did.
+	Sighted []string `json:"sighted,omitempty"`
+}
+
+// Pending is an open window: a resolution stopped and is waiting on a decision.
+//
+// While one is open the world is frozen — every verb that would change it is
+// rejected until the window is answered. Read verbs stay available, because a
+// client cannot render "waiting on Alice" without asking what the world looks
+// like.
+type Pending struct {
+	// Window identifies this window for Answer. It is opaque and stable across
+	// a process restart; do not parse it.
+	Window string `json:"window"`
+
+	// Audience is the member who owes the answer. Nobody else may give it.
+	Audience string `json:"audience"`
+
+	// Options are the choices on offer. Answering with anything else is a
+	// rejection.
+	Options []Option `json:"options"`
+
+	// Prompt is enough to render the moment.
+	Prompt Prompt `json:"prompt"`
+}
+
+// frozenResolution is the in-between state of a suspended resolution, stored as
+// opaque bytes in the window that suspended it.
+//
+// It is a value, never a goroutine and never a stack (S7). That is what lets a
+// window outlive the process that opened it: the answer may arrive days later,
+// on a different machine, and resuming is just reading this back.
+//
+// Kind discriminates which resolution froze. Today only a walk can suspend, but
+// the field is written from the first version so that a later resolution kind
+// is additive rather than an ambiguous payload nobody can safely parse.
+type frozenResolution struct {
+	// Kind names the resolution that froze.
+	Kind string `json:"kind"`
+
+	// Member is whose resolution it is.
+	Member string `json:"member"`
+
+	// Path is the whole walk as originally requested.
+	Path []spatial.Position `json:"path"`
+
+	// Index is how many cells of Path have actually been entered, which is the
+	// explicit phase index: resuming means continuing at Path[Index].
+	Index int `json:"index"`
+
+	// Prompt is what the audience was shown, kept here so Pending can answer
+	// "what is open?" from session state alone, without reloading the world and
+	// trying to recompute a perception delta that has already been folded in.
+	Prompt Prompt `json:"prompt"`
+}
+
+// kindWalk marks a frozen path walk.
+const kindWalk = "walk"
+
+// walkResult is what one run of the walk phase machine produced.
+type walkResult struct {
+	steps      []Step
+	discovered map[string]Discovery
+	outcome    *Outcome
+	pending    *Pending
+}
+
+// runWalk advances a walk from its phase index toward the end of its path,
+// stopping at the first checkpoint, the first ending, or the last cell.
+//
+// This is the re-enterable phase machine. The loop holds nothing across a
+// suspension: everything it would need to continue lives in the frozenResolution
+// it is handed, which is a value that can be written to storage and read back by
+// a different process. A straight-line loop with the state on the Go stack would
+// have made suspension impossible without parking a goroutine, and a parked
+// goroutine is a resolution that dies when the process does.
+func (m *Manager) runWalk(scope *writeScope, w *frozenResolution) (*walkResult, error) {
+	res := &walkResult{discovered: map[string]Discovery{}}
+
+	for w.Index < len(w.Path) {
+		cell := w.Path[w.Index]
+
+		moved, err := scope.enc.Move(&encounter.MoveInput{
+			Member: encounter.MemberID(w.Member),
+			To:     cell,
+		})
+		if err != nil {
+			// Nothing is saved on a mid-walk rejection. The member has really
+			// moved in memory for the steps already taken, but that encounter is
+			// discarded unsaved, so the persisted world is untouched.
+			return nil, fmt.Errorf("step %d of %d: %w",
+				w.Index+1, len(w.Path), translate(err))
+		}
+
+		w.Index++
+		res.steps = append(res.steps, Step{Position: moved.Moved.To, Seq: moved.Seq})
+
+		delta := projectDiscoveries(moved.IntelDeltas)
+		mergeDiscoveries(res.discovered, delta)
+
+		if moved.Outcome != nil {
+			// The encounter ended underfoot. Every remaining step is abandoned:
+			// a closed encounter refuses movement anyway, and attempting them
+			// would turn a clean stop into a rejection the caller must interpret.
+			res.outcome = projectOutcome(moved.Outcome)
+			return res, nil
+		}
+
+		// A checkpoint on the final cell would be a window whose every option is
+		// a no-op: there is nothing left to continue and nothing left to stop.
+		// Freezing the world to ask a question that cannot change anything is
+		// worse than not asking.
+		if w.Index == len(w.Path) {
+			break
+		}
+
+		sighted := firstContactFor(delta, w.Member)
+		if len(sighted) == 0 {
+			continue
+		}
+
+		pending, err := m.poseWalk(scope, w, sighted, moved.Seq)
+		if err != nil {
+			return nil, err
+		}
+		res.pending = pending
+		return res, nil
+	}
+
+	return res, nil
+}
+
+// firstContactFor reports what a member saw for the first time in one step,
+// sorted.
+//
+// Sorting is not cosmetic. C8, the encounter composition's determinism law,
+// requires that what a checkpoint enumerates be a function of persisted data
+// rather than of iteration or subscription order — otherwise a resolution
+// reloaded and re-run could pose its windows in a different order and the
+// "identical inputs, identical outputs" promise would hold everywhere except
+// the one place a human is watching.
+func firstContactFor(delta map[string]Discovery, member string) []string {
+	seen := delta[member].FirstContact
+	if len(seen) == 0 {
+		return nil
+	}
+	subjects := make([]string, 0, len(seen))
+	for _, r := range seen {
+		subjects = append(subjects, r.Subject)
+	}
+	sort.Strings(subjects)
+	return subjects
+}
+
+// poseWalk freezes the walk into an open window and returns what the audience
+// is being asked.
+func (m *Manager) poseWalk(
+	scope *writeScope, w *frozenResolution, sighted []string, at uint64,
+) (*Pending, error) {
+	room, cell, err := whereIs(scope.enc, encounter.MemberID(w.Member))
+	if err != nil {
+		return nil, err
+	}
+
+	w.Prompt = Prompt{
+		Member:  w.Member,
+		Room:    room,
+		At:      cell,
+		Sighted: sighted,
+	}
+
+	payload, err := json.Marshal(w)
+	if err != nil {
+		return nil, fmt.Errorf("freezing walk: %w", err)
+	}
+
+	posed, err := scope.ledger.Pose(&interrupt.PoseInput{
+		Audience: core.EntityID(w.Member),
+		Options:  []interrupt.Option{interrupt.Option(OptionContinue), interrupt.Option(OptionStop)},
+		Payload:  payload,
+		At:       at,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("opening window: %w", err)
+	}
+
+	scope.touched = true
+	return projectPending(posed.Window, w.Prompt), nil
+}
+
+// projectPending turns a custody-module window into the SDK's own shape.
+//
+// The inner Window never crosses the boundary: the whole point of the custody
+// module being replaceable is that a host names Pending and Option, not
+// interrupt.Window and interrupt.Option.
+func projectPending(w interrupt.Window, prompt Prompt) *Pending {
+	options := make([]Option, 0, len(w.Options))
+	for _, opt := range w.Options {
+		options = append(options, Option{Kind: OptionKind(opt), Token: string(opt)})
+	}
+	return &Pending{
+		Window:   strconv.FormatUint(uint64(w.ID), 10),
+		Audience: string(w.Audience),
+		Options:  options,
+		Prompt:   prompt,
+	}
+}
+
+// thaw reads a frozen resolution back out of a window's payload.
+//
+// A payload this module did not write is a rejection rather than a best-effort
+// parse: resuming a resolution we cannot fully understand would move a member
+// through cells on the strength of a guess.
+func thaw(payload []byte) (*frozenResolution, error) {
+	var w frozenResolution
+	if err := json.Unmarshal(payload, &w); err != nil {
+		return nil, fmt.Errorf("%w: unreadable frozen resolution: %w", ErrInvalidSession, err)
+	}
+	if w.Kind != kindWalk {
+		return nil, fmt.Errorf("%w: frozen resolution of kind %q", ErrInvalidSession, w.Kind)
+	}
+	if w.Index < 0 || w.Index > len(w.Path) {
+		return nil, fmt.Errorf("%w: frozen walk at step %d of %d",
+			ErrInvalidSession, w.Index, len(w.Path))
+	}
+	return &w, nil
+}

--- a/rulebooks/dnd5e/session/suspend_test.go
+++ b/rulebooks/dnd5e/session/suspend_test.go
@@ -40,6 +40,14 @@ func (s *SuspendTestSuite) SetupSubTest() {
 }
 
 func managerOver(t fataler, sessions *fakeSessions, encounters *fakeEncounters) *session.Manager {
+	return managerOverRepos(t, sessions, encounters)
+}
+
+// managerOverRepos builds a manager over any repositories, so a test can swap
+// in one that fails on demand without rebuilding the world it already set up.
+func managerOverRepos(
+	t fataler, sessions session.SessionRepository, encounters session.EncounterRepository,
+) *session.Manager {
 	mgr, err := session.NewManager(&session.Config{
 		Sessions: sessions, Encounters: encounters, Events: session.DiscardEvents{},
 	})
@@ -626,6 +634,57 @@ func (s *SuspendTestSuite) TestASuspendingWalkWritesBothAggregates() {
 	s.Equal([]string{"encounter:world", "session:sess"}, out.Saved.Written,
 		"the world first, then what is owed — the order persist chose deliberately")
 	s.Empty(out.Saved.Failed)
+}
+
+// TestAPartialSaveTellsTheCallerWhichHalfLanded is S6 reaching a caller, which
+// is not the same as S6 being computed.
+//
+// A verb returns no output when it returns an error, so a report that only
+// exists inside persist is a report nobody can act on. This is the first
+// genuinely reachable partial save in the module: the encounter is durable and
+// the window that was owed is not, and the caller has to be able to tell that
+// from "nothing was written" — one is a retry, the other is a repair.
+func (s *SuspendTestSuite) TestAPartialSaveTellsTheCallerWhichHalfLanded() {
+	s.startAmbush()
+
+	// Arm the session store to fail only now, after the world is in place.
+	sessions := &failingSessions{fakeSessions: s.sessions, saveErr: errBroken}
+	mgr := managerOverRepos(s.T(), sessions, s.encounters)
+
+	_, err := mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().Error(err, "the walk suspended, so the session had to be written")
+	s.Require().ErrorIs(err, session.ErrSaveFailed, "the condition is matchable")
+	s.ErrorIs(err, errBroken, "and so is the store's own failure")
+
+	var saved *session.SaveError
+	s.Require().ErrorAs(err, &saved, "the report must survive the error, not die in persist")
+	s.Equal([]string{"encounter:world"}, saved.Report.Written,
+		"the world landed — the steps she took are real")
+	s.Equal([]string{"session:sess"}, saved.Report.Failed,
+		"the window she owes did not — this is a repair, not a retry")
+}
+
+// TestATotalSaveFailureNamesOnlyWhatWasAttempted is the contrast that gives the
+// test above its meaning: a report naming one failure and nothing written is a
+// different situation from one naming a success and a failure.
+func (s *SuspendTestSuite) TestATotalSaveFailureNamesOnlyWhatWasAttempted() {
+	s.startAmbush()
+
+	encounters := &failingEncounters{fakeEncounters: s.encounters, saveErr: errBroken}
+	mgr := managerOverRepos(s.T(), s.sessions, encounters)
+
+	_, err := mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 2}},
+	})
+	s.Require().Error(err)
+
+	var saved *session.SaveError
+	s.Require().ErrorAs(err, &saved)
+	s.Empty(saved.Report.Written, "nothing landed")
+	s.Equal([]string{"encounter:world"}, saved.Report.Failed)
 }
 
 // TestHostileSessionBlobIsRejectedNotCrashed pins reject-never-crash on the new

--- a/rulebooks/dnd5e/session/suspend_test.go
+++ b/rulebooks/dnd5e/session/suspend_test.go
@@ -1,0 +1,600 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// SuspendTestSuite covers the interrupt spine: a resolution that stops mid-way,
+// persists as data, and resumes — possibly in a different process.
+type SuspendTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	mgr        *session.Manager
+}
+
+func (s *SuspendTestSuite) SetupTest() {
+	s.sessions = newFakeSessions()
+	s.encounters = newFakeEncounters()
+	s.mgr = managerOver(s.T(), s.sessions, s.encounters)
+}
+
+// SetupSubTest gives every s.Run() its own stores. Without it a table would
+// share a session across rows, and the second row would fail to start one
+// rather than testing what it claims to test.
+func (s *SuspendTestSuite) SetupSubTest() {
+	s.SetupTest()
+}
+
+func managerOver(t fataler, sessions *fakeSessions, encounters *fakeEncounters) *session.Manager {
+	mgr, err := session.NewManager(&session.Config{
+		Sessions: sessions, Encounters: encounters, Events: session.DiscardEvents{},
+	})
+	if err != nil {
+		t.Fatalf("building manager: %v", err)
+	}
+	return mgr
+}
+
+// ambushWorld is a hall split by a wall of occluders with a single gap at y=3.
+//
+// Alice starts at (1,1) with no line of sight to anything; the ogre waits at
+// (5,3) behind the wall. Walking north to (2,3) lines her up with the gap and
+// the ogre comes into view — first contact, mid-path, with a cell still to go.
+// That is scene 2 with no combat in it: perception alone is enough to stop the
+// world, which is why this wave lands before entities.
+func ambushWorld(t fataler, extra ...encounter.MemberInput) *encounter.EncounterData {
+	occluders := make([]spatial.Position, 0, 7)
+	for y := 0; y < 8; y++ {
+		if y == 3 {
+			continue // the gap
+		}
+		occluders = append(occluders, spatial.Position{X: 3, Y: float64(y)})
+	}
+
+	members := []encounter.MemberInput{
+		{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+		{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 5, Y: 3}},
+	}
+	members = append(members, extra...)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: "hall", Width: 8, Height: 8, Occluders: occluders},
+		}},
+		Members: members,
+		Endings: []encounter.EndingInput{
+			{Key: "stairs", Trigger: encounter.TriggerReachedPosition{
+				Room: "hall", Position: spatial.Position{X: 7, Y: 7},
+			}},
+		},
+		Retention: encounter.RetentionUnbounded,
+	})
+	if err != nil {
+		t.Fatalf("building ambush world: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
+func (s *SuspendTestSuite) startAmbush(extra ...encounter.MemberInput) {
+	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: ambushWorld(s.T(), extra...),
+	})
+	s.Require().NoError(err)
+}
+
+// walkIntoTheAmbush walks the three-cell path that trips the checkpoint on cell
+// two, and returns the output.
+func (s *SuspendTestSuite) walkIntoTheAmbush() *session.MoveOutput {
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().NoError(err)
+	return out
+}
+
+// TestPerceptionStopsTheWalk is the headline of this wave, and scene 2.
+//
+// Alice asks for three cells and gets two, because the second brought the ogre
+// into view. The walk did not fail — it suspended, which is a different thing
+// and is reported differently: no error, a short Steps, and a window naming who
+// owes an answer.
+func (s *SuspendTestSuite) TestPerceptionStopsTheWalk() {
+	s.startAmbush()
+	out := s.walkIntoTheAmbush()
+
+	s.Require().Len(out.Steps, 2, "the walk stopped where perception changed")
+	s.Equal(spatial.Position{X: 2, Y: 3}, out.Steps[1].Position)
+
+	s.Require().NotNil(out.Pending, "and the world is waiting on a decision")
+	s.Equal("alice", out.Pending.Audience, "the walker owes the answer")
+	s.Equal([]string{"ogre"}, out.Pending.Prompt.Sighted, "and is shown what she just saw")
+	s.Equal(spatial.Position{X: 2, Y: 3}, out.Pending.Prompt.At, "where she stopped, not where she was headed")
+	s.Equal("hall", out.Pending.Prompt.Room)
+
+	kinds := make([]session.OptionKind, 0, len(out.Pending.Options))
+	for _, opt := range out.Pending.Options {
+		kinds = append(kinds, opt.Kind)
+	}
+	s.Equal([]session.OptionKind{session.OptionContinue, session.OptionStop}, kinds)
+}
+
+// TestSeeingNothingNewDoesNotStopTheWalk is the negative control.
+//
+// Same world, same path, same ogre — but alice already holds it, because a
+// first walk revealed it and a second cannot reveal it again. The walk runs to
+// the end. Without this, every assertion above is equally consistent with "any
+// walk near a monster stops", which is not the rule and would be a much worse
+// game.
+func (s *SuspendTestSuite) TestSeeingNothingNewDoesNotStopTheWalk() {
+	s.startAmbush()
+	ctx := context.Background()
+
+	first := s.walkIntoTheAmbush()
+	s.Require().NotNil(first.Pending, "precondition: the first sighting suspends")
+	_, err := s.mgr.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: first.Pending.Window,
+		Member: "alice", Option: string(session.OptionStop),
+	})
+	s.Require().NoError(err)
+
+	// She is at (2,3) holding the ogre. Walking on cannot be first contact.
+	out, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 4}, {X: 2, Y: 5}},
+	})
+	s.Require().NoError(err)
+	s.Nil(out.Pending, "a subject already known is not a discovery")
+	s.Len(out.Steps, 2, "so the whole path is walked")
+}
+
+// TestNoWindowOnTheFinalCell pins that a checkpoint with nothing left to decide
+// is not opened.
+//
+// If the last cell of a path reveals something, continuing and stopping are the
+// same act. Freezing the world to offer a choice between two identical
+// outcomes would be a pause the player cannot make wrong and cannot skip.
+func (s *SuspendTestSuite) TestNoWindowOnTheFinalCell() {
+	s.startAmbush()
+
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}}, // sighting lands on the last cell
+	})
+	s.Require().NoError(err)
+	s.Require().Len(out.Steps, 2, "the walk finished")
+	s.Nil(out.Pending, "and nothing was left to ask about")
+
+	seen, err := s.mgr.View(context.Background(), &session.ViewInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Len(seen, 1, "she did see the ogre — the sighting is real, the window is not")
+	s.Equal("ogre", seen[0].Subject)
+}
+
+// TestSightedIsSortedRatherThanIterationOrdered pins C8 at this seam.
+//
+// Two subjects revealed by the same step must be enumerated in an order that is
+// a function of persisted data. Iterating a map would pass this test most of
+// the time, which is exactly why it is asserted rather than assumed: a resumed
+// resolution that enumerated differently would break "identical inputs yield
+// identical outputs" only under load, only in production.
+func (s *SuspendTestSuite) TestSightedIsSortedRatherThanIterationOrdered() {
+	// "aardvark" sorts before "ogre"; declared after it, so insertion order and
+	// sorted order disagree.
+	s.startAmbush(encounter.MemberInput{
+		ID: "aardvark", Kind: encounter.KindMonster,
+		Room: "hall", Position: spatial.Position{X: 5, Y: 3},
+	})
+
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+	s.Equal([]string{"aardvark", "ogre"}, out.Pending.Prompt.Sighted,
+		"enumeration is sorted, not whatever order the composition reported")
+}
+
+// TestContinueResumesFromWhereItStopped is scene 3's second half.
+func (s *SuspendTestSuite) TestContinueResumesFromWhereItStopped() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	resumed, err := s.mgr.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: out.Pending.Window,
+		Member: "alice", Option: string(session.OptionContinue),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resumed.Steps, 1, "exactly the cell that was left")
+	s.Equal(spatial.Position{X: 2, Y: 4}, resumed.Steps[0].Position)
+	s.Nil(resumed.Pending, "and the window is closed")
+
+	s.Greater(resumed.Steps[0].Seq, out.Steps[1].Seq,
+		"the story continues rather than restarting")
+}
+
+// TestStopAbandonsTheRemainderWithoutUndoing pins that stopping is not rewinding.
+//
+// The two steps she took are not taken back. A player who spots an ogre and
+// halts is standing where she halted, not back where she started — anything
+// else would make the pause itself change the world.
+func (s *SuspendTestSuite) TestStopAbandonsTheRemainderWithoutUndoing() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	stopped, err := s.mgr.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: out.Pending.Window,
+		Member: "alice", Option: string(session.OptionStop),
+	})
+	s.Require().NoError(err)
+	s.Empty(stopped.Steps, "nothing further was walked")
+
+	// And the world runs again: a verb that would change it now succeeds.
+	moved, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 2}},
+	})
+	s.Require().NoError(err, "answering unfroze the world")
+	s.Require().Len(moved.Steps, 1)
+	s.Equal(spatial.Position{X: 2, Y: 2}, moved.Steps[0].Position,
+		"she resumed from (2,3), which is where she stopped")
+}
+
+// TestEveryChangeVerbIsRefusedWhileFrozen is T2.2, asserted over the whole
+// surface rather than the one verb that happens to have suspended.
+//
+// The table is the point: a future verb that forgets the freeze is only caught
+// if the rule is stated once for all of them.
+func (s *SuspendTestSuite) TestEveryChangeVerbIsRefusedWhileFrozen() {
+	ctx := context.Background()
+
+	attempts := map[string]func(*session.Manager) error{
+		"Move": func(m *session.Manager) error {
+			_, err := m.Move(ctx, &session.MoveInput{
+				Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 4}},
+			})
+			return err
+		},
+		"Traverse": func(m *session.Manager) error {
+			_, err := m.Traverse(ctx, &session.TraverseInput{
+				Session: "sess", Member: "alice", Connection: "anything",
+			})
+			return err
+		},
+		"Join": func(m *session.Manager) error {
+			_, err := m.Join(ctx, &session.JoinInput{
+				Session: "sess", Member: "bob", Kind: session.KindPlayer,
+				Room: "hall", Position: spatial.Position{X: 0, Y: 0},
+			})
+			return err
+		},
+		"Exit": func(m *session.Manager) error {
+			_, err := m.Exit(ctx, &session.ExitInput{Session: "sess", Member: "alice"})
+			return err
+		},
+		"End": func(m *session.Manager) error {
+			_, err := m.End(ctx, &session.EndInput{Session: "sess", Ending: "stairs"})
+			return err
+		},
+	}
+
+	for name, attempt := range attempts {
+		s.Run(name, func() {
+			s.startAmbush()
+			out := s.walkIntoTheAmbush()
+			s.Require().NotNil(out.Pending, "precondition: the world is frozen")
+
+			err := attempt(s.mgr)
+			s.Require().Error(err, "%s changes the world, so it must be refused", name)
+			s.Require().ErrorIs(err, session.ErrFrozen)
+
+			var frozen *session.FrozenError
+			s.Require().ErrorAs(err, &frozen,
+				"the rejection carries the window, so the caller is not sent hunting for it")
+			s.Equal(out.Pending.Window, frozen.Window)
+			s.Equal("alice", frozen.Audience)
+		})
+	}
+}
+
+// TestReadVerbsSurviveTheFreeze is the other half of T2.2.
+//
+// A freeze that blinded everyone would be worse than no freeze: a client cannot
+// render "waiting on Alice" without asking what the world looks like. What is
+// frozen is change, not observation.
+func (s *SuspendTestSuite) TestReadVerbsSurviveTheFreeze() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	_, err := s.mgr.Atlas(ctx, &session.AtlasInput{Session: "sess"})
+	s.NoError(err, "Atlas")
+
+	_, err = s.mgr.Status(ctx, &session.StatusInput{Session: "sess"})
+	s.NoError(err, "Status")
+
+	_, err = s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "alice"})
+	s.NoError(err, "View")
+
+	_, err = s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	s.NoError(err, "Story")
+
+	pending, err := s.mgr.Pending(ctx, &session.PendingInput{Session: "sess"})
+	s.Require().NoError(err, "Pending")
+	s.Require().Len(pending.Windows, 1, "and it reports the window blocking everything else")
+	s.Equal(out.Pending.Window, pending.Windows[0].Window)
+	s.Equal([]string{"ogre"}, pending.Windows[0].Prompt.Sighted,
+		"including what the audience was shown when it opened")
+}
+
+// TestSuspensionSurvivesAProcessRestart is S7, and the reason a frozen
+// resolution is data rather than a parked goroutine.
+//
+// Both stores are marshalled to JSON and read back into fresh repositories
+// behind a fresh Manager — everything in memory is gone, exactly as it would be
+// if the answer arrived the next morning on another machine. The window is
+// still open, still knows what it was waiting on, and still resumes correctly.
+func (s *SuspendTestSuite) TestSuspensionSurvivesAProcessRestart() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	sessions, encounters := s.roundTripStores()
+	restarted := managerOver(s.T(), sessions, encounters)
+
+	pending, err := restarted.Pending(ctx, &session.PendingInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Require().Len(pending.Windows, 1, "the window outlived the process")
+	s.Equal(out.Pending.Window, pending.Windows[0].Window, "and kept its identity")
+	s.Equal([]string{"ogre"}, pending.Windows[0].Prompt.Sighted)
+
+	resumed, err := restarted.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: pending.Windows[0].Window,
+		Member: "alice", Option: string(session.OptionContinue),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resumed.Steps, 1, "and the walk picked up exactly where it stopped")
+	s.Equal(spatial.Position{X: 2, Y: 4}, resumed.Steps[0].Position)
+}
+
+// roundTripStores marshals both repositories through JSON into fresh ones,
+// which is the closest a test can get to "a different process picked this up".
+func (s *SuspendTestSuite) roundTripStores() (*fakeSessions, *fakeEncounters) {
+	sessions := newFakeSessions()
+	for id, data := range s.sessions.byID {
+		raw, err := json.Marshal(data)
+		s.Require().NoError(err)
+		var reloaded session.SessionData
+		s.Require().NoError(json.Unmarshal(raw, &reloaded))
+		sessions.byID[id] = &reloaded
+	}
+
+	encounters := newFakeEncounters()
+	for id, data := range s.encounters.byID {
+		raw, err := json.Marshal(data)
+		s.Require().NoError(err)
+		var reloaded encounter.EncounterData
+		s.Require().NoError(json.Unmarshal(raw, &reloaded))
+		encounters.byID[id] = &reloaded
+	}
+	return sessions, encounters
+}
+
+// TestTheStoryIsOneContinuousSequence is T2.4's transcript claim.
+//
+// A suspension is invisible in the record: the beats before the freeze and the
+// beats after it form one unbroken, ascending sequence. That is what makes S10
+// work — a client that reconnects mid-freeze and re-queries Story cannot tell
+// from the log that anything stopped.
+func (s *SuspendTestSuite) TestTheStoryIsOneContinuousSequence() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	resumed, err := s.mgr.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: out.Pending.Window,
+		Member: "alice", Option: string(session.OptionContinue),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resumed.Steps, 1)
+
+	story, err := s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(story)
+
+	for i := 1; i < len(story); i++ {
+		s.Greater(story[i].Seq, story[i-1].Seq, "sequence %d does not advance", i)
+	}
+
+	last := story[len(story)-1].Seq
+	s.Equal(resumed.Steps[0].Seq, last,
+		"the resumed step is the newest beat, in the same sequence as the earlier ones")
+}
+
+// TestOnlyTheAudienceMayAnswer pins that a window is owed by someone specific.
+func (s *SuspendTestSuite) TestOnlyTheAudienceMayAnswer() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	_, err := s.mgr.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: out.Pending.Window,
+		Member: "ogre", Option: string(session.OptionContinue),
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNotAudience)
+
+	pending, err := s.mgr.Pending(ctx, &session.PendingInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Len(pending.Windows, 1, "a rejected answer leaves the window open")
+}
+
+// TestUnofferedChoiceIsRejected pins that the option list is the menu, not a
+// suggestion.
+func (s *SuspendTestSuite) TestUnofferedChoiceIsRejected() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	_, err := s.mgr.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: out.Pending.Window,
+		Member: "alice", Option: "teleport",
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNotOffered)
+}
+
+// TestOneAnswerPerWindow pins that answering is not idempotent.
+//
+// A retried answer must not resume a walk twice. The second attempt finds no
+// such window, which is the correct answer: the window is gone because it was
+// used.
+func (s *SuspendTestSuite) TestOneAnswerPerWindow() {
+	s.startAmbush()
+	ctx := context.Background()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	answer := &session.AnswerInput{
+		Session: "sess", Window: out.Pending.Window,
+		Member: "alice", Option: string(session.OptionStop),
+	}
+	_, err := s.mgr.Answer(ctx, answer)
+	s.Require().NoError(err)
+
+	_, err = s.mgr.Answer(ctx, answer)
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNoWindow)
+}
+
+// TestUnknownWindowIsRejected covers the identifiers a caller can get wrong.
+func (s *SuspendTestSuite) TestUnknownWindowIsRejected() {
+	ctx := context.Background()
+
+	cases := map[string]struct {
+		window string
+		expect error
+	}{
+		"empty":        {"", session.ErrNoWindowID},
+		"not a number": {"window-1", session.ErrNoWindowID},
+		"zero":         {"0", session.ErrNoWindowID},
+		"never opened": {"77", session.ErrNoWindow},
+	}
+	for name, tc := range cases {
+		s.Run(name, func() {
+			s.startAmbush()
+			_, err := s.mgr.Answer(ctx, &session.AnswerInput{
+				Session: "sess", Window: tc.window,
+				Member: "alice", Option: string(session.OptionContinue),
+			})
+			s.Require().Error(err)
+			s.ErrorIs(err, tc.expect)
+		})
+	}
+}
+
+// TestAWalkThatSuspendsNothingWritesOnlyTheEncounter pins write proportionality.
+//
+// Session state did not change, so the session blob is not rewritten. The cost
+// of windows existing must be paid by walks that open one, not by every walk.
+func (s *SuspendTestSuite) TestAWalkThatSuspendsNothingWritesOnlyTheEncounter() {
+	s.startAmbush()
+
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 2}},
+	})
+	s.Require().NoError(err)
+	s.Require().Nil(out.Pending, "precondition: nothing suspended")
+	s.Equal([]string{"encounter:world"}, out.Saved.Written,
+		"the session blob is left alone when session state did not change")
+}
+
+// TestASuspendingWalkWritesBothAggregates is the other side of that rule, and
+// the first time SaveReport names more than one thing.
+func (s *SuspendTestSuite) TestASuspendingWalkWritesBothAggregates() {
+	s.startAmbush()
+	out := s.walkIntoTheAmbush()
+
+	s.Require().NotNil(out.Pending)
+	s.Equal([]string{"encounter:world", "session:sess"}, out.Saved.Written,
+		"the world first, then what is owed — the order persist chose deliberately")
+	s.Empty(out.Saved.Failed)
+}
+
+// TestHostileSessionBlobIsRejectedNotCrashed pins reject-never-crash on the new
+// persisted surface.
+//
+// A ledger that could not have been written by this module is refused. The
+// alternative — repairing it into something plausible — would resume a
+// resolution that never happened, moving a member through cells on the strength
+// of a guess.
+func (s *SuspendTestSuite) TestHostileSessionBlobIsRejectedNotCrashed() {
+	s.startAmbush()
+	ctx := context.Background()
+	s.Require().NotNil(s.walkIntoTheAmbush().Pending)
+
+	// A window claiming an ID at or above next_id cannot have been issued.
+	stored := s.sessions.byID["sess"]
+	stored.Windows.Windows[0].ID = 9999
+
+	_, err := s.mgr.Pending(ctx, &session.PendingInput{Session: "sess"})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrInvalidSession)
+
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 4}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrInvalidSession, "and every verb refuses the same way")
+}
+
+// TestFrozenErrorMatchesBothWays pins the error's contract: the sentinel for
+// detecting the condition, the type for acting on it.
+func (s *SuspendTestSuite) TestFrozenErrorMatchesBothWays() {
+	frozen := &session.FrozenError{Window: "7", Audience: "alice"}
+
+	s.True(errors.Is(frozen, session.ErrFrozen), "errors.Is finds the condition")
+
+	var recovered *session.FrozenError
+	s.True(errors.As(error(frozen), &recovered), "errors.As recovers the detail")
+	s.Equal("7", recovered.Window)
+	s.Contains(frozen.Error(), "alice", "and the message names who is holding things up")
+}
+
+// TestPromptCarriesNoCheckpointReason pins the asymmetry S5 depends on.
+//
+// The client renders the moment and branches on OptionKind. It is never told
+// which kind of checkpoint fired, so new checkpoint kinds — a trap, an offered
+// reaction, whatever a later wave invents — arrive without any client learning
+// a new reason code. A field named Reason or Kind here would quietly become the
+// thing clients switch on, and then it could never change.
+func (s *SuspendTestSuite) TestPromptCarriesNoCheckpointReason() {
+	s.Equal([]string{"Member", "Room", "At", "Sighted"}, structFields(session.Prompt{}),
+		"Prompt describes what the player sees, never why the resolution stopped")
+}
+
+func TestSuspendSuite(t *testing.T) {
+	suite.Run(t, new(SuspendTestSuite))
+}

--- a/rulebooks/dnd5e/session/suspend_test.go
+++ b/rulebooks/dnd5e/session/suspend_test.go
@@ -430,6 +430,91 @@ func (s *SuspendTestSuite) TestTheStoryIsOneContinuousSequence() {
 		"the resumed step is the newest beat, in the same sequence as the earlier ones")
 }
 
+// positionJSON renders a position the way the frozen payload stores it, without
+// a test having to know its field tags.
+func positionJSON(t fataler, p spatial.Position) any {
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshalling position: %v", err)
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("unmarshalling position: %v", err)
+	}
+	return v
+}
+
+// tamperFrozenPath rewrites the stored path inside the open window's frozen
+// payload, standing in for a blob that does not match the world it refers to.
+func (s *SuspendTestSuite) tamperFrozenPath(mutate func(path []any)) {
+	stored := s.sessions.byID["sess"]
+	s.Require().Len(stored.Windows.Windows, 1, "precondition: one open window")
+
+	var payload map[string]any
+	s.Require().NoError(json.Unmarshal(stored.Windows.Windows[0].Payload, &payload))
+	path, ok := payload["path"].([]any)
+	s.Require().True(ok, "the frozen payload carries the path")
+
+	mutate(path)
+	payload["path"] = path
+
+	raw, err := json.Marshal(payload)
+	s.Require().NoError(err)
+	stored.Windows.Windows[0].Payload = raw
+}
+
+func (s *SuspendTestSuite) answerContinue(window string) (*session.AnswerOutput, error) {
+	return s.mgr.Answer(context.Background(), &session.AnswerInput{
+		Session: "sess", Window: window,
+		Member: "alice", Option: string(session.OptionContinue),
+	})
+}
+
+// TestResumeRejectsAPathThatNoLongerLinesUp pins the re-validation in resume.
+//
+// A window and a world are two stored records, and nothing guarantees a stored
+// window describes the world that actually loaded — a hand-edited blob is
+// enough. Resuming on trust would walk a member from where she stands to
+// somewhere across the room in one step, because the phase index says there is
+// a cell left and the cell says (7,7).
+func (s *SuspendTestSuite) TestResumeRejectsAPathThatNoLongerLinesUp() {
+	s.startAmbush()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	// The one unwalked cell is moved across the room.
+	s.tamperFrozenPath(func(path []any) {
+		path[2] = positionJSON(s.T(), spatial.Position{X: 7, Y: 7})
+	})
+
+	_, err := s.answerContinue(out.Pending.Window)
+	s.Require().Error(err, "a resume that does not line up is refused, not walked")
+	s.ErrorIs(err, session.ErrBrokenPath)
+}
+
+// TestResumeChecksOnlyWhatIsLeftToWalk is the other half, and the reason the
+// check is over a suffix rather than the whole path.
+//
+// The cells already walked are behind her. Re-validating them against where she
+// now stands would reject legitimate resumes for describing a journey that has
+// already happened — the walk is driven by the phase index, and the phase index
+// is the only part of the path that is still ahead.
+func (s *SuspendTestSuite) TestResumeChecksOnlyWhatIsLeftToWalk() {
+	s.startAmbush()
+	out := s.walkIntoTheAmbush()
+	s.Require().NotNil(out.Pending)
+
+	// The already-walked first cell becomes nonsense. It must not matter.
+	s.tamperFrozenPath(func(path []any) {
+		path[0] = positionJSON(s.T(), spatial.Position{X: 7, Y: 7})
+	})
+
+	resumed, err := s.answerContinue(out.Pending.Window)
+	s.Require().NoError(err, "the walked prefix is history, not a precondition")
+	s.Require().Len(resumed.Steps, 1)
+	s.Equal(spatial.Position{X: 2, Y: 4}, resumed.Steps[0].Position)
+}
+
 // TestOnlyTheAudienceMayAnswer pins that a window is owed by someone specific.
 func (s *SuspendTestSuite) TestOnlyTheAudienceMayAnswer() {
 	s.startAmbush()

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -6,7 +6,9 @@ package session
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/KirkDiggler/rpg-toolkit/play/interrupt"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -123,7 +125,7 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 		return nil, fmt.Errorf("join: %w", ErrNoMemberID)
 	}
 
-	scope, err := m.openForWrite(ctx, in.Session)
+	scope, err := m.openForChange(ctx, in.Session)
 	if err != nil {
 		return nil, fmt.Errorf("join: %w", err)
 	}
@@ -169,7 +171,7 @@ func (m *Manager) Exit(ctx context.Context, in *ExitInput) (*ExitOutput, error) 
 		return nil, fmt.Errorf("exit: %w", ErrNoMemberID)
 	}
 
-	scope, err := m.openForWrite(ctx, in.Session)
+	scope, err := m.openForChange(ctx, in.Session)
 	if err != nil {
 		return nil, fmt.Errorf("exit: %w", err)
 	}
@@ -204,7 +206,7 @@ func (m *Manager) End(ctx context.Context, in *EndInput) (*EndOutput, error) {
 		return nil, fmt.Errorf("end: %w", ErrNilInput)
 	}
 
-	scope, err := m.openForWrite(ctx, in.Session)
+	scope, err := m.openForChange(ctx, in.Session)
 	if err != nil {
 		return nil, fmt.Errorf("end: %w", err)
 	}
@@ -237,6 +239,14 @@ func (m *Manager) openForWrite(ctx context.Context, sessionID string) (*writeSco
 	if err != nil {
 		return nil, err
 	}
+	ledger, err := interrupt.LoadLedger(data.Windows)
+	if err != nil {
+		// Reject, never crash. A stored ledger that LoadLedger refuses is a blob
+		// no version of this module wrote, so the honest answer is that the
+		// session record is unreadable — not to repair it into something
+		// plausible and resume a resolution that never happened.
+		return nil, fmt.Errorf("session %q: %w: %w", sessionID, ErrInvalidSession, err)
+	}
 	enc, baseline, err := m.loadWorldWithBaseline(ctx, data.Encounter)
 	if err != nil {
 		return nil, err
@@ -244,35 +254,114 @@ func (m *Manager) openForWrite(ctx context.Context, sessionID string) (*writeSco
 	return &writeScope{
 		session:   sessionID,
 		encounter: data.Encounter,
+		data:      data,
 		enc:       enc,
+		ledger:    ledger,
 		baseline:  baseline,
 	}, nil
 }
 
+// openForChange is openForWrite plus the freeze: a verb that would change the
+// world is refused while a window is open.
+//
+// The split is deliberate and structural. Answer must reach a frozen session —
+// it is the only thing that can unfreeze it — so the check cannot live inside
+// openForWrite. Putting it in a differently named opener means a new verb picks
+// its policy by picking its opener, and forgetting the freeze requires choosing
+// the one Answer uses rather than merely omitting a line.
+func (m *Manager) openForChange(ctx context.Context, sessionID string) (*writeScope, error) {
+	scope, err := m.openForWrite(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if err := scope.frozen(); err != nil {
+		return nil, err
+	}
+	return scope, nil
+}
+
+// frozen reports the oldest open window as an error, or nil if the world is
+// running.
+//
+// The oldest rather than an arbitrary one: windows are ordered by pose, that
+// order is persisted, and a caller who is told which window blocks them should
+// be told the same one every time they ask.
+func (s *writeScope) frozen() error {
+	open, err := s.ledger.Open()
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidSession, err)
+	}
+	if len(open) == 0 {
+		return nil
+	}
+	w := open[0]
+	return &FrozenError{
+		Window:   strconv.FormatUint(uint64(w.ID), 10),
+		Audience: string(w.Audience),
+	}
+}
+
 // writeScope is everything a write verb needs to act, save, and fan out: the
-// live encounter, the IDs to save and address it under, and the sequence
-// boundary separating what was already recorded from what this verb records.
+// live encounter, the session record and its window ledger, the IDs to save and
+// address them under, and the sequence boundary separating what was already
+// recorded from what this verb records.
 type writeScope struct {
 	session   string
 	encounter string
+	data      *SessionData
 	enc       *encounter.Encounter
+	ledger    *interrupt.Ledger
 	baseline  uint64
+
+	// touched marks the ledger as changed by this verb, so a walk that opened
+	// or closed a window writes the session and one that did not leaves it
+	// alone. Writes stay proportional to what actually changed: the common
+	// case is a walk that suspends nothing and touches one aggregate, exactly
+	// as it did before windows existed.
+	touched bool
 }
 
-// persist writes the mutated encounter back and reports the result.
+// persist writes the mutated aggregates back and reports the result.
 //
-// Only the encounter changes on these verbs: a join, an exit, and an ending all
-// mutate the world, while SessionData holds only an ID and the encounter it
-// points at, neither of which any of them touches. So the report names one
-// aggregate, and a partial save is not reachable here — the multi-write case
-// lives in StartSession today and will return when entities do.
+// The encounter is written first and the session second, and the order is a
+// correctness decision rather than a style one. Both orders can fail halfway;
+// they fail differently:
+//
+//   - Encounter lands, session does not: the world holds the steps that were
+//     taken and no window remembers the pause. The walk is stuck, but every
+//     persisted fact is true, and the caller is told the save failed.
+//   - Session lands, encounter does not: a window says "resume from step three"
+//     over a world that still has the walker at step zero. Resuming would skip
+//     three cells nobody walked, silently.
+//
+// The first is a stoppage; the second is corruption that looks like progress.
+// So the aggregate that records what happened goes first, and the one that
+// records what is owed goes second. Resume re-validates against the world it
+// actually loads, which turns even the bad half of the first case into a clean
+// rejection rather than a wrong walk.
 func (m *Manager) persist(ctx context.Context, scope *writeScope) (SaveReport, *encounter.EncounterData, error) {
 	data := scope.enc.ToData()
 	if err := m.encounters.SaveEncounter(ctx, scope.encounter, &data); err != nil {
 		return SaveReport{Failed: []string{"encounter:" + scope.encounter}}, nil,
 			fmt.Errorf("saving world: %w: %w", ErrSaveFailed, err)
 	}
-	return SaveReport{Written: []string{"encounter:" + scope.encounter}}, &data, nil
+	report := SaveReport{Written: []string{"encounter:" + scope.encounter}}
+
+	if !scope.touched {
+		return report, &data, nil
+	}
+
+	scope.data.Windows = scope.ledger.ToData()
+	if err := m.sessions.SaveSession(ctx, scope.data); err != nil {
+		// The encounter is already durable, so the report names both what landed
+		// and what did not (S6). A bare error here would leave the caller unable
+		// to tell a total failure from a half one, which is the difference
+		// between "retry the verb" and "the world moved but the window is gone".
+		report.Failed = append(report.Failed, "session:"+scope.session)
+		return report, nil, fmt.Errorf("saving session: %w: %w", ErrSaveFailed, err)
+	}
+	report.Written = append(report.Written, "session:"+scope.session)
+	return report, &data, nil
 }
 
 // commit saves the mutated world and then fans out what it recorded.

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -342,8 +342,11 @@ type writeScope struct {
 func (m *Manager) persist(ctx context.Context, scope *writeScope) (SaveReport, *encounter.EncounterData, error) {
 	data := scope.enc.ToData()
 	if err := m.encounters.SaveEncounter(ctx, scope.encounter, &data); err != nil {
-		return SaveReport{Failed: []string{"encounter:" + scope.encounter}}, nil,
-			fmt.Errorf("saving world: %w: %w", ErrSaveFailed, err)
+		report := SaveReport{Failed: []string{"encounter:" + scope.encounter}}
+		return report, nil, &SaveError{
+			Report: report,
+			Err:    fmt.Errorf("saving world: %w", err),
+		}
 	}
 	report := SaveReport{Written: []string{"encounter:" + scope.encounter}}
 
@@ -358,7 +361,10 @@ func (m *Manager) persist(ctx context.Context, scope *writeScope) (SaveReport, *
 		// to tell a total failure from a half one, which is the difference
 		// between "retry the verb" and "the world moved but the window is gone".
 		report.Failed = append(report.Failed, "session:"+scope.session)
-		return report, nil, fmt.Errorf("saving session: %w: %w", ErrSaveFailed, err)
+		return report, nil, &SaveError{
+			Report: report,
+			Err:    fmt.Errorf("saving session: %w", err),
+		}
 	}
 	report.Written = append(report.Written, "session:"+scope.session)
 	return report, &data, nil


### PR DESCRIPTION
Closes #943. Ships `rulebooks/dnd5e/session/v0.2.0` — `gorelease` confirms every change is an addition and suggests exactly that version.

## What this is

Alice walks a path. The third cell brings an ogre into view. The world freezes mid-walk, the whole thing persists, and a different process — different machine, next morning — answers and she carries on.

**No combat anywhere in it.** The composition's existing perception is enough to stop the world, which is why this wave lands before entities rather than after. Wave 1 was wrapper work by design; this is the first thing the SDK does that nothing underneath it could.

```
== something moves in the dark ==
   alice enters (1,1)
   alice enters (1,2)
   alice enters (1,3)
   the world freezes after 3/4: alice sees [wight]
   end refused while frozen: end: world frozen: window 1 awaits alice
   alice presses on to (1,4)
```

That is the workbench, and its test asserts each of those lines separately.

## The custody module had already done the hard part

`play/interrupt` v0.1.0 poses windows, validates answers, and persists a ledger with full R9 validation. It never interprets an option or a payload byte. So this wave is **wiring and phase discipline, not invention** — which is what the layering was for.

## Decisions worth reviewing

**The walk is a re-enterable phase machine.** It holds nothing across a suspension: an explicit phase index and the path live in a value written to storage and read back. A straight-line loop could only have suspended by parking a goroutine, and a parked goroutine is a resolution that dies with the process.

**Two aggregates now save, and the order is a correctness decision.** Encounter first, session second, because the half-failures are not symmetric:

| Order | Failure mode |
|---|---|
| World lands, window does not | The walk is stuck, but every persisted fact is true |
| Window lands, world does not | Resume walks past cells nobody walked — *silently* |

The first is a stoppage; the second is corruption that looks like progress. Resume re-validates against the world it actually loads, so even the survivable case becomes a clean rejection. `SaveReport` names both halves — S6 is finally exercised rather than promised.

**The freeze is structural, not a repeated check.** World-changing verbs open through `openForChange`; `Answer` opens through `openForWrite`, because a frozen session is what it exists to operate on. Forgetting the freeze requires actively choosing the other opener. Read verbs stay available — what is frozen is change, not observation — and the rejection is a typed `*FrozenError` naming the window and its audience, so a blocked caller is not sent to `Pending` to learn what the error already knew.

**`Prompt` carries the moment, never the mechanism.** No field names which checkpoint fired. Clients render what the player sees and branch on `OptionKind`, so new checkpoint kinds arrive without any client learning a reason code. There is a test asserting `Prompt` has exactly the fields it has, because a `Reason` field would quietly become the thing clients switch on and then could never change.

**No window opens on the final cell.** Continuing and stopping would be the same act; a choice that cannot matter is worse than no choice.

**Enumeration is sorted, not iteration-ordered** (C8). A resumed resolution that enumerated differently would break determinism only under load, only in production.

## Evidence

- **120 tests**, `-race` clean, `verify.sh` clean, lint clean, no `nolint` anywhere.
- **15 mutants, all killed.** Including the negative control: with the ogre already known, the same walk over the same path does not stop — so the assertions are not equally consistent with "any walk near a monster suspends".
- **One mutant survived on the first pass**, and it mattered: the resume test asserted the right cell was walked, which stayed true with re-validation aimed at the whole path instead of the unwalked suffix, because the walk is driven by the phase index. A pin that does not pin. Two tests replaced it (7121d31) and the mutant dies.
- **Process restart is a real restart**: both stores are marshalled to JSON and read into fresh repositories behind a fresh Manager before the window is answered.

## Boundary

`interrupt.LedgerData` joins the allow list as a persistence shape the host stores opaquely (S3), with a note recording what that does *not* admit: `interrupt.Window` and `interrupt.Option` stay off every signature, which is the whole reason the custody module can be replaced.

## Docs

`doc.go` stops hedging — S5 and S7 were commitments at v0.1.0 and are descriptions now. The architecture component gains the spine and gets its write-order note corrected (the old text said "a collectable orphan", which understated the asymmetry).

**`quality.md` holds at A- and says why it did not rise.** The thin partial-save path called out at v0.1.0 is genuinely closed. A new reservation opened in its place: *"stop the walk when the walker sees something new"* is a judgement about the game, living in a module whose charter says it owns no rules. It is here because no module owns **when a resolution should pause** — perception owns what is seen, not what that should interrupt. Named as squatting, with the condition under which it moves: the second checkpoint kind, which makes the deciding thing's shape visible. Inventing that owner from one example would be guessing.

The design doc records what implementation corrected: it gave `SessionData` a `Frozen []byte`, and the field turned out redundant — a window already carries an opaque payload and the suspended state belongs to the window. It becomes additive if reactions ever need state shared across windows. Kept as a correction *with its reason* rather than a quiet rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler

---

## Review round (Copilot, 1 finding, legitimate)

**The save report never reached the caller.** It falsified the claim above: `commit` computed the report and every verb dropped it, because a verb returns no output when it returns an error. S6 named the pieces to nobody. Survivable while `StartSession` was the only two-aggregate writer; not once windows make a partial save reachable on an ordinary walk, where *the world moved but the window it owes did not* (a repair) must not look like *nothing was written* (a retry).

Fixed with a typed `*SaveError` carrying the report — `errors.Is` for `ErrSaveFailed`, `errors.As` for the detail, `Unwrap` returning the sentinel **and** the store's own error so neither is swallowed. Same shape as `*FrozenError`, and it keeps the convention that an error means no output rather than asking callers to check both. Two tests over the two situations that must not look alike; **4 more mutants, all killed** (19 total). `gorelease` still v0.2.0.

Also fixed in this round: `go.mod` tidy drift caught by CI's modification check — `core` is a direct dependency now, since `core.EntityID` is named at the interrupt seam and the local tidy predated that import. That falsified `quality.md`'s "One direct dependency" line, which is corrected to the real list with a note that `core` is held off the boundary.
