### PR TITLE
feat(encounter): placement reads and movement beats speak dungeon-absolute (#1040)

### DIFF
--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -698,7 +698,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 
 	// All validated; now reconstruct via the same path Setup uses
 	e := &Encounter{
-		members:     make(map[MemberID]*Member),
+		members:     make(map[MemberID]*memberRecord),
 		everMembers: make(map[MemberID]bool),
 		deciders:    make(map[MemberID]Decider),
 		initiative:  input.Initiative,
@@ -793,7 +793,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 			return nil, fmt.Errorf("load encounter member placement: %w: %w: %w", ErrInvalidData, ErrBadPlacement, err)
 		}
 
-		member := &Member{
+		member := &memberRecord{
 			ID:   m.ID,
 			Kind: m.Kind,
 			Room: m.Room,

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -50,7 +50,7 @@ type Encounter struct {
 	bubbles     []*clock.Turn
 	intelLog    *intel.Intel
 	story       *record.Log
-	members     map[MemberID]*Member
+	members     map[MemberID]*memberRecord
 	everMembers map[MemberID]bool // Track all members who have ever joined (for Story access)
 	deciders    map[MemberID]Decider
 
@@ -974,7 +974,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 
 	// After validation passes, construct (R5: no observable state until success)
 	e := &Encounter{
-		members:          make(map[MemberID]*Member),
+		members:          make(map[MemberID]*memberRecord),
 		everMembers:      make(map[MemberID]bool),
 		deciders:         make(map[MemberID]Decider),
 		initiative:       in.Initiative,
@@ -1088,7 +1088,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 			return nil, fmt.Errorf("newencounter member placement: %w: %w", ErrBadPlacement, err)
 		}
 
-		member := &Member{
+		member := &memberRecord{
 			ID:   mi.ID,
 			Kind: mi.Kind,
 			Room: mi.Room,
@@ -1194,7 +1194,18 @@ func (e *Encounter) buildMemberOutcomes() []MemberOutcome {
 	return outcomes
 }
 
-// Members returns the current member roster in stable order.
+// Members returns the current member roster in stable order, each with the
+// dungeon-absolute cell they stand on.
+//
+// The position is why this exists in its current shape. Projecting a roster
+// used to mean calling ToData — serializing clock, intel, log, field and
+// endings to read two floats per member, once per frame in the worst case
+// (rpg-toolkit#933). A roster read should cost a roster read.
+//
+// Returns ErrNoField if a member's room or cell cannot be resolved, which
+// would mean the roster and the spatial field disagree about who is placed —
+// a defect worth surfacing rather than papering over with a zero position
+// that reads like the map's origin.
 func (e *Encounter) Members() ([]Member, error) {
 	// Sort by ID for stability
 	ids := make([]MemberID, 0, len(e.members))
@@ -1207,9 +1218,73 @@ func (e *Encounter) Members() ([]Member, error) {
 
 	members := make([]Member, 0, len(ids))
 	for _, id := range ids {
-		members = append(members, *e.members[id])
+		member, err := e.placementOf(e.members[id])
+		if err != nil {
+			return nil, fmt.Errorf("members: %w", err)
+		}
+		members = append(members, member)
 	}
 	return members, nil
+}
+
+// placementOf builds a member's read shape: the stored record plus where they
+// actually stand, projected into dungeon-absolute space.
+//
+// ONE projection path, used by every read that reports a member. Join and
+// Members answering the same question differently is the kind of drift that
+// stays invisible until two clients disagree about where somebody is.
+func (e *Encounter) placementOf(record *memberRecord) (Member, error) {
+	local, err := e.cellOf(record)
+	if err != nil {
+		return Member{}, err
+	}
+
+	// Origin lives in construction truth, never on the spatial room — the
+	// same source Absolute projects through, so the two cannot disagree.
+	ri, ok := e.roomInput(record.Room)
+	if !ok {
+		return Member{}, fmt.Errorf("member %q: unknown room %q: %w", record.ID, record.Room, ErrNoField)
+	}
+
+	return Member{
+		ID:       record.ID,
+		Kind:     record.Kind,
+		Room:     record.Room,
+		Position: local.Add(ri.Origin),
+	}, nil
+}
+
+// cellOf reads a member's room-local cell from the spatial room that owns it,
+// which is the only place that knows it.
+func (e *Encounter) cellOf(record *memberRecord) (spatial.Position, error) {
+	room, ok := e.orchestrator.GetRoom(record.Room)
+	if !ok {
+		return spatial.Position{}, fmt.Errorf("member %q: unknown room %q: %w", record.ID, record.Room, ErrNoField)
+	}
+	local, ok := room.GetEntityPosition(string(record.ID))
+	if !ok {
+		return spatial.Position{}, fmt.Errorf("member %q: not placed in room %q: %w", record.ID, record.Room, ErrNoField)
+	}
+	return local, nil
+}
+
+// absoluteOf projects a room-local cell for a beat or a report.
+//
+// Beats speak absolute for the same reason Member.Position does: a
+// room-local coordinate with no room attached — which is exactly what the
+// moved beat carried before rpg-toolkit#1040 — cannot be resolved to
+// anywhere in a multi-room field.
+func (e *Encounter) absoluteOf(room string, local spatial.Position) spatial.Position {
+	ri, ok := e.roomInput(room)
+	if !ok {
+		// Unreachable through any verb: every beat is built from a room the
+		// verb just moved a member into or out of, and construction validates
+		// every room in the field. Returning the local cell unprojected is
+		// the least-wrong answer if that ever stops being true, and it is
+		// wrong in a way a test can see rather than a panic in a host.
+		return local
+	}
+	return local.Add(ri.Origin)
 }
 
 // Status returns the encounter's current state (Open or Closed with Outcome).
@@ -1291,7 +1366,7 @@ func (e *Encounter) Story(in *StoryInput) ([]record.Entry, error) {
 // or an error if the spatial move was rejected. This is the shared managed seam for both
 // player moves (Move verb) and monster moves (Pump). The member must exist and be in an
 // open encounter; spatial rejection does not abort the operation (handled by caller).
-func (e *Encounter) moveMember(member *Member, to spatial.Position) (spatial.Position, error) {
+func (e *Encounter) moveMember(member *memberRecord, to spatial.Position) (spatial.Position, error) {
 	// Get the room and current position
 	room, ok := e.orchestrator.GetRoom(member.Room)
 	if !ok {
@@ -1402,9 +1477,13 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	clockReadingInt := e.clock.ToData().HighWater
 	clockReadingForBeat := uint64(clockReadingInt)
 	beatPayload := map[string]interface{}{
-		"beat":     "moved",
-		"member":   string(in.Member),
-		"position": in.To,
+		"beat":   "moved",
+		"member": string(in.Member),
+		// DUNGEON-ABSOLUTE (#1040). This beat carried the room-local cell and
+		// no room at all, which in a multi-room field named nowhere: two
+		// members in different rooms could report the same "position" and mean
+		// cells at opposite ends of the map.
+		"position": e.absoluteOf(member.Room, in.To),
 	}
 	beatBytes, _ := json.Marshal(beatPayload)
 
@@ -1522,7 +1601,7 @@ type traverseResult struct {
 // Pump's silent-skip-on-failure semantics: ANY error returned here is
 // treated exactly like a spatially-rejected IntentMoveTo — the monster
 // simply fails to act this tick, no abort).
-func (e *Encounter) traverseMember(member *Member, connectionID string) (traverseResult, error) {
+func (e *Encounter) traverseMember(member *memberRecord, connectionID string) (traverseResult, error) {
 	var conn *ConnectionInput
 	for i := range e.connectionsInput {
 		if e.connectionsInput[i].ID == connectionID {
@@ -1677,8 +1756,10 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 		"beat":       "traversed",
 		"member":     string(in.Member),
 		"connection": in.Connection,
-		"room":       result.toRoom,
-		"position":   result.toPos,
+		// The arrival cell, DUNGEON-ABSOLUTE (#1040). The room key is gone
+		// with it: rooms are this composition's own business, and a caller
+		// that wants the arrival room asks Locate.
+		"position": e.absoluteOf(result.toRoom, result.toPos),
 	}
 	beatBytes, _ := json.Marshal(beatPayload)
 
@@ -1909,7 +1990,7 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 	// deterministic per-monster order the deciders were consulted in
 	// (C8) — not "all moves then all traverses".
 	type executedAction struct {
-		member     *Member
+		member     *memberRecord
 		kind       string // "move" or "traverse"
 		connection string // only meaningful for "traverse"
 		fromRoom   string // only meaningful for "traverse"; a move never changes room
@@ -1999,15 +2080,14 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 			beatPayload = map[string]interface{}{
 				"beat":     "moved",
 				"member":   string(action.member.ID),
-				"position": action.to,
+				"position": e.absoluteOf(action.member.Room, action.to),
 			}
 		case "traverse":
 			beatPayload = map[string]interface{}{
 				"beat":       "traversed",
 				"member":     string(action.member.ID),
 				"connection": action.connection,
-				"room":       action.toRoom,
-				"position":   action.to,
+				"position":   e.absoluteOf(action.toRoom, action.to),
 			}
 		}
 		beatBytes, _ := json.Marshal(beatPayload)
@@ -2336,7 +2416,7 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 	}
 
 	// Register the member
-	member := &Member{
+	member := &memberRecord{
 		ID:   in.Member.ID,
 		Kind: in.Member.Kind,
 		Room: in.Member.Room,
@@ -2445,9 +2525,14 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 		break
 	}
 
+	placement, err := e.placementOf(member)
+	if err != nil {
+		return nil, fmt.Errorf("join: %w", err)
+	}
+
 	return &JoinOutput{
 		Formed:      formed,
-		Member:      *member,
+		Member:      placement,
 		IntelDeltas: intelDeltas,
 		Seq:         seqNum,
 		Outcome:     firedOutcome,

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -251,8 +251,43 @@ type StoryInput struct {
 	AfterSeq uint64
 }
 
-// Member represents a member's public read-side data.
+// Member represents a member's public read-side data: who they are, and
+// where they stand on the dungeon map.
+//
+// A READ SHAPE, not the stored record. What this composition keeps about a
+// member is [memberRecord]; a member's cell is the spatial room's to know,
+// and this type is built by asking it. The two were one type until #1040,
+// which put a position on the record that the record did not own — the dual
+// state this module has paid for before.
 type Member struct {
+	ID   MemberID
+	Kind MemberKind
+	Room string
+
+	// Position is where the member stands, in DUNGEON-ABSOLUTE space —
+	// already projected through their room's origin, so it can be compared
+	// with any other absolute coordinate this composition reports (an Atlas
+	// cell, a doorway endpoint, another member) without the caller redoing
+	// the arithmetic.
+	//
+	// Absolute rather than room-local because a position without its room is
+	// not an answer in a multi-room field, and pairing every coordinate with
+	// a room ID is the dialect the seam reshape exists to remove: the
+	// composition has rooms, and it projects the absolute geometry so its
+	// caller sees one map (rpg-project#227). W4 already put projection on
+	// this side of the line — absolute coordinates belong in query outputs,
+	// never in a rule's own logic.
+	//
+	// The room-local cell is still available: pass this position to [Locate],
+	// which is the exact inverse.
+	Position spatial.Position
+}
+
+// memberRecord is what the composition stores about a member: identity, kind,
+// and which room owns them. Deliberately NOT their cell — the spatial room
+// holds that, and duplicating it here would create a second truth that the
+// verbs would have to keep in step.
+type memberRecord struct {
 	ID   MemberID
 	Kind MemberKind
 	Room string

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -1,0 +1,220 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// placement_test.go pins what this composition says about WHERE somebody is
+// (rpg-toolkit#1040). Every answer is dungeon-absolute: the composition keeps
+// rooms, and projects the absolute geometry so its caller sees one map
+// (rpg-project#227).
+//
+// Every fixture here anchors its rooms AWAY from the origin, and that is the
+// whole design of the file. A room at (0,0) makes local and absolute the same
+// number, so a test built on one passes identically against an implementation
+// that never projects at all — which is exactly why the module's existing
+// suites went green on this change without noticing it.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type PlacementSuite struct {
+	suite.Suite
+	enc *encounter.Encounter
+}
+
+func TestPlacementSuite(t *testing.T) {
+	suite.Run(t, new(PlacementSuite))
+}
+
+// hallOrigin and vaultOrigin are deliberately non-zero and different from each
+// other, so that a projection using the wrong room's origin is as visible as
+// one that forgets to project.
+var (
+	hallOrigin  = spatial.Position{X: 30, Y: 10}
+	vaultOrigin = spatial.Position{X: 38, Y: 10}
+)
+
+// gate joins the two rooms. Its endpoints are chosen so the doorway kisses in
+// absolute space (W3): hall-local (7,4) is absolute (37,14), vault-local (0,4)
+// is absolute (38,14), and those are adjacent.
+var gate = encounter.ConnectionInput{
+	ID: "gate", From: "hall", To: "vault",
+	FromPosition: spatial.Position{X: 7, Y: 4},
+	ToPosition:   spatial.Position{X: 0, Y: 4},
+}
+
+func (s *PlacementSuite) SetupTest() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hall", Width: 8, Height: 8, Origin: hallOrigin},
+				{ID: "vault", Width: 8, Height: 8, Origin: vaultOrigin},
+			},
+			Connections: []encounter.ConnectionInput{gate},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 3}},
+			{ID: "ogre", Kind: encounter.KindMonster, Room: "vault", Position: spatial.Position{X: 5, Y: 1}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	s.Require().NoError(err)
+	s.enc = enc
+}
+
+// absolute is what the composition's own bridge says, used as the cross-check
+// throughout: a roster read and a coordinate projection must never disagree
+// about the same cell, whichever of them a caller happens to use.
+func (s *PlacementSuite) absolute(room string, local spatial.Position) spatial.Position {
+	out, err := s.enc.Absolute(&encounter.AbsoluteInput{Room: room, Position: local})
+	s.Require().NoError(err)
+	return out.Position
+}
+
+// TestTheRosterSaysWhereEverybodyStands is #933's half 2: a caller reads
+// placement without serializing the aggregate to get at two floats.
+func (s *PlacementSuite) TestTheRosterSaysWhereEverybodyStands() {
+	members, err := s.enc.Members()
+	s.Require().NoError(err)
+	s.Require().Len(members, 2)
+
+	// Sorted by ID, so alice then ogre.
+	s.Equal(encounter.MemberID("alice"), members[0].ID)
+	s.Equal(spatial.Position{X: 32, Y: 13}, members[0].Position, "hall-local (2,3) anchored at (30,10)")
+	s.Equal(s.absolute("hall", spatial.Position{X: 2, Y: 3}), members[0].Position,
+		"the roster and the projection bridge must agree")
+
+	s.Equal(encounter.MemberID("ogre"), members[1].ID)
+	s.Equal(spatial.Position{X: 43, Y: 11}, members[1].Position, "vault-local (5,1) anchored at (38,10)")
+	s.Equal(s.absolute("vault", spatial.Position{X: 5, Y: 1}), members[1].Position,
+		"and for the other room's anchor too")
+}
+
+// TestTheRosterAgreesWithTheMap crosses the roster against the static map, the
+// two reads a client renders together. A member reported at a cell the Atlas
+// does not contain is a member drawn outside the room they are standing in.
+func (s *PlacementSuite) TestTheRosterAgreesWithTheMap() {
+	members, err := s.enc.Members()
+	s.Require().NoError(err)
+
+	atlas, err := s.enc.Atlas()
+	s.Require().NoError(err)
+
+	cells := map[spatial.Position]string{}
+	for _, room := range atlas.Rooms {
+		for _, cell := range room.Cells {
+			cells[cell] = room.ID
+		}
+	}
+
+	for _, member := range members {
+		owner, ok := cells[member.Position]
+		s.Require().True(ok, "%s stands at %v, which is not a cell of any room on the map",
+			member.ID, member.Position)
+		s.Equal(member.Room, owner, "%s is reported in %q but their cell belongs to %q",
+			member.ID, member.Room, owner)
+	}
+}
+
+// TestJoiningReportsAbsolutePlacement: the verb that places somebody answers in
+// the same space the roster does. A join that reported local would hand a host
+// a coordinate it could only fix by knowing about rooms.
+func (s *PlacementSuite) TestJoiningReportsAbsolutePlacement() {
+	out, err := s.enc.Join(&encounter.JoinInput{
+		Member: encounter.MemberInput{
+			ID: "bob", Kind: encounter.KindPlayer, Room: "vault", Position: spatial.Position{X: 1, Y: 6},
+		},
+	})
+	s.Require().NoError(err)
+
+	s.Equal(spatial.Position{X: 39, Y: 16}, out.Member.Position, "vault-local (1,6) anchored at (38,10)")
+	s.Equal(s.absolute("vault", spatial.Position{X: 1, Y: 6}), out.Member.Position)
+}
+
+// beatAt decodes the story beat a verb reported, found by the sequence the verb
+// itself returned rather than by taking the last entry.
+//
+// Not fussiness: a doorway crossing can put two sides in sight of each other
+// and start a fight, whose own beat lands AFTER the crossing's. Reading "the
+// last beat" would silently assert against a bubble-formed payload — which is
+// exactly what it did on the first run of this file.
+func (s *PlacementSuite) beatAt(member encounter.MemberID, seq uint64) map[string]interface{} {
+	entries, err := s.enc.Story(&encounter.StoryInput{Audience: member})
+	s.Require().NoError(err)
+
+	for _, entry := range entries {
+		if entry.Seq != seq {
+			continue
+		}
+		var payload map[string]interface{}
+		s.Require().NoError(json.Unmarshal(entry.Payload, &payload))
+		return payload
+	}
+	s.Require().Fail("no beat at seq", "%d is not in %s's story", seq, member)
+	return nil
+}
+
+// TestTheMovedBeatSpeaksAbsolute.
+//
+// This beat is the one that was not merely a dialect mismatch but unresolvable:
+// it carried a room-local cell and NO room, so two members standing in
+// different rooms could report the same "position" and mean cells at opposite
+// ends of the dungeon.
+func (s *PlacementSuite) TestTheMovedBeatSpeaksAbsolute() {
+	moved, err := s.enc.Move(&encounter.MoveInput{Member: "alice", To: spatial.Position{X: 3, Y: 3}})
+	s.Require().NoError(err)
+
+	payload := s.beatAt("alice", moved.Seq)
+	s.Equal("moved", payload["beat"])
+	s.Equal(map[string]interface{}{"x": float64(33), "y": float64(13)}, payload["position"],
+		"hall-local (3,3) anchored at (30,10)")
+}
+
+// TestTheTraversedBeatSpeaksAbsoluteAndNamesNoRoom.
+//
+// Two assertions, and the second is the point of the slice: the room key is
+// GONE, not merely projected alongside. A beat that still named a room would
+// leave the concept crossing the seam in the one place a client actually reads.
+func (s *PlacementSuite) TestTheTraversedBeatSpeaksAbsoluteAndNamesNoRoom() {
+	// Walk to the doorway first — traversal requires standing on the endpoint.
+	_, err := s.enc.Move(&encounter.MoveInput{Member: "alice", To: spatial.Position{X: 3, Y: 4}})
+	s.Require().NoError(err)
+	for _, x := range []float64{4, 5, 6, 7} {
+		_, err = s.enc.Move(&encounter.MoveInput{Member: "alice", To: spatial.Position{X: x, Y: 4}})
+		s.Require().NoError(err)
+	}
+
+	crossed, err := s.enc.Traverse(&encounter.TraverseInput{Member: "alice", Connection: "gate"})
+	s.Require().NoError(err)
+
+	payload := s.beatAt("alice", crossed.Seq)
+	s.Equal("traversed", payload["beat"])
+	s.Equal(map[string]interface{}{"x": float64(38), "y": float64(14)}, payload["position"],
+		"vault-local (0,4) anchored at (38,10) — the far side of the doorway")
+	s.NotContains(payload, "room", "rooms are the composition's own business")
+}
+
+// TestTheDoorwayKissesInAbsoluteSpace is not a pin on this change so much as
+// the reason the change is coherent: the two endpoint cells are ADJACENT once
+// projected, which is what makes a crossing an ordinary step on one map rather
+// than a jump between two coordinate systems.
+func (s *PlacementSuite) TestTheDoorwayKissesInAbsoluteSpace() {
+	atlas, err := s.enc.Atlas()
+	s.Require().NoError(err)
+	s.Require().Len(atlas.Doorways, 1)
+
+	doorway := atlas.Doorways[0]
+	s.Equal(spatial.Position{X: 37, Y: 14}, doorway.FromCell)
+	s.Equal(spatial.Position{X: 38, Y: 14}, doorway.ToCell)
+	s.Equal(float64(1), doorway.ToCell.X-doorway.FromCell.X, "one step apart on the dungeon map")
+	s.Equal(doorway.FromCell.Y, doorway.ToCell.Y)
+}


### PR DESCRIPTION
Closes #1040. First slice of the seam reshape (rpg-project#227).

Kirk's ruling: *"the encounter has rooms but projects the absolute geo of the dungeon so
the session package sees it as all one map."* This slice is the half with no coupling to
anything else — **what the composition says about where somebody is**.

## What changes

**`Members()` reports each member's dungeon-absolute cell.** Projecting a roster used to
mean `ToData()` — serializing clock, intel, log, field and endings to read two floats per
member. The session seam does exactly that today, in `whereIs` (`session/move.go:349`),
whose doc already names #933 as the fix. `JoinOutput.Member` reports the same shape
through the same path, because two reads answering "where is bob" differently is drift
waiting to happen.

**The stored record and the read shape are now different types.** `Member` was both, so
adding a position would have put a field on the stored record whose truth lives in the
spatial room — a second truth the verbs would have to keep in step, which is the dual
state this module has paid for before. `memberRecord` is what is stored; `Member` is what
is read.

**The four movement beats speak absolute, and `traversed` no longer names a room.** Two
`moved` sites and two `traversed` sites, one of each emitted by a verb and by `Pump`. The
`moved` case was not merely a dialect mismatch: it carried a room-local cell with **no
room at all**, which in a multi-room field resolves to nowhere — two members in different
rooms could report the same `position` and mean opposite ends of the dungeon.

**Beat strings are untouched**, per the standing rider: `session`'s `kindOf` maps them onto
wire event kinds, and renaming one degrades a client to `EventUnknown` in silence.

## Forks and leans this rests on

- **F2 (where projection lives) — resolved per lean: the composition.** It is the only
  thing that knows origins, and W4 already puts absolute coordinates in query outputs
  rather than in a rule's logic. Kirk's phrasing is the direct authority.
- **Slice 1 split into 1a/1b, and this is 1a.** Sight payloads are NOT here. `SightPayload`
  is read by deciders, whose `Snapshot` gives them their own ROOM-LOCAL position and whose
  `IntentMoveTo.To` is room-local — flipping the payload to absolute while a decider still
  answers in local breaks the contract for whoever writes the first real one. That is a
  shape ruling about the monster-behavior seam and lands as its own slice. Beats have no
  such coupling: nothing but a host reads one.
- Not in scope, deliberately: the seam-side changes (session outputs, Atlas flattening,
  Move crossing a doorway, Traverse retiring), and anything about sight or fights stopping
  at doorways.

## Verification

- Full `encounter` module suite green; `gofmt -l` clean; `go mod tidy` a no-op.
- **The new pins anchor every room AWAY from (0,0), and that is the design of the file.**
  A room at the origin makes local and absolute the same number, so a test built on one
  passes identically against an implementation that never projects — which is exactly why
  every existing suite in this module went green on this change without noticing it. The
  pins also cross-check the roster against `Absolute` and against the `Atlas` cells, so a
  read and a projection cannot drift apart.
- **Sensitivity checked by mutation, both directions.** Making `absoluteOf` return the
  local cell fails the two beat pins; making `placementOf` return the local cell fails the
  three placement pins. Worth recording how the second one nearly lied: the first attempt
  left `ri` declared and unused, so the package did not compile and the failure grep found
  nothing — which reads exactly like a surviving mutant. A mutant that does not compile is
  not a kill and is not a survival; it is nothing.

— asset-pipeline agent, on behalf of KirkDiggler
