### PR TITLE
fix(spatial): sight is a lane, not a line (#1022)

### DIFF
--- a/tools/spatial/boundary_test.go
+++ b/tools/spatial/boundary_test.go
@@ -2,6 +2,7 @@ package spatial_test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 
@@ -402,15 +403,40 @@ func (s *BoundaryTestSuite) TestBoundaryLineOfSightUsesCanonicalSquareRay() {
 	s.Equal(forwardBlocked, reverseBlocked, "boundary LoS must be reciprocal")
 }
 
-func (s *BoundaryTestSuite) TestCanonicalBoundaryRayDoesNotWeakenEntityBlockers() {
+// TestEntityBlockersUseTheCanonicalRayAndCanBeSeenAround replaces a pin that
+// was right for its era and is now the bug's own fingerprint.
+//
+// It used to be TestCanonicalBoundaryRayDoesNotWeakenEntityBlockers, and it
+// asserted that (2,1)→(0,0) is blocked by a lone entity at (1,1) BECAUSE the
+// reverse Bresenham ray visits (1,1) while the canonical ray does not. Read
+// that again: the guarantee it protected was that entity sight depends on
+// which end asked. That is not a feature preserved — it is exactly the
+// direction-dependence reported as rpg-toolkit#1022, written down as a
+// promise.
+//
+// Two things are true now, and the old test could hold neither. Entity
+// blocking rasterizes the SAME canonical ray as boundary blocking, so one call
+// no longer consults two different rays. And a lone blocker in open ground is
+// seen around, because sight asks for a lane rather than a line: the corner
+// rule the game actually states agrees, and so does anyone at the table.
+func (s *BoundaryTestSuite) TestEntityBlockersUseTheCanonicalRayAndCanBeSeenAround() {
 	from := spatial.Position{X: 0, Y: 0}
 	to := spatial.Position{X: 2, Y: 1}
 	blocker := NewMockEntity("directional-ray-blocker", "wall").WithBlocking(false, true)
-
-	// The reverse Bresenham ray visits (1,1), while the canonical boundary
-	// ray does not. Entity blocker checks retain the requested-direction ray.
 	s.Require().NoError(s.room.PlaceEntity(blocker, spatial.Position{X: 1, Y: 1}))
-	s.True(s.room.IsLineOfSightBlocked(to, from))
+
+	s.False(s.room.IsLineOfSightBlocked(to, from), "one body in the open is leaned around")
+	s.Equal(s.room.IsLineOfSightBlocked(from, to), s.room.IsLineOfSightBlocked(to, from),
+		"and the answer no longer depends on which end asked")
+
+	// It is not that the blocker stopped mattering. Wall the lanes around it
+	// and it decides the sightline again.
+	for i, cell := range []spatial.Position{{X: 1, Y: 0}, {X: 1, Y: 2}} {
+		s.Require().NoError(s.room.PlaceEntity(
+			NewMockEntity(fmt.Sprintf("flank-%d", i), "wall").WithBlocking(false, true), cell))
+	}
+	s.True(s.room.IsLineOfSightBlocked(to, from), "with no lane left, the wall blocks")
+	s.True(s.room.IsLineOfSightBlocked(from, to))
 }
 
 func (s *BoundaryTestSuite) TestBoundaryClearAndRemovalRestoreOnlyThatCrossing() {

--- a/tools/spatial/data_test.go
+++ b/tools/spatial/data_test.go
@@ -2,6 +2,7 @@ package spatial
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -585,13 +586,34 @@ func (s *RoomDataTestSuite) TestSpatialPropertiesPreserved() {
 	loadedRoom, err := LoadRoomFromContext(context.Background(), gameCtx)
 	s.Require().NoError(err)
 
-	// Test that spatial queries work correctly
-	// Ghost should not block line of sight
-	blocked := loadedRoom.IsLineOfSightBlocked(Position{X: 0, Y: 5}, Position{X: 10, Y: 5})
+	// Test that spatial queries work correctly.
+	//
+	// The probe is a WALLED lane rather than an open one, and that is the
+	// change rpg-toolkit#1022 made: a lone body in open ground stops nothing
+	// now, because sight leans around it. This test is about a FLAG surviving
+	// a round trip, so the query has to be one the flag can still decide —
+	// wall the column except for the cell the creature stands in, and the
+	// answer turns on that creature and nothing else.
+	wallColumn := func(col int, gap int) {
+		for y := 0; y < 20; y++ {
+			if y == gap {
+				continue
+			}
+			s.Require().NoError(loadedRoom.PlaceEntity(&MockEntity{
+				id: fmt.Sprintf("wall-%d-%d", col, y), entityType: "wall",
+				size: 1, blocksMovement: true, blocksLineOfSight: true,
+			}, Position{X: float64(col), Y: float64(y)}))
+		}
+	}
+
+	// Ghost should not block line of sight: its cell is the gap in the wall.
+	wallColumn(5, 5)
+	blocked := loadedRoom.IsLineOfSightBlocked(Position{X: 0, Y: 5}, Position{X: 9, Y: 5})
 	s.False(blocked, "Ghost should not block line of sight")
 
-	// Dragon should block line of sight
-	blocked = loadedRoom.IsLineOfSightBlocked(Position{X: 0, Y: 10}, Position{X: 20, Y: 10})
+	// Dragon should block line of sight: same wall, same gap, opaque occupant.
+	wallColumn(10, 10)
+	blocked = loadedRoom.IsLineOfSightBlocked(Position{X: 0, Y: 10}, Position{X: 19, Y: 10})
 	s.True(blocked, "Dragon should block line of sight")
 }
 

--- a/tools/spatial/los_law_test.go
+++ b/tools/spatial/los_law_test.go
@@ -1,0 +1,379 @@
+package spatial_test
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// LineOfSightLawSuite holds the two properties sight must satisfy in every grid
+// family, over rooms nobody wrote by hand.
+//
+// They are laws rather than cases because rpg-toolkit#1022 was a defect no case
+// would have caught: sight disagreed with itself by direction on squares, and
+// hid roughly one in seven things a player should have seen on hexes. Both had
+// been shipped for a long time under a suite of green hand-written examples.
+//
+// FIXTURE RULE FOR ANYONE ADDING TO THIS FILE — walls in hex tests are built
+// and classified IN THE PLANE, never by offset column. A hex offset column is a
+// DIAGONAL once embedded, so "cells with X == 4" is not a wall and "cells with
+// X < 4" is not a side of one. The first version of the leak law below did
+// exactly that and produced a confident, meaningless number: it reported the
+// rule leaking through a wall that had holes in it by construction. If a test
+// here needs a barrier, it gets one from plane geometry.
+type LineOfSightLawSuite struct {
+	suite.Suite
+}
+
+func TestLineOfSightLawSuite(t *testing.T) {
+	suite.Run(t, new(LineOfSightLawSuite))
+}
+
+const (
+	lawRoomType   = "law"
+	lawGridSquare = "square"
+)
+
+// opaque is a wall for the purposes of these laws.
+type opaque struct{ id string }
+
+func (o *opaque) GetID() string            { return o.id }
+func (o *opaque) GetType() core.EntityType { return "wall" }
+func (o *opaque) GetSize() int             { return 1 }
+func (o *opaque) BlocksMovement() bool     { return true }
+func (o *opaque) BlocksLineOfSight() bool  { return true }
+
+// lawGrid is one grid family plus the plane embedding its cells live in, which
+// is what lets a test say "this wall is solid" in a way that means the same
+// thing on squares and hexes.
+type lawGrid struct {
+	name   string
+	grid   spatial.Grid
+	cells  []spatial.Position
+	centre func(spatial.Position) (float64, float64)
+	// half is the cell's inradius in that embedding: a wall of cells whose
+	// centres lie within half of a line leaves no gap for sight to pass.
+	half float64
+	// tiles reports whether this family's cells tile the plane. Gridless is
+	// the one that does not — see TestASolidWallLeaksNothing.
+	tiles bool
+}
+
+// hexPixel embeds a cube coordinate in the plane, pointy-top, circumradius 1.
+func hexPixel(c spatial.CubeCoordinate) (float64, float64) {
+	q, r := float64(c.X), float64(c.Z)
+	return math.Sqrt(3) * (q + r/2), 1.5 * r
+}
+
+func lawGrids() []lawGrid {
+	const w, h = 8, 8
+	rect := func() []spatial.Position {
+		out := make([]spatial.Position, 0, w*h)
+		for x := 0; x < w; x++ {
+			for y := 0; y < h; y++ {
+				out = append(out, spatial.Position{X: float64(x), Y: float64(y)})
+			}
+		}
+		return out
+	}
+
+	grids := []lawGrid{{
+		name:   lawGridSquare,
+		grid:   spatial.NewSquareGrid(spatial.SquareGridConfig{Width: w, Height: h}),
+		cells:  rect(),
+		centre: func(p spatial.Position) (float64, float64) { return p.X, p.Y },
+		half:   0.5,
+		tiles:  true,
+	}}
+
+	for _, o := range []struct {
+		label string
+		or    spatial.HexOrientation
+	}{
+		{"hex-pointy", spatial.HexOrientationPointyTop},
+		{"hex-flat", spatial.HexOrientationFlatTop},
+	} {
+		orientation := o.or
+		grids = append(grids, lawGrid{
+			name:  o.label,
+			grid:  spatial.NewHexGrid(spatial.HexGridConfig{Width: w, Height: h, Orientation: orientation}),
+			cells: rect(),
+			centre: func(p spatial.Position) (float64, float64) {
+				return hexPixel(spatial.OffsetCoordinateToCubeWithOrientation(p, orientation))
+			},
+			half:  math.Sqrt(3) / 2,
+			tiles: true,
+		})
+	}
+
+	const span = 4
+	axial := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: span, SpanHeight: span})
+	axialCells := []spatial.Position{}
+	for q := -span; q <= span; q++ {
+		for r := -span; r <= span; r++ {
+			p := spatial.Position{X: float64(q), Y: float64(r)}
+			if axial.IsValidPosition(p) {
+				axialCells = append(axialCells, p)
+			}
+		}
+	}
+	grids = append(grids, lawGrid{
+		name:  "axial-hex",
+		grid:  axial,
+		cells: axialCells,
+		centre: func(p spatial.Position) (float64, float64) {
+			return hexPixel(spatial.CubeCoordinate{X: int(p.X), Y: int(-p.X - p.Y), Z: int(p.Y)})
+		},
+		half:  math.Sqrt(3) / 2,
+		tiles: true,
+	})
+
+	grids = append(grids, lawGrid{
+		name: "gridless",
+		grid: spatial.NewGridlessRoom(spatial.GridlessConfig{Width: w, Height: h}),
+		cells: func() []spatial.Position {
+			out := []spatial.Position{}
+			for x := 0; x < w; x++ {
+				for y := 0; y < h; y++ {
+					out = append(out, spatial.Position{X: float64(x), Y: float64(y)})
+				}
+			}
+			return out
+		}(),
+		centre: func(p spatial.Position) (float64, float64) { return p.X, p.Y },
+		half:   0.5,
+		tiles:  false,
+	})
+
+	return grids
+}
+
+// TestSightIsSymmetric is the law rpg-toolkit#1022 is named for: what two cells
+// can see of each other cannot depend on which one asked.
+//
+// Fuzzed rather than enumerated. The defect this replaces was a rasterizer tie
+// broken one way going out and the other coming back, which no hand-written
+// case had happened to straddle — before this law, squares disagreed with
+// themselves on 4.97% of pairs in a cluttered room, and the suite was green.
+func (s *LineOfSightLawSuite) TestSightIsSymmetric() {
+	//nolint:gosec // G404: seeded for reproducible fuzz rooms, not cryptographic
+	rng := rand.New(rand.NewSource(1022))
+
+	for _, g := range lawGrids() {
+		s.Run(g.name, func() {
+			for run := 0; run < 12; run++ {
+				room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+					ID: lawRoomType, Type: lawRoomType, Grid: g.grid,
+				})
+				for i := 0; i < 8; i++ {
+					cell := g.cells[rng.Intn(len(g.cells))]
+					_ = room.PlaceEntity(&opaque{id: fmt.Sprintf("w%d-%d", run, i)}, cell)
+				}
+				for i := 0; i < len(g.cells); i++ {
+					for j := i + 1; j < len(g.cells); j++ {
+						a, b := g.cells[i], g.cells[j]
+						s.Require().Equal(
+							room.IsLineOfSightBlocked(a, b),
+							room.IsLineOfSightBlocked(b, a),
+							"run %d: sight between %v and %v depends on who asked", run, a, b)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestASolidWallLeaksNothing is the law that keeps the other one honest.
+//
+// Sight became more permissive with rpg-toolkit#1022 — that was the point, the
+// old rule hid about one in seven things a player should have seen. Permissive
+// has a floor: a barrier with no gap in it must stop everything, or "you can
+// lean around a corner" quietly becomes "you can see through walls". Every
+// future loosening has to clear this.
+//
+// The wall is built in the plane (see the fixture rule on the suite), so it is
+// genuinely solid in every family rather than solid-looking in one coordinate
+// system and full of holes in another.
+//
+// GRIDLESS IS EXEMPT, and not as a convenience. Its positions are points in
+// continuous space with no cell around them, so entities placed on a lattice
+// leave the space between them empty and no arrangement of them is a barrier
+// at all. That is a fact about the model, not about the sight rule — and it is
+// the same fact that keeps gridless on the single-lane rule in
+// IsLineOfSightBlocked. Gridless still owes the symmetry law above.
+func (s *LineOfSightLawSuite) TestASolidWallLeaksNothing() {
+	for _, g := range lawGrids() {
+		if !g.tiles {
+			continue
+		}
+		s.Run(g.name, func() {
+			room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+				ID: "wall", Type: lawRoomType, Grid: g.grid,
+			})
+
+			minX, maxX := math.Inf(1), math.Inf(-1)
+			for _, c := range g.cells {
+				x, _ := g.centre(c)
+				minX, maxX = math.Min(minX, x), math.Max(maxX, x)
+			}
+			wallX := (minX + maxX) / 2
+
+			side := map[spatial.Position]int{}
+			walls := 0
+			for _, c := range g.cells {
+				x, _ := g.centre(c)
+				if math.Abs(x-wallX) <= g.half {
+					s.Require().NoError(room.PlaceEntity(&opaque{id: fmt.Sprintf("wall%d", walls)}, c))
+					walls++
+					continue
+				}
+				if x < wallX {
+					side[c] = -1
+				} else {
+					side[c] = 1
+				}
+			}
+			s.Require().Positive(walls, "the fixture must actually build a wall")
+
+			crossings := 0
+			for i := 0; i < len(g.cells); i++ {
+				for j := i + 1; j < len(g.cells); j++ {
+					a, b := g.cells[i], g.cells[j]
+					if side[a] == 0 || side[b] == 0 || side[a] == side[b] {
+						continue
+					}
+					crossings++
+					s.Require().True(room.IsLineOfSightBlocked(a, b),
+						"%v sees %v through a solid wall", a, b)
+				}
+			}
+			s.Require().Positive(crossings, "the fixture must actually pose the question")
+		})
+	}
+}
+
+// TestLeaningIsNotWandering pins the guard that keeps an alternative lane
+// honest: a neighbour must be strictly CLOSER to the other end, not merely no
+// further from it.
+//
+// One blocker, diagonally between two cells two steps apart. The only cells
+// that would restore sight are the ones beside the viewer — a full cell
+// sideways, no closer to the target than where they already stand. Letting
+// those count turns leaning around an obstacle into wandering to a different
+// vantage, and it is measurably worse: with the looser guard, hexes let
+// through 88 pairs the game's corner rule denies instead of 3, and squares 226
+// instead of 158.
+//
+// Being honest about the cost, since this test is where someone will come
+// looking: the corner rule would allow THIS pair. Strict is deliberately the
+// more conservative of the two grid-native options — it gives up a little on
+// cases like this one to give up much less on seeing through things elsewhere.
+// If that trade is ever revisited, revisit it here, with numbers.
+func (s *LineOfSightLawSuite) TestLeaningIsNotWandering() {
+	for _, tc := range []struct {
+		name    string
+		grid    spatial.Grid
+		blocker spatial.Position
+		from    spatial.Position
+		// sideways is reached only by giving ground, so it stays blocked.
+		sideways spatial.Position
+		// forward is reached by a neighbour that closes the distance.
+		forward spatial.Position
+	}{
+		{
+			name:     lawGridSquare,
+			grid:     spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 6, Height: 6}),
+			blocker:  spatial.Position{X: 1, Y: 1},
+			from:     spatial.Position{X: 0, Y: 0},
+			sideways: spatial.Position{X: 2, Y: 2},
+			forward:  spatial.Position{X: 0, Y: 2},
+		},
+		{
+			name: "hex-pointy",
+			grid: spatial.NewHexGrid(spatial.HexGridConfig{
+				Width: 6, Height: 6, Orientation: spatial.HexOrientationPointyTop,
+			}),
+			blocker:  spatial.Position{X: 0, Y: 1},
+			from:     spatial.Position{X: 0, Y: 0},
+			sideways: spatial.Position{X: 0, Y: 2},
+			forward:  spatial.Position{X: 1, Y: 2},
+		},
+	} {
+		s.Run(tc.name, func() {
+			room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+				ID: "lean", Type: lawRoomType, Grid: tc.grid,
+			})
+			s.Require().NoError(room.PlaceEntity(&opaque{id: "pillar"}, tc.blocker))
+
+			s.True(room.IsLineOfSightBlocked(tc.from, tc.sideways),
+				"a sideways step is not a lane: it gives no ground toward the target")
+			s.True(room.IsLineOfSightBlocked(tc.sideways, tc.from), "and the answer is symmetric")
+
+			// The guard is about DIRECTION, not about refusing alternatives. The
+			// same blocker, a target reached by a neighbour that genuinely closes
+			// the distance: sight comes back. Without this half the test above
+			// would also pass on an implementation that blocked everything.
+			s.False(room.IsLineOfSightBlocked(tc.from, tc.forward),
+				"a neighbour that closes the distance is a real lane")
+			s.False(room.IsLineOfSightBlocked(tc.forward, tc.from))
+		})
+	}
+}
+
+// TestMovementDoesNotConsultSight pins the separation rpg-toolkit#1022 was
+// careful not to cross.
+//
+// Sight and movement share a rasterizer — GetLineOfSight — and the sight rule
+// changed while the rasterizer did not. That is deliberate and it is the whole
+// reason movement was safe to leave alone: MoveEntity and the movement query
+// walk the ray themselves and consult movement boundaries, never
+// IsLineOfSightBlocked. Whether a charge lane or a reach check WANTS the
+// permissive rule is a separate question per call site, and answering it
+// silently for all of them would have been a gameplay change nobody asked for.
+//
+// This is a structural pin, not a behavioural one: it fails the day something
+// routes movement through sight.
+func (s *LineOfSightLawSuite) TestMovementDoesNotConsultSight() {
+	grid := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 8, Height: 8})
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID: "movement", Type: lawRoomType, Grid: grid,
+	})
+
+	// A curtain wall: opaque along its whole length, and no obstacle at all to
+	// anything walking. Solid enough that even the permissive rule stops.
+	for y := 0; y < 8; y++ {
+		s.Require().NoError(room.PlaceEntity(
+			&sightOnly{id: fmt.Sprintf("curtain%d", y)}, spatial.Position{X: 4, Y: float64(y)}))
+	}
+
+	mover := &sightOnly{id: "mover", transparent: true}
+	s.Require().NoError(room.PlaceEntity(mover, spatial.Position{X: 3, Y: 4}))
+
+	s.True(room.IsLineOfSightBlocked(spatial.Position{X: 3, Y: 4}, spatial.Position{X: 5, Y: 4}),
+		"the curtain is solid, so sight stops at it")
+
+	// And movement walks straight through it, because movement never asked.
+	s.Require().NoError(room.MoveEntity(mover.GetID(), spatial.Position{X: 4, Y: 4}),
+		"an opaque entity that does not block movement must not stop a mover")
+	s.Require().NoError(room.MoveEntity(mover.GetID(), spatial.Position{X: 5, Y: 4}),
+		"including straight out the other side")
+}
+
+// sightOnly blocks line of sight and never movement, which is the combination
+// that tells the two systems apart.
+type sightOnly struct {
+	id          string
+	transparent bool
+}
+
+func (o *sightOnly) GetID() string            { return o.id }
+func (o *sightOnly) GetType() core.EntityType { return "curtain" }
+func (o *sightOnly) GetSize() int             { return 1 }
+func (o *sightOnly) BlocksMovement() bool     { return false }
+func (o *sightOnly) BlocksLineOfSight() bool  { return !o.transparent }

--- a/tools/spatial/los_law_test.go
+++ b/tools/spatial/los_law_test.go
@@ -38,6 +38,11 @@ func TestLineOfSightLawSuite(t *testing.T) {
 const (
 	lawRoomType   = "law"
 	lawGridSquare = "square"
+
+	// blockersPerRoom is how cluttered a fuzzed room gets. Eight in an 8x8 is
+	// enough to produce the corner-clipping cases the old rule disagreed with
+	// itself about — it measured 4.97% asymmetric at this density.
+	blockersPerRoom = 8
 )
 
 // opaque is a wall for the purposes of these laws.
@@ -171,10 +176,22 @@ func (s *LineOfSightLawSuite) TestSightIsSymmetric() {
 				room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
 					ID: lawRoomType, Type: lawRoomType, Grid: g.grid,
 				})
-				for i := 0; i < 8; i++ {
+				// Distinct cells, and every placement is REQUIRED to land.
+				// Drawing at random and discarding the error looked like eight
+				// blockers and was sometimes fewer: opaque blocks movement, so
+				// a repeat draw collides and is refused. A fuzz whose strength
+				// is unknown is a fuzz that quietly weakens.
+				chosen := make(map[spatial.Position]bool, blockersPerRoom)
+				for len(chosen) < blockersPerRoom {
 					cell := g.cells[rng.Intn(len(g.cells))]
-					_ = room.PlaceEntity(&opaque{id: fmt.Sprintf("w%d-%d", run, i)}, cell)
+					if chosen[cell] {
+						continue
+					}
+					chosen[cell] = true
+					s.Require().NoError(room.PlaceEntity(
+						&opaque{id: fmt.Sprintf("w%d-%d", run, len(chosen))}, cell))
 				}
+				s.Require().Len(chosen, blockersPerRoom, "the room must be as cluttered as claimed")
 				for i := 0; i < len(g.cells); i++ {
 					for j := i + 1; j < len(g.cells); j++ {
 						a, b := g.cells[i], g.cells[j]

--- a/tools/spatial/room.go
+++ b/tools/spatial/room.go
@@ -343,24 +343,6 @@ func (r *BasicRoom) isBoundaryLineOfSightBlockedUnsafe(from, to Position) bool {
 	return exists && boundary.BlocksLineOfSight
 }
 
-// isDirectLineOfSightBoundaryBlockedUnsafe checks boundary crossings on a
-// canonical grid ray. Square Bresenham can choose different cells by direction,
-// so canonical endpoint ordering makes boundary LoS reciprocal. Entity blockers
-// intentionally continue to use the caller's requested ray.
-func (r *BasicRoom) isDirectLineOfSightBoundaryBlockedUnsafe(from, to Position) bool {
-	if len(r.boundaries) == 0 {
-		return false
-	}
-
-	path := CanonicalBoundaryRay(r.grid, from, to)
-	for i := 1; i < len(path); i++ {
-		if r.isBoundaryLineOfSightBlockedUnsafe(path[i-1], path[i]) {
-			return true
-		}
-	}
-	return false
-}
-
 // GetEntitiesAt returns all entities at a specific position
 func (r *BasicRoom) GetEntitiesAt(pos Position) []core.Entity {
 	r.mutex.RLock()
@@ -515,35 +497,169 @@ func (r *BasicRoom) GetLineOfSight(from, to Position) []Position {
 	return r.grid.GetLineOfSight(from, to)
 }
 
-// IsLineOfSightBlocked checks if line of sight is blocked by entities
+// IsLineOfSightBlocked reports whether sight between two cells is blocked.
+//
+// SIGHT IS NOT ONE LINE. A single centre-to-centre ray was the rule here until
+// rpg-toolkit#1022, and it was wrong in two ways that turned out to be one:
+// squares disagreed with themselves by direction (Bresenham steps X first one
+// way and Y first the other, so A→B and B→A are different cells), and every
+// grid family blocked far more than the game's own rule allows. Measured
+// against 5e's stated test — you can see a target if a line from ANY corner of
+// your space to ANY corner of theirs is unobstructed — the old rule blocked
+// 3.6x too many pairs on squares and 4.5x too many on hexes, and hid about one
+// in seven things a player should have been able to see. It never blocked too
+// little; it was uniformly stricter than the game.
+//
+// So sight asks for a LANE rather than a line: blocked only when the direct
+// lane is obstructed AND so is every lane from a neighbouring cell that does
+// not give ground. Corner-clipping stops costing you the whole sightline,
+// which is what a player at the table already assumes.
+//
+// This reaches the corner rule exactly on squares and within 0.01% of it on
+// hexes. The remaining gap is the price of staying grid-native: the corner rule
+// itself needs cell-polygon geometry and a plane embedding, which this module
+// does not have — see [BasicRoom.lineOfSightLaneBlockedUnsafe] for why that is
+// the endpoint rather than the answer today.
+//
+// SYMMETRY IS STRUCTURAL, not incidental: every lane is rasterized on the
+// canonical ray, and the neighbour lanes are explored from both ends, so the
+// rule has no direction left to disagree about. It is pinned as a law over
+// fuzzed rooms in every grid family.
+//
+// The common case costs exactly what it used to. A pair whose direct lane is
+// clear returns on that first test, and most pairs are clear — the extra work
+// lands only where the answer used to be wrong. That matters because callers
+// run this O(range²) per viewer.
 func (r *BasicRoom) IsLineOfSightBlocked(from, to Position) bool {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	losPositions := r.grid.GetLineOfSight(from, to)
-
-	if r.isDirectLineOfSightBoundaryBlockedUnsafe(from, to) {
+	// A BOUNDARY IS AN EDGE AND STAYS A HARD BLOCK. Neighbour lanes model
+	// leaning around something that has extent — an occluding cell is a pillar
+	// or a wall block, and a viewer really can look past its corner. A boundary
+	// is a wall drawn ON the edge between two cells, with no extent in this
+	// model and no stated length, so "around it" is not a thing the data
+	// describes. Softening it would rewrite a primitive nobody reported, and
+	// rpg-toolkit#1022 is about occluders: the wall cells a player watches
+	// swallow their sightline.
+	if r.boundaryBlocksSightUnsafe(from, to) {
 		return true
 	}
 
-	// Check each position along the caller's requested line of sight (except
-	// start and end). Keeping this ray preserves established entity-blocker
-	// semantics even when the canonical boundary ray differs on square grids.
-	for i := 1; i < len(losPositions)-1; i++ {
-		pos := losPositions[i]
-		if entityIDs, exists := r.occupancy[pos]; exists {
-			for _, entityID := range entityIDs {
-				if entity, exists := r.entities[entityID]; exists {
-					if placeable, ok := entity.(Placeable); ok {
-						if placeable.BlocksLineOfSight() {
-							return true
-						}
-					}
-				}
-			}
+	if !r.lineOfSightLaneBlockedUnsafe(from, to) {
+		return false
+	}
+
+	// GRIDLESS KEEPS THE SINGLE LANE, for the same reason boundaries do.
+	// Neighbour lanes model a CELL'S EXTENT — a square or a hex tiles the
+	// plane, so a viewer really can look past its corner. A gridless position
+	// is a point in continuous space with no cell around it and no neighbours
+	// of its own; what GetNeighbors offers there is eight samples on a unit
+	// circle, an arbitrary distance that means one thing in a ten-foot room
+	// and nothing at all in a mile-wide one. Leaning by an arbitrary amount is
+	// not the rule this fixes.
+	if r.grid.GetShape() == GridShapeGridless {
+		return true
+	}
+
+	// The direct lane is obstructed. Sight survives if any neighbour of either
+	// end has a clear lane — that is the corner a player would lean around.
+	//
+	// A neighbour must MAKE PROGRESS: strictly closer to the other end than the
+	// cell itself. Merely "no further" was tried and measured worse on every
+	// grid family — it turns leaning into wandering, letting sight recover from
+	// a vantage a full cell sideways, and on squares it doubled the pairs seen
+	// that the game's corner rule denies. Progress keeps the alternative on the
+	// way to the target rather than beside it.
+	distance := r.grid.Distance(from, to)
+	for _, alt := range r.grid.GetNeighbors(from) {
+		if r.blocksLineOfSightUnsafe(alt) || r.grid.Distance(alt, to) >= distance {
+			continue
+		}
+		if !r.lineOfSightLaneBlockedUnsafe(alt, to) {
+			return false
+		}
+	}
+	for _, alt := range r.grid.GetNeighbors(to) {
+		if r.blocksLineOfSightUnsafe(alt) || r.grid.Distance(from, alt) >= distance {
+			continue
+		}
+		if !r.lineOfSightLaneBlockedUnsafe(from, alt) {
+			return false
 		}
 	}
 
+	return true
+}
+
+// boundaryBlocksSightUnsafe reports whether the canonical ray between two cells
+// crosses a sight-blocking boundary.
+//
+// Split out from the lane test because the two are not the same kind of
+// obstacle: this one is absolute, and the lane test is what neighbour lanes are
+// allowed to route around. Both rasterize the same canonical ray, so a boundary
+// answer never depends on which end asked — that was already true before
+// rpg-toolkit#1022 and is unchanged by it.
+func (r *BasicRoom) boundaryBlocksSightUnsafe(from, to Position) bool {
+	if len(r.boundaries) == 0 {
+		return false
+	}
+	path := CanonicalBoundaryRay(r.grid, from, to)
+	for i := 1; i < len(path); i++ {
+		if r.isBoundaryLineOfSightBlockedUnsafe(path[i-1], path[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// lineOfSightLaneBlockedUnsafe reports whether ONE lane between two cells is
+// obstructed, by a boundary it crosses or by something standing in it.
+//
+// It rasterizes the canonical ray for BOTH checks. Until rpg-toolkit#1022 a
+// single call consulted two different rays — [CanonicalBoundaryRay] for
+// boundaries, the caller's own ray for entities — and the second of those was
+// the direction-dependence this issue is named for. One lane, one ray.
+//
+// The endpoints are never opaque: you are not blocked by the cell you stand in
+// or the one you are looking at.
+//
+// THE ENDPOINT THIS APPROXIMATES is 5e's corner rule, evaluated as real
+// geometry: cell polygons in a plane, and a lane for every corner pair. That
+// is exact where this is within 0.01%, and it is what belongs here the day
+// this module grows a plane embedding — it has none today, and measured 5x the
+// cost per query on hexes, on a path callers already run O(range²) per viewer.
+// Recorded so the comparison does not have to be re-derived: rpg-toolkit#1022.
+func (r *BasicRoom) lineOfSightLaneBlockedUnsafe(from, to Position) bool {
+	if r.boundaryBlocksSightUnsafe(from, to) {
+		return true
+	}
+
+	path := CanonicalBoundaryRay(r.grid, from, to)
+	for i := 1; i < len(path)-1; i++ {
+		if r.blocksLineOfSightUnsafe(path[i]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// blocksLineOfSightUnsafe reports whether anything standing in a cell is opaque.
+func (r *BasicRoom) blocksLineOfSightUnsafe(pos Position) bool {
+	entityIDs, exists := r.occupancy[pos]
+	if !exists {
+		return false
+	}
+	for _, entityID := range entityIDs {
+		entity, exists := r.entities[entityID]
+		if !exists {
+			continue
+		}
+		if placeable, ok := entity.(Placeable); ok && placeable.BlocksLineOfSight() {
+			return true
+		}
+	}
 	return false
 }
 

--- a/tools/spatial/room.go
+++ b/tools/spatial/room.go
@@ -534,6 +534,9 @@ func (r *BasicRoom) IsLineOfSightBlocked(from, to Position) bool {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
+	// ONE RASTERIZATION FOR THE DIRECT LANE, reused by both checks below.
+	direct := CanonicalBoundaryRay(r.grid, from, to)
+
 	// A BOUNDARY IS AN EDGE AND STAYS A HARD BLOCK. Neighbour lanes model
 	// leaning around something that has extent — an occluding cell is a pillar
 	// or a wall block, and a viewer really can look past its corner. A boundary
@@ -542,11 +545,11 @@ func (r *BasicRoom) IsLineOfSightBlocked(from, to Position) bool {
 	// describes. Softening it would rewrite a primitive nobody reported, and
 	// rpg-toolkit#1022 is about occluders: the wall cells a player watches
 	// swallow their sightline.
-	if r.boundaryBlocksSightUnsafe(from, to) {
+	if r.boundaryBlocksAlongUnsafe(direct) {
 		return true
 	}
 
-	if !r.lineOfSightLaneBlockedUnsafe(from, to) {
+	if !r.entityBlocksAlongUnsafe(direct) {
 		return false
 	}
 
@@ -592,34 +595,16 @@ func (r *BasicRoom) IsLineOfSightBlocked(from, to Position) bool {
 	return true
 }
 
-// boundaryBlocksSightUnsafe reports whether the canonical ray between two cells
-// crosses a sight-blocking boundary.
-//
-// Split out from the lane test because the two are not the same kind of
-// obstacle: this one is absolute, and the lane test is what neighbour lanes are
-// allowed to route around. Both rasterize the same canonical ray, so a boundary
-// answer never depends on which end asked — that was already true before
-// rpg-toolkit#1022 and is unchanged by it.
-func (r *BasicRoom) boundaryBlocksSightUnsafe(from, to Position) bool {
-	if len(r.boundaries) == 0 {
-		return false
-	}
-	path := CanonicalBoundaryRay(r.grid, from, to)
-	for i := 1; i < len(path); i++ {
-		if r.isBoundaryLineOfSightBlockedUnsafe(path[i-1], path[i]) {
-			return true
-		}
-	}
-	return false
-}
-
 // lineOfSightLaneBlockedUnsafe reports whether ONE lane between two cells is
 // obstructed, by a boundary it crosses or by something standing in it.
 //
-// It rasterizes the canonical ray for BOTH checks. Until rpg-toolkit#1022 a
-// single call consulted two different rays — [CanonicalBoundaryRay] for
-// boundaries, the caller's own ray for entities — and the second of those was
-// the direction-dependence this issue is named for. One lane, one ray.
+// It rasterizes the canonical ray ONCE and runs both checks over it. Until
+// rpg-toolkit#1022 a single call consulted two different rays —
+// [CanonicalBoundaryRay] for boundaries, the caller's own ray for entities —
+// and the second of those was the direction-dependence this issue is named
+// for. One lane, one ray, and one rasterization of it: alternative lanes are
+// only built when the direct one is already blocked, which is the case the
+// cost lands on.
 //
 // The endpoints are never opaque: you are not blocked by the cell you stand in
 // or the one you are looking at.
@@ -631,17 +616,36 @@ func (r *BasicRoom) boundaryBlocksSightUnsafe(from, to Position) bool {
 // cost per query on hexes, on a path callers already run O(range²) per viewer.
 // Recorded so the comparison does not have to be re-derived: rpg-toolkit#1022.
 func (r *BasicRoom) lineOfSightLaneBlockedUnsafe(from, to Position) bool {
-	if r.boundaryBlocksSightUnsafe(from, to) {
-		return true
-	}
-
 	path := CanonicalBoundaryRay(r.grid, from, to)
+	return r.boundaryBlocksAlongUnsafe(path) || r.entityBlocksAlongUnsafe(path)
+}
+
+// boundaryBlocksAlongUnsafe reports whether a rasterized ray crosses a
+// sight-blocking boundary.
+//
+// Split from the entity check because the two are not the same kind of
+// obstacle: this one is absolute, and the entity one is what neighbour lanes
+// are allowed to route around.
+func (r *BasicRoom) boundaryBlocksAlongUnsafe(path []Position) bool {
+	if len(r.boundaries) == 0 {
+		return false
+	}
+	for i := 1; i < len(path); i++ {
+		if r.isBoundaryLineOfSightBlockedUnsafe(path[i-1], path[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// entityBlocksAlongUnsafe reports whether anything opaque stands in a
+// rasterized ray, endpoints excluded.
+func (r *BasicRoom) entityBlocksAlongUnsafe(path []Position) bool {
 	for i := 1; i < len(path)-1; i++ {
 		if r.blocksLineOfSightUnsafe(path[i]) {
 			return true
 		}
 	}
-
 	return false
 }
 


### PR DESCRIPTION
Closes #1022. Option D from the [stage-1 census](https://github.com/KirkDiggler/rpg-toolkit/issues/1022#issuecomment-5303904558), signed off after the numbers came in.

## Sight was one line, and everything on it was opaque

Two defects fell out of that single decision, and they turned out to be one:

- **Squares disagreed with themselves by direction.** Bresenham steps X first going one way and Y first coming back, so A→B and B→A are different cells. **4.97%** of pairs in a cluttered 8×8 room.
- **Every family blocked far more than the game's own rule allows.** Against 5e's stated test — visible if a line from ANY corner of your space to ANY corner of theirs is unobstructed — the old rule blocked **3.6× too many** pairs on squares and **4.5× too many** on hexes, and in a wall-with-a-gap scene hid **7.6%** (square) to **15.4%** (hex-flat) of what a player should have been able to see. That is the half Kirk noticed at the table.

Sight now asks for a **lane**: blocked only when the direct lane is obstructed AND so is every lane from a neighbouring cell strictly closer to the other end. Corner-clipping stops costing the whole sightline.

| | before | after |
|---|---|---|
| symmetry, square | 4.97% asymmetric | **0.000%** |
| symmetry, hex / axial | 0.000% | 0.000% |
| over-block vs corner rule, square | 3.20% | **0.00%** |
| over-block vs corner rule, hex | 4.14% | **0.27%** |
| wall-with-gap, square hidden | 7.6% | **0.0%** |
| wall-with-gap, hex-pointy hidden | 13.8% | **2.1%** |
| wall-with-gap, hex-flat hidden | 15.4% | **2.0%** |
| wall-with-gap, axial hidden | 14.8% | **1.9%** |

Symmetry is now **structural rather than incidental**: every lane rasterizes the canonical ray, and alternatives are explored from both ends, so the rule has no direction left to disagree about. One call no longer consults two different rays — the boundary-vs-entity split that produced the asymmetry is gone.

## The trade, stated

The new rule is more permissive, and permissiveness has a cost the census under-reported. Scored against the corner rule with a lone obstacle, it now **under**-blocks 0.92% of pairs on squares and 0.01% on hexes — cases where the corner rule says a lone pillar exactly between two cells blocks, and the lane rule lets you past it.

Two guards keep that honest:

- **Strict progress.** An alternative neighbour must be strictly *closer* to the other end. "No further" was tried and measured worse everywhere: it turns leaning into wandering, and on hexes it let through 88 pairs the corner rule denies instead of 3 (squares: 226 instead of 158). Pinned by `TestLeaningIsNotWandering`, which also states the cost — the corner rule would allow the pair that test requires blocked. Revisit it there, with numbers.
- **The leak law.** A wall solid in the plane leaks nothing, in every family. That is the floor every future loosening has to clear.

## Deliberately kept out

A neighbour lane models a **cell's extent**. Two things have none:

- **Boundaries.** A boundary is a wall drawn *on* an edge, with no extent and no stated length, so "around it" is not something the data describes. Hard block, unchanged — and this is why the rest of the boundary suite still passes untouched.
- **Gridless.** A gridless position is a point in continuous space with no cell around it. What `GetNeighbors` offers there is eight samples on a unit circle: an arbitrary distance that means one thing in a ten-foot room and nothing in a mile-wide one. Single lane, unchanged. The same fact exempts gridless from the leak law — entities on a lattice leave the space between them empty, so no arrangement of them is a barrier at all.

## Movement is untouched, by construction

`GetLineOfSight` is byte-identical. Every movement path — `MoveEntity`, `handleMovement`, and `encounter`'s own `space.go` validator — walks that rasterizer and consults movement boundaries, never `IsLineOfSightBlocked`. So the census's widest risk, *movement legality rides the same rasterizer*, is closed by not touching the rasterizer at all.

Whether a charge lane or a reach check **wants** the permissive rule is a separate question per call site, and answering it silently for all of them would have been a gameplay change nobody asked for. `TestMovementDoesNotConsultSight` is a structural pin: it fails the day something routes movement through sight.

## The pin that had to be overturned

`TestCanonicalBoundaryRayDoesNotWeakenEntityBlockers` asserted that (2,1)→(0,0) is blocked by a lone entity at (1,1) **because the reverse ray visits (1,1) and the canonical ray does not**. Read plainly, the guarantee it protected was that entity sight depends on which end asked — not a feature preserved, but this issue's defect written down as a promise. It is replaced by `TestEntityBlockersUseTheCanonicalRayAndCanBeSeenAround`, which states why, and which still requires the blocker to matter once its lanes are walled.

`TestSpatialPropertiesPreserved` also changed: it proved a `BlocksLineOfSight` flag round-tripped by watching a lone dragon block a corridor, and a lone body in the open stops nothing now. It walls the column except for the creature's own cell, so the answer still turns on that creature and nothing else — verified by mutation (make the dragon transparent and the test fails).

## Performance, bought and named

Per query, 8×8 rooms, full pair sweep:

| scene | before | after | |
|---|---|---|---|
| square, open room | 160.7 ns | 169.1 ns | +5% |
| hex, open room | 158.6 ns | 160.8 ns | +1% |
| square, walled | 217.3 ns | 674.6 ns | **×3.1** |
| hex, walled | 224.2 ns | 687.1 ns | **×3.1** |

**This is worse than stage 1 estimated** (it projected 1.25–1.6×), and the reason is worth writing down: stage 1 measured with a single blocker, where almost every pair is clear and returns on the first lane. A walled room is the opposite — the extra work lands exactly on the pairs whose answer used to be wrong, and a dungeon is walls.

The open-room case is what most queries are, and it is +1–5%. For the hot path, `encounter/perception/los_stub.go` runs this O(range²) per viewer: at range 10 on hexes that is ~331 queries per viewer per refresh, so ~0.22 ms per viewer at the walled rate. Acceptable, and now on the record rather than discovered later.

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok** |
| `golangci-lint run ./...` | 35 issues, **all pre-existing** (baseline measured on a stashed tree; this branch adds none) |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

**Mutation table** — every mutant applied under an assert-it-applied guard, after one silently no-op'd and another failed to compile (a compile error is not a kill):

| mutant | killed by |
|---|---|
| revert to the single caller's ray | `TestSightIsSymmetric/square`, `TestEntityBlockersUseTheCanonicalRay…` |
| loosen the progress guard to "no further" | `TestLeaningIsNotWandering`, both families |
| let boundaries be seen around | 4 tests in the boundary suite |
| let gridless adopt neighbour lanes | `TestGridlessRoomsWithoutBoundariesKeepLegacyRayUse…` |
| allow lanes originating inside a wall | `TestASolidWallLeaksNothing`, every family |

## For consumers

No `replace` directives anywhere, so this reaches consumers one bump at a time. `encounter` is the heaviest (`perception/los_stub.go`, `floor_mask.go`, `range_gate.go`, `space.go`) and holds ~20 exact-coordinate assertions that need a pass at its bump; three of its fixture helpers derive coordinates from the rasterization and will neither break nor catch a regression. The `rulebooks/dnd5e/encounter` bump flips `TestTheOgreCanSeeWhatAliceCannot` in `session` to assert symmetry and corrects `classify()`'s doc to cite this issue.

## The review round (1870ea4)

Copilot found two, both real, both about not checking a result.

**The lane rasterized twice.** The lane test built the canonical ray, then the boundary check built it again — two builds of the same ray per lane plus a second boundary traversal, in rooms that have boundaries. The ray is now built once and both checks run over it, and the top-level rule reuses the direct lane's ray rather than rebuilding it. The benchmark above barely moves because it registers no boundaries and the boundary check returns before rasterizing when there are none; the saving is in boundary rooms, which is where the duplicate work was. Said plainly rather than quoting an improvement this change did not produce.

**The symmetry fuzz was quietly thinner than it claimed.** It drew blockers at random and discarded `PlaceEntity`'s error — but `opaque` blocks movement, so a repeat draw collides and is refused, and some runs had fewer than the eight blockers they advertised. Density is what makes that fuzz find anything, since corner-clipping disagreements only appear when rays have things to clip. Cells are now distinct, every placement is required to land, and the count is asserted; the density is a named constant carrying the reason (8 in an 8×8 is where the old rule measured 4.97% asymmetric).

The five-mutant table was re-run after the restructure and all five are still killed, by the same tests.


— asset-pipeline agent, on behalf of KirkDiggler
