### PR TITLE
fix(combat): immunity negates damage — dispatch on presence, not on zero

### DIFF
--- a/rulebooks/dnd5e/combat/final_damage.go
+++ b/rulebooks/dnd5e/combat/final_damage.go
@@ -11,11 +11,8 @@ import (
 )
 
 // FinalDamage turns folded damage components into the instances that land,
-// applying 5e's resistance and vulnerability stacking, and reports the total
-// alongside them.
-//
-// IMMUNITY IS NOT APPLIED — see the gap named below. Do not read this as
-// "damage multipliers, handled".
+// applying 5e's resistance, vulnerability, and immunity stacking, and reports
+// the total alongside them.
 //
 // Bus-free on purpose. This is the arithmetic half of [ResolveDamage], split
 // out so a caller that folds the damage chain on its own bus can still get the
@@ -27,17 +24,14 @@ import (
 // ResolveDamage calls this too, so there is one implementation rather than a
 // copy per stack.
 //
-// Components carrying a non-zero Multiplier are modifiers (resistance 0.5,
-// vulnerability 2.0); every other component contributes its Total() as base
-// damage. Both are grouped by damage type before the multipliers apply,
-// because 5e resists a TYPE rather than a source.
+// Components carrying a Multiplier are modifiers (resistance 0.5,
+// vulnerability 2.0, immunity 0.0); every other component contributes its
+// Total() as base damage. Both are grouped by damage type before the
+// multipliers apply, because 5e resists a TYPE rather than a source.
 //
-// KNOWN GAP — immunity does not reduce damage (rpg-toolkit#1012). Immunity is
-// authored as Multiplier: 0, and "is this a modifier" is decided by
-// Multiplier != 0, so an immunity component fails that test and is read as a
-// base contribution of Total() == 0 — discarded, with full damage landing on
-// an immune target. A caller must not rely on this function to enforce
-// immunity until #1012 lands. Pinned by TestKnownGapImmunityIsIgnored.
+// Modifier-or-damage is decided by the Multiplier's PRESENCE, never its value:
+// immunity's factor is zero, so a value test cannot tell it from an absent
+// modifier. It could not, and immunity silently did nothing (rpg-toolkit#1012).
 //
 // Instances come back sorted by damage type, and a zero or negative instance
 // is dropped rather than reported as landing.
@@ -55,10 +49,6 @@ func FinalDamage(components []dnd5eEvents.DamageComponent) (instances []DamageIn
 // - Resistance (0.5) halves damage, Vulnerability (2.0) doubles it, Immunity (0.0) negates
 // - Multiple resistances don't stack (apply most beneficial once)
 // - If both resistance and vulnerability exist for a type, they cancel out
-//
-// The immunity line above describes the RULE, not this code: the dispatch
-// below reads a component as a multiplier only when Multiplier != 0, so
-// immunity's 0.0 never reaches resolveMultipliers (rpg-toolkit#1012).
 func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInstanceInput {
 	// Group damage and multipliers by type
 	type damageGroup struct {
@@ -73,10 +63,11 @@ func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInst
 			byType[dmgType] = &damageGroup{}
 		}
 
-		// If component has a multiplier, it's a modifier (resistance/vulnerability)
-		// Otherwise, it contributes base damage
-		if component.Multiplier != 0 {
-			byType[dmgType].multipliers = append(byType[dmgType].multipliers, component.Multiplier)
+		// Presence, not value: a component either IS a modifier or is damage,
+		// and immunity's factor is zero. Testing `!= 0` conflated the two and
+		// dropped immunity entirely (rpg-toolkit#1012).
+		if component.Multiplier != nil {
+			byType[dmgType].multipliers = append(byType[dmgType].multipliers, *component.Multiplier)
 		} else {
 			byType[dmgType].baseDamage += component.Total()
 		}
@@ -114,11 +105,6 @@ func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInst
 }
 
 // resolveMultipliers applies D&D 5e stacking rules for resistance/vulnerability.
-//
-// Its immunity branch is UNREACHABLE today: callers only reach this function
-// with multipliers that passed a `!= 0` test, so 0.0 never arrives
-// (rpg-toolkit#1012). The branch is kept rather than deleted because it is the
-// correct rule and #1012's fix is to make it reachable, not to write it.
 // - Immunity (0.0) always wins
 // - Resistance (0.5) and vulnerability (2.0) cancel out if both present
 // - Multiple resistances don't stack (use 0.5 once)

--- a/rulebooks/dnd5e/combat/final_damage.go
+++ b/rulebooks/dnd5e/combat/final_damage.go
@@ -104,7 +104,8 @@ func calculateFinalDamage(components []dnd5eEvents.DamageComponent) []DamageInst
 	return result
 }
 
-// resolveMultipliers applies D&D 5e stacking rules for resistance/vulnerability.
+// resolveMultipliers applies D&D 5e stacking rules for resistance,
+// vulnerability, and immunity.
 // - Immunity (0.0) always wins
 // - Resistance (0.5) and vulnerability (2.0) cancel out if both present
 // - Multiple resistances don't stack (use 0.5 once)

--- a/rulebooks/dnd5e/combat/final_damage_test.go
+++ b/rulebooks/dnd5e/combat/final_damage_test.go
@@ -34,7 +34,7 @@ func (s *FinalDamageTestSuite) flat(amount int, t damage.Type) dnd5eEvents.Damag
 func (s *FinalDamageTestSuite) multiplier(m float64, t damage.Type) dnd5eEvents.DamageComponent {
 	return dnd5eEvents.DamageComponent{
 		Source:     dnd5eEvents.DamageSourceCondition,
-		Multiplier: m,
+		Multiplier: dnd5eEvents.Multiply(m),
 		DamageType: t,
 	}
 }
@@ -109,42 +109,28 @@ func (s *FinalDamageTestSuite) TestVulnerabilityDoubles() {
 	s.Require().Equal(14, total)
 }
 
-// KNOWN GAP — damage immunity does not reduce damage, and never has.
+// Immunity negates, and an instance that lands for nothing is not reported as
+// landing at all.
 //
-// Pinned rather than fixed, in the style of TestKnownRoundTripGaps (#987):
-// this PR moves the arithmetic without changing it, and correcting immunity is
-// a live behavior change to the legacy stack. Filed separately.
-//
-// The mechanism: a component is read as a MULTIPLIER only when
-// `component.Multiplier != 0`, so immunity — which monstertraits/immunity.go
-// expresses as `Multiplier: 0` with the comment "Multiply by 0 = no damage" —
-// fails that test and is read as a base-damage contribution of Total() == 0
-// instead. The immunity component is silently discarded and full damage lands.
-// resolveMultipliers' `m == 0.0 -> hasImmunity` branch is unreachable as a
-// direct consequence.
-//
-// Nothing pins the correct behavior today, which is why it went unnoticed:
-// monstertraits' immunity tests assert the condition applies, never that
-// damage drops. WHEN THIS IS FIXED, THIS TEST SHOULD FAIL — update it to
-// assert the poison instance is dropped entirely.
-func (s *FinalDamageTestSuite) TestKnownGapImmunityIsIgnored() {
+// This is rpg-toolkit#1012's fix-day assertion. Until the dispatch keyed on
+// presence rather than the value zero, immunity's 0.0 was indistinguishable
+// from "no multiplier" and the immune target took full damage — the shape of
+// bug where the rule is written, the branch exists, and nothing ever reaches it.
+func (s *FinalDamageTestSuite) TestImmunityDropsTheInstanceEntirely() {
 	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
 		s.flat(12, damage.Poison),
 		s.multiplier(0.0, damage.Poison),
 		s.flat(4, damage.Slashing),
 	})
 
-	s.Require().Equal([]combat.DamageInstanceInput{
-		{Amount: 12, Type: damage.Poison},
-		{Amount: 4, Type: damage.Slashing},
-	}, instances, "CURRENT behavior: the immune target takes full poison damage")
-	s.Require().Equal(16, total)
+	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 4, Type: damage.Slashing}}, instances,
+		"the poison instance is gone, not present at zero")
+	s.Require().Equal(4, total)
 }
 
