### PR TITLE
feat(encounter): the story can carry a rule resolved somewhere else (#966)

### DIFF
--- a/rulebooks/dnd5e/encounter/outcome.go
+++ b/rulebooks/dnd5e/encounter/outcome.go
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/record"
+)
+
+// OutcomeKind names a rulebook result the story can carry.
+//
+// A CLOSED SET, and that is the point of the whole shape. The composition is
+// the only thing that can write to an encounter's record, which is what keeps
+// one transcript honest — every beat is stamped by the same hand, at the same
+// clock, with the same audience rule. Letting a rulebook write whatever it
+// liked would keep the transcript in one place and give up the reason that
+// mattered: that a reader can trust what is in it.
+//
+// So a rulebook does not describe what happened. It names a kind the
+// composition already knows and hands over numbers. Adding a kind is a change
+// here, visible in a diff, and that is the cost being chosen on purpose.
+type OutcomeKind string
+
+const (
+	// OutcomeStruck is an attack that landed.
+	OutcomeStruck OutcomeKind = "struck"
+
+	// OutcomeMissed is an attack that did not.
+	OutcomeMissed OutcomeKind = "missed"
+)
+
+// OutcomeValue names one number a rulebook outcome carries.
+//
+// Deliberately generic — "the roll", "what it needed", "how much" — because
+// the composition must not learn what an armour class is. The rulebook knows
+// which of its numbers is which; the composition knows only that they are
+// numbers, and refuses any name not on this list.
+type OutcomeValue string
+
+const (
+	// ValueRoll is the die as rolled.
+	ValueRoll OutcomeValue = "roll"
+
+	// ValueTotal is the roll plus whatever the rules added to it.
+	ValueTotal OutcomeValue = "total"
+
+	// ValueAgainst is the number the total had to reach.
+	ValueAgainst OutcomeValue = "against"
+
+	// ValueAmount is how much was done — damage, healing, whatever the kind
+	// means by it.
+	ValueAmount OutcomeValue = "amount"
+)
+
+// RecordInput is one rulebook outcome, offered to the story.
+//
+// THERE IS NO STRING FIELD HERE, and there will not be one. Every member is an
+// ID the composition validates against its own roster, the kind is a closed
+// enum, and the values are integers under closed keys. Prose is not something
+// this input can express — not discouraged, not filtered, INEXPRESSIBLE — so
+// no caller can narrate into a transcript that other players read, and no
+// future caller can start.
+//
+// That is the difference between this and the general "append anything" hole
+// it replaces the need for. The composition stays the only author of its
+// record, and what a rulebook contributes is facts it can check.
+type RecordInput struct {
+	// Kind is what happened. Must be a kind this composition knows.
+	Kind OutcomeKind
+
+	// Actor is who did it. Must be a current member.
+	Actor MemberID
+
+	// Targets are who it was done to, if anyone. Each must be a current
+	// member. Recorded sorted, for the same C8 reason every other list here
+	// is: identical inputs must produce identical stories.
+	Targets []MemberID
+
+	// Values are the numbers, under names from the closed set. Absent is
+	// legal — a kind that carries no numbers is a kind, not an error.
+	Values map[OutcomeValue]int
+}
+
+// RecordOutput reports where the outcome landed in the story.
+type RecordOutput struct {
+	// Seq is the story sequence of the recorded beat.
+	Seq uint64
+}
+
+// Record puts one rulebook outcome into the encounter's story.
+//
+// It exists because a strike resolved outside this module was INVISIBLE:
+// resolution returns an outcome value and writes no beat, appendBeat is
+// unexported, and the SDK builds every client event by reading each member's
+// story — so an attack produced nothing to render and nothing to re-read
+// (rpg-toolkit#966). One transcript is the product; a rule that resolves
+// somewhere else still has to land in it.
+//
+// It records and does NOTHING ELSE. No sight refresh, no trigger detection, no
+// clock movement — the beat is the whole effect. That is what makes the
+// ordering law hold for free: the rule at [Encounter.refreshSight] is that a
+// verb's own beat precedes any beat its consequences append, and an outcome IS
+// a consequence, of whatever the caller did to produce it. Its beat therefore
+// lands after that verb's, because the caller records it after, and nothing
+// here can reorder them.
+//
+// The audience is every current member, at the current clock reading — the
+// same convention the clock beats use. An outcome is not secret: a fight is
+// localized but visible, and a client that learned about a strike only from
+// the striker's own response could not render the scene the party is in.
+//
+// Errors: ErrNilInput, ErrClosed, ErrNoMember (empty or unknown actor, unknown
+// target), ErrInvalidData (a kind or value name this composition does not
+// know).
+func (e *Encounter) Record(in *RecordInput) (*RecordOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("record: %w", ErrNilInput)
+	}
+	if e.outcome != nil {
+		return nil, fmt.Errorf("record: %w", ErrClosed)
+	}
+
+	switch in.Kind {
+	case OutcomeStruck, OutcomeMissed:
+	default:
+		return nil, fmt.Errorf("record: outcome kind %q: %w", in.Kind, ErrInvalidData)
+	}
+
+	if in.Actor == "" {
+		return nil, fmt.Errorf("record: actor: %w", ErrNoMember)
+	}
+	if _, ok := e.members[in.Actor]; !ok {
+		return nil, fmt.Errorf("record: actor %q: %w", in.Actor, ErrNoMember)
+	}
+
+	targets := append([]MemberID(nil), in.Targets...)
+	for _, id := range targets {
+		if _, ok := e.members[id]; !ok {
+			return nil, fmt.Errorf("record: target %q: %w", id, ErrNoMember)
+		}
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i] < targets[j] })
+
+	// Values are marshalled through a sorted slice rather than the map: a Go
+	// map has no order, and a beat whose bytes differ between two runs of the
+	// same input is a transcript that cannot be compared (C8).
+	names := make([]OutcomeValue, 0, len(in.Values))
+	for name := range in.Values {
+		switch name {
+		case ValueRoll, ValueTotal, ValueAgainst, ValueAmount:
+			names = append(names, name)
+		default:
+			return nil, fmt.Errorf("record: value %q: %w", name, ErrInvalidData)
+		}
+	}
+	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+
+	payload := map[string]interface{}{
+		"beat":  string(in.Kind),
+		"actor": string(in.Actor),
+	}
+	if len(targets) > 0 {
+		out := make([]string, 0, len(targets))
+		for _, id := range targets {
+			out = append(out, string(id))
+		}
+		payload["targets"] = out
+	}
+	for _, name := range names {
+		payload[string(name)] = in.Values[name]
+	}
+
+	beatBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("record: outcome payload: %w", err)
+	}
+
+	memberIDs := make([]MemberID, 0, len(e.members))
+	for id := range e.members {
+		memberIDs = append(memberIDs, id)
+	}
+	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
+
+	appended, err := e.appendBeat(&record.AppendInput{
+		At:       uint64(e.clock.ToData().HighWater),
+		Audience: memberIDs,
+		Tags:     map[string]string{"tag": "outcome"},
+		Payload:  beatBytes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("record: %w", err)
+	}
+
+	return &RecordOutput{Seq: appended.Seq}, nil
+}

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -1,0 +1,214 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// OutcomeTestSuite covers Record: the one way a rule resolved somewhere else
+// reaches this encounter's story.
+type OutcomeTestSuite struct {
+	suite.Suite
+}
+
+func TestOutcomeSuite(t *testing.T) {
+	suite.Run(t, new(OutcomeTestSuite))
+}
+
+const outcomeRoom = "yard"
+
+// scene opens a room with alice and a goblin standing apart, out of each
+// other's sight, so nothing forms a fight before a test asks for one.
+func (s *OutcomeTestSuite) scene() *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{
+			ID: outcomeRoom, Width: 12, Height: 12, Occluders: wallRow(6, 4, 8),
+		}}},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: outcomeRoom, Position: spatial.Position{X: 6, Y: 2}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: outcomeRoom, Position: spatial.Position{X: 6, Y: 10}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// TestARuleResolvedElsewhereReachesTheStory is why Record exists.
+//
+// A strike resolves in another module entirely: it returns a value and writes
+// no beat, and this package's appendBeat is unexported. Before Record there
+// was no way for that to become something a player could read — the SDK builds
+// every client event by reading each member's story, so an attack was
+// invisible in both places at once (rpg-toolkit#966).
+func (s *OutcomeTestSuite) TestARuleResolvedElsewhereReachesTheStory() {
+	enc := s.scene()
+
+	out, err := enc.Record(&encounter.RecordInput{
+		Kind:    encounter.OutcomeStruck,
+		Actor:   alice,
+		Targets: []encounter.MemberID{goblin},
+		Values: map[encounter.OutcomeValue]int{
+			encounter.ValueRoll:    17,
+			encounter.ValueTotal:   22,
+			encounter.ValueAgainst: 15,
+			encounter.ValueAmount:  9,
+		},
+	})
+	s.Require().NoError(err)
+	s.NotZero(out.Seq)
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: goblin})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(story)
+	last := story[len(story)-1]
+	s.Equal(out.Seq, last.Seq, "RecordOutput.Seq references the beat it wrote")
+	s.Equal("outcome", last.Tags["tag"])
+
+	var beat map[string]any
+	s.Require().NoError(json.Unmarshal(last.Payload, &beat))
+	s.Equal("struck", beat["beat"])
+	s.Equal("alice", beat["actor"])
+	s.Equal([]any{"goblin"}, beat["targets"])
+	s.Equal(float64(17), beat["roll"])
+	s.Equal(float64(22), beat["total"])
+	s.Equal(float64(15), beat["against"])
+	s.Equal(float64(9), beat["amount"])
+}
+
+// TestTheTargetHearsItToo pins the audience rule.
+//
+// An outcome is not secret. A fight is localized, but it is not private: a
+// client that learned about a strike only from the striker's own response
+// could not render the scene the rest of the party is standing in.
+func (s *OutcomeTestSuite) TestTheTargetHearsItToo() {
+	enc := s.scene()
+	_, err := enc.Record(&encounter.RecordInput{
+		Kind: encounter.OutcomeMissed, Actor: alice, Targets: []encounter.MemberID{goblin},
+	})
+	s.Require().NoError(err)
+
+	for _, who := range []encounter.MemberID{alice, goblin} {
+		story, serr := enc.Story(&encounter.StoryInput{Audience: who})
+		s.Require().NoError(serr)
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(story[len(story)-1].Payload, &beat))
+		s.Equal("missed", beat["beat"], "%s hears it", who)
+	}
+}
+
+// TestAnOutcomeCarriesNoProse is the shape's whole claim, asserted rather than
+// promised.
+//
+// The reason the composition owns its record is that a reader can trust what
+// is in it. An append taking free bytes would have kept the transcript in one
+// place and given that up — any caller could narrate at other players through
+// it. So RecordInput has NO string field: the kind is a closed enum, members
+// are IDs checked against the roster, values are integers under closed keys.
+//
+// This test reads the type rather than exercising it, because the guarantee is
+// structural: prose is not filtered here, it is INEXPRESSIBLE, and the day
+// someone adds a Description field this fails and says why.
+func (s *OutcomeTestSuite) TestAnOutcomeCarriesNoProse() {
+	s.Equal([]string{"Kind", "Actor", "Targets", "Values"},
+		structFieldNames(encounter.RecordInput{}),
+		"a new field on RecordInput needs an argument: free text here is prose "+
+			"in a transcript other players read")
+}
+
+// TestRefusalsAreCheckedAgainstTheRoster pins that the composition validates
+// what it stamps, which is the other half of owning the record.
+func (s *OutcomeTestSuite) TestRefusalsAreCheckedAgainstTheRoster() {
+	s.Run("nil input", func() {
+		_, err := s.scene().Record(nil)
+		s.ErrorIs(err, encounter.ErrNilInput)
+	})
+
+	s.Run("a kind this composition does not know", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeKind("disintegrated"), Actor: alice,
+		})
+		s.ErrorIs(err, encounter.ErrInvalidData)
+	})
+
+	s.Run("a value name this composition does not know", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeStruck, Actor: alice,
+			Values: map[encounter.OutcomeValue]int{encounter.OutcomeValue("temp_hp"): 3},
+		})
+		s.ErrorIs(err, encounter.ErrInvalidData)
+	})
+
+	s.Run("an actor who is not a member", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeStruck, Actor: "nobody",
+		})
+		s.ErrorIs(err, encounter.ErrNoMember)
+	})
+
+	s.Run("an empty actor", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{Kind: encounter.OutcomeStruck})
+		s.ErrorIs(err, encounter.ErrNoMember)
+	})
+
+	s.Run("a target who is not a member", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeStruck, Actor: alice,
+			Targets: []encounter.MemberID{"ghost"},
+		})
+		s.ErrorIs(err, encounter.ErrNoMember)
+	})
+
+	s.Run("a closed encounter", func() {
+		enc := s.scene()
+		_, err := enc.End(&encounter.EndInput{Ending: "withdrawn"})
+		s.Require().NoError(err)
+		_, err = enc.Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeStruck, Actor: alice,
+		})
+		s.ErrorIs(err, encounter.ErrClosed)
+	})
+}
+
+// TestTheOutcomeLandsAfterTheVerbThatCausedIt is Record's half of the
+// cause-before-effect law (see refreshSight).
+//
+// An outcome is a CONSEQUENCE — of a walk, an arrival, whatever produced it —
+// so it lands after that verb's own beat. Record holds that for free by doing
+// nothing but record: no sight refresh, no trigger detection, no clock
+// movement, so there is nothing it could append first and nothing it could
+// reorder. This pins both halves: the order, and the "nothing else" that makes
+// the order structural rather than a habit.
+func (s *OutcomeTestSuite) TestTheOutcomeLandsAfterTheVerbThatCausedIt() {
+	enc := s.scene()
+
+	moved, err := enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 5, Y: 2}})
+	s.Require().NoError(err)
+	s.Require().Nil(moved.Formed, "the wall keeps this walk quiet")
+
+	recorded, err := enc.Record(&encounter.RecordInput{
+		Kind: encounter.OutcomeMissed, Actor: alice, Targets: []encounter.MemberID{goblin},
+	})
+	s.Require().NoError(err)
+	s.Greater(recorded.Seq, moved.Seq, "the walk happened, THEN what came of it")
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: alice})
+	s.Require().NoError(err)
+	kinds := make([]string, 0, len(story))
+	for _, entry := range story {
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		kinds = append(kinds, beat["beat"].(string))
+	}
+	s.Equal([]string{"scene-opened", "moved", "missed"}, kinds,
+		"recording appends exactly one beat and nothing before it")
+}

