### PR TITLE
feat(resolution): compile a character's equipped weapon into an attack profile

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// CharacterAttackInput names which swing to compile.
+//
+// The grip is the caller's to state rather than the compiler's to infer. A
+// versatile weapon in a free off hand is *usually* two-handed, but "usually"
+// is a turn-economy question — a character may choose a one-handed grip to
+// keep a hand free — and this compiler answers only what the sheet and the
+// weapon already know.
+type CharacterAttackInput struct {
+	// Slot names the equipped weapon to swing. The main hand for a standard
+	// attack; the off hand for the second swing of two-weapon fighting, whose
+	// economy and ability-modifier rules live above this compiler.
+	Slot character.InventorySlot
+
+	// TwoHanded says the weapon is gripped in both hands. It changes the dice
+	// of a versatile weapon and nothing else — not the ability, not the
+	// proficiency, not the bonus.
+	TwoHanded bool
+}
+
+// AttackFromCharacter compiles an equipped weapon and the sheet holding it
+// into the same neutral profile a monster action compiles into. It is the
+// character half of the seam [StrikeInput.Attack] names, and the machine
+// cannot tell the two apart — that indistinguishability is the whole point
+// (rpg-toolkit#1003).
+//
+// # What compiles here, and what does not
+//
+// Only STATIC facts: the weapon's dice and damage type, whether finesse lets
+// DEX win, whether the sheet is proficient, and whether a versatile grip
+// steps the die. Every one of them is knowable before the swing and cannot
+// change between two swings of the same weapon by the same character.
+//
+// Situational effects are deliberately absent and MUST stay absent. Rage's
+// damage bonus, Bless, Sneak Attack's dice, advantage from any source — each
+// has its own predicate that decides per swing, and each arrives through the
+// chain folds the machine already runs. A Raging character's profile is
+// byte-identical to the same character's profile when calm; the +2 arrives at
+// the damage fold, attributed to Raging's own ref. If a mechanic seems to
+// want a new field here, it is almost certainly a chain contribution wearing
+// a disguise.
+//
+// # Named gaps
+//
+// Melee only. A ranged weapon is refused by name for the same reason the
+// monster's ranged action is: the strike has no range semantics — no range
+// brackets, no long-range disadvantage, and prone's interaction reverses at
+// distance. Compiler and machine both grow when that arrives.
+//
+// No unarmed strike. An empty slot is refused rather than falling back to the
+// catalog's unarmed weapon, because a silent 1d1 fallback is how a character
+// who dropped their sword keeps "attacking" and nobody notices. Monk martial
+// arts dice are a future compiler's business.
+//
+// Reach and adjacency are unenforced, exactly as for the bite: the strike
+// does not check distance at all. One shared, named gap, not one this case
+// adds.
+func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (AttackProfile, error) {
+	if c == nil {
+		return AttackProfile{}, fmt.Errorf("%w: no character to compile", ErrNilInput)
+	}
+	if in == nil {
+		return AttackProfile{}, fmt.Errorf("%w: no attack input", ErrNilInput)
+	}
+
+	weapon, err := equippedWeapon(c, in.Slot)
+	if err != nil {
+		return AttackProfile{}, err
+	}
+
+	// Category, not the presence of a Range: a dagger is a melee weapon that
+	// carries a thrown range, and refusing on Range != nil would reject every
+	// thrown melee weapon in the catalog.
+	if weapon.IsRanged() {
+		return AttackProfile{}, fmt.Errorf(
+			"%w: %q is a ranged weapon (the strike has no range semantics yet)", ErrBadAttack, weapon.ID)
+	}
+
+	ref := refs.Weapons.ByID(string(weapon.ID))
+	if ref == nil {
+		return AttackProfile{}, fmt.Errorf("%w: no ref for weapon %q", ErrBadAttack, weapon.ID)
+	}
+
+	ability := attackAbility(c, weapon)
+	modifier := c.GetAbilityModifier(ability)
+
+	// Proficiency is a fact about the sheet, not about the swing: a character
+	// wielding a weapon they were never trained on adds their ability modifier
+	// and nothing else.
+	attackBonus := modifier
+	if c.IsProficientWith(weapon) {
+		attackBonus += c.ProficiencyBonus()
+	}
+
+	dice := weapon.Damage
+	if in.TwoHanded {
+		dice = weapon.VersatileDamage()
+	}
+
+	return AttackProfile{
+		Ref:         ref,
+		AttackBonus: attackBonus,
+		// The ability modifier rides the notation rather than a separate
+		// field, and that is load-bearing for critical hits: the machine
+		// doubles a crit by rolling the pool a second time and takes the flat
+		// modifier from the FIRST roll only, so "+3" inside "1d8+3" doubles
+		// the dice and not the modifier — which is exactly ADR-0036's rule.
+		DamageDice: fmt.Sprintf("%s%+d", dice, modifier),
+		DamageType: weapon.DamageType,
+		// Which ability swung. Not arithmetic — the modifier is already in the
+		// notation above — but the fact effects predicate on: Rage pays out on
+		// melee Strength attacks and needs to know this was one.
+		AbilityUsed: ability,
+		// Weapons declare no rider. A gate on a character's attack comes from
+		// class content (a monk's Flurry), which compiles elsewhere.
+		Gate: nil,
+	}, nil
+}
+
+// equippedWeapon reads the weapon out of a slot, refusing an empty or
+// non-weapon slot by name.
+func equippedWeapon(c *character.Character, slot character.InventorySlot) (*weapons.Weapon, error) {
+	if slot == "" {
+		return nil, fmt.Errorf("%w: no equipment slot named", ErrBadAttack)
+	}
+
+	equipped := c.GetEquippedSlot(slot)
+	if equipped == nil {
+		return nil, fmt.Errorf("%w: nothing equipped in %q", ErrBadAttack, slot)
+	}
+
+	weapon := equipped.AsWeapon()
+	if weapon == nil {
+		return nil, fmt.Errorf("%w: %q holds no weapon", ErrBadAttack, slot)
+	}
+
+	return weapon, nil
+}
+
+// attackAbility picks the ability a melee weapon swings with: Strength,
+// unless the weapon is finesse and the character's Dexterity is strictly
+// better.
+//
+// Strictly better, not merely different: 5e lets a finesse wielder choose,
+// and a tie is not a choice worth making — the two produce identical numbers,
+// so STR wins by being the default rather than by being larger.
+func attackAbility(c *character.Character, weapon *weapons.Weapon) abilities.Ability {
+	if !weapon.HasProperty(weapons.PropertyFinesse) {
+		return abilities.STR
+	}
+
+	if c.GetAbilityModifier(abilities.DEX) > c.GetAbilityModifier(abilities.STR) {
+		return abilities.DEX
+	}
+
+	return abilities.STR
+}

