### PR TITLE
feat(dnd5e): the prone condition (#961)

### DIFF
--- a/rulebooks/dnd5e/conditions/factory.go
+++ b/rulebooks/dnd5e/conditions/factory.go
@@ -98,6 +98,8 @@ func CreateFromRef(input *CreateFromRefInput) (*CreateFromRefOutput, error) {
 		condition = NewDisengagingCondition(input.CharacterID)
 	case refs.Conditions.Dodging().ID:
 		condition = NewDodgingCondition(input.CharacterID)
+	case refs.Conditions.Prone().ID:
+		condition = NewProneCondition(input.CharacterID)
 	case refs.Conditions.Hidden().ID:
 		condition = NewHiddenCondition(input.CharacterID)
 	case refs.Conditions.Helped().ID:

--- a/rulebooks/dnd5e/conditions/loader.go
+++ b/rulebooks/dnd5e/conditions/loader.go
@@ -139,6 +139,13 @@ func LoadJSON(data json.RawMessage) (dnd5eEvents.ConditionBehavior, error) {
 		}
 		return dodging, nil
 
+	case refs.Conditions.Prone().ID:
+		prone := &ProneCondition{}
+		if err := prone.loadJSON(data); err != nil {
+			return nil, rpgerr.Wrap(err, "failed to load prone condition")
+		}
+		return prone, nil
+
 	case refs.Conditions.Hidden().ID:
 		hidden := &HiddenCondition{}
 		if err := hidden.loadJSON(data); err != nil {

--- a/rulebooks/dnd5e/conditions/prone.go
+++ b/rulebooks/dnd5e/conditions/prone.go
@@ -1,0 +1,281 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// proneReachCells is "within 5 feet" in the units a grid answers in: one cell.
+//
+// Every grid in tools/spatial reports distance in cells — Chebyshev on a square
+// grid, hex distance on a hex grid, Euclidean cell-widths when gridless — and a
+// cell is 5 feet. Comparing against 1 rather than 5 is therefore the correct
+// reading of the rule, not an approximation of it; the same conversion is
+// spelled out in FightingStyleProtectionCondition ("adjacent on grid = distance
+// 1") and in SneakAttackCondition ("1 square = 5ft").
+const proneReachCells = 1.0
+
+// ProneConditionData is the serializable form of the prone condition.
+// This is stored by the game server as an opaque JSON blob.
+type ProneConditionData struct {
+	Ref         *core.Ref `json:"ref"`
+	CharacterID string    `json:"character_id"`
+}
+
+// ProneCondition is D&D 5e's prone condition, as it affects attack rolls.
+//
+// Two rules, and they pull in opposite directions:
+//
+//   - The prone creature attacks at disadvantage. Always — being on the floor
+//     is bad for your aim regardless of who you are swinging at.
+//   - Attacks against the prone creature have advantage if the attacker is
+//     within 5 feet, and disadvantage otherwise. Standing over someone is an
+//     opportunity; shooting at someone lying down is not.
+//
+// The second rule is why this condition reads the room. Distance is not on the
+// attack event and cannot be inferred from it: AttackChainEvent.IsMelee is not
+// a proxy for "within 5 feet" in either direction — a glaive is melee at ten
+// feet, and a shortbow fired point-blank is ranged at zero. So the position of
+// both parties is read from the room in [gamectx], the way every other
+// range-dependent predicate in this package does.
+//
+// **When there is no room, the second rule does not fire.** No advantage, no
+// disadvantage: the attack rolls straight, and the prone creature's own
+// disadvantage is unaffected. That is a rule silently not applied, which is
+// worth stating plainly rather than discovering — but the alternative is worse.
+// A handler that returned an error would abort the whole attack chain (a bus
+// publish stops at the first handler error), so a caller that never installed a
+// room would find that attacking a prone creature failed rather than merely
+// rolled straight. Pinned by TestNoRoomLeavesTheTargetSideRuleUnapplied so it
+// cannot be mistaken for a guarantee.
+//
+// What this condition does NOT do: the movement half of prone. Crawling at half
+// speed and standing up costing half your movement are real rules, and movement
+// cost is not modelled at this seam — see rpg-toolkit#961. Nothing here applies
+// the condition to anyone either; what knocks a creature down is its own
+// concern (rpg-toolkit#962).
+type ProneCondition struct {
+	CharacterID     string
+	bus             events.EventBus
+	subscriptionIDs []string
+}
+
+// Ensure ProneCondition implements dnd5eEvents.ConditionBehavior
+var _ dnd5eEvents.ConditionBehavior = (*ProneCondition)(nil)
+
+// NewProneCondition creates a prone condition for the specified creature.
+//
+// It does not remove itself: prone lasts until something stands the creature up,
+// unlike Dodging, which expires at the start of its owner's next turn.
+func NewProneCondition(characterID string) *ProneCondition {
+	return &ProneCondition{
+		CharacterID: characterID,
+	}
+}
+
+// IsApplied returns true if this condition is currently applied.
+func (p *ProneCondition) IsApplied() bool {
+	return p.bus != nil
+}
+
+// Apply subscribes this condition to the attack chain, which is where both of
+// its rules are expressed — one for attacks the prone creature makes, one for
+// attacks made against it.
+//
+// A failed Apply leaves nothing behind: the condition does not end up holding a
+// bus it never subscribed to, so it can be applied again.
+func (p *ProneCondition) Apply(ctx context.Context, bus events.EventBus) error {
+	if p.IsApplied() {
+		return rpgerr.New(rpgerr.CodeAlreadyExists, "prone condition already applied")
+	}
+	if bus == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "event bus is required")
+	}
+	p.bus = bus
+
+	attackChain := dnd5eEvents.AttackChain.On(bus)
+	subID, err := attackChain.SubscribeWithChain(ctx, p.onAttackChain)
+	if err != nil {
+		p.bus = nil
+		return rpgerr.Wrap(err, "failed to subscribe to attack chain")
+	}
+	p.subscriptionIDs = append(p.subscriptionIDs, subID)
+
+	return nil
+}
+
+// Remove unsubscribes this condition from all events.
+func (p *ProneCondition) Remove(ctx context.Context, bus events.EventBus) error {
+	if p.bus == nil {
+		return nil // Not applied, nothing to remove
+	}
+
+	total := len(p.subscriptionIDs)
+	var errs []error
+	for _, subID := range p.subscriptionIDs {
+		if err := bus.Unsubscribe(ctx, subID); err != nil {
+			errs = append(errs, fmt.Errorf("unsubscribe %s: %w", subID, err))
+		}
+	}
+
+	p.subscriptionIDs = nil
+	p.bus = nil
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to unsubscribe %d/%d subscriptions: %w", len(errs), total, errors.Join(errs...))
+	}
+	return nil
+}
+
+// ToJSON converts the condition to JSON for persistence.
+func (p *ProneCondition) ToJSON() (json.RawMessage, error) {
+	data := ProneConditionData{
+		Ref:         refs.Conditions.Prone(),
+		CharacterID: p.CharacterID,
+	}
+	return json.Marshal(data)
+}
+
+// loadJSON loads prone condition state from JSON.
+func (p *ProneCondition) loadJSON(data json.RawMessage) error {
+	var proneData ProneConditionData
+	if err := json.Unmarshal(data, &proneData); err != nil {
+		return rpgerr.Wrap(err, "failed to unmarshal prone data")
+	}
+
+	p.CharacterID = proneData.CharacterID
+	return nil
+}
+
+// onAttackChain applies whichever of prone's two attack rules this attack is
+// subject to.
+//
+// The attacker branch is checked first, so a prone creature attacking itself —
+// which no rule contemplates, but which the event shape permits — gets the
+// disadvantage it would get attacking anyone else, and not both modifiers at
+// once.
+func (p *ProneCondition) onAttackChain(
+	ctx context.Context,
+	event dnd5eEvents.AttackChainEvent,
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	switch {
+	case event.AttackerID == p.CharacterID:
+		return p.attackingWhileProne(c)
+	case event.TargetID == p.CharacterID:
+		return p.attackedWhileProne(ctx, event, c)
+	default:
+		return c, nil
+	}
+}
+
+// attackingWhileProne imposes the prone creature's own disadvantage. No geometry
+// is involved: it applies to every attack it makes, at any range.
+func (p *ProneCondition) attackingWhileProne(
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+		e.DisadvantageSources = append(e.DisadvantageSources, dnd5eEvents.AttackModifierSource{
+			SourceRef: refs.Conditions.Prone(),
+			SourceID:  p.CharacterID,
+			Reason:    "Prone attacker",
+		})
+		return e, nil
+	}
+
+	if err := c.Add(combat.StageConditions, "prone_attacker_disadvantage", modifyAttack); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add prone attacker disadvantage for character %s", p.CharacterID)
+	}
+
+	return c, nil
+}
+
+// attackedWhileProne resolves the range split: advantage from within 5 feet,
+// disadvantage from beyond it.
+//
+// Both directions are decided here rather than one being the default, because
+// "no modifier" is a third, wrong answer that a half-implemented range check
+// silently produces.
+func (p *ProneCondition) attackedWhileProne(
+	ctx context.Context,
+	event dnd5eEvents.AttackChainEvent,
+	c chain.Chain[dnd5eEvents.AttackChainEvent],
+) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	within, known := p.attackerIsWithinReach(ctx, event.AttackerID)
+	if !known {
+		// No room, or someone is not on the map. See the type's godoc: the rule
+		// cannot be decided, and refusing the attack outright would be worse
+		// than leaving it to roll straight.
+		return c, nil
+	}
+
+	key := "prone_target_disadvantage"
+	reason := "Prone target beyond 5 feet"
+	appendSource := func(e dnd5eEvents.AttackChainEvent, src dnd5eEvents.AttackModifierSource) dnd5eEvents.AttackChainEvent {
+		e.DisadvantageSources = append(e.DisadvantageSources, src)
+		return e
+	}
+
+	if within {
+		key = "prone_target_advantage"
+		reason = "Prone target within 5 feet"
+		appendSource = func(e dnd5eEvents.AttackChainEvent, src dnd5eEvents.AttackModifierSource) dnd5eEvents.AttackChainEvent {
+			e.AdvantageSources = append(e.AdvantageSources, src)
+			return e
+		}
+	}
+
+	modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+		return appendSource(e, dnd5eEvents.AttackModifierSource{
+			SourceRef: refs.Conditions.Prone(),
+			SourceID:  p.CharacterID,
+			Reason:    reason,
+		}), nil
+	}
+
+	if err := c.Add(combat.StageConditions, key, modifyAttack); err != nil {
+		return c, rpgerr.Wrapf(err, "failed to add %s for character %s", key, p.CharacterID)
+	}
+
+	return c, nil
+}
+
+// attackerIsWithinReach answers whether the attacker is within 5 feet of this
+// prone creature, and whether that could be answered at all.
+//
+// The second return is the whole reason this is not a plain bool: "not within
+// reach" and "nobody knows where these two are standing" call for different
+// modifiers, and collapsing them would make an unmapped attacker roll at
+// disadvantage — a rule invented out of missing data.
+func (p *ProneCondition) attackerIsWithinReach(ctx context.Context, attackerID string) (within, known bool) {
+	room, ok := gamectx.Room(ctx)
+	if !ok {
+		return false, false
+	}
+
+	attackerPos, attackerPlaced := room.GetEntityPosition(attackerID)
+	if !attackerPlaced {
+		return false, false
+	}
+
+	pronePos, pronePlaced := room.GetEntityPosition(p.CharacterID)
+	if !pronePlaced {
+		return false, false
+	}
+
+	return room.GetGrid().Distance(attackerPos, pronePos) <= proneReachCells, true
+}

