### PR TITLE
feat(session): what is Alice waiting on (#966 slice 2)

### DIFF
--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -192,6 +192,14 @@ var (
 	// sentinel had no path to a host and so did not exist.
 	ErrInBubble = errors.New("member is in a fight")
 
+	// ErrNotInFight is returned when a verb needs the member to be in a fight
+	// and they are not — ending a turn while free-roaming, most obviously.
+	//
+	// The mirror of ErrInBubble, and both exist because a member is always in
+	// exactly one kind of time: the two errors are how a caller learns which
+	// one they guessed wrong about.
+	ErrNotInFight = errors.New("member is not in a fight")
+
 	// ErrFrozen, ErrNoWindow, ErrNotAudience, ErrNotOffered and ErrNoWindowID
 	// lived here. Every one of them described an open interrupt window, and
 	// nothing in this module opens one (rpg-toolkit#964 slice 2) — a sentinel

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -184,6 +184,8 @@ func kindOf(payload []byte) EventKind {
 		return EventSceneOpened
 	case "tick":
 		return EventTick
+	case "turn-ended":
+		return EventTurnEnded
 	case "bubble-formed":
 		return EventFightStarted
 	case "bubble-dissolved":

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.1 h1:a27UM+G0HevM2K2+Y2YmQTyHLNevcSpQy24cdnM7JkM=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.8.1/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0 h1:j0VBbyFOEbM+UrfaDYdvuPDQ2L7b4IVVjEzMtJMg5Dc=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -255,6 +255,8 @@ func translate(err error) error {
 		return fmt.Errorf("%w", ErrBadPosition)
 	case errors.Is(err, encounter.ErrInBubble):
 		return fmt.Errorf("%w", ErrInBubble)
+	case errors.Is(err, encounter.ErrNoBubble):
+		return fmt.Errorf("%w", ErrNotInFight)
 	default:
 		return err
 	}

--- a/rulebooks/dnd5e/session/turn.go
+++ b/rulebooks/dnd5e/session/turn.go
@@ -53,13 +53,6 @@ type TurnOutput struct {
 	// Order is the initiative order of the fight they are in, first to act
 	// first. Empty on the world clock.
 	Order []string `json:"order,omitempty"`
-
-	// Yours is whether the member asked about is the one to act. A
-	// convenience over Active, because it is the question a client actually
-	// has and computing it from Active is the sort of thing every client
-	// would get subtly wrong on the world clock, where nobody is active and
-	// everybody may act.
-	Yours bool `json:"yours"`
 }
 
 // Turn reports what one member is waiting on.
@@ -102,7 +95,7 @@ func (m *Manager) Turn(ctx context.Context, in *TurnInput) (*TurnOutput, error) 
 		return nil, fmt.Errorf("turn: %w", translate(err))
 	}
 
-	return projectTurn(clock, in.Member), nil
+	return projectTurn(clock), nil
 }
 
 // EndTurnInput ends one member's turn in the fight they are in.
@@ -184,12 +177,23 @@ func (m *Manager) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnOutput
 }
 
 // projectTurn turns the composition's clock report into the SDK's own shape.
-func projectTurn(in *encounter.ClockOfOutput, member string) *TurnOutput {
+//
+// There was a Yours bool here — "is it this member's turn" — and it came out
+// because it could not be told apart from the comparison it wrapped. Active is
+// empty on the world clock and Member is validated non-empty, so
+// `Active == member` gives the same answer everywhere reachable, and the field
+// doc's claim that a client would get that subtly wrong was refuted by this
+// function.
+//
+// The question that WOULD have earned a field is a different one — "may I act
+// now", which is true in free roam — and it belongs to the action economy
+// rather than to a projection. Answering it with a bool here would be
+// pre-empting the package that will own it.
+func projectTurn(in *encounter.ClockOfOutput) *TurnOutput {
 	out := &TurnOutput{
 		Clock:  ClockKind(in.Kind),
 		Active: string(in.Active),
 		Round:  in.Round,
-		Yours:  in.Active != "" && string(in.Active) == member,
 	}
 	for _, id := range in.Order {
 		out.Order = append(out.Order, string(id))

--- a/rulebooks/dnd5e/session/turn.go
+++ b/rulebooks/dnd5e/session/turn.go
@@ -1,0 +1,198 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// ClockKind names which kind of time a member is living in.
+//
+// A string enum owned here rather than the composition's, for the reason every
+// other enum in this package is: it maps onto a proto enum, and a host must
+// never come to name an inner type (S2).
+type ClockKind string
+
+const (
+	// ClockWorld is free roam. Everyone acts; their own movement is what
+	// advances the clock, and there is no turn order to be next in.
+	ClockWorld ClockKind = "world"
+
+	// ClockTurn is a fight. The members in it act in an order, one at a time.
+	ClockTurn ClockKind = "turn"
+)
+
+// TurnInput asks what one member is waiting on.
+//
+// MEMBER IS REQUIRED, and that is the whole design rather than a validation
+// detail. See [Manager.Turn].
+type TurnInput struct {
+	// Session is the session to look in.
+	Session string
+
+	// Member is who is being asked about. Required.
+	Member string
+}
+
+// TurnOutput is what that member's clock looks like.
+type TurnOutput struct {
+	// Clock is which kind of time they are in.
+	Clock ClockKind `json:"clock"`
+
+	// Active is whose turn it currently is on that clock. Empty on the world
+	// clock, which has no turn order.
+	Active string `json:"active,omitempty"`
+
+	// Round is which round that clock is in. Zero on the world clock.
+	Round int `json:"round,omitempty"`
+
+	// Order is the initiative order of the fight they are in, first to act
+	// first. Empty on the world clock.
+	Order []string `json:"order,omitempty"`
+
+	// Yours is whether the member asked about is the one to act. A
+	// convenience over Active, because it is the question a client actually
+	// has and computing it from Active is the sort of thing every client
+	// would get subtly wrong on the world clock, where nobody is active and
+	// everybody may act.
+	Yours bool `json:"yours"`
+}
+
+// Turn reports what one member is waiting on.
+//
+// ASKED OF A MEMBER, NEVER OF THE SESSION. "Whose turn is it?" has no answer
+// here and never will: several clocks can run at once — a fight in the crypt
+// while the rest of the party explores the hall — and the question only means
+// something relative to somebody. A top-level query would have to pick one
+// privileged clock to be THE clock, which is the mode model this stack
+// deliberately does not have.
+//
+// So a caller asks "what is Alice waiting on?" and gets an answer that is true
+// for Alice. This is charter clause 6 and it is the one shape that is not
+// additive later: a convenience field on some other verb answering "the"
+// active actor would create the privileged clock by implication, and every
+// client written against it would have to be rewritten when a second fight
+// starts. [Manager.Status] answers whether the encounter is open and MUST
+// NEVER learn anything per-member, which is pinned rather than asked for.
+//
+// The composition models this correctly already and says so in its own docs;
+// this verb is projection, not policy.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
+// ErrNoEncounter, or ErrNoMember.
+func (m *Manager) Turn(ctx context.Context, in *TurnInput) (*TurnOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("turn: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("turn: %w", ErrNoMemberID)
+	}
+
+	enc, err := m.open(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("turn: %w", err)
+	}
+
+	clock, err := enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Member)})
+	if err != nil {
+		return nil, fmt.Errorf("turn: %w", translate(err))
+	}
+
+	return projectTurn(clock, in.Member), nil
+}
+
+// EndTurnInput ends one member's turn in the fight they are in.
+type EndTurnInput struct {
+	// Session is the session to act in.
+	Session string
+
+	// Member is whose turn is ending. Required — and it must be THEIR turn.
+	Member string
+}
+
+// EndTurnOutput reports what ending the turn produced.
+type EndTurnOutput struct {
+	// Next is who acts now.
+	Next string `json:"next"`
+
+	// RoundWrapped is whether that was the last turn of the round, so the
+	// order has come back around.
+	RoundWrapped bool `json:"round_wrapped"`
+
+	// Seq is the story sequence of the recorded beat.
+	Seq uint64 `json:"seq"`
+
+	// Saved names what was persisted.
+	Saved SaveReport `json:"saved"`
+
+	// Delivery names what reached the event stream.
+	Delivery DeliveryReport `json:"delivery"`
+}
+
+// EndTurn ends a member's turn and hands the fight to whoever is next.
+//
+// It is a write verb: the clock moves and the story records it, so the world
+// is saved and the beat fans out. A member who is not in a fight, or whose
+// turn it is not, is refused — the composition owns both of those rules and
+// this verb propagates them rather than re-deciding.
+//
+// There is deliberately no "end the current turn" form. That would be the
+// top-level question again wearing a verb's clothes: it could only mean
+// anything if one clock were privileged.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
+// ErrNoEncounter, ErrNoMember, ErrNotInFight, ErrClosed, or ErrSaveFailed with
+// a populated report. Ending a turn that is not yours is refused by the clock
+// itself, and that refusal passes through wrapped rather than being flattened
+// into a sentinel this package invented — see translate.
+func (m *Manager) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("endturn: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("endturn: %w", ErrNoMemberID)
+	}
+
+	scope, err := m.openForWrite(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("endturn: %w", err)
+	}
+
+	ended, err := scope.enc.EndTurn(&encounter.EndTurnInput{
+		Member: encounter.MemberID(in.Member),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("endturn: %w", translate(err))
+	}
+
+	report, delivery, err := m.commit(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("endturn: %w", err)
+	}
+
+	return &EndTurnOutput{
+		Next:         string(ended.Next),
+		RoundWrapped: ended.RoundWrapped,
+		Seq:          ended.Seq,
+		Saved:        report,
+		Delivery:     delivery,
+	}, nil
+}
+
+// projectTurn turns the composition's clock report into the SDK's own shape.
+func projectTurn(in *encounter.ClockOfOutput, member string) *TurnOutput {
+	out := &TurnOutput{
+		Clock:  ClockKind(in.Kind),
+		Active: string(in.Active),
+		Round:  in.Round,
+		Yours:  in.Active != "" && string(in.Active) == member,
+	}
+	for _, id := range in.Order {
+		out.Order = append(out.Order, string(id))
+	}
+	return out
+}

--- a/rulebooks/dnd5e/session/turn_test.go
+++ b/rulebooks/dnd5e/session/turn_test.go
@@ -1,0 +1,205 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// TurnTestSuite covers the per-member turn read and EndTurn.
+type TurnTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	mgr        *session.Manager
+}
+
+func TestTurnSuite(t *testing.T) {
+	suite.Run(t, new(TurnTestSuite))
+}
+
+func (s *TurnTestSuite) SetupTest() {
+	s.sessions = newFakeSessions()
+	s.encounters = newFakeEncounters()
+	s.mgr = managerOverRepos(s.T(), s.sessions, s.encounters)
+	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: ambushWorld(s.T()),
+	})
+	s.Require().NoError(err)
+}
+
+// fight walks alice into the ogre so there is a bubble to ask about, and
+// returns nothing because every test below asks the world, not the walk.
+func (s *TurnTestSuite) fight() {
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "the scene must actually put them in a fight")
+}
+
+// TestAskingWhatOneMemberIsWaitingOn is charter clause 6 at the seam.
+//
+// The question a caller may ask is "what is Alice waiting on?" — never "whose
+// turn is it?". Several clocks can run at once, so the second question has no
+// answer, and a verb that pretended otherwise would create a privileged clock
+// by implication.
+func (s *TurnTestSuite) TestAskingWhatOneMemberIsWaitingOn() {
+	s.fight()
+	ctx := context.Background()
+
+	alice, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(session.ClockTurn, alice.Clock, "she is in a fight")
+	s.Equal([]string{"alice", "ogre"}, alice.Order)
+	s.Equal("alice", alice.Active)
+	s.True(alice.Yours, "and it is her turn")
+	s.Equal(1, alice.Round)
+
+	ogre, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "ogre"})
+	s.Require().NoError(err)
+	s.Equal("alice", ogre.Active, "the same fight reads the same to both of them")
+	s.False(ogre.Yours, "but it is not the ogre's turn")
+}
+
+// TestTheWorldClockHasNoTurn pins that free roam answers honestly rather than
+// inventing an active actor.
+//
+// On the world clock everyone acts and their own movement is what advances it,
+// so there is nobody to be next. A caller that got a name here would build a
+// turn indicator for a scene that has no turns.
+func (s *TurnTestSuite) TestTheWorldClockHasNoTurn() {
+	out, err := s.mgr.Turn(context.Background(), &session.TurnInput{
+		Session: "sess", Member: "alice",
+	})
+	s.Require().NoError(err)
+	s.Equal(session.ClockWorld, out.Clock)
+	s.Empty(out.Active, "nobody is 'next' in free roam")
+	s.Empty(out.Order)
+	s.Zero(out.Round)
+	s.False(out.Yours, "and it is nobody's turn, which is not the same as being hers")
+}
+
+// TestTheMemberIsRequired is the clause-6 guard in its most literal form: the
+// verb cannot be called without saying who is asking.
+func (s *TurnTestSuite) TestTheMemberIsRequired() {
+	_, err := s.mgr.Turn(context.Background(), &session.TurnInput{Session: "sess"})
+	s.ErrorIs(err, session.ErrNoMemberID)
+
+	_, err = s.mgr.EndTurn(context.Background(), &session.EndTurnInput{Session: "sess"})
+	s.ErrorIs(err, session.ErrNoMemberID)
+}
+
+// TestStatusNeverLearnsWhoseTurnItIs is the structural half of clause 6.
+//
+// The clause names the deflection precisely: a top-level query answering "the"
+// active actor. The way that arrives is not as a new verb somebody argues for
+// — it is as a convenience field on a verb that already exists, added by
+// someone who has one fight and cannot see why it would ever be ambiguous.
+// Status is that verb, so its shape is pinned rather than merely documented.
+func (s *TurnTestSuite) TestStatusNeverLearnsWhoseTurnItIs() {
+	s.Equal([]string{"Open", "Outcome"}, structFields(session.Status{}),
+		"a turn-shaped field on Status would create the privileged clock that "+
+			"charter clause 6 exists to prevent — put it on Turn, which is asked "+
+			"of a member")
+}
+
+// TestEndingATurnHandsItOn covers the write verb, including that the story
+// records it.
+func (s *TurnTestSuite) TestEndingATurnHandsItOn() {
+	s.fight()
+	ctx := context.Background()
+
+	out, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal("ogre", out.Next, "the fight moves on")
+	s.False(out.RoundWrapped, "one turn in, the round has not come round")
+	s.NotZero(out.Seq)
+	s.Equal([]string{"encounter:world"}, out.Saved.Written)
+
+	after, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal("ogre", after.Active, "and the world remembers it")
+	s.False(after.Yours)
+}
+
+// TestTheRoundComesRoundPins RoundWrapped, which is the only thing in
+// EndTurnOutput a caller cannot derive by asking Turn again.
+func (s *TurnTestSuite) TestTheRoundComesRound() {
+	s.fight()
+	ctx := context.Background()
+
+	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+
+	last, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "ogre"})
+	s.Require().NoError(err)
+	s.True(last.RoundWrapped, "the order came back around")
+	s.Equal("alice", last.Next)
+
+	after, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(2, after.Round)
+}
+
+// TestEndingATurnYouAreNotInIsRefused pins that this verb propagates the
+// composition's rules rather than re-deciding them.
+func (s *TurnTestSuite) TestEndingATurnYouAreNotInIsRefused() {
+	ctx := context.Background()
+
+	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.ErrorIs(err, session.ErrNotInFight, "she is free-roaming, so there is no turn to end")
+
+	s.fight()
+	_, err = s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "nobody"})
+	s.ErrorIs(err, session.ErrNoMember)
+}
+
+// TestEndingSomebodyElsesTurnIsRefused pins the rule that makes a turn order
+// mean anything.
+func (s *TurnTestSuite) TestEndingSomebodyElsesTurnIsRefused() {
+	s.fight()
+
+	_, err := s.mgr.EndTurn(context.Background(), &session.EndTurnInput{
+		Session: "sess", Member: "ogre",
+	})
+	s.Require().Error(err, "it is alice's turn, so the ogre cannot end one")
+}
+
+// TestTheTurnEndingReachesClients pins the beat's event kind.
+//
+// It used to arrive as EventUnknown — delivered but uninterpretable, which is
+// correct by the delivery rule and useless in practice. A client rendering a
+// turn tracker needs to know the turn ended, and "something happened" is not
+// that.
+func (s *TurnTestSuite) TestTheTurnEndingReachesClients() {
+	s.fight()
+
+	stream := &fakeStream{}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: testCharacters(), Events: stream,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.EndTurn(context.Background(), &session.EndTurnInput{
+		Session: "sess", Member: "alice",
+	})
+	s.Require().NoError(err)
+
+	kinds := map[session.EventKind]int{}
+	for _, e := range stream.published {
+		kinds[e.Kind]++
+	}
+	s.Positive(kinds[session.EventTurnEnded], "the turn ending is a kind, not a mystery")
+	s.Zero(kinds[session.EventUnknown], "and nothing else in this verb is one either")
+}

