### PR TITLE
feat(dnd5e): the save gate, and the bite declares one (#962)

### DIFF
--- a/rulebooks/dnd5e/monster/actions/bite.go
+++ b/rulebooks/dnd5e/monster/actions/bite.go
@@ -21,7 +21,8 @@ import (
 
 const monsterActionEntityType core.EntityType = "monster-action"
 
-// BiteConfig holds configuration for creating a bite action with knockdown
+// BiteConfig holds configuration for creating a bite action. The knockdown is
+// optional and lives in SaveGate.
 type BiteConfig struct {
 	AttackBonus int    `json:"attack_bonus"` // e.g., +4
 	DamageDice  string `json:"damage_dice"`  // e.g., "2d4+2"
@@ -38,8 +39,18 @@ type BiteConfig struct {
 	SaveGate *saves.SaveGate `json:"save_gate,omitempty"`
 }
 
-// BiteAction implements a bite attack with knockdown effect.
-// On hit, target must make a STR save or be knocked prone.
+// BiteAction is a melee bite attack that may carry a rider its target can
+// contest.
+//
+// The rider is a [saves.SaveGate] and is optional: the wolf's bite declares a
+// STR save against DC 11 or be knocked prone, while another creature's could
+// name a different ability, a different DC, or half damage instead of nothing
+// (ADR-0039). Nil means the bite just bites.
+//
+// What the gate is not is behaviour. This action declares what can be
+// contested; imposing the consequence, and running the save that gates it, is
+// resolution's job — which is what makes "can I resist this bite, and how?"
+// answerable from the stat block before anything runs.
 type BiteAction struct {
 	attackBonus int
 	damageDice  string

--- a/rulebooks/dnd5e/monster/actions/bite.go
+++ b/rulebooks/dnd5e/monster/actions/bite.go
@@ -11,20 +11,31 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
 )
 
 const monsterActionEntityType core.EntityType = "monster-action"
 
 // BiteConfig holds configuration for creating a bite action with knockdown
 type BiteConfig struct {
-	AttackBonus int         `json:"attack_bonus"` // e.g., +4
-	DamageDice  string      `json:"damage_dice"`  // e.g., "2d4+2"
-	KnockdownDC int         `json:"knockdown_dc"` // DC for STR save to avoid prone
-	DamageType  damage.Type `json:"damage_type"`  // typically piercing
+	AttackBonus int    `json:"attack_bonus"` // e.g., +4
+	DamageDice  string `json:"damage_dice"`  // e.g., "2d4+2"
+	// Deprecated: read on the way in, never written on the way out. A bite
+	// persisted by an older build carries this instead of a SaveGate, and
+	// NewBiteAction translates it; new content declares SaveGate directly.
+	// See gateFromKnockdownDC for why the translation is exact.
+	KnockdownDC int         `json:"knockdown_dc,omitempty"`
+	DamageType  damage.Type `json:"damage_type"` // typically piercing
+
+	// SaveGate is what the bite's consequence can be contested with, if
+	// anything: the wolf declares a STR save against DC 11 or be knocked prone
+	// (ADR-0039). Nil means the bite just bites.
+	SaveGate *saves.SaveGate `json:"save_gate,omitempty"`
 }
 
 // BiteAction implements a bite attack with knockdown effect.
@@ -32,21 +43,57 @@ type BiteConfig struct {
 type BiteAction struct {
 	attackBonus int
 	damageDice  string
-	knockdownDC int
 	damageType  damage.Type
+	saveGate    *saves.SaveGate
 }
 
 // Ensure BiteAction implements MonsterAction
 var _ monster.MonsterAction = (*BiteAction)(nil)
 
-// NewBiteAction creates a bite action with the given config
+// NewBiteAction creates a bite action with the given config.
+//
+// A config carrying only the deprecated KnockdownDC gets the gate that field
+// always meant — see [BiteConfig.KnockdownDC]. A config carrying both keeps its
+// SaveGate, because the explicit declaration is the one someone wrote on
+// purpose.
 func NewBiteAction(config BiteConfig) *BiteAction {
+	gate := config.SaveGate
+	if gate == nil {
+		gate = gateFromKnockdownDC(config.KnockdownDC)
+	}
+
 	return &BiteAction{
 		attackBonus: config.AttackBonus,
 		damageDice:  config.DamageDice,
-		knockdownDC: config.KnockdownDC,
 		damageType:  config.DamageType,
+		saveGate:    gate,
 	}
+}
+
+// gateFromKnockdownDC translates the field this action used to carry into the
+// declaration it always described.
+//
+// The translation is exact rather than approximate: KnockdownDC only ever meant
+// "the DC of the STR save that avoids being knocked prone", so its gate is
+// [STR], a static DC, negated on a success, no recurrence — every axis pinned by
+// what the old field could express.
+//
+// A DC of zero means no knockdown, which is the only reading that does not
+// invent a rule: a bite with no knockdown is not a bite whose knockdown save is
+// automatically failed (rpg-toolkit#962).
+func gateFromKnockdownDC(dc int) *saves.SaveGate {
+	if dc <= 0 {
+		return nil
+	}
+
+	return saves.NewSaveGate(abilities.STR, dc)
+}
+
+// SaveGate returns what this bite's consequence can be contested with, or nil
+// if it carries none. Data, not behaviour: whoever imposes the consequence asks
+// for the declaration and turns it into a save.
+func (b *BiteAction) SaveGate() *saves.SaveGate {
+	return b.saveGate
 }
 
 // GetID implements core.Entity
@@ -79,8 +126,12 @@ func (b *BiteAction) Score(_ *monster.Monster, perception *monster.PerceptionDat
 		baseScore += 20
 	}
 
-	// Extra bonus for knockdown potential
-	baseScore += 10
+	// Extra bonus for knockdown potential — now read from the declaration
+	// rather than assumed. A bite with no gate knocks nobody down, and used to
+	// score as though it did.
+	if b.saveGate != nil {
+		baseScore += 10
+	}
 
 	return baseScore
 }
@@ -144,13 +195,19 @@ func (b *BiteAction) Activate(ctx context.Context, owner core.Entity, input mons
 	return nil
 }
 
-// ToData converts the action to its serializable form
+// ToData converts the action to its serializable form.
+//
+// It writes the gate and never the deprecated KnockdownDC, so there is one
+// place a bite's knockdown is described rather than two that can disagree. A
+// blob written by an older build still loads (see [BiteConfig.KnockdownDC]);
+// it comes back expressed as a gate, which is a migration rather than a loss —
+// nothing the old field said is missing from the new one.
 func (b *BiteAction) ToData() monster.ActionData {
 	config := BiteConfig{
 		AttackBonus: b.attackBonus,
 		DamageDice:  b.damageDice,
-		KnockdownDC: b.knockdownDC,
 		DamageType:  b.damageType,
+		SaveGate:    b.saveGate,
 	}
 	configJSON, _ := json.Marshal(config)
 

--- a/rulebooks/dnd5e/monster/actions/bite_gate_test.go
+++ b/rulebooks/dnd5e/monster/actions/bite_gate_test.go
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package actions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+)
+
+// BiteSaveGateSuite covers the bite's move from a bare KnockdownDC to a
+// declared SaveGate, and the promise that comes with it: a blob written by an
+// older build still loads, and still means what it meant.
+type BiteSaveGateSuite struct {
+	suite.Suite
+}
+
+func TestBiteSaveGateSuite(t *testing.T) {
+	suite.Run(t, new(BiteSaveGateSuite))
+}
+
+// legacyBlob is a bite exactly as an older build persisted it: a DC and no gate.
+func (s *BiteSaveGateSuite) legacyBlob(knockdownDC int) monster.ActionData {
+	raw, err := json.Marshal(map[string]any{
+		"attack_bonus": 4,
+		"damage_dice":  "2d4+2",
+		"knockdown_dc": knockdownDC,
+		"damage_type":  damage.Piercing,
+	})
+	s.Require().NoError(err)
+
+	return monster.ActionData{Ref: *refs.MonsterActions.Bite(), Config: raw}
+}
+
+func (s *BiteSaveGateSuite) loadBite(data monster.ActionData) *BiteAction {
+	loaded, err := LoadAction(data)
+	s.Require().NoError(err)
+
+	bite, ok := loaded.(*BiteAction)
+	s.Require().True(ok)
+
+	return bite
+}
+
+// The legacy field maps to the gate it always described, on every axis: STR,
+// that DC, negated, no recurrence. Not "roughly equivalent" — KnockdownDC could
+// express nothing else.
+func (s *BiteSaveGateSuite) TestALegacyKnockdownDCLoadsAsItsGate() {
+	bite := s.loadBite(s.legacyBlob(11))
+
+	s.Require().NotNil(bite.SaveGate())
+	s.Assert().Equal(saves.NewSaveGate(abilities.STR, 11), bite.SaveGate())
+	s.Assert().Equal([]abilities.Ability{abilities.STR}, bite.SaveGate().Abilities)
+	s.Assert().Equal(11, bite.SaveGate().DC.DC(saves.DCInput{}))
+	s.Assert().Equal(saves.Negated, bite.SaveGate().OnSuccess)
+	s.Assert().Equal(saves.RecurrenceNone, bite.SaveGate().Recurrence)
+}
+
+// A DC of zero means no knockdown. The other reading — a save whose DC nobody
+// can fail to beat, or worse, one that auto-fails — would invent a rule out of
+// an empty field (rpg-toolkit#962's done-when calls this out by name).
+func (s *BiteSaveGateSuite) TestAZeroKnockdownDCIsNoGateAtAll() {
+	s.Assert().Nil(s.loadBite(s.legacyBlob(0)).SaveGate())
+
+	// And the same for a blob that never mentioned knockdown.
+	raw, err := json.Marshal(map[string]any{"attack_bonus": 4, "damage_dice": "1d6"})
+	s.Require().NoError(err)
+	s.Assert().Nil(s.loadBite(monster.ActionData{Ref: *refs.MonsterActions.Bite(), Config: raw}).SaveGate())
+
+	// Negative is the same answer, for the same reason.
+	s.Assert().Nil(s.loadBite(s.legacyBlob(-3)).SaveGate())
+}
+
+// The migration, pinned from the writing end: a legacy blob comes back
+// expressed as a gate, and the deprecated field is not written beside it. Two
+// places to say the same thing is two places that can disagree.
+func (s *BiteSaveGateSuite) TestALegacyBlobIsRewrittenAsAGate() {
+	out := s.loadBite(s.legacyBlob(11)).ToData()
+
+	s.Assert().Contains(string(out.Config), `"save_gate"`)
+	s.Assert().NotContains(string(out.Config), `"knockdown_dc"`)
+
+	// Nothing the old field said is missing from the new one.
+	reloaded := s.loadBite(out)
+	s.Assert().Equal(saves.NewSaveGate(abilities.STR, 11), reloaded.SaveGate())
+}
+
+// A gate-carrying bite round-trips byte-identically, which is the property the
+// legacy blob cannot have and this one must.
+func (s *BiteSaveGateSuite) TestAGateCarryingBiteRoundTripsByteIdentical() {
+	bite := NewBiteAction(BiteConfig{
+		AttackBonus: 4,
+		DamageDice:  "2d4+2",
+		DamageType:  damage.Piercing,
+		SaveGate:    saves.NewSaveGate(abilities.STR, 11),
+	})
+
+	first := bite.ToData()
+	second := s.loadBite(first).ToData()
+
+	s.Assert().Equal(string(first.Config), string(second.Config))
+	s.Assert().Equal(first.Ref, second.Ref)
+}
+
+// A bite carrying a gate that is not a knockdown survives too — the point of
+// declaring the ability rather than assuming it.
+func (s *BiteSaveGateSuite) TestANonKnockdownGateSurvives() {
+	gate := &saves.SaveGate{
+		Abilities:  []abilities.Ability{abilities.CON},
+		DC:         saves.DCFivePlusDamageTaken(),
+		OnSuccess:  saves.Half,
+		Recurrence: saves.RecurrenceEndOfTurn,
+	}
+
+	reloaded := s.loadBite(NewBiteAction(BiteConfig{
+		AttackBonus: 4,
+		DamageDice:  "2d4+2",
+		DamageType:  damage.Piercing,
+		SaveGate:    gate,
+	}).ToData())
+
+	s.Assert().Equal(gate, reloaded.SaveGate())
+	s.Assert().Equal(12, reloaded.SaveGate().DC.DC(saves.DCInput{DamageTaken: 7}))
+}
+
+// A config carrying both keeps the explicit one: somebody wrote the gate on
+// purpose, where the DC may just be a field nobody cleaned up.
+func (s *BiteSaveGateSuite) TestAnExplicitGateBeatsTheDeprecatedField() {
+	bite := NewBiteAction(BiteConfig{
+		AttackBonus: 4,
+		DamageDice:  "2d4+2",
+		KnockdownDC: 11,
+		SaveGate:    saves.NewSaveGate(abilities.DEX, 15),
+	})
+
+	s.Assert().Equal(saves.NewSaveGate(abilities.DEX, 15), bite.SaveGate())
+}
+
+// The scoring bonus that was always described as "knockdown potential" now
+// depends on there being a knockdown. Both existing Score tests build a bite
+// with a DC, so both still see it.
+func (s *BiteSaveGateSuite) TestScoringReadsTheGate() {
+	adjacent := &monster.PerceptionData{Enemies: []monster.PerceivedEntity{{Adjacent: true}}}
+
+	gated := NewBiteAction(BiteConfig{DamageDice: "2d4+2", SaveGate: saves.NewSaveGate(abilities.STR, 11)})
+	plain := NewBiteAction(BiteConfig{DamageDice: "2d4+2"})
+
+	s.Assert().Equal(80, gated.Score(nil, adjacent))
+	s.Assert().Equal(70, plain.Score(nil, adjacent), "a bite that knocks nobody down does not score for it")
+}

--- a/rulebooks/dnd5e/monster/monsters/wolf.go
+++ b/rulebooks/dnd5e/monster/monsters/wolf.go
@@ -9,6 +9,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 )
 
@@ -30,12 +31,15 @@ func NewWolf(id string) *monster.Monster {
 		},
 	})
 
