### PR TITLE
docs: make the play/ layering discoverable, and charter wave 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,41 @@ and never imports rpg-api or rpg-api-protos.
 - `docs/how-to/` — task guides: run-tests, add-a-mechanic, add-a-rulebook-entry, fix-go-mod-replace-directives, verified-transcripts (show a module working as designed: `./scripts/verify.sh <module>`)
 - `docs/archive/` — genuine archive: pre-Dec-2025 design docs, diagrams, guides that no longer reflect current architecture. Read for historical context only.
 
+## How live play is layered
+
+Three kinds of package. The difference between them is a real contract, not a
+naming convention — and knowing which kind you are in answers most "where does
+this go?" questions on its own.
+
+- **`play/*` — composable leaves.** One concern each, deliberately ignorant of
+  everything else. Each depends only on `core`, takes no `context.Context`,
+  **returns its results as values and never publishes**, and is bound by a
+  numbered contract (R1–R10) in `docs/ideas/play/<name>/design.md`. They never
+  interpret what they hold: the ledger does not read the payload, the intel
+  store cannot tell a lie from the truth, the clock holds no rules and no
+  randomness. See `play/README.md`.
+
+- **A composition.** The **courier** between leaves, and the first layer allowed
+  to have an opinion about the game. Rules and trigger detection belong here.
+  Each carries its own numbered laws.
+
+- **A host seam.** The one interface a game server implements: verbs take IDs,
+  repositories are key-value, no runtime object crosses the boundary. It owns
+  **no** rules.
+
+Which packages currently play which part is the rulebook's own business — see
+that rulebook's `CLAUDE.md` (for D&D 5e, `rulebooks/dnd5e/CLAUDE.md`).
+
+The direction that matters: **each layer absorbs wiring so the layer beneath it
+does not have to.** The seam spares the host the composition's complexity; the
+composition spares the leaves the bus, the persistence, and each other. A
+rule that appears in `play/` or in a seam is a layering bug, not a shortcut.
+
+**Read the package's godoc before designing anything in this area** — every one
+of these states its own contract in `doc.go`, names the laws that bind it, and
+points at its design doc. That is the discoverable surface; this section only
+tells you the shape so you know to go looking.
+
 ## RPG Toolkit Development Guidelines
 
 ## Slash Commands for Common Workflows

--- a/docs/ideas/session-sdk/plan.md
+++ b/docs/ideas/session-sdk/plan.md
@@ -336,7 +336,78 @@ machine **from its first line**, even though nothing suspends until wave 5 —
 `ReactionTriggerEvent` happened because attack resolution was a straight-line
 function, and this is the one lesson that must not be relearned.
 
