### PR TITLE
feat(resolution): attach through the pure-load API (#989)

### DIFF
--- a/rulebooks/dnd5e/resolution/README.md
+++ b/rulebooks/dnd5e/resolution/README.md
@@ -78,14 +78,32 @@ vocabulary over pure data, and resolution is the only attacher. A condition
 was never really *inside* a character — the sheet carries its persisted JSON,
 and the bus belongs to whoever runs the attach loop.
 
-Today is one inversion short: `Resolve` delegates each load to
-`character.LoadFromData` / the monster three-call assembly, which still take
-a bus (the `EffectScoper` seam, #982, keeps attribution per-effect through
-the delegation). What pins the bus there is not conditions but the entity's
-own five self-subscriptions — the sheet reacting to the world. The remaining
-migration PR inverts the loop into this package, drops the bus from the
-entity loaders, and extracts those handlers into a sheet-keeper attachable.
-See "Where this sits on the migration" in [doc.go](doc.go).
+That inversion has landed (#985, #986, #989). The entity loaders come in two
+halves now: `character.Load` and `monstertraits.LoadMonster` turn data into a
+sheet with no bus anywhere in the call, and `character.Attach` /
+`monstertraits.AttachMonster` put that sheet on the bus **this** package made —
+the sheet's own keeper first, then each effect through a view stamped with its
+ref. The five self-subscriptions that used to pin the bus inside a constructor
+are a sheet-keeper attachable, so they show up in the registration list under
+the participant that made them rather than as the anonymous zero-Ref entries
+this section used to warn about.
+
+Two consequences, worth knowing before you read a failure here:
+
+- **Resolution is strict.** A persisted effect blob this build cannot route
+  fails the whole resolution, naming the blob. The legacy path logged it and
+  carried on — which is how a sheet came back one effect short and was
+  persisted in that state (#948). `Resolve` hands sheets back to be saved, so
+  forgiving here means deleting there.
+- **A failed attach is a no-op.** Whatever attached before the failure comes
+  back off: by the entity's own contract, and again by this package's teardown
+  on the error path. A refused resolution leaves no hooks on a bus and no
+  half-written sheet.
+
+What remains is retirement rather than inversion. `character.LoadFromData` and
+the monster three-call assembly still exist for their other callers, and the
+bus a sheet parks for its verb methods is still parked. Both go with #965 and
+#966. See "Where this sits on the migration" in [doc.go](doc.go).
 
 ## Reading order
 

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -64,24 +64,30 @@
 // its loader, call Apply. That loop is free-standing, and this package is
 // where it ends up.
 //
-// Today is one inversion short of that. [Resolve] delegates each
-// participant's load to character.LoadFromData and the monster three-call
-// assembly, which still take a bus and run the condition loop themselves;
-// the EffectScoper seam (#982) is how per-effect attribution survives the
-// delegation. What actually keeps the bus in those signatures is not the
-// conditions — it is the entity's own machinery: a character subscribes five
-// handlers for itself (conditions applied to it, healing received, actions
-// granted) and mutates its sheet when those events land. That is the sheet
-// reacting to the world, which is real behaviour — it is just behaviour that
-// belongs in an attachable of its own, attached and attributed like any
-// effect, rather than wired invisibly inside a constructor.
+// That inversion has landed. [Resolve] loads each participant purely —
+// character.Load, monstertraits.LoadMonster: data → sheet, no bus in the call —
+// and then attaches it to the bus this package made, through
+// character.Attach and monstertraits.AttachMonster. Each of those runs the
+// loop this package used to delegate: the sheet's own keeper first, then every
+// persisted effect through a view stamped with the ref its loader routed on.
+// The entity's own machinery — the handlers a character keeps for itself, the
+// two a monster does, the recoverable resources — is a sheet-keeper attachable,
+// so it appears in the registration list under the participant that made it
+// instead of as the zero-Ref entries this paragraph used to describe.
 //
-// The remaining migration is therefore its own PR, not a side effect of any
-// machine landing: the entity loaders drop their bus parameter and become
-// data → sheet; this package runs the ref → loader → Apply loop itself; the
-// self-subscriptions extract into a sheet-keeper attachable. Until then,
-// those self-subscriptions are the zero-Ref entries in the registration
-// list.
+// Two behaviours ride in with it. Loading is strict: a persisted effect blob
+// this build cannot route fails the resolution and names the blob, where the
+// legacy path logged and carried on — and since [Resolve] hands sheets back to
+// be persisted, an effect dropped on the way in is an effect deleted on the way
+// out. And a failed attach is a no-op: whatever attached before the failure
+// comes back off, by the entity's contract and again by this package's teardown
+// on the error path, so a refused resolution leaves nothing on a bus and no
+// half-written sheet.
+//
+// What remains is retirement rather than migration. character.LoadFromData and
+// the monster three-call assembly still exist for their other callers, and a
+// sheet still parks a bus for the verb methods that read one. Both go with
+// #965 and #966.
 //
 // # What this package does not do yet
 //

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.84.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.85.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.84.0 h1:kkNDxhi1UWfwuudMDaojhtVSrTIKlLZAkQqiK1thIWY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.84.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.85.1 h1:mDyKxOoKhgre6pM5MnI/YPtpqd6ssLYQRDTHRox3EC8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.85.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0 h1:GcwmLanoceCnrQ1R1Z61N7qLqMBY8VUPq5TpL1BhfUw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0/go.mod h1:ZYYd+oFBN6WUPIb+OTaAu6X7CQtVhOjEg9i0GJM0o6Q=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -14,7 +14,6 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
-	monsterActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
 )
 
@@ -317,30 +316,27 @@ func attachCharacter(
 	return ch, nil
 }
 
-// attachMonster is the same two steps with the monster's third call in the
-// middle, which is import-cycle bookkeeping rather than a decision: the action
-// loader imports the monster package, so only a caller can run both.
+// attachMonster is the same two calls, over the composition that knows what a
+// whole monster is.
+//
+// monstertraits.LoadMonster is the pure load — sheet, actions, and the trait
+// blobs it was persisted with — and it lives in that package because it is the
+// only one that can see both loaders without an import cycle. Calling it rather
+// than assembling the pieces here is safer by construction than by test: the
+// actions round-trip pin would catch a forgotten LoadMonsterActions, but a
+// composition that cannot forget it needs no pin at all, and this caller is the
+// one it was written for.
 //
 // The trait blobs ride on the loaded monster rather than being passed alongside
-// it — monster.Load carries them, monstertraits.AttachMonster drains them — so
-// the old failure mode of this function, where forgetting a call wrote a
-// monster back without what that call would have restored, is no longer
-// reachable for conditions. And a failed attach is a no-op: the blobs go back,
-// whatever was applied comes off, and nothing half-attached survives the error
-// this returns.
-//
-// monstertraits.LoadMonster would collapse the first two calls into one. It is
-// spelled out here because #989 specified these three by name; folding it is a
-// one-line change if the composition is preferred.
+// it, so the assembly's other old failure — writing a monster back without the
+// conditions a skipped call would have restored — is unreachable too. And a
+// failed attach is a no-op: the blobs go back, whatever was applied comes off,
+// and nothing half-attached survives the error this returns.
 func attachMonster(
 	ctx context.Context, view *surface, data *monster.Data, roller dice.Roller,
 ) (*monster.Monster, error) {
-	m, err := monster.Load(ctx, data)
+	m, err := monstertraits.LoadMonster(ctx, data)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := monsterActions.LoadMonsterActions(m, data.Actions); err != nil {
 		return nil, err
 	}
 

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -266,7 +266,7 @@ func attachAll(
 
 		switch {
 		case p.Character != nil:
-			ch, err := character.LoadFromData(ctx, p.Character, view)
+			ch, err := attachCharacter(ctx, view, p.Character)
 			if err != nil {
 				return nil, fmt.Errorf("resolution: attach character %q: %w", id, err)
 			}
@@ -286,16 +286,56 @@ func attachAll(
 	return cast, nil
 }
 
-// attachMonster performs the three-call assembly the monster package documents.
+// attachCharacter loads a sheet and puts it on this participant's view of the
+// bus — two calls, and the split between them is the point.
 //
-// All three calls, not one: monster.LoadFromData deliberately loads neither
-// actions nor conditions (both would be import cycles), and ToData serializes
-// both. Skipping either call therefore does not merely leave a monster
-// underpowered — it writes back a monster that has silently lost them.
+// character.Load is data → sheet: no bus, no subscriptions, nothing applied.
+// character.Attach is the loop this package used to delegate: the sheet's own
+// keeper first, then each condition through a bus scoped to the ref its loader
+// routed on. The view implements dnd5eEvents.EffectScoper, so that scoping is
+// what fills the registration list — attribution by construction, and now by
+// construction *here*, rather than inside a constructor two modules away
+// (rpg-toolkit#985).
+//
+// Loading strictly is the behaviour change that comes with it: a condition blob
+// that will not parse fails the resolution, naming the blob, where the legacy
+// path logged and carried on. Resolution is the wrong place to be forgiving —
+// it hands back sheets to be persisted, so an effect quietly dropped on the way
+// in is an effect deleted on the way out (rpg-toolkit#948).
+func attachCharacter(
+	ctx context.Context, view *surface, data *character.Data,
+) (*character.Character, error) {
+	ch, err := character.Load(ctx, data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := character.Attach(ctx, ch, view); err != nil {
+		return nil, err
+	}
+
+	return ch, nil
+}
+
+// attachMonster is the same two steps with the monster's third call in the
+// middle, which is import-cycle bookkeeping rather than a decision: the action
+// loader imports the monster package, so only a caller can run both.
+//
+// The trait blobs ride on the loaded monster rather than being passed alongside
+// it — monster.Load carries them, monstertraits.AttachMonster drains them — so
+// the old failure mode of this function, where forgetting a call wrote a
+// monster back without what that call would have restored, is no longer
+// reachable for conditions. And a failed attach is a no-op: the blobs go back,
+// whatever was applied comes off, and nothing half-attached survives the error
+// this returns.
+//
+// monstertraits.LoadMonster would collapse the first two calls into one. It is
+// spelled out here because #989 specified these three by name; folding it is a
+// one-line change if the composition is preferred.
 func attachMonster(
 	ctx context.Context, view *surface, data *monster.Data, roller dice.Roller,
 ) (*monster.Monster, error) {
-	m, err := monster.LoadFromData(ctx, data, view)
+	m, err := monster.Load(ctx, data)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +344,7 @@ func attachMonster(
 		return nil, err
 	}
 
-	if err := monstertraits.LoadMonsterConditions(ctx, m, data.Conditions, view, roller); err != nil {
+	if err := monstertraits.AttachMonster(ctx, m, view, roller); err != nil {
 		return nil, err
 	}
 

--- a/rulebooks/dnd5e/resolution/strictness_test.go
+++ b/rulebooks/dnd5e/resolution/strictness_test.go
@@ -1,0 +1,282 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// errRefused is what the refusing bus answers with.
+var errRefused = errors.New("bus refused the subscription")
+
+// corruptID sorts after heroID, so a resolution carrying both attaches the hero
+// first and fails on this one — which is what makes "nothing survived the
+// failure" a claim about teardown rather than about never having attached.
+const corruptID = "villain"
+
+// unroutable is a condition blob shaped like every other one and naming a ref
+// no loader in this build recognises. It is the realistic corruption: not
+// garbage bytes, but a persisted effect from a build that knew something this
+// one does not.
+var unroutable = json.RawMessage(`{"ref":{"module":"dnd5e","type":"conditions","id":"nope"}}`)
+
+// StrictnessTestSuite pins the behaviour change that rides in with the pure-load
+// API (rpg-toolkit#985): resolution refuses a sheet it cannot fully reconstitute
+// instead of quietly resolving without part of it.
+//
+// This is not fussiness. Resolve hands back sheets to be persisted, so an effect
+// dropped on the way in is an effect deleted on the way out, and the deletion
+// looks exactly like the effect never having been there — rpg-toolkit#948, whose
+// whole difficulty was that nothing anywhere said it had happened.
+type StrictnessTestSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	roller *scriptedRoller
+}
+
+func (s *StrictnessTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.roller = &scriptedRoller{single: straightRoll, pair: []int{straightRoll, advantageRoll}}
+}
+
+// world is a two-member encounter: the hero, and a second character whose sheet
+// is the corrupt one.
+func (s *StrictnessTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: corruptID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+func (s *StrictnessTestSuite) sheet(id string, conds ...json.RawMessage) *character.Data {
+	return &character.Data{
+		ID:       id,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ProficiencyBonus: 2,
+		SavingThrows: map[abilities.Ability]shared.ProficiencyLevel{
+			abilities.STR: shared.Proficient,
+		},
+		Conditions: conds,
+	}
+}
+
+func (s *StrictnessTestSuite) raging(id string) json.RawMessage {
+	raw, err := (&conditions.RagingCondition{
+		CharacterID: id,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+func (s *StrictnessTestSuite) save() Machine {
+	return NewSave(&SaveInput{
+		SaverID: heroID,
+		Ability: abilities.STR,
+		DC:      saveDifficulty,
+		Roller:  s.roller,
+	})
+}
+
+// A condition blob this build cannot route fails the whole resolution, and the
+// error says which participant and which blob. The legacy path resolved it
+// happily, one effect short, and returned a sheet to persist in that state.
+func (s *StrictnessTestSuite) TestAnUnroutableConditionFailsTheResolution() {
+	out, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: s.sheet(heroID, unroutable)}},
+		Machine:      s.save(),
+	})
+
+	s.Require().Error(err)
+	s.Require().Nil(out, "a resolution that failed produces no output to act on")
+	s.Require().Contains(err.Error(), heroID, "the error names the participant")
+	s.Require().Contains(err.Error(), `"id":"nope"`, "and the blob that could not be read")
+}
+
+// The control that makes the refusal mean something: the same sheet, the same
+// machine, a condition this build does know — and the resolution runs.
+func (s *StrictnessTestSuite) TestTheSameSheetWithAReadableConditionResolves() {
+	out, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: s.sheet(heroID, s.raging(heroID))}},
+		Machine:      s.save(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+}
+
+// Nothing is half-attached. The hero attaches first and its Raging subscribes to
+// the saving-throw chain; the corrupt sheet then fails the resolution — and the
+// chain the hero's condition had joined answers nobody afterwards.
+//
+// Two independent guarantees have to hold for this: the entity-side contract
+// that a failed attach leaves nothing behind, and resolution's own teardown on
+// the error path. Asserting on the bus rather than on either mechanism is what
+// makes the test survive a change to which one does the work.
+func (s *StrictnessTestSuite) TestAFailedResolutionLeavesNothingOnTheBus() {
+	inner := events.NewEventBus()
+
+	out, err := resolveOn(s.ctx, &Input{
+		World: s.world(),
+		Participants: []Participant{
+			{Character: s.sheet(heroID, s.raging(heroID))},
+			{Character: s.sheet(corruptID, unroutable)},
+		},
+		Machine: s.save(),
+	}, newSurface(inner))
+
+	s.Require().Error(err)
+	s.Require().Nil(out)
+
+	event := &dnd5eEvents.SavingThrowChainEvent{SaverID: heroID, Ability: abilities.STR, DC: saveDifficulty}
+	chain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+
+	modified, err := dnd5eEvents.SavingThrowChain.On(inner).PublishWithChain(s.ctx, event, chain)
+	s.Require().NoError(err)
+
+	folded, err := modified.Execute(s.ctx, event)
+	s.Require().NoError(err)
+
+	s.Require().False(folded.HasAdvantage(),
+		"the hero's Raging attached before the failure and does not answer this chain")
+}
+
+// A monster's traits get the same treatment: an unroutable trait ref fails the
+// resolution rather than producing a monster missing an immunity nobody removed.
+func (s *StrictnessTestSuite) TestAnUnroutableMonsterTraitFailsTheResolution() {
+	skeleton := &monster.Data{
+		ID:            skeletonID,
+		Name:          "Skeleton",
+		HitPoints:     13,
+		MaxHitPoints:  13,
+		ArmorClass:    13,
+		AbilityScores: shared.AbilityScores{},
+		Conditions: []json.RawMessage{
+			json.RawMessage(`{"ref":{"module":"dnd5e","type":"monster_traits","id":"nope"}}`),
+		},
+	}
+
+	world, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: skeletonID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	out, resolveErr := Resolve(s.ctx, &Input{
+		World: world.ToData(),
+		Participants: []Participant{
+			{Character: s.sheet(heroID)},
+			{Monster: skeleton},
+		},
+		Machine: s.save(),
+	})
+
+	s.Require().Error(resolveErr)
+	s.Require().Nil(out)
+	s.Require().Contains(resolveErr.Error(), skeletonID)
+	s.Require().Contains(resolveErr.Error(), `"id":"nope"`)
+}
+
+// refusingBus is a real bus that refuses the nth Subscribe. A sheet whose data
+// is perfectly readable can still fail to attach — a bus that will not take a
+// subscription is the general case — and that failure has to reach the caller
+// too, not only the failures that happen while parsing.
+type refusingBus struct {
+	inner  events.EventBus
+	failOn int // 1-based
+	calls  int
+}
+
+func (b *refusingBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	b.calls++
+	if b.calls == b.failOn {
+		return "", errRefused
+	}
+
+	return b.inner.Subscribe(ctx, topic, handler)
+}
+
+func (b *refusingBus) Unsubscribe(ctx context.Context, id string) error {
+	return b.inner.Unsubscribe(ctx, id)
+}
+
+func (b *refusingBus) Publish(ctx context.Context, topic events.Topic, event any) error {
+	return b.inner.Publish(ctx, topic, event)
+}
+
+// An attach that fails for a reason other than an unreadable blob fails the
+// resolution just the same. Without this, resolution could swallow
+// character.Attach's error and hand back a sheet that quietly attached nothing —
+// the same silent loss as a dropped blob, arriving through a different door.
+func (s *StrictnessTestSuite) TestAnAttachThatFailsFailsTheResolution() {
+	bus := &refusingBus{inner: events.NewEventBus(), failOn: 1}
+
+	out, err := resolveOn(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: s.sheet(heroID, s.raging(heroID))}},
+		Machine:      s.save(),
+	}, newSurface(bus))
+
+	s.Require().Error(err)
+	s.Require().Nil(out)
+	s.Require().ErrorIs(err, errRefused)
+	s.Require().Contains(err.Error(), heroID, "the error names the participant that would not attach")
+}
+
+func TestStrictnessSuite(t *testing.T) {
+	suite.Run(t, new(StrictnessTestSuite))
+}


### PR DESCRIPTION
## Why

[ADR-0038](https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/adr/0038-resolution-owns-the-bus.md)'s
end state has resolution as the only attacher, and #985 named this as the
follow-up it deliberately left: `attachAll` still delegated each participant's
load to a path that applied effects itself. #986 landed the pure-load API;
this inverts onto it, so the loop that puts effects on a bus lives in the one
package that owns a bus.

## What changed

```go
// attachCharacter
character.Load(ctx, data)                          // data → sheet, no bus
character.Attach(ctx, ch, view)                    // keeper, then each effect

// attachMonster
monstertraits.LoadMonster(ctx, data)               // sheet + actions + blobs, no bus
monstertraits.AttachMonster(ctx, m, view, roller)  // keeper, then each trait
```

The per-participant view is untouched and does the same work: `Attach` routes
each effect through `BusForEffect` with the ref its loader captured, and the
view implements `EffectScoper` — so the registration list is filled by the same
#982 seam, with the loop now on this side of it. The zero-Ref entries the old
docs warned about are gone: those hooks are the entity's sheet-keeper, attached
first and attributed to the participant that owns it.

`monster.Load` carries its trait blobs rather than dropping them, and
`AttachMonster` drains them, so the composition cannot lose conditions by
forgetting a call. Note the double-attach guard makes a *wrong* composition
loud rather than silent — see mutant e below.

Docs: the "Where this sits on the migration" sections in `README.md` and
`doc.go` described the pre-#985 world. Both now say the inversion has landed,
what strictness and the failed-attach no-op mean for reading a failure here,
and that what remains is retirement of the legacy paths under #965/#966.

Pin: `rulebooks/dnd5e` **v0.85.1**, not the v0.86.0 gorelease suggested on
#986 — that PR's squash title was not conventional so the tagger graded it a
patch, and v0.85.1 carries the identical additive API (#917). `encounter`
stays v0.7.0. No `replace` directives, no `go.work`.

## Behaviour pinned, not absorbed

**Resolution is strict.** A persisted effect blob this build cannot route now
fails `Resolve`, naming the participant and the blob, where the legacy path
logged and continued. `Resolve` hands sheets back to be persisted, so an effect
dropped on the way in is an effect deleted on the way out — #948's species.

**A failed resolution leaves nothing on the bus.** Two independent guarantees
cover it: the entity-side contract that a failed attach is a no-op (#986's
review round), and this package's teardown on the error path for participants
that had already attached. The test asserts on the bus, not on either
mechanism, so it survives a change to which one does the work.

New suite, `strictness_test.go` (5 tests):

| Test | Pins |
|---|---|
| `TestAnUnroutableConditionFailsTheResolution` | the blob fails `Resolve`; the error names participant and blob |
| `TestTheSameSheetWithAReadableConditionResolves` | the control — the blob is the only difference |
| `TestAFailedResolutionLeavesNothingOnTheBus` | hero attaches, second sheet fails; the chain hero's Raging joined answers nobody after |
| `TestAnUnroutableMonsterTraitFailsTheResolution` | the monster half of the same contract |
| `TestAnAttachThatFailsFailsTheResolution` | an attach that fails for any other reason (a bus that refuses a subscription) also fails the resolution |

## Verification

**The existing suite passes unmodified** — including
`TestRegistrationsDoNotDependOnInputOrder` and the per-participant hook
assertions. The ledger's new keeper-before-effects order does not disturb them
because they assert per-ref and per-participant; no order-of-entry assertion
needed touching.

From `rulebooks/dnd5e/resolution/`: `go build ./...` clean, `go test ./...`
`ok`, `golangci-lint run ./...` **0 issues**, `gofmt` clean, `go mod tidy` a
no-op beyond the pin.

Mutation — commit first, `go build` each mutant, revert from the repo root:

| # | Mutant | Result |
|---|---|---|
| a | `attachCharacter` back on `character.LoadFromData` (the lenient path) | killed — `TestAnUnroutableConditionFailsTheResolution`, `TestAFailedResolutionLeavesNothingOnTheBus` |
| b | `AttachMonster`'s error swallowed | killed — `TestAnUnroutableMonsterTraitFailsTheResolution` |
| c | `character.Attach`'s error swallowed | **survived at first** — a real gap: `Load` is what refuses a bad blob, so nothing covered `Attach` failing for another reason. Closed by adding `TestAnAttachThatFailsFailsTheResolution`; now killed. |
| d | no teardown on the attach error path | killed — `TestAFailedResolutionLeavesNothingOnTheBus` |
| e | monster load back to `monster.LoadFromData` (drops the trait blobs) | killed — 6 pre-existing tests plus the strictness suite; the keeper's double-attach guard turns the wrong composition into an error rather than a silent trait loss |
| f | `monstertraits.LoadMonster` skips its actions load (mutated across a temporary local `replace`, reverted with it) | killed — `TestAMonstersActionsSurviveResolution`, i.e. the composition's own guarantee is pinned from this side too |

No survivors; every mutant compiled first. Mutants a–d and f were re-run after
the fold; e was re-expressed against the composed call and still dies.

**gorelease**: `compat.yml` has no job for this module (its path filter covers
`play/**`, `encounter`, `session` — see #917). Run by hand with the workflow's
pinned version against the module's current tag `v0.1.0`:

```
$ go run golang.org/x/exp/cmd/gorelease@v0.0.0-20260727155853-b88d891fe743 -base v0.1.0

# summary
Suggested version: v0.2.0 (with tag rulebooks/dnd5e/resolution/v0.2.0)
```

**No API section at all** — neither compatible nor incompatible changes:
`attachCharacter` and `attachMonster` are unexported and `Resolve`'s signature
is untouched. The suggested minor comes from the changed `go.mod` requirement,
not from the exported surface.

## Out of scope

- Retiring `character.LoadFromData`, the monster three-call assembly, or the
  `bus` field a sheet parks for its verb methods — #965 / #966. They stay for
  their other callers.
- The conditions→effects rename (1.0).
- Anything in `rulebooks/dnd5e`, `encounter`, or `session` — this PR touches
  only the `resolution` module.

Closes #989

— asset-pipeline agent, on behalf of KirkDiggler
