### PR TITLE
feat(dnd5e): add monster saving throw modifiers

### DIFF
--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -200,6 +200,11 @@ func (m *Monster) ProficiencyBonus() int {
 	return m.proficiencyBonus
 }
 
+// GetSavingThrowModifier returns the monster's modifier for a saving throw.
+func (m *Monster) GetSavingThrowModifier(ability abilities.Ability) int {
+	return m.abilityScores.Modifier(ability)
+}
+
 // PassivePerception returns the monster's passive Perception score, from the
 // static Senses field seeded at load time. Implements combat.Combatant.
 func (m *Monster) PassivePerception() int {

--- a/rulebooks/dnd5e/monster/monster_test.go
+++ b/rulebooks/dnd5e/monster/monster_test.go
@@ -75,6 +75,35 @@ func (s *MonsterTestSuite) TestNewGoblin() {
 	s.Equal(2, scores.Modifier(abilities.DEX))
 }
 
+func (s *MonsterTestSuite) TestGetSavingThrowModifier() {
+	monster := New(Config{
+		ID:   "test-monster-1",
+		Name: "Test Monster",
+		HP:   10,
+		AC:   10,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.CON: 10,
+			abilities.INT: 8,
+		},
+	})
+
+	tests := map[string]struct {
+		ability abilities.Ability
+		want    int
+	}{
+		"positive modifier": {ability: abilities.STR, want: 3},
+		"zero modifier":     {ability: abilities.CON, want: 0},
+		"negative modifier": {ability: abilities.INT, want: -1},
+	}
+
+	for name, test := range tests {
+		s.Run(name, func() {
+			s.Equal(test.want, monster.GetSavingThrowModifier(test.ability))
+		})
+	}
+}
+
 // TestMeleeWeapon_GoblinResolvesScimitar is the regression guard for
 // rpg-toolkit#722: a goblin's OA must swing its real scimitar, not fall
 // back to unarmed. NewGoblin's default action ID ("scimitar") must resolve

--- a/rulebooks/dnd5e/monster/monster_test.go
+++ b/rulebooks/dnd5e/monster/monster_test.go
@@ -84,7 +84,8 @@ func (s *MonsterTestSuite) TestGetSavingThrowModifier() {
 		AbilityScores: shared.AbilityScores{
 			abilities.STR: 16,
 			abilities.CON: 10,
-			abilities.INT: 8,
+			abilities.INT: 3,
+			abilities.WIS: 8,
 		},
 	})
 
@@ -92,9 +93,10 @@ func (s *MonsterTestSuite) TestGetSavingThrowModifier() {
 		ability abilities.Ability
 		want    int
 	}{
-		"positive modifier": {ability: abilities.STR, want: 3},
-		"zero modifier":     {ability: abilities.CON, want: 0},
-		"negative modifier": {ability: abilities.INT, want: -1},
+		"positive modifier":  {ability: abilities.STR, want: 3},
+		"zero modifier":      {ability: abilities.CON, want: 0},
+		"negative modifier":  {ability: abilities.WIS, want: -1},
+		"odd score below 10": {ability: abilities.INT, want: -4},
 	}
 
 	for name, test := range tests {

--- a/rulebooks/dnd5e/shared/types.go
+++ b/rulebooks/dnd5e/shared/types.go
@@ -89,7 +89,11 @@ func (a AbilityScores) ApplyIncreases(increases map[abilities.Ability]int) error
 
 // Modifier calculates the ability modifier for a given ability
 func (a AbilityScores) Modifier(ability abilities.Ability) int {
-	return (a[ability] - 10) / 2
+	difference := a[ability] - 10
+	if difference >= 0 {
+		return difference / 2
+	}
+	return (difference - 1) / 2
 }
 
 // ProficiencyLevel represents expertise levels

--- a/rulebooks/dnd5e/shared/types_test.go
+++ b/rulebooks/dnd5e/shared/types_test.go
@@ -1,0 +1,35 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+)
+
+type AbilityScoresTestSuite struct {
+	suite.Suite
+}
+
+func TestAbilityScoresSuite(t *testing.T) {
+	suite.Run(t, new(AbilityScoresTestSuite))
+}
+
+func (s *AbilityScoresTestSuite) TestModifierRoundsNegativeHalvesDown() {
+	tests := map[string]struct {
+		score int
+		want  int
+	}{
+		"score 9": {score: 9, want: -1},
+		"score 3": {score: 3, want: -4},
+	}
+
+	for name, test := range tests {
+		s.Run(name, func() {
+			scores := AbilityScores{abilities.INT: test.score}
+
+			s.Equal(test.want, scores.Modifier(abilities.INT))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add `Monster.GetSavingThrowModifier` using the monster’s ability scores
- fix shared ability-modifier calculation to floor negative halves as required by D&D 5e
- cover positive, zero, even-negative, and odd-negative modifiers, including the wolf’s INT 3 → -4 case
- keep the saving-throw API on the concrete monster model without expanding the legacy `combat.Combatant` interface

## Motivation

The resolution saving-throw machine currently supports characters but explicitly refuses monster savers because the concrete monster model does not expose its saving-throw modifier. This is the inside-out prerequisite for enabling monster saves in the resolution module and, ultimately, Wolf Bite knockdown.

Review exposed an existing bug in `shared.AbilityScores.Modifier`: Go integer division truncated negative halves toward zero, while D&D 5e requires rounding down. Because the new monster method delegates to that shared calculation—and the catalog wolf has INT 3—the shared correction is required for this API to return the declared modifier.

This PR intentionally does not add saving-throw proficiency persistence or resolution wiring. Current catalog monsters do not declare proficient saves; those concerns should land with a concrete content need and the consuming resolution boundary.

## Verification

- focused shared and monster modifier regression tests
- `go test -race ./...` from `rulebooks/dnd5e`
- `git diff --check origin/main...HEAD`