--- a/rulebooks/dnd5e/encounter/testwalls_test.go
+++ b/rulebooks/dnd5e/encounter/testwalls_test.go
@@ -4,6 +4,8 @@
 package encounter_test
 
 import (
+	"reflect"
+
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
@@ -47,4 +49,22 @@ func wallColumn(x, fromY, toY int) []spatial.Position {
 		out = append(out, spatial.Position{X: float64(x), Y: float64(y)})
 	}
 	return out
+}
+
+// structFieldNames reports a struct's exported field names in declaration
+// order, so a test can assert on a type's SHAPE rather than on the values one
+// instance happens to carry.
+//
+// Used where the guarantee is structural: RecordInput's claim is that prose is
+// inexpressible, and the only way to hold that is to notice a new field.
+func structFieldNames(v any) []string {
+	t := reflect.TypeOf(v)
+	if t == nil || t.Kind() != reflect.Struct {
+		return nil
+	}
+	names := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		names = append(names, t.Field(i).Name)
+	}
+	return names
 }

--- a/rulebooks/dnd5e/encounter/testwalls_test.go
+++ b/rulebooks/dnd5e/encounter/testwalls_test.go
@@ -51,12 +51,15 @@ func wallColumn(x, fromY, toY int) []spatial.Position {
 	return out
 }
 
