### PR TITLE
chore(session): align the dnd5e pin with resolution's, ahead of the combat verbs

### DIFF
--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.78.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.78.0 h1:lp+SOi1H0RTb3y+91u8LJZ0I6Y92QFsLHZpUDkQP+XM=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.78.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.0 h1:HUZdBPXmmCqsZKY6XCmtQSHW5mmakB7Dk6lTUobMOkE=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.0/go.mod h1:ZYYd+oFBN6WUPIb+OTaAu6X7CQtVhOjEg9i0GJM0o6Q=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=


### PR DESCRIPTION
Slice 1 of #966, from the [stage-1 census](https://github.com/KirkDiggler/rpg-toolkit/issues/966#issuecomment-5304167452). Deliberately alone, deliberately boring.

## Why it is its own PR

The wave's first verb adopts the `resolution` module. Resolution pins `rulebooks/dnd5e` **v0.94.1**; session pinned **v0.78.0** — sixteen minors apart. Landing that jump underneath a new verb would make any failure ambiguous between the two, which is the whole argument for doing it first and alone.

## The census over-estimated this, and that is worth recording

I called it "a migration with its own failure surface". It is **a one-line pin edit, no code change, green suite**.

The reason is legible rather than lucky: the sixteen minors in that range are all combat work — the `combat.FinalDamage` custody move, immunity presence-dispatch, `AttackProfile.Imposes`, the character-as-attacker compiler — and **session imports none of it**. Its `dnd5e` surface is data shapes only:

```
character  monster  refs  races  classes  conditions  initiative
```

So the risk in slice 4 is not the version distance. It is the **new surface** — and now that is the only thing left to be wrong.

The discriminating check is `TestSpeedIsDerivedRatherThanDefaulted`, which passes. Speed is not a stored field on the sheet, so asserting it proves the character is genuinely reconstituted across the jump rather than echoed back — a green suite full of round-trip assertions would not have proved that on its own.

## What is deliberately NOT here

**Encounter alignment.** Resolution also trails there (`encounter` v0.7.0 against session's v0.8.0), and both modules must land on the tag the #1022 consumer chain ([#1027](https://github.com/KirkDiggler/rpg-toolkit/pull/1027)) is about to cut. Doing it now would be two bumps for one alignment.

**No new `Config` field, now or at slice 4** — the census's other finding, and it matters here because `session.go:34-43` warns in its own words that a new REQUIRED field is "a silent runtime break wearing a green CI check", and that every required field must land at or before the migration wave. `resolution.Input` wants a `World`, `Participants`, a `Machine` and a `dice.Roller`; session already holds all four, and `initiative.go`'s `diceSeam` already adapts `Config.Dice` to `dice.Roller`. The combat verbs cost the host nothing.

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok**, both packages |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | applied; `go.sum` is the only other change |

Part of #966. Does not close it.

— asset-pipeline agent, on behalf of KirkDiggler