-	// Bite attack with knockdown (DC 11 STR save or prone)
+	// Bite attack: "if the target is a creature, it must succeed on a DC 11
+	// Strength saving throw or be knocked prone" — declared as a gate rather
+	// than as a bare DC, so the stat block says what can be contested and how
+	// (ADR-0039).
 	m.AddAction(actions.NewBiteAction(actions.BiteConfig{
 		AttackBonus: 4,       // +2 DEX + 2 proficiency
 		DamageDice:  "2d4+2", // 2d4 + STR
-		KnockdownDC: 11,      // DC 11 STR save
 		DamageType:  damage.Piercing,
+		SaveGate:    saves.NewSaveGate(abilities.STR, 11),
 	}))
 
 	// Set movement speed (wolves are fast)

--- a/rulebooks/dnd5e/monster/monsters/wolf_gate_test.go
+++ b/rulebooks/dnd5e/monster/monsters/wolf_gate_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monsters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+)
+
+// WolfSaveGateSuite pins the first authored gate in the roster. The wolf is the
+// case rpg-toolkit#962 started from: a stat block that carried a knockdown DC
+// and could not say whether anything read it.
+type WolfSaveGateSuite struct {
+	suite.Suite
+}
+
+func TestWolfSaveGateSuite(t *testing.T) {
+	suite.Run(t, new(WolfSaveGateSuite))
+}
+
+// "If the target is a creature, it must succeed on a DC 11 Strength saving
+// throw or be knocked prone" — declared, and answerable from the stat block
+// without executing anything.
+func (s *WolfSaveGateSuite) TestTheWolfDeclaresItsKnockdown() {
+	wolf := NewWolf("wolf-1")
+
+	s.Require().Len(wolf.Actions(), 1)
+	bite, ok := wolf.Actions()[0].(*actions.BiteAction)
+	s.Require().True(ok, "the wolf's one action is its bite")
+
+	gate := bite.SaveGate()
+	s.Require().NotNil(gate, "and the bite says what can be contested")
+	s.Assert().Equal([]abilities.Ability{abilities.STR}, gate.Abilities)
+	s.Assert().Equal(11, gate.DC.DC(saves.DCInput{}))
+	s.Assert().Equal(saves.Negated, gate.OnSuccess)
+	s.Assert().Equal(saves.RecurrenceNone, gate.Recurrence)
+	s.Assert().Equal("DC 11 str save, negated on success, recurrence none", gate.String())
+}
+
+// The declaration survives the round trip a spawned wolf actually takes.
+func (s *WolfSaveGateSuite) TestTheDeclarationSurvivesSerialization() {
+	data := NewWolf("wolf-1").ToData()
+	s.Require().Len(data.Actions, 1)
+
+	loaded, err := actions.LoadAction(data.Actions[0])
+	s.Require().NoError(err)
+
+	bite, ok := loaded.(*actions.BiteAction)
+	s.Require().True(ok)
+	s.Require().Equal(saves.NewSaveGate(abilities.STR, 11), bite.SaveGate())
+}

