### PR TITLE
fix(encounter): adopt lane-based sight, and correct a claim v1 got wrong (#1022)

### DIFF
--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -173,8 +173,9 @@ func (s *BeatOrderTestSuite) TestJoinBeforeItFights() {
 }
 
 // blockedScene opens the shared set with alice at (6,2) and the goblin at
-// (0,10) — the wall sits square between them, so first light starts no fight
-// and each verb under test is the sole cause of the one that follows. An optional decider drives the goblin for the Pump pin.
+// (6,10) — the wall spans x=4..8 at y=6, so the file they share is blocked and
+// first light starts no fight. Each verb under test is then the sole cause of
+// the one that follows. An optional decider drives the goblin for the Pump pin.
 func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encounter.Encounter {
 	monster := encounter.MemberInput{
 		ID: goblin, Kind: encounter.KindMonster, Room: beatOrderRoom,

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -31,9 +31,9 @@ import (
 // All five are asserted here so a future verb inherits a guarded law rather
 // than a remembered one.
 //
-// Every scene below uses the same set: a 12x12 room with a pillar at (6,6),
-// and sight blocked exactly along the file the pillar stands on. Nobody is in
-// contact until the verb under test puts them in contact.
+// Every scene below uses the same set: a 12x12 room split by a wall across
+// y=6, open at either end. Nobody is in contact until the verb under test puts
+// them in contact.
 type BeatOrderTestSuite struct {
 	suite.Suite
 }
@@ -44,11 +44,16 @@ func TestBeatOrderSuite(t *testing.T) {
 
 const beatOrderRoom = "hall"
 
-// pillarRoom is the shared set: one room, one occluder at (6,6).
-func pillarRoom() encounter.RoomInput {
+// wallRoom is the shared set: one room, split by a wall across y=6 with open
+// ground at either end of it.
+//
+// It was a single pillar until spatial v0.9.1, which leans around a lone
+// obstacle — see testwalls_test.go. The scenes are unchanged; what changed is
+// that the set has to be something a sightline genuinely cannot get past.
+func wallRoom() encounter.RoomInput {
 	return encounter.RoomInput{
 		ID: beatOrderRoom, Width: 12, Height: 12,
-		Occluders: []spatial.Position{{X: 6, Y: 6}},
+		Occluders: wallRow(6, 4, 8),
 	}
 }
 
@@ -72,11 +77,11 @@ func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encoun
 func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{pillarRoom()}},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
-			// Off the pillar's file: they see each other at first light.
-			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 2, Y: 2}},
-			{ID: goblin, Kind: encounter.KindMonster, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 10}},
+			// Both clear of the wall's span: they see each other at first light.
+			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 0, Y: 2}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: beatOrderRoom, Position: spatial.Position{X: 0, Y: 10}},
 		},
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -86,13 +91,13 @@ func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 		"the scene opens, THEN the fight inside it starts")
 }
 
-// TestMoveBeforeItFights pins Move's half. Alice starts behind the pillar's
-// file and steps off it; stepping off is what puts her in contact, so the
+// TestMoveBeforeItFights pins Move's half. Alice starts behind the wall and
+// walks out past its end; clearing it is what puts her in contact, so the
 // moved beat is the cause and the bubble-formed beat is its effect.
 func (s *BeatOrderTestSuite) TestMoveBeforeItFights() {
 	enc := s.blockedScene()
 
-	out, err := enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 2, Y: 2}})
+	out, err := enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 1, Y: 2}})
 	s.Require().NoError(err)
 	s.Require().NotNil(out.Formed, "stepping into the open puts her in contact")
 	s.Greater(out.Formed.Seq, out.Seq, "she moves, THEN the fight starts")
@@ -138,11 +143,11 @@ func (s *BeatOrderTestSuite) TestTraverseBeforeItFights() {
 // own beats are the tick frame AND the action inside it, so both precede the
 // fight the action caused.
 func (s *BeatOrderTestSuite) TestPumpBeforeItFights() {
-	enc := s.blockedScene(&patrolDecider{positions: []spatial.Position{{X: 2, Y: 10}}})
+	enc := s.blockedScene(&patrolDecider{positions: []spatial.Position{{X: 0, Y: 10}}})
 
 	out, err := enc.Pump(&encounter.PumpInput{})
 	s.Require().NoError(err)
-	s.Require().NotNil(out.Formed, "the goblin steps out from behind the pillar and is seen")
+	s.Require().NotNil(out.Formed, "the goblin steps out from behind the wall and is seen")
 	s.Require().Len(out.Seqs, 2, "pump's own beats: the tick frame and the goblin's step")
 	for _, seq := range out.Seqs {
 		s.Greater(out.Formed.Seq, seq, "the world moves, THEN the fight starts")
@@ -158,7 +163,7 @@ func (s *BeatOrderTestSuite) TestJoinBeforeItFights() {
 
 	out, err := enc.Join(&encounter.JoinInput{Member: encounter.MemberInput{
 		ID: cormac, Kind: encounter.KindPlayer, Room: beatOrderRoom,
-		Position: spatial.Position{X: 2, Y: 2},
+		Position: spatial.Position{X: 0, Y: 2},
 	}})
 	s.Require().NoError(err)
 	s.Require().NotNil(out.Formed, "he lands in the open, in the goblin's sight")
@@ -168,9 +173,8 @@ func (s *BeatOrderTestSuite) TestJoinBeforeItFights() {
 }
 
 // blockedScene opens the shared set with alice at (6,2) and the goblin at
-// (6,10) — the pillar at (6,6) sits square between them, so first light
-// starts no fight and each verb under test is the sole cause of the one that
-// follows. An optional decider drives the goblin for the Pump pin.
+// (0,10) — the wall sits square between them, so first light starts no fight
+// and each verb under test is the sole cause of the one that follows. An optional decider drives the goblin for the Pump pin.
 func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encounter.Encounter {
 	monster := encounter.MemberInput{
 		ID: goblin, Kind: encounter.KindMonster, Room: beatOrderRoom,
@@ -182,7 +186,7 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{pillarRoom()}},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 2}},
 			monster,
@@ -191,6 +195,6 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 	})
 	s.Require().NoError(err)
 	s.Require().Equal([]string{"scene-opened"}, s.beatKinds(enc, alice),
-		"the pillar keeps them apart: no fight before the verb under test")
+		"the wall keeps them apart: no fight before the verb under test")
 	return enc
 }

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -392,7 +392,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 						ID:        "crypt",
 						Width:     10,
 						Height:    10,
