### PR TITLE
docs(ideas): session SDK wave 3 — entities, and the two promises at the boundary (#945)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,29 +32,37 @@ These commands guide you through best practices and ensure nothing is missed.
 
 ## Module Development Workflow
 
-**IMPORTANT: NO go.work FILES OR LOCAL REPLACE DIRECTIVES**
+**IMPORTANT: LOCAL OVERRIDES ARE FINE — THEY MUST NEVER REACH CI**
 
-This project uses a clean module development approach:
+Local `replace` directives and `go.work` files are a normal part of developing
+across modules here. Working outside-in (build the consumer against a local
+sibling, discover the contract, then merge inside-out) depends on them.
 
-1. **Each module is developed independently**
-   - Work on one module at a time
-   - Use published dependencies only
-   - No replace directives pointing to local paths
-   - No go.work files
+The rule this section used to state — "no replace directives, no go.work" — was
+written because those overrides were being *committed* and breaking CI. That is
+the actual failure, and that is what stays banned.
+
+1. **Override locally, publish before you merge**
+   - Use `replace` or `go.work` freely while developing across modules
+   - **Never commit them.** A `replace` pointing at a local path fails CI, and
+     it fails it for everyone, not just you
+   - Before merging: publish the dependency, then point at the published
+     version and remove the override
 
 2. **Dependency Management**
-   - Modules reference published versions (e.g., `v0.1.0`)
-   - When you need updates from another module:
-     - Push the changes to that module first
-     - Then `go get -u` in the dependent module
-   - During development, Go creates pseudo-versions automatically (e.g., `v0.0.0-20230907052031-37f5183ecf93`)
+   - Committed `go.mod` files reference published versions (e.g., `v0.1.0`)
+   - To take an update from another module: tag and push that module first,
+     then `go get` it in the dependent module
+   - Go creates pseudo-versions automatically for un-tagged commits
+     (e.g., `v0.0.0-20230907052031-37f5183ecf93`)
 
-3. **Why This Approach**
-   - Keeps development honest - you work with real APIs
-   - Focuses work on one module at a time
-   - Avoids local development issues and CI failures
-   - Clear dependency tracking
-   - No confusion about which version is being used
+3. **Why This Shape**
+   - Local overrides make cross-module work possible without a release per edit
+   - Requiring published versions *at merge* keeps the committed graph honest:
+     what CI builds is what a consumer would get
+   - Editing a sibling module on disk does **not** change what your module
+     compiles against unless you have an override in place — the most common
+     source of "I fixed it but nothing changed"
 
 ## Testing Strategy
 

--- a/docs/ideas/session-sdk/design.md
+++ b/docs/ideas/session-sdk/design.md
@@ -113,6 +113,19 @@ type SessionRepository   interface { /* SessionData             — session stat
 type CharacterRepository interface { /* character.Data — arrives with entities   */ }
 ```
 
+**Wave 3 declared `CharacterRepository`, and the deferral paid for itself.**
+Waiting meant the interface arrived with a caller to shape it, and the caller
+settled a question that would have been guessed a wave earlier: the seam takes
+**IDs, not characters**. Verbs name members by ID, `Member.Kind` routes to the
+right repository, and `character.Data` appears in exactly one place — the
+repository the host implements. It never appears in a verb input. Had the
+repository been declared up front, nothing would have forced that distinction
+and `Data` would plausibly have leaked into verb signatures where it does not
+belong.
+
+The paragraph below is the original reasoning, kept because the rule it states
+is the reusable part:
+
 **`CharacterRepository` is deferred to the entities wave, not defined up front**
 — a correction the implementation forced. `character` is a package *inside* the
 large `rulebooks/dnd5e` module, so declaring it early would take a permanent
@@ -272,6 +285,28 @@ mgr, err := session.NewManager(&session.Config{
 with an error naming it (S8), checked in a fixed order so the first complaint is
 deterministic. `CharacterRepository` is absent because nothing calls it yet, not
 because it is optional.
+
+**Wave 3 adds `Characters`.** The deferral paid off as intended — the interface
+arrived with a caller to shape it instead of a guess to maintain, which is also
+why `NPCRepository` is still absent.
+
+But the addition exposes a blind spot in the compatibility gate, and it is worth
+recording plainly:
+
+> **`gorelease` will call a new `Config` field compatible, and for a *required*
+> field that verdict is wrong.** Adding one compiles everywhere and breaks every
+> existing host at runtime, on the first `NewManager` call, because construction
+> is total (S8) and the host does not set the field it has never heard of.
+
+This is free right now — rpg-api has not adopted the SDK, so no host is on
+`v0.2.0` and there is nothing to break. It stops being free at wave 4, the
+migration wave, which is where the version-bump promise starts. So:
+
+**Every required `Config` field must land at or before wave 4.** After that, a
+new one is a silent runtime break wearing a green CI check. This is the same
+species of gap as the boundary test's sentinel errors — a mechanical gate that
+is sound for the thing it inspects and blind to a thing next to it — and it gets
+the same treatment: name it, and put the discipline where the gate cannot reach.
 
 This settles the capability-config question `scenes.md` left open, and settles it
 by deleting it: there are no optional components, so `Config` never became
@@ -557,6 +592,45 @@ falsifiable claim: *after the migration wave, no subsequent wave changes any
 rpg-api source file.* If one does, S2 was violated somewhere and the violation
 is findable.
 
+### Two promises, not one
+
+Wave 3 forced a distinction the allow-list had been blurring. Its entries looked
+like one list of exceptions, but they were always two kinds of thing:
+
+| | Example | Does the host construct it? |
+|---|---|---|
+| **Contract type** | `spatial.Position` | Yes |
+| **Persistence shape** | `encounter.EncounterData`, `interrupt.LedgerData` | No — round-trips it untouched |
+
+These carry different promises. A persistence shape promises **replaceability**:
+we can swap what is underneath and the host never notices, which is why only
+`interrupt.LedgerData` crosses and `interrupt.Window` never does. A contract type
+promises the opposite — it is **shared vocabulary**, a domain noun both sides
+name, and a change to it is a breaking change we announce rather than hide.
+
+`character.Data` is a contract type, beside `spatial.Position`. A character is a
+thing, not an implementation detail we would want to refactor without telling
+the host. Reading it as a grudging exception to the replaceability promise gets
+the intent exactly backwards: for this category, surfacing a change is the
+correct behavior.
+
+Two facts make it a comfortable one. Its type surface bottoms out in strings and
+ints — `skills.Skill` and `classes.Class` are literal aliases to `string`, the
+`races`/`abilities`/`proficiencies` types are defined string types, and features
+and conditions are already `[]json.RawMessage`. And rpg-api has imported
+`rulebooks/dnd5e/character` in 47 files since well before this SDK existed, so
+naming it here joins coupling that already exists rather than creating any.
+
+The version-bump claim above is unaffected, because it was only ever about
+replaceability. **The allow-list should name both categories rather than reading
+as a flat list**, so a future exception is weighed against the right promise.
+
+The direction this points: `character` eventually becoming its own module
+alongside `encounter`, with its own version line. That also dissolves the one
+real cost of naming it here — today it inherits the release cadence of the
+`rulebooks/dnd5e` root module, which has 179 tags. Not a wave-3 blocker; wave 3
+consumes `character.Data` from the root module as it stands.
+
 ---
 
 ## Inside the boundary
@@ -578,6 +652,46 @@ None of this is customer-visible; all of it can change under a compatible tag.
   code** — explicit phase index, no Go stack held across a wait, in-between
   state serializable — even in waves where nothing suspends. `ReactionTrigger`
   happened because attack resolution was a straight-line function.
+
+### Loading an entity, and the cleanup that must not happen
+
+There is no session process. A verb loads what it needs, attaches it to a bus
+created for that call, acts, writes back, and returns; the whole object graph is
+garbage the moment the response is written. `Answer` is not a resumption of
+anything living — it is the same load-and-attach performed again from persisted
+data.
+
+```go
+ch, err := character.LoadFromData(ctx, data, bus)  // features + conditions subscribe
+...act...
+out := ch.ToData()                                 // durable state back to the blob
+```
+
+**`character.Cleanup` must not be called in this loop.** Its first statement is
+`c.conditions = nil`, and `ToData()` serializes `c.conditions` — so cleaning up
+before the save persists a character with **zero conditions**, with no error and
+no failed call. Rage, unconscious, a death save in progress: gone. Its other
+half, unsubscribing, buys nothing here because the bus dies with the response.
+`Cleanup` is built for a long-lived character in a long-lived process, which is
+the architecture we do not have.
+
+Skipping it is safe rather than merely tolerable: conditions intercept on the
+bus rather than mutating character fields, so there is no modification left
+un-reversed. `RagingCondition.Remove` is a pure unsubscribe. rpg-api has been
+doing exactly this — load with an inline `NewEventBus()`, `ToData()`, no
+cleanup.
+
+**This is why durable condition state must round-trip through the blob**, and it
+is forced rather than chosen. Wave 2 established that no Go stack survives a
+wait; a loaded character with live subscriptions is exactly that kind of state.
+So a suspension drops every entity, and `Answer` rebuilds them from data.
+Anything a condition holds that does not survive `ToData()` is lost across a
+suspension — silently, and only in the one path hardest to notice.
+
+The cost of all this is real and structural: every verb pays load and attach for
+every entity, and `LoadFromData` wires each feature and condition individually.
+That is the price of the condition decoupling, and it is the risk this plan
+already named. Wave 3 measures it rather than reasoning about it.
 
 ---
 

--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -145,13 +145,64 @@ and gets the identical window order.
 
 ## Wave 3 — entities on the bus
 
-Characters and NPCs load through their repositories, conditions attach for the
-duration of a call and detach after (S1), and durable condition state lives in
-the entity's own blob. `Member.Kind` selects the repository. NPCs live in
+Characters and NPCs load through their repositories, features and conditions
+attach for the duration of a call, and durable condition state lives in the
+entity's own blob. `Member.Kind` selects the repository. NPCs live in
 `SessionData` and vanish with the session.
 
 The bus carries **observation only** — journey 052's rule, enforced by the fact
 that nothing in this wave can suspend.
+
+**This is the wave the bus enters the composition at all.** Neither `encounter`
+nor `session` uses `events.EventBus` today; both carry `events` as an indirect
+dependency only. Everything so far has been bus-free, which is much of why
+journey 052's rule has held so easily — there was nothing to put control flow
+on. That changes here, which is why the determinism pin below is a wave-3
+concern and not a wave-4 one.
+
+**T3.1 — the bus, per call.** One bus per verb, shared by every entity loaded in
+that call, discarded with the response. There is no session process: a verb
+loads, attaches, acts, saves, and everything dies with the response. Shared
+rather than per-entity, because a condition on one member must be able to
+observe what happens to another — the prerequisite for reactions in wave 5.
+
+**T3.2 — `CharacterRepository`, and `Member.Kind` routing.** Declared with
+`character.Data`. Players resolve through the repository; NPCs through
+`SessionData`. The seam takes **IDs, not characters** — `character.Data` appears
+only on the repository the host implements, never in a verb input, and
+`*character.Character` never crosses at all.
+
+**T3.3 — NPCs in `SessionData`.** `NPCs []npc.Data`, session-scoped, no
+repository until a durable NPC exists. Asymmetric reversibility again: adding a
+`Config` field later is compatible; removing one a host implemented is not.
+
+**T3.4 — attach and detach, across a suspension.** The load → attach → act →
+`ToData()` → save loop, and that same loop re-entered by `Answer`. **Do not call
+`character.Cleanup`** — see design.md; it nils the conditions that `ToData`
+serializes, and its unsubscribe half is meaningless when the bus dies with the
+response.
+
+**T3.5 — the benchmark.** Load + attach at party scale (4–6 characters with a
+realistic feature and condition load), measured per verb. This plan already
+names *"stateless-per-call proves too slow once entities load on every verb"* as
+something that would make it wrong; wave 3 is where that stops being
+hypothetical. Measure before anyone designs a cache around a cost nobody has
+seen — the fallback (a checkpointing repository on the host side) was already
+the design's answer and changes no SDK signature.
+
+**T3.6 — the scene**, continuing the story with a pinned transcript: Alice
+raging when she is loaded, without the caller ever mentioning rage (scene 4).
+
+**Pins:** a condition active before a verb is still active and still behaving
+after save and reload — *mutation: `Cleanup` before `ToData`, which must fail,
+because the failure it models is silent*; a condition active at the moment of
+suspension survives a process restart and an `Answer` from a different process;
+the boundary test still rejects `*character.Character` while admitting
+`character.Data` as a contract type with a recorded reason; one shared bus per
+call, proven by a condition on member A observing an event about member B
+(*mutation: per-entity buses*); and enumeration order at a checkpoint stays a
+function of persisted data rather than subscription order (C8) — the pin that
+matters most now that a bus exists to make the other thing tempting.
 
 ---
 
@@ -189,6 +240,12 @@ retires T3, and may push that wave ahead of this one.
 - Scenes as one continuous story with exact pinned transcripts.
 - `gorelease` green on every wave; a wave that reports *incompatible* does not
   ship without a deliberate, recorded decision.
+- **Every required `Config` field lands at or before wave 4.** `gorelease` calls
+  a new struct field compatible, and for a *required* one that verdict is wrong:
+  it compiles everywhere and fails every existing host at its first
+  `NewManager`, because construction is total (S8). Free until the migration
+  wave, a silent runtime break wearing a green check after it. The gate cannot
+  see this, so the discipline has to.
 - No draft PRs; no `--no-verify`; no force-push; no `nolint`.
 
 ## What would make this plan wrong

--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -19,9 +19,26 @@ gate from the first tag.
 | **0** ✅ | Encounter log retention | `encounter/v0.4.0` | — |
 | **1** ✅ | Shell, free-roam verbs, event stream | `session/v0.1.0` | — |
 | **2** ✅ | The interrupt spine, proven by the perception pause | `session/v0.2.0` | 1 |
-| **3** | Entities on the bus — characters, NPCs, conditions | `session/v0.3.0` | 1 |
-| **4** | Combat | `session/v0.4.0` | 2, 3 |
-| **5** | Reactions — opportunity attack (closes #916) | `session/v0.5.0` | 4 |
+| **3** | Entities on the bus — characters, NPCs, conditions | from `session/v0.3.0` | 1 |
+| **4** | Combat | — | 2, 3 |
+| **5** | Reactions — opportunity attack (closes #916) | — | 4 |
+
+**The tag column stops predicting after wave 3, which is a correction rather than
+an omission.** It assumed one merge per wave. The repo **auto-tags on merge to
+main**, deriving the bump from conventional-commit prefixes, so a wave landing in
+two steps consumes two versions — wave 3's first step (characters load) took
+`session/v0.3.0` by itself.
+
+Nothing real depended on the numbering. Semver here tracks API change, not
+project milestones, and the claim that matters — *after the migration wave, no
+subsequent wave changes an rpg-api source file* — is about **which** wave migrates
+(4, combat), not what number it carries. Writing a version beside a wave was
+quietly promising that a wave is one PR. That is not a promise worth making, and
+the auto-tagger was never going to keep it.
+
+Practical consequence while planning a wave: a `feat:` commit takes the minor
+bump the moment it lands on main, so the version a wave "ships at" is decided by
+its first merge, not its last.
 
 Waves 0 and 1 are independent and can run in parallel — different modules, and
 the house rule is one in-flight PR per module.


### PR DESCRIPTION
Design pass for **wave 3 — entities on the bus** (#945), cutting it into tasks
and settling the decisions that shape its public surface before any of it is
code. Per the triplet convention this stays open through implementation and
merges as ratification.

## What this settles

**The seam takes IDs, not characters.** Verbs name members by ID; `Member.Kind`
routes to the right repository. `character.Data` appears in exactly one place —
the `CharacterRepository` interface the host implements — and never in a verb
input. `*character.Character` never crosses at all: it is loaded inside a call,
attached to a bus, acted on, converted back to data, and discarded. The boundary
test keeps rejecting the runtime type.

**Two promises, not one.** The allow-list had been reading as a flat list of
grudging exceptions, but its entries were always two kinds of thing:

| | Example | Does the host construct it? |
|---|---|---|
| **Contract type** | `spatial.Position` | Yes |
| **Persistence shape** | `encounter.EncounterData`, `interrupt.LedgerData` | No — round-trips it untouched |

A persistence shape promises **replaceability** — we swap what is underneath and
the host never notices, which is why `interrupt.LedgerData` crosses and
`interrupt.Window` does not. A contract type promises the opposite: shared
vocabulary, a domain noun both sides name, whose change we *announce* rather
than hide.

`character.Data` is a contract type. A character is a thing, not an
implementation detail we would want to refactor without telling rpg-api.
Reading it as an erosion of the version-bump promise gets the intent backwards
— that promise was only ever about replaceability.

Two facts make it comfortable: its type surface bottoms out in strings and ints
(`skills.Skill` and `classes.Class` are literal aliases to `string`; features and
conditions are already `[]json.RawMessage`), and rpg-api has imported
`rulebooks/dnd5e/character` in 47 files since long before this SDK existed.

**`character.Cleanup` must not be called** in the load/act/save loop. Its first
statement is `c.conditions = nil`, and `ToData()` serializes `c.conditions` — so
cleaning up before the save persists a character with **zero conditions**, with
no error. Its unsubscribe half buys nothing when the bus dies with the response.
Verified safe to skip: conditions intercept on the bus rather than mutating
fields (`RagingCondition.Remove` is a pure unsubscribe), and rpg-api already
does exactly this.

**Durable condition state must round-trip through the blob** — forced by wave 2,
not chosen. No Go stack survives a wait, so a suspension drops every loaded
entity and `Answer` rebuilds them from data.

## Found while writing this up

**`gorelease` has a blind spot, and wave 3 walks into it.** It calls a new
`Config` field compatible. For a *required* field that verdict is wrong: it
compiles everywhere and fails every existing host at its first `NewManager`,
because construction is total (S8).

This is free today — rpg-api has not adopted the SDK, so no host is on `v0.2.0`.
It stops being free at wave 4, the migration wave, which is where the
version-bump promise starts. So a new discipline is recorded: **every required
`Config` field lands at or before wave 4.** After that, a new one is a silent
runtime break wearing a green check.

Same species as the boundary test's sentinel-error gap — a mechanical gate sound
for what it inspects and blind to the thing beside it — and it gets the same
treatment: name it, and put the discipline where the gate cannot reach.

## Also here

`CLAUDE.md`'s module workflow rule said "NO go.work FILES OR LOCAL REPLACE
DIRECTIVES". That is stale and actively misleads a session that reads it cold:
local overrides are normal and are how outside-in/merge-inside-out works. The
real failure was overrides being *committed* and breaking CI. Rewritten to ban
that instead, and to note the trap it protects against — editing a sibling
module on disk does not change what your module compiles against without an
override, which is the most common source of "I fixed it but nothing changed."

## Verified rather than assumed

- **dnd5e root builds and passes all 25 test packages at `spatial v0.9.0` +
  `core v0.11.0`** — the versions `session` is on. Minimal version selection
  will bump it there once the modules link, and I checked that rather than
  reasoning about it. `go.mod` was restored afterward; nothing in this PR
  changes it.
- Neither `encounter` nor `session` uses `events.EventBus` today; both carry
  `events` as indirect only. Wave 3 is when the bus enters the composition.
- rpg-api owns character creation (`FinalizeDraft`), so the SDK needs no
  creation verb — scene 8 stays a later wave.

## Not in scope

Implementation. Combat (wave 4), reactions (wave 5, closes #916). The
character-as-its-own-module direction is recorded separately in #946 and blocks
nothing.

Closes nothing on merge — #945 stays open until wave 3 ships.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq
