### PR TITLE
test(session): conditions survive a suspension, and the character store is never damaged (#945)

### DIFF
--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -21,7 +21,7 @@ gate from the first tag.
 | **2** ✅ | The interrupt spine, proven by the perception pause | `session/v0.2.0` | 1 |
 | **3** | Entities on the bus — characters, NPCs, conditions | from `session/v0.3.0` | 1 |
 | **4** | Combat | — | 2, 3 |
-| **5** | Reactions — opportunity attack (closes #916) | — | 4 |
+| **5** | Reactions — opportunity attack | — | 4 |
 
 **The tag column stops predicting after wave 3, which is a correction rather than
 an omission.** It assumed one merge per wave. The repo **auto-tags on merge to
@@ -199,6 +199,34 @@ repository until a durable NPC exists. Asymmetric reversibility again: adding a
 serializes, and its unsubscribe half is meaningless when the bus dies with the
 response.
 
+> **Amended during wave 3: the SAVE half moves to wave 4.** Written above as one
+> loop, because a load that never writes back looked like an unfinished thought.
+> Building it showed the opposite — the write is the dangerous half, and nothing
+> in this wave needs it.
+>
+> Two facts, both measured rather than reasoned. First, **nothing in wave 3
+> mutates a character**: there is no damage, no condition-applying verb, and the
+> composition publishes nothing to the bus, so an attached condition has nothing
+> to react to. A save would persist a character identical to the one loaded.
+>
+> Second, that save is not free. `character.LoadFromData` drops conditions it
+> cannot parse and `Character.ToData` drops conditions it cannot serialise —
+> both silently, both returning no error (toolkit#948, whose load-half framing
+> was itself too narrow). Measured across three corruption modes — unknown ref,
+> malformed JSON, a real ref with a wrong-typed body — every one loads with
+> `err == nil` and one condition fewer. While the SDK only reads, a blob it
+> cannot fully parse stays whole in the host's store. **A `SaveCharacter` in the
+> write path turns that into permanent loss on an ordinary walk**, and
+> `ToData` stamps `UpdatedAt` with `time.Now()` besides, so the write is not
+> even inert on a character nothing touched.
+>
+> So wave 3 pins the negative — every write verb, including the one that
+> suspends and the `Answer` that resumes it, leaves the character store
+> byte-identical — and wave 4 adds the write when damage finally makes it mean
+> something. **#948 is a prerequisite for that wave**, not a follow-up to it:
+> the wave that starts writing characters is the wave that makes the silent drop
+> permanent.
+
 **T3.5 — the benchmark.** Load + attach at party scale (4–6 characters with a
 realistic feature and condition load), measured per verb. This plan already
 names *"stateless-per-call proves too slow once entities load on every verb"* as
@@ -212,14 +240,40 @@ raging when she is loaded, without the caller ever mentioning rage (scene 4).
 
 **Pins:** a condition active before a verb is still active and still behaving
 after save and reload — *mutation: `Cleanup` before `ToData`, which must fail,
-because the failure it models is silent*; a condition active at the moment of
-suspension survives a process restart and an `Answer` from a different process;
-the boundary test still rejects `*character.Character` while admitting
-`character.Data` as a contract type with a recorded reason; one shared bus per
-call, proven by a condition on member A observing an event about member B
-(*mutation: per-entity buses*); and enumeration order at a checkpoint stays a
-function of persisted data rather than subscription order (C8) — the pin that
-matters most now that a bus exists to make the other thing tempting.
+because the failure it models is silent*
+> **Amended: this pin moves to wave 4 with the save it describes.** It cannot be
+> written honestly here. "Still behaving" needs an observable consequence, and
+> this wave has none — nothing publishes to the bus and no read verb reports a
+> character's active conditions, so any assertion would pass whether the
+> condition attached or not. The `Cleanup` mutant has the same problem: with no
+> save, nilling the conditions changes nothing anyone can see, so the mutant
+> survives for a reason that says nothing about the code. Wave 3 pins the
+> reachable half instead — *the store is byte-identical after every write verb*,
+> which kills both a `SaveCharacter` in `Join` and the walk-loads-and-writes-back
+> shape T3.4 originally prescribed.
+
+**What wave 3 actually pins**, after the amendment above:
+
+- a condition active at the moment of suspension survives a process restart and
+  an `Answer` from a different process — asserted on the rage's *durable* fields
+  (`TurnsActive`, `WasHitThisTurn`, `DidAttackThisTurn`), because mere presence
+  is what a rage reconstructed from scratch would also satisfy ✅;
+- every write verb leaves the character store byte-identical, including the one
+  that suspends and the `Answer` that resumes it ✅;
+- a character carrying a condition this build cannot parse joins successfully
+  and is **still stored intact** — the case where not-writing is load-bearing
+  rather than tidy ✅;
+- the boundary test still rejects `*character.Character` while admitting
+  `character.Data` as a contract type with a recorded reason ✅ (step 1).
+
+**Moved to wave 4, for the same reason as the save:** *one shared bus per call,
+proven by a condition on member A observing an event about member B* (*mutation:
+per-entity buses*). Nothing publishes to the bus in this wave, so a per-entity
+bus is indistinguishable from a shared one — the mutant survives by default and
+the pin proves nothing. It becomes writable the moment something publishes.
+
+Already pinned in wave 2 and unchanged here: enumeration order at a checkpoint
+is a function of persisted data rather than subscription order (C8).
 
 ---
 
@@ -241,7 +295,7 @@ This is the wave rpg-api migrates on.
 
 ## Wave 5 — reactions
 
-Opportunity attack on the wave-2 spine, closing #916. Reaction economy, and the
+Opportunity attack on the wave-2 spine. Reaction economy, and the
 cross-doorway threat question — which is blocked on the perception wave that
 retires T3, and may push that wave ahead of this one.
 

--- a/rulebooks/dnd5e/session/conditions_test.go
+++ b/rulebooks/dnd5e/session/conditions_test.go
@@ -1,0 +1,245 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// Durable condition state across a suspension.
+//
+// Wave 2 established that no Go stack survives a wait: a suspension drops every
+// entity, and Answer reloads from data. That turns a question the design could
+// have deferred into an invariant it must honour — if a condition's durable
+// state does not round-trip through the character's own blob, a suspension
+// quietly ends the rage.
+//
+// WHAT THESE TESTS PIN, EXACTLY: that the SDK does not damage the host's stored
+// character. They do NOT claim a condition intercepted anything during a verb,
+// because as of this wave nothing in the composition publishes to the bus and
+// no read verb reports a character's active conditions — so "the condition
+// behaved" has no observable consequence to assert. Claiming it here would be
+// the kind of comment that survives its own mutant. Behaviour is pinned in the
+// wave that gives it something to observe.
+//
+// The guarantee this file does carry is the one that is load-bearing right now,
+// and it is a negative: a verb leaves the character store byte-for-byte as it
+// found it. That matters because character.LoadFromData drops conditions it
+// cannot parse and Character.ToData drops conditions it cannot serialise, both
+// silently and with no error (toolkit#948). While the SDK only reads, a corrupt
+// blob stays corrupt but stays WHOLE. The moment the SDK writes a character
+// back, that loss becomes permanent on an ordinary walk. So "we do not write
+// yet" is a data-safety property, not an omission, and it is pinned as one.
+type ConditionsTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+	mgr        *session.Manager
+}
+
+func TestConditionsSuite(t *testing.T) {
+	suite.Run(t, new(ConditionsTestSuite))
+}
+
+func (s *ConditionsTestSuite) SetupTest() {
+	s.sessions = newFakeSessions()
+	s.encounters = newFakeEncounters()
+	s.characters = newFakeCharacters(ragingDwarf("alice"), dwarfCharacter("bob"))
+	s.mgr = s.managerOverStores(s.sessions, s.encounters, s.characters)
+
+	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: ambushWorld(s.T()),
+	})
+	s.Require().NoError(err)
+}
+
+func (s *ConditionsTestSuite) SetupSubTest() { s.SetupTest() }
+
+func (s *ConditionsTestSuite) managerOverStores(
+	sessions *fakeSessions, encounters *fakeEncounters, characters *fakeCharacters,
+) *session.Manager {
+	mgr, err := session.NewManager(&session.Config{
+		Sessions: sessions, Encounters: encounters,
+		Characters: characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+	return mgr
+}
+
+// ragingDwarf is Alice mid-rage, with the durable state a rage actually carries.
+//
+// The fields are deliberately non-zero and non-default: TurnsActive 2 rather
+// than 0, both this-turn flags set. A round-trip that reconstructed a rage from
+// scratch would produce zeroes here and pass any test that only asked "is she
+// still raging".
+func ragingDwarf(id string) *character.Data {
+	data := dwarfCharacter(id)
+	raging := &conditions.RagingCondition{
+		CharacterID:       id,
+		DamageBonus:       2,
+		Level:             3,
+		Source:            refs.Features.Rage().String(),
+		TurnsActive:       2,
+		WasHitThisTurn:    true,
+		DidAttackThisTurn: true,
+	}
+	blob, err := raging.ToJSON()
+	if err != nil {
+		panic("building the raging fixture: " + err.Error())
+	}
+	data.Conditions = []json.RawMessage{blob}
+	return data
+}
+
+// storedBytes is the character exactly as the host holds it.
+func (s *ConditionsTestSuite) storedBytes(id string) []byte {
+	data, ok := s.characters.byID[id]
+	s.Require().True(ok, "the store holds %q", id)
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+	return raw
+}
+
+func (s *ConditionsTestSuite) walkIntoTheAmbush(mgr *session.Manager) *session.MoveOutput {
+	out, err := mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().NoError(err)
+	return out
+}
+
+// TestAVerbLeavesTheCharacterStoreUntouched is the no-clobber pin.
+//
+// Every write verb, including the one that suspends. Byte comparison rather
+// than a field-by-field check on purpose: the failure this guards against is a
+// well-meaning SaveCharacter added to the write path, and ToData stamps
+// UpdatedAt with time.Now() on every call — so an unconditional save changes
+// the bytes even when it changes no game state. A field-wise assertion chosen
+// by whoever added the save would likely skip that field and pass.
+func (s *ConditionsTestSuite) TestAVerbLeavesTheCharacterStoreUntouched() {
+	ctx := context.Background()
+
+	s.Run("join", func() {
+		before := s.storedBytes("bob")
+		_, err := s.mgr.Join(ctx, &session.JoinInput{
+			Session: "sess", Member: "bob", Kind: session.KindPlayer,
+			Room: "hall", Position: spatial.Position{X: 0, Y: 0},
+		})
+		s.Require().NoError(err)
+		s.Equal(string(before), string(s.storedBytes("bob")))
+	})
+
+	s.Run("move that suspends", func() {
+		before := s.storedBytes("alice")
+		out := s.walkIntoTheAmbush(s.mgr)
+		s.Require().NotNil(out.Pending, "this walk is supposed to suspend")
+		s.Equal(string(before), string(s.storedBytes("alice")))
+	})
+
+	s.Run("answer that resumes", func() {
+		out := s.walkIntoTheAmbush(s.mgr)
+		s.Require().NotNil(out.Pending)
+		before := s.storedBytes("alice")
+		_, err := s.mgr.Answer(ctx, &session.AnswerInput{
+			Session: "sess", Window: out.Pending.Window,
+			Member: "alice", Option: string(session.OptionContinue),
+		})
+		s.Require().NoError(err)
+		s.Equal(string(before), string(s.storedBytes("alice")))
+	})
+}
+
+// TestTheRageSurvivesSuspensionRestartAndAnswer is the wave-2 invariant applied
+// to an entity, and the closest a test gets to the real failure: the answer
+// arrives from a process that never saw the walk begin.
+//
+// All three stores round-trip through JSON, so the resumed manager shares no
+// pointer with the one that suspended. The assertion is on the DURABLE fields
+// rather than on "a condition is present", because presence is what a
+// reconstructed-from-scratch rage would also satisfy.
+func (s *ConditionsTestSuite) TestTheRageSurvivesSuspensionRestartAndAnswer() {
+	ctx := context.Background()
+
+	out := s.walkIntoTheAmbush(s.mgr)
+	s.Require().NotNil(out.Pending)
+
+	sessions, encounters, characters := s.roundTripAllStores()
+	restarted := s.managerOverStores(sessions, encounters, characters)
+
+	pending, err := restarted.Pending(ctx, &session.PendingInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Require().Len(pending.Windows, 1, "the window outlived the process")
+
+	resumed, err := restarted.Answer(ctx, &session.AnswerInput{
+		Session: "sess", Window: pending.Windows[0].Window,
+		Member: "alice", Option: string(session.OptionContinue),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resumed.Steps, 1, "the walk picked up where it stopped")
+
+	stored, ok := characters.byID["alice"]
+	s.Require().True(ok)
+	s.Require().Len(stored.Conditions, 1, "she is still raging on the far side")
+
+	var got conditions.RagingData
+	s.Require().NoError(json.Unmarshal(stored.Conditions[0], &got))
+	s.Equal(refs.Conditions.Raging().String(), got.Ref.String())
+	s.Equal(2, got.TurnsActive, "the rage remembers how long it has run")
+	s.True(got.WasHitThisTurn, "and what happened to her during it")
+	s.True(got.DidAttackThisTurn)
+	s.Equal(2, got.DamageBonus)
+	s.Equal(3, got.Level)
+	s.Equal(refs.Features.Rage().String(), got.Source)
+}
+
+// roundTripAllStores marshals all three repositories through JSON into fresh
+// ones — as close as a test gets to "a different process picked this up".
+//
+// The character store is included deliberately. Without it the resumed manager
+// would read from the same map the suspended one wrote to, and every claim
+// about a condition surviving would be a claim about a pointer that never went
+// anywhere.
+func (s *ConditionsTestSuite) roundTripAllStores() (*fakeSessions, *fakeEncounters, *fakeCharacters) {
+	sessions := newFakeSessions()
+	for id, data := range s.sessions.byID {
+		var reloaded session.SessionData
+		s.requeueJSON(data, &reloaded)
+		sessions.byID[id] = &reloaded
+	}
+
+	encounters := newFakeEncounters()
+	for id, data := range s.encounters.byID {
+		var reloaded encounter.EncounterData
+		s.requeueJSON(data, &reloaded)
+		encounters.byID[id] = &reloaded
+	}
+
+	characters := newFakeCharacters()
+	for id, data := range s.characters.byID {
+		var reloaded character.Data
+		s.requeueJSON(data, &reloaded)
+		characters.byID[id] = &reloaded
+	}
+	return sessions, encounters, characters
+}
+
+func (s *ConditionsTestSuite) requeueJSON(from any, into any) {
+	raw, err := json.Marshal(from)
+	s.Require().NoError(err)
+	s.Require().NoError(json.Unmarshal(raw, into))
+}

--- a/rulebooks/dnd5e/session/conditions_test.go
+++ b/rulebooks/dnd5e/session/conditions_test.go
@@ -243,3 +243,41 @@ func (s *ConditionsTestSuite) requeueJSON(from any, into any) {
 	s.Require().NoError(err)
 	s.Require().NoError(json.Unmarshal(raw, into))
 }
+
+// TestACharacterTheSDKCannotFullyLoadIsStillNotDamaged is where the no-clobber
+// property earns its keep.
+//
+// Alice's blob carries a condition this build cannot parse — a ref from a
+// module that is not installed, a body written by a newer version, a partial
+// write. character.LoadFromData does not reject her: it logs, drops the
+// condition, and returns a perfectly usable character with no error. The join
+// therefore SUCCEEDS, and nothing in the response hints that anything was lost.
+//
+// That is toolkit#948, and it is only latent because the SDK does not write.
+// The store still holds both conditions afterwards, so whatever could not be
+// read here is still there to be read by a build that understands it. Add a
+// SaveCharacter to this path and the unreadable condition is gone forever,
+// destroyed by a verb that merely moved somebody.
+func (s *ConditionsTestSuite) TestACharacterTheSDKCannotFullyLoadIsStillNotDamaged() {
+	corrupt := ragingDwarf("dave")
+	corrupt.Conditions = append(corrupt.Conditions,
+		json.RawMessage(`{"ref":"homebrew:conditions:hexed","character_id":"dave","stacks":3}`))
+	s.characters.byID["dave"] = corrupt
+
+	before := s.storedBytes("dave")
+
+	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "dave", Kind: session.KindPlayer,
+		Room: "hall", Position: spatial.Position{X: 0, Y: 0},
+	})
+	s.Require().NoError(err, "the unreadable condition does not fail the join — that is the trap")
+
+	s.Equal(string(before), string(s.storedBytes("dave")),
+		"and the condition this build could not read is still in the store")
+
+	var held []json.RawMessage
+	s.Require().NoError(json.Unmarshal(s.storedBytes("dave"), &struct {
+		Conditions *[]json.RawMessage `json:"conditions"`
+	}{Conditions: &held}))
+	s.Require().Len(held, 2, "both conditions, including the one we cannot parse")
+}


### PR DESCRIPTION
Wave 3 step 2. Closes the invariant wave 2 forced: **durable condition state survives a suspension, a process restart, and an `Answer` from a process that never saw the walk begin.**

The wave's remaining goal was "conditions across a suspension." Investigating how to pin that turned up *why* it holds — and it is not the mechanism T3.4 described.

## The finding

T3.4 specified `load → attach → act → ToData() → save`. Building it showed the write is the dangerous half, and this wave does not need it.

**Nothing in wave 3 mutates a character.** No damage, no condition-applying verb, and the composition publishes nothing to the bus — so an attached condition has nothing to react to. A save would persist a character identical to the one loaded.

**But the save is not inert.** `character.LoadFromData` drops conditions it cannot parse, and `Character.ToData` has its own skip for conditions it cannot serialise — both silently, both returning no error. Measured across three corruption modes:

| input | conditions in | loaded | persisted | error |
|---|---|---|---|---|
| unknown ref | 2 | 1 | 1 | `nil` |
| malformed JSON | 2 | 1 | 1 | `nil` |
| real ref, wrong-typed body | 2 | 1 | 1 | `nil` |

That is #948, whose load-half framing was itself too narrow — commented there with the measurements.

While the SDK only reads, a blob it cannot fully parse **stays whole** in the host's store. A `SaveCharacter` in the write path turns that into permanent loss on an ordinary walk. `ToData` also stamps `UpdatedAt` with `time.Now()`, so the write is not even inert on a character nothing touched.

**So "we do not write yet" is a data-safety property, not an omission, and this PR pins it as one.**

## What ships

Test-only. No production code changes.

- **every write verb leaves the character store byte-identical** — `Join`, the `Move` that suspends, and the `Answer` that resumes it. Byte comparison rather than field-wise, because `UpdatedAt` is exactly the field whoever adds the save would forget to assert on.
- **the rage survives suspension → restart → `Answer`.** All three stores round-trip through JSON, so the resumed manager shares no pointer with the one that suspended. Asserted on the *durable* fields — `TurnsActive`, `WasHitThisTurn`, `DidAttackThisTurn`, `DamageBonus`, `Level`, `Source` — because presence alone is what a rage reconstructed from scratch would also satisfy.
- **a character carrying an unparseable condition joins successfully and is still stored intact.** This is where not-writing is load-bearing rather than tidy.

The character store is included in the restart round trip deliberately: the existing harness rebuilds the manager with a *fresh* character store, so any claim about a condition surviving would otherwise be a claim about a pointer that never went anywhere.

## Mutants

3 authored, 3 killed.

1. `SaveCharacter` after the load in `Join` → killed (`updated_at` stamped, `inventory: null → []`).
2. **The walk loads the walker and writes it back — T3.4 exactly as originally written** → killed.
3. Mutant 1 against the corrupt-condition pin → killed, and its output is the demonstration: `homebrew:conditions:hexed` simply gone from the persisted blob.

## What this PR deliberately does not claim

The tests do **not** assert that a condition intercepted anything during a verb. Nothing publishes to the bus and no read verb reports active conditions, so "the condition behaved" has no observable consequence — an assertion would pass whether the condition attached or not. Claiming it would be the kind of comment that survives its own mutant, which is the lesson #949's mutation round already taught once.

Two plan pins move to wave 4 for that reason, annotated in `plan.md` with the reasoning rather than quietly dropped: the *"still behaving after save and reload"* pin with its `Cleanup` mutant, and *"one shared bus per call, proven by a condition on A observing an event about B."* Both need a publisher or a writer to be falsifiable. **#948 becomes a prerequisite for wave 4**, not a follow-up to it.

Also drops the two stale `closes #916` references — that issue was closed 2026-08-13. The wave 5 deliverable is unchanged; only the dangling reference is gone.

## Verification

`./scripts/verify.sh rulebooks/dnd5e/session` — build ✓, **143 tests** ✓, vet ✓, gofmt ✓, lint ✓ (no `nolint`), transcripts re-proved ✓.

## Still open for the rest of wave 3

Two upstream gaps found while scoping T3.3, neither addressed here:

- **NPCs cannot join by ID.** `MemberData` persists `{ID, Kind, Room, Position}` — a monster member does not record *which* monster it is, so nobody can rehydrate it, us included. The registry (`monsters.ByRef`) is ready; it needs a ref on the encounter member.
- **`ConditionBehavior` cannot name itself.** The interface is `IsApplied/Apply/Remove/ToJSON` with no `Ref()`, so reporting a character's active conditions at the seam would mean unmarshalling `ToJSON()` and reading the `ref` field — the exact payload-interpretation anti-pattern #941 already files against us.

Refs #945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler