### PR TITLE
feat(encounter): bubble town — Form, Transfer, EndTurn, Dissolve (#963)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -134,6 +134,11 @@ the contract rather than being coded defensively.
   just means that monster fails to act this tick. Everything else proceeds.
 - **Sight refreshes once**, after all actions — then one tick beat, then the
   move/traverse beats in decision order.
+- **A monster in a fight is not consulted.** `Pump` is the world thinking, and
+  a monster caught in a turn bubble (`Form`) belongs to the fight, not the
+  world — its decider is skipped entirely until the fight dissolves or the
+  monster transfers out. Your decider never needs to detect "am I in combat";
+  if it is being asked, it is free-roaming.
 
 ### What you cannot express yet
 

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -4,10 +4,13 @@
 package encounter
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/KirkDiggler/rpg-toolkit/play/record"
 )
 
 // ClockKind names which kind of clock a member is on.
@@ -88,14 +91,16 @@ func (e *Encounter) ClockOf(in *ClockOfInput) (*ClockOfOutput, error) {
 		// answering ClockWorld without checking would make the two
 		// indistinguishable.
 		//
-		// This branch is UNREACHABLE through today's API and is not covered by
-		// a test, which is stated rather than implied: every construction seam
-		// joins the world clock, and load puts any member it finds on no clock
-		// onto it. It is here for the verbs arriving next — Transfer and
+		// This check is the net under the clock verbs. Form, Transfer, and
 		// Dissolve move members BETWEEN clocks, and the way that goes wrong is
-		// leaving somebody on neither. Without this check that bug reports
-		// "free roaming", which is a plausible answer and therefore the
-		// expensive kind of wrong. A test lands with the verb that can reach it.
+		// leaving somebody on neither — a failure mid-Dissolve, for example,
+		// returns with only some members re-homed to the world clock (doc.go:
+		// the mutate phase is not atomic, and the caller's obligation on error
+		// is to drop the encounter unsaved). Without this check that bug would
+		// report "free roaming", which is a plausible answer and therefore the
+		// expensive kind of wrong.
+		// TestClockOfReportsAMemberOnNoClockInsteadOfGuessing fabricates the
+		// exact defect this nets and pins the rejection.
 		onWorld, cerr := e.clock.Contains(&clock.ContainsInput{ID: core.EntityID(in.Member)})
 		if cerr != nil {
 			return nil, fmt.Errorf("clock_of %q world: %w", in.Member, cerr)
@@ -159,9 +164,393 @@ func (e *Encounter) leaveAnyClock(id MemberID) error {
 		return err
 	}
 	if bubble != nil {
-		_, rerr := bubble.Remove(&clock.RemoveInput{ID: core.EntityID(id)})
-		return rerr
+		if _, rerr := bubble.Remove(&clock.RemoveInput{ID: core.EntityID(id)}); rerr != nil {
+			return rerr
+		}
+		return e.dropBubbleIfIdle(bubble)
 	}
 	_, lerr := e.clock.Leave(&clock.LeaveInput{ID: core.EntityID(id)})
 	return lerr
+}
+
+// dropBubbleIfIdle removes b from the bubble list once its order has emptied.
+//
+// A bubble exists only while a fight does (see Encounter.bubbles). Exit and
+// Transfer can each drain a fight one member at a time, and the moment the
+// last member is gone the husk must go too: an idle bubble would persist as a
+// fight that is not happening, ToData would write it into every blob, and
+// LoadEncounter rejects exactly that shape at the trust boundary — the two
+// ends of the module must agree on what a bubble in a blob means.
+func (e *Encounter) dropBubbleIfIdle(b *clock.Turn) error {
+	order, err := b.Order()
+	if err != nil {
+		return err
+	}
+	if len(order) > 0 {
+		return nil
+	}
+	for i, x := range e.bubbles {
+		if x == b {
+			e.bubbles = append(e.bubbles[:i], e.bubbles[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// appendClockBeat records one clock-lifecycle story beat, heard by every
+// current member and stamped at the world clock's current reading — the same
+// audience-and-timestamp convention the membership beats use (Join, Exit).
+// Tag "clock" matches Pump's tick beat: one tag family for everything the
+// clocks do.
+func (e *Encounter) appendClockBeat(payload map[string]interface{}) (uint64, error) {
+	memberIDs := make([]MemberID, 0, len(e.members))
+	for id := range e.members {
+		memberIDs = append(memberIDs, id)
+	}
+	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
+
+	beatBytes, _ := json.Marshal(payload)
+	out, err := e.appendBeat(&record.AppendInput{
+		At:       uint64(e.clock.ToData().HighWater),
+		Audience: memberIDs,
+		Tags:     map[string]string{"tag": "clock"},
+		Payload:  beatBytes,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return out.Seq, nil
+}
+
+// FormInput carries the rulebook-rolled initiative order a new bubble starts
+// with.
+type FormInput struct {
+	// Order is the complete initiative order for the fight, first-to-act
+	// first. It comes from OUTSIDE: play/clock holds no randomness (R7) and
+	// this composition holds none either — the rulebook rolls initiative and
+	// hands the result in.
+	Order []MemberID
+}
+
+// FormOutput reports what forming the bubble appended to the story.
+type FormOutput struct {
+	// Seq is the story sequence of the formation beat.
+	Seq uint64
+}
+
+// Form starts a fight: the named members leave the world clock together and
+// become a turn bubble in the given order. Everyone NOT named stays on the
+// world clock and keeps free-roaming while the fight runs — a fight is
+// localized, and the rest of the encounter is not paused by it.
+//
+// Form does not decide WHEN a fight starts. Trigger detection is a later
+// step and is deliberately absent here: this verb is explicit and
+// caller-driven, and something else decides to call it.
+//
+// Policy today is ONE bubble per encounter — fights stay linear and the
+// party stays together. A second Form while a bubble runs is rejected with
+// ErrInBubble whether or not the two fights share a member; when that policy
+// lifts, the per-member overlap check below becomes the load-bearing one
+// (overlapping bubbles merge via a Merge verb then, but they never form).
+//
+// Errors: ErrNilInput, ErrClosed, ErrNoMember (empty order or a duplicated
+// entry), ErrNotMember (the order names somebody not in this encounter),
+// ErrInBubble.
+func (e *Encounter) Form(in *FormInput) (*FormOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("form: %w", ErrNilInput)
+	}
+	if e.outcome != nil {
+		return nil, fmt.Errorf("form: %w", ErrClosed)
+	}
+	if len(in.Order) == 0 {
+		return nil, fmt.Errorf("form: order is empty: %w", ErrNoMember)
+	}
+	seen := make(map[MemberID]bool, len(in.Order))
+	for _, id := range in.Order {
+		if seen[id] {
+			return nil, fmt.Errorf("form: %q appears twice in the order: %w", id, ErrNoMember)
+		}
+		seen[id] = true
+		if _, ok := e.members[id]; !ok {
+			return nil, fmt.Errorf("form: %q: %w", id, ErrNotMember)
+		}
+		bubble, err := e.bubbleFor(id)
+		if err != nil {
+			return nil, fmt.Errorf("form %q: %w", id, err)
+		}
+		if bubble != nil {
+			return nil, fmt.Errorf("form: %q: %w", id, ErrInBubble)
+		}
+	}
+	if len(e.bubbles) > 0 {
+		return nil, fmt.Errorf("form: a bubble is already running and policy is one per encounter: %w", ErrInBubble)
+	}
+
+	// Mutate. Validation above guarantees every named member is on the world
+	// clock (member + not-in-a-bubble + R6), so these cannot fail against a
+	// coherent encounter — but a failure here still returns, and the caller's
+	// obligation is doc.go's: drop the encounter unsaved.
+	for _, id := range in.Order {
+		if _, lerr := e.clock.Leave(&clock.LeaveInput{ID: core.EntityID(id)}); lerr != nil {
+			return nil, fmt.Errorf("form member %q world clock: %w", id, lerr)
+		}
+	}
+	bubble := &clock.Turn{}
+	if _, serr := bubble.SetOrder(&clock.SetOrderInput{Order: in.Order}); serr != nil {
+		return nil, fmt.Errorf("form set order: %w", serr)
+	}
+	e.bubbles = append(e.bubbles, bubble)
+
+	seq, err := e.appendClockBeat(map[string]interface{}{
+		"beat":  "bubble-formed",
+		"order": in.Order,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("form append beat: %w", err)
+	}
+	return &FormOutput{Seq: seq}, nil
+}
+
+// TransferInput moves one member between the world clock and the running
+// bubble, in either direction.
+type TransferInput struct {
+	// Member is who is being moved.
+	Member MemberID
+
+	// To names the DESTINATION clock kind explicitly. It is not inferred
+	// from where the member currently is: that would make the verb a
+	// toggle, and under load-act-save a toggle applied to stale state
+	// silently moves somebody the WRONG way instead of failing.
+	To ClockKind
+
+	// Pos is the slot the member lands at in the bubble's order, 0-based,
+	// and is only read when To is ClockTurn — the world clock is unordered,
+	// the same convention as the Membership seam's own JoinMember on a Tick.
+	Pos int
+}
+
+// TransferOutput reports what the transfer appended to the story.
+type TransferOutput struct {
+	// Seq is the story sequence of the transfer beat.
+	Seq uint64
+}
+
+// Transfer moves a member between the world clock and the running bubble —
+// the straggler who wandered too close falls in mid-round at a caller-chosen
+// slot, and someone the fight is done with steps back out without ending it.
+// R6 holds through the move: the underlying play/clock Transfer joins first
+// and compensates on failure, so a rejected transfer leaves both clocks
+// exactly as they were.
+//
+// The destination bubble is unambiguous while policy holds one bubble per
+// encounter; addressing a specific fight (through one of its members — a
+// bubble is never named) arrives with multiple bubbles.
+//
+// Errors: ErrNilInput, ErrClosed, ErrNoMember, ErrNotMember, ErrBadClock
+// (To names neither kind), ErrInBubble (To is ClockTurn but the member is
+// already fighting), ErrNoBubble (To is ClockTurn with no fight running, or
+// To is ClockWorld for a member not in one), and play/clock's own rejections
+// — an out-of-range Pos propagates clock.ErrBadPosition.
+func (e *Encounter) Transfer(in *TransferInput) (*TransferOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("transfer: %w", ErrNilInput)
+	}
+	if e.outcome != nil {
+		return nil, fmt.Errorf("transfer: %w", ErrClosed)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("transfer: %w", ErrNoMember)
+	}
+	if _, ok := e.members[in.Member]; !ok {
+		return nil, fmt.Errorf("transfer %q: %w", in.Member, ErrNotMember)
+	}
+	bubble, err := e.bubbleFor(in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("transfer %q: %w", in.Member, err)
+	}
+
+	switch in.To {
+	case ClockTurn:
+		if bubble != nil {
+			return nil, fmt.Errorf("transfer %q: %w", in.Member, ErrInBubble)
+		}
+		if len(e.bubbles) == 0 {
+			return nil, fmt.Errorf("transfer %q: no fight is running: %w", in.Member, ErrNoBubble)
+		}
+		if _, terr := clock.Transfer(&clock.TransferInput{
+			From: e.clock,
+			To:   e.bubbles[0],
+			ID:   core.EntityID(in.Member),
+			Pos:  in.Pos,
+		}); terr != nil {
+			return nil, fmt.Errorf("transfer %q into bubble: %w", in.Member, terr)
+		}
+	case ClockWorld:
+		if bubble == nil {
+			return nil, fmt.Errorf("transfer %q: %w", in.Member, ErrNoBubble)
+		}
+		if _, terr := clock.Transfer(&clock.TransferInput{
+			From: bubble,
+			To:   e.clock,
+			ID:   core.EntityID(in.Member),
+		}); terr != nil {
+			return nil, fmt.Errorf("transfer %q out of bubble: %w", in.Member, terr)
+		}
+		if derr := e.dropBubbleIfIdle(bubble); derr != nil {
+			return nil, fmt.Errorf("transfer %q prune bubble: %w", in.Member, derr)
+		}
+	default:
+		return nil, fmt.Errorf("transfer %q to %q: %w", in.Member, in.To, ErrBadClock)
+	}
+
+	seq, err := e.appendClockBeat(map[string]interface{}{
+		"beat":   "transferred",
+		"member": string(in.Member),
+		"to":     string(in.To),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transfer append beat: %w", err)
+	}
+	return &TransferOutput{Seq: seq}, nil
+}
+
+// EndTurnInput names the member ending their own turn in the fight they are
+// in.
+type EndTurnInput struct {
+	// Member is whose turn is ending. It must actually BE their turn —
+	// ending somebody else's is rejected by the bubble itself.
+	Member MemberID
+}
+
+// EndTurnOutput reports who acts next and whether the round wrapped.
+type EndTurnOutput struct {
+	// Next is whose turn it now is in the same bubble.
+	Next MemberID
+
+	// RoundWrapped is true when this end closed the round — the order
+	// cycled back to its first member and the bubble's round advanced.
+	RoundWrapped bool
+
+	// Seq is the story sequence of the turn-ended beat.
+	Seq uint64
+}
+
+// EndTurn advances the fight past the member's turn. This is the bubble's
+// own advancement — the world clock is untouched, and members outside the
+// fight never appear in it.
+//
+// Errors: ErrNilInput, ErrClosed, ErrNoMember, ErrNotMember, ErrNoBubble
+// (the member is not in a fight), and the bubble's own rejection when it is
+// not this member's turn (clock.ErrNotActive, with no state change).
+func (e *Encounter) EndTurn(in *EndTurnInput) (*EndTurnOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("end turn: %w", ErrNilInput)
+	}
+	if e.outcome != nil {
+		return nil, fmt.Errorf("end turn: %w", ErrClosed)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("end turn: %w", ErrNoMember)
+	}
+	if _, ok := e.members[in.Member]; !ok {
+		return nil, fmt.Errorf("end turn %q: %w", in.Member, ErrNotMember)
+	}
+	bubble, err := e.bubbleFor(in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("end turn %q: %w", in.Member, err)
+	}
+	if bubble == nil {
+		return nil, fmt.Errorf("end turn %q: %w", in.Member, ErrNoBubble)
+	}
+
+	out, err := bubble.End(&clock.EndInput{Actor: core.EntityID(in.Member)})
+	if err != nil {
+		return nil, fmt.Errorf("end turn %q: %w", in.Member, err)
+	}
+
+	seq, err := e.appendClockBeat(map[string]interface{}{
+		"beat":   "turn-ended",
+		"member": string(in.Member),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("end turn append beat: %w", err)
+	}
+	return &EndTurnOutput{
+		Next:         MemberID(out.Next),
+		RoundWrapped: out.RoundWrapped,
+		Seq:          seq,
+	}, nil
+}
+
+// DissolveInput names a member of the fight being ended. The bubble is
+// reached through a member — never addressed by name — which R6 makes a
+// total function.
+type DissolveInput struct {
+	// Member is anyone in the fight to dissolve.
+	Member MemberID
+}
+
+// DissolveOutput reports who the fight held and where the story recorded
+// its end.
+type DissolveOutput struct {
+	// Members is everyone the fight held, in bubble order, all re-homed to
+	// the world clock at budget zero.
+	Members []MemberID
+
+	// Seq is the story sequence of the dissolution beat.
+	Seq uint64
+}
+
+// Dissolve ends the fight holding the named member: the bubble empties and
+// every member re-homes to the world clock, at budget zero — time spent
+// fighting was spent, not banked.
+//
+// Errors: ErrNilInput, ErrClosed, ErrNoMember, ErrNotMember, ErrNoBubble
+// (the member is not in a fight). A failure while re-homing leaves members
+// between clocks — the window ClockOf's on-no-clock check nets — and the
+// caller's obligation is doc.go's: drop the encounter unsaved.
+func (e *Encounter) Dissolve(in *DissolveInput) (*DissolveOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("dissolve: %w", ErrNilInput)
+	}
+	if e.outcome != nil {
+		return nil, fmt.Errorf("dissolve: %w", ErrClosed)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("dissolve: %w", ErrNoMember)
+	}
+	if _, ok := e.members[in.Member]; !ok {
+		return nil, fmt.Errorf("dissolve %q: %w", in.Member, ErrNotMember)
+	}
+	bubble, err := e.bubbleFor(in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("dissolve %q: %w", in.Member, err)
+	}
+	if bubble == nil {
+		return nil, fmt.Errorf("dissolve %q: %w", in.Member, ErrNoBubble)
+	}
+
+	out, err := bubble.Dissolve(&clock.DissolveInput{})
+	if err != nil {
+		return nil, fmt.Errorf("dissolve: %w", err)
+	}
+	for _, id := range out.Members {
+		if _, jerr := e.clock.Join(&clock.JoinInput{ID: id}); jerr != nil {
+			return nil, fmt.Errorf("dissolve member %q world clock: %w", id, jerr)
+		}
+	}
+	if derr := e.dropBubbleIfIdle(bubble); derr != nil {
+		return nil, fmt.Errorf("dissolve prune bubble: %w", derr)
+	}
+
+	seq, err := e.appendClockBeat(map[string]interface{}{
+		"beat":    "bubble-dissolved",
+		"members": out.Members,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dissolve append beat: %w", err)
+	}
+	return &DissolveOutput{Members: out.Members, Seq: seq}, nil
 }

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -210,7 +210,16 @@ func (e *Encounter) appendClockBeat(payload map[string]interface{}) (uint64, err
 	}
 	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
 
-	beatBytes, _ := json.Marshal(payload)
+	// Unreachable for today's payloads (strings and ID slices marshal
+	// unconditionally), but this helper is the one seam every clock beat
+	// flows through — a future payload that cannot marshal must fail its
+	// verb loudly here, not append a truncated beat and lose the failure.
+	// The per-verb beat sites elsewhere in this module predate the seam and
+	// keep their own convention.
+	beatBytes, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("clock beat payload: %w", err)
+	}
 	out, err := e.appendBeat(&record.AppendInput{
 		At:       uint64(e.clock.ToData().HighWater),
 		Audience: memberIDs,

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// TestClockOfReportsAMemberOnNoClockInsteadOfGuessing pins ClockOf's
+// on-no-clock check — the net under the clock verbs' non-atomic mutate
+// phases (doc.go). It was added in step 4.1 explicitly unreachable, with a
+// promise that "a test lands with the verb that can reach it"; this is that
+// test, and it is deliberately WHITE-BOX: every public verb upholds R6, and
+// the load seam re-homes anyone it finds on no clock, so the only way to
+// probe the net is to fabricate the exact defect it exists to catch — a verb
+// that dropped somebody from a bubble and forgot to re-home them (the
+// mid-Dissolve failure window, frozen).
+//
+// What makes the check worth a test at all is the SHAPE of the wrong answer
+// it prevents: without it, a member on no clock reports ClockWorld — "free
+// roaming" — which is plausible, silent, and would be persisted by the next
+// save. With it, the defect is loud: ErrInvalidData, never a guess.
+func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
+	enc, err := NewEncounter(&SetupInput{
+		Field: FieldInput{
+			Rooms: []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []MemberInput{
+			{ID: "alice", Kind: KindPlayer, Room: "room-1", Position: spatial.Position{X: 2, Y: 2}},
+			{ID: "goblin", Kind: KindMonster, Room: "room-1", Position: spatial.Position{X: 7, Y: 7}},
+		},
+		Endings: []EndingInput{
+			{Key: "called", Trigger: TriggerExternal{}},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = enc.Form(&FormInput{Order: []MemberID{"alice", "goblin"}})
+	require.NoError(t, err)
+
+	// The bug, fabricated: alice leaves the fight and nobody re-homes her.
+	// No public verb can do this — that is the point of the net.
+	_, err = enc.bubbles[0].Remove(&clock.RemoveInput{ID: "alice"})
+	require.NoError(t, err)
+
+	_, err = enc.ClockOf(&ClockOfInput{Member: "alice"})
+	require.Error(t, err, "a member on no clock must be a loud defect, not a free-roamer")
+	require.ErrorIs(t, err, ErrInvalidData)
+	require.ErrorContains(t, err, "on no clock")
+
+	// The member still IN the fight is unaffected — the defect is reported
+	// exactly where it is, not smeared across the encounter.
+	out, err := enc.ClockOf(&ClockOfInput{Member: "goblin"})
+	require.NoError(t, err)
+	require.Equal(t, ClockTurn, out.Kind)
+}

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -4,6 +4,7 @@
 package encounter_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -329,6 +330,500 @@ func (s *ClocksTestSuite) TestABlobFromBeforeClockMembershipLoadsEveryoneOntoThe
 	saved := reloaded.ToData()
 	s.Contains(saved.Clock.Budgets, alice)
 	s.Contains(saved.Clock.Budgets, goblin)
+}
+
+const (
+	carl = core.EntityID("carl")
+	dana = core.EntityID("dana")
+)
+
+// fiveMemberEncounter is the DOS2 split-party cast: four players and a
+// monster in one room, plus an external ending so closure is reachable.
+func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
+			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 3, Y: 2}},
+			{ID: carl, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 8, Y: 8}},
+			{ID: dana, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 9, Y: 8}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 2, Y: 3}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: endingStairs, Trigger: encounter.TriggerReachedPosition{
+				Room: room1, Position: spatial.Position{X: 0, Y: 0},
+			}},
+			{Key: "called", Trigger: encounter.TriggerExternal{}},
+		},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// assertR6 sweeps the invariant after a transition: every member answers
+// ClockOf (on at least one clock — the on-no-clock check would reject), and
+// the persisted shape passes the trust boundary, whose load validation is
+// the full R6 statement (nobody on two clocks, nobody on a clock who is not
+// a member). Asserted after EVERY transition, not only at the end — the
+// issue's own requirement, because a transient violation between verbs is
+// exactly what load-act-save would persist.
+func (s *ClocksTestSuite) assertR6(enc *encounter.Encounter, members ...core.EntityID) {
+	s.T().Helper()
+	for _, id := range members {
+		_, err := enc.ClockOf(&encounter.ClockOfInput{Member: id})
+		s.Require().NoError(err, "member %q must be on exactly one clock", id)
+	}
+	_, err := encounter.LoadEncounter(enc.ToData(), nil)
+	s.Require().NoError(err, "the persisted shape must pass the trust boundary (R6)")
+}
+
+// TestDOS2SplitPartyThroughTheComposition is step 4.2's done-when headline:
+// the play/clock DOS2 scenario (dos2_test.go — the specification), expressed
+// through the composition's own verbs rather than the leaves. Four players
+// and a goblin free-roam; a fight pulls three of them into a bubble; the
+// distant pair keeps living on the world clock while it runs; one wanders
+// too close and falls in mid-round at the requested slot; the round wraps
+// with them in the order; the fight dissolves and everyone re-homes.
+func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
+	enc := s.fiveMemberEncounter()
+	everyone := []core.EntityID{alice, bob, carl, dana, goblin}
+
+	// Everyone free-roams: the world clock is the default, not a mode.
+	s.assertR6(enc, everyone...)
+	for _, id := range everyone {
+		out, err := enc.ClockOf(&encounter.ClockOfInput{Member: id})
+		s.Require().NoError(err)
+		s.Require().Equal(encounter.ClockWorld, out.Kind, "member %q", id)
+	}
+
+	// Alice and Bob trigger a fight with the goblin. The rulebook has rolled
+	// initiative — the order arrives from outside (R7); trigger detection is
+	// deliberately not this step's business.
+	formOut, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, bob}})
+	s.Require().NoError(err)
+	s.NotZero(formOut.Seq, "forming a fight is a story beat")
+	s.assertR6(enc, everyone...)
+
+	fighting, err := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal(encounter.ClockTurn, fighting.Kind)
+	s.Equal(alice, fighting.Active, "round 1 opens with the first in the order")
+	s.Equal(1, fighting.Round)
+	s.Equal([]core.EntityID{alice, goblin, bob}, fighting.Order)
+
+	// The fight is LOCALIZED: the distant pair is not in it and not paused
+	// by it.
+	for _, id := range []core.EntityID{carl, dana} {
+		out, cerr := enc.ClockOf(&encounter.ClockOfInput{Member: id})
+		s.Require().NoError(cerr)
+		s.Equal(encounter.ClockWorld, out.Kind, "member %q keeps free-roaming", id)
+	}
+
+	// The distant pair keeps living while the fight runs: carl moves freely,
+	// and when the world thinks, only world-clock members accrue. (Player
+	// movement driving Advance directly — the leaf's own accrual model —
+	// is not wired into Move yet; Pump is the composition's accrual
+	// mechanism today, and the pin here is WHO accrues, not how much.)
+	_, err = enc.Move(&encounter.MoveInput{Member: carl, To: spatial.Position{X: 8, Y: 7}})
+	s.Require().NoError(err)
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	budgets := enc.ToData().Clock.Budgets
+	s.Equal(1, budgets[carl], "the distant pair accrues while the fight runs")
+	s.Equal(1, budgets[dana])
+	s.NotContains(budgets, alice, "fight members are off the tick entirely")
+	s.NotContains(budgets, goblin)
+	s.NotContains(budgets, bob)
+
+	// A round of combat: alice and the goblin take their turns.
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal(goblin, et.Next)
+	s.False(et.RoundWrapped)
+	et, err = enc.EndTurn(&encounter.EndTurnInput{Member: goblin})
+	s.Require().NoError(err)
+	s.Equal(bob, et.Next)
+	s.assertR6(enc, everyone...)
+
+	// Carl wanders too close and falls in mid-round, slotted after the
+	// goblin. The slot is the caller's choice (R7 again — the rulebook
+	// rolled his initiative), and the active member is undisturbed.
+	_, err = enc.Transfer(&encounter.TransferInput{Member: carl, To: encounter.ClockTurn, Pos: 2})
+	s.Require().NoError(err)
+	s.assertR6(enc, everyone...)
+
+	joined, err := enc.ClockOf(&encounter.ClockOfInput{Member: carl})
+	s.Require().NoError(err)
+	s.Equal(encounter.ClockTurn, joined.Kind)
+	s.Equal([]core.EntityID{alice, goblin, carl, bob}, joined.Order, "carl landed at the requested slot")
+	s.Equal(bob, joined.Active, "falling in does not steal the active turn")
+	s.Equal(1, joined.Round)
+
+	// And having fallen in, carl is the fight's now — free-roam movement is
+	// no longer his to make.
+	_, err = enc.Move(&encounter.MoveInput{Member: carl, To: spatial.Position{X: 8, Y: 8}})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrInBubble)
+
+	// Bob closes the round: it wraps into round 2 with carl in the order.
+	et, err = enc.EndTurn(&encounter.EndTurnInput{Member: bob})
+	s.Require().NoError(err)
+	s.True(et.RoundWrapped, "the round wraps across the grown order")
+	s.Equal(alice, et.Next)
+	wrapped, err := enc.ClockOf(&encounter.ClockOfInput{Member: carl})
+	s.Require().NoError(err)
+	s.Equal(2, wrapped.Round)
+
+	// The fight ends, reached through any of its members: everyone re-homes
+	// to the world clock at budget zero — time spent fighting was spent,
+	// not banked. Dana never left, so hers is intact.
+	dis, err := enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal([]core.EntityID{alice, goblin, carl, bob}, dis.Members, "dissolve reports the bubble order")
+	s.assertR6(enc, everyone...)
+
+	for _, id := range everyone {
+		out, cerr := enc.ClockOf(&encounter.ClockOfInput{Member: id})
+		s.Require().NoError(cerr)
+		s.Equal(encounter.ClockWorld, out.Kind, "member %q is home", id)
+	}
+	after := enc.ToData()
+	s.Empty(after.Bubbles, "a bubble exists only while a fight does")
+	s.Equal(0, after.Clock.Budgets[carl], "re-homed at zero")
+	s.Equal(1, after.Clock.Budgets[dana], "never left, kept her budget")
+
+	// The story heard it all — dana included, from the other side of the
+	// map. The clock-tagged transcript is the composition's analogue of the
+	// leaf test's milestone transcript: formation, the world thinking
+	// (Pump's tick), three turn ends, the fall-in, dissolution.
+	story, err := enc.Story(&encounter.StoryInput{Audience: dana})
+	s.Require().NoError(err)
+	var clockBeats []string
+	for _, entry := range story {
+		if entry.Tags["tag"] != "clock" {
+			continue
+		}
+		var p struct {
+			Beat string `json:"beat"`
+		}
+		s.Require().NoError(json.Unmarshal(entry.Payload, &p))
+		clockBeats = append(clockBeats, p.Beat)
+	}
+	s.Equal([]string{
+		"bubble-formed",
+		"tick",
+		"turn-ended", "turn-ended",
+		"transferred",
+		"turn-ended",
+		"bubble-dissolved",
+	}, clockBeats)
+}
+
+// TestFormRejections pins Form's refusals, including the issue's named
+// requirement: a member already in a bubble is rejected, never silently
+// merged. The disjoint-second-fight case is the one-bubble policy — when
+// that policy lifts, the per-member overlap check is what remains.
+func (s *ClocksTestSuite) TestFormRejections() {
+	s.Run("an empty order", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: nil})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNoMember)
+	})
+
+	s.Run("a duplicated entry", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, alice}})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNoMember)
+	})
+
+	s.Run("a non-member in the order", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, "stranger"}})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNotMember)
+	})
+
+	s.Run("a member who is already fighting", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, bob}})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrInBubble)
+	})
+
+	s.Run("a disjoint second fight while one runs", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{carl, dana}})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrInBubble)
+	})
+
+	s.Run("a rejected form touches nothing", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, "stranger"}})
+		s.Require().Error(err)
+
+		// alice and the goblin were named BEFORE the defect: R5 means they
+		// were never pulled off the world clock.
+		for _, id := range []core.EntityID{alice, goblin} {
+			out, cerr := enc.ClockOf(&encounter.ClockOfInput{Member: id})
+			s.Require().NoError(cerr)
+			s.Equal(encounter.ClockWorld, out.Kind, "member %q", id)
+		}
+		s.Empty(enc.ToData().Bubbles)
+	})
+}
+
+// TestTransferRejections pins Transfer's refusals, and the one guarantee a
+// refusal must keep: both clocks unchanged (the leaf compensates, R6).
+func (s *ClocksTestSuite) TestTransferRejections() {
+	s.Run("into a fight that is not running", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockTurn})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNoBubble)
+	})
+
+	s.Run("into a fight the member is already in", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockTurn})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrInBubble)
+	})
+
+	s.Run("out of a fight the member is not in", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.Transfer(&encounter.TransferInput{Member: bob, To: encounter.ClockWorld})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNoBubble)
+	})
+
+	s.Run("to an unknown clock kind", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockKind("lunch")})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrBadClock)
+	})
+
+	s.Run("an out-of-range slot leaves both clocks unchanged", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.Transfer(&encounter.TransferInput{Member: bob, To: encounter.ClockTurn, Pos: 7})
+		s.Require().Error(err)
+		s.ErrorIs(err, clock.ErrBadPosition, "the leaf's own rejection propagates")
+
+		// The failed transfer compensated: bob is still free-roaming, the
+		// fight is still two, and the whole shape still loads (R6).
+		out, cerr := enc.ClockOf(&encounter.ClockOfInput{Member: bob})
+		s.Require().NoError(cerr)
+		s.Equal(encounter.ClockWorld, out.Kind)
+		s.assertR6(enc, alice, bob, carl, dana, goblin)
+	})
+}
+
+// TestEndTurnRejections pins that turn discipline is the bubble's, surfaced
+// through the composition: no fight, no turn to end; not your turn, no
+// state change.
+func (s *ClocksTestSuite) TestEndTurnRejections() {
+	s.Run("a member not in a fight", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNoBubble)
+	})
+
+	s.Run("not their turn", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.EndTurn(&encounter.EndTurnInput{Member: goblin})
+		s.Require().Error(err)
+		s.ErrorIs(err, clock.ErrNotActive)
+
+		still, cerr := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
+		s.Require().NoError(cerr)
+		s.Equal(alice, still.Active, "a rejected end changes nothing")
+	})
+}
+
+// TestDissolveRejectsAMemberNotInAFight pins that dissolving is reached
+// through a fight member — a free-roamer names no bubble.
+func (s *ClocksTestSuite) TestDissolveRejectsAMemberNotInAFight() {
+	enc := s.fiveMemberEncounter()
+	_, err := enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrNoBubble)
+}
+
+// TestClockVerbsRejectAClosedEncounter pins ErrClosed uniformly across the
+// four clock verbs: a closed encounter's clocks are history, not state.
+func (s *ClocksTestSuite) TestClockVerbsRejectAClosedEncounter() {
+	enc := s.fiveMemberEncounter()
+	_, err := enc.End(&encounter.EndInput{Ending: "called"})
+	s.Require().NoError(err)
+
+	_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+	s.ErrorIs(err, encounter.ErrClosed)
+	_, err = enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockTurn})
+	s.ErrorIs(err, encounter.ErrClosed)
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.ErrorIs(err, encounter.ErrClosed)
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	s.ErrorIs(err, encounter.ErrClosed)
+}
+
+// TestAFightMemberCannotFreeRoam pins the coexistence rule from the verb
+// side: Move and Traverse are world-clock verbs. A fight member acts through
+// the bubble — there is no in-fight movement verb yet, and until one
+// arrives a fight member moving AT ALL would be moving outside initiative.
+func (s *ClocksTestSuite) TestAFightMemberCannotFreeRoam() {
+	enc := s.fiveMemberEncounter()
+	_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+	s.Require().NoError(err)
+
+	_, err = enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 2, Y: 1}})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrInBubble)
+
+	// The gate outranks connection resolution: this fixture has no
+	// connections at all, and the answer is still "you are fighting",
+	// not "no such connection".
+	_, err = enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door"})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrInBubble)
+
+	// Everyone else's world is still running.
+	_, err = enc.Move(&encounter.MoveInput{Member: carl, To: spatial.Position{X: 8, Y: 7}})
+	s.Require().NoError(err)
+}
+
+// TestPumpDoesNotThinkForAFightMonster pins the other half of coexistence:
+// the world thinks on the tick, and a fight thinks in turns. A monster in a
+// bubble is not consulted at all — and the skip is fight-scoped, not
+// permanent: dissolve the fight and the same decider wakes back up.
+func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
+	wanderer := &patrolDecider{positions: []spatial.Position{{X: 5, Y: 5}, {X: 6, Y: 5}}}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 7, Y: 7}, Decider: wanderer},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "called", Trigger: encounter.TriggerExternal{}},
+		},
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{goblin, alice}})
+	s.Require().NoError(err)
+
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Zero(wanderer.callCount, "a fight monster is not the world's to think for")
+
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: goblin})
+	s.Require().NoError(err)
+
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Equal(1, wanderer.callCount, "the skip is fight-scoped: dissolved means free to wander again")
+}
+
+// TestADrainedBubbleIsPruned pins the husk rule: a bubble exists only while
+// a fight does. Exit and Transfer can each drain a fight one member at a
+// time, and the moment the last member is gone the bubble must be too —
+// otherwise ToData writes a fight that is not happening into every blob,
+// which Load rejects.
+func (s *ClocksTestSuite) TestADrainedBubbleIsPruned() {
+	s.Run("drained by Exit", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.Exit(&encounter.ExitInput{Member: alice})
+		s.Require().NoError(err)
+		s.Len(enc.ToData().Bubbles, 1, "a fight of one is still a fight")
+
+		_, err = enc.Exit(&encounter.ExitInput{Member: goblin})
+		s.Require().NoError(err)
+		s.Empty(enc.ToData().Bubbles, "the last member gone takes the bubble with them")
+	})
+
+	s.Run("drained by Transfer", func() {
+		enc := s.fiveMemberEncounter()
+		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
+		s.Require().NoError(err)
+
+		_, err = enc.Transfer(&encounter.TransferInput{Member: goblin, To: encounter.ClockWorld})
+		s.Require().NoError(err)
+		s.Len(enc.ToData().Bubbles, 1)
+
+		_, err = enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockWorld})
+		s.Require().NoError(err)
+		s.Empty(enc.ToData().Bubbles)
+		s.assertR6(enc, alice, bob, carl, dana, goblin)
+	})
+}
+
+// TestLoadRejectsAnIdleBubble pins the other end of the husk rule at the
+// trust boundary: this module never persists an empty bubble (every verb
+// that can empty one prunes it in the same call), so reading one means the
+// blob was edited — rejected, not silently carried.
+func (s *ClocksTestSuite) TestLoadRejectsAnIdleBubble() {
+	enc := s.fiveMemberEncounter()
+	data := enc.ToData()
+	data.Bubbles = []clock.TurnData{{}}
+
+	_, err := encounter.LoadEncounter(data, nil)
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrInvalidData)
+}
+
+// TestAMidFightBlobRoundTrips pins that a fight survives load-act-save: the
+// composition's own Form (not a hand-written blob) produces the persisted
+// shape, and the reloaded encounter continues the same round.
+func (s *ClocksTestSuite) TestAMidFightBlobRoundTrips() {
+	enc := s.fiveMemberEncounter()
+	_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, bob}})
+	s.Require().NoError(err)
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	reloaded, err := encounter.LoadEncounter(enc.ToData(), nil)
+	s.Require().NoError(err)
+
+	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: bob})
+	s.Require().NoError(err)
+	s.Equal(encounter.ClockTurn, out.Kind)
+	s.Equal(goblin, out.Active, "the reloaded fight is mid-round, exactly where it was")
+	s.Equal(1, out.Round)
+
+	// And it keeps playing: the goblin's turn ends in the reloaded world.
+	et, err := reloaded.EndTurn(&encounter.EndTurnInput{Member: goblin})
+	s.Require().NoError(err)
+	s.Equal(bob, et.Next)
 }
 
 func TestClocksSuite(t *testing.T) {

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -560,6 +560,13 @@ func LoadEncounter(data EncounterData, deciders map[MemberID]Decider) (*Encounte
 	if len(data.Bubbles) > 0 {
 		loadedBubbles = make([]*clock.Turn, 0, len(data.Bubbles))
 		for i := range data.Bubbles {
+			// An idle bubble has no meaning in a blob: a bubble exists only
+			// while a fight does, and every verb that can empty one prunes it
+			// in the same call (dropBubbleIfIdle) — this module never writes
+			// this shape, so reading it means the blob was edited.
+			if len(data.Bubbles[i].Order) == 0 {
+				return nil, fmt.Errorf("load encounter bubble %d: idle bubble persisted: %w", i, ErrInvalidData)
+			}
 			b, berr := clock.LoadTurn(data.Bubbles[i])
 			if berr != nil {
 				return nil, fmt.Errorf("load encounter bubble %d: %w: %w", i, ErrInvalidData, berr)

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -10,6 +10,17 @@
 // Members exit, encounters close; player activity pumps the clock, the world
 // thinks on the tick.
 //
+// Every member is on exactly one clock (R6). The world tick is the default —
+// free roam is not a mode, it is where you are when no fight has pulled you
+// elsewhere. A fight is a turn bubble: Form pulls its members off the world
+// clock into a caller-rolled order (R7 — initiative arrives from outside),
+// Transfer moves a straggler in or out mid-round, EndTurn advances the fight,
+// and Dissolve re-homes everyone to the tick. Everyone not in the fight keeps
+// free-roaming while it runs; everyone in it is the fight's alone — Move,
+// Traverse, and Pump are world-clock verbs and will not act for a fight
+// member. Which clock somebody is on is always askable, per member, via
+// ClockOf.
+//
 // # Atomicity, and what R5 does and does not promise
 //
 // Verbs validate before they mutate, and the first validation failure wins
@@ -19,7 +30,11 @@
 // It does NOT mean a verb's MUTATE phase is atomic. Join and Exit each perform
 // several fallible steps after their first mutation — refreshSight and
 // appendBeat both come after placement and member registration — so a failure
-// late in a verb can leave the in-memory encounter partially changed.
+// late in a verb can leave the in-memory encounter partially changed. The
+// clock verbs are the same: Form moves members off the world clock one at a
+// time and Dissolve re-homes them one at a time, so a failure mid-verb can
+// leave a member between clocks — a state ClockOf reports as a defect rather
+// than guessing (see its on-no-clock check).
 //
 // That is safe because of how this module is used, not by accident: every
 // caller loads, acts, and saves, so a verb returning an error means the

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1338,6 +1338,19 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 		return nil, fmt.Errorf("move: %w", ErrNotMember)
 	}
 
+	// Free-roam movement is a world-clock verb. A member caught in a bubble
+	// acts through the fight's own turn structure — the composition has no
+	// in-fight movement verb yet (that arrives with the resolution work), and
+	// until it does a fight member cannot move at all rather than moving
+	// outside initiative.
+	bubble, err := e.bubbleFor(in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("move: %w", err)
+	}
+	if bubble != nil {
+		return nil, fmt.Errorf("move: member %q: %w", in.Member, ErrInBubble)
+	}
+
 	// Execute the move through the managed seam
 	currentPos, err := e.moveMember(member, in.To)
 	if err != nil {
@@ -1599,6 +1612,16 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 		return nil, fmt.Errorf("traverse: %w", ErrNotMember)
 	}
 
+	// Same world-clock gate as Move, checked before the connection resolves:
+	// a fight member cannot free-roam through a doorway either.
+	bubble, err := e.bubbleFor(in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("traverse: %w", err)
+	}
+	if bubble != nil {
+		return nil, fmt.Errorf("traverse: member %q: %w", in.Member, ErrInBubble)
+	}
+
 	result, err := e.traverseMember(member, in.Connection)
 	if err != nil {
 		return nil, fmt.Errorf("traverse: %w", err)
@@ -1766,6 +1789,20 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		if m.Kind != KindMonster {
 			continue
 		}
+
+		// A monster caught in a bubble is not the world's to think for: the
+		// world thinks on the tick, and a fight thinks in turns. Skipped, not
+		// rejected — being mid-fight is ordinary state, and Pump's job is
+		// everyone else. Its budget entry is gone with it (Form removed it
+		// from the tick), so the Advance below grants it nothing either.
+		bubble, berr := e.bubbleFor(m.ID)
+		if berr != nil {
+			return nil, fmt.Errorf("pump bubble: %w", berr)
+		}
+		if bubble != nil {
+			continue
+		}
+
 		decider, hasDecider := e.deciders[m.ID]
 		if !hasDecider {
 			continue // no decider = hold

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -128,6 +128,31 @@ var (
 	// ErrBadConnection, which is a declaration-time defect at Setup/Load.
 	ErrNoConnection = errors.New("no such connection")
 
+	// ErrInBubble is returned when a verb requires its member NOT be in a
+	// running bubble and they are: Form names a member already in a fight
+	// (rejected, never silently merged — merging is a Merge-verb decision
+	// that arrives with multiple bubbles), Form is called while this
+	// encounter's one allowed bubble is already running (#963 policy: one
+	// bubble per encounter, so fights stay linear and the party stays
+	// together), Transfer names ClockTurn for a member already in the
+	// fight, or Move/Traverse is asked to free-roam a member who is
+	// mid-fight — a fight member acts through the bubble's own turn
+	// structure, never by stepping around it.
+	ErrInBubble = errors.New("already in a bubble")
+
+	// ErrNoBubble is returned when a verb requires a running bubble and
+	// finds none: Transfer names ClockTurn while no fight is running, or
+	// Transfer-to-world, EndTurn, or Dissolve names a member who is on the
+	// world clock — there is no bubble to leave, act in, or dissolve.
+	ErrNoBubble = errors.New("no bubble")
+
+	// ErrBadClock is returned when TransferInput.To names neither
+	// ClockWorld nor ClockTurn. Direction is load-bearing on a transfer —
+	// inferring it from the member's current clock would make the verb a
+	// toggle, and a toggle applied to stale state silently moves somebody
+	// the WRONG way instead of failing.
+	ErrBadClock = errors.New("unknown clock kind")
+
 	// ErrInvalidData is returned when LoadEncounter rejects the input data.
 	ErrInvalidData = errors.New("invalid encounter data")
 


### PR DESCRIPTION
Closes #963. Wave 4 step 4.2 of #959, on the ground #960 (step 4.1, `encounter/v0.5.0`) prepared.

## What this adds

Four verbs on the composition — pure clock wiring plus the composition's own rules about when each is legal. `play/clock` already implemented all the mechanics.

- **`Form`** — the named members leave the world clock together and become a turn bubble in a **caller-supplied order** (R7: the rulebook rolls initiative, the composition holds no randomness). Policy is one bubble per encounter; a member already fighting is **rejected, never silently merged** (merging is a Merge-verb decision that arrives with multiple bubbles).
- **`Transfer`** — one member moves world↔bubble at a caller-chosen slot mid-round. Direction is an **explicit `To ClockKind`**, not inferred from current state: a toggle applied to stale state under load-act-save would silently move somebody the wrong way instead of failing. R6 holds even through rejection — the leaf transfer compensates, and the test pins both clocks unchanged after a bad slot.
- **`EndTurn`** — advances the fight past the member's own turn. Not in the issue's pointer list, but the done-when requires the round to **wrap** and nothing can wrap a round without it.
- **`Dissolve`** — ends the fight *reached through any of its members* (a bubble is never addressed by name), re-homing everyone to the tick at budget zero.

Coexistence rules ride along: **Move/Traverse reject fight members** (`ErrInBubble`) and **Pump skips them** — the world thinks on the tick, a fight thinks in turns. A decider is not even consulted while its monster fights, and wakes again after dissolve (README states this in the contributor-facing contract). A bubble drained one member at a time (Exit, Transfer) is **pruned the moment it empties**, and Load **rejects a persisted idle bubble** — both ends of the module agree on what a bubble in a blob means.

New sentinels: `ErrInBubble`, `ErrNoBubble`, `ErrBadClock`.

## Done-when, item by item

- **DOS2 through the composition** — `TestDOS2SplitPartyThroughTheComposition`: five members; three form a bubble; the distant pair keeps accruing while the fight runs (and fight members are off the tick entirely); one wanders in mid-round at the requested slot without stealing the active turn; the round wraps across the grown order; dissolve re-homes everyone at budget zero (the member who never left keeps hers). Closes on the clock-tagged story transcript — the composition's analogue of the leaf's milestone transcript.
- **R6 after every transition, not only at the end** — the test's `assertR6` sweep runs after each verb: `ClockOf` per member (on-no-clock rejects) plus a full `LoadEncounter(ToData())` round trip, whose validation is the complete R6 statement.
- **`ClockOf`'s on-no-clock guard reachable and tested** — 4.1 added it deliberately unreachable with a promise that "a test lands with the verb that can reach it". `TestClockOfReportsAMemberOnNoClockInsteadOfGuessing` is that test, deliberately white-box: every public verb upholds R6 and load re-homes strays, so the only way to probe the net is to fabricate the exact defect it exists to catch (a member dropped from a bubble and never re-homed — the mid-Dissolve failure window, frozen). The pin is the *shape* of the answer: `ErrInvalidData`, never a plausible "free roaming".
- **Forming from a member already in a bubble rejected** — pinned directly, plus the disjoint-second-fight policy case as its own subtest.

## Evidence

- Full suite green; `golangci-lint` 0 issues; `gofmt -l` clean; `go mod tidy` no diff.
- Mutation spot-checks on the load-bearing pins, each killed by its intended test: Pump's skip deleted, Form's one-bubble policy deleted, prune disabled, Move's gate deleted, the on-no-clock guard made to guess "world", Load's idle-bubble check deleted.

Out of scope, per the issue: trigger detection (#964 — these verbs are explicit and caller-driven), multiple bubbles and `Merge`, in-fight movement/actions (the resolution work, #965, under ADR-0038). Player movement driving `Advance` directly (the leaf's own accrual model) is not wired into `Move` yet — Pump remains the composition's accrual mechanism; the DOS2 test pins *who* accrues, not how much, and notes the gap.

`feat:` on the encounter module — takes a minor version on merge.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrXECgbKdAm5pcwJJkarfq
