### PR TITLE
feat(dnd5e): loaders can attribute an effect's subscriptions to that effect

### DIFF
--- a/rulebooks/dnd5e/character/data.go
+++ b/rulebooks/dnd5e/character/data.go
@@ -235,10 +235,18 @@ func LoadFromData(ctx context.Context, d *Data, bus events.EventBus) (*Character
 			continue
 		}
 
+		// Apply through the bus this particular effect should be attributed to.
+		// A plain bus returns itself, so this is a no-op for every caller that
+		// is not an attach site keeping a registration list; a bus that
+		// implements dnd5eEvents.EffectScoper gets to record which effect made
+		// each subscription. The ref is the one conditions.LoadJSON just routed
+		// on, peeked again here because a ConditionBehavior cannot name itself.
+		effectBus := dnd5eEvents.BusForEffect(bus, peekEffectRef(rawCondition))
+
 		// Re-apply the condition so it subscribes to events
-		if err := condition.Apply(ctx, bus); err != nil {
+		if err := condition.Apply(ctx, effectBus); err != nil {
 			// Clean up any partial subscriptions to avoid resource leaks
-			_ = condition.Remove(ctx, bus)
+			_ = condition.Remove(ctx, effectBus)
 			// Log error but continue loading other conditions
 			// TODO: Consider how to handle condition apply errors
 			continue
@@ -283,4 +291,19 @@ func LoadFromData(ctx context.Context, d *Data, bus events.EventBus) (*Character
 	}
 
 	return char, nil
+}
+
+// peekEffectRef reads the ref a persisted effect routes on, which is the same
+// field its loader routes on. It returns the zero Ref for a blob that has none
+// rather than an error: an effect that loaded is applied either way, and the
+// only thing a missing ref costs is attribution.
+func peekEffectRef(raw json.RawMessage) core.Ref {
+	var peek struct {
+		Ref core.Ref `json:"ref"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return core.Ref{}
+	}
+
+	return peek.Ref
 }

--- a/rulebooks/dnd5e/character/effect_scoping_test.go
+++ b/rulebooks/dnd5e/character/effect_scoping_test.go
@@ -1,0 +1,186 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// unattributed is the key subscriptions land under when they were made through
+// the bus itself rather than through an effect's scoped view — the character's
+// own machinery, for instance.
+var unattributed = core.Ref{}
+
+// scopeRecord is the registration list an attach site would keep: which effect
+// subscribed to what. Shared by the root bus and every scoped view it hands out.
+type scopeRecord struct {
+	asked []core.Ref
+	byRef map[core.Ref][]events.Topic
+}
+
+// recordingBus delegates every call to a real bus and notes, per subscription,
+// which effect was mid-Apply when it was made. It is the shape of the
+// instrumented surface resolution will own, reduced to what this test needs.
+type recordingBus struct {
+	inner  events.EventBus
+	ref    core.Ref
+	record *scopeRecord
+}
+
+func newRecordingBus() *recordingBus {
+	return &recordingBus{
+		inner:  events.NewEventBus(),
+		ref:    unattributed,
+		record: &scopeRecord{byRef: make(map[core.Ref][]events.Topic)},
+	}
+}
+
+func (b *recordingBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	id, err := b.inner.Subscribe(ctx, topic, handler)
+	if err != nil {
+		return "", err
+	}
+
+	b.record.byRef[b.ref] = append(b.record.byRef[b.ref], topic)
+
+	return id, nil
+}
+
+func (b *recordingBus) Unsubscribe(ctx context.Context, id string) error {
+	return b.inner.Unsubscribe(ctx, id)
+}
+
+func (b *recordingBus) Publish(ctx context.Context, topic events.Topic, event any) error {
+	return b.inner.Publish(ctx, topic, event)
+}
+
+// ScopeToEffect implements dnd5eEvents.EffectScoper.
+func (b *recordingBus) ScopeToEffect(ref core.Ref) events.EventBus {
+	b.record.asked = append(b.record.asked, ref)
+
+	return &recordingBus{inner: b.inner, ref: ref, record: b.record}
+}
+
+type EffectScopingTestSuite struct {
+	suite.Suite
+
+	ctx       context.Context
+	bus       *recordingBus
+	ragingRef core.Ref
+}
+
+func (s *EffectScopingTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = newRecordingBus()
+	s.ragingRef = *refs.Conditions.Raging()
+}
+
+// ragingBarbarian returns character data carrying one persisted Raging
+// condition — the effect the saving-throw slice is built on.
+func (s *EffectScopingTestSuite) ragingBarbarian() *Data {
+	raging := &conditions.RagingCondition{
+		CharacterID: "char-scope",
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	}
+
+	raw, err := raging.ToJSON()
+	s.Require().NoError(err)
+
+	return &Data{
+		ID:       "char-scope",
+		PlayerID: "player-scope",
+		Name:     "Scoped Barbarian",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ProficiencyBonus: 2,
+		Conditions:       []json.RawMessage{raw},
+	}
+}
+
+// The load path asks the bus to scope to each effect it is about to apply, and
+// names the effect by the ref its loader routed on. This is the moment
+// attribution is knowable, and the only one.
+func (s *EffectScopingTestSuite) TestLoadScopesEachEffectToItsRef() {
+	_, err := LoadFromData(s.ctx, s.ragingBarbarian(), s.bus)
+	s.Require().NoError(err)
+
+	s.Require().Equal([]core.Ref{s.ragingRef}, s.bus.record.asked)
+}
+
+// The subscriptions Raging makes are attributed to Raging — including the
+// saving-throw chain, which is the hook the first resolution slice folds.
+func (s *EffectScopingTestSuite) TestRagingsSubscriptionsAreAttributedToRaging() {
+	_, err := LoadFromData(s.ctx, s.ragingBarbarian(), s.bus)
+	s.Require().NoError(err)
+
+	s.Require().Contains(s.bus.record.byRef, s.ragingRef)
+	s.Require().Contains(s.bus.record.byRef[s.ragingRef], events.Topic("dnd5e.saves.chain"))
+}
+
+// The character's own machinery is not laundered into an effect's name. Without
+// this, "Raging attached N hooks" would quietly include hooks Raging never made.
+func (s *EffectScopingTestSuite) TestCharacterMachineryIsNotAttributedToAnEffect() {
+	_, err := LoadFromData(s.ctx, s.ragingBarbarian(), s.bus)
+	s.Require().NoError(err)
+
+	s.Require().NotEmpty(s.bus.record.byRef[unattributed],
+		"the character's own subscriptions should still be recorded, just not under an effect")
+	s.Require().NotContains(s.bus.record.byRef[unattributed], events.Topic("dnd5e.saves.chain"))
+}
+
+// A character with no persisted effects asks for no scopes at all: the absence
+// of an effect is observable rather than indistinguishable from a silent one.
+func (s *EffectScopingTestSuite) TestNoEffectsMeansNoScopesRequested() {
+	data := s.ragingBarbarian()
+	data.Conditions = nil
+
+	_, err := LoadFromData(s.ctx, data, s.bus)
+	s.Require().NoError(err)
+
+	s.Require().Empty(s.bus.record.asked)
+	s.Require().NotContains(s.bus.record.byRef, s.ragingRef)
+}
+
+// A plain bus is unchanged by any of this — the seam is opt-in, and the ~20
+// existing LoadFromData callers keep the behaviour they have.
+func (s *EffectScopingTestSuite) TestPlainBusLoadsIdentically() {
+	plain := events.NewEventBus()
+
+	char, err := LoadFromData(s.ctx, s.ragingBarbarian(), plain)
+	s.Require().NoError(err)
+
+	conds := char.GetConditions()
+	s.Require().Len(conds, 1)
+	s.Require().True(conds[0].IsApplied())
+}
+
+func TestEffectScopingSuite(t *testing.T) {
+	suite.Run(t, new(EffectScopingTestSuite))
+}

--- a/rulebooks/dnd5e/events/scope.go
+++ b/rulebooks/dnd5e/events/scope.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package events
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+)
+
+// EffectScoper is an optional interface an events.EventBus may implement so
+// that the subscriptions an effect makes can be attributed to that effect.
+//
+// It exists because attribution is only knowable at one moment. An effect is
+// self-contained: it names its own topics inside Apply, and nothing holds a
+// registry of what any effect does (ADR-0038 §4). A ConditionBehavior cannot
+// name itself either — it is IsApplied/Apply/Remove/ToJSON and nothing more.
+// So the only party that knows "the subscriptions about to be made belong to
+// this effect" is the loader that just routed a ref to build the behaviour,
+// in the instant before it calls Apply. A loader that consults this interface
+// hands that knowledge to the bus instead of discarding it.
+//
+// This is an optional interface rather than a parameter on purpose. Adding it
+// to events.EventBus would break every implementer for a concern only an
+// attach site has; adding it as a parameter would fork every load path into a
+// scoped and an unscoped variant. A bus that does not implement it is used
+// exactly as before, so every existing caller is unaffected.
+type EffectScoper interface {
+	// ScopeToEffect returns the bus an effect's Apply should be given, so that
+	// subscriptions made during that call are attributed to ref. The returned
+	// bus must behave as the bus it came from; scoping is bookkeeping, not a
+	// change in delivery.
+	ScopeToEffect(ref core.Ref) events.EventBus
+}
+
+// BusForEffect returns the bus that the effect named by ref should be applied
+// with: a scoped view when bus is an EffectScoper, and bus itself otherwise.
+//
+// A nil return from ScopeToEffect falls back to bus rather than propagating a
+// nil bus into Apply, because a bookkeeping implementation must never be able
+// to stop an effect from working.
+func BusForEffect(bus events.EventBus, ref core.Ref) events.EventBus {
+	scoper, ok := bus.(EffectScoper)
+	if !ok {
+		return bus
+	}
+
+	scoped := scoper.ScopeToEffect(ref)
+	if scoped == nil {
+		return bus
+	}
+
+	return scoped
+}

--- a/rulebooks/dnd5e/events/scope_test.go
+++ b/rulebooks/dnd5e/events/scope_test.go
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package events_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// plainBus is an events.EventBus that knows nothing about effect scoping —
+// the shape every caller outside an attach site has.
+type plainBus struct {
+	name string
+}
+
+func (b *plainBus) Subscribe(_ context.Context, _ events.Topic, _ any) (string, error) {
+	return b.name, nil
+}
+
+func (b *plainBus) Unsubscribe(_ context.Context, _ string) error { return nil }
+
+func (b *plainBus) Publish(_ context.Context, _ events.Topic, _ any) error { return nil }
+
+// scopingBus records what it was asked to scope to and returns whatever the
+// test told it to, including nil.
+type scopingBus struct {
+	plainBus
+	returns events.EventBus
+	asked   []core.Ref
+}
+
+func (b *scopingBus) ScopeToEffect(ref core.Ref) events.EventBus {
+	b.asked = append(b.asked, ref)
+	return b.returns
+}
+
+type ScopeTestSuite struct {
+	suite.Suite
+
+	ref core.Ref
+}
+
+func (s *ScopeTestSuite) SetupTest() {
+	s.ref = core.Ref{Module: "dnd5e", Type: "conditions", ID: "raging"}
+}
+
+// A bus that does not implement EffectScoper is handed back untouched, which is
+// what keeps this seam free for every existing caller.
+func (s *ScopeTestSuite) TestPlainBusIsReturnedUnchanged() {
+	bus := &plainBus{name: "plain"}
+
+	got := dnd5eEvents.BusForEffect(bus, s.ref)
+
+	s.Require().Same(bus, got)
+}
+
+// The whole point: a scoper is consulted, with the effect's own ref, and its
+// answer is what the effect gets applied with.
+func (s *ScopeTestSuite) TestScoperIsConsultedAndItsBusUsed() {
+	scoped := &plainBus{name: "scoped"}
+	bus := &scopingBus{returns: scoped}
+
+	got := dnd5eEvents.BusForEffect(bus, s.ref)
+
+	s.Require().Same(scoped, got)
+	s.Require().Equal([]core.Ref{s.ref}, bus.asked)
+}
+
+// Bookkeeping must never be able to break an effect: a scoper that answers nil
+// leaves the effect on the bus it would have had anyway.
+func (s *ScopeTestSuite) TestNilScopeFallsBackToTheBus() {
+	bus := &scopingBus{returns: nil}
+
+	got := dnd5eEvents.BusForEffect(bus, s.ref)
+
+	s.Require().Same(bus, got)
+	s.Require().Len(bus.asked, 1)
+}
+
+// A blob with no ref still applies; it is only unattributed. Asserting the
+// scoper is asked (rather than skipped) keeps the zero ref a decision the
+// attach site makes, not one this helper makes for it.
+func (s *ScopeTestSuite) TestZeroRefStillConsultsTheScoper() {
+	scoped := &plainBus{name: "scoped"}
+	bus := &scopingBus{returns: scoped}
+
+	got := dnd5eEvents.BusForEffect(bus, core.Ref{})
+
+	s.Require().Same(scoped, got)
+	s.Require().Equal([]core.Ref{{}}, bus.asked)
+}
+
+func TestScopeSuite(t *testing.T) {
+	suite.Run(t, new(ScopeTestSuite))
+}

--- a/rulebooks/dnd5e/monstertraits/effect_scoping_test.go
+++ b/rulebooks/dnd5e/monstertraits/effect_scoping_test.go
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monstertraits
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// unattributed is the key subscriptions land under when they were made through
+// the bus itself rather than through a trait's scoped view.
+var unattributed = core.Ref{}
+
+type scopeRecord struct {
+	asked []core.Ref
+	byRef map[core.Ref][]events.Topic
+}
+
+// recordingBus delegates to a real bus and notes which trait was mid-Apply when
+// each subscription was made.
+type recordingBus struct {
+	inner  events.EventBus
+	ref    core.Ref
+	record *scopeRecord
+}
+
+func newRecordingBus() *recordingBus {
+	return &recordingBus{
+		inner:  events.NewEventBus(),
+		ref:    unattributed,
+		record: &scopeRecord{byRef: make(map[core.Ref][]events.Topic)},
+	}
+}
+
+func (b *recordingBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	id, err := b.inner.Subscribe(ctx, topic, handler)
+	if err != nil {
+		return "", err
+	}
+
+	b.record.byRef[b.ref] = append(b.record.byRef[b.ref], topic)
+
+	return id, nil
+}
+
+func (b *recordingBus) Unsubscribe(ctx context.Context, id string) error {
+	return b.inner.Unsubscribe(ctx, id)
+}
+
+func (b *recordingBus) Publish(ctx context.Context, topic events.Topic, event any) error {
+	return b.inner.Publish(ctx, topic, event)
+}
+
+// ScopeToEffect implements dnd5eEvents.EffectScoper.
+func (b *recordingBus) ScopeToEffect(ref core.Ref) events.EventBus {
+	b.record.asked = append(b.record.asked, ref)
+
+	return &recordingBus{inner: b.inner, ref: ref, record: b.record}
+}
+
+type TraitScopingTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+	bus *recordingBus
+}
+
+func (s *TraitScopingTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = newRecordingBus()
+}
+
+func (s *TraitScopingTestSuite) skeleton() *monster.Monster {
+	m, err := monster.LoadFromData(s.ctx, &monster.Data{
+		ID:            "skeleton-scope",
+		Name:          "Skeleton",
+		Ref:           refs.Monsters.Skeleton(),
+		HitPoints:     13,
+		MaxHitPoints:  13,
+		ArmorClass:    13,
+		AbilityScores: shared.AbilityScores{},
+	}, s.bus)
+	s.Require().NoError(err)
+
+	return m
+}
+
+func (s *TraitScopingTestSuite) immunityBlob() json.RawMessage {
+	raw, err := json.Marshal(ImmunityData{
+		Ref:        refs.MonsterTraits.Immunity(),
+		OwnerID:    "skeleton-scope",
+		DamageType: damage.Piercing,
+	})
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// Monsters get the same attribution characters do. Their loader was already
+// caller-driven; what it lacked was a way to say which trait it was applying.
+func (s *TraitScopingTestSuite) TestTraitSubscriptionsAreAttributedToTheirRef() {
+	m := s.skeleton()
+	immunityRef := *refs.MonsterTraits.Immunity()
+
+	err := LoadMonsterConditions(s.ctx, m, []json.RawMessage{s.immunityBlob()}, s.bus, nil)
+	s.Require().NoError(err)
+
+	s.Require().Equal([]core.Ref{immunityRef}, s.bus.record.asked)
+	s.Require().NotEmpty(s.bus.record.byRef[immunityRef],
+		"the immunity trait subscribed to something, and it should be recorded under immunity")
+}
+
+// The monster's own machinery, subscribed while it loaded, stays unattributed
+// rather than being folded into whichever trait is applied next.
+func (s *TraitScopingTestSuite) TestMonsterMachineryIsNotAttributedToATrait() {
+	m := s.skeleton()
+
+	s.Require().NotEmpty(s.bus.record.byRef[unattributed],
+		"loading the monster subscribes its own hooks")
+	s.Require().Empty(s.bus.record.asked,
+		"loading a monster applies no traits, so nothing should have been scoped yet")
+
+	err := LoadMonsterConditions(s.ctx, m, []json.RawMessage{s.immunityBlob()}, s.bus, nil)
+	s.Require().NoError(err)
+
+	s.Require().Len(s.bus.record.asked, 1)
+}
+
+// A plain bus is unaffected — the seam is opt-in.
+func (s *TraitScopingTestSuite) TestPlainBusLoadsIdentically() {
+	plain := events.NewEventBus()
+
+	m, err := monster.LoadFromData(s.ctx, &monster.Data{
+		ID:            "skeleton-plain",
+		Name:          "Skeleton",
+		Ref:           refs.Monsters.Skeleton(),
+		HitPoints:     13,
+		MaxHitPoints:  13,
+		ArmorClass:    13,
+		AbilityScores: shared.AbilityScores{},
+	}, plain)
+	s.Require().NoError(err)
+
+	raw, err := json.Marshal(ImmunityData{
+		Ref:        refs.MonsterTraits.Immunity(),
+		OwnerID:    "skeleton-plain",
+		DamageType: damage.Piercing,
+	})
+	s.Require().NoError(err)
+
+	s.Require().NoError(LoadMonsterConditions(s.ctx, m, []json.RawMessage{raw}, plain, nil))
+	s.Require().Len(m.GetConditions(), 1)
+}
+
+func TestTraitScopingSuite(t *testing.T) {
+	suite.Run(t, new(TraitScopingTestSuite))
+}

--- a/rulebooks/dnd5e/monstertraits/loader.go
+++ b/rulebooks/dnd5e/monstertraits/loader.go
@@ -120,14 +120,37 @@ func LoadMonsterConditions(
 			return rpgerr.Wrap(err, "failed to load monster condition")
 		}
 
+		// Apply through the bus this particular trait should be attributed to.
+		// A plain bus returns itself, so this is a no-op for every caller that
+		// is not an attach site keeping a registration list; a bus that
+		// implements dnd5eEvents.EffectScoper gets to record which trait made
+		// each subscription. The ref is the one LoadJSON just routed on, peeked
+		// again here because a ConditionBehavior cannot name itself.
+		traitBus := dnd5eEvents.BusForEffect(bus, peekTraitRef(data))
+
 		// Apply the condition so it subscribes to events
-		if err := condition.Apply(ctx, bus); err != nil {
+		if err := condition.Apply(ctx, traitBus); err != nil {
 			// Clean up any partial subscriptions
-			_ = condition.Remove(ctx, bus)
+			_ = condition.Remove(ctx, traitBus)
 			return rpgerr.Wrap(err, "failed to apply monster condition")
 		}
 
 		m.AddCondition(condition)
 	}
 	return nil
+}
+
+// peekTraitRef reads the ref a persisted trait routes on, which is the same
+// field LoadJSON routes on. It returns the zero Ref for a blob that has none
+// rather than an error: LoadJSON has already accepted the blob by this point,
+// and the only thing a missing ref costs is attribution.
+func peekTraitRef(data json.RawMessage) core.Ref {
+	var peek struct {
+		Ref core.Ref `json:"ref"`
+	}
+	if err := json.Unmarshal(data, &peek); err != nil {
+		return core.Ref{}
+	}
+
+	return peek.Ref
 }


### PR DESCRIPTION
Closes #982. Prerequisite for #974 (resolution PR 1).

## Why this exists

The landing plan (`docs/ideas/session-sdk/resolution.md`) says PR 1 changes
nothing else in the repo. Building it turned up one thing it cannot do without.

ADR-0038 §2 has resolution attach every participant's effects through an
instrumented surface that records each subscription, and rests two of its three
claims on that record being **per effect**: pre-execution inspection, and
"this ref attached zero hooks" being an assertable fact rather than silence.

Resolution does not get to drive that loop. `character.LoadFromData` routes each
persisted condition through `conditions.LoadJSON` and calls `Apply(ctx, bus)`
itself, with one bus for the whole character — so a caller can only ever learn
"this *participant* attached N hooks". `ConditionBehavior` cannot name itself
(#971), so after-the-fact attribution is out too. `monstertraits.LoadMonsterConditions`
is caller-driven but likewise takes one bus for every trait in the list.

The plan's own "what would make this plan wrong" section names this case, and
it is the one that came true.

This lands now rather than later because **the registration list is
resolution's public API at v0.1.0**. Shipping it keyed by participant and
re-keying it by ref afterwards is a breaking change to a brand-new module.

## What changed

`rulebooks/dnd5e/events/scope.go` — new, ~50 lines:

```go
type EffectScoper interface {
    ScopeToEffect(ref core.Ref) events.EventBus
}

func BusForEffect(bus events.EventBus, ref core.Ref) events.EventBus
```

`BusForEffect` returns `bus` unchanged when it is not an `EffectScoper`, and
falls back to `bus` when a scoper answers nil — bookkeeping must never be able
to stop an effect from working.

The two paths that apply persisted effects now go through it:

- `character/data.go` — the condition loop
- `monstertraits/loader.go` — `LoadMonsterConditions`

Each peeks the ref its loader already routed on. A blob with no ref applies
exactly as before and is simply unattributed; a missing ref costs attribution,
never behaviour.

## Why an optional interface

Putting `ScopeToEffect` on `events.EventBus` would break every implementer for
a concern only an attach site has. Adding a parameter would fork every load
path into a scoped and an unscoped variant. The only party that knows "the
subscriptions about to be made belong to this effect" is the loader that just
routed a ref to build the behaviour, in the instant before it calls `Apply` —
this hands that knowledge over instead of discarding it, and asks nothing of
anyone who does not want it.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run` — all green across the
`dnd5e` module (full suite, not just the touched packages). Three new suites,
12 assertions:

- `events/scope_test.go` — a plain bus comes back identical; a scoper is asked
  with the effect's ref and its answer is used; a nil answer falls back; a zero
  ref still consults the scoper rather than being special-cased away
- `character/effect_scoping_test.go` — loading a barbarian with a persisted
  Raging condition asks to scope to `dnd5e:conditions:raging` and records
  Raging's `dnd5e.saves.chain` subscription **under Raging**; the character's
  own five hooks stay unattributed rather than being laundered into an effect's
  name; a character with no effects requests no scopes at all; a plain bus
  loads identically
- `monstertraits/effect_scoping_test.go` — the same for a skeleton with an
  immunity trait

The "character's own machinery is not attributed" pin is the one that matters
most: without it, "Raging attached N hooks" would quietly include hooks Raging
never made, and the zero-hooks claim would be unfalsifiable.

## Compatibility

Purely additive — one new interface, one new function, no signature changes.
The ~20 existing `LoadFromData` callers and the single non-test one
(`session/entities.go:88`) are unaffected; `TestPlainBusLoadsIdentically` pins
that in both packages. `feat:` on a v0.x module, so this tags `dnd5e v0.84.0`.

## Explicitly out of scope

- Collapsing the N load paths behind resolution (ADR-0038's Consequences) —
  that is the migration, and it wants its own PR
- Character **resources**, which also `Apply` to the bus. They are not effects
  and no claim rests on naming them; they stay unattributed
- `features`, which are loaded but never applied

— asset-pipeline agent, on behalf of KirkDiggler
