### PR TITLE
feat(encounter): trigger detection — sight starts the fight (#964 v1)

### DIFF
--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -26,6 +26,7 @@ import (
 // all exercised by the same tests that already cover Cells/Occluders.
 func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
@@ -64,6 +65,7 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 // a point off in empty space (#929 T3 fix round item 5).
 func validAtlasVoidGapSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "gap-a", Width: 3, Height: 3, Origin: spatial.Position{X: 0, Y: 0}},
@@ -83,6 +85,7 @@ func validAtlasVoidGapSetup() *encounter.SetupInput {
 // IsValidPosition without any Origin arithmetic in the way.
 func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
 		},
@@ -461,6 +464,7 @@ func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripFractionalSquare() {
 func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripExactAtExtremeOrigin() {
 	const extreme = (1 << 30) - 8
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "extreme", Width: 10, Height: 10, Origin: spatial.Position{X: extreme, Y: -extreme}},

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -345,7 +345,8 @@ func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 	s.Require().NoError(err)
 
 	data := enc1.ToData()
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	atlas2, err := enc2.Atlas()

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// BeatOrderTestSuite guards ONE law, at every verb that can trigger a fight:
+//
+//	A VERB'S OWN BEAT PRECEDES ANY BEAT ITS CONSEQUENCES APPEND.
+//
+// Cause before effect, in every story. A reader of Story must be able to see
+// the walk that started the fight before the fight — an engine whose product
+// IS the narration cannot narrate backwards.
+//
+// The law is stated at [refreshSight]; these are its five guards. Setup ruled
+// it first (a scene records that it opened before it records a fight starting
+// inside it), and trigger detection then arrived at Move, Traverse, Pump and
+// Join. Two of the four (Traverse via TestTraverseBeatPinned, Join via
+// TestTombWatch) inverted the moment trigger detection moved inside
+// refreshSight; the other two were latent only because nothing asserted them.
+// All five are asserted here so a future verb inherits a guarded law rather
+// than a remembered one.
+//
+// Every scene below uses the same set: a 12x12 room with a pillar at (6,6),
+// and sight blocked exactly along the file the pillar stands on. Nobody is in
+// contact until the verb under test puts them in contact.
+type BeatOrderTestSuite struct {
+	suite.Suite
+}
+
+func TestBeatOrderSuite(t *testing.T) {
+	suite.Run(t, new(BeatOrderTestSuite))
+}
+
+const beatOrderRoom = "hall"
+
+// pillarRoom is the shared set: one room, one occluder at (6,6).
+func pillarRoom() encounter.RoomInput {
+	return encounter.RoomInput{
+		ID: beatOrderRoom, Width: 12, Height: 12,
+		Occluders: []spatial.Position{{X: 6, Y: 6}},
+	}
+}
+
+// beatKinds reads one audience's whole story as its list of beat kinds.
+func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encounter.MemberID) []string {
+	story, err := enc.Story(&encounter.StoryInput{Audience: audience})
+	s.Require().NoError(err)
+	kinds := make([]string, 0, len(story))
+	for _, entry := range story {
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		kinds = append(kinds, beat["beat"].(string))
+	}
+	return kinds
+}
+
+// TestSetupOpensBeforeItFights is the pin Setup already earned: first light
+// can start a fight, and the fight belongs INSIDE the scene it happens in.
+// Classifying before the opening beat is appended reads as a fight in a room
+// that has not opened yet.
+func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{pillarRoom()}},
+		Members: []encounter.MemberInput{
+			// Off the pillar's file: they see each other at first light.
+			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 2, Y: 2}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 10}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	s.Equal([]string{"scene-opened", "bubble-formed"}, s.beatKinds(enc, alice),
+		"the scene opens, THEN the fight inside it starts")
+}
+
+// TestMoveBeforeItFights pins Move's half. Alice starts behind the pillar's
+// file and steps off it; stepping off is what puts her in contact, so the
+// moved beat is the cause and the bubble-formed beat is its effect.
+func (s *BeatOrderTestSuite) TestMoveBeforeItFights() {
+	enc := s.blockedScene()
+
+	out, err := enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 2, Y: 2}})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "stepping into the open puts her in contact")
+	s.Greater(out.Formed.Seq, out.Seq, "she moves, THEN the fight starts")
+
+	s.Equal([]string{"scene-opened", "moved", "bubble-formed"}, s.beatKinds(enc, alice))
+}
+
+// TestTraverseBeforeItFights pins Traverse's half — the verb whose inversion
+// this suite was written from. Alice walks through a door into the goblin's
+// room: the traversed beat is the cause, the fight is the effect.
+func (s *BeatOrderTestSuite) TestTraverseBeforeItFights() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: room1, Width: 10, Height: 10},
+				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
+			},
+			Connections: []encounter.ConnectionInput{
+				{ID: "door1", From: room1, To: room2,
+					FromPosition: spatial.Position{X: 9, Y: 5},
+					ToPosition:   spatial.Position{X: 0, Y: 5}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 9, Y: 5}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: room2, Position: spatial.Position{X: 1, Y: 5}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "she walks into the room the goblin is standing in")
+	s.Greater(out.Formed.Seq, out.Seq, "she goes through the door, THEN the fight starts")
+
+	s.Equal([]string{"scene-opened", "traversed", "bubble-formed"}, s.beatKinds(enc, alice))
+}
+
+// TestPumpBeforeItFights pins Pump's half, and Pump is the verb the whole
+// placement argument rests on: here NOBODY walks — the monster does. Pump's
+// own beats are the tick frame AND the action inside it, so both precede the
+// fight the action caused.
+func (s *BeatOrderTestSuite) TestPumpBeforeItFights() {
+	enc := s.blockedScene(&patrolDecider{positions: []spatial.Position{{X: 2, Y: 10}}})
+
+	out, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "the goblin steps out from behind the pillar and is seen")
+	s.Require().Len(out.Seqs, 2, "pump's own beats: the tick frame and the goblin's step")
+	for _, seq := range out.Seqs {
+		s.Greater(out.Formed.Seq, seq, "the world moves, THEN the fight starts")
+	}
+
+	s.Equal([]string{"scene-opened", "tick", "moved", "bubble-formed"}, s.beatKinds(enc, alice))
+}
+
+// TestJoinBeforeItFights pins Join's half. Cormac connects late and lands in
+// the goblin's sight: he arrives, and the fight is what his arrival caused.
+func (s *BeatOrderTestSuite) TestJoinBeforeItFights() {
+	enc := s.blockedScene()
+
+	out, err := enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{
+		ID: cormac, Kind: encounter.KindPlayer, Room: beatOrderRoom,
+		Position: spatial.Position{X: 2, Y: 2},
+	}})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "he lands in the open, in the goblin's sight")
+	s.Greater(out.Formed.Seq, out.Seq, "he arrives, THEN the fight starts")
+
+	s.Equal([]string{"scene-opened", "joined", "bubble-formed"}, s.beatKinds(enc, alice))
+}
+
+// blockedScene opens the shared set with alice at (6,2) and the goblin at
+// (6,10) — the pillar at (6,6) sits square between them, so first light
+// starts no fight and each verb under test is the sole cause of the one that
+// follows. An optional decider drives the goblin for the Pump pin.
+func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encounter.Encounter {
+	monster := encounter.MemberInput{
+		ID: goblin, Kind: encounter.KindMonster, Room: beatOrderRoom,
+		Position: spatial.Position{X: 6, Y: 10},
+	}
+	if len(decider) > 0 {
+		monster.Decider = decider[0]
+	}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{pillarRoom()}},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 2}},
+			monster,
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	s.Require().Equal([]string{"scene-opened"}, s.beatKinds(enc, alice),
+		"the pillar keeps them apart: no fight before the verb under test")
+	return enc
+}

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -49,6 +49,7 @@ func TestVaultChase(t *testing.T) {
 	// Holdings + its own construction-time config is all it gets (C2).
 	pursuit := &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: corridorRoom, Width: 10, Height: 10},
@@ -76,6 +77,12 @@ func TestVaultChase(t *testing.T) {
 	require.Equal(t, intel.Current, st, "beat 1: alice sees the goblin across the open corridor")
 	st, _ = seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Current, st, "beat 1: and the goblin sees her back — intel is symmetric")
+
+	// Seeing each other started the fight (rpg-toolkit#964). She breaks off
+	// to run — which is what a chase IS, and what this scene always showed
+	// without having to say so.
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	require.NoError(t, err, "beat 1: alice breaks off to run")
 
 	// ---- Beat 2: to the threshold, and through it ----------------------
 	// Alice crosses to the gate, then slips through it into the vault.
@@ -225,7 +232,10 @@ func TestVaultChase(t *testing.T) {
 		kinds = append(kinds, beat["beat"].(string))
 	}
 	require.Equal(t, []string{
-		"scene-opened",  // beat 1
+		"scene-opened", // beat 1
+		// beat 1: they see each other, so the fight starts; she breaks off
+		// to run, which is what makes the rest of this a chase
+		"bubble-formed", "bubble-dissolved",
 		"moved",         // beat 2: alice crosses to the gate
 		"traversed",     // beat 2: she slips through
 		"moved",         // beat 2: she moves deeper into the vault

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -117,9 +117,10 @@ func TestVaultChase(t *testing.T) {
 	// same topology and target, no memory of its own carried over (its
 	// INTEL does — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
-		goblin: &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice},
-	}})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+			goblin: &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice},
+		}})
 	require.NoError(t, err, "beat 3: the suspended chase crosses a process boundary")
 	enc = enc2 // the reload IS the encounter now
 

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -233,13 +233,22 @@ func (e *Encounter) appendClockBeat(payload map[string]interface{}) (uint64, err
 }
 
 // FormInput carries the rulebook-rolled initiative order a new bubble starts
-// with.
+// with. Built by trigger detection; see form.
 type FormInput struct {
 	// Order is the complete initiative order for the fight, first-to-act
 	// first. It comes from OUTSIDE: play/clock holds no randomness (R7) and
 	// this composition holds none either — the rulebook rolls initiative and
 	// hands the result in.
 	Order []MemberID
+
+	// Surprised names the members entering this fight unaware, and is carried
+	// rather than derived because awareness is a fact about the moment the
+	// bubble formed: a member surprised at formation stays surprised through
+	// their first turn however the fight then develops.
+	//
+	// A subset of Order. Nobody outside the order can be surprised by a fight
+	// they are not in.
+	Surprised []MemberID
 }
 
 // FormOutput reports what forming the bubble appended to the story.
@@ -253,9 +262,20 @@ type FormOutput struct {
 // world clock and keeps free-roaming while the fight runs — a fight is
 // localized, and the rest of the encounter is not paused by it.
 //
-// Form does not decide WHEN a fight starts. Trigger detection is a later
-// step and is deliberately absent here: this verb is explicit and
-// caller-driven, and something else decides to call it.
+// UNEXPORTED as of rpg-toolkit#964, and the doc this replaces predicted it:
+// "Form does not decide WHEN a fight starts. Trigger detection is a later step
+// and is deliberately absent here... something else decides to call it." That
+// something else now exists. The verb was scaffolding until its decider
+// arrived, and a caller-driven Form beside an automatic one would be two
+// systems deciding the same thing (ADR-0032) — with the caller always losing,
+// because trigger detection reaches the contact first.
+//
+// The public story of "a fight exists" is unchanged and lives elsewhere:
+// [Encounter.Transfer] moves members in and out, [Encounter.ClockOf] and
+// [Encounter.Status] report who is on which clock, [Encounter.Dissolve] ends
+// it, and [FormedBubble] on the move-path outputs announces the start with its
+// order and who was surprised. What went away is the ability to start a fight
+// that nothing noticed.
 //
 // Policy today is ONE bubble per encounter — fights stay linear and the
 // party stays together. A second Form while a bubble runs is rejected with
@@ -266,7 +286,7 @@ type FormOutput struct {
 // Errors: ErrNilInput, ErrClosed, ErrNoMember (empty order or a duplicated
 // entry), ErrNotMember (the order names somebody not in this encounter),
 // ErrInBubble.
-func (e *Encounter) Form(in *FormInput) (*FormOutput, error) {
+func (e *Encounter) form(in *FormInput) (*FormOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("form: %w", ErrNilInput)
 	}
@@ -296,6 +316,14 @@ func (e *Encounter) Form(in *FormInput) (*FormOutput, error) {
 	if len(e.bubbles) > 0 {
 		return nil, fmt.Errorf("form: a bubble is already running and policy is one per encounter: %w", ErrInBubble)
 	}
+	// Surprise is a fact about members of THIS fight. Somebody outside the
+	// order cannot be surprised by it, and accepting that quietly would put a
+	// name in the story that the order does not explain.
+	for _, id := range in.Surprised {
+		if !seen[id] {
+			return nil, fmt.Errorf("form: %q is surprised but not in the order: %w", id, ErrNotMember)
+		}
+	}
 
 	// Mutate. Validation above guarantees every named member is on the world
 	// clock (member + not-in-a-bubble + R6), so these cannot fail against a
@@ -312,10 +340,17 @@ func (e *Encounter) Form(in *FormInput) (*FormOutput, error) {
 	}
 	e.bubbles = append(e.bubbles, bubble)
 
-	seq, err := e.appendClockBeat(map[string]interface{}{
+	beat := map[string]interface{}{
 		"beat":  "bubble-formed",
 		"order": in.Order,
-	})
+	}
+	// Recorded rather than merely returned: surprise is consumed a turn later
+	// (a surprised creature loses its first turn), so the story has to carry
+	// it for a reader reconstructing the fight from beats alone.
+	if len(in.Surprised) > 0 {
+		beat["surprised"] = in.Surprised
+	}
+	seq, err := e.appendClockBeat(beat)
 	if err != nil {
 		return nil, fmt.Errorf("form append beat: %w", err)
 	}

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -28,6 +28,7 @@ import (
 // save. With it, the defect is loud: ErrInvalidData, never a guess.
 func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
+		Initiative: orderAsGiven{},
 		Field: FieldInput{
 			Rooms: []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -41,8 +42,9 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = enc.Form(&FormInput{Order: []MemberID{"alice", "goblin"}})
-	require.NoError(t, err)
+	// They saw each other at first light, so the fight already exists — no
+	// caller-driven form needed, and none available (rpg-toolkit#964).
+	require.Len(t, enc.bubbles, 1, "first light started the fight")
 
 	// The bug, fabricated: alice leaves the fight and nobody re-homes her.
 	// No public verb can do this — that is the point of the net.
@@ -59,4 +61,89 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	out, err := enc.ClockOf(&ClockOfInput{Member: "goblin"})
 	require.NoError(t, err)
 	require.Equal(t, ClockTurn, out.Kind)
+}
+
+// TestFormRejections pins form's refusals. It lives in the internal package
+// because form is unexported as of rpg-toolkit#964: trigger detection is the
+// only thing that starts a fight, so the verb's validation is reachable only
+// from inside. The refusals still matter — trigger detection builds the input
+// and a bad one must not half-start a fight.
+func TestFormRejections(t *testing.T) {
+	newEnc := func() *Encounter {
+		enc, err := NewEncounter(&SetupInput{
+			Initiative: orderAsGiven{},
+			Field: FieldInput{Rooms: []RoomInput{
+				{ID: "r1", Width: 8, Height: 8},
+				{ID: "r2", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},
+			}},
+			Members: []MemberInput{
+				{ID: "alice", Kind: KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
+				{ID: "bob", Kind: KindPlayer, Room: "r1", Position: spatial.Position{X: 2, Y: 1}},
+				{ID: "carl", Kind: KindPlayer, Room: "r1", Position: spatial.Position{X: 3, Y: 1}},
+				{ID: "dana", Kind: KindPlayer, Room: "r1", Position: spatial.Position{X: 4, Y: 1}},
+				// Next door, so first light does not start the fight these
+				// cases are about starting badly.
+				{ID: "goblin", Kind: KindMonster, Room: "r2", Position: spatial.Position{X: 6, Y: 6}},
+			},
+			Endings: []EndingInput{{Key: "called", Trigger: TriggerExternal{}}},
+		})
+		require.NoError(t, err)
+		return enc
+	}
+
+	t.Run("an empty order", func(t *testing.T) {
+		_, err := newEnc().form(&FormInput{Order: nil})
+		require.ErrorIs(t, err, ErrNoMember)
+	})
+
+	t.Run("a duplicated entry", func(t *testing.T) {
+		_, err := newEnc().form(&FormInput{Order: []MemberID{"alice", "goblin", "alice"}})
+		require.ErrorIs(t, err, ErrNoMember)
+	})
+
+	t.Run("a non-member in the order", func(t *testing.T) {
+		_, err := newEnc().form(&FormInput{Order: []MemberID{"alice", "stranger"}})
+		require.ErrorIs(t, err, ErrNotMember)
+	})
+
+	t.Run("surprised names somebody outside the order", func(t *testing.T) {
+		_, err := newEnc().form(&FormInput{
+			Order:     []MemberID{"alice", "goblin"},
+			Surprised: []MemberID{"bob"},
+		})
+		require.ErrorIs(t, err, ErrNotMember)
+	})
+
+	t.Run("a member who is already fighting", func(t *testing.T) {
+		enc := newEnc()
+		_, err := enc.form(&FormInput{Order: []MemberID{"alice", "goblin"}})
+		require.NoError(t, err)
+
+		_, err = enc.form(&FormInput{Order: []MemberID{"alice", "bob"}})
+		require.ErrorIs(t, err, ErrInBubble)
+	})
+
+	t.Run("a disjoint second fight while one runs", func(t *testing.T) {
+		enc := newEnc()
+		_, err := enc.form(&FormInput{Order: []MemberID{"alice", "goblin"}})
+		require.NoError(t, err)
+
+		_, err = enc.form(&FormInput{Order: []MemberID{"carl", "dana"}})
+		require.ErrorIs(t, err, ErrInBubble)
+	})
+
+	t.Run("a rejected form touches nothing", func(t *testing.T) {
+		enc := newEnc()
+		_, err := enc.form(&FormInput{Order: []MemberID{"alice", "goblin", "stranger"}})
+		require.Error(t, err)
+
+		// alice and the goblin were named BEFORE the defect: R5 means they
+		// were never pulled off the world clock.
+		for _, id := range []MemberID{"alice", "goblin"} {
+			out, cerr := enc.ClockOf(&ClockOfInput{Member: id})
+			require.NoError(t, cerr)
+			require.Equal(t, ClockWorld, out.Kind, "member %q", id)
+		}
+		require.Empty(t, enc.ToData().Bubbles)
+	})
 }

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -135,7 +135,8 @@ func (s *ClocksTestSuite) TestABubbleRoundTripsAndIsReachedThroughItsMembers() {
 		Round:     3,
 	}}
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -186,7 +187,8 @@ func (s *ClocksTestSuite) TestAMemberOutsideTheFightKeepsFreeRoamingWhileItRuns(
 		Order: []core.EntityID{alice, goblin}, ActiveIdx: 0, Round: 1,
 	}}
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	fighting, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -219,7 +221,8 @@ func (s *ClocksTestSuite) TestMutatingTheReturnedOrderCannotCorruptTheEncounter(
 	delete(data.Clock.Budgets, goblin)
 	data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -242,7 +245,8 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		delete(data.Clock.Budgets, goblin)
 		data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -257,7 +261,8 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 			{Order: []core.EntityID{alice}, ActiveIdx: 0, Round: 1},
 		}
 
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -282,7 +287,8 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		data := enc.ToData()
 		data.Clock.Budgets["ghost"] = 0
 
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -295,7 +301,8 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 			Order: []core.EntityID{alice, core.EntityID("ghost")}, ActiveIdx: 0, Round: 1,
 		}}
 
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -307,7 +314,8 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 			Order: []core.EntityID{"ghost", "phantom"}, ActiveIdx: 0, Round: 1,
 		}}
 
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -326,7 +334,8 @@ func (s *ClocksTestSuite) TestABlobFromBeforeClockMembershipLoadsEveryoneOntoThe
 	data.Clock.Budgets = nil
 	data.Bubbles = nil
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	for _, id := range []core.EntityID{alice, goblin} {
@@ -396,7 +405,8 @@ func (s *ClocksTestSuite) assertR6(enc *encounter.Encounter, members ...core.Ent
 		_, err := enc.ClockOf(&encounter.ClockOfInput{Member: id})
 		s.Require().NoError(err, "member %q must be on exactly one clock", id)
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: enc.ToData()})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err, "the persisted shape must pass the trust boundary (R6)")
 }
 
@@ -751,7 +761,8 @@ func (s *ClocksTestSuite) TestLoadRejectsAnIdleBubble() {
 	data := enc.ToData()
 	data.Bubbles = []clock.TurnData{{}}
 
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrInvalidData)
 }
@@ -764,7 +775,8 @@ func (s *ClocksTestSuite) TestAMidFightBlobRoundTrips() {
 	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
 	s.Require().NoError(err)
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: enc.ToData()})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	// Reached through a member of the fight — bob is exploring next door.

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -26,12 +26,23 @@ type ClocksTestSuite struct {
 // monster in one room.
 func (s *ClocksTestSuite) twoMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+			// The goblin waits in the NEXT ROOM, which is how real content is
+			// authored and is the only way to open a scene that is not
+			// already a fight: sight is symmetric and unlimited within a room,
+			// so co-locating them means trigger detection forms the bubble at
+			// first light (rpg-toolkit#964). These tests drive the clock verbs
+			// against a fight they start themselves, so the scene has to begin
+			// as free roam.
+			Rooms: []encounter.RoomInput{
+				{ID: room1, Width: 10, Height: 10},
+				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
+			},
 		},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
-			{ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 7, Y: 7}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: room2, Position: spatial.Position{X: 7, Y: 7}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: endingStairs, Trigger: encounter.TriggerReachedPosition{
@@ -341,15 +352,25 @@ const (
 // monster in one room, plus an external ending so closure is reachable.
 func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+			Rooms: []encounter.RoomInput{
+				{ID: room1, Width: 10, Height: 10},
+				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
+			},
 		},
+		// The split party, which is now a SCENE rather than a sequence of
+		// calls: alice walks into the goblin's room and the two of them are a
+		// fight from first light, while bob, carl and dana explore next door
+		// none the wiser. Trigger detection forms the bubble — there is no
+		// caller-driven Form any more — and it forms it LOCALIZED, around the
+		// members who actually noticed each other (rpg-toolkit#964).
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
-			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 3, Y: 2}},
-			{ID: carl, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 8, Y: 8}},
-			{ID: dana, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 9, Y: 8}},
-			{ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 2, Y: 3}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 7, Y: 7}},
+			{ID: bob, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 3, Y: 2}},
+			{ID: carl, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 8, Y: 8}},
+			{ID: dana, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 9, Y: 8}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: endingStairs, Trigger: encounter.TriggerReachedPosition{
@@ -390,20 +411,17 @@ func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
 	enc := s.fiveMemberEncounter()
 	everyone := []core.EntityID{alice, bob, carl, dana, goblin}
 
-	// Everyone free-roams: the world clock is the default, not a mode.
+	// The fight is already on when the scene opens — alice and the goblin
+	// share a room, so first light formed their bubble (rpg-toolkit#964). The
+	// party next door is the point: a fight is LOCALIZED, so bob, carl and
+	// dana keep free-roaming while it runs.
 	s.assertR6(enc, everyone...)
-	for _, id := range everyone {
+	for _, id := range []core.EntityID{bob, carl, dana} {
 		out, err := enc.ClockOf(&encounter.ClockOfInput{Member: id})
 		s.Require().NoError(err)
 		s.Require().Equal(encounter.ClockWorld, out.Kind, "member %q", id)
 	}
 
-	// Alice and Bob trigger a fight with the goblin. The rulebook has rolled
-	// initiative — the order arrives from outside (R7); trigger detection is
-	// deliberately not this step's business.
-	formOut, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, bob}})
-	s.Require().NoError(err)
-	s.NotZero(formOut.Seq, "forming a fight is a story beat")
 	s.assertR6(enc, everyone...)
 
 	fighting, err := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -411,7 +429,9 @@ func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
 	s.Equal(encounter.ClockTurn, fighting.Kind)
 	s.Equal(alice, fighting.Active, "round 1 opens with the first in the order")
 	s.Equal(1, fighting.Round)
-	s.Equal([]core.EntityID{alice, goblin, bob}, fighting.Order)
+	// Sorted, because trigger detection orders the engaged deterministically
+	// and the suite's roller keeps what it is handed.
+	s.Equal([]core.EntityID{alice, goblin}, fighting.Order)
 
 	// The fight is LOCALIZED: the distant pair is not in it and not paused
 	// by it.
@@ -432,11 +452,11 @@ func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
 	s.Require().NoError(err)
 
 	budgets := enc.ToData().Clock.Budgets
-	s.Equal(1, budgets[carl], "the distant pair accrues while the fight runs")
+	s.Equal(1, budgets[bob], "the distant party accrues while the fight runs")
+	s.Equal(1, budgets[carl])
 	s.Equal(1, budgets[dana])
 	s.NotContains(budgets, alice, "fight members are off the tick entirely")
 	s.NotContains(budgets, goblin)
-	s.NotContains(budgets, bob)
 
 	// A round of combat: alice and the goblin take their turns.
 	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
@@ -445,7 +465,8 @@ func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
 	s.False(et.RoundWrapped)
 	et, err = enc.EndTurn(&encounter.EndTurnInput{Member: goblin})
 	s.Require().NoError(err)
-	s.Equal(bob, et.Next)
+	s.Equal(alice, et.Next, "two in the fight, so the round wraps back to her")
+	s.True(et.RoundWrapped)
 	s.assertR6(enc, everyone...)
 
 	// Carl wanders too close and falls in mid-round, slotted after the
@@ -458,9 +479,8 @@ func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
 	joined, err := enc.ClockOf(&encounter.ClockOfInput{Member: carl})
 	s.Require().NoError(err)
 	s.Equal(encounter.ClockTurn, joined.Kind)
-	s.Equal([]core.EntityID{alice, goblin, carl, bob}, joined.Order, "carl landed at the requested slot")
-	s.Equal(bob, joined.Active, "falling in does not steal the active turn")
-	s.Equal(1, joined.Round)
+	s.Equal([]core.EntityID{alice, goblin, carl}, joined.Order, "carl landed at the requested slot")
+	s.Equal(alice, joined.Active, "falling in does not steal the active turn")
 
 	// And having fallen in, carl is the fight's now — free-roam movement is
 	// no longer his to make.
@@ -468,21 +488,26 @@ func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrInBubble)
 
-	// Bob closes the round: it wraps into round 2 with carl in the order.
-	et, err = enc.EndTurn(&encounter.EndTurnInput{Member: bob})
+	// Alice and the goblin take their turns again; carl closes the round he
+	// fell into, and it wraps across the grown order.
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: goblin})
+	s.Require().NoError(err)
+	et, err = enc.EndTurn(&encounter.EndTurnInput{Member: carl})
 	s.Require().NoError(err)
 	s.True(et.RoundWrapped, "the round wraps across the grown order")
 	s.Equal(alice, et.Next)
 	wrapped, err := enc.ClockOf(&encounter.ClockOfInput{Member: carl})
 	s.Require().NoError(err)
-	s.Equal(2, wrapped.Round)
+	s.Equal(3, wrapped.Round)
 
 	// The fight ends, reached through any of its members: everyone re-homes
 	// to the world clock at budget zero — time spent fighting was spent,
 	// not banked. Dana never left, so hers is intact.
 	dis, err := enc.Dissolve(&encounter.DissolveInput{Member: alice})
 	s.Require().NoError(err)
-	s.Equal([]core.EntityID{alice, goblin, carl, bob}, dis.Members, "dissolve reports the bubble order")
+	s.Equal([]core.EntityID{alice, goblin, carl}, dis.Members, "dissolve reports the bubble order")
 	s.assertR6(enc, everyone...)
 
 	for _, id := range everyone {
@@ -517,78 +542,16 @@ func (s *ClocksTestSuite) TestDOS2SplitPartyThroughTheComposition() {
 		"tick",
 		"turn-ended", "turn-ended",
 		"transferred",
-		"turn-ended",
+		"turn-ended", "turn-ended", "turn-ended",
 		"bubble-dissolved",
 	}, clockBeats)
 }
 
-// TestFormRejections pins Form's refusals, including the issue's named
-// requirement: a member already in a bubble is rejected, never silently
-// merged. The disjoint-second-fight case is the one-bubble policy — when
-// that policy lifts, the per-member overlap check is what remains.
-func (s *ClocksTestSuite) TestFormRejections() {
-	s.Run("an empty order", func() {
-		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: nil})
-		s.Require().Error(err)
-		s.ErrorIs(err, encounter.ErrNoMember)
-	})
-
-	s.Run("a duplicated entry", func() {
-		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, alice}})
-		s.Require().Error(err)
-		s.ErrorIs(err, encounter.ErrNoMember)
-	})
-
-	s.Run("a non-member in the order", func() {
-		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, "stranger"}})
-		s.Require().Error(err)
-		s.ErrorIs(err, encounter.ErrNotMember)
-	})
-
-	s.Run("a member who is already fighting", func() {
-		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
-
-		_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, bob}})
-		s.Require().Error(err)
-		s.ErrorIs(err, encounter.ErrInBubble)
-	})
-
-	s.Run("a disjoint second fight while one runs", func() {
-		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
-
-		_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{carl, dana}})
-		s.Require().Error(err)
-		s.ErrorIs(err, encounter.ErrInBubble)
-	})
-
-	s.Run("a rejected form touches nothing", func() {
-		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, "stranger"}})
-		s.Require().Error(err)
-
-		// alice and the goblin were named BEFORE the defect: R5 means they
-		// were never pulled off the world clock.
-		for _, id := range []core.EntityID{alice, goblin} {
-			out, cerr := enc.ClockOf(&encounter.ClockOfInput{Member: id})
-			s.Require().NoError(cerr)
-			s.Equal(encounter.ClockWorld, out.Kind, "member %q", id)
-		}
-		s.Empty(enc.ToData().Bubbles)
-	})
-}
-
-// TestTransferRejections pins Transfer's refusals, and the one guarantee a
-// refusal must keep: both clocks unchanged (the leaf compensates, R6).
 func (s *ClocksTestSuite) TestTransferRejections() {
 	s.Run("into a fight that is not running", func() {
-		enc := s.fiveMemberEncounter()
+		// The two-member scene opens with the goblin a room away, so no
+		// bubble exists to transfer into.
+		enc := s.twoMemberEncounter()
 		_, err := enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockTurn})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrNoBubble)
@@ -596,20 +559,16 @@ func (s *ClocksTestSuite) TestTransferRejections() {
 
 	s.Run("into a fight the member is already in", func() {
 		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
 
-		_, err = enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockTurn})
+		_, err := enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockTurn})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInBubble)
 	})
 
 	s.Run("out of a fight the member is not in", func() {
 		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
 
-		_, err = enc.Transfer(&encounter.TransferInput{Member: bob, To: encounter.ClockWorld})
+		_, err := enc.Transfer(&encounter.TransferInput{Member: bob, To: encounter.ClockWorld})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrNoBubble)
 	})
@@ -623,10 +582,8 @@ func (s *ClocksTestSuite) TestTransferRejections() {
 
 	s.Run("an out-of-range slot leaves both clocks unchanged", func() {
 		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
 
-		_, err = enc.Transfer(&encounter.TransferInput{Member: bob, To: encounter.ClockTurn, Pos: 7})
+		_, err := enc.Transfer(&encounter.TransferInput{Member: bob, To: encounter.ClockTurn, Pos: 7})
 		s.Require().Error(err)
 		s.ErrorIs(err, clock.ErrBadPosition, "the leaf's own rejection propagates")
 
@@ -645,17 +602,17 @@ func (s *ClocksTestSuite) TestTransferRejections() {
 func (s *ClocksTestSuite) TestEndTurnRejections() {
 	s.Run("a member not in a fight", func() {
 		enc := s.fiveMemberEncounter()
-		_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+		// bob explores next door while alice and the goblin fight, so he is
+		// the one with no turn to end.
+		_, err := enc.EndTurn(&encounter.EndTurnInput{Member: bob})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrNoBubble)
 	})
 
 	s.Run("not their turn", func() {
 		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
 
-		_, err = enc.EndTurn(&encounter.EndTurnInput{Member: goblin})
+		_, err := enc.EndTurn(&encounter.EndTurnInput{Member: goblin})
 		s.Require().Error(err)
 		s.ErrorIs(err, clock.ErrNotActive)
 
@@ -669,7 +626,9 @@ func (s *ClocksTestSuite) TestEndTurnRejections() {
 // through a fight member — a free-roamer names no bubble.
 func (s *ClocksTestSuite) TestDissolveRejectsAMemberNotInAFight() {
 	enc := s.fiveMemberEncounter()
-	_, err := enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	// bob is exploring next door while alice and the goblin fight, so he
+	// names no bubble to dissolve.
+	_, err := enc.Dissolve(&encounter.DissolveInput{Member: bob})
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrNoBubble)
 }
@@ -681,8 +640,8 @@ func (s *ClocksTestSuite) TestClockVerbsRejectAClosedEncounter() {
 	_, err := enc.End(&encounter.EndInput{Ending: "called"})
 	s.Require().NoError(err)
 
-	_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-	s.ErrorIs(err, encounter.ErrClosed)
+	// Form's row is gone with the verb (rpg-toolkit#964) — it is unexported
+	// now, and its ErrClosed is pinned from inside in clocks_internal_test.go.
 	_, err = enc.Transfer(&encounter.TransferInput{Member: alice, To: encounter.ClockTurn})
 	s.ErrorIs(err, encounter.ErrClosed)
 	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
@@ -697,10 +656,8 @@ func (s *ClocksTestSuite) TestClockVerbsRejectAClosedEncounter() {
 // arrives a fight member moving AT ALL would be moving outside initiative.
 func (s *ClocksTestSuite) TestAFightMemberCannotFreeRoam() {
 	enc := s.fiveMemberEncounter()
-	_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-	s.Require().NoError(err)
 
-	_, err = enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 2, Y: 1}})
+	_, err := enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 2, Y: 1}})
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrInBubble)
 
@@ -723,9 +680,14 @@ func (s *ClocksTestSuite) TestAFightMemberCannotFreeRoam() {
 func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 	wanderer := &patrolDecider{positions: []spatial.Position{{X: 5, Y: 5}, {X: 6, Y: 5}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
 		},
+		// Same room, so they see each other at first light and the fight
+		// forms — which is the state this test is about. The goblin's decider
+		// is willing; the world simply is not the thing that consults it any
+		// more.
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 7, Y: 7}, Decider: wanderer},
@@ -734,9 +696,6 @@ func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 			{Key: "called", Trigger: encounter.TriggerExternal{}},
 		},
 	})
-	s.Require().NoError(err)
-
-	_, err = enc.Form(&encounter.FormInput{Order: []core.EntityID{goblin, alice}})
 	s.Require().NoError(err)
 
 	_, err = enc.Pump(&encounter.PumpInput{})
@@ -759,10 +718,8 @@ func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 func (s *ClocksTestSuite) TestADrainedBubbleIsPruned() {
 	s.Run("drained by Exit", func() {
 		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
 
-		_, err = enc.Exit(&encounter.ExitInput{Member: alice})
+		_, err := enc.Exit(&encounter.ExitInput{Member: alice})
 		s.Require().NoError(err)
 		s.Len(enc.ToData().Bubbles, 1, "a fight of one is still a fight")
 
@@ -773,10 +730,8 @@ func (s *ClocksTestSuite) TestADrainedBubbleIsPruned() {
 
 	s.Run("drained by Transfer", func() {
 		enc := s.fiveMemberEncounter()
-		_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin}})
-		s.Require().NoError(err)
 
-		_, err = enc.Transfer(&encounter.TransferInput{Member: goblin, To: encounter.ClockWorld})
+		_, err := enc.Transfer(&encounter.TransferInput{Member: goblin, To: encounter.ClockWorld})
 		s.Require().NoError(err)
 		s.Len(enc.ToData().Bubbles, 1)
 
@@ -806,24 +761,25 @@ func (s *ClocksTestSuite) TestLoadRejectsAnIdleBubble() {
 // shape, and the reloaded encounter continues the same round.
 func (s *ClocksTestSuite) TestAMidFightBlobRoundTrips() {
 	enc := s.fiveMemberEncounter()
-	_, err := enc.Form(&encounter.FormInput{Order: []core.EntityID{alice, goblin, bob}})
-	s.Require().NoError(err)
-	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
 	s.Require().NoError(err)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: enc.ToData()})
 	s.Require().NoError(err)
 
-	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: bob})
+	// Reached through a member of the fight — bob is exploring next door.
+	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: goblin})
 	s.Require().NoError(err)
 	s.Equal(encounter.ClockTurn, out.Kind)
 	s.Equal(goblin, out.Active, "the reloaded fight is mid-round, exactly where it was")
 	s.Equal(1, out.Round)
 
-	// And it keeps playing: the goblin's turn ends in the reloaded world.
+	// And it keeps playing: the goblin's turn ends in the reloaded world and
+	// the round wraps back to alice, the two of them being the whole fight.
 	et, err := reloaded.EndTurn(&encounter.EndTurnInput{Member: goblin})
 	s.Require().NoError(err)
-	s.Equal(bob, et.Next)
+	s.Equal(alice, et.Next)
+	s.True(et.RoundWrapped)
 }
 
 func TestClocksSuite(t *testing.T) {

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -493,9 +493,10 @@ func main() {
 				fmt.Println(" ", err)
 				continue
 			}
-			loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
-				"goblin": goblinPatrol(),
-			}})
+			loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Initiative: rollOrderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+					"goblin": goblinPatrol(),
+				}})
 			if err != nil {
 				fmt.Println(" ", err)
 				continue

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -82,6 +82,7 @@ func goblinPatrol() *patrol {
 // someone launches the workbench by hand.
 func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: rollOrderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{
@@ -532,4 +533,13 @@ func showView(enc *encounter.Encounter, who core.EntityID) {
 func num(s string) float64 {
 	f, _ := strconv.ParseFloat(s, 64)
 	return f
+}
+
+// rollOrderAsGiven is the workbench's initiative roller: it keeps the order it
+// is handed. The workbench is a deterministic demo, so a shuffle would make
+// its transcript differ run to run for no gain.
+type rollOrderAsGiven struct{}
+
+func (rollOrderAsGiven) RollInitiative(members []encounter.MemberID) ([]encounter.MemberID, error) {
+	return members, nil
 }

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -90,6 +90,7 @@ func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()
 	pursuit := &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice}
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
@@ -181,6 +182,11 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	require.Equal(t, intel.Current, st, "beat 1: alice sees the goblin across the open corridor")
 	st, _ = seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Current, st, "beat 1: and the goblin sees her back")
+
+	// Seeing each other started the fight (rpg-toolkit#964); she breaks off
+	// before she runs.
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	require.NoError(t, err, "beat 1: alice breaks off to run")
 
 	// ---- Beat 2: alice steps toward the gate, one hex at a time ----------
 	for _, to := range []spatial.Position{{X: 2, Y: 1}, {X: 3, Y: 1}, {X: 4, Y: 1}} {

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -224,9 +224,10 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	// path a host is actively rendering, not just a static snapshot.
 	beforeReload := alicePath[len(alicePath)-1]
 	data := enc.ToData()
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
-		goblin: &pursuitDecider{connections: []encounter.ConnectionInput{vaultChaseHexGate()}, target: alice},
-	}})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+			goblin: &pursuitDecider{connections: []encounter.ConnectionInput{vaultChaseHexGate()}, target: alice},
+		}})
 	require.NoError(t, err, "the suspended chase crosses a process boundary")
 	enc = enc2
 	proj.useEncounter(enc) // SAME projector, reloaded enc — the transcript keeps accumulating

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -358,6 +358,14 @@ type LoadEncounterInput struct {
 	// Nil is legal and means no member acts on its own. A player member naming a
 	// Decider here is rejected (design law C2).
 	Deciders map[MemberID]Decider
+
+	// Initiative rolls the order a bubble forms in. REQUIRED, exactly as it is
+	// on SetupInput: a loaded encounter runs trigger detection from its first
+	// sight refresh, so it can start a fight before its caller does anything,
+	// and one it cannot order is a misconfiguration. Refused here rather than
+	// guarded where it is used — a nil roller is an error returned at the
+	// door, not a branch taken deep inside a verb.
+	Initiative InitiativeRoller
 }
 
 // Validate reports whether the input is usable. It checks only the input's own
@@ -371,6 +379,9 @@ type LoadEncounterInput struct {
 func (in *LoadEncounterInput) Validate() error {
 	if in == nil {
 		return fmt.Errorf("load encounter: %w", ErrNilInput)
+	}
+	if in.Initiative == nil {
+		return fmt.Errorf("load encounter: Initiative is required: %w", ErrNoInitiative)
 	}
 
 	return nil
@@ -690,6 +701,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		members:     make(map[MemberID]*Member),
 		everMembers: make(map[MemberID]bool),
 		deciders:    make(map[MemberID]Decider),
+		initiative:  input.Initiative,
 		endings:     nil,
 		retention:   normalizeRetention(data.Retention),
 		logFloor:    logFloorOf(data.Log),

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -126,7 +126,8 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	}
 	enc1, err := encounter.NewEncounter(setup)
 	s.Require().NoError(err)
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: enc1.ToData()})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: enc1.ToData()})
 	s.Require().NoError(err)
 
 	out, err := enc2.Move(&encounter.MoveInput{Member: "p1", To: spatial.Position{X: 3, Y: 3}})
@@ -186,7 +187,8 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	}
 	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
 
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data1})
 	s.Require().NoError(err)
 
 	data2 := enc2.ToData()
@@ -228,7 +230,8 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 
-	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	got := enc.ToData().Field.Connections
@@ -273,7 +276,8 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Require().Len(data1.Field.Rooms, 1)
 		s.Equal("", data1.Field.Rooms[0].Grid, "square is the zero value — omitted, not the literal \"square\"")
 
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -301,7 +305,8 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Require().Len(data1.Field.Rooms, 1)
 		s.Equal(spatial.GridTypeHex, data1.Field.Rooms[0].Grid)
 
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -365,7 +370,8 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom
 	// was an encounter that became permanently unsavable).
-	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 }
 
@@ -429,7 +435,8 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 		data1 := enc1.ToData()
 
 		// Load from data (without decider for goblin)
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Convert to data again
@@ -514,7 +521,8 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 		data1 := enc1.ToData()
 
 		// Load and verify ghost is still there
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Get holdings - ghost should still be Held (not Current)
@@ -584,7 +592,8 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 		data1 := enc1.ToData()
 
 		// Load and verify everMembers includes the exited player
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Story should work for the exited member
@@ -652,7 +661,8 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 		data1 := enc1.ToData()
 
 		// Load and verify outcome matches
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		status2, _ := enc2.Status()
@@ -716,7 +726,8 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 		data1 := enc1.ToData()
 		s.Require().Equal(2, data1.Clock.HighWater, "precondition: two ticks persisted")
 
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		out, err := enc2.Pump(&encounter.PumpInput{})
@@ -770,7 +781,8 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 		data1 := enc1.ToData()
 
 		// Load
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Move should work
@@ -1009,7 +1021,8 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 
 		// Load FIRST, then vandalize the caller's Data: the loaded
 		// aggregate must be untouched (load-side deep copy).
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err)
 
 		data.Members[0].ID = "mutated"
@@ -1057,7 +1070,8 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		holding.CurrentVia = nil
 		data.Intel.Holdings["playerA"]["goblin"] = holding
 
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err)
 
 		view, err := enc2.View(&encounter.ViewInput{Member: "playerA"})
@@ -1123,9 +1137,10 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 				To: spatial.Position{X: 7, Y: 7},
 			},
 		}
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
-			encounter.MemberID("goblin"): decider,
-		}})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+				encounter.MemberID("goblin"): decider,
+			}})
 		s.Require().NoError(err)
 
 		// Pump should execute the decider's move intent
@@ -1191,7 +1206,8 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 		data1 := enc1.ToData()
 
 		// Load WITHOUT goblin's decider
-		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Pump should succeed (goblin holds)
@@ -1227,9 +1243,10 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	s.Require().NoError(err)
 	data1 := enc1.ToData()
 
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
-		"goblin": nil,
-	}})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+			"goblin": nil,
+		}})
 	s.Require().NoError(err, "a present-but-nil reattachment entry must load, not reject")
 
 	s.Require().NotPanics(func() {
@@ -1270,10 +1287,11 @@ func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	data1 := enc1.ToData()
 
 	ratDecider := &testDecider{intent: encounter.IntentMoveTo{To: spatial.Position{X: 3, Y: 8}}}
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
-		"goblin": nil,
-		"rat":    ratDecider,
-	}})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+			"goblin": nil,
+			"rat":    ratDecider,
+		}})
 	s.Require().NoError(err)
 
 	out, err := enc2.Pump(&encounter.PumpInput{})
@@ -1358,7 +1376,8 @@ func validEncounterDataWithConnection() encounter.EncounterData {
 func (s *DataTestSuite) TestLoadSquareOccluderFractionalRejected() {
 	data := validEncounterDataWithConnection()
 	data.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1397,7 +1416,8 @@ func (s *DataTestSuite) TestLoadNilInputRejected() {
 // call sites, so it is stated once rather than left implied by them.
 func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: validEncounterData(),
+		Initiative: orderAsGiven{},
+		Data:       validEncounterData(),
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(enc)
@@ -1417,7 +1437,8 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
@@ -1436,7 +1457,8 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide at Load either`)
 }
 
@@ -1453,7 +1475,8 @@ func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1473,7 +1496,8 @@ func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
 			{Key: "dup", Kind: "external"},
 		},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -1587,7 +1611,8 @@ func (s *DataTestSuite) TestLoadRejections() {
 		s.Run(tc.name, func() {
 			data := validEncounterData()
 			tc.mutate(&data)
-			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().Contains(err.Error(), tc.fragment,
@@ -1600,7 +1625,8 @@ func (s *DataTestSuite) TestLoadRejections() {
 
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: validEncounterData()})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: validEncounterData()})
 	s.Require().NoError(err, "the valid base fixture must load")
 
 	// The valid CONNECTION base must also load. Since FromPosition{9,1} is
@@ -1611,7 +1637,8 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// in convertConnectionDataToConnectionInput would not error here —
 	// it would silently swap the values — so the values are re-inspected,
 	// not just the absence of an error).
-	connEnc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: validEncounterDataWithConnection()})
+	connEnc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: validEncounterDataWithConnection()})
 	s.Require().NoError(err, "the valid connection base fixture must load")
 	connData := connEnc.ToData()
 	s.Require().Len(connData.Field.Connections, 1)
@@ -1661,7 +1688,8 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 	s.Run("X exactly at width is rejected", func() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 4, Y: 0}
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1669,7 +1697,8 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 	s.Run("Y exactly at height is rejected", func() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: 3}
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1677,7 +1706,8 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 	s.Run("negative X is rejected", func() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: -1, Y: 0}
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1685,7 +1715,8 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 	s.Run("negative Y is rejected", func() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: -1}
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1693,7 +1724,8 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 	s.Run("Width-1,Height-1 is accepted (positive control)", func() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 3, Y: 2}
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err, "the last valid cell must be accepted")
 	})
 }
@@ -1722,7 +1754,8 @@ func (s *DataTestSuite) TestLoadRoomValidation() {
 		s.Run(tc.name, func() {
 			data := validEncounterData()
 			tc.mutate(&data)
-			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoField, tc.name)
@@ -1748,7 +1781,8 @@ func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
 	data.Field.Rooms[0].ID = ""
 	data.Field.Rooms[0].Origin = nil
 
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1780,29 +1814,34 @@ func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 // encounter_test.go's TestHexRoomBounds.
 func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 	s.Run("positive Q, positive R within span accepted", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: connHexRoomData(encounter.PositionData{X: 1, Y: 1})})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 1, Y: 1})})
 		s.Require().NoError(err)
 	})
 
 	s.Run("negative Q within span accepted — rejected under the old offset HexGrid", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: connHexRoomData(encounter.PositionData{X: -1, Y: 0})})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -1, Y: 0})})
 		s.Require().NoError(err, "axial hex rooms are origin-centered; negative Q is ordinary, not a defect")
 	})
 
 	s.Run("Q at exactly +Width/2 rejected (upper bound exclusive)", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "out of bounds")
 	})
 
 	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: connHexRoomData(encounter.PositionData{X: -2, Y: 0})})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -2, Y: 0})})
 		s.Require().NoError(err)
 	})
 
 	s.Run("Q beyond -Width/2 rejected", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "out of bounds")
@@ -1835,7 +1874,8 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
 }
 
@@ -1895,7 +1935,8 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 		s.Run(tc.name, func() {
 			data := validHexAxialData()
 			tc.mutate(&data)
-			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			if tc.alsoErr != nil {
@@ -1906,7 +1947,8 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 		})
 	}
 
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: validHexAxialData()})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: validHexAxialData()})
 	s.Require().NoError(err, "integral axial positions, including negative ones, must be accepted")
 }
 
@@ -2030,7 +2072,8 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 		s.Run(tc.name, func() {
 			data := validAnchoredHexData()
 			tc.mutate(&data)
-			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
@@ -2041,7 +2084,8 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: validAnchoredHexData()})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err, "the valid anchored base fixture must load")
 }
 
@@ -2066,7 +2110,8 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2094,7 +2139,8 @@ func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2126,7 +2172,8 @@ func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2166,7 +2213,8 @@ func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2191,7 +2239,8 @@ func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint()
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2214,7 +2263,8 @@ func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a 2^30 x 2^30 room from a persisted blob must REJECT, not panic")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2234,7 +2284,8 @@ func (s *DataTestSuite) TestLoadOversizedRoomHeightRejected() {
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2260,7 +2311,8 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 		Field:   encounter.FieldData{Rooms: rooms},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2302,7 +2354,8 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 		s.Run(tc.name, func() {
 			data := validEndingTriggerData()
 			tc.mutate(&data)
-			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoEnding, tc.name)
@@ -2311,7 +2364,8 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 		})
 	}
 
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: validEndingTriggerData()})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: validEndingTriggerData()})
 	s.Require().NoError(err, "a trigger naming a real room and in-bounds position must validate")
 }
 
@@ -2326,7 +2380,8 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 			{Key: "reach", Kind: "reached_position", Room: "hall", Position: &encounter.PositionData{X: 1.5, Y: 0}},
 		},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -2340,13 +2395,15 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 // catches a tag or field-order regression a decoded-struct comparison
 // would not.
 func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
-	enc1, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: validAnchoredHexData()})
+	enc1, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err)
 	data1 := enc1.ToData()
 	bs1, err := json.Marshal(data1.Field)
 	s.Require().NoError(err)
 
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data1})
 	s.Require().NoError(err)
 	data2 := enc2.ToData()
 	bs2, err := json.Marshal(data2.Field)
@@ -2404,7 +2461,8 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 			dataPreTraverse.Members[i].Position = encounter.PositionData{X: 4, Y: 0}
 		}
 	}
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: dataPreTraverse})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: dataPreTraverse})
 	s.Require().NoError(err)
 
 	out2, err := enc2.Traverse(&encounter.TraverseInput{Member: "p1", Connection: "gate"})
@@ -2438,7 +2496,8 @@ func (s *DataTestSuite) TestLoadAnchoringSquareEndpointNotAdjacentDistance2() {
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2468,7 +2527,8 @@ func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
 	var data encounter.EncounterData
 	s.Require().NoError(json.Unmarshal(hostile, &data))
 
-	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a hand-edited blob with a non-kissing doorway must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2501,7 +2561,8 @@ func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 // regardless of the member position within it.
 func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 	s.Run("gridless grid string rejected regardless of member position", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
 		s.Require().Error(err, `a stored "gridless" grid string no longer loads`)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2510,7 +2571,8 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 	})
 
 	s.Run("still rejected for a position that would also be out of bounds", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField,
@@ -2522,9 +2584,10 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 // cannot carry a decider at load any more than at Setup or Join.
 func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 	data := validEncounterData()
-	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
-		"p1": &spyDecider{},
-	}})
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+			"p1": &spyDecider{},
+		}})
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().Contains(err.Error(), "cannot carry a decider")
 }
@@ -2668,7 +2731,8 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		dataB := encB.ToData()
 
 		// Control: loading dataA verbatim, p1 holds p2.
-		ctrl, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: dataA})
+		ctrl, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: dataA})
 		s.Require().NoError(err)
 		ctrlView, err := ctrl.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2678,7 +2742,8 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		// must reflect the LOADED intel — empty — proving the Intel field
 		// is genuinely consumed, never re-derived from the field.
 		dataA.Intel = dataB.Intel
-		swapped, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: dataA})
+		swapped, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: dataA})
 		s.Require().NoError(err)
 		swappedView, err := swapped.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2708,7 +2773,8 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 			},
 		}
 
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().Error(err)
 		s.True(errors.Is(err, encounter.ErrInvalidData), "must validate member rooms exist")
 	})
@@ -2764,7 +2830,8 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 		}
 
 		data := enc1.ToData()
-		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 
 		holdings2, _ := enc2.View(&encounter.ViewInput{Member: "playerA"})
 		var goblinStatusAfter intel.Status
@@ -2804,7 +2871,8 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 		data1 := enc1.ToData()
 		tick1 := data1.Clock.HighWater
 
-		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		data2 := enc2.ToData()
 		tick2 := data2.Clock.HighWater
 

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -71,6 +71,7 @@ type DataTestSuite struct {
 // of the shift vector's own shape.
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
@@ -113,7 +114,8 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 // ending order changes which outcome the campaign receives.
 func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	setup := &encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -154,6 +156,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 // origin simultaneously.
 func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
@@ -251,6 +254,7 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 	s.Run("square", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "square-room", Width: 5, Height: 5},
@@ -278,6 +282,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 
 	s.Run("hex", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
@@ -320,6 +325,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 // so they stay disjoint (W2) regardless of y.
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}}},
@@ -373,6 +379,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 	s.Run("post-setup open encounter survives round-trip", func() {
 		// Create a simple encounter
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -443,6 +450,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 	s.Run("mid-fade ghost survives reload still Held", func() {
 		// Create encounter with a pillar that will cause a ghost to form
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -489,6 +497,13 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 		})
 		s.Require().NoError(err)
 
+		// The two saw each other, which starts a fight (rpg-toolkit#964), and
+		// a fight member cannot free-roam — so they break off before the
+		// goblin steps behind the pillar and becomes the ghost this test is
+		// about.
+		_, err = enc1.Dissolve(&encounter.DissolveInput{Member: "goblin"})
+		s.Require().NoError(err)
+
 		// Move goblin to create ghost at last-seen position
 		_, err = enc1.Move(&encounter.MoveInput{
 			Member: "goblin",
@@ -524,13 +539,20 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 func (s *DataTestSuite) TestRoundTripPostExit() {
 	s.Run("exited member persists in everMembers and can Story", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:         "crypt",
-						Width:      10,
-						Height:     10,
-						Occluders:  []spatial.Position{},
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						// A pillar on the diagonal keeps playerA and the
+						// goblin out of each other's sight, so the scene
+						// opens in free roam and the goblin stays the
+						// world's to pump. Co-located and visible would be
+						// a fight at first light (rpg-toolkit#964), and a
+						// fight monster's decider is never consulted.
+						Occluders:  []spatial.Position{{X: 5, Y: 5}},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -577,13 +599,20 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 func (s *DataTestSuite) TestRoundTripClosed() {
 	s.Run("closed encounter with ending outcome round-trips", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:         "crypt",
-						Width:      10,
-						Height:     10,
-						Occluders:  []spatial.Position{},
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						// A pillar on the diagonal keeps playerA and the
+						// goblin out of each other's sight, so the scene
+						// opens in free roam and the goblin stays the
+						// world's to pump. Co-located and visible would be
+						// a fight at first light (rpg-toolkit#964), and a
+						// fight monster's decider is never consulted.
+						Occluders:  []spatial.Position{{X: 5, Y: 5}},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -639,13 +668,20 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 func (s *DataTestSuite) TestPumpContinuesTick() {
 	s.Run("Pump continues tick sequence post-reload", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:         "crypt",
-						Width:      10,
-						Height:     10,
-						Occluders:  []spatial.Position{},
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						// A pillar on the diagonal keeps playerA and the
+						// goblin out of each other's sight, so the scene
+						// opens in free roam and the goblin stays the
+						// world's to pump. Co-located and visible would be
+						// a fight at first light (rpg-toolkit#964), and a
+						// fight monster's decider is never consulted.
+						Occluders:  []spatial.Position{{X: 5, Y: 5}},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -693,13 +729,20 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 func (s *DataTestSuite) TestMoveWorksPostReload() {
 	s.Run("Move works on reloaded encounter", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:         "crypt",
-						Width:      10,
-						Height:     10,
-						Occluders:  []spatial.Position{},
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						// A pillar on the diagonal keeps playerA and the
+						// goblin out of each other's sight, so the scene
+						// opens in free roam and the goblin stays the
+						// world's to pump. Co-located and visible would be
+						// a fight at first light (rpg-toolkit#964), and a
+						// fight monster's decider is never consulted.
+						Occluders:  []spatial.Position{{X: 5, Y: 5}},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -746,6 +789,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 func (s *DataTestSuite) TestGoldenJSONOpen() {
 	s.Run("small open encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -795,6 +839,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 func (s *DataTestSuite) TestGoldenJSONClosed() {
 	s.Run("small closed encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -860,6 +905,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 func (s *DataTestSuite) TestAliasImmunityToData() {
 	s.Run("mutating ToData result doesn't affect aggregate", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -927,6 +973,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 	s.Run("mutating caller's Data after LoadEncounter doesn't affect loaded aggregate", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -990,7 +1037,8 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		// persisted holding says Held (a ghost). A load that re-runs
 		// first-light surveil would resurrect it to Current.
 		enc1, err := encounter.NewEncounter(&encounter.SetupInput{
-			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
+			Initiative: orderAsGiven{},
+			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
 			Members: []encounter.MemberInput{
 				{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
 				{ID: "goblin", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 5, Y: 5}},
@@ -1022,13 +1070,20 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 func (s *DataTestSuite) TestDeciderReattachment() {
 	s.Run("reload with decider resumes monster decision", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:         "crypt",
-						Width:      10,
-						Height:     10,
-						Occluders:  []spatial.Position{},
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						// A pillar on the diagonal keeps playerA and the
+						// goblin out of each other's sight, so the scene
+						// opens in free roam and the goblin stays the
+						// world's to pump. Co-located and visible would be
+						// a fight at first light (rpg-toolkit#964), and a
+						// fight monster's decider is never consulted.
+						Occluders:  []spatial.Position{{X: 5, Y: 5}},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -1088,13 +1143,20 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 	s.Run("reload without decider makes monster hold", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:         "crypt",
-						Width:      10,
-						Height:     10,
-						Occluders:  []spatial.Position{},
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						// A pillar on the diagonal keeps playerA and the
+						// goblin out of each other's sight, so the scene
+						// opens in free roam and the goblin stays the
+						// world's to pump. Co-located and visible would be
+						// a fight at first light (rpg-toolkit#964), and a
+						// fight monster's decider is never consulted.
+						Occluders:  []spatial.Position{{X: 5, Y: 5}},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -1149,6 +1211,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 // nil entry is equivalent to an absent one: the monster simply holds.
 func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
 		},
@@ -1181,11 +1244,19 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 // same reattachment map: the real one decides normally, the nil one holds.
 func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
+			Rooms: []encounter.RoomInput{
+				{ID: "crypt", Width: 10, Height: 10},
+				// playerA watches from the antechamber. Two monsters sharing
+				// the crypt see only each other, which starts nothing —
+				// classification pairs players against monsters — so both
+				// stay the world's to pump (rpg-toolkit#964).
+				{ID: "antechamber", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
+			},
 		},
 		Members: []encounter.MemberInput{
-			{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "playerA", Kind: encounter.KindPlayer, Room: "antechamber", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "goblin", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 8, Y: 8},
 				Decider: &testDecider{intent: encounter.IntentHold{}}},
 			{ID: "rat", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 2, Y: 8},
@@ -2295,6 +2366,7 @@ func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 // Origins it didn't in v0.2.
 func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
@@ -2460,6 +2532,7 @@ func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 func (s *DataTestSuite) TestMutation1ToDataAliases() {
 	s.Run("mutation 1: ToData aliases slices", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2499,6 +2572,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 	s.Run("mutation 2: wire tag renamed", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2529,6 +2603,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 func (s *DataTestSuite) TestMutation3StowawayField() {
 	s.Run("mutation 3: stowaway field in EncounterData", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2561,6 +2636,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 	s.Run("mutation 4: leaf data substitution (Intel/Log swapped)", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2642,6 +2718,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 	s.Run("mutation 6: no re-surveil on load (ghost stays ghost)", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2666,9 +2743,14 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 		enc1, err := encounter.NewEncounter(setup)
 		s.Require().NoError(err)
 
-		// Create a ghost
+		// Create a ghost. Stepping into view starts a fight
+		// (rpg-toolkit#964), and a fight member cannot free-roam — so the two
+		// break off before the goblin walks back out of sight and fades. The
+		// ghost this makes is the same ghost; it just has a story now.
 		_, err = enc1.Move(&encounter.MoveInput{Member: "playerA", To: spatial.Position{X: 4, Y: 1}})
 		s.Require().NoError(err)
+		_, err = enc1.Dissolve(&encounter.DissolveInput{Member: "goblin"})
+		s.Require().NoError(err, "the sighting formed a fight to break off")
 		_, err = enc1.Move(&encounter.MoveInput{Member: "goblin", To: spatial.Position{X: 5, Y: 6}})
 		s.Require().NoError(err)
 
@@ -2703,6 +2785,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 	s.Run("mutation 7: tick continuation (clock not reset)", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 10, Height: 10, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1114,7 +1114,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	}
 
 	// First light: build sight percepts for each member using refreshSight
-	firstLight, err := e.refreshSight(memberIDs)
+	firstLight, err := e.rebuildPercepts(memberIDs)
 	if err != nil {
 		return nil, fmt.Errorf("newencounter first light: %w", err)
 	}
@@ -1136,7 +1136,8 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// waited for somebody to take a step would let them stand there
 	// indefinitely — but the story still has to read in the order it happened,
 	// and a fight that starts before the scene opens is a story nobody can
-	// follow.
+	// follow. Setup ruled that first; it generalizes to every verb and the
+	// law is stated at [Encounter.refreshSight].
 	//
 	// This is also what makes reading only the transition lists complete
 	// everywhere else: every awareness that exists was created by some
@@ -1396,13 +1397,8 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	}
 	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
 
-	// Refresh sight for all members
-	intelDeltas, err := e.refreshSight(memberIDs)
-	if err != nil {
-		return nil, fmt.Errorf("move refresh sight: %w", err)
-	}
-
-	// Record the movement beat
+	// Record the movement beat BEFORE refreshing sight: the walk is the cause,
+	// anything trigger detection appends is its effect (see refreshSight).
 	clockReadingInt := e.clock.ToData().HighWater
 	clockReadingForBeat := uint64(clockReadingInt)
 	beatPayload := map[string]interface{}{
@@ -1423,6 +1419,12 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	}
 
 	seqNum := appendOut.Seq
+
+	// Refresh sight for all members
+	intelDeltas, formed, err := e.refreshSight(memberIDs)
+	if err != nil {
+		return nil, fmt.Errorf("move refresh sight: %w", err)
+	}
 
 	// Evaluate ReachedPosition endings
 	var firedOutcome *Outcome
@@ -1475,20 +1477,6 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 			Members: outcomeMembers,
 		}
 		break
-	}
-
-	// Trigger detection, after the beat so the story reads in the order it
-	// happened: the move, then whatever noticing it caused.
-	//
-	// Skipped once an ending has fired. A closed encounter has nothing to
-	// start a fight about, and Form refuses a closed encounter anyway — this
-	// turns that refusal into a non-event rather than an error on the way out.
-	var formed *FormedBubble
-	if firedOutcome == nil {
-		formed, err = e.applyTrigger(intelDeltas)
-		if err != nil {
-			return nil, fmt.Errorf("move: %w", err)
-		}
 	}
 
 	return &MoveOutput{
@@ -1680,12 +1668,9 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 	}
 	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
 
-	intelDeltas, err := e.refreshSight(memberIDs)
-	if err != nil {
-		return nil, fmt.Errorf("traverse refresh sight: %w", err)
-	}
-
-	// Record the traversal beat. The clock is NOT advanced (law T4).
+	// Record the traversal beat BEFORE refreshing sight: walking through the
+	// doorway is the cause, anything trigger detection appends is its effect
+	// (see refreshSight). The clock is NOT advanced (law T4).
 	clockReadingInt := e.clock.ToData().HighWater
 	clockReadingForBeat := uint64(clockReadingInt)
 	beatPayload := map[string]interface{}{
@@ -1708,6 +1693,11 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 	}
 
 	seqNum := appendOut.Seq
+
+	intelDeltas, formed, err := e.refreshSight(memberIDs)
+	if err != nil {
+		return nil, fmt.Errorf("traverse refresh sight: %w", err)
+	}
 
 	// Evaluate ReachedPosition endings against the ARRIVAL room/position.
 	var firedOutcome *Outcome
@@ -1762,6 +1752,7 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 	}
 
 	return &TraverseOutput{
+		Formed: formed,
 		Traversed: struct {
 			Member   MemberID
 			FromRoom string
@@ -1977,11 +1968,10 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 	}
 	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
 
-	intelDeltas, err := e.refreshSight(memberIDs)
-	if err != nil {
-		return nil, fmt.Errorf("pump refresh sight: %w", err)
-	}
-
+	// Pump's own beats — the tick frame and every action inside it — are
+	// recorded BEFORE sight refreshes: the monsters' walk is the cause,
+	// anything trigger detection appends is its effect (see refreshSight).
+	//
 	// Record the tick beat first (the frame)
 	tickBeatPayload := map[string]interface{}{
 		"beat": "tick",
@@ -2033,6 +2023,11 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		}
 
 		seqs = append(seqs, actionAppendOut.Seq)
+	}
+
+	intelDeltas, formed, err := e.refreshSight(memberIDs)
+	if err != nil {
+		return nil, fmt.Errorf("pump refresh sight: %w", err)
 	}
 
 	// Evaluate ReachedPosition endings, in decision order. For a
@@ -2128,17 +2123,6 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		}
 	}
 
-	// Trigger detection on the monsters' own movement. This is the call site
-	// a walk-only seam would not have: nobody walked, and a fight can still
-	// start because a monster rounded a corner.
-	var formed *FormedBubble
-	if firedOutcome == nil {
-		formed, err = e.applyTrigger(intelDeltas)
-		if err != nil {
-			return nil, fmt.Errorf("pump: %w", err)
-		}
-	}
-
 	return &PumpOutput{
 		Tick:             newTickReading,
 		MonsterMoves:     outputMoves,
@@ -2150,11 +2134,51 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 	}, nil
 }
 
-// refreshSight rebuilds the complete percept for all given observers,
+// refreshSight rebuilds every observer's percept AND runs trigger detection on
+// what changed, returning the deltas and any fight that started.
+//
+// The two are ONE call on purpose. Trigger detection is a rule about sight, so
+// it belongs wherever sight changes — and wiring it at the verbs instead left
+// Traverse and Join silently untriggered until review caught them
+// (rpg-toolkit#964). A verb cannot refresh sight and forget the rule if
+// refreshing sight IS running the rule; a future verb gets it by writing the
+// obvious call.
+//
+// CALL THIS AFTER YOUR VERB HAS APPENDED ITS OWN BEAT. The law, stated once
+// here because here is where every verb meets it: A VERB'S OWN BEAT PRECEDES
+// ANY BEAT ITS CONSEQUENCES APPEND — cause before effect, in every story. A
+// reader of Story must be able to see the walk that started the fight before
+// the fight. Setup ruled this first (a scene records that it opened before it
+// records a fight starting inside it); the same law holds for Move, Traverse,
+// Pump and Join, and each one pins its own half of it.
+//
+// [Encounter.rebuildPercepts] is the half without the rule, and Setup is its
+// only caller — Setup needs the two halves separated so its scene-opened beat
+// can land between them.
+func (e *Encounter) refreshSight(observers []MemberID) (map[MemberID]*intel.SurveilOutput, *FormedBubble, error) {
+	deltas, err := e.rebuildPercepts(observers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// A closed encounter has nothing to start a fight about, and form refuses
+	// one anyway — checking here turns that refusal into a non-event.
+	if e.outcome != nil {
+		return deltas, nil, nil
+	}
+
+	formed, err := e.applyTrigger(deltas)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return deltas, formed, nil
+}
+
+// rebuildPercepts rebuilds the complete percept for all given observers,
 // surveils each, and returns a map of member IDs to their SurveilOutput deltas.
-// This is shared between Setup's first-light and Move's percept refresh.
 // The current clock reading is stamped on each Surveil call.
-func (e *Encounter) refreshSight(observers []MemberID) (map[MemberID]*intel.SurveilOutput, error) {
+func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.SurveilOutput, error) {
 	// Get current clock reading
 	clockReadingInt := e.clock.ToData().HighWater
 	clockReading := uint64(clockReadingInt)
@@ -2332,19 +2356,17 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 		e.deciders[in.Member.ID] = in.Member.Decider
 	}
 
-	// refreshSight for all members: the joiner sees incumbents, incumbents see the joiner
+	// Audience for both the join beat and the sight refresh: the joiner sees
+	// incumbents, incumbents see the joiner.
 	memberIDs := make([]MemberID, 0, len(e.members))
 	for id := range e.members {
 		memberIDs = append(memberIDs, id)
 	}
 	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
 
-	intelDeltas, err := e.refreshSight(memberIDs)
-	if err != nil {
-		return nil, fmt.Errorf("join refresh sight: %w", err)
-	}
-
-	// Record the join beat (audience = all members including the joiner)
+	// Record the join beat BEFORE refreshing sight: arriving is the cause,
+	// anything trigger detection appends is its effect (see refreshSight).
+	// Audience = all members including the joiner.
 	clockReadingInt := e.clock.ToData().HighWater
 	clockReadingForBeat := uint64(clockReadingInt)
 	beatPayload := map[string]interface{}{
@@ -2364,6 +2386,11 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 	}
 
 	seqNum := appendOut.Seq
+
+	intelDeltas, formed, err := e.refreshSight(memberIDs)
+	if err != nil {
+		return nil, fmt.Errorf("join refresh sight: %w", err)
+	}
 
 	// Evaluate ReachedPosition endings (a player could join ON the stairs)
 	var firedOutcome *Outcome
@@ -2419,6 +2446,7 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 	}
 
 	return &JoinOutput{
+		Formed:      formed,
 		Member:      *member,
 		IntelDeltas: intelDeltas,
 		Seq:         seqNum,
@@ -2525,7 +2553,7 @@ func (e *Encounter) Exit(in *ExitInput) (*ExitOutput, error) {
 
 	// refreshSight for REMAINING members only (the exiter's holdings remain in intel archive)
 	if len(memberIDs) > 0 {
-		_, err := e.refreshSight(memberIDs)
+		_, _, err := e.refreshSight(memberIDs)
 		if err != nil {
 			return nil, fmt.Errorf("exit refresh sight: %w", err)
 		}

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -53,6 +53,11 @@ type Encounter struct {
 	members     map[MemberID]*Member
 	everMembers map[MemberID]bool // Track all members who have ever joined (for Story access)
 	deciders    map[MemberID]Decider
+
+	// initiative rolls the order a bubble forms with. Nil until Setup is given
+	// one; trigger detection refuses to start a fight without it rather than
+	// dropping the fight silently.
+	initiative InitiativeRoller
 	// endings holds declared endings in Setup order. Evaluation is
 	// deterministic (law C8), but NOT globally "first-declared-wins":
 	// for a single action (Move, Traverse, Join) declaration order is
@@ -881,6 +886,17 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		return nil, fmt.Errorf("newencounter: %w", ErrNoEnding)
 	}
 
+	// Required, because construction is total (S8): trigger detection runs
+	// from first light onward, so an encounter that can hold players and
+	// monsters can start a fight before its caller does anything, and a fight
+	// it cannot order is a misconfiguration. Refusing here rather than
+	// mid-fight is the difference between a bug report and a bug — the
+	// alternative, discovering it when two members finally see each other,
+	// fails at the least convenient moment and looks like a rules bug.
+	if in.Initiative == nil {
+		return nil, fmt.Errorf("newencounter: %w", ErrNoInitiative)
+	}
+
 	// Check ending keys: empty/reserved, and duplicate (#929 hardening
 	// round E — two endings sharing a key both used to load; End scans
 	// in declaration order, so a reached_position twin declared FIRST
@@ -961,6 +977,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		members:          make(map[MemberID]*Member),
 		everMembers:      make(map[MemberID]bool),
 		deciders:         make(map[MemberID]Decider),
+		initiative:       in.Initiative,
 		endings:          nil,
 		retention:        normalizeRetention(in.Retention),
 		fieldInput:       deepCopyRoomInputs(in.Field.Rooms),
@@ -1097,7 +1114,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	}
 
 	// First light: build sight percepts for each member using refreshSight
-	_, err = e.refreshSight(memberIDs)
+	firstLight, err := e.refreshSight(memberIDs)
 	if err != nil {
 		return nil, fmt.Errorf("newencounter first light: %w", err)
 	}
@@ -1112,6 +1129,21 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("newencounter append beat: %w", err)
+	}
+
+	// Trigger detection at first light, AFTER the scene has opened. A scene
+	// can open with a wolf already staring at the party, and a fight that
+	// waited for somebody to take a step would let them stand there
+	// indefinitely — but the story still has to read in the order it happened,
+	// and a fight that starts before the scene opens is a story nobody can
+	// follow.
+	//
+	// This is also what makes reading only the transition lists complete
+	// everywhere else: every awareness that exists was created by some
+	// refreshSight, and this is the first one, so no awareness predates
+	// classification and no stale asymmetry can be missed.
+	if _, terr := e.applyTrigger(firstLight); terr != nil {
+		return nil, fmt.Errorf("newencounter first light: %w", terr)
 	}
 
 	return e, nil
@@ -1445,6 +1477,20 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 		break
 	}
 
+	// Trigger detection, after the beat so the story reads in the order it
+	// happened: the move, then whatever noticing it caused.
+	//
+	// Skipped once an ending has fired. A closed encounter has nothing to
+	// start a fight about, and Form refuses a closed encounter anyway — this
+	// turns that refusal into a non-event rather than an error on the way out.
+	var formed *FormedBubble
+	if firedOutcome == nil {
+		formed, err = e.applyTrigger(intelDeltas)
+		if err != nil {
+			return nil, fmt.Errorf("move: %w", err)
+		}
+	}
+
 	return &MoveOutput{
 		Moved: struct {
 			Member MemberID
@@ -1458,6 +1504,7 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 		IntelDeltas: intelDeltas,
 		Seq:         seqNum,
 		Outcome:     firedOutcome,
+		Formed:      formed,
 	}, nil
 }
 
@@ -1739,6 +1786,19 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 // the complete sight refresh happens once, and the story accrues tick and
 // move/traverse beats. Errors from a decider abort the pump atomically (R5):
 // no clock advance, no moves, no record entries.
+//
+// WHAT PUMP DRIVES IN v1, stated plainly because the answer narrowed: members
+// on the WORLD clock. Under v1's sight model (rpg-toolkit#964) any monster a
+// player can see is in a bubble, and a bubble member is deliberately not
+// pumped — so in practice this verb moves the monsters NOBODY HAS SEEN YET.
+// Free-roam monster behaviour is offscreen behaviour.
+//
+// That is a narrowing rather than the intent. It widens back when percept
+// production grows: asymmetric perception (#1020) lets a monster be watched
+// without a fight starting, and a faction model lets a visible creature be
+// non-hostile. Both change what forms a bubble, not what Pump does — see
+// classify's doc for the invariant. Pinned by
+// TestPumpStopsMovingAMonsterOnceSeen.
 //
 // Semantics:
 //   - Tick advances by exactly 1 (via clock.Advance with displacement 1).
@@ -2068,6 +2128,17 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		}
 	}
 
+	// Trigger detection on the monsters' own movement. This is the call site
+	// a walk-only seam would not have: nobody walked, and a fight can still
+	// start because a monster rounded a corner.
+	var formed *FormedBubble
+	if firedOutcome == nil {
+		formed, err = e.applyTrigger(intelDeltas)
+		if err != nil {
+			return nil, fmt.Errorf("pump: %w", err)
+		}
+	}
+
 	return &PumpOutput{
 		Tick:             newTickReading,
 		MonsterMoves:     outputMoves,
@@ -2075,6 +2146,7 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		IntelDeltas:      intelDeltas,
 		Seqs:             seqs,
 		Outcome:          firedOutcome,
+		Formed:           formed,
 	}, nil
 }
 

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -1702,7 +1702,8 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 			s.Require().NoError(err, tc.name)
 
 			data := enc.ToData()
-			_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+			_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Initiative: orderAsGiven{}, Data: data})
 			s.Require().NoError(err, "%s must survive a ToData/LoadEncounter round trip", tc.name)
 		})
 	}
@@ -1727,7 +1728,8 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() 
 	s.Require().NoError(err, "a negative-axial hex trigger position is the NORMAL case, not an edge case")
 
 	data := enc.ToData()
-	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "must survive a ToData/LoadEncounter round trip")
 }
 
@@ -2513,6 +2515,10 @@ func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Enco
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: "room-a", Position: spatial.Position{X: 9, Y: 5}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: "room-a", Position: spatial.Position{X: 8, Y: 5}},
+			// The goblin stands in room-b, which means walking through the
+			// door starts a fight (rpg-toolkit#964). Tests here that only
+			// look at what arrived can leave it running; the ones that hop
+			// back break off first.
 			{ID: goblin, Kind: encounter.KindMonster, Room: "room-b", Position: spatial.Position{X: 1, Y: 5}},
 		},
 		Endings: []encounter.EndingInput{
@@ -2624,7 +2630,12 @@ func (s *EncounterTestSuite) TestTraverseBothDirections() {
 
 	s.Run("room-b to room-a (bidirectional through the same connection)", func() {
 		enc := s.newTwoRoomEncounterWithConnection()
-		_, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+		arrived, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+		s.Require().NoError(err)
+		s.Require().NotNil(arrived.Formed, "walking in on the goblin starts a fight")
+
+		// Break off before walking back out — a fight member cannot free-roam.
+		_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
 		s.Require().NoError(err)
 
 		out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
@@ -2823,6 +2834,12 @@ func (s *EncounterTestSuite) TestTraverseMonsterOnUnfilteredEndingDoesNotClose()
 
 // TestTraverseBeatPinned pins the traversed beat: tag, payload, and
 // Story reflects it in position (the Move/Exit precedent applied here).
+//
+// Walking through this door lands alice in the goblin's room, so the
+// traverse also starts a fight and appends a beat of its own AFTER the
+// traversed beat — hence len-2 rather than last. That ordering is the
+// cause-before-effect law and is pinned in beatorder_test.go; here it is
+// only the reason this test reads the second-to-last entry.
 func (s *EncounterTestSuite) TestTraverseBeatPinned() {
 	enc := s.newTwoRoomEncounterWithConnection()
 	out, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
@@ -2830,12 +2847,12 @@ func (s *EncounterTestSuite) TestTraverseBeatPinned() {
 
 	story, err := enc.Story(&encounter.StoryInput{Audience: alice})
 	s.Require().NoError(err)
-	s.Require().NotEmpty(story)
-	last := story[len(story)-1]
-	s.Equal(out.Seq, last.Seq, "TraverseOutput.Seq references the traversed beat")
+	s.Require().GreaterOrEqual(len(story), 2)
+	traversed := story[len(story)-2]
+	s.Equal(out.Seq, traversed.Seq, "TraverseOutput.Seq references the traversed beat")
 
 	var beat map[string]any
-	s.Require().NoError(json.Unmarshal(last.Payload, &beat))
+	s.Require().NoError(json.Unmarshal(traversed.Payload, &beat))
 	s.Equal("traversed", beat["beat"])
 	s.Equal(string(alice), beat["member"])
 	s.Equal("door1", beat["connection"])
@@ -2865,6 +2882,12 @@ func (s *EncounterTestSuite) TestTraverseThenJoinVacatedCellThenTraverseBack() {
 	enc := s.newTwoRoomEncounterWithConnection()
 
 	_, err := enc.Traverse(&encounter.TraverseInput{Member: alice, Connection: "door1"})
+	s.Require().NoError(err)
+
+	// She walked in on the goblin, so a fight started; she breaks off before
+	// walking back out (rpg-toolkit#964). The registry question this test is
+	// about is unaffected either way.
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
 	s.Require().NoError(err)
 
 	_, err = enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -21,10 +21,14 @@ import (
 
 // Shared test constants
 const (
-	alice        = core.EntityID("alice")
-	bob          = core.EntityID("bob")
-	goblin       = core.EntityID("goblin")
-	room1        = "room-1"
+	alice  = core.EntityID("alice")
+	bob    = core.EntityID("bob")
+	goblin = core.EntityID("goblin")
+	room1  = "room-1"
+	// room2 exists so a scene can open with a monster OUT of contact — the
+	// only way to begin in free roam now that any co-located pair forms a
+	// bubble at first light (rpg-toolkit#964).
+	room2        = "room-2"
 	endingStairs = "stairs"
 )
 
@@ -43,6 +47,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 	s.Run("two members clear line of sight", func() {
 		// Arrange: 10x10 room, alice at (2,2) player, goblin at (7,7) monster
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -120,6 +125,7 @@ func (s *EncounterTestSuite) TestSetupPillarBlocksSight() {
 	s.Run("occluder blocks both directions", func() {
 		// Arrange: alice and goblin separated by a pillar
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -182,6 +188,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no field", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{},
 			},
@@ -196,6 +203,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no endings", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -210,6 +218,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: reserved ending key", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -226,6 +235,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty ending key", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -242,6 +252,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty member ID", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -261,6 +272,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("validation order: duplicate member IDs", func() {
 		alice := core.EntityID("alice")
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -283,8 +295,9 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("atomicity: after error, valid setup works", func() {
 		// First attempt: fails validation
 		setup1 := &encounter.SetupInput{
-			Field:   encounter.FieldInput{Rooms: []encounter.RoomInput{}},
-			Members: []encounter.MemberInput{},
+			Initiative: orderAsGiven{},
+			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{}},
+			Members:    []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
 				{Key: "stairs", Trigger: encounter.TriggerExternal{}},
 			},
@@ -294,6 +307,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 		// Second attempt: valid
 		setup2 := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -333,6 +347,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 // all, so they stay disjoint (W2) regardless of their y overlap.
 func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -377,6 +392,7 @@ func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
 // interior one.
 func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{
@@ -404,6 +420,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 // this exact colliding pair must construct without error.
 func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
@@ -428,6 +445,7 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 // room-list defect vocabulary.
 func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}, {X: 3, Y: 3}}},
@@ -449,6 +467,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 // forever, the external ending having no other way to fire).
 func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
@@ -541,6 +560,7 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 // share no x value and so stay disjoint (W2) regardless of y.
 func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 4, Height: 3},
@@ -609,6 +629,7 @@ func (s *EncounterTestSuite) TestConnectionEndpointBoundsBoundaries() {
 // and one member — the base for TestSetupRoomValidation's one-defect rows.
 func validRoomSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
@@ -693,6 +714,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 	// Width=4, Height=3 => Q valid in [-2,2), R valid in [-1.5,1.5).
 	hexSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
@@ -750,6 +772,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 // hex-a's ([-5,4]), so the rooms stay disjoint (W2) regardless of R.
 func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
@@ -787,6 +810,7 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 // regardless of R.
 func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
@@ -859,6 +883,7 @@ func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 // Pump's IntentMoveTo, so this also covers decider-driven moves).
 func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -885,6 +910,7 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 // TestJoinHexIntegralAxial is Join's verb-seam counterpart.
 func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -926,6 +952,7 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 	gridlessSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
@@ -984,6 +1011,7 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 // rooms are disjoint, touching only through the one declared doorway.
 func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
@@ -1102,6 +1130,7 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 // proves it independently for square's own distance formula).
 func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "sq-a", Width: 5, Height: 5},
@@ -1135,6 +1164,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 // in r2 projects to absolute (4,1) — Chebyshev distance 2, not 1.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance2() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
@@ -1169,6 +1199,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance
 // rejection pin that closes that hole.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0.5, Y: 1.5}},
@@ -1200,6 +1231,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 // message.
 func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
 		},
@@ -1219,6 +1251,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 // room legality's OWN message.
 func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
 		},
@@ -1239,6 +1272,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() 
 // direction.
 func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "square-first", Width: 5, Height: 5},
@@ -1273,6 +1307,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 // interval mins.
 func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r-a", Width: 5, Height: 5},
@@ -1304,6 +1339,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 // 1.
 func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
@@ -1337,6 +1373,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 // "close enough"; the strict `!= 1` correctly rejects it.
 func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDistance() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
@@ -1372,6 +1409,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDi
 // before W2 ever sees it, and specifically NOT with a W2 "overlap" message.
 func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 1e19, Y: 0}},
@@ -1409,6 +1447,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 // rejected — oversized, not evaluated for overlap at all.
 func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 1000, Height: 5},
@@ -1436,6 +1475,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisj
 // with maxRoomCells' message, never construct.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
 		},
@@ -1457,6 +1497,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 // an EXPLICIT hex room.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
 		},
@@ -1486,6 +1527,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex(
 // check alone would not.
 func (s *EncounterTestSuite) TestSetupOversizedRoomHeightRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
 		},
@@ -1520,8 +1562,9 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 		rooms[i] = encounter.RoomInput{ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024}
 	}
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field:   encounter.FieldInput{Rooms: rooms},
-		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: rooms},
+		Endings:    []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1536,6 +1579,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 // thing about (#929 T3 Opus round F5).
 func validEndingTriggerSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
@@ -1586,6 +1630,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerValidation() {
 // Opus round F5).
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -1608,6 +1653,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 // NOT over-reach.
 func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -1669,6 +1715,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 // any room, not an edge case — the realistic hazard N2 names explicitly.
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() {
 	setup := &encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -1688,15 +1735,21 @@ func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 	s.Run("opening beat reaches all members via Story", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
+					{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
 				},
 			},
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 0, Y: 0}},
 				{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
-				{ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
+				// The goblin waits next door: co-located and visible would mean
+				// a fight forms at first light and appends its own beat, and this
+				// test is about the OPENING beat being the only one
+				// (rpg-toolkit#964).
+				{ID: goblin, Kind: encounter.KindMonster, Room: room2, Position: spatial.Position{X: 2, Y: 2}},
 			},
 			Endings: []encounter.EndingInput{
 				{Key: "stairs", Trigger: encounter.TriggerExternal{}},
@@ -1736,6 +1789,7 @@ func (s *EncounterTestSuite) TestSetupBadPlacementSentinel() {
 	s.Run("member placed in nonexistent room errors with ErrBadPlacement", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -1763,6 +1817,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 	s.Run("three members mutually visible all see each other", func() {
 		// Arrange: ONE room, THREE mutually visible members (alice, bob players; goblin monster)
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
@@ -1818,6 +1873,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 func (s *EncounterTestSuite) TestMembers() {
 	s.Run("returns stable order", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -1845,6 +1901,7 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 	s.Run("mover's vantage refreshes, others see mover at new position", func() {
 		// Arrange: alice and bob in clear sight
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1930,6 +1987,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		// alice moves to (10,2): the line (10,2)->(10,18) is the x=10
 		// vertical and crosses (10,10): blocked BOTH ways.
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1995,6 +2053,7 @@ func (s *EncounterTestSuite) TestMoveSequentialConsistency() {
 	s.Run("after sequential moves, spatial index remains valid (CanMoveEntityBetweenRooms-style)", func() {
 		// Arrange: alice in one room
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2050,6 +2109,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 	s.Run("player reaching ReachedPosition trigger fires the ending", func() {
 		// Arrange: alice is player, will reach stairs (no member filter = any player)
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2057,6 +2117,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 						Width:  20,
 						Height: 20,
 					},
+					{ID: room2, Width: 20, Height: 20, Origin: spatial.Position{X: 20, Y: 0}},
 				},
 				Connections: []encounter.ConnectionInput{},
 			},
@@ -2068,9 +2129,11 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 					Position: spatial.Position{X: 5, Y: 5},
 				},
 				{
-					ID:       goblin,
-					Kind:     encounter.KindMonster,
-					Room:     room1,
+					ID:   goblin,
+					Kind: encounter.KindMonster,
+					// Next door, so alice can walk to her stairs without a fight
+					// starting underfoot (rpg-toolkit#964).
+					Room:     room2,
 					Position: spatial.Position{X: 10, Y: 10},
 				},
 			},
@@ -2135,6 +2198,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 	s.Run("validation order and R5 atomicity", func() {
 		s.Run("nil input returns ErrNilInput", func() {
 			setup := &encounter.SetupInput{
+				Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2156,6 +2220,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("empty member ID returns ErrNoMember", func() {
 			setup := &encounter.SetupInput{
+				Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2180,6 +2245,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("closed encounter returns ErrClosed", func() {
 			setup := &encounter.SetupInput{
+				Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2215,6 +2281,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("not a member returns ErrNotMember", func() {
 			setup := &encounter.SetupInput{
+				Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2239,6 +2306,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("failed move leaves members unchanged", func() {
 			setup := &encounter.SetupInput{
+				Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2281,6 +2349,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 	s.Run("mutating returned outcome does not affect internal state", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
@@ -2335,7 +2404,8 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 // (19,19).
 func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2353,7 +2423,8 @@ func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 // an External ending (for testing End verb).
 func (s *EncounterTestSuite) newBasicEncounterWithExternalEnding() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2423,6 +2494,7 @@ func (s *EncounterTestSuite) TestMoveSpatialRejectionAtomic() {
 // arrival-Current and T3 pins).
 func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -2494,6 +2566,7 @@ func (s *EncounterTestSuite) TestTraverseValidation() {
 		// the connection doesn't touch at all. Proves room membership is
 		// checked, not just coordinate equality.
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-a", Width: 10, Height: 10},
@@ -2674,6 +2747,7 @@ func (s *EncounterTestSuite) TestTraverseOwnView() {
 // like Move firing endings at a movement target.
 func (s *EncounterTestSuite) TestTraverseEndingFiresOnArrival() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -2715,6 +2789,7 @@ func (s *EncounterTestSuite) TestTraverseEndingFiresOnArrival() {
 // NOT close the encounter.
 func (s *EncounterTestSuite) TestTraverseMonsterOnUnfilteredEndingDoesNotClose() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -2809,6 +2884,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 	s.Run("late joiner seen by and sees incumbents", func() {
 		// Arrange: setup with alice and bob
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2983,6 +3059,7 @@ func (s *EncounterTestSuite) TestJoinValidation() {
 func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 	s.Run("join on stairs fires ReachedPosition ending", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3038,6 +3115,7 @@ func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 func (s *EncounterTestSuite) TestExitCarryForward() {
 	s.Run("exit carry-forward matches final state", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3133,6 +3211,7 @@ func (s *EncounterTestSuite) TestExitValidation() {
 func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 	s.Run("last member exit closes with abandoned ending", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3185,6 +3264,7 @@ func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 func (s *EncounterTestSuite) TestExitDepartedGhostFades() {
 	s.Run("remaining member's holdings persist after departure", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3257,6 +3337,7 @@ func (s *EncounterTestSuite) TestEndExternalOnly() {
 
 	s.Run("End fires External endings", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -3402,6 +3483,7 @@ func (s *EncounterTestSuite) TestQueriesLivePostClose() {
 func (s *EncounterTestSuite) TestStoryForExitedMembers() {
 	s.Run("exited members can still read story", func() {
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -170,4 +170,9 @@ var (
 	// send what you have," which is always answerable. The distinction is
 	// between a first load and a reconnect (#937).
 	ErrTrimmed = errors.New("story range trimmed")
+
+	// ErrNoInitiative indicates Setup was given no InitiativeRoller. Trigger
+	// detection runs from first light, so every encounter needs one — refused
+	// at construction rather than at the moment a fight would have started.
+	ErrNoInitiative = errors.New("encounter: no initiative roller")
 )

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -27,6 +27,7 @@ func Example_theDungeon() {
 		ToPosition:   spatial.Position{X: 0, Y: 4},
 	}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -45,6 +45,7 @@ func Example_theTombWatch() {
 	// The crypt: a pillar at (6,6); alice enters at (2,6); a goblin
 	// stands at (6,10). One way out: the stairs at (11,11).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: "crypt", Width: 12, Height: 12,
@@ -68,6 +69,13 @@ func Example_theTombWatch() {
 	fmt.Println("-- first light --")
 	tell(enc, "alice", "goblin")
 	tell(enc, "goblin", "alice")
+
+	// Seeing each other starts a fight (rpg-toolkit#964); the party breaks
+	// off, which is what lets alice slip away rather than trade blows.
+	if _, err := enc.Dissolve(&encounter.DissolveInput{Member: "alice"}); err != nil {
+		fmt.Println("dissolve:", err)
+		return
+	}
 
 	fmt.Println("-- alice slips behind the pillar's file --")
 	if _, err := enc.Move(&encounter.MoveInput{Member: "alice", To: spatial.Position{X: 6, Y: 2}}); err != nil {

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -87,7 +87,8 @@ func Example_theTombWatch() {
 
 	fmt.Println("-- the table saves and comes back tomorrow --")
 	data := enc.ToData()
-	enc, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	enc, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	if err != nil {
 		fmt.Println("load:", err)
 		return

--- a/rulebooks/dnd5e/encounter/example_traverse_test.go
+++ b/rulebooks/dnd5e/encounter/example_traverse_test.go
@@ -28,6 +28,7 @@ func Example_theTraverse() {
 		ToPosition:   spatial.Position{X: 0, Y: 4},
 	}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},
@@ -56,6 +57,13 @@ func Example_theTraverse() {
 	fmt.Println("-- first light --")
 	tell(enc, "alice", "goblin")
 	tell(enc, "goblin", "alice")
+
+	// Seeing each other starts a fight (rpg-toolkit#964); alice breaks off
+	// before she runs, which is what makes the rest of this a chase.
+	if _, err := enc.Dissolve(&encounter.DissolveInput{Member: "alice"}); err != nil {
+		fmt.Println("dissolve:", err)
+		return
+	}
 
 	fmt.Println("-- alice slips through the gate --")
 	if _, err := enc.Traverse(&encounter.TraverseInput{Member: "alice", Connection: "gate"}); err != nil {

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -359,6 +359,11 @@ type TraverseOutput struct {
 		To       spatial.Position
 	}
 
+	// Formed is set when walking through the door started a fight — the case
+	// review caught, because traversing into a room refreshes sight exactly
+	// like moving within one does.
+	Formed *FormedBubble
+
 	// IntelDeltas maps member IDs to their updated percepts after traversal
 	// (SurveilOutput deltas from the refreshSight cycle, across both rooms).
 	IntelDeltas map[MemberID]*intel.SurveilOutput
@@ -424,6 +429,10 @@ type JoinInput struct {
 type JoinOutput struct {
 	// Member is the joined member's read-side data.
 	Member Member
+
+	// Formed is set when arriving in sight of the other side started a fight.
+	// A joiner walks into a scene like anybody else.
+	Formed *FormedBubble
 
 	// IntelDeltas maps member IDs to their updated percepts after the join
 	// (SurveilOutput deltas from the refreshSight cycle).

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -197,6 +197,13 @@ type SetupInput struct {
 	// Endings are the declared ways the encounter can close.
 	Endings []EndingInput
 
+	// Initiative rolls the order a bubble forms in when trigger detection
+	// starts a fight (rpg-toolkit#964). REQUIRED — trigger detection runs from
+	// first light, so a fight can start before the caller does anything, and
+	// an encounter that cannot order one is a misconfiguration. Setup refuses
+	// without it (ErrNoInitiative).
+	Initiative InitiativeRoller
+
 	// Retention is how many story beats the encounter keeps. Older beats are
 	// trimmed after each append, so an encounter's blob does not grow without
 	// bound and a save does not rewrite the whole history.
@@ -311,6 +318,22 @@ type MoveOutput struct {
 
 	// Outcome is the encounter outcome if an ending fired; nil otherwise.
 	Outcome *Outcome
+
+	// Formed is set when this step started a fight. Nil otherwise.
+	Formed *FormedBubble
+}
+
+// FormedBubble reports a fight that trigger detection started.
+type FormedBubble struct {
+	// Order is the initiative order the bubble formed with, first to act
+	// first.
+	Order []MemberID
+
+	// Surprised names who entered unaware, sorted. A subset of Order.
+	Surprised []MemberID
+
+	// Seq is the story sequence of the formation beat.
+	Seq uint64
 }
 
 // TraverseInput contains the member and connection to traverse. The member
@@ -385,6 +408,10 @@ type PumpOutput struct {
 
 	// Outcome is the encounter outcome if an ending fired; nil otherwise.
 	Outcome *Outcome
+
+	// Formed is set when a monster's own movement started a fight — first
+	// contact with nobody walking, the case a walk-only trigger seam misses.
+	Formed *FormedBubble
 }
 
 // JoinInput contains the member and placement information for joining the encounter.

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -72,13 +72,13 @@ func (f *failOnceDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error)
 
 // vandalDecider mutates every byte of its view then holds.
 type vandalDecider struct {
-	sawAlice bool
+	sawPeer bool
 }
 
 func (v *vandalDecider) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
 	for i := range snap.Holdings {
-		if snap.Holdings[i].Subject == "alice" {
-			v.sawAlice = true
+		if snap.Holdings[i].Subject == "rat" {
+			v.sawPeer = true
 		}
 		for j := range snap.Holdings[i].Payload {
 			snap.Holdings[i].Payload[j] = 'X'
@@ -174,9 +174,10 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 // cleanup: an exited monster's decider must never be consulted again.
 func (s *PumpTestSuite) TestPumpDoesNotConsultExitedMonsterDecider() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
-			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
 				Position: spatial.Position{X: 4, Y: 4}, Decider: &errorDecider{err: errors.New("must never be called")}},
 		},
@@ -208,12 +209,19 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		}
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -222,7 +230,7 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 				},
 				{
@@ -254,26 +262,17 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		s.Equal(spatial.Position{X: 1, Y: 1}, pumpOut1.MonsterMoves[0].From, "goblin should start at (1,1)")
 		s.Equal(spatial.Position{X: 5, Y: 5}, pumpOut1.MonsterMoves[0].To, "goblin should move to (5,5)")
 
-		// Assert: alice sees goblin at new position via View
-		aliceView, err := enc.View(&encounter.ViewInput{Member: aliceID})
-		s.Require().NoError(err)
-		s.Len(aliceView, 1, "alice should see goblin after pump")
-
-		var payload encounter.SightPayload
-		err = json.Unmarshal(aliceView[0].Payload, &payload)
-		s.Require().NoError(err)
-		s.Equal(5.0, payload.X, "alice should see goblin at x=5")
-		s.Equal(5.0, payload.Y, "alice should see goblin at y=5")
-
-		// Assert: goblin sees alice via its own View (symmetric intel)
+		// The mutual-sight half of this test is gone with rpg-toolkit#964's v1:
+		// alice waits in the next room because a monster she can SEE is a
+		// monster she is FIGHTING, and Pump does not move a fight member. What
+		// a patrol looks like once somebody notices it is pinned separately,
+		// by TestPumpStopsMovingAMonsterOnceSeen.
+		//
+		// The goblin's own view is still the honest check that it moved and
+		// perceives from where it now stands.
 		goblinView, err := enc.View(&encounter.ViewInput{Member: goblinID})
 		s.Require().NoError(err)
-		s.Len(goblinView, 1, "goblin should see alice after pump")
-
-		err = json.Unmarshal(goblinView[0].Payload, &payload)
-		s.Require().NoError(err)
-		s.Equal(0.0, payload.X, "goblin should see alice at x=0")
-		s.Equal(0.0, payload.Y, "goblin should see alice at y=0")
+		s.Empty(goblinView, "nobody to see from (5,5) — alice is a room away")
 
 		// Second Pump: goblin should move to (3,3)
 		pumpOut2, err := enc.Pump(&encounter.PumpInput{})
@@ -284,86 +283,70 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		s.Equal(spatial.Position{X: 3, Y: 3}, pumpOut2.MonsterMoves[0].To, "goblin should move to (3,3)")
 
 		// Assert: alice sees goblin at new position
-		aliceView, err = enc.View(&encounter.ViewInput{Member: aliceID})
+		goblinView, err = enc.View(&encounter.ViewInput{Member: goblinID})
 		s.Require().NoError(err)
-		err = json.Unmarshal(aliceView[0].Payload, &payload)
-		s.Require().NoError(err)
-		s.Equal(3.0, payload.X)
-		s.Equal(3.0, payload.Y)
+		s.Empty(goblinView, "still a room away")
 	})
 }
 
 func (s *PumpTestSuite) TestPumpDeciderIsolation() {
-	s.Run("decider receives exactly its own holdings (anti-wall-hack)", func() {
-		// Arrange: alice, bob (players), and goblin (monster) in same room
+	s.Run("a decider's snapshot holds what it can see and nothing else", func() {
 		aliceID := core.EntityID("alice")
-		bobID := core.EntityID("bob")
 		goblinID := core.EntityID("goblin")
 
-		spyDecider := &spyDecider{}
+		spy := &spyDecider{}
 
-		setup := &encounter.SetupInput{
+		// Alice stands ONE CELL from the goblin with a wall between them. She
+		// is real, adjacent, and invisible — which is the only way to ask the
+		// anti-wall-hack question in v1: a monster that could SEE her would be
+		// fighting her, and Pump would not consult its decider at all
+		// (rpg-toolkit#964).
+		//
+		// WHAT THIS TEST LOST, named rather than quietly dropped: C2 has two
+		// halves, and only the no-leak half survives here. The other half —
+		// "holdings contain what it DID see" — needs a monster that watches
+		// players peacefully, which v1 cannot express. It comes back with
+		// asymmetric perception (#1020) or a faction model, at which point
+		// this test should grow the positive case again.
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Rooms: []encounter.RoomInput{
-					{
-						ID:     room1,
-						Width:  10,
-						Height: 10,
-					},
-				},
-				Connections: []encounter.ConnectionInput{},
+				Rooms: []encounter.RoomInput{{
+					ID: room1, Width: 10, Height: 10,
+					Occluders: []spatial.Position{{X: 5, Y: 5}},
+				}},
 			},
 			Members: []encounter.MemberInput{
+				{ID: aliceID, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 4, Y: 5}},
 				{
-					ID:       aliceID,
-					Kind:     encounter.KindPlayer,
-					Room:     room1,
-					Position: spatial.Position{X: 0, Y: 0},
-				},
-				{
-					ID:       bobID,
-					Kind:     encounter.KindPlayer,
-					Room:     room1,
-					Position: spatial.Position{X: 2, Y: 2},
-				},
-				{
-					ID:       goblinID,
-					Kind:     encounter.KindMonster,
-					Room:     room1,
-					Position: spatial.Position{X: 5, Y: 5},
-					Decider:  spyDecider,
+					ID: goblinID, Kind: encounter.KindMonster, Room: room1,
+					Position: spatial.Position{X: 6, Y: 5}, Decider: spy,
 				},
 			},
-			Endings: []encounter.EndingInput{
-				{
-					Key:     endingStairs,
-					Trigger: encounter.TriggerReachedPosition{Room: room1, Position: spatial.Position{X: 9, Y: 9}},
-				},
-			},
-		}
-
-		// Act: Create encounter and pump
-		enc, err := encounter.NewEncounter(setup)
+			Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+		})
 		s.Require().NoError(err)
+
+		// Nothing formed: the wall means neither noticed the other, so the
+		// goblin is still the world's to move and its decider still runs.
+		clockOf, err := enc.ClockOf(&encounter.ClockOfInput{Member: goblinID})
+		s.Require().NoError(err)
+		s.Require().Equal(encounter.ClockWorld, clockOf.Kind)
 
 		_, err = enc.Pump(&encounter.PumpInput{})
 		s.Require().NoError(err)
 
-		// Assert: goblin's spy decider saw exactly one holding (alice only, as bob is further away)
-		// In this setup, alice at (0,0) and goblin at (5,5) are in LoS; bob at (2,2) and goblin at (5,5) are also in LoS
-		// So goblin should see both alice and bob. But the key test is: did it see ONLY them, not anything else?
-		s.Len(spyDecider.capturedView, 2, "goblin should see exactly two holdings (alice and bob)")
+		s.Equal(room1, spy.capturedSnap.Room, "its own room")
+		s.Equal(spatial.Position{X: 6, Y: 5}, spy.capturedSnap.Position, "its own position")
 
-		// Verify the holdings are alice and bob (order may vary, so check both are present)
-		holdingSubjects := make(map[intel.Subject]bool)
-		for _, holding := range spyDecider.capturedView {
-			holdingSubjects[holding.Subject] = true
-		}
-		s.True(holdingSubjects[intel.Subject(aliceID)], "goblin should see alice")
-		s.True(holdingSubjects[intel.Subject(bobID)], "goblin should see bob")
+		// THE PIN: alice exists one cell away and does not appear. The
+		// snapshot is built from what this member holds, not from the
+		// encounter's live truth — so an adjacent player it cannot see is a
+		// player it cannot read.
+		s.Empty(spy.capturedView,
+			"an adjacent but unseen player must not leak into a decider's snapshot")
 	})
 }
-
 func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 	s.Run("decider error aborts pump atomically", func() {
 		// Arrange
@@ -374,12 +357,19 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		errDecider := &errorDecider{err: deciderErr}
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -388,7 +378,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 				},
 				{
@@ -428,13 +418,18 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		s.Require().NoError(err)
 		s.Equal(initialLen, len(afterStory), "story should not have new entries after failed pump")
 
-		// Assert: alice's holding of the goblin is unchanged (it never moved)
-		aliceView, err := enc.View(&encounter.ViewInput{Member: aliceID})
-		s.Require().NoError(err)
-		s.Require().Len(aliceView, 1, "alice must still hold the goblin")
-		var payload encounter.SightPayload
-		s.Require().NoError(json.Unmarshal(aliceView[0].Payload, &payload))
-		s.Equal(5.0, payload.X, "goblin must not have moved on a failed pump (R5)")
+		// Assert: the goblin is where it started. Read from placement rather
+		// than from alice's percept — she waits a room away, because a
+		// monster she could see would be a monster she was fighting, and a
+		// fight monster is never pumped at all (rpg-toolkit#964).
+		var goblinPos encounter.PositionData
+		for _, m := range enc.ToData().Members {
+			if m.ID == goblinID {
+				goblinPos = m.Position
+			}
+		}
+		s.Equal(5.0, goblinPos.X, "goblin must not have moved on a failed pump (R5)")
+		s.Equal(5.0, goblinPos.Y)
 	})
 }
 
@@ -443,9 +438,10 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 // NEXT (successful) pump reports reading 1, not 2.
 func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
-			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
 				Position: spatial.Position{X: 4, Y: 4}, Decider: &failOnceDecider{}},
 		},
@@ -467,9 +463,10 @@ func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 // have moved — no partial mutation (R5).
 func (s *PumpTestSuite) TestPumpPartialAbort() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
-			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			// "aaa-goblin" sorts before "zzz-goblin": it decides (and
 			// would move) before the erroring decider is consulted.
 			{ID: core.EntityID("aaa-goblin"), Kind: encounter.KindMonster, Room: room1,
@@ -511,9 +508,17 @@ func (s *PumpTestSuite) TestPumpPartialAbort() {
 func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	vandal := &vandalDecider{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
-			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
+			// The vandal's victim is a MONSTER peer, not a player. Two
+			// monsters seeing each other starts no fight — classification
+			// pairs players against monsters — so the goblin keeps a real,
+			// current holding to scribble on while staying the world's to
+			// pump (rpg-toolkit#964).
+			{ID: core.EntityID("rat"), Kind: encounter.KindMonster, Room: room1,
+				Position: spatial.Position{X: 6, Y: 6}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
 				Position: spatial.Position{X: 4, Y: 4}, Decider: vandal},
 		},
@@ -524,7 +529,7 @@ func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 
 	_, err = enc.Pump(&encounter.PumpInput{})
 	s.Require().NoError(err)
-	s.Require().True(vandal.sawAlice, "precondition: the vandal saw and scribbled on a holding")
+	s.Require().True(vandal.sawPeer, "precondition: the vandal saw and scribbled on a holding")
 
 	goblinView, err := enc.View(&encounter.ViewInput{Member: core.EntityID("goblin")})
 	s.Require().NoError(err)
@@ -547,12 +552,19 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 		}
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -561,7 +573,7 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 				},
 				{
@@ -607,12 +619,19 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -621,7 +640,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 				},
 				{
@@ -650,14 +669,17 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		// Assert: No monster moves recorded
 		s.Len(pumpOut.MonsterMoves, 0, "monster with nil decider should not move")
 
-		// Assert: Goblin is still at (5,5) via alice's view
-		aliceView, err := enc.View(&encounter.ViewInput{Member: aliceID})
-		s.Require().NoError(err)
-		var payload encounter.SightPayload
-		err = json.Unmarshal(aliceView[0].Payload, &payload)
-		s.Require().NoError(err)
-		s.Equal(5.0, payload.X)
-		s.Equal(5.0, payload.Y)
+		// Assert: the goblin is still at (5,5), read from placement. Alice
+		// waits a room away — a monster she could see would be one she was
+		// fighting, and a fight monster is never pumped (rpg-toolkit#964).
+		var goblinPos encounter.PositionData
+		for _, m := range enc.ToData().Members {
+			if m.ID == goblinID {
+				goblinPos = m.Position
+			}
+		}
+		s.Equal(5.0, goblinPos.X)
+		s.Equal(5.0, goblinPos.Y)
 	})
 }
 
@@ -669,9 +691,10 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 // this seam.
 func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
-			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 0, Y: 0}},
+			{ID: alice, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 0, Y: 0}},
 		},
 		Endings: []encounter.EndingInput{{Key: endingStairs, Trigger: encounter.TriggerReachedPosition{
 			Room: room1, Position: spatial.Position{X: 9, Y: 9}}}},
@@ -704,12 +727,19 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 		}
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -718,7 +748,7 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 				},
 				{
@@ -777,12 +807,19 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 		}
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -791,7 +828,7 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 				},
 				{
@@ -856,12 +893,19 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 		goblinID := core.EntityID("goblin")
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -870,7 +914,7 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 				},
 				{
@@ -930,12 +974,19 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
+			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
 						Width:  10,
 						Height: 10,
+					},
+					{
+						ID:     room2,
+						Width:  10,
+						Height: 10,
+						Origin: spatial.Position{X: 10, Y: 0},
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -944,7 +995,7 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 				{
 					ID:       aliceID,
 					Kind:     encounter.KindPlayer,
-					Room:     room1,
+					Room:     room2,
 					Position: spatial.Position{X: 0, Y: 0},
 					Decider:  &patrolDecider{}, // Players cannot have deciders!
 				},
@@ -989,6 +1040,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	spyB := &snapshotSpyDecider{}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1029,6 +1081,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseSuccess() {
 	decider := &onceTraverseDecider{connection: "door1"}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1074,6 +1127,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
 	decider := &onceTraverseDecider{connection: "door1"}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1128,6 +1182,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseUnknownConnectionDoesNotAbort() {
 	decider := &onceTraverseDecider{connection: "no-such-door"}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1179,6 +1234,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	deciderErr := errors.New("test decider error")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1222,6 +1278,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	goblinID := core.EntityID("goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1243,6 +1300,12 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	s.Require().NoError(err)
 	s.Require().Len(goblinView, 1)
 	s.Equal(intel.Current, goblinView[0].Status, "precondition: goblin must see alice before she leaves")
+
+	// Seeing each other started a fight (rpg-toolkit#964), and a fight member
+	// cannot free-roam. Alice breaks off before she runs — which is the story
+	// this test always told, now with the fight it implied made explicit.
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: aliceID})
+	s.Require().NoError(err)
 
 	// Stage 1: alice traverses away, then repositions within room-b so
 	// the monster's eventual arrival isn't a trivial same-cell coincidence.
@@ -1322,6 +1385,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	bID := core.EntityID("zzz-goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1420,7 +1484,8 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("control: decision order and declaration order agree", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+			Initiative: orderAsGiven{},
+			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				{ID: aID, Kind: encounter.KindMonster, Room: room1,
 					Position: spatial.Position{X: 5, Y: 5}, Decider: &patrolDecider{positions: []spatial.Position{posA}}},
@@ -1444,7 +1509,8 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+			Initiative: orderAsGiven{},
+			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				// Same decision order (aaa first, zzz second), but now each
 				// monster's landing position fires the OTHER declared ending.
@@ -1502,9 +1568,10 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 	decider := &reentrantSelfExitDecider{self: goblinID}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
-			{ID: aliceID, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: aliceID, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: goblinID, Kind: encounter.KindMonster, Room: room1,
 				Position: spatial.Position{X: 4, Y: 4}, Decider: decider},
 		},
@@ -1523,4 +1590,182 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 	s.Require().NoError(err)
 	s.Require().Len(members, 1, "only alice remains — goblin's self-exit went through")
 	s.Equal(aliceID, members[0].ID)
+}
+
+// TestPumpStopsMovingAMonsterOnceSeen pins the invariant v1's trigger
+// detection creates, deliberately rather than incidentally: a monster the
+// party has seen is in a bubble, and Pump does not move a bubble member.
+//
+// This is a regression guard as much as a rule. Pump drives everyone on the
+// WORLD clock; if it ever also drove fight members, a monster would act twice
+// per round — once on its turn and once on the world tick — and the symptom
+// would be a monster that moves further than its turn allowed rather than an
+// error anybody could see.
+//
+// The patrol walks the goblin out of its own room and into alice's view. The
+// step that reaches her forms the bubble; the step after that does not happen.
+func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
+	aliceID := core.EntityID("alice")
+	goblinID := core.EntityID("goblin")
+
+	// Two cells, one each side of the doorway: the goblin traverses into
+	// alice's room and is seen the moment it arrives.
+	gate := encounter.ConnectionInput{
+		ID: "door", From: room1, To: room2,
+		FromPosition: spatial.Position{X: 9, Y: 5},
+		ToPosition:   spatial.Position{X: 0, Y: 5},
+	}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: room1, Width: 10, Height: 10},
+				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
+			},
+			Connections: []encounter.ConnectionInput{gate},
+		},
+		Members: []encounter.MemberInput{
+			{ID: aliceID, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 3, Y: 5}},
+			{
+				ID: goblinID, Kind: encounter.KindMonster, Room: room1,
+				Position: spatial.Position{X: 9, Y: 5},
+				Decider:  &traverseThenWander{connection: "door"},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	// Free roam to start: nobody has seen anybody.
+	clockOf, err := enc.ClockOf(&encounter.ClockOfInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Equal(encounter.ClockWorld, clockOf.Kind, "unseen monsters are the world's to move")
+
+	// The pump that walks it through the door is the pump that starts the fight.
+	first, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(first.MonsterTraverses, 1, "the goblin went through the door")
+	s.Require().NotNil(first.Formed, "and was seen on arrival, so the bubble formed")
+	s.Require().ElementsMatch([]core.EntityID{aliceID, goblinID}, first.Formed.Order)
+
+	clockOf, err = enc.ClockOf(&encounter.ClockOfInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Equal(encounter.ClockTurn, clockOf.Kind, "a seen monster is in the fight")
+
+	// THE PIN: the next pump leaves it alone. Its decider would happily wander
+	// again — the pump simply is not the thing that moves it any more.
+	second, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Empty(second.MonsterMoves, "a seen monster is not the world's to move")
+	s.Empty(second.MonsterTraverses, "and not the world's to walk through doors either")
+}
+
+// traverseThenWander goes through its connection once, then shuffles.
+type traverseThenWander struct {
+	connection string
+	gone       bool
+}
+
+func (t *traverseThenWander) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
+	if !t.gone {
+		t.gone = true
+		return encounter.IntentTraverse{Connection: t.connection}, nil
+	}
+
+	return encounter.IntentMoveTo{To: spatial.Position{X: snap.Position.X + 1, Y: snap.Position.Y}}, nil
+}
+
+// TestPumpDeciderHuntsLastKnownPosition is C2's anti-wall-hack contract in
+// full — both halves — in a scene v1 can actually reach.
+//
+// The trick is fight → Dissolve → hunt. Contact forms the bubble; Dissolve
+// returns the goblin to the world clock still CARRYING what it saw, because
+// dissolving moves clocks and never touches intel; alice then steps behind a
+// pillar, which fades her from the goblin's percept without deleting her from
+// its memory. Now the goblin is a world-clock monster with real, stale intel,
+// so Pump consults its decider and the snapshot has something to be wrong
+// about.
+//
+// Both halves pin at once:
+//   - POSITIVE: the snapshot holds what the goblin ITSELF saw — alice at the
+//     cell she was standing in when it last had eyes on her.
+//   - NEGATIVE: it does NOT hold where she actually is now.
+//
+// That is the anti-wall-hack in its truest form: the monster hunts your last
+// known position rather than your current one. It is falsifiable in the way
+// that matters — a snapshot builder that read the room's ground truth instead
+// of the member's holdings would report alice's NEW cell, and this test would
+// fail with the two coordinates side by side.
+func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
+	aliceID := core.EntityID("alice")
+	goblinID := core.EntityID("goblin")
+
+	spy := &spyDecider{}
+
+	seen := spatial.Position{X: 7, Y: 5}
+	hidden := spatial.Position{X: 4, Y: 5}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{
+				ID: room1, Width: 10, Height: 10,
+				// One pillar, positioned so that alice is visible from the
+				// goblin where she starts and hidden where she ends up.
+				Occluders: []spatial.Position{{X: 5, Y: 5}},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: aliceID, Kind: encounter.KindPlayer, Room: room1, Position: seen},
+			{
+				ID: goblinID, Kind: encounter.KindMonster, Room: room1,
+				Position: spatial.Position{X: 6, Y: 5}, Decider: spy,
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	// They saw each other at first light, so they are fighting.
+	clockOf, err := enc.ClockOf(&encounter.ClockOfInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Equal(encounter.ClockTurn, clockOf.Kind)
+
+	// The fight breaks off. Dissolve moves clocks and nothing else — the
+	// goblin walks away still remembering where alice was.
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: goblinID})
+	s.Require().NoError(err)
+
+	clockOf, err = enc.ClockOf(&encounter.ClockOfInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Equal(encounter.ClockWorld, clockOf.Kind, "back to the world's to move")
+
+	// Alice slips behind the pillar. She fades from the goblin's percept — no
+	// current sight, so nothing re-triggers (classification reads first
+	// contact, and a fade is not a contact).
+	moved, err := enc.Move(&encounter.MoveInput{Member: aliceID, To: hidden})
+	s.Require().NoError(err)
+	s.Require().Nil(moved.Formed, "she left its sight rather than entering it")
+
+	clockOf, err = enc.ClockOf(&encounter.ClockOfInput{Member: goblinID})
+	s.Require().NoError(err)
+	s.Require().Equal(encounter.ClockWorld, clockOf.Kind, "and no fight restarted")
+
+	// The pump consults the decider, because the goblin is the world's again.
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Require().Len(spy.capturedView, 1, "the goblin still remembers alice")
+
+	var payload encounter.SightPayload
+	s.Require().NoError(json.Unmarshal(spy.capturedView[0].Payload, &payload))
+
+	// POSITIVE: its own memory, at the cell it last saw her in.
+	s.Equal(float64(seen.X), payload.X, "the goblin hunts where it last saw her")
+	s.Equal(float64(seen.Y), payload.Y)
+
+	// NEGATIVE: not where she actually is. A snapshot built from ground truth
+	// would report this instead.
+	s.NotEqual(float64(hidden.X), payload.X, "her live position must not leak into the snapshot")
 }

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -34,7 +34,8 @@ type RetentionTestSuite struct {
 // with the ending at (4,4).
 func (s *RetentionTestSuite) walkingEncounter(retention int) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Initiative: orderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -241,7 +241,8 @@ func (s *RetentionTestSuite) TestRetentionSurvivesReload() {
 	data := enc.ToData()
 	s.Equal(window, data.Retention, "retention is persisted, not inferred")
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	// The reloaded encounter must still be trimming to the SAME window: keep
@@ -261,7 +262,8 @@ func (s *RetentionTestSuite) TestFloorSurvivesReload() {
 	enc := s.walkingEncounter(window)
 	s.generateBeats(enc, 40)
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: enc.ToData()})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	_, err = reloaded.Story(&encounter.StoryInput{Audience: "p1", AfterSeq: 33})
@@ -280,7 +282,8 @@ func (s *RetentionTestSuite) TestUntrimmedEncounterHasNoFloor() {
 	enc := s.walkingEncounter(encounter.RetentionUnbounded)
 	s.generateBeats(enc, 5)
 
-	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: enc.ToData()})
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	for seq := uint64(1); seq <= 6; seq++ {

--- a/rulebooks/dnd5e/encounter/testroller_internal_test.go
+++ b/rulebooks/dnd5e/encounter/testroller_internal_test.go
@@ -1,0 +1,13 @@
+package encounter
+
+// orderAsGiven is the initiative roller the internal tests install.
+//
+// It returns the members untouched, which is deterministic on purpose: these
+// tests assert on what trigger detection DECIDED, and a shuffled order would
+// make every assertion about the bubble depend on a roll nobody is testing.
+// The rulebook's real roller is the production consumer's business.
+type orderAsGiven struct{}
+
+func (orderAsGiven) RollInitiative(members []MemberID) ([]MemberID, error) {
+	return members, nil
+}

--- a/rulebooks/dnd5e/encounter/testroller_test.go
+++ b/rulebooks/dnd5e/encounter/testroller_test.go
@@ -1,0 +1,14 @@
+package encounter_test
+
+import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+
+// orderAsGiven is the initiative roller these tests install.
+//
+// It returns the members untouched, which is deterministic on purpose: these
+// tests assert on what trigger detection DECIDED, and a shuffled order would
+// make every assertion about the bubble depend on a roll nobody is testing.
+type orderAsGiven struct{}
+
+func (orderAsGiven) RollInitiative(members []encounter.MemberID) ([]encounter.MemberID, error) {
+	return members, nil
+}

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -52,6 +52,7 @@ func TestTombWatch(t *testing.T) {
 	// enter; a goblin patrols the far end between (7,10) and (6,10).
 	goblinPatrol := &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
@@ -78,6 +79,11 @@ func TestTombWatch(t *testing.T) {
 	require.Equal(t, intel.Current, st, "beat 1: bella sees it too")
 	st, _ = seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Current, st, "beat 1: and the goblin sees them back — intel is symmetric, nobody wall-hacks")
+
+	// Seeing each other started the fight (rpg-toolkit#964). The party breaks
+	// off to keep watching rather than trading blows — the watch is the scene.
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	require.NoError(t, err, "beat 1: the party breaks off to watch")
 
 	// ---- Beat 2: the watch -----------------------------------------
 	// Alice advances to (2,6) to watch; the world moves on her action:
@@ -214,7 +220,10 @@ func TestTombWatch(t *testing.T) {
 		kinds = append(kinds, beat["beat"].(string))
 	}
 	require.Equal(t, []string{
-		"scene-opened",  // beat 1
+		"scene-opened", // beat 1
+		// beat 1: they see each other, the fight starts, the party breaks off
+		// to watch instead
+		"bubble-formed", "bubble-dissolved",
 		"moved",         // beat 2: alice advances
 		"tick", "moved", // beat 2: pump 1, goblin steps out
 		"tick", "moved", // beat 2: pump 2, goblin steps back
@@ -240,6 +249,7 @@ func TestTombWatch(t *testing.T) {
 		})
 	}
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -127,9 +127,10 @@ func TestTombWatch(t *testing.T) {
 	// goblin's patrol at load (its route position restarts; its INTEL
 	// does not — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
-	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
-		goblin: &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}},
-	}})
+	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+			goblin: &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}},
+		}})
 	require.NoError(t, err, "beat 4: the suspended scene crosses a process boundary")
 	enc = enc2 // the reload IS the encounter now
 
@@ -150,6 +151,9 @@ func TestTombWatch(t *testing.T) {
 	require.Equal(t, intel.Current, st, "beat 5: from (10,2) the pillar doesn't block him — first light lands")
 	st, _ = seen(t, enc, goblin, cormac)
 	require.Equal(t, intel.Current, st, "beat 5: the goblin notices the newcomer")
+	require.NotNil(t, joinOut.Formed, "beat 5: noticing each other IS the fight starting")
+	require.Greater(t, joinOut.Formed.Seq, joinOut.Seq,
+		"beat 5: he arrives, THEN the fight starts — the story never runs backwards")
 	st, _ = seen(t, enc, alice, goblin)
 	require.Equal(t, intel.Held, st, "beat 5: the join's refresh does not disturb alice's ghost")
 
@@ -229,8 +233,13 @@ func TestTombWatch(t *testing.T) {
 		"tick", "moved", // beat 2: pump 2, goblin steps back
 		"moved",  // beat 3: alice slips behind the pillar's file
 		"joined", // beat 5: cormac (the pause leaves no beat — pause is free)
-		"exited", // beat 6: bella
-		"moved",  // beat 7: alice reaches the stairs
+		// beat 5: and the goblin sees him arrive — his fight starts AFTER the
+		// arrival that caused it. Cause before effect: the reverse order is
+		// what this transcript caught when trigger detection moved inside
+		// refreshSight (see refreshSight's law).
+		"bubble-formed",
+		"exited", // beat 6: bella (alice and the goblin's watchers free-roam
+		"moved",  // beat 7: on — cormac's fight is localized to cormac)
 	}, kinds, "beat 8: the story IS the scene, told in order")
 
 	// ---- Beat 9: the sequel seed -----------------------------------

--- a/rulebooks/dnd5e/encounter/trigger.go
+++ b/rulebooks/dnd5e/encounter/trigger.go
@@ -1,0 +1,386 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+)
+
+// InitiativeRoller turns the members entering a fight into the order they act
+// in. The composition asks; the rulebook answers.
+//
+// Injected rather than held, exactly as [Decider] is. The composition owns no
+// randomness (R7) — Form's own doc says the order "comes from OUTSIDE" — but
+// trigger detection has to start a fight at the moment it detects one, which
+// means asking for the order rather than being handed it. Holding the SEAM is
+// not holding the randomness, and this is the module's existing pattern for
+// exactly that distinction.
+//
+// Errors abort whatever verb was running, atomically (R5): a fight that cannot
+// be ordered does not half-start.
+type InitiativeRoller interface {
+	// RollInitiative returns the given members in the order they act, first
+	// to act first. The result must contain exactly the members it was given.
+	RollInitiative(members []MemberID) ([]MemberID, error)
+}
+
+// contactKind is what one player-monster pair's awareness amounts to after a
+// sight refresh.
+//
+// The four cases are the whole rule. 5e's surprise is an asymmetry — you are
+// surprised if you did not notice your enemy — so a trigger built on who saw
+// whom gets surprise as a consequence rather than as a later bolt-on.
+type contactKind int
+
+const (
+	// contactNone: neither noticed the other this step.
+	contactNone contactKind = iota
+
+	// contactDrop: the player saw the monster and the monster did not see
+	// back. The designed behavior is that the walk ends early and the player
+	// decides in free roam — back away, sneak, or approach — with attacking
+	// from here counting as initiation.
+	//
+	// UNREACHABLE TODAY, and deliberately kept. Sight is pure symmetric
+	// geometry: refreshSight builds every percept from IsLineOfSightBlocked
+	// with no facing, stealth, or perception input, so if the player sees the
+	// wolf the wolf sees the player and this case has no producible input.
+	// rpg-toolkit#1020 is the prerequisite that makes it real. The arm stays
+	// because it is the documented design rather than dead ceremony — what is
+	// NOT here is any behavior hanging off it, because unbuilt beats
+	// built-and-dead.
+	contactDrop
+
+	// contactSpotted: the monster saw the player and the player did not see
+	// back. The bubble forms; nobody had a choice to make.
+	contactSpotted
+
+	// contactMutual: both saw each other. The bubble forms.
+	contactMutual
+)
+
+// trigger is what one classification pass concluded.
+type trigger struct {
+	// form names the members who should enter a bubble, sorted. Empty when
+	// nothing forms.
+	form []MemberID
+
+	// surprised names the members who enter that bubble unaware, sorted.
+	surprised []MemberID
+
+	// joined names members pulled into a bubble that was ALREADY running —
+	// the straggler case, sorted. Mutually exclusive with form: a fight
+	// either starts or is joined.
+	joined []MemberID
+}
+
+// classify reads one sight refresh and decides what it triggered.
+//
+// # v1, and how it evolves
+//
+// THE INVARIANT: upgrades change how percepts are PRODUCED, never how they are
+// consumed. Everything below this comment — the four-case table, the
+// precedence law, the transition-only induction, awareness-based surprise — is
+// written against asymmetric sight and does not move again. That is what makes
+// the next two versions cheap.
+//
+// v1, WHICH IS WHAT THIS IS: sight is symmetric line-of-sight, so any first
+// contact forms the bubble and the drop case has no producible input. Surprise
+// is computed correctly and is always empty, for the same reason — everyone
+// sees everyone, so nobody is unaware. Honest option C under B-prime's design,
+// not a compromise: the machinery is the permanent part and the percepts are
+// the part that grows.
+//
+// v2 is asymmetric perception (rpg-toolkit#1020), where Stealth against
+// passive Perception decides whether an observer's percept exists at all. The
+// drop, real surprise, and initiating from unseen all come alive there with no
+// change to this function. v3 is richer senses — blindsight and tremorsense
+// defeating stealth — through the same production seam.
+//
+// The full evolution record, including the design questions reserved for v2's
+// own moment, is issue #964's ratification comment.
+//
+// # Transitions, not states
+//
+// Only intel.SurveilOutput.FirstContact is read — never Refreshed. A subject
+// already being watched is not news, so a player who spotted a wolf and keeps
+// walking with it in view does not re-trigger on every step: the sneak-past
+// works by construction rather than by a "have I already reported this" flag.
+//
+// Reading transitions is COMPLETE rather than merely cheap, and the induction
+// is worth writing down because it is what makes the shortcut safe. This runs
+// at every refreshSight from first light onward — setup, move, traverse, pump,
+// join. Every awareness that exists was created by some step, and that step
+// classified it. So a stale asymmetry — a monster that has "already been
+// watching" without anything forming — cannot arise: the step that created the
+// watching was itself classified, and either formed a bubble or was a drop.
+//
+// # Precedence
+//
+// Within one pass, any spotted or mutual pair forms the bubble, and the drop's
+// walk-stop applies only when no pair does. A player who gets the drop on one
+// wolf while a second wolf spots them is in a fight, not in a choice: the
+// bubble is the strictly stronger outcome and the drop's freedom is gone.
+//
+// # Surprise is read from now, not from the trigger
+//
+// Classification uses the transition lists; surprise does NOT. A member is
+// surprised iff its CURRENT view holds no opposing member at the moment the
+// bubble forms.
+//
+// The walked-behind case is why. A player gets the drop on a wolf (no bubble,
+// free roam), then circles behind it while keeping it in sight — the wolf is
+// Refreshed on every step and never FirstContact again. Later the wolf turns
+// and first-contacts the player: spotted, bubble forms, correct. But the
+// PLAYER has been watching the whole time and is plainly not surprised, while
+// FirstContact-only surprise would say they were, because the player's own
+// first contact happened long ago and is not in this delta.
+func (e *Encounter) classify(deltas map[MemberID]*intel.SurveilOutput) (*trigger, error) {
+	sawFirst := func(observer, subject MemberID) bool {
+		delta, ok := deltas[observer]
+		if !ok || delta == nil {
+			return false
+		}
+		for _, report := range delta.FirstContact {
+			if MemberID(report.Subject) == subject {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	players, monsters := e.sidesInContactOrder()
+
+	var (
+		engaged = map[MemberID]bool{}
+		drops   []MemberID
+		dropBy  MemberID
+	)
+
+	for _, player := range players {
+		for _, monster := range monsters {
+			switch contactBetween(sawFirst(player, monster), sawFirst(monster, player)) {
+			case contactMutual, contactSpotted:
+				// mutual or spotted — the bubble forms either way, and which
+				// of the two it was only matters to surprise, which is read
+				// from current awareness rather than from here.
+				//
+				// BOTH sides of the pair are engaged, and only they. A fight
+				// is localized: the members who noticed each other are in it
+				// and everyone else keeps free-roaming, which is the whole
+				// point of a bubble being a bubble rather than a mode. Pulling
+				// the entire roster in would delete the split party the
+				// composition exists to support.
+				engaged[player] = true
+				engaged[monster] = true
+			case contactDrop:
+				drops = append(drops, monster)
+				if dropBy == "" {
+					dropBy = player
+				}
+			case contactNone:
+			}
+		}
+	}
+
+	if len(engaged) > 0 {
+		return e.formation(engaged)
+	}
+
+	// The drop arm classifies and then does nothing, because nothing can reach
+	// it (rpg-toolkit#1020) and a walk-stop built against an unreachable case
+	// would be untestable behavior shipped on faith. When #1020 lands, this is
+	// where the early stop attaches.
+	_, _ = drops, dropBy
+
+	return &trigger{}, nil
+}
+
+// formation names the members entering the bubble and who enters it unaware.
+//
+// Only the engaged: a fight is localized, so the members who noticed each
+// other leave the world clock and everybody else keeps exploring. Stragglers
+// join later through the same classification, which is what makes a fight
+// grow rather than start twice.
+func (e *Encounter) formation(engaged map[MemberID]bool) (*trigger, error) {
+	form := make([]MemberID, 0, len(engaged))
+	for id := range engaged {
+		form = append(form, id)
+	}
+	sort.Slice(form, func(i, j int) bool { return form[i] < form[j] })
+
+	// A fight already running is JOINED, not started again. This is 4.2's
+	// straggler mechanic arriving automatically: a second wolf that rounds the
+	// corner into a live fight belongs in it, and the alternative — refusing,
+	// or forming a second bubble — is either a rule that stops working the
+	// moment a fight exists or two fights nobody asked for.
+	//
+	// Everyone in contact who is not already on a turn clock transfers in at
+	// the END of the order: they arrive after the creatures who were already
+	// trading blows, which is the only ordering that does not silently give a
+	// latecomer a turn ahead of somebody mid-fight.
+	if len(e.bubbles) > 0 {
+		var joined []MemberID
+		for _, id := range form {
+			bubble, err := e.bubbleFor(id)
+			if err != nil {
+				return nil, err
+			}
+			if bubble == nil {
+				joined = append(joined, id)
+			}
+		}
+
+		return &trigger{joined: joined}, nil
+	}
+
+	surprised := make([]MemberID, 0, len(form))
+	for _, id := range form {
+		unaware, err := e.unawareOfOpposition(id)
+		if err != nil {
+			return nil, err
+		}
+		if unaware {
+			surprised = append(surprised, id)
+		}
+	}
+
+	return &trigger{form: form, surprised: surprised}, nil
+}
+
+// unawareOfOpposition reports whether this member's CURRENT view holds nobody
+// from the other side — which is exactly 5e's surprise condition, read at
+// formation rather than inferred from whatever triggered it.
+func (e *Encounter) unawareOfOpposition(id MemberID) (bool, error) {
+	member, ok := e.members[id]
+	if !ok {
+		return false, nil
+	}
+
+	holdings, err := e.intelLog.HeldBy(&intel.HeldByInput{Observer: id})
+	if err != nil {
+		return false, err
+	}
+
+	for _, holding := range holdings {
+		// Held, not Current, is a ghost — a subject remembered from before
+		// rather than one being watched now. Remembering where a wolf used to
+		// be does not stop it surprising you.
+		if holding.Status != intel.Current {
+			continue
+		}
+		other, ok := e.members[MemberID(holding.Subject)]
+		if !ok {
+			continue
+		}
+		if other.Kind != member.Kind {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// sidesInContactOrder returns the players and the monsters, each sorted.
+//
+// Sorted because e.members is a map and C8 requires that what a pass concludes
+// be a function of persisted data rather than of iteration order — the same
+// reason buildMemberOutcomes sorts.
+func (e *Encounter) sidesInContactOrder() (players, monsters []MemberID) {
+	for id, member := range e.members {
+		switch member.Kind {
+		case KindPlayer:
+			players = append(players, id)
+		case KindMonster:
+			monsters = append(monsters, id)
+		}
+	}
+	sort.Slice(players, func(i, j int) bool { return players[i] < players[j] })
+	sort.Slice(monsters, func(i, j int) bool { return monsters[i] < monsters[j] })
+
+	return players, monsters
+}
+
+// applyTrigger turns a classification into what actually happened: a fight
+// starts, or nothing does.
+//
+// Called by every verb that refreshes sight, right after it does. Placement is
+// the point: sight changes in more places than a player's walk, and the one
+// that breaks a walk-only seam is Pump — a monster walking into view is first
+// contact with nobody walking, and a trigger living in the walker's loop would
+// never see it. The old stack learned this the expensive way and ended up
+// calling its check from two call sites (encounter/combat.go's
+// checkCombatEntry, reached from Move AND AddMonster); this sits at the one
+// place all of them already pass through.
+func (e *Encounter) applyTrigger(deltas map[MemberID]*intel.SurveilOutput) (*FormedBubble, error) {
+	verdict, err := e.classify(deltas)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(verdict.joined) > 0 {
+		for _, id := range verdict.joined {
+			if _, err := e.Transfer(&TransferInput{
+				Member: id,
+				To:     ClockTurn,
+				Pos:    e.bubbleSize(),
+			}); err != nil {
+				return nil, fmt.Errorf("trigger transfer %q: %w", id, err)
+			}
+		}
+
+		return nil, nil
+	}
+
+	if len(verdict.form) == 0 {
+		return nil, nil
+	}
+
+	order, err := e.initiative.RollInitiative(append([]MemberID(nil), verdict.form...))
+	if err != nil {
+		return nil, fmt.Errorf("trigger roll initiative: %w", err)
+	}
+
+	formed, err := e.form(&FormInput{Order: order, Surprised: verdict.surprised})
+	if err != nil {
+		return nil, fmt.Errorf("trigger form: %w", err)
+	}
+
+	return &FormedBubble{
+		Order:     order,
+		Surprised: verdict.surprised,
+		Seq:       formed.Seq,
+	}, nil
+}
+
+// bubbleSize reports how many members the running bubble holds, which is the
+// slot a straggler lands in: the end of the order.
+func (e *Encounter) bubbleSize() int {
+	if len(e.bubbles) == 0 {
+		return 0
+	}
+
+	return len(e.bubbles[0].ToData().Order)
+}
+
+// contactBetween names what one pair's two first-contact answers amount to.
+//
+// Written as its own function so the four cases are stated once, in the order
+// the rule reads, rather than inferred from the shape of an if.
+func contactBetween(playerSaw, monsterSaw bool) contactKind {
+	switch {
+	case playerSaw && monsterSaw:
+		return contactMutual
+	case monsterSaw:
+		return contactSpotted
+	case playerSaw:
+		return contactDrop
+	default:
+		return contactNone
+	}
+}


### PR DESCRIPTION
Closes #964. Encounter module only. **v1 of trigger detection: sight starts the fight.**

## The ruling chain, in order

This landed through six decisions, and the PR is easier to read with them in front of you:

1. **[Kirk's ratification](https://github.com/KirkDiggler/rpg-toolkit/issues/964#issuecomment-5301910431)** — *"on sight forming a bubble is a fine v1"*, with the evolution path recorded: v1 → v2 asymmetric perception (#1020) → v3 richer senses, under one invariant — **upgrades change how percepts are PRODUCED, never how they are consumed.**
2. **Placement** — the trigger belongs at `refreshSight`, not in the walk.
3. **The drop is unreachable** — sight is symmetric, so v1 ships as honest option C with `StopReason` unbuilt.
4. **`Initiative` required at Setup** — construction is total.
5. **`Form` goes internal** — two fight-starting paths would be two systems.
6. **C2 preserved by recast** — the anti-wall-hack pin survives, both halves.

## What it does

Classification runs at `refreshSight`, the one function every sight change flows through. Per player-monster pair, from the two first-contact lists: **none / drop / spotted / mutual**. Spotted or mutual forms a bubble; either beats a drop within a pass.

**Why not the walk.** `Pump` refreshes sight too, and a monster walking into view is first contact with *nobody walking*. A trigger in a walker's loop never sees it — the old stack learned this and ended up calling `checkCombatEntry` from two sites.

**Transitions only.** A subject already watched is not news, so walking past a sleeping wolf does not re-trigger each step. That is complete rather than merely cheap, and the induction is in the code: classification runs from first light onward, so every awareness was created by a step that classified it.

**A fight is localized.** Only the members who noticed each other leave the world clock — pulling the whole roster in would delete the split party the composition exists for. Stragglers `Transfer` into a running fight at the end of the order rather than being refused.

**Surprise is read from current awareness at formation**, never from the triggering delta — the walked-behind case, where a player circling a wolf while watching it would otherwise be marked surprised.

## v1 is honest option C, and says so

Sight is symmetric line-of-sight, so **any first contact is mutual**: the drop cannot fire, and `Surprised` is computed correctly and always empty. Both are stated in `classify`'s doc alongside the invariant, with #1020 and hostility filtering named as what makes them live.

**Two consequences worth stating plainly, both user-visible:**

- **Free roam with a co-located visible monster is unreachable** until production-side upgrades land.
- **`Pump` now moves the monsters nobody has seen.** Free-roam monster behaviour is offscreen behaviour. Its doc says so.

**This is continuity, not regression.** The shipped game is already combat-on-sight — the old stack's `checkCombatEntry` fires the moment a player sees a monster — so the state that becomes unreachable was never reachable there either.

## API changes

| Change | Why |
|---|---|
| `Form` → unexported | Its own doc predicted it: *"something else decides to call it."* Zero production callers; two fight-starting paths would be two systems |
| `SetupInput.Initiative` **required** | Trigger detection runs from first light, so a scene that cannot order a fight it will start is a misconfiguration — refused at construction, not mid-fight |
| `FormInput.Surprised` | Carried, validated as a subset of `Order`, recorded in the formation beat |
| `MoveOutput.Formed`, `PumpOutput.Formed` | A fight started, with its order and who was surprised |

`Transfer`, `ClockOf`, `Status`, `Dissolve` and those outputs remain the public story of "a fight exists" — stated in the internalization comment where the verb disappeared.

`StopReason` is **not** built. The drop arm classifies and does nothing, kept as documented design: unbuilt beats built-and-dead.

## Evidence

| Check | Result |
|---|---|
| `go test -count=1 ./...` | **exit 0 — 660 pass, 0 fail** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

## The three commits

Deliberately separated so the production change reads apart from the test work:

1. **`feat`** — trigger detection itself.
2. **`test`: the fixture pass** — mechanical. 138 `SetupInput` literals across 13 files plus the workbench gained a deterministic roller.
3. **`test`: the scenario pass** — the judgment. Every test here changed because v1 removes one state: *a monster you can see but are not fighting*.

Scenes that wanted free roam got it honestly (next room, or a pillar). Scenes that wanted a fight stopped asking — co-location **is** the fight, and `DOS2SplitParty` reads better as a scene than as setup calls. The narrative scenes — chase, continuity, tomb watch, both Examples — gained an explicit **break-off**: each was already a story about *not* fighting, and `Dissolve` says out loud what they implied.

### Two pins that earned their place

**`TestPumpDeciderHuntsLastKnownPosition`** — C2's anti-wall-hack contract, **both halves**, via fight → `Dissolve` → hunt. `Dissolve` moves clocks and never touches intel (verified), so the goblin keeps what it saw; alice steps behind a pillar and fades without leaving its memory. The snapshot holds where it **last saw** her and **not** where she is. A snapshot builder reading ground truth reports the new cell and fails with the coordinates side by side.

**`TestPumpStopsMovingAMonsterOnceSeen`** — the invariant v1 creates, as a regression guard. A double-driven monster would move *too far* rather than error, which is the kind of bug nobody sees.

The occlusion no-leak pin stays alongside them: they fail for different reasons.

## Found and fixed on the way

- **`formation()` originally pulled every member into the bubble**, which would have deleted the localized fight. The suite caught it.
- **First-light classification ran before the `scene-opened` beat**, so a fight starting at setup was recorded before the scene it happens in. `TestSetupOpeningBeat` caught it — my instinct was to update the fixture, and the test was right.
- **Contact with a running bubble used to fail the whole verb** — `formation` called `form`, `form` returned `ErrInBubble`. A second wolf mid-fight broke the Move. Now it transfers.

## The review round (f8d0e51)

Copilot's two comments were one bug seen from both ends, and fixing them
turned up a third thing the suite caught immediately.

**The wiring had drifted from this PR's own census.** Trigger detection was
pasted into `Move` and `Pump` but not into `Traverse` or `Join` — walking
through a door into a monster's room, or connecting late into its sight,
started no fight. Fixed **by construction** rather than by adding two more
call sites: `refreshSight` now rebuilds percepts **and** runs the rule, so a
verb that refreshes sight cannot forget it. `rebuildPercepts` is the half
without the rule and `Setup` is its only caller, because `Setup` needs its
`scene-opened` beat to land between the halves.

**With `Traverse` and `Join` wired, a `LoadEncounter` without a roller became
a live panic**, not a latent one — `TestTombWatch` crashed on a nil map the
moment `Join` could reach the roller. Kirk's ruling: *a nil initiative is an
error returned way upstream.* `LoadEncounterInput` gains a **REQUIRED**
`Initiative`, refused in `Validate` with `ErrNoInitiative`. Refuse at the
door; never guard at the use site.

**Making the rule automatic exposed a story-order inversion.** Consequences
were being appended before their causes: `bubble-formed, joined`. The law,
now stated once on `refreshSight` where every verb meets it:

> **A verb's own beat precedes any beat its consequences append.**

Cause before effect, in every story. `Setup` already ruled this; `Move`,
`Traverse`, `Pump` and `Join` now obey it too, and `Pump`'s own beats are the
tick frame **and** the actions inside it, so both precede the fight an action
caused. `Exit` already had it.

`beatorder_test.go` is **five pins, one law** — one per verb plus setup. Each
was verified by re-inverting that verb's ordering: five mutants, five kills,
each by its own pin (`Traverse` also takes `TestTraverseBeatPinned` with it,
`Join` also takes `TestTombWatch`, setup also takes `TestTombWatch` and
`TestVaultChase`).

Seq re-verification, since the reorder moves what `appendOut.Seq` refers to:
`MoveOutput.Seq`, `TraverseOutput.Seq`, `JoinOutput.Seq` and `PumpOutput.Seqs`
now sit **below** `FormedBubble.Seq` instead of above it — the values are the
same beats, only their position relative to the trigger's beat changed. No
test asserts seq contiguity across the verb+trigger pair; `retention_test.go`'s
gapless-seq assertion is over the retained log and is unaffected. The `At`
stamps are unchanged: `HighWater` moves only in `Advance`, and `form` does not
advance the world clock, so reading the clock before rather than after
`refreshSight` reads the same number (`Outcome.At` included).

**Adoption path for consumers.** `resolution` calls `LoadEncounter` in
`resolveOn` and pins a released `encounter`, so it is not broken today; it
adopts at its next bump. It already carries `in.Roller` (a `dice.Roller`), and
that is the thing to wrap — `InitiativeRoller` is a different interface, so
the bump wants a small adapter that rolls initiative from the dice roller
rather than a second injection point.


— asset-pipeline agent, on behalf of KirkDiggler