--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -1,0 +1,568 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// CharacterAttackTestSuite drives the character half of the attack seam: a
+// sheet plus an equipped weapon compiles into the same profile a stat block
+// does, and the machine runs it without knowing the difference.
+type CharacterAttackTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestCharacterAttackSuite(t *testing.T) {
+	suite.Run(t, new(CharacterAttackTestSuite))
+}
+
+func (s *CharacterAttackTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// heroSheet is a fighter's persisted sheet: STR 16 (+3), DEX 14 (+2),
+// proficiency +2, and whatever weapons and grants the case needs.
+//
+// Ability scores are chosen so STR and DEX are DIFFERENT (+3 vs +2). A sheet
+// where they tie cannot tell a finesse derivation from a Strength one.
+func (s *CharacterAttackTestSuite) heroSheet(
+	profs []proficiencies.Weapon, equipped map[character.InventorySlot]string, conds ...json.RawMessage,
+) *character.Data {
+	inventory := make([]character.InventoryItemData, 0, len(equipped))
+	slots := character.EquipmentSlots{}
+	for slot, id := range equipped {
+		inventory = append(inventory, character.InventoryItemData{
+			Type: shared.EquipmentTypeWeapon, ID: id, Quantity: 1,
+		})
+		slots[slot] = id
+	}
+
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:           14,
+		MaxHitPoints:        14,
+		ArmorClass:          14,
+		ProficiencyBonus:    2,
+		WeaponProficiencies: profs,
+		Inventory:           inventory,
+		EquipmentSlots:      slots,
+		Conditions:          conds,
+	}
+}
+
+// martialHero is the common case: proficient with everything, longsword in
+// the main hand.
+func (s *CharacterAttackTestSuite) martialHero(conds ...json.RawMessage) *character.Data {
+	return s.heroSheet(
+		[]proficiencies.Weapon{proficiencies.WeaponSimple, proficiencies.WeaponMartial},
+		map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Longsword)},
+		conds...,
+	)
+}
+
+// load reconstitutes a sheet into the live character the compiler reads.
+func (s *CharacterAttackTestSuite) load(data *character.Data) *character.Character {
+	c, err := character.Load(s.ctx, data)
+	s.Require().NoError(err)
+
+	return c
+}
+
+func (s *CharacterAttackTestSuite) compile(
+	data *character.Data, in *CharacterAttackInput,
+) AttackProfile {
+	profile, err := AttackFromCharacter(s.load(data), in)
+	s.Require().NoError(err)
+
+	return profile
+}
+
+func (s *CharacterAttackTestSuite) mainHand() *CharacterAttackInput {
+	return &CharacterAttackInput{Slot: character.SlotMainHand}
+}
+
+// world puts the hero next to the wolf. Adjacency matters only to prone's
+// range predicate, which nobody here triggers.
+func (s *CharacterAttackTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+func (s *CharacterAttackTestSuite) swingAt(
+	hero *character.Data, profile AttackProfile, roller *sequenceRoller,
+) (*Output, error) {
+	return Resolve(s.ctx, &Input{
+		World: s.world(),
+		Participants: []Participant{
+			{Character: hero},
+			{Monster: s.wolfData()},
+		},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: heroID,
+			TargetID:   wolfID,
+			Attack:     profile,
+			Roller:     roller,
+		}),
+	})
+}
+
+func (s *CharacterAttackTestSuite) wolfData() *monster.Data {
+	return monsters.NewWolf(wolfID).ToData()
+}
+
+func (s *CharacterAttackTestSuite) outcomeOf(out *Output) StrikeOutcome {
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok, "a strike produces a StrikeOutcome")
+
+	return outcome
+}
+
+func (s *CharacterAttackTestSuite) raging() json.RawMessage {
+	raw, err := (&conditions.RagingCondition{
+		CharacterID: heroID,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// ---------------------------------------------------------------------------
+// 1. THE HEADLINE: a hero's own longsword takes a wolf's hit points.
+// ---------------------------------------------------------------------------
+
+// The sheet and the equipped weapon are the whole input. One compilation step
+// later the wolf has exactly dice-plus-modifier fewer hit points, through the
+// same machine the wolf's own bite drives.
+func (s *CharacterAttackTestSuite) TestAHeroSwingsTheirLongswordAtAWolf() {
+	profile := s.compile(s.martialHero(), s.mainHand())
+
+	// STR 16 (+3) plus proficiency +2 to hit; the +3 rides the damage pool.
+	s.Require().Equal(refs.Weapons.Longsword(), profile.Ref)
+	s.Require().Equal(3+2, profile.AttackBonus)
+	s.Require().Equal("1d8+3", profile.DamageDice)
+	s.Require().Equal(damage.Slashing, profile.DamageType)
+	s.Require().Nil(profile.Gate, "a weapon declares no rider")
+
+	out, err := s.swingAt(s.martialHero(), profile,
+		&sequenceRoller{singles: []int{15}, pair: []int{5}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome := s.outcomeOf(out)
+	s.Require().True(outcome.Hit, "15 + 5 beats the wolf's AC 13")
+	s.Require().False(outcome.Critical)
+	s.Require().Equal(5+3, outcome.Damage, "1d8 rolled [5], plus the +3 — exact, not merely positive")
+	s.Require().Nil(outcome.Contest, "no gate, no save")
+
+	s.Require().Len(out.DirtyMonsters, 1)
+	s.Require().Equal(wolfID, out.DirtyMonsters[0].ID)
+	s.Require().Equal(11-8, out.DirtyMonsters[0].HitPoints, "the wolf's 11 hit points, less exactly 8")
+}
+
+// ---------------------------------------------------------------------------
+// 2. Finesse: the better ability wins, and it shows up in BOTH numbers.
+// ---------------------------------------------------------------------------
+
+// One sheet, two weapons. The dagger is finesse and this hero's DEX beats
+// their STR, so the dagger derives from DEX while the mace — same sheet, same
+// turn — still derives from STR. Asserting one weapon alone cannot tell a
+// finesse rule from a hard-coded ability.
+func (s *CharacterAttackTestSuite) TestFinesseTakesTheBetterAbilityInBothNumbers() {
+	// STR 10 (+0), DEX 18 (+4): a spread no tie can hide inside.
+	sheet := s.heroSheet(
+		[]proficiencies.Weapon{proficiencies.WeaponSimple},
+		map[character.InventorySlot]string{
+			character.SlotMainHand: string(weapons.Dagger),
+			character.SlotOffHand:  string(weapons.Mace),
+		},
+	)
+	sheet.AbilityScores[abilities.STR] = 10
+	sheet.AbilityScores[abilities.DEX] = 18
+
+	dagger := s.compile(sheet, &CharacterAttackInput{Slot: character.SlotMainHand})
+	s.Require().Equal(4+2, dagger.AttackBonus, "DEX +4 plus proficiency +2")
+	s.Require().Equal("1d4+4", dagger.DamageDice, "and the DEX modifier rides the damage too")
+	s.Require().Equal(damage.Piercing, dagger.DamageType)
+
+	mace := s.compile(sheet, &CharacterAttackInput{Slot: character.SlotOffHand})
+	s.Require().Equal(0+2, mace.AttackBonus, "no finesse: STR +0 plus proficiency +2")
+	s.Require().Equal("1d6+0", mace.DamageDice, "and STR rides the damage, at +0")
+
+	// The whole point, stated as the difference the property makes.
+	s.Require().Equal(4, dagger.AttackBonus-mace.AttackBonus,
+		"finesse is worth exactly the DEX-over-STR spread")
+}
+
+// Finesse picks the BETTER ability, not simply Dexterity: the same dagger on a
+// strong, clumsy hero derives from Strength.
+func (s *CharacterAttackTestSuite) TestFinesseKeepsStrengthWhenStrengthIsBetter() {
+	sheet := s.heroSheet(
+		[]proficiencies.Weapon{proficiencies.WeaponSimple},
+		map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Dagger)},
+	)
+	sheet.AbilityScores[abilities.STR] = 18 // +4
+	sheet.AbilityScores[abilities.DEX] = 10 // +0
+
+	dagger := s.compile(sheet, s.mainHand())
+	s.Require().Equal(4+2, dagger.AttackBonus, "STR +4 wins")
+	s.Require().Equal("1d4+4", dagger.DamageDice)
+}
+
+// A tie is not a choice: identical modifiers produce identical numbers, so the
+// default stands rather than flipping on equality.
+func (s *CharacterAttackTestSuite) TestFinesseOnATieIsStillTheSameArithmetic() {
+	sheet := s.heroSheet(
+		[]proficiencies.Weapon{proficiencies.WeaponSimple},
+		map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Dagger)},
+	)
+	sheet.AbilityScores[abilities.STR] = 14 // +2
+	sheet.AbilityScores[abilities.DEX] = 14 // +2
+
+	dagger := s.compile(sheet, s.mainHand())
+	s.Require().Equal(2+2, dagger.AttackBonus)
+	s.Require().Equal("1d4+2", dagger.DamageDice)
+}
+
+// ---------------------------------------------------------------------------
+// 3. Proficiency: present or absent, and exactly the bonus apart.
+// ---------------------------------------------------------------------------
+
+// The same hero with the same longsword, granted martial weapons or not. The
+// attack bonus differs by exactly the proficiency bonus and the damage does
+// not move at all — proficiency buys accuracy, never harm.
+func (s *CharacterAttackTestSuite) TestProficiencyIsWorthExactlyTheProficiencyBonus() {
+	equipped := map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Longsword)}
+
+	trained := s.compile(
+		s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponMartial}, equipped), s.mainHand())
+	// Simple weapons only: a longsword is martial, so this grant does not reach it.
+	untrained := s.compile(
+		s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponSimple}, equipped), s.mainHand())
+
+	s.Require().Equal(3+2, trained.AttackBonus, "STR +3 plus proficiency +2")
+	s.Require().Equal(3, untrained.AttackBonus, "STR +3 and nothing else")
+	s.Require().Equal(2, trained.AttackBonus-untrained.AttackBonus,
+		"exactly the sheet's proficiency bonus apart")
+
+	s.Require().Equal(untrained.DamageDice, trained.DamageDice,
+		"proficiency never touches the damage pool")
+	s.Require().Equal("1d8+3", trained.DamageDice)
+}
+
+// A sheet with no weapon grants at all adds nothing.
+func (s *CharacterAttackTestSuite) TestNoGrantsAddsNoProficiencyBonus() {
+	profile := s.compile(
+		s.heroSheet(nil, map[character.InventorySlot]string{
+			character.SlotMainHand: string(weapons.Longsword),
+		}), s.mainHand())
+
+	s.Require().Equal(3, profile.AttackBonus)
+}
+
+// ---------------------------------------------------------------------------
+// 4. A character's critical hit doubles the dice and not the modifier.
+// ---------------------------------------------------------------------------
+
+// The ability modifier rides inside "1d8+3", and that is exactly why the crit
+// is right: the machine rolls the pool twice and takes the flat modifier from
+// the first roll only. Two d8s, one +3.
+func (s *CharacterAttackTestSuite) TestACharacterCritDoublesTheDiceNotTheAbilityModifier() {
+	profile := s.compile(s.martialHero(), s.mainHand())
+	s.Require().Equal("1d8+3", profile.DamageDice)
+
+	out, err := s.swingAt(s.martialHero(), profile,
+		&sequenceRoller{singles: []int{20}, pair: []int{5, 4}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome := s.outcomeOf(out)
+	s.Require().True(outcome.Hit, "a natural 20 always hits")
+	s.Require().True(outcome.Critical)
+	s.Require().Equal(5+4+3, outcome.Damage,
+		"1d8 rolled twice — [5] then [4] — plus the +3 exactly once, not twice")
+
+	// Spelled out, because this is the arithmetic that would silently be wrong
+	// if the modifier rode a separate field the machine doubled.
+	s.Require().NotEqual(5+4+3+3, outcome.Damage, "the ability modifier must not double")
+}
+
+// ---------------------------------------------------------------------------
+// 5. THE LOAD-BEARING ROW: the compiler does not know Rage exists.
+// ---------------------------------------------------------------------------
+
+// Rage's damage bonus is situational — its own predicate decides per swing —
+// so it must arrive through the damage fold and never through the compiler.
+// Two things prove the split: the profile is IDENTICAL whether the hero is
+// raging or calm, and the extra damage still lands, attributed to Raging.
+func (s *CharacterAttackTestSuite) TestARagingHerosBonusArrivesViaTheChainNotTheCompiler() {
+	calm := s.compile(s.martialHero(), s.mainHand())
+	raging := s.compile(s.martialHero(s.raging()), s.mainHand())
+
+	s.Require().Equal(calm, raging,
+		"the compiler reads static facts only — Rage is invisible to it")
+	s.Require().Equal("1d8+3", raging.DamageDice, "no +2 anywhere in the compiled pool")
+	s.Require().Equal(3+2, raging.AttackBonus)
+
+	out, err := s.swingAt(s.martialHero(s.raging()), raging,
+		&sequenceRoller{singles: []int{15}, pair: []int{5}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome := s.outcomeOf(out)
+	s.Require().True(outcome.Hit)
+	s.Require().Equal(5+3+2, outcome.Damage,
+		"1d8 [5] + STR +3 from the compiler, + Rage's +2 from the fold")
+
+	// And the ledger names who did it, which is what makes the attribution a
+	// fact rather than an arithmetic coincidence.
+	s.Require().True(s.attachedBy(out, refs.Conditions.Raging()),
+		"Raging subscribed to the interaction's bus")
+}
+
+// The same swing without Rage lands exactly two less — the difference IS the
+// fold's contribution, measured rather than asserted.
+func (s *CharacterAttackTestSuite) TestTheSameSwingWithoutRageLandsExactlyTwoLess() {
+	profile := s.compile(s.martialHero(), s.mainHand())
+
+	out, err := s.swingAt(s.martialHero(), profile,
+		&sequenceRoller{singles: []int{15}, pair: []int{5}, fallback: 2})
+	s.Require().NoError(err)
+
+	s.Require().Equal(5+3, s.outcomeOf(out).Damage)
+	s.Require().False(s.attachedBy(out, refs.Conditions.Raging()), "nobody is raging here")
+}
+
+// The other direction, and the one that proves AbilityUsed is derived rather
+// than hard-coded: Rage pays out on melee STRENGTH attacks. The same raging
+// hero swinging a finesse dagger off DEX gets the weapon's damage and NOT the
+// rage bonus — 5e's rule, and it only works because the compiler reported
+// which ability it actually chose.
+func (s *CharacterAttackTestSuite) TestRageDoesNotPayOutOnADexterityFinesseSwing() {
+	equipped := map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Dagger)}
+	grants := []proficiencies.Weapon{proficiencies.WeaponSimple}
+
+	sheet := s.heroSheet(grants, equipped, s.raging())
+	sheet.AbilityScores[abilities.STR] = 10 // +0
+	sheet.AbilityScores[abilities.DEX] = 18 // +4
+
+	profile := s.compile(sheet, s.mainHand())
+	s.Require().Equal(abilities.DEX, profile.AbilityUsed, "finesse chose DEX")
+	s.Require().Equal("1d4+4", profile.DamageDice)
+
+	freshSheet := s.heroSheet(grants, equipped, s.raging())
+	freshSheet.AbilityScores[abilities.STR] = 10
+	freshSheet.AbilityScores[abilities.DEX] = 18
+
+	out, err := s.swingAt(freshSheet, profile,
+		&sequenceRoller{singles: []int{15}, pair: []int{3}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome := s.outcomeOf(out)
+	s.Require().True(outcome.Hit)
+	s.Require().Equal(3+4, outcome.Damage,
+		"1d4 [3] + DEX +4, and no rage bonus — Rage is a Strength rule")
+	s.Require().True(s.attachedBy(out, refs.Conditions.Raging()),
+		"Raging was attached and simply declined to contribute")
+}
+
+// A Strength swing by the same raging hero DOES pay out, which is what makes
+// the case above a rule rather than a broken subscription.
+func (s *CharacterAttackTestSuite) TestRagePaysOutOnTheStrengthSwing() {
+	profile := s.compile(s.martialHero(s.raging()), s.mainHand())
+	s.Require().Equal(abilities.STR, profile.AbilityUsed)
+
+	out, err := s.swingAt(s.martialHero(s.raging()), profile,
+		&sequenceRoller{singles: []int{15}, pair: []int{5}, fallback: 2})
+	s.Require().NoError(err)
+
+	s.Require().Equal(5+3+2, s.outcomeOf(out).Damage)
+}
+
+// attachedBy reports whether any subscription in the ledger was made by the
+// named effect.
+func (s *CharacterAttackTestSuite) attachedBy(out *Output, effect *core.Ref) bool {
+	for _, hook := range out.Hooks {
+		if hook.Effect.Module == effect.Module &&
+			hook.Effect.Type == effect.Type &&
+			hook.Effect.ID == effect.ID {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// 6. Determinism.
+// ---------------------------------------------------------------------------
+
+// The same sheet compiled and resolved twice produces the same registration
+// list, in the same order. Map iteration over equipment or proficiencies would
+// show up here as a flake.
+func (s *CharacterAttackTestSuite) TestTwoIdenticalRunsRegisterTheSameHooksInOrder() {
+	first, err := s.swingAt(s.martialHero(s.raging()), s.compile(s.martialHero(s.raging()), s.mainHand()),
+		&sequenceRoller{singles: []int{15}, pair: []int{5}, fallback: 2})
+	s.Require().NoError(err)
+
+	second, err := s.swingAt(s.martialHero(s.raging()), s.compile(s.martialHero(s.raging()), s.mainHand()),
+		&sequenceRoller{singles: []int{15}, pair: []int{5}, fallback: 2})
+	s.Require().NoError(err)
+
+	s.Require().Equal(s.hookShape(first), s.hookShape(second))
+	s.Require().NotEmpty(s.hookShape(first), "something was attached, so the comparison means something")
+	s.Require().Equal(s.outcomeOf(first).Damage, s.outcomeOf(second).Damage)
+}
+
+// hookShape reduces the ledger to what is stable across runs: who attached
+// what topic, in order. Subscription IDs are the bus's own counter and are
+// deliberately excluded.
+func (s *CharacterAttackTestSuite) hookShape(out *Output) []string {
+	shape := make([]string, 0, len(out.Hooks))
+	for _, hook := range out.Hooks {
+		shape = append(shape, hook.Participant+"|"+hook.Effect.String()+"|"+string(hook.Topic))
+	}
+
+	return shape
+}
+
+// The compiler itself is deterministic: same sheet in, identical profile out.
+func (s *CharacterAttackTestSuite) TestTheCompilerIsDeterministic() {
+	first := s.compile(s.martialHero(), s.mainHand())
+	second := s.compile(s.martialHero(), s.mainHand())
+
+	s.Require().Equal(first, second)
+}
+
+// ---------------------------------------------------------------------------
+// Versatile, and the refusals.
+// ---------------------------------------------------------------------------
+
+// A versatile weapon gripped in two hands steps its die and moves nothing
+// else: same ref, same bonus, same damage type, one bigger die.
+func (s *CharacterAttackTestSuite) TestAVersatileWeaponStepsItsDieAndNothingElse() {
+	oneHanded := s.compile(s.martialHero(), s.mainHand())
+	twoHanded := s.compile(s.martialHero(),
+		&CharacterAttackInput{Slot: character.SlotMainHand, TwoHanded: true})
+
+	s.Require().Equal("1d8+3", oneHanded.DamageDice)
+	s.Require().Equal("1d10+3", twoHanded.DamageDice)
+
+	s.Require().Equal(oneHanded.AttackBonus, twoHanded.AttackBonus, "the grip does not change accuracy")
+	s.Require().Equal(oneHanded.Ref, twoHanded.Ref)
+	s.Require().Equal(oneHanded.DamageType, twoHanded.DamageType)
+}
+
+// A non-versatile weapon in two hands is the same weapon: the flag asks the
+// weapon a question, and a greatsword's answer is its own 2d6.
+func (s *CharacterAttackTestSuite) TestTwoHandedOnANonVersatileWeaponChangesNothing() {
+	sheet := s.heroSheet(
+		[]proficiencies.Weapon{proficiencies.WeaponMartial},
+		map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Greatsword)},
+	)
+
+	oneHanded := s.compile(sheet, s.mainHand())
+	twoHanded := s.compile(sheet, &CharacterAttackInput{Slot: character.SlotMainHand, TwoHanded: true})
+
+	s.Require().Equal("2d6+3", oneHanded.DamageDice)
+	s.Require().Equal(oneHanded, twoHanded)
+}
+
+func (s *CharacterAttackTestSuite) TestRefusesWhatItCannotCompile() {
+	equippedLongsword := map[character.InventorySlot]string{
+		character.SlotMainHand: string(weapons.Longsword),
+	}
+
+	s.Run("a ranged weapon, because the strike has no range semantics", func() {
+		sheet := s.heroSheet(
+			[]proficiencies.Weapon{proficiencies.WeaponMartial},
+			map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Longbow)},
+		)
+		_, err := AttackFromCharacter(s.load(sheet), s.mainHand())
+		s.Require().ErrorIs(err, ErrBadAttack)
+	})
+
+	s.Run("a thrown MELEE weapon is not ranged — a dagger still compiles", func() {
+		sheet := s.heroSheet(
+			[]proficiencies.Weapon{proficiencies.WeaponSimple},
+			map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Dagger)},
+		)
+		profile, err := AttackFromCharacter(s.load(sheet), s.mainHand())
+		s.Require().NoError(err, "a dagger carries a thrown range but is a melee weapon")
+		s.Require().Equal("1d4+3", profile.DamageDice)
+	})
+
+	s.Run("an empty slot, rather than a silent unarmed strike", func() {
+		sheet := s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponMartial}, nil)
+		_, err := AttackFromCharacter(s.load(sheet), s.mainHand())
+		s.Require().ErrorIs(err, ErrBadAttack)
+	})
+
+	s.Run("a slot holding nothing this build calls a weapon", func() {
+		sheet := s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponMartial}, equippedLongsword)
+		_, err := AttackFromCharacter(s.load(sheet), &CharacterAttackInput{Slot: character.SlotArmor})
+		s.Require().ErrorIs(err, ErrBadAttack)
+	})
+
+	s.Run("no slot named at all", func() {
+		sheet := s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponMartial}, equippedLongsword)
+		_, err := AttackFromCharacter(s.load(sheet), &CharacterAttackInput{})
+		s.Require().ErrorIs(err, ErrBadAttack)
+	})
+
+	s.Run("a nil character or nil input", func() {
+		_, err := AttackFromCharacter(nil, s.mainHand())
+		s.Require().ErrorIs(err, ErrNilInput)
+
+		sheet := s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponMartial}, equippedLongsword)
+		_, err = AttackFromCharacter(s.load(sheet), nil)
+		s.Require().ErrorIs(err, ErrNilInput)
+	})
+}

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.90.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.93.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.90.0 h1:7/TkXhl5KaarTj3Htjp2X/J53n/7bX/LZirY+pfJx/I=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.90.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.93.0 h1:yDQ7GOPt8D6ubdM14h9IdTqJS0NZTf6+xgp1c26z95A=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.93.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0 h1:GcwmLanoceCnrQ1R1Z61N7qLqMBY8VUPq5TpL1BhfUw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0/go.mod h1:ZYYd+oFBN6WUPIb+OTaAu6X7CQtVhOjEg9i0GJM0o6Q=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
@@ -67,6 +68,24 @@ type AttackProfile struct {
 
 	// DamageType is what kind of harm lands.
 	DamageType damage.Type
+
+	// AbilityUsed is the ability the compiler swung with, when it chose one.
+	//
+	// It carries no arithmetic — the modifier is already inside DamageDice —
+	// and exists because effects predicate on it. Rage's damage bonus applies
+	// only to melee attacks made with Strength, so it reads this off the
+	// folded damage event; with the field empty its predicate never matches
+	// and a raging character silently loses the bonus. Measured, not assumed:
+	// a raging hero's longsword dealt 8 instead of 10 before this was
+	// plumbed (TestARagingHerosBonusArrivesViaTheChainNotTheCompiler).
+	//
+	// The empty value is meaningful and correct for a stat block: a monster
+	// action's numbers are pre-computed and name no ability, so
+	// AttackFromMonsterAction leaves it unset rather than guessing STR.
+	//
+	// This is the field the attack-profile seam named as additive when a
+	// predicate finally needed it (docs/ideas/session-sdk/attack-profile-seam.md).
+	AbilityUsed abilities.Ability
 
 	// Gate is the rider's contest, if the attack declares one (ADR-0039).
 	// Nil means the attack just hits.
@@ -312,7 +331,11 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 		HasAdvantage: len(m.outcome.Folded.AdvantageSources) > 0,
 		WeaponDamage: m.in.Attack.DamageDice,
 		IsMelee:      true,
-		WeaponRef:    m.in.Attack.Ref,
+		// Which ability swung, for the effects that predicate on it — Rage
+		// only pays out on a melee Strength attack. Empty when the compiler
+		// named none, which is a stat block's honest answer.
+		AbilityUsed: m.in.Attack.AbilityUsed,
+		WeaponRef:   m.in.Attack.Ref,
 	}, m.afterDamageChain), nil
 }
 


### PR DESCRIPTION
Closes #1003. Second half of the split whose first half was #1006 (merged, tagged `rulebooks/dnd5e/v0.93.0`).

## The claim this PR is here to stop asserting

The strike machine reads an `AttackProfile` and does not know who filled it in. With one compiler that was an assertion. This is the second consumer — a character's sheet plus the weapon in their hand — and **the machine's phases did not change to accept it**.

```go
profile, _ := resolution.AttackFromCharacter(hero, &resolution.CharacterAttackInput{
    Slot: character.SlotMainHand,
})
// AttackProfile{Ref: dnd5e:weapons:longsword, AttackBonus: 5,
//               DamageDice: "1d8+3", DamageType: Slashing,
//               AbilityUsed: str, Gate: nil}

resolution.NewStrike(&resolution.StrikeInput{
    AttackerID: "hero", TargetID: "wolf-1", Attack: profile,
})
```

`strike.go` does not import `character` at all — the machine cannot reach the compiler's types even in principle. That is the mutation the review checklist asked for and it is inexpressible by construction, which is the strongest form of the answer.

## What compiles, and what deliberately does not

Static facts only: weapon dice and damage type, finesse's ability choice, proficiency coverage, and a versatile grip's die step. The ability modifier rides **inside the notation** (`"1d8+3"`) rather than a separate field, which makes a character's critical hit correct for free — the machine doubles a crit by rolling the pool twice and takes the flat modifier from the first roll only, so the dice double and the `+3` does not.

