### PR TITLE
feat(dnd5e): weapon derivation surface — versatile notation and proficiency coverage (#1003 PR A)

### DIFF
--- a/rulebooks/dnd5e/character/equipment_display.go
+++ b/rulebooks/dnd5e/character/equipment_display.go
@@ -133,8 +133,12 @@ func MainHandDamage(mainWeapon *weapons.Weapon, offHand *EquippedItem) string {
 		return ""
 	}
 
+	// An empty off hand is the whole of this function's contribution: it means
+	// the weapon is gripped two-handed. Whether that changes the die is the
+	// weapon's own business, which is what VersatileDamage answers — a
+	// property check here would ask the same question twice.
 	damage := mainWeapon.Damage
-	if mainWeapon.HasProperty(weapons.PropertyVersatile) && offHand == nil {
+	if offHand == nil {
 		damage = mainWeapon.VersatileDamage()
 	}
 

--- a/rulebooks/dnd5e/character/equipment_display.go
+++ b/rulebooks/dnd5e/character/equipment_display.go
@@ -6,7 +6,6 @@ package character
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
@@ -136,7 +135,7 @@ func MainHandDamage(mainWeapon *weapons.Weapon, offHand *EquippedItem) string {
 
 	damage := mainWeapon.Damage
 	if mainWeapon.HasProperty(weapons.PropertyVersatile) && offHand == nil {
-		damage = versatileTwoHandedDamage(damage)
+		damage = mainWeapon.VersatileDamage()
 	}
 
 	line := fmt.Sprintf("%s %s", damage, mainWeapon.DamageType)
@@ -144,35 +143,6 @@ func MainHandDamage(mainWeapon *weapons.Weapon, offHand *EquippedItem) string {
 		line += fmt.Sprintf(" · off-hand %s", offWeapon.Damage)
 	}
 	return line
-}
-
-// versatileStepUp is the standard 5e versatile-weapon die progression: a
-// versatile weapon's two-handed die is always exactly one step up from
-// its one-handed die on this table (longsword 1d8 -> 1d10, spear 1d6 ->
-// 1d8, etc — no versatile weapon in the ruleset skips a step).
-var versatileStepUp = map[int]int{4: 6, 6: 8, 8: 10, 10: 12}
-
-// versatileTwoHandedDamage steps a "NdM" damage notation's die size up
-// one notch per versatileStepUp, e.g. "1d8" -> "1d10". Returns damage
-// unchanged if it doesn't parse as "NdM" or the size isn't in the table.
-func versatileTwoHandedDamage(damage string) string {
-	parts := strings.SplitN(damage, "d", 2)
-	if len(parts) != 2 {
-		return damage
-	}
-	count, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return damage
-	}
-	size, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return damage
-	}
-	next, ok := versatileStepUp[size]
-	if !ok {
-		return damage
-	}
-	return fmt.Sprintf("%dd%d", count, next)
 }
 
 // slotFor returns the slot itemID is equipped in, or "" if it's carried

--- a/rulebooks/dnd5e/character/weapon_proficiency.go
+++ b/rulebooks/dnd5e/character/weapon_proficiency.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+
+// IsProficientWith reports whether this character's weapon proficiencies
+// cover the given weapon — the sheet's half of the question weapons.CoveredBy
+// answers per grant.
+//
+// A nil weapon is not proficient rather than a panic: callers reach this from
+// an equipped slot, and an empty slot resolves to nil weapon on a path where
+// "no proficiency bonus" is the answer that keeps the arithmetic honest.
+func (c *Character) IsProficientWith(w *weapons.Weapon) bool {
+	if w == nil {
+		return false
+	}
+
+	for _, grant := range c.weaponProficiencies {
+		if w.CoveredBy(grant) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/rulebooks/dnd5e/character/weapon_proficiency_test.go
+++ b/rulebooks/dnd5e/character/weapon_proficiency_test.go
@@ -1,0 +1,148 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+type WeaponProficiencyTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *WeaponProficiencyTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+func TestWeaponProficiencySuite(t *testing.T) {
+	suite.Run(t, new(WeaponProficiencyTestSuite))
+}
+
+// sheet loads a character carrying exactly the weapon proficiencies given —
+// through the real loader, so the grants travel the same path a persisted
+// character's do.
+func (s *WeaponProficiencyTestSuite) sheet(profs ...proficiencies.Weapon) *Character {
+	c, err := Load(s.ctx, &Data{
+		ID:       "hero-1",
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:           12,
+		MaxHitPoints:        12,
+		ArmorClass:          16,
+		ProficiencyBonus:    2,
+		WeaponProficiencies: profs,
+	})
+	s.Require().NoError(err)
+
+	return c
+}
+
+func (s *WeaponProficiencyTestSuite) weapon(id weapons.WeaponID) *weapons.Weapon {
+	w, err := weapons.GetByID(id)
+	s.Require().NoError(err)
+
+	return &w
+}
+
+// THE HEADLINE. A fighter's real class grant — simple and martial, exactly
+// what classes.Fighter hands out — covers both halves of the catalog.
+func (s *WeaponProficiencyTestSuite) TestAFightersCategoryGrantsCoverSimpleAndMartial() {
+	fighter := s.sheet(proficiencies.WeaponSimple, proficiencies.WeaponMartial)
+
+	s.Assert().True(fighter.IsProficientWith(s.weapon(weapons.Longsword)), "martial")
+	s.Assert().True(fighter.IsProficientWith(s.weapon(weapons.Club)), "simple")
+	s.Assert().True(fighter.IsProficientWith(s.weapon(weapons.Greatsword)), "martial")
+	s.Assert().True(fighter.IsProficientWith(s.weapon(weapons.Dagger)), "simple")
+}
+
+// A wizard's real grant list is specific, not categorical: it reaches the
+// weapons it names and stops. This is the case that makes the compiler's
+// proficiency branch worth having at all.
+func (s *WeaponProficiencyTestSuite) TestAWizardsSpecificGrantsReachOnlyWhatTheyName() {
+	wizard := s.sheet(
+		proficiencies.WeaponDagger,
+		proficiencies.WeaponDart,
+		proficiencies.WeaponSling,
+		proficiencies.WeaponQuarterstaff,
+		proficiencies.WeaponLightCrossbow,
+	)
+
+	s.Assert().True(wizard.IsProficientWith(s.weapon(weapons.Dagger)))
+	s.Assert().True(wizard.IsProficientWith(s.weapon(weapons.Quarterstaff)))
+
+	s.Assert().False(wizard.IsProficientWith(s.weapon(weapons.Longsword)))
+	s.Assert().False(wizard.IsProficientWith(s.weapon(weapons.Greatsword)))
+	// A simple weapon it was not granted: proximity in category is not a grant.
+	s.Assert().False(wizard.IsProficientWith(s.weapon(weapons.Club)))
+	s.Assert().False(wizard.IsProficientWith(s.weapon(weapons.Handaxe)))
+}
+
+// One grant among several is enough — the scan is an any, not an all.
+func (s *WeaponProficiencyTestSuite) TestOneMatchingGrantAmongManyIsEnough() {
+	rogue := s.sheet(
+		proficiencies.WeaponSimple,
+		proficiencies.WeaponHandCrossbow,
+		proficiencies.WeaponLongsword,
+		proficiencies.WeaponRapier,
+		proficiencies.WeaponShortsword,
+	)
+
+	// Reached by the last specific grant in the list, not the first.
+	s.Assert().True(rogue.IsProficientWith(s.weapon(weapons.Shortsword)))
+	// Reached by the category grant that leads the list.
+	s.Assert().True(rogue.IsProficientWith(s.weapon(weapons.Mace)))
+	// Reached by nothing.
+	s.Assert().False(rogue.IsProficientWith(s.weapon(weapons.Greataxe)))
+}
+
+// A character with no weapon proficiencies is proficient with nothing in the
+// catalog — the whole catalog, so a default-true implementation cannot hide.
+func (s *WeaponProficiencyTestSuite) TestNoGrantsMeansProficientWithNothing() {
+	commoner := s.sheet()
+
+	for id, weapon := range weapons.All {
+		s.Assert().False(commoner.IsProficientWith(&weapon), "%s", id)
+	}
+}
+
+// And with both category grants, proficient with everything in the catalog.
+func (s *WeaponProficiencyTestSuite) TestBothCategoryGrantsCoverTheWholeCatalog() {
+	fighter := s.sheet(proficiencies.WeaponSimple, proficiencies.WeaponMartial)
+
+	for id, weapon := range weapons.All {
+		s.Assert().True(fighter.IsProficientWith(&weapon), "%s", id)
+	}
+}
+
+// A nil weapon is not proficient rather than a panic: an empty equipment slot
+// resolves to nil on the caller's path.
+func (s *WeaponProficiencyTestSuite) TestANilWeaponIsNotProficient() {
+	fighter := s.sheet(proficiencies.WeaponSimple, proficiencies.WeaponMartial)
+
+	s.Assert().NotPanics(func() {
+		s.Assert().False(fighter.IsProficientWith(nil))
+	})
+}

--- a/rulebooks/dnd5e/weapons/proficiency.go
+++ b/rulebooks/dnd5e/weapons/proficiency.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package weapons
+
+import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+
+// This mapping lives in weapons, and must stay here.
+//
+// It reads like proficiencies package material — it is, after all, about
+// proficiency grants — but moving it there is an import cycle: shared imports
+// proficiencies (shared/types.go), and weapons imports shared, so proficiencies
+// can never import weapons or shared back. weapons already depends on
+// proficiencies transitively through shared, so this direction is free.
+//
+// Stated here because "tidy this into the proficiencies package" is the
+// obvious-looking refactor, and it does not compile.
+
+// specificWeaponGrants maps each specific weapon proficiency to the weapon it
+// names. Grants are plural nouns ("longswords") where weapon IDs are singular
+// ("longsword"), so the two vocabularies need a table rather than a cast.
+//
+// A table rather than depluralization-by-trimming-an-s: every grant in the
+// ruleset happens to be the weapon ID plus "s" today, but that is a
+// coincidence of which weapons have class grants, not a rule — and a silent
+// mismatch here reads as "not proficient", which costs a character their
+// proficiency bonus without erroring. TestSpecificGrantsNameRealWeapons pins
+// every entry against the catalog.
+var specificWeaponGrants = map[proficiencies.Weapon]WeaponID{
+	proficiencies.WeaponClub:          Club,
+	proficiencies.WeaponDagger:        Dagger,
+	proficiencies.WeaponDart:          Dart,
+	proficiencies.WeaponJavelin:       Javelin,
+	proficiencies.WeaponLightCrossbow: LightCrossbow,
+	proficiencies.WeaponMace:          Mace,
+	proficiencies.WeaponQuarterstaff:  Quarterstaff,
+	proficiencies.WeaponShortbow:      Shortbow,
+	proficiencies.WeaponSickle:        Sickle,
+	proficiencies.WeaponSling:         Sling,
+	proficiencies.WeaponSpear:         Spear,
+
+	proficiencies.WeaponHandCrossbow: HandCrossbow,
+	proficiencies.WeaponLongbow:      Longbow,
+	proficiencies.WeaponLongsword:    Longsword,
+	proficiencies.WeaponRapier:       Rapier,
+	proficiencies.WeaponScimitar:     Scimitar,
+	proficiencies.WeaponShortsword:   Shortsword,
+}
+
+// CoveredBy reports whether a single weapon-proficiency grant covers this
+// weapon. A category grant ("simple"/"martial") covers every weapon of that
+// category; a specific grant ("longswords") covers the one weapon it names.
+//
+// This is the first place in the toolkit that answers the question at all:
+// the old attack path adds the proficiency bonus unconditionally, to every
+// attacker with any weapon (rpg-toolkit#1005). Fixing that path is its own
+// change — this one only supplies the rule it will need.
+func (w Weapon) CoveredBy(grant proficiencies.Weapon) bool {
+	switch grant {
+	case proficiencies.WeaponSimple:
+		return w.IsSimple()
+	case proficiencies.WeaponMartial:
+		return w.IsMartial()
+	default:
+		named, ok := specificWeaponGrants[grant]
+
+		return ok && named == w.ID
+	}
+}

--- a/rulebooks/dnd5e/weapons/proficiency_internal_test.go
+++ b/rulebooks/dnd5e/weapons/proficiency_internal_test.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package weapons
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// The external suite in proficiency_test.go keeps its own copy of the
+// grant-to-weapon mapping so the two can disagree. That leaves one gap it
+// cannot see by construction: a grant added to specificWeaponGrants and not
+// to the test's list is simply never exercised. These two assertions close it
+// from inside the package.
+type ProficiencyTableTestSuite struct {
+	suite.Suite
+}
+
+func TestProficiencyTableSuite(t *testing.T) {
+	suite.Run(t, new(ProficiencyTableTestSuite))
+}
+
+// A count, deliberately. Adding a grant without adding it to the external
+// suite's list fails here, which is the only place that can notice.
+func (s *ProficiencyTableTestSuite) TestTheSpecificGrantTableHoldsEveryGrantTheTestsKnowAbout() {
+	s.Assert().Len(specificWeaponGrants, 17,
+		"a grant was added or removed — mirror it in proficiency_test.go's specificGrants")
+}
+
+// Every entry resolves against the catalog. A grant naming a weapon that does
+// not exist reads as "not proficient" at runtime rather than erroring.
+func (s *ProficiencyTableTestSuite) TestEveryTableEntryNamesACatalogWeapon() {
+	for grant, id := range specificWeaponGrants {
+		weapon, err := GetByID(id)
+		s.Require().NoError(err, "grant %q names weapon %q", grant, id)
+		s.Assert().Equal(id, weapon.ID)
+	}
+}

--- a/rulebooks/dnd5e/weapons/proficiency_test.go
+++ b/rulebooks/dnd5e/weapons/proficiency_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package weapons_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+type ProficiencyCoverageTestSuite struct {
+	suite.Suite
+}
+
+func TestProficiencyCoverageSuite(t *testing.T) {
+	suite.Run(t, new(ProficiencyCoverageTestSuite))
+}
+
+// specificGrants is this test's own copy of the grant-to-weapon mapping,
+// deliberately not read from the package. A table and its test that share one
+// source agree by construction and prove nothing; two independent lists
+// disagree the moment either drifts.
+var specificGrants = map[proficiencies.Weapon]weapons.WeaponID{
+	proficiencies.WeaponClub:          weapons.Club,
+	proficiencies.WeaponDagger:        weapons.Dagger,
+	proficiencies.WeaponDart:          weapons.Dart,
+	proficiencies.WeaponJavelin:       weapons.Javelin,
+	proficiencies.WeaponLightCrossbow: weapons.LightCrossbow,
+	proficiencies.WeaponMace:          weapons.Mace,
+	proficiencies.WeaponQuarterstaff:  weapons.Quarterstaff,
+	proficiencies.WeaponShortbow:      weapons.Shortbow,
+	proficiencies.WeaponSickle:        weapons.Sickle,
+	proficiencies.WeaponSling:         weapons.Sling,
+	proficiencies.WeaponSpear:         weapons.Spear,
+	proficiencies.WeaponHandCrossbow:  weapons.HandCrossbow,
+	proficiencies.WeaponLongbow:       weapons.Longbow,
+	proficiencies.WeaponLongsword:     weapons.Longsword,
+	proficiencies.WeaponRapier:        weapons.Rapier,
+	proficiencies.WeaponScimitar:      weapons.Scimitar,
+	proficiencies.WeaponShortsword:    weapons.Shortsword,
+}
+
+// THE HEADLINE. A category grant covers exactly its own category, for every
+// weapon in the catalog — so adding a weapon cannot silently land outside the
+// rule. Both directions: the matching grant covers, the other one does not.
+func (s *ProficiencyCoverageTestSuite) TestEveryCatalogWeaponIsCoveredByItsOwnCategoryGrant() {
+	s.Require().NotEmpty(weapons.All)
+
+	for id, weapon := range weapons.All {
+		s.Assert().Equal(weapon.IsSimple(), weapon.CoveredBy(proficiencies.WeaponSimple),
+			"%s (%s) vs the simple grant", id, weapon.Category)
+		s.Assert().Equal(weapon.IsMartial(), weapon.CoveredBy(proficiencies.WeaponMartial),
+			"%s (%s) vs the martial grant", id, weapon.Category)
+
+		// Exactly one of the two, never neither and never both: a weapon
+		// whose category is neither simple nor martial would be coverable by
+		// nothing, and would silently lose its wielder the proficiency bonus.
+		s.Assert().NotEqual(weapon.IsSimple(), weapon.IsMartial(),
+			"%s belongs to exactly one category (%s)", id, weapon.Category)
+	}
+}
+
+// Every specific grant names a weapon the catalog actually holds. A grant
+// naming a weapon that does not exist reads as "not proficient" at runtime —
+// no error, just a quietly missing bonus.
+func (s *ProficiencyCoverageTestSuite) TestSpecificGrantsNameRealWeapons() {
+	for grant, id := range specificGrants {
+		weapon, err := weapons.GetByID(id)
+		s.Require().NoError(err, "grant %q names weapon %q", grant, id)
+		s.Assert().True(weapon.CoveredBy(grant), "grant %q covers %q", grant, id)
+	}
+}
+
+// A specific grant covers the one weapon it names and nothing else in the
+// catalog — the exclusivity a "does the grant mention this weapon at all"
+// implementation loses.
+func (s *ProficiencyCoverageTestSuite) TestASpecificGrantCoversExactlyTheWeaponItNames() {
+	for grant, named := range specificGrants {
+		for id, weapon := range weapons.All {
+			covered := weapon.CoveredBy(grant)
+			if id == named {
+				s.Assert().True(covered, "grant %q covers the %q it names", grant, id)
+				continue
+			}
+			s.Assert().False(covered, "grant %q does not cover %q", grant, id)
+		}
+	}
+}
+
+// Worked case, spelled out rather than derived from a loop: the longswords
+// grant is a martial-weapon grant's opposite number.
+func (s *ProficiencyCoverageTestSuite) TestTheLongswordsGrantCoversOnlyTheLongsword() {
+	longsword, err := weapons.GetByID(weapons.Longsword)
+	s.Require().NoError(err)
+	shortsword, err := weapons.GetByID(weapons.Shortsword)
+	s.Require().NoError(err)
+
+	s.Assert().True(longsword.CoveredBy(proficiencies.WeaponLongsword))
+	s.Assert().False(shortsword.CoveredBy(proficiencies.WeaponLongsword))
+
+	// And the category grant it belongs to, from the other side.
+	s.Assert().True(longsword.CoveredBy(proficiencies.WeaponMartial))
+	s.Assert().False(longsword.CoveredBy(proficiencies.WeaponSimple))
+}
+
+// A simple weapon is not covered by the martial grant, which is the branch a
+// "category grant covers everything" mutation erases.
+func (s *ProficiencyCoverageTestSuite) TestACategoryGrantDoesNotReachTheOtherCategory() {
+	club, err := weapons.GetByID(weapons.Club)
+	s.Require().NoError(err)
+
+	s.Assert().True(club.CoveredBy(proficiencies.WeaponSimple))
+	s.Assert().False(club.CoveredBy(proficiencies.WeaponMartial))
+}
+
+// A grant nobody has defined covers nothing rather than everything.
+func (s *ProficiencyCoverageTestSuite) TestAnUnknownGrantCoversNothing() {
+	for id, weapon := range weapons.All {
+		s.Assert().False(weapon.CoveredBy(proficiencies.Weapon("greatswords")), "%s", id)
+		s.Assert().False(weapon.CoveredBy(proficiencies.Weapon("")), "%s", id)
+	}
+}
+
+// The singular weapon ID is not itself a grant: grants are plural nouns, and
+// a lookup that fell back to matching the raw ID would make this pass.
+func (s *ProficiencyCoverageTestSuite) TestAWeaponIDIsNotAGrant() {
+	longsword, err := weapons.GetByID(weapons.Longsword)
+	s.Require().NoError(err)
+
+	s.Assert().False(longsword.CoveredBy(proficiencies.Weapon(weapons.Longsword)))
+}

--- a/rulebooks/dnd5e/weapons/versatile.go
+++ b/rulebooks/dnd5e/weapons/versatile.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package weapons
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// versatileStepUp is the standard 5e versatile-weapon die progression: a
+// versatile weapon's two-handed die is always exactly one step up from its
+// one-handed die on this table (longsword 1d8 -> 1d10, spear 1d6 -> 1d8, etc
+// — no versatile weapon in the ruleset skips a step).
+//
+// This table is the one copy. It lived unexported in the character package's
+// display code until rpg-toolkit#1003 needed the same step at notation level
+// for an attack profile; a second copy there would have been free to drift
+// from this one the first time a weapon was added.
+var versatileStepUp = map[int]int{4: 6, 6: 8, 8: 10, 10: 12}
+
+// VersatileTwoHandedDamage steps a "NdM" damage notation's die size up one
+// notch per versatileStepUp, e.g. "1d8" -> "1d10".
+//
+// Returns notation unchanged when it does not parse as "NdM" or the die size
+// is not on the table. That passthrough is not defensive padding: the catalog
+// holds weapons whose damage is not dice at all (a blowgun's "1", a net's
+// "0"), and stepping them would invent a die the weapon does not have.
+func VersatileTwoHandedDamage(notation string) string {
+	parts := strings.SplitN(notation, "d", 2)
+	if len(parts) != 2 {
+		return notation
+	}
+	count, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return notation
+	}
+	size, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return notation
+	}
+	next, ok := versatileStepUp[size]
+	if !ok {
+		return notation
+	}
+
+	return fmt.Sprintf("%dd%d", count, next)
+}
+
+// VersatileDamage returns the damage notation this weapon deals gripped in
+// two hands: the stepped-up die for a versatile weapon, and its one-handed
+// Damage for everything else.
+//
+// The property check lives here so callers that already know the grip ask for
+// the notation they want rather than re-deriving "is this versatile" at every
+// site — the attack-profile compiler (rpg-toolkit#1003) and the equipment
+// display each needed it, and each would have written the same two lines.
+func (w Weapon) VersatileDamage() string {
+	if !w.HasProperty(PropertyVersatile) {
+		return w.Damage
+	}
+
+	return VersatileTwoHandedDamage(w.Damage)
+}

--- a/rulebooks/dnd5e/weapons/versatile_test.go
+++ b/rulebooks/dnd5e/weapons/versatile_test.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package weapons_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+type VersatileTestSuite struct {
+	suite.Suite
+}
+
+func TestVersatileSuite(t *testing.T) {
+	suite.Run(t, new(VersatileTestSuite))
+}
+
+// THE HEADLINE. Every versatile weapon in the catalog, gripped two-handed,
+// steps to the exact notation the ruleset prints for it — real content, not a
+// synthetic "1d8".
+func (s *VersatileTestSuite) TestEveryCatalogVersatileWeaponStepsToItsPrintedDie() {
+	stepped := map[weapons.WeaponID]string{
+		weapons.Battleaxe:    "1d10",
+		weapons.Longsword:    "1d10",
+		weapons.Warhammer:    "1d10",
+		weapons.Quarterstaff: "1d8",
+		weapons.Spear:        "1d8",
+		weapons.Trident:      "1d8",
+	}
+
+	for id, want := range stepped {
+		weapon, err := weapons.GetByID(id)
+		s.Require().NoError(err)
+		s.Require().True(weapon.HasProperty(weapons.PropertyVersatile), "%s is versatile", id)
+
+		s.Assert().Equal(want, weapon.VersatileDamage(), "%s two-handed", id)
+	}
+}
+
+// The catalog's versatile weapons only exercise two rows of the step-up table
+// (1d6 and 1d8). All four rows are asserted directly so dropping or changing
+// any single entry fails, not just the two content happens to reach.
+func (s *VersatileTestSuite) TestTheStepUpTableIsExactAtEveryRow() {
+	s.Assert().Equal("1d6", weapons.VersatileTwoHandedDamage("1d4"))
+	s.Assert().Equal("1d8", weapons.VersatileTwoHandedDamage("1d6"))
+	s.Assert().Equal("1d10", weapons.VersatileTwoHandedDamage("1d8"))
+	s.Assert().Equal("1d12", weapons.VersatileTwoHandedDamage("1d10"))
+}
+
+// A d12 is the top of the progression: nothing steps past it.
+func (s *VersatileTestSuite) TestADieAboveTheTableDoesNotStep() {
+	s.Assert().Equal("1d12", weapons.VersatileTwoHandedDamage("1d12"))
+	s.Assert().Equal("1d20", weapons.VersatileTwoHandedDamage("1d20"))
+}
+
+// The die count rides through untouched — only the size steps. Pins the
+// count against a step that rebuilds the notation as "1d{next}".
+func (s *VersatileTestSuite) TestTheDieCountIsPreserved() {
+	s.Assert().Equal("2d8", weapons.VersatileTwoHandedDamage("2d6"))
+	s.Assert().Equal("3d12", weapons.VersatileTwoHandedDamage("3d10"))
+}
+
+// Notation that is not "NdM" passes through, and the catalog is where that
+// case comes from rather than a hypothetical: a blowgun deals "1" and a net
+// deals "0". Stepping either would invent a die the weapon has not got.
+func (s *VersatileTestSuite) TestNonDiceNotationPassesThrough() {
+	blowgun, err := weapons.GetByID(weapons.Blowgun)
+	s.Require().NoError(err)
+	s.Assert().Equal("1", blowgun.Damage)
+	s.Assert().Equal("1", weapons.VersatileTwoHandedDamage(blowgun.Damage))
+
+	net, err := weapons.GetByID(weapons.Net)
+	s.Require().NoError(err)
+	s.Assert().Equal("0", net.Damage)
+	s.Assert().Equal("0", weapons.VersatileTwoHandedDamage(net.Damage))
+}
+
+func (s *VersatileTestSuite) TestUnparseableNotationPassesThrough() {
+	s.Assert().Equal("", weapons.VersatileTwoHandedDamage(""))
+	s.Assert().Equal("d8", weapons.VersatileTwoHandedDamage("d8"))
+	s.Assert().Equal("1dX", weapons.VersatileTwoHandedDamage("1dX"))
+	s.Assert().Equal("greatsword", weapons.VersatileTwoHandedDamage("greatsword"))
+}
+
+// A weapon without the property reports its one-handed die whatever the grip:
+// a greatsword is two-handed, not versatile, and 2d6 never becomes 2d8.
+func (s *VersatileTestSuite) TestANonVersatileWeaponNeverSteps() {
+	greatsword, err := weapons.GetByID(weapons.Greatsword)
+	s.Require().NoError(err)
+	s.Require().False(greatsword.HasProperty(weapons.PropertyVersatile))
+	s.Assert().Equal("2d6", greatsword.VersatileDamage())
+
+	// A rapier's die IS on the step-up table — the property, not the die, is
+	// what decides. This is the case a check-the-table-not-the-property
+	// implementation gets wrong.
+	rapier, err := weapons.GetByID(weapons.Rapier)
+	s.Require().NoError(err)
+	s.Require().False(rapier.HasProperty(weapons.PropertyVersatile))
+	s.Assert().Equal("1d8", rapier.VersatileDamage())
+}
+
+// Every non-versatile weapon in the catalog reports Damage verbatim.
+func (s *VersatileTestSuite) TestVersatileDamageMatchesDamageForEveryNonVersatileWeapon() {
+	checked := 0
+	for id, weapon := range weapons.All {
+		if weapon.HasProperty(weapons.PropertyVersatile) {
+			continue
+		}
+		s.Assert().Equal(weapon.Damage, weapon.VersatileDamage(), "%s is not versatile", id)
+		checked++
+	}
+	s.Require().Positive(checked, "the catalog holds non-versatile weapons")
+}


### PR DESCRIPTION
## What and why

The attack-profile compiler #1003 builds needs two static facts about a character's equipped weapon that nothing in this module exposes. Both are rules knowledge `rulebooks/dnd5e` owns, so they land here rather than being re-derived in `resolution` — a module that cannot even see the one existing copy.

**This PR does not close #1003.** It is PR-A of a two-PR split: `resolution/go.mod` pins `rulebooks/dnd5e v0.90.0` with no `replace`, so PR-B (`AttackFromCharacter`, closing #1003) cannot compile until this merges and tags.

### A1 — versatile notation, in `weapons`

The 5e step-up table already existed, **unexported, inside the character package's display code** (`character/equipment_display.go`), reachable only through `MainHandDamage` — which returns a display line (`"1d10 slashing · off-hand 1d4"`), not dice notation, and triggers on "off hand empty" rather than an explicit grip. Unusable as an `AttackProfile.DamageDice`.

The table moves to `weapons` as the one copy and gains a notation-level entry point:

```go
func VersatileTwoHandedDamage(notation string) string  // "1d8" -> "1d10"
func (w Weapon) VersatileDamage() string               // stepped if versatile, Damage otherwise
```

`MainHandDamage` now delegates. Its condition is unchanged, the display tests are unmodified and green.

### A2 — proficiency coverage, in `weapons` + `character`

Nothing in the toolkit answered "is this character proficient with this weapon". Grants are plural nouns (`"longswords"`) plus two category grants, where weapon IDs are singular (`"longsword"`), so the two vocabularies need a table rather than a cast.

```go
func (w Weapon) CoveredBy(grant proficiencies.Weapon) bool   // package weapons
func (c *Character) IsProficientWith(w *weapons.Weapon) bool // package character
```

**On placement:** the mapping reads like `proficiencies` material, but putting it there is an import cycle — `shared` imports `proficiencies` (`shared/types.go`), and `weapons` imports `shared`, so `proficiencies` can never import back. `weapons` already depends on `proficiencies` transitively through `shared`, so this direction is free. That reasoning is recorded in `weapons/proficiency.go` because "tidy this into the proficiencies package" is the obvious-looking refactor and it does not compile.

### Explicitly out of scope

The old attack path adds the proficiency bonus **unconditionally**, to every attacker with any weapon (`combat/attack_phases.go:252`). That is #1005 — a behavior change to live combat, its own PR. This change only supplies the rule it will need; `CoveredBy`'s doc comment references the issue and nothing else changes.

## Evidence

Run from `rulebooks/dnd5e/`:

| Check | Result |
|---|---|
| `go test ./...` | **exit 0 — 27 packages ok**, 0 failures |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` | clean (no output) |
| `go vet ./...` | clean |
| `go mod tidy` | no diff to `go.mod` / `go.sum` |

No existing test was modified. The only pre-existing file touched is `character/equipment_display.go` (delete the moved helper + delegate + drop the now-unused `strconv` import). No `replace` committed.

## Mutation table

12 mutants, all killed by assertion failures. Three (M4/M8/M10) first came back as compile errors — weak evidence — so they were rewritten to compile and re-run; the table reports the compiling versions.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | step-up table: `8: 10` entry dropped | KILLED | `TestEveryCatalogVersatileWeaponStepsToItsPrintedDie`, `TestTheStepUpTableIsExactAtEveryRow` |
| M2 | step-up table: `6: 8` becomes `6: 10` | KILLED | `TestEveryCatalogVersatileWeaponStepsToItsPrintedDie`, `TestTheDieCountIsPreserved` |
| M3 | not-on-table steps (`size*2`) instead of passing through | KILLED | `TestADieAboveTheTableDoesNotStep` |
| M4 | die count hardcoded to 1 (`"1d%d"`) | KILLED | `TestTheDieCountIsPreserved` |
| M5 | versatile property check dropped — the die decides, not the property | KILLED | `TestANonVersatileWeaponNeverSteps`, `TestVersatileDamageMatchesDamageForEveryNonVersatileWeapon` |
| M6 | simple category grant always covers | KILLED | `TestEveryCatalogWeaponIsCoveredByItsOwnCategoryGrant`, `TestTheLongswordsGrantCoversOnlyTheLongsword` |
| M7 | martial category grant never covers | KILLED | `TestEveryCatalogWeaponIsCoveredByItsOwnCategoryGrant`, `TestTheLongswordsGrantCoversOnlyTheLongsword` |
| M8 | specific grant ignores *which* weapon (`return ok`) | KILLED | `TestASpecificGrantCoversExactlyTheWeaponItNames`, `TestTheLongswordsGrantCoversOnlyTheLongsword` |
| M9 | unknown grant covers everything | KILLED | `TestASpecificGrantCoversExactlyTheWeaponItNames`, `TestAWeaponIDIsNotAGrant` |
| M10 | `IsProficientWith` always true | KILLED | `TestAWizardsSpecificGrantsReachOnlyWhatTheyName`, `TestOneMatchingGrantAmongManyIsEnough` |
| M11 | nil-weapon guard removed | KILLED | `TestANilWeaponIsNotProficient` |
| M12 | only the first grant consulted | KILLED | `TestAFightersCategoryGrantsCoverSimpleAndMartial`, `TestAWizardsSpecificGrantsReachOnlyWhatTheyName` |

### Drift pins worth calling out

- `TestEveryCatalogWeaponIsCoveredByItsOwnCategoryGrant` iterates **all** of `weapons.All` and asserts each weapon is covered by its own category grant and not the other, plus that exactly one category applies — so a weapon added later cannot land outside the rule silently.
- `proficiency_test.go` keeps its **own independent copy** of the 17-entry grant map. A table and its test sharing one source agree by construction and prove nothing; two lists disagree the moment either drifts.
- That leaves one gap the external suite cannot see — a grant added to the package table but not the test's list is simply never exercised. `proficiency_internal_test.go` closes it with a count assertion that fails and names the file to update.
- Non-dice passthrough is pinned against **real catalog content** (blowgun `"1"`, net `"0"`), not synthetic input.

— asset-pipeline agent, on behalf of KirkDiggler
