### PR TITLE
feat(session): characters load through the host's repository (#945)

### DIFF
--- a/rulebooks/dnd5e/session/boundary_test.go
+++ b/rulebooks/dnd5e/session/boundary_test.go
@@ -41,19 +41,61 @@ type BoundaryTestSuite struct {
 // are not modules we intend to replace underneath the host.
 const forbiddenPrefix = "github.com/KirkDiggler/rpg-toolkit/"
 
-// allowed is the complete set of toolkit types permitted in exported
-// signatures, written out rather than derived from a pattern.
+// The types permitted in exported signatures, written out rather than derived
+// from a pattern.
 //
 // A rule like "any name ending in Data" would be less typing and would quietly
 // admit types nobody weighed. Listing them means every future exception is a
 // visible line in a diff with a reason attached, which is the only version of
 // an exception list that stays honest.
-var allowed = map[string]string{
+//
+// They are split into TWO CATEGORIES because they make two different promises,
+// and a flat list hid that. The entities wave forced the distinction: reading
+// character.Data as one more grudging exception to replaceability got the
+// intent exactly backwards.
+//
+// The split is not decoration. It tells a future author which question to ask
+// about a new entry, and the two questions have different answers.
+
+// contractTypes are shared vocabulary: the host constructs these, names them in
+// its own code, and reasons about them.
+//
+// Their promise is NOT replaceability. It is the opposite — a change to one is
+// a breaking change we ANNOUNCE. These are domain nouns both sides agree on,
+// and refactoring one without telling the host would be the bug, not the
+// safeguard.
+//
+// The question to ask before adding one: is this a thing the host legitimately
+// knows about, such that we would want it to hear about a change?
+var contractTypes = map[string]string{
 	// A coordinate is a coordinate. spatial.Position is a stable value type
 	// with no behaviour to replace, and inventing a twin for it would force
 	// hosts to convert on every call for no benefit.
-	"spatial.Position": "stable value type",
+	"spatial.Position": "stable value type; shared vocabulary for placement",
 
+	// A character is a thing, not an implementation detail we would refactor
+	// without telling the host. Its surface bottoms out in strings and ints —
+	// skills.Skill and classes.Class are literal aliases to string, and
+	// features and conditions are already []json.RawMessage — so naming it
+	// commits us to a shape that is already wire-like.
+	//
+	// It appears on CharacterRepository ONLY. Verbs take member IDs, and
+	// Member.Kind routes to the repository; character.Data is never a verb
+	// input. What crosses is the shape the host already persists, not the
+	// object we build from it.
+	"character.Data": "contract type: the sheet the host owns, stores, and constructs",
+}
+
+// persistenceShapes are bytes the host round-trips and never builds.
+//
+// Their promise IS replaceability: the module underneath can be reshaped or
+// swapped and the host never notices, because it stores these opaquely rather
+// than reading them.
+//
+// The question to ask before adding one: does the host store this without ever
+// constructing or inspecting it? If the host would have to build one field by
+// field, it is a contract type and belongs above, under a stricter promise.
+var persistenceShapes = map[string]string{
 	// The documented S3 exception: persistence shapes cross the boundary
 	// because they are exactly the bytes the host already stores. Data types
 	// are the slowest-moving surface in the toolkit and carry their own
@@ -78,6 +120,18 @@ var allowed = map[string]string{
 	// module underneath can be replaced. Only the stored shape crosses.
 	"interrupt.LedgerData": "persistence shape the host stores opaquely (S3)",
 }
+
+// allowed is the union the detector checks against.
+var allowed = func() map[string]string {
+	all := map[string]string{}
+	for k, v := range contractTypes {
+		all[k] = v
+	}
+	for k, v := range persistenceShapes {
+		all[k] = v
+	}
+	return all
+}()
 
 // TestNoInnerTypeCrossesTheBoundary parses this package's non-test sources and
 // fails on any toolkit type reachable from an exported declaration.
@@ -189,6 +243,35 @@ func (s *BoundaryTestSuite) TestAllowListIsJustified() {
 	for qualified, reason := range allowed {
 		s.NotEmpty(reason, "allowed type %s must record why it is permitted", qualified)
 	}
+}
+
+// TestTheTwoCategoriesAreDisjoint pins the split itself.
+//
+// A type listed in both would mean nobody decided which promise it makes, and
+// the whole value of the split is that the decision is forced. Merging silently
+// into `allowed` would hide that, since the union does not care.
+func (s *BoundaryTestSuite) TestTheTwoCategoriesAreDisjoint() {
+	for qualified := range contractTypes {
+		s.NotContains(persistenceShapes, qualified,
+			"%s is in both categories; it must promise one thing or the other", qualified)
+	}
+	s.Len(allowed, len(contractTypes)+len(persistenceShapes),
+		"the union must not silently collapse an entry listed twice")
+}
+
+// TestTheRuntimeCharacterIsNotAdmitted is the discriminating half of admitting
+// character.Data.
+//
+// Letting the stored shape cross is a decision about persistence. Letting the
+// loaded object cross would be a different decision entirely — it carries
+// behaviour, a live bus, and subscriptions, none of which survive a response.
+// A rejection table proves the detector refuses things; this names the one
+// refusal that admitting its neighbour makes tempting.
+func (s *BoundaryTestSuite) TestTheRuntimeCharacterIsNotAdmitted() {
+	s.NotContains(allowed, "character.Character",
+		"the loaded character must never cross the boundary")
+	s.Contains(allowed, "character.Data",
+		"while the stored shape it is built from does")
 }
 
 type typeUse struct {

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -21,7 +21,10 @@ import (
 	"os"
 	"sort"
 
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -89,6 +92,48 @@ func (m *memEncounters) SaveEncounter(_ context.Context, id string, data *encoun
 	return nil
 }
 
+// memCharacters is a CharacterRepository over a map.
+//
+// The host owns character storage; this package only ever asks for one by ID
+// and hands back data. Nothing here holds a loaded character, because nothing
+// can: a character lives for one verb.
+type memCharacters struct {
+	byID map[string]*character.Data
+}
+
+func (m *memCharacters) GetCharacter(_ context.Context, id string) (*character.Data, error) {
+	data, ok := m.byID[id]
+	if !ok {
+		return nil, session.ErrNotFound
+	}
+	return data, nil
+}
+
+func (m *memCharacters) SaveCharacter(_ context.Context, data *character.Data) error {
+	m.byID[data.ID] = data
+	return nil
+}
+
+// bobTheDwarf is the stored sheet the workbench loads.
+//
+// Note what is NOT here: speed. It is derived from race when the character is
+// reconstituted, which is why the transcript printing 25 is evidence the load
+// really happened rather than evidence a map lookup returned something.
+func bobTheDwarf() *character.Data {
+	return &character.Data{
+		ID:               "bob",
+		PlayerID:         "player-bob",
+		Name:             "Bob",
+		Level:            3,
+		ProficiencyBonus: 2,
+		RaceID:           races.Dwarf,
+		ClassID:          classes.Fighter,
+		HitPoints:        24,
+		MaxHitPoints:     28,
+		ArmorClass:       16,
+	}
+}
+
 // printStream shows the fan-out as it happens, one line per addressed event —
 // which is what a host would be shipping to each connected client.
 type printStream struct{ out *bytes.Buffer }
@@ -108,6 +153,7 @@ func drive(out *bytes.Buffer) error {
 	mgr, err := session.NewManager(&session.Config{
 		Sessions:   &memSessions{byID: map[string]*session.SessionData{}},
 		Encounters: &memEncounters{byID: map[string]*encounter.EncounterData{}},
+		Characters: &memCharacters{byID: map[string]*character.Data{"bob": bobTheDwarf()}},
 		Events:     &printStream{out: out},
 	})
 	if err != nil {
@@ -134,6 +180,14 @@ func drive(out *bytes.Buffer) error {
 		return err
 	}
 	fmt.Fprintf(out, "   bob joins the %s\n", joined.Member.Room)
+
+	// The sheet came back derived, not echoed. Speed is not a field of the
+	// stored data at all — a dwarf's 25 comes from reconstituting the
+	// character and asking it, which is the whole point of loading here.
+	if c := joined.Character; c != nil {
+		fmt.Fprintf(out, "   %s, level %d — %d/%d hp, ac %d, speed %d\n",
+			c.Name, c.Level, c.HitPoints, c.MaxHitPoints, c.ArmorClass, c.Speed)
+	}
 
 	atlas, err := mgr.Atlas(ctx, &session.AtlasInput{Session: "crypt-run"})
 	if err != nil {

--- a/rulebooks/dnd5e/session/entities.go
+++ b/rulebooks/dnd5e/session/entities.go
@@ -90,24 +90,28 @@ func (m *Manager) loadCharacter(
 
 // projectCharacter reports the state of a loaded character.
 //
-// Everything here is DERIVED by the loaded character rather than copied out of
-// its stored data. That is deliberate: it is what makes this projection proof
-// that a character actually reconstituted, rather than proof that a repository
-// returned some bytes. Speed and armour class in particular are computed from
-// race, equipment and whatever conditions attached on the way in.
+// Read through the character's own accessors, never through ToData(). ToData is
+// a SERIALISATION, not a getter: it clones several maps, marshals every feature
+// and condition to JSON, and stamps UpdatedAt with the current time. Calling it
+// to read three integers would put that cost on every join, and would make a
+// read path non-deterministic for no reason.
+//
+// Speed is the field that carries the weight here. It is not stored on the
+// character at all — it is derived from race when asked — so it is the one value
+// that cannot be produced by echoing bytes, and the one the tests lean on to
+// prove reconstitution actually happened. The rest are reported as loaded.
 func projectCharacter(ch *character.Character) *CharacterState {
 	if ch == nil {
 		return nil
 	}
-	data := ch.ToData()
 	return &CharacterState{
 		ID:               ch.GetID(),
 		Name:             ch.GetName(),
 		Level:            ch.GetLevel(),
 		Speed:            ch.GetSpeed(),
-		HitPoints:        data.HitPoints,
-		MaxHitPoints:     data.MaxHitPoints,
-		ArmorClass:       data.ArmorClass,
+		HitPoints:        ch.GetHitPoints(),
+		MaxHitPoints:     ch.GetMaxHitPoints(),
+		ArmorClass:       ch.AC(),
 		ProficiencyBonus: ch.ProficiencyBonus(),
 	}
 }

--- a/rulebooks/dnd5e/session/entities.go
+++ b/rulebooks/dnd5e/session/entities.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+)
+
+// Loading an entity, and the cleanup that must not happen.
+//
+// There is no session process. A verb loads what it needs, attaches it to a bus
+// created for that call, acts, writes back, and returns; the whole object graph
+// is garbage the moment the response is written. Answer is not the resumption
+// of anything living — it is this same load-and-attach performed again from
+// persisted data.
+//
+// That shape is forced rather than chosen. The interrupt spine established that
+// no Go stack survives a wait, and a loaded character with live subscriptions
+// is exactly that kind of state. So a suspension drops every entity, and
+// anything a condition holds that does not survive ToData() is lost across it.
+//
+// ONE BUS PER CALL, SHARED BY EVERY ENTITY IN THAT CALL. Shared rather than
+// per-entity because a condition on one member must be able to observe what
+// happens to another — that is the whole reason the bus exists here, and it is
+// the prerequisite for reactions. A bus per character would compile, pass any
+// test that loaded one character, and quietly make cross-entity observation
+// impossible.
+//
+// CHARACTER.CLEANUP MUST NOT BE CALLED. Its first statement is
+// `c.conditions = nil`, and ToData() serializes c.conditions — so cleaning up
+// before the save persists a character with ZERO conditions. Raging,
+// unconscious, a death save in progress: gone, with no error and no failed
+// call. Its other half, unsubscribing, buys nothing when the bus dies with the
+// response; Cleanup is built for a long-lived character in a long-lived
+// process, which is the architecture we do not have.
+//
+// Skipping it is safe rather than merely tolerable: conditions intercept on the
+// bus rather than mutating character fields, so there is no modification left
+// un-reversed when the character is dropped.
+
+// newCallBus returns the event bus for one verb.
+//
+// A function rather than an inline call so there is exactly one place to look
+// when asking what the lifetime is, and so the answer stays "one call" when a
+// later wave is tempted to cache one.
+func newCallBus() events.EventBus {
+	return events.NewEventBus()
+}
+
+// loadCharacter reconstitutes a player character and attaches its features and
+// conditions to the call's bus.
+//
+// Returns ErrNoCharacter when the repository does not hold the ID, and
+// ErrBadCharacter when it holds bytes that cannot be reconstituted. The two are
+// kept apart because they send whoever debugs it to different places: a bad
+// request versus corrupt storage.
+//
+// The returned character is for this call only. It is never stored on the
+// manager (S1), never held across a suspension, and never returned to the host
+// (S2) — the host named an ID and gets data back, not an object.
+func (m *Manager) loadCharacter(
+	ctx context.Context, bus events.EventBus, id string,
+) (*character.Character, error) {
+	data, err := m.characters.GetCharacter(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("character %q: %w", id, ErrNoCharacter)
+		}
+		return nil, fmt.Errorf("character %q: %w", id, err)
+	}
+	if data == nil {
+		// A repository reporting success with no data has violated its
+		// contract. Guessing in either direction — treating it as absent, or
+		// carrying a nil into LoadFromData — is worse than saying so.
+		return nil, fmt.Errorf("character %q: %w", id, ErrBadRepository)
+	}
+
+	ch, err := character.LoadFromData(ctx, data, bus)
+	if err != nil {
+		return nil, fmt.Errorf("character %q: %w: %w", id, ErrBadCharacter, err)
+	}
+	return ch, nil
+}
+
+// projectCharacter reports the state of a loaded character.
+//
+// Everything here is DERIVED by the loaded character rather than copied out of
+// its stored data. That is deliberate: it is what makes this projection proof
+// that a character actually reconstituted, rather than proof that a repository
+// returned some bytes. Speed and armour class in particular are computed from
+// race, equipment and whatever conditions attached on the way in.
+func projectCharacter(ch *character.Character) *CharacterState {
+	if ch == nil {
+		return nil
+	}
+	data := ch.ToData()
+	return &CharacterState{
+		ID:               ch.GetID(),
+		Name:             ch.GetName(),
+		Level:            ch.GetLevel(),
+		Speed:            ch.GetSpeed(),
+		HitPoints:        data.HitPoints,
+		MaxHitPoints:     data.MaxHitPoints,
+		ArmorClass:       data.ArmorClass,
+		ProficiencyBonus: ch.ProficiencyBonus(),
+	}
+}

--- a/rulebooks/dnd5e/session/entities_test.go
+++ b/rulebooks/dnd5e/session/entities_test.go
@@ -1,0 +1,232 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// EntitiesTestSuite covers loading a character through the host's repository:
+// the first wave in which this package holds a domain entity at all, even for
+// the length of one call.
+type EntitiesTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+	mgr        *session.Manager
+}
+
+func (s *EntitiesTestSuite) SetupTest() {
+	s.sessions = newFakeSessions()
+	s.encounters = newFakeEncounters()
+	s.characters = testCharacters()
+	mgr, err := session.NewManager(&session.Config{
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
+		Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: hexWorld(s.T()),
+	})
+	s.Require().NoError(err)
+}
+
+func (s *EntitiesTestSuite) SetupSubTest() { s.SetupTest() }
+
+func (s *EntitiesTestSuite) joinBob() (*session.JoinOutput, error) {
+	return s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "bob", Kind: session.KindPlayer,
+		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+	})
+}
+
+// TestJoiningAPlayerLoadsTheirCharacter is the wave's headline, and the
+// assertion is chosen so it cannot pass without a real load.
+//
+// SPEED IS NOT A FIELD OF character.Data. There is nothing to echo. A dwarf's
+// 25 exists only because the stored bytes were reconstituted into a character
+// and asked, so this single number distinguishes "the repository returned
+// something" from "a character actually loaded".
+func (s *EntitiesTestSuite) TestJoiningAPlayerLoadsTheirCharacter() {
+	out, err := s.joinBob()
+	s.Require().NoError(err)
+
+	s.Require().NotNil(out.Character, "a player join must report the loaded character")
+	s.Equal("bob", out.Character.ID)
+	s.Equal(25, out.Character.Speed, "a dwarf's speed is derived from race, not stored")
+	s.Equal(24, out.Character.HitPoints)
+	s.Equal(28, out.Character.MaxHitPoints)
+	s.Equal(16, out.Character.ArmorClass)
+	s.Equal(3, out.Character.Level)
+}
+
+// TestSpeedIsDerivedRatherThanDefaulted is the discriminating control for the
+// assertion above.
+//
+// GetSpeed falls back to 30 when it cannot find race data, and 30 is also a
+// human's speed. So "25" proving derivation depends on the fallback not being
+// 25 — this pins that two characters differing ONLY in race report different
+// speeds, which a default could not produce.
+func (s *EntitiesTestSuite) TestSpeedIsDerivedRatherThanDefaulted() {
+	human := dwarfCharacter("human-one")
+	human.RaceID = races.Human
+	s.characters.byID[human.ID] = human
+
+	dwarf, err := s.joinBob()
+	s.Require().NoError(err)
+
+	humanOut, err := s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "human-one", Kind: session.KindPlayer,
+		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+	})
+	s.Require().NoError(err)
+
+	s.Equal(25, dwarf.Character.Speed)
+	s.Equal(30, humanOut.Character.Speed)
+	s.NotEqual(dwarf.Character.Speed, humanOut.Character.Speed,
+		"characters differing only in race must differ in derived speed")
+}
+
+// TestJoiningAPlayerWithNoCharacterIsRejected is why the load happens at join
+// rather than at first use.
+func (s *EntitiesTestSuite) TestJoiningAPlayerWithNoCharacterIsRejected() {
+	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "nobody", Kind: session.KindPlayer,
+		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNoCharacter)
+	s.NotErrorIs(err, session.ErrNoMember, "absent sheet is not an absent roster entry")
+}
+
+// TestARejectedJoinPlacesNobody pins the ORDER, which is the part that could
+// regress silently.
+//
+// Loading before the placement means a failed load leaves no half-joined
+// member behind. Loading after would still return the same error while having
+// already put someone in the room — and nothing about the error would say so.
+func (s *EntitiesTestSuite) TestARejectedJoinPlacesNobody() {
+	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "nobody", Kind: session.KindPlayer,
+		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+	})
+	s.Require().Error(err)
+
+	// No read verb lists members yet (toolkit#933), so the placement is
+	// observed through the verb that requires one: exiting someone who was
+	// never placed must fail as an absent member.
+	_, err = s.mgr.Exit(context.Background(), &session.ExitInput{
+		Session: "sess", Member: "nobody",
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNoMember, "a rejected join must not leave a member placed")
+}
+
+// TestAMonsterJoinsWithoutACharacter is the over-tightening defense.
+//
+// The rejection above proves the check refuses. Only this proves it does not
+// over-reach: monsters have no sheet, and a load that fired for every kind
+// would break every monster join while passing every rejection row.
+func (s *EntitiesTestSuite) TestAMonsterJoinsWithoutACharacter() {
+	before := s.characters.loads
+
+	out, err := s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "ogre-7", Kind: session.KindMonster,
+		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+	})
+	s.Require().NoError(err, "a monster has no character sheet and must not need one")
+	s.Nil(out.Character, "and reports none")
+	s.Equal(before, s.characters.loads, "the character repository must not be consulted at all")
+}
+
+// TestTheCharacterIsLoadedPerCallRatherThanCached pins S1 at the entity level.
+//
+// There is no session process: nothing is held between verbs, so every call
+// that needs a character asks the repository again. A cache would be invisible
+// in a single-call test and wrong the moment two processes served one session.
+func (s *EntitiesTestSuite) TestTheCharacterIsLoadedPerCallRatherThanCached() {
+	_, err := s.joinBob()
+	s.Require().NoError(err)
+	first := s.characters.loads
+	s.Positive(first, "joining a player must consult the repository")
+
+	_, err = s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "carol", Kind: session.KindPlayer,
+		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+	})
+	s.Require().NoError(err)
+	s.Greater(s.characters.loads, first, "a second join must load again, not reuse")
+}
+
+// TestARepositoryReportingSuccessWithNoDataIsRejected covers the contract
+// violation rather than the absence: a store that returns (nil, nil) is broken,
+// and guessing in either direction is worse than saying so.
+func (s *EntitiesTestSuite) TestARepositoryReportingSuccessWithNoDataIsRejected() {
+	mgr, err := session.NewManager(&session.Config{
+		Sessions: s.sessions, Encounters: s.encounters,
+		Characters: &nilDataCharacters{},
+		Events:     session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "bob", Kind: session.KindPlayer,
+		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadRepository)
+	s.NotErrorIs(err, session.ErrNoCharacter, "broken is not the same as absent")
+}
+
+// TestACorruptConditionIsDroppedRatherThanRejected documents UPSTREAM
+// behaviour that this wave inherits and does not yet fix.
+//
+// character.LoadFromData logs and continues past a condition it cannot parse
+// or apply, so a corrupt blob vanishes silently instead of failing the load.
+// That matters here more than it did before: the durable-condition-state
+// invariant says a condition must survive save and reload, and this is a path
+// where one does not — with no error anywhere.
+//
+// Pinned rather than fixed because the swallow is in the character package, not
+// this one. The test exists so the behaviour is known and so a future upstream
+// change that starts returning an error is noticed here rather than in a game.
+func (s *EntitiesTestSuite) TestACorruptConditionIsDroppedRatherThanRejected() {
+	corrupt := dwarfCharacter("corrupt-one")
+	corrupt.Conditions = []json.RawMessage{json.RawMessage(`{"ref":"nonsense","x":`)}
+	s.characters.byID[corrupt.ID] = corrupt
+
+	out, err := s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "corrupt-one", Kind: session.KindPlayer,
+		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+	})
+
+	s.Require().NoError(err, "upstream currently swallows this; if that changes, so must this test")
+	s.Require().NotNil(out.Character)
+	s.Equal(25, out.Character.Speed, "the rest of the character still loaded")
+}
+
+// nilDataCharacters violates the repository contract by reporting success with
+// no data.
+type nilDataCharacters struct{}
+
+func (n *nilDataCharacters) GetCharacter(_ context.Context, _ string) (*character.Data, error) {
+	return nil, nil
+}
+
+func (n *nilDataCharacters) SaveCharacter(_ context.Context, _ *character.Data) error { return nil }
+
+func TestEntitiesSuite(t *testing.T) { suite.Run(t, new(EntitiesTestSuite)) }

