### PR TITLE
fix(resolution): the attack declares its rider's consequence, the machine obeys

### DIFF
--- a/rulebooks/dnd5e/resolution/declared_consequence_test.go
+++ b/rulebooks/dnd5e/resolution/declared_consequence_test.go
@@ -1,0 +1,255 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// DeclaredConsequenceTestSuite covers the half of a rider that used to be
+// stranded in the machine: WHAT a failed save costs, as opposed to what the
+// save is (rpg-toolkit#1013).
+//
+// The wolf's own knockdown is pinned end to end by the existing headline test
+// TestAWolfBitesTheHeroAndKnocksHimDown, which is unmodified and still passes
+// — that is the "nothing regressed" half. These are the cases it could never
+// catch, because prone was the only answer the machine could give.
+type DeclaredConsequenceTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestDeclaredConsequenceSuite(t *testing.T) {
+	suite.Run(t, new(DeclaredConsequenceTestSuite))
+}
+
+func (s *DeclaredConsequenceTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// biteProfile is the wolf's bite as its own compiler produces it.
+func (s *DeclaredConsequenceTestSuite) biteProfile() AttackProfile {
+	data := monsters.NewWolf(wolfID).ToData()
+	s.Require().Len(data.Actions, 1)
+
+	profile, err := AttackFromMonsterAction(data.Actions[0])
+	s.Require().NoError(err)
+
+	return profile
+}
+
+// world places the hero and the wolf three cells apart — far enough that
+// prone's range predicate stays out of these cases.
+func (s *DeclaredConsequenceTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 8, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+// hero is a sheet with a +5 STR save: DC 11 is a real contest either way.
+func (s *DeclaredConsequenceTestSuite) hero() *character.Data {
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ArmorClass:       14,
+		ProficiencyBonus: 2,
+		SavingThrows: map[abilities.Ability]shared.ProficiencyLevel{
+			abilities.STR: shared.Proficient,
+		},
+	}
+}
+
+func (s *DeclaredConsequenceTestSuite) resolve(machine Machine) (*Output, error) {
+	return Resolve(s.ctx, &Input{
+		World: s.world(),
+		Participants: []Participant{
+			{Character: s.hero()},
+			{Monster: monsters.NewWolf(wolfID).ToData()},
+		},
+		Machine: machine,
+	})
+}
+
+// THE COMPILER NAMES IT. The bite's knockdown arrives as a gate AND as prone,
+// both from the compiler — the machine is told, it does not know.
+func (s *DeclaredConsequenceTestSuite) TestTheBitesCompilerNamesProneAlongsideItsGate() {
+	profile := s.biteProfile()
+
+	s.Require().NotNil(profile.Gate, "the bite declares a contest")
+	s.Require().NotNil(profile.Imposes, "and names what rides on it")
+	s.Require().Equal(refs.Conditions.Prone(), profile.Imposes.atStake().Ref,
+		"a stat block's KnockdownDC means prone, and the compiler is where that is translated")
+}
+
+// A plain weapon declares neither half. The generic melee action and a
+// character's weapon both compile to no gate, so neither carries a
+// consequence that nothing could trigger.
+func (s *DeclaredConsequenceTestSuite) TestAnUngatedAttackNamesNoConsequence() {
+	skeleton := monsters.NewSkeleton("sk-1").ToData()
+	var melee AttackProfile
+	for _, action := range skeleton.Actions {
+		if action.Ref.ID == refs.MonsterActions.Melee().ID {
+			compiled, err := AttackFromMonsterAction(action)
+			s.Require().NoError(err)
+			melee = compiled
+
+			break
+		}
+	}
+
+	s.Require().NotEmpty(melee.DamageDice, "the skeleton has a generic melee action")
+	s.Require().Nil(melee.Gate, "a plain weapon just hits")
+	s.Require().Nil(melee.Imposes, "so there is nothing riding on it")
+}
+
+// A gate that names no consequence is refused BY NAME, before anything rolls.
+//
+// The alternative is worse than an error: the target rolls a save, can fail
+// it, and suffers nothing — a rule that reads as working and means nothing.
+func (s *DeclaredConsequenceTestSuite) TestAGateWithNoConsequenceIsRefused() {
+	orphaned := s.biteProfile()
+	orphaned.Imposes = nil
+
+	err := orphaned.validate()
+	s.Require().ErrorIs(err, ErrBadAttack)
+	s.Require().Contains(err.Error(), "names no consequence")
+}
+
+// And the machine refuses it too, rather than only the constructor — a
+// hand-built profile reaches Start without passing through any compiler.
+func (s *DeclaredConsequenceTestSuite) TestTheMachineRefusesAGateWithNoConsequence() {
+	orphaned := s.biteProfile()
+	orphaned.Imposes = nil
+
+	_, err := s.resolve(NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		Attack:     orphaned,
+		Roller:     &sequenceRoller{singles: []int{hitRoll, 2}, pair: []int{3, 4}, fallback: 2},
+	}))
+	s.Require().ErrorIs(err, ErrBadAttack)
+}
+
+// THE POINT OF THE WHOLE CHANGE: a profile naming a different consequence
+// imposes THAT one, and prone never appears.
+//
+// The pairing is deliberate nonsense — a wolf's bite does not make anyone
+// Dodging — and that is exactly what makes it a good test: it is unreachable
+// from content, so the only way this passes is if the machine imposes what it
+// was told rather than what it assumes. A rules-sensible second gated attack
+// arrives with the ghoul's paralysis; this proves the mechanism before the
+// content needs it.
+func (s *DeclaredConsequenceTestSuite) TestAProfileNamingADifferentConsequenceImposesThatOne() {
+	profile := s.biteProfile()
+	profile.Imposes = ImposeCondition(refs.Conditions.Dodging(), dnd5eEvents.ConditionDodging)
+
+	out, err := s.resolve(NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		// hitRoll lands the bite; the 2 fails the DC 11 save even with the
+		// hero's +5, so the consequence is imposed rather than negated.
+		Attack: profile,
+		Roller: &sequenceRoller{singles: []int{hitRoll, 2}, pair: []int{3, 4}, fallback: 2},
+	}))
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Require().True(outcome.Hit)
+	s.Require().NotNil(outcome.Contest)
+	s.Require().False(outcome.Contest.Succeeded, "a 2 against DC 11 fails")
+
+	s.Require().Equal(refs.Conditions.Dodging(), outcome.Contest.AtStake.Ref,
+		"the contest was about what the profile named")
+
+	s.Require().Len(out.DirtyCharacters, 1)
+	conditions := string(out.DirtyCharacters[0].Conditions[0])
+	s.Require().Contains(conditions, refs.Conditions.Dodging().ID,
+		"the hero gained what the profile named")
+	s.Require().NotContains(conditions, refs.Conditions.Prone().ID,
+		"and NOT prone — the machine imposed no opinion of its own")
+}
+
+// The same swing whose save SUCCEEDS imposes nothing at all, so the test above
+// is measuring the consequence and not merely the presence of a condition.
+func (s *DeclaredConsequenceTestSuite) TestASavedGateImposesNothing() {
+	profile := s.biteProfile()
+	profile.Imposes = ImposeCondition(refs.Conditions.Dodging(), dnd5eEvents.ConditionDodging)
+
+	out, err := s.resolve(NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		// 18 + the hero's +5 STR beats DC 11 comfortably.
+		Attack: profile,
+		Roller: &sequenceRoller{singles: []int{hitRoll, 18}, pair: []int{3, 4}, fallback: 2},
+	}))
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Require().NotNil(outcome.Contest)
+	s.Require().True(outcome.Contest.Succeeded)
+	s.Require().Empty(out.DirtyCharacters[0].Conditions, "a made save costs nothing")
+}
+
+// A gate is still refused when it names abilities nobody can roll — the
+// consequence rule is additive to the gate's own validation, not a
+// replacement for it.
+func (s *DeclaredConsequenceTestSuite) TestTheGatesOwnValidationStillApplies() {
+	profile := s.biteProfile()
+	profile.Gate = &saves.SaveGate{
+		Abilities:  []abilities.Ability{},
+		DC:         saves.DCStatic(11),
+		OnSuccess:  saves.Negated,
+		Recurrence: saves.RecurrenceNone,
+	}
+
+	_, err := s.resolve(NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		Attack:     profile,
+		Roller:     &sequenceRoller{singles: []int{hitRoll, 2}, pair: []int{3, 4}, fallback: 2},
+	}))
+	s.Require().Error(err, "a gate nobody can roll is still refused")
+}

--- a/rulebooks/dnd5e/resolution/declared_consequence_test.go
+++ b/rulebooks/dnd5e/resolution/declared_consequence_test.go
@@ -5,6 +5,7 @@ package resolution
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -12,8 +13,11 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	monsterActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
@@ -141,6 +145,30 @@ func (s *DeclaredConsequenceTestSuite) TestAnUngatedAttackNamesNoConsequence() {
 	s.Require().NotEmpty(melee.DamageDice, "the skeleton has a generic melee action")
 	s.Require().Nil(melee.Gate, "a plain weapon just hits")
 	s.Require().Nil(melee.Imposes, "so there is nothing riding on it")
+}
+
+// A bite with no gate names no consequence either. Content can author one —
+// BiteConfig's own doc says "Nil means the bite just bites" — and a
+// consequence sitting on a profile nothing can trigger is a claim the code
+// would be making and never honouring.
+func (s *DeclaredConsequenceTestSuite) TestAGatelessBiteNamesNoConsequence() {
+	config, err := json.Marshal(monsterActions.BiteConfig{
+		AttackBonus: 4,
+		DamageDice:  "2d4+2",
+		DamageType:  damage.Piercing,
+		// No SaveGate, no KnockdownDC: a bite that just bites.
+	})
+	s.Require().NoError(err)
+
+	profile, err := AttackFromMonsterAction(monster.ActionData{
+		Ref:    *refs.MonsterActions.Bite(),
+		Config: config,
+	})
+	s.Require().NoError(err)
+
+	s.Require().Nil(profile.Gate, "nothing to contest")
+	s.Require().Nil(profile.Imposes, "so nothing rides on it")
+	s.Require().Equal("2d4+2", profile.DamageDice, "and it is still a bite")
 }
 
 // A gate that names no consequence is refused BY NAME, before anything rolls.

--- a/rulebooks/dnd5e/resolution/declared_consequence_test.go
+++ b/rulebooks/dnd5e/resolution/declared_consequence_test.go
@@ -184,6 +184,35 @@ func (s *DeclaredConsequenceTestSuite) TestAGateWithNoConsequenceIsRefused() {
 	s.Require().Contains(err.Error(), "names no consequence")
 }
 
+// The other direction is refused too: a consequence with no gate would never
+// be imposed, because a strike with no gate never contests anything. Accepting
+// it would silently discard a rule its author believed they had written.
+//
+// The pair is a pair, and validating only one direction would make that a
+// comment rather than a contract (Copilot review, #1014).
+func (s *DeclaredConsequenceTestSuite) TestAConsequenceWithNoGateIsRefused() {
+	stranded := s.biteProfile()
+	stranded.Gate = nil
+
+	err := stranded.validate()
+	s.Require().ErrorIs(err, ErrBadAttack)
+	s.Require().Contains(err.Error(), "declares no gate")
+}
+
+// And the machine refuses that direction too, not only the constructor.
+func (s *DeclaredConsequenceTestSuite) TestTheMachineRefusesAConsequenceWithNoGate() {
+	stranded := s.biteProfile()
+	stranded.Gate = nil
+
+	_, err := s.resolve(NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		Attack:     stranded,
+		Roller:     &sequenceRoller{singles: []int{hitRoll, 2}, pair: []int{3, 4}, fallback: 2},
+	}))
+	s.Require().ErrorIs(err, ErrBadAttack)
+}
+
 // And the machine refuses it too, rather than only the constructor — a
 // hand-built profile reaches Start without passing through any compiler.
 func (s *DeclaredConsequenceTestSuite) TestTheMachineRefusesAGateWithNoConsequence() {
@@ -232,6 +261,10 @@ func (s *DeclaredConsequenceTestSuite) TestAProfileNamingADifferentConsequenceIm
 		"the contest was about what the profile named")
 
 	s.Require().Len(out.DirtyCharacters, 1)
+	// Require the condition landed before indexing it: a consequence that
+	// failed to apply should fail this test by NAMING the missing condition,
+	// not by panicking on an empty slice.
+	s.Require().Len(out.DirtyCharacters[0].Conditions, 1, "exactly one condition was imposed")
 	conditions := string(out.DirtyCharacters[0].Conditions[0])
 	s.Require().Contains(conditions, refs.Conditions.Dodging().ID,
 		"the hero gained what the profile named")
@@ -258,6 +291,7 @@ func (s *DeclaredConsequenceTestSuite) TestASavedGateImposesNothing() {
 	s.Require().True(ok)
 	s.Require().NotNil(outcome.Contest)
 	s.Require().True(outcome.Contest.Succeeded)
+	s.Require().Len(out.DirtyCharacters, 1)
 	s.Require().Empty(out.DirtyCharacters[0].Conditions, "a made save costs nothing")
 }
 

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -90,6 +90,23 @@ type AttackProfile struct {
 	// Gate is the rider's contest, if the attack declares one (ADR-0039).
 	// Nil means the attack just hits.
 	Gate *saves.SaveGate
+
+	// Imposes is what the rider does to a target who fails the gate's save.
+	//
+	// Gate and Imposes are the two halves of one rider and travel together:
+	// the gate is the contest — which abilities, what DC, what a success buys —
+	// and this is the consequence the contest is about. ADR-0039 deliberately
+	// kept the two apart in the gate's own shape, which left the consequence
+	// with nowhere to live: the machine hardcoded prone, so every gated attack
+	// knocked its target down whatever the attack was (rpg-toolkit#1013).
+	//
+	// Nil whenever Gate is nil, and required whenever Gate is not — a contest
+	// that gates nothing is not a rule, it is a roll with no meaning.
+	//
+	// The compiler names it, because translating an action's semantics is the
+	// compiler's job: the wolf's KnockdownDC becomes both the gate and prone in
+	// the same place, rather than the DC here and the meaning in the machine.
+	Imposes Consequence
 }
 
 // validate refuses a profile that cannot drive a strike, naming what is
@@ -100,6 +117,15 @@ func (p *AttackProfile) validate() error {
 	}
 	if p.DamageDice == "" {
 		return fmt.Errorf("%w: the attack declares no damage dice", ErrBadAttack)
+	}
+
+	// A gate with nothing riding on it is refused rather than run. The
+	// alternative — contest it and impose nothing — is a save the target rolls,
+	// can fail, and suffers nothing for, which reads as working while meaning
+	// nothing. Same principle the consequence's own validate states: failing at
+	// construction is a bug report, failing soft is a bug that ships.
+	if p.Gate != nil && p.Imposes == nil {
+		return fmt.Errorf("%w: the attack declares a gate but names no consequence", ErrBadAttack)
 	}
 
 	return nil
@@ -400,9 +426,13 @@ func (m *strikeMachine) afterNotify(_ context.Context) (Step, error) {
 	}
 
 	return requestContest(&ContestInput{
-		Gate:        m.in.Attack.Gate,
-		SaverID:     m.in.TargetID,
-		Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
+		Gate:    m.in.Attack.Gate,
+		SaverID: m.in.TargetID,
+		// What the profile named, not what this machine assumes. Until
+		// rpg-toolkit#1013 this was a hardcoded prone, so a ghoul's paralysis
+		// would have knocked its target over instead — the machine deciding a
+		// rule that belongs to the attack.
+		Consequence: m.in.Attack.Imposes,
 		DamageTaken: m.outcome.Damage,
 		Roller:      m.in.Roller,
 	}, func(_ context.Context, contest ContestOutcome) (Step, error) {
@@ -492,6 +522,19 @@ func attackFromBite(action monster.ActionData) (AttackProfile, error) {
 		if bite, ok := mustLoadBite(action); ok {
 			profile.Gate = bite.SaveGate()
 		}
+	}
+
+	// A bite's gate is a KNOCKDOWN — that is what the stat block's
+	// KnockdownDC means, and translating it is this function's job in both
+	// directions: the DC becomes the contest, and knocked-down becomes prone.
+	// Naming it here rather than in the machine is the whole of #1013: the
+	// machine imposed prone on every gated attack because the consequence had
+	// nowhere else to be said.
+	//
+	// Conditional on the gate, so a bite authored without one stays a plain
+	// bite rather than carrying a consequence nothing can trigger.
+	if profile.Gate != nil {
+		profile.Imposes = ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne)
 	}
 
 	return profile, nil

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -100,8 +100,13 @@ type AttackProfile struct {
 	// with nowhere to live: the machine hardcoded prone, so every gated attack
 	// knocked its target down whatever the attack was (rpg-toolkit#1013).
 	//
-	// Nil whenever Gate is nil, and required whenever Gate is not — a contest
-	// that gates nothing is not a rule, it is a roll with no meaning.
+	// Nil whenever Gate is nil, and required whenever Gate is not. BOTH
+	// DIRECTIONS ARE ENFORCED by validate, because a consequence with no
+	// contest is as meaningless as a contest with no consequence: one is a
+	// roll that costs nothing, the other is a cost nothing ever rolls for.
+	// Enforcing only the first half is what let a stranded Imposes pass
+	// validation and then be silently dropped by afterNotify's early exit
+	// (Copilot review, #1014).
 	//
 	// The compiler names it, because translating an action's semantics is the
 	// compiler's job: the wolf's KnockdownDC becomes both the gate and prone in

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -128,6 +128,15 @@ func (p *AttackProfile) validate() error {
 		return fmt.Errorf("%w: the attack declares a gate but names no consequence", ErrBadAttack)
 	}
 
+	// And the other direction, because the pair is a pair. A consequence with
+	// no gate is never imposed — afterNotify returns early on a nil gate — so
+	// accepting it would silently discard a rule its author believed they had
+	// written. Refusing both directions is what makes "Gate and Imposes travel
+	// together" a contract rather than a comment.
+	if p.Gate == nil && p.Imposes != nil {
+		return fmt.Errorf("%w: the attack names a consequence but declares no gate to contest it", ErrBadAttack)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Closes #1013. Resolution module only. **Found by Kirk reviewing the strike machine** — this is design pressure from review, not from a failing test.

## The bug

`strike.go:405` built the consequence inline:

```go
Consequence: ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne),
```

Not a default — the *only* thing the machine could do. **Any** attack carrying a `SaveGate` knocked its target down, whatever the attack was.

ADR-0039 made the gate declare the **contest** — which abilities, what DC, what a success buys — and deliberately not the consequence. That was right, and it left the consequence homeless: the wolf's `KnockdownDC: 11` meant prone *by definition*, so when the translation preserved the contest mechanics the meaning was stranded in the machine as a hardcode.

Nothing reachable was wrong yet. The bite is the only gated content — stat-block weapons and character attacks compile `Gate: nil` — so prone was always the right answer. Open Hand Flurry would have hidden it longer by *also* being prone. **The ghoul is what breaks it**: paralysis contested by CON, imposing prone instead.

## The fix

`AttackProfile` gains `Imposes Consequence` — the other half of one rider. Gate and Imposes travel together: the gate is the contest, Imposes is what the contest is *about*.

The **compiler** names it, because translating an action's semantics is the compiler's job and it is already where `KnockdownDC → gate` happens. The bite's case names prone in the same place it builds the gate. The machine imposes what it is told and knows nothing about bites.

A gate that names no consequence is **refused by name**, before anything rolls. Contesting it would mean a target who rolls a save, can fail it, and suffers nothing — a rule that reads as working and means nothing. That is the same principle `conditionConsequence.validate` already states at `contest.go:144`: *failing at construction is a bug report, failing soft is a bug that ships*.

**No content or wire change.** Whether action data should declare its own `Imposes` is the question the ghoul's paralysis forces, and it waits for the second real case rather than being designed against one example.

### Why this is safe by construction

`Consequence` is a **sealed interface** (`contest.go:104`) — all four methods unexported, `ImposeCondition` the only exported constructor. So the new field can hold one, callers build it through the constructor, and nothing outside the package can forge or misimplement one. No new type, no vocabulary growth.

## Evidence

From `rulebooks/dnd5e/resolution/`:

| Check | Result |
|---|---|
| `go test ./...` | **exit 0 — 77 subtests pass, 0 fail** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

**Existing tests unmodified** — including `TestAWolfBitesTheHeroAndKnocksHimDown`, which still pins the wolf's knockdown end to end and is the "nothing regressed" half of the done-when. The hand-built profiles in `TestRefusesAStrikeItCannotRun` carry `Gate: nil`, so the new validation rule does not touch them. No `replace`. One module.

## New tests

| Test | Pins |
|---|---|
| `TestTheBitesCompilerNamesProneAlongsideItsGate` | the compiler emits gate **and** prone together |
| `TestAProfileNamingADifferentConsequenceImposesThatOne` | a different consequence lands, **and prone never appears** |
| `TestASavedGateImposesNothing` | the above measures the consequence, not merely a condition's presence |
| `TestAGateWithNoConsequenceIsRefused` | refused by name at `validate` |
| `TestTheMachineRefusesAGateWithNoConsequence` | and by the machine, for a hand-built profile that met no compiler |
| `TestAnUngatedAttackNamesNoConsequence` | a plain weapon declares neither half |
| `TestAGatelessBiteNamesNoConsequence` | a bite authored without a gate names nothing either |
| `TestTheGatesOwnValidationStillApplies` | the new rule is additive to the gate's own validation |

On the different-consequence test: the pairing is **deliberate nonsense** — a wolf's bite does not make anyone Dodging — and that is what makes it a good pin. It is unreachable from content, so the only way it passes is if the machine imposes what it was *told* rather than what it assumes. A rules-sensible second gated attack arrives with the ghoul; this proves the mechanism before the content needs it.

## Mutation table

5 mutants, 5 killed. Q5 **survived the first pass**, and it caught a real weakness: my conditional's comment claimed the consequence rides on the gate, and nothing checked it. `BiteConfig`'s own doc says a nil `SaveGate` means "the bite just bites", so a gateless bite is real content. Added `TestAGatelessBiteNamesNoConsequence` and committed it separately (`d7335cf`) rather than widening an existing test.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| Q1 | consequence hardcoded back to prone | KILLED | `TestAProfileNamingADifferentConsequenceImposesThatOne` |
| Q2 | refusal dropped — gate without consequence runs | KILLED | `TestAGateWithNoConsequenceIsRefused`, `TestTheMachineRefusesAGateWithNoConsequence` |
| Q3 | bite compiler names nothing | KILLED | `TestTheBitesCompilerNamesProneAlongsideItsGate`, **existing** `TestStrikeSuite/TestABiteThatMissesRollsNoSave` |
| Q4 | bite names the wrong condition | KILLED | `TestTheBitesCompilerNamesProneAlongsideItsGate`, **existing** `TestStrikeSuite/TestAWolfBitesTheHeroAndKnocksHimDown` |
| Q5 | compiler names it unconditionally | KILLED *(after adding coverage)* | `TestAGatelessBiteNamesNoConsequence` |

Q3 and Q4 dying on the **existing** wolf tests is the useful signal: the old behavior is still pinned by the tests that always pinned it, so the refactor moved the decision without moving the outcome.

— asset-pipeline agent, on behalf of KirkDiggler
