### PR TITLE
feat(session): a swing stops arriving as an unknown event (#1038)

### DIFF
--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -76,21 +76,16 @@ func armedFighter(id string) *character.Data {
 // field to make a swing miss changes nothing at all.
 const duelAC = 12
 
-// duel is two armed characters standing next to each other, which is the
+// duelWorld is two armed characters standing next to each other, which is the
 // smallest world where a swing means anything.
 //
 // Both sides are CHARACTERS on purpose: damage dirties the target's stored
 // sheet, which is the case that earns Attack its row in the no-clobber pin.
-func (s *AttackTestSuite) duel(dice session.Roller) *session.Manager {
-	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
-	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
-
-	mgr, err := session.NewManager(&session.Config{
-		Dice: dice, Sessions: s.sessions, Encounters: s.encounters,
-		Characters: s.characters, Events: session.DiscardEvents{},
-	})
-	s.Require().NoError(err)
-
+//
+// Shared with the event-kind pins (attackevents_test.go), which need the same
+// duel delivered to a real stream rather than discarded. One world, so a
+// fixture drift cannot make the two suites disagree about what was swung at.
+func duelWorld(t fataler) *encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: encOrderAsGiven{},
 		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
@@ -101,11 +96,26 @@ func (s *AttackTestSuite) duel(dice session.Roller) *session.Manager {
 		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 		Retention: encounter.RetentionUnbounded,
 	})
-	s.Require().NoError(err)
+	if err != nil {
+		t.Fatalf("building the duel: %v", err)
+	}
 	data := enc.ToData()
+	return &data
+}
+
+// duel wires the duel world to a manager whose events go nowhere.
+func (s *AttackTestSuite) duel(dice session.Roller) *session.Manager {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: dice, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
 
 	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: &data,
+		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
 	})
 	s.Require().NoError(err)
 	return mgr

--- a/rulebooks/dnd5e/session/attackevents_test.go
+++ b/rulebooks/dnd5e/session/attackevents_test.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+)
+
+// AttackEventsTestSuite covers what a client is told when somebody swings.
+//
+// Separate from AttackTestSuite because it asks a different question. That one
+// asks what the RULES produced — the roll, the arithmetic, the beat in the
+// story. This one asks what reached the TABLE: the same swing, delivered to a
+// real stream, named as something a client can branch on rather than as the
+// EventUnknown every attack arrived as before rpg-toolkit#1038.
+type AttackEventsTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+	stream     *fakeStream
+}
+
+func TestAttackEventsSuite(t *testing.T) {
+	suite.Run(t, new(AttackEventsTestSuite))
+}
+
+// duelWithStream is AttackTestSuite's duel wired to a stream that records.
+func (s *AttackEventsTestSuite) duelWithStream(dice session.Roller) *session.Manager {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	s.stream = &fakeStream{}
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: dice, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: s.stream,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	s.stream.published = nil // the opening beats predate any client
+	return mgr
+}
+
+// swing runs alice at bob and returns what the caller was told.
+func (s *AttackEventsTestSuite) swing(mgr *session.Manager) *session.AttackOutput {
+	out, err := mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "bob",
+	})
+	s.Require().NoError(err)
+	return out
+}
+
+// kindsAtSeq collects the event kinds delivered for one story sequence, keyed
+// by recipient — so an assertion can name WHO was told WHAT, rather than
+// counting events and hoping the count means what it looks like.
+func (s *AttackEventsTestSuite) kindsAtSeq(seq uint64) map[string]session.EventKind {
+	out := map[string]session.EventKind{}
+	for _, event := range s.stream.published {
+		if event.Seq != seq {
+			continue
+		}
+		s.Require().NotContains(out, event.Recipient, "one event per recipient per beat")
+		out[event.Recipient] = event.Kind
+	}
+	return out
+}
+
+// TestAHitIsNamedOnTheStream is the headline, and the reason the swing is real
+// rather than a payload handed to the mapper.
+//
+// The beat string is written by the composition (encounter's Record) and read
+// by this package (kindOf), and nothing else checks that the two agree. A test
+// that fed the mapper a literal "struck" would pass just as happily with a
+// composition that had renamed the beat, which is the exact failure mode the
+// mapper's own doc warns about: detection fails SILENTLY and everything
+// degrades to unknown.
+//
+// So the swing is driven end to end with scripted dice, and the event is found
+// by the sequence the caller's own AttackOutput reports. Both ends of the
+// coupling are exercised, and the assertion is tied to the swing that produced
+// it rather than to a string typed twice.
+func (s *AttackEventsTestSuite) TestAHitIsNamedOnTheStream() {
+	mgr := s.duelWithStream(&sequenceDice{rolls: []int{15, 5}})
+
+	out := s.swing(mgr)
+	s.Require().True(out.Hit, "15 + 3 STR + 2 proficiency clears AC 12")
+
+	s.Equal(
+		map[string]session.EventKind{"alice": session.EventStruck, "bob": session.EventStruck},
+		s.kindsAtSeq(out.Seq),
+		"both the striker and the struck hear that it landed",
+	)
+}
+
+// TestAMissIsNamedOnTheStream pins the other arm.
+//
+// Worth its own case rather than a subtest of the hit: the two beats are
+// separate strings on the composition's side and separate cases on this one, so
+// a mapper that named only the hit would leave every miss unknown — and a table
+// that narrates hits but not misses is arguably worse than one that narrates
+// neither, because the silence looks like nothing happened.
+func (s *AttackEventsTestSuite) TestAMissIsNamedOnTheStream() {
+	mgr := s.duelWithStream(&sequenceDice{rolls: []int{2, 5}})
+
+	out := s.swing(mgr)
+	s.Require().False(out.Hit, "2 + 5 is under AC 12")
+
+	s.Equal(
+		map[string]session.EventKind{"alice": session.EventMissed, "bob": session.EventMissed},
+		s.kindsAtSeq(out.Seq),
+		"a miss is a fact of the fight too",
+	)
+}
+
+// TestTheSwingLeavesNothingUnknown guards the verb as a whole rather than the
+// one beat under test.
+//
+// Attack records its outcome, and anything the world does in response — a fight
+// starting underfoot, an ending firing — records its own beats behind it. If any
+// of those reached a client as unknown, naming the strike would have fixed the
+// headline and left the scene around it unreadable.
+func (s *AttackEventsTestSuite) TestTheSwingLeavesNothingUnknown() {
+	mgr := s.duelWithStream(&sequenceDice{rolls: []int{15, 5}})
+
+	s.swing(mgr)
+
+	s.Require().NotEmpty(s.stream.published, "a swing with two members in the room reaches clients")
+	for _, event := range s.stream.published {
+		s.NotEqual(session.EventUnknown, event.Kind,
+			"beat at seq %d reached %s unnamed", event.Seq, event.Recipient)
+	}
+}

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -190,6 +190,15 @@ func kindOf(payload []byte) EventKind {
 		return EventFightStarted
 	case "bubble-dissolved":
 		return EventFightEnded
+	// The two outcome beats. Unlike every other case here, these strings are
+	// not the composition's own vocabulary for a verb it ran — they are the
+	// OutcomeKind a rulebook handed it (encounter's Record), which is why the
+	// mapping is worth a word: adding an outcome kind upstream means adding a
+	// case here, or the new outcome goes out unnamed.
+	case "struck":
+		return EventStruck
+	case "missed":
+		return EventMissed
 	default:
 		return EventUnknown
 	}