--- a/rulebooks/dnd5e/session/entities_test.go
+++ b/rulebooks/dnd5e/session/entities_test.go
@@ -246,3 +246,65 @@ func (n *nilDataCharacters) GetCharacter(_ context.Context, _ string) (*characte
 func (n *nilDataCharacters) SaveCharacter(_ context.Context, _ *character.Data) error { return nil }
 
 func TestEntitiesSuite(t *testing.T) { suite.Run(t, new(EntitiesTestSuite)) }
+
+// benchManager builds a fresh, started session for one benchmark iteration.
+type benchFataler struct{ b *testing.B }
+
+func (f benchFataler) Fatalf(format string, args ...any) { f.b.Fatalf(format, args...) }
+
+func benchManager(b *testing.B) *session.Manager {
+	b.Helper()
+	mgr, err := session.NewManager(&session.Config{
+		Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	if err != nil {
+		b.Fatalf("manager: %v", err)
+	}
+	if _, err := mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: hexWorld(benchFataler{b}),
+	}); err != nil {
+		b.Fatalf("start: %v", err)
+	}
+	return mgr
+}
+
+// BenchmarkJoinPlayer and BenchmarkJoinMonster differ by exactly one thing: the
+// player join loads a character and the monster join does not. The DELTA is the
+// per-verb cost of reconstituting a sheet and attaching its features and
+// conditions to the call's bus.
+//
+// That cost is the wave's stated risk — "stateless-per-call proves too slow once
+// entities load on every verb" — and the reason to measure it rather than design
+// a cache around a number nobody has seen.
+func BenchmarkJoinPlayer(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		mgr := benchManager(b)
+		b.StartTimer()
+
+		if _, err := mgr.Join(ctx, &session.JoinInput{
+			Session: "sess", Member: "bob", Kind: session.KindPlayer,
+			Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		}); err != nil {
+			b.Fatalf("join: %v", err)
+		}
+	}
+}
+
+func BenchmarkJoinMonster(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		mgr := benchManager(b)
+		b.StartTimer()
+
+		if _, err := mgr.Join(ctx, &session.JoinInput{
+			Session: "sess", Member: "ogre-7", Kind: session.KindMonster,
+			Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		}); err != nil {
+			b.Fatalf("join: %v", err)
+		}
+	}
+}

--- a/rulebooks/dnd5e/session/entities_test.go
+++ b/rulebooks/dnd5e/session/entities_test.go
@@ -113,12 +113,21 @@ func (s *EntitiesTestSuite) TestJoiningAPlayerWithNoCharacterIsRejected() {
 	s.NotErrorIs(err, session.ErrNoMember, "absent sheet is not an absent roster entry")
 }
 
-// TestARejectedJoinPlacesNobody pins the ORDER, which is the part that could
-// regress silently.
+// TestARejectedJoinPlacesNobody pins that a failed load ABORTS the join.
 //
-// Loading before the placement means a failed load leaves no half-joined
-// member behind. Loading after would still return the same error while having
-// already put someone in the room — and nothing about the error would say so.
+// Worth being precise about what makes this true, because the obvious answer is
+// wrong. It is NOT the ordering: mutating the load to run after the placement
+// leaves this test passing, because load-act-save (S4) already discards the
+// in-memory encounter when a verb returns before commit. Nothing was going to
+// persist either way.
+//
+// What it does guard is the error actually stopping the verb. Swallow the load
+// failure and carry on, and the join commits a member whose sheet does not
+// exist — which is precisely the state loading at join time is meant to
+// prevent.
+//
+// The ordering is still chosen deliberately, just not for correctness: there is
+// no reason to touch the world when the call is already doomed.
 func (s *EntitiesTestSuite) TestARejectedJoinPlacesNobody() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "nobody", Kind: session.KindPlayer,
