### PR TITLE
feat(resolution): the Request step, and the contest it was built for (#962)

### DIFF
--- a/rulebooks/dnd5e/resolution/README.md
+++ b/rulebooks/dnd5e/resolution/README.md
@@ -35,12 +35,40 @@ What happens, in order:
 4. **attach everyone, sorted by ID** — each sheet through its own view of the
    surface, each effect through a view stamped with its ref
 5. **drive the machine** — it yields `Gather`, resolution folds the chain on
-   *its* bus and hands back the folded result; it yields `Done`
+   *its* bus and hands back the folded result; or it yields `Request`, and
+   resolution runs that interaction here, on the same bus, and hands back its
+   outcome; it yields `Done`
 6. **teardown** — revoke every subscription this call granted, newest first
 7. **return data** — the world, the dirty sheets (and only those), the
    outcome, and the full registration list
 
 Nothing survives step 7. Not the bus, not a loaded sheet, not a subscription.
+
+## Two machines, one interaction
+
+The knockdown lane is the first thing built out of `Request`, and it is the
+whole ADR-0039 loop in one call:
+
+```go
+out, err := resolution.Resolve(ctx, &resolution.Input{
+    World:        worldData,
+    Participants: []resolution.Participant{{Character: heroData}, {Monster: wolfData}},
+    Machine: resolution.NewContest(&resolution.ContestInput{
+        Gate:        bite.SaveGate(),  // the wolf's stat block says DC 11 STR or prone
+        SaverID:     "hero",
+        Consequence: resolution.ImposeCondition(refs.Conditions.Prone(), events.ConditionProne),
+    }),
+})
+```
+
+Nobody wired anything. The gate is data the content declared; the contest reads
+which abilities it offers, asks the gate for its DC, requests the save, and on a
+failure announces the condition on the bus — where the sheet's own keeper hears
+it, applies it, and marks the sheet dirty. What comes back is the hero's data
+with prone in it.
+
+The contest is gate-generic: nothing in it knows what a bite is, so the monk's
+Flurry — same shape, DEX, a different DC — needs no code here.
 
 ## What comes back
 
@@ -60,10 +88,13 @@ stamps the surface before calling `Apply`.
 
 ## The vocabulary, deliberately incomplete
 
-`Gather | Done`, and no others. The ADR seals
-`Gather | Pose | Request | Done`, but that table was written when exactly one
-machine existed — so each case lands with the caller that forces it: `Pose`
-with the walk machine, `Request` with concentration. Sealing an enumeration
+`Gather | Request | Done`. The ADR seals
+`Gather | Pose | Request | Done`, and each case lands with the caller that
+forces it rather than in advance. `Request` arrived with the contest machine —
+"roll this save, and tell me whether the consequence lands" — and it runs the
+requested machine on the same bus, over the same cast, so an effect attached
+for the interaction folds into the requested save exactly as it would into a
+direct one. `Pose` still waits for the walk machine. Sealing an enumeration
 against hypotheticals is the ADR-0007 mistake.
 
 `Gather` is opaque on purpose: its fields are unexported, so a machine cannot

--- a/rulebooks/dnd5e/resolution/README.md
+++ b/rulebooks/dnd5e/resolution/README.md
@@ -56,7 +56,7 @@ out, err := resolution.Resolve(ctx, &resolution.Input{
     Machine: resolution.NewContest(&resolution.ContestInput{
         Gate:        bite.SaveGate(),  // the wolf's stat block says DC 11 STR or prone
         SaverID:     "hero",
-        Consequence: resolution.ImposeCondition(refs.Conditions.Prone(), events.ConditionProne),
+        Consequence: resolution.ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
     }),
 })
 ```

--- a/rulebooks/dnd5e/resolution/contest.go
+++ b/rulebooks/dnd5e/resolution/contest.go
@@ -102,8 +102,12 @@ func (ContestOutcome) isOutcome() {}
 // imposed is resolution's to know. A caller names one through a constructor
 // here.
 type Consequence interface {
+	// validate reports whether this consequence could actually be imposed, so
+	// that a contest refuses one that could not before it rolls anything.
+	validate() error
+
 	// atStake describes what the contest is about, before it is known whether
-	// it lands.
+	// it lands. It may assume validate passed.
 	atStake() ImposedEffect
 
 	// impose puts the consequence on the saver.
@@ -136,6 +140,22 @@ type conditionConsequence struct {
 }
 
 func (conditionConsequence) isConsequence() {}
+
+// validate refuses a consequence naming no condition.
+//
+// Checked once, at the seam, so that atStake and impose can rely on the ref
+// rather than each guarding it. The alternative — a stable "unknown" whenever
+// the ref is missing — would turn a caller's mistake into a contest that runs,
+// rolls, and imposes something nobody can name, which is the shape of wrongness
+// this codebase refuses on principle: failing at construction is a bug report,
+// failing soft is a bug that ships.
+func (c conditionConsequence) validate() error {
+	if c.ref == nil {
+		return fmt.Errorf("%w: consequence names no condition ref", ErrNilInput)
+	}
+
+	return nil
+}
 
 func (c conditionConsequence) atStake() ImposedEffect {
 	return ImposedEffect{
@@ -216,6 +236,9 @@ func (m *contestMachine) Start(_ context.Context, cast *Participants) (Step, err
 	}
 	if m.in.Consequence == nil {
 		return nil, fmt.Errorf("%w: contest has no consequence", ErrNilInput)
+	}
+	if err := m.in.Consequence.validate(); err != nil {
+		return nil, err
 	}
 	if m.in.Gate.Recurrence != saves.RecurrenceNone {
 		// Silently treating a recurring gate as a one-shot would produce a

--- a/rulebooks/dnd5e/resolution/contest.go
+++ b/rulebooks/dnd5e/resolution/contest.go
@@ -1,0 +1,367 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+)
+
+// ContestInput describes a consequence somebody may save against.
+//
+// The gate is data the content declared — the wolf's bite carries "DC 11 STR or
+// prone" in its stat block — and this input is the whole of what turns that
+// declaration into an interaction. Nothing here restates the gate: the
+// abilities, the DC formula, and what a success buys are read off it, so a
+// caller cannot pass a gate saying one thing and a DC saying another.
+type ContestInput struct {
+	// Gate is the declaration being contested (ADR-0039). Required: a nil gate
+	// means there is nothing to contest, which is a caller defect rather than
+	// an interaction with no consequence.
+	Gate *saves.SaveGate
+
+	// SaverID names the participant the consequence would land on.
+	SaverID string
+
+	// Consequence is what a failed save imposes.
+	Consequence Consequence
+
+	// Cause is what provoked the save, and is what effect predicates read to
+	// decide whether they apply.
+	Cause dnd5eEvents.SaveCause
+
+	// DamageTaken is the damage of the blow that provoked this save, read only
+	// by the derived DC formulas — Undead Fortitude's 5 + damage, and
+	// concentration's max(10, damage / 2). A static gate ignores it.
+	DamageTaken int
+
+	// Roller rolls the save. Nil takes the default roller.
+	Roller dice.Roller
+}
+
+// ImposedEffect names one thing a contest put on, or would have put on, the
+// saver.
+//
+// Carried in the outcome whichever way the save went, because "the save
+// succeeded" and "the save succeeded against *what*" are different facts, and
+// only the second one lets a client say "you resisted being knocked prone".
+type ImposedEffect struct {
+	// Ref identifies the effect — a condition ref today.
+	Ref *core.Ref
+
+	// Description is the effect in a sentence, for a log line or a UI.
+	Description string
+}
+
+// ContestOutcome is what a contested consequence produced.
+//
+// It records the whole interaction rather than its verdict: the save with the
+// full breakdown of which effects folded into it, the DC that was actually
+// evaluated, the ability actually used, and what was at stake either way. A
+// bare "the save succeeded" would be the answer to a different question than
+// the one a player asks after rolling.
+type ContestOutcome struct {
+	// Save is the requested saving throw, with its folded chain.
+	Save SaveOutcome
+
+	// DC is the difficulty class the gate evaluated to for this instance.
+	DC int
+
+	// Ability is the one actually rolled. Interesting when the gate offered a
+	// choice — see [ContestInput.Gate].
+	Ability abilities.Ability
+
+	// Succeeded is whether the saver beat the DC, and therefore whether the
+	// consequence was averted.
+	Succeeded bool
+
+	// AtStake is what the contest was about, set whichever way it went.
+	AtStake ImposedEffect
+
+	// Imposed is what actually landed. Empty on a successful save — and empty
+	// is a fact here rather than an absence of one, because AtStake says what
+	// did not land.
+	Imposed []ImposedEffect
+}
+
+func (ContestOutcome) isOutcome() {}
+
+// Consequence is what a failed contest imposes.
+//
+// Sealed like [Step] and [Outcome], and for the same reason: whatever imposes
+// an effect does it on resolution's bus, so the set of things that can be
+// imposed is resolution's to know. A caller names one through a constructor
+// here.
+type Consequence interface {
+	// atStake describes what the contest is about, before it is known whether
+	// it lands.
+	atStake() ImposedEffect
+
+	// impose puts the consequence on the saver.
+	impose(ctx context.Context, in imposeInput) ([]ImposedEffect, error)
+
+	isConsequence()
+}
+
+// imposeInput is what a consequence gets to work with: the interaction's bus,
+// the cast that is attached to it, and who failed.
+type imposeInput struct {
+	bus     events.EventBus
+	cast    *Participants
+	saverID string
+}
+
+// ImposeCondition returns the consequence "the saver gains this condition".
+//
+// Generic over the condition rather than special-cased per rule: the ref goes
+// to conditions.CreateFromRef, so anything the rulebook's factory can build is
+// a consequence a gate can name — the wolf's prone today, the ghoul's
+// paralysis when its gate arrives, with no case added here for either.
+func ImposeCondition(ref *core.Ref, conditionType dnd5eEvents.ConditionType) Consequence {
+	return conditionConsequence{ref: ref, conditionType: conditionType}
+}
+
+type conditionConsequence struct {
+	ref           *core.Ref
+	conditionType dnd5eEvents.ConditionType
+}
+
+func (conditionConsequence) isConsequence() {}
+
+func (c conditionConsequence) atStake() ImposedEffect {
+	return ImposedEffect{
+		Ref:         c.ref,
+		Description: fmt.Sprintf("the %s condition", c.ref.ID),
+	}
+}
+
+// impose builds the condition for this saver and announces it on the bus.
+//
+// Announcing rather than applying directly is the point. The sheet's own keeper
+// is subscribed to ConditionAppliedEvent; it applies the condition, appends it
+// to the sheet, and marks the sheet dirty — so the condition reaches the sheet
+// through the same path a condition applied by any other effect takes, and
+// comes back in Output.DirtyCharacters without this package knowing how a
+// character stores anything.
+func (c conditionConsequence) impose(ctx context.Context, in imposeInput) ([]ImposedEffect, error) {
+	target, err := in.cast.entity(in.saverID)
+	if err != nil {
+		return nil, err
+	}
+
+	built, err := conditions.CreateFromRef(&conditions.CreateFromRefInput{
+		Ref:         c.ref.String(),
+		CharacterID: in.saverID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build %s for %q: %w", c.ref.ID, in.saverID, err)
+	}
+
+	err = dnd5eEvents.ConditionAppliedTopic.On(in.bus).Publish(ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target: target,
+		Type:   c.conditionType,
+		// The nearest existing source: a consequence of being struck rather
+		// than of the target's own activation. None of the four sources names
+		// a failed save, and adding one belongs in the rulebook rather than
+		// here — nothing reads this field today.
+		Source:    dnd5eEvents.ConditionSourceDamage,
+		Condition: built.Condition,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("apply %s to %q: %w", c.ref.ID, in.saverID, err)
+	}
+
+	return []ImposedEffect{c.atStake()}, nil
+}
+
+// NewContest returns the machine for a contested consequence: request the save
+// the gate declares, then impose the consequence or do not.
+//
+// Gate-generic, and deliberately not knockdown-generic. Nothing here knows what
+// a bite is: it reads which abilities the gate offers, asks the gate for its
+// DC, requests the save, and hands the verdict to a consequence that knows how
+// to impose itself. The wolf's knockdown is one instantiation, and the monk's
+// Flurry — same shape, different ability, different DC — needs no code here.
+func NewContest(in *ContestInput) Machine {
+	return &contestMachine{in: in}
+}
+
+type contestMachine struct {
+	in *ContestInput
+}
+
+// Start validates the gate, picks the ability, evaluates the DC, and requests
+// the save.
+func (m *contestMachine) Start(_ context.Context, cast *Participants) (Step, error) {
+	if m.in == nil {
+		return nil, ErrNilInput
+	}
+	if m.in.Gate == nil {
+		// A nil gate is not "a consequence nobody can contest" — that would be
+		// a consequence imposed without a contest, which is not this machine's
+		// job. It is a caller that forgot the declaration.
+		return nil, fmt.Errorf("%w: contest has no save gate", ErrNilInput)
+	}
+	if err := m.in.Gate.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrBadGate, err)
+	}
+	if m.in.Consequence == nil {
+		return nil, fmt.Errorf("%w: contest has no consequence", ErrNilInput)
+	}
+	if m.in.Gate.Recurrence != saves.RecurrenceNone {
+		// Silently treating a recurring gate as a one-shot would produce a
+		// paralysis nobody ever shakes off, and it would look like it worked.
+		return nil, fmt.Errorf("%w: %q (lands with the ghoul)",
+			ErrRecurrenceUnsupported, m.in.Gate.Recurrence)
+	}
+
+	ability, err := m.chooseAbility(cast)
+	if err != nil {
+		return nil, err
+	}
+
+	// Evaluated by the gate, not by this package: the formulas and their
+	// rounding are the rulebook's, and a second implementation here is a second
+	// thing to get wrong.
+	dc := m.in.Gate.DC.DC(saves.DCInput{DamageTaken: m.in.DamageTaken})
+
+	return requestSave(&SaveInput{
+		SaverID: m.in.SaverID,
+		Ability: ability,
+		DC:      dc,
+		Cause:   m.in.Cause,
+		Roller:  m.in.Roller,
+	}, func(ctx context.Context, save SaveOutcome) (Step, error) {
+		return m.resolve(ctx, cast, ability, dc, save)
+	}), nil
+}
+
+// chooseAbility picks which of the gate's abilities the saver rolls.
+//
+// RAW, a multi-ability gate is the saver's choice, and there is no way to ask
+// them yet — asking is a suspension, which is Pose's job. Until then this picks
+// the best modifier, which is what a player would choose anyway in the absence
+// of a reason not to. **Provisional**: when Pose lands, this becomes the
+// default rather than the rule. Ties keep the gate's own order, so the choice
+// is deterministic and a registration list stays reproducible.
+func (m *contestMachine) chooseAbility(cast *Participants) (abilities.Ability, error) {
+	best := m.in.Gate.Abilities[0]
+	bestModifier, err := savingThrowModifier(cast, m.in.SaverID, best)
+	if err != nil {
+		return "", err
+	}
+
+	for _, ability := range m.in.Gate.Abilities[1:] {
+		modifier, modErr := savingThrowModifier(cast, m.in.SaverID, ability)
+		if modErr != nil {
+			return "", modErr
+		}
+
+		if modifier > bestModifier {
+			best, bestModifier = ability, modifier
+		}
+	}
+
+	return best, nil
+}
+
+// resolve turns the save's verdict into a consequence, or into an averted one.
+func (m *contestMachine) resolve(
+	_ context.Context, cast *Participants, ability abilities.Ability, dc int, save SaveOutcome,
+) (Step, error) {
+	outcome := ContestOutcome{
+		Save:      save,
+		DC:        dc,
+		Ability:   ability,
+		Succeeded: save.Result != nil && save.Result.Success,
+		AtStake:   m.in.Consequence.atStake(),
+	}
+
+	if outcome.Succeeded {
+		return Done{Outcome: outcome}, nil
+	}
+
+	// Yielded rather than done inline: imposing touches the bus, and a machine
+	// never holds one (R6). The closure that does is built here, on
+	// resolution's side, exactly as the chain folds are.
+	return imposeOnBus(m.in.Consequence, cast, m.in.SaverID, func(imposed []ImposedEffect) Step {
+		outcome.Imposed = imposed
+
+		return Done{Outcome: outcome}
+	}), nil
+}
+
+// imposeOnBus builds the step that puts a consequence on the saver.
+//
+// A [Gather] rather than a new case in the vocabulary: mechanically it is the
+// same thing — a closure resolution runs with the bus, yielding the next step —
+// and ADR-0038's set has no case for "do this on the bus" beyond the one that
+// already is that. Its Name says what it is, so a reader of the step log sees
+// "impose the prone condition" rather than a fold that folds nothing.
+func imposeOnBus(
+	consequence Consequence, cast *Participants, saverID string, next func([]ImposedEffect) Step,
+) Gather {
+	return Gather{
+		name: "impose " + consequence.atStake().Description,
+		run: func(ctx context.Context, bus events.EventBus) (Step, error) {
+			imposed, err := consequence.impose(ctx, imposeInput{bus: bus, cast: cast, saverID: saverID})
+			if err != nil {
+				return nil, err
+			}
+
+			return next(imposed), nil
+		},
+	}
+}
+
+// savingThrowModifier reads one participant's modifier for an ability off the
+// sheet resolution loaded.
+func savingThrowModifier(cast *Participants, saverID string, ability abilities.Ability) (int, error) {
+	if saver, ok := cast.Character(saverID); ok {
+		return saver.GetSavingThrowModifier(ability), nil
+	}
+	if saver, ok := cast.Monster(saverID); ok {
+		return saver.GetSavingThrowModifier(ability), nil
+	}
+
+	return 0, fmt.Errorf("%w: %q", ErrNoSaver, saverID)
+}
+
+// entity returns the loaded sheet for an ID as a core.Entity, which is what a
+// ConditionAppliedEvent targets.
+func (p *Participants) entity(id string) (core.Entity, error) {
+	if character, ok := p.Character(id); ok {
+		return character, nil
+	}
+	if monster, ok := p.Monster(id); ok {
+		return monster, nil
+	}
+
+	return nil, fmt.Errorf("%w: %q", ErrNoSaver, id)
+}
+
+// requestSave builds the Request step for a saving throw, typed so the
+// requester resumes with a SaveOutcome rather than switching on Outcome.
+func requestSave(in *SaveInput, next func(context.Context, SaveOutcome) (Step, error)) Request {
+	return Request{
+		name:    "saving throw",
+		machine: NewSave(in),
+		next: func(ctx context.Context, out Outcome) (Step, error) {
+			save, ok := out.(SaveOutcome)
+			if !ok {
+				return nil, fmt.Errorf("%w: saving throw produced %T", ErrBadStep, out)
+			}
+
+			return next(ctx, save)
+		},
+	}
+}

--- a/rulebooks/dnd5e/resolution/contest_test.go
+++ b/rulebooks/dnd5e/resolution/contest_test.go
@@ -1,0 +1,406 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	monsterActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// ContestTestSuite drives the knockdown lane end to end: content declares a
+// gate, resolution contests it, and a failed save lands a condition on a sheet
+// that comes back dirty.
+type ContestTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestContestSuite(t *testing.T) {
+	suite.Run(t, new(ContestTestSuite))
+}
+
+func (s *ContestTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// wolfsKnockdown reads the gate off the actual catalog wolf rather than
+// building one here. That is the point of the lane: the declaration is content,
+// so a test that hand-builds it proves the machine works on a gate nobody
+// ships.
+func (s *ContestTestSuite) wolfsKnockdown() *saves.SaveGate {
+	wolf := monsters.NewWolf(wolfID)
+	s.Require().Len(wolf.Actions(), 1)
+
+	bite, ok := wolf.Actions()[0].(*monsterActions.BiteAction)
+	s.Require().True(ok, "the wolf's action is its bite")
+
+	gate := bite.SaveGate()
+	s.Require().NotNil(gate, "and the bite declares what its knockdown can be contested with")
+
+	return gate
+}
+
+func (s *ContestTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+// hero is a barbarian with STR 16 and proficiency in STR saves: a +5 modifier,
+// which the DC 11 gate is a real contest against.
+func (s *ContestTestSuite) hero(conds ...json.RawMessage) *character.Data {
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, // +3
+			abilities.DEX: 14, // +2
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ProficiencyBonus: 2,
+		SavingThrows: map[abilities.Ability]shared.ProficiencyLevel{
+			abilities.STR: shared.Proficient,
+		},
+		Conditions: conds,
+	}
+}
+
+func (s *ContestTestSuite) raging() json.RawMessage {
+	raw, err := (&conditions.RagingCondition{
+		CharacterID: heroID,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+func (s *ContestTestSuite) wolfData() *monster.Data {
+	return &monster.Data{
+		ID:            wolfID,
+		Name:          "Wolf",
+		Ref:           refs.Monsters.Wolf(),
+		HitPoints:     11,
+		MaxHitPoints:  11,
+		ArmorClass:    13,
+		AbilityScores: shared.AbilityScores{},
+	}
+}
+
+// contest builds the interaction the wolf's bite would raise on a hit.
+func (s *ContestTestSuite) contest(gate *saves.SaveGate, roller *scriptedRoller) Machine {
+	return NewContest(&ContestInput{
+		Gate:        gate,
+		SaverID:     heroID,
+		Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+		Roller:      roller,
+	})
+}
+
+func (s *ContestTestSuite) resolve(hero *character.Data, machine Machine) *Output {
+	out, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: hero}, {Monster: s.wolfData()}},
+		Machine:      machine,
+	})
+	s.Require().NoError(err)
+
+	return out
+}
+
+func (s *ContestTestSuite) contestOutcome(out *Output) ContestOutcome {
+	outcome, ok := out.Outcome.(ContestOutcome)
+	s.Require().True(ok, "a contest produces a ContestOutcome")
+
+	return outcome
+}
+
+// conditionRefs reads the refs of the conditions a persisted sheet carries.
+func (s *ContestTestSuite) conditionRefs(data *character.Data) []string {
+	out := make([]string, 0, len(data.Conditions))
+	for _, raw := range data.Conditions {
+		var peek struct {
+			Ref core.Ref `json:"ref"`
+		}
+		s.Require().NoError(json.Unmarshal(raw, &peek))
+		out = append(out, peek.Ref.String())
+	}
+
+	return out
+}
+
+// THE HEADLINE. Nobody wired anything: the wolf's stat block says its bite can
+// be contested with a DC 11 STR save, the hero rolls badly, and prone is on the
+// hero's sheet in the data that comes back to be persisted.
+func (s *ContestTestSuite) TestAFailedSaveKnocksTheHeroProne() {
+	// +5 modifier, roll 3, total 8 against DC 11.
+	out := s.resolve(s.hero(), s.contest(s.wolfsKnockdown(), &scriptedRoller{single: straightRoll}))
+
+	outcome := s.contestOutcome(out)
+	s.Require().False(outcome.Succeeded)
+	s.Require().Equal(11, outcome.DC, "the DC came from the gate")
+	s.Require().Equal(abilities.STR, outcome.Ability)
+	s.Require().Equal(refs.Conditions.Prone(), outcome.AtStake.Ref)
+	s.Require().Len(outcome.Imposed, 1)
+	s.Require().Equal(refs.Conditions.Prone(), outcome.Imposed[0].Ref)
+
+	s.Require().Len(out.DirtyCharacters, 1, "the sheet changed, so it comes back to be saved")
+	s.Require().Equal(heroID, out.DirtyCharacters[0].ID)
+	s.Require().Equal([]string{refs.Conditions.Prone().String()}, s.conditionRefs(out.DirtyCharacters[0]))
+}
+
+// The control that makes the headline mean something: same wolf, same gate,
+// a better roll — and the hero is still standing, with nothing to persist.
+func (s *ContestTestSuite) TestAPassedSaveLeavesTheHeroStanding() {
+	// +5 modifier, roll 18, total 23 against DC 11.
+	out := s.resolve(s.hero(), s.contest(s.wolfsKnockdown(), &scriptedRoller{single: advantageRoll}))
+
+	outcome := s.contestOutcome(out)
+	s.Require().True(outcome.Succeeded)
+	s.Require().Empty(outcome.Imposed, "nothing landed")
+	s.Require().Equal(refs.Conditions.Prone().String(), outcome.AtStake.Ref.String(),
+		"and the outcome still says what was resisted")
+
+	s.Require().Empty(out.DirtyCharacters, "a save that changed nothing leaves nothing to save")
+}
+
+// The requested save folds the interaction's chains, so an effect attached for
+// this interaction contributes to it. Raging grants advantage on STR saves —
+// and here that is the difference between standing and lying down.
+func (s *ContestTestSuite) TestRagingFoldsIntoTheContestsSave() {
+	roller := &scriptedRoller{single: straightRoll, pair: []int{straightRoll, advantageRoll}}
+
+	out := s.resolve(s.hero(s.raging()), s.contest(s.wolfsKnockdown(), roller))
+
+	outcome := s.contestOutcome(out)
+	s.Require().Equal(advantageRoll, outcome.Save.Result.Roll,
+		"only a rolled-twice-take-higher can produce this die")
+	s.Require().True(outcome.Save.Folded.HasAdvantage())
+	s.Require().Len(outcome.Save.Folded.AdvantageSources, 1)
+	s.Require().Equal(refs.Conditions.Raging(), outcome.Save.Folded.AdvantageSources[0].SourceRef,
+		"and it is Raging that says so, through the Request")
+
+	s.Require().True(outcome.Succeeded, "the barbarian shrugs off the wolf")
+	s.Require().Empty(outcome.Imposed)
+}
+
+// Without the rage, the identical roller knocks the same hero down: the
+// advantage above came from the condition and not from the dice.
+func (s *ContestTestSuite) TestTheSameRollWithoutRageKnocksHimDown() {
+	roller := &scriptedRoller{single: straightRoll, pair: []int{straightRoll, advantageRoll}}
+
+	out := s.resolve(s.hero(), s.contest(s.wolfsKnockdown(), roller))
+
+	s.Require().False(s.contestOutcome(out).Succeeded)
+	s.Require().Len(out.DirtyCharacters, 1)
+}
+
+// Two machines, one registration list: the requested save attaches nothing of
+// its own, so the ledger is the participants' and stays reproducible across
+// input orders (R4).
+func (s *ContestTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
+	// A raging hero rolls with advantage, so the roller must have a pair to
+	// give; both dice are the low roll, so the save still fails either way.
+	roller := func() *scriptedRoller {
+		return &scriptedRoller{single: straightRoll, pair: []int{straightRoll, straightRoll}}
+	}
+
+	forward, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: s.hero(s.raging())}, {Monster: s.wolfData()}},
+		Machine:      s.contest(s.wolfsKnockdown(), roller()),
+	})
+	s.Require().NoError(err)
+
+	reversed, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Monster: s.wolfData()}, {Character: s.hero(s.raging())}},
+		Machine:      s.contest(s.wolfsKnockdown(), roller()),
+	})
+	s.Require().NoError(err)
+
+	s.Require().NotEmpty(forward.Hooks)
+	s.Require().Equal(forward.Hooks, reversed.Hooks)
+}
+
+// A gate offering a choice gets the saver's best modifier — provisional until
+// an interaction can ask (Pose). Detectable rather than asserted: DC 8 is
+// beaten by the hero's proficient STR (+5, total 8) and not by his DEX (+2,
+// total 5), so which one was rolled decides the outcome.
+func (s *ContestTestSuite) TestAMultiAbilityGatePicksTheBestModifier() {
+	forEach := []struct {
+		name  string
+		order []abilities.Ability
+	}{
+		{"strength first", []abilities.Ability{abilities.STR, abilities.DEX}},
+		{"dexterity first", []abilities.Ability{abilities.DEX, abilities.STR}},
+	}
+
+	for _, tc := range forEach {
+		s.Run(tc.name, func() {
+			gate := &saves.SaveGate{
+				Abilities:  tc.order,
+				DC:         saves.DCStatic(8),
+				OnSuccess:  saves.Negated,
+				Recurrence: saves.RecurrenceNone,
+			}
+
+			out := s.resolve(s.hero(), s.contest(gate, &scriptedRoller{single: straightRoll}))
+
+			outcome := s.contestOutcome(out)
+			s.Require().Equal(abilities.STR, outcome.Ability, "the better save, whichever order it is listed in")
+			s.Require().True(outcome.Succeeded, "8 beats DC 8; the DEX save's 5 would not have")
+		})
+	}
+}
+
+// The DC is the gate's to compute, not this package's. A derived formula proves
+// the delegation: nothing here knows that Undead Fortitude is 5 + damage.
+func (s *ContestTestSuite) TestTheDCComesFromTheGate() {
+	gate := &saves.SaveGate{
+		Abilities:  []abilities.Ability{abilities.STR},
+		DC:         saves.DCFivePlusDamageTaken(),
+		OnSuccess:  saves.Negated,
+		Recurrence: saves.RecurrenceNone,
+	}
+
+	out, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
+		Machine: NewContest(&ContestInput{
+			Gate:        gate,
+			SaverID:     heroID,
+			Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+			DamageTaken: 9,
+			Roller:      &scriptedRoller{single: advantageRoll},
+		}),
+	})
+	s.Require().NoError(err)
+
+	s.Require().Equal(14, s.contestOutcome(out).DC, "5 + 9 damage, computed by the gate")
+}
+
+// A recurring gate is refused rather than run once. Treating "save again at the
+// end of each of your turns" as a single save would produce a paralysis nobody
+// ever shakes off, and it would look like it worked.
+func (s *ContestTestSuite) TestARecurringGateIsRefused() {
+	gate := saves.NewSaveGate(abilities.STR, 11)
+	gate.Recurrence = saves.RecurrenceEndOfTurn
+
+	_, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
+		Machine:      s.contest(gate, &scriptedRoller{single: straightRoll}),
+	})
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, ErrRecurrenceUnsupported)
+	s.Require().Contains(err.Error(), "ghoul", "and it says what it is waiting for")
+}
+
+func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
+	s.Run("no gate", func() {
+		_, err := Resolve(s.ctx, &Input{
+			World:        s.world(),
+			Participants: []Participant{{Character: s.hero()}},
+			Machine: NewContest(&ContestInput{
+				SaverID:     heroID,
+				Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+			}),
+		})
+		s.Require().ErrorIs(err, ErrNilInput)
+	})
+
+	s.Run("an invalid gate", func() {
+		_, err := Resolve(s.ctx, &Input{
+			World:        s.world(),
+			Participants: []Participant{{Character: s.hero()}},
+			Machine: NewContest(&ContestInput{
+				Gate:        &saves.SaveGate{DC: saves.DCStatic(11)}, // no ability to roll
+				SaverID:     heroID,
+				Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+			}),
+		})
+		s.Require().ErrorIs(err, ErrBadGate)
+	})
+
+	s.Run("no consequence", func() {
+		_, err := Resolve(s.ctx, &Input{
+			World:        s.world(),
+			Participants: []Participant{{Character: s.hero()}},
+			Machine:      NewContest(&ContestInput{Gate: s.wolfsKnockdown(), SaverID: heroID}),
+		})
+		s.Require().ErrorIs(err, ErrNilInput)
+	})
+
+	s.Run("a saver who is not a participant", func() {
+		_, err := Resolve(s.ctx, &Input{
+			World:        s.world(),
+			Participants: []Participant{{Character: s.hero()}},
+			Machine: NewContest(&ContestInput{
+				Gate:        s.wolfsKnockdown(),
+				SaverID:     "nobody",
+				Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+			}),
+		})
+		s.Require().ErrorIs(err, ErrNoSaver)
+	})
+}
+
+// The step log says what the interaction did, in order: request the save, then
+// impose. A reader of the ledger should not have to infer the second half.
+func (s *ContestTestSuite) TestTheStepsAreNamedForWhatTheyDo() {
+	gate := s.wolfsKnockdown()
+
+	machine := s.contest(gate, &scriptedRoller{single: straightRoll})
+	step, err := machine.Start(s.ctx, &Participants{
+		characters: map[string]*character.Character{},
+		monsters:   map[string]*monster.Monster{},
+	})
+
+	// The cast is empty, so the ability choice cannot read a modifier.
+	s.Require().ErrorIs(err, ErrNoSaver)
+	s.Require().Nil(step)
+}

--- a/rulebooks/dnd5e/resolution/contest_test.go
+++ b/rulebooks/dnd5e/resolution/contest_test.go
@@ -49,16 +49,20 @@ func (s *ContestTestSuite) SetupTest() {
 // so a test that hand-builds it proves the machine works on a gate nobody
 // ships.
 func (s *ContestTestSuite) wolfsKnockdown() *saves.SaveGate {
-	wolf := monsters.NewWolf(wolfID)
-	s.Require().Len(wolf.Actions(), 1)
+	for _, action := range monsters.NewWolf(wolfID).Actions() {
+		bite, isBite := action.(*monsterActions.BiteAction)
+		if !isBite {
+			continue
+		}
 
-	bite, ok := wolf.Actions()[0].(*monsterActions.BiteAction)
-	s.Require().True(ok, "the wolf's action is its bite")
+		if gate := bite.SaveGate(); gate != nil {
+			return gate
+		}
+	}
 
-	gate := bite.SaveGate()
-	s.Require().NotNil(gate, "and the bite declares what its knockdown can be contested with")
+	s.Require().Fail("the catalog wolf has no bite declaring a save gate")
 
-	return gate
+	return nil
 }
 
 func (s *ContestTestSuite) world() encounter.EncounterData {
@@ -389,18 +393,48 @@ func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	})
 }
 
-// The step log says what the interaction did, in order: request the save, then
-// impose. A reader of the ledger should not have to infer the second half.
-func (s *ContestTestSuite) TestTheStepsAreNamedForWhatTheyDo() {
-	gate := s.wolfsKnockdown()
+// Choosing which ability to roll reads a modifier off a sheet, so a saver the
+// cast does not have is refused there rather than rolling without one.
+func (s *ContestTestSuite) TestASaverTheCastDoesNotHaveIsRefusedBeforeAnyRoll() {
+	machine := s.contest(s.wolfsKnockdown(), &scriptedRoller{single: straightRoll})
 
-	machine := s.contest(gate, &scriptedRoller{single: straightRoll})
 	step, err := machine.Start(s.ctx, &Participants{
 		characters: map[string]*character.Character{},
 		monsters:   map[string]*monster.Monster{},
 	})
 
-	// The cast is empty, so the ability choice cannot read a modifier.
 	s.Require().ErrorIs(err, ErrNoSaver)
-	s.Require().Nil(step)
+	s.Require().Nil(step, "and no step is yielded, so nothing is rolled or imposed")
+}
+
+// The imposition step says what it does, so a reader of the step log sees
+// "impose the prone condition" rather than a fold that folds nothing.
+func (s *ContestTestSuite) TestTheImpositionStepSaysWhatItDoes() {
+	step := imposeOnBus(
+		ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+		&Participants{},
+		heroID,
+		func([]ImposedEffect) Step { return Done{} },
+	)
+
+	s.Require().Equal("impose the prone condition", step.Name())
+}
+
+// A consequence naming no condition is a caller defect, refused before the
+// contest rolls anything — rather than a description reading "unknown" and a
+// contest that imposes something nobody can name.
+func (s *ContestTestSuite) TestAConsequenceWithNoRefIsRefused() {
+	_, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
+		Machine: NewContest(&ContestInput{
+			Gate:        s.wolfsKnockdown(),
+			SaverID:     heroID,
+			Consequence: ImposeCondition(nil, dnd5eEvents.ConditionProne),
+			Roller:      &scriptedRoller{single: straightRoll},
+		}),
+	})
+
+	s.Require().ErrorIs(err, ErrNilInput)
+	s.Require().Contains(err.Error(), "condition ref")
 }

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -91,20 +91,32 @@
 //
 // # What this package does not do yet
 //
-// The step vocabulary is [Gather] and [Done], and nothing else. [ADR-0038]
-// seals it as Gather | Pose | Request | Done, but that set was derived from a
-// table of six machines of which one was implemented; each remaining case
-// lands with the caller that forces it — Pose with the walk machine, Request
-// with concentration. Sealing an enumeration against hypotheticals is the
-// mistake [ADR-0007] exists to remember.
+// The step vocabulary is [Gather], [Request] and [Done]. [ADR-0038] seals it as
+// Gather | Pose | Request | Done, and each case lands with the caller that
+// forces it rather than in advance: Request arrived with the contest machine,
+// which needs a saving throw's answer before it knows whether to impose
+// anything, and Pose waits for the walk machine. Sealing an enumeration against
+// hypotheticals is the mistake [ADR-0007] exists to remember.
+//
+// [Request] runs its machine to Done inside the requester's own step loop —
+// no suspension. That is enough for every consumer today, and the boundary it
+// crosses is self-describing data (a machine, and a continuation taking its
+// outcome), so the case where the answer comes from outside the process is a
+// new step rather than a redesign of this one.
 //
 // No game context is installed. Effect predicates read world state through
-// five separate installers in the gamectx package, and a saving throw's
-// predicates read none of them — [conditions.RagingCondition] decides on the
-// event alone. Resolution is where they will be populated, because it is the
-// one place that holds both the world and the effects; the first predicate
-// that needs one brings its installer with it. Populating a registry nothing
-// reads would be building the wrong thing convincingly.
+// five separate installers in the gamectx package, and neither a saving throw's
+// predicates nor a contest's read any of them — [conditions.RagingCondition]
+// decides on the event alone. Resolution is where they will be populated,
+// because it is the one place that holds both the world and the effects; the
+// first predicate that needs one brings its installer with it. Populating a
+// registry nothing reads would be building the wrong thing convincingly.
+//
+// The knockdown lane is the case that nearly forces one and does not. The prone
+// condition reads positions — advantage from within five feet, disadvantage
+// beyond — but it reads them on the *attack* chain, and a contest folds a
+// saving throw. So the room arrives with the strike (#965), which is the
+// interaction whose predicates actually ask where everyone is standing.
 //
 // The machine for a saving throw lives here rather than in the rules package
 // that owns saves, because `rulebooks/dnd5e` cannot import this module — this

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -25,4 +25,16 @@ var (
 	// passed in. Silently rolling without the saver's modifier would be a
 	// wrong answer wearing a right one's clothes.
 	ErrNoSaver = errors.New("resolution: saver is not a participant")
+
+	// ErrBadGate indicates a save gate that does not describe a save anyone
+	// could make — no ability to roll, no DC source, a DC nobody can fail. The
+	// declaration is content, so this is content being wrong rather than a
+	// caller being wrong, and it says which.
+	ErrBadGate = errors.New("resolution: invalid save gate")
+
+	// ErrRecurrenceUnsupported indicates a gate asking for a repeat save this
+	// package cannot yet run. Refusing is the point: treating "save again at
+	// the end of each of your turns" as a single save would produce a
+	// paralysis nobody ever shakes off, and it would look like it worked.
+	ErrRecurrenceUnsupported = errors.New("resolution: save gate recurrence not supported yet")
 )

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.86.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.90.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.86.0 h1:OQ6RU7n0f3Nljg+QgOhKndLh4PUkajCTJzRAUP151sw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.86.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.90.0 h1:7/TkXhl5KaarTj3Htjp2X/J53n/7bX/LZirY+pfJx/I=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.90.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0 h1:GcwmLanoceCnrQ1R1Z61N7qLqMBY8VUPq5TpL1BhfUw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0/go.mod h1:ZYYd+oFBN6WUPIb+OTaAu6X7CQtVhOjEg9i0GJM0o6Q=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=

--- a/rulebooks/dnd5e/resolution/step.go
+++ b/rulebooks/dnd5e/resolution/step.go
@@ -25,19 +25,21 @@ type Machine interface {
 // this package and nowhere else — because every yield point is also a legal
 // suspension point, and a case nobody drives is a case nobody can resume.
 //
-// Today the set is [Gather] and [Done]. ADR-0038 also names Pose and Request;
-// each lands with the caller that forces it rather than now, when it would be
-// an enumeration against hypotheticals.
+// Today the set is [Gather], [Request] and [Done]. ADR-0038 also names Pose,
+// which lands with the caller that forces it — the walk machine — rather than
+// now, when it would be an enumeration against a hypothetical.
 type Step interface {
 	isStep()
 }
 
-// Gather is "fold this chain and hand me the result".
+// Gather is "do this on the bus and hand me what happened" — folding a chain,
+// first and mainly, and imposing a consequence a contest just decided on.
 //
 // It is opaque on purpose. A machine cannot construct one directly — it calls a
-// constructor in this package naming the chain it wants — which is what keeps
-// the fold, and therefore the bus, on resolution's side of the seam while the
-// machine still gets a typed result back.
+// constructor in this package naming what it wants — which is what keeps the
+// bus on resolution's side of the seam while the machine still gets a typed
+// result back. [Gather.Name] is what it asked for, so a fold and an imposition
+// are told apart by reading rather than by type.
 type Gather struct {
 	name string
 	run  func(ctx context.Context, bus events.EventBus) (Step, error)
@@ -48,6 +50,35 @@ func (Gather) isStep() {}
 // Name identifies the chain being folded, for logs and for tests that want to
 // assert what a machine asked for without reaching into it.
 func (g Gather) Name() string { return g.name }
+
+// Request is "run this interaction, then continue with what it produced".
+//
+// It is how one machine composes another without either knowing the other
+// exists: a contest asks for a saving throw and resumes with its outcome,
+// while the save machine remains a machine anyone can drive on its own. Like
+// [Gather] it is opaque — a machine calls a constructor here naming the
+// follow-up it wants, and the driver is what actually runs it, on the same bus
+// and over the same cast. That sameness is load-bearing: the sub-machine folds
+// its chains on the interaction's own bus, so an effect attached for this
+// interaction contributes to the requested save exactly as it would to a
+// direct one.
+//
+// No suspension yet. The requested machine runs to Done inside this one's
+// step loop, which is enough for every consumer today, and the boundary is
+// self-describing data — a machine, and a continuation taking its outcome — so
+// the later case where the answer comes from outside the process (Pose) is a
+// new step rather than a redesign of this one.
+type Request struct {
+	name    string
+	machine Machine
+	next    func(ctx context.Context, out Outcome) (Step, error)
+}
+
+func (Request) isStep() {}
+
+// Name identifies the interaction being requested, for logs and for tests that
+// want to assert what a machine asked for without reaching into it.
+func (r Request) Name() string { return r.name }
 
 // Done ends a machine and carries what the interaction produced.
 type Done struct {
@@ -79,6 +110,27 @@ func drive(ctx context.Context, bus events.EventBus, machine Machine, cast *Part
 		switch s := step.(type) {
 		case Done:
 			return s.Outcome, nil
+
+		case Request:
+			if s.machine == nil || s.next == nil {
+				// A Request that did not come from this package's
+				// constructors. Refusing beats running nothing and feeding the
+				// requester a nil outcome, which would look exactly like an
+				// interaction that produced nothing to say.
+				return nil, fmt.Errorf("%w: Request built outside this package", ErrBadStep)
+			}
+
+			// The same bus and the same cast: a requested interaction happens
+			// inside this one, not beside it.
+			out, runErr := drive(ctx, bus, s.machine, cast)
+			if runErr != nil {
+				return nil, fmt.Errorf("requested %s: %w", s.name, runErr)
+			}
+
+			step, err = s.next(ctx, out)
+			if err != nil {
+				return nil, err
+			}
 
 		case Gather:
 			if s.run == nil {


### PR DESCRIPTION
## Why

The seam test for [ADR-0039](https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/adr/0039-the-save-gate.md).
PR A (#997) made the wolf's stat block *say* "DC 11 STR save or prone". This
makes the sentence do something: read as data off the catalog wolf, it knocks a
hero prone, and the hero's sheet comes back with prone on it.

## `Request` — the vocabulary's third case

A machine names a follow-up interaction and a continuation taking its outcome;
the driver runs it **on the same bus, over the same cast**, and hands the
outcome back. The sameness is load-bearing rather than incidental: an effect
attached for this interaction folds into the requested save exactly as it would
into a direct one — which is why a raging barbarian gets advantage on a
knockdown save without anything in the contest mentioning rage.

No suspension: the requested machine runs to `Done` inside the requester's step
loop. That is enough for every consumer today, and the boundary is
self-describing data (a machine, and a continuation over its outcome), so the
case where the answer comes from outside the process is a **new step** rather
than a redesign of this one. `Pose` still waits for the walk machine.

Constructed like `Gather`: sealed, unexported workings, a machine obtains one
from a constructor here. `Request.Name()` says what was asked for.

## The contest machine — the constructor's exact shape

```go
type ContestInput struct {
    Gate        *saves.SaveGate       // the declaration, required
    SaverID     string                // who would suffer the consequence
    Consequence Consequence           // what a failed save imposes
    Cause       dnd5eEvents.SaveCause // passed through to the save
    DamageTaken int                   // read only by the derived DC formulas
    Roller      dice.Roller           // nil takes the default
}

func NewContest(in *ContestInput) Machine
func ImposeCondition(ref *core.Ref, conditionType dnd5eEvents.ConditionType) Consequence
```

**Gate-generic, not bite-specific.** Nothing in it knows what a bite is: it reads
which abilities the gate offers, asks the **gate** for its DC, requests the save,
and hands the verdict to a consequence that knows how to impose itself. The
monk's Flurry — same shape, DEX, a derived static DC — needs no code here.
`ImposeCondition` is likewise generic over the condition: the ref goes to
`conditions.CreateFromRef`, so the ghoul's paralysis will need no case either.

`ContestOutcome` records the interaction, not its verdict: the full `SaveOutcome`
(roll and folded chain), the **evaluated** `DC`, the `Ability` actually rolled,
`Succeeded`, `AtStake` (set either way — "you resisted *being knocked prone*"),
and `Imposed` (empty on a success, where empty is a fact because `AtStake` says
what did not land). That is #970's rich-breakdown convention.

## Decisions, and their reasons

- **DC evaluation is delegated**, never reimplemented: `gate.DC.DC(saves.DCInput{...})`.
  Pinned with a `DCFivePlusDamageTaken` gate and 9 damage → DC 14, so the
  delegation is observable and not just claimed. The formulas' arithmetic stays
  pinned in dnd5e where it lives.
- **Multiple abilities** are the saver's choice in RAW, and nothing can ask them
  yet — asking is a suspension, which is `Pose`'s job. Until then the **best
  modifier** is used, which is what a player would choose absent a reason not
  to. Documented as provisional-until-Pose; ties keep the gate's order so the
  registration list stays reproducible. Pinned with a DC 8 gate where the hero's
  STR (+5, total 8) beats it and his DEX (+2, total 5) does not — so *which
  ability was chosen* decides the outcome — run in both list orders.
- **Recurrence**: `RecurrenceNone` only. `RecurrenceEndOfTurn` is refused by
  name (`ErrRecurrenceUnsupported`, "lands with the ghoul"), never silently
  treated as one-shot — that would produce a paralysis nobody ever shakes off,
  and it would look like it worked.
- **Imposing prone goes through the bus**, verified against
  `character.onConditionApplied` rather than assumed: it applies the condition,
  appends it to the sheet, and marks the sheet dirty. So the condition arrives
  by the same path any other effect's would, and this package learns nothing
  about how a character stores anything.
- **Imposition yields a step** rather than reaching for a bus, because a machine
  never holds one (R6). It rides `Gather` — mechanically the same closure
  resolution runs with the bus — rather than adding a fifth case ADR-0038 does
  not name; its `Name()` is "impose the prone condition", so the step log reads
  as what it is. **Flagging this as the one place I stretched an existing case**;
  the alternative was a vocabulary the ADR would have to be amended for.
- **`WithRoom`/`gamectx` is out**, deliberately. Prone reads positions on the
  *attack* chain, and a contest folds a *saving throw* — no predicate in this
  interaction asks where anyone is standing. Installing a room nothing reads is
  doc.go's "building the wrong thing convincingly". It arrives with the strike
  (#965).
- `ConditionAppliedEvent.Source` has no case for a failed save; the four are
  class / feature / combat ability / damage. Used `ConditionSourceDamage` as the
  nearest (a consequence of being struck rather than of the target's own
  activation) and said so in a comment. Nothing reads the field today; a proper
  constant belongs in the rulebook, not here.

## Verification

Module suite from `rulebooks/dnd5e/resolution/`: `go build ./...` clean,
`go test ./...` `ok`, `golangci-lint run ./...` **0 issues**, `gofmt` clean,
`go mod tidy` a no-op beyond the pin. **Existing tests unmodified.** Pin: dnd5e
**v0.90.0**; encounter stays v0.7.0. No `replace`.

Headline tests, in `contest_test.go` — the gate is read off `monsters.NewWolf`,
never hand-built, because a test that builds its own gate proves the machine
works on a gate nobody ships:

| Test | Pins |
|---|---|
| `TestAFailedSaveKnocksTheHeroProne` | prone in `out.DirtyCharacters[hero].Conditions`; outcome carries DC 11, STR, `Imposed` |
| `TestAPassedSaveLeavesTheHeroStanding` | nothing imposed, **nothing dirty**, `AtStake` still says what was resisted |
| `TestRagingFoldsIntoTheContestsSave` | advantage through the `Request`, attributed to Raging's ref |
| `TestTheSameRollWithoutRageKnocksHimDown` | the control — the advantage came from the condition, not the dice |
| `TestRegistrationsDoNotDependOnInputOrder` | R4 determinism across the two-machine flow |
| `TestAMultiAbilityGatePicksTheBestModifier` | both list orders, choice detectable from the modifier used |
| `TestTheDCComesFromTheGate` | 5 + 9 damage = 14, computed by the gate |
| `TestARecurringGateIsRefused` | named error, and it says what it is waiting for |
| `TestRefusesAContestItCannotRun` | nil gate, invalid gate, no consequence, saver not a participant |

Mutation — commit first, `go build` each mutant, revert from the repo root:

| # | Mutant | Killed by |
|---|---|---|
| a | a failed save imposes nothing | `TestAFailedSaveKnocksTheHeroProne`, `TestTheSameRollWithoutRageKnocksHimDown` |
| b | the verdict inverted (success imposes) | 5 tests |
| c | `Request`'s outcome not fed back (continuation gets a zero outcome) | 3 tests |
| d | `RecurrenceEndOfTurn` silently accepted | `TestARecurringGateIsRefused` |
| e | DC evaluation bypassed with a literal `11` | `TestTheDCComesFromTheGate`, both multi-ability cases |
| f | multi-ability picks the first rather than the best | `TestAMultiAbilityGatePicksTheBestModifier/dexterity_first` |
| g | the condition is built but never announced on the bus | `TestAFailedSaveKnocksTheHeroProne`, `TestTheSameRollWithoutRageKnocksHimDown` |
| h | the `Request` runs on a *different* bus | `TestRagingFoldsIntoTheContestsSave` — the fold is the point |

No survivors; every mutant compiled first.

**gorelease** (no CI job for this module — #917), against `resolution/v0.3.0`:
compatible changes only, suggested **v0.4.0**. Added: `Request`, `NewContest`,
`ContestInput`, `ContestOutcome`, `Consequence`, `ImposeCondition`,
`ImposedEffect`, `ErrBadGate`, `ErrRecurrenceUnsupported`.

## One done-when I cannot honestly claim

#962 says "a bite that misses rolls no save". **Not provable here.** Nothing in
this PR observes hit or miss — the contest is raised by whoever decides the bite
landed, and that trigger is the strike's to plumb. The machine is ready for it
(a caller that never raises the contest rolls no save), but the wiring that
*decides* is #965's. Residual noted there rather than claimed here.

## Out of scope

`WithRoom`/`gamectx` (see above, #965); converting ghoul / Undead Fortitude /
concentration to gates; #927's damage integration; condition immunity.

Closes #962
Closes #970

— asset-pipeline agent, on behalf of KirkDiggler
