### PR TITLE
feat(session): a character can swing (#966)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -128,6 +128,17 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotACharacter)
 	}
 
+	// A member with no stored sheet cannot be swung at: there is nothing to
+	// read an armour class off and nothing for damage to land on. Authored
+	// content placed straight into a world has no sheet until something spawns
+	// it, so this is reachable and worth naming here — the alternative is the
+	// strike failing later, further from the cause.
+	if kinds[in.Target] == encounter.MemberKind(KindMonster) {
+		if _, ok := m.storedNPC(scope, in.Target); !ok {
+			return nil, fmt.Errorf("attack: target %q: %w", in.Target, ErrNoSheet)
+		}
+	}
+
 	profile, err := m.compileAttack(ctx, in.Attacker)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
@@ -219,6 +230,11 @@ func translateResolution(err error) error {
 	switch {
 	case errors.Is(err, resolution.ErrBadParticipant):
 		return fmt.Errorf("%w: %w", ErrBadCharacter, err)
+	case errors.Is(err, resolution.ErrNoCombatant):
+		// Reachable when a member has no stored sheet — an authored monster
+		// standing in a world nobody spawned. Refused earlier by name, so this
+		// arm is the backstop rather than the path.
+		return fmt.Errorf("%w: %w", ErrNoSheet, err)
 	case errors.Is(err, resolution.ErrNilInput), errors.Is(err, resolution.ErrNoMachine):
 		return fmt.Errorf("%w: %w", ErrNilInput, err)
 	default:
@@ -299,6 +315,16 @@ func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolutio
 // is the effect's own predicate (ADR-0038). A bard three cells away whose
 // Bless is running has to be in the room for their subscription to fire, and
 // deciding they are irrelevant here would be this package deciding a rule.
+// storedNPC finds an NPC's sheet in the session record.
+func (m *Manager) storedNPC(scope *writeScope, id string) (*monster.Data, bool) {
+	for i := range scope.data.NPCs {
+		if scope.data.NPCs[i].ID == id {
+			return &scope.data.NPCs[i], true
+		}
+	}
+	return nil, false
+}
+
 func (m *Manager) castFor(
 	ctx context.Context, scope *writeScope, roster []encounter.Member,
 ) ([]resolution.Participant, error) {
@@ -342,14 +368,20 @@ func (m *Manager) castFor(
 // verb in the package that writes a character at all — damage has to persist —
 // and the no-clobber pin gained a row for it rather than losing its guard.
 func (m *Manager) saveDirty(ctx context.Context, scope *writeScope, out *resolution.Output) error {
+	// The report names what LANDED as well as what did not (S6). A sheet
+	// written before the failure is durable, and a caller told only about the
+	// failure would retry a write that already succeeded — which is the
+	// difference between repair and retry that the report exists to carry.
+	var written []string
 	for _, data := range out.DirtyCharacters {
 		if data == nil {
 			continue
 		}
 		if err := m.characters.SaveCharacter(ctx, data); err != nil {
-			report := SaveReport{Failed: []string{"character:" + data.ID}}
+			report := SaveReport{Written: written, Failed: []string{"character:" + data.ID}}
 			return &SaveError{Report: report, Err: fmt.Errorf("saving character: %w", err)}
 		}
+		written = append(written, "character:"+data.ID)
 	}
 
 	for _, dirty := range out.DirtyMonsters {

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -1,0 +1,368 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
+)
+
+// AttackInput swings one member at another.
+//
+// MEMBER-NEUTRAL ON PURPOSE. Both sides are IDs and nothing here is
+// character-shaped, even though v1 only compiles character attackers (see
+// [Manager.Attack]). Scope by the case, shape for the future: the day a
+// monster attacker is compiled, this input does not change, and no host that
+// wrote against it has to.
+type AttackInput struct {
+	// Session is the session to act in.
+	Session string
+
+	// Attacker is who swings. Required.
+	Attacker string
+
+	// Target is who they swing at. Required.
+	Target string
+}
+
+// AttackOutput is what the swing produced.
+type AttackOutput struct {
+	// Roll is the d20 as rolled, after any advantage or disadvantage.
+	Roll int `json:"roll"`
+
+	// Total is the roll plus everything the attack chain added.
+	Total int `json:"total"`
+
+	// Against is the number the total had to reach.
+	Against int `json:"against"`
+
+	// Hit is whether it landed.
+	Hit bool `json:"hit"`
+
+	// Critical is whether it was a critical hit.
+	Critical bool `json:"critical"`
+
+	// Damage is what was dealt. Zero on a miss.
+	Damage int `json:"damage,omitempty"`
+
+	// Seq is the story sequence of the recorded beat.
+	Seq uint64 `json:"seq"`
+
+	// Saved names what was persisted.
+	Saved SaveReport `json:"saved"`
+
+	// Delivery names what reached the event stream.
+	Delivery DeliveryReport `json:"delivery"`
+}
+
+// Attack swings one member's weapon at another and records what happened.
+//
+// # v1 compiles CHARACTER attackers only
+//
+// A monster attacker is refused with [ErrNotACharacter]. The refusal is scope
+// rather than a limitation nobody thought about: a monster's action can declare
+// a save gate, which makes a strike's rider — a whole second interaction with
+// its own DC, ability and imposed effects — reachable, and this seam has no
+// vocabulary for recording one. That case belongs to the monster behavior work,
+// which is its caller, and it earns its shape then. The same discipline
+// [DissolveCause] uses for defeat.
+//
+// Main hand, one-handed, melee. Two-handed grips and the off-hand swing are
+// the compiler's own named gaps and arrive with the economy that decides when
+// a second swing is allowed at all.
+//
+// # Nothing spends
+//
+// A character can attack as many times in a turn as the caller asks. That is a
+// KNOWN GAP, not a ruling that attacks are free: the thing that spends is an
+// economy machine that sits above this one and does not exist. It is named at
+// the one place it will go — see the comment at the resolution call below —
+// and pinned by TestNothingSpendsYet so it cannot be mistaken for a decision.
+//
+// # How it runs
+//
+// The world goes into resolution as data and a different world comes back, so
+// the scope adopts the returned one before anything else touches it
+// ([Manager.adopt] carries that invariant). The outcome is then recorded on the
+// world the interaction produced — a consequence lands after its cause — and
+// every dirty sheet is written back.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
+// ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrBadAttack, ErrClosed, or
+// ErrSaveFailed with a populated report.
+func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("attack: %w", ErrNilInput)
+	}
+	if in.Attacker == "" || in.Target == "" {
+		return nil, fmt.Errorf("attack: %w", ErrNoMemberID)
+	}
+
+	scope, err := m.openForWrite(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
+	roster, err := scope.enc.Members()
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+	kinds := map[string]encounter.MemberKind{}
+	for _, member := range roster {
+		kinds[string(member.ID)] = member.Kind
+	}
+	if _, ok := kinds[in.Attacker]; !ok {
+		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNoMember)
+	}
+	if _, ok := kinds[in.Target]; !ok {
+		return nil, fmt.Errorf("attack: target %q: %w", in.Target, ErrNoMember)
+	}
+	if kinds[in.Attacker] != encounter.MemberKind(KindPlayer) {
+		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotACharacter)
+	}
+
+	profile, err := m.compileAttack(ctx, in.Attacker)
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
+	cast, err := m.castFor(ctx, scope, roster)
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
+	// THE ONE PLACE A SPEND WILL GO. An economy machine belongs above this
+	// call: it chooses what the actor is doing, spends the action or bonus
+	// action that buys it, and requests the strike below. Today nothing does,
+	// so nothing is spent — the strike runs directly. When the economy lands
+	// (its home is the combat package, whose ActionEconomy vocabulary already
+	// exists), the machine handed to Resolve becomes that one, and this line
+	// is where it changes. Nothing persistent or wire-shaped assumes attacks
+	// are free, so that change costs no migration.
+	out, err := resolution.Resolve(ctx, &resolution.Input{
+		World:        scope.enc.ToData(),
+		Participants: cast,
+		Initiative:   m.initiative,
+		Machine: resolution.NewStrike(&resolution.StrikeInput{
+			AttackerID: in.Attacker,
+			TargetID:   in.Target,
+			Attack:     profile,
+			// The machine rolls the attack and its damage; Input.Roller only
+			// reconstitutes effects that need one. Two rollers because they
+			// are two jobs — and BOTH must be the host's, or the swing is
+			// resolved with randomness the host never supplied. StrikeInput's
+			// still defaults silently when nil, which is the class resolution
+			// just closed on its own Input (#1033); leaving it unset here is
+			// how this verb first resolved with unreproducible dice.
+			Roller: &diceSeam{roller: m.dice},
+		}),
+		Roller: &diceSeam{roller: m.dice},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", translateResolution(err))
+	}
+
+	struck, ok := out.Outcome.(resolution.StrikeOutcome)
+	if !ok {
+		return nil, fmt.Errorf("attack: %w: strike produced %T", ErrInvalidWorld, out.Outcome)
+	}
+
+	// The world that came back is the only true one now.
+	if err := m.adopt(scope, out.World); err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
+	recorded, err := scope.enc.Record(recordFor(in, struck))
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", translate(err))
+	}
+
+	if err := m.saveDirty(ctx, scope, out); err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
+	report, delivery, err := m.commit(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
+	return &AttackOutput{
+		Roll:     struck.Roll,
+		Total:    struck.Total,
+		Against:  struck.TargetAC,
+		Hit:      struck.Hit,
+		Critical: struck.Critical,
+		Damage:   struck.Damage,
+		Seq:      recorded.Seq,
+		Saved:    report,
+		Delivery: delivery,
+	}, nil
+}
+
+// translateResolution maps the resolution module's sentinels onto this
+// package's own.
+//
+// The same reason translate exists for the composition's: a sentinel is not a
+// type in a signature, so the boundary test cannot see it, and a host that
+// matched on resolution.ErrBadParticipant would be coupled to a module we
+// intend to keep replaceable. Unrecognised errors pass through wrapped rather
+// than flattened — an error nobody anticipated is more useful with its own
+// message intact.
+func translateResolution(err error) error {
+	switch {
+	case errors.Is(err, resolution.ErrBadParticipant):
+		return fmt.Errorf("%w: %w", ErrBadCharacter, err)
+	case errors.Is(err, resolution.ErrNilInput), errors.Is(err, resolution.ErrNoMachine):
+		return fmt.Errorf("%w: %w", ErrNilInput, err)
+	default:
+		return err
+	}
+}
+
+// recordFor turns a strike into the outcome the composition will stamp.
+//
+// CRITICAL IS NOT RECORDED, and the reason has an expiry date worth writing
+// down. ValueRoll is the RAW d20, so today a beat carrying roll:20 already says
+// the blow was critical — a reader derives it, and adding a kind for it would
+// be vocabulary earning nothing.
+//
+// That holds ONLY while every reachable attack crits on a natural 20 alone.
+// The machine already supports a crit threshold, so an expanded range — a
+// Champion's 19–20 — produces a critical hit at roll:19 that this beat cannot
+// tell from an ordinary one. THAT is the caller that earns recorded crit
+// vocabulary, and when it arrives this comment is where to start.
+func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.RecordInput {
+	values := map[encounter.OutcomeValue]int{
+		encounter.ValueRoll:    struck.Roll,
+		encounter.ValueTotal:   struck.Total,
+		encounter.ValueAgainst: struck.TargetAC,
+	}
+	kind := encounter.OutcomeMissed
+	if struck.Hit {
+		kind = encounter.OutcomeStruck
+		values[encounter.ValueAmount] = struck.Damage
+	}
+	return &encounter.RecordInput{
+		Kind:    kind,
+		Actor:   encounter.MemberID(in.Attacker),
+		Targets: []encounter.MemberID{encounter.MemberID(in.Target)},
+		Values:  values,
+	}
+}
+
+// compileAttack turns the attacker's stored sheet into the neutral profile the
+// strike machine takes.
+//
+// The sheet is loaded here as well as inside Resolve, and that is not a
+// duplicate to be optimised away: character.Load is bus-free, so this
+// reconstitution attaches nothing and subscribes nothing. The compiler needs a
+// live character to read static facts off; resolution needs its own cast to
+// attach effects to. Two purposes, one stored sheet, and no shared bus between
+// them.
+func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolution.AttackProfile, error) {
+	data, err := m.characters.GetCharacter(ctx, attacker)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w", attacker, ErrBadCharacter)
+		}
+		return resolution.AttackProfile{}, err
+	}
+	if data == nil {
+		return resolution.AttackProfile{}, fmt.Errorf(
+			"attacker %q: GetCharacter reported success with no data: %w", attacker, ErrBadRepository)
+	}
+
+	loaded, err := character.Load(ctx, data)
+	if err != nil {
+		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %w", attacker, ErrNoCharacter, err)
+	}
+
+	profile, err := resolution.AttackFromCharacter(loaded, &resolution.CharacterAttackInput{
+		Slot: character.SlotMainHand,
+	})
+	if err != nil {
+		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %w", attacker, ErrBadAttack, err)
+	}
+	return profile, nil
+}
+
+// castFor gathers every member of the encounter as a participant.
+//
+// EVERY member, not the two swinging: scope is the caller's and applicability
+// is the effect's own predicate (ADR-0038). A bard three cells away whose
+// Bless is running has to be in the room for their subscription to fire, and
+// deciding they are irrelevant here would be this package deciding a rule.
+func (m *Manager) castFor(
+	ctx context.Context, scope *writeScope, roster []encounter.Member,
+) ([]resolution.Participant, error) {
+	npcs := map[string]*monster.Data{}
+	for i := range scope.data.NPCs {
+		npcs[scope.data.NPCs[i].ID] = &scope.data.NPCs[i]
+	}
+
+	cast := make([]resolution.Participant, 0, len(roster))
+	for _, member := range roster {
+		id := string(member.ID)
+		if member.Kind == encounter.MemberKind(KindMonster) {
+			sheet, ok := npcs[id]
+			if !ok {
+				continue // content with no stored sheet contributes nothing
+			}
+			cast = append(cast, resolution.Participant{Monster: sheet})
+			continue
+		}
+
+		data, err := m.characters.GetCharacter(ctx, id)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return nil, fmt.Errorf("participant %q: %w", id, ErrBadCharacter)
+			}
+			return nil, err
+		}
+		if data == nil {
+			return nil, fmt.Errorf(
+				"participant %q: GetCharacter reported success with no data: %w", id, ErrBadRepository)
+		}
+		cast = append(cast, resolution.Participant{Character: data})
+	}
+	return cast, nil
+}
+
+// saveDirty writes back every sheet the interaction changed.
+//
+// Characters go to the host's repository; NPCs live in the session record, so
+// they are folded into it and the record is marked touched. This is the first
+// verb in the package that writes a character at all — damage has to persist —
+// and the no-clobber pin gained a row for it rather than losing its guard.
+func (m *Manager) saveDirty(ctx context.Context, scope *writeScope, out *resolution.Output) error {
+	for _, data := range out.DirtyCharacters {
+		if data == nil {
+			continue
+		}
+		if err := m.characters.SaveCharacter(ctx, data); err != nil {
+			report := SaveReport{Failed: []string{"character:" + data.ID}}
+			return &SaveError{Report: report, Err: fmt.Errorf("saving character: %w", err)}
+		}
+	}
+
+	for _, dirty := range out.DirtyMonsters {
+		if dirty == nil {
+			continue
+		}
+		for i := range scope.data.NPCs {
+			if scope.data.NPCs[i].ID == dirty.ID {
+				scope.data.NPCs[i] = *dirty
+				scope.touched = true
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
+)
+
+// halfBrokenCharacters writes the first sheet and refuses the second.
+type halfBrokenCharacters struct {
+	written []string
+	err     error
+}
+
+func (h *halfBrokenCharacters) GetCharacter(context.Context, string) (*character.Data, error) {
+	return nil, ErrNotFound
+}
+
+func (h *halfBrokenCharacters) SaveCharacter(_ context.Context, data *character.Data) error {
+	if len(h.written) > 0 {
+		return h.err
+	}
+	h.written = append(h.written, data.ID)
+	return nil
+}
+
+// TestAPartialCharacterSaveNamesWhatLanded pins S6 across MULTIPLE sheets.
+//
+// One swing can dirty both sides — the target takes damage, and an effect that
+// writes the attacker's own sheet dirties them too. If the second write fails,
+// the first is ALREADY DURABLE, and a caller told only about the failure would
+// retry a write that succeeded. Naming both halves is the difference between
+// repair and retry, which is the whole reason the report exists.
+//
+// Tested against saveDirty directly rather than through a swing, because no v1
+// interaction dirties two character sheets: the strike damages its target and
+// nothing yet writes the attacker back. A test that drove this through Attack
+// would skip, and a skipping test proves nothing. When an effect that writes
+// the swinger arrives, this pin is already here and already honest.
+func TestAPartialCharacterSaveNamesWhatLanded(t *testing.T) {
+	broken := errors.New("store is down")
+	store := &halfBrokenCharacters{err: broken}
+	m := &Manager{characters: store}
+
+	err := m.saveDirty(context.Background(), &writeScope{data: &SessionData{}}, &resolution.Output{
+		DirtyCharacters: []*character.Data{{ID: "alice"}, {ID: "bob"}},
+	})
+
+	require.Error(t, err)
+	var saved *SaveError
+	require.ErrorAs(t, err, &saved)
+	require.ErrorIs(t, err, broken)
+
+	require.Equal(t, []string{"character:alice"}, saved.Report.Written,
+		"alice's sheet is durable and the caller must not be told to retry it")
+	require.Equal(t, []string{"character:bob"}, saved.Report.Failed,
+		"and bob's is the one that needs repair")
+}

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -1,0 +1,311 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// AttackTestSuite covers the swing — the wave's last verb, and the first that
+// drives a rules machine through the seam.
+type AttackTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+}
+
+func TestAttackSuite(t *testing.T) {
+	suite.Run(t, new(AttackTestSuite))
+}
+
+// armedFighter is a sheet that can actually swing: a longsword in the main
+// hand and the proficiency to use it.
+//
+// The shared dwarf fixture carries no weapon, which is correct for every other
+// verb and useless here — an empty hand is refused by the compiler rather than
+// falling back to an unarmed strike, deliberately.
+func armedFighter(id string) *character.Data {
+	return &character.Data{
+		ID:       id,
+		PlayerID: "player-" + id,
+		Name:     id,
+		Level:    3,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints:           24,
+		MaxHitPoints:        28,
+		ArmorClass:          16,
+		ProficiencyBonus:    2,
+		WeaponProficiencies: []proficiencies.Weapon{proficiencies.WeaponMartial},
+		Inventory: []character.InventoryItemData{
+			{Type: shared.EquipmentTypeWeapon, ID: string(weapons.Longsword), Quantity: 1},
+		},
+		EquipmentSlots: character.EquipmentSlots{
+			character.SlotMainHand: string(weapons.Longsword),
+		},
+	}
+}
+
+// duelAC is what these fixtures actually defend with: 12.
+//
+// NOT the sheet's ArmorClass field, which is 16 and inert. The strike resolves
+// against the EFFECTIVE armour class — folded on the interaction's own bus from
+// armour worn and Dexterity — and an unarmoured fighter with DEX 14 is 10 + 2.
+// Worth stating rather than discovering twice: a fixture that raises the stored
+// field to make a swing miss changes nothing at all.
+const duelAC = 12
+
+// duel is two armed characters standing next to each other, which is the
+// smallest world where a swing means anything.
+//
+// Both sides are CHARACTERS on purpose: damage dirties the target's stored
+// sheet, which is the case that earns Attack its row in the no-clobber pin.
+func (s *AttackTestSuite) duel(dice session.Roller) *session.Manager {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: dice, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: encOrderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &data,
+	})
+	s.Require().NoError(err)
+	return mgr
+}
+
+func (s *AttackTestSuite) swing(mgr *session.Manager) (*session.AttackOutput, error) {
+	return mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "bob",
+	})
+}
+
+// TestASwingLandsAndTheStoryRecordsIt is the headline: a rules machine runs
+// through the seam, and what it produced reaches both the caller and the
+// transcript.
+//
+// Exact arithmetic rather than "damage is positive". A d20 of 15 plus a
+// proficient Strength longsword (+3 STR, +2 proficiency) totals 20 against
+// AC 12 — a hit, and the damage die scripted to 5 with the +3 modifier deals
+// 8. A loose assertion here would pass on an implementation that dropped the
+// modifier, halved the die, or resolved against the wrong sheet.
+func (s *AttackTestSuite) TestASwingLandsAndTheStoryRecordsIt() {
+	mgr := s.duel(&sequenceDice{rolls: []int{15, 5}})
+
+	out, err := s.swing(mgr)
+	s.Require().NoError(err)
+	s.Equal(15, out.Roll)
+	s.Equal(20, out.Total, "15 + 3 STR + 2 proficiency")
+	s.Equal(duelAC, out.Against, "effective AC: unarmoured, DEX 14")
+	s.True(out.Hit)
+	s.False(out.Critical)
+	s.Equal(8, out.Damage, "d8 scripted to 5, plus 3 STR")
+	s.NotZero(out.Seq)
+
+	story, err := mgr.Story(context.Background(), &session.StoryInput{Session: "sess", Member: "bob"})
+	s.Require().NoError(err)
+	last := story[len(story)-1]
+	s.Equal(out.Seq, last.Seq, "AttackOutput.Seq references the recorded beat")
+	s.Equal("outcome", last.Tags["tag"])
+	s.JSONEq(
+		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":8}`,
+		string(last.Payload))
+}
+
+// TestAMissIsRecordedToo pins the other arm, including that a miss carries no
+// amount — a beat saying "missed for 0" would read as a hit that did nothing.
+func (s *AttackTestSuite) TestAMissIsRecordedToo() {
+	mgr := s.duel(&sequenceDice{rolls: []int{2, 5}})
+
+	out, err := s.swing(mgr)
+	s.Require().NoError(err)
+	s.False(out.Hit, "2 + 5 is under 12")
+	s.Zero(out.Damage)
+
+	story, err := mgr.Story(context.Background(), &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.JSONEq(
+		`{"beat":"missed","actor":"alice","targets":["bob"],"roll":2,"total":7,"against":12}`,
+		string(story[len(story)-1].Payload))
+}
+
+// TestDamagePersists is the row Attack earns in the no-clobber pin.
+//
+// Every other verb leaves the character store untouched and TestAVerbLeaves-
+// TheCharacterStoreUntouched guards that. This is the one that must write:
+// damage that did not persist is damage that did not happen. The target is a
+// CHARACTER precisely so the write lands in the host's repository rather than
+// in the session's own NPC list.
+func (s *AttackTestSuite) TestDamagePersists() {
+	mgr := s.duel(&sequenceDice{rolls: []int{15, 5}})
+	before := s.characters.byID["bob"].HitPoints
+
+	out, err := s.swing(mgr)
+	s.Require().NoError(err)
+	s.Require().True(out.Hit)
+
+	s.Equal(before-out.Damage, s.characters.byID["bob"].HitPoints,
+		"the blow reached the stored sheet")
+	s.Equal(24, s.characters.byID["alice"].HitPoints, "and the swinger is untouched")
+}
+
+// TestNothingSpendsYet is the known gap, pinned so it cannot be mistaken for a
+// decision that attacks are free.
+//
+// A character may swing as many times in a turn as the caller asks, because
+// the thing that spends is an economy machine above this one and it does not
+// exist. The verb names the single place it will go. When it lands, THIS test
+// is the one that should fail — and its failure is the signal to write the
+// real economy assertions rather than to relax this one.
+func (s *AttackTestSuite) TestNothingSpendsYet() {
+	mgr := s.duel(&sequenceDice{rolls: []int{15, 5, 15, 5, 15, 5}})
+
+	for i := 0; i < 3; i++ {
+		out, err := s.swing(mgr)
+		s.Require().NoError(err, "swing %d", i+1)
+		s.True(out.Hit, "swing %d", i+1)
+	}
+
+	s.Equal(28-24, 4, "sanity: the fixture starts damaged, so HP is not clamped at max")
+	s.Less(s.characters.byID["bob"].HitPoints, 24,
+		"three unspent swings all landed — nothing anywhere is counting actions")
+}
+
+// TestAMonsterAttackerIsRefused pins v1's scope as a decision with a successor.
+//
+// A monster's action can declare a save gate, which makes a strike's rider —
+// a second interaction with its own DC and imposed effects — reachable, and
+// this seam has no vocabulary for recording one. So the case is refused by
+// name until the behavior work that calls for it arrives, exactly as defeat
+// waits for the composition to be able to see it.
+func (s *AttackTestSuite) TestAMonsterAttackerIsRefused() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: encOrderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &data,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "ogre", Target: "alice",
+	})
+	s.ErrorIs(err, session.ErrNotACharacter)
+}
+
+// TestTheInputIsMemberNeutral pins the shape rather than the scope.
+//
+// v1 compiles character attackers only, but nothing in the INPUT says so —
+// both sides are plain IDs. The day a monster attacker compiles, this input
+// does not change and no host that wrote against it has to. Scope by the case,
+// shape for the future.
+func (s *AttackTestSuite) TestTheInputIsMemberNeutral() {
+	s.Equal([]string{"Session", "Attacker", "Target"}, structFields(session.AttackInput{}),
+		"a character-shaped field here would make the v1 scope permanent")
+}
+
+// TestRefusals covers the ways a caller can get it wrong.
+func (s *AttackTestSuite) TestRefusals() {
+	mgr := s.duel(testDice{})
+	ctx := context.Background()
+
+	_, err := mgr.Attack(ctx, nil)
+	s.ErrorIs(err, session.ErrNilInput)
+
+	_, err = mgr.Attack(ctx, &session.AttackInput{Session: "sess", Target: "bob"})
+	s.ErrorIs(err, session.ErrNoMemberID)
+
+	_, err = mgr.Attack(ctx, &session.AttackInput{Session: "sess", Attacker: "alice"})
+	s.ErrorIs(err, session.ErrNoMemberID)
+
+	_, err = mgr.Attack(ctx, &session.AttackInput{Session: "sess", Attacker: "nobody", Target: "bob"})
+	s.ErrorIs(err, session.ErrNoMember)
+
+	_, err = mgr.Attack(ctx, &session.AttackInput{Session: "sess", Attacker: "alice", Target: "nobody"})
+	s.ErrorIs(err, session.ErrNoMember)
+}
+
+// TestAnEmptyHandIsRefused pins the compiler's own gap reaching the host under
+// this package's sentinel rather than the rulebook's.
+func (s *AttackTestSuite) TestAnEmptyHandIsRefused() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(dwarfCharacter("alice"), armedFighter("bob"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: encOrderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &data,
+	})
+	s.Require().NoError(err)
+
+	_, err = s.swing(mgr)
+	s.ErrorIs(err, session.ErrBadAttack,
+		"an unarmed character is refused rather than silently swinging for 1")
+}

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -309,3 +309,42 @@ func (s *AttackTestSuite) TestAnEmptyHandIsRefused() {
 	s.ErrorIs(err, session.ErrBadAttack,
 		"an unarmed character is refused rather than silently swinging for 1")
 }
+
+// TestASheetlessTargetIsRefusedByName covers content standing in a world that
+// nobody spawned.
+//
+// An authored monster has no stored sheet until Spawn records one, so there is
+// nothing to read an armour class off and nothing for damage to land on. The
+// strike would fail on its own, but further from the cause and in the
+// resolution module's vocabulary — this refuses earlier, names who, and keeps
+// that module's sentinels off the seam.
+func (s *AttackTestSuite) TestASheetlessTargetIsRefusedByName() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: encOrderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &data,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "ogre",
+	})
+	s.ErrorIs(err, session.ErrNoSheet)
+}

--- a/rulebooks/dnd5e/session/conditions_test.go
+++ b/rulebooks/dnd5e/session/conditions_test.go
@@ -127,7 +127,12 @@ func (s *ConditionsTestSuite) walkIntoTheAmbush(mgr *session.Manager) *session.M
 
 // TestAVerbLeavesTheCharacterStoreUntouched is the no-clobber pin.
 //
-// Every write verb, including the one that ends in a fight. Byte comparison rather
+// Every write verb EXCEPT Attack, which must write — see
+// TestDamagePersists. That exception is the pin getting stronger rather than
+// weaker: the rule is now "only the verb that should, does", and the guard
+// still covers every verb that has no business touching a sheet.
+//
+// Byte comparison rather
 // than a field-by-field check on purpose: the failure this guards against is a
 // well-meaning SaveCharacter added to the write path, and ToData stamps
 // UpdatedAt with time.Now() on every call — so an unconditional save changes

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -208,6 +208,20 @@ var (
 	// account of it.
 	ErrNoCause = errors.New("no cause given")
 
+	// ErrNotACharacter is returned when a verb needs a character and was
+	// given a member that is not one.
+	//
+	// Attack has it: v1 compiles character attackers only, because a
+	// monster's action can declare a save gate and the rider that gate
+	// resolves has no recorded vocabulary yet. Scope, not oversight — the
+	// case arrives with the behavior work that calls for it.
+	ErrNotACharacter = errors.New("member is not a character")
+
+	// ErrBadAttack is returned when an attack cannot be compiled from the
+	// attacker's sheet — an empty hand, or a weapon the strike has no
+	// semantics for.
+	ErrBadAttack = errors.New("attack cannot be made")
+
 	// ErrFrozen, ErrNoWindow, ErrNotAudience, ErrNotOffered and ErrNoWindowID
 	// lived here. Every one of them described an open interrupt window, and
 	// nothing in this module opens one (rpg-toolkit#964 slice 2) — a sentinel

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -217,6 +217,14 @@ var (
 	// case arrives with the behavior work that calls for it.
 	ErrNotACharacter = errors.New("member is not a character")
 
+	// ErrNoSheet is returned when a member has no stored sheet to resolve
+	// against — an authored monster standing in a world nobody spawned.
+	//
+	// Distinct from ErrNoCharacter, which is about a player's sheet being
+	// missing from the host's repository: this one is about content the
+	// session itself never recorded.
+	ErrNoSheet = errors.New("member has no stored sheet")
+
 	// ErrBadAttack is returned when an attack cannot be compiled from the
 	// attacker's sheet — an empty hand, or a weapon the strike has no
 	// semantics for.

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,6 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdaw
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0 h1:j0VBbyFOEbM+UrfaDYdvuPDQ2L7b4IVVjEzMtJMg5Dc=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2 h1:I8cobvZ+E2lk5no782XSFCoODqt3l+LLgJaKUkBz1WU=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2/go.mod h1:akIVBXf3LdfHmcKlliUngpzKWWCZOl6DWpK9CPFetPo=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/session.go
+++ b/rulebooks/dnd5e/session/session.go
@@ -90,6 +90,11 @@ type Manager struct {
 	characters CharacterRepository
 	events     EventStream
 	initiative encounter.InitiativeRoller
+
+	// dice is the host's randomness, kept as well as wrapped: the initiative
+	// seam needs it wrapped for the composition, and a resolution machine
+	// needs it wrapped for the rulebook. One source, two adapters.
+	dice Roller
 }
 
 // NewManager returns a Manager wired to what the host supplied.
@@ -132,5 +137,6 @@ func NewManager(cfg *Config) (*Manager, error) {
 		characters: cfg.Characters,
 		events:     cfg.Events,
 		initiative: initiativeSeam{dice: cfg.Dice},
+		dice:       cfg.Dice,
 	}, nil
 }

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -457,6 +457,35 @@ type writeScope struct {
 	touched bool
 }
 
+// adopt replaces the scope's encounter with one loaded from a world that came
+// back from somewhere else.
+//
+// ONE VERB NEEDS THIS AND MORE WILL. A resolution takes the world as data and
+// returns a different world as data — that is the seam's whole design — so a
+// verb that resolves through it is holding a stale encounter the moment Resolve
+// returns. Recording the outcome or saving from the old one would drop
+// everything the interaction did.
+//
+// THE INVARIANT: after adopt, every earlier reference to the encounter is
+// DEAD. Read nothing from before it, and record only after it — the outcome is
+// a consequence of the interaction, so its beat belongs on the world the
+// interaction produced, in that order.
+//
+// It is a named method rather than an assignment inlined in the verb so the
+// next verb that resolves through data reuses this instead of hand-rolling the
+// swap, and so the novelty has exactly one home to document.
+func (m *Manager) adopt(scope *writeScope, world encounter.EncounterData) error {
+	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:       world,
+		Initiative: m.initiative,
+	})
+	if err != nil {
+		return fmt.Errorf("%q: %w: %w", scope.encounter, ErrInvalidWorld, err)
+	}
+	scope.enc = enc
+	return nil
+}
+
 // persist writes the mutated aggregates back and reports the result.
 //
 // The encounter is written first and the session second, and the order is a