-// The same gap from the stacking side: with immunity inert, a target that is
-// vulnerable AND resistant AND immune resolves as the cancel case (1.0) rather
-// than as immune (0.0).
-func (s *FinalDamageTestSuite) TestKnownGapImmunityDoesNotTrumpTheOthers() {
+// Immunity beats vulnerability and resistance both, whatever else is stacked —
+// the branch that was unreachable until #1012, now reached.
+func (s *FinalDamageTestSuite) TestImmunityTrumpsEverythingElse() {
 	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
 		s.flat(20, damage.Fire),
 		s.multiplier(2.0, damage.Fire),
@@ -152,9 +138,23 @@ func (s *FinalDamageTestSuite) TestKnownGapImmunityDoesNotTrumpTheOthers() {
 		s.multiplier(0.0, damage.Fire),
 	})
 
-	s.Require().Equal([]combat.DamageInstanceInput{{Amount: 20, Type: damage.Fire}}, instances,
-		"CURRENT behavior: resistance and vulnerability cancel, immunity never counted")
-	s.Require().Equal(20, total)
+	s.Require().Empty(instances, "immune, so nothing lands — not the 1.0 cancel case")
+	s.Require().Zero(total)
+}
+
+// A zero factor is a MODIFIER, not an absent one. The distinction the whole
+// fix rests on, asserted directly rather than only through its consequences:
+// a component carrying Multiply(0) must never be read as damage of zero.
+func (s *FinalDamageTestSuite) TestAZeroFactorIsAModifierNotAbsentDamage() {
+	// If Multiply(0) were read as a base contribution, its Total() of 0 would
+	// add nothing and the fire would land in full.
+	instances, total := combat.FinalDamage([]dnd5eEvents.DamageComponent{
+		s.flat(15, damage.Fire),
+		s.multiplier(0.0, damage.Fire),
+	})
+
+	s.Require().Empty(instances)
+	s.Require().Zero(total)
 }
 
 // Resistance and vulnerability cancel exactly — not 0.5 * 2.0 applied in some

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -348,7 +348,7 @@ func (r *RagingCondition) onDamageChain(
 				Source:     dnd5eEvents.DamageSourceCondition,
 				SourceRef:  refs.Conditions.Raging(),
 				DamageType: e.DamageType,
-				Multiplier: 0.5, // Resistance halves damage
+				Multiplier: dnd5eEvents.Multiply(0.5), // Resistance halves damage
 			})
 			return e, nil
 		}

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -815,7 +815,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionAppliesResistanceToPhysica
 
 			// Verify resistance component was added with 0.5 multiplier
 			s.Equal(dnd5eEvents.DamageSourceCondition, finalEvent.Components[1].Source)
-			s.Equal(0.5, finalEvent.Components[1].Multiplier, "Resistance should halve damage")
+			s.Require().NotNil(finalEvent.Components[1].Multiplier)
+			s.Equal(0.5, *finalEvent.Components[1].Multiplier, "Resistance should halve damage")
 		})
 	}
 }

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -171,11 +171,30 @@ type DamageComponent struct {
 	FlatBonus         int              // Flat modifier (0 if none)
 	DamageType        damage.Type      // damage.Slashing, damage.Fire, etc.
 	IsCritical        bool             // Was this doubled for crit?
-	// Multiplier for this component (0 means 1.0/no multiplier).
-	// Used for vulnerability (2.0), resistance (0.5), or immunity (0.0 to negate).
-	// When non-zero, this component represents a multiplier to apply to other
-	// components of the same damage type, not additional damage itself.
-	Multiplier float64
+	// Multiplier scales the other components of the same damage type rather
+	// than adding damage of its own: vulnerability (2.0), resistance (0.5),
+	// immunity (0.0).
+	//
+	// A pointer because ZERO IS A LEGAL FACTOR. This was a plain float64 whose
+	// doc read "0 means 1.0/no multiplier" and, two lines later, "immunity (0.0
+	// to negate)" — one value carrying both meanings. The dispatch had to pick
+	// one, picked "absent", and immunity silently stopped working: an immune
+	// target took full damage and the immunity branch of the stacking rules was
+	// unreachable (rpg-toolkit#1012). Nil now means "this component is damage",
+	// and any float — zero included — means "this component modifies damage".
+	//
+	// Build one with [Multiply]; &0.0 is not expressible inline.
+	Multiplier *float64
+}
+
+// Multiply returns a factor for [DamageComponent.Multiplier].
+//
+// It exists because the zero factor — immunity — cannot be written inline as
+// a pointer, and because a named constructor makes "this component is a
+// modifier" the visible act at every call site rather than a consequence of
+// which field happens to be set.
+func Multiply(factor float64) *float64 {
+	return &factor
 }
 
 // Total returns the total damage for this component

