### PR TITLE
fix(session): sight is symmetric now, and the test that proved otherwise says so (#1022)

### DIFF
--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -343,8 +343,11 @@ func authoredCrypt() (*encounter.EncounterData, error) {
 			Rooms: []encounter.RoomInput{
 				{ID: "antechamber", Width: 6, Height: 6},
 				// The vault is split by rubble with one sightline through it at
-				// y=3, so what waits at (4,3) is invisible until someone lines
-				// up with the gap.
+				// y=3. Crossing the gate puts alice where both of them can be
+				// seen — sight is a LANE now (spatial v0.9.1), so she looks
+				// past the rubble's corner rather than dead down its file, and
+				// the fight that starts is the whole room's rather than one
+				// skeleton's.
 				{ID: "vault", Width: 6, Height: 6, Origin: spatial.Position{X: 6, Y: 0}, Occluders: []spatial.Position{
 					{X: 2, Y: 0}, {X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 4}, {X: 2, Y: 5},
 				}},

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
@@ -33,9 +33,9 @@ func TestWorkbenchRuns(t *testing.T) {
 
 		// A fight that starts itself, end to end. Each of these is a different
 		// claim, and any one regressing would leave the others still true:
-		"a fight starts, in order [alice skel-1]",    // contact at the doorway starts it, unasked
-		"free roam refused for a fight member: true", // and a fighter stops free-roaming
-		"bob walks on regardless, 1 step(s)",         // while everyone not in it carries on
+		"a fight starts, in order [alice skel-1 wight]", // contact at the doorway starts it, unasked
+		"free roam refused for a fight member: true",    // and a fighter stops free-roaming
+		"bob walks on regardless, 1 step(s)",            // while everyone not in it carries on
 
 		`ended by "withdraw"`,
 		"alice in vault at (0,1)", // she is where the fight stopped her, and it persisted

--- a/rulebooks/dnd5e/session/conditions_test.go
+++ b/rulebooks/dnd5e/session/conditions_test.go
@@ -119,7 +119,7 @@ func (s *ConditionsTestSuite) storedBytes(id string) []byte {
 func (s *ConditionsTestSuite) walkIntoTheAmbush(mgr *session.Manager) *session.MoveOutput {
 	out, err := mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
 	})
 	s.Require().NoError(err)
 	return out

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -147,7 +147,7 @@ func Example_theFightThatStartsItself() {
 		panic(err)
 	}
 
-	path := []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}}
+	path := []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}}
 	out, err := mgr.Move(ctx, &session.MoveInput{Session: "run", Member: "alice", Path: path})
 	if err != nil {
 		panic(err)
@@ -163,12 +163,12 @@ func Example_theFightThatStartsItself() {
 	// She cannot simply walk on: she is in the fight, and free roam is for
 	// members who are not. The refusal is the composition's, translated.
 	_, err = mgr.Move(ctx, &session.MoveInput{
-		Session: "run", Member: "alice", Path: []spatial.Position{{X: 2, Y: 4}},
+		Session: "run", Member: "alice", Path: []spatial.Position{{X: 2, Y: 3}},
 	})
 	fmt.Printf("walking on is refused: %v\n", errors.Is(err, session.ErrInBubble))
 
 	// Output:
-	// stopped after 2/3: a fight starts, in order [alice ogre]
+	// stopped after 2/4: a fight starts, in order [alice ogre]
 	// walking on is refused: true
 }
 

--- a/rulebooks/dnd5e/session/fight_starts_test.go
+++ b/rulebooks/dnd5e/session/fight_starts_test.go
@@ -67,16 +67,32 @@ func managerOverRepos(
 
 // ambushWorld is a hall split by a wall of occluders with a single gap at y=3.
 //
-// Alice starts at (1,1) with no line of sight to anything; the ogre waits at
-// (5,3) behind the wall. Walking north to (2,3) lines her up with the gap and
-// they see each other — first contact, mid-path, with a cell still to go.
+// Alice starts at (1,0) with no line of sight to anything; the ogre waits at
+// (5,3) behind the wall. Walking north brings her close enough to the gap that
+// they see each other — first contact, mid-path, with cells still to go.
+//
+// She used to start at (1,1), one row further in. Sight became a LANE rather
+// than a line (rpg-toolkit#1022, spatial v0.9.1): a viewer leans around
+// obstacles now, so from (1,1) she already found the gap at first light and
+// the scene opened mid-fight. One row back and the wall does its job again —
+// the geometry moved because the rule did, not because the scene changed.
 //
 // The scene outlived the rule it was built for. It was written when THIS
 // package decided that a sighting stops a walk; the composition owns that now
 // (rpg-toolkit#964) and the same geometry produces a started fight instead of
 // an opened window. A fixture that survives the rule it was built to test is
 // a fixture that was describing the world rather than the code.
+// ambushWorldWithAliceAt is ambushWorld with alice moved, for tests that ask
+// what the wall does from a particular spot rather than what a walk produces.
+func ambushWorldWithAliceAt(t fataler, at spatial.Position) *encounter.EncounterData {
+	return buildAmbush(t, at)
+}
+
 func ambushWorld(t fataler, extra ...encounter.MemberInput) *encounter.EncounterData {
+	return buildAmbush(t, spatial.Position{X: 1, Y: 0}, extra...)
+}
+
+func buildAmbush(t fataler, alice spatial.Position, extra ...encounter.MemberInput) *encounter.EncounterData {
 	occluders := make([]spatial.Position, 0, 7)
 	for y := 0; y < 8; y++ {
 		if y == 3 {
@@ -86,7 +102,7 @@ func ambushWorld(t fataler, extra ...encounter.MemberInput) *encounter.Encounter
 	}
 
 	members := []encounter.MemberInput{
-		{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+		{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: alice},
 		{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 5, Y: 3}},
 	}
 	members = append(members, extra...)
@@ -122,7 +138,7 @@ func (s *FightStartsTestSuite) startAmbush(extra ...encounter.MemberInput) {
 func (s *FightStartsTestSuite) walkIntoTheAmbush() *session.MoveOutput {
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
 	})
 	s.Require().NoError(err)
 	return out
@@ -143,7 +159,7 @@ func (s *FightStartsTestSuite) TestTheFightStopsTheWalk() {
 	out := s.walkIntoTheAmbush()
 
 	s.Require().Len(out.Steps, 2, "the walk stopped where the fight started")
-	s.Equal(spatial.Position{X: 2, Y: 3}, out.Steps[1].Position,
+	s.Equal(spatial.Position{X: 2, Y: 2}, out.Steps[1].Position,
 		"where she stopped, not where she was headed")
 
 	s.Require().NotNil(out.Formed, "lining up with the gap started a fight")
@@ -202,7 +218,7 @@ func (s *FightStartsTestSuite) TestTheDiceDecideTheOrder() {
 
 		out, err := mgr.Move(context.Background(), &session.MoveInput{
 			Session: "sess", Member: "alice",
-			Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}},
+			Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}},
 		})
 		s.Require().NoError(err)
 		s.Require().NotNil(out.Formed, "run %d", i)
@@ -233,7 +249,7 @@ func (s *FightStartsTestSuite) TestADiceFailureAbortsTheFight() {
 
 	_, err = mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}},
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}},
 	})
 	s.Require().Error(err, "the fight could not be ordered, so the verb fails")
 	s.ErrorIs(err, errNoRandomness, "and the host's own failure is still matchable")