Situational effects stay out, per the seam's stress table. The load-bearing test proves the split rather than describing it: a raging hero's compiled profile is **identical** to the same hero's when calm, and Rage's `+2` arrives at the damage fold attributed to `dnd5e:conditions:raging`.

### Named refusals

- **Ranged weapons**, by name — the strike has no range semantics. The guard keys on the weapon's **category** (`IsRanged()`), *not* on carrying a `Range`: a dagger is `simple-melee` and carries `Range{20,60}` for throwing, so a `Range != nil` guard would refuse every thrown melee weapon. Both directions are tested and mutation-covered (N5/N6).
- **An empty slot**, rather than falling back to the catalog's unarmed strike. A silent `1d1` is how a disarmed character keeps "attacking" and nobody notices. Note `character.MeleeWeapon()` does exactly that fallback, which is why this compiler does not reuse it.
- Unarmed strike and Monk martial-arts dice are a future compiler's business.

## ⚠️ One change outside the compiler — measured, not chosen

`AttackProfile` gained `AbilityUsed`, and the machine passes it into the damage chain. **Two lines, and I want it called out rather than buried**, because the brief for this slice was compiler-only.

I did not go looking for this. Headline test 5 failed: a raging hero's longsword dealt **8** where it should deal **10**. Rage's damage bonus predicates on *"melee attack made with Strength"* (`conditions/raging.go`: `if e.AbilityUsed != abilities.STR || !e.IsMelee`). The machine set `IsMelee: true` but never `AbilityUsed`, so the predicate could not match.