-// structFieldNames reports a struct's exported field names in declaration
-// order, so a test can assert on a type's SHAPE rather than on the values one
-// instance happens to carry.
+// structFieldNames reports EVERY field name a struct declares, in declaration
+// order — unexported ones included — so a test can assert on a type's SHAPE
+// rather than on the values one instance happens to carry.
 //
-// Used where the guarantee is structural: RecordInput's claim is that prose is
-// inexpressible, and the only way to hold that is to notice a new field.
+// Including the unexported ones is the point rather than an oversight. This
+// exists to hold RecordInput's claim that prose is inexpressible, and a claim
+// about what a type can EXPRESS is not weakened by a field being lowercase:
+// an unexported string on an input that callers construct is a smell of its
+// own, and a shape pin that looked away from it would be choosing not to see.
 func structFieldNames(v any) []string {
 	t := reflect.TypeOf(v)
 	if t == nil || t.Kind() != reflect.Struct {


### PR DESCRIPTION
Census item **(e)** from #966's [stage-1 census](https://github.com/KirkDiggler/rpg-toolkit/issues/966#issuecomment-5304167452). Part of #966; does not close it.

## A rule that resolves elsewhere was invisible

A strike resolves in the `resolution` module: it returns an outcome value and **writes no beat**. `appendBeat` here is unexported. And the session SDK builds every client event by reading each member's `Story`.

So an attack driven through the seam produced **nothing to render and nothing to re-read** — invisible in the event stream and in the transcript at once. One transcript is the product; a rule that resolves somewhere else still has to land in it.

`Record` is the way in.

## Deliberately narrow: prose is inexpressible, not filtered

```go
type RecordInput struct {
    Kind    OutcomeKind           // closed enum: struck | missed
    Actor   MemberID              // validated against the roster
    Targets []MemberID            // validated, recorded sorted (C8)
    Values  map[OutcomeValue]int  // closed keys, INTEGERS only
}
```

**There is no string field, and there will not be one.** The reason the composition owns its record is that a reader can trust what is in it — an append taking free bytes would have kept the transcript in one place and given up the thing that mattered, because any caller could then narrate at other players through a log they all read. Prose here is not discouraged or sanitised; it is not expressible.

`OutcomeValue` is deliberately generic — `roll`, `total`, `against`, `amount` — because **the composition must not learn what an armour class is.** The rulebook knows which of its numbers is which; the composition knows only that they are numbers, and refuses any name off the list. The names were derived from `resolution.StrikeOutcome`'s real fields rather than imagined.

Values marshal through a **sorted slice** rather than the map, so two runs of the same input produce byte-identical beats (C8) — a transcript whose bytes wander cannot be compared.

## It records and does nothing else

No sight refresh, no trigger detection, no clock movement. That is what makes the cause-before-effect law hold **for free**: an outcome is a consequence of whatever produced it, and there is nothing here that could append before it or reorder anything.

`TestTheOutcomeLandsAfterTheVerbThatCausedIt` pins both halves — the order (`moved` then `missed`, by seq) and the "nothing else" (the whole transcript is exactly `scene-opened, moved, missed`). The second is what makes the first structural rather than a habit.

## What is pinned

| test | claim |
|---|---|
| `TestARuleResolvedElsewhereReachesTheStory` | the beat lands, tagged `outcome`, with every value intact and `Seq` referencing it |
| `TestTheTargetHearsItToo` | audience is every member — a localized fight is not a private one |
| `TestAnOutcomeCarriesNoProse` | reads the TYPE, because the guarantee is structural |
| `TestRefusalsAreCheckedAgainstTheRoster` | unknown kind, unknown value name, non-member actor, empty actor, non-member target, closed encounter |
| `TestTheOutcomeLandsAfterTheVerbThatCausedIt` | the ordering law, and the "nothing else" that makes it structural |

**Mutation-verified**: adding a `Note string` field to `RecordInput` fails `TestAnOutcomeCarriesNoProse`. That is the whole point of asserting on the shape rather than on behaviour — a field nobody argued for gets caught by a test that says why.

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok**, both packages |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

## Sequencing

The consumer is #966's `Attack` slice, which is blocked on this being tagged. Nothing calls `Record` yet, and that is the sequencing this issue's census argued for rather than speculation: the shape was derived from a real `StrikeOutcome`, and the verb that uses it is next in the queue.

— asset-pipeline agent, on behalf of KirkDiggler
