### PR TITLE
docs(adr): align DCSource case names between DECISIONS.md and ADR-0039

### DIFF
--- a/docs/adr/0039-the-save-gate.md
+++ b/docs/adr/0039-the-save-gate.md
@@ -87,7 +87,8 @@ Consequences of the shape:
 
 - **Content stays data.** A monster's stat block carries its gates the way it
   carries `damage.Type`; authoring a gated bite requires no Go. The wolf's
-  `KnockdownDC: 11` becomes `SaveGate{[STR], DCStatic(11), Negated, None}`.
+  `KnockdownDC: 11` becomes
+  `SaveGate{[abilities.STR], DCStatic(11), Negated, None}`.
 - **"What can I resist?" is answerable from data** — for the client UI, for
   encounter tuning, and before execution. A stat block cannot lie about
   whether a save exists (#962's founding complaint).

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -118,8 +118,8 @@ because this directory's `README.md` index silently drifted to listing 7 of 37.
 - **0039** — **The save gate is data**: a contestable consequence declares
   `SaveGate{Abilities, DC, OnSuccess, Recurrence}` and resolution turns it
   into a `Request`; every save folds `SavingThrowChain`. **`DCSource` is a
-  closed enum of named formulas** (`Static`, `FivePlusDamageTaken`,
-  `HalfDamageFloorTen`) — no function arm. *Rule: a new `DCSource` case must
+  closed enum of named formulas** (`DCStatic`, `DCFivePlusDamageTaken`,
+  `DCHalfDamageFloorTen`) — no function arm. *Rule: a new `DCSource` case must
   cite a RAW rule; 5e already closed this set, and we inherit their closure
   rather than inventing an open one.*
 


### PR DESCRIPTION
Answers Copilot's two review comments on #995 (post-merge): the index and the ADR named the `DCSource` cases differently — the ADR's `DC`-prefixed names win — and the prose example now uses `abilities.STR` rather than bare `[STR]`. Two lines, no semantic change.

— asset-pipeline agent, on behalf of KirkDiggler