### PR TITLE
feat(session): a fight can end (#1024 verb half)

### DIFF
--- a/rulebooks/dnd5e/session/boundary_test.go
+++ b/rulebooks/dnd5e/session/boundary_test.go
@@ -389,3 +389,26 @@ func structFields(v any) []string {
 	}
 	return names
 }
+
+// interfaceMethodNames reports the method names an interface type declares,
+// including the unexported ones — which is the point, since an unexported
+// method is how a Go interface seals its set of implementations.
+//
+// Pass a typed nil pointer: interfaceMethodNames((*Foo)(nil)).
+func interfaceMethodNames(ptr any) []string {
+	t := reflect.TypeOf(ptr)
+	if t == nil || t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Interface {
+		return nil
+	}
+	iface := t.Elem()
+	names := make([]string, 0, iface.NumMethod())
+	for i := 0; i < iface.NumMethod(); i++ {
+		names = append(names, iface.Method(i).Name)
+	}
+	return names
+}
+
+// isExportedName reports whether a Go identifier is exported.
+func isExportedName(name string) bool {
+	return name != "" && ast.IsExported(name)
+}

--- a/rulebooks/dnd5e/session/boundary_test.go
+++ b/rulebooks/dnd5e/session/boundary_test.go
@@ -390,25 +390,31 @@ func structFields(v any) []string {
 	return names
 }
 
-// interfaceMethodNames reports the method names an interface type declares,
-// including the unexported ones — which is the point, since an unexported
-// method is how a Go interface seals its set of implementations.
+// unexportedInterfaceMethods reports the UNEXPORTED methods an interface
+// declares — the ones that seal it, since a type outside the declaring package
+// cannot implement them.
 //
-// Pass a typed nil pointer: interfaceMethodNames((*Foo)(nil)).
-func interfaceMethodNames(ptr any) []string {
+// Reflection rather than the AST parsing above, and deliberately: for an
+// INTERFACE type, reflect's NumMethod includes unexported methods and reports
+// each one's package. That is documented behaviour rather than an accident of
+// same-module compilation — verified from a separate module entirely, where
+// DissolveCause reports NumMethod=2 with isDissolveCause carrying
+// PkgPath=".../session" and IsExported()=false. (It is NON-interface types
+// whose unexported methods reflect omits, which is the rule this is often
+// confused with.)
+//
+// Pass a typed nil pointer: unexportedInterfaceMethods((*Foo)(nil)).
+func unexportedInterfaceMethods(ptr any) []string {
 	t := reflect.TypeOf(ptr)
 	if t == nil || t.Kind() != reflect.Pointer || t.Elem().Kind() != reflect.Interface {
 		return nil
 	}
 	iface := t.Elem()
-	names := make([]string, 0, iface.NumMethod())
+	var sealed []string
 	for i := 0; i < iface.NumMethod(); i++ {
-		names = append(names, iface.Method(i).Name)
+		if m := iface.Method(i); !m.IsExported() {
+			sealed = append(sealed, m.Name)
+		}
 	}
-	return names
-}
-
-// isExportedName reports whether a Go identifier is exported.
-func isExportedName(name string) bool {
-	return name != "" && ast.IsExported(name)
+	return sealed
 }

--- a/rulebooks/dnd5e/session/dissolve.go
+++ b/rulebooks/dnd5e/session/dissolve.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// DissolveKind names why a fight ended, for the wire form.
+type DissolveKind string
+
+// DissolveByDecision is a fight the members chose to leave.
+const DissolveByDecision DissolveKind = "decision"
+
+// DissolveCause is why a fight ended: a closed set, sealed the way
+// [saves.DCSource] is and for the same reason.
+//
+// A fight can end for reasons of two different kinds, and the difference is
+// the whole design. A party DECIDING to disengage is a choice somebody makes,
+// so it reaches the toolkit as a verb. Being DEFEATED is a fact the world
+// notices, so when the composition can see it, it will end fights the way
+// sight already starts them — automatically, with no caller involved
+// (rpg-toolkit#964's mirror).
+//
+// Those are different events, which is why they are not two mechanisms. When
+// defeat becomes visible it arrives as another CALLER of this shape, not as a
+// second way to end a fight — and its case is earned then, by the caller that
+// forces it, rather than declared now against a future nobody has built.
+//
+// The unexported method is what makes that structural rather than aspirational:
+// a second case cannot be declared outside this package, so adding one means
+// editing this file, and editing this file means having the caller in hand.
+// A bare string enum would have let any caller invent `DissolveCause("defeat")`
+// today and pretend the world noticed something it cannot yet see.
+//
+// [saves.DCSource]: https://pkg.go.dev/github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves#DCSource
+type DissolveCause interface {
+	// Kind names which cause this is.
+	Kind() DissolveKind
+
+	// isDissolveCause seals the set. See the type's godoc.
+	isDissolveCause()
+}
+
+// ByDecision is a fight its members chose to walk away from: the party breaks
+// off to watch the goblin rather than trade blows with it.
+//
+// The only cause today, and the only one that is a DECISION. It is a function
+// rather than a package-level variable so nothing can reassign what it means
+// at runtime, matching how the save gate's sources read at a call site.
+func ByDecision() DissolveCause { return byDecision{} }
+
+type byDecision struct{}
+
+func (byDecision) Kind() DissolveKind { return DissolveByDecision }
+func (byDecision) isDissolveCause()   {}
+
+// DissolveInput ends the fight a member is in.
+type DissolveInput struct {
+	// Session is the session to act in.
+	Session string
+
+	// Member is anyone in the fight. Required.
+	//
+	// A fight is reached THROUGH a member rather than by name, because it has
+	// no name: the composition models a bubble as something you find by asking
+	// who is in it, which R6 ("an entity belongs to at most one clock") makes
+	// a total question.
+	Member string
+
+	// Cause is why it is ending. Required.
+	Cause DissolveCause
+}
+
+// DissolveOutput reports what ending the fight produced.
+type DissolveOutput struct {
+	// Members are everyone who was in it, now back on the world clock.
+	Members []string `json:"members"`
+
+	// Cause is why it ended, echoed for a caller handling the response.
+	Cause DissolveKind `json:"cause"`
+
+	// Seq is the story sequence of the recorded beat.
+	Seq uint64 `json:"seq"`
+
+	// Saved names what was persisted.
+	Saved SaveReport `json:"saved"`
+
+	// Delivery names what reached the event stream.
+	Delivery DeliveryReport `json:"delivery"`
+}
+
+// Dissolve ends the fight a member is in and returns everyone to free roam.
+//
+// Fights start on their own — sight starts them, and nothing asks the caller
+// first (rpg-toolkit#964) — and until now nothing could end one. Members were
+// refused every free-roam verb with ErrInBubble, correctly and forever
+// (rpg-toolkit#1024). This is the half of that a verb can fix: the party
+// deciding to disengage.
+//
+// It is NOT the other half. Defeat ending a fight is a fact the world notices,
+// not a decision anyone makes, and it belongs where sight already lives — in
+// the composition, automatically. That cannot be built yet because nothing in
+// the composition can see defeat: it has no hit points, no damage and no death.
+// When it can, it arrives as another caller of [DissolveCause], never as a
+// second mechanism.
+//
+// Time spent fighting is spent, not banked: everyone re-homes to the world
+// clock at budget zero. That is the composition's rule and this verb does not
+// soften it.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoCause, ErrNoSession,
+// ErrNoEncounter, ErrNoMember, ErrNotInFight, ErrClosed, or ErrSaveFailed with
+// a populated report.
+func (m *Manager) Dissolve(ctx context.Context, in *DissolveInput) (*DissolveOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("dissolve: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("dissolve: %w", ErrNoMemberID)
+	}
+	if in.Cause == nil {
+		return nil, fmt.Errorf("dissolve: %w", ErrNoCause)
+	}
+
+	scope, err := m.openForWrite(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("dissolve: %w", err)
+	}
+
+	dissolved, err := scope.enc.Dissolve(&encounter.DissolveInput{
+		Member: encounter.MemberID(in.Member),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dissolve: %w", translate(err))
+	}
+
+	report, delivery, err := m.commit(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("dissolve: %w", err)
+	}
+
+	members := make([]string, 0, len(dissolved.Members))
+	for _, id := range dissolved.Members {
+		members = append(members, string(id))
+	}
+
+	return &DissolveOutput{
+		Members:  members,
+		Cause:    in.Cause.Kind(),
+		Seq:      dissolved.Seq,
+		Saved:    report,
+		Delivery: delivery,
+	}, nil
+}

--- a/rulebooks/dnd5e/session/dissolve_test.go
+++ b/rulebooks/dnd5e/session/dissolve_test.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// DissolveTestSuite covers ending a fight — the half of rpg-toolkit#1024 that
+// a verb can fix.
+type DissolveTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	mgr        *session.Manager
+}
+
+func TestDissolveSuite(t *testing.T) {
+	suite.Run(t, new(DissolveTestSuite))
+}
+
+func (s *DissolveTestSuite) SetupTest() {
+	s.sessions = newFakeSessions()
+	s.encounters = newFakeEncounters()
+	s.mgr = managerOverRepos(s.T(), s.sessions, s.encounters)
+	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: ambushWorld(s.T()),
+	})
+	s.Require().NoError(err)
+}
+
+// fight walks alice into the ogre, which starts one.
+func (s *DissolveTestSuite) fight() {
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "the scene must actually put them in a fight")
+}
+
+// TestTheDeadEndIsClosed is why this verb exists.
+//
+// Fights start on their own and, until now, nothing could end one: a member
+// was refused every free-roam verb with ErrInBubble, correctly and forever
+// (rpg-toolkit#1024). The scene is the one the encounter module's own
+// narratives use — the party sees the goblin, decides not to fight it, and
+// walks away watching.
+func (s *DissolveTestSuite) TestTheDeadEndIsClosed() {
+	s.fight()
+	ctx := context.Background()
+
+	// The dead end, before it is closed.
+	_, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 3}},
+	})
+	s.Require().ErrorIs(err, session.ErrInBubble, "a fight member does not free-roam")
+
+	out, err := s.mgr.Dissolve(ctx, &session.DissolveInput{
+		Session: "sess", Member: "alice", Cause: session.ByDecision(),
+	})
+	s.Require().NoError(err)
+	s.ElementsMatch([]string{"alice", "ogre"}, out.Members, "everyone in it comes back")
+	s.Equal(session.DissolveByDecision, out.Cause)
+	s.NotZero(out.Seq)
+
+	// And she can walk again.
+	moved, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 3}},
+	})
+	s.Require().NoError(err, "free roam is hers again")
+	s.Len(moved.Steps, 1)
+}
+
+// TestEveryoneComesBackToFreeRoam pins that the fight is gone rather than
+// merely left, asked of both sides.
+func (s *DissolveTestSuite) TestEveryoneComesBackToFreeRoam() {
+	s.fight()
+	ctx := context.Background()
+
+	_, err := s.mgr.Dissolve(ctx, &session.DissolveInput{
+		Session: "sess", Member: "ogre", Cause: session.ByDecision(),
+	})
+	s.Require().NoError(err, "reached through either of them — a fight has no name")
+
+	for _, who := range []string{"alice", "ogre"} {
+		turn, terr := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: who})
+		s.Require().NoError(terr)
+		s.Equal(session.ClockWorld, turn.Clock, "%s is back in free roam", who)
+		s.Empty(turn.Order, "and there is no order left to be in")
+	}
+}
+
+// TestTheCauseIsRequired is the shape Kirk ruled, asserted.
+//
+// A fight ends either because somebody chose to leave or because the world
+// noticed something. A caller that will not say which is asking for an effect
+// with no account of it — and the field is what lets defeat arrive later as
+// another caller rather than as a second way to end a fight.
+func (s *DissolveTestSuite) TestTheCauseIsRequired() {
+	s.fight()
+
+	_, err := s.mgr.Dissolve(context.Background(), &session.DissolveInput{
+		Session: "sess", Member: "alice",
+	})
+	s.ErrorIs(err, session.ErrNoCause)
+}
+
+// TestTheCauseSetIsSealed pins the discipline rather than the type.
+//
+// A bare string enum would let any caller write DissolveCause("defeat") today
+// and pretend the world noticed something it cannot yet see — the composition
+// has no hit points, no damage and no death. The unexported method makes a
+// second case impossible to declare outside this package, so adding one means
+// editing the file, and editing the file means having the caller in hand.
+//
+// This reads the interface's own method set, because the guarantee is
+// structural: the day the seal is removed, this fails and says why.
+func (s *DissolveTestSuite) TestTheCauseSetIsSealed() {
+	sealed := false
+	for _, name := range interfaceMethodNames((*session.DissolveCause)(nil)) {
+		if !isExportedName(name) {
+			sealed = true
+		}
+	}
+	s.True(sealed,
+		"DissolveCause must keep an unexported method: without it any caller can "+
+			"declare a cause the world cannot yet notice, and defeat stops being "+
+			"something earned by the caller that forces it")
+}
+
+// TestDissolvingWhatIsNotAFightIsRefused pins that this verb propagates the
+// composition's rules rather than re-deciding them.
+func (s *DissolveTestSuite) TestDissolvingWhatIsNotAFightIsRefused() {
+	ctx := context.Background()
+
+	_, err := s.mgr.Dissolve(ctx, &session.DissolveInput{
+		Session: "sess", Member: "alice", Cause: session.ByDecision(),
+	})
+	s.ErrorIs(err, session.ErrNotInFight, "she is free-roaming; there is no fight to end")
+
+	s.fight()
+	_, err = s.mgr.Dissolve(ctx, &session.DissolveInput{
+		Session: "sess", Member: "nobody", Cause: session.ByDecision(),
+	})
+	s.ErrorIs(err, session.ErrNoMember)
+
+	_, err = s.mgr.Dissolve(ctx, &session.DissolveInput{Session: "sess", Cause: session.ByDecision()})
+	s.ErrorIs(err, session.ErrNoMemberID)
+
+	_, err = s.mgr.Dissolve(ctx, nil)
+	s.ErrorIs(err, session.ErrNilInput)
+}
+
+// TestTheEndingReachesClients pins that the story carries it.
+//
+// EventFightEnded and its beat mapping have existed since the trigger wave —
+// wired, tested, and unreachable, because nothing in this package could
+// produce the beat. This is the verb that makes them real.
+func (s *DissolveTestSuite) TestTheEndingReachesClients() {
+	s.fight()
+
+	stream := &fakeStream{}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: testCharacters(), Events: stream,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Dissolve(context.Background(), &session.DissolveInput{
+		Session: "sess", Member: "alice", Cause: session.ByDecision(),
+	})
+	s.Require().NoError(err)
+
+	kinds := map[session.EventKind]int{}
+	for _, e := range stream.published {
+		kinds[e.Kind]++
+	}
+	s.Positive(kinds[session.EventFightEnded], "the fight ending is a kind, not a mystery")
+	s.Zero(kinds[session.EventUnknown])
+}