@@ -153,12 +162,19 @@ func (s *EntitiesTestSuite) TestAMonsterJoinsWithoutACharacter() {
 	s.Equal(before, s.characters.loads, "the character repository must not be consulted at all")
 }
 
-// TestTheCharacterIsLoadedPerCallRatherThanCached pins S1 at the entity level.
+// TestEveryPlayerJoinConsultsTheRepository pins that the load is per member
+// rather than done once for the session.
 //
-// There is no session process: nothing is held between verbs, so every call
-// that needs a character asks the repository again. A cache would be invisible
-// in a single-call test and wrong the moment two processes served one session.
-func (s *EntitiesTestSuite) TestTheCharacterIsLoadedPerCallRatherThanCached() {
+// Deliberately NOT claiming to pin "no caching between calls", which is what an
+// earlier version of this test said. It cannot: only one verb loads a character
+// today, and it joins a DIFFERENT member each time, so a per-ID cache would
+// change nothing observable here. Mutation confirmed that — the caching mutant
+// survived.
+//
+// The real per-call pin becomes writable when a second verb loads a character
+// and the same member can be loaded twice. Until then this guards the weaker
+// but still useful property, and says so rather than overclaiming.
+func (s *EntitiesTestSuite) TestEveryPlayerJoinConsultsTheRepository() {
 	_, err := s.joinBob()
 	s.Require().NoError(err)
 	first := s.characters.loads

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -59,6 +59,25 @@ var (
 	// request.
 	ErrNoEncounter = errors.New("no such encounter")
 
+	// ErrNoCharacter is returned when a player joins naming a character the
+	// character repository does not hold.
+	//
+	// Distinct from ErrNoMember, which is about the encounter's roster: this
+	// one fires before anyone is placed, and it is the whole point of loading
+	// at join time. A session that accepted a player with no character would
+	// look fine until the first verb that needed a sheet, and would fail then
+	// in a place with no obvious connection to the join that caused it.
+	ErrNoCharacter = errors.New("no such character")
+
+	// ErrBadCharacter is returned when a character's stored data exists but
+	// cannot be reconstituted into a usable character.
+	//
+	// Separate from ErrNoCharacter for the same reason ErrBadRepository is
+	// separate from ErrNotFound: absent and corrupt send whoever debugs it to
+	// different places. This is also the boundary at which hostile or stale
+	// stored bytes are refused rather than carried into a resolution.
+	ErrBadCharacter = errors.New("character data could not be loaded")
+
 	// ErrNoMemberID is returned when a verb is given an empty member ID.
 	ErrNoMemberID = errors.New("empty member id")
 

--- a/rulebooks/dnd5e/session/events_test.go
+++ b/rulebooks/dnd5e/session/events_test.go
@@ -26,6 +26,7 @@ type EventsTestSuite struct {
 
 	sessions   *fakeSessions
 	encounters *fakeEncounters
+	characters *fakeCharacters
 	stream     *fakeStream
 	mgr        *session.Manager
 }
@@ -33,9 +34,10 @@ type EventsTestSuite struct {
 func (s *EventsTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
+	s.characters = testCharacters()
 	s.stream = &fakeStream{}
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: s.sessions, Encounters: s.encounters, Events: s.stream,
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters, Events: s.stream,
 	})
 	s.Require().NoError(err)
 	s.mgr = mgr
@@ -151,7 +153,7 @@ func (s *EventsTestSuite) TestNothingIsPublishedWhenTheSaveFails() {
 	encounters := &failingEncounters{fakeEncounters: newFakeEncounters()}
 	stream := &fakeStream{}
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: newFakeSessions(), Encounters: encounters, Events: stream,
+		Sessions: newFakeSessions(), Encounters: encounters, Characters: testCharacters(), Events: stream,
 	})
 	s.Require().NoError(err)
 
@@ -179,7 +181,7 @@ func (s *EventsTestSuite) TestNothingIsPublishedWhenTheSaveFails() {
 // gapless, so clients self-heal.
 func (s *EventsTestSuite) TestDeliveryFailureDoesNotFailTheVerb() {
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: s.sessions, Encounters: s.encounters,
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: &failingStream{err: errBroken},
 	})
 	s.Require().NoError(err)
@@ -213,7 +215,7 @@ func (s *EventsTestSuite) TestDeliveryFailureDoesNotFailTheVerb() {
 // one.
 func (s *EventsTestSuite) TestDiscardingEventsStillReportsHonestly() {
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: s.sessions, Encounters: s.encounters,
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -34,8 +34,8 @@ func Example_theSession() {
 	// The host's entire integration: two stores.
 	mgr, err := session.NewManager(&session.Config{
 		Sessions:   newFakeSessions(),
-		Encounters: newFakeEncounters(),
-		Events:     session.DiscardEvents{},
+		Encounters: newFakeEncounters(), Characters: testCharacters(),
+		Events: session.DiscardEvents{},
 	})
 	if err != nil {
 		panic(err)
@@ -137,7 +137,7 @@ func Example_theSession() {
 func Example_thePending() {
 	ctx := context.Background()
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Sessions: newFakeSessions(), Encounters: newFakeEncounters(), Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	if err != nil {

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -1,21 +1,25 @@
 module github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session
 
-go 1.24
+go 1.24.1
 
 require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
+	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/interrupt v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.78.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.4.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/events v0.6.2 // indirect
+	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 // indirect
 	github.com/KirkDiggler/rpg-toolkit/game v0.1.0 // indirect
+	github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 // indirect
 	github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0 // indirect
+	github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -1,9 +1,13 @@
 github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
 github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
-github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
-github.com/KirkDiggler/rpg-toolkit/events v0.6.2/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
+github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
+github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
+github.com/KirkDiggler/rpg-toolkit/events v0.6.3 h1:F5bbCJLHjhfiwUHngnkEtj/ZoXFzDW4BBMZZJ6c3CMc=
+github.com/KirkDiggler/rpg-toolkit/events v0.6.3/go.mod h1:JNzyCw1l/RL4nyoCpx3tSko8Dsocwye9eFg33Ot6mUw=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0 h1:jXYlCqkqK0LCHquu+1vgTEbedhgQbspR6748sO/KYqE=
 github.com/KirkDiggler/rpg-toolkit/game v0.1.0/go.mod h1:6k+SKiGEAjeI4JRaQtVKOcsUsp3O/sDDee4GH9rl+WM=
+github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1 h1:wRshHQZfLnEh03/Gqy96ZvuZ6Wc/Zl3whhBLbFGWnQY=
+github.com/KirkDiggler/rpg-toolkit/mechanics/resources v0.3.1/go.mod h1:LzyZd5OAAic1UnyPwCx6HnmWcOQ/jZvqMSc+Q0k7fH8=
 github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0 h1:uKGivoRcgQW3sQ0I0G5ct0DkPBkSUwD/yX6bfK0i4XA=
 github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0/go.mod h1:LRzXoz7Is2z6s4KWtVG6B68uunxJgE5qWdk14EtHlbk=
 github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0 h1:89nU27faMf80JrIJlQeVeYacQIexkgBFzHomvXWyE/I=
@@ -12,6 +16,10 @@ github.com/KirkDiggler/rpg-toolkit/play/interrupt v0.1.0 h1:L9ozHqfxKo8Ca/z4EF/j
 github.com/KirkDiggler/rpg-toolkit/play/interrupt v0.1.0/go.mod h1:IRzIF0Rp4mzlan3SxrRR41drGYsL3DY4p8oM7qRSBag=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q+6k8n0krpcnka+lLyflk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
+github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
+github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.78.0 h1:lp+SOi1H0RTb3y+91u8LJZ0I6Y92QFsLHZpUDkQP+XM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.78.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.4.0 h1:27AxCK1/Ypt16fjhALdu1br27j7syvVm3y8s/uylF58=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.4.0/go.mod h1:ZYYd+oFBN6WUPIb+OTaAu6X7CQtVhOjEg9i0GJM0o6Q=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=
@@ -24,6 +32,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
+go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/rulebooks/dnd5e/session/manager_test.go
+++ b/rulebooks/dnd5e/session/manager_test.go
@@ -9,7 +9,10 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 )
 
@@ -59,6 +62,72 @@ func (f *fakeEncounters) SaveEncounter(_ context.Context, id string, data *encou
 	return nil
 }
 
+// fakeCharacters is an in-memory CharacterRepository.
+type fakeCharacters struct {
+	byID map[string]*character.Data
+
+	// loads counts GetCharacter calls, so a test can assert that loading
+	// happens per call rather than being cached between them.
+	loads int
+}
+
+func newFakeCharacters(chars ...*character.Data) *fakeCharacters {
+	f := &fakeCharacters{byID: map[string]*character.Data{}}
+	for _, c := range chars {
+		f.byID[c.ID] = c
+	}
+	return f
+}
+
+func (f *fakeCharacters) GetCharacter(_ context.Context, id string) (*character.Data, error) {
+	f.loads++
+	data, ok := f.byID[id]
+	if !ok {
+		return nil, session.ErrNotFound
+	}
+	return data, nil
+}
+
+func (f *fakeCharacters) SaveCharacter(_ context.Context, data *character.Data) error {
+	f.byID[data.ID] = data
+	return nil
+}
+
+// dwarfCharacter builds a minimal stored character.
+//
+// A DWARF on purpose. Speed is not a field of character.Data at all — it is
+// derived from race by the loaded character — and a dwarf's 25 is distinct
+// both from a human's 30 and from the 30 that GetSpeed falls back to when race
+// data is missing. So an assertion of 25 can only pass if the stored bytes were
+// genuinely reconstituted, which is the thing worth proving.
+func dwarfCharacter(id string) *character.Data {
+	return &character.Data{
+		ID:               id,
+		PlayerID:         "player-" + id,
+		Name:             "Alice",
+		Level:            3,
+		ProficiencyBonus: 2,
+		RaceID:           races.Dwarf,
+		ClassID:          classes.Fighter,
+		HitPoints:        24,
+		MaxHitPoints:     28,
+		ArmorClass:       16,
+	}
+}
+
+// testCharacters holds the cast the suites join through Join. Members placed
+// directly into a world fixture never pass through the repository, so only the
+// ones a test actually joins need to exist here.
+func testCharacters() *fakeCharacters {
+	return newFakeCharacters(
+		dwarfCharacter("alice"),
+		dwarfCharacter("bob"),
+		dwarfCharacter("carol"),
+		dwarfCharacter("dave"),
+		dwarfCharacter("erin"),
+	)
+}
+
 // fakeStream records what was published.
 type fakeStream struct {
 	published []session.Event
@@ -104,16 +173,30 @@ func (s *ManagerTestSuite) TestEachRequirementIsCheckedByName() {
 		{
 			name: "sessions absent",
 			config: &session.Config{Encounters: newFakeEncounters(),
-				Events: session.DiscardEvents{},
+				Characters: testCharacters(), Events: session.DiscardEvents{},
 			},
 			expect: "Sessions",
 		},
 		{
 			name: "encounters absent",
 			config: &session.Config{Sessions: newFakeSessions(),
-				Events: session.DiscardEvents{},
+				Characters: testCharacters(), Events: session.DiscardEvents{},
 			},
 			expect: "Encounters",
+		},
+		{
+			name: "characters absent",
+			config: &session.Config{Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+				Events: session.DiscardEvents{},
+			},
+			expect: "Characters",
+		},
+		{
+			name: "events absent",
+			config: &session.Config{Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+				Characters: testCharacters(),
+			},
+			expect: "Events",
 		},
 	}
 
@@ -154,6 +237,7 @@ func (s *ManagerTestSuite) TestDiscardEventsIsAcceptedAsAStream() {
 	mgr, err := session.NewManager(&session.Config{
 		Sessions:   newFakeSessions(),
 		Encounters: newFakeEncounters(),
+		Characters: testCharacters(),
 		Events:     session.DiscardEvents{},
 	})
 	s.Require().NoError(err, "an explicit no-op stream is a legitimate configuration")
@@ -166,6 +250,7 @@ func (s *ManagerTestSuite) TestFullyWiredConstructs() {
 	mgr, err := session.NewManager(&session.Config{
 		Sessions:   newFakeSessions(),
 		Encounters: newFakeEncounters(),
+		Characters: testCharacters(),
 		Events:     &fakeStream{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -21,14 +21,16 @@ type MoveTestSuite struct {
 
 	sessions   *fakeSessions
 	encounters *fakeEncounters
+	characters *fakeCharacters
 	mgr        *session.Manager
 }
 
 func (s *MoveTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
+	s.characters = testCharacters()
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: s.sessions, Encounters: s.encounters,
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -22,14 +22,16 @@ type ReadTestSuite struct {
 
 	sessions   *fakeSessions
 	encounters *fakeEncounters
+	characters *fakeCharacters
 	mgr        *session.Manager
 }
 
 func (s *ReadTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
+	s.characters = testCharacters()
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: s.sessions, Encounters: s.encounters,
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -180,7 +182,7 @@ func (s *ReadTestSuite) TestGridProjectionCoversBothFamilies() {
 
 	square := newFakeSessions()
 	squareEnc := newFakeEncounters()
-	mgr, err := session.NewManager(&session.Config{Sessions: square, Encounters: squareEnc,
+	mgr, err := session.NewManager(&session.Config{Sessions: square, Encounters: squareEnc, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/repositories.go
+++ b/rulebooks/dnd5e/session/repositories.go
@@ -6,6 +6,7 @@ package session
 import (
 	"context"
 
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 )
 
@@ -70,6 +71,51 @@ type EncounterRepository interface {
 
 	// SaveEncounter writes the encounter, creating or replacing it wholesale.
 	SaveEncounter(ctx context.Context, id string, data *encounter.EncounterData) error
+}
+
+// CharacterRepository persists player characters.
+//
+// Required. This is the repository the deferral rule was waiting on: it is
+// declared now because something finally calls it, and arriving with a caller
+// is what settled its shape rather than a guess.
+//
+// It names character.Data, and that crosses the boundary on purpose. The
+// distinction worth holding is between two kinds of type this package lets out:
+//
+//   - A PERSISTENCE SHAPE (encounter.EncounterData, interrupt.LedgerData) is
+//     bytes the host round-trips and never builds. It promises REPLACEABILITY —
+//     we can swap what is underneath and the host never notices.
+//   - A CONTRACT TYPE (spatial.Position, character.Data) is shared vocabulary
+//     the host constructs and reasons about. It promises the opposite: a change
+//     to it is announced, not hidden.
+//
+// A character is a thing, not an implementation detail we would refactor
+// without telling the host. Reading it as a grudging exception gets the intent
+// backwards. The version-bump promise is unaffected because that promise was
+// only ever about replaceability.
+//
+// What does NOT cross is *character.Character, the runtime object. It is loaded
+// inside a verb, attached to that call's bus, acted on, converted back to data,
+// and dropped. The boundary test rejects it, and should.
+//
+// SaveCharacter takes only the data because character.Data carries its own ID,
+// the same asymmetry SaveSession has and for the same reason: passing a key
+// alongside a payload that already contains one puts identity in two places.
+//
+// Save is declared now although the first wave to use this repository only
+// reads. Adding a method to an interface the host has already implemented stops
+// it compiling, so the reversible direction is to declare both up front — the
+// same rule that governs Config fields.
+//
+// Implementations must return an error satisfying errors.Is(err, ErrNotFound)
+// when the ID is absent, and must never report success with no data.
+type CharacterRepository interface {
+	// GetCharacter returns the character with the given ID, or an ErrNotFound
+	// error if it does not exist.
+	GetCharacter(ctx context.Context, id string) (*character.Data, error)
+
+	// SaveCharacter writes the character, creating or replacing it wholesale.
+	SaveCharacter(ctx context.Context, data *character.Data) error
 }
 
 // Concurrency: two doors deliberately left open.

--- a/rulebooks/dnd5e/session/session.go
+++ b/rulebooks/dnd5e/session/session.go
@@ -24,6 +24,21 @@ type Config struct {
 	// Encounters persists the world. Required.
 	Encounters EncounterRepository
 
+	// Characters persists player characters. Required.
+	//
+	// Added in the entities wave, when something finally called it. A new
+	// REQUIRED Config field is worth a note, because gorelease will call it a
+	// compatible change and for a required field that verdict is wrong: it
+	// compiles everywhere and fails every existing host at its first
+	// NewManager, since construction is total (S8).
+	//
+	// It is free here only because no host has adopted this package yet. Once
+	// one has, a new required field is a silent runtime break wearing a green
+	// CI check — so every required field must land at or before the migration
+	// wave, and after that the answer is a separately type-asserted capability
+	// rather than a Config field.
+	Characters CharacterRepository
+
 	// Events is the live channel to connected clients. Required.
 	//
 	// Required because a verb's response tells the CALLER about the caller's
@@ -52,6 +67,7 @@ type Config struct {
 type Manager struct {
 	sessions   SessionRepository
 	encounters EncounterRepository
+	characters CharacterRepository
 	events     EventStream
 }
 
@@ -79,6 +95,7 @@ func NewManager(cfg *Config) (*Manager, error) {
 	}{
 		{"Sessions", cfg.Sessions != nil},
 		{"Encounters", cfg.Encounters != nil},
+		{"Characters", cfg.Characters != nil},
 		{"Events", cfg.Events != nil},
 	}
 	for _, dep := range required {
@@ -90,6 +107,7 @@ func NewManager(cfg *Config) (*Manager, error) {
 	return &Manager{
 		sessions:   cfg.Sessions,
 		encounters: cfg.Encounters,
+		characters: cfg.Characters,
 		events:     cfg.Events,
 	}, nil
 }

--- a/rulebooks/dnd5e/session/start_test.go
+++ b/rulebooks/dnd5e/session/start_test.go
@@ -61,6 +61,7 @@ type StartSessionTestSuite struct {
 
 	sessions   *fakeSessions
 	encounters *fakeEncounters
+	characters *fakeCharacters
 	mgr        *session.Manager
 	world      *encounter.EncounterData
 }
@@ -68,11 +69,12 @@ type StartSessionTestSuite struct {
 func (s *StartSessionTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
+	s.characters = testCharacters()
 
 	mgr, err := session.NewManager(&session.Config{
 		Sessions:   s.sessions,
-		Encounters: s.encounters,
-		Events:     session.DiscardEvents{},
+		Encounters: s.encounters, Characters: s.characters,
+		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
 	s.mgr = mgr
@@ -188,7 +190,7 @@ func (s *StartSessionTestSuite) TestExistingSessionIsNotOverwritten() {
 func (s *StartSessionTestSuite) TestBrokenStoreIsNotMistakenForAFreeID() {
 	sessions := &failingSessions{fakeSessions: newFakeSessions(), getErr: errBroken}
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: sessions, Encounters: s.encounters,
+		Sessions: sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -216,7 +218,7 @@ func (s *StartSessionTestSuite) TestBrokenStoreIsNotMistakenForAFreeID() {
 func (s *StartSessionTestSuite) TestBrokenRepositoryIsNotReadAsAnExistingSession() {
 	sessions := &nilDataSessions{fakeSessions: newFakeSessions()}
 	encounters := newFakeEncounters()
-	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters,
+	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -268,7 +270,7 @@ func (s *StartSessionTestSuite) TestSuccessWritesWorldThenSession() {
 func (s *StartSessionTestSuite) TestWorldSaveFailureLeavesNoDanglingSession() {
 	encounters := &failingEncounters{fakeEncounters: newFakeEncounters(), saveErr: errBroken}
 	sessions := newFakeSessions()
-	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters,
+	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -289,7 +291,7 @@ func (s *StartSessionTestSuite) TestWorldSaveFailureLeavesNoDanglingSession() {
 func (s *StartSessionTestSuite) TestSessionSaveFailureLeavesOnlyAnOrphan() {
 	sessions := &failingSessions{fakeSessions: newFakeSessions(), saveErr: errBroken}
 	encounters := newFakeEncounters()
-	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters,
+	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/suspend_test.go
+++ b/rulebooks/dnd5e/session/suspend_test.go
@@ -23,12 +23,14 @@ type SuspendTestSuite struct {
 
 	sessions   *fakeSessions
 	encounters *fakeEncounters
+	characters *fakeCharacters
 	mgr        *session.Manager
 }
 
 func (s *SuspendTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
+	s.characters = testCharacters()
 	s.mgr = managerOver(s.T(), s.sessions, s.encounters)
 }
 
@@ -49,7 +51,7 @@ func managerOverRepos(
 	t fataler, sessions session.SessionRepository, encounters session.EncounterRepository,
 ) *session.Manager {
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: sessions, Encounters: encounters, Events: session.DiscardEvents{},
+		Sessions: sessions, Encounters: encounters, Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	if err != nil {
 		t.Fatalf("building manager: %v", err)

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -319,10 +319,13 @@ type Member struct {
 //
 // This package's own twin, not character.Data: the stored shape is what the
 // host persists, while this is what one call observed after reconstitution.
-// They differ in exactly the way that matters — every field here is DERIVED by
-// the loaded character, so armour class already accounts for equipment and
-// speed already accounts for whatever conditions attached on the way in. A host
-// reading its own stored blob would get the un-derived numbers.
+// Read through the character's accessors rather than by serialising it, so this
+// stays a cheap read.
+//
+// Most of these fields are reported as loaded. SPEED is the exception and the
+// interesting one: it is not stored on a character at all, but derived from
+// race when asked, which is why it is the value the tests use to prove a sheet
+// genuinely reconstituted rather than that a repository returned some bytes.
 //
 // Deliberately small. It carries what a client needs to render a member and
 // what proves the load happened; the sheet in full is the host's own copy to
@@ -338,8 +341,12 @@ type CharacterState struct {
 	// Level is the character's level.
 	Level int `json:"level"`
 
-	// Speed is the character's current movement speed in feet, after race,
-	// equipment and any active conditions.
+	// Speed is the character's BASE walking speed in feet, from race.
+	//
+	// Base, not effective: condition-driven modifiers (Unarmored Movement and
+	// the like) are applied during resolution through the movement chain, not
+	// folded in here. A client rendering this is showing the sheet's speed, not
+	// what the next step will cost.
 	Speed int `json:"speed"`
 
 	// HitPoints is the character's current hit points.

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -315,6 +315,46 @@ type Member struct {
 	Room string `json:"room"`
 }
 
+// CharacterState is what a loaded character reports about itself.
+//
+// This package's own twin, not character.Data: the stored shape is what the
+// host persists, while this is what one call observed after reconstitution.
+// They differ in exactly the way that matters — every field here is DERIVED by
+// the loaded character, so armour class already accounts for equipment and
+// speed already accounts for whatever conditions attached on the way in. A host
+// reading its own stored blob would get the un-derived numbers.
+//
+// Deliberately small. It carries what a client needs to render a member and
+// what proves the load happened; the sheet in full is the host's own copy to
+// read, and re-exporting it here would make character.Data's every field a wire
+// commitment of this package.
+type CharacterState struct {
+	// ID is the character's identifier.
+	ID string `json:"id"`
+
+	// Name is the character's name.
+	Name string `json:"name"`
+
+	// Level is the character's level.
+	Level int `json:"level"`
+
+	// Speed is the character's current movement speed in feet, after race,
+	// equipment and any active conditions.
+	Speed int `json:"speed"`
+
+	// HitPoints is the character's current hit points.
+	HitPoints int `json:"hit_points"`
+
+	// MaxHitPoints is the character's hit point maximum.
+	MaxHitPoints int `json:"max_hit_points"`
+
+	// ArmorClass is the character's current armour class.
+	ArmorClass int `json:"armor_class"`
+
+	// ProficiencyBonus is the character's proficiency bonus.
+	ProficiencyBonus int `json:"proficiency_bonus"`
+}
+
 // Discovery is what changed in one observer's perception.
 //
 // Three disjoint lists rather than a single "here is everything you now

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -36,6 +36,10 @@ type JoinOutput struct {
 	// Member is the joined member's placement.
 	Member Member
 
+	// Character is the joined character's state, derived after loading. Nil
+	// for kinds that have no character sheet.
+	Character *CharacterState
+
 	// Discovered is what changed in each observer's perception, keyed by
 	// observer. Absent observers saw nothing new.
 	Discovered map[string]Discovery
@@ -130,6 +134,23 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 		return nil, fmt.Errorf("join: %w", err)
 	}
 
+	// Kind selects the repository. A player's sheet lives in the host's
+	// character store; anything else does not have one yet, and asking for one
+	// would fail every monster join.
+	//
+	// Loading HERE, before the placement, is the point of doing it at join at
+	// all: a session that accepted a player with no character would look
+	// healthy until the first verb that needed a sheet, and would then fail
+	// somewhere with no visible connection to the join that caused it.
+	var loaded *CharacterState
+	if in.Kind == KindPlayer {
+		ch, cErr := m.loadCharacter(ctx, newCallBus(), in.Member)
+		if cErr != nil {
+			return nil, fmt.Errorf("join: %w", cErr)
+		}
+		loaded = projectCharacter(ch)
+	}
+
 	joined, err := scope.enc.Join(&encounter.JoinInput{
 		Member: encounter.MemberInput{
 			ID:       encounter.MemberID(in.Member),
@@ -149,6 +170,7 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 
 	return &JoinOutput{
 		Member:     projectMember(joined.Member),
+		Character:  loaded,
 		Discovered: projectDiscoveries(joined.IntelDeltas),
 		Seq:        joined.Seq,
 		Outcome:    projectOutcome(joined.Outcome),

--- a/rulebooks/dnd5e/session/write_test.go
+++ b/rulebooks/dnd5e/session/write_test.go
@@ -19,14 +19,16 @@ type WriteTestSuite struct {
 
 	sessions   *fakeSessions
 	encounters *fakeEncounters
+	characters *fakeCharacters
 	mgr        *session.Manager
 }
 
 func (s *WriteTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
+	s.characters = testCharacters()
 	mgr, err := session.NewManager(&session.Config{
-		Sessions: s.sessions, Encounters: s.encounters,
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -192,7 +194,7 @@ func (s *WriteTestSuite) TestWriteVerbsRejectMissingIdentifiers() {
 func (s *WriteTestSuite) TestFailedSaveIsReportedNotSwallowed() {
 	encounters := &failingEncounters{fakeEncounters: newFakeEncounters()}
 	sessions := newFakeSessions()
-	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters,
+	mgr, err := session.NewManager(&session.Config{Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -227,7 +229,7 @@ func (s *WriteTestSuite) TestStaleWorldIsNotResurrected() {
 	ctx := context.Background()
 
 	other, err := session.NewManager(&session.Config{
-		Sessions: s.sessions, Encounters: s.encounters,
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)


### PR DESCRIPTION
**Wave 3, step one: the SDK can load a character.** That was the stated goal for
the wave, and this is the smallest honest version of it — the repository, the
routing, and the load, with the sheet coming back derived rather than echoed.

Design is #947 (approved). Tracking issue #945.

## What it does

`Join` with `Kind: KindPlayer` loads the character through the host's
`CharacterRepository` and reports its state:

```
   bob joins the antechamber
   Bob, level 3 — 24/28 hp, ac 16, speed 25
```

That `25` is the whole proof. **Speed is not a field of `character.Data`.** It is
derived from race by the reconstituted character, so the number cannot come from
echoing stored bytes — only from a sheet that actually loaded. A human built from
the same fixture reports 30, which is also `GetSpeed`'s not-found fallback, so
there is a control test pinning that two characters differing *only* in race
differ in derived speed.

## The seam

`character.Data` appears on `CharacterRepository` and nowhere else. Verbs take
member IDs; `Member.Kind` routes to the repository. `*character.Character` is
built inside the call, attached to that call's bus, and dropped — it never
crosses, and the boundary test still refuses it.

The allow-list is now split into the two categories the design named, because
they promise different things:

| | Example | Host constructs it? | Promise |
|---|---|---|---|
| **Contract type** | `spatial.Position`, `character.Data` | Yes | change is **announced** |
| **Persistence shape** | `encounter.EncounterData`, `interrupt.LedgerData` | No | **replaceability** |

A test pins that the two are disjoint — a type in both would mean nobody chose
which promise it makes.

## Found while building

**`gorelease` reports `Config.Characters: added` as a compatible change.** It is
not, for a required field: it compiles everywhere and fails every existing host
at its first `NewManager`. This PR is the live demonstration of the blind spot
#947 documents. Free here only because no host has adopted the SDK yet — I
verified rpg-api imports none of it.

**`character.LoadFromData` swallows condition errors.** Every failure path in
loading a condition logs and `continue`s, so a corrupt blob vanishes silently
rather than failing the load. That matters more in this wave than it did before,
because the durable-condition-state invariant says a condition must survive save
and reload — and this is a path where one does not, with no error anywhere. It
is upstream in the `character` package, so it is **pinned rather than fixed**:
a test documents the behaviour so a future upstream change is noticed here
rather than in a game. Filed separately as #948.

## Two pins I had to correct

Mutation testing caught both. Neither was a code defect — both were test comments
claiming a guarantee the test did not provide, which is the more dangerous kind
of wrong:

- One claimed to pin the **order** of load versus placement. It does not: moving
  the load after the placement leaves it passing, because load-act-save already
  discards the in-memory encounter when a verb errors before commit. Reframed to
  what it actually guards — the failure aborting the verb — with the swallowed-
  error mutant, which it kills.
- One claimed to pin the **absence of caching**. It cannot: only one verb loads a
  character today and each row joins a different member, so a per-ID cache would
  change nothing observable. The caching mutant survived, which was the honest
  signal. Renamed and rescoped, and it records that the real per-call pin becomes
  writable once a second verb loads a character.

## Review round (Copilot)

One finding, legitimate: `projectCharacter` read HP/AC through `ch.ToData()`.
`ToData` is a serialisation rather than a getter — it clones several maps,
marshals every feature and condition to JSON, and stamps `UpdatedAt: time.Now()`,
which also made a read path non-deterministic. Fixed in 2656f68 to use
`GetHitPoints()` / `GetMaxHitPoints()` / `AC()`, which return the same values, so
it is behaviour-identical.

Measured rather than assumed, on a fixture with no conditions:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| via `ToData()` | 24,565 | 18,093 | 214 |
| via accessors | 23,549 | 17,604 | 213 |

~1.0µs and ~489B per join — the floor, not the typical case, since `ToData`
marshals each condition and this fixture has none.

**The more useful half was what it exposed in the surrounding docs**, where I had
written two things a host would have believed and both were wrong: `CharacterState`
claimed every field was derived and that armour class accounted for equipment
(`AC()` returns the stored field), and `Speed` was documented as accounting for
active conditions (`GetSpeed` returns **base** speed from race; condition
modifiers ride the movement chain during resolution). Both corrected. Speed is
still genuinely derived — it is not a field of `character.Data` at all — but it is
base speed, and now says so.

## The benchmark the wave owed

Player and monster joins differ by exactly the character load, so the delta is
its per-verb cost: **~5.1µs and 64 allocs** (23.5µs vs 18.4µs). At party scale
that is roughly 30µs a verb. The wave named "stateless-per-call proves too slow
once entities load on every verb" as something that would make the plan wrong;
on this evidence it does not, and the caching-repository escape hatch stays
theoretical.

## On tagging

Merging this auto-tags **`rulebooks/dnd5e/session/v0.3.0`** — the `feat:` commit
gives a minor bump, and `gorelease` independently suggests the same version.

That consumes wave 3's tag on wave 3's first step, so the rest of the wave will
land on v0.4.0 and everything after shifts by one. Nothing real breaks: the tag
column in `plan.md` was a prediction, and it assumed one merge per wave. The
falsifiable claim that matters — *after the migration wave, no subsequent wave
changes an rpg-api source file* — is about which wave migrates, not what number
it carries.

The honest fix is to stop promising tag numbers per wave, since semver should
track API changes and not project milestones. Corrected in the plan on #947.

## Verification

- **136 tests**, `-race` clean, `./scripts/verify.sh` clean incl. transcripts
- **9 mutants, all killed** (kind routing, swallowed load failure, untranslated
  `ErrNotFound`, accepted nil data, underived speed, speed hardcoded to the
  fallback, `Characters` unvalidated, `character.Data` removed from the
  allow-list, categories not disjoint)
- lint **0 issues**, `gofmt` clean, **no `nolint` anywhere**
- `gorelease -base v0.2.0` → **v0.3.0**, all additions
- dnd5e root verified to build and pass all 25 test packages at the `spatial`
  and `core` versions MVS resolves to here

## Not in this step

NPCs in `SessionData`, and conditions surviving a suspension. Those are the rest
of wave 3; this one is the load itself, which is what the wave was asked to reach
first. (The benchmark was going to be a later step — Copilot's review made it
worth having now, so it is in.)

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq
