### PR TITLE
fix(release): a nested module's changes never bump its parent (#917)

### DIFF
--- a/.github/workflows/auto-tag-modules-safe.yml
+++ b/.github/workflows/auto-tag-modules-safe.yml
@@ -34,6 +34,20 @@ jobs:
     
     - name: Analyze commits and tag modules
       run: |
+        # Pathspecs excluding any nested module living inside this one, so a
+        # child module's changes never mark or grade the parent. Without this,
+        # every resolution-only merge minted a phantom parent dnd5e version
+        # (#917: v0.85.0, v0.91.0, v0.92.0 all point at child-only merges).
+        # vendor/ go.mod files are vendored dependencies, not module
+        # boundaries, and stay included in the parent's diff.
+        nested_module_excludes() {
+          local module=$1
+          find "$module" -mindepth 2 -name "go.mod" -type f -not -path "*/vendor/*" | \
+            while read -r nested; do
+              printf ':(exclude)%s\n' "$(dirname "$nested")"
+            done
+        }
+
         # Function to determine version bump from commit messages
         # Looks for conventional commit patterns:
         # - feat: minor bump
@@ -52,8 +66,10 @@ jobs:
             compare_from="$last_tag"
           fi
           
-          # Check commit messages for this module
-          commits=$(git log --format="%s" "$compare_from..HEAD" -- "$module" 2>/dev/null || echo "")
+          # Check commit messages for this module — excluding nested modules,
+          # whose subjects must not grade the parent's bump (#917)
+          mapfile -t excludes < <(nested_module_excludes "$module")
+          commits=$(git log --format="%s" "$compare_from..HEAD" -- "$module" "${excludes[@]}" 2>/dev/null || echo "")
           
           # Default to patch
           bump="patch"
@@ -129,11 +145,13 @@ jobs:
           # Get last tag for this module
           last_tag=$(git tag -l "${module_path}/v*" | sort -V | tail -1)
           
-          # Check if module has changes since last tag
+          # Check if module has changes since last tag — a nested module's
+          # files are a different module's changes and do not count (#917)
+          mapfile -t excludes < <(nested_module_excludes "$module_path")
           if [[ -z "$last_tag" ]]; then
             has_changes=true  # New module
           else
-            changes=$(git diff --name-only "$last_tag" HEAD -- "$module_path" | head -1)
+            changes=$(git diff --name-only "$last_tag" HEAD -- "$module_path" "${excludes[@]}" | head -1)
             has_changes=$([[ -n "$changes" ]] && echo true || echo false)
           fi
           
@@ -175,7 +193,7 @@ jobs:
             if [[ -n "$last_tag" ]]; then
               # Include commit summary
               release_notes="${release_notes}### Changes\n"
-              git log --format="- %s (%h)" "$last_tag..HEAD" -- "$module_path" | while read -r line; do
+              git log --format="- %s (%h)" "$last_tag..HEAD" -- "$module_path" "${excludes[@]}" | while read -r line; do
                 release_notes="${release_notes}${line}\n"
               done
             else

--- a/.github/workflows/auto-tag-modules-safe.yml
+++ b/.github/workflows/auto-tag-modules-safe.yml
@@ -67,7 +67,11 @@ jobs:
           fi
           
           # Check commit messages for this module — excluding nested modules,
-          # whose subjects must not grade the parent's bump (#917)
+          # whose subjects must not grade the parent's bump (#917). local, so
+          # this can never shadow a caller's excludes — belt and braces: the
+          # function is only ever invoked via $(...) command substitution,
+          # whose subshell already isolates it.
+          local -a excludes
           mapfile -t excludes < <(nested_module_excludes "$module")
           commits=$(git log --format="%s" "$compare_from..HEAD" -- "$module" "${excludes[@]}" 2>/dev/null || echo "")
           
@@ -193,9 +197,14 @@ jobs:
             if [[ -n "$last_tag" ]]; then
               # Include commit summary
               release_notes="${release_notes}### Changes\n"
-              git log --format="- %s (%h)" "$last_tag..HEAD" -- "$module_path" "${excludes[@]}" | while read -r line; do
-                release_notes="${release_notes}${line}\n"
-              done
+              # Captured, not piped into `while read`: the pipe's subshell
+              # discarded every appended line, so annotated tags have carried
+              # an empty change list since this workflow was written. The
+              # capture has real newlines; echo -e passes them through.
+              commit_lines=$(git log --format="- %s (%h)" "$last_tag..HEAD" -- "$module_path" "${excludes[@]}")
+              if [[ -n "$commit_lines" ]]; then
+                release_notes="${release_notes}${commit_lines}\n"
+              fi
             else
               release_notes="${release_notes}Initial release\n"
             fi


### PR DESCRIPTION
Closes the nested-module-leak half of #917's remaining findings (the compat-gate path filter and the squash-title rule stay open there).

**The defect**: `has_changes` and `determine_bump` both use prefix pathspecs (`-- $module`), so a child module's merge marks the parent changed and grades it off the child's subjects. Three phantom dnd5e versions exist as evidence — v0.85.0, v0.91.0, v0.92.0 all point at resolution-only merges.

**The fix**: `nested_module_excludes` emits `:(exclude)` pathspecs for every in-module directory carrying its own go.mod (vendor/ excepted — vendored go.mods are dependencies, not boundaries), applied to the change check, the bump grading, and the release notes.

**Verification** — the modified logic run as a harness against the exact history that minted the phantoms (table in the commit): phantom range reports no changes; the real #1006 range still grades feat/minor; leaf and quiet modules byte-identical. Plus `bash -n` and YAML parse.

**Production check after merge**: the next resolution-module merge (PR-B of #1003 is in flight) must mint a resolution tag and NO new dnd5e tag — that's this fix observed live, the #981 precedent.

— asset-pipeline agent, on behalf of KirkDiggler