@@ -267,7 +283,7 @@ func (s *FightStartsTestSuite) TestAWalkThatStartsNoFightRunsToTheEnd() {
 	// also be the answer if the walk had simply failed.
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 0, Y: 1}, {X: 0, Y: 0}},
+		Path: []spatial.Position{{X: 2, Y: 0}, {X: 2, Y: 1}},
 	})
 	s.Require().NoError(err)
 	s.Nil(out.Formed, "nobody saw anybody, so no fight started")
@@ -284,50 +300,59 @@ func (s *FightStartsTestSuite) TestAWalkThatStartsNoFightRunsToTheEnd() {
 	}
 }
 
-// TestTheOgreCanSeeWhatAliceCannot records a live fact this wave discovered,
-// and it contradicts something rpg-toolkit#964 slice 1 shipped in a comment.
+// TestSightIsSymmetric is what TestTheOgreCanSeeWhatAliceCannot became.
 //
-// Slice 1 reasoned that sight is symmetric line-of-sight with no stealth,
-// facing or range, so a one-sided contact — and therefore Surprised — could
-// not happen until asymmetric perception lands (rpg-toolkit#1020). It happens
-// today. Alice steps to (1,2), a diagonal across the wall from the ogre at
-// (5,3): the ogre holds her and she holds nothing, so the fight starts with
-// her surprised.
+// That test recorded a defect as evidence and deliberately did not bless it:
+// alice stepped to (1,2), a diagonal across the wall from the ogre at (5,3),
+// and the ogre held her while she held nothing — a one-sided contact with
+// Surprised populated and NO STEALTH ANYWHERE IN THE MODULE. It was not a
+// rule, it was the ray: occluders blocked by rasterizing the line between two
+// cells, and that rasterization was direction-dependent on a square grid, so
+// A→B and B→A were different cells and one of them clipped the wall.
 //
-// The cause is not a rule, it is the ray. Occluders block by rasterizing the
-// line between two cells, and the rasterization is direction-dependent on a
-// square grid — spatial's own IsLineOfSightBlocked comments that "the
-// canonical boundary ray differs on square grids". A→B and B→A are not the
-// same set of cells, so one of them can clip the wall and the other miss it.
+// Filed as rpg-toolkit#1022, ruled a BUG by Kirk — line of sight should be
+// symmetric by definition, and asymmetry should arrive deliberately with
+// #1020's stealth and perception, never by rounding. Fixed in spatial v0.9.1,
+// which now pins symmetry as a LAW over fuzzed rooms in every grid family.
 //
-// This test does NOT bless that. It pins what the module does today so the
-// claim in slice 1 stops being believed, and so that whoever decides whether
-// direction-dependent sight is a feature or a spatial bug finds the evidence
-// rather than the assumption. What it proves for THIS wave is the part that is
-// not in doubt: the consumer was built right. Surprised is populated, carried
-// across the boundary, and reported — no upgrade required.
-func (s *FightStartsTestSuite) TestTheOgreCanSeeWhatAliceCannot() {
-	s.startAmbush()
+// So the test flips: same scene, opposite claim. What it proved for this
+// module has not changed — the consumer was always right. Surprised populated,
+// crossed the boundary and reported correctly the whole time; what was wrong
+// was the PRODUCTION of percepts, exactly where the design said a fix belongs.
+func (s *FightStartsTestSuite) TestSightIsSymmetric() {
 	ctx := context.Background()
 
-	out, err := s.mgr.Move(ctx, &session.MoveInput{
-		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
-	})
-	s.Require().NoError(err)
+	// Walked one cell at a time, each in its own session, because a fight
+	// forming would stop the walk — the question here is what the WALL does at
+	// each spot, not what happens after contact.
+	contacts := 0
+	for _, at := range []spatial.Position{
+		{X: 1, Y: 1}, {X: 1, Y: 2}, {X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3},
+	} {
+		sessions, encounters := newFakeSessions(), newFakeEncounters()
+		mgr := managerOverRepos(s.T(), sessions, encounters)
+		_, err := mgr.StartSession(ctx, &session.StartSessionInput{
+			Session: "sess", Encounter: "world",
+			World: ambushWorldWithAliceAt(s.T(), at),
+		})
+		s.Require().NoError(err)
 
-	s.Require().NotNil(out.Formed, "the ogre noticing her is enough to start it")
-	s.Equal([]string{"alice", "ogre"}, out.Formed.Order)
-	s.Equal([]string{"alice"}, out.Formed.Surprised,
-		"she is in a fight she never saw coming")
+		aliceSees, err := mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "alice"})
+		s.Require().NoError(err)
+		ogreSees, err := mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "ogre"})
+		s.Require().NoError(err)
 
