### PR TITLE
fix(release): a breaking change on a v0.x module is a minor bump (#917)

### DIFF
--- a/.github/workflows/auto-tag-modules-safe.yml
+++ b/.github/workflows/auto-tag-modules-safe.yml
@@ -37,8 +37,10 @@ jobs:
         # Function to determine version bump from commit messages
         # Looks for conventional commit patterns:
         # - feat: minor bump
-        # - fix: patch bump  
-        # - BREAKING CHANGE: major bump
+        # - fix: patch bump
+        # - BREAKING CHANGE: major bump — but see increment_version: on a v0.x
+        #   module this lands as a MINOR bump, per semver §4. v1.0.0 is never
+        #   reached automatically.
         # - chore/docs/style/refactor/test: patch bump
         determine_bump() {
           local module=$1
@@ -80,9 +82,24 @@ jobs:
           
           case $bump in
             major)
-              major=$((major + 1))
-              minor=0
-              patch=0
+              # Semver §4: "Major version zero (0.y.z) is for initial development.
+              # Anything MAY change at any time." On a v0.x module a breaking change
+              # is therefore a MINOR bump, not a major one — and reaching v1.0.0 is a
+              # deliberate act of declaring an API stable, never a side effect of a
+              # commit message containing "!:".
+              #
+              # Without this, a single `refactor(x)!:` promotes a mid-development
+              # module straight to v1.0.0. Every module in this repo is currently
+              # v0.x, so that promotion would always be wrong and is not something a
+              # tag can cleanly take back once a consumer has fetched it.
+              if [[ "$major" == "0" ]]; then
+                minor=$((minor + 1))
+                patch=0
+              else
+                major=$((major + 1))
+                minor=0
+                patch=0
+              fi
               ;;
             minor)
               minor=$((minor + 1))


### PR DESCRIPTION
**Merge this before #980.** That PR is the one that would have tripped the bug.

## The bug

`auto-tag-modules-safe.yml` maps `BREAKING CHANGE` or `!:` to a major bump, then
increments major unconditionally:

```bash
if echo "$commits" | grep -q "BREAKING CHANGE\|!:"; then bump="major"
...
major) major=$((major + 1)); minor=0; patch=0 ;;
```

**Every module in this repo is v0.x.** So any breaking change promotes a
mid-development module straight to **v1.0.0** — declaring an API stable as a side
effect of a commit message, and a tag is not cleanly retractable once a consumer has
fetched it.

## It was about to fire

`rulebooks/dnd5e/encounter` is at **v0.6.0**. #980's commit subject is
`refactor(encounter)!: LoadEncounter takes a single Input`, which matches `!:`, so
merging it would have tagged **`rulebooks/dnd5e/encounter/v1.0.0`**.

In the *same CI run*, gorelease said:

```
## incompatible changes
LoadEncounter: changed from func(EncounterData, map[MemberID]Decider) ... to func(*LoadEncounterInput) ...
Suggested version: v0.7.0
```

So the two halves of the release machinery already disagreed, and the tagger — the
half that actually writes the tag — was the wrong one.

## The fix

Semver §4: *"Major version zero (0.y.z) is for initial development. Anything MAY
change at any time."* On `0.y.z` a breaking change is a **minor** bump, and reaching
`1.0.0` stays a deliberate act rather than an accident of wording.

v1+ behaviour is untouched.

## Evidence

Verified by extracting `increment_version` **from the workflow file itself** and
running it, rather than reimplementing it and testing the reimplementation:

| current | bump | result | before this PR |
|---|---|---|---|
| `v0.6.0` | major | **v0.7.0** | ~~v1.0.0~~ — matches gorelease |
| `v0.82.0` | major | **v0.83.0** | ~~v1.0.0~~ |
| `v0.1.0` | major | **v0.2.0** | ~~v1.0.0~~ |
| `v1.2.3` | major | v2.0.0 | unchanged |
| `v1.2.3` | minor | v1.3.0 | unchanged |

Workflow YAML still parses (`yaml.safe_load`, one job: `auto-tag`); extracted
function passes `bash -n`.

## Scope

**Partial fix for #917**, which asks for auto-tagging to be *"compatibility- and
CI-aware."* This is the compatibility half only. The CI-awareness half — tagging
should not fire when checks did not pass — is deliberately untouched, and #917 stays
open for it.

Also worth noting for whoever takes the rest of #917: `determine_bump` reads
`git log --format="%s"`, i.e. **subjects only**, so a `BREAKING CHANGE:` footer in a
commit *body* is never seen. Only `!:` in the subject triggers major today. That
asymmetry is real but is not changed here.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML1kZSxV8xStbCDzx5MPBC