### PR DESCRIPTION
The wave's last verb. **Closes #966.**

The first time `session` drives a rules machine: the world goes into `resolution` as data, a different world comes back, the outcome is recorded on the world the interaction produced, and every dirty sheet is written back.

```go
out, err := mgr.Attack(ctx, &session.AttackInput{
    Session: s, Attacker: "alice", Target: "bob",
})
```

## v1 compiles character attackers only

A monster attacker is refused with `ErrNotACharacter`. **Scope with a named successor, not a limitation nobody thought about:** a monster's action can declare a save gate, which makes a strike's *rider* — a second interaction with its own DC, ability and imposed effects — reachable, and this seam has no vocabulary for recording one. The case is earned by the monster behavior work that calls for it, exactly as defeat earns its `DissolveCause`.

**The input stays member-neutral** — `{Session, Attacker, Target}`, asserted structurally — so the day a monster attacker compiles, no host that wrote against it changes a line. Scope by the case, shape for the future.

## Nothing spends, and that is pinned

A character may swing as many times as the caller asks. The thing that spends is an economy machine that sits *above* this one and does not exist; its home is the `combat` package, whose `ActionEconomy` vocabulary already exists. **The one place it will go is named at the `Resolve` call**, documented rather than stubbed.

`TestNothingSpendsYet` lands three unspent swings so this cannot be mistaken for a ruling that attacks are free. When the economy arrives, that test is what should fail — and its failure is the signal to write the real economy assertions, not to relax it.