-	aliceSees, err := s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "alice"})
-	s.Require().NoError(err)
-	s.Empty(aliceSees, "she holds nothing — the wall is between them from her side")
+		s.Equal(len(aliceSees), len(ogreSees),
+			"at %v the wall must do the same thing to both of them", at)
+		if len(aliceSees) > 0 {
+			contacts++
+		}
+	}
 
-	ogreSees, err := s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "ogre"})
-	s.Require().NoError(err)
-	s.Require().Len(ogreSees, 1, "and it holds her — the same wall, the other direction")
-	s.Equal("alice", ogreSees[0].Subject)
+	s.Require().Positive(contacts,
+		"the fixture must actually put them in sight somewhere, or this proves nothing")
+	s.Require().Less(contacts, 5,
+		"and must block them somewhere, or the wall is not in the way")
 }
 
 // TestAFightOnTheFinalCellIsStillReported is the inverted twin of a rule that
@@ -346,7 +371,7 @@ func (s *FightStartsTestSuite) TestAFightOnTheFinalCellIsStillReported() {
 
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 2, Y: 2}, {X: 2, Y: 3}}, // contact lands on the last cell
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}}, // contact lands on the last cell
 	})
 	s.Require().NoError(err)
 	s.Require().Len(out.Steps, 2, "the walk finished")
@@ -396,7 +421,7 @@ func (s *FightStartsTestSuite) TestAWalkWritesOnlyTheEncounter() {
 
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 1, Y: 2}},
+		Path: []spatial.Position{{X: 2, Y: 0}},
 	})
 	s.Require().NoError(err)
 	s.Equal([]string{"encounter:world"}, out.Saved.Written,
@@ -448,7 +473,7 @@ func (s *FightStartsTestSuite) TestATotalSaveFailureNamesOnlyWhatWasAttempted() 
 	mgr := managerOverRepos(s.T(), s.sessions, encounters)
 
 	_, err := mgr.Move(context.Background(), &session.MoveInput{
-		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 2}},
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 1}},
 	})
 	s.Require().Error(err)
 

--- a/rulebooks/dnd5e/session/fight_starts_test.go
+++ b/rulebooks/dnd5e/session/fight_starts_test.go
@@ -133,8 +133,9 @@ func (s *FightStartsTestSuite) startAmbush(extra ...encounter.MemberInput) {
 	s.Require().NoError(err)
 }
 
-// walkIntoTheAmbush walks the three-cell path that meets the ogre on cell two,
-// and returns the output.
+// walkIntoTheAmbush walks the four-cell path that meets the ogre on cell two,
+// and returns the output — two cells still to go, which is what makes "the
+// fight stopped the walk" a claim rather than a coincidence.
 func (s *FightStartsTestSuite) walkIntoTheAmbush() *session.MoveOutput {
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
@@ -277,10 +278,15 @@ func (s *FightStartsTestSuite) TestADiceFailureAbortsTheFight() {
 func (s *FightStartsTestSuite) TestAWalkThatStartsNoFightRunsToTheEnd() {
 	s.startAmbush()
 
-	// She walks the other way, into the corner at (0,0). The wall stays
-	// between her and the ogre the whole time and neither ever holds the
-	// other — verified below rather than assumed, because "no fight" would
-	// also be the answer if the walk had simply failed.
+	// She walks up the near side of the wall, (2,0) then (2,1), staying off
+	// the file the gap opens onto. Neither ever holds the other — verified
+	// below rather than assumed, because "no fight" would also be the answer
+	// if the walk had simply failed.
+	//
+	// This route used to run to the corner at (0,0). Lane sight reaches
+	// through the gap at a much shallower angle than a single ray did, and the
+	// whole x=0 column turned out to be in view of it — so the old "quiet"
+	// corner is now the loudest cell in the room.
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
 		Path: []spatial.Position{{X: 2, Y: 0}, {X: 2, Y: 1}},
@@ -292,7 +298,7 @@ func (s *FightStartsTestSuite) TestAWalkThatStartsNoFightRunsToTheEnd() {
 
 	// Both directions, because sight is NOT symmetric in this composition: a
 	// walk the ogre could see would start a fight just as surely as one alice
-	// could see (see TestTheOgreCanSeeWhatAliceCannot).
+	// could see (see TestSightIsSymmetric).
 	for _, who := range []string{"alice", "ogre"} {
 		seen, verr := s.mgr.View(context.Background(), &session.ViewInput{Session: "sess", Member: who})
 		s.Require().NoError(verr)
@@ -319,6 +325,21 @@ func (s *FightStartsTestSuite) TestAWalkThatStartsNoFightRunsToTheEnd() {
 // module has not changed — the consumer was always right. Surprised populated,
 // crossed the boundary and reported correctly the whole time; what was wrong
 // was the PRODUCTION of percepts, exactly where the design said a fix belongs.
+// holds reports whether these holdings include a live sighting of a named
+// subject.
+//
+// The symmetry claim is about WHO each side can see, not how many things they
+// hold: equal counts would still pass if the two were seeing different things,
+// and a symmetry test that cannot tell those apart is not one.
+func holds(holdings []session.Sighting, subject string) bool {
+	for _, h := range holdings {
+		if h.Subject == subject {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *FightStartsTestSuite) TestSightIsSymmetric() {
 	ctx := context.Background()
 
@@ -342,9 +363,13 @@ func (s *FightStartsTestSuite) TestSightIsSymmetric() {
 		ogreSees, err := mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "ogre"})
 		s.Require().NoError(err)
 
-		s.Equal(len(aliceSees), len(ogreSees),
+		// Subjects rather than counts. Equal lengths would still pass if the
+		// two were seeing DIFFERENT things, and a symmetry claim that cannot
+		// tell those apart is not a symmetry claim.
+		aliceHoldsOgre, ogreHoldsAlice := holds(aliceSees, "ogre"), holds(ogreSees, "alice")
+		s.Equal(aliceHoldsOgre, ogreHoldsAlice,
 			"at %v the wall must do the same thing to both of them", at)
-		if len(aliceSees) > 0 {
+		if aliceHoldsOgre {
 			contacts++
 		}
 	}

--- a/rulebooks/dnd5e/session/fight_starts_test.go
+++ b/rulebooks/dnd5e/session/fight_starts_test.go
@@ -296,9 +296,10 @@ func (s *FightStartsTestSuite) TestAWalkThatStartsNoFightRunsToTheEnd() {
 	s.Len(out.Steps, 2, "so the whole path is walked")
 	s.Empty(out.Discovered["alice"].FirstContact, "and there was nothing to see")
 
-	// Both directions, because sight is NOT symmetric in this composition: a
-	// walk the ogre could see would start a fight just as surely as one alice
-	// could see (see TestSightIsSymmetric).
+	// Both directions on purpose, even though TestSightIsSymmetric proves they
+	// must agree. A negative control that leans on another test's conclusion
+	// inherits its failure: if symmetry ever broke, this test would go on
+	// reporting a quiet walk while only checking the quiet half.
 	for _, who := range []string{"alice", "ogre"} {
 		seen, verr := s.mgr.View(context.Background(), &session.ViewInput{Session: "sess", Member: who})
 		s.Require().NoError(verr)

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.1
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,10 +18,10 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.0 h1:HUZdBPXmmCqsZKY6XCmtQSHW5mmakB7Dk6lTUobMOkE=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.0/go.mod h1:ZYYd+oFBN6WUPIb+OTaAu6X7CQtVhOjEg9i0GJM0o6Q=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0 h1:y43RqrCtZMh3F9wf4a0xdJxANTVt4SikZE205sHt1gA=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.1 h1:a27UM+G0HevM2K2+Y2YmQTyHLNevcSpQy24cdnM7JkM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.1/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -149,13 +149,19 @@ type Formed struct {
 
 	// Surprised names the members who entered unaware, a subset of Order.
 	//
-	// It is populated TODAY, which is worth saying because the composition's
-	// own notes predicted it would stay empty until asymmetric perception
-	// arrives (rpg-toolkit#1020). Occlusion already produces one-sided
-	// contact: a wall's line-of-sight ray is direction-dependent on a square
-	// grid, so a monster can hold a player who does not hold it back, and the
-	// player enters that fight surprised. See
-	// TestTheOgreCanSeeWhatAliceCannot.
+	// EMPTY TODAY, and the round trip is worth recording. The composition's
+	// notes originally predicted it would stay empty until asymmetric
+	// perception arrives (rpg-toolkit#1020) — then this doc said the opposite,
+	// because occlusion really was producing one-sided contact: a wall's
+	// line-of-sight ray was direction-dependent on a square grid, so a monster
+	// could hold a player who did not hold it back. That was a defect, not a
+	// rule (rpg-toolkit#1022), and spatial v0.9.1 fixed it by making symmetry
+	// a law. Under symmetric sight nobody can be unaware of somebody who is
+	// aware of them, so this cannot fill.
+	//
+	// The original prediction is therefore true again: it fills when #1020
+	// brings asymmetry DELIBERATELY, through stealth against perception, and
+	// never through geometry. See TestSightIsSymmetric.
 	//
 	// Surprise is a fact about the MOMENT the fight started — a member
 	// surprised at formation stays surprised through their first turn however


### PR DESCRIPTION
Link 2 — the last of the #1022 consumer chain. `encounter` **v0.8.1**, which brings `spatial` **v0.9.1**'s lane-based sight.

## The ogre pin flips

`TestTheOgreCanSeeWhatAliceCannot` was written during #964 slice 2 to record a defect **as evidence, deliberately unblessed**: alice stepped to a diagonal across the wall, the ogre held her, she held nothing — a one-sided contact with `Surprised` populated and **no stealth anywhere in the module**.

It was never a rule. It was the ray: occluders blocked by rasterizing the line between two cells, and that rasterization was direction-dependent on a square grid, so A→B and B→A were different cells and one of them clipped the wall. Kirk ruled it a bug (#1022) — line of sight should be symmetric by definition, and asymmetry should arrive deliberately with #1020's stealth and perception, never by rounding.

So it becomes **`TestSightIsSymmetric`**, and it is a **sweep rather than a single pair**: five positions around the wall, each requiring alice and the ogre to see the same thing of each other. The fixture is required to produce **both** contact and blocking —

```go
s.Require().Positive(contacts, "the fixture must actually put them in sight somewhere, or this proves nothing")
s.Require().Less(contacts, 5, "and must block them somewhere, or the wall is not in the way")
```

— because the naive version of this test (`aliceSees == ogreSees`) passes trivially when neither sees anything, which would have been a green test asserting nothing.

**What it proved for this module has not changed.** The consumer was always right: `Surprised` populated, crossed the boundary and reported correctly the whole time. What was wrong was the PRODUCTION of percepts, exactly where the design said a fix belongs.

## The ambush moved one row

Alice started at (1,1). Under lane sight she finds the gap from there at first light, so the scene opened **mid-fight** and every walk failed with `member is in a fight` before it began. From **(1,0)** the wall does its job again, and the walk that meets the ogre gained a leading cell.

The geometry moved because the rule did, not because the scene changed. Every assertion about what the scene MEANS is intact — including that the walk stops with cells still to go, which is the whole point of `TestTheFightStopsTheWalk`.

Where cells moved, they were chosen from a measured contact map rather than guessed:

```
      x=0 x=1 x=2
y=0    X   .   .        X = sees the ogre
y=1    X   X   .        . = blocked by the wall
y=2    X   X   X
```

That is also why the "quiet walk" negative control changed route: its old corner path at x=0 is in full view of the gap now.

## The workbench's fight got bigger, and that is the fix in a transcript

`[alice skel-1]` became `[alice skel-1 wight]`. Crossing the gate lets alice look **past the rubble's corner** rather than only down its file, so the fight that starts is the whole room's. The demo keeps it and says why — it is the clearest thing in the repo showing what changed.

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok**, both packages |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |
| `go run ./cmd/session-workbench` | runs; transcript updated |

## Chain

Completes the #1022 consumer chain for the new stack: spatial → encounter → session. The root `encounter` module's bump is **#1026**, ruled by Kirk as sequenced after the wave. #964's ratification comment is corrected separately by the lead.

— asset-pipeline agent, on behalf of KirkDiggler
