### PR TITLE
dnd5e: entity loaders go pure — Load without a bus, and the sheet-keeper attachable

### DIFF
--- a/rulebooks/dnd5e/README.md
+++ b/rulebooks/dnd5e/README.md
@@ -48,12 +48,20 @@ ref/key → definition or factory → runtime rule behavior → Data/JSON → ho
    currently composes D&D 5e monster decisions, combat resolution, spatial
    state, and encounter events. It is D&D-5e-coupled today.
 
-For monsters, loading is currently multi-step: `monster.LoadFromData` creates
-and subscribes the base runtime monster, `monster/actions.LoadMonsterActions`
-restores its action implementations, and
-`monstertraits.LoadMonsterConditions` loads and applies persisted traits. The
-`encounter.LoadFromData` hydration cascade performs all three. Calling only
-`monster.LoadFromData` does **not** restore a complete factory-created monster.
+Loading has two halves, and they are separately callable: `character.Load` and
+`monstertraits.LoadMonster` turn data into a sheet with no event bus involved,
+and `character.Attach` / `monstertraits.AttachMonster` put that sheet on a bus
+— its own keeper first, then each persisted effect through a bus scoped to that
+effect's ref. `Load(d).ToData()` is the data it was given.
+
+The older single-step loaders remain for their existing callers.
+`character.LoadFromData` is the two halves in one call, still forgiving about a
+blob it cannot read where `Load` refuses and names it. For monsters the older
+shape is three calls — `monster.LoadFromData`, then
+`monster/actions.LoadMonsterActions`, then
+`monstertraits.LoadMonsterConditions` — and calling only the first does **not**
+restore a complete factory-created monster; worse, `ToData` will then write it
+back without what the skipped calls would have restored.
 
 ## Current package map
 

--- a/rulebooks/dnd5e/character/attach_rollback_test.go
+++ b/rulebooks/dnd5e/character/attach_rollback_test.go
@@ -1,0 +1,233 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+)
+
+// errRefused is what the stub bus answers with. Any error would do; a named one
+// keeps the failure legible when a test reports it.
+var errRefused = errors.New("bus refused the subscription")
+
+// failingBus is a real bus that refuses the nth Subscribe and behaves normally
+// otherwise. Counting rather than matching on topic is deliberate: it lets one
+// stub reach every stage of an attach — a keeper handler, a resource, an
+// effect — by number, including the stages a test would otherwise have no way
+// to make fail.
+type failingBus struct {
+	inner  events.EventBus
+	failOn int // 1-based; 0 never fails
+	calls  int
+}
+
+func newFailingBus(failOn int) *failingBus {
+	return &failingBus{inner: events.NewEventBus(), failOn: failOn}
+}
+
+func (b *failingBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	b.calls++
+	if b.calls == b.failOn {
+		return "", errRefused
+	}
+
+	return b.inner.Subscribe(ctx, topic, handler)
+}
+
+func (b *failingBus) Unsubscribe(ctx context.Context, id string) error {
+	return b.inner.Unsubscribe(ctx, id)
+}
+
+func (b *failingBus) Publish(ctx context.Context, topic events.Topic, event any) error {
+	return b.inner.Publish(ctx, topic, event)
+}
+
+// AttachRollbackTestSuite holds one contract to three sites: a failed attach is
+// a no-op. The sheet's data is untouched, the bus carries nothing the failed
+// call put there, and the attach can simply be tried again.
+//
+// The three assertions are the same every time — same data out, nothing
+// listening, retry works — because a rollback that satisfies two of them is
+// still a bug, just a quieter one.
+type AttachRollbackTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func (s *AttachRollbackTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// assertNothingListening publishes on the bus the failed attach was given and
+// checks that none of it lands: no healing, no condition.
+func (s *AttachRollbackTestSuite) assertNothingListening(char *Character, bus events.EventBus) {
+	hitPoints := char.GetHitPoints()
+	conditions := len(char.GetConditions())
+
+	s.Require().NoError(dnd5eEvents.HealingReceivedTopic.On(bus).Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: char.GetID(),
+		Amount:   5,
+	}))
+	s.Require().Equal(hitPoints, char.GetHitPoints(), "the sheet is not listening for healing")
+	s.Require().False(char.IsDirty(), "and nothing has changed on it")
+
+	s.Require().NoError(dnd5eEvents.ConditionAppliedTopic.On(bus).Publish(s.ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    char,
+		Condition: &keptCondition{},
+	}))
+	s.Require().Len(char.GetConditions(), conditions, "no condition arrived on the sheet")
+}
+
+// assertRetryWorks attaches to a working bus and checks the sheet came through
+// whole: conditions applied, keeper listening, resources hearing a rest.
+func (s *AttachRollbackTestSuite) assertRetryWorks(char *Character) {
+	bus := events.NewEventBus()
+
+	s.Require().NoError(Attach(s.ctx, char, bus))
+
+	s.Require().Len(char.GetConditions(), 1)
+	s.Require().True(char.GetConditions()[0].IsApplied(), "the condition attached on the retry")
+
+	s.Require().NoError(dnd5eEvents.HealingReceivedTopic.On(bus).Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: char.GetID(),
+		Amount:   5,
+	}))
+	s.Require().Equal(27, char.GetHitPoints(), "the keeper attached on the retry")
+
+	s.Require().NoError(dnd5eEvents.RestTopic.On(bus).Publish(s.ctx, dnd5eEvents.RestEvent{
+		RestType:    "long_rest",
+		CharacterID: char.GetID(),
+	}))
+	s.Require().Equal(3, char.GetResource(resources.RageCharges).Current(),
+		"the resources attached on the retry")
+}
+
+// The third of the keeper's five handlers is refused. The two that landed come
+// back off, and the sheet is not left reacting to a third of the world.
+func (s *AttachRollbackTestSuite) TestKeeperRollsBackAPartialSubscribe() {
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
+	s.Require().NoError(err)
+	before := marshalData(&s.Suite, char.ToData())
+
+	bus := newFailingBus(3)
+	err = Attach(s.ctx, char, bus)
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errRefused)
+	s.Require().Equal(before, marshalData(&s.Suite, char.ToData()))
+	s.Require().Empty(char.subscriptionIDs, "the sheet claims no subscriptions")
+	s.Require().Nil(char.bus, "and holds the bus it held before, which was none")
+	s.assertNothingListening(char, bus)
+	s.assertRetryWorks(char)
+}
+
+// The keeper's handlers all land and its one resource is refused — the sixth
+// subscription. The handlers come back off with it: a sheet listening to the
+// world but not recovering on a rest is a state nothing about the sheet
+// records.
+func (s *AttachRollbackTestSuite) TestKeeperRollsBackAFailedResource() {
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
+	s.Require().NoError(err)
+	before := marshalData(&s.Suite, char.ToData())
+
+	bus := newFailingBus(6)
+	err = Attach(s.ctx, char, bus)
+
+	s.Require().Error(err)
+	s.Require().Equal(before, marshalData(&s.Suite, char.ToData()))
+	s.Require().Empty(char.subscriptionIDs)
+	s.Require().Nil(char.bus)
+	s.assertNothingListening(char, bus)
+	s.assertRetryWorks(char)
+}
+
+// The keeper attaches, and the condition after it is refused — the seventh
+// subscription is the first one Raging makes. Everything that went on comes
+// back off, and the condition is pending again with its ref, so the retry can
+// attribute it exactly as the first attempt would have.
+func (s *AttachRollbackTestSuite) TestAttachRollsBackAFailedCondition() {
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
+	s.Require().NoError(err)
+	before := marshalData(&s.Suite, char.ToData())
+
+	bus := newFailingBus(7)
+	err = Attach(s.ctx, char, bus)
+
+	s.Require().Error(err)
+	s.Require().Equal(before, marshalData(&s.Suite, char.ToData()))
+	s.Require().Len(char.GetConditions(), 1, "the condition is still on the sheet")
+	s.Require().False(char.GetConditions()[0].IsApplied(), "just not applied")
+	s.Require().Len(char.pendingEffects, 1, "and still waiting to be, ref and all")
+	s.Require().Empty(char.subscriptionIDs)
+	s.Require().Nil(char.bus)
+	s.assertNothingListening(char, bus)
+	s.assertRetryWorks(char)
+}
+
+// A condition that fails after another has already applied takes that one off
+// with it. Half a sheet's conditions attached is a character playing by rules
+// nobody wrote — and unlike the other failures here, this one leaves live
+// subscriptions from an effect the caller was told did not attach.
+func (s *AttachRollbackTestSuite) TestASecondConditionFailingRemovesTheFirst() {
+	// Counted, not guessed: the same sheet carrying only its first condition
+	// tells us how many subscriptions land before a second one would start, so
+	// this stays pointed at the right moment if Raging's internals change.
+	counter := newFailingBus(0)
+	warmup, err := Load(s.ctx, fullSheet(&s.Suite))
+	s.Require().NoError(err)
+	s.Require().NoError(Attach(s.ctx, warmup, counter))
+	firstSubscriptionOfTheSecondCondition := counter.calls + 1
+
+	data := fullSheet(&s.Suite)
+	data.Conditions = append(data.Conditions, brutalCriticalBlob(&s.Suite))
+
+	char, err := Load(s.ctx, data)
+	s.Require().NoError(err)
+	s.Require().Len(char.GetConditions(), 2)
+	before := marshalData(&s.Suite, char.ToData())
+
+	bus := newFailingBus(firstSubscriptionOfTheSecondCondition)
+	err = Attach(s.ctx, char, bus)
+
+	s.Require().Error(err)
+	s.Require().Equal(before, marshalData(&s.Suite, char.ToData()))
+	s.Require().Len(char.pendingEffects, 2, "both are waiting again")
+	for _, cond := range char.GetConditions() {
+		s.Require().False(cond.IsApplied(), "including the one that had applied")
+	}
+	s.assertNothingListening(char, bus)
+
+	good := events.NewEventBus()
+	s.Require().NoError(Attach(s.ctx, char, good))
+	s.Require().Len(char.GetConditions(), 2)
+	for _, cond := range char.GetConditions() {
+		s.Require().True(cond.IsApplied(), "the retry attached both")
+	}
+}
+
+// The lenient path keeps the behaviour its callers have: a condition that will
+// not apply is dropped and the load succeeds. Rolling the whole attach back
+// here would turn a survivable load into a failure for twenty callers.
+func (s *AttachRollbackTestSuite) TestLenientAttachStillDropsAndContinues() {
+	bus := newFailingBus(7)
+
+	char, err := LoadFromData(s.ctx, fullSheet(&s.Suite), bus)
+
+	s.Require().NoError(err)
+	s.Require().Empty(char.GetConditions(), "the condition that would not apply was dropped")
+	s.Require().NotEmpty(char.subscriptionIDs, "the sheet is attached")
+}
+
+func TestAttachRollbackSuite(t *testing.T) {
+	suite.Run(t, new(AttachRollbackTestSuite))
+}

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -89,12 +89,22 @@ type Character struct {
 	// Conditions (raging, poisoned, stunned, etc) - passive effects
 	conditions []dnd5eEvents.ConditionBehavior
 
+	// Conditions the load parsed but no bus has seen yet, each still paired
+	// with the ref its loader routed on. Attach drains this; a character that
+	// was never loaded from data has none.
+	pendingEffects []loadedEffect
+
+	// What this sheet does with a persisted blob it cannot read - decided by
+	// how it was loaded, and honored again when it is attached.
+	policy effectPolicy
+
 	// Death saves (tracked when at 0 HP)
 	deathSaveState *saves.DeathSaveState
 
 	// Event handling
 	bus             events.EventBus
 	subscriptionIDs []string
+	keeper          *SheetKeeper
 
 	// Action economy state (nil outside combat)
 	actionEconomy *ActionEconomyData
@@ -1082,71 +1092,49 @@ func (c *Character) ToData() *Data {
 	return data
 }
 
-// subscribeToEvents subscribes the character to gameplay events
+// subscribeToEvents subscribes the character to gameplay events on the bus it
+// is already holding.
+//
+// The subscriptions are the [SheetKeeper]'s — this is the same five handlers,
+// reached the way a character that was built rather than loaded reaches them:
+// Draft.Finalize wires the bus into the sheet and then asks it to listen.
+// Deliberately not the keeper's full Apply, which would also put the
+// character's resources on the bus; see SheetKeeper.subscribeSelf.
 func (c *Character) subscribeToEvents(ctx context.Context) error {
 	if c.bus == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "character has no event bus")
 	}
 
-	// Subscribe to condition applied events
-	appliedTopic := dnd5eEvents.ConditionAppliedTopic.On(c.bus)
-	subID, err := appliedTopic.Subscribe(ctx, c.onConditionApplied)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to condition applied")
-	}
-	c.subscriptionIDs = append(c.subscriptionIDs, subID)
-
-	// Subscribe to condition removed events
-	removedTopic := dnd5eEvents.ConditionRemovedTopic.On(c.bus)
-	subID, err = removedTopic.Subscribe(ctx, c.onConditionRemoved)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to condition removed events")
-	}
-	c.subscriptionIDs = append(c.subscriptionIDs, subID)
-
-	// Subscribe to healing received events
-	healingTopic := dnd5eEvents.HealingReceivedTopic.On(c.bus)
-	subID, err = healingTopic.Subscribe(ctx, c.onHealingReceived)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to healing received")
-	}
-	c.subscriptionIDs = append(c.subscriptionIDs, subID)
-
-	// Subscribe to action granted events
-	actionGrantedTopic := dnd5eEvents.ActionGrantedTopic.On(c.bus)
-	subID, err = actionGrantedTopic.Subscribe(ctx, c.onActionGranted)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to action granted")
-	}
-	c.subscriptionIDs = append(c.subscriptionIDs, subID)
-
-	// Subscribe to action removed events
-	actionRemovedTopic := dnd5eEvents.ActionRemovedTopic.On(c.bus)
-	subID, err = actionRemovedTopic.Subscribe(ctx, c.onActionRemoved)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to action removed")
-	}
-	c.subscriptionIDs = append(c.subscriptionIDs, subID)
-
-	return nil
+	return c.SheetKeeper().subscribeSelf(ctx, c.bus)
 }
 
-// onConditionApplied handles ConditionAppliedEvent
-func (c *Character) onConditionApplied(ctx context.Context, event dnd5eEvents.ConditionAppliedEvent) error {
+// onConditionApplied handles ConditionAppliedEvent.
+//
+// bus is the one the sheet was attached to, handed down from the
+// [SheetKeeper] rather than read off the character: a purely loaded sheet has
+// no bus of its own, and one that does must not answer on a different bus than
+// the one that delivered the event.
+func (c *Character) onConditionApplied(
+	ctx context.Context, bus events.EventBus, event dnd5eEvents.ConditionAppliedEvent,
+) error {
 	// Only process events for this character
 	if event.Target.GetID() != c.id {
 		return nil
 	}
 
 	// Apply the condition (subscribes to events)
-	if err := event.Condition.Apply(ctx, c.bus); err != nil {
+	if err := event.Condition.Apply(ctx, bus); err != nil {
 		// Clean up any partial subscriptions to avoid resource leaks
-		_ = event.Condition.Remove(ctx, c.bus)
+		_ = event.Condition.Remove(ctx, bus)
 		return rpgerr.Wrapf(err, "failed to apply condition")
 	}
 
 	// Store the condition
 	c.conditions = append(c.conditions, event.Condition)
+
+	// ToData serializes conditions, so a sheet that gained one and did not go
+	// dirty is a sheet whose new condition never gets written down.
+	c.dirty = true
 
 	return nil
 }
@@ -1180,6 +1168,11 @@ func (c *Character) onConditionRemoved(_ context.Context, event dnd5eEvents.Cond
 			filtered = append(filtered, cond)
 		}
 	}
+
+	if len(filtered) != len(c.conditions) {
+		// Same reason as onConditionApplied: what ToData writes has changed.
+		c.dirty = true
+	}
 	c.conditions = filtered
 
 	return nil
@@ -1198,11 +1191,17 @@ func (c *Character) onHealingReceived(_ context.Context, event dnd5eEvents.Heali
 		c.hitPoints = c.maxHitPoints
 	}
 
+	// HP is persisted, and ApplyDamage marks dirty for the same reason.
+	c.dirty = true
+
 	return nil
 }
 