-						Occluders: []spatial.Position{{X: 5, Y: 5}},
+						Occluders: wallColumn(5, 3, 7),
 						Boundaries: []spatial.Boundary{
 							{
 								From:              spatial.Position{X: 3, Y: 3},
@@ -455,7 +455,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 // round-trip with the ghost still Held.
 func (s *DataTestSuite) TestRoundTripMidFade() {
 	s.Run("mid-fade ghost survives reload still Held", func() {
-		// Create encounter with a pillar that will cause a ghost to form
+		// Create encounter with a wall that will cause a ghost to form
 		setup := &encounter.SetupInput{
 			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
@@ -464,8 +464,13 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 						ID:     "crypt",
 						Width:  10,
 						Height: 10,
-						// Pillar at (5, 5) blocks sight
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						// A wall across y=3 blocks sight. It was a lone pillar
+						// until spatial v0.9.1, which leans around one — see
+						// testwalls_test.go. Its span is chosen so the scene
+						// still reads the same three ways: blocked at first
+						// light, open once playerA steps to (4,1), blocked
+						// again once the goblin ducks behind it.
+						Occluders:  wallRow(3, 3, 5),
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -497,7 +502,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 		enc1, err := encounter.NewEncounter(setup)
 		s.Require().NoError(err)
 
-		// Move goblin behind pillar to create a ghost
+		// Move goblin behind the wall to create a ghost
 		_, err = enc1.Move(&encounter.MoveInput{
 			Member: "playerA",
 			To:     spatial.Position{X: 4, Y: 1},
@@ -506,7 +511,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 
 		// The two saw each other, which starts a fight (rpg-toolkit#964), and
 		// a fight member cannot free-roam — so they break off before the
-		// goblin steps behind the pillar and becomes the ghost this test is
+		// goblin steps behind the wall and becomes the ghost this test is
 		// about.
 		_, err = enc1.Dissolve(&encounter.DissolveInput{Member: "goblin"})
 		s.Require().NoError(err)
@@ -514,7 +519,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 		// Move goblin to create ghost at last-seen position
 		_, err = enc1.Move(&encounter.MoveInput{
 			Member: "goblin",
-			To:     spatial.Position{X: 5, Y: 6}, // Behind pillar from A's view
+			To:     spatial.Position{X: 5, Y: 6}, // Behind the wall from A's view
 		})
 		s.Require().NoError(err)
 
@@ -2788,10 +2793,16 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:         "crypt",
-						Width:      10,
-						Height:     10,
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						// A wall across y=3, not the lone pillar this fixture
+						// used to have: spatial v0.9.1 leans around one (see
+						// testwalls_test.go). Its span is chosen so the scene
+						// still reads the same three ways — blocked at first
+						// light, open once playerA steps to (4,1), blocked
+						// again once the goblin ducks to (5,6).
+						Occluders:  wallRow(3, 3, 5),
 						Boundaries: []spatial.Boundary{},
 					},
 				},

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -123,18 +123,18 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 
 func (s *EncounterTestSuite) TestSetupPillarBlocksSight() {
 	s.Run("occluder blocks both directions", func() {
-		// Arrange: alice and goblin separated by a pillar
+		// Arrange: alice and goblin separated by a WALL — a pillar is leaned
+		// around now (spatial v0.9.1, see testwalls_test.go), so a fixture
+		// that wants sight blocked has to build something worth blocking.
 		setup := &encounter.SetupInput{
 			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:     room1,
-						Width:  10,
-						Height: 10,
-						Occluders: []spatial.Position{
-							{X: 4, Y: 5}, // Pillar in the middle
-						},
+						ID:        room1,
+						Width:     10,
+						Height:    10,
+						Occluders: wallColumn(4, 0, 9),
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -171,7 +171,7 @@ func (s *EncounterTestSuite) TestSetupPillarBlocksSight() {
 		// Assert: alice does not see goblin
 		aliceView, err := enc.View(&encounter.ViewInput{Member: alice})
 		s.Require().NoError(err)
-		s.Len(aliceView, 0, "alice should see nothing (blocked by pillar)")
+		s.Len(aliceView, 0, "alice should see nothing (blocked by the wall)")
 
 		// Assert: goblin does not see alice (symmetric)
 		goblinView, err := enc.View(&encounter.ViewInput{Member: goblin})
@@ -1983,22 +1983,23 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 }
 
 func (s *EncounterTestSuite) TestMoveGhostForms() {
-	s.Run("moving behind the pillar fades holdings both ways", func() {
-		// Geometry: pillar at (10,10). alice starts at (2,2); bob at (10,18).
-		// The line (2,2)->(10,18) misses the pillar: initially visible.
-		// alice moves to (10,2): the line (10,2)->(10,18) is the x=10
-		// vertical and crosses (10,10): blocked BOTH ways.
+	s.Run("moving behind the wall fades holdings both ways", func() {
+		// Geometry: a wall across y=10 from x=7 to x=13. alice starts at
+		// (2,2); bob at (10,18). The line (2,2)->(10,18) passes west of the
+		// wall's end: initially visible. alice moves to (10,2), square behind
+		// it: blocked BOTH ways.
+		//
+		// A wall rather than the single pillar this fixture used to have —
+		// spatial v0.9.1 leans around a lone obstacle (see testwalls_test.go).
 		setup := &encounter.SetupInput{
 			Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
-						ID:     room1,
-						Width:  20,
-						Height: 20,
-						Occluders: []spatial.Position{
-							{X: 10, Y: 10},
-						},
+						ID:        room1,
+						Width:     20,
+						Height:    20,
+						Occluders: wallRow(10, 7, 13),
 					},
 				},
 			},
@@ -2026,7 +2027,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		aliceView, err := enc.View(&encounter.ViewInput{Member: alice})
 		s.Require().NoError(err)
 		s.Require().Len(aliceView, 1, "the ghost is HELD, not gone")
-		s.Equal(intel.Held, aliceView[0].Status, "alice's sight of bob must fade behind the pillar")
+		s.Equal(intel.Held, aliceView[0].Status, "alice's sight of bob must fade behind the wall")
 		var bobSeen encounter.SightPayload
 		s.Require().NoError(json.Unmarshal(aliceView[0].Payload, &bobSeen))
 		s.Equal(18.0, bobSeen.Y, "ghost holds bob at his last-seen position")

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -121,7 +121,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 	})
 }
 
-func (s *EncounterTestSuite) TestSetupPillarBlocksSight() {
+func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 	s.Run("occluder blocks both directions", func() {
 		// Arrange: alice and goblin separated by a WALL — a pillar is leaned
 		// around now (spatial v0.9.1, see testwalls_test.go), so a fixture
@@ -176,7 +176,7 @@ func (s *EncounterTestSuite) TestSetupPillarBlocksSight() {
 		// Assert: goblin does not see alice (symmetric)
 		goblinView, err := enc.View(&encounter.ViewInput{Member: goblin})
 		s.Require().NoError(err)
-		s.Len(goblinView, 0, "goblin should see nothing (blocked by pillar)")
+		s.Len(goblinView, 0, "goblin should see nothing (blocked by the wall)")
 	})
 }
 

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -42,14 +42,14 @@ func tell(enc *encounter.Encounter, who, about core.EntityID) {
 // this narration can never drift from what the composition actually
 // does. This is the pre-UI loop: the story is the screen.
 func Example_theTombWatch() {
-	// The crypt: a pillar at (6,6); alice enters at (2,6); a goblin
+	// The crypt: a wall across y=6 from x=5 to x=7; alice enters at (2,6); a goblin
 	// stands at (6,10). One way out: the stairs at (11,11).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: "crypt", Width: 12, Height: 12,
-				Occluders: []spatial.Position{{X: 6, Y: 6}},
+				Occluders: wallRow(6, 5, 7),
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -77,7 +77,7 @@ func Example_theTombWatch() {
 		return
 	}
 
-	fmt.Println("-- alice slips behind the pillar's file --")
+	fmt.Println("-- alice slips behind the wall --")
 	if _, err := enc.Move(&encounter.MoveInput{Member: "alice", To: spatial.Position{X: 6, Y: 2}}); err != nil {
 		fmt.Println("move:", err)
 		return
@@ -111,7 +111,7 @@ func Example_theTombWatch() {
 	// -- first light --
 	// alice sees goblin at (6,10)
 	// goblin sees alice at (2,6)
-	// -- alice slips behind the pillar's file --
+	// -- alice slips behind the wall --
 	// alice holds a GHOST of goblin at last-seen (6,10)
 	// goblin holds a GHOST of alice at last-seen (2,6)
 	// -- the table saves and comes back tomorrow --

--- a/rulebooks/dnd5e/encounter/go.mod
+++ b/rulebooks/dnd5e/encounter/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/rulebooks/dnd5e/encounter/go.sum
+++ b/rulebooks/dnd5e/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0 h1:89nU27faMf80JrIJlQeVeYac
 github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0/go.mod h1:BlYgBeigB1mUum7FG8AUxWX32tgBrBLFg4/t//+tSvk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q+6k8n0krpcnka+lLyflk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -313,7 +313,10 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{{
 					ID: room1, Width: 10, Height: 10,
-					Occluders: []spatial.Position{{X: 5, Y: 5}},
+					// A wall down x=5 rather than one cell of it: spatial
+					// v0.9.1 leans around a lone obstacle, so a fixture that
+					// wants sight blocked builds a wall (testwalls_test.go).
+					Occluders: wallColumn(5, 4, 6),
 				}},
 			},
 			Members: []encounter.MemberInput{
@@ -1682,7 +1685,7 @@ func (t *traverseThenWander) Decide(snap encounter.Snapshot) (encounter.Intent, 
 // The trick is fight → Dissolve → hunt. Contact forms the bubble; Dissolve
 // returns the goblin to the world clock still CARRYING what it saw, because
 // dissolving moves clocks and never touches intel; alice then steps behind a
-// pillar, which fades her from the goblin's percept without deleting her from
+// wall, which fades her from the goblin's percept without deleting her from
 // its memory. Now the goblin is a world-clock monster with real, stale intel,
 // so Pump consults its decider and the snapshot has something to be wrong
 // about.
@@ -1711,9 +1714,11 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: room1, Width: 10, Height: 10,
-				// One pillar, positioned so that alice is visible from the
-				// goblin where she starts and hidden where she ends up.
-				Occluders: []spatial.Position{{X: 5, Y: 5}},
+				// A short wall, positioned so that alice is visible from the
+				// goblin where she starts and hidden where she ends up. It
+				// was a single pillar until spatial v0.9.1, which leans
+				// around one — see testwalls_test.go.
+				Occluders: wallColumn(5, 4, 6),
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -1741,7 +1746,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 	s.Require().NoError(err)
 	s.Require().Equal(encounter.ClockWorld, clockOf.Kind, "back to the world's to move")
 
-	// Alice slips behind the pillar. She fades from the goblin's percept — no
+	// Alice slips behind the wall. She fades from the goblin's percept — no
 	// current sight, so nothing re-triggers (classification reads first
 	// contact, and a fade is not a contact).
 	moved, err := enc.Move(&encounter.MoveInput{Member: aliceID, To: hidden})

--- a/rulebooks/dnd5e/encounter/testwalls_test.go
+++ b/rulebooks/dnd5e/encounter/testwalls_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// A LONE PILLAR NO LONGER BLOCKS ANYTHING, and these helpers exist because of
+// it.
+//
+// Sight used to be one rasterized line, so a single occluding cell sitting on
+// it stopped the sightline dead. That was the defect behind rpg-toolkit#1022:
+// measured against the rule 5e actually states — visible if a line from any
+// corner of your space to any corner of theirs is unobstructed — the old rule
+// blocked 4.5x too many pairs on hexes and hid about one in seven things a
+// player should have seen. spatial v0.9.1 asks for a LANE instead: blocked
+// only when the direct lane AND every lane from a neighbour closer to the
+// target are obstructed. You lean around a pillar, exactly as you would at the
+// table.
+//
+// So a fixture that wants sight BLOCKED needs a wall, not a pillar. That is
+// not a workaround — the old fixtures were describing a rule that was wrong,
+// and reading one of them now ("the pillar blocks sight") tells you something
+// the engine no longer believes.
+//
+// The width is not decoration either. A wall must be wide enough that the
+// neighbour lanes are obstructed too, which means covering the cells a viewer
+// would lean toward, not just the one on the centre line.
+
+// wallRow returns a horizontal run of occluder cells at the given row,
+// inclusive of both ends.
+func wallRow(y, fromX, toX int) []spatial.Position {
+	out := make([]spatial.Position, 0, toX-fromX+1)
+	for x := fromX; x <= toX; x++ {
+		out = append(out, spatial.Position{X: float64(x), Y: float64(y)})
+	}
+	return out
+}
+
+// wallColumn returns a vertical run of occluder cells in the given column,
+// inclusive of both ends.
+func wallColumn(x, fromY, toY int) []spatial.Position {
+	out := make([]spatial.Position, 0, toY-fromY+1)
+	for y := fromY; y <= toY; y++ {
+		out = append(out, spatial.Position{X: float64(x), Y: float64(y)})
+	}
+	return out
+}

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -48,15 +48,19 @@ func seen(t *testing.T, enc *encounter.Encounter, observer core.EntityID, subjec
 // documentation: a host wires the free-roam encounter exactly like this.
 func TestTombWatch(t *testing.T) {
 	// ---- Beat 1: the crypt lights up -------------------------------
-	// A 12x12 crypt with a pillar at (6,6). Alice (2,2) and Bella (3,2)
-	// enter; a goblin patrols the far end between (7,10) and (6,10).
+	// A 12x12 crypt with a wall across the middle, x=5..7 at y=6. Alice
+	// (2,2) and Bella (3,2) enter; a goblin patrols the far end between
+	// (7,10) and (6,10). The wall is three cells wide rather than the one
+	// this scene used to have: spatial v0.9.1 leans around a lone pillar
+	// (see testwalls_test.go), and this crypt needs a sightline that really
+	// cannot get through.
 	goblinPatrol := &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
-				Occluders: []spatial.Position{{X: 6, Y: 6}},
+				Occluders: wallRow(6, 5, 7),
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -97,18 +101,18 @@ func TestTombWatch(t *testing.T) {
 	require.Equal(t, 7.0, p.X, "beat 2: alice's view tracks the patrol step to (7,10)")
 
 	// A second pump brings the goblin back to (6,10) — directly behind
-	// the pillar's file, setting up the ghost.
+	// the wall, setting up the ghost.
 	_, err = enc.Pump(&encounter.PumpInput{})
 	require.NoError(t, err, "beat 2: the watch continues")
 	_, p = seen(t, enc, alice, goblin)
 	require.Equal(t, 6.0, p.X, "beat 2: the goblin returns to (6,10), still in alice's sight from (2,6)")
 
 	// ---- Beat 3: the ghost forms -----------------------------------
-	// Alice slips to (6,2): the pillar at (6,6) now sits square on the
+	// Alice slips to (6,2): the wall now sits square on the
 	// vertical line between her and the goblin at (6,10). Both lose
 	// sight of each other — and both keep a ghost at last-seen.
 	_, err = enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 6, Y: 2}})
-	require.NoError(t, err, "beat 3: alice slips behind the pillar's file")
+	require.NoError(t, err, "beat 3: alice slips behind the wall")
 
 	st, p = seen(t, enc, alice, goblin)
 	require.Equal(t, intel.Held, st, "beat 3: alice's sight of the goblin fades — the ghost forms")
@@ -148,7 +152,7 @@ func TestTombWatch(t *testing.T) {
 	require.NoError(t, err, "beat 5: cormac joins the delve")
 	require.NotZero(t, joinOut.Seq, "beat 5: his arrival is a story beat")
 	st, _ = seen(t, enc, cormac, goblin)
-	require.Equal(t, intel.Current, st, "beat 5: from (10,2) the pillar doesn't block him — first light lands")
+	require.Equal(t, intel.Current, st, "beat 5: from (10,2) the wall doesn't block him — first light lands")
 	st, _ = seen(t, enc, goblin, cormac)
 	require.Equal(t, intel.Current, st, "beat 5: the goblin notices the newcomer")
 	require.NotNil(t, joinOut.Formed, "beat 5: noticing each other IS the fight starting")
@@ -231,7 +235,7 @@ func TestTombWatch(t *testing.T) {
 		"moved",         // beat 2: alice advances
 		"tick", "moved", // beat 2: pump 1, goblin steps out
 		"tick", "moved", // beat 2: pump 2, goblin steps back
-		"moved",  // beat 3: alice slips behind the pillar's file
+		"moved",  // beat 3: alice slips behind the wall
 		"joined", // beat 5: cormac (the pause leaves no beat — pause is free)
 		// beat 5: and the goblin sees him arrive — his fight starts AFTER the
 		// arrival that caused it. Cause before effect: the reverse order is
@@ -262,7 +266,7 @@ func TestTombWatch(t *testing.T) {
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
-				Occluders: []spatial.Position{{X: 6, Y: 6}},
+				Occluders: wallRow(6, 5, 7),
 			}},
 		},
 		Members: sequelMembers,

--- a/rulebooks/dnd5e/encounter/trigger.go
+++ b/rulebooks/dnd5e/encounter/trigger.go
@@ -45,14 +45,25 @@ const (
 	// decides in free roam — back away, sneak, or approach — with attacking
 	// from here counting as initiation.
 	//
-	// UNREACHABLE TODAY, and deliberately kept. Sight is pure symmetric
-	// geometry: refreshSight builds every percept from IsLineOfSightBlocked
-	// with no facing, stealth, or perception input, so if the player sees the
-	// wolf the wolf sees the player and this case has no producible input.
-	// rpg-toolkit#1020 is the prerequisite that makes it real. The arm stays
-	// because it is the documented design rather than dead ceremony — what is
-	// NOT here is any behavior hanging off it, because unbuilt beats
-	// built-and-dead.
+	// UNREACHABLE TODAY, and deliberately kept. Sight is symmetric: every
+	// percept is built from IsLineOfSightBlocked with no facing, stealth or
+	// perception input, and that predicate is symmetric BY LAW as of
+	// rpg-toolkit#1022 — spatial pins it as a property over fuzzed rooms in
+	// every grid family. So if the player sees the wolf, the wolf sees the
+	// player, and this case has no producible input.
+	//
+	// It was briefly reachable and nobody meant it to be, which is why the law
+	// exists: sight used to be one rasterized line, and Bresenham chose
+	// different cells by direction on square grids, so a wall corner could
+	// hide a player from a monster it did not hide the monster from. A
+	// one-sided ambush earned by ray-rounding rather than by anything in the
+	// fiction. Fixed in spatial v0.9.1, and asymmetry now arrives only where
+	// it is designed to.
+	//
+	// rpg-toolkit#1020 is that design and the prerequisite that makes this arm
+	// real. It stays because it is the documented shape rather than dead
+	// ceremony — what is NOT here is any behavior hanging off it, because
+	// unbuilt beats built-and-dead.
 	contactDrop
 
 	// contactSpotted: the monster saw the player and the player did not see
@@ -94,6 +105,20 @@ type trigger struct {
 // sees everyone, so nobody is unaware. Honest option C under B-prime's design,
 // not a compromise: the machinery is the permanent part and the percepts are
 // the part that grows.
+//
+// THAT CLAIM WAS FALSE WHEN IT WAS FIRST WRITTEN, and the correction is worth
+// keeping rather than quietly editing away. Sight was symmetric by intent and
+// not in fact: it was decided by one rasterized line, and the line differed by
+// direction on square grids, so a wall corner produced real one-sided contact
+// — Surprised populated, with no stealth anywhere in the module. Found by the
+// session wave probing this very seam, filed as rpg-toolkit#1022, and fixed in
+// spatial v0.9.1, which now pins symmetry as a LAW over fuzzed rooms in every
+// grid family rather than leaving it as a property of an algorithm.
+//
+// The consumer needed no change, which is the part that mattered: Surprised
+// populated, crossed the boundary and reported correctly the whole time. The
+// invariant above held — what was wrong was the PRODUCTION of percepts, and
+// fixing it there is exactly where the design said it would happen.
 //
 // v2 is asymmetric perception (rpg-toolkit#1020), where Stealth against
 // passive Perception decides whether an observer's percept exists at all. The


### PR DESCRIPTION
First link of the #1022 consumer chain. Adopts `tools/spatial` **v0.9.1** and corrects the v1 record that this module shipped.

## The claim v1 got wrong

`classify()`'s doc said drop, spotted and surprise were unreachable because "sight is pure symmetric geometry". **Sight was symmetric by intent and not in fact.** It was decided by one rasterized line, and Bresenham chose different cells by direction on square grids, so a wall corner produced real one-sided contact — `Surprised` populated, with no stealth anywhere in the module. The session wave found it probing this very seam (#1023), it was filed as #1022, and it is fixed in spatial v0.9.1.

The doc now states what happened, cites the fix, and records the stronger fact: **symmetry is a LAW in spatial as of v0.9.1** — pinned as a property over fuzzed rooms in every grid family — rather than a property of an algorithm that happened to hold.

Both edited docs keep the correction visible rather than editing it away, because the interesting part is that **the consumer needed no change**. `Surprised` populated, crossed the boundary and reported correctly the whole time. The invariant v1 wrote down — *upgrades change how percepts are PRODUCED, never how they are consumed* — held exactly as designed: what was wrong was production, and that is where the fix landed.

## A lone pillar no longer blocks anything

Eleven fixtures used a single occluding cell to mean "sight is blocked". Under the lane rule you lean around one, so those fixtures were describing a rule this engine no longer has — and reading one now would tell you something untrue.

Each is a wall instead, wide enough that the neighbour lanes are obstructed too. `testwalls_test.go` carries `wallRow`/`wallColumn` and the reason, so the next fixture author does not rediscover it.

Two needed real geometry work rather than a wider wall. The ghost fixtures in `data_test.go` have to read **three ways at once** — blocked at first light, open after playerA steps to (4,1), blocked again once the goblin ducks to (5,6) — and the diagonal makes those conditions fight each other. The span that satisfies all three (`wallRow(3, 3, 5)`) was found by search rather than guessed at.

`TestTombWatch` needed a wall narrow enough to keep bella's sightline: `wallRow(6, 5, 7)` blocks alice's file at x=6 while leaving bella's diagonal from (3,2) clear, which is what "bella, off the blocked file, still sees the goblin plainly" has always asserted.

## Verified rather than assumed

The **diagonal-pillar fixtures elsewhere in `data_test.go` still block** — five of them say "a pillar on the diagonal keeps playerA and the goblin out of each other's sight", and they pass. Rather than trust that, I probed it: at (1,1) and (9,9) with a pillar at (5,5), the only neighbour that makes progress is (2,2), whose lane is blocked by the same pillar. Their comments are still true, so they are left alone.

Prose was refreshed everywhere a fixture became a wall, including inside `Example_theTombWatch`'s expected output. A comment that survives the rule it describes is the failure mode this module has been bitten by before.

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok**, both packages |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

## Chain

This is link 1 of 2. On its tag, `rulebooks/dnd5e/session` bumps and flips `TestTheOgreCanSeeWhatAliceCannot` — the test that recorded the asymmetry as evidence — to assert symmetry instead. The root `encounter` module's bump is #1026, scoped separately: its risk is a pseudo-version gap of two spatial minors, not this fix.

#964's ratification comment is corrected separately by the lead.

— asset-pipeline agent, on behalf of KirkDiggler