## Two things the seam taught me

**The machine has its own roller.** `Input.Roller` reconstitutes effects; the strike rolls with `StrikeInput.Roller`, which *still defaults silently when nil* — the exact class [#1033](https://github.com/KirkDiggler/rpg-toolkit/pull/1033) just closed one field away. Leaving it unset resolved real swings with randomness the host never supplied, and the only reason it was caught is that these tests script their dice: every assertion about a specific roll failed at once. Both rollers are now the host's, with the reason in the code.

**Armour class is derived, not stored.** The strike folds effective AC from armour worn and Dexterity on its own bus, so the sheet's `ArmorClass` field is inert here — a fixture raising it to 18 to force a miss changes nothing. `duelAC` states that so it is not discovered twice.

## The no-clobber pin gains an exception and gets stronger

`TestAVerbLeavesTheCharacterStoreUntouched` guarded against "a well-meaning `SaveCharacter` added to the write path". Attack is the verb that must write — damage that did not persist is damage that did not happen — so the rule becomes **only the verb that should, does**, and the guard still covers every other verb. `TestDamagePersists` earns the exception with a **character** target, so the write lands in the host's repository rather than the session's own NPC list.

## What is pinned

| test | claim |
|---|---|
| `TestASwingLandsAndTheStoryRecordsIt` | exact arithmetic — 15 + 3 STR + 2 proficiency = 20 vs AC 12, d8→5 plus 3 = 8 — and the full beat JSON |
| `TestAMissIsRecordedToo` | the other arm, and that a miss carries **no** amount |
| `TestDamagePersists` | the blow reaches the stored sheet; the swinger is untouched |
| `TestNothingSpendsYet` | the known gap, three swings deep |
| `TestAMonsterAttackerIsRefused` | v1 scope, by name |
| `TestTheInputIsMemberNeutral` | the scope cannot become permanent by accident |
| `TestAnEmptyHandIsRefused` | the compiler's own gap, under this package's sentinel |
| `TestRefusals` | five ways to get it wrong |

## Verification

| check | result |
|---|---|
| `go test -count=1 ./...` | **ok**, both packages |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| `go mod tidy` | applied — resolution v0.7.2 |

## The wave

This closes **#966** and wave 4. The stack is version-aligned for the first time: `dnd5e` v0.94.1, `encounter` v0.9.0, `spatial` v0.9.1, `resolution` v0.7.2 across session and resolution both.

Still open by design: **#1024**'s ending-trigger half (waiting for defeat to be composition-visible), **#1026** (the root encounter module's bump), **#1020** (asymmetric perception), and the economy follow-up filed alongside this PR.

— asset-pipeline agent, on behalf of KirkDiggler
