### PR TITLE
docs: route monster behavior work to the decider seam

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -1,0 +1,175 @@
+# encounter
+
+The D&D 5e **composition**: the module that turns the `play/*` leaves into a
+world you can actually play in.
+
+If you are here to write **monster behavior**, skip to
+[Writing a decider](#writing-a-decider). That is the seam, and it is the whole
+job.
+
+## What it is
+
+An encounter is a composition with an outcome — Setup → play → Outcome. It is
+the **courier** between `play/clock`, `play/intel`, `play/record` and
+`tools/spatial`: it surveils percepts into intel, lets deciders act on their own
+intel, appends the story to record, and pumps the clock.
+
+It is also the first layer allowed to have an opinion about D&D. Rules and
+trigger detection belong here. The leaves beneath it hold no rules, and the
+session seam above it holds no rules either.
+
+## What it is not
+
+- **Not a leaf.** It composes published modules and exposes one aggregate
+  persistence pair at the host seam. It is allowed dependencies the `play/*`
+  modules are not.
+- **Not the old `encounter` module.** The top-level `encounter/` package is the
+  previous generation — `NPCAct`, `Monster.TakeTurn`, `ModeFreeRoam` /
+  `ModeTurnBased`, a wired `CombatResolver`. That stack still runs the shipped
+  game. This one is what new work builds on. They do not share a world model,
+  and there is deliberately no adapter between them.
+- **Not the host's interface.** That is `rulebooks/dnd5e/session`.
+
+## Why it exists
+
+Because the interesting problems in live play are *compositions* of small
+guarantees, and those guarantees are much easier to keep honest when each one
+lives alone. Intel cannot lie to you about whether it is lying. A clock cannot
+accidentally contain a rule. A ledger cannot peek at the payload it is holding.
+Somebody still has to put them together — that is this module, and keeping the
+assembly in one place is what lets the pieces stay small.
+
+## Writing a decider
+
+**A decider is monster intelligence.** One method:
+
+```go
+type Decider interface {
+    Decide(snap Snapshot) (Intent, error)
+}
+```
+
+### You are given only what you know
+
+```go
+type Snapshot struct {
+    Room     string          // your own current room
+    Position spatial.Position // your own position within it
+    Holdings []intel.Holding  // your own held intel — nothing more
+}
+```
+
+That is the **anti-wall-hack contract (C2)**, and it is structural rather than a
+convention: there is no field on `Snapshot` that reaches the world or another
+member's live truth, so a decider cannot cheat even by accident. What it gets
+instead is *belief* — percepts that may be stale, and may be false. An illusion
+is ordinary testimony here. A monster chasing a player who moved away two ticks
+ago is behaving correctly.
+
+Note that the contract covers **placement**, not just sight: a decider learns
+where *it* stands, never where anyone else stands except through its own
+percepts.
+
+### You return an intent, not an action
+
+`Intent` is a sealed type — three today:
+
+| Intent | Means |
+|---|---|
+| `IntentMoveTo{To}` | walk to a position in my current room |
+| `IntentTraverse{Connection}` | cross a connection I am standing on |
+| `IntentHold{}` | do nothing this tick |
+
+You return what you *want*. The composition decides whether it happens and makes
+it happen. This is what keeps a decider testable: it is a pure function from a
+struct to a struct, and a unit test needs no encounter at all.
+
+### A worked example
+
+The pursuit decider from `pump_test.go`, which is about as much as a decider
+ever needs to do:
+
+```go
+func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
+    for _, h := range snap.Holdings {
+        if h.Subject != intel.Subject(p.target) {
+            continue
+        }
+        var seen encounter.SightPayload
+        if err := json.Unmarshal(h.Payload, &seen); err != nil {
+            return nil, err
+        }
+        // A percept in another room is out of this simple pursuer's reach.
+        if snap.Room != seen.Room {
+            return encounter.IntentHold{}, nil
+        }
+        // Standing exactly where the percept places them: try a door, else wait.
+        if snap.Position.X == seen.X && snap.Position.Y == seen.Y {
+            /* ... look for a connection at this cell ... */
+            return encounter.IntentHold{}, nil
+        }
+        return encounter.IntentMoveTo{To: spatial.Position{X: seen.X, Y: seen.Y}}, nil
+    }
+    return encounter.IntentHold{}, nil // never seen them — nothing to chase
+}
+```
+
+Read the last line carefully: **no percept means no pursuit.** The monster is not
+told the player is absent; it simply holds nothing about them. That falls out of
+the contract rather than being coded defensively.
+
+### What `Pump` guarantees you
+
+`Pump` advances the world one tick, and its ordering is the part worth knowing:
+
+- **Two phases.** *Every* decider is consulted before *anything* executes. So no
+  decider can observe another monster's move within the same tick — the pack does
+  not get a free turn order advantage, and you never have to reason about who was
+  polled first.
+- **Deterministic order.** Monsters act in stable `Members()` order.
+- **A decider error aborts the pump atomically.** No clock advance, no moves, no
+  record beats. Return an error only when you genuinely cannot decide.
+- **A rejected move does not abort.** A spatially illegal `IntentMoveTo`, or an
+  `IntentTraverse` naming an unknown connection or one you are not standing on,
+  just means that monster fails to act this tick. Everything else proceeds.
+- **Sight refreshes once**, after all actions — then one tick beat, then the
+  move/traverse beats in decision order.
+
+### What you cannot express yet
+
+**There is no attack intent.** Movement, pursuit, positioning, patrol, and
+traversal are all expressible today; attacking, targeting and the action economy
+are wave-4 work (see `docs/ideas/session-sdk/plan.md`). Worth knowing before
+choosing a first task — behavior that decides *where to be* is buildable now,
+behavior that decides *what to do to someone* is not.
+
+## Contents
+
+| File | Holds |
+|---|---|
+| `encounter.go` | the aggregate: setup, verbs, `Pump`, member management |
+| `decider.go` | `Decider`, `Snapshot`, `Intent` and its three implementations |
+| `atlas.go` | the read projection — absolute coordinates appear only here |
+| `field.go` | rooms, connections, and the per-verb output shapes |
+| `data.go` | `EncounterData` and the `ToData` / `LoadFromData` round trip |
+
+## Reading it
+
+Start with `doc.go` — it names the laws that bind this module (**C1–C8**, plus
+anchoring **W1–W5**) and points at the design contract in
+`docs/ideas/encounter/design.md`. Comments cite those laws by number, so `(C2)`
+in the source is pointing at a specific sentence.
+
+Then `example_tombwatch_test.go`, which narrates one member's beliefs as prose
+and is the fastest way to feel what intel does.
+
+For the layer above and below, see `play/README.md` and
+`rulebooks/dnd5e/session/README.md`.
+
+## Deliberately not here
+
+- **Clocks, turns, initiative.** `play/clock` owns those — `Tick` for the
+  world, `Turn` for a localized initiative bubble, `Transfer` between them. There
+  is no `Mode` enum in this stack.
+- **Storage.** The composition hands out data; the host persists it.
+- **Randomness in the leaves.** Orderings and rolls arrive from the rulebook.

--- a/rulebooks/dnd5e/monster/README.md
+++ b/rulebooks/dnd5e/monster/README.md
@@ -1,7 +1,33 @@
 # D&D 5e monsters: current guide
 
-This directory is the nearest orientation point for current monster work. It is
-inside the single `rulebooks/dnd5e` Go module.
+This directory is the nearest orientation point for monster **content** — stat
+blocks, actions, traits, refs. It is inside the single `rulebooks/dnd5e` Go
+module.
+
+> ### Working on monster *behavior*? Start somewhere else.
+>
+> Behavior has a new seam, and it is not `TakeTurn`. Read
+> **[`rulebooks/dnd5e/encounter/README.md`](../encounter/README.md)** →
+> *Writing a decider*.
+>
+> The short version: behavior is a `Decider` — one method, `Decide(Snapshot)
+> (Intent, error)`. A `Snapshot` gives you **your own room, your own position,
+> your own held intel and nothing else**, so a decider structurally cannot read
+> the world or another member's truth (the anti-wall-hack contract, C2). You
+> return an *intent* — move, traverse, or hold — and the composition decides
+> whether it happens. That makes a decider a pure function you can unit-test
+> with a plain struct and no encounter at all.
+>
+> **Honest limit:** there is no attack intent yet. Movement, pursuit, patrol and
+> traversal are expressible today; attacking and targeting are wave-4 work.
+>
+> Everything below about **`NPCAct`, `TakeTurn`, and the wired `CombatResolver`
+> describes the OLD encounter module** — the stack that runs the shipped game.
+> It is accurate about that stack and useful if you are working in it. It is not
+> what new work builds on, and the two do not share a world model.
+
+The **content** model below is current either way: a new monster still needs a
+factory, a canonical ref, actions and traits, whichever stack drives it.
 
 ## Current packages
 


### PR DESCRIPTION
Closes #957

A contributor is joining to work on **monster behavior**, and today they would
land on the old stack.

`rulebooks/dnd5e/monster/README.md` is the nearest orientation point, and it
describes `NPCAct`, `Monster.TakeTurn`, and the wired `CombatResolver`. It is a
careful, honest document — about the *previous* generation. It never mentions
`Decider`, `Snapshot`, `Intent`, `Pump`, or the `play/*` leaves. And
`rulebooks/dnd5e/encounter`, where the new behavior seam actually lives, had **no
README at all**.

## `encounter/README.md` (new)

House style, leading with the decider contract because for this job that *is* the
whole surface:

- **`Decide(Snapshot) (Intent, error)`** — one method.
- **A `Snapshot` is your own room, your own position, your own held intel, and
  nothing else.** The anti-wall-hack contract (C2) is structural, not a
  convention: there is no field that reaches the world or another member's truth,
  so a decider cannot cheat even by accident. What it gets instead is *belief* —
  stale or false percepts included. A monster chasing where the player *was* is
  behaving correctly.
- **`Intent` is sealed** — `MoveTo`, `Traverse`, `Hold`. You return what you
  *want*; the composition decides whether it happens. That is what makes a
  decider a pure struct→struct function, unit-testable with no encounter at all.
- **`Pump`'s two phases** — every decider is consulted *before* anything
  executes, so no decider observes another monster's move within the same tick,
  and you never reason about who was polled first.
- **Failure modes differ on purpose** — a decider error aborts the pump
  atomically; a spatially rejected move just means that monster fails to act.

It also includes the `pursuitDecider` from `pump_test.go` as a worked example,
with the point drawn out: *no percept means no pursuit* — the monster is never
told the player is absent, it simply holds nothing about them. That falls out of
the contract rather than being coded defensively.

**And it states the limit up front rather than letting it be discovered: there is
no attack intent yet.** Movement, pursuit, patrol and traversal are expressible
today; attacking, targeting and the action economy are wave-4 work. Better to
know that before choosing a first task.

## `monster/README.md` (edited)

Keeps its content model — a new monster still needs a factory, a canonical ref,
actions and traits whichever stack drives it. What changes is the opening: it now
separates *behavior* work (new seam, with a pointer) from *content* work, and
labels the `NPCAct`/`TakeTurn` material as the old stack rather than as current
instructions.

## Scope

Markdown only. No code touched, no behaviour changed. Note this bumps two modules
(`rulebooks/dnd5e` and `rulebooks/dnd5e/encounter`) since the tagger keys on the
module directory regardless of whether code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq

— asset-pipeline agent, on behalf of KirkDiggler