### PR TITLE
feat(resolution): the strike machine, and the room its predicates read (#965 slice 1)

### DIFF
--- a/rulebooks/dnd5e/resolution/README.md
+++ b/rulebooks/dnd5e/resolution/README.md
@@ -70,6 +70,41 @@ with prone in it.
 The contest is gate-generic: nothing in it knows what a bite is, so the monk's
 Flurry — same shape, DEX, a different DC — needs no code here.
 
+## The strike, and the room it needs
+
+The strike machine is the first interaction that folds an attack chain, and the
+first that needs to know where anybody is standing:
+
+```go
+out, err := resolution.Resolve(ctx, &resolution.Input{
+    World:        worldData,
+    Participants: []resolution.Participant{{Character: heroData}, {Monster: wolfData}},
+    Machine: resolution.NewStrike(&resolution.StrikeInput{
+        AttackerID: "wolf", TargetID: "hero",
+        Action:     wolfData.Actions[0], // the bite, as content persists it
+    }),
+})
+```
+
+Phases, each a yielded value: fold the attack chain → roll against AC → on a
+miss, done (and **no save is rolled** — the rider is gated on the blow landing)
+→ on a hit, fold the damage chain and apply it to the sheet → if the action
+declared a `SaveGate`, `Request` the contest.
+
+ADR-0026's third beat — Notify — is deliberately missing: publishing
+`DamageReceivedEvent` applies the damage *again* to a monster target, whose
+sheet keeper subscribes to that topic and treats it as an instruction, while a
+character has no such handler and the event is inert. Measured, not assumed. One
+topic meaning two things is exactly the rules-versus-notification classification
+slice 2 owes.
+
+`Resolve` builds a `spatial` room from `Input.World` — the persisted world
+already carries every member's room and position — and installs it via
+`gamectx`, which is what lets prone's predicate answer *advantage from within
+five feet, disadvantage from beyond*. Participants spanning rooms install none,
+and a machine that needs positions says so rather than measuring across two
+rooms' coordinate systems.
+
 ## What comes back
 
 `Output.Hooks` is the registration list: every subscription granted, in

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -89,6 +89,39 @@
 // sheet still parks a bus for the verb methods that read one. Both go with
 // #965 and #966.
 //
+// # The bus-effect tally
+//
+// Steps come in two kinds, and the difference is worth counting because
+// [Gather]'s name only fits one of them. Three fold a chain and hand back the
+// folded event — the saving throw, the attack chain, the damage chain. One does
+// something on the bus and hands back nothing but the next step: imposing a
+// contest's consequence. Both kinds are built by constructors here, both run on
+// resolution's bus, and both are named for what they do; what differs is
+// whether anything is gathered.
+//
+// ADR-0026's Notify would have been a second of the latter kind, and is
+// deliberately absent — see strikeMachine.afterDamage. Publishing
+// DamageReceivedEvent applies the damage a second time to a monster target,
+// because that sheet's keeper treats the topic as an instruction, while a
+// character has no such handler and the same event is inert. One event meaning
+// two things is the classification slice 2 owes, and slice 1 records it rather
+// than shipping a double-apply.
+//
+// Two consumers now agree on that shape, which is the evidence the question was
+// waiting for: either Gather means "do this on the bus and hand me what
+// happened" — which is what it has always been mechanically — or the step
+// vocabulary grows a case ADR-0038 does not name. That is a decision for the
+// ADR, not for this file.
+//
+// One of the three folds carries a debt. The damage chain is folded by
+// combat.ResolveDamage, which takes a bus, because every exported attack and
+// damage entry point in that package requires one and the arithmetic that
+// applies resistance and vulnerability is unexported — folding here would mean
+// reimplementing damage multipliers. The fold still happens on this package's
+// bus, over subscribers this package attached; what differs from the save
+// precedent is custody of the fold mechanics. Every such call site says
+// "divestment debt — #965 slice 2" so the divestment has a grep-able worklist.
+//
 // # What this package does not do yet
 //
 // The step vocabulary is [Gather], [Request] and [Done]. [ADR-0038] seals it as
@@ -112,11 +145,17 @@
 // first predicate that needs one brings its installer with it. Populating a
 // registry nothing reads would be building the wrong thing convincingly.
 //
-// The knockdown lane is the case that nearly forces one and does not. The prone
-// condition reads positions — advantage from within five feet, disadvantage
-// beyond — but it reads them on the *attack* chain, and a contest folds a
-// saving throw. So the room arrives with the strike (#965), which is the
-// interaction whose predicates actually ask where everyone is standing.
+// One installer is now populated, by the machine that forced it. The strike
+// folds the attack chain, and prone's predicate reads positions off that chain —
+// advantage from within five feet, disadvantage beyond — so [Resolve] builds a
+// spatial room out of [Input.World] and installs it for the interaction. The
+// world it builds from is the persisted one the caller already handed over:
+// members carry their room and position, rooms carry their grid and size. See
+// interactionRoom for why one room rather than all of them, and why a
+// participant list spanning rooms installs none.
+//
+// Nothing else is installed. The other four registries stay empty until a
+// predicate that reads one arrives with its own consumer.
 //
 // The machine for a saving throw lives here rather than in the rules package
 // that owns saves, because `rulebooks/dnd5e` cannot import this module — this

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -32,6 +32,19 @@ var (
 	// caller being wrong, and it says which.
 	ErrBadGate = errors.New("resolution: invalid save gate")
 
+	// ErrBadWorld indicates world data this package cannot make sense of — a
+	// member placed in a room the field does not contain, or a position the
+	// room refuses. The world is the caller's to hand over intact.
+	ErrBadWorld = errors.New("resolution: world data is unusable")
+
+	// ErrBadAttack indicates an action this build cannot read as an attack.
+	// Refused by name rather than treated as a generic swing, because guessing
+	// an attack bonus is how a stat block starts lying again.
+	ErrBadAttack = errors.New("resolution: unreadable attack")
+
+	// ErrNoCombatant indicates a strike naming somebody who was not passed in.
+	ErrNoCombatant = errors.New("resolution: combatant is not a participant")
+
 	// ErrRecurrenceUnsupported indicates a gate asking for a repeat save this
 	// package cannot yet run. Refusing is the point: treating "save again at
 	// the end of each of your turns" as a single save would produce a

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
 )
@@ -201,6 +202,20 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("resolution: load world: %w", err)
+	}
+
+	// Install the room this interaction happens in, so that a predicate which
+	// reads positions — prone's advantage-within-five-feet, first of them —
+	// has them. Built from in.World, which is the persisted world the caller
+	// handed over: see interactionRoom. Nothing is installed when the
+	// participants do not share one room, and a machine that needs positions
+	// says so rather than measuring across coordinate systems.
+	room, err := interactionRoom(in.World, in.Participants)
+	if err != nil {
+		return nil, err
+	}
+	if room != nil {
+		ctx = gamectx.WithRoom(ctx, room)
 	}
 
 	cast, err := attachAll(ctx, surf, in.Participants, roller)

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -394,14 +394,54 @@ func (m *strikeMachine) afterNotify(_ context.Context) (Step, error) {
 // StrikeInput.Attack names; a character's weapon-plus-sheet compiler is its
 // sibling (rpg-toolkit#1003) and the machine cannot tell them apart.
 //
-// One ref for slice 1. An action this build cannot read is refused by name
+// Two refs for slice 1: the bite, and the generic melee action every
+// stat-block weapon is authored as (a skeleton's scimitar is a MeleeAction
+// named "scimitar"). An action this build cannot read is refused by name
 // rather than treated as a generic swing, because guessing an attack bonus is
-// how a stat block starts lying again.
+// how a stat block starts lying again — the ranged action waits on range
+// semantics the strike does not have, and multiattack is turn economy, not a
+// single swing.
+//
+// Reach is not enforced, for melee weapons exactly as for the bite: the
+// strike does not yet check adjacency at all. That is one shared, named gap
+// (#965 slice 2's list), not one this case adds.
 func AttackFromMonsterAction(action monster.ActionData) (AttackProfile, error) {
-	if action.Ref.ID != refs.MonsterActions.Bite().ID {
-		return AttackProfile{}, fmt.Errorf("%w: %q (slice 1 understands the bite)", ErrBadAttack, action.Ref.ID)
+	switch action.Ref.ID {
+	case refs.MonsterActions.Bite().ID:
+		return attackFromBite(action)
+	case refs.MonsterActions.Melee().ID:
+		return attackFromMelee(action)
+	default:
+		return AttackProfile{}, fmt.Errorf(
+			"%w: %q (the strike compiles the bite and the generic melee action)", ErrBadAttack, action.Ref.ID)
+	}
+}
+
+// attackFromMelee compiles a stat-block weapon — MeleeConfig is the profile's
+// shape already, and a plain weapon declares no gate: the blow just lands.
+func attackFromMelee(action monster.ActionData) (AttackProfile, error) {
+	var config monsterActions.MeleeConfig
+	if len(action.Config) > 0 {
+		if err := json.Unmarshal(action.Config, &config); err != nil {
+			return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
+		}
 	}
 
+	if config.DamageDice == "" {
+		return AttackProfile{}, fmt.Errorf("%w: the action declares no damage dice", ErrBadAttack)
+	}
+
+	ref := action.Ref
+
+	return AttackProfile{
+		Ref:         &ref,
+		AttackBonus: config.AttackBonus,
+		DamageDice:  config.DamageDice,
+		DamageType:  config.DamageType,
+	}, nil
+}
+
+func attackFromBite(action monster.ActionData) (AttackProfile, error) {
 	var config monsterActions.BiteConfig
 	if len(action.Config) > 0 {
 		if err := json.Unmarshal(action.Config, &config); err != nil {

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -1,0 +1,517 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	monsterActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+)
+
+// criticalThreshold is the roll at or above which an attack crits. A flat 20
+// here rather than a field: nothing in slice 1 lowers it, and the attack chain
+// carries the number so an effect that does will be read from the folded event
+// rather than from this constant.
+const criticalThreshold = 20
+
+// StrikeInput describes one attack.
+//
+// The attack itself arrives as content — the action's persisted data, exactly
+// as a monster's stat block carries it — rather than as a runtime object with
+// its numbers pulled out. That is the same seam every other input here uses,
+// and it is what lets the headline test drive the catalog wolf's own bite
+// instead of a hand-built approximation of it.
+type StrikeInput struct {
+	// AttackerID names the participant swinging.
+	AttackerID string
+
+	// TargetID names the participant being swung at.
+	TargetID string
+
+	// Action is the attack, as the content declares it. Slice 1 understands
+	// the bite; another ref is refused by name rather than guessed at.
+	Action monster.ActionData
+
+	// Roller rolls the attack and its damage. Nil takes the default roller.
+	Roller dice.Roller
+}
+
+// StrikeOutcome is what an attack produced, in enough detail to explain it.
+//
+// A bare "hit for 6" cannot answer the question a player actually asks, which
+// is why: what made it hit, what the target's AC was, which effects granted
+// advantage, and — when the blow carried a rider — whether the save that gated
+// it succeeded. All of that is here, and the miss case carries the same
+// breakdown rather than an empty struct.
+type StrikeOutcome struct {
+	// AttackerID and TargetID name the two sides.
+	AttackerID string
+	TargetID   string
+
+	// Roll is the d20 as rolled, after advantage or disadvantage was applied.
+	Roll int
+
+	// Total is Roll plus the attack bonus the chain settled on.
+	Total int
+
+	// TargetAC is what the total had to reach.
+	TargetAC int
+
+	// Hit is whether it landed. A natural 1 never does and a natural 20
+	// always does, whatever the arithmetic says.
+	Hit bool
+
+	// Critical is whether the roll was a natural 20.
+	Critical bool
+
+	// Folded is the attack chain after every subscriber had its say — the
+	// record of which effects granted advantage or imposed disadvantage.
+	Folded dnd5eEvents.AttackChainEvent
+
+	// Damage is what was dealt. Zero on a miss.
+	Damage int
+
+	// Contest is the interaction that gated the blow's rider, when the action
+	// declared one and the blow landed. Nil when the action carries no gate,
+	// and nil on a miss — a strike that misses rolls no save.
+	Contest *ContestOutcome
+}
+
+func (StrikeOutcome) isOutcome() {}
+
+// NewStrike returns the machine for one attack: fold the attack chain, roll it
+// against AC, and on a hit deal damage and contest whatever rider the action
+// declared.
+//
+// Linear, and re-enterable by construction rather than by intent. Every phase
+// boundary is a yielded step, so the machine's own fields are the only state
+// there is and nothing accumulates on the Go stack between phases — which is
+// what the reaction windows of ADR-0027 will need, and why they can be added
+// without rebuilding this. They are not here: reactions are wave 5.
+func NewStrike(in *StrikeInput) Machine {
+	return &strikeMachine{in: in}
+}
+
+type strikeMachine struct {
+	in *StrikeInput
+
+	// cast is the sheets this interaction attached, kept because a phase after
+	// the first needs them and a step's closure is handed only a bus.
+	cast *Participants
+
+	// attack is the content's numbers, decoded once.
+	attack strikeProfile
+
+	// outcome accumulates across phases. It is the machine's whole state, and
+	// the reason a suspension between any two phases would need nothing else.
+	outcome StrikeOutcome
+}
+
+// strikeProfile is what this machine needs to know about an attack, decoded
+// from whatever action data it was handed.
+type strikeProfile struct {
+	attackBonus int
+	damageDice  string
+	damageType  string
+	gate        *saves.SaveGate
+}
+
+// Start decodes the action, reads the target's AC, and folds the attack chain.
+func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, error) {
+	if m.in == nil {
+		return nil, ErrNilInput
+	}
+	if m.in.AttackerID == "" || m.in.TargetID == "" {
+		return nil, fmt.Errorf("%w: a strike needs an attacker and a target", ErrNilInput)
+	}
+
+	m.cast = cast
+
+	profile, err := decodeStrikeProfile(m.in.Action)
+	if err != nil {
+		return nil, err
+	}
+	m.attack = profile
+
+	if _, err := combatantFor(cast, m.in.AttackerID); err != nil {
+		return nil, err
+	}
+
+	target, err := combatantFor(cast, m.in.TargetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Plain AC, deliberately. Folding the AC chain is GetEffectiveAC's job and
+	// it folds on the character's own parked bus — the legacy shape this
+	// migration is retiring — so slice 1 uses the number on the sheet and
+	// names the gap rather than papering it. Divestment debt — #965 slice 2.
+	m.outcome = StrikeOutcome{
+		AttackerID: m.in.AttackerID,
+		TargetID:   m.in.TargetID,
+		TargetAC:   target.AC(),
+	}
+
+	event := dnd5eEvents.AttackChainEvent{
+		AttackerID:        m.in.AttackerID,
+		TargetID:          m.in.TargetID,
+		WeaponRef:         &m.in.Action.Ref,
+		IsMelee:           true,
+		AttackBonus:       profile.attackBonus,
+		TargetAC:          target.AC(),
+		CriticalThreshold: criticalThreshold,
+	}
+
+	return gatherAttack(event, m.afterAttackChain), nil
+}
+
+// afterAttackChain rolls the die the fold decided the shape of, and decides
+// whether the blow lands.
+//
+// The advantage rules are 5e's and are mirrored from combat.ResolveAttackHit
+// rather than invented: advantage and disadvantage cancel exactly, a natural 1
+// always misses, a natural 20 always hits. Rolling here rather than calling
+// combat is not a preference — every exported attack entry point in that
+// package requires an event bus, and there is no bus-free roll to call.
+// Divestment debt — #965 slice 2.
+func (m *strikeMachine) afterAttackChain(ctx context.Context, folded dnd5eEvents.AttackChainEvent) (Step, error) {
+	roller := m.in.Roller
+	if roller == nil {
+		roller = dice.NewRoller()
+	}
+
+	hasAdvantage := len(folded.AdvantageSources) > 0
+	hasDisadvantage := len(folded.DisadvantageSources) > 0
+
+	var roll int
+	var err error
+	switch {
+	case hasAdvantage == hasDisadvantage:
+		// Both or neither: one die either way.
+		roll, err = roller.Roll(ctx, 20)
+	case hasAdvantage:
+		roll, err = rollTwice(ctx, roller, takeHigher)
+	default:
+		roll, err = rollTwice(ctx, roller, takeLower)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("roll attack: %w", err)
+	}
+
+	m.outcome.Roll = roll
+	m.outcome.Total = roll + folded.AttackBonus
+	m.outcome.TargetAC = folded.TargetAC
+	m.outcome.Critical = roll >= folded.CriticalThreshold
+	m.outcome.Folded = folded
+
+	switch {
+	case roll == 1:
+		m.outcome.Hit = false
+	case m.outcome.Critical:
+		m.outcome.Hit = true
+	default:
+		m.outcome.Hit = m.outcome.Total >= folded.TargetAC
+	}
+
+	if !m.outcome.Hit {
+		// A miss ends the strike here: no damage, and no save. The rider the
+		// action declares is gated on the blow landing, so a bite that misses
+		// rolls no save (rpg-toolkit#962's residual).
+		return Done{Outcome: m.outcome}, nil
+	}
+
+	return m.rollDamage(ctx, roller)
+}
+
+// rollDamage rolls the action's damage dice and yields the fold that lets
+// effects modify it (ADR-0026's Resolve).
+func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Step, error) {
+	pool, err := dice.ParseNotation(m.attack.damageDice)
+	if err != nil {
+		return nil, fmt.Errorf("%w: damage dice %q: %w", ErrBadAttack, m.attack.damageDice, err)
+	}
+
+	result := pool.RollContext(ctx, roller)
+	if result.Error() != nil {
+		return nil, fmt.Errorf("roll damage: %w", result.Error())
+	}
+
+	rolled := 0
+	for _, group := range result.Rolls() {
+		for _, die := range group {
+			rolled += die
+		}
+	}
+
+	component := dnd5eEvents.DamageComponent{
+		Source:            dnd5eEvents.DamageSourceWeapon,
+		SourceRef:         &m.in.Action.Ref,
+		OriginalDiceRolls: []int{rolled},
+		FinalDiceRolls:    []int{rolled},
+		DamageType:        damage.Type(m.attack.damageType),
+		IsCritical:        m.outcome.Critical,
+	}
+
+	return foldDamage(&combat.ResolveDamageInput{
+		AttackerID:   m.in.AttackerID,
+		TargetID:     m.in.TargetID,
+		Components:   []dnd5eEvents.DamageComponent{component},
+		IsCritical:   m.outcome.Critical,
+		HasAdvantage: len(m.outcome.Folded.AdvantageSources) > 0,
+		WeaponDamage: m.attack.damageDice,
+		IsMelee:      true,
+		WeaponRef:    &m.in.Action.Ref,
+	}, m.afterDamageChain), nil
+}
+
+// afterDamageChain applies what the fold settled on — bus-free, straight onto
+// the sheet — and then yields the notification (ADR-0026's Apply, then Notify).
+func (m *strikeMachine) afterDamageChain(
+	ctx context.Context, resolved *combat.ResolveDamageOutput,
+) (Step, error) {
+	target, err := combatantFor(m.cast, m.in.TargetID)
+	if err != nil {
+		return nil, err
+	}
+
+	instances := make([]combat.DamageInstance, 0, len(resolved.FinalInstances))
+	for _, instance := range resolved.FinalInstances {
+		instances = append(instances, combat.DamageInstance{
+			Amount: instance.Amount,
+			Type:   string(instance.Type),
+		})
+	}
+
+	// Bus-free, and the only phase that is: applying damage is the sheet's own
+	// business and takes no bus on either a character or a monster.
+	applied := target.ApplyDamage(ctx, &combat.ApplyDamageInput{
+		Instances:  instances,
+		IsCritical: m.outcome.Critical,
+	})
+	m.outcome.Damage = applied.TotalDamage
+
+	return m.afterDamage(ctx)
+}
+
+// afterDamage would be where ADR-0026's Notify goes, and deliberately is not.
+//
+// Publishing DamageReceivedEvent here applies the damage a SECOND time to a
+// monster target: monster.SheetKeeper subscribes to that topic and its handler
+// calls TakeDamage, so the event is an instruction to that listener rather than
+// a notification. Measured, not assumed — a 4-damage bite took a wolf from 11
+// to 3 with the publish in place. A character has no such handler, so the same
+// event is inert for half the roster: the topic means two different things
+// depending on who is listening.
+//
+// That is the rules-versus-notification classification #965 slice 2 exists to
+// make, arriving as evidence rather than as opinion, so slice 1 applies damage
+// once and announces nothing. What it costs is real and worth naming: Undead
+// Fortitude listens to this topic legitimately, and does not fire here. It
+// converts with its gate (#977), by which point the double-apply is gone.
+//
+// Divestment debt — #965 slice 2.
+func (m *strikeMachine) afterDamage(ctx context.Context) (Step, error) {
+	return m.afterNotify(ctx)
+}
+
+// afterNotify contests the blow's rider, if it declared one.
+func (m *strikeMachine) afterNotify(_ context.Context) (Step, error) {
+	if m.attack.gate == nil {
+		return Done{Outcome: m.outcome}, nil
+	}
+
+	return requestContest(&ContestInput{
+		Gate:        m.attack.gate,
+		SaverID:     m.in.TargetID,
+		Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+		DamageTaken: m.outcome.Damage,
+		Roller:      m.in.Roller,
+	}, func(_ context.Context, contest ContestOutcome) (Step, error) {
+		m.outcome.Contest = &contest
+
+		return Done{Outcome: m.outcome}, nil
+	}), nil
+}
+
+// decodeStrikeProfile reads an action's numbers out of the data content
+// declares it with.
+//
+// One ref for slice 1. An action this build cannot read is refused by name
+// rather than treated as a generic swing, because guessing an attack bonus is
+// how a stat block starts lying again.
+func decodeStrikeProfile(action monster.ActionData) (strikeProfile, error) {
+	if action.Ref.ID != refs.MonsterActions.Bite().ID {
+		return strikeProfile{}, fmt.Errorf("%w: %q (slice 1 understands the bite)", ErrBadAttack, action.Ref.ID)
+	}
+
+	var config monsterActions.BiteConfig
+	if len(action.Config) > 0 {
+		if err := json.Unmarshal(action.Config, &config); err != nil {
+			return strikeProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
+		}
+	}
+
+	if config.DamageDice == "" {
+		return strikeProfile{}, fmt.Errorf("%w: the action declares no damage dice", ErrBadAttack)
+	}
+
+	profile := strikeProfile{
+		attackBonus: config.AttackBonus,
+		damageDice:  config.DamageDice,
+		damageType:  string(config.DamageType),
+		gate:        config.SaveGate,
+	}
+
+	// A bite persisted by an older build carries a bare knockdown DC rather
+	// than a gate; NewBiteAction is what translates it, so the profile comes
+	// through the action rather than the config when the gate is absent.
+	if profile.gate == nil {
+		if bite, ok := mustLoadBite(action); ok {
+			profile.gate = bite.SaveGate()
+		}
+	}
+
+	return profile, nil
+}
+
+// mustLoadBite reconstitutes the action so its own loader can apply whatever
+// translation the content needs. Failure is not fatal: the numbers are already
+// decoded, and only the gate would be missing.
+func mustLoadBite(action monster.ActionData) (*monsterActions.BiteAction, bool) {
+	loaded, err := monsterActions.LoadAction(action)
+	if err != nil {
+		return nil, false
+	}
+
+	bite, ok := loaded.(*monsterActions.BiteAction)
+
+	return bite, ok
+}
+
+// combatantFor finds a participant's sheet as something that can be hit.
+func combatantFor(cast *Participants, id string) (combat.Combatant, error) {
+	if character, ok := cast.Character(id); ok {
+		return character, nil
+	}
+	if monster, ok := cast.Monster(id); ok {
+		return monster, nil
+	}
+
+	return nil, fmt.Errorf("%w: %q", ErrNoCombatant, id)
+}
+
+// rollTwice rolls two d20s and picks one, which is what advantage and
+// disadvantage each are.
+func rollTwice(ctx context.Context, roller dice.Roller, pick func(a, b int) int) (int, error) {
+	rolls, err := roller.RollN(ctx, 2, 20)
+	if err != nil {
+		return 0, err
+	}
+	if len(rolls) < 2 {
+		return 0, fmt.Errorf("%w: roller returned %d dice for a pair", ErrBadAttack, len(rolls))
+	}
+
+	return pick(rolls[0], rolls[1]), nil
+}
+
+func takeHigher(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}
+
+func takeLower(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+// gatherAttack builds the step that folds the attack chain.
+//
+// A genuine fold, and the phase where prone's range predicate fires: it reads
+// both combatants' positions out of the room this interaction installed, and
+// answers advantage from within five feet, disadvantage from beyond.
+func gatherAttack(
+	event dnd5eEvents.AttackChainEvent,
+	next func(context.Context, dnd5eEvents.AttackChainEvent) (Step, error),
+) Gather {
+	return Gather{
+		name: "attack chain",
+		run: func(ctx context.Context, bus events.EventBus) (Step, error) {
+			chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+
+			modified, err := dnd5eEvents.AttackChain.On(bus).PublishWithChain(ctx, event, chain)
+			if err != nil {
+				return nil, fmt.Errorf("publish attack chain: %w", err)
+			}
+
+			folded, err := modified.Execute(ctx, event)
+			if err != nil {
+				return nil, fmt.Errorf("execute attack chain: %w", err)
+			}
+
+			return next(ctx, folded)
+		},
+	}
+}
+
+// foldDamage builds the step that folds the damage chain.
+//
+// **Divestment debt — #965 slice 2.** This hands resolution's own bus to
+// combat.ResolveDamage, which folds the chain itself. Functionally it is the
+// save precedent — the fold happens on the interaction's bus either way, since
+// resolution attached every subscriber to it — and what differs is custody of
+// the fold mechanics. There is no bus-free alternative to call: every exported
+// attack and damage entry point in combat requires a bus, and the arithmetic
+// that applies resistance and vulnerability is unexported, so folding here
+// would mean reimplementing damage multipliers. Slice 2 retires this.
+func foldDamage(
+	in *combat.ResolveDamageInput,
+	next func(context.Context, *combat.ResolveDamageOutput) (Step, error),
+) Gather {
+	return Gather{
+		name: "damage chain",
+		run: func(ctx context.Context, bus events.EventBus) (Step, error) {
+			in.EventBus = bus
+
+			resolved, err := combat.ResolveDamage(ctx, in)
+			if err != nil {
+				return nil, fmt.Errorf("resolve damage: %w", err)
+			}
+
+			return next(ctx, resolved)
+		},
+	}
+}
+
+// requestContest builds the Request step for a contested rider, typed so the
+// requester resumes with a ContestOutcome.
+func requestContest(in *ContestInput, next func(context.Context, ContestOutcome) (Step, error)) Request {
+	return Request{
+		name:    "contest",
+		machine: NewContest(in),
+		next: func(ctx context.Context, out Outcome) (Step, error) {
+			contest, ok := out.(ContestOutcome)
+			if !ok {
+				return nil, fmt.Errorf("%w: contest produced %T", ErrBadStep, out)
+			}
+
+			return next(ctx, contest)
+		},
+	}
+}

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -212,17 +212,22 @@ func (m *strikeMachine) afterAttackChain(ctx context.Context, folded dnd5eEvents
 	m.outcome.Roll = roll
 	m.outcome.Total = roll + folded.AttackBonus
 	m.outcome.TargetAC = folded.TargetAC
-	m.outcome.Critical = roll >= folded.CriticalThreshold
 	m.outcome.Folded = folded
 
+	// A natural 20 is the only automatic hit and a natural 1 the only
+	// automatic miss; everything between is arithmetic. The crit range is
+	// not a hit range: an effect that widens CriticalThreshold to 19–20
+	// widens which HITS crit, never which rolls hit — a 19 that cannot
+	// reach the AC is still a miss.
 	switch {
+	case roll == 20:
+		m.outcome.Hit = true
 	case roll == 1:
 		m.outcome.Hit = false
-	case m.outcome.Critical:
-		m.outcome.Hit = true
 	default:
 		m.outcome.Hit = m.outcome.Total >= folded.TargetAC
 	}
+	m.outcome.Critical = m.outcome.Hit && roll >= folded.CriticalThreshold
 
 	if !m.outcome.Hit {
 		// A miss ends the strike here: no damage, and no save. The rider the
@@ -247,18 +252,30 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 		return nil, fmt.Errorf("roll damage: %w", result.Error())
 	}
 
-	rolled := 0
-	for _, group := range result.Rolls() {
-		for _, die := range group {
-			rolled += die
+	// Per-die, not summed: OriginalDiceRolls/FinalDiceRolls are a per-die
+	// contract — downstream rerolls address dice by index — and the
+	// notation's static modifier is not a die, so it rides FlatBonus and is
+	// never doubled.
+	rolls := flattenDice(result.Rolls())
+
+	// A critical hit doubles the weapon pool's DICE and nothing else
+	// (ADR-0036: only the weapon pool doubles, and a flat modifier is not a
+	// die). Combat's fold records IsCritical but rolls nothing, so the
+	// doubling happens here, where the dice are.
+	if m.outcome.Critical {
+		again := pool.RollContext(ctx, roller)
+		if again.Error() != nil {
+			return nil, fmt.Errorf("roll critical damage: %w", again.Error())
 		}
+		rolls = append(rolls, flattenDice(again.Rolls())...)
 	}
 
 	component := dnd5eEvents.DamageComponent{
 		Source:            dnd5eEvents.DamageSourceWeapon,
 		SourceRef:         &m.in.Action.Ref,
-		OriginalDiceRolls: []int{rolled},
-		FinalDiceRolls:    []int{rolled},
+		OriginalDiceRolls: rolls,
+		FinalDiceRolls:    append([]int(nil), rolls...),
+		FlatBonus:         result.Modifier(),
 		DamageType:        damage.Type(m.attack.damageType),
 		IsCritical:        m.outcome.Critical,
 	}
@@ -276,7 +293,11 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 }
 
 // afterDamageChain applies what the fold settled on — bus-free, straight onto
-// the sheet — and then yields the notification (ADR-0026's Apply, then Notify).
+// the sheet (ADR-0026's Apply). Notify is deliberately absent: publishing
+// DamageReceivedEvent would apply the damage a second time to a monster
+// target, whose sheet-keeper treats that topic as an instruction — the
+// one-topic-two-meanings finding #965 slice 2 owes a classification for.
+// Pinned by TestAMonsterTargetTakesItsDamageOnce.
 func (m *strikeMachine) afterDamageChain(
 	ctx context.Context, resolved *combat.ResolveDamageOutput,
 ) (Step, error) {
@@ -497,6 +518,18 @@ func foldDamage(
 			return next(ctx, resolved)
 		},
 	}
+}
+
+// flattenDice collapses a pool's grouped rolls into one per-die list, in roll
+// order. Per-die rather than summed because OriginalDiceRolls/FinalDiceRolls
+// are a per-die contract — downstream rerolls address dice by index.
+func flattenDice(groups [][]int) []int {
+	var dice []int
+	for _, group := range groups {
+		dice = append(dice, group...)
+	}
+
+	return dice
 }
 
 // requestContest builds the Request step for a contested rider, typed so the

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
@@ -27,11 +28,10 @@ const criticalThreshold = 20
 
 // StrikeInput describes one attack.
 //
-// The attack itself arrives as content — the action's persisted data, exactly
-// as a monster's stat block carries it — rather than as a runtime object with
-// its numbers pulled out. That is the same seam every other input here uses,
-// and it is what lets the headline test drive the catalog wolf's own bite
-// instead of a hand-built approximation of it.
+// The attack arrives as an [AttackProfile] — attacker-kind-neutral, compiled
+// at the seam from whatever persisted form the attacker has. The headline
+// tests still drive the catalog wolf's own bite: content in, one compilation
+// step, machine unchanged.
 type StrikeInput struct {
 	// AttackerID names the participant swinging.
 	AttackerID string
@@ -39,12 +39,51 @@ type StrikeInput struct {
 	// TargetID names the participant being swung at.
 	TargetID string
 
-	// Action is the attack, as the content declares it. Slice 1 understands
-	// the bite; another ref is refused by name rather than guessed at.
-	Action monster.ActionData
+	// Attack is the attack's numbers, attacker-kind-neutral. The machine
+	// never learns who compiled them: a monster action converts through
+	// AttackFromMonsterAction, and a character's weapon-plus-sheet compiles
+	// through a sibling constructor when it arrives (rpg-toolkit#1003). The
+	// phases are the same swing either way — only the compilation differs.
+	Attack AttackProfile
 
 	// Roller rolls the attack and its damage. Nil takes the default roller.
 	Roller dice.Roller
+}
+
+// AttackProfile is what a strike needs to know about an attack, whoever is
+// making it. It is derived at strike time, never persisted: the persisted
+// forms are the monster's action data and the character's sheet, and each
+// compiles into this shape at the seam.
+type AttackProfile struct {
+	// Ref names the attack for attribution — the weapon or action behind
+	// the swing.
+	Ref *core.Ref
+
+	// AttackBonus is added to the d20.
+	AttackBonus int
+
+	// DamageDice is the weapon pool's notation ("2d4+2").
+	DamageDice string
+
+	// DamageType is what kind of harm lands.
+	DamageType damage.Type
+
+	// Gate is the rider's contest, if the attack declares one (ADR-0039).
+	// Nil means the attack just hits.
+	Gate *saves.SaveGate
+}
+
+// validate refuses a profile that cannot drive a strike, naming what is
+// missing. Constructors produce valid profiles; this catches the hand-built.
+func (p *AttackProfile) validate() error {
+	if p.Ref == nil {
+		return fmt.Errorf("%w: the attack names no ref", ErrBadAttack)
+	}
+	if p.DamageDice == "" {
+		return fmt.Errorf("%w: the attack declares no damage dice", ErrBadAttack)
+	}
+
+	return nil
 }
 
 // StrikeOutcome is what an attack produced, in enough detail to explain it.
@@ -110,24 +149,12 @@ type strikeMachine struct {
 	// the first needs them and a step's closure is handed only a bus.
 	cast *Participants
 
-	// attack is the content's numbers, decoded once.
-	attack strikeProfile
-
 	// outcome accumulates across phases. It is the machine's whole state, and
 	// the reason a suspension between any two phases would need nothing else.
 	outcome StrikeOutcome
 }
 
-// strikeProfile is what this machine needs to know about an attack, decoded
-// from whatever action data it was handed.
-type strikeProfile struct {
-	attackBonus int
-	damageDice  string
-	damageType  string
-	gate        *saves.SaveGate
-}
-
-// Start decodes the action, reads the target's AC, and folds the attack chain.
+// Start validates the profile, reads the target's AC, and folds the attack chain.
 func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, error) {
 	if m.in == nil {
 		return nil, ErrNilInput
@@ -135,14 +162,11 @@ func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, erro
 	if m.in.AttackerID == "" || m.in.TargetID == "" {
 		return nil, fmt.Errorf("%w: a strike needs an attacker and a target", ErrNilInput)
 	}
-
-	m.cast = cast
-
-	profile, err := decodeStrikeProfile(m.in.Action)
-	if err != nil {
+	if err := m.in.Attack.validate(); err != nil {
 		return nil, err
 	}
-	m.attack = profile
+
+	m.cast = cast
 
 	if _, err := combatantFor(cast, m.in.AttackerID); err != nil {
 		return nil, err
@@ -166,9 +190,9 @@ func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, erro
 	event := dnd5eEvents.AttackChainEvent{
 		AttackerID:        m.in.AttackerID,
 		TargetID:          m.in.TargetID,
-		WeaponRef:         &m.in.Action.Ref,
+		WeaponRef:         m.in.Attack.Ref,
 		IsMelee:           true,
-		AttackBonus:       profile.attackBonus,
+		AttackBonus:       m.in.Attack.AttackBonus,
 		TargetAC:          target.AC(),
 		CriticalThreshold: criticalThreshold,
 	}
@@ -242,9 +266,9 @@ func (m *strikeMachine) afterAttackChain(ctx context.Context, folded dnd5eEvents
 // rollDamage rolls the action's damage dice and yields the fold that lets
 // effects modify it (ADR-0026's Resolve).
 func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Step, error) {
-	pool, err := dice.ParseNotation(m.attack.damageDice)
+	pool, err := dice.ParseNotation(m.in.Attack.DamageDice)
 	if err != nil {
-		return nil, fmt.Errorf("%w: damage dice %q: %w", ErrBadAttack, m.attack.damageDice, err)
+		return nil, fmt.Errorf("%w: damage dice %q: %w", ErrBadAttack, m.in.Attack.DamageDice, err)
 	}
 
 	result := pool.RollContext(ctx, roller)
@@ -272,11 +296,11 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 
 	component := dnd5eEvents.DamageComponent{
 		Source:            dnd5eEvents.DamageSourceWeapon,
-		SourceRef:         &m.in.Action.Ref,
+		SourceRef:         m.in.Attack.Ref,
 		OriginalDiceRolls: rolls,
 		FinalDiceRolls:    append([]int(nil), rolls...),
 		FlatBonus:         result.Modifier(),
-		DamageType:        damage.Type(m.attack.damageType),
+		DamageType:        m.in.Attack.DamageType,
 		IsCritical:        m.outcome.Critical,
 	}
 
@@ -286,9 +310,9 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 		Components:   []dnd5eEvents.DamageComponent{component},
 		IsCritical:   m.outcome.Critical,
 		HasAdvantage: len(m.outcome.Folded.AdvantageSources) > 0,
-		WeaponDamage: m.attack.damageDice,
+		WeaponDamage: m.in.Attack.DamageDice,
 		IsMelee:      true,
-		WeaponRef:    &m.in.Action.Ref,
+		WeaponRef:    m.in.Attack.Ref,
 	}, m.afterDamageChain), nil
 }
 
@@ -348,12 +372,12 @@ func (m *strikeMachine) afterDamage(ctx context.Context) (Step, error) {
 
 // afterNotify contests the blow's rider, if it declared one.
 func (m *strikeMachine) afterNotify(_ context.Context) (Step, error) {
-	if m.attack.gate == nil {
+	if m.in.Attack.Gate == nil {
 		return Done{Outcome: m.outcome}, nil
 	}
 
 	return requestContest(&ContestInput{
-		Gate:        m.attack.gate,
+		Gate:        m.in.Attack.Gate,
 		SaverID:     m.in.TargetID,
 		Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
 		DamageTaken: m.outcome.Damage,
@@ -365,41 +389,45 @@ func (m *strikeMachine) afterNotify(_ context.Context) (Step, error) {
 	}), nil
 }
 
-// decodeStrikeProfile reads an action's numbers out of the data content
-// declares it with.
+// AttackFromMonsterAction compiles a monster action's persisted data into the
+// neutral profile a strike consumes. This is the monster half of the seam
+// StrikeInput.Attack names; a character's weapon-plus-sheet compiler is its
+// sibling (rpg-toolkit#1003) and the machine cannot tell them apart.
 //
 // One ref for slice 1. An action this build cannot read is refused by name
 // rather than treated as a generic swing, because guessing an attack bonus is
 // how a stat block starts lying again.
-func decodeStrikeProfile(action monster.ActionData) (strikeProfile, error) {
+func AttackFromMonsterAction(action monster.ActionData) (AttackProfile, error) {
 	if action.Ref.ID != refs.MonsterActions.Bite().ID {
-		return strikeProfile{}, fmt.Errorf("%w: %q (slice 1 understands the bite)", ErrBadAttack, action.Ref.ID)
+		return AttackProfile{}, fmt.Errorf("%w: %q (slice 1 understands the bite)", ErrBadAttack, action.Ref.ID)
 	}
 
 	var config monsterActions.BiteConfig
 	if len(action.Config) > 0 {
 		if err := json.Unmarshal(action.Config, &config); err != nil {
-			return strikeProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
+			return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
 		}
 	}
 
 	if config.DamageDice == "" {
-		return strikeProfile{}, fmt.Errorf("%w: the action declares no damage dice", ErrBadAttack)
+		return AttackProfile{}, fmt.Errorf("%w: the action declares no damage dice", ErrBadAttack)
 	}
 
-	profile := strikeProfile{
-		attackBonus: config.AttackBonus,
-		damageDice:  config.DamageDice,
-		damageType:  string(config.DamageType),
-		gate:        config.SaveGate,
+	ref := action.Ref
+	profile := AttackProfile{
+		Ref:         &ref,
+		AttackBonus: config.AttackBonus,
+		DamageDice:  config.DamageDice,
+		DamageType:  config.DamageType,
+		Gate:        config.SaveGate,
 	}
 
 	// A bite persisted by an older build carries a bare knockdown DC rather
 	// than a gate; NewBiteAction is what translates it, so the profile comes
 	// through the action rather than the config when the gate is absent.
-	if profile.gate == nil {
+	if profile.Gate == nil {
 		if bite, ok := mustLoadBite(action); ok {
-			profile.gate = bite.SaveGate()
+			profile.Gate = bite.SaveGate()
 		}
 	}
 

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -219,10 +219,10 @@ func (m *strikeMachine) afterAttackChain(ctx context.Context, folded dnd5eEvents
 	// not a hit range: an effect that widens CriticalThreshold to 19–20
 	// widens which HITS crit, never which rolls hit — a 19 that cannot
 	// reach the AC is still a miss.
-	switch {
-	case roll == 20:
+	switch roll {
+	case 20:
 		m.outcome.Hit = true
-	case roll == 1:
+	case 1:
 		m.outcome.Hit = false
 	default:
 		m.outcome.Hit = m.outcome.Total >= folded.TargetAC

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -596,3 +596,60 @@ func (s *StrikeTestSuite) wolfAttack() AttackProfile {
 
 	return profile
 }
+
+// The compiler's second source: a stat-block weapon. The skeleton's shortsword
+// is a generic MeleeAction — proof the profile seam is attack-kind-neutral on
+// the monster side too, and that a weapon with no gate just hits.
+func (s *StrikeTestSuite) TestASkeletonSwingsItsShortsword() {
+	skeleton := monsters.NewSkeleton("skeleton").ToData()
+
+	var sword monster.ActionData
+	found := false
+	for _, action := range skeleton.Actions {
+		if action.Ref.ID == refs.MonsterActions.Melee().ID {
+			sword, found = action, true
+			break
+		}
+	}
+	s.Require().True(found, "the catalog skeleton carries a melee weapon")
+
+	attack, err := AttackFromMonsterAction(sword)
+	s.Require().NoError(err)
+	s.Require().Nil(attack.Gate, "a plain weapon declares no rider")
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: "skeleton", Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	out, err := Resolve(s.ctx, &Input{
+		World: enc.ToData(),
+		Participants: []Participant{
+			{Character: s.hero()},
+			{Monster: skeleton},
+		},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: "skeleton",
+			TargetID:   heroID,
+			Attack:     attack,
+			Roller:     &sequenceRoller{singles: []int{hitRoll}, pair: []int{3}, fallback: 2},
+		}),
+	})
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().True(outcome.Hit, "15 + 4 beats AC 14")
+	s.Require().Equal(3+2, outcome.Damage, "1d6 rolled [3], plus the +2 — exact, not merely positive")
+	s.Require().Nil(outcome.Contest, "no gate, no save, nobody falls over")
+
+	s.Require().Len(out.DirtyCharacters, 1)
+	s.Require().Equal(14-5, out.DirtyCharacters[0].HitPoints)
+	s.Require().Empty(out.DirtyCharacters[0].Conditions)
+}

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -1,0 +1,458 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+const secondWolfID = "wolf-2"
+
+// hitRoll beats the hero's AC 14 with the wolf's +4; missRoll does not.
+const (
+	hitRoll  = 15
+	missRoll = 4
+)
+
+// sequenceRoller answers each Roll from a queue, so one interaction can script
+// several different dice — an attack that hits and then a save that fails,
+// which a single fixed value cannot express. RollN takes the fallback unless a
+// pair is queued, which is what the damage dice consume.
+type sequenceRoller struct {
+	singles  []int
+	pair     []int
+	fallback int
+}
+
+func (r *sequenceRoller) Roll(_ context.Context, _ int) (int, error) {
+	if len(r.singles) > 0 {
+		next := r.singles[0]
+		r.singles = r.singles[1:]
+
+		return next, nil
+	}
+
+	return r.fallback, nil
+}
+
+func (r *sequenceRoller) RollN(_ context.Context, count, _ int) ([]int, error) {
+	if len(r.pair) >= count {
+		next := r.pair[:count]
+		r.pair = r.pair[count:]
+
+		return next, nil
+	}
+
+	out := make([]int, count)
+	for i := range out {
+		out[i] = r.fallback
+	}
+
+	return out, nil
+}
+
+// StrikeTestSuite drives the whole lane against catalog content: the wolf's own
+// bite, the wolf's own gate, the prone condition's own range predicate.
+type StrikeTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestStrikeSuite(t *testing.T) {
+	suite.Run(t, new(StrikeTestSuite))
+}
+
+func (s *StrikeTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// wolfBite is the catalog wolf's bite as content persists it — the action data
+// the strike machine reads its numbers out of.
+func (s *StrikeTestSuite) wolfBite() monster.ActionData {
+	data := monsters.NewWolf(wolfID).ToData()
+	s.Require().Len(data.Actions, 1)
+
+	return data.Actions[0]
+}
+
+// world places the hero and both wolves. adjacent puts wolf-2 one cell from the
+// hero; otherwise it stands three cells away — the two sides of prone's range
+// split.
+func (s *StrikeTestSuite) world(secondWolfAt spatial.Position) encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: secondWolfID, Kind: encounter.KindMonster, Room: "room-1", Position: secondWolfAt},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+// hero has AC 14 and a +5 STR save: the wolf's +4 bite needs an 10 to hit, and
+// its DC 11 knockdown is a real contest.
+func (s *StrikeTestSuite) hero(conds ...json.RawMessage) *character.Data {
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ArmorClass:       14,
+		ProficiencyBonus: 2,
+		SavingThrows: map[abilities.Ability]shared.ProficiencyLevel{
+			abilities.STR: shared.Proficient,
+		},
+		Conditions: conds,
+	}
+}
+
+func (s *StrikeTestSuite) wolf(id string) *monster.Data {
+	data := monsters.NewWolf(id).ToData()
+
+	return data
+}
+
+func (s *StrikeTestSuite) raging() json.RawMessage {
+	raw, err := (&conditions.RagingCondition{
+		CharacterID: heroID,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// strike builds the interaction one wolf's bite raises against the hero.
+func (s *StrikeTestSuite) strike(attacker string, roller *scriptedRoller) Machine {
+	return NewStrike(&StrikeInput{
+		AttackerID: attacker,
+		TargetID:   heroID,
+		Action:     s.wolfBite(),
+		Roller:     roller,
+	})
+}
+
+func (s *StrikeTestSuite) resolve(
+	world encounter.EncounterData, hero *character.Data, machine Machine,
+) (*Output, error) {
+	return Resolve(s.ctx, &Input{
+		World: world,
+		Participants: []Participant{
+			{Character: hero},
+			{Monster: s.wolf(wolfID)},
+			{Monster: s.wolf(secondWolfID)},
+		},
+		Machine: machine,
+	})
+}
+
+func (s *StrikeTestSuite) strikeOutcome(out *Output) StrikeOutcome {
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok, "a strike produces a StrikeOutcome")
+
+	return outcome
+}
+
+// THE HEADLINE. The wolf's stat block is the whole input: its bite's attack
+// bonus, its damage dice, and its declared knockdown. One Resolve later the
+// hero has taken damage and is on the floor, in the data that comes back to be
+// persisted.
+func (s *StrikeTestSuite) TestAWolfBitesTheHeroAndKnocksHimDown() {
+	// The attack rolls 15 (+4 beats AC 14); the damage dice take the fallback;
+	// the hero's STR save then rolls 4, and 4 + 5 is under the gate's DC 11.
+	out, err := s.resolve(s.world(spatial.Position{X: 8, Y: 5}), s.hero(), NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		Action:     s.wolfBite(),
+		Roller:     &sequenceRoller{singles: []int{hitRoll, missRoll}, fallback: 2},
+	}))
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().True(outcome.Hit, "15 + 4 beats AC 14")
+	s.Require().Equal(14, outcome.TargetAC)
+	s.Require().Positive(outcome.Damage, "a bite that lands does damage")
+
+	s.Require().NotNil(outcome.Contest, "the bite declares a knockdown, so it was contested")
+	s.Require().False(outcome.Contest.Succeeded, "the save rolled 4, and 4 + 5 is under DC 11")
+	s.Require().Equal(11, outcome.Contest.DC)
+
+	s.Require().Len(out.DirtyCharacters, 1)
+	hero := out.DirtyCharacters[0]
+	s.Require().Less(hero.HitPoints, 14, "the damage is on the sheet")
+	s.Require().Len(hero.Conditions, 1)
+	s.Require().Contains(string(hero.Conditions[0]), refs.Conditions.Prone().ID)
+}
+
+// #962's residual, and the reason it could not be pinned there: a bite that
+// misses rolls no save. Nothing here decides not to — the contest is simply
+// never requested, because the strike ends at the miss.
+func (s *StrikeTestSuite) TestABiteThatMissesRollsNoSave() {
+	out, err := s.resolve(s.world(spatial.Position{X: 8, Y: 5}), s.hero(),
+		s.strike(wolfID, &scriptedRoller{single: missRoll, pair: []int{missRoll, missRoll}}))
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().False(outcome.Hit, "4 + 4 does not reach AC 14")
+	s.Require().Zero(outcome.Damage, "and a miss does no damage")
+	s.Require().Nil(outcome.Contest, "and rolls no save")
+
+	s.Require().Empty(out.DirtyCharacters, "nothing about the hero changed")
+}
+
+// Prone's range predicate, near half — and the reason WithRoom lands in this
+// PR. The hero is already prone; the second wolf is one cell away, so its bite
+// has advantage.
+func (s *StrikeTestSuite) TestASecondBiteFromAdjacentHasAdvantage() {
+	out, err := s.resolve(
+		s.world(spatial.Position{X: 5, Y: 4}), // one cell from the hero at (5,5)
+		s.hero(s.proneBlob()),
+		s.strike(secondWolfID, &scriptedRoller{single: missRoll, pair: []int{missRoll, hitRoll}}),
+	)
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().Equal(hitRoll, outcome.Roll, "only a rolled-twice-take-higher can produce this die")
+	s.Require().Len(outcome.Folded.AdvantageSources, 1)
+	s.Require().Equal(refs.Conditions.Prone(), outcome.Folded.AdvantageSources[0].SourceRef)
+	s.Require().Empty(outcome.Folded.DisadvantageSources)
+}
+
+// Prone's range predicate, far half. Same prone hero, same roller — the wolf
+// three cells away rolls at disadvantage instead, and takes the lower die.
+func (s *StrikeTestSuite) TestASecondBiteFromRangeHasDisadvantage() {
+	out, err := s.resolve(
+		s.world(spatial.Position{X: 8, Y: 5}), // three cells from the hero
+		s.hero(s.proneBlob()),
+		s.strike(secondWolfID, &scriptedRoller{single: hitRoll, pair: []int{missRoll, hitRoll}}),
+	)
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().Equal(missRoll, outcome.Roll, "only a rolled-twice-take-lower can produce this die")
+	s.Require().Len(outcome.Folded.DisadvantageSources, 1)
+	s.Require().Equal(refs.Conditions.Prone(), outcome.Folded.DisadvantageSources[0].SourceRef)
+	s.Require().Empty(outcome.Folded.AdvantageSources)
+}
+
+// proneBlob is the persisted prone condition, so the hero starts the
+// interaction already on the floor.
+func (s *StrikeTestSuite) proneBlob() json.RawMessage {
+	raw, err := conditions.NewProneCondition(heroID).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// An effect on the target folds into the attack chain, attributed to its own
+// ref — the same seam prone uses, proving the fold is general rather than
+// prone-shaped. Dodging imposes disadvantage on attacks against its owner.
+func (s *StrikeTestSuite) TestDodgingFoldsIntoTheAttackChain() {
+	dodging, err := conditions.NewDodgingCondition(heroID).ToJSON()
+	s.Require().NoError(err)
+
+	out, resolveErr := s.resolve(s.world(spatial.Position{X: 8, Y: 5}), s.hero(dodging),
+		s.strike(wolfID, &scriptedRoller{single: hitRoll, pair: []int{missRoll, hitRoll}}))
+	s.Require().NoError(resolveErr)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().Equal(missRoll, outcome.Roll, "disadvantage took the lower die")
+	s.Require().Len(outcome.Folded.DisadvantageSources, 1)
+	s.Require().Equal(refs.Conditions.Dodging(), outcome.Folded.DisadvantageSources[0].SourceRef)
+}
+
+// Two machines and four phases, one registration list: the ledger is the
+// participants' and does not depend on the order they were passed in (R4).
+func (s *StrikeTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
+	world := s.world(spatial.Position{X: 8, Y: 5})
+	roller := func() *scriptedRoller {
+		return &scriptedRoller{single: hitRoll, pair: []int{hitRoll, hitRoll}}
+	}
+
+	forward, err := Resolve(s.ctx, &Input{
+		World: world,
+		Participants: []Participant{
+			{Character: s.hero(s.raging())},
+			{Monster: s.wolf(wolfID)},
+			{Monster: s.wolf(secondWolfID)},
+		},
+		Machine: s.strike(wolfID, roller()),
+	})
+	s.Require().NoError(err)
+
+	reversed, err := Resolve(s.ctx, &Input{
+		World: world,
+		Participants: []Participant{
+			{Monster: s.wolf(secondWolfID)},
+			{Monster: s.wolf(wolfID)},
+			{Character: s.hero(s.raging())},
+		},
+		Machine: s.strike(wolfID, roller()),
+	})
+	s.Require().NoError(err)
+
+	s.Require().NotEmpty(forward.Hooks)
+	s.Require().Equal(forward.Hooks, reversed.Hooks)
+}
+
+// RE-ENTERABILITY, DEMONSTRATED. The machine is driven by hand, one step at a
+// time, with the loop this test writes rather than the package's — which is
+// only possible because every phase boundary is a value the machine hands back
+// and the machine's own fields are the only state. A resolution that kept
+// anything on the Go stack between phases could not be walked like this, and
+// could not be suspended at one of them either.
+func (s *StrikeTestSuite) TestTheStrikeRunsInPieces() {
+	world := s.world(spatial.Position{X: 8, Y: 5})
+	surf := newSurface(events.NewEventBus())
+
+	room, err := interactionRoom(world, []Participant{{Character: s.hero()}, {Monster: s.wolf(wolfID)}})
+	s.Require().NoError(err)
+	s.Require().NotNil(room, "the participants share a room, so one is installed")
+
+	ctx := gamectx.WithRoom(s.ctx, room)
+	cast, err := attachAll(ctx, surf, []Participant{
+		{Character: s.hero()},
+		{Monster: s.wolf(wolfID)},
+	}, nil)
+	s.Require().NoError(err)
+
+	machine := s.strike(wolfID, &scriptedRoller{single: hitRoll, pair: []int{hitRoll, hitRoll}})
+
+	// Step one: the machine yields, and has done nothing else.
+	step, err := machine.Start(ctx, cast)
+	s.Require().NoError(err)
+
+	names := []string{}
+	for i := 0; i < 10; i++ {
+		switch typed := step.(type) {
+		case Done:
+			s.Require().Equal([]string{"attack chain", "damage chain"}, names,
+				"every phase boundary was a value this test drove by hand")
+
+			outcome, ok := typed.Outcome.(StrikeOutcome)
+			s.Require().True(ok)
+			s.Require().True(outcome.Hit)
+			s.Require().Positive(outcome.Damage)
+
+			return
+
+		case Gather:
+			names = append(names, typed.Name())
+			step, err = typed.run(ctx, surf)
+			s.Require().NoError(err)
+
+		case Request:
+			// The contest is a machine of its own; driving it is the same loop
+			// one level down, which is the point of the case existing.
+			out, runErr := drive(ctx, surf, typed.machine, cast)
+			s.Require().NoError(runErr)
+			step, err = typed.next(ctx, out)
+			s.Require().NoError(err)
+
+		default:
+			s.Require().Failf("unexpected step", "%T", step)
+		}
+	}
+
+	s.Require().Fail("the machine did not finish")
+}
+
+// Damage lands exactly once. It is applied to the sheet directly, and NOT
+// announced on DamageReceivedTopic — because a monster's own sheet keeper
+// subscribes to that topic and applies the damage again, which took this wolf
+// from 11 to 3 on a 4-damage bite before the publish came out. See
+// strikeMachine.afterDamage: the topic is an instruction to one listener and a
+// notification to another, which is slice 2's classification to make.
+func (s *StrikeTestSuite) TestAMonsterTargetTakesItsDamageOnce() {
+	out, err := Resolve(s.ctx, &Input{
+		World: s.world(spatial.Position{X: 5, Y: 4}),
+		Participants: []Participant{
+			{Character: s.hero()},
+			{Monster: s.wolf(wolfID)},
+			{Monster: s.wolf(secondWolfID)},
+		},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   secondWolfID,
+			Action:     s.wolfBite(),
+			Roller:     &sequenceRoller{singles: []int{hitRoll, missRoll}, fallback: 2},
+		}),
+	})
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().True(outcome.Hit)
+	s.Require().Positive(outcome.Damage)
+
+	s.Require().Len(out.DirtyMonsters, 1)
+	s.Require().Equal(secondWolfID, out.DirtyMonsters[0].ID)
+	s.Require().Equal(11-outcome.Damage, out.DirtyMonsters[0].HitPoints,
+		"exactly the damage the strike resolved, applied exactly once")
+}
+
+func (s *StrikeTestSuite) TestRefusesAStrikeItCannotRun() {
+	world := s.world(spatial.Position{X: 8, Y: 5})
+
+	s.Run("an action this build cannot read", func() {
+		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Action:     monster.ActionData{Ref: *refs.MonsterActions.Scimitar()},
+		}))
+		s.Require().ErrorIs(err, ErrBadAttack)
+	})
+
+	s.Run("a target who is not a participant", func() {
+		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   "nobody",
+			Action:     s.wolfBite(),
+		}))
+		s.Require().ErrorIs(err, ErrNoCombatant)
+	})
+
+	s.Run("no attacker or target named", func() {
+		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{Action: s.wolfBite()}))
+		s.Require().ErrorIs(err, ErrNilInput)
+	})
+}

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -170,7 +170,7 @@ func (s *StrikeTestSuite) strike(attacker string, roller *scriptedRoller) Machin
 	return NewStrike(&StrikeInput{
 		AttackerID: attacker,
 		TargetID:   heroID,
-		Action:     s.wolfBite(),
+		Attack:     s.wolfAttack(),
 		Roller:     roller,
 	})
 }
@@ -206,7 +206,7 @@ func (s *StrikeTestSuite) TestAWolfBitesTheHeroAndKnocksHimDown() {
 	out, err := s.resolve(s.world(spatial.Position{X: 8, Y: 5}), s.hero(), NewStrike(&StrikeInput{
 		AttackerID: wolfID,
 		TargetID:   heroID,
-		Action:     s.wolfBite(),
+		Attack:     s.wolfAttack(),
 		Roller:     &sequenceRoller{singles: []int{hitRoll, missRoll}, fallback: 2},
 	}))
 	s.Require().NoError(err)
@@ -417,7 +417,7 @@ func (s *StrikeTestSuite) TestAMonsterTargetTakesItsDamageOnce() {
 		Machine: NewStrike(&StrikeInput{
 			AttackerID: wolfID,
 			TargetID:   secondWolfID,
-			Action:     s.wolfBite(),
+			Attack:     s.wolfAttack(),
 			Roller:     &sequenceRoller{singles: []int{hitRoll, missRoll}, fallback: 2},
 		}),
 	})
@@ -436,11 +436,16 @@ func (s *StrikeTestSuite) TestAMonsterTargetTakesItsDamageOnce() {
 func (s *StrikeTestSuite) TestRefusesAStrikeItCannotRun() {
 	world := s.world(spatial.Position{X: 8, Y: 5})
 
-	s.Run("an action this build cannot read", func() {
+	s.Run("an action this build cannot read is refused at compilation", func() {
+		_, err := AttackFromMonsterAction(monster.ActionData{Ref: *refs.MonsterActions.Scimitar()})
+		s.Require().ErrorIs(err, ErrBadAttack)
+	})
+
+	s.Run("a hand-built profile with no dice is refused by the machine", func() {
 		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{
 			AttackerID: wolfID,
 			TargetID:   heroID,
-			Action:     monster.ActionData{Ref: *refs.MonsterActions.Scimitar()},
+			Attack:     AttackProfile{Ref: refs.MonsterActions.Bite()},
 		}))
 		s.Require().ErrorIs(err, ErrBadAttack)
 	})
@@ -449,13 +454,13 @@ func (s *StrikeTestSuite) TestRefusesAStrikeItCannotRun() {
 		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{
 			AttackerID: wolfID,
 			TargetID:   "nobody",
-			Action:     s.wolfBite(),
+			Attack:     s.wolfAttack(),
 		}))
 		s.Require().ErrorIs(err, ErrNoCombatant)
 	})
 
 	s.Run("no attacker or target named", func() {
-		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{Action: s.wolfBite()}))
+		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{Attack: s.wolfAttack()}))
 		s.Require().ErrorIs(err, ErrNilInput)
 	})
 }
@@ -509,7 +514,7 @@ func (s *StrikeTestSuite) TestAWidenedCritRangeDoesNotWidenTheHitRange() {
 		NewStrike(&StrikeInput{
 			AttackerID: wolfID,
 			TargetID:   heroID,
-			Action:     s.wolfBite(),
+			Attack:     s.wolfAttack(),
 			Roller:     &sequenceRoller{singles: []int{19}, fallback: 2},
 		}))
 	s.Require().NoError(err)
@@ -531,7 +536,7 @@ func (s *StrikeTestSuite) TestAWidenedCritRangeCritsOnAHit() {
 		NewStrike(&StrikeInput{
 			AttackerID: wolfID,
 			TargetID:   heroID,
-			Action:     s.wolfBite(),
+			Attack:     s.wolfAttack(),
 			Roller:     &sequenceRoller{singles: []int{19, 11}, pair: []int{3, 4, 1, 2}, fallback: 2},
 		}))
 	s.Require().NoError(err)
@@ -550,7 +555,7 @@ func (s *StrikeTestSuite) TestDamageKeepsItsFlatModifierExactlyOnce() {
 		NewStrike(&StrikeInput{
 			AttackerID: wolfID,
 			TargetID:   heroID,
-			Action:     s.wolfBite(),
+			Attack:     s.wolfAttack(),
 			Roller:     &sequenceRoller{singles: []int{hitRoll, 11}, pair: []int{3, 4}, fallback: 2},
 		}))
 	s.Require().NoError(err)
@@ -570,7 +575,7 @@ func (s *StrikeTestSuite) TestANaturalTwentyDoublesTheDiceNotTheModifier() {
 		NewStrike(&StrikeInput{
 			AttackerID: wolfID,
 			TargetID:   heroID,
-			Action:     s.wolfBite(),
+			Attack:     s.wolfAttack(),
 			Roller:     &sequenceRoller{singles: []int{20, 11}, pair: []int{3, 4, 1, 2}, fallback: 2},
 		}))
 	s.Require().NoError(err)
@@ -580,4 +585,14 @@ func (s *StrikeTestSuite) TestANaturalTwentyDoublesTheDiceNotTheModifier() {
 	s.Require().True(outcome.Critical)
 	s.Require().Equal(3+4+1+2+2, outcome.Damage,
 		"four dice for the crit, the modifier exactly once")
+}
+
+// wolfAttack compiles the catalog wolf's bite into the neutral profile the
+// strike consumes — the monster half of the StrikeInput.Attack seam.
+func (s *StrikeTestSuite) wolfAttack() AttackProfile {
+	profile, err := AttackFromMonsterAction(s.wolfBite())
+	s.Require().NoError(err)
+	s.Require().NotNil(profile.Gate, "the catalog wolf declares its knockdown")
+
+	return profile
 }

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -10,12 +10,15 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
@@ -455,4 +458,126 @@ func (s *StrikeTestSuite) TestRefusesAStrikeItCannotRun() {
 		_, err := s.resolve(world, s.hero(), NewStrike(&StrikeInput{Action: s.wolfBite()}))
 		s.Require().ErrorIs(err, ErrNilInput)
 	})
+}
+
+// widenCritTo subscribes an attack-chain modifier that widens the critical
+// threshold, the way a Champion-style effect would — the shape that made the
+// crit-range-is-not-a-hit-range distinction matter (Copilot review, #1002).
+func (s *StrikeTestSuite) widenCritTo(bus events.EventBus, threshold int) {
+	_, err := dnd5eEvents.AttackChain.On(bus).SubscribeWithChain(s.ctx,
+		func(_ context.Context, _ dnd5eEvents.AttackChainEvent,
+			c chain.Chain[dnd5eEvents.AttackChainEvent],
+		) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+			err := c.Add(combat.StageConditions, "widen_crit",
+				func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+					e.CriticalThreshold = threshold
+					return e, nil
+				})
+
+			return c, err
+		})
+	s.Require().NoError(err)
+}
+
+// resolveWith is resolve on a bus the test holds, so a test can subscribe its
+// own chain modifiers before the machine folds.
+func (s *StrikeTestSuite) resolveWith(
+	bus events.EventBus, world encounter.EncounterData, hero *character.Data, machine Machine,
+) (*Output, error) {
+	return resolveOn(s.ctx, &Input{
+		World: world,
+		Participants: []Participant{
+			{Character: hero},
+			{Monster: s.wolf(wolfID)},
+			{Monster: s.wolf(secondWolfID)},
+		},
+		Machine: machine,
+	}, newSurface(bus))
+}
+
+// The crit range is not a hit range: with the threshold widened to 19, a 19
+// against armor it cannot reach is still a miss. Before the fix, any roll in
+// the crit range auto-hit.
+func (s *StrikeTestSuite) TestAWidenedCritRangeDoesNotWidenTheHitRange() {
+	bus := events.NewEventBus()
+	s.widenCritTo(bus, 19)
+
+	armored := s.hero()
+	armored.ArmorClass = 25
+
+	out, err := s.resolveWith(bus, s.world(spatial.Position{X: 8, Y: 5}), armored,
+		NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Action:     s.wolfBite(),
+			Roller:     &sequenceRoller{singles: []int{19}, fallback: 2},
+		}))
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().False(outcome.Hit, "19 + 4 cannot reach AC 25, widened crit range or not")
+	s.Require().False(outcome.Critical, "a roll that misses crits nothing")
+	s.Require().Zero(outcome.Damage)
+	s.Require().Nil(outcome.Contest)
+}
+
+// The companion direction: the same widened 19 against reachable armor both
+// hits and crits — the range widened which hits crit, and only that.
+func (s *StrikeTestSuite) TestAWidenedCritRangeCritsOnAHit() {
+	bus := events.NewEventBus()
+	s.widenCritTo(bus, 19)
+
+	out, err := s.resolveWith(bus, s.world(spatial.Position{X: 8, Y: 5}), s.hero(),
+		NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Action:     s.wolfBite(),
+			Roller:     &sequenceRoller{singles: []int{19, 11}, pair: []int{3, 4, 1, 2}, fallback: 2},
+		}))
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().True(outcome.Hit, "19 + 4 beats AC 14")
+	s.Require().True(outcome.Critical, "and 19 is in the widened range")
+	s.Require().Equal(3+4+1+2+2, outcome.Damage,
+		"2d4 rolled twice — [3 4] then [1 2] — plus the +2 modifier exactly once")
+}
+
+// The notation's +2 is not a die: it lands once, on top of the dice as rolled.
+// Before the fix it was dropped entirely.
+func (s *StrikeTestSuite) TestDamageKeepsItsFlatModifierExactlyOnce() {
+	out, err := s.resolve(s.world(spatial.Position{X: 8, Y: 5}), s.hero(),
+		NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Action:     s.wolfBite(),
+			Roller:     &sequenceRoller{singles: []int{hitRoll, 11}, pair: []int{3, 4}, fallback: 2},
+		}))
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().True(outcome.Hit)
+	s.Require().Equal(3+4+2, outcome.Damage, "2d4 rolled [3 4], plus the +2 — derived, not echoed")
+}
+
+// A natural twenty doubles the DICE and nothing else: two extra d4s arrive,
+// the +2 modifier does not double, and the roll auto-hits at any armor.
+func (s *StrikeTestSuite) TestANaturalTwentyDoublesTheDiceNotTheModifier() {
+	armored := s.hero()
+	armored.ArmorClass = 25
+
+	out, err := s.resolve(s.world(spatial.Position{X: 8, Y: 5}), armored,
+		NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Action:     s.wolfBite(),
+			Roller:     &sequenceRoller{singles: []int{20, 11}, pair: []int{3, 4, 1, 2}, fallback: 2},
+		}))
+	s.Require().NoError(err)
+
+	outcome := s.strikeOutcome(out)
+	s.Require().True(outcome.Hit, "a natural 20 hits AC 25 or any other")
+	s.Require().True(outcome.Critical)
+	s.Require().Equal(3+4+1+2+2, outcome.Damage,
+		"four dice for the crit, the modifier exactly once")
 }

--- a/rulebooks/dnd5e/resolution/world.go
+++ b/rulebooks/dnd5e/resolution/world.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// placedMember is a member as the spatial room needs it: an ID at a position.
+// The room stores entities, and nothing here reads anything else off them.
+type placedMember struct {
+	id string
+}
+
+func (m placedMember) GetID() string            { return m.id }
+func (m placedMember) GetType() core.EntityType { return "member" }
+
+// interactionRoom builds the room an interaction's predicates read positions
+// from, out of the world the caller handed in.
+//
+// The positions are already here. [Input.World] is the persisted world —
+// EncounterData.Members carries every member's room and position, and
+// Field.Rooms carries each room's grid, size and origin — so this reconstructs
+// the room from the same bytes the encounter itself loads from, rather than
+// asking the encounter for a runtime object it does not expose. There is no
+// C2 question in that: C2 governs what a *decider* may see during a pump, and
+// resolution is not a decider. It is handed every sheet by construction (R3)
+// and is the one place that holds the whole world.
+//
+// One room, not all of them. An interaction happens where its participants
+// are, and if they are not all in one room this returns nil — a machine that
+// needs positions then refuses, rather than measuring a distance between two
+// rooms' local coordinate systems, which would be a number with no meaning.
+// (Members' positions are room-local: encounter's ToData reads them out of
+// each room, so two members of the same room are directly comparable and two
+// members of different rooms are not.)
+//
+// Positions are as-persisted. Nothing moves during an interaction — movement
+// is the walk machine's, and it is a different interaction — so a room built
+// once at the start stays true for the whole call. A live-truth projection,
+// for when an interaction does move somebody, is #964's question.
+func interactionRoom(world encounter.EncounterData, participants []Participant) (spatial.Room, error) {
+	wanted := make(map[string]struct{}, len(participants))
+	for _, p := range participants {
+		if id := p.ID(); id != "" {
+			wanted[id] = struct{}{}
+		}
+	}
+
+	roomID := ""
+	placed := make([]encounter.MemberData, 0, len(wanted))
+	for _, member := range world.Members {
+		if _, ok := wanted[string(member.ID)]; !ok {
+			continue
+		}
+
+		if roomID == "" {
+			roomID = member.Room
+		} else if member.Room != roomID {
+			// Participants span rooms: no single room describes this
+			// interaction, so none is installed.
+			return nil, nil
+		}
+
+		placed = append(placed, member)
+	}
+
+	if roomID == "" {
+		// No participant is a member of this world — legal (a saving throw
+		// needs no geometry) and simply means no room to install.
+		return nil, nil
+	}
+
+	data, ok := roomByID(world, roomID)
+	if !ok {
+		return nil, fmt.Errorf("%w: member room %q is not in the field", ErrBadWorld, roomID)
+	}
+
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   data.ID,
+		Type: "encounter",
+		Grid: buildRoomGrid(data),
+	})
+
+	for _, member := range placed {
+		position := spatial.Position{X: member.Position.X, Y: member.Position.Y}
+		if err := room.PlaceEntity(placedMember{id: string(member.ID)}, position); err != nil {
+			return nil, fmt.Errorf("%w: place %q: %w", ErrBadWorld, member.ID, err)
+		}
+	}
+
+	return room, nil
+}
+
+// roomByID finds a room's persisted description.
+func roomByID(world encounter.EncounterData, id string) (encounter.RoomData, bool) {
+	for _, room := range world.Field.Rooms {
+		if room.ID == id {
+			return room, true
+		}
+	}
+
+	return encounter.RoomData{}, false
+}
+
+// buildRoomGrid mirrors the encounter's own grid construction, deliberately.
+//
+// A room built with a different grid than the encounter loaded would measure
+// different distances from identical data — the prone predicate would answer
+// "within five feet" where the encounter says otherwise — so the mapping here
+// tracks encounter.buildRoomGrid rather than choosing for itself: hex rooms
+// are axial hex with the size as its span, everything else is a square grid.
+func buildRoomGrid(data encounter.RoomData) spatial.Grid {
+	if data.Grid == spatial.GridTypeHex {
+		return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{
+			SpanWidth:  float64(data.Width),
+			SpanHeight: float64(data.Height),
+		})
+	}
+
+	return spatial.NewSquareGrid(spatial.SquareGridConfig{
+		Width:  float64(data.Width),
+		Height: float64(data.Height),
+	})
+}


### PR DESCRIPTION
## Why

#965 slice 1, per the scoping comment. The headline is the whole lane in one
call: **a wolf bites the hero, hits, damages him, and knocks him down** — driven
by the wolf's own stat block, not a hand-built approximation — and then **a
second wolf standing over the prone hero bites at advantage, while the same wolf
three cells away bites at disadvantage.** That second sentence is why `WithRoom`
lands here: prone's range predicate contributes to *attack* chains, and this is
the first machine that folds one.

## Investigate-first findings

**(a) Encounter room access — dissolved, exactly as you called it.** I surveyed
the `*Encounter` runtime object and found no `spatial.Room` and no member
positions (`Member` is `{ID, Kind, Room}`). But resolution's input is
`encounter.EncounterData`, and the blob carries ground truth:
`Members[].Position` and `Field.Rooms[].{Width,Height,Grid,Origin}`. So no
encounter PR: `interactionRoom` builds a real `tools/spatial` room from the
world the caller already handed over, mirroring `encounter.buildRoomGrid`'s
choice (hex → axial hex, else square) so distances agree with the encounter's
own. Scope guards as directed — one room, the participants'; spanning rooms
installs none and a machine needing positions says so; positions are
as-persisted, commented, because movement is the walk machine's. The live-truth
projection question is noted for #964, not built.

**(b) Combat's bus — Option 1, with the guardrails.** Confirmed: `ResolveDamage`
(`damage.go:284`), `DealDamage` (`:97`), `ResolveAttackHit`/`ApplyAttackOutcome`
(`attack_phases.go:189`) and `ResolveAttack` (`attack.go:78`) all require a bus,
and `calculateFinalDamage` — the resistance/vulnerability arithmetic — is
unexported, so there is no bus-free half to call. The damage fold therefore
hands **resolution's own bus** to `combat.ResolveDamage` from inside a
resolution-owned step. Every such site is commented `divestment debt — #965
slice 2`; `grep -rn "divestment debt" resolution/` is slice 2's worklist. The
machine never sees a bus.

Per the ruling, AC uses plain `Combatant.AC()`; folding the AC chain is
`GetEffectiveAC`'s job on the character's *parked* bus, and that is named in the
same comment as a slice-2 item rather than papered over.

## The bus-effect tally

| Step | Kind |
|---|---|
| `saving throw` | folds a chain |
| `attack chain` | folds a chain |
| `damage chain` | folds a chain — **via a bus-taking combat call** (debt) |
| `impose <consequence>` | does something on the bus, gathers nothing |

Three folds, one bus effect. **Two consumers now agree on that shape**, which is
the evidence the Gather-widening question was waiting for: either `Gather` means
"do this on the bus and hand me what happened" — mechanically what it has always
been — or the vocabulary grows a case ADR-0038 does not name. Not decided here.

## A finding that changed the phase list

**ADR-0026's Notify is deliberately absent, and this is a deviation from the
brief.** Publishing `DamageReceivedEvent` applies the damage a *second* time to a
monster target: `monster.SheetKeeper` subscribes to that topic and its handler
calls `TakeDamage`. Measured, not assumed — with the publish in place a
4-damage bite took a wolf from **11 to 3**. A character has no such handler, so
the same event is inert for half the roster: one topic meaning two different
things depending on who is listening.

That is precisely the rules-versus-notification classification slice 2 exists to
make, arriving as evidence rather than opinion. Slice 1 applies damage once and
pins it (`TestAMonsterTargetTakesItsDamageOnce`). The cost is named: Undead
Fortitude legitimately listens to that topic and does not fire here; it converts
with its gate (#977), by which point the double-apply is gone.

## Verification

Module suite from `rulebooks/dnd5e/resolution/`: `go build ./...` clean,
`go test ./...` `ok`, `golangci-lint run ./...` **0 issues**, `gofmt` clean.
**Existing tests unmodified.** Pin: dnd5e **v0.90.0** (unchanged), encounter
v0.7.0. No `replace`.

Tests, all against catalog content:

| Test | Pins |
|---|---|
| `TestAWolfBitesTheHeroAndKnocksHimDown` | hit → damage on the sheet → gate contested → prone in `DirtyCharacters` |
| `TestABiteThatMissesRollsNoSave` | **#962's residual** — no damage, `Contest` nil, nothing dirty |
| `TestASecondBiteFromAdjacentHasAdvantage` | prone's near half, through `WithRoom` |
| `TestASecondBiteFromRangeHasDisadvantage` | prone's far half |
| `TestDodgingFoldsIntoTheAttackChain` | the fold is general, not prone-shaped |
| `TestAMonsterTargetTakesItsDamageOnce` | the Notify finding |
| `TestRegistrationsDoNotDependOnInputOrder` | R4 across the two-machine flow |
| `TestTheStrikeRunsInPieces` | **re-enterability, demonstrated** — the test drives the machine with its own loop, one step at a time |
| `TestRefusesAStrikeItCannotRun` | unreadable action, absent target, unnamed sides |

Mutation — commit first, `go build` each mutant, revert from the repo root:

| # | Mutant | Killed by |
|---|---|---|
| a | a miss still applies damage | `TestABiteThatMissesRollsNoSave` |
| b | hit-vs-AC comparison inverted | 3 tests |
| c | the damage chain fold skipped | `TestAWolfBitesTheHeroAndKnocksHimDown`, `TestTheStrikeRunsInPieces` |
| d | the gate consulted on a miss | `TestABiteThatMissesRollsNoSave` |
| e | `WithRoom` not installed | **both** prone-range tests |
| f | damage announced *as well as* applied (the double-apply, i.e. Notify reinstated) | `TestAMonsterTargetTakesItsDamageOnce`, `TestTheStrikeRunsInPieces` |
| g | the room built with positions dropped | `TestASecondBiteFromRangeHasDisadvantage` |

No survivors; every mutant compiled first. (f) replaces the brief's "Notify
dropped" mutant, which has no code to mutate now that the step is deliberately
absent — the inverse is the honest test of the same axis.

**gorelease** (no CI job — #917), against `resolution/v0.4.0`: compatible only,
suggested **v0.5.0**. Added: `NewStrike`, `StrikeInput`, `StrikeOutcome`,
`ErrBadAttack`, `ErrBadWorld`, `ErrNoCombatant`.

## Scope

Reaction windows are out (wave 5), and every phase boundary is a suspension
point by construction so they need no rebuild. A character-as-attacker path is
**not** here — the attack arrives as `monster.ActionData` and slice 1 reads the
bite; a character's weapon attack is a named follow-up, not a free fall-out of
this machinery. Cross-room and ranged strikes are refused rather than guessed.

**This PR does not close #965** — slice 2 (combat's divestment, with this
slice's debt list as its worklist) remains.

Part of #965, slice 1.

— asset-pipeline agent, on behalf of KirkDiggler