--- a/rulebooks/dnd5e/saves/gate.go
+++ b/rulebooks/dnd5e/saves/gate.go
@@ -1,0 +1,369 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package saves
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+)
+
+// SaveEffect is what a successful save buys.
+type SaveEffect string
+
+const (
+	// Negated means a successful save prevents the consequence entirely. A gate
+	// that produces a condition uses this: you are knocked prone or you are not.
+	Negated SaveEffect = "negated"
+
+	// Half means a successful save halves the damage. Only meaningful for a gate
+	// on a damage pool.
+	Half SaveEffect = "half"
+)
+
+// Recurrence is WHEN the save happens.
+type Recurrence string
+
+const (
+	// RecurrenceNone means the save happens once, when the consequence would
+	// apply. Most gates.
+	RecurrenceNone Recurrence = "none"
+
+	// RecurrenceEndOfTurn means the saver may try again at the end of each of
+	// their turns to end the effect — the ghoul's paralysis.
+	RecurrenceEndOfTurn Recurrence = "end_of_turn"
+)
+
+// DCKind names one member of the closed DC formula set. It is the tag the wire
+// form routes on, and the answer to "which rule is this number from".
+type DCKind string
+
+const (
+	// DCKindStatic is a number written in the stat block.
+	DCKindStatic DCKind = "static"
+
+	// DCKindFivePlusDamageTaken is Undead Fortitude's 5 + damage taken.
+	DCKindFivePlusDamageTaken DCKind = "five_plus_damage_taken"
+
+	// DCKindHalfDamageFloorTen is concentration's max(10, damage / 2).
+	DCKindHalfDamageFloorTen DCKind = "half_damage_floor_ten"
+)
+
+// DCInput is everything a derived DC formula is allowed to read: the damage of
+// the blow that triggered the save.
+//
+// Deliberately a struct rather than a bare int, so that a formula needing
+// another fact about the trigger extends this rather than changing every
+// signature — but note that adding a field is not the cheap half. The
+// expensive half is [DCSource]'s extension discipline.
+type DCInput struct {
+	// DamageTaken is the damage the saver just took, before any halving this
+	// save might buy. Zero for a gate whose DC does not derive from damage.
+	DamageTaken int
+}
+
+// DCSource is where a save's difficulty class comes from: a closed enum of
+// named 5e formulas, per [ADR-0039].
+//
+// Closed, and closed on purpose. The ADR's discipline is worth quoting:
+//
+//	The extension discipline: a new DCSource case must cite a RAW rule — the
+//	same price extending the step vocabulary pays (an ADR). This is the line
+//	that keeps the enum from becoming a formula language: 5e's designers
+//	already closed this set; we inherit their closure instead of inventing an
+//	open one.
+//
+// The unexported method is what makes that discipline structural rather than
+// aspirational: a fourth case cannot be declared outside this package, so
+// adding one means editing this file, and editing this file means writing the
+// rule down. The rejected alternative was a function arm (FromEvent(fn)) —
+// total coverage, and the exact seam where a data model starts becoming a
+// language.
+//
+// [ADR-0039]: https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/adr/0039-the-save-gate.md
+type DCSource interface {
+	// DC computes the difficulty class for one instance of this gate.
+	DC(in DCInput) int
+
+	// Kind names which formula this is — for the wire form, and for a UI that
+	// wants to say "DC 11" rather than "some number".
+	Kind() DCKind
+
+	// isDCSource seals the set. See the type's godoc.
+	isDCSource()
+}
+
+// DCStatic is a difficulty class written in the stat block: the wolf's 11.
+func DCStatic(n int) DCSource {
+	return staticDC{n: n}
+}
+
+// DCFivePlusDamageTaken is Undead Fortitude's DC: 5 + the damage taken.
+//
+// A function rather than a package-level variable, so nothing can reassign the
+// meaning of a RAW rule at runtime — and so all three constructors read alike
+// at a call site.
+func DCFivePlusDamageTaken() DCSource {
+	return fivePlusDamageTakenDC{}
+}
+
+// DCHalfDamageFloorTen is the concentration DC: max(10, damage taken / 2),
+// rounded down. 21 damage is DC 10, not DC 10.5; 25 is DC 12.
+func DCHalfDamageFloorTen() DCSource {
+	return halfDamageFloorTenDC{}
+}
+
+type staticDC struct {
+	n int
+}
+
+func (d staticDC) DC(_ DCInput) int { return d.n }
+func (staticDC) Kind() DCKind       { return DCKindStatic }
+func (staticDC) isDCSource()        {}
+
+type fivePlusDamageTakenDC struct{}
+
+func (fivePlusDamageTakenDC) DC(in DCInput) int {
+	return 5 + nonNegative(in.DamageTaken)
+}
+func (fivePlusDamageTakenDC) Kind() DCKind { return DCKindFivePlusDamageTaken }
+func (fivePlusDamageTakenDC) isDCSource()  {}
+
+type halfDamageFloorTenDC struct{}
+
+func (halfDamageFloorTenDC) DC(in DCInput) int {
+	half := nonNegative(in.DamageTaken) / 2 // damage is never negative, so this floors
+	if half < 10 {
+		return 10
+	}
+
+	return half
+}
+func (halfDamageFloorTenDC) Kind() DCKind { return DCKindHalfDamageFloorTen }
+func (halfDamageFloorTenDC) isDCSource()  {}
+
+// nonNegative clamps damage at zero. Negative damage is not a thing 5e has, and
+// a formula that quietly produced a DC below its floor because someone passed
+// -4 would be a worse bug than the clamp.
+func nonNegative(damage int) int {
+	if damage < 0 {
+		return 0
+	}
+
+	return damage
+}
+
+// SaveGate is a declaration that a consequence can be contested with a saving
+// throw. It is data — content carries it, nothing here executes it.
+//
+// The split of responsibility is [ADR-0039]'s: whatever wants to impose a
+// consequence declares the gate, and resolution turns the declaration into a
+// Request whose result decides whether the consequence lands. That separation
+// is what makes "can this be resisted, and how?" answerable from a stat block,
+// before anything runs — the founding complaint of rpg-toolkit#962 was that a
+// stat block could carry a knockdown DC and be lying about whether anything
+// read it.
+//
+// Because every save resolves through SavingThrowChain, a gate never needs to
+// know that Raging or Bless exist: modifiers arrive by construction.
+//
+// [ADR-0039]: https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/adr/0039-the-save-gate.md
+type SaveGate struct {
+	// Abilities the saver may use. One entry for most gates; the wolf's
+	// knockdown is STR where the monk's Flurry is DEX — same gate shape,
+	// different ability, which is why the ability lives in the declaration and
+	// not in a "knockdown" concept.
+	Abilities []abilities.Ability
+
+	// DC is where the number comes from.
+	DC DCSource
+
+	// OnSuccess is what a successful save buys.
+	OnSuccess SaveEffect
+
+	// Recurrence is when the save happens. Deliberately a separate axis from
+	// OnSuccess: conflating "what success does" with "when you may try" was the
+	// most likely modelling mistake here.
+	Recurrence Recurrence
+}
+
+// NewSaveGate builds the common gate — one ability, a static DC, negated on a
+// success, no recurrence — which is every knockdown in the roster.
+//
+// The struct literal is still there for the other shapes; this exists so that
+// the common case does not have to spell out two fields whose value is "the
+// usual one".
+func NewSaveGate(ability abilities.Ability, dc int) *SaveGate {
+	return &SaveGate{
+		Abilities:  []abilities.Ability{ability},
+		DC:         DCStatic(dc),
+		OnSuccess:  Negated,
+		Recurrence: RecurrenceNone,
+	}
+}
+
+// Validate reports whether this gate describes a save anyone could actually
+// make.
+//
+// A gate with no abilities is a save nobody can roll, and a static DC of zero
+// or less is a save nobody can fail — both are almost certainly a field left
+// empty rather than a rule, so they are refused here instead of resolving into
+// a silent auto-success.
+func (g *SaveGate) Validate() error {
+	if g == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "save gate is nil")
+	}
+	if len(g.Abilities) == 0 {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "save gate names no ability to save with")
+	}
+	if g.DC == nil {
+		return rpgerr.New(rpgerr.CodeInvalidArgument, "save gate has no DC source")
+	}
+	if static, ok := g.DC.(staticDC); ok && static.n <= 0 {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument, "static save DC must be positive, got %d", static.n)
+	}
+	if g.OnSuccess != Negated && g.OnSuccess != Half {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown save effect %q", g.OnSuccess)
+	}
+	if g.Recurrence != RecurrenceNone && g.Recurrence != RecurrenceEndOfTurn {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument, "unknown recurrence %q", g.Recurrence)
+	}
+
+	return nil
+}
+
+// saveGateData is the wire form. Unexported because nothing outside this
+// package should build one: a caller holds a [SaveGate] and lets the marshaller
+// decide what the bytes look like, which is what lets the bytes change without
+// every content package changing with them.
+type saveGateData struct {
+	Abilities  []abilities.Ability `json:"abilities"`
+	DC         dcSourceData        `json:"dc"`
+	OnSuccess  SaveEffect          `json:"on_success"`
+	Recurrence Recurrence          `json:"recurrence"`
+}
+
+// dcSourceData is a DC source as bytes: the kind it is, plus the number the
+// static kind carries. Kind-tagged rather than a bare int, because the whole
+// point of the enum is that a reader can tell which rule produced the number.
+type dcSourceData struct {
+	Kind DCKind `json:"kind"`
+	N    int    `json:"n,omitempty"`
+}
+
+// MarshalJSON implements json.Marshaler.
+//
+// Always writes OnSuccess and Recurrence explicitly, even when they hold the
+// common value, so a stored gate says what it means rather than relying on the
+// reader to know the defaults.
+func (g SaveGate) MarshalJSON() ([]byte, error) {
+	gate := g
+	gate.normalize()
+
+	if err := gate.Validate(); err != nil {
+		return nil, rpgerr.Wrap(err, "refusing to serialize an invalid save gate")
+	}
+
+	dc := dcSourceData{Kind: gate.DC.Kind()}
+	if static, ok := gate.DC.(staticDC); ok {
+		dc.N = static.n
+	}
+
+	return json.Marshal(saveGateData{
+		Abilities:  gate.Abilities,
+		DC:         dc,
+		OnSuccess:  gate.OnSuccess,
+		Recurrence: gate.Recurrence,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+//
+// Strict about what it cannot make sense of and forgiving only about what it
+// can: an omitted OnSuccess or Recurrence means the common value, while an
+// unknown DC kind, save effect, or recurrence fails the load naming the value.
+// A blob that named a fourth DC formula came from a build that knew a rule this
+// one does not, and quietly dropping the gate would leave a consequence nobody
+// could contest — with nothing anywhere saying so.
+func (g *SaveGate) UnmarshalJSON(raw []byte) error {
+	var data saveGateData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return rpgerr.Wrapf(err, "failed to unmarshal save gate: %s", raw)
+	}
+
+	dc, err := dcSourceFromData(data.DC)
+	if err != nil {
+		return err
+	}
+
+	g.Abilities = data.Abilities
+	g.DC = dc
+	g.OnSuccess = data.OnSuccess
+	g.Recurrence = data.Recurrence
+	g.normalize()
+
+	return g.Validate()
+}
+
+// normalize fills the fields an author may leave out with the value they would
+// almost always have written.
+func (g *SaveGate) normalize() {
+	if g.OnSuccess == "" {
+		g.OnSuccess = Negated
+	}
+	if g.Recurrence == "" {
+		g.Recurrence = RecurrenceNone
+	}
+}
+
+// dcSourceFromData routes a wire kind back to its formula.
+func dcSourceFromData(data dcSourceData) (DCSource, error) {
+	switch data.Kind {
+	case DCKindStatic:
+		return DCStatic(data.N), nil
+	case DCKindFivePlusDamageTaken:
+		return DCFivePlusDamageTaken(), nil
+	case DCKindHalfDamageFloorTen:
+		return DCHalfDamageFloorTen(), nil
+	default:
+		return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"unknown save DC kind %q: a new formula must cite a RAW rule (ADR-0039)", data.Kind)
+	}
+}
+
+// String renders the gate the way a stat block would say it, so a log line or a
+// UI tooltip has something to show without reaching into the fields.
+func (g *SaveGate) String() string {
+	if g == nil {
+		return "no save"
+	}
+
+	dc := "DC ?"
+	if g.DC != nil {
+		if static, ok := g.DC.(staticDC); ok {
+			dc = fmt.Sprintf("DC %d", static.n)
+		} else {
+			dc = string(g.DC.Kind())
+		}
+	}
+
+	return fmt.Sprintf("%s %s save, %s on success, recurrence %s",
+		dc, abilityList(g.Abilities), g.OnSuccess, g.Recurrence)
+}
+
+// abilityList joins the abilities a saver may choose between.
+func abilityList(list []abilities.Ability) string {
+	if len(list) == 0 {
+		return "(no ability)"
+	}
+
+	out := string(list[0])
+	for _, ability := range list[1:] {
+		out += "/" + string(ability)
+	}
+
+	return out
+}

--- a/rulebooks/dnd5e/saves/gate_test.go
+++ b/rulebooks/dnd5e/saves/gate_test.go
@@ -1,0 +1,238 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package saves_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+)
+
+// DCSourceSuite checks each formula's arithmetic against hand-computed 5e
+// values. Two of the three have no consumer in this lane; they are implemented
+// and pinned now because the arithmetic is two lines and the alternative is a
+// half-built enum whose unused arms nobody has ever run.
+type DCSourceSuite struct {
+	suite.Suite
+}
+
+func TestDCSourceSuite(t *testing.T) {
+	suite.Run(t, new(DCSourceSuite))
+}
+
+// A static DC ignores the trigger entirely — that is what makes it static.
+func (s *DCSourceSuite) TestStaticIgnoresDamage() {
+	dc := saves.DCStatic(11)
+
+	s.Assert().Equal(11, dc.DC(saves.DCInput{}))
+	s.Assert().Equal(11, dc.DC(saves.DCInput{DamageTaken: 37}))
+	s.Assert().Equal(saves.DCKindStatic, dc.Kind())
+}
+
+// Undead Fortitude: "the zombie must succeed on a Constitution saving throw
+// with a DC of 5 + the damage taken".
+func (s *DCSourceSuite) TestFivePlusDamageTaken() {
+	dc := saves.DCFivePlusDamageTaken()
+
+	s.Assert().Equal(5, dc.DC(saves.DCInput{DamageTaken: 0}), "no damage is still DC 5")
+	s.Assert().Equal(6, dc.DC(saves.DCInput{DamageTaken: 1}))
+	s.Assert().Equal(12, dc.DC(saves.DCInput{DamageTaken: 7}))
+	s.Assert().Equal(25, dc.DC(saves.DCInput{DamageTaken: 20}))
+	s.Assert().Equal(saves.DCKindFivePlusDamageTaken, dc.Kind())
+}
+
+// Concentration: "DC 10 or half the damage taken, whichever number is higher".
+// The half is rounded down, which is where a wrong implementation hides: the
+// floor only becomes visible on odd damage.
+func (s *DCSourceSuite) TestHalfDamageFloorTen() {
+	dc := saves.DCHalfDamageFloorTen()
+
+	s.Run("the floor holds below 20 damage", func() {
+		s.Assert().Equal(10, dc.DC(saves.DCInput{DamageTaken: 0}))
+		s.Assert().Equal(10, dc.DC(saves.DCInput{DamageTaken: 1}))
+		s.Assert().Equal(10, dc.DC(saves.DCInput{DamageTaken: 19}), "19/2 = 9, so the floor wins")
+	})
+
+	s.Run("the boundary", func() {
+		s.Assert().Equal(10, dc.DC(saves.DCInput{DamageTaken: 20}), "20/2 = 10, floor and half agree")
+		s.Assert().Equal(10, dc.DC(saves.DCInput{DamageTaken: 21}), "21/2 rounds DOWN to 10, not up to 11")
+	})
+
+	s.Run("odd damage rounds down above the floor", func() {
+		s.Assert().Equal(11, dc.DC(saves.DCInput{DamageTaken: 22}))
+		s.Assert().Equal(11, dc.DC(saves.DCInput{DamageTaken: 23}), "23/2 = 11, not 12")
+		s.Assert().Equal(12, dc.DC(saves.DCInput{DamageTaken: 25}), "25/2 = 12, not 13")
+		s.Assert().Equal(37, dc.DC(saves.DCInput{DamageTaken: 75}), "75/2 = 37")
+	})
+
+	s.Assert().Equal(saves.DCKindHalfDamageFloorTen, dc.Kind())
+}
+
+// Damage below zero is not a thing, and a formula that answered below its floor
+// because someone passed a negative would be worse than the clamp.
+func (s *DCSourceSuite) TestNegativeDamageIsClamped() {
+	s.Assert().Equal(5, saves.DCFivePlusDamageTaken().DC(saves.DCInput{DamageTaken: -4}))
+	s.Assert().Equal(10, saves.DCHalfDamageFloorTen().DC(saves.DCInput{DamageTaken: -4}))
+}
+
+// SaveGateSuite covers the declaration itself: what it refuses, and what it
+// looks like as bytes.
+type SaveGateSuite struct {
+	suite.Suite
+}
+
+func TestSaveGateSuite(t *testing.T) {
+	suite.Run(t, new(SaveGateSuite))
+}
+
+func (s *SaveGateSuite) wolfKnockdown() *saves.SaveGate {
+	return &saves.SaveGate{
+		Abilities:  []abilities.Ability{abilities.STR},
+		DC:         saves.DCStatic(11),
+		OnSuccess:  saves.Negated,
+		Recurrence: saves.RecurrenceNone,
+	}
+}
+
+// The common gate, spelled out once and then not spelled out again.
+func (s *SaveGateSuite) TestNewSaveGateIsTheCommonShape() {
+	s.Assert().Equal(s.wolfKnockdown(), saves.NewSaveGate(abilities.STR, 11))
+}
+
+// The wire form is kind-tagged, so a reader can tell which rule produced the
+// number rather than finding a bare int and guessing.
+func (s *SaveGateSuite) TestMarshalsKindTagged() {
+	raw, err := json.Marshal(s.wolfKnockdown())
+	s.Require().NoError(err)
+
+	s.Assert().JSONEq(
+		`{"abilities":["str"],"dc":{"kind":"static","n":11},"on_success":"negated","recurrence":"none"}`,
+		string(raw))
+}
+
+func (s *SaveGateSuite) TestRoundTrips() {
+	s.Run("static", func() {
+		s.assertRoundTrips(s.wolfKnockdown())
+	})
+
+	s.Run("derived, and multi-ability", func() {
+		s.assertRoundTrips(&saves.SaveGate{
+			Abilities:  []abilities.Ability{abilities.CON, abilities.WIS},
+			DC:         saves.DCFivePlusDamageTaken(),
+			OnSuccess:  saves.Half,
+			Recurrence: saves.RecurrenceEndOfTurn,
+		})
+	})
+
+	s.Run("the concentration formula", func() {
+		s.assertRoundTrips(&saves.SaveGate{
+			Abilities:  []abilities.Ability{abilities.CON},
+			DC:         saves.DCHalfDamageFloorTen(),
+			OnSuccess:  saves.Negated,
+			Recurrence: saves.RecurrenceNone,
+		})
+	})
+}
+
+// assertRoundTrips checks both directions: the gate comes back equal, and the
+// bytes come back identical. Equality alone would miss a marshaller that
+// dropped a field the unmarshaller then defaulted back to the same value.
+func (s *SaveGateSuite) assertRoundTrips(gate *saves.SaveGate) {
+	raw, err := json.Marshal(gate)
+	s.Require().NoError(err)
+
+	var back saves.SaveGate
+	s.Require().NoError(json.Unmarshal(raw, &back))
+	s.Require().Equal(gate, &back)
+
+	again, err := json.Marshal(&back)
+	s.Require().NoError(err)
+	s.Require().JSONEq(string(raw), string(again))
+
+	// And the formula survived, not just its name.
+	s.Require().Equal(gate.DC.DC(saves.DCInput{DamageTaken: 25}), back.DC.DC(saves.DCInput{DamageTaken: 25}))
+}
+
+// An omitted OnSuccess or Recurrence means the common value. Authors write the
+// two fields that vary and leave the two that almost never do.
+func (s *SaveGateSuite) TestOmittedFieldsTakeTheCommonValue() {
+	var gate saves.SaveGate
+	s.Require().NoError(json.Unmarshal([]byte(`{"abilities":["str"],"dc":{"kind":"static","n":11}}`), &gate))
+
+	s.Assert().Equal(saves.Negated, gate.OnSuccess)
+	s.Assert().Equal(saves.RecurrenceNone, gate.Recurrence)
+}
+
+// A DC formula this build does not know came from a build that knew a rule this
+// one does not. Dropping the gate would leave a consequence nobody can contest,
+// with nothing saying so.
+func (s *SaveGateSuite) TestUnknownDCKindIsRefused() {
+	var gate saves.SaveGate
+	err := json.Unmarshal([]byte(`{"abilities":["str"],"dc":{"kind":"twice_the_moon_phase"}}`), &gate)
+
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "twice_the_moon_phase")
+	s.Assert().Contains(err.Error(), "RAW", "and the error says what the price of a new one is")
+}
+
+func (s *SaveGateSuite) TestUnknownEnumValuesAreRefused() {
+	var gate saves.SaveGate
+
+	err := json.Unmarshal([]byte(`{"abilities":["str"],"dc":{"kind":"static","n":11},"on_success":"quarter"}`), &gate)
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "quarter")
+
+	err = json.Unmarshal([]byte(`{"abilities":["str"],"dc":{"kind":"static","n":11},"recurrence":"hourly"}`), &gate)
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "hourly")
+}
+
+// A gate nobody can roll against, and a gate nobody can fail, are both a field
+// left empty rather than a rule.
+func (s *SaveGateSuite) TestRefusesAGateNobodyCouldMake() {
+	s.Run("no ability", func() {
+		err := (&saves.SaveGate{DC: saves.DCStatic(11)}).Validate()
+		s.Require().Error(err)
+		s.Assert().Contains(err.Error(), "no ability")
+	})
+
+	s.Run("no DC source", func() {
+		err := (&saves.SaveGate{Abilities: []abilities.Ability{abilities.STR}}).Validate()
+		s.Require().Error(err)
+	})
+
+	s.Run("a static DC of zero", func() {
+		err := (&saves.SaveGate{
+			Abilities: []abilities.Ability{abilities.STR},
+			DC:        saves.DCStatic(0),
+			OnSuccess: saves.Negated,
+		}).Validate()
+		s.Require().Error(err)
+		s.Assert().Contains(err.Error(), "positive")
+	})
+
+	s.Run("a nil gate", func() {
+		var gate *saves.SaveGate
+		s.Require().Error(gate.Validate())
+	})
+}
+
+// An invalid gate must not become bytes: a stored gate nobody could save
+// against is the stat block lying again.
+func (s *SaveGateSuite) TestRefusesToSerializeAnInvalidGate() {
+	_, err := json.Marshal(&saves.SaveGate{DC: saves.DCStatic(11)})
+
+	s.Require().Error(err)
+}
+
+func (s *SaveGateSuite) TestStringReadsLikeAStatBlock() {
+	s.Assert().Equal("DC 11 str save, negated on success, recurrence none", s.wolfKnockdown().String())
+
+	var absent *saves.SaveGate
+	s.Assert().Equal("no save", absent.String())
+}


### PR DESCRIPTION
## Why

[ADR-0039](https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/adr/0039-the-save-gate.md)'s
declaration half. #962's founding complaint was that the wolf's stat block
carried `KnockdownDC: 11` and could not say whether anything read it — a stat
block that can lie. A contestable consequence now declares a `SaveGate`, which
is pure data: nothing here executes it, and turning a declaration into a
`Request` is resolution's job (PR B, after this tags).

## The types (`saves` package)

```go
saves.SaveGate{
    Abilities:  []abilities.Ability{abilities.STR},
    DC:         saves.DCStatic(11),
    OnSuccess:  saves.Negated,      // or saves.Half
    Recurrence: saves.RecurrenceNone, // or saves.RecurrenceEndOfTurn
}
```

`saves.NewSaveGate(ability, dc)` is the common shape — one ability, static DC,
negated, no recurrence — which is every knockdown in the roster.

**All three DC formulas evaluate now**, though only `DCStatic` gets an
end-to-end consumer in this lane. The arithmetic is two lines each, and a
half-built enum whose other arms nobody has run is how the *second* consumer
discovers the formula was wrong. Both derived ones are pinned against
hand-computed 5e values, including where a wrong implementation hides: 21 damage
is DC 10 (not 11), 25 is DC 12 (not 13), and 19 is DC 10 because the floor wins.