--- a/rulebooks/dnd5e/conditions/prone.go
+++ b/rulebooks/dnd5e/conditions/prone.go
@@ -119,25 +119,46 @@ func (p *ProneCondition) Apply(ctx context.Context, bus events.EventBus) error {
 }
 
 // Remove unsubscribes this condition from all events.
+//
+// A nil bus falls back to the one Apply was given, because that is the bus the
+// subscription IDs were issued by and the only one that can revoke them —
+// passing some other bus revokes nothing, since IDs mean nothing to a bus that
+// did not grant them.
+//
+// The condition stays applied if any unsubscription fails. Clearing state
+// regardless would have it report itself removed while its handler is still on
+// the bus, and a modifier that keeps appearing from a condition nobody can see
+// is a bad afternoon; leaving it applied keeps IsApplied honest and lets the
+// caller try again.
 func (p *ProneCondition) Remove(ctx context.Context, bus events.EventBus) error {
 	if p.bus == nil {
 		return nil // Not applied, nothing to remove
 	}
 
+	if bus == nil {
+		bus = p.bus
+	}
+
 	total := len(p.subscriptionIDs)
 	var errs []error
+	var stillSubscribed []string
 	for _, subID := range p.subscriptionIDs {
 		if err := bus.Unsubscribe(ctx, subID); err != nil {
 			errs = append(errs, fmt.Errorf("unsubscribe %s: %w", subID, err))
+			stillSubscribed = append(stillSubscribed, subID)
 		}
+	}
+
+	if len(errs) > 0 {
+		// Keep exactly the ones that are still live, so a retry does not try to
+		// revoke what is already gone.
+		p.subscriptionIDs = stillSubscribed
+		return fmt.Errorf("failed to unsubscribe %d/%d subscriptions: %w", len(errs), total, errors.Join(errs...))
 	}
 
 	p.subscriptionIDs = nil
 	p.bus = nil
 
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to unsubscribe %d/%d subscriptions: %w", len(errs), total, errors.Join(errs...))
-	}
 	return nil
 }
 