-// onActionGranted handles ActionGrantedEvent
-func (c *Character) onActionGranted(ctx context.Context, event dnd5eEvents.ActionGrantedEvent) error {
+// onActionGranted handles ActionGrantedEvent.
+//
+// bus is the sheet's attached bus, for the reason given on onConditionApplied.
+// Granted actions are not persisted, so this does not mark the sheet dirty.
+func (c *Character) onActionGranted(ctx context.Context, bus events.EventBus, event dnd5eEvents.ActionGrantedEvent) error {
 	// Only process events for this character
 	if event.CharacterID != c.id {
 		return nil
@@ -1216,7 +1215,7 @@ func (c *Character) onActionGranted(ctx context.Context, event dnd5eEvents.Actio
 
 	// Apply the action (subscribes to events like TurnEnd for cleanup).
 	// Ignore AlreadyExists errors since the granter may have already called Apply.
-	if err := action.Apply(ctx, c.bus); err != nil {
+	if err := action.Apply(ctx, bus); err != nil {
 		if rpgerr.GetCode(err) != rpgerr.CodeAlreadyExists {
 			return rpgerr.Wrapf(err, "failed to apply action")
 		}
@@ -1281,6 +1280,42 @@ func (c *Character) Cleanup(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// dropCondition takes a condition back off the sheet by identity.
+//
+// By identity rather than by ref because this runs when a condition failed to
+// apply, and the sheet may legitimately carry two conditions with the same ref
+// — only the one instance that failed should leave.
+func (c *Character) dropCondition(behavior dnd5eEvents.ConditionBehavior) {
+	for i, cond := range c.conditions {
+		if cond == behavior {
+			c.conditions = append(c.conditions[:i], c.conditions[i+1:]...)
+			return
+		}
+	}
+}
+
+// forgetSubscriptions drops the given subscription IDs from the character's
+// list, so that a Cleanup after a [SheetKeeper.Remove] does not try to revoke
+// hooks that are already gone.
+func (c *Character) forgetSubscriptions(revoked []string) {
+	if len(revoked) == 0 || len(c.subscriptionIDs) == 0 {
+		return
+	}
+
+	gone := make(map[string]struct{}, len(revoked))
+	for _, id := range revoked {
+		gone[id] = struct{}{}
+	}
+
+	kept := make([]string, 0, len(c.subscriptionIDs))
+	for _, id := range c.subscriptionIDs {
+		if _, ok := gone[id]; !ok {
+			kept = append(kept, id)
+		}
+	}
+	c.subscriptionIDs = kept
 }
 
 // calculateArmorAC creates an AC component for equipped armor

--- a/rulebooks/dnd5e/character/data.go
+++ b/rulebooks/dnd5e/character/data.go
@@ -3,21 +3,14 @@ package character
 import (
 	"context"
 	"encoding/json"
-	"maps"
 	"time"
 
-	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/backgrounds"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
-	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/languages"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
@@ -115,195 +108,33 @@ type RecoverableResourceData struct {
 	ResetType coreResources.ResetType `json:"reset_type"`
 }
 
-// LoadFromData creates a Character from persistent data
+// LoadFromData creates a Character from persistent data and puts it on the bus.
+//
+// It is [Load] followed by [Attach], and nothing else. The two halves are
+// separately callable — a sheet loaded with Load exists without a bus at all —
+// and this signature stays for the callers that have it, until
+// rpg-toolkit#965 and #966 retire the verb methods that need the character to
+// be holding a bus of its own.
+//
+// This path is forgiving where Load is strict: a condition, feature, or
+// inventory item it cannot make sense of is dropped and the load continues,
+// which is the behaviour every existing caller has. Read that as a warning
+// rather than a feature — it means a sheet can come back from a round trip
+// missing something nobody removed (rpg-toolkit#948). Load refuses instead,
+// and names the blob.
 func LoadFromData(ctx context.Context, d *Data, bus events.EventBus) (*Character, error) {
 	if bus == nil {
 		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
 	}
 
-	char := &Character{
-		id:                  d.ID,
-		playerID:            d.PlayerID,
-		name:                d.Name,
-		level:               d.Level,
-		proficiencyBonus:    d.ProficiencyBonus,
-		raceID:              d.RaceID,
-		subraceID:           d.SubraceID,
-		classID:             d.ClassID,
-		subclassID:          d.SubclassID,
-		abilityScores:       d.AbilityScores,
-		hitPoints:           d.HitPoints,
-		maxHitPoints:        d.MaxHitPoints,
-		armorClass:          d.ArmorClass,
-		deathSaveState:      d.DeathSaveState,
-		skills:              d.Skills,
-		savingThrows:        d.SavingThrows,
-		languages:           d.Languages,
-		armorProficiencies:  d.ArmorProficiencies,
-		weaponProficiencies: d.WeaponProficiencies,
-		toolProficiencies:   d.ToolProficiencies,
-		equipmentSlots:      d.EquipmentSlots,
-		// Round-trip fix (#659): SpellSlots and ClassResources are written
-		// by ToData (character.go ~954-957) via maps.Clone, but were not
-		// being read back here. A finalized character round-tripping through
-		// Data lost its spell slots and class resources, breaking any
-		// consumer that gates on them — most visibly Wave 2.11d's
-		// applyReactionConditions.hasFirstLevelSpellSlot check in rpg-api
-		// that decides whether to Apply()  the Shield reaction.
-		// maps.Clone(nil) safely returns nil; consumers (hasFirstLevelSpellSlot,
-		// etc.) already handle the nil-map case.
-		spellSlots:      maps.Clone(d.SpellSlots),
-		classResources:  maps.Clone(d.ClassResources),
-		bus:             bus,
-		subscriptionIDs: make([]string, 0),
-		resources:       make(map[coreResources.ResourceKey]*combat.RecoverableResource),
+	char, err := loadSheet(d, lenientEffects)
+	if err != nil {
+		return nil, err
 	}
 
-	// Deep-copy action economy state to avoid aliasing mutable Granted map.
-	// Granted is tagged json:"granted,omitempty", so a freshly-StartTurn-seeded
-	// EMPTY map is omitted from the serialized JSON and comes back nil after a
-	// round-trip. fromToolkitActionEconomy writes into Granted unconditionally,
-	// so a nil map there panics ("assignment to entry in nil map") on the next
-	// ability activation. Always re-init: clone when non-nil, else make a fresh
-	// empty map so the loaded economy is immediately writable (#706).
-	if d.ActionEconomy != nil {
-		aeCopy := *d.ActionEconomy
-		if d.ActionEconomy.Granted != nil {
-			aeCopy.Granted = maps.Clone(d.ActionEconomy.Granted)
-		} else {
-			aeCopy.Granted = make(map[GrantedActionKey]int)
-		}
-		char.actionEconomy = &aeCopy
-	}
-
-	// Get hit dice from class data
-	if classData := classes.GetData(d.ClassID); classData != nil {
-		char.hitDice = classData.HitDice
-	}
-
-	// Convert inventory data back to Equipment items
-	char.inventory = make([]InventoryItem, 0, len(d.Inventory))
-	for _, itemData := range d.Inventory {
-		// Use the unified GetByID function
-		equip, err := equipment.GetByID(itemData.ID)
-		if err != nil {
-			// Log error but continue loading other items
-			// TODO: Consider how to handle missing equipment
-			continue
-		}
-		char.inventory = append(char.inventory, InventoryItem{
-			Equipment: equip,
-			Quantity:  itemData.Quantity,
-		})
-	}
-
-	// Load features from persisted JSON data
-	char.features = make([]features.Feature, 0, len(d.Features))
-	for _, rawFeature := range d.Features {
-		// Peek at the ref to check module
-		var peek struct {
-			Ref core.Ref `json:"ref"`
-		}
-		if err := json.Unmarshal(rawFeature, &peek); err != nil {
-			// Skip malformed features
-			continue
-		}
-
-		// Check if this is a dnd5e feature (for now, only module we support)
-		if peek.Ref.Module == "dnd5e" {
-			// Load the actual feature implementation
-			feature, err := features.LoadJSON(rawFeature)
-			if err != nil {
-				// Log error but continue loading other features
-				// TODO: Consider how to handle feature loading errors
-				continue
-			}
-			char.features = append(char.features, feature)
-		}
-		// Silently skip non-dnd5e features for now
-		// In the future, this would route to a module registry
-	}
-
-	// Load conditions from persisted JSON data (following same pattern as features)
-	char.conditions = make([]dnd5eEvents.ConditionBehavior, 0, len(d.Conditions))
-	for _, rawCondition := range d.Conditions {
-		// Load the actual condition implementation
-		condition, err := conditions.LoadJSON(rawCondition)
-		if err != nil {
-			// Log error but continue loading other conditions
-			// TODO: Consider how to handle condition loading errors
-			continue
-		}
-
-		// Apply through the bus this particular effect should be attributed to.
-		// A plain bus returns itself, so this is a no-op for every caller that
-		// is not an attach site keeping a registration list; a bus that
-		// implements dnd5eEvents.EffectScoper gets to record which effect made
-		// each subscription. The ref is the one conditions.LoadJSON just routed
-		// on, peeked again here because a ConditionBehavior cannot name itself.
-		effectBus := dnd5eEvents.BusForEffect(bus, peekEffectRef(rawCondition))
-
-		// Re-apply the condition so it subscribes to events
-		if err := condition.Apply(ctx, effectBus); err != nil {
-			// Clean up any partial subscriptions to avoid resource leaks
-			_ = condition.Remove(ctx, effectBus)
-			// Log error but continue loading other conditions
-			// TODO: Consider how to handle condition apply errors
-			continue
-		}
-
-		char.conditions = append(char.conditions, condition)
-	}
-
-	// Load resources from persisted data
-	for key, resData := range d.Resources {
-		resource := combat.NewRecoverableResource(combat.RecoverableResourceConfig{
-			ID:          string(key),
-			Maximum:     resData.Maximum,
-			CharacterID: char.id,
-			ResetType:   resData.ResetType,
-		})
-
-		// Set current value if different from maximum
-		if resData.Current != resData.Maximum {
-			deficit := resData.Maximum - resData.Current
-			_ = resource.Use(deficit) // Ignore error - we know the value is valid
-		}
-
-		// Apply resource to subscribe to rest events
-		if err := resource.Apply(ctx, bus); err != nil {
-			// Clean up on failure
-			_ = resource.Remove(ctx, bus)
-			// Log error but continue loading other resources
-			// TODO: Consider how to handle resource apply errors
-			continue
-		}
-
-		char.resources[key] = resource
-	}
-
-	// Re-register standard combat abilities (not persisted, always available)
-	initStandardCombatAbilities(char)
-
-	// Subscribe to events - character comes out fully initialized
-	if err := char.subscribeToEvents(ctx); err != nil {
-		return nil, rpgerr.Wrapf(err, "failed to subscribe to events")
+	if err := Attach(ctx, char, bus); err != nil {
+		return nil, err
 	}
 
 	return char, nil
-}
-
-// peekEffectRef reads the ref a persisted effect routes on, which is the same
-// field its loader routes on. It returns the zero Ref for a blob that has none
-// rather than an error: an effect that loaded is applied either way, and the
-// only thing a missing ref costs is attribution.
-func peekEffectRef(raw json.RawMessage) core.Ref {
-	var peek struct {
-		Ref core.Ref `json:"ref"`
-	}
-	if err := json.Unmarshal(raw, &peek); err != nil {
-		return core.Ref{}
-	}
-
-	return peek.Ref
 }

--- a/rulebooks/dnd5e/character/load.go
+++ b/rulebooks/dnd5e/character/load.go
@@ -1,0 +1,388 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// effectPolicy decides what a load does with a persisted blob it cannot make
+// sense of. It is a property of how a sheet was loaded, and it travels with the
+// sheet: a sheet loaded leniently attaches leniently, because the two halves of
+// one loader must not disagree about what a failure means.
+type effectPolicy int
+
+const (
+	// strictEffects refuses the whole load and names what failed. This is the
+	// zero value, so anything not loaded from persisted data — a finalized
+	// draft, for instance — is strict without having to say so.
+	strictEffects effectPolicy = iota
+
+	// lenientEffects drops what it cannot read and carries on, which is what
+	// [LoadFromData] has always done.
+	lenientEffects
+)
+
+// loadedEffect pairs a condition's behaviour with the ref its loader routed on.
+//
+// The pairing is only knowable here. A [dnd5eEvents.ConditionBehavior] cannot
+// name itself (rpg-toolkit#971), so the moment the load routes a blob's ref to
+// a loader is the one moment the (ref, behaviour) pair exists — and per-effect
+// attribution downstream is built entirely out of that pair.
+type loadedEffect struct {
+	ref      core.Ref
+	behavior dnd5eEvents.ConditionBehavior
+}
+
+// Load turns persisted data into a character sheet, and does nothing else.
+//
+// No event bus, no subscriptions, no effect applied — a loaded sheet is inert
+// until [Attach] puts it on a bus. Conditions are still parsed into behaviours
+// and kept on the sheet, together with the ref their loader routed on, so that
+// [Attach] can attribute each one later and so that ToData writes back what
+// the sheet was loaded with. Load(d).ToData() is the data it was handed.
+//
+// Load is strict where [LoadFromData] is forgiving: a persisted blob it cannot
+// make sense of — a condition, a feature, an inventory item — fails the load,
+// and the error names the blob. LoadFromData drops that blob and carries on,
+// which is the behaviour its callers have today and keep. The divergence is
+// deliberate. A loader that continues past what it cannot read hands back a
+// sheet that is quietly missing something, and the next save persists the
+// loss; that is the shape of rpg-toolkit#948, and refusing is the only way the
+// round trip can be an actual guarantee.
+//
+// Two fields of [Data] do not survive a round trip through any loader:
+// BackgroundID and CreatedAt have nowhere to live on the sheet, and ToData
+// does not write them. That is a pre-existing gap in the sheet rather than in
+// this loader — pinned by TestKnownRoundTripGaps so it cannot be mistaken for
+// a guarantee — and closing it means changing ToData, which belongs in its own
+// change.
+//
+// ctx is unused: a pure load has nothing to cancel and reads no clock. It is
+// part of the signature so that the pure and legacy loaders read the same at a
+// call site, and so that adding cancellable work here is never a breaking
+// change.
+func Load(_ context.Context, d *Data) (*Character, error) {
+	if d == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "character data is required")
+	}
+
+	return loadSheet(d, strictEffects)
+}
+
+// Attach puts a loaded sheet on an event bus: the sheet's own keeper first,
+// then every condition the load parsed, each through the bus scoped to its own
+// ref.
+//
+// This is the whole attach loop, in one call, on the dnd5e side of the seam.
+// Ordering is fixed rather than incidental: the sheet's own hooks are attached
+// before any effect's, so two attaches over identical data grant identical
+// registrations in identical order (ADR-0038 R4), and so an effect's hooks are
+// never interleaved with the sheet's in a registration list.
+//
+// Each condition goes on through [dnd5eEvents.BusForEffect] with the ref the
+// load captured. A plain bus returns itself and nothing changes; a bus that
+// keeps a registration list gets to record which effect made which
+// subscription. The sheet keeper is applied with the bus itself, so the
+// character's own machinery is never laundered into an effect's name.
+//
+// Attaching also parks the bus on the sheet, for the verb methods that still
+// read it (MakeSavingThrow, ActivateCombatAbility, EffectiveAC, the rests).
+// That is the keeper's doing, not this function's, because a character built
+// by Draft.Finalize gets there without ever passing through here; see
+// SheetKeeper.subscribeSelf.
+func Attach(ctx context.Context, c *Character, bus events.EventBus) error {
+	if c == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "character is required")
+	}
+	if bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
+	}
+
+	if err := c.SheetKeeper().Apply(ctx, bus); err != nil {
+		return err
+	}
+
+	// Drained, not read: a second Attach must not put the same conditions on a
+	// second bus, and the sheet keeps them in c.conditions either way.
+	pending := c.pendingEffects
+	c.pendingEffects = nil
+
+	for _, effect := range pending {
+		effectBus := dnd5eEvents.BusForEffect(bus, effect.ref)
+
+		if err := effect.behavior.Apply(ctx, effectBus); err != nil {
+			// Undo whatever the failed Apply managed to subscribe.
+			_ = effect.behavior.Remove(ctx, effectBus)
+
+			if c.policy == strictEffects {
+				return rpgerr.Wrapf(err, "failed to apply condition %s", effect.ref.String())
+			}
+
+			// Lenient: the legacy path drops a condition it could not apply.
+			c.dropCondition(effect.behavior)
+		}
+	}
+
+	return nil
+}
+
+// loadSheet builds the sheet both loaders hand back. Everything that reads
+// [Data] and writes the character lives here; everything that touches a bus
+// lives in [Attach] and [SheetKeeper]. The split is the point of this file:
+// what a character *is* no longer depends on there being a bus to load it onto.
+func loadSheet(d *Data, policy effectPolicy) (*Character, error) {
+	char := &Character{
+		id:                  d.ID,
+		playerID:            d.PlayerID,
+		name:                d.Name,
+		level:               d.Level,
+		proficiencyBonus:    d.ProficiencyBonus,
+		raceID:              d.RaceID,
+		subraceID:           d.SubraceID,
+		classID:             d.ClassID,
+		subclassID:          d.SubclassID,
+		abilityScores:       d.AbilityScores,
+		hitPoints:           d.HitPoints,
+		maxHitPoints:        d.MaxHitPoints,
+		armorClass:          d.ArmorClass,
+		deathSaveState:      d.DeathSaveState,
+		skills:              d.Skills,
+		savingThrows:        d.SavingThrows,
+		languages:           d.Languages,
+		armorProficiencies:  d.ArmorProficiencies,
+		weaponProficiencies: d.WeaponProficiencies,
+		toolProficiencies:   d.ToolProficiencies,
+		equipmentSlots:      d.EquipmentSlots,
+		// Round-trip fix (#659): SpellSlots and ClassResources are written
+		// by ToData (character.go ~954-957) via maps.Clone, but were not
+		// being read back here. A finalized character round-tripping through
+		// Data lost its spell slots and class resources, breaking any
+		// consumer that gates on them — most visibly Wave 2.11d's
+		// applyReactionConditions.hasFirstLevelSpellSlot check in rpg-api
+		// that decides whether to Apply()  the Shield reaction.
+		// maps.Clone(nil) safely returns nil; consumers (hasFirstLevelSpellSlot,
+		// etc.) already handle the nil-map case.
+		spellSlots:      maps.Clone(d.SpellSlots),
+		classResources:  maps.Clone(d.ClassResources),
+		subscriptionIDs: make([]string, 0),
+		policy:          policy,
+	}
+
+	// Deep-copy action economy state to avoid aliasing mutable Granted map.
+	// Granted is tagged json:"granted,omitempty", so a freshly-StartTurn-seeded
+	// EMPTY map is omitted from the serialized JSON and comes back nil after a
+	// round-trip. fromToolkitActionEconomy writes into Granted unconditionally,
+	// so a nil map there panics ("assignment to entry in nil map") on the next
+	// ability activation. Always re-init: clone when non-nil, else make a fresh
+	// empty map so the loaded economy is immediately writable (#706).
+	if d.ActionEconomy != nil {
+		aeCopy := *d.ActionEconomy
+		if d.ActionEconomy.Granted != nil {
+			aeCopy.Granted = maps.Clone(d.ActionEconomy.Granted)
+		} else {
+			aeCopy.Granted = make(map[GrantedActionKey]int)
+		}
+		char.actionEconomy = &aeCopy
+	}
+
+	// Get hit dice from class data
+	if classData := classes.GetData(d.ClassID); classData != nil {
+		char.hitDice = classData.HitDice
+	}
+
+	inventory, err := loadInventory(d.Inventory, policy)
+	if err != nil {
+		return nil, err
+	}
+	char.inventory = inventory
+
+	loadedFeatures, err := loadFeatures(d.Features, policy)
+	if err != nil {
+		return nil, err
+	}
+	char.features = loadedFeatures
+
+	effects, err := loadEffects(d.Conditions, policy)
+	if err != nil {
+		return nil, err
+	}
+	char.pendingEffects = effects
+	char.conditions = make([]dnd5eEvents.ConditionBehavior, 0, len(effects))
+	for _, effect := range effects {
+		char.conditions = append(char.conditions, effect.behavior)
+	}
+
+	char.resources = loadResources(d.Resources, char.id)
+
+	// Re-register standard combat abilities (not persisted, always available)
+	initStandardCombatAbilities(char)
+
+	return char, nil
+}
+
+// loadInventory resolves persisted item IDs against the equipment catalog.
+// An ID the catalog does not know is a lost item: ToData writes back only what
+// resolved, so the lenient path's skip is how an item disappears from a
+// character between two saves.
+func loadInventory(items []InventoryItemData, policy effectPolicy) ([]InventoryItem, error) {
+	inventory := make([]InventoryItem, 0, len(items))
+
+	for i, itemData := range items {
+		equip, err := equipment.GetByID(itemData.ID)
+		if err != nil {
+			if policy == strictEffects {
+				return nil, rpgerr.Wrapf(err, "inventory item %d (%q) is not in the equipment catalog", i, itemData.ID)
+			}
+
+			// Log error but continue loading other items
+			// TODO: Consider how to handle missing equipment
+			continue
+		}
+
+		inventory = append(inventory, InventoryItem{
+			Equipment: equip,
+			Quantity:  itemData.Quantity,
+		})
+	}
+
+	return inventory, nil
+}
+
+// loadFeatures reconstitutes persisted features by routing each blob's ref to
+// its loader. A blob from another module has no loader here; the lenient path
+// skips it silently, and skipping it is what drops it from the next ToData.
+func loadFeatures(raw []json.RawMessage, policy effectPolicy) ([]features.Feature, error) {
+	loaded := make([]features.Feature, 0, len(raw))
+
+	for i, rawFeature := range raw {
+		// Peek at the ref to check module
+		var peek struct {
+			Ref core.Ref `json:"ref"`
+		}
+		if err := json.Unmarshal(rawFeature, &peek); err != nil {
+			if policy == strictEffects {
+				return nil, rpgerr.Wrapf(err, "failed to read the ref of feature %d: %s", i, rawFeature)
+			}
+
+			// Skip malformed features
+			continue
+		}
+
+		// Only dnd5e features have a loader here; another module's feature
+		// would need a module registry that does not exist yet.
+		if peek.Ref.Module != refs.Module {
+			if policy == strictEffects {
+				return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"feature %d has no loader here: module %q, blob %s", i, peek.Ref.Module, rawFeature)
+			}
+
+			// Silently skip non-dnd5e features for now
+			// In the future, this would route to a module registry
+			continue
+		}
+
+		feature, err := features.LoadJSON(rawFeature)
+		if err != nil {
+			if policy == strictEffects {
+				return nil, rpgerr.Wrapf(err, "failed to load feature %d: %s", i, rawFeature)
+			}
+
+			// Log error but continue loading other features
+			// TODO: Consider how to handle feature loading errors
+			continue
+		}
+
+		loaded = append(loaded, feature)
+	}
+
+	return loaded, nil
+}
+
+// loadEffects reconstitutes persisted conditions, keeping each behaviour with
+// the ref its loader routed on. Nothing is applied here — that is [Attach]'s
+// job, and the ref is what lets it attribute the subscriptions each condition
+// then makes.
+func loadEffects(raw []json.RawMessage, policy effectPolicy) ([]loadedEffect, error) {
+	effects := make([]loadedEffect, 0, len(raw))
+
+	for i, rawCondition := range raw {
+		condition, err := conditions.LoadJSON(rawCondition)
+		if err != nil {
+			if policy == strictEffects {
+				return nil, rpgerr.Wrapf(err, "failed to load condition %d: %s", i, rawCondition)
+			}
+
+			// Log error but continue loading other conditions
+			// TODO: Consider how to handle condition loading errors
+			continue
+		}
+
+		effects = append(effects, loadedEffect{
+			// Peeked rather than asked for: the ref conditions.LoadJSON just
+			// routed on is the only name this behaviour will ever have.
+			ref:      peekEffectRef(rawCondition),
+			behavior: condition,
+		})
+	}
+
+	return effects, nil
+}
+
+// loadResources rebuilds the character's recoverable resources at their
+// persisted values. They are inert until a [SheetKeeper] puts them on a bus,
+// which is what makes them recover on a rest.
+func loadResources(
+	persisted map[coreResources.ResourceKey]RecoverableResourceData, characterID string,
+) map[coreResources.ResourceKey]*combat.RecoverableResource {
+	loaded := make(map[coreResources.ResourceKey]*combat.RecoverableResource, len(persisted))
+
+	for key, resData := range persisted {
+		resource := combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+			ID:          string(key),
+			Maximum:     resData.Maximum,
+			CharacterID: characterID,
+			ResetType:   resData.ResetType,
+		})
+
+		// Set current value if different from maximum
+		if resData.Current != resData.Maximum {
+			deficit := resData.Maximum - resData.Current
+			_ = resource.Use(deficit) // Ignore error - we know the value is valid
+		}
+
+		loaded[key] = resource
+	}
+
+	return loaded
+}
+
+// peekEffectRef reads the ref a persisted effect routes on, which is the same
+// field its loader routes on. It returns the zero Ref for a blob that has none
+// rather than an error: an effect that loaded is applied either way, and the
+// only thing a missing ref costs is attribution.
+func peekEffectRef(raw json.RawMessage) core.Ref {
+	var peek struct {
+		Ref core.Ref `json:"ref"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return core.Ref{}
+	}
+
+	return peek.Ref
+}

--- a/rulebooks/dnd5e/character/load.go
+++ b/rulebooks/dnd5e/character/load.go
@@ -106,6 +106,18 @@ func Load(_ context.Context, d *Data) (*Character, error) {
 // That is the keeper's doing, not this function's, because a character built
 // by Draft.Finalize gets there without ever passing through here; see
 // SheetKeeper.subscribeSelf.
+//
+// **A failed strict Attach is a no-op.** Every effect that did go on comes back
+// off, newest first; the keeper is removed; the sheet gets back the bus it was
+// holding; and the conditions the load parsed are still pending, still paired
+// with their refs. So the bus is left carrying nothing this call put there, the
+// sheet is unchanged (ToData writes exactly what it wrote before), and the
+// caller can attach again — to this bus or another one. Half-attached and
+// reported as failed is the worst of the three states: the leak has an alibi
+// and the retry is impossible.
+//
+// The lenient path is unchanged: it is LoadFromData's, and dropping what will
+// not apply is the behaviour its callers have.
 func Attach(ctx context.Context, c *Character, bus events.EventBus) error {
 	if c == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "character is required")
@@ -114,14 +126,20 @@ func Attach(ctx context.Context, c *Character, bus events.EventBus) error {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
 	}
 
+	previousBus := c.bus
+
 	if err := c.SheetKeeper().Apply(ctx, bus); err != nil {
+		// A failed Apply already put itself back; there is nothing else to undo.
 		return err
 	}
 
 	// Drained, not read: a second Attach must not put the same conditions on a
-	// second bus, and the sheet keeps them in c.conditions either way.
+	// second bus, and the sheet keeps them in c.conditions either way. A strict
+	// failure below puts them back.
 	pending := c.pendingEffects
 	c.pendingEffects = nil
+
+	attached := make([]attachedEffect, 0, len(pending))
 
 	for _, effect := range pending {
 		effectBus := dnd5eEvents.BusForEffect(bus, effect.ref)
@@ -131,15 +149,53 @@ func Attach(ctx context.Context, c *Character, bus events.EventBus) error {
 			_ = effect.behavior.Remove(ctx, effectBus)
 
 			if c.policy == strictEffects {
+				c.unattach(ctx, bus, attached, pending, previousBus)
+
 				return rpgerr.Wrapf(err, "failed to apply condition %s", effect.ref.String())
 			}
 
 			// Lenient: the legacy path drops a condition it could not apply.
 			c.dropCondition(effect.behavior)
+
+			continue
 		}
+
+		attached = append(attached, attachedEffect{effect: effect, bus: effectBus})
 	}
 
 	return nil
+}
+
+// attachedEffect is an effect this attach put on a bus, with the bus it was put
+// on. Remembered rather than recomputed: asking an EffectScoper for a scope is
+// how it learns an effect exists, and a rollback that asked again would leave a
+// registration ledger describing an attach that did not happen.
+type attachedEffect struct {
+	effect loadedEffect
+	bus    events.EventBus
+}
+
+// unattach returns the sheet to the state [Attach] found it in: every effect
+// that went on comes back off newest first, the keeper is removed, the pending
+// effects are restored whole, and the sheet gets back the bus it was holding.
+func (c *Character) unattach(
+	ctx context.Context,
+	bus events.EventBus,
+	attached []attachedEffect,
+	pending []loadedEffect,
+	previousBus events.EventBus,
+) {
+	// Newest first, the order resolution tears down in (ADR-0038 R5).
+	for i := len(attached) - 1; i >= 0; i-- {
+		_ = attached[i].effect.behavior.Remove(ctx, attached[i].bus)
+	}
+
+	_ = c.SheetKeeper().Remove(ctx, bus)
+
+	// All of them, including the one that failed: nothing is applied now, so
+	// nothing has been attached, so everything is still waiting to be.
+	c.pendingEffects = pending
+	c.bus = previousBus
 }
 
 // loadSheet builds the sheet both loaders hand back. Everything that reads

--- a/rulebooks/dnd5e/character/load_test.go
+++ b/rulebooks/dnd5e/character/load_test.go
@@ -1,0 +1,366 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/backgrounds"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/equipment"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/languages"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+type PureLoadTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func (s *PureLoadTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// ragingBlob is a persisted Raging condition in the exact bytes its own
+// serializer produces, so that a byte comparison downstream is a claim about
+// the loader carrying it rather than about this test's JSON matching the
+// serializer's field order.
+func (s *PureLoadTestSuite) ragingBlob() json.RawMessage {
+	raging := &conditions.RagingCondition{
+		CharacterID: "char-load",
+		DamageBonus: 2,
+		Level:       3,
+		Source:      "rage",
+	}
+
+	raw, err := raging.ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// rageBlob is a persisted Rage feature, canonicalized the same way.
+func (s *PureLoadTestSuite) rageBlob() json.RawMessage {
+	seed, err := json.Marshal(features.RageData{
+		Ref:   refs.Features.Rage(),
+		ID:    "rage-1",
+		Name:  "Rage",
+		Level: 3,
+	})
+	s.Require().NoError(err)
+
+	feature, err := features.LoadJSON(seed)
+	s.Require().NoError(err)
+
+	raw, err := feature.ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// fullSheet is character data with something in every field a loader is
+// responsible for carrying — the ones that are only a copy, and the ones
+// (inventory, features, conditions, resources) that have to be reconstituted
+// and then serialized back.
+func (s *PureLoadTestSuite) fullSheet() *Data {
+	sword, err := equipment.GetByID(weapons.Longsword)
+	s.Require().NoError(err)
+
+	return &Data{
+		ID:               "char-load",
+		PlayerID:         "player-load",
+		Name:             "Round Tripper",
+		Level:            3,
+		ProficiencyBonus: 2,
+		RaceID:           races.Human,
+		ClassID:          classes.Barbarian,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    22,
+		MaxHitPoints: 34,
+		ArmorClass:   15,
+		Skills: map[skills.Skill]shared.ProficiencyLevel{
+			skills.Athletics: shared.Proficient,
+		},
+		SavingThrows: map[abilities.Ability]shared.ProficiencyLevel{
+			abilities.STR: shared.Proficient,
+		},
+		Languages:           []languages.Language{languages.Common, languages.Orc},
+		ArmorProficiencies:  []proficiencies.Armor{proficiencies.ArmorLight},
+		WeaponProficiencies: []proficiencies.Weapon{proficiencies.WeaponMartial},
+		Inventory: []InventoryItemData{
+			{Type: sword.EquipmentType(), ID: sword.EquipmentID(), Quantity: 1},
+		},
+		EquipmentSlots: EquipmentSlots{SlotMainHand: string(weapons.Longsword)},
+		SpellSlots:     map[int]SpellSlotData{1: {Max: 2, Used: 1}},
+		ClassResources: map[shared.ClassResourceType]ResourceData{
+			shared.ClassResourceRage: {Name: "Rage", Max: 3, Current: 2, Resets: shared.ResetTypeLongRest},
+		},
+		Resources: map[coreResources.ResourceKey]RecoverableResourceData{
+			resources.RageCharges: {Current: 2, Maximum: 3, ResetType: coreResources.ResetLongRest},
+		},
+		Features:   []json.RawMessage{s.rageBlob()},
+		Conditions: []json.RawMessage{s.ragingBlob()},
+		ActionEconomy: &ActionEconomyData{
+			TurnNumber:            4,
+			ActionsRemaining:      1,
+			BonusActionsRemaining: 1,
+			ReactionsRemaining:    1,
+			MovementRemaining:     30,
+		},
+	}
+}
+
+// comparable strips the fields no loader can round-trip, so that what is left
+// is a claim about the loader rather than about the clock. UpdatedAt is
+// re-stamped by ToData on purpose; the other two are the gap
+// TestKnownRoundTripGaps pins.
+func comparable(d *Data) *Data {
+	stripped := *d
+	stripped.CreatedAt = time.Time{}
+	stripped.UpdatedAt = time.Time{}
+	stripped.BackgroundID = ""
+
+	return &stripped
+}
+
+func (s *PureLoadTestSuite) marshal(d *Data) string {
+	raw, err := json.Marshal(comparable(d))
+	s.Require().NoError(err)
+
+	return string(raw)
+}
+
+// The whole point of a pure load: data in, the same data out, with no bus
+// anywhere in the call. Byte-for-byte, because "equivalent" is what a sheet
+// that has quietly dropped a condition also looks like (rpg-toolkit#948).
+func (s *PureLoadTestSuite) TestRoundTripsByteIdenticalWithNoBus() {
+	data := s.fullSheet()
+
+	char, err := Load(s.ctx, data)
+	s.Require().NoError(err)
+
+	s.Require().Equal(s.marshal(data), s.marshal(char.ToData()))
+}
+
+// Named separately because it is the one this migration exists to protect: the
+// conditions survive a load that never saw a bus, which is what lets the attach
+// loop move out of the loader.
+func (s *PureLoadTestSuite) TestConditionsSurviveALoadWithNoBus() {
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+
+	s.Require().Len(char.GetConditions(), 1)
+	s.Require().Equal(s.ragingBlob(), char.ToData().Conditions[0])
+}
+
+// A loaded sheet is inert. Nothing is applied, nothing is subscribed, and no
+// bus is held — the conditions are parsed and waiting, not running.
+func (s *PureLoadTestSuite) TestLoadAppliesNothing() {
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+
+	s.Require().Nil(char.bus, "a pure load holds no bus")
+	s.Require().Empty(char.subscriptionIDs, "a pure load subscribes to nothing")
+
+	for _, cond := range char.GetConditions() {
+		s.Require().False(cond.IsApplied(), "a pure load applies no condition")
+	}
+}
+
+// The strict path refuses a condition blob it cannot read, and the error says
+// which blob. Refusing is the whole divergence: a sheet that comes back short
+// one condition looks exactly like a sheet that never had it.
+func (s *PureLoadTestSuite) TestStrictLoadRefusesAMalformedCondition() {
+	data := s.fullSheet()
+	data.Conditions = append(data.Conditions, json.RawMessage(`{"ref":{"module":"dnd5e","type":"conditions","id":"nope"}}`))
+
+	_, err := Load(s.ctx, data)
+
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), `"id":"nope"`, "the error names the blob that failed")
+}
+
+// The same blob on the legacy path loads, and the condition is gone. This is
+// not a bug being pinned as correct — it is the behaviour ~20 callers have,
+// asserted so that the divergence is a decision rather than a surprise.
+func (s *PureLoadTestSuite) TestLegacyLoadDropsAMalformedCondition() {
+	data := s.fullSheet()
+	data.Conditions = append(data.Conditions, json.RawMessage(`{"ref":{"module":"dnd5e","type":"conditions","id":"nope"}}`))
+
+	char, err := LoadFromData(s.ctx, data, events.NewEventBus())
+
+	s.Require().NoError(err)
+	s.Require().Len(char.GetConditions(), 1, "the unreadable condition is silently dropped")
+}
+
+// Features are the same species of loss as conditions, and get the same
+// treatment: a blob with no loader here fails the strict load.
+func (s *PureLoadTestSuite) TestStrictLoadRefusesAFeatureFromAnotherModule() {
+	data := s.fullSheet()
+	data.Features = append(data.Features, json.RawMessage(`{"ref":{"module":"artificer","type":"features","id":"infusion"}}`))
+
+	_, err := Load(s.ctx, data)
+
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "artificer")
+}
+
+func (s *PureLoadTestSuite) TestLegacyLoadDropsAFeatureFromAnotherModule() {
+	data := s.fullSheet()
+	data.Features = append(data.Features, json.RawMessage(`{"ref":{"module":"artificer","type":"features","id":"infusion"}}`))
+
+	char, err := LoadFromData(s.ctx, data, events.NewEventBus())
+
+	s.Require().NoError(err)
+	s.Require().Len(char.ToData().Features, 1, "the foreign feature is silently dropped")
+}
+
+// An inventory item the catalog does not know disappears from the sheet on the
+// legacy path, which is how an item goes missing between two saves.
+func (s *PureLoadTestSuite) TestStrictLoadRefusesAnUnknownInventoryItem() {
+	data := s.fullSheet()
+	data.Inventory = append(data.Inventory, InventoryItemData{ID: "vorpal-spork", Quantity: 1})
+
+	_, err := Load(s.ctx, data)
+
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "vorpal-spork")
+}
+
+func (s *PureLoadTestSuite) TestLoadRejectsNilData() {
+	_, err := Load(s.ctx, nil)
+
+	s.Require().Error(err)
+}
+
+// Two fields of Data survive no loader, because the sheet has nowhere to put
+// them and ToData does not write them. Pinned so the round-trip guarantee above
+// is read with its actual scope, and so closing the gap (a change to ToData,
+// not to a loader) breaks this test loudly rather than passing silently.
+func (s *PureLoadTestSuite) TestKnownRoundTripGaps() {
+	data := s.fullSheet()
+	data.BackgroundID = backgrounds.Soldier
+	data.CreatedAt = time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+
+	char, err := Load(s.ctx, data)
+	s.Require().NoError(err)
+
+	out := char.ToData()
+	s.Require().Empty(out.BackgroundID, "BackgroundID has no home on the sheet")
+	s.Require().True(out.CreatedAt.IsZero(), "CreatedAt has no home on the sheet")
+}
+
+// A character loaded strictly and then attached is a character loaded the old
+// way: the compatibility claim runs in both directions, so the recomposition
+// cannot drift from the path it replaced.
+func (s *PureLoadTestSuite) TestLoadThenAttachMatchesLoadFromData() {
+	pure, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+	s.Require().NoError(Attach(s.ctx, pure, events.NewEventBus()))
+
+	legacy, err := LoadFromData(s.ctx, s.fullSheet(), events.NewEventBus())
+	s.Require().NoError(err)
+
+	s.Require().Equal(s.marshal(legacy.ToData()), s.marshal(pure.ToData()))
+}
+
+// Attach is what applies the conditions a load parsed, and what puts the
+// sheet's own resources on the bus.
+func (s *PureLoadTestSuite) TestAttachAppliesWhatLoadParsed() {
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+
+	s.Require().NoError(Attach(s.ctx, char, events.NewEventBus()))
+
+	s.Require().Len(char.GetConditions(), 1)
+	s.Require().True(char.GetConditions()[0].IsApplied())
+	s.Require().NotEmpty(char.subscriptionIDs, "the sheet keeper subscribed")
+}
+
+// The load's pending effects are drained, not read: what has been put on a bus
+// is not waiting to be put on another one.
+func (s *PureLoadTestSuite) TestAttachDrainsWhatItApplied() {
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+
+	s.Require().NoError(Attach(s.ctx, char, events.NewEventBus()))
+
+	s.Require().Empty(char.pendingEffects)
+	s.Require().Len(char.GetConditions(), 1, "draining does not take the conditions off the sheet")
+}
+
+// Attaching the same sheet twice is refused rather than silently doubling every
+// handler it has.
+func (s *PureLoadTestSuite) TestAttachingTwiceIsRefused() {
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+	s.Require().NoError(Attach(s.ctx, char, events.NewEventBus()))
+
+	s.Require().Error(Attach(s.ctx, char, events.NewEventBus()))
+}
+
+func (s *PureLoadTestSuite) TestAttachRejectsANilBus() {
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+
+	s.Require().Error(Attach(s.ctx, char, nil))
+}
+
+// Attribution, pinned: every condition goes on through the bus scoped to the
+// ref its loader routed on, and the ref comes from the load. A ConditionBehavior
+// cannot name itself, so if this pairing is not carried from load to attach,
+// per-effect attribution is not recoverable later.
+func (s *PureLoadTestSuite) TestAttachScopesEachConditionToItsRef() {
+	bus := newRecordingBus()
+
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+	s.Require().NoError(Attach(s.ctx, char, bus))
+
+	s.Require().Equal([]core.Ref{*refs.Conditions.Raging()}, bus.record.asked)
+	s.Require().Contains(bus.record.byRef[*refs.Conditions.Raging()], events.Topic("dnd5e.saves.chain"))
+}
+
+// The sheet keeper's own hooks are not laundered into an effect's name: they
+// land unattributed, where a registration ledger can tell them apart from what
+// an effect subscribed.
+func (s *PureLoadTestSuite) TestKeeperHooksAreNotAttributedToAnEffect() {
+	bus := newRecordingBus()
+
+	char, err := Load(s.ctx, s.fullSheet())
+	s.Require().NoError(err)
+	s.Require().NoError(Attach(s.ctx, char, bus))
+
+	s.Require().NotEmpty(bus.record.byRef[unattributed])
+	s.Require().NotContains(bus.record.byRef[unattributed], events.Topic("dnd5e.saves.chain"))
+}
+
+func TestPureLoadSuite(t *testing.T) {
+	suite.Run(t, new(PureLoadTestSuite))
+}

--- a/rulebooks/dnd5e/character/load_test.go
+++ b/rulebooks/dnd5e/character/load_test.go
@@ -44,7 +44,7 @@ func (s *PureLoadTestSuite) SetupTest() {
 // serializer produces, so that a byte comparison downstream is a claim about
 // the loader carrying it rather than about this test's JSON matching the
 // serializer's field order.
-func (s *PureLoadTestSuite) ragingBlob() json.RawMessage {
+func ragingBlob(s *suite.Suite) json.RawMessage {
 	raging := &conditions.RagingCondition{
 		CharacterID: "char-load",
 		DamageBonus: 2,
@@ -59,7 +59,7 @@ func (s *PureLoadTestSuite) ragingBlob() json.RawMessage {
 }
 
 // rageBlob is a persisted Rage feature, canonicalized the same way.
-func (s *PureLoadTestSuite) rageBlob() json.RawMessage {
+func rageBlob(s *suite.Suite) json.RawMessage {
 	seed, err := json.Marshal(features.RageData{
 		Ref:   refs.Features.Rage(),
 		ID:    "rage-1",
@@ -77,11 +77,26 @@ func (s *PureLoadTestSuite) rageBlob() json.RawMessage {
 	return raw
 }
 
+// brutalCriticalBlob is a second persisted condition, canonicalized the same
+// way, for the tests that need a sheet carrying more than one.
+func brutalCriticalBlob(s *suite.Suite) json.RawMessage {
+	brutal := &conditions.BrutalCriticalCondition{
+		CharacterID: "char-load",
+		Level:       9,
+		ExtraDice:   1,
+	}
+
+	raw, err := brutal.ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
 // fullSheet is character data with something in every field a loader is
 // responsible for carrying — the ones that are only a copy, and the ones
 // (inventory, features, conditions, resources) that have to be reconstituted
 // and then serialized back.
-func (s *PureLoadTestSuite) fullSheet() *Data {
+func fullSheet(s *suite.Suite) *Data {
 	sword, err := equipment.GetByID(weapons.Longsword)
 	s.Require().NoError(err)
 
@@ -124,8 +139,8 @@ func (s *PureLoadTestSuite) fullSheet() *Data {
 		Resources: map[coreResources.ResourceKey]RecoverableResourceData{
 			resources.RageCharges: {Current: 2, Maximum: 3, ResetType: coreResources.ResetLongRest},
 		},
-		Features:   []json.RawMessage{s.rageBlob()},
-		Conditions: []json.RawMessage{s.ragingBlob()},
+		Features:   []json.RawMessage{rageBlob(s)},
+		Conditions: []json.RawMessage{ragingBlob(s)},
 		ActionEconomy: &ActionEconomyData{
 			TurnNumber:            4,
 			ActionsRemaining:      1,
@@ -149,7 +164,7 @@ func comparable(d *Data) *Data {
 	return &stripped
 }
 
-func (s *PureLoadTestSuite) marshal(d *Data) string {
+func marshalData(s *suite.Suite, d *Data) string {
 	raw, err := json.Marshal(comparable(d))
 	s.Require().NoError(err)
 
@@ -160,29 +175,29 @@ func (s *PureLoadTestSuite) marshal(d *Data) string {
 // anywhere in the call. Byte-for-byte, because "equivalent" is what a sheet
 // that has quietly dropped a condition also looks like (rpg-toolkit#948).
 func (s *PureLoadTestSuite) TestRoundTripsByteIdenticalWithNoBus() {
-	data := s.fullSheet()
+	data := fullSheet(&s.Suite)
 
 	char, err := Load(s.ctx, data)
 	s.Require().NoError(err)
 
-	s.Require().Equal(s.marshal(data), s.marshal(char.ToData()))
+	s.Require().Equal(marshalData(&s.Suite, data), marshalData(&s.Suite, char.ToData()))
 }
 
 // Named separately because it is the one this migration exists to protect: the
 // conditions survive a load that never saw a bus, which is what lets the attach
 // loop move out of the loader.
 func (s *PureLoadTestSuite) TestConditionsSurviveALoadWithNoBus() {
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 
 	s.Require().Len(char.GetConditions(), 1)
-	s.Require().Equal(s.ragingBlob(), char.ToData().Conditions[0])
+	s.Require().Equal(ragingBlob(&s.Suite), char.ToData().Conditions[0])
 }
 
 // A loaded sheet is inert. Nothing is applied, nothing is subscribed, and no
 // bus is held — the conditions are parsed and waiting, not running.
 func (s *PureLoadTestSuite) TestLoadAppliesNothing() {
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 
 	s.Require().Nil(char.bus, "a pure load holds no bus")
@@ -197,7 +212,7 @@ func (s *PureLoadTestSuite) TestLoadAppliesNothing() {
 // which blob. Refusing is the whole divergence: a sheet that comes back short
 // one condition looks exactly like a sheet that never had it.
 func (s *PureLoadTestSuite) TestStrictLoadRefusesAMalformedCondition() {
-	data := s.fullSheet()
+	data := fullSheet(&s.Suite)
 	data.Conditions = append(data.Conditions, json.RawMessage(`{"ref":{"module":"dnd5e","type":"conditions","id":"nope"}}`))
 
 	_, err := Load(s.ctx, data)
@@ -210,7 +225,7 @@ func (s *PureLoadTestSuite) TestStrictLoadRefusesAMalformedCondition() {
 // not a bug being pinned as correct — it is the behaviour ~20 callers have,
 // asserted so that the divergence is a decision rather than a surprise.
 func (s *PureLoadTestSuite) TestLegacyLoadDropsAMalformedCondition() {
-	data := s.fullSheet()
+	data := fullSheet(&s.Suite)
 	data.Conditions = append(data.Conditions, json.RawMessage(`{"ref":{"module":"dnd5e","type":"conditions","id":"nope"}}`))
 
 	char, err := LoadFromData(s.ctx, data, events.NewEventBus())
@@ -222,7 +237,7 @@ func (s *PureLoadTestSuite) TestLegacyLoadDropsAMalformedCondition() {
 // Features are the same species of loss as conditions, and get the same
 // treatment: a blob with no loader here fails the strict load.
 func (s *PureLoadTestSuite) TestStrictLoadRefusesAFeatureFromAnotherModule() {
-	data := s.fullSheet()
+	data := fullSheet(&s.Suite)
 	data.Features = append(data.Features, json.RawMessage(`{"ref":{"module":"artificer","type":"features","id":"infusion"}}`))
 
 	_, err := Load(s.ctx, data)
@@ -232,7 +247,7 @@ func (s *PureLoadTestSuite) TestStrictLoadRefusesAFeatureFromAnotherModule() {
 }
 
 func (s *PureLoadTestSuite) TestLegacyLoadDropsAFeatureFromAnotherModule() {
-	data := s.fullSheet()
+	data := fullSheet(&s.Suite)
 	data.Features = append(data.Features, json.RawMessage(`{"ref":{"module":"artificer","type":"features","id":"infusion"}}`))
 
 	char, err := LoadFromData(s.ctx, data, events.NewEventBus())
@@ -244,7 +259,7 @@ func (s *PureLoadTestSuite) TestLegacyLoadDropsAFeatureFromAnotherModule() {
 // An inventory item the catalog does not know disappears from the sheet on the
 // legacy path, which is how an item goes missing between two saves.
 func (s *PureLoadTestSuite) TestStrictLoadRefusesAnUnknownInventoryItem() {
-	data := s.fullSheet()
+	data := fullSheet(&s.Suite)
 	data.Inventory = append(data.Inventory, InventoryItemData{ID: "vorpal-spork", Quantity: 1})
 
 	_, err := Load(s.ctx, data)
@@ -264,7 +279,7 @@ func (s *PureLoadTestSuite) TestLoadRejectsNilData() {
 // is read with its actual scope, and so closing the gap (a change to ToData,
 // not to a loader) breaks this test loudly rather than passing silently.
 func (s *PureLoadTestSuite) TestKnownRoundTripGaps() {
-	data := s.fullSheet()
+	data := fullSheet(&s.Suite)
 	data.BackgroundID = backgrounds.Soldier
 	data.CreatedAt = time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
 
@@ -280,20 +295,20 @@ func (s *PureLoadTestSuite) TestKnownRoundTripGaps() {
 // way: the compatibility claim runs in both directions, so the recomposition
 // cannot drift from the path it replaced.
 func (s *PureLoadTestSuite) TestLoadThenAttachMatchesLoadFromData() {
-	pure, err := Load(s.ctx, s.fullSheet())
+	pure, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 	s.Require().NoError(Attach(s.ctx, pure, events.NewEventBus()))
 
-	legacy, err := LoadFromData(s.ctx, s.fullSheet(), events.NewEventBus())
+	legacy, err := LoadFromData(s.ctx, fullSheet(&s.Suite), events.NewEventBus())
 	s.Require().NoError(err)
 
-	s.Require().Equal(s.marshal(legacy.ToData()), s.marshal(pure.ToData()))
+	s.Require().Equal(marshalData(&s.Suite, legacy.ToData()), marshalData(&s.Suite, pure.ToData()))
 }
 
 // Attach is what applies the conditions a load parsed, and what puts the
 // sheet's own resources on the bus.
 func (s *PureLoadTestSuite) TestAttachAppliesWhatLoadParsed() {
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 
 	s.Require().NoError(Attach(s.ctx, char, events.NewEventBus()))
@@ -306,7 +321,7 @@ func (s *PureLoadTestSuite) TestAttachAppliesWhatLoadParsed() {
 // The load's pending effects are drained, not read: what has been put on a bus
 // is not waiting to be put on another one.
 func (s *PureLoadTestSuite) TestAttachDrainsWhatItApplied() {
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 
 	s.Require().NoError(Attach(s.ctx, char, events.NewEventBus()))
@@ -318,7 +333,7 @@ func (s *PureLoadTestSuite) TestAttachDrainsWhatItApplied() {
 // Attaching the same sheet twice is refused rather than silently doubling every
 // handler it has.
 func (s *PureLoadTestSuite) TestAttachingTwiceIsRefused() {
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 	s.Require().NoError(Attach(s.ctx, char, events.NewEventBus()))
 
@@ -326,7 +341,7 @@ func (s *PureLoadTestSuite) TestAttachingTwiceIsRefused() {
 }
 
 func (s *PureLoadTestSuite) TestAttachRejectsANilBus() {
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 
 	s.Require().Error(Attach(s.ctx, char, nil))
@@ -339,7 +354,7 @@ func (s *PureLoadTestSuite) TestAttachRejectsANilBus() {
 func (s *PureLoadTestSuite) TestAttachScopesEachConditionToItsRef() {
 	bus := newRecordingBus()
 
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 	s.Require().NoError(Attach(s.ctx, char, bus))
 
@@ -353,7 +368,7 @@ func (s *PureLoadTestSuite) TestAttachScopesEachConditionToItsRef() {
 func (s *PureLoadTestSuite) TestKeeperHooksAreNotAttributedToAnEffect() {
 	bus := newRecordingBus()
 
-	char, err := Load(s.ctx, s.fullSheet())
+	char, err := Load(s.ctx, fullSheet(&s.Suite))
 	s.Require().NoError(err)
 	s.Require().NoError(Attach(s.ctx, char, bus))
 

--- a/rulebooks/dnd5e/character/sheet_keeper.go
+++ b/rulebooks/dnd5e/character/sheet_keeper.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// SheetKeeper is a character's own reaction to the world, made attachable.
+//
+// A sheet does not merely sit there while an encounter happens around it: a
+// condition applied to this character has to land on its list, a condition
+// removed has to leave it, healing has to move its hit points, and an action
+// granted or removed has to show up among the things it can do. Its recoverable
+// resources have to hear a rest. That is five subscriptions and a handful of
+// resources, and until this type existed they were wired invisibly inside
+// LoadFromData — real behaviour that no caller could see, name, or take back.
+//
+// Here it is an attachable like any other: [SheetKeeper.Apply] takes a bus,
+// [SheetKeeper.Remove] gives it back. Whoever owns the bus decides when the
+// sheet starts listening, and the subscriptions appear in a registration
+// ledger under the participant that made them instead of as anonymous entries
+// nobody can attribute (ADR-0038, and rpg-toolkit#985).
+//
+// Get one from [Character.SheetKeeper]. It is the character's, not a copy of
+// it: applying the same character's keeper twice subscribes it twice.
+type SheetKeeper struct {
+	character *Character
+
+	// subscriptionIDs are the hooks this keeper granted, so Remove can revoke
+	// exactly those and nothing else.
+	subscriptionIDs []string
+}
+
+// SheetKeeper returns the attachable that carries this character's own
+// behaviour — the five self-subscriptions and its recoverable resources.
+//
+// The keeper is created once and kept, so that two callers asking a character
+// for its keeper get the same one and cannot accidentally subscribe the sheet
+// twice.
+func (c *Character) SheetKeeper() *SheetKeeper {
+	if c.keeper == nil {
+		c.keeper = &SheetKeeper{character: c}
+	}
+
+	return c.keeper
+}
+
+// Apply subscribes the sheet's five handlers to bus and puts the character's
+// recoverable resources on it.
+//
+// The handlers close over this bus rather than reading one off the character:
+// a sheet that was loaded purely has no bus of its own, and a sheet that does
+// must still react on the bus it was attached to and no other.
+//
+// A resource that fails to apply fails the whole attach on a strictly loaded
+// sheet, and is dropped from the sheet on a leniently loaded one — dropping is
+// what LoadFromData has always done, and it is exactly how a resource goes
+// missing between two saves.
+func (k *SheetKeeper) Apply(ctx context.Context, bus events.EventBus) error {
+	if err := k.subscribeSelf(ctx, bus); err != nil {
+		return err
+	}
+
+	return k.applyResources(ctx, bus)
+}
+
+// subscribeSelf makes the five self-subscriptions, and nothing else.
+//
+// Separate from the resources because a freshly finalized character has always
+// had the handlers without its resources on the bus: Character.LongRest
+// restores its resources directly and then publishes the rest event, so a
+// character whose resources are also subscribed recovers hit dice twice. Load
+// has always attached both and inherits that; Finalize has always attached
+// neither of the two halves' resources, and this keeps it that way.
+func (k *SheetKeeper) subscribeSelf(ctx context.Context, bus events.EventBus) error {
+	if k.character == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "sheet keeper has no character")
+	}
+	if bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
+	}
+	if len(k.subscriptionIDs) > 0 {
+		// Attaching a sheet twice would double every handler it has: a healing
+		// event would heal twice, a granted action would be added twice. The
+		// recoverable resources refuse a second Apply for the same reason, so
+		// this was already an error for any character carrying one — it is an
+		// error for all of them now, and it says so.
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "sheet keeper is already applied")
+	}
+
+	c := k.character
+
+	// Park the bus on the sheet for the verb methods that still read it —
+	// MakeSavingThrow, ActivateCombatAbility, EffectiveAC, the rests, Cleanup.
+	// They go away with rpg-toolkit#965 and #966, and this line goes with them.
+	// Nothing here reads that field: every handler below closes over the bus it
+	// was handed.
+	c.bus = bus
+
+	appliedID, err := dnd5eEvents.ConditionAppliedTopic.On(bus).Subscribe(ctx,
+		func(ctx context.Context, event dnd5eEvents.ConditionAppliedEvent) error {
+			return c.onConditionApplied(ctx, bus, event)
+		})
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to subscribe to condition applied")
+	}
+	k.track(appliedID)
+
+	removedID, err := dnd5eEvents.ConditionRemovedTopic.On(bus).Subscribe(ctx, c.onConditionRemoved)
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to subscribe to condition removed events")
+	}
+	k.track(removedID)
+
+	healingID, err := dnd5eEvents.HealingReceivedTopic.On(bus).Subscribe(ctx, c.onHealingReceived)
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to subscribe to healing received")
+	}
+	k.track(healingID)
+
+	grantedID, err := dnd5eEvents.ActionGrantedTopic.On(bus).Subscribe(ctx,
+		func(ctx context.Context, event dnd5eEvents.ActionGrantedEvent) error {
+			return c.onActionGranted(ctx, bus, event)
+		})
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to subscribe to action granted")
+	}
+	k.track(grantedID)
+
+	actionRemovedID, err := dnd5eEvents.ActionRemovedTopic.On(bus).Subscribe(ctx, c.onActionRemoved)
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to subscribe to action removed")
+	}
+	k.track(actionRemovedID)
+
+	return nil
+}
+
+// Remove revokes every subscription this keeper granted and takes the
+// character's recoverable resources back off the bus.
+//
+// It revokes what it granted and nothing else: the sheet may be carrying
+// subscriptions from elsewhere, and a keeper that unsubscribed a list it did
+// not build would silence hooks it never made.
+func (k *SheetKeeper) Remove(ctx context.Context, bus events.EventBus) error {
+	if k.character == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "sheet keeper has no character")
+	}
+	if bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
+	}
+
+	var firstErr error
+
+	for _, subID := range k.subscriptionIDs {
+		if err := bus.Unsubscribe(ctx, subID); err != nil && firstErr == nil {
+			firstErr = rpgerr.Wrapf(err, "failed to unsubscribe")
+		}
+	}
+
+	for key, resource := range k.character.resources {
+		if err := resource.Remove(ctx, bus); err != nil && firstErr == nil {
+			firstErr = rpgerr.Wrapf(err, "failed to remove resource %q", key)
+		}
+	}
+
+	k.character.forgetSubscriptions(k.subscriptionIDs)
+	k.subscriptionIDs = nil
+
+	return firstErr
+}
+
+// applyResources puts each recoverable resource on the bus so it hears rests.
+func (k *SheetKeeper) applyResources(ctx context.Context, bus events.EventBus) error {
+	c := k.character
+
+	for key, resource := range c.resources {
+		if err := resource.Apply(ctx, bus); err != nil {
+			// Clean up whatever the failed Apply managed to subscribe.
+			_ = resource.Remove(ctx, bus)
+
+			if c.policy == strictEffects {
+				return rpgerr.Wrapf(err, "failed to apply resource %q", key)
+			}
+
+			// Lenient: the legacy path kept only the resources that applied.
+			delete(c.resources, key)
+		}
+	}
+
+	return nil
+}
+
+// track records a subscription on the keeper and on the character.
+//
+// Both, because the two have different questions to answer: the keeper needs
+// to know what to revoke in Remove, and Cleanup — which predates the keeper
+// and is still what most callers use to tear a character down — unsubscribes
+// whatever the character is carrying.
+func (k *SheetKeeper) track(subID string) {
+	k.subscriptionIDs = append(k.subscriptionIDs, subID)
+	k.character.subscriptionIDs = append(k.character.subscriptionIDs, subID)
+}

--- a/rulebooks/dnd5e/character/sheet_keeper.go
+++ b/rulebooks/dnd5e/character/sheet_keeper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 )
 
@@ -27,8 +28,10 @@ import (
 // ledger under the participant that made them instead of as anonymous entries
 // nobody can attribute (ADR-0038, and rpg-toolkit#985).
 //
-// Get one from [Character.SheetKeeper]. It is the character's, not a copy of
-// it: applying the same character's keeper twice subscribes it twice.
+// Get one from [Character.SheetKeeper]. It is the character's own, not a fresh
+// one per call, and an already-applied keeper refuses a second [SheetKeeper.Apply]
+// with [rpgerr.CodeAlreadyExists] rather than quietly subscribing the sheet
+// twice. A failed Apply leaves nothing behind and can be retried.
 type SheetKeeper struct {
 	character *Character
 
@@ -62,12 +65,35 @@ func (c *Character) SheetKeeper() *SheetKeeper {
 // sheet, and is dropped from the sheet on a leniently loaded one — dropping is
 // what LoadFromData has always done, and it is exactly how a resource goes
 // missing between two saves.
+//
+// **A failed Apply is a no-op.** Whatever it managed to subscribe before the
+// failure is revoked, the sheet is left holding the bus it held before, and the
+// keeper is not left in the applied state — so the bus carries no hooks nobody
+// asked for, and the caller can retry against another bus. A half-attached
+// sheet that still reports itself attached is worse than one that never
+// attached: the second is a failure, the first is a leak with an alibi.
 func (k *SheetKeeper) Apply(ctx context.Context, bus events.EventBus) error {
+	// Read before subscribeSelf parks the new one, so the rollback below can
+	// give the sheet back exactly what it was holding.
+	var previousBus events.EventBus
+	if k.character != nil {
+		previousBus = k.character.bus
+	}
+
 	if err := k.subscribeSelf(ctx, bus); err != nil {
 		return err
 	}
 
-	return k.applyResources(ctx, bus)
+	if err := k.applyResources(ctx, bus); err != nil {
+		// The handlers went on before the resources did, so they are this
+		// function's to take back.
+		k.unsubscribeSelf(ctx, bus)
+		k.character.bus = previousBus
+
+		return err
+	}
+
+	return nil
 }
 
 // subscribeSelf makes the five self-subscriptions, and nothing else.
@@ -95,6 +121,7 @@ func (k *SheetKeeper) subscribeSelf(ctx context.Context, bus events.EventBus) er
 	}
 
 	c := k.character
+	previousBus := c.bus
 
 	// Park the bus on the sheet for the verb methods that still read it —
 	// MakeSavingThrow, ActivateCombatAbility, EffectiveAC, the rests, Cleanup.
@@ -103,43 +130,64 @@ func (k *SheetKeeper) subscribeSelf(ctx context.Context, bus events.EventBus) er
 	// was handed.
 	c.bus = bus
 
-	appliedID, err := dnd5eEvents.ConditionAppliedTopic.On(bus).Subscribe(ctx,
-		func(ctx context.Context, event dnd5eEvents.ConditionAppliedEvent) error {
-			return c.onConditionApplied(ctx, bus, event)
-		})
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to condition applied")
+	// One table rather than five near-identical blocks, so that the rollback
+	// on a failed subscription is written once and cannot be forgotten for one
+	// of them.
+	handlers := []struct {
+		what      string
+		subscribe func() (string, error)
+	}{
+		{"condition applied", func() (string, error) {
+			return dnd5eEvents.ConditionAppliedTopic.On(bus).Subscribe(ctx,
+				func(ctx context.Context, event dnd5eEvents.ConditionAppliedEvent) error {
+					return c.onConditionApplied(ctx, bus, event)
+				})
+		}},
+		{"condition removed events", func() (string, error) {
+			return dnd5eEvents.ConditionRemovedTopic.On(bus).Subscribe(ctx, c.onConditionRemoved)
+		}},
+		{"healing received", func() (string, error) {
+			return dnd5eEvents.HealingReceivedTopic.On(bus).Subscribe(ctx, c.onHealingReceived)
+		}},
+		{"action granted", func() (string, error) {
+			return dnd5eEvents.ActionGrantedTopic.On(bus).Subscribe(ctx,
+				func(ctx context.Context, event dnd5eEvents.ActionGrantedEvent) error {
+					return c.onActionGranted(ctx, bus, event)
+				})
+		}},
+		{"action removed", func() (string, error) {
+			return dnd5eEvents.ActionRemovedTopic.On(bus).Subscribe(ctx, c.onActionRemoved)
+		}},
 	}
-	k.track(appliedID)
 
-	removedID, err := dnd5eEvents.ConditionRemovedTopic.On(bus).Subscribe(ctx, c.onConditionRemoved)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to condition removed events")
-	}
-	k.track(removedID)
+	for _, handler := range handlers {
+		subID, err := handler.subscribe()
+		if err != nil {
+			// Take back the ones that did land, and give the sheet back the bus
+			// it was holding: a sheet subscribed to two of its five handlers
+			// reacts to some of the world and not the rest, which is a harder
+			// bug to see than not attaching at all.
+			k.unsubscribeSelf(ctx, bus)
+			c.bus = previousBus
 
-	healingID, err := dnd5eEvents.HealingReceivedTopic.On(bus).Subscribe(ctx, c.onHealingReceived)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to healing received")
-	}
-	k.track(healingID)
+			return rpgerr.Wrapf(err, "failed to subscribe to %s", handler.what)
+		}
 
-	grantedID, err := dnd5eEvents.ActionGrantedTopic.On(bus).Subscribe(ctx,
-		func(ctx context.Context, event dnd5eEvents.ActionGrantedEvent) error {
-			return c.onActionGranted(ctx, bus, event)
-		})
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to action granted")
+		k.track(subID)
 	}
-	k.track(grantedID)
-
-	actionRemovedID, err := dnd5eEvents.ActionRemovedTopic.On(bus).Subscribe(ctx, c.onActionRemoved)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to action removed")
-	}
-	k.track(actionRemovedID)
 
 	return nil
+}
+
+// unsubscribeSelf revokes the subscriptions this keeper granted and forgets
+// them, leaving the keeper unapplied and therefore appliable again.
+func (k *SheetKeeper) unsubscribeSelf(ctx context.Context, bus events.EventBus) {
+	for _, subID := range k.subscriptionIDs {
+		_ = bus.Unsubscribe(ctx, subID)
+	}
+
+	k.character.forgetSubscriptions(k.subscriptionIDs)
+	k.subscriptionIDs = nil
 }
 
 // Remove revokes every subscription this keeper granted and takes the
@@ -177,8 +225,14 @@ func (k *SheetKeeper) Remove(ctx context.Context, bus events.EventBus) error {
 }
 
 // applyResources puts each recoverable resource on the bus so it hears rests.
+//
+// On the strict path a resource that will not apply takes the whole attach with
+// it, and the ones already applied come back off: a sheet holding some of its
+// resources on a bus and the rest off it recovers unevenly on the next rest,
+// and nothing about the sheet says which is which.
 func (k *SheetKeeper) applyResources(ctx context.Context, bus events.EventBus) error {
 	c := k.character
+	applied := make([]*combat.RecoverableResource, 0, len(c.resources))
 
 	for key, resource := range c.resources {
 		if err := resource.Apply(ctx, bus); err != nil {
@@ -186,12 +240,20 @@ func (k *SheetKeeper) applyResources(ctx context.Context, bus events.EventBus) e
 			_ = resource.Remove(ctx, bus)
 
 			if c.policy == strictEffects {
+				for i := len(applied) - 1; i >= 0; i-- {
+					_ = applied[i].Remove(ctx, bus)
+				}
+
 				return rpgerr.Wrapf(err, "failed to apply resource %q", key)
 			}
 
 			// Lenient: the legacy path kept only the resources that applied.
 			delete(c.resources, key)
+
+			continue
 		}
+
+		applied = append(applied, resource)
 	}
 
 	return nil

--- a/rulebooks/dnd5e/character/sheet_keeper_test.go
+++ b/rulebooks/dnd5e/character/sheet_keeper_test.go
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// keptCondition is a condition that does nothing but exist and serialize —
+// enough to be applied to a sheet and found on it again.
+type keptCondition struct {
+	applied bool
+}
+
+func (c *keptCondition) IsApplied() bool { return c.applied }
+
+func (c *keptCondition) Apply(_ context.Context, _ events.EventBus) error {
+	c.applied = true
+	return nil
+}
+
+func (c *keptCondition) Remove(_ context.Context, _ events.EventBus) error {
+	c.applied = false
+	return nil
+}
+
+func (c *keptCondition) ToJSON() (json.RawMessage, error) {
+	return json.Marshal(map[string]any{"ref": refs.Conditions.Dodging()})
+}
+
+// SheetKeeperTestSuite drives each of the five things a sheet does about the
+// world through a real bus. Every test here fails outright for a keeper whose
+// Apply subscribes nothing, which is the mutation this file exists to catch:
+// the wiring it replaced was invisible, so nothing would have noticed its
+// absence except behaviour that quietly stopped happening.
+type SheetKeeperTestSuite struct {
+	suite.Suite
+
+	ctx  context.Context
+	bus  events.EventBus
+	char *Character
+}
+
+func (s *SheetKeeperTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+
+	char, err := Load(s.ctx, s.sheet())
+	s.Require().NoError(err)
+	s.Require().NoError(Attach(s.ctx, char, s.bus))
+
+	s.char = char
+}
+
+func (s *SheetKeeperTestSuite) sheet() *Data {
+	return &Data{
+		ID:               "keeper-char",
+		PlayerID:         "keeper-player",
+		Name:             "Kept",
+		Level:            3,
+		ProficiencyBonus: 2,
+		RaceID:           races.Human,
+		ClassID:          classes.Barbarian,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    10,
+		MaxHitPoints: 30,
+		ArmorClass:   14,
+		Resources: map[coreResources.ResourceKey]RecoverableResourceData{
+			resources.RageCharges: {Current: 1, Maximum: 3, ResetType: coreResources.ResetLongRest},
+		},
+	}
+}
+
+// A condition applied to this character lands on its sheet — and the sheet goes
+// dirty, because ToData serializes conditions and only dirty sheets get written
+// back.
+func (s *SheetKeeperTestSuite) TestConditionAppliedLandsOnTheSheet() {
+	condition := &keptCondition{}
+
+	err := dnd5eEvents.ConditionAppliedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    s.char,
+		Type:      dnd5eEvents.ConditionDodging,
+		Condition: condition,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Len(s.char.GetConditions(), 1)
+	s.Require().True(condition.applied, "the keeper applies the condition it was handed")
+	s.Require().True(s.char.IsDirty(), "a sheet that gained a condition needs saving")
+}
+
+func (s *SheetKeeperTestSuite) TestConditionAppliedToSomeoneElseIsIgnored() {
+	other, err := Load(s.ctx, s.sheet())
+	s.Require().NoError(err)
+	other.id = "someone-else"
+
+	condition := &keptCondition{}
+	err = dnd5eEvents.ConditionAppliedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    other,
+		Condition: condition,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Empty(s.char.GetConditions())
+	s.Require().False(s.char.IsDirty())
+}
+
+func (s *SheetKeeperTestSuite) TestConditionRemovedLeavesTheSheet() {
+	s.Require().NoError(dnd5eEvents.ConditionAppliedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    s.char,
+		Condition: &keptCondition{},
+	}))
+	s.char.MarkClean()
+
+	err := dnd5eEvents.ConditionRemovedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.ConditionRemovedEvent{
+		CharacterID:  s.char.GetID(),
+		ConditionRef: refs.Conditions.Dodging().String(),
+		Reason:       "test",
+	})
+
+	s.Require().NoError(err)
+	s.Require().Empty(s.char.GetConditions())
+	s.Require().True(s.char.IsDirty(), "a sheet that lost a condition needs saving")
+}
+
+func (s *SheetKeeperTestSuite) TestHealingReceivedMovesHitPoints() {
+	err := dnd5eEvents.HealingReceivedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: s.char.GetID(),
+		Amount:   5,
+		Source:   "test",
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(15, s.char.GetHitPoints())
+	s.Require().True(s.char.IsDirty())
+}
+
+func (s *SheetKeeperTestSuite) TestHealingIsCappedAtMaximum() {
+	err := dnd5eEvents.HealingReceivedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: s.char.GetID(),
+		Amount:   500,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(30, s.char.GetHitPoints())
+}
+
+func (s *SheetKeeperTestSuite) TestActionGrantedJoinsTheSheet() {
+	action := &mockAction{id: "granted-action", temporary: true}
+
+	err := dnd5eEvents.ActionGrantedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.ActionGrantedEvent{
+		CharacterID: s.char.GetID(),
+		Action:      action,
+		Source:      "test",
+	})
+
+	s.Require().NoError(err)
+	s.Require().Len(s.char.actions, 1)
+	s.Require().True(action.applied, "the keeper applies the action on the bus it was attached to")
+}
+
+func (s *SheetKeeperTestSuite) TestActionRemovedLeavesTheSheet() {
+	action := &mockAction{id: "granted-action", temporary: true}
+	s.Require().NoError(dnd5eEvents.ActionGrantedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.ActionGrantedEvent{
+		CharacterID: s.char.GetID(),
+		Action:      action,
+	}))
+
+	err := dnd5eEvents.ActionRemovedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.ActionRemovedEvent{
+		ActionID: "granted-action",
+		OwnerID:  s.char.GetID(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().Empty(s.char.actions)
+}
+
+// The keeper's other half: the character's recoverable resources are on the
+// bus, so a rest recovers them.
+func (s *SheetKeeperTestSuite) TestResourcesHearARest() {
+	s.Require().Equal(1, s.char.GetResource(resources.RageCharges).Current())
+
+	err := dnd5eEvents.RestTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.RestEvent{
+		RestType:    coreResources.ResetLongRest,
+		CharacterID: s.char.GetID(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(3, s.char.GetResource(resources.RageCharges).Current())
+}
+
+// Remove gives the bus back: nothing the keeper subscribed is still listening,
+// and the sheet is not left claiming subscriptions that no longer exist.
+func (s *SheetKeeperTestSuite) TestRemoveStopsTheSheetListening() {
+	s.Require().NoError(s.char.SheetKeeper().Remove(s.ctx, s.bus))
+
+	err := dnd5eEvents.HealingReceivedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: s.char.GetID(),
+		Amount:   5,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(10, s.char.GetHitPoints(), "the sheet is no longer listening")
+	s.Require().Empty(s.char.subscriptionIDs, "and no longer claims to be")
+}
+
+// A keeper is the character's own, not a fresh one per call: two callers asking
+// cannot subscribe the same sheet twice between them.
+func (s *SheetKeeperTestSuite) TestKeeperIsTheCharactersOwn() {
+	s.Require().Same(s.char.SheetKeeper(), s.char.SheetKeeper())
+}
+
+func TestSheetKeeperSuite(t *testing.T) {
+	suite.Run(t, new(SheetKeeperTestSuite))
+}

--- a/rulebooks/dnd5e/monster/README.md
+++ b/rulebooks/dnd5e/monster/README.md
@@ -33,7 +33,7 @@ factory, a canonical ref, actions and traits, whichever stack drives it.
 
 | Import path suffix | Current responsibility |
 |---|---|
-| `monster` | `Monster` runtime type, `Data`, action/perception contracts, targeting, `TakeTurn`, base `LoadFromData` / `ToData`; also the older `NewGoblin` factory |
+| `monster` | `Monster` runtime type, `Data`, action/perception contracts, targeting, `TakeTurn`, pure `Load` + `SheetKeeper`, legacy `LoadFromData` / `ToData`; also the older `NewGoblin` factory |
 | `monster/actions` | Loadable generic melee, ranged, multiattack, and bite action implementations plus the action loader |
 | `monster/monsters` | Built-in stat factories and the canonical-ref-to-constructor registry |
 | `monstertraits` | Loadable condition-style monster traits (separate sibling package to avoid import cycles) |
@@ -125,8 +125,21 @@ A factory returns a ready-to-serialize runtime monster:
 monster/monsters constructor → *monster.Monster → ToData / JSON
 ```
 
-Reload currently has multiple explicit steps because importing action or trait
-loaders from package `monster` would create cycles:
+Reload comes in two shapes. The one to write new code against is a pure load
+and an attach, and neither can be two-thirds made:
+
+```text
+monstertraits.LoadMonster(ctx, data)             # sheet + actions + the trait blobs, no bus
+monstertraits.AttachMonster(ctx, mon, bus, roller)  # sheet keeper, then each trait, attributed
+```
+
+`LoadMonster(data).ToData()` is the data it was given, actions and conditions
+included, with no bus anywhere in the call. The composition lives in
+`monstertraits` for a mechanical reason: package `monster` cannot import either
+loader (both import it), and `monstertraits` is the only package that can see
+both without a cycle.
+
+The older shape is the three-call assembly, still used by existing callers:
 
 ```text
 monster.LoadFromData(ctx, data, bus)             # base state + monster subscriptions
@@ -139,7 +152,10 @@ monstertraits.LoadMonsterConditions(             # trait JSON → Apply on bus �
 The encounter's `LoadFromData` hydration cascade performs all three and later
 writes held combatants back through `ToData`. Outside the encounter, the caller
 must perform the extra action and trait steps. A test that calls only
-`monster.LoadFromData` has not proven a full monster round trip.
+`monster.LoadFromData` has not proven a full monster round trip — and neither
+has production code: `ToData` serializes actions and conditions, so a monster
+assembled by two of the three calls is written back with the third's contents
+silently gone. That trap is the reason the pair above exists.
 
 ## Supported first contribution
 

--- a/rulebooks/dnd5e/monster/attach_rollback_test.go
+++ b/rulebooks/dnd5e/monster/attach_rollback_test.go
@@ -1,0 +1,119 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// errRefused is what the stub bus answers with.
+var errRefused = errors.New("bus refused the subscription")
+
+// failingBus is a real bus that refuses the nth Subscribe and behaves normally
+// otherwise — the only way to reach the second half of a two-step attach and
+// make it fail.
+type failingBus struct {
+	inner  events.EventBus
+	failOn int // 1-based; 0 never fails
+	calls  int
+}
+
+func newFailingBus(failOn int) *failingBus {
+	return &failingBus{inner: events.NewEventBus(), failOn: failOn}
+}
+
+func (b *failingBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	b.calls++
+	if b.calls == b.failOn {
+		return "", errRefused
+	}
+
+	return b.inner.Subscribe(ctx, topic, handler)
+}
+
+func (b *failingBus) Unsubscribe(ctx context.Context, id string) error {
+	return b.inner.Unsubscribe(ctx, id)
+}
+
+func (b *failingBus) Publish(ctx context.Context, topic events.Topic, event any) error {
+	return b.inner.Publish(ctx, topic, event)
+}
+
+// MonsterAttachRollbackTestSuite pins the same contract the character side
+// keeps: a failed attach is a no-op — same data out, nothing listening, retry
+// works.
+type MonsterAttachRollbackTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func (s *MonsterAttachRollbackTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// The keeper subscribes damage, then healing. Refusing the second one used to
+// leave the first live and the keeper convinced it was applied — a leaked
+// subscription that also refused every retry.
+func (s *MonsterAttachRollbackTestSuite) TestKeeperRollsBackAPartialSubscribe() {
+	m, err := Load(s.ctx, s.sheet())
+	s.Require().NoError(err)
+	before := s.marshal(m.ToData())
+
+	bus := newFailingBus(2)
+	err = m.SheetKeeper().Apply(s.ctx, bus)
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errRefused)
+	s.Require().Equal(before, s.marshal(m.ToData()))
+	s.Require().Empty(m.subscriptionIDs, "the monster claims no subscriptions")
+	s.Require().Nil(m.bus, "and holds the bus it held before, which was none")
+
+	// Nothing is listening: the damage handler that did land is gone.
+	s.Require().NoError(dnd5eEvents.DamageReceivedTopic.On(bus).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: m.GetID(),
+		Amount:   4,
+	}))
+	s.Require().Equal(9, m.HP())
+	s.Require().False(m.IsDirty())
+
+	// And the attach can simply be tried again.
+	good := events.NewEventBus()
+	s.Require().NoError(m.SheetKeeper().Apply(s.ctx, good))
+	s.Require().NoError(dnd5eEvents.DamageReceivedTopic.On(good).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: m.GetID(),
+		Amount:   4,
+	}))
+	s.Require().Equal(5, m.HP(), "the retry attached both handlers")
+}
+
+func (s *MonsterAttachRollbackTestSuite) sheet() *Data {
+	return &Data{
+		ID:           "skel-rollback",
+		Name:         "Skeleton",
+		HitPoints:    9,
+		MaxHitPoints: 13,
+		ArmorClass:   13,
+		Actions:      []ActionData{},
+	}
+}
+
+func (s *MonsterAttachRollbackTestSuite) marshal(d *Data) string {
+	raw, err := json.Marshal(d)
+	s.Require().NoError(err)
+
+	return string(raw)
+}
+
+func TestMonsterAttachRollbackSuite(t *testing.T) {
+	suite.Run(t, new(MonsterAttachRollbackTestSuite))
+}

--- a/rulebooks/dnd5e/monster/load.go
+++ b/rulebooks/dnd5e/monster/load.go
@@ -1,0 +1,258 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monster
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// conditionPolicy decides what a load does with the condition blobs a monster
+// was persisted with.
+type conditionPolicy int
+
+const (
+	// carryConditions keeps the blobs on the monster, unapplied, so that
+	// ToData writes back what it read. This is the zero value: carrying is
+	// what a loader should do, and losing them takes a deliberate choice.
+	carryConditions conditionPolicy = iota
+
+	// dropConditions ignores them, which is what [LoadFromData] has always
+	// done — its callers pass the same blobs to
+	// monstertraits.LoadMonsterConditions themselves, and carrying them here
+	// too would write every condition back twice.
+	dropConditions
+)
+
+// Load turns persisted data into a monster, with no event bus involved.
+//
+// Nothing subscribes, nothing is applied; the monster is inert until a
+// [SheetKeeper] puts it on a bus. Unlike [LoadFromData], Load does not throw
+// away the condition blobs it was handed: this package cannot route them to
+// their loaders (monstertraits imports monster, so monster cannot import
+// monstertraits), but it can carry them, and carrying them is what makes
+// Load(d).ToData() the data it was given. monstertraits.AttachMonster is what
+// turns them into behaviour.
+//
+// Load is strict about those blobs to the extent it can be without a loader:
+// one that is not JSON, or that names no ref for a loader to route on, fails
+// the load and the error names it. Whether the ref resolves to a trait this
+// build knows is monstertraits' answer to give, at attach time.
+//
+// Actions are not loaded here either, and for the same reason — the action
+// loader imports this package. monstertraits.LoadMonster is the composition
+// that does both; a monster loaded by Load alone has no actions, and ToData
+// will say so.
+//
+// Two fields of [Data] survive no loader: Features and Inventory have nowhere
+// to live on the monster and ToData does not write them. That is a gap in the
+// sheet rather than in this loader, pinned by TestKnownRoundTripGaps so it
+// cannot be mistaken for a guarantee.
+//
+// ctx is unused: a pure load has nothing to cancel. It is in the signature so
+// that the pure and legacy loaders read alike at a call site.
+func Load(_ context.Context, d *Data) (*Monster, error) {
+	if d == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "monster data is required")
+	}
+
+	return loadMonster(d, carryConditions)
+}
+
+// TakeUnappliedConditions returns the condition blobs this monster is carrying
+// that no bus has seen, and clears them from the monster.
+//
+// Draining rather than reading, because ToData serializes both the applied
+// conditions and the unapplied blobs: an attach helper that loaded the blobs
+// into behaviours without clearing them would write the monster back carrying
+// every condition twice.
+func (m *Monster) TakeUnappliedConditions() []json.RawMessage {
+	pending := m.traitData
+	m.traitData = nil
+
+	return pending
+}
+
+// loadMonster builds the sheet both loaders hand back. Everything that reads
+// [Data] lives here; everything that touches a bus lives in [SheetKeeper].
+func loadMonster(d *Data, policy conditionPolicy) (*Monster, error) {
+	// Handle proficiency bonus - default to 2 if not set
+	profBonus := d.ProficiencyBonus
+	if profBonus == 0 {
+		profBonus = 2
+	}
+
+	m := &Monster{
+		id:               d.ID,
+		name:             d.Name,
+		ref:              d.Ref,
+		hp:               d.HitPoints,
+		maxHP:            d.MaxHitPoints,
+		ac:               d.ArmorClass,
+		abilityScores:    d.AbilityScores,
+		proficiencyBonus: profBonus,
+		speed:            d.Speed,
+		senses:           d.Senses,
+		targeting:        d.Targeting,
+		subscriptionIDs:  make([]string, 0),
+		actions:          make([]MonsterAction, 0, len(d.Actions)),
+		proficiencies:    make(map[string]int),
+		conditions:       make([]dnd5eEvents.ConditionBehavior, 0, len(d.Conditions)),
+	}
+
+	// Actions must be loaded by the caller to avoid import cycles.
+	// The monster package cannot import monster/actions because actions imports monster.
+	// Use LoadMonsterActions helper to load actions after creating the monster.
+
+	// Load proficiencies
+	for _, prof := range d.Proficiencies {
+		m.proficiencies[prof.Skill] = prof.Bonus
+	}
+
+	if policy == dropConditions {
+		return m, nil
+	}
+
+	for i, raw := range d.Conditions {
+		var peek struct {
+			Ref core.Ref `json:"ref"`
+		}
+		if err := json.Unmarshal(raw, &peek); err != nil {
+			return nil, rpgerr.Wrapf(err, "failed to read the ref of condition %d: %s", i, raw)
+		}
+		if peek.Ref.ID == "" {
+			return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"condition %d names no ref for a loader to route on: %s", i, raw)
+		}
+	}
+	m.traitData = append(m.traitData, d.Conditions...)
+
+	return m, nil
+}
+
+// SheetKeeper is a monster's own reaction to the world, made attachable.
+//
+// A monster sheet has less to keep than a character's — damage taken and
+// healing received, both of which move its hit points — but the principle is
+// the same one rpg-toolkit#985 is about: that is behaviour, and behaviour
+// belongs in something a caller can attach, name in a registration ledger, and
+// take back, rather than in wiring hidden inside a constructor.
+//
+// Get one from [Monster.SheetKeeper].
+type SheetKeeper struct {
+	monster *Monster
+
+	// subscriptionIDs are the hooks this keeper granted, so Remove revokes
+	// exactly those and nothing else.
+	subscriptionIDs []string
+}
+
+// SheetKeeper returns the attachable carrying this monster's own behaviour.
+//
+// The keeper is created once and kept, so two callers asking a monster for its
+// keeper get the same one and cannot accidentally subscribe it twice.
+func (m *Monster) SheetKeeper() *SheetKeeper {
+	if m.keeper == nil {
+		m.keeper = &SheetKeeper{monster: m}
+	}
+
+	return m.keeper
+}
+
+// Apply subscribes the monster's damage and healing handlers to bus.
+//
+// The handlers close over this bus rather than reading one off the monster: a
+// purely loaded monster has none of its own.
+func (k *SheetKeeper) Apply(ctx context.Context, bus events.EventBus) error {
+	if k.monster == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "sheet keeper has no monster")
+	}
+	if bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
+	}
+	if len(k.subscriptionIDs) > 0 {
+		// Attaching twice would double the handlers: one damage event would
+		// take its damage twice.
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "sheet keeper is already applied")
+	}
+
+	m := k.monster
+
+	// Park the bus on the monster for Cleanup, which is the only method still
+	// reading it. It goes away with the rest of the migration
+	// (rpg-toolkit#965, #966); the handlers below never read it.
+	m.bus = bus
+
+	damageID, err := dnd5eEvents.DamageReceivedTopic.On(bus).Subscribe(ctx, m.onDamageReceived)
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to subscribe to damage received")
+	}
+	k.track(damageID)
+
+	healingID, err := dnd5eEvents.HealingReceivedTopic.On(bus).Subscribe(ctx, m.onHealingReceived)
+	if err != nil {
+		return rpgerr.Wrapf(err, "failed to subscribe to healing received")
+	}
+	k.track(healingID)
+
+	return nil
+}
+
+// Remove revokes every subscription this keeper granted, and nothing else.
+func (k *SheetKeeper) Remove(ctx context.Context, bus events.EventBus) error {
+	if k.monster == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "sheet keeper has no monster")
+	}
+	if bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
+	}
+
+	var firstErr error
+
+	for _, subID := range k.subscriptionIDs {
+		if err := bus.Unsubscribe(ctx, subID); err != nil && firstErr == nil {
+			firstErr = rpgerr.Wrapf(err, "failed to unsubscribe")
+		}
+	}
+
+	k.monster.forgetSubscriptions(k.subscriptionIDs)
+	k.subscriptionIDs = nil
+
+	return firstErr
+}
+
+// track records a subscription on the keeper and on the monster: the keeper
+// needs to know what to revoke, and Cleanup — which predates the keeper —
+// revokes whatever the monster is carrying.
+func (k *SheetKeeper) track(subID string) {
+	k.subscriptionIDs = append(k.subscriptionIDs, subID)
+	k.monster.subscriptionIDs = append(k.monster.subscriptionIDs, subID)
+}
+
+// forgetSubscriptions drops the given subscription IDs from the monster's
+// list, so a Cleanup after a [SheetKeeper.Remove] does not try to revoke hooks
+// that are already gone.
+func (m *Monster) forgetSubscriptions(revoked []string) {
+	if len(revoked) == 0 || len(m.subscriptionIDs) == 0 {
+		return
+	}
+
+	gone := make(map[string]struct{}, len(revoked))
+	for _, id := range revoked {
+		gone[id] = struct{}{}
+	}
+
+	kept := make([]string, 0, len(m.subscriptionIDs))
+	for _, id := range m.subscriptionIDs {
+		if _, ok := gone[id]; !ok {
+			kept = append(kept, id)
+		}
+	}
+	m.subscriptionIDs = kept
+}

--- a/rulebooks/dnd5e/monster/load.go
+++ b/rulebooks/dnd5e/monster/load.go
@@ -169,6 +169,12 @@ func (m *Monster) SheetKeeper() *SheetKeeper {
 //
 // The handlers close over this bus rather than reading one off the monster: a
 // purely loaded monster has none of its own.
+//
+// **A failed Apply is a no-op.** A monster subscribed to damage but not healing
+// would take every hit and heal from nothing, and a keeper left holding that
+// half-attachment would refuse every later Apply as already applied — a leak
+// that also cannot be retried. So whatever went on comes back off, the monster
+// gets back the bus it was holding, and the keeper is appliable again.
 func (k *SheetKeeper) Apply(ctx context.Context, bus events.EventBus) error {
 	if k.monster == nil {
 		return rpgerr.New(rpgerr.CodeInvalidArgument, "sheet keeper has no monster")
@@ -183,25 +189,49 @@ func (k *SheetKeeper) Apply(ctx context.Context, bus events.EventBus) error {
 	}
 
 	m := k.monster
+	previousBus := m.bus
 
 	// Park the bus on the monster for Cleanup, which is the only method still
 	// reading it. It goes away with the rest of the migration
 	// (rpg-toolkit#965, #966); the handlers below never read it.
 	m.bus = bus
 
-	damageID, err := dnd5eEvents.DamageReceivedTopic.On(bus).Subscribe(ctx, m.onDamageReceived)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to damage received")
+	handlers := []struct {
+		what      string
+		subscribe func() (string, error)
+	}{
+		{"damage received", func() (string, error) {
+			return dnd5eEvents.DamageReceivedTopic.On(bus).Subscribe(ctx, m.onDamageReceived)
+		}},
+		{"healing received", func() (string, error) {
+			return dnd5eEvents.HealingReceivedTopic.On(bus).Subscribe(ctx, m.onHealingReceived)
+		}},
 	}
-	k.track(damageID)
 
-	healingID, err := dnd5eEvents.HealingReceivedTopic.On(bus).Subscribe(ctx, m.onHealingReceived)
-	if err != nil {
-		return rpgerr.Wrapf(err, "failed to subscribe to healing received")
+	for _, handler := range handlers {
+		subID, err := handler.subscribe()
+		if err != nil {
+			k.unsubscribeSelf(ctx, bus)
+			m.bus = previousBus
+
+			return rpgerr.Wrapf(err, "failed to subscribe to %s", handler.what)
+		}
+
+		k.track(subID)
 	}
-	k.track(healingID)
 
 	return nil
+}
+
+// unsubscribeSelf revokes the subscriptions this keeper granted and forgets
+// them, leaving the keeper unapplied and therefore appliable again.
+func (k *SheetKeeper) unsubscribeSelf(ctx context.Context, bus events.EventBus) {
+	for _, subID := range k.subscriptionIDs {
+		_ = bus.Unsubscribe(ctx, subID)
+	}
+
+	k.monster.forgetSubscriptions(k.subscriptionIDs)
+	k.subscriptionIDs = nil
 }
 
 // Remove revokes every subscription this keeper granted, and nothing else.

--- a/rulebooks/dnd5e/monster/load_test.go
+++ b/rulebooks/dnd5e/monster/load_test.go
@@ -1,0 +1,250 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monster
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+type PureLoadTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func (s *PureLoadTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// immunityBlob is a persisted trait. This package cannot route it to a loader
+// — monstertraits imports this one — so it is carried as the bytes it is,
+// which is exactly what the round trip below is about.
+func (s *PureLoadTestSuite) immunityBlob() json.RawMessage {
+	raw, err := json.Marshal(map[string]any{
+		"ref":         refs.MonsterTraits.Immunity(),
+		"monster_id":  "skel-load",
+		"damage_type": "poison",
+	})
+	s.Require().NoError(err)
+
+	return raw
+}
+
+func (s *PureLoadTestSuite) sheet() *Data {
+	return &Data{
+		ID:   "skel-load",
+		Name: "Skeleton",
+		Ref:  refs.Monsters.Skeleton(),
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 10,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 6,
+			abilities.WIS: 8,
+			abilities.CHA: 5,
+		},
+		HitPoints:        9,
+		MaxHitPoints:     13,
+		ArmorClass:       13,
+		ProficiencyBonus: 2,
+		Speed:            SpeedData{Walk: 30},
+		Senses:           SensesData{Darkvision: 60, PassivePerception: 9},
+		Actions:          []ActionData{},
+		Proficiencies:    []ProficiencyData{{Skill: "stealth", Bonus: 4}},
+		Conditions:       []json.RawMessage{s.immunityBlob()},
+		Targeting:        TargetLowestHP,
+	}
+}
+
+func (s *PureLoadTestSuite) marshal(d *Data) string {
+	raw, err := json.Marshal(d)
+	s.Require().NoError(err)
+
+	return string(raw)
+}
+
+// Data in, the same data out, with no bus in the call — conditions included.
+// Actions are the one thing this package cannot load (the action loader imports
+// it); monstertraits.LoadMonster is the composition that does both, and its
+// tests pin the round trip with actions in it.
+func (s *PureLoadTestSuite) TestRoundTripsByteIdenticalWithNoBus() {
+	data := s.sheet()
+
+	m, err := Load(s.ctx, data)
+	s.Require().NoError(err)
+
+	s.Require().Equal(s.marshal(data), s.marshal(m.ToData()))
+}
+
+// The legacy path throws the conditions away. Its callers are expected to pass
+// the same blobs to monstertraits.LoadMonsterConditions themselves, and a
+// caller who forgets writes the monster back without them — the trap the
+// carried blobs close.
+func (s *PureLoadTestSuite) TestLegacyLoadDropsTheConditions() {
+	m, err := LoadFromData(s.ctx, s.sheet(), events.NewEventBus())
+	s.Require().NoError(err)
+
+	s.Require().Empty(m.ToData().Conditions)
+}
+
+func (s *PureLoadTestSuite) TestLoadAppliesNothing() {
+	m, err := Load(s.ctx, s.sheet())
+	s.Require().NoError(err)
+
+	s.Require().Nil(m.bus, "a pure load holds no bus")
+	s.Require().Empty(m.subscriptionIDs, "a pure load subscribes to nothing")
+	s.Require().Empty(m.GetConditions(), "nothing is applied until a trait loader runs")
+}
+
+// The blobs are taken, not read: whoever loads them into behaviour clears them,
+// so ToData cannot write the same condition twice.
+func (s *PureLoadTestSuite) TestTakeUnappliedConditionsDrains() {
+	m, err := Load(s.ctx, s.sheet())
+	s.Require().NoError(err)
+
+	s.Require().Equal([]json.RawMessage{s.immunityBlob()}, m.TakeUnappliedConditions())
+	s.Require().Empty(m.TakeUnappliedConditions())
+	s.Require().Empty(m.ToData().Conditions)
+}
+
+// Strict as far as it can be without a loader: a blob that is not JSON fails
+// the load, and the error names it.
+func (s *PureLoadTestSuite) TestStrictLoadRefusesAMalformedCondition() {
+	data := s.sheet()
+	data.Conditions = append(data.Conditions, json.RawMessage(`{"ref":`))
+
+	_, err := Load(s.ctx, data)
+
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), `{"ref":`)
+}
+
+// A blob with no ref could never be routed to a loader, so accepting it would
+// only defer the failure to a place with less to say about it.
+func (s *PureLoadTestSuite) TestStrictLoadRefusesAConditionWithNoRef() {
+	data := s.sheet()
+	data.Conditions = append(data.Conditions, json.RawMessage(`{"monster_id":"skel-load"}`))
+
+	_, err := Load(s.ctx, data)
+
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "names no ref")
+}
+
+func (s *PureLoadTestSuite) TestLoadRejectsNilData() {
+	_, err := Load(s.ctx, nil)
+
+	s.Require().Error(err)
+}
+
+// Two fields of Data survive no loader: a monster has nowhere to hold features
+// or inventory and ToData does not write them. Pinned so the round-trip
+// guarantee above is read with its actual scope.
+func (s *PureLoadTestSuite) TestKnownRoundTripGaps() {
+	data := s.sheet()
+	data.Features = []json.RawMessage{json.RawMessage(`{"ref":"whatever"}`)}
+	data.Inventory = []InventoryItemData{{ID: "potion", Name: "Potion", Quantity: 1}}
+
+	m, err := Load(s.ctx, data)
+	s.Require().NoError(err)
+
+	out := m.ToData()
+	s.Require().Empty(out.Features, "Features has no home on a monster")
+	s.Require().Empty(out.Inventory, "Inventory has no home on a monster")
+}
+
+// MonsterKeeperTestSuite drives the two things a monster sheet does about the
+// world. Both fail for a keeper whose Apply subscribes nothing.
+type MonsterKeeperTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+	bus events.EventBus
+	mon *Monster
+}
+
+func (s *MonsterKeeperTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+
+	m, err := Load(s.ctx, &Data{
+		ID:           "skel-keeper",
+		Name:         "Skeleton",
+		HitPoints:    10,
+		MaxHitPoints: 13,
+		ArmorClass:   13,
+	})
+	s.Require().NoError(err)
+	s.Require().NoError(m.SheetKeeper().Apply(s.ctx, s.bus))
+
+	s.mon = m
+}
+
+func (s *MonsterKeeperTestSuite) TestDamageReceivedMovesHitPoints() {
+	err := dnd5eEvents.DamageReceivedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: s.mon.GetID(),
+		Amount:   4,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(6, s.mon.HP())
+	s.Require().True(s.mon.IsDirty(), "a monster that took damage needs saving")
+}
+
+func (s *MonsterKeeperTestSuite) TestHealingReceivedMovesHitPoints() {
+	err := dnd5eEvents.HealingReceivedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: s.mon.GetID(),
+		Amount:   2,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(12, s.mon.HP())
+	s.Require().True(s.mon.IsDirty())
+}
+
+func (s *MonsterKeeperTestSuite) TestEventsForOtherMonstersAreIgnored() {
+	err := dnd5eEvents.DamageReceivedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: "someone-else",
+		Amount:   4,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(10, s.mon.HP())
+	s.Require().False(s.mon.IsDirty())
+}
+
+func (s *MonsterKeeperTestSuite) TestRemoveStopsTheMonsterListening() {
+	s.Require().NoError(s.mon.SheetKeeper().Remove(s.ctx, s.bus))
+
+	err := dnd5eEvents.DamageReceivedTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: s.mon.GetID(),
+		Amount:   4,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(10, s.mon.HP())
+	s.Require().Empty(s.mon.subscriptionIDs)
+}
+
+func (s *MonsterKeeperTestSuite) TestApplyingTwiceIsRefused() {
+	s.Require().Error(s.mon.SheetKeeper().Apply(s.ctx, s.bus))
+}
+
+func TestPureLoadSuite(t *testing.T) {
+	suite.Run(t, new(PureLoadTestSuite))
+}
+
+func TestMonsterKeeperSuite(t *testing.T) {
+	suite.Run(t, new(MonsterKeeperTestSuite))
+}

--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -56,6 +56,7 @@ type Monster struct {
 	// Event bus wiring
 	bus             events.EventBus
 	subscriptionIDs []string
+	keeper          *SheetKeeper
 
 	// Dirty tracking for persistence
 	dirty bool
@@ -333,97 +334,39 @@ func (m *Monster) AddCondition(condition dnd5eEvents.ConditionBehavior) {
 // This is used by factory functions to store trait data before a bus is available.
 // The traits will be serialized to Data.Conditions and applied when LoadFromData
 // is called with LoadMonsterConditions.
+//
+// [Load] carries persisted condition blobs the same way, and
+// monstertraits.AttachMonster is what turns either into behaviour — see
+// [Monster.TakeUnappliedConditions].
 func (m *Monster) AddTraitData(data json.RawMessage) {
 	m.traitData = append(m.traitData, data)
 }
 
 // LoadFromData creates a Monster from persistent data and wires it to the bus.
-// This follows the same pattern as character.LoadFromData.
+//
+// It is [Load] followed by the monster's own [SheetKeeper], with one
+// difference that is the whole reason both exist: LoadFromData throws away the
+// condition blobs in d, because its callers hand the same blobs to
+// monstertraits.LoadMonsterConditions themselves and carrying them here too
+// would write every condition back twice. Load carries them instead, and
+// monstertraits.AttachMonster is what applies them — so the new path cannot
+// lose a monster's conditions by forgetting a second call, which is exactly
+// how the three-call assembly has always been able to.
 func LoadFromData(ctx context.Context, d *Data, bus events.EventBus) (*Monster, error) {
 	if bus == nil {
 		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
 	}
 
-	// Handle proficiency bonus - default to 2 if not set
-	profBonus := d.ProficiencyBonus
-	if profBonus == 0 {
-		profBonus = 2
+	m, err := loadMonster(d, dropConditions)
+	if err != nil {
+		return nil, err
 	}
 
-	// Create the monster with basic data
-	m := &Monster{
-		id:               d.ID,
-		name:             d.Name,
-		ref:              d.Ref,
-		hp:               d.HitPoints,
-		maxHP:            d.MaxHitPoints,
-		ac:               d.ArmorClass,
-		abilityScores:    d.AbilityScores,
-		proficiencyBonus: profBonus,
-		speed:            d.Speed,
-		senses:           d.Senses,
-		targeting:        d.Targeting,
-		bus:              bus,
-		subscriptionIDs:  make([]string, 0),
-		actions:          make([]MonsterAction, 0, len(d.Actions)),
-		proficiencies:    make(map[string]int),
-	}
-
-	// Actions must be loaded by the caller to avoid import cycles.
-	// The monster package cannot import monster/actions because actions imports monster.
-	// Use LoadMonsterActions helper to load actions after creating the monster.
-	// Example:
-	//   monster, err := LoadFromData(ctx, data, bus)
-	//   if err := LoadMonsterActions(monster, data.Actions); err != nil {
-	//       // handle error
-	//   }
-
-	// Load proficiencies
-	for _, prof := range d.Proficiencies {
-		m.proficiencies[prof.Skill] = prof.Bonus
-	}
-
-	// Conditions must be loaded by the caller to avoid import cycles.
-	// The monster package cannot import monstertraits because traits need monster types.
-	// Use LoadMonsterConditions helper to load conditions after creating the monster.
-	// Example:
-	//   monster, err := LoadFromData(ctx, data, bus)
-	//   if err := monstertraits.LoadMonsterConditions(ctx, monster, data.Conditions, bus, roller); err != nil {
-	//       // handle error
-	//   }
-	m.conditions = make([]dnd5eEvents.ConditionBehavior, 0, len(d.Conditions))
-
-	// Subscribe to events
-	if err := m.subscribeToEvents(ctx); err != nil {
+	if err := m.SheetKeeper().Apply(ctx, bus); err != nil {
 		return nil, rpgerr.Wrapf(err, "failed to subscribe to events")
 	}
 
 	return m, nil
-}
-
-// subscribeToEvents subscribes the monster to gameplay events
-func (m *Monster) subscribeToEvents(ctx context.Context) error {
-	if m.bus == nil {
-		return rpgerr.New(rpgerr.CodeInvalidArgument, "monster has no event bus")
-	}
-
-	// Subscribe to damage received
-	damageTopic := dnd5eEvents.DamageReceivedTopic.On(m.bus)
-	subID, err := damageTopic.Subscribe(ctx, m.onDamageReceived)
-	if err != nil {
-		return err
-	}
-	m.subscriptionIDs = append(m.subscriptionIDs, subID)
-
-	// Subscribe to healing received
-	healingTopic := dnd5eEvents.HealingReceivedTopic.On(m.bus)
-	subID, err = healingTopic.Subscribe(ctx, m.onHealingReceived)
-	if err != nil {
-		return err
-	}
-	m.subscriptionIDs = append(m.subscriptionIDs, subID)
-
-	return nil
 }
 
 // onDamageReceived handles damage events
@@ -432,6 +375,12 @@ func (m *Monster) onDamageReceived(_ context.Context, event dnd5eEvents.DamageRe
 		return nil
 	}
 	m.TakeDamage(event.Amount)
+
+	// HP is persisted, and ApplyDamage marks dirty for the same reason: a
+	// monster that took damage and did not go dirty is a monster whose new HP
+	// never gets written down.
+	m.dirty = true
+
 	return nil
 }
 
@@ -444,6 +393,8 @@ func (m *Monster) onHealingReceived(_ context.Context, event dnd5eEvents.Healing
 	if m.hp > m.maxHP {
 		m.hp = m.maxHP
 	}
+	m.dirty = true
+
 	return nil
 }
 

--- a/rulebooks/dnd5e/monstertraits/attach_rollback_test.go
+++ b/rulebooks/dnd5e/monstertraits/attach_rollback_test.go
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monstertraits
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// errRefused is what the stub bus answers with.
+var errRefused = errors.New("bus refused the subscription")
+
+// failingBus is a real bus that refuses the nth Subscribe and behaves normally
+// otherwise, so a test can make a trait's Apply fail after the keeper's has
+// succeeded.
+type failingBus struct {
+	inner  events.EventBus
+	failOn int // 1-based; 0 never fails
+	calls  int
+}
+
+func newFailingBus(failOn int) *failingBus {
+	return &failingBus{inner: events.NewEventBus(), failOn: failOn}
+}
+
+func (b *failingBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	b.calls++
+	if b.calls == b.failOn {
+		return "", errRefused
+	}
+
+	return b.inner.Subscribe(ctx, topic, handler)
+}
+
+func (b *failingBus) Unsubscribe(ctx context.Context, id string) error {
+	return b.inner.Unsubscribe(ctx, id)
+}
+
+func (b *failingBus) Publish(ctx context.Context, topic events.Topic, event any) error {
+	return b.inner.Publish(ctx, topic, event)
+}
+
+// AttachMonsterRollbackTestSuite is the sharpest version of the contract: the
+// trait blobs come off the monster before anything is known to work, so a
+// failure that did not put them back would write the monster to storage
+// without conditions nobody removed. Same three assertions as everywhere else —
+// same data out, nothing listening, retry works.
+type AttachMonsterRollbackTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func (s *AttachMonsterRollbackTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func (s *AttachMonsterRollbackTestSuite) immunityBlob() json.RawMessage {
+	raw, err := json.Marshal(ImmunityData{
+		Ref:        refs.MonsterTraits.Immunity(),
+		OwnerID:    "gob-rollback",
+		DamageType: damage.Poison,
+	})
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// goblin carries two trait blobs so that a failure on the second can be told
+// apart from a failure that lost the lot.
+func (s *AttachMonsterRollbackTestSuite) goblin() *monster.Data {
+	data := monster.NewGoblin("gob-rollback").ToData()
+	data.Conditions = []json.RawMessage{s.immunityBlob(), s.vulnerabilityBlob()}
+
+	return data
+}
+
+func (s *AttachMonsterRollbackTestSuite) vulnerabilityBlob() json.RawMessage {
+	raw, err := json.Marshal(VulnerabilityData{
+		Ref:        refs.MonsterTraits.Vulnerability(),
+		OwnerID:    "gob-rollback",
+		DamageType: damage.Bludgeoning,
+	})
+	s.Require().NoError(err)
+
+	return raw
+}
+
+func (s *AttachMonsterRollbackTestSuite) marshal(d *monster.Data) string {
+	raw, err := json.Marshal(d)
+	s.Require().NoError(err)
+
+	return string(raw)
+}
+
+// assertNothingListening checks the keeper came back off with everything else.
+func (s *AttachMonsterRollbackTestSuite) assertNothingListening(m *monster.Monster, bus events.EventBus) {
+	before := m.HP()
+
+	s.Require().NoError(dnd5eEvents.DamageReceivedTopic.On(bus).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: m.GetID(),
+		Amount:   3,
+	}))
+
+	s.Require().Equal(before, m.HP(), "the monster is not listening")
+	s.Require().False(m.IsDirty())
+}
+
+// A ref no loader here can route fails the attach — and every blob, including
+// the ones never reached, is back on the monster. Without this, ToData writes
+// the goblin back with no conditions at all and nothing anywhere says so.
+func (s *AttachMonsterRollbackTestSuite) TestAnUnroutableTraitLosesNothing() {
+	data := s.goblin()
+	data.Conditions = append(data.Conditions,
+		json.RawMessage(`{"ref":{"module":"dnd5e","type":"monster_traits","id":"nope"}}`))
+
+	m, err := LoadMonster(s.ctx, data)
+	s.Require().NoError(err)
+	before := s.marshal(m.ToData())
+
+	bus := events.NewEventBus()
+	err = AttachMonster(s.ctx, m, bus, nil)
+
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), `"id":"nope"`, "the error names the blob")
+	s.Require().Equal(before, s.marshal(m.ToData()), "the monster writes back exactly what it did before")
+	s.Require().Empty(m.GetConditions(), "and nothing was half-added to it")
+	s.assertNothingListening(m, bus)
+
+	// The blobs are where they were, in order, ready for another attempt.
+	s.Require().Len(m.TakeUnappliedConditions(), 3)
+}
+
+// The keeper attaches, then the first trait's Apply is refused — the third
+// subscription. Everything unwinds, and the same monster attaches cleanly to a
+// working bus afterwards.
+func (s *AttachMonsterRollbackTestSuite) TestARefusedTraitRollsTheAttachBack() {
+	data := s.goblin()
+
+	m, err := LoadMonster(s.ctx, data)
+	s.Require().NoError(err)
+	before := s.marshal(m.ToData())
+
+	bus := newFailingBus(3)
+	err = AttachMonster(s.ctx, m, bus, nil)
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errRefused)
+	s.Require().Equal(before, s.marshal(m.ToData()))
+	s.Require().Empty(m.GetConditions())
+	s.assertNothingListening(m, bus)
+
+	good := events.NewEventBus()
+	s.Require().NoError(AttachMonster(s.ctx, m, good, nil))
+	s.Require().Len(m.GetConditions(), 2, "the retry attached both traits")
+	s.Require().Equal(before, s.marshal(m.ToData()), "and the monster still writes back the same bytes")
+
+	s.Require().NoError(dnd5eEvents.DamageReceivedTopic.On(good).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: m.GetID(),
+		Amount:   3,
+	}))
+	s.Require().Equal(4, m.HP(), "and the keeper attached on the retry")
+}
+
+// A trait that fails after another has already applied takes that one off with
+// it: half a monster's traits attached is a monster with rules nobody wrote.
+func (s *AttachMonsterRollbackTestSuite) TestASecondTraitFailingRemovesTheFirst() {
+	m, err := LoadMonster(s.ctx, s.goblin())
+	s.Require().NoError(err)
+	before := s.marshal(m.ToData())
+
+	// 1-2 are the keeper's, 3 is the immunity trait's; the vulnerability trait
+	// is refused after immunity has applied.
+	bus := newFailingBus(4)
+	err = AttachMonster(s.ctx, m, bus, nil)
+
+	s.Require().Error(err)
+	s.Require().Equal(before, s.marshal(m.ToData()))
+	s.Require().Empty(m.GetConditions())
+	s.assertNothingListening(m, bus)
+	s.Require().Len(m.TakeUnappliedConditions(), 2, "both blobs are back")
+}
+
+func TestAttachMonsterRollbackSuite(t *testing.T) {
+	suite.Run(t, new(AttachMonsterRollbackTestSuite))
+}

--- a/rulebooks/dnd5e/monstertraits/load_test.go
+++ b/rulebooks/dnd5e/monstertraits/load_test.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monstertraits
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// MonsterCompositionTestSuite covers the pair of calls that replace the
+// three-call assembly: one pure load, one attach.
+type MonsterCompositionTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func (s *MonsterCompositionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func (s *MonsterCompositionTestSuite) immunityBlob() json.RawMessage {
+	raw, err := json.Marshal(ImmunityData{
+		Ref:        refs.MonsterTraits.Immunity(),
+		OwnerID:    "gob-compose",
+		DamageType: damage.Poison,
+	})
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// goblin is a monster with real actions on it — taken from the factory rather
+// than hand-written, so the ActionData below is exactly what this build's
+// action serializer produces and the byte comparison is about the loader.
+func (s *MonsterCompositionTestSuite) goblin() *monster.Data {
+	data := monster.NewGoblin("gob-compose").ToData()
+	data.Conditions = []json.RawMessage{s.immunityBlob()}
+
+	return data
+}
+
+func (s *MonsterCompositionTestSuite) marshal(d *monster.Data) string {
+	raw, err := json.Marshal(d)
+	s.Require().NoError(err)
+
+	return string(raw)
+}
+
+// The whole monster, loaded with no bus and written back byte for byte —
+// actions and conditions included. This is what the three-call assembly could
+// never promise: two of its three calls produce a monster that serializes
+// without the third one's contents, and says nothing about it.
+func (s *MonsterCompositionTestSuite) TestRoundTripsByteIdenticalWithNoBus() {
+	data := s.goblin()
+
+	m, err := LoadMonster(s.ctx, data)
+	s.Require().NoError(err)
+
+	s.Require().Equal(s.marshal(data), s.marshal(m.ToData()))
+}
+
+// Actions are the half monster.Load cannot do on its own.
+func (s *MonsterCompositionTestSuite) TestLoadMonsterLoadsTheActions() {
+	m, err := LoadMonster(s.ctx, s.goblin())
+	s.Require().NoError(err)
+
+	s.Require().NotEmpty(m.Actions())
+}
+
+// Attach turns the carried blobs into behaviour, and the monster still writes
+// back the same bytes: the trait moved from unapplied to applied without being
+// counted twice or re-serialized differently.
+func (s *MonsterCompositionTestSuite) TestAttachAppliesTheTraitsItCarried() {
+	data := s.goblin()
+
+	m, err := LoadMonster(s.ctx, data)
+	s.Require().NoError(err)
+	s.Require().NoError(AttachMonster(s.ctx, m, events.NewEventBus(), nil))
+
+	s.Require().Len(m.GetConditions(), 1)
+	s.Require().Equal(s.marshal(data), s.marshal(m.ToData()))
+}
+
+// Attribution, pinned: each trait goes on through the bus scoped to its own
+// ref, and the monster's own hooks stay unattributed.
+func (s *MonsterCompositionTestSuite) TestAttachScopesEachTraitToItsRef() {
+	bus := newRecordingBus()
+
+	m, err := LoadMonster(s.ctx, s.goblin())
+	s.Require().NoError(err)
+	s.Require().NoError(AttachMonster(s.ctx, m, bus, nil))
+
+	s.Require().Equal([]core.Ref{*refs.MonsterTraits.Immunity()}, bus.record.asked)
+	s.Require().NotEmpty(bus.record.byRef[*refs.MonsterTraits.Immunity()])
+	s.Require().NotEmpty(bus.record.byRef[unattributed], "the monster's own hooks are its own")
+}
+
+// The sheet keeper is part of the attach: a monster that was attached hears
+// damage.
+func (s *MonsterCompositionTestSuite) TestAttachPutsTheMonsterOnTheBus() {
+	bus := events.NewEventBus()
+
+	m, err := LoadMonster(s.ctx, s.goblin())
+	s.Require().NoError(err)
+	s.Require().NoError(AttachMonster(s.ctx, m, bus, nil))
+
+	err = dnd5eEvents.DamageReceivedTopic.On(bus).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
+		TargetID: m.GetID(),
+		Amount:   3,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Equal(4, m.HP(), "a goblin has 7 HP and took 3")
+	s.Require().True(m.IsDirty())
+}
+
+// A trait ref this build cannot route fails the attach rather than being
+// dropped — the strictness LoadMonsterConditions already had, kept.
+func (s *MonsterCompositionTestSuite) TestAttachRefusesAnUnknownTrait() {
+	data := s.goblin()
+	data.Conditions = append(data.Conditions,
+		json.RawMessage(`{"ref":{"module":"dnd5e","type":"monster_traits","id":"nope"}}`))
+
+	m, err := LoadMonster(s.ctx, data)
+	s.Require().NoError(err)
+
+	s.Require().Error(AttachMonster(s.ctx, m, events.NewEventBus(), nil))
+}
+
+func (s *MonsterCompositionTestSuite) TestAttachRejectsMissingArguments() {
+	m, err := LoadMonster(s.ctx, s.goblin())
+	s.Require().NoError(err)
+
+	s.Require().Error(AttachMonster(s.ctx, m, nil, nil))
+	s.Require().Error(AttachMonster(s.ctx, nil, events.NewEventBus(), nil))
+}
+
+func TestMonsterCompositionSuite(t *testing.T) {
+	suite.Run(t, new(MonsterCompositionTestSuite))
+}

--- a/rulebooks/dnd5e/monstertraits/loader.go
+++ b/rulebooks/dnd5e/monstertraits/loader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
 
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
@@ -107,6 +108,11 @@ func AllTraitRefs() []string {
 //	if err := monstertraits.LoadMonsterConditions(ctx, mon, data.Conditions, bus, roller); err != nil {
 //	    // handle error
 //	}
+//
+// New code should use [AttachMonster] instead. It is this function plus the
+// monster's own sheet keeper, over the blobs the monster is already carrying
+// rather than blobs the caller has to remember to pass — which is the
+// difference between forgetting a call and being unable to.
 func LoadMonsterConditions(
 	ctx context.Context,
 	m *monster.Monster,
@@ -138,6 +144,67 @@ func LoadMonsterConditions(
 		m.AddCondition(condition)
 	}
 	return nil
+}
+
+// LoadMonster is the whole pure load of a monster: the sheet, its actions, and
+// the trait blobs it was persisted with. No event bus is involved and nothing
+// is applied — [AttachMonster] is what puts the result on a bus.
+//
+// This lives here for a mechanical reason rather than a conceptual one: the
+// monster package cannot import either loader (both import it), and this
+// package is the only one that can see both without a cycle. What it buys is
+// worth the odd address. The three-call assembly this replaces could lose a
+// monster's actions or conditions by forgetting a call — ToData serializes
+// both, so a monster loaded by two of the three calls is written back with the
+// third one's contents gone. One call cannot be two-thirds made.
+//
+// LoadMonster(d).ToData() is the data it was given, with the caveats in
+// [monster.Load]'s godoc: Data.Features and Data.Inventory have nowhere to
+// live on a monster and no loader carries them.
+func LoadMonster(ctx context.Context, d *monster.Data) (*monster.Monster, error) {
+	m, err := monster.Load(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := actions.LoadMonsterActions(m, d.Actions); err != nil {
+		return nil, rpgerr.Wrap(err, "failed to load monster actions")
+	}
+
+	return m, nil
+}
+
+// AttachMonster puts a loaded monster on an event bus: its sheet keeper first,
+// then every trait it is carrying, each through the bus scoped to that trait's
+// own ref.
+//
+// The traits it applies are the blobs the monster came back from [LoadMonster]
+// holding — taken off it, so a second attach cannot apply them twice and
+// ToData cannot write them twice. That is the difference from
+// [LoadMonsterConditions], which is handed its blobs by a caller who read them
+// out of the data itself.
+//
+// Ordering is fixed rather than incidental: the monster's own hooks are
+// attached before any trait's, so two attaches over identical data grant
+// identical registrations in identical order (ADR-0038 R4).
+func AttachMonster(
+	ctx context.Context,
+	m *monster.Monster,
+	bus events.EventBus,
+	roller dice.Roller,
+) error {
+	if m == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "monster is required")
+	}
+	if bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
+	}
+
+	if err := m.SheetKeeper().Apply(ctx, bus); err != nil {
+		return rpgerr.Wrap(err, "failed to attach monster sheet keeper")
+	}
+
+	return LoadMonsterConditions(ctx, m, m.TakeUnappliedConditions(), bus, roller)
 }
 
 // peekTraitRef reads the ref a persisted trait routes on, which is the same

--- a/rulebooks/dnd5e/monstertraits/loader.go
+++ b/rulebooks/dnd5e/monstertraits/loader.go
@@ -187,6 +187,17 @@ func LoadMonster(ctx context.Context, d *monster.Data) (*monster.Monster, error)
 // Ordering is fixed rather than incidental: the monster's own hooks are
 // attached before any trait's, so two attaches over identical data grant
 // identical registrations in identical order (ADR-0038 R4).
+//
+// **A failed attach is a no-op**, and here that is the whole point rather than
+// tidiness. The blobs come off the monster before anything is known to work, so
+// an error partway through — an unroutable ref, a bus that will not take a
+// subscription — would otherwise leave every unprocessed blob nowhere at all,
+// and the next ToData would write the monster back without conditions nobody
+// removed. That is the silent loss rpg-toolkit#948 named and this PR exists to
+// close, so: nothing is added to the monster until every trait has loaded and
+// applied, and any failure puts the blobs back, takes off whatever went on, and
+// removes the keeper. ToData after a failed attach writes what it wrote before
+// it, and the attach can be retried.
 func AttachMonster(
 	ctx context.Context,
 	m *monster.Monster,
@@ -204,7 +215,75 @@ func AttachMonster(
 		return rpgerr.Wrap(err, "failed to attach monster sheet keeper")
 	}
 
-	return LoadMonsterConditions(ctx, m, m.TakeUnappliedConditions(), bus, roller)
+	blobs := m.TakeUnappliedConditions()
+	attached := make([]attachedTrait, 0, len(blobs))
+
+	for i, blob := range blobs {
+		condition, err := LoadJSON(blob, roller)
+		if err != nil {
+			unattachMonster(ctx, m, bus, attached, blobs)
+
+			return rpgerr.Wrapf(err, "failed to load monster condition %d: %s", i, blob)
+		}
+
+		// The ref LoadJSON just routed on, peeked again because a
+		// ConditionBehavior cannot name itself.
+		traitBus := dnd5eEvents.BusForEffect(bus, peekTraitRef(blob))
+
+		if err := condition.Apply(ctx, traitBus); err != nil {
+			// Clean up any partial subscriptions from the failed Apply.
+			_ = condition.Remove(ctx, traitBus)
+			unattachMonster(ctx, m, bus, attached, blobs)
+
+			return rpgerr.Wrapf(err, "failed to apply monster condition %d: %s", i, blob)
+		}
+
+		attached = append(attached, attachedTrait{condition: condition, bus: traitBus})
+	}
+
+	// Only now, when every one of them worked. A trait added to the monster
+	// mid-loop would have to be taken back out again on the next failure, and
+	// the monster has no verb for that — which is exactly the kind of missing
+	// undo that makes partial writes permanent.
+	for _, trait := range attached {
+		m.AddCondition(trait.condition)
+	}
+
+	return nil
+}
+
+// attachedTrait is a trait this attach put on a bus, with the bus it went on.
+// Remembered rather than recomputed: asking an EffectScoper for a scope is how
+// it learns an effect exists, and a rollback that asked again would leave a
+// registration ledger describing an attach that did not happen.
+type attachedTrait struct {
+	condition dnd5eEvents.ConditionBehavior
+	bus       events.EventBus
+}
+
+// unattachMonster returns the monster to the state [AttachMonster] found it in:
+// every trait that went on comes back off newest first, the keeper is removed,
+// and the blobs go back where they were taken from, in order.
+func unattachMonster(
+	ctx context.Context,
+	m *monster.Monster,
+	bus events.EventBus,
+	attached []attachedTrait,
+	blobs []json.RawMessage,
+) {
+	// Newest first, the order resolution tears down in (ADR-0038 R5).
+	for i := len(attached) - 1; i >= 0; i-- {
+		_ = attached[i].condition.Remove(ctx, attached[i].bus)
+	}
+
+	_ = m.SheetKeeper().Remove(ctx, bus)
+
+	// All of them, including the one that failed and every one never reached.
+	// Nothing was added to the monster, so putting the blobs back is the whole
+	// of the undo, and ToData writes exactly what it wrote before the attach.
+	for _, blob := range blobs {
+		m.AddTraitData(blob)
+	}
 }
 
 // peekTraitRef reads the ref a persisted trait routes on, which is the same


### PR DESCRIPTION
## Why

[ADR-0038](https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/adr/0038-resolution-owns-the-bus.md)'s
end state is one sentence of its Consequences: character and combat shed
infrastructure and become what they are — rules vocabulary and data. #985 is
the inversion that gets the entity loaders there. A condition was never
*inside* a character: the sheet carries its persisted JSON, and the attach loop
is free-standing. What actually pinned the bus in `LoadFromData` was the
entity's **own machinery** — the five handlers a character subscribes for
itself, the two a monster does, the recoverable resources it applies. That is
real behaviour. It just belongs in an attachable of its own, attached and
attributed like any effect, rather than wired invisibly inside a constructor.

This lands before the knockdown lane so the lane is built on the final shape.

## What's new

| | |
|---|---|
| `character.Load(ctx, d)` / `monster.Load(ctx, d)` | data → sheet. No bus, no subscriptions, nothing applied. `Load(d).ToData()` is the data it was given. |
| `character.SheetKeeper` / `monster.SheetKeeper` | the entity's own behaviour as an attachable — `Apply(ctx, bus)` / `Remove(ctx, bus)`. Reached via `c.SheetKeeper()`, created once and kept. |
| `character.Attach(ctx, c, bus)` | the whole attach loop: keeper first, then each condition through `dnd5eEvents.BusForEffect(bus, ref)` with the ref captured at load. |
| `monstertraits.AttachMonster(ctx, m, bus, roller)` | the monster equivalent — keeper, then each carried trait, attributed the same way. |
| `monstertraits.LoadMonster(ctx, d)` | the pure composition (sheet + actions + carried trait blobs) that collapses the three-call assembly. It lives in `monstertraits` because that is the only package that can see both loaders without a cycle. |
| `monster.TakeUnappliedConditions()` | drains the blobs a pure load carried. Draining, not reading: `ToData` writes applied conditions *and* unapplied blobs, so an attach that loaded without clearing would write every condition twice. |

**Conditions survive a load with no bus.** The character parses them into
behaviours and keeps each paired with the ref its loader routed on — a
`ConditionBehavior` cannot name itself (#971), so that pairing is the only
moment attribution is knowable, and everything downstream is built out of it.
The monster cannot route its blobs (monstertraits imports monster), so it
carries them as the bytes they are.

## What's recomposed

`character.LoadFromData` is `loadSheet` + `Attach`. `monster.LoadFromData` is
`loadMonster` + the keeper. Both keep their exact behaviour, and **every
pre-existing test passes unmodified** — including the four that call
`subscribeToEvents` directly, which is now a thin call into the keeper.

Two deliberate divergences, both documented in the godoc of both paths:

- **Strictness.** `Load` refuses a persisted blob it cannot make sense of — a
  condition, a feature, an inventory item — and the error names the blob.
  `LoadFromData` drops it and continues, which is what its ~20 callers have.
  Continuing hands back a sheet quietly missing something and the next save
  persists the loss; that is #948's species, and refusing is the only way the
  round trip is a guarantee rather than a hope. Pinned from both sides.
- **Monster conditions.** `Load` carries them; `LoadFromData` still throws them
  away, because its callers pass the same blobs to `LoadMonsterConditions`
  themselves and carrying them in both places would write each condition twice.

Two smaller changes ride along, the same species as the above:

- A sheet now goes **dirty** when an event changes what `ToData` writes — a
  condition landing or leaving, healing received, a monster taking damage.
  Resolution persists only the dirty sheets, so a condition that lands without
  marking the sheet is a condition that never gets written down. No existing
  test asserted the old behaviour.
- Subscription **order** changed on the legacy path: the entity's own hooks now
  precede its effects' (they used to follow). The five/two self-topics have no
  other subscribers in this module; the one overlap is `RestTopic`, where
  `RagingCondition.onRest` and `RecoverableResource.onRest` are independent.
  Fixed order rather than incidental order is ADR-0038 R4. `resolve_test`'s
  hook assertions are per-ref and per-participant, so this does not disturb
  them.

## Verification

**Full module suite** (`rulebooks/dnd5e`, not just touched packages):

```
go build ./... && go test ./... && golangci-lint run ./...
```

26 packages `ok`, **0 lint issues**, `gofmt` clean, `go mod tidy` a no-op (no
new dependencies). Nothing outside `rulebooks/dnd5e` is touched; the
`resolution`, `encounter`, and `session` submodules are untouched and build
against the published version.

**Mutation results** — commit first, `go build` each mutant, revert from the
repo root:

| # | Mutant | Killed by |
|---|---|---|
| a | `SheetKeeper.subscribeSelf` returns before subscribing anything | **40** failures — the new keeper suite plus `TestCharacterConditionsTestSuite`, `TestActionLifecycleSuite`, `TestEffectScopingSuite`, `TestFighterFinalizeSuite`, hit dice |
| b | `Attach` uses the plain bus instead of `BusForEffect` | `TestAttachScopesEachConditionToItsRef`, `TestKeeperHooksAreNotAttributedToAnEffect`, and all three pre-existing `TestEffectScopingSuite` pins |
| b2 | `LoadMonsterConditions` same mutation | `TestAttachScopesEachTraitToItsRef` + both pre-existing `TestTraitScopingSuite` pins |
| c | `loadSheet` loads no conditions | **13** failures incl. `TestConditionsSurviveALoadWithNoBus`, `TestRoundTripsByteIdenticalWithNoBus`, `TestCharacterConditionRoundTrip` |
| d | `Load` made lenient (strictness inverted) | `TestStrictLoadRefusesAMalformedCondition`, `…AFeatureFromAnotherModule`, `…AnUnknownInventoryItem` |
| e | `monster.Load` drops the blobs it carries | `TestRoundTripsByteIdenticalWithNoBus` (both suites), `TestTakeUnappliedConditionsDrains`, `TestAttachAppliesTheTraitsItCarried` |
| f | `TakeUnappliedConditions` reads instead of draining | `TestTakeUnappliedConditionsDrains`, and `TestAttachAppliesTheTraitsItCarried` catches the doubled write |
| g | `onConditionApplied` does not mark dirty | `TestConditionAppliedLandsOnTheSheet` |
| h | `SheetKeeper.Apply` skips `applyResources` | `TestResourcesHearARest` |
| i | monster keeper subscribes nothing | `TestMonsterKeeperSuite` (3), `TestAttachPutsTheMonsterOnTheBus`, `TestMonsterMachineryIsNotAttributedToATrait` |
| j | `LoadFromData` made strict (leniency inverted) | `TestLegacyLoadDropsAMalformedCondition`, `TestLegacyLoadDropsAFeatureFromAnotherModule` |

No survivors; every mutant compiled first, so none is inconclusive.

**gorelease: compatible.** No CI job covers this — `.github/workflows/compat.yml`
filters on `play/*`, `rulebooks/dnd5e/encounter/**`, and
`rulebooks/dnd5e/session/**`, so the parent `rulebooks/dnd5e` module (and
`resolution`) have no compatibility gate. Worth closing separately. Run by hand
against the current tag, same pinned version the workflow uses:

```
$ cd rulebooks/dnd5e && go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base v0.85.0

# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character
## compatible changes
(*Character).SheetKeeper: added
Attach: added
Load: added
SheetKeeper: added

# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster
## compatible changes
(*Monster).SheetKeeper: added
(*Monster).TakeUnappliedConditions: added
Load: added
SheetKeeper: added

# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits
## compatible changes
AttachMonster: added
LoadMonster: added

# summary
Suggested version: v0.86.0 (with tag rulebooks/dnd5e/v0.86.0)
```

Compatible changes only, no incompatible section, minor bump suggested — which
is what additive means.

## Known gaps, pinned rather than fixed

Four `Data` fields survive no loader because they have nowhere to live on the
sheet, and `ToData` does not write them: character `BackgroundID` and
`CreatedAt`, monster `Features` and `Inventory`. Closing that means changing
`ToData`, which is a different change with a different blast radius — so
`TestKnownRoundTripGaps` (both packages) asserts the loss instead, and the
round-trip guarantee is stated with its actual scope. Worth its own issue.

## Out of scope

- `rulebooks/dnd5e/resolution`, `encounter`, `session` — the resolution-side
  inversion (call `Load` + the helper, delete the delegation) is a follow-up PR
  in the resolution module after this tags, per one-in-flight-PR-per-module.
- Retiring the legacy paths or the `c.bus` field — #965 / #966.
- The conditions→effects rename (1.0).
- #979 (multi-pool damage), #978 (save-gate design).

Closes #985

— asset-pipeline agent, on behalf of KirkDiggler