Precisely what this is, and what it is not: **nothing shipped was ever wrong.** No character could drive this machine at all before this PR, so the gap was latent rather than live — the seam doc's prediction landing on schedule, exposed by the first character attacker, not a live bug retro-fixed. What it *would* have been, had the field stayed absent, is every character melee attack silently losing the bonus. That is why it is fixed here, in the PR that first makes the path reachable, rather than deferred.

This is the field the seam doc named in advance as additive when a predicate finally needed one:

> **`AbilityUsed` on the attack chain event** — if an effect ever predicates on "attacks using Strength", the folded event will need to carry which ability the compiler chose. Additive when needed; not built against hypotheticals.

It is also static-fact data by the stress table's own rule, so it belongs on the profile. A stat block leaves it empty and that is correct — a monster action's numbers are pre-computed and name no ability, so `AttackFromMonsterAction` does not guess `STR`. Every existing monster test passes untouched.

Both directions are pinned: a raging hero's **Strength** longsword gets the `+2`; the same raging hero's **Dexterity** finesse dagger does not, and the ledger shows Raging attached and declining. That pair is what proves `AbilityUsed` is genuinely derived rather than hard-coded (N10 dies on exactly it).

**If you would rather this ride its own PR, say so and I will back it out** — the cost is that headline test 5 cannot pass and Rage stays broken for characters.