--- a/rulebooks/dnd5e/session/events_internal_test.go
+++ b/rulebooks/dnd5e/session/events_internal_test.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnUnrecognisedBeatStaysUnknown pins the mapper's default arm.
+//
+// Pinned HERE, against kindOf directly, rather than through a verb — because no
+// verb can produce it. Every beat the composition emits today has a case, which
+// is the point of rpg-toolkit#1038; the arm exists for the beat a LATER
+// composition adds, and there is no honest way to drive that from this side of
+// the seam without faking the composition itself.
+//
+// It is load-bearing rather than defensive. Delivering an uninterpretable beat
+// keeps a client's sequence gapless, so it can tell "I do not understand this"
+// from "I missed something" — dropping it would manufacture a hole and send the
+// client into a resync it never needed. That is also what lets a newer
+// composition ship a beat this version has never heard of without older clients
+// losing their place.
+func TestAnUnrecognisedBeatStaysUnknown(t *testing.T) {
+	require.Equal(t, EventUnknown, kindOf([]byte(`{"beat":"transmogrified"}`)),
+		"a beat this version does not know is delivered, not dropped")
+	require.Equal(t, EventUnknown, kindOf([]byte(`{"actor":"alice"}`)),
+		"and so is a beat with no name at all")
+	require.Equal(t, EventUnknown, kindOf([]byte(`not json`)),
+		"including a payload this package cannot even parse")
+}
+
+// TestTheAttackBeatsAreTheCompositionsOwnStrings guards the coupling from the
+// other side.
+//
+// The seam-level pins in attackevents_test.go drive a real swing and are the
+// evidence that matters; this states the two strings plainly, so that a diff
+// renaming one of them has to say so out loud rather than degrading a table to
+// unknown silently.
+func TestTheAttackBeatsAreTheCompositionsOwnStrings(t *testing.T) {
+	require.Equal(t, EventStruck, kindOf([]byte(`{"beat":"struck"}`)))
+	require.Equal(t, EventMissed, kindOf([]byte(`{"beat":"missed"}`)))
+}

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -288,8 +288,10 @@ const (
 	EventFightEnded EventKind = "fight_ended"
 
 	// EventStruck reports that an attack landed, and EventMissed that one did
-	// not. The beat carries the numbers behind it — the roll, what it totalled,
-	// what it had to reach, and how much was done.
+	// not. The beat carries the numbers behind it: the roll, what it totalled,
+	// and what it had to reach. A landed blow carries how much was done as
+	// well; a miss OMITS that key rather than reporting zero, because a beat
+	// saying "missed for 0" reads as a hit that did nothing.
 	//
 	// Two kinds rather than one with a hit flag, because a client branches on
 	// them: a landed blow and a whiffed one are different animations, different

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -287,6 +287,31 @@ const (
 	// to free roam.
 	EventFightEnded EventKind = "fight_ended"
 
+	// EventStruck reports that an attack landed, and EventMissed that one did
+	// not. The beat carries the numbers behind it — the roll, what it totalled,
+	// what it had to reach, and how much was done.
+	//
+	// Two kinds rather than one with a hit flag, because a client branches on
+	// them: a landed blow and a whiffed one are different animations, different
+	// sounds, and different things to say. Reading a boolean out of the payload
+	// to decide which is exactly the interpretation this enum exists to spare
+	// whoever renders it.
+	//
+	// The same round trip EventTurnEnded and EventFightStarted went through,
+	// and the third time it has happened: the beat existed as soon as a strike
+	// could be recorded (rpg-toolkit#966), and until rpg-toolkit#1038 every
+	// swing reached a client as EventUnknown — delivered, uninterpretable, and
+	// useless for the most common thing in a fight.
+	//
+	// Everyone in the encounter hears both, for the reason EventFightStarted
+	// spells out: an outcome is not secret, and a table that learned about a
+	// blow only from the striker's own response could not narrate the scene it
+	// is in.
+	EventStruck EventKind = "struck"
+
+	// EventMissed reports that an attack did not land. See EventStruck.
+	EventMissed EventKind = "missed"
+
 	// EventUnknown is a beat this version does not recognise.
 	//
 	// Delivered rather than dropped on purpose: a client that cannot interpret


### PR DESCRIPTION
Closes #1038.

The composition records an attack as a beat named `"struck"` or `"missed"` (encounter's
`Record`). `kindOf` had a case for every other beat it emits and neither of these, so the
default arm fired and **every swing reached a client as `EventUnknown`** — delivered,
sequence intact, and uninterpretable. The most common thing that happens in a fight was
the one thing the event stream could not name.

`EventStruck`, `EventMissed`, and the two cases that produce them.

## Deliberately nothing else

- **No new beat vocabulary.** `"struck"` and `"missed"` are what the composition already
  writes; this adds no third outcome.
- **No payload change.** The beat still carries `roll`, `total`, `against`, `amount`.
  Whether the transcript should carry *more* than that — a critical flag, advantage
  sources, a damage type, everything `AttackOutput` tells the striker and the beat does
  not — is a separate conversation about extending a closed enum, and is not this PR.
- **The default arm stays load-bearing.** An unrecognised beat still maps to
  `EventUnknown`, and now says so in a test.

This is the third time this round trip has happened — `EventTurnEnded` and
`EventFightStarted` both existed as beats first and arrived as unknown until a verb could
produce them. The new doc says so, so the fourth time is easier to spot.

## The pins drive a real swing, on purpose

The beat string is written by one module and read by another, and nothing else checks
that the two agree. A test that handed `kindOf` a literal `"struck"` would pass just as
happily against a composition that had renamed the beat — which is precisely the
silent-degradation failure `kindOf`'s own doc warns about: detection fails quietly,
nothing errors, and the symptom is a table where nothing narrates.

So `attackevents_test.go` runs alice at bob through the seam with scripted dice — one hit
(15 + 3 STR + 2 proficiency vs AC 12), one miss (2 + 5) — publishes to a recording
stream, and finds the event **by the sequence `AttackOutput` itself reports**. The
assertion is a map of recipient to kind, so it names who was told what rather than
counting events and hoping the count means what it looks like. A third case guards the
whole verb: nothing a swing produces may reach a client unnamed, not just the beat under
test.

`events_internal_test.go` pins the default arm against `kindOf` directly, and says why it
is pinned there: no verb can produce an unrecognised beat today — every beat has a case,
which is the point of the issue — so there is no honest way to drive that arm from
outside without faking the composition.

## Verification

- Full `session` module suite green; `gofmt -l` clean; `go mod tidy` a no-op.
- `golangci-lint run --config=../../../.golangci.yml ./...` — no findings in any file this
  PR touches. (Local runs report goconst/dupl noise across the module's existing tests
  that CI does not: the repo config uses the v1-style `issues.exclude-rules` /
  `linters-settings` keys, which CI's golangci-lint 2.3.1 honours and a newer local one
  ignores.)
- **Sensitivity checked, not assumed.** With the two `case` arms deleted, all three
  stream pins fail — the hit and miss maps come back `unknown`, and the whole-verb guard
  trips — and they pass again with the arms restored. A future change that stops naming
  these beats ships red.

— asset-pipeline agent, on behalf of KirkDiggler