--- a/rulebooks/dnd5e/session/dissolve_test.go
+++ b/rulebooks/dnd5e/session/dissolve_test.go
@@ -125,13 +125,7 @@ func (s *DissolveTestSuite) TestTheCauseIsRequired() {
 // This reads the interface's own method set, because the guarantee is
 // structural: the day the seal is removed, this fails and says why.
 func (s *DissolveTestSuite) TestTheCauseSetIsSealed() {
-	sealed := false
-	for _, name := range interfaceMethodNames((*session.DissolveCause)(nil)) {
-		if !isExportedName(name) {
-			sealed = true
-		}
-	}
-	s.True(sealed,
+	s.NotEmpty(unexportedInterfaceMethods((*session.DissolveCause)(nil)),
 		"DissolveCause must keep an unexported method: without it any caller can "+
 			"declare a cause the world cannot yet notice, and defeat stops being "+
 			"something earned by the caller that forces it")

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -200,6 +200,14 @@ var (
 	// one they guessed wrong about.
 	ErrNotInFight = errors.New("member is not in a fight")
 
+	// ErrNoCause is returned when a verb that must say WHY is not told.
+	//
+	// Ending a fight is the one that has it: a fight ends either because
+	// somebody chose to leave or because the world noticed something, and a
+	// caller that will not say which is asking for an effect without an
+	// account of it.
+	ErrNoCause = errors.New("no cause given")
+
 	// ErrFrozen, ErrNoWindow, ErrNotAudience, ErrNotOffered and ErrNoWindowID
 	// lived here. Every one of them described an open interrupt window, and
 	// nothing in this module opens one (rpg-toolkit#964 slice 2) — a sentinel


### PR DESCRIPTION
The verb half of #1024, ruled by Kirk. Part of #966.

## Fights could start and never end

Sight starts a fight and nothing asks the caller first (#964). Until now nothing could end one: a member was refused every free-roam verb with `ErrInBubble` — correctly, and forever. That is the live dead-end #1024 named, and this closes the half a verb can close.

```go
out, err := mgr.Dissolve(ctx, &session.DissolveInput{
    Session: s, Member: "alice", Cause: session.ByDecision(),
})
```

## Dissolution carries its cause, sealed like `saves.DCSource`

A fight ends for reasons of **two different kinds**, and the difference is the whole design:

- **Deciding to disengage** is a choice somebody makes → it reaches the toolkit as a verb.
- **Being defeated** is a fact the world notices → when the composition can see it, that will end fights the way sight already starts them, with no caller involved.

Different events, so **not two mechanisms**. ADR-0032's objection was to two systems deciding the *same* thing.

**One case today, and nothing defeat-shaped is built — not even an enum case.** The composition has no hit points, no damage and no death, so there is nothing for it to notice yet. Defeat arrives as another **caller** of this shape, and its case is earned then, by the caller that forces it.

The unexported method makes that structural rather than aspirational: a second case cannot be declared outside this package, so adding one means editing this file, and editing this file means having the caller in hand. A bare string enum would have let anyone write `DissolveCause("defeat")` today and pretend the world noticed something it cannot see.

`TestTheCauseSetIsSealed` reads the interface's own method set and fails the day the seal is removed. **Mutation-verified**: deleting `isDissolveCause()` fails it and nothing else.

## The cause is not in the story, and that is deliberate

With exactly one cause, recording *why* adds nothing to a transcript that already says a fight ended. It becomes informative the day a second cause exists — **which is the same day the enum case is earned**. Deferral by sequencing, not an omission: when defeat lands, the cause reaching the story and the case existing are one change.

## What this makes real

`EventFightEnded` and the `bubble-dissolved` → kind mapping have been wired, tested and **unreachable** since the trigger wave, because nothing in this package could produce the beat. This verb is what makes them reachable.

## What is pinned

| test | claim |
|---|---|
| `TestTheDeadEndIsClosed` | the refusal before, the dissolve, and free roam working after — the whole #1024 arc in one scene |
| `TestEveryoneComesBackToFreeRoam` | asked of both sides; reached through either, because a fight has no name |
| `TestTheCauseIsRequired` | an effect with no account of it is refused |
| `TestTheCauseSetIsSealed` | the discipline, structurally |
| `TestDissolvingWhatIsNotAFightIsRefused` | four refusals; the composition's rules propagated, not re-decided |
| `TestTheEndingReachesClients` | `EventFightEnded`, and nothing left `EventUnknown` |

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok**, both packages |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | no diff |

## On #1024

This closes its **verb half**. The ending-trigger half stays open by Kirk's ruling and cannot be built yet — the composition cannot see defeat. I have left #1024 open rather than letting the merge close it; when defeat becomes composition-visible, that issue is where the mirror of #964 belongs.

Attack follows on this merge, and that closes #966 and the wave.

— asset-pipeline agent, on behalf of KirkDiggler
