### PR TITLE
feat(resolution): take custody of the damage fold (#965 slice 2)

### DIFF
--- a/rulebooks/dnd5e/resolution/damage_custody_test.go
+++ b/rulebooks/dnd5e/resolution/damage_custody_test.go
@@ -1,0 +1,218 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// DamageCustodyTestSuite covers the fold this package took custody of in #965
+// slice 2: resolution publishes and executes the damage chain itself and calls
+// the bus-free combat.FinalDamage, where slice 1 handed its bus to
+// combat.ResolveDamage and let the other module do both.
+//
+// The behavior must not have moved. What these pin is that the fold still
+// reaches every subscriber, that the multiplier arithmetic still applies, and
+// that both are true through resolution's own step rather than through
+// combat's entry point.
+type DamageCustodyTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestDamageCustodySuite(t *testing.T) {
+	suite.Run(t, new(DamageCustodyTestSuite))
+}
+
+func (s *DamageCustodyTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// wolfBiteAt runs the catalog wolf's bite at the hero on a bus the caller
+// holds, so a test can install its own chain subscriber first.
+func (s *DamageCustodyTestSuite) biteOnBus(
+	bus events.EventBus, target *monster.Data, roller *sequenceRoller,
+) (*Output, error) {
+	data := monsters.NewWolf(wolfID).ToData()
+	attack, err := AttackFromMonsterAction(data.Actions[0])
+	s.Require().NoError(err)
+
+	return resolveOn(s.ctx, &Input{
+		World:        s.roomWith(encounter.MemberID(wolfID), encounter.MemberID(target.ID)),
+		Participants: []Participant{{Monster: data}, {Monster: target}},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   target.ID,
+			Attack:     attack,
+			Roller:     roller,
+		}),
+	}, newSurface(bus))
+}
+
+// THE HEADLINE. Damage lands with the multipliers applied, through
+// resolution's own fold and combat's exported arithmetic.
+//
+// The bite is 2d4+2. Scripted [3 4] gives 3+4+2 = 9. Resistance halves the
+// TYPE's total after grouping — 9 halved is 4, truncating — which is exactly
+// what a fold that skipped FinalDamage would get wrong by reporting 9.
+func (s *DamageCustodyTestSuite) TestResistanceHalvesDamageThroughTheOwnedFold() {
+	bus := events.NewEventBus()
+	s.halveOnBus(bus, damage.Piercing)
+
+	out, err := s.biteOnBus(bus, monsters.NewWolf(secondWolfID).ToData(),
+		&sequenceRoller{singles: []int{hitRoll, 18}, pair: []int{3, 4}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Require().True(outcome.Hit)
+	s.Require().Equal(4, outcome.Damage, "2d4[3 4]+2 = 9, halved to 4 — the arithmetic, not the raw pool")
+
+	s.Require().Len(out.DirtyMonsters, 1)
+	s.Require().Equal(11-4, out.DirtyMonsters[0].HitPoints)
+}
+
+// THE BORN-CORRECT PAYOFF. An immune target takes nothing.
+//
+// This is why the module pins dnd5e v0.94.1 rather than v0.94.0: immunity is
+// authored as a zero factor, and until #1012 the dispatch read zero as "no
+// modifier" and let full damage through. Pinning the earlier tag would have
+// given this fold the bug at birth AND pinned the wrong number here as
+// expected behavior.
+func (s *DamageCustodyTestSuite) TestImmunityNegatesDamageThroughTheOwnedFold() {
+	bus := events.NewEventBus()
+	s.multiplyOnBus(bus, damage.Piercing, 0)
+
+	out, err := s.biteOnBus(bus, monsters.NewWolf(secondWolfID).ToData(),
+		&sequenceRoller{singles: []int{hitRoll, 18}, pair: []int{3, 4}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Require().True(outcome.Hit, "the blow lands")
+	s.Require().Zero(outcome.Damage, "and does nothing — immunity, not resistance")
+
+	// The sheet is still handed back (ApplyDamage marks it seen either way);
+	// what matters is that its hit points did not move.
+	s.Require().Len(out.DirtyMonsters, 1)
+	s.Require().Equal(11, out.DirtyMonsters[0].HitPoints, "full health — nothing got through")
+}
+
+// The fold reaches subscribers on THIS package's bus. A modifier installed by
+// the test contributes, and its ref rides the component — which is the whole
+// reason custody mattered: the fold has to happen where the subscribers are.
+func (s *DamageCustodyTestSuite) TestASubscriberOnResolutionsBusContributes() {
+	bus := events.NewEventBus()
+	s.addFlatOnBus(bus, 5, damage.Piercing)
+
+	out, err := s.biteOnBus(bus, monsters.NewWolf(secondWolfID).ToData(),
+		&sequenceRoller{singles: []int{hitRoll, 18}, pair: []int{3, 4}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Require().Equal(3+4+2+5, outcome.Damage, "the pool's 9 plus the fold's 5")
+}
+
+// Two modifiers of different types stay separate: 5e resists a TYPE, so a
+// resistance to one does not touch the other, and both land.
+func (s *DamageCustodyTestSuite) TestTypesAreGroupedSeparatelyThroughTheFold() {
+	bus := events.NewEventBus()
+	s.addFlatOnBus(bus, 6, damage.Fire)
+	s.halveOnBus(bus, damage.Piercing)
+
+	out, err := s.biteOnBus(bus, monsters.NewWolf(secondWolfID).ToData(),
+		&sequenceRoller{singles: []int{hitRoll, 18}, pair: []int{3, 4}, fallback: 2})
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	// Piercing 9 halved to 4; fire 6 untouched.
+	s.Require().Equal(4+6, outcome.Damage, "each type resolves on its own")
+}
+
+// --- chain-subscriber helpers -------------------------------------------------
+
+func (s *DamageCustodyTestSuite) onDamageChain(
+	bus events.EventBus, name string, modify func(*dnd5eEvents.DamageChainEvent),
+) {
+	_, err := dnd5eEvents.DamageChain.On(bus).SubscribeWithChain(s.ctx,
+		func(_ context.Context, _ *dnd5eEvents.DamageChainEvent,
+			c chain.Chain[*dnd5eEvents.DamageChainEvent],
+		) (chain.Chain[*dnd5eEvents.DamageChainEvent], error) {
+			err := c.Add(combat.StageFinal, name,
+				func(_ context.Context, e *dnd5eEvents.DamageChainEvent) (*dnd5eEvents.DamageChainEvent, error) {
+					modify(e)
+					return e, nil
+				})
+
+			return c, err
+		})
+	s.Require().NoError(err)
+}
+
+// multiplyOnBus installs a modifier component carrying the given factor —
+// the shape resistance, vulnerability, and immunity all take.
+func (s *DamageCustodyTestSuite) multiplyOnBus(bus events.EventBus, t damage.Type, factor float64) {
+	s.onDamageChain(bus, "test_multiplier_"+string(t), func(e *dnd5eEvents.DamageChainEvent) {
+		e.Components = append(e.Components, dnd5eEvents.DamageComponent{
+			Source:     dnd5eEvents.DamageSourceCondition,
+			SourceRef:  &core.Ref{Module: "test", Type: "conditions", ID: "multiplier"},
+			Multiplier: dnd5eEvents.Multiply(factor),
+			DamageType: t,
+		})
+	})
+}
+
+func (s *DamageCustodyTestSuite) halveOnBus(bus events.EventBus, t damage.Type) {
+	s.multiplyOnBus(bus, t, 0.5)
+}
+
+// addFlatOnBus contributes extra damage of a type, the way Rage or a Divine
+// Smite does.
+func (s *DamageCustodyTestSuite) addFlatOnBus(bus events.EventBus, amount int, t damage.Type) {
+	s.onDamageChain(bus, "test_flat_"+string(t), func(e *dnd5eEvents.DamageChainEvent) {
+		e.Components = append(e.Components, dnd5eEvents.DamageComponent{
+			Source:     dnd5eEvents.DamageSourceCondition,
+			SourceRef:  refs.Conditions.Raging(),
+			FlatBonus:  amount,
+			DamageType: t,
+		})
+	})
+}
+
+// roomWith puts two monsters a cell apart. Monster-versus-monster on purpose:
+// it keeps a character's AC chain out of the arithmetic under test, and the
+// damage fold is the same fold whoever is swinging.
+func (s *DamageCustodyTestSuite) roomWith(attacker, target encounter.MemberID) encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: attacker, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: target, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}

--- a/rulebooks/dnd5e/resolution/damage_custody_test.go
+++ b/rulebooks/dnd5e/resolution/damage_custody_test.go
@@ -5,6 +5,7 @@ package resolution
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -12,13 +13,19 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
@@ -146,6 +153,91 @@ func (s *DamageCustodyTestSuite) TestTypesAreGroupedSeparatelyThroughTheFold() {
 	s.Require().True(ok)
 	// Piercing 9 halved to 4; fire 6 untouched.
 	s.Require().Equal(4+6, outcome.Damage, "each type resolves on its own")
+}
+
+// The event's own DamageType is load-bearing, not decoration: Rage's
+// resistance predicates on it twice — event.DamageType.IsPhysical() decides
+// whether to resist at all, and the multiplier component it appends carries
+// event.DamageType so the grouping puts it with the right damage.
+//
+// Real content, and the case a synthetic subscriber cannot pin: a raging
+// barbarian takes half from the wolf's piercing bite.
+func (s *DamageCustodyTestSuite) TestARagingTargetsResistanceReadsTheEventsDamageType() {
+	world, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 8, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	data := monsters.NewWolf(wolfID).ToData()
+	attack, err := AttackFromMonsterAction(data.Actions[0])
+	s.Require().NoError(err)
+
+	raging, err := (&conditions.RagingCondition{
+		CharacterID: heroID,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	out, err := Resolve(s.ctx, &Input{
+		World: world.ToData(),
+		Participants: []Participant{
+			{Character: s.ragingHero(raging)},
+			{Monster: data},
+		},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Attack:     attack,
+			Roller:     &sequenceRoller{singles: []int{hitRoll, 18}, pair: []int{3, 4}, fallback: 2},
+		}),
+	})
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Require().True(outcome.Hit)
+	s.Require().Equal(4, outcome.Damage,
+		"2d4[3 4]+2 = 9 piercing, halved by rage to 4 — resistance the event's type selected")
+
+	s.Require().Len(out.DirtyCharacters, 1)
+	s.Require().Equal(14-4, out.DirtyCharacters[0].HitPoints)
+}
+
+// ragingHero is a barbarian who can take the hit: AC 14, 14 hit points.
+func (s *DamageCustodyTestSuite) ragingHero(conds ...json.RawMessage) *character.Data {
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ArmorClass:       14,
+		ProficiencyBonus: 2,
+		SavingThrows: map[abilities.Ability]shared.ProficiencyLevel{
+			abilities.STR: shared.Proficient,
+		},
+		Conditions: conds,
+	}
 }
 
 // --- chain-subscriber helpers -------------------------------------------------

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -91,13 +91,12 @@
 //
 // # The bus-effect tally
 //
-// Steps come in two kinds, and the difference is worth counting because
-// [Gather]'s name only fits one of them. Three fold a chain and hand back the
-// folded event — the saving throw, the attack chain, the damage chain. One does
-// something on the bus and hands back nothing but the next step: imposing a
-// contest's consequence. Both kinds are built by constructors here, both run on
-// resolution's bus, and both are named for what they do; what differs is
-// whether anything is gathered.
+// [Gather] is a step resolution runs with the bus in hand — folding a chain,
+// first and mainly. Three of the four do exactly that and hand back the folded
+// event: the saving throw, the attack chain, the damage chain. The fourth does
+// something on the bus and hands back nothing but the next step — imposing a
+// contest's consequence. All four are built by constructors here, all four run
+// on resolution's bus, and each is named for what it does.
 //
 // ADR-0026's Notify would have been a second of the latter kind, and is
 // deliberately absent — see strikeMachine.afterDamage. Publishing
@@ -107,20 +106,26 @@
 // two things is the classification slice 2 owes, and slice 1 records it rather
 // than shipping a double-apply.
 //
-// Two consumers now agree on that shape, which is the evidence the question was
-// waiting for: either Gather means "do this on the bus and hand me what
-// happened" — which is what it has always been mechanically — or the step
-// vocabulary grows a case ADR-0038 does not name. That is a decision for the
-// ADR, not for this file.
+// Slice 2 settled it: the vocabulary does NOT grow a case. Three folds to one
+// pure effect does not justify a fifth step kind, the odd one out is honest
+// about itself, and its Name already reads correctly in a step log ("impose the
+// prone condition" rather than a fold that folds nothing). Not extending a
+// sealed set costs nothing; extending it against one example is the mistake
+// [ADR-0007] exists to remember.
 //
-// One of the three folds carries a debt. The damage chain is folded by
-// combat.ResolveDamage, which takes a bus, because every exported attack and
-// damage entry point in that package requires one and the arithmetic that
-// applies resistance and vulnerability is unexported — folding here would mean
-// reimplementing damage multipliers. The fold still happens on this package's
-// bus, over subscribers this package attached; what differs from the save
-// precedent is custody of the fold mechanics. Every such call site says
-// "divestment debt — #965 slice 2" so the divestment has a grep-able worklist.
+// The trigger for reopening it is recorded rather than left to memory: if wave
+// 5's reactions multiply the pure-effect steps — several suspension windows
+// that act on the bus without folding — the three-to-one ratio reverses and the
+// argument reverses with it. At that point the question comes back as an ADR
+// with the new tally as its evidence. Until then there is nothing to decide.
+//
+// All three folds are this package's own. The damage chain was the last one
+// held elsewhere: slice 1 handed resolution's bus to combat.ResolveDamage,
+// because every exported attack and damage entry point in that package required
+// one and the multiplier arithmetic was unexported. Slice 2 exported that
+// arithmetic bus-free ([combat.FinalDamage]) and moved the fold here, so
+// custody now matches where the bus lives. The grep-able worklist that tracked
+// it — every call site marked "divestment debt — #965 slice 2" — is empty.
 //
 // # What this package does not do yet
 //

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.93.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.93.0 h1:yDQ7GOPt8D6ubdM14h9IdTqJS0NZTf6+xgp1c26z95A=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.93.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0 h1:GcwmLanoceCnrQ1R1Z61N7qLqMBY8VUPq5TpL1BhfUw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.7.0/go.mod h1:ZYYd+oFBN6WUPIb+OTaAu6X7CQtVhOjEg9i0GJM0o6Q=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -214,7 +214,7 @@ type strikeMachine struct {
 }
 
 // Start validates the profile, reads the target's AC, and folds the attack chain.
-func (m *strikeMachine) Start(ctx context.Context, cast *Participants) (Step, error) {
+func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, error) {
 	if m.in == nil {
 		return nil, ErrNilInput
 	}
@@ -236,44 +236,24 @@ func (m *strikeMachine) Start(ctx context.Context, cast *Participants) (Step, er
 		return nil, err
 	}
 
-	// The AC the target actually has, armor and effects included, rather than
-	// the flat number on the sheet.
+	// The flat number the sheet carries: a character's ArmorClass field, a
+	// monster's stat-block AC. Armor worn and effects folded onto the AC chain
+	// do NOT reach it — an unarmored character whose sheet says 14 is measured
+	// against 14 here, whatever the rules would compute.
 	//
-	// GetEffectiveAC is bus-free at its signature and dispatches to the sheet:
-	// a character folds combat.ACChain on its parked bus, and under Resolve
-	// that bus IS this interaction's surface — Attach was handed it — so the
-	// fold runs among the same subscribers everything else in this strike
-	// folds among. A monster has no such method and falls through to its stat
-	// block's number, which is correct for a stat block.
+	// That is the current behavior, and it is wrong on purpose for one more
+	// change. combat.GetEffectiveAC would fold the AC chain correctly from
+	// inside an interaction — measured, not assumed, in a proving suite that
+	// watches a Defense-style fighter's +1 reach the number the d20 is compared
+	// against. What the flip also does is make character.Data.ArmorClass inert
+	// on this path, which two existing tests depend on, so it carries a
+	// behavior change and two test redesigns of its own: rpg-toolkit#1018.
 	//
-	// Slice 1 used the flat number because it could not tell whether that fold
-	// would reach the right bus; measured now, it does. Pinned end to end by
-	// TestTheDefenseStyleFoldsIntoTheACTheStrikeUses — a Defense fighter's +1
-	// changes the number the d20 is compared against, not merely the report.
-	//
-	// The fold rides the character's parked bus rather than a step this machine
-	// owns, which is the legacy shape and still is. A resolution-owned version
-	// — an AC Gather before the attack event is built — is the eventual shape
-	// if AC folding ever needs to be inspectable or suspendable. Deferred with
-	// no consumer asking for it, not because anything blocks it.
-	// The flat number on the sheet, still — and now for a sequencing reason
-	// rather than an unknown one.
-	//
-	// Slice 1 could not tell whether combat.GetEffectiveAC would fold the AC
-	// chain on the right bus from inside an interaction. It does: measured, in
-	// a proving suite that shows a Defense-style fighter's +1 reaching the
-	// number the d20 is compared against. What the flip also does is make
-	// character.Data.ArmorClass INERT on this path, which two existing tests
-	// depend on (one sets an AC no rules-legal character can have, to prove a
-	// widened crit range is not a widened hit range). That is a behavior
-	// change with its own evidence to produce and two existing tests to
-	// redesign, so it ships as its own change rather than riding this one.
-	// The proving suite is written and green; it lands with that change.
-	//
-	// Read once and used for both the outcome and the chain event: the event's
-	// number is what decides the hit, since afterAttackChain compares against
+	// Read once and used for both the outcome and the chain event, because the
+	// event's number is what decides the hit: afterAttackChain compares against
 	// the FOLDED event and overwrites the outcome from it. Setting only the
-	// outcome would report one AC and roll against another.
+	// outcome would report one AC and roll against another — the trap #1018's
+	// proving test caught.
 	effectiveAC := target.AC()
 
 	m.outcome = StrikeOutcome{

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -214,7 +214,7 @@ type strikeMachine struct {
 }
 
 // Start validates the profile, reads the target's AC, and folds the attack chain.
-func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, error) {
+func (m *strikeMachine) Start(ctx context.Context, cast *Participants) (Step, error) {
 	if m.in == nil {
 		return nil, ErrNilInput
 	}
@@ -236,14 +236,49 @@ func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, erro
 		return nil, err
 	}
 
-	// Plain AC, deliberately. Folding the AC chain is GetEffectiveAC's job and
-	// it folds on the character's own parked bus — the legacy shape this
-	// migration is retiring — so slice 1 uses the number on the sheet and
-	// names the gap rather than papering it. Divestment debt — #965 slice 2.
+	// The AC the target actually has, armor and effects included, rather than
+	// the flat number on the sheet.
+	//
+	// GetEffectiveAC is bus-free at its signature and dispatches to the sheet:
+	// a character folds combat.ACChain on its parked bus, and under Resolve
+	// that bus IS this interaction's surface — Attach was handed it — so the
+	// fold runs among the same subscribers everything else in this strike
+	// folds among. A monster has no such method and falls through to its stat
+	// block's number, which is correct for a stat block.
+	//
+	// Slice 1 used the flat number because it could not tell whether that fold
+	// would reach the right bus; measured now, it does. Pinned end to end by
+	// TestTheDefenseStyleFoldsIntoTheACTheStrikeUses — a Defense fighter's +1
+	// changes the number the d20 is compared against, not merely the report.
+	//
+	// The fold rides the character's parked bus rather than a step this machine
+	// owns, which is the legacy shape and still is. A resolution-owned version
+	// — an AC Gather before the attack event is built — is the eventual shape
+	// if AC folding ever needs to be inspectable or suspendable. Deferred with
+	// no consumer asking for it, not because anything blocks it.
+	// The flat number on the sheet, still — and now for a sequencing reason
+	// rather than an unknown one.
+	//
+	// Slice 1 could not tell whether combat.GetEffectiveAC would fold the AC
+	// chain on the right bus from inside an interaction. It does: measured, in
+	// a proving suite that shows a Defense-style fighter's +1 reaching the
+	// number the d20 is compared against. What the flip also does is make
+	// character.Data.ArmorClass INERT on this path, which two existing tests
+	// depend on (one sets an AC no rules-legal character can have, to prove a
+	// widened crit range is not a widened hit range). That is a behavior
+	// change with its own evidence to produce, so it ships as its own change
+	// rather than riding this one — rpg-toolkit#1017.
+	//
+	// Read once and used for both the outcome and the chain event: the event's
+	// number is what decides the hit, since afterAttackChain compares against
+	// the FOLDED event and overwrites the outcome from it. Setting only the
+	// outcome would report one AC and roll against another.
+	effectiveAC := target.AC()
+
 	m.outcome = StrikeOutcome{
 		AttackerID: m.in.AttackerID,
 		TargetID:   m.in.TargetID,
-		TargetAC:   target.AC(),
+		TargetAC:   effectiveAC,
 	}
 
 	event := dnd5eEvents.AttackChainEvent{
@@ -252,7 +287,7 @@ func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, erro
 		WeaponRef:         m.in.Attack.Ref,
 		IsMelee:           true,
 		AttackBonus:       m.in.Attack.AttackBonus,
-		TargetAC:          target.AC(),
+		TargetAC:          effectiveAC,
 		CriticalThreshold: criticalThreshold,
 	}
 
@@ -267,7 +302,11 @@ func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, erro
 // always misses, a natural 20 always hits. Rolling here rather than calling
 // combat is not a preference — every exported attack entry point in that
 // package requires an event bus, and there is no bus-free roll to call.
-// Divestment debt — #965 slice 2.
+//
+// Slice 2 left it that way on purpose. Exporting a bus-free attack roll would
+// be a second divestment with its own evidence to produce, and the old attack
+// path is the one that would have to give it up; it retires with #966, which
+// is when this stops being a mirror and starts being the only copy.
 func (m *strikeMachine) afterAttackChain(ctx context.Context, folded dnd5eEvents.AttackChainEvent) (Step, error) {
 	roller := m.in.Roller
 	if roller == nil {
@@ -363,10 +402,11 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 		IsCritical:        m.outcome.Critical,
 	}
 
-	return foldDamage(&combat.ResolveDamageInput{
+	return foldDamage(&dnd5eEvents.DamageChainEvent{
 		AttackerID:   m.in.AttackerID,
 		TargetID:     m.in.TargetID,
 		Components:   []dnd5eEvents.DamageComponent{component},
+		DamageType:   m.in.Attack.DamageType,
 		IsCritical:   m.outcome.Critical,
 		HasAdvantage: len(m.outcome.Folded.AdvantageSources) > 0,
 		WeaponDamage: m.in.Attack.DamageDice,
@@ -386,15 +426,21 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 // one-topic-two-meanings finding #965 slice 2 owes a classification for.
 // Pinned by TestAMonsterTargetTakesItsDamageOnce.
 func (m *strikeMachine) afterDamageChain(
-	ctx context.Context, resolved *combat.ResolveDamageOutput,
+	ctx context.Context, folded *dnd5eEvents.DamageChainEvent,
 ) (Step, error) {
 	target, err := combatantFor(m.cast, m.in.TargetID)
 	if err != nil {
 		return nil, err
 	}
 
-	instances := make([]combat.DamageInstance, 0, len(resolved.FinalInstances))
-	for _, instance := range resolved.FinalInstances {
+	// The multipliers are combat's arithmetic, called bus-free now that it is
+	// exported (#965 slice 2 PR-A). Resistance, vulnerability, and immunity
+	// stacking stays one implementation shared with the legacy stack rather
+	// than a copy that can drift.
+	final, _ := combat.FinalDamage(folded.Components)
+
+	instances := make([]combat.DamageInstance, 0, len(final))
+	for _, instance := range final {
 		instances = append(instances, combat.DamageInstance{
 			Amount: instance.Amount,
 			Type:   string(instance.Type),
@@ -422,13 +468,23 @@ func (m *strikeMachine) afterDamageChain(
 // event is inert for half the roster: the topic means two different things
 // depending on who is listening.
 //
-// That is the rules-versus-notification classification #965 slice 2 exists to
-// make, arriving as evidence rather than as opinion, so slice 1 applies damage
-// once and announces nothing. What it costs is real and worth naming: Undead
-// Fortitude listens to this topic legitimately, and does not fire here. It
-// converts with its gate (#977), by which point the double-apply is gone.
+// Slice 2's census classified it, and the answer was sharper than the question:
+// DamageReceivedTopic has FIVE subscribers across THREE meanings. One applies
+// damage (monster.onDamageReceived calls TakeDamage — the instruction). Three
+// are genuine rules that only observe: Undead Fortitude's survival save,
+// Unconscious's death-save failures, and Rage's was-I-hit upkeep. One is the
+// encounter layer, which captures the events and DRAINS them precisely to stop
+// the damage landing twice. A character subscribes for none of it, so the topic
+// is inert for half the roster.
 //
-// Divestment debt — #965 slice 2.
+// The topic MEANS "damage has landed" — a notification. The subscriber that
+// treats it as an instruction is the defect, not the topic, and it retires with
+// #977 when Undead Fortitude converts to a gate. Publishing here before then
+// would double-apply to every monster; publishing after costs nothing and buys
+// the three rules back. So this waits on that conversion, not on a question.
+//
+// What it costs meanwhile is named rather than hidden: those three rules do not
+// fire for resolution-driven damage yet.
 func (m *strikeMachine) afterDamage(ctx context.Context) (Step, error) {
 	return m.afterNotify(ctx)
 }
@@ -470,8 +526,12 @@ func (m *strikeMachine) afterNotify(_ context.Context) (Step, error) {
 // single swing.
 //
 // Reach is not enforced, for melee weapons exactly as for the bite: the
-// strike does not yet check adjacency at all. That is one shared, named gap
-// (#965 slice 2's list), not one this case adds.
+// strike does not check adjacency at all. Deferred explicitly rather than
+// carried silently — rpg-toolkit#1010 owns the rule inventory (five-foot
+// reach, the reach property, ranged brackets) and it lands with the movement
+// wave, where the MovementChain custody it belongs beside already sits.
+// Positions exist and the room is built, so the check is cheap whenever
+// someone owns the rule.
 func AttackFromMonsterAction(action monster.ActionData) (AttackProfile, error) {
 	switch action.Ref.ID {
 	case refs.MonsterActions.Bite().ID:
@@ -639,31 +699,40 @@ func gatherAttack(
 	}
 }
 
-// foldDamage builds the step that folds the damage chain.
+// foldDamage builds the step that folds the damage chain on this
+// interaction's own bus.
 //
-// **Divestment debt — #965 slice 2.** This hands resolution's own bus to
-// combat.ResolveDamage, which folds the chain itself. Functionally it is the
-// save precedent — the fold happens on the interaction's bus either way, since
-// resolution attached every subscriber to it — and what differs is custody of
-// the fold mechanics. There is no bus-free alternative to call: every exported
-// attack and damage entry point in combat requires a bus, and the arithmetic
-// that applies resistance and vulnerability is unexported, so folding here
-// would mean reimplementing damage multipliers. Slice 2 retires this.
+// Resolution publishes and executes the chain itself, the same way it already
+// does for the attack and the saving throw, and then calls the exported
+// [combat.FinalDamage] for the multiplier arithmetic. Slice 1 handed its bus
+// to combat.ResolveDamage instead — the fold happened on the right bus either
+// way, since resolution attached every subscriber to it, but custody of the
+// fold sat in the other module and there was no bus-free arithmetic to call.
+// PR-A exported that arithmetic; this is the half that uses it.
+//
+// What is deliberately NOT reimplemented: the stacking rules. FinalDamage is
+// shared with the legacy stack, so resistance and immunity cannot drift
+// between the two.
 func foldDamage(
-	in *combat.ResolveDamageInput,
-	next func(context.Context, *combat.ResolveDamageOutput) (Step, error),
+	event *dnd5eEvents.DamageChainEvent,
+	next func(context.Context, *dnd5eEvents.DamageChainEvent) (Step, error),
 ) Gather {
 	return Gather{
 		name: "damage chain",
 		run: func(ctx context.Context, bus events.EventBus) (Step, error) {
-			in.EventBus = bus
+			chain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
 
-			resolved, err := combat.ResolveDamage(ctx, in)
+			modified, err := dnd5eEvents.DamageChain.On(bus).PublishWithChain(ctx, event, chain)
 			if err != nil {
-				return nil, fmt.Errorf("resolve damage: %w", err)
+				return nil, fmt.Errorf("publish damage chain: %w", err)
 			}
 
-			return next(ctx, resolved)
+			folded, err := modified.Execute(ctx, event)
+			if err != nil {
+				return nil, fmt.Errorf("execute damage chain: %w", err)
+			}
+
+			return next(ctx, folded)
 		},
 	}
 }

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -266,8 +266,9 @@ func (m *strikeMachine) Start(ctx context.Context, cast *Participants) (Step, er
 	// character.Data.ArmorClass INERT on this path, which two existing tests
 	// depend on (one sets an AC no rules-legal character can have, to prove a
 	// widened crit range is not a widened hit range). That is a behavior
-	// change with its own evidence to produce, so it ships as its own change
-	// rather than riding this one — rpg-toolkit#1017.
+	// change with its own evidence to produce and two existing tests to
+	// redesign, so it ships as its own change rather than riding this one.
+	// The proving suite is written and green; it lands with that change.
 	//
 	// Read once and used for both the outcome and the chain event: the event's
 	// number is what decides the hit, since afterAttackChain compares against


### PR DESCRIPTION
The #965 slice 2 closer. Resolution module only. **Does not close #965** — the retirement scope ends here; the bookkeeping on what remains is the lead's.

## The last fold comes home

Resolution folds its own chains — except one. The damage chain was folded by `combat.ResolveDamage`, handed *this package's bus*, because every exported attack and damage entry point in that module required one and the multiplier arithmetic was unexported. Folding here would have meant reimplementing damage multipliers, which is how two copies of a rule start disagreeing.

PR-A (#1011) exported that arithmetic bus-free. This is the half that uses it:

```go
// resolution now publishes and executes the chain itself — exactly as it
// already does for the attack chain and the saving throw
modified, err := dnd5eEvents.DamageChain.On(bus).PublishWithChain(ctx, event, chain)
folded, err := modified.Execute(ctx, event)
// ...then combat's shared arithmetic, bus-free
final, _ := combat.FinalDamage(folded.Components)
```

The fold always happened on the right bus — this package attached every subscriber to it — so **what moved is custody, not behavior**. Every existing test passes unmodified, which is the evidence that claim needs.

## Pinned to v0.94.1, deliberately

Both v0.94.0 and v0.94.1 carry `FinalDamage`; only v0.94.1 carries the immunity fix (#1012). Pinning the earlier tag would have given this fold the bug **at birth** and pinned the wrong arithmetic here as expected behavior — a failure that presents as passing tests. `TestImmunityNegatesDamageThroughTheOwnedFold` is the payoff.

## The divestment-debt worklist is empty

`grep -rn "divestment debt" .` returns one line: the past-tense sentence in `doc.go` recording that it is empty. Each former marker became a **decision that names its own sequencing reason** — none is justified by compatibility:

| Was | Now |
|---|---|
| damage fold held by combat | **retired** — custody moved, this PR |
| bus-free attack roll missing | mirrored from combat by choice; exporting one is a second divestment, and the old attack path retires with **#966** |
| `DamageReceivedEvent` unpublished | waits for **#977**, with the census's finding recorded at the site: five subscribers, three meanings |
| reach unenforced | names **#1010**, which owns the rule inventory, landing with the movement wave |
| AC chain custody | **proven foldable, ships separately** — see below |

### The `DamageReceivedEvent` comment now records what the census found

Five subscribers across three meanings: one *applies* damage (`monster.onDamageReceived` → `TakeDamage`), three are genuine rules that only observe (Undead Fortitude's survival save, Unconscious's death-save failures, Rage's was-I-hit upkeep), and one is the encounter layer capturing and *draining* the events precisely to stop a double-apply. A character subscribes for none of it. The topic means "damage has landed"; the instruction-shaped subscriber is the defect, not the topic.

### Gather's doc says what it always meant

Reframed to *"a step resolution runs with the bus in hand — folding a chain, first and mainly"*, and the vocabulary does **not** grow a case for the one pure-effect step. The reopening trigger is recorded rather than left to memory: if wave 5's reactions multiply pure-effect steps, three-to-one reverses and it returns as an ADR.

## ⚠️ The AC flip is proven but ships separately

The census read was right, and I measured it: `combat.GetEffectiveAC` folds the AC chain on this interaction's bus, and a Defense-style fighter's +1 reaches the number the d20 is compared against. **The proving suite passes.**

It is not in this PR, for a reason the gate did not anticipate. The flip makes `character.Data.ArmorClass` **inert** on this path, and two existing tests depend on the flat field:

- `TestAWolfBitesTheHeroAndKnocksHimDown` — the `hero()` fixture declares `ArmorClass: 14` while wearing no armor. An unarmored DEX-14 character is really **AC 12**; the flat read was honoring a fiction.
- `TestAWidenedCritRangeDoesNotWidenTheHitRange` — sets `ArmorClass = 25` to prove a widened crit range is not a widened hit range. No rules-legal character reaches 25, so the technique itself stops working; it wants a monster target, not an adaptation.

That is a behavior change with its own evidence to produce and two existing tests to redesign — one mechanic per PR. The proving suite and the flip are written and green; they land as their own change, once the issue is filed.

**One implementation note worth carrying to that change:** setting only `StrikeOutcome.TargetAC` is not enough. `afterAttackChain` compares against the **folded event** and overwrites the outcome from it, so the `AttackChainEvent`'s own `TargetAC` must carry the effective number too — otherwise the strike reports the right AC and rolls against the wrong one. I hit exactly that and the proving test caught it.

## Evidence

From `rulebooks/dnd5e/resolution/`:

| Check | Result |
|---|---|
| `go test ./...` | **exit 0 — 84 subtests pass, 0 fail** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff beyond the intended `v0.93.0 → v0.94.1` bump |

One module. No `replace`. **Existing tests unmodified.** `ARCHITECTURE.md` needed no change — its strike description (`Gather(attack) → roll vs AC → Gather(damage) → apply → Request(contest) → Done`) is still exactly true, since custody moved without changing the step sequence.

## Mutation table

5 mutants: 4 killed, 1 equivalent.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| S1 | multipliers skipped — raw components summed | KILLED | `TestImmunityNegates…`, `TestResistanceHalves…` |
| S2 | fold uses the pre-chain event | **EQUIVALENT** | see below |
| S3 | chain never published — no subscriber runs | KILLED | `TestARagingHerosBonusArrivesViaTheChain…` (**existing**) |
| S4 | `DamageType` dropped from the event | KILLED *(after adding coverage)* | `TestARagingTargetsResistanceReadsTheEventsDamageType` |
| S5 | `AbilityUsed` dropped from the damage event | KILLED | `TestRagePaysOutOnTheStrengthSwing` (**existing**) |

**S2 is a true equivalent mutant, verified rather than assumed.** Chain modifiers mutate the event in place and return the same pointer, so `folded == event` — probed directly, it reports `true`. No test can distinguish them because there is nothing to distinguish. Using `folded` remains the correct code (a subscriber returning a *new* event would break the alternative), so it stays.

**S4 survived the first pass and found a real gap:** the event-level `DamageType` is load-bearing — Rage's resistance predicates on `event.DamageType.IsPhysical()` *and* stamps the multiplier component with it — and nothing pinned it. The new test uses real content rather than a synthetic subscriber, because a synthetic one reads whatever type the test hands it and would pass either way. Committed separately as `fbad149`.

S3 and S5 dying on **existing** tests is the recomposition evidence: the fold still reaches the subscribers it always reached.

— asset-pipeline agent, on behalf of KirkDiggler

