### PR TITLE
feat(encounter): adopt lane-based sight — rooms stop over-blocking (#1026)

### DIFF
--- a/encounter/data.go
+++ b/encounter/data.go
@@ -257,10 +257,21 @@ type ObstacleData struct {
 	// blocking entity onto this obstacle's hex, exactly like a wall.
 	BlocksMovement bool `json:"blocks_movement"`
 
-	// BlocksLoS mirrors environments.WallProperties.BlocksLoS — when
-	// true, the reconstructed spatial.Room's IsLineOfSightBlocked reports
-	// true for any line of sight passing through this obstacle's hex,
-	// exactly like a wall.
+	// BlocksLoS mirrors environments.WallProperties.BlocksLoS — when true,
+	// this obstacle OCCLUDES its hex: the reconstructed spatial.Room counts
+	// it as something standing in the way, exactly like a wall entity.
+	//
+	// Occluding a hex is not the same as blocking every ray through it, and
+	// this doc used to say it was. Since spatial v0.9.1 (rpg-toolkit#1022)
+	// sight is a lane rather than a line: when the direct ray is obstructed,
+	// sight survives if a neighbour of either end that is strictly CLOSER to
+	// the other end has a clear lane — the corner a player leans around. A
+	// straight-axis hex sightline has no such neighbour (the only cell
+	// strictly closer is the next one on the same line, which meets the same
+	// occluder), so an obstacle on axis still blocks; off axis a viewer can
+	// often see past a single obstacle, depending on whether an alternative
+	// lane clears it. Boundaries — authored walls drawn on an edge rather
+	// than standing in a cell — stay hard blocks either way.
 	BlocksLoS bool `json:"blocks_los"`
 
 	// Facing is optional authored floor-prop metadata in canonical

--- a/encounter/go.mod
+++ b/encounter/go.mod
@@ -3,12 +3,12 @@ module github.com/KirkDiggler/rpg-toolkit/encounter
 go 1.24.1
 
 require (
-	github.com/KirkDiggler/rpg-toolkit/core v0.10.0
+	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.71.1-0.20260808232907-1eb7569a9e1f
 	github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/encounter/go.sum
+++ b/encounter/go.sum
@@ -1,5 +1,5 @@
-github.com/KirkDiggler/rpg-toolkit/core v0.10.0 h1:LLsvsYsukE26BlRS0wL1o3UjjmP5Qm2Bq5Hb6yFdxzs=
-github.com/KirkDiggler/rpg-toolkit/core v0.10.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0 h1:VnGI17Bnm6cLqI7Rn3RukUZHVfTAPUKTdoKTYqbGRtk=
+github.com/KirkDiggler/rpg-toolkit/core v0.11.0/go.mod h1:XFQXYViPZUTYu/a8jdRadI3rGnKk4r7tRtPm++vSUV0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2 h1:cLLP4Z+4VYSxeRkNbmI5gym6dC/xBOw6kDIylWDK/z0=
 github.com/KirkDiggler/rpg-toolkit/dice v0.3.2/go.mod h1:JEWKuYBi+h9f8jFAcE2MI2yVDFV6ldOVx36y5fbc6p4=
 github.com/KirkDiggler/rpg-toolkit/events v0.6.2 h1:lRtKXko35bGw/l2TKYsN7JKOODUi6u66J8QcnQavm3s=
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb
 github.com/KirkDiggler/rpg-toolkit/tools/environments v0.4.3-0.20260719192245-bb98112c5ba3/go.mod h1:tchpvtZ7MTh7P5J1efr2Wigw108VzQBQEojlVFbw8rM=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2 h1:81iz712+EXhitPNgcf0tMDqvqI/0u9k26Hbdph62QZU=
 github.com/KirkDiggler/rpg-toolkit/tools/selectables v0.1.2/go.mod h1:tnhhn+fRcklWqwIu5lOtBA2uCn1amkp5ZAARsqAgJqI=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857 h1:cVyWXDe/fEaQLwyub4N732O/juf0tkzQCUR1rwJz8PY=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.6.1-0.20260809025703-5acea6e99857/go.mod h1:z5WFtaT46GCz4lmDOKzeuFbSk8SRuZbKCf441M0yDa8=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/encounter/obstacle_test.go
+++ b/encounter/obstacle_test.go
@@ -120,6 +120,14 @@ func (s *ObstacleSuite) TestObstacle_BlocksMovement_False() {
 // HexNeighbors(h)[0] and [3] are diametrically opposite directions (their
 // deltas negate each other), so the obstacle sits exactly on the line
 // between them.
+//
+// The geometry is load-bearing, not incidental: since spatial v0.9.1
+// (rpg-toolkit#1022) an occluder on the direct ray does not block on its
+// own — sight survives if a neighbour strictly closer to the other end has
+// a clear lane. Two hexes that are one step apart on either side of the
+// obstacle leave no such neighbour, so this case still blocks. A pair
+// further apart and off axis would not, which is the point of the fix and
+// not a regression here.
 func (s *ObstacleSuite) TestObstacle_BlocksLoS_True() {
 	enc := encounter.New(context.Background(), "enc-obstacle-los-block", s.broker)
 	s.Require().NoError(enc.InitRoom(10, 10, environments.PatternEmpty))

--- a/encounter/occluder_sight_test.go
+++ b/encounter/occluder_sight_test.go
@@ -1,0 +1,108 @@
+package encounter_test
+
+// occluder_sight_test.go pins what an occluding cell does to sight after
+// spatial v0.9.1 (rpg-toolkit#1022/#1025, adopted by #1026): sight is a
+// LANE, not a line. An obstacle standing on the direct ray is a corner to
+// lean around, not a curtain — unless the geometry offers no corner.
+//
+// These are the module's own occluder pins, and they exist because the rest
+// of the suite cannot see this behavior at all. Every other sight fixture
+// here is built on a straight hex axis or on two cells either side of one
+// obstacle, and both of those are exactly the geometries the lane rule does
+// NOT change: the bump that carried it flipped 994 of 10302 sightlines in a
+// measured two-chamber dungeon and not one test in this module failed.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/core"
+	"github.com/KirkDiggler/rpg-toolkit/encounter/perception"
+	"github.com/KirkDiggler/rpg-toolkit/tools/environments"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type OccluderSightSuite struct {
+	suite.Suite
+	transport *encounter.InMemoryTransport
+	broker    *encounter.Broker
+	viewer    core.Hex
+}
+
+func TestOccluderSightSuite(t *testing.T) {
+	suite.Run(t, new(OccluderSightSuite))
+}
+
+func (s *OccluderSightSuite) SetupTest() {
+	s.transport = encounter.NewInMemoryTransport()
+	s.broker = encounter.NewBroker(s.transport)
+	// Offset (9,9) of the 20x20 room every case below builds: far enough
+	// from every edge that a six-hex sightline in any direction stays in
+	// bounds, so nothing here is decided by the room boundary.
+	s.viewer = core.HexFromPosition(spatial.Position{X: 9, Y: 9})
+}
+
+// shifted returns the hex reached from the viewer by the given cube delta.
+func (s *OccluderSightSuite) shifted(q, r, t int) core.Hex {
+	return core.Hex{Q: s.viewer.Q + q, R: s.viewer.R + r, S: s.viewer.S + t}
+}
+
+// roomWithPillar builds a 20x20 room whose only occluder is a single
+// sight-blocking, movement-free obstacle at pillar, and requires that the
+// pillar actually lies on the direct ray to target — so a case that stops
+// blocking has stopped because of the RULE, not because the fixture missed.
+func (s *OccluderSightSuite) roomWithPillar(id core.EncounterID, pillar, target core.Hex, want int) spatial.Room {
+	enc := encounter.New(context.Background(), id, s.broker)
+	s.Require().NoError(enc.InitRoom(20, 20, environments.PatternEmpty))
+	s.Require().NoError(enc.AddObstacle("pillar-1", "dnd5e:obstacles:pillar", pillar, false, true))
+
+	room := enc.Room()
+	s.Require().NotNil(room)
+	s.Require().Equal(want, perception.HexDistance(s.viewer, target), "fixture geometry drifted")
+
+	onRay := false
+	for _, position := range room.GetLineOfSight(s.viewer.ToPosition(), target.ToPosition()) {
+		if position == pillar.ToPosition() {
+			onRay = true
+		}
+	}
+	s.Require().True(onRay, "the pillar must stand on the direct ray or this case pins nothing")
+	return room
+}
+
+// TestAPillarOnTheAxisStillBlocks: a straight hex axis offers no corner.
+// Every neighbour of the viewer except the next cell on the line itself is
+// the SAME distance from the target, not closer, so the lane rule's
+// strict-progress requirement rules them all out — and the one neighbour
+// that does make progress meets the same pillar. Sight stays blocked, and
+// that is the fix behaving, not the fix missing.
+func (s *OccluderSightSuite) TestAPillarOnTheAxisStillBlocks() {
+	target := s.shifted(6, -6, 0)
+	pillar := s.shifted(3, -3, 0)
+	room := s.roomWithPillar("enc-occluder-axis", pillar, target, 6)
+
+	s.True(room.IsLineOfSightBlocked(s.viewer.ToPosition(), target.ToPosition()),
+		"an occluder on a straight-axis sightline has no corner to lean around")
+	s.True(room.IsLineOfSightBlocked(target.ToPosition(), s.viewer.ToPosition()),
+		"and the answer must not depend on which end is asking")
+}
+
+// TestAPillarOffTheAxisIsLeanedAround: the half of the rule the old pin got
+// wrong. The pillar stands on the direct ray here too, but the target is off
+// axis, so a neighbour of the viewer is strictly closer to it and has a
+// clear lane — the corner a player leans around. Under the spatial version
+// this module pinned before #1026 this pair was BLOCKED; that over-blocking
+// is what Kirk watched swallow sightlines in play.
+func (s *OccluderSightSuite) TestAPillarOffTheAxisIsLeanedAround() {
+	target := s.shifted(5, -3, -2)
+	pillar := s.shifted(2, -1, -1)
+	room := s.roomWithPillar("enc-occluder-off-axis", pillar, target, 5)
+
+	s.False(room.IsLineOfSightBlocked(s.viewer.ToPosition(), target.ToPosition()),
+		"a single occluder off the axis must be seen past, not treated as a curtain")
+	s.False(room.IsLineOfSightBlocked(target.ToPosition(), s.viewer.ToPosition()),
+		"and the answer must not depend on which end is asking")
+}

--- a/encounter/perception/room_los_test.go
+++ b/encounter/perception/room_los_test.go
@@ -44,6 +44,16 @@ func newTestRoom(id string) *spatial.BasicRoom {
 // room's line of sight, so a wall placed there is guaranteed to sit on the
 // path IsLineOfSightBlocked actually walks (rather than a hand-picked
 // coordinate that may not land on the lerped hex line).
+//
+// Sitting on that path is necessary but no longer sufficient to block:
+// since spatial v0.9.1 (rpg-toolkit#1022) sight leans, and an occluder on
+// the direct ray is seen past whenever a neighbour strictly closer to the
+// other end has a clear lane. What makes the suite's cases block is that
+// the viewer and target sit on a straight hex axis (0,0,0 -> 4,-4,0), where
+// the only cell strictly closer is the next one on the same line and meets
+// the same wall. A helper that derives the wall from the ray therefore
+// cannot, by itself, tell a blocking rule from a broken one — see the
+// module's own occluder pins for the off-axis half.
 func midpointWallPosition(s *suite.Suite, room spatial.Room, from, to core.Hex) spatial.Position {
 	los := room.GetLineOfSight(from.ToPosition(), to.ToPosition())
 	s.Require().GreaterOrEqual(len(los), 3, "need an intermediate hex to place a wall on")


### PR DESCRIPTION
Closes #1026.

Takes the root `encounter` module — the old stack's composition, the one the live game
runs through rpg-api — from its `tools/spatial` pseudo-version (`v0.6.1-0.20260809...`)
to **v0.9.1**, which carries the lane-based sight fix (#1022 → #1025). This is the only
path by which that fix reaches players before the new stack ships.

`core` rides along v0.10.0 → v0.11.0 (additive `EntityID` newtype), required by spatial
v0.9.1. That is the whole go.mod diff.

## The bump is mechanical; what it carries is not

Nothing in this module used what the gap removed (#915: `QueryUtils`, `spatial.EntityID`,
the transition system, the entity filters) or what it reshaped (#913: every connection
helper signature, entity mutation moved onto managed verbs). Build, vet and the full
suite pass untouched.

## What actually changes, measured

A canvas dungeon shaped like the authored ones — two chambers joined by a one-cell
corridor, 102 floor cells, 6 pillars — with all 10,302 ordered pairs evaluated through
`Encounter.Room()` under each pin:

| | old pin | v0.9.1 |
|---|---|---|
| blocked pairs, whole map | 6,728 (65.3%) | 5,734 (55.7%) |
| blocked pairs, within a chamber | 1,496 / 4,704 (31.8%) | 608 (12.9%) |

**The change is strictly opening: 994 pairs unblocked, 0 newly blocked** — not one pair
goes the other way. Inside a room, nearly 60% of the blocking disappears. That is the
over-blocking Kirk watched swallow sightlines in play.

**Scoped honestly:** #1022 had two halves, and only one of them lands here. Sight through
this module measured **0 asymmetric pairs under both pins**, so the direction-dependence
half does not reproduce through the hex wrapper; over-blocking is the whole of what this
bump delivers.

## Why the suite was silent — and the pin that fixes that

The full suite is green under **both** pins. 994 changed live answers, zero tests able to
tell. The reason is structural, not sloppiness: sight only opens where a neighbour
**strictly closer** to the other end has a clear lane, and a straight hex axis has no such
neighbour — the off-line neighbours are the same distance from the target, not closer, and
the one that does make progress meets the same occluder. Every existing sight fixture in
this module sits on a straight axis (`lineHex(k)`, viewer `(0,0,0)` → target `(4,-4,0)`)
or on the two cells either side of one obstacle. Both are exactly the geometries the rule
leaves alone.

`occluder_sight_test.go` adds the two pins that close it, one law in two halves — *an
occluder on the direct ray is a corner, not a curtain*:

- **on the axis it still blocks** (distance 6, pillar at 3) — the fix behaving, not missing;
- **off the axis it is leaned around** (distance 5, pillar on the ray) — blocked before this
  bump, open after.

Both halves `Require` that the pillar stands on the direct ray, so a case that stops
blocking has stopped for the rule rather than because the fixture missed. Verified
sensitive by re-running them against the old pin: the off-axis pin fails in both
directions, the axis pin still passes.

## Docs corrected (module sweep, not diff sweep)

- `data.go` — `BlocksLoS` claimed the room "reports true for **any** line of sight passing
  through this obstacle's hex, exactly like a wall". After this bump that is false, and it
  was the one genuinely wrong doc. It now says what occluding means and when leaning is
  available.
- `obstacle_test.go` — its "exactly like a wall" comment now names why the
  adjacent-opposite geometry still blocks and that a wider off-axis pair would not.
- `perception/room_los_test.go` — `midpointWallPosition` claimed that deriving the wall
  from the ray guarantees a block. It no longer does; the doc now says what actually makes
  those cases block and that a raster-derived helper cannot tell a working rule from a
  broken one.

## Also measured, no action proposed

`floorMaskRoom.IsLineOfSightBlocked` hard-blocks whenever the direct ray leaves the
structural floor, before spatial's lane logic runs — 4,218 pairs map-wide but only **34
within a chamber**. So it does not meaningfully shadow the fix inside a room; it does mean
cross-room sightlines keep single-lane semantics whatever spatial does.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — green (encounter, core, dungeonspec,
  events, perception)
- `gofmt -l .` clean, `go mod tidy` no-op
- `golangci-lint run --config=../.golangci.yml ./...` — 85 goconst findings, all
  pre-existing and untouched by this PR (local linter 2.12.2 vs CI's 2.3.1); the new test
  file adds none

Adoption of the resulting tag by rpg-api is a separate step in a different repo, and is
what actually puts changed sight in front of players.

— asset-pipeline agent, on behalf of KirkDiggler