--- a/rulebooks/dnd5e/conditions/prone_test.go
+++ b/rulebooks/dnd5e/conditions/prone_test.go
@@ -1,0 +1,366 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+const (
+	proneID    = "goblin-on-the-floor"
+	attackerID = "attacker-1"
+)
+
+// proneTestEntity implements core.Entity so a combatant can be placed in a room.
+type proneTestEntity struct {
+	id string
+}
+
+func (e *proneTestEntity) GetID() string            { return e.id }
+func (e *proneTestEntity) GetType() core.EntityType { return "character" }
+
+// ProneConditionSuite covers prone's two attack rules, the range split between
+// them, and what happens when the range cannot be known.
+type ProneConditionSuite struct {
+	suite.Suite
+
+	ctx  context.Context
+	bus  events.EventBus
+	room spatial.Room
+}
+
+func TestProneConditionSuite(t *testing.T) {
+	suite.Run(t, new(ProneConditionSuite))
+}
+
+func (s *ProneConditionSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   "test-room",
+		Type: "dungeon",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
+	})
+}
+
+func (s *ProneConditionSuite) place(id string, x, y float64) {
+	s.Require().NoError(s.room.PlaceEntity(&proneTestEntity{id: id}, spatial.Position{X: x, Y: y}))
+}
+
+// applied returns a prone condition already on the bus.
+func (s *ProneConditionSuite) applied() *conditions.ProneCondition {
+	prone := conditions.NewProneCondition(proneID)
+	s.Require().NoError(prone.Apply(s.ctx, s.bus))
+
+	return prone
+}
+
+// resolveAttack runs one attack through the chain and returns the event as the
+// modifiers left it. ctx is explicit because whether a room is installed is the
+// variable half of these tests.
+func (s *ProneConditionSuite) resolveAttack(ctx context.Context, attacker, target string) dnd5eEvents.AttackChainEvent {
+	event := dnd5eEvents.AttackChainEvent{
+		AttackerID: attacker,
+		TargetID:   target,
+		IsMelee:    true,
+	}
+
+	staged := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	modified, err := dnd5eEvents.AttackChain.On(s.bus).PublishWithChain(ctx, event, staged)
+	s.Require().NoError(err)
+
+	final, err := modified.Execute(ctx, event)
+	s.Require().NoError(err)
+
+	return final
+}
+
+// withRoom is the context an attack resolves in when somebody knows where
+// everyone is standing.
+func (s *ProneConditionSuite) withRoom() context.Context {
+	return gamectx.WithRoom(s.ctx, s.room)
+}
+
+func (s *ProneConditionSuite) TestApplyAndRemove() {
+	prone := conditions.NewProneCondition(proneID)
+	s.Assert().Equal(proneID, prone.CharacterID)
+	s.Assert().False(prone.IsApplied())
+
+	s.Require().NoError(prone.Apply(s.ctx, s.bus))
+	s.Assert().True(prone.IsApplied())
+
+	s.Assert().Error(prone.Apply(s.ctx, s.bus), "a second Apply would double every modifier")
+
+	s.Require().NoError(prone.Remove(s.ctx, s.bus))
+	s.Assert().False(prone.IsApplied())
+}
+
+// A failed Apply must leave nothing behind, so the condition can be applied to
+// another bus afterwards.
+func (s *ProneConditionSuite) TestApplyRejectsANilBus() {
+	prone := conditions.NewProneCondition(proneID)
+
+	s.Require().Error(prone.Apply(s.ctx, nil))
+	s.Assert().False(prone.IsApplied(), "a refused Apply does not leave the condition holding a bus")
+	s.Require().NoError(prone.Apply(s.ctx, s.bus), "and it can still be applied afterwards")
+}
+
+// Rule one: the creature on the floor attacks at disadvantage. No room needed —
+// this half of prone is not about geometry at all.
+func (s *ProneConditionSuite) TestProneAttackerRollsAtDisadvantage() {
+	s.applied()
+
+	final := s.resolveAttack(s.ctx, proneID, "someone-else")
+
+	s.Require().Len(final.DisadvantageSources, 1)
+	s.Assert().Equal(refs.Conditions.Prone(), final.DisadvantageSources[0].SourceRef)
+	s.Assert().Equal(proneID, final.DisadvantageSources[0].SourceID)
+	s.Assert().Empty(final.AdvantageSources)
+}
+
+// Rule two, near half: standing over a prone creature is advantage.
+func (s *ProneConditionSuite) TestAttackerWithinFiveFeetGetsAdvantage() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 6) // one square away
+	s.applied()
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+
+	s.Require().Len(final.AdvantageSources, 1)
+	s.Assert().Equal(refs.Conditions.Prone(), final.AdvantageSources[0].SourceRef)
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// Rule two, far half — the direction that is easy to leave unimplemented,
+// because forgetting it looks like "no modifier" rather than like a failure.
+func (s *ProneConditionSuite) TestAttackerBeyondFiveFeetGetsDisadvantage() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 8) // three squares away
+	s.applied()
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+
+	s.Require().Len(final.DisadvantageSources, 1)
+	s.Assert().Equal(refs.Conditions.Prone(), final.DisadvantageSources[0].SourceRef)
+	s.Assert().Empty(final.AdvantageSources)
+}
+
+// The boundary, from both sides, in one test: two squares away is out of reach,
+// one square is in it. A range check written with the wrong comparison passes
+// one of these and fails the other.
+func (s *ProneConditionSuite) TestTheBoundaryIsOneSquare() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 7) // exactly two squares — 10 feet
+	s.applied()
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+
+	s.Require().Len(final.DisadvantageSources, 1, "10 feet is beyond reach")
+	s.Assert().Empty(final.AdvantageSources)
+}
+
+// Diagonals are one square on this grid (Chebyshev distance), so a diagonal
+// attacker is within 5 feet. Measuring with Euclidean distance would make this
+// ~1.41 and quietly move the attacker out of reach.
+func (s *ProneConditionSuite) TestDiagonalAdjacencyIsWithinFiveFeet() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 6, 6)
+	s.applied()
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+
+	s.Require().Len(final.AdvantageSources, 1)
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// The documented gap: with no room installed, the range cannot be decided, so
+// the target-side rule contributes nothing and the attack rolls straight.
+// Erroring instead would abort the whole attack chain for every caller that has
+// not installed a room — resolution, today, is one of them.
+func (s *ProneConditionSuite) TestNoRoomLeavesTheTargetSideRuleUnapplied() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 6)
+	s.applied()
+
+	final := s.resolveAttack(s.ctx, attackerID, proneID) // no gamectx.WithRoom
+
+	s.Assert().Empty(final.AdvantageSources)
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// Same gap, other cause: a room exists but somebody is not on the map. "Not
+// within reach" and "nobody knows where they are" must not collapse into each
+// other, or an unplaced attacker would roll at disadvantage on no evidence.
+func (s *ProneConditionSuite) TestAnUnplacedAttackerLeavesTheRuleUnapplied() {
+	s.place(proneID, 5, 5)
+	s.applied()
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+
+	s.Assert().Empty(final.AdvantageSources)
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+func (s *ProneConditionSuite) TestAnUnplacedProneCreatureLeavesTheRuleUnapplied() {
+	s.place(attackerID, 5, 6)
+	s.applied()
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+
+	s.Assert().Empty(final.AdvantageSources)
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// An attack between two other people is none of this condition's business.
+func (s *ProneConditionSuite) TestAnUnrelatedAttackIsUntouched() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 6)
+	s.applied()
+
+	final := s.resolveAttack(s.withRoom(), attackerID, "third-party")
+
+	s.Assert().Empty(final.AdvantageSources)
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// A removed condition stops modifying attacks. Without this, "Remove" could
+// unsubscribe nothing and no other test would notice.
+func (s *ProneConditionSuite) TestRemovedProneStopsModifyingAttacks() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 6)
+	prone := s.applied()
+
+	s.Require().NoError(prone.Remove(s.ctx, s.bus))
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+
+	s.Assert().Empty(final.AdvantageSources)
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// The persisted form round-trips through the loader that routes on its ref, and
+// the condition that comes back is a working one rather than a shell.
+func (s *ProneConditionSuite) TestRoundTripsThroughTheLoader() {
+	raw, err := conditions.NewProneCondition(proneID).ToJSON()
+	s.Require().NoError(err)
+
+	var data conditions.ProneConditionData
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	s.Require().Equal(refs.Conditions.Prone(), data.Ref, "the blob names the ref its loader routes on")
+	s.Require().Equal(proneID, data.CharacterID)
+
+	loaded, err := conditions.LoadJSON(raw)
+	s.Require().NoError(err)
+
+	reloaded, ok := loaded.(*conditions.ProneCondition)
+	s.Require().True(ok, "the loader routes prone's ref to a ProneCondition")
+	s.Require().Equal(proneID, reloaded.CharacterID)
+
+	again, err := reloaded.ToJSON()
+	s.Require().NoError(err)
+	s.Require().JSONEq(string(raw), string(again))
+
+	// And it still works: a loaded condition that subscribes nothing would
+	// round-trip perfectly and change no roll.
+	s.Require().NoError(reloaded.Apply(s.ctx, s.bus))
+	final := s.resolveAttack(s.ctx, proneID, "someone-else")
+	s.Require().Len(final.DisadvantageSources, 1)
+}
+
+// The other routing site: a host holding only the ref string can build one.
+func (s *ProneConditionSuite) TestCreatesFromItsRef() {
+	out, err := conditions.CreateFromRef(&conditions.CreateFromRefInput{
+		Ref:         refs.Conditions.Prone().String(),
+		CharacterID: proneID,
+	})
+	s.Require().NoError(err)
+
+	prone, ok := out.Condition.(*conditions.ProneCondition)
+	s.Require().True(ok)
+	s.Assert().Equal(proneID, prone.CharacterID)
+}
+
+// recordingBus delegates to a real bus and notes which effect was mid-Apply
+// when each subscription was made — the shape of the instrumented surface
+// resolution owns, reduced to what this test needs.
+type recordingBus struct {
+	inner  events.EventBus
+	ref    core.Ref
+	byRef  map[core.Ref][]events.Topic
+	asked  *[]core.Ref
+	shared *recordingBus
+}
+
+func newRecordingBus() *recordingBus {
+	b := &recordingBus{
+		inner: events.NewEventBus(),
+		byRef: make(map[core.Ref][]events.Topic),
+		asked: &[]core.Ref{},
+	}
+	b.shared = b
+
+	return b
+}
+
+func (b *recordingBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	id, err := b.inner.Subscribe(ctx, topic, handler)
+	if err != nil {
+		return "", err
+	}
+	b.shared.byRef[b.ref] = append(b.shared.byRef[b.ref], topic)
+
+	return id, nil
+}
+
+func (b *recordingBus) Unsubscribe(ctx context.Context, id string) error {
+	return b.inner.Unsubscribe(ctx, id)
+}
+
+func (b *recordingBus) Publish(ctx context.Context, topic events.Topic, event any) error {
+	return b.inner.Publish(ctx, topic, event)
+}
+
+// ScopeToEffect implements dnd5eEvents.EffectScoper.
+func (b *recordingBus) ScopeToEffect(ref core.Ref) events.EventBus {
+	*b.shared.asked = append(*b.shared.asked, ref)
+
+	return &recordingBus{inner: b.inner, ref: ref, shared: b.shared}
+}
+
+// Prone's destination is resolution, which applies every effect through a view
+// of the bus stamped with that effect's ref. The condition has to work through
+// that view, and its subscription has to land under its own name — otherwise a
+// registration ledger would credit prone's hooks to nobody.
+func (s *ProneConditionSuite) TestWorksThroughAScopedView() {
+	root := newRecordingBus()
+	proneRef := *refs.Conditions.Prone()
+
+	scoped := dnd5eEvents.BusForEffect(root, proneRef)
+	prone := conditions.NewProneCondition(proneID)
+	s.Require().NoError(prone.Apply(s.ctx, scoped))
+
+	s.Require().Equal([]core.Ref{proneRef}, *root.asked)
+	s.Require().Contains(root.byRef[proneRef], events.Topic("dnd5e.combat.attack.chain"))
+
+	// And it still modifies attacks published on the underlying bus.
+	s.bus = root
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 6)
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+	s.Require().Len(final.AdvantageSources, 1)
+	s.Assert().Equal(refs.Conditions.Prone(), final.AdvantageSources[0].SourceRef)
+}

--- a/rulebooks/dnd5e/conditions/prone_test.go
+++ b/rulebooks/dnd5e/conditions/prone_test.go
@@ -6,6 +6,7 @@ package conditions_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -249,6 +250,56 @@ func (s *ProneConditionSuite) TestRemovedProneStopsModifyingAttacks() {
 
 	s.Assert().Empty(final.AdvantageSources)
 	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// unsubscribeFailingBus is a real bus whose Unsubscribe always refuses, so a
+// test can reach Remove's failure path — which no real bus in this repo takes,
+// and which is exactly why it is worth pinning.
+type unsubscribeFailingBus struct {
+	events.EventBus
+}
+
+func (b *unsubscribeFailingBus) Unsubscribe(_ context.Context, _ string) error {
+	return errUnsubscribeRefused
+}
+
+var errUnsubscribeRefused = errors.New("bus refused the unsubscribe")
+
+// Remove with no bus falls back to the one Apply was given. Without the
+// fallback this is a nil-interface panic, not a graceful no-op.
+func (s *ProneConditionSuite) TestRemoveWithANilBusUsesTheAppliedOne() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 6)
+	prone := s.applied()
+
+	s.Require().NoError(prone.Remove(s.ctx, nil))
+	s.Assert().False(prone.IsApplied())
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+	s.Assert().Empty(final.AdvantageSources, "the handler really is off the bus")
+	s.Assert().Empty(final.DisadvantageSources)
+}
+
+// A Remove that could not unsubscribe leaves the condition applied rather than
+// reporting a removal that did not happen. The handler is still live, and
+// IsApplied still says so.
+func (s *ProneConditionSuite) TestAFailedRemoveLeavesTheConditionApplied() {
+	s.place(proneID, 5, 5)
+	s.place(attackerID, 5, 6)
+	prone := s.applied()
+
+	err := prone.Remove(s.ctx, &unsubscribeFailingBus{EventBus: s.bus})
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errUnsubscribeRefused)
+	s.Assert().True(prone.IsApplied(), "it is still on the bus, so it still says so")
+
+	final := s.resolveAttack(s.withRoom(), attackerID, proneID)
+	s.Require().Len(final.AdvantageSources, 1, "and the handler is indeed still live")
+
+	// The retry, on a bus that cooperates, works.
+	s.Require().NoError(prone.Remove(s.ctx, s.bus))
+	s.Assert().False(prone.IsApplied())
 }
 
 // The persisted form round-trips through the loader that routes on its ref, and


### PR DESCRIPTION
## Why

`prone` was a name in three places and behaviour in none: a ref in
`refs/conditions.go`, a `ConditionType` in `events`, a mention in
`StageConditions`' doc comment. Content could reference it, persistence could
round-trip it, and no roll changed — the worst of both worlds, and the
prerequisite for anything that knocks a creature down (#962).

## The design question this issue turned on

Prone's attacker-side rule splits on **range**: advantage within 5 ft,
disadvantage beyond. So: how does distance reach a condition's chain handler?

**Answer: world (b) — via `gamectx`, with two existing precedents.**

- `AttackChainEvent` carries no distance and no positions. It has `IsMelee`,
  which is **not** a proxy for "within 5 ft" in either direction: a glaive is
  melee at ten feet, a shortbow fired point-blank is ranged at zero. World (a)
  is out.
- `gamectx.Room(ctx)` yields a `spatial.Room` — its godoc names this exact use
  ("check distances"), and two conditions already do it inside chain handlers:
  `fighting_style_protection.go:152` (`grid.Distance(a, b)`, "adjacent on grid =
  distance 1") and `sneak_attack.go:228` (`GetEntitiesInRange(pos, 1.5)`, "1
  square = 5ft").

Prone uses the first idiom: `room.GetGrid().Distance(attacker, prone) <= 1`.
Every grid answers in cells — Chebyshev on square, hex distance on hex,
Euclidean cell-widths gridless — and a cell is 5 feet, so comparing against 1 is
the rule rather than an approximation of it.

### The one judgment call: no room installed

`gamectx` may be absent. Prone's target-side rule then **contributes nothing**
and the attack rolls straight; the prone creature's own disadvantage is
unaffected. That is a rule silently not applied, which is worth stating rather
than discovering — but the alternative is worse. A handler that returned an
error would abort the **whole attack chain**: `simpleEventBus.Publish` stops at
the first handler error, so a caller that never installed a room would find that
attacking a prone creature *failed* rather than merely rolled straight.
Documented on the type and pinned by `TestNoRoomLeavesTheTargetSideRuleUnapplied`
(plus the same gap arriving via an unplaced combatant) so it cannot be mistaken
for a guarantee.

**Worth flagging:** `resolution` installs no room today — its `doc.go` says "the
first predicate that needs one brings its installer with it". Prone is that
first predicate. Wiring it is out of scope here (resolution is a separate
module, untouched).

## What landed

`conditions/prone.go` — `ProneCondition` on the established shape (`IsApplied` /
`Apply` / `Remove` / `ToJSON` / `loadJSON`, typed `ProneConditionData` carrying
its ref), one `AttackChain` subscription, no self-removal (prone lasts until
something stands you up, unlike Dodging).

Registered in **both** routing sites: `conditions.LoadJSON` (persistence) and
`CreateFromRef` (a host holding only the ref string). The factory case is
additive rather than mirroring a pattern — `Unconscious` and `OpportunityAttack`
are LoadJSON-only, because the factory's other callers are class grants and
fighting styles. No `AllConditionRefs`-style mirror list needed updating:
`character.StructurallyPermanentConditionRefs` is derived from class grants and
fighting styles, and prone is neither.

## Verification

Full module suite from `rulebooks/dnd5e/`: `go build ./...` clean,
`go test ./...` 26 packages `ok`, `golangci-lint run ./...` **0 issues**,
`gofmt` clean, `go mod tidy` a no-op. **No existing test modified** — the two
existing files touched are `loader.go` and `factory.go`, one case each.

14 tests in `conditions/prone_test.go` (testify suite, external test package).
Mutation — commit first, `go build` each mutant, revert from the repo root:

| # | Mutant | Killed by |
|---|---|---|
| a | attacker-side disadvantage removed | `TestProneAttackerRollsAtDisadvantage`, `TestRoundTripsThroughTheLoader` |
| b | range comparison inverted (`>` for `<=`) | 5 tests — both direction tests, the boundary, the diagonal, the scoped view |
| c | far half dropped (no modifier beyond reach) | `TestAttackerBeyondFiveFeetGetsDisadvantage`, `TestTheBoundaryIsOneSquare` |
| d | "range unknown" collapsed into "not within" | all three unknown-range tests |
| e | boundary off-by-one (`<` for `<=`) | `TestAttackerWithinFiveFeetGetsAdvantage`, `TestDiagonalAdjacencyIsWithinFiveFeet`, scoped view |
| f | `LoadJSON` case removed | `TestRoundTripsThroughTheLoader` |
| g | `CreateFromRef` case removed | `TestCreatesFromItsRef` |
| h | `Apply` subscribes nothing | 7 tests |
| i | `Remove` unsubscribes nothing | `TestRemovedProneStopsModifyingAttacks` |

No survivors; every mutant compiled first.

The round-trip test does not stop at the bytes: it re-applies the loaded
condition and checks it still modifies an attack, because a loaded condition
that subscribes nothing round-trips perfectly and changes no roll.
`TestWorksThroughAScopedView` pins the destination consumer's shape — prone
applied through an `EffectScoper` view lands its subscription under its own ref
and still works.

**gorelease** (no CI job covers this module — #917), against the current tag
`v0.86.0`:

```
# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions
## compatible changes
NewProneCondition: added
ProneCondition: added
ProneConditionData: added

# summary
Suggested version: v0.87.0 (with tag rulebooks/dnd5e/v0.87.0)
```

Compatible changes only, no incompatible section.

## Out of scope

- **The movement half of prone** — crawling at half speed, standing up costing
  half your movement. Movement cost is not modelled at this seam, and bolting it
  on here would put a rules decision in the wrong place. Wants its own issue.
- **Applying the condition to anybody** — what knocks a creature down is #962.
- Installing a room in `resolution` (see above), and #970 / #979.

Closes #961

— asset-pipeline agent, on behalf of KirkDiggler