## Evidence

From `rulebooks/dnd5e/resolution/`:

| Check | Result |
|---|---|
| `go test ./...` | **exit 0 — 69 subtests pass, 0 fail** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff beyond the intended `v0.90.0 → v0.93.0` bump |

Only the `resolution` module is touched. `go.mod` pins `rulebooks/dnd5e v0.93.0` — deliberately **not** v0.91.0/v0.92.0, which are phantom tags from the #917 nested-module leak pointing at resolution-only merges (`v0.92.0` → `df26d0b`, the #1002 squash) and contain none of #1006's code. **No `replace` committed.** No existing test modified — `strike_test.go` is untouched and green.

## Mutation table

15 mutants, all killed by assertion failures (each rewritten to compile where a naive edit would have died on `declared and not used`).

| # | Mutation | Result | Killed by |
|---|---|---|---|
| N1 | finesse takes DEX first, not the better | KILLED | `TestFinesseKeepsStrengthWhenStrengthIsBetter` |
| N2 | proficiency bonus always added | KILLED | `TestNoGrantsAddsNoProficiencyBonus`, `TestProficiencyIsWorthExactlyTheProficiencyBonus` |
| N3 | proficiency bonus never added | KILLED | `TestAHeroSwingsTheirLongswordAtAWolf` |
| N4 | ability modifier dropped from the notation | KILLED | `TestACharacterCritDoublesTheDiceNotTheAbilityModifier`, `TestAHeroSwingsTheirLongswordAtAWolf` |
| N5 | ranged weapon accepted | KILLED | `TestRefusesWhatItCannotCompile/a_ranged_weapon…` |
| N6 | melee guard keys on `Range != nil` not category | KILLED | `TestFinesseKeepsStrengthWhenStrengthIsBetter`, `TestFinesseOnATieIsStillTheSameArithmetic` |
| N7 | empty slot falls back to unarmed silently | KILLED | `TestRefusesWhatItCannotCompile/an_empty_slot…` |
| N8 | `TwoHanded` ignored — never steps the die | KILLED | `TestAVersatileWeaponStepsItsDieAndNothingElse` |
| N9 | always steps the die — grip ignored | KILLED | `TestAHeroSwingsTheirLongswordAtAWolf` |
| N10 | `AbilityUsed` hard-coded to STR | KILLED | `TestRageDoesNotPayOutOnADexterityFinesseSwing` |
| N11 | `AbilityUsed` left empty by the compiler | KILLED | `TestARagingHerosBonusArrivesViaTheChainNotTheCompiler`, `TestRageDoesNotPayOutOnADexterityFinesseSwing` |
| N12 | machine drops `AbilityUsed` (the bug as found) | KILLED | `TestARagingHerosBonusArrivesViaTheChainNotTheCompiler`, `TestRagePaysOutOnTheStrengthSwing` |
| N13 | crit doubles the flat modifier too | KILLED | `TestACharacterCritDoublesTheDiceNotTheAbilityModifier`, **and the existing** `TestStrikeSuite/TestANaturalTwentyDoublesTheDiceNotTheModifier` |
| N14 | attack bonus omits the ability modifier | KILLED | `TestAHeroSwingsTheirLongswordAtAWolf` |
| N15 | compiler invents a save gate | KILLED | `TestAHeroSwingsTheirLongswordAtAWolf` |
| — | *machine consults the compiler's internals* | **inexpressible** | `strike.go` does not import `character`; it cannot compile |

Every damage assertion is exact arithmetic against scripted dice — `5+3`, `5+4+3`, `3+4` — never `Positive()`.

— asset-pipeline agent, on behalf of KirkDiggler