**The closure is structural.** `DCSource` carries an unexported method, so a
fourth case cannot be declared outside the package — adding one means editing
this file, and editing this file means writing the rule down. That is the ADR's
extension discipline as a compile error rather than a comment; the rejected
`FromEvent(fn)` arm is not expressible.

## The wire shape, and why

```json
{"abilities":["str"],"dc":{"kind":"static","n":11},
 "on_success":"negated","recurrence":"none"}
```

- **Kind-tagged**, because the whole point of the enum is that a reader can tell
  *which rule* produced the number rather than finding a bare int and guessing.
- **Typed, and the wire struct is unexported** — content holds a `SaveGate` and
  lets the marshaller decide the bytes, which is what lets the bytes change
  without every content package changing with them.
- **Strict about what it cannot make sense of** (unknown DC kind, save effect,
  or recurrence → error naming the value; the DC-kind error also names the price
  of adding one), **forgiving only about what it can** (an omitted `on_success`
  or `recurrence` means the common value). A blob naming a fourth formula came
  from a build that knew a rule this one does not; dropping the gate would leave
  a consequence nobody can contest with nothing saying so.
- `Validate` refuses a gate nobody could roll (no abilities) or nobody could
  fail (static DC ≤ 0), and `MarshalJSON` refuses to write one — a stored gate
  that cannot be saved against is the stat block lying again.

## The KnockdownDC decision: deprecated read-only

`KnockdownDC` **stays on `BiteConfig` for reading and is gone from the write
path.** `NewBiteAction` translates it when no gate is present; `ToData` writes
only `save_gate`. One place describes a bite's knockdown instead of two that can
disagree.

The translation is **exact, not approximate**: `KnockdownDC` could only ever mean
"the DC of the STR save that avoids being knocked prone", so its gate is `[STR]`,
static, `Negated`, `RecurrenceNone` — every axis pinned by what the old field
could express. A legacy blob therefore round-trips to a *different* but
semantically identical blob, which is a migration rather than a loss (#948's
line): nothing the old field said is missing from the new one, and
`TestALegacyBlobIsRewrittenAsAGate` pins both halves — `save_gate` present,
`knockdown_dc` absent, and the reloaded gate equal to the original.

**A DC of zero is no gate at all** (and so is a negative, and so is an absent
field). The other reading invents a save out of an empty field, which #962's
done-when calls out by name.

If both are set, the explicit `SaveGate` wins: somebody wrote it on purpose,
where the DC may be a field nobody cleaned up.

One behaviour follows the data: the bite's `+10` "knockdown potential" score was
**unconditional** — it never read `KnockdownDC` at all, despite the comment. It
now depends on there being a gate. Both existing `Score` tests build a bite with
a DC, so both still see the bonus, unmodified.

## Verification

Full module suite from `rulebooks/dnd5e/`: `go build ./...` clean,
`go test ./...` all packages `ok`, `golangci-lint run ./...` **0 issues**,
`gofmt` clean, `go mod tidy` a no-op. **No existing test modified.**

Mutation — commit first, `go build` each mutant, revert from the repo root:

| # | Mutant | Killed by |
|---|---|---|
| a | legacy `KnockdownDC` mapping dropped | `TestALegacyKnockdownDCLoadsAsItsGate`, `TestALegacyBlobIsRewrittenAsAGate`, and the **pre-existing** `TestScore_NoAdjacentEnemy` |
| b | zero DC becomes a gate (`< 0` for `<= 0`) | `TestAZeroKnockdownDCIsNoGateAtAll`, `TestScoringReadsTheGate` |
| c | `5 + damage` becomes `5 + damage/2` | `TestFivePlusDamageTaken`, `TestANonKnockdownGateSurvives` |
| d | half-damage rounds **up** | `TestHalfDamageFloorTen` (the boundary and odd-damage subtests) |
| e | the DC 10 floor removed | `TestHalfDamageFloorTen` (floor subtest), `TestNegativeDamageIsClamped` |
| f | static DC ignores its number | `TestStaticIgnoresDamage`, the legacy-mapping pin, `TestTheWolfDeclaresItsKnockdown` |
| g | unknown DC kind silently becomes static | `TestUnknownDCKindIsRefused` |
| h | `ToData` writes the deprecated field again | `TestALegacyBlobIsRewrittenAsAGate` |
| i | `Validate` stops rejecting a zero static DC | `TestRefusesAGateNobodyCouldMake` |
| j | gate dropped from `ToData` | 3 tests across the bite and the wolf |