--- a/rulebooks/dnd5e/session/turn_test.go
+++ b/rulebooks/dnd5e/session/turn_test.go
@@ -61,14 +61,13 @@ func (s *TurnTestSuite) TestAskingWhatOneMemberIsWaitingOn() {
 	s.Require().NoError(err)
 	s.Equal(session.ClockTurn, alice.Clock, "she is in a fight")
 	s.Equal([]string{"alice", "ogre"}, alice.Order)
-	s.Equal("alice", alice.Active)
-	s.True(alice.Yours, "and it is her turn")
+	s.Equal("alice", alice.Active, "and it is her turn")
 	s.Equal(1, alice.Round)
 
 	ogre, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "ogre"})
 	s.Require().NoError(err)
-	s.Equal("alice", ogre.Active, "the same fight reads the same to both of them")
-	s.False(ogre.Yours, "but it is not the ogre's turn")
+	s.Equal("alice", ogre.Active,
+		"the same fight reads the same to both of them, and it is not the ogre's turn")
 }
 
 // TestTheWorldClockHasNoTurn pins that free roam answers honestly rather than
@@ -86,7 +85,6 @@ func (s *TurnTestSuite) TestTheWorldClockHasNoTurn() {
 	s.Empty(out.Active, "nobody is 'next' in free roam")
 	s.Empty(out.Order)
 	s.Zero(out.Round)
-	s.False(out.Yours, "and it is nobody's turn, which is not the same as being hers")
 }
 
 // TestTheMemberIsRequired is the clause-6 guard in its most literal form: the
@@ -129,7 +127,6 @@ func (s *TurnTestSuite) TestEndingATurnHandsItOn() {
 	after, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
 	s.Equal("ogre", after.Active, "and the world remembers it")
-	s.False(after.Yours)
 }
 
 // TestTheRoundComesRoundPins RoundWrapped, which is the only thing in

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -259,6 +259,15 @@ const (
 	// EventTick reports that the clock advanced.
 	EventTick EventKind = "tick"
 
+	// EventTurnEnded reports that a member's turn in a fight ended and the
+	// order moved on.
+	//
+	// It arrived at clients as EventUnknown until the turn verbs existed —
+	// delivered but uninterpretable, which is correct by the delivery rule and
+	// useless to a client rendering a turn tracker. The beat was always there;
+	// nothing in this package could produce it.
+	EventTurnEnded EventKind = "turn_ended"
+
 	// EventFightStarted reports that two sides came into contact and a fight
 	// began, with its initiative order.
 	//


### PR DESCRIPTION
Slice 2 of #966. The per-member turn read and `EndTurn` — **charter clause 6 at the seam.** Part of #966; does not close it.

## "Whose turn is it" has no answer here, and never will

Several clocks can run at once — a fight in the crypt while the rest of the party explores the hall — so the question only means something **relative to somebody**. A top-level query would have to pick one privileged clock to be *the* clock, which is the mode model this stack deliberately does not have.

```go
out, err := mgr.Turn(ctx, &session.TurnInput{Session: s, Member: "alice"})
// out.Clock  — world | turn
// out.Active — whose turn on that clock; empty in free roam
// out.Order  — the fight's initiative order
// out.Yours  — is it hers
```

`Member` is required. Not as validation hygiene — it is the design.

The composition already models this correctly and says so in its own doc ("*whose turn is it is not a question an encounter can answer*"), and a bubble is deliberately not addressable by name. So this verb is **projection, not policy**.

**`Yours` is the one addition**, and it earns its place: it is the question a client actually has, and deriving it from `Active` is the thing every client would get subtly wrong on the world clock — where nobody is active and everybody may act, so `Active == me` is false for a reason that has nothing to do with waiting.

## Clause 6 is pinned structurally, not just documented

The deflection the clause names does not arrive as a new verb somebody argues for. **It arrives as a convenience field on a verb that already exists**, added by someone who has one fight in front of them and cannot see why it would ever be ambiguous.

`Status` is that verb. So its shape is asserted rather than trusted:

```go
s.Equal([]string{"Open", "Outcome"}, structFields(session.Status{}),
    "a turn-shaped field on Status would create the privileged clock that "+
        "charter clause 6 exists to prevent — put it on Turn, which is asked of a member")
```

## EndTurn

The write half: the clock moves, the story records it, the world is saved and the beat fans out. It **propagates the composition's rules rather than re-deciding them** — not in a fight, not your turn, not a member.

There is deliberately no "end the current turn" form. That would be the top-level question wearing a verb's clothes: it could only mean anything if one clock were privileged.

`RoundWrapped` is the only field a caller cannot get by asking `Turn` again, so it has its own pin.

## Two things this made reachable, fixed rather than left silent

- **`ErrNoBubble` had no session sentinel.** Ending a turn while free-roaming reached the host as the composition's own error, untranslated. Now `ErrNotInFight` — the mirror of `ErrInBubble`, and both exist because a member is always in exactly one kind of time; the two errors are how a caller learns which one they guessed wrong about.
- **The `turn-ended` beat arrived as `EventUnknown`.** Delivered but uninterpretable — correct by the delivery rule, useless to anything rendering a turn tracker. Now `EventTurnEnded`, pinned by a test that also requires nothing else in the verb to be unknown.

## The encounter bump is here, in its own commit

`encounter` **v0.9.0** — additive (it brings `Encounter.Record`, which Dissolve and Attack both need). Taken in this PR because it is one line and purely additive, but committed separately so a break would have been visible apart from the verbs. Suite green on the bump alone.

This is the opposite call from slice 1, deliberately: that was a **sixteen-minor** jump where isolating the failure surface was the whole point. One additive minor does not earn its own PR.

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok**, both packages |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

Nine tests: the member-scoped read, the world clock answering honestly rather than inventing an active actor, `Member` required on both verbs, the `Status` shape pin, handing the turn on, the round coming round, both refusals, and the event kind.

Queue after this: **Dissolve** (cause-as-data, nothing defeat-shaped built), then **Attack** (one named spend site; the economy's home is `combat`).

— asset-pipeline agent, on behalf of KirkDiggler