-This is the wave rpg-api migrates on.
+**rpg-api does NOT migrate here.** That was the original plan and Kirk retired it
+on 2026-08-13: integration comes after the session package runs free roam *and*
+combat, and there is no adapter to the old encounter — a wrapper would dictate
+what the session contract looks like. See `sessions/active.md` in rpg-project.
+
+### The charter — what to deflect, what to ponder
+
+**Goal: combat the encounter *composes*, not combat the encounter *implements*.**
+
+**1 — Every combat action is a load-act-save.** No fight object alive between
+requests, exactly as there is no session process (S4).
+*Deflect:* anything holding combat state across calls, or needing a subscriber
+still listening next request.
+*Ponder:* what must be in the persisted shape for the **next** action to be
+decidable without replaying this one.
+
+**2 — The encounter owns the wiring; combat owns the rules.** The model is
+`play/clock`: a leaf that returns milestones as values and **never publishes**,
+with the composition as courier. Today `combat` is the inverse —
+`NewTurnManager` *requires* an `EventBus` and publishes `TurnStartEvent`/
+`TurnEndEvent` itself.
+*Deflect:* new code making combat responsible for who hears about it.
+*Ponder:* how much of combat's bus use is genuinely **rules** (conditions
+intercepting a chain — real and load-bearing) versus **notification** (the
+encounter's job). This clause is not free: 3,362 lines are built around that
+bus and ADR-0027's reaction windows are bus-shaped. It is the ponder, not a
+foregone conclusion.
+
+**3 — Resolution is a re-enterable phase machine from line one.** This is the
+*same* design as clause 2, not an extra constraint: a resolution returning its
+phases as values has no stack to preserve, which is why a frozen resolution can
+be "a value, never a goroutine and never a stack" (S7) and outlive its process.
+*Deflect:* "we'll make it re-enterable when reactions land in W5" — precisely
+how `ReactionTriggerEvent` happened.
+*Ponder:* where the phase boundaries actually fall.
+
+**4 — Ownership is already assigned. Do not relitigate.** `play/clock` owns
+clocks and transfers, holds no rules and no randomness (R7). The composition
+owns trigger detection. The rulebook owns the rolls. The session owns none of it.
+*Deflect:* any rule landing in `play/*` or in `session` — including the one
+currently sitting in `runWalk`.
+*Ponder:* only the trigger's shape. That part is genuinely ours and genuinely open.
+
+**5 — Composable means usable apart.** The test is not "is it layered" but
+"could someone use `combat` without `encounter`, or `encounter` without
+`session`?"
+*Deflect:* convenience methods fusing two concerns because one caller wanted one
+call.
+*Ponder:* the smallest honest input to a combat action.
+
+**6 — Shape for N, build for 1.** Bubbles persist as a **list** while policy
+allows one; "whose turn is it" is **clock-scoped** while there is one clock.
+*Deflect:* a top-level `ActiveActor()` on the encounter or the session.
+*Ponder:* nothing. This one is discipline.
+
+### Scope (Kirk, 2026-08-13)
+
+**In:** the world `Tick` plus **one** `Turn` bubble, with `Transfer` in and
+`Dissolve` out. Turn clocks stay linear within an encounter — it keeps the party
+together, and the v1 feature that buys is real: *a player off picking a lock or
+searching for treasure joins the fight at a rolled slot mid-round, instead of
+waiting it out.* That is `Transfer`, and `play/clock` already does it.
+
+**Concurrency:** pessimistic, via Redis — a lock with a buffer and timeout covers
+the simple cases. It arrives as an optional capability the manager type-asserts
+for (`SessionLocker`), **never** as a method added to `SessionRepository`, which
+would stop every host compiling. The optimistic/checksum door stays documented
+and open in `session/repositories.go` but is not being built.
+
+**Out, but shaped for:** multiple bubbles, for branching/non-linear dungeons.
+
+**Out:** rpg-api integration; reactions and opportunity attacks (wave 5).
 
 ---
 

--- a/play/README.md
+++ b/play/README.md
@@ -1,0 +1,82 @@
+# `play/` — the composable pieces of live play
+
+o/ Hi. If you landed here trying to work out how a walk, a fight, or "wait,
+what did that goblin actually *see*?" gets modelled, this is the right floor of
+the building.
+
+`play/` holds the **leaves**: small modules that each own exactly one concern
+about a game in motion and know nothing about each other. None of them know what
+D&D is. None of them can tell you what happened in your game — they hold the
+pieces that something above them assembles into an answer.
+
+## The four
+
+| Package | Owns | Deliberately does *not* |
+|---|---|---|
+| **`clock`** | Who may act, and what advances time. Two clocks: `Tick`, the player-driven world clock, and `Turn`, a localized initiative bubble — plus `Transfer`, which moves an entity between them atomically. | Decide *when* a bubble should form. Trigger detection belongs to the composition. It also contains no randomness — orderings arrive from the caller. |
+| **`intel`** | What each observer *believes*: channel-sourced holdings that may be false, may be stale. Deciders consult their own intel and nothing else. | See the world, or verify anything. Illusions, disguises and planted lies are ordinary testimony here. |
+| **`interrupt`** | Custody of open windows — a resolution that stopped and is waiting on an outside decision, frozen as an opaque value. | Interpret an option, a choice, or a single byte of a payload. Custody, not execution. |
+| **`record`** | The retained story: append-only, sequence-ordered, audience-projected, tag-queryable entries. | Interpret an entry, or stream it. Payloads and tag vocabularies belong to the composition. |
+
+## What all four promise
+
+"Leaf" means the same thing in every one of them:
+
+- depends only on `core` and the standard library
+- takes no `context.Context`
+- **returns its results as values, and never publishes to a bus**
+- is atomic per verb — on a non-nil error, state is unchanged
+- round-trips its state through `ToData` / `Load…`, and rejects invalid state on load
+- contains no randomness
+- carries a **numbered design contract, R1–R10**, in `docs/ideas/play/<name>/design.md`
+
+That last one is worth knowing about before you argue with one of these modules:
+the rules are numbered, and the code cites them by number. If a comment says
+`(R6)`, there is a specific sentence in a specific design doc it is pointing at.
+
+## Why leaves, and why they never publish
+
+Because a game that stops has to be able to start again.
+
+Everything above these modules is load-act-save: a request loads state, acts,
+saves, and dies with the response. Nothing is held between calls. A module that
+returned its results by publishing to a bus would need a live subscriber at the
+moment it ran — which is exactly the thing that does not survive a process
+restart. A module that returns values doesn't care: the value gets persisted, and
+the answer can arrive days later on a different machine.
+
+This is also why `interrupt` freezes a suspended resolution as a *value* rather
+than a goroutine or a stack. No stack means nothing to preserve.
+
+## Where they get assembled
+
+A **composition** is the courier. For D&D 5e that is `rulebooks/dnd5e/encounter`:
+it surveils percepts into intel, lets deciders act on their own intel, appends
+the story to record, and pumps the clock. The composition is the first layer
+allowed to have an opinion about the game — rules and trigger detection live
+there, never down here.
+
+Above that sits a **host seam** (`rulebooks/dnd5e/session`), which is what a game
+server actually talks to.
+
+Each layer absorbs wiring so the layer beneath it doesn't have to.
+
+## A worked example
+
+`clock/dos2_test.go` runs the Divinity: Original Sin 2 split-party scenario end
+to end, and it is the fastest way to understand what these modules feel like in
+combination:
+
+1. Four players and a goblin are on the world clock, free-roaming.
+2. Alice and Bob pick a fight. A `Turn` bubble forms around the three of them.
+3. **The distant pair keeps exploring** — their own moves keep advancing the
+   world clock while the fight runs. They are not paused, and they are not in
+   the fight.
+4. Carl wanders too close and `Transfer`s into the bubble mid-round, at a slot
+   the rulebook chose.
+5. The round wraps with Carl in the order.
+6. The fight ends. `Dissolve` hands back the members, and everyone re-homes to
+   the world clock.
+
+The test asserts the full milestone transcript, so it doubles as the
+specification for what each verb emits.

--- a/rulebooks/dnd5e/CLAUDE.md
+++ b/rulebooks/dnd5e/CLAUDE.md
@@ -2,6 +2,38 @@
 
 This document contains patterns specific to the dnd5e rulebook module.
 
+## Live play — who plays which part
+
+The three-kind layering is described in the root `CLAUDE.md` ("How live play is
+layered"). In this rulebook the parts are currently cast like this:
+
+- **`encounter/` is the composition** — a composable approach to encounter
+  tracking. It is the courier between the `play/*` leaves (`clock`, `intel`,
+  `interrupt`, `record`) and `tools/spatial`: it surveils percepts into intel,
+  lets deciders act on their own intel, appends the story to record, and pumps
+  the clock. **Game rules and trigger detection belong here** — it is the first
+  layer allowed an opinion about D&D. Laws C1–C8, plus anchoring W1–W5.
+
+- **`session/` is the host seam** — rpg-api's one interface to the toolkit.
+  Verbs take IDs, repositories are key-value (S12), every verb loads-acts-saves
+  with no session process (S4), and no runtime object crosses the boundary (S2,
+  enforced by `TestNoInnerTypeCrossesTheBoundary`). **It owns no rules.** A rule
+  found here is misplaced, not convenient.
+
+- **`combat/`, `character/`, `conditions/`, `features/` … are the rules.** They
+  know what Rage does. They do not know what a session is.
+
+**Time, turns, and "whose turn is it" are not this rulebook's invention.** They
+live in `play/clock`: `Tick` is the player-driven world clock, `Turn` is a
+localized initiative bubble, and `Transfer` moves an entity between them
+atomically under R6 (an entity belongs to at most one clock). There is no
+`Mode` enum anywhere in the new stack, and `FREE_ROAM`/`TURN_BASED` is an
+artifact of the *old* encounter module rather than a D&D concept. Read
+`play/README.md` and `play/clock`'s godoc before designing anything that
+touches turns, rounds, or initiative — the vocabulary already exists.
+
+_(`initiative/` in this module is dead — imported by nothing. `play/clock` superseded it.)_
+
 ## Refs Pattern
 
 **Everything has a Ref.** All identifiable content (features, conditions, combat abilities, actions, weapons, etc.) must have a `*core.Ref` with `{Module, Type, ID}`.


### PR DESCRIPTION
Closes #954

The `play/*` family is the composable foundation of live play, and each of those
packages already states its contract well in `doc.go`. The gap was upstream:
**nothing pointed at the layer.** The root `CLAUDE.md` did not contain the string
`play/` anywhere, so finding it required already knowing it existed.

The cost is measured, not hypothetical — see #954 for the full account. Short
version: a design session spent a turn deriving a clock/mode model from first
principles when `play/clock` already had all of it, and separately reported a gap
in `rulebooks/dnd5e/initiative` without noticing nothing imports it.

## Three surfaces, three readers

**Root `CLAUDE.md` — the shape only.** Three kinds of package (leaf /
composition / host seam), the contract each implies, and the rule that each
layer absorbs wiring so the layer beneath it need not. Which packages currently
play which part is deliberately *not* here — that is the rulebook's business and
it changes.

**`rulebooks/dnd5e/CLAUDE.md` — the current casting.** `encounter/` is the
composition, `session/` is the host seam, `combat/` and friends are the rules.
Plus three facts that were costing time:

- turns, rounds and initiative are **`play/clock`'s**, not this rulebook's
- there is **no `Mode` enum** in the new stack — `FREE_ROAM`/`TURN_BASED` is an
  artifact of the *old* encounter module, not a D&D concept
- `initiative/` is **dead**, superseded by `play/clock`

**`play/README.md` — for a human arriving cold.** What each of the four leaves
owns, what it deliberately refuses to do, the shared leaf promise, *why* they
never publish (load-act-save cannot rely on a live subscriber still being there),
and `dos2_test.go` walked through as the worked example.

## Also: wave 4 is chartered

`docs/ideas/session-sdk/plan.md` gains a charter for the combat wave — six
clauses, each split into **what to deflect** and **what to ponder**, so most of
the wave's arguments become deflections and the three genuinely open questions
stay visible.

It also corrects a line that is now false: **rpg-api does not migrate on wave 4.**
Kirk retired that on 2026-08-13 — integration comes after the session package
runs free roam *and* combat, and there is no adapter to the old encounter,
because a wrapper would dictate what the session contract looks like.

## Scope

Markdown only. No code touched, no behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler