### PR TITLE
fix(resolution): the strike rolls against the AC the target actually has

### DIFF
--- a/rulebooks/dnd5e/resolution/effective_ac_test.go
+++ b/rulebooks/dnd5e/resolution/effective_ac_test.go
@@ -1,0 +1,217 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// EffectiveACTestSuite is the proving test for the AC-chain custody question
+// (#965 slice 2's census).
+//
+// The strike read target.AC() — the flat number on the sheet — because slice 1
+// could not tell whether the AC chain would fold correctly from inside an
+// interaction. The census argued it would: combat.GetEffectiveAC is bus-free
+// at its signature, Character.EffectiveAC folds combat.ACChain on the
+// character's parked bus, and Attach sets that bus to whatever it is handed —
+// which under Resolve is this interaction's own surface. The two AC
+// subscribers, Defense and Unarmored Defense, attach to the same surface.
+//
+// Argued is not measured. These tests measure it: a Defense-style fighter's
+// +1 must reach the number the attack is rolled against, end to end through
+// Resolve, or the flip does not happen.
+type EffectiveACTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestEffectiveACSuite(t *testing.T) {
+	suite.Run(t, new(EffectiveACTestSuite))
+}
+
+func (s *EffectiveACTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// armoredHero wears chain mail (AC 16, no DEX) and carries whatever conditions
+// the case needs. Chain mail rather than leather on purpose: its MaxDexBonus
+// of zero takes the hero's DEX out of the arithmetic, so the only number that
+// can move the total is the one under test.
+func (s *EffectiveACTestSuite) armoredHero(conds ...json.RawMessage) *character.Data {
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    14,
+		MaxHitPoints: 14,
+		// The flat sheet number, deliberately DIFFERENT from what the armor
+		// and the fighting style compute. If the strike reads this, the tests
+		// below fail with a number that says so.
+		ArmorClass:       10,
+		ProficiencyBonus: 2,
+		Inventory: []character.InventoryItemData{
+			{Type: shared.EquipmentTypeArmor, ID: string(armor.ChainMail), Quantity: 1},
+		},
+		EquipmentSlots: character.EquipmentSlots{
+			character.SlotArmor: string(armor.ChainMail),
+		},
+		Conditions: conds,
+	}
+}
+
+func (s *EffectiveACTestSuite) defenseStyle() json.RawMessage {
+	raw, err := (&conditions.FightingStyleDefenseCondition{
+		CharacterID: heroID,
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+func (s *EffectiveACTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 8, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+// biteAt runs the wolf's bite against the given hero and reports what AC the
+// strike measured itself against.
+func (s *EffectiveACTestSuite) biteAt(hero *character.Data, roll int) StrikeOutcome {
+	data := monsters.NewWolf(wolfID).ToData()
+	attack, err := AttackFromMonsterAction(data.Actions[0])
+	s.Require().NoError(err)
+
+	out, err := Resolve(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: hero}, {Monster: data}},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Attack:     attack,
+			Roller:     &sequenceRoller{singles: []int{roll, 18}, pair: []int{3, 4}, fallback: 2},
+		}),
+	})
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+
+	return outcome
+}
+
+// THE PROVING TEST. Worn armor reaches the strike.
+//
+// Chain mail is AC 16 with no DEX contribution. The sheet's flat ArmorClass
+// says 10. If the strike measured against the flat number this reports 10.
+func (s *EffectiveACTestSuite) TestWornArmorReachesTheStrike() {
+	outcome := s.biteAt(s.armoredHero(), 12)
+
+	s.Require().Equal(16, outcome.TargetAC,
+		"chain mail's 16, not the sheet's flat 10")
+}
+
+// AND THE ONE THAT MATTERS: a fighting style that folds onto the AC chain
+// reaches it too. Defense is +1 while wearing armor, so 16 becomes 17.
+//
+// This is the case the flat number could never produce and the armor lookup
+// alone could not either — it can only arrive through the AC chain folding on
+// this interaction's bus.
+func (s *EffectiveACTestSuite) TestTheDefenseStyleFoldsIntoTheACTheStrikeUses() {
+	plain := s.biteAt(s.armoredHero(), 12)
+	defended := s.biteAt(s.armoredHero(s.defenseStyle()), 12)
+
+	s.Require().Equal(16, plain.TargetAC)
+	s.Require().Equal(17, defended.TargetAC, "Defense is +1 in armor")
+	s.Require().Equal(1, defended.TargetAC-plain.TargetAC,
+		"exactly the fighting style's contribution, folded on this interaction's bus")
+}
+
+// The folded AC is the number the hit is DECIDED against, not merely reported.
+//
+// The wolf's +4 against 16 needs a 12; against 17 it needs a 13. A 12 must
+// therefore hit the plain fighter and miss the defended one — the same roll,
+// the same attacker, one point of fighting style between them.
+func (s *EffectiveACTestSuite) TestTheFoldedACDecidesTheHitNotJustTheReport() {
+	plain := s.biteAt(s.armoredHero(), 12)
+	s.Require().True(plain.Hit, "12 + 4 = 16 meets AC 16")
+
+	defended := s.biteAt(s.armoredHero(s.defenseStyle()), 12)
+	s.Require().False(defended.Hit, "the same 16 falls short of AC 17")
+	s.Require().Zero(defended.Damage, "and a miss deals nothing")
+}
+
+// A monster target has no AC chain to fold — stat blocks carry a number — so
+// it reports its own AC unchanged. Confirms the character path did not become
+// a requirement for everyone.
+func (s *EffectiveACTestSuite) TestAMonsterTargetStillReportsItsStatBlockAC() {
+	data := monsters.NewWolf(wolfID).ToData()
+	second := monsters.NewWolf(secondWolfID).ToData()
+	attack, err := AttackFromMonsterAction(data.Actions[0])
+	s.Require().NoError(err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: secondWolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	out, err := Resolve(s.ctx, &Input{
+		World:        enc.ToData(),
+		Participants: []Participant{{Monster: data}, {Monster: second}},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   secondWolfID,
+			Attack:     attack,
+			Roller:     &sequenceRoller{singles: []int{15, 18}, pair: []int{3, 4}, fallback: 2},
+		}),
+	})
+	s.Require().NoError(err)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Require().Equal(13, outcome.TargetAC, "the wolf's own natural armor")
+}

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -253,12 +253,19 @@ func (m *strikeMachine) Start(ctx context.Context, cast *Participants) (Step, er
 	// nothing asks for it yet, and the fold reaches the right subscribers
 	// either way.
 	//
-	// Read once and used for BOTH the outcome and the chain event, because the
-	// event's number is what decides the hit: afterAttackChain compares against
-	// the FOLDED event and overwrites the outcome from it. Setting only the
-	// outcome would report the effective AC and roll against the flat one — a
-	// strike that tells the truth and does something else. Pinned by
-	// TestTheFoldedACDecidesTheHitNotJustTheReport.
+	// THE CHAIN EVENT'S COPY IS THE ONE THAT MATTERS. afterAttackChain compares
+	// against the FOLDED event and then assigns m.outcome.TargetAC from it, so
+	// the event's number both decides the hit and replaces whatever the outcome
+	// was built with. Setting only the outcome would report the effective AC
+	// and roll against the flat one — a strike that tells the truth and does
+	// something else. Pinned by TestTheFoldedACDecidesTheHitNotJustTheReport.
+	//
+	// The outcome is seeded with it anyway, and that seed is dead on every
+	// path that exists today: nothing returns a StrikeOutcome before the fold
+	// runs. It stays because a future phase that can end the strike earlier —
+	// a reaction window declining the attack, say — would otherwise hand back
+	// an outcome with a zero AC, and that is a worse failure than a redundant
+	// assignment.
 	effectiveAC := combat.GetEffectiveAC(ctx, target)
 
 	m.outcome = StrikeOutcome{

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -214,7 +214,7 @@ type strikeMachine struct {
 }
 
 // Start validates the profile, reads the target's AC, and folds the attack chain.
-func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, error) {
+func (m *strikeMachine) Start(ctx context.Context, cast *Participants) (Step, error) {
 	if m.in == nil {
 		return nil, ErrNilInput
 	}
@@ -236,25 +236,30 @@ func (m *strikeMachine) Start(_ context.Context, cast *Participants) (Step, erro
 		return nil, err
 	}
 
-	// The flat number the sheet carries: a character's ArmorClass field, a
-	// monster's stat-block AC. Armor worn and effects folded onto the AC chain
-	// do NOT reach it — an unarmored character whose sheet says 14 is measured
-	// against 14 here, whatever the rules would compute.
+	// The AC the target actually has — armor worn and every effect folded onto
+	// the AC chain — rather than the flat number the sheet happens to carry.
 	//
-	// That is the current behavior, and it is wrong on purpose for one more
-	// change. combat.GetEffectiveAC would fold the AC chain correctly from
-	// inside an interaction — measured, not assumed, in a proving suite that
-	// watches a Defense-style fighter's +1 reach the number the d20 is compared
-	// against. What the flip also does is make character.Data.ArmorClass inert
-	// on this path, which two existing tests depend on, so it carries a
-	// behavior change and two test redesigns of its own: rpg-toolkit#1018.
+	// combat.GetEffectiveAC is bus-free at its signature and dispatches on the
+	// sheet: a character folds combat.ACChain, a monster has no such method and
+	// falls through to its stat block's AC, which is correct for a stat block.
 	//
-	// Read once and used for both the outcome and the chain event, because the
+	// The character's fold rides the bus parked on the sheet, and under Resolve
+	// that bus IS this interaction's participant view — Attach was handed it —
+	// so the fold runs among the same subscribers everything else in this strike
+	// folds among. That is the legacy shape and it is load-bearing here: a
+	// resolution-owned step (an AC Gather before the attack event is built) is
+	// the eventual form if AC folding ever needs to be inspectable in the step
+	// log or suspendable at a reaction window. Documented rather than built —
+	// nothing asks for it yet, and the fold reaches the right subscribers
+	// either way.
+	//
+	// Read once and used for BOTH the outcome and the chain event, because the
 	// event's number is what decides the hit: afterAttackChain compares against
 	// the FOLDED event and overwrites the outcome from it. Setting only the
-	// outcome would report one AC and roll against another — the trap #1018's
-	// proving test caught.
-	effectiveAC := target.AC()
+	// outcome would report the effective AC and roll against the flat one — a
+	// strike that tells the truth and does something else. Pinned by
+	// TestTheFoldedACDecidesTheHitNotJustTheReport.
+	effectiveAC := combat.GetEffectiveAC(ctx, target)
 
 	m.outcome = StrikeOutcome{
 		AttackerID: m.in.AttackerID,

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
@@ -120,6 +121,14 @@ func (s *StrikeTestSuite) world(secondWolfAt spatial.Position) encounter.Encount
 
 // hero has AC 14 and a +5 STR save: the wolf's +4 bite needs an 10 to hit, and
 // its DC 11 knockdown is a real contest.
+//
+// The 14 is EARNED rather than declared: hide armor's 12 plus a capped +2 from
+// DEX 14. It used to be a bare ArmorClass field on an unarmored sheet, which
+// the strike honored only because it read that field directly — an unarmored
+// character with DEX 14 is really AC 12, so the number was a fiction the flat
+// read kept alive. Now that the strike folds the AC chain (#1018), the fixture
+// has to be a character who could actually have this AC, and every assertion
+// about 14 in this file stays true because the arithmetic agrees.
 func (s *StrikeTestSuite) hero(conds ...json.RawMessage) *character.Data {
 	return &character.Data{
 		ID:       heroID,
@@ -142,6 +151,12 @@ func (s *StrikeTestSuite) hero(conds ...json.RawMessage) *character.Data {
 		ProficiencyBonus: 2,
 		SavingThrows: map[abilities.Ability]shared.ProficiencyLevel{
 			abilities.STR: shared.Proficient,
+		},
+		Inventory: []character.InventoryItemData{
+			{Type: shared.EquipmentTypeArmor, ID: string(armor.Hide), Quantity: 1},
+		},
+		EquipmentSlots: character.EquipmentSlots{
+			character.SlotArmor: string(armor.Hide),
 		},
 		Conditions: conds,
 	}
@@ -486,15 +501,24 @@ func (s *StrikeTestSuite) widenCritTo(bus events.EventBus, threshold int) {
 
 // resolveWith is resolve on a bus the test holds, so a test can subscribe its
 // own chain modifiers before the machine folds.
+//
+// secondWolf replaces the stock second wolf when a case needs a specific one —
+// a stat block with an armor class no character could wear, say.
 func (s *StrikeTestSuite) resolveWith(
 	bus events.EventBus, world encounter.EncounterData, hero *character.Data, machine Machine,
+	secondWolf ...*monster.Data,
 ) (*Output, error) {
+	second := s.wolf(secondWolfID)
+	if len(secondWolf) > 0 {
+		second = secondWolf[0]
+	}
+
 	return resolveOn(s.ctx, &Input{
 		World: world,
 		Participants: []Participant{
 			{Character: hero},
 			{Monster: s.wolf(wolfID)},
-			{Monster: s.wolf(secondWolfID)},
+			{Monster: second},
 		},
 		Machine: machine,
 	}, newSurface(bus))
@@ -507,16 +531,24 @@ func (s *StrikeTestSuite) TestAWidenedCritRangeDoesNotWidenTheHitRange() {
 	bus := events.NewEventBus()
 	s.widenCritTo(bus, 19)
 
-	armored := s.hero()
+	// A MONSTER wearing an absurd armor class, not a character.
+	//
+	// The rule under test needs a target the attack cannot reach, and 25 is
+	// past anything 5e's armor can produce — plate and a shield stop at 20. A
+	// character's AC is now computed from what they wear (#1018), so a flat 25
+	// on a character sheet is simply ignored and the test would prove nothing.
+	// A stat block's AC is a declared number by design: monsters have no AC
+	// chain, GetEffectiveAC falls through to AC(), and 25 stands.
+	armored := s.wolf(secondWolfID)
 	armored.ArmorClass = 25
 
-	out, err := s.resolveWith(bus, s.world(spatial.Position{X: 8, Y: 5}), armored,
+	out, err := s.resolveWith(bus, s.world(spatial.Position{X: 8, Y: 5}), s.hero(),
 		NewStrike(&StrikeInput{
 			AttackerID: wolfID,
-			TargetID:   heroID,
+			TargetID:   secondWolfID,
 			Attack:     s.wolfAttack(),
 			Roller:     &sequenceRoller{singles: []int{19}, fallback: 2},
-		}))
+		}), armored)
 	s.Require().NoError(err)
 
 	outcome := s.strikeOutcome(out)


### PR DESCRIPTION
Closes #1018. Resolution module only; no pin change. The parked-and-proven work from #1017, with #1018's decided redesigns applied.

## The bug

The strike measured every attack against the **flat number on the sheet**. A fighter in chain mail with the Defense fighting style was hit as though wearing whatever somebody had typed into `ArmorClass` by hand: worn armor reached the roll only if the total had already been written down, and an effect that folds onto the AC chain never reached it at all.

```go
TargetAC: target.AC()   // the field, not the rules
```

## The fix

`combat.GetEffectiveAC` dispatches on the sheet — a character folds `combat.ACChain`, a monster has no such method and falls through to its stat block's number, which is correct for a stat block.

The character's fold rides the bus **parked on the sheet**, and under `Resolve` that bus *is* this interaction's participant view (`Attach` was handed it), so the fold runs among the same subscribers everything else in the strike folds among. Slice 1 could not tell that from the outside and used the flat number rather than guess; #965 slice 2's census argued it; this measures it.

**A resolution-owned AC step** — a `Gather` before the attack event is built — is the eventual shape if AC folding ever needs to be inspectable in the step log or suspendable at a reaction window. Documented, not built: nothing asks for it, and the fold reaches the right subscribers either way.

## The trap this would otherwise have shipped

Setting only `StrikeOutcome.TargetAC` is **not enough**. `afterAttackChain` compares against the **folded event** and then assigns the outcome's `TargetAC` from it — so the event's copy both decides the hit and replaces the outcome's. A flip that touched only the outcome would produce a strike that *reports* the effective AC and *rolls against* the flat one.

I hit exactly that on the first pass and the proving test caught it. It is pinned by `TestTheFoldedACDecidesTheHitNotJustTheReport` and mutation-checked in both directions.

## Two existing tests changed — the sanctioned exception, decided in #1018

Both because the flip makes `character.Data.ArmorClass` inert on this path. Everything else is untouched.

**1. The hero fixture now EARNS its AC 14** — hide armor's 12 plus a capped +2 from DEX 14 — where it used to *declare* 14 on an unarmored sheet. An unarmored character with DEX 14 is really AC 12; the number was a fiction the flat read kept alive. **Every assertion about 14 in that file still holds**, because the arithmetic now agrees with them rather than being overridden.

**2. The widened-crit test targets a MONSTER** with an absurd armor class instead of a character. The rule under test needs a target the attack cannot reach, and 25 is past anything 5e armor produces (plate + shield stops at 20). A stat block's AC is a declared number *by design* — monsters have no AC chain — so the rule survives intact rather than being weakened to fit.

## Evidence

From `rulebooks/dnd5e/resolution/`:

| Check | Result |
|---|---|
| `go test ./...` | **exit 0 — 88 subtests pass, 0 fail** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

One module, no pin change, no `replace`.

## The proving suite

| Test | Pins |
|---|---|
| `TestWornArmorReachesTheStrike` | chain mail's 16, not the sheet's flat 10 |
| `TestTheDefenseStyleFoldsIntoTheACTheStrikeUses` | Defense's +1 arrives — 16 → 17, the case only an AC-chain fold can produce |
| `TestTheFoldedACDecidesTheHitNotJustTheReport` | the same roll hits at 16 and **misses** at 17 — decided, not merely reported |
| `TestAMonsterTargetStillReportsItsStatBlockAC` | the character path did not become a requirement for everyone |

The fixture sets `ArmorClass: 10` deliberately against chain mail's 16, so a regression to the flat read fails with a number that says exactly what happened.

## Mutation table

3 mutants: 2 killed, 1 equivalent.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| T1 | flip reverted to flat `AC()` | KILLED | `TestTheDefenseStyleFolds…`, `TestTheFoldedACDecides…` |
| T2 | effective on the outcome, flat on the folded event | KILLED | `TestTheDefenseStyleFolds…`, `TestTheFoldedACDecides…` |
| T3 | effective on the event, flat on the outcome seed | **EQUIVALENT** | see below |

T1 and T2 are the two minimums, and T2 is the important one — it is precisely the rolls-versus-reports split, and it dies.

**T3 survived, and it was telling me something true.** The outcome's `TargetAC` seed is dead on every path that exists: `afterAttackChain` assigns it from the folded event before any `StrikeOutcome` is returned, and nothing returns one earlier. So no test can distinguish the mutant — but my comment had claimed the value was "used for BOTH", which overstated it. Corrected in `9c67b46`: the comment now says the event's copy decides and replaces, and why the seed stays anyway — a future phase that ends a strike before the fold would otherwise hand back an outcome with a zero AC, which is a worse failure than a redundant assignment.

— asset-pipeline agent, on behalf of KirkDiggler