No survivors; every mutant compiled first.

**gorelease** (no CI job for this module — #917), against the current tag
`v0.89.0`: compatible changes only, suggested `v0.90.0`. New surface is
`saves.{SaveGate, NewSaveGate, DCSource, DCStatic, DCFivePlusDamageTaken,
DCHalfDamageFloorTen, DCInput, DCKind + 3 kinds, SaveEffect + 2, Recurrence + 2}`,
plus `BiteConfig.SaveGate` and `(*BiteAction).SaveGate`. `KnockdownDC` keeps its
type and name, so nothing breaks at compile time.

## Two things worth an issue, found on the way

- **`ToData` discards its marshal error** across the monster actions
  (`configJSON, _ := json.Marshal(config)`) — pre-existing, and not fixable here
  because `MonsterAction.ToData()` cannot return one. Reachable now only by
  hand-building an invalid gate in Go; content paths cannot, since the
  constructors and the loader both validate.
- The naming deviates once from the ADR's prose: `RecurrenceNone` /
  `RecurrenceEndOfTurn` rather than bare `None` / `EndOfTurn`, because
  `saves.None` says nothing at a call site. `Negated` and `Half` keep their ADR
  names — they are distinctive enough to stand alone.

## Out of scope (PR B and beyond)

- Anything in `resolution`: the `Request` step, the contest machine, `WithRoom`.
- Applying prone to anyone — the condition exists (#961), the wiring does not.
- Converting ghoul / Undead Fortitude / concentration to gates; #927's damage
  integration; condition immunity (sequenced out by the ADR).

Part of #962

— asset-pipeline agent, on behalf of KirkDiggler