--- a/rulebooks/dnd5e/monstertraits/immunity.go
+++ b/rulebooks/dnd5e/monstertraits/immunity.go
@@ -161,7 +161,7 @@ func (i *immunityCondition) onDamageChain(
 			Source:     dnd5eEvents.DamageSourceMonsterTrait,
 			SourceRef:  refs.MonsterTraits.Immunity(),
 			DamageType: i.damageType,
-			Multiplier: 0, // Multiply by 0 = no damage
+			Multiplier: dnd5eEvents.Multiply(0), // immunity: nothing gets through
 		})
 		return e, nil
 	}

--- a/rulebooks/dnd5e/monstertraits/immunity_test.go
+++ b/rulebooks/dnd5e/monstertraits/immunity_test.go
@@ -77,7 +77,9 @@ func (s *ImmunityTestSuite) TestImmunityAddsZeroMultiplierComponent() {
 	// Second component: immunity multiplier (0 = negate damage)
 	s.Assert().Equal(dnd5eEvents.DamageSourceMonsterTrait, result.Components[1].Source)
 	s.Assert().Equal(damage.Poison, result.Components[1].DamageType)
-	s.Assert().Equal(0.0, result.Components[1].Multiplier)
+	s.Require().NotNil(result.Components[1].Multiplier,
+		"immunity is a modifier carrying the factor zero, not an absent modifier — rpg-toolkit#1012")
+	s.Assert().Equal(0.0, *result.Components[1].Multiplier)
 }
 
 func (s *ImmunityTestSuite) TestImmunityDoesNotAffectOtherDamageTypes() {

--- a/rulebooks/dnd5e/monstertraits/vulnerability.go
+++ b/rulebooks/dnd5e/monstertraits/vulnerability.go
@@ -161,7 +161,7 @@ func (v *vulnerabilityCondition) onDamageChain(
 			Source:     dnd5eEvents.DamageSourceMonsterTrait,
 			SourceRef:  refs.MonsterTraits.Vulnerability(),
 			DamageType: v.damageType,
-			Multiplier: 2.0,
+			Multiplier: dnd5eEvents.Multiply(2.0),
 		})
 		return e, nil
 	}

--- a/rulebooks/dnd5e/monstertraits/vulnerability_test.go
+++ b/rulebooks/dnd5e/monstertraits/vulnerability_test.go
@@ -77,7 +77,8 @@ func (s *VulnerabilityTestSuite) TestVulnerabilityAddsMultiplierComponent() {
 	// Second component: vulnerability multiplier
 	s.Assert().Equal(dnd5eEvents.DamageSourceMonsterTrait, result.Components[1].Source)
 	s.Assert().Equal(damage.Bludgeoning, result.Components[1].DamageType)
-	s.Assert().Equal(2.0, result.Components[1].Multiplier)
+	s.Require().NotNil(result.Components[1].Multiplier, "the component is a modifier, not damage")
+	s.Assert().Equal(2.0, *result.Components[1].Multiplier)
 }
 
 func (s *VulnerabilityTestSuite) TestVulnerabilityDoesNotAffectOtherDamageTypes() {


### PR DESCRIPTION
Closes #1012. Found while pinning the arithmetic in #1011, and independently by Copilot on that PR.

## Damage immunity has never worked

An immune target took full damage, and the immunity branch of the stacking rules was **unreachable code**.

`DamageComponent.Multiplier` was a `float64` whose doc said, two lines apart:

> Multiplier for this component (**0 means 1.0/no multiplier**).
> Used for vulnerability (2.0), resistance (0.5), or **immunity (0.0 to negate)**.

One value, two meanings. The dispatch had to pick one and picked "absent":

```go
if component.Multiplier != 0 {   // immunity's 0.0 fails this
```

So an immunity component fell through to the damage branch, contributed its `Total()` of zero, and vanished. `resolveMultipliers`' `m == 0.0 → hasImmunity` case could never be reached — which is the tell that nothing ever exercised it.

Nothing pinned it, either. The immunity trait's tests assert the condition applies and that a component carrying zero gets appended — never that damage drops. Both passed throughout.

## The fix: presence, not value

```go
// Multiplier scales the other components of the same damage type rather than
// adding damage of its own: vulnerability (2.0), resistance (0.5), immunity (0.0).
//
// A pointer because ZERO IS A LEGAL FACTOR.
Multiplier *float64

func Multiply(factor float64) *float64
```

`nil` means this component **is** damage; any factor — zero included — means it **modifies** damage. `events.Multiply` exists because `&0.0` is not expressible inline, and because a named constructor makes "this is a modifier" the visible act at each of the three call sites rather than a consequence of which field happens to be set.

**No compatibility hedging**, per Kirk's ruling that the toolkit carries no backwards-compatibility baggage: fixed where it lives rather than adapted around.

## Existing tests: three assertions changed, and why

The type changed, so three existing assertions had to become pointer-aware. **They are strengthened, not weakened** — each gained a `NotNil` check that is now meaningful:

| File | Change |
|---|---|
| `monstertraits/immunity_test.go` | `Equal(0.0, …Multiplier)` → `NotNil` + `Equal(0.0, *…Multiplier)`, with the comment that a zero factor is a modifier rather than an absent one — **the distinction that was missing** |
| `monstertraits/vulnerability_test.go` | same shape, `2.0` |
| `conditions/raging_test.go` | same shape, `0.5` |

Worth naming plainly: `immunity_test.go`'s old assertion is *why this hid*. It checked that the component carried `0.0` — true both before and after — and never that the zero did anything.

The two `TestKnownGap…` tripwires from #1011 are **flipped to their fix-day assertions** as designed, and their KNOWN GAP comments deleted wholesale. A third test was added for the distinction directly.

## Evidence

From `rulebooks/dnd5e/`:

| Check | Result |
|---|---|
| `go test ./...` | **exit 0 — 27 packages ok**, 0 failures |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

One module. No `replace`. Other modules (`resolution`, `encounter`) pin tagged dnd5e versions and are unaffected until they bump; the only other `Multiplier` in the repo (`mechanics/effects`) is an unrelated field in a different module.

## Mutation table

6 mutants, 6 killed. R2/R4/R5 were re-run after their first attempts produced a compile error and two failed edits — the table reports only clean, compiling mutants.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| R1 | dispatch reverts to the value-zero test (the bug itself) | KILLED | `TestAZeroFactorIsAModifierNotAbsentDamage`, `TestImmunityDropsTheInstanceEntirely` |
| R2 | immunity no longer trumps | KILLED | `TestImmunityDropsTheInstanceEntirely`, `TestAZeroFactorIsAModifierNotAbsentDamage` |
| R3 | immunity classified as resistance | KILLED | same pair |
| R4 | immunity trait emits no multiplier at all | KILLED | `TestImmunityTestSuite/TestImmunityAddsZeroMultiplierComponent` |
| R5 | immunity trait emits resistance instead | KILLED | same |
| R6 | `Multiply` drops its factor | KILLED | `TestMultipleResistancesDoNotStack`, `TestComponentsGroupBeforeTheMultiplierApplies` |

R1 is the important row: it reintroduces the exact bug this PR fixes and dies immediately — the regression is pinned, not just repaired.

— asset-pipeline agent, on behalf of KirkDiggler
