### PR TITLE
feat(combat): export the damage multiplier arithmetic, bus-free and ordered (#965 slice 2 PR-A)

### DIFF
--- a/rulebooks/dnd5e/combat/damage.go
+++ b/rulebooks/dnd5e/combat/damage.go
@@ -190,6 +190,15 @@ func DealDamage(ctx context.Context, input *DealDamageInput) (*DealDamageOutput,
 	})
 
 	// NOTIFY: publish DamageReceivedEvent for reactions
+	//
+	// Applying above and publishing here is a latent double-apply for a target
+	// that treats this topic as an instruction: a bus-attached monster's sheet
+	// keeper subscribes and calls TakeDamage, so the same damage lands twice.
+	// Latent rather than live — nothing ships a DealDamage caller with a
+	// subscribed monster target yet — and dispositioned in rpg-toolkit#1009
+	// rather than changed here, because ApplyAttackOutcome's publish is the
+	// opposite case (there it IS the only application path) and the two cannot
+	// be fixed by the same edit.
 	damageTopic := dnd5eEvents.DamageReceivedTopic.On(input.EventBus)
 	err = damageTopic.Publish(ctx, dnd5eEvents.DamageReceivedEvent{
 		TargetID:   targetID,
@@ -316,14 +325,10 @@ func ResolveDamage(ctx context.Context, input *ResolveDamageInput) (*ResolveDama
 		return nil, rpgerr.Wrap(err, "failed to execute damage chain")
 	}
 
-	// Apply multipliers (resistance, vulnerability, immunity)
-	finalInstances := calculateFinalDamage(finalEvent.Components)
-
-	// Calculate total
-	totalDamage := 0
-	for _, inst := range finalInstances {
-		totalDamage += inst.Amount
-	}
+	// Apply multipliers (resistance, vulnerability, immunity) and total them.
+	// Shared with any caller that folds the chain on its own bus — one
+	// implementation of the arithmetic rather than a copy per stack.
+	finalInstances, totalDamage := FinalDamage(finalEvent.Components)
 
 	return &ResolveDamageOutput{
 		TotalDamage:     totalDamage,
@@ -331,96 +336,4 @@ func ResolveDamage(ctx context.Context, input *ResolveDamageInput) (*ResolveDama
 		FinalComponents: finalEvent.Components,
 		AbilityUsed:     finalEvent.AbilityUsed,
 	}, nil
-}
-
-// calculateFinalDamage processes damage components and applies multipliers.
-// In D&D 5e:
-// - Resistance (0.5) halves damage, Vulnerability (2.0) doubles it, Immunity (0.0) negates
-// - Multiple resistances don't stack (apply most beneficial once)
-// - If both resistance and vulnerability exist for a type, they cancel out
-func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInstanceInput {
-	// Group damage and multipliers by type
-	type damageGroup struct {
-		baseDamage  int
-		multipliers []float64
-	}
-	byType := make(map[damage.Type]*damageGroup)
-
-	for _, component := range components {
-		dmgType := component.DamageType
-		if byType[dmgType] == nil {
-			byType[dmgType] = &damageGroup{}
-		}
-
-		// If component has a multiplier, it's a modifier (resistance/vulnerability)
-		// Otherwise, it contributes base damage
-		if component.Multiplier != 0 {
-			byType[dmgType].multipliers = append(byType[dmgType].multipliers, component.Multiplier)
-		} else {
-			byType[dmgType].baseDamage += component.Total()
-		}
-	}
-
-	// Apply multipliers to each damage type
-	result := make([]DamageInstanceInput, 0, len(byType))
-	for dmgType, group := range byType {
-		finalDamage := group.baseDamage
-
-		if len(group.multipliers) > 0 {
-			// Apply D&D 5e stacking rules
-			effectiveMultiplier := resolveMultipliers(group.multipliers)
-			finalDamage = int(float64(finalDamage) * effectiveMultiplier)
-		}
-
-		if finalDamage > 0 {
-			result = append(result, DamageInstanceInput{
-				Amount: finalDamage,
-				Type:   dmgType,
-			})
-		}
-	}
-
-	return result
-}
-
-// resolveMultipliers applies D&D 5e stacking rules for resistance/vulnerability.
-// - Immunity (0.0) always wins
-// - Resistance (0.5) and vulnerability (2.0) cancel out if both present
-// - Multiple resistances don't stack (use 0.5 once)
-// - Multiple vulnerabilities don't stack (use 2.0 once)
-func resolveMultipliers(multipliers []float64) float64 {
-	hasImmunity := false
-	hasResistance := false
-	hasVulnerability := false
-
-	for _, m := range multipliers {
-		switch {
-		case m == 0.0:
-			hasImmunity = true
-		case m < 1.0:
-			hasResistance = true
-		case m > 1.0:
-			hasVulnerability = true
-		}
-	}
-
-	// Immunity trumps everything
-	if hasImmunity {
-		return 0.0
-	}
-
-	// Resistance and vulnerability cancel out
-	if hasResistance && hasVulnerability {
-		return 1.0
-	}
-
-	// Apply resistance (0.5) or vulnerability (2.0)
-	if hasResistance {
-		return 0.5
-	}
-	if hasVulnerability {
-		return 2.0
-	}
-
-	return 1.0
 }

--- a/rulebooks/dnd5e/combat/final_damage.go
+++ b/rulebooks/dnd5e/combat/final_damage.go
@@ -1,0 +1,142 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat
+
+import (
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// FinalDamage turns folded damage components into the instances that land,
+// applying 5e's resistance, vulnerability, and immunity stacking, and reports
+// the total alongside them.
+//
+// Bus-free on purpose. This is the arithmetic half of [ResolveDamage], split
+// out so a caller that folds the damage chain on its own bus can still get the
+// multipliers right instead of reimplementing them (rpg-toolkit#965 slice 2 —
+// the resolution module owns its own folds and had no way to reach this).
+// The shape mirrors [github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves.MakeSavingThrow]:
+// fold outside, hand in what the fold settled on, take back the arithmetic.
+//
+// ResolveDamage calls this too, so there is one implementation rather than a
+// copy per stack.
+//
+// Components carrying a Multiplier are modifiers (resistance 0.5,
+// vulnerability 2.0, immunity 0.0); every other component contributes its
+// Total() as base damage. Both are grouped by damage type before the
+// multipliers apply, because 5e resists a TYPE rather than a source.
+//
+// Instances come back sorted by damage type, and a zero or negative instance
+// is dropped rather than reported as landing.
+func FinalDamage(components []dnd5eEvents.DamageComponent) (instances []DamageInstanceInput, total int) {
+	instances = calculateFinalDamage(components)
+	for _, instance := range instances {
+		total += instance.Amount
+	}
+
+	return instances, total
+}
+
+// calculateFinalDamage processes damage components and applies multipliers.
+// In D&D 5e:
+// - Resistance (0.5) halves damage, Vulnerability (2.0) doubles it, Immunity (0.0) negates
+// - Multiple resistances don't stack (apply most beneficial once)
+// - If both resistance and vulnerability exist for a type, they cancel out
+func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInstanceInput {
+	// Group damage and multipliers by type
+	type damageGroup struct {
+		baseDamage  int
+		multipliers []float64
+	}
+	byType := make(map[damage.Type]*damageGroup)
+
+	for _, component := range components {
+		dmgType := component.DamageType
+		if byType[dmgType] == nil {
+			byType[dmgType] = &damageGroup{}
+		}
+
+		// If component has a multiplier, it's a modifier (resistance/vulnerability)
+		// Otherwise, it contributes base damage
+		if component.Multiplier != 0 {
+			byType[dmgType].multipliers = append(byType[dmgType].multipliers, component.Multiplier)
+		} else {
+			byType[dmgType].baseDamage += component.Total()
+		}
+	}
+
+	// Apply multipliers to each damage type
+	result := make([]DamageInstanceInput, 0, len(byType))
+	for dmgType, group := range byType {
+		finalDamage := group.baseDamage
+
+		if len(group.multipliers) > 0 {
+			// Apply D&D 5e stacking rules
+			effectiveMultiplier := resolveMultipliers(group.multipliers)
+			finalDamage = int(float64(finalDamage) * effectiveMultiplier)
+		}
+
+		if finalDamage > 0 {
+			result = append(result, DamageInstanceInput{
+				Amount: finalDamage,
+				Type:   dmgType,
+			})
+		}
+	}
+
+	// Sorted, because the grouping above is a map and a map's iteration order
+	// is random per run. Nothing can correctly depend on that order — anything
+	// that did was already flaky — so ordering by damage type is the one
+	// direction of change that cannot break a correct consumer, and it makes a
+	// mixed-type hit (a flame tongue's slashing plus fire) report the same way
+	// twice. Prior art: ToData's member sort exists because map iteration made
+	// round-trips intermittently fail.
+	sort.Slice(result, func(i, j int) bool { return result[i].Type < result[j].Type })
+
+	return result
+}
+
+// resolveMultipliers applies D&D 5e stacking rules for resistance/vulnerability.
+// - Immunity (0.0) always wins
+// - Resistance (0.5) and vulnerability (2.0) cancel out if both present
+// - Multiple resistances don't stack (use 0.5 once)
+// - Multiple vulnerabilities don't stack (use 2.0 once)
+func resolveMultipliers(multipliers []float64) float64 {
+	hasImmunity := false
+	hasResistance := false
+	hasVulnerability := false
+
+	for _, m := range multipliers {
+		switch {
+		case m == 0.0:
+			hasImmunity = true
+		case m < 1.0:
+			hasResistance = true
+		case m > 1.0:
+			hasVulnerability = true
+		}
+	}
+
+	// Immunity trumps everything
+	if hasImmunity {
+		return 0.0
+	}
+
+	// Resistance and vulnerability cancel out
+	if hasResistance && hasVulnerability {
+		return 1.0
+	}
+
+	// Apply resistance (0.5) or vulnerability (2.0)
+	if hasResistance {
+		return 0.5
+	}
+	if hasVulnerability {
+		return 2.0
+	}
+
+	return 1.0
+}

--- a/rulebooks/dnd5e/combat/final_damage.go
+++ b/rulebooks/dnd5e/combat/final_damage.go
@@ -11,8 +11,11 @@ import (
 )
 
 // FinalDamage turns folded damage components into the instances that land,
-// applying 5e's resistance, vulnerability, and immunity stacking, and reports
-// the total alongside them.
+// applying 5e's resistance and vulnerability stacking, and reports the total
+// alongside them.
+//
+// IMMUNITY IS NOT APPLIED — see the gap named below. Do not read this as
+// "damage multipliers, handled".
 //
 // Bus-free on purpose. This is the arithmetic half of [ResolveDamage], split
 // out so a caller that folds the damage chain on its own bus can still get the
@@ -24,10 +27,17 @@ import (
 // ResolveDamage calls this too, so there is one implementation rather than a
 // copy per stack.
 //
-// Components carrying a Multiplier are modifiers (resistance 0.5,
-// vulnerability 2.0, immunity 0.0); every other component contributes its
-// Total() as base damage. Both are grouped by damage type before the
-// multipliers apply, because 5e resists a TYPE rather than a source.
+// Components carrying a non-zero Multiplier are modifiers (resistance 0.5,
+// vulnerability 2.0); every other component contributes its Total() as base
+// damage. Both are grouped by damage type before the multipliers apply,
+// because 5e resists a TYPE rather than a source.
+//
+// KNOWN GAP — immunity does not reduce damage (rpg-toolkit#1012). Immunity is
+// authored as Multiplier: 0, and "is this a modifier" is decided by
+// Multiplier != 0, so an immunity component fails that test and is read as a
+// base contribution of Total() == 0 — discarded, with full damage landing on
+// an immune target. A caller must not rely on this function to enforce
+// immunity until #1012 lands. Pinned by TestKnownGapImmunityIsIgnored.
 //
 // Instances come back sorted by damage type, and a zero or negative instance
 // is dropped rather than reported as landing.
@@ -45,6 +55,10 @@ func FinalDamage(components []dnd5eEvents.DamageComponent) (instances []DamageIn
 // - Resistance (0.5) halves damage, Vulnerability (2.0) doubles it, Immunity (0.0) negates
 // - Multiple resistances don't stack (apply most beneficial once)
 // - If both resistance and vulnerability exist for a type, they cancel out
+//
+// The immunity line above describes the RULE, not this code: the dispatch
+// below reads a component as a multiplier only when Multiplier != 0, so
+// immunity's 0.0 never reaches resolveMultipliers (rpg-toolkit#1012).
 func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInstanceInput {
 	// Group damage and multipliers by type
 	type damageGroup struct {
@@ -100,6 +114,11 @@ func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInst
 }
 
 // resolveMultipliers applies D&D 5e stacking rules for resistance/vulnerability.
+//
+// Its immunity branch is UNREACHABLE today: callers only reach this function
+// with multipliers that passed a `!= 0` test, so 0.0 never arrives
+// (rpg-toolkit#1012). The branch is kept rather than deleted because it is the
+// correct rule and #1012's fix is to make it reachable, not to write it.
 // - Immunity (0.0) always wins
 // - Resistance (0.5) and vulnerability (2.0) cancel out if both present
 // - Multiple resistances don't stack (use 0.5 once)

--- a/rulebooks/dnd5e/combat/final_damage_test.go
+++ b/rulebooks/dnd5e/combat/final_damage_test.go
@@ -1,0 +1,252 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+type FinalDamageTestSuite struct {
+	suite.Suite
+}
+
+func TestFinalDamageSuite(t *testing.T) {
+	suite.Run(t, new(FinalDamageTestSuite))
+}
+
+// flat builds a plain damage component contributing Amount of a type.
+func (s *FinalDamageTestSuite) flat(amount int, t damage.Type) dnd5eEvents.DamageComponent {
+	return dnd5eEvents.DamageComponent{
+		Source:     dnd5eEvents.DamageSourceWeapon,
+		FlatBonus:  amount,
+		DamageType: t,
+	}
+}
+
+// multiplier builds a modifier component — resistance, vulnerability, immunity.
+func (s *FinalDamageTestSuite) multiplier(m float64, t damage.Type) dnd5eEvents.DamageComponent {
+	return dnd5eEvents.DamageComponent{
+		Source:     dnd5eEvents.DamageSourceCondition,
+		Multiplier: m,
+		DamageType: t,
+	}
+}
+
+// THE ORDER PIN. A mixed-type hit reports its instances sorted by damage type,
+// the same way every run.
+//
+// This is the one observable change in the split: the grouping is a map, and a
+// map's iteration order is random per run, so before this the order was
+// whatever Go felt like. Nothing can correctly depend on a random order, which
+// is why sorting cannot break a correct consumer — and why this assertion is
+// on the exact slice rather than on a set.
+func (s *FinalDamageTestSuite) TestInstancesComeBackSortedByDamageType() {
+	// Deliberately built out of alphabetical order, and not in one grouping
+	// pass either — slashing, then fire, then more slashing.
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(7, damage.Slashing),
+		s.flat(3, damage.Fire),
+		s.flat(2, damage.Slashing),
+		s.flat(1, damage.Cold),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{
+		{Amount: 1, Type: damage.Cold},
+		{Amount: 3, Type: damage.Fire},
+		{Amount: 9, Type: damage.Slashing},
+	}, instances)
+	s.Require().Equal(1+3+9, total)
+}
+
+// Repeated calls agree exactly — the assertion a map-ordered implementation
+// fails intermittently rather than never.
+func (s *FinalDamageTestSuite) TestTheSameComponentsProduceTheSameOrderEveryTime() {
+	components := []dnd5eEvents.DamageComponent{
+		s.flat(4, damage.Thunder),
+		s.flat(6, damage.Acid),
+		s.flat(5, damage.Radiant),
+		s.flat(2, damage.Necrotic),
+		s.flat(8, damage.Piercing),
+	}
+
+	first, firstTotal := combat.FinalDamage(components)
+	for i := 0; i < 50; i++ {
+		again, againTotal := combat.FinalDamage(components)
+		s.Require().Equal(first, again, "run %d disagreed with the first", i)
+		s.Require().Equal(firstTotal, againTotal)
+	}
+}
+
+// Resistance halves, and the total follows the instances.
+func (s *FinalDamageTestSuite) TestResistanceHalvesItsOwnTypeOnly() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(10, damage.Slashing),
+		s.flat(10, damage.Fire),
+		s.multiplier(0.5, damage.Fire),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{
+		{Amount: 5, Type: damage.Fire},
+		{Amount: 10, Type: damage.Slashing},
+	}, instances, "fire halved, slashing untouched")
+	s.Require().Equal(15, total)
+}
+
+func (s *FinalDamageTestSuite) TestVulnerabilityDoubles() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(7, damage.Fire),
+		s.multiplier(2.0, damage.Fire),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 14, Type: damage.Fire}}, instances)
+	s.Require().Equal(14, total)
+}
+
+// KNOWN GAP — damage immunity does not reduce damage, and never has.
+//
+// Pinned rather than fixed, in the style of TestKnownRoundTripGaps (#987):
+// this PR moves the arithmetic without changing it, and correcting immunity is
+// a live behavior change to the legacy stack. Filed separately.
+//
+// The mechanism: a component is read as a MULTIPLIER only when
+// `component.Multiplier != 0`, so immunity — which monstertraits/immunity.go
+// expresses as `Multiplier: 0` with the comment "Multiply by 0 = no damage" —
+// fails that test and is read as a base-damage contribution of Total() == 0
+// instead. The immunity component is silently discarded and full damage lands.
+// resolveMultipliers' `m == 0.0 -> hasImmunity` branch is unreachable as a
+// direct consequence.
+//
+// Nothing pins the correct behavior today, which is why it went unnoticed:
+// monstertraits' immunity tests assert the condition applies, never that
+// damage drops. WHEN THIS IS FIXED, THIS TEST SHOULD FAIL — update it to
+// assert the poison instance is dropped entirely.
+func (s *FinalDamageTestSuite) TestKnownGapImmunityIsIgnored() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(12, damage.Poison),
+		s.multiplier(0.0, damage.Poison),
+		s.flat(4, damage.Slashing),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{
+		{Amount: 12, Type: damage.Poison},
+		{Amount: 4, Type: damage.Slashing},
+	}, instances, "CURRENT behavior: the immune target takes full poison damage")
+	s.Require().Equal(16, total)
+}
+
+// The same gap from the stacking side: with immunity inert, a target that is
+// vulnerable AND resistant AND immune resolves as the cancel case (1.0) rather
+// than as immune (0.0).
+func (s *FinalDamageTestSuite) TestKnownGapImmunityDoesNotTrumpTheOthers() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(20, damage.Fire),
+		s.multiplier(2.0, damage.Fire),
+		s.multiplier(0.5, damage.Fire),
+		s.multiplier(0.0, damage.Fire),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 20, Type: damage.Fire}}, instances,
+		"CURRENT behavior: resistance and vulnerability cancel, immunity never counted")
+	s.Require().Equal(20, total)
+}
+
+// Resistance and vulnerability cancel exactly — not 0.5 * 2.0 applied in some
+// order, but a flat 1.0.
+func (s *FinalDamageTestSuite) TestResistanceAndVulnerabilityCancel() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(9, damage.Cold),
+		s.multiplier(0.5, damage.Cold),
+		s.multiplier(2.0, damage.Cold),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 9, Type: damage.Cold}}, instances)
+	s.Require().Equal(9, total)
+}
+
+// Two resistances are still one resistance — 5e does not stack them into a
+// quarter.
+func (s *FinalDamageTestSuite) TestMultipleResistancesDoNotStack() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(20, damage.Bludgeoning),
+		s.multiplier(0.5, damage.Bludgeoning),
+		s.multiplier(0.5, damage.Bludgeoning),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 10, Type: damage.Bludgeoning}}, instances,
+		"halved once, not twice")
+	s.Require().Equal(10, total)
+}
+
+func (s *FinalDamageTestSuite) TestMultipleVulnerabilitiesDoNotStack() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(5, damage.Fire),
+		s.multiplier(2.0, damage.Fire),
+		s.multiplier(2.0, damage.Fire),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 10, Type: damage.Fire}}, instances,
+		"doubled once, not quadrupled")
+	s.Require().Equal(10, total)
+}
+
+// Components of one type sum before the multiplier applies — resistance halves
+// the TYPE's total, not each contribution, which rounds differently.
+func (s *FinalDamageTestSuite) TestComponentsGroupBeforeTheMultiplierApplies() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(3, damage.Fire),
+		s.flat(3, damage.Fire),
+		s.flat(3, damage.Fire),
+		s.multiplier(0.5, damage.Fire),
+	})
+
+	// 9 halved is 4 (truncating). Halving each 3 first would give 1+1+1 = 3.
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 4, Type: damage.Fire}}, instances)
+	s.Require().Equal(4, total)
+}
+
+// Dice ride through Total() alongside the flat bonus.
+func (s *FinalDamageTestSuite) TestDiceAndFlatBonusBothCount() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		{
+			Source:            dnd5eEvents.DamageSourceWeapon,
+			OriginalDiceRolls: []int{4, 5},
+			FinalDiceRolls:    []int{4, 5},
+			FlatBonus:         3,
+			DamageType:        damage.Slashing,
+		},
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 4 + 5 + 3, Type: damage.Slashing}}, instances)
+	s.Require().Equal(12, total)
+}
+
+func (s *FinalDamageTestSuite) TestNoComponentsIsNoDamage() {
+	instances, total := combat.FinalDamage(nil)
+
+	s.Require().Empty(instances)
+	s.Require().Zero(total)
+}
+
+// The reported total is the sum of the instances reported, not a separately
+// accumulated number that could drift from them.
+func (s *FinalDamageTestSuite) TestTheTotalIsTheSumOfTheInstances() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(10, damage.Fire),
+		s.multiplier(0.5, damage.Fire),
+		s.flat(7, damage.Slashing),
+	})
+
+	sum := 0
+	for _, instance := range instances {
+		sum += instance.Amount
+	}
+	s.Require().Equal(sum, total)
+	s.Require().Equal(5+7, total, "fire halved to 5, slashing 7")
+}

--- a/rulebooks/dnd5e/combat/final_damage_test.go
+++ b/rulebooks/dnd5e/combat/final_damage_test.go
@@ -227,6 +227,34 @@ func (s *FinalDamageTestSuite) TestDiceAndFlatBonusBothCount() {
 	s.Require().Equal(12, total)
 }
 
+// An instance that resolves to zero is not reported as landing. Resistance
+// halving a single point of damage is the realistic way to get there — 1
+// halved truncates to 0 — and a target that took no cold damage should not
+// appear in the breakdown as having taken cold damage of zero.
+func (s *FinalDamageTestSuite) TestAnInstanceThatResolvesToZeroIsDropped() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(1, damage.Cold),
+		s.multiplier(0.5, damage.Cold),
+		s.flat(6, damage.Slashing),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 6, Type: damage.Slashing}}, instances,
+		"the cold instance is absent, not present at zero")
+	s.Require().Equal(6, total)
+}
+
+// The same boundary from a component that simply carries no damage — the
+// catalog has weapons whose damage is "0" (a net).
+func (s *FinalDamageTestSuite) TestAComponentCarryingNoDamageProducesNoInstance() {
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(0, damage.Bludgeoning),
+		s.flat(3, damage.Piercing),
+	})
+
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 3, Type: damage.Piercing}}, instances)
+	s.Require().Equal(3, total)
+}
+
 func (s *FinalDamageTestSuite) TestNoComponentsIsNoDamage() {
 	instances, total := combat.FinalDamage(nil)
 


### PR DESCRIPTION
Stage 2, PR-A of #965 slice 2. Additive and bus-free; PR-B (resolution takes custody of the damage fold) follows once this merges and tags.

## What and why

Resolution folds the damage chain on its own bus but had no way to reach the arithmetic that turns folded components into what actually lands — resistance, vulnerability, immunity, and the grouping by damage type. Every exported route to it required a bus, so resolution hands its bus to `combat.ResolveDamage` instead. That is slice 2's largest single debt (`strike.go:587`).

```go
// package combat — new, bus-free
func FinalDamage(components []dnd5eEvents.DamageComponent) (instances []DamageInstanceInput, total int)
```

Fold outside, hand in what the fold settled on, take back the arithmetic. It mirrors `saves.MakeSavingThrow`, whose `EventBus` is already optional for exactly this reason and which resolution already calls with `nil`. `ResolveDamage` is **recomposed** to call it, so there is one implementation rather than a copy per stack — the moved code is unchanged line for line, and `resolveMultipliers` stays unexported.

No attack-side export is needed: resolution already folds `AttackChain` itself in `gatherAttack`.

## The one behavior change: ordering

Instances now come back **sorted by damage type**.

The grouping is a `map[damage.Type]`, and a map's iteration order is random per run, so a mixed-type hit (a flame tongue's slashing plus fire) reported its instances in a different order each time. No consumer can correctly depend on a random order — anything that did was already flaky — which makes nondeterministic→deterministic the one direction of change that cannot break a correct consumer. Prior art in this repo: `ToData`'s member sort exists because map iteration made round-trips intermittently fail.

Pinned two ways: an exact-slice assertion on a deliberately out-of-order mixed-type hit, and a fifty-run agreement test.

## ⚠️ Found while pinning: damage immunity has never worked

Filed rather than fixed, and I want it seen.

A component counts as a multiplier only when `component.Multiplier != 0`. Immunity is expressed as `Multiplier: 0` (`monstertraits/immunity.go:164`, comment: *"Multiply by 0 = no damage"*). So an immunity component fails that test, falls to the `else` branch, and is read as a **base-damage contribution of `Total() == 0`** — silently discarded. Full damage lands on an immune target. As a direct consequence, `resolveMultipliers`' `m == 0.0 → hasImmunity` branch is unreachable dead code.

It went unnoticed because nothing pins it: `monstertraits`' immunity tests assert the *condition applies*, never that damage drops.

The fix is **sequenced separately, not deferred for compatibility** — this PR carries one mechanic (the bus-free split and its ordering), and a damage-rule correction is a different mechanic with its own evidence to produce. It is tracked as #1012 and lands in its own PR immediately after this one.

Meanwhile the behavior is **pinned as a named gap** in the style of `TestKnownRoundTripGaps` (#987) — `TestKnownGapImmunityIsIgnored` and `TestKnownGapImmunityDoesNotTrumpTheOthers`, both carrying "WHEN THIS IS FIXED, THIS TEST SHOULD FAIL" and the exact assertion to replace it with. So #1012 gets a failing test the moment it changes the dispatch, and the gap cannot quietly persist.

Also documented, not changed: `DealDamage` applies HP **and** publishes `DamageReceivedEvent`, a latent double-apply for a bus-attached monster target — #1009, referenced at the site.

## Evidence

From `rulebooks/dnd5e/`:

| Check | Result |
|---|---|
| `go test ./...` | **exit 0 — 27 packages ok** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

Existing tests unmodified. The only pre-existing file touched is `combat/damage.go` (move out + recompose + the #1009 comment). No `replace`.

## Mutation table

8 mutants, 8 killed. P7 **survived the first pass** — nothing covered the zero-damage boundary — so I added the two tests that kill it and committed them separately (`3adb8d7`) rather than quietly widening the original.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| P1 | sort removed (map order returns) | KILLED | `TestInstancesComeBackSortedByDamageType`, `TestResistanceHalvesItsOwnTypeOnly` |
| P2 | sort reversed | KILLED | `TestInstancesComeBackSortedByDamageType` |
| P3 | total not summed | KILLED | `TestAttackPhasesSuite/...ACBonus_HitStillHits` (**existing** legacy tests) |
| P4 | resistance becomes vulnerability | KILLED | `TestMultipleResistancesDoNotStack`, `TestComponentsGroupBeforeTheMultiplierApplies` |
| P5 | resistance/vulnerability cancel rule dropped | KILLED | `TestResistanceAndVulnerabilityCancel` |
| P6 | multipliers stack instead of applying once | KILLED | `TestMultipleResistancesDoNotStack`, `TestMultipleVulnerabilitiesDoNotStack` |
| P7 | zero instances still reported (`> 0` → `>= 0`) | KILLED *(after adding coverage)* | `TestAnInstanceThatResolvesToZeroIsDropped`, `TestAComponentCarryingNoDamageProducesNoInstance` |
| P8 | grouping dropped (`+=` → `=`) | KILLED | `TestAttackSuite/TestResolveAttack_BasicMeleeHit` (**existing**) |

P3 and P8 dying on *existing legacy tests* is the useful signal here: it is direct evidence the recomposition kept the old stack's behavior, not just that the new tests agree with themselves.

— asset-pipeline agent, on behalf of KirkDiggler

