### PR TITLE
feat(session)!: the Atlas is one map, not a list of rooms (#1042)

### DIFF
--- a/rulebooks/dnd5e/session/atlasmap_test.go
+++ b/rulebooks/dnd5e/session/atlasmap_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -28,6 +29,40 @@ func TestAtlasMapSuite(t *testing.T) {
 	suite.Run(t, new(AtlasMapSuite))
 }
 
+// backwardsWorld is two 4x4 square rooms joined by a doorway, anchored so that
+// ROOM ORDER AND COORDINATE ORDER DISAGREE: the alphabetically-first room
+// ("alpha") sits to the RIGHT, at x 4..7, and "beta" occupies x 0..3.
+//
+// That disagreement is the entire reason this fixture exists rather than
+// reusing hexWorld. There, the first room by ID is also the leftmost, so a map
+// concatenated room by room comes out in coordinate order BY ACCIDENT — and an
+// order pin written against it passes with the sorting deleted, which is
+// exactly what the first version of this file did.
+func backwardsWorld(t fataler) *encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "alpha", Width: 4, Height: 4, Origin: spatial.Position{X: 4, Y: 0}},
+				{ID: "beta", Width: 4, Height: 4, Origin: spatial.Position{X: 0, Y: 0}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "alpha", To: "beta",
+				FromPosition: spatial.Position{X: 0, Y: 0},
+				ToPosition:   spatial.Position{X: 3, Y: 0},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "beta", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "out", Trigger: encounter.TriggerExternal{}}},
+	})
+	if err != nil {
+		t.Fatalf("building backwards world: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
 func (s *AtlasMapSuite) SetupTest() {
 	mgr, err := session.NewManager(&session.Config{
 		Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
@@ -35,12 +70,12 @@ func (s *AtlasMapSuite) SetupTest() {
 	})
 	s.Require().NoError(err)
 
-	// hexWorld's vault is anchored at (6,0), away from the origin, which is
-	// what makes the projection observable at all: in a field where every room
-	// sits at (0,0), local and absolute are the same number and a map that
-	// never projected would look identical to one that did.
+	// Both rooms are anchored away from where their local coordinates would
+	// put them, which is what makes the projection observable at all: in a
+	// field where a room sits at (0,0), local and absolute are the same number
+	// and a map that never projected would look identical to one that did.
 	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: hexWorld(s.T()),
+		Session: "sess", Encounter: "world", World: backwardsWorld(s.T()),
 	})
 	s.Require().NoError(err)
 	s.mgr = mgr
@@ -81,13 +116,13 @@ func (s *AtlasMapSuite) TestNothingOnTheMapNamesARoom() {
 // TestTheMapIsEveryCellOnce: the two rooms' footprints are folded together,
 // nothing lost and nothing counted twice.
 //
-// The count is exact and derived from the fixture's own geometry: two 6x6 hex
-// rooms, disjoint by W2, so 72 distinct cells. A projection that dropped the
+// The count is exact and derived from the fixture's own geometry: two 4x4
+// rooms, disjoint by W2, so 32 distinct cells. A projection that dropped the
 // second room, or emitted one room twice, moves this number.
 func (s *AtlasMapSuite) TestTheMapIsEveryCellOnce() {
 	atlas := s.atlas()
 
-	s.Len(atlas.Cells, 72, "two 6x6 rooms, folded into one map")
+	s.Len(atlas.Cells, 32, "two 4x4 rooms, folded into one map")
 
 	seen := map[spatial.Position]bool{}
 	for _, cell := range atlas.Cells {
@@ -95,10 +130,10 @@ func (s *AtlasMapSuite) TestTheMapIsEveryCellOnce() {
 		seen[cell] = true
 	}
 
-	// Cells from BOTH anchors are present. The vault's cells only exist at
-	// these coordinates if the projection happened.
-	s.True(seen[spatial.Position{X: -3, Y: -3}], "a corridor cell, anchored at the origin")
-	s.True(seen[spatial.Position{X: 8, Y: 2}], "a vault cell, anchored at (6,0)")
+	// Cells from BOTH anchors are present, and alpha's only exist at these
+	// coordinates if the projection happened.
+	s.True(seen[spatial.Position{X: 0, Y: 0}], "beta's corner, anchored at the origin")
+	s.True(seen[spatial.Position{X: 7, Y: 3}], "alpha's far corner, anchored at (4,0)")
 }
 
 // TestTheMapIsInCoordinateOrder guards the subtler half of flattening.
@@ -126,9 +161,9 @@ func (s *AtlasMapSuite) TestADoorwayIsTwoAdjacentCells() {
 
 	gate := atlas.Doorways[0]
 	s.Equal("gate", gate.Connection)
-	s.Equal(spatial.Position{X: 2, Y: 0}, gate.From, "corridor-local (2,0), anchored at the origin")
-	s.Equal(spatial.Position{X: 3, Y: 0}, gate.To, "vault-local (-3,0), anchored at (6,0)")
-	s.Equal(float64(1), gate.To.X-gate.From.X, "one step apart on the map")
+	s.Equal(spatial.Position{X: 4, Y: 0}, gate.From, "alpha-local (0,0), anchored at (4,0)")
+	s.Equal(spatial.Position{X: 3, Y: 0}, gate.To, "beta-local (3,0), anchored at the origin")
+	s.Equal(float64(1), gate.From.X-gate.To.X, "one step apart on the map")
 	s.Equal(gate.From.Y, gate.To.Y)
 }
 

--- a/rulebooks/dnd5e/session/atlasmap_test.go
+++ b/rulebooks/dnd5e/session/atlasmap_test.go
@@ -1,0 +1,145 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+// atlasmap_test.go pins that the map this seam hands out is ONE MAP
+// (rpg-toolkit#1042). The composition underneath keeps rooms; by the time a
+// client sees a map, the decomposition has done its job and is gone.
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type AtlasMapSuite struct {
+	suite.Suite
+
+	mgr *session.Manager
+}
+
+func TestAtlasMapSuite(t *testing.T) {
+	suite.Run(t, new(AtlasMapSuite))
+}
+
+func (s *AtlasMapSuite) SetupTest() {
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	// hexWorld's vault is anchored at (6,0), away from the origin, which is
+	// what makes the projection observable at all: in a field where every room
+	// sits at (0,0), local and absolute are the same number and a map that
+	// never projected would look identical to one that did.
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: hexWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+}
+
+func (s *AtlasMapSuite) atlas() *session.Atlas {
+	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
+	s.Require().NoError(err)
+	return atlas
+}
+
+// TestNothingOnTheMapNamesARoom is the slice's whole claim, checked
+// structurally rather than by eye.
+//
+// A field-name assertion rather than a "no room ids in the values" scan: the
+// concern is not that today's fixture happens to leave rooms out, it is that
+// the TYPE cannot carry one. Adding a room id back — for a renderer that wants
+// to chunk by chamber, which is exactly how this would return — fails here
+// instead of passing review.
+func (s *AtlasMapSuite) TestNothingOnTheMapNamesARoom() {
+	s.Equal(
+		[]string{"Grid", "Cells", "Occluders", "Boundaries", "Doorways"},
+		fieldsOf(session.Atlas{}),
+		"the map is a grid, its cells, what blocks sight, its walls, and its doorways",
+	)
+	s.Equal(
+		[]string{"Connection", "From", "To"},
+		fieldsOf(session.AtlasDoorway{}),
+		"a doorway is an identity and two cells",
+	)
+	s.Equal(
+		[]string{"From", "To", "BlocksMovement", "BlocksLineOfSight"},
+		fieldsOf(session.AtlasBoundary{}),
+		"a wall is two cells and what it stops",
+	)
+}
+
+// TestTheMapIsEveryCellOnce: the two rooms' footprints are folded together,
+// nothing lost and nothing counted twice.
+//
+// The count is exact and derived from the fixture's own geometry: two 6x6 hex
+// rooms, disjoint by W2, so 72 distinct cells. A projection that dropped the
+// second room, or emitted one room twice, moves this number.
+func (s *AtlasMapSuite) TestTheMapIsEveryCellOnce() {
+	atlas := s.atlas()
+
+	s.Len(atlas.Cells, 72, "two 6x6 rooms, folded into one map")
+
+	seen := map[spatial.Position]bool{}
+	for _, cell := range atlas.Cells {
+		s.False(seen[cell], "cell %v appears twice on a map whose rooms cannot overlap", cell)
+		seen[cell] = true
+	}
+
+	// Cells from BOTH anchors are present. The vault's cells only exist at
+	// these coordinates if the projection happened.
+	s.True(seen[spatial.Position{X: -3, Y: -3}], "a corridor cell, anchored at the origin")
+	s.True(seen[spatial.Position{X: 8, Y: 2}], "a vault cell, anchored at (6,0)")
+}
+
+// TestTheMapIsInCoordinateOrder guards the subtler half of flattening.
+//
+// Concatenating room by room would leave the grouping perfectly visible in the
+// iteration order — a client could recover the decomposition by looking for the
+// seams, and would eventually depend on doing so. Sorting by coordinate means
+// the order says nothing about which chamber a cell came from.
+func (s *AtlasMapSuite) TestTheMapIsInCoordinateOrder() {
+	atlas := s.atlas()
+
+	for i := 1; i < len(atlas.Cells); i++ {
+		previous, cell := atlas.Cells[i-1], atlas.Cells[i]
+		ordered := previous.X < cell.X || (previous.X == cell.X && previous.Y < cell.Y)
+		s.True(ordered, "cell %d %v comes after %v", i, cell, previous)
+	}
+}
+
+// TestADoorwayIsTwoAdjacentCells is why a crossing can stop being its own verb:
+// on one map the two sides of a doorway are one step apart, so walking through
+// it is walking.
+func (s *AtlasMapSuite) TestADoorwayIsTwoAdjacentCells() {
+	atlas := s.atlas()
+	s.Require().Len(atlas.Doorways, 1)
+
+	gate := atlas.Doorways[0]
+	s.Equal("gate", gate.Connection)
+	s.Equal(spatial.Position{X: 2, Y: 0}, gate.From, "corridor-local (2,0), anchored at the origin")
+	s.Equal(spatial.Position{X: 3, Y: 0}, gate.To, "vault-local (-3,0), anchored at (6,0)")
+	s.Equal(float64(1), gate.To.X-gate.From.X, "one step apart on the map")
+	s.Equal(gate.From.Y, gate.To.Y)
+}
+
+// fieldsOf reports a struct's exported field names in declaration order.
+func fieldsOf(v any) []string {
+	t := reflect.TypeOf(v)
+	names := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		if t.Field(i).IsExported() {
+			names = append(names, t.Field(i).Name)
+		}
+	}
+	return names
+}

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -240,15 +240,11 @@ func drive(out *bytes.Buffer) error {
 		return err
 	}
 	fmt.Fprintln(out, "\n== the map, in dungeon-absolute space ==")
-	for _, room := range atlas.Rooms {
-		fmt.Fprintf(out, "   %-12s %dx%d %-6s origin (%v,%v)  %d cells\n",
-			room.ID, room.Width, room.Height, room.Grid,
-			room.Origin.X, room.Origin.Y, len(room.Cells))
-	}
+	fmt.Fprintf(out, "   one %s map: %d cells, %d of them blocking sight, %d walls\n",
+		atlas.Grid, len(atlas.Cells), len(atlas.Occluders), len(atlas.Boundaries))
 	for _, d := range atlas.Doorways {
-		fmt.Fprintf(out, "   %s: %s (%v,%v) kisses %s (%v,%v)\n",
-			d.Connection, d.From, d.FromCell.X, d.FromCell.Y,
-			d.To, d.ToCell.X, d.ToCell.Y)
+		fmt.Fprintf(out, "   %s: (%v,%v) kisses (%v,%v)\n",
+			d.Connection, d.From.X, d.From.Y, d.To.X, d.To.Y)
 	}
 
 	fmt.Fprintln(out, "\n== alice walks to the gate ==")

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
@@ -27,9 +27,12 @@ func TestWorkbenchRuns(t *testing.T) {
 
 	for _, want := range []string{
 		"the party enters the crypt",
-		"gate: antechamber (5,1) kisses vault (6,1)", // W3 holds in absolute space
-		"alice enters (5,1)",                         // the walk reached the doorway
-		"antechamber (5,1) → vault (0,1)",            // and crossed it
+		// W3 holds in absolute space, and the map that reports it no longer
+		// names the rooms on either side (rpg-toolkit#1042).
+		"gate: (5,1) kisses (6,1)",
+		"one square map: 72 cells",
+		"alice enters (5,1)",              // the walk reached the doorway
+		"antechamber (5,1) → vault (0,1)", // and crossed it
 
 		// A fight that starts itself, end to end. Each of these is a different
 		// claim, and any one regressing would leave the others still true:

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -4,6 +4,8 @@
 package session
 
 import (
+	"sort"
+
 	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/play/record"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
@@ -42,45 +44,69 @@ func projectGrid(shape spatial.GridShape) GridKind {
 	}
 }
 
+// projectAtlas flattens the composition's room-by-room map into one map.
+//
+// The composition answers in its own terms — a footprint per room, a doorway
+// naming the two it joins — because rooms are how it holds a field together.
+// This is where that stops being anybody else's problem: the cells are
+// concatenated and sorted, and a doorway becomes the pair of adjacent cells
+// it always was in absolute space.
+//
+// Sorting matters more than it looks. Concatenating room by room would leave
+// the grouping perfectly visible in the order, so a client could reconstruct
+// the decomposition the reshape exists to hide — and would eventually depend
+// on it. One order, derived from the coordinates themselves.
 func projectAtlas(in encounter.Atlas) Atlas {
-	out := Atlas{
-		Rooms:    make([]AtlasRoom, 0, len(in.Rooms)),
-		Doorways: make([]AtlasDoorway, 0, len(in.Doorways)),
-	}
+	out := Atlas{Doorways: make([]AtlasDoorway, 0, len(in.Doorways))}
 
 	for _, room := range in.Rooms {
-		projected := AtlasRoom{
-			ID:         room.ID,
-			Grid:       projectGrid(room.Grid),
-			Origin:     room.Origin,
-			Width:      room.Width,
-			Height:     room.Height,
-			Cells:      append([]spatial.Position(nil), room.Cells...),
-			Occluders:  append([]spatial.Position(nil), room.Occluders...),
-			Boundaries: make([]AtlasBoundary, 0, len(room.Boundaries)),
-		}
+		// W1: every room in a field shares one grid family, so the last
+		// writer wins and every writer agrees.
+		out.Grid = projectGrid(room.Grid)
+		out.Cells = append(out.Cells, room.Cells...)
+		out.Occluders = append(out.Occluders, room.Occluders...)
 		for _, b := range room.Boundaries {
-			projected.Boundaries = append(projected.Boundaries, AtlasBoundary{
+			out.Boundaries = append(out.Boundaries, AtlasBoundary{
 				From:              b.From,
 				To:                b.To,
 				BlocksMovement:    b.BlocksMovement,
 				BlocksLineOfSight: b.BlocksLineOfSight,
 			})
 		}
-		out.Rooms = append(out.Rooms, projected)
 	}
+
+	sortCells(out.Cells)
+	sortCells(out.Occluders)
+	sort.Slice(out.Boundaries, func(i, j int) bool {
+		if out.Boundaries[i].From != out.Boundaries[j].From {
+			return before(out.Boundaries[i].From, out.Boundaries[j].From)
+		}
+		return before(out.Boundaries[i].To, out.Boundaries[j].To)
+	})
 
 	for _, d := range in.Doorways {
 		out.Doorways = append(out.Doorways, AtlasDoorway{
 			Connection: d.Connection,
-			From:       d.From,
-			FromCell:   d.FromCell,
-			To:         d.To,
-			ToCell:     d.ToCell,
+			From:       d.FromCell,
+			To:         d.ToCell,
 		})
 	}
 
 	return out
+}
+
+// sortCells puts positions in one deterministic order: by X, then by Y.
+func sortCells(cells []spatial.Position) {
+	sort.Slice(cells, func(i, j int) bool { return before(cells[i], cells[j]) })
+}
+
+// before is the map's coordinate order, shared by every sorted list on the
+// Atlas so that two of them can be read side by side.
+func before(a, b spatial.Position) bool {
+	if a.X != b.X {
+		return a.X < b.X
+	}
+	return a.Y < b.Y
 }
 
 func projectStatus(in *encounter.Status) *Status {

--- a/rulebooks/dnd5e/session/convert_test.go
+++ b/rulebooks/dnd5e/session/convert_test.go
@@ -43,7 +43,13 @@ var projectedPairs = []struct {
 	outer any
 }{
 	{"Atlas", encounter.Atlas{}, session.Atlas{}},
-	{"AtlasRoom", encounter.AtlasRoom{}, session.AtlasRoom{}},
+	// The composition's per-room footprint is checked against the FLAT map it
+	// is folded into (rpg-toolkit#1042), not against a type of its own — there
+	// is no longer a room-shaped thing on this side. Pairing it this way keeps
+	// every field of a room accounted for: the ones that survive match by
+	// name, and the four that describe a room AS a room have to be justified
+	// below rather than quietly disappearing with the type that held them.
+	{"AtlasRoom folded into Atlas", encounter.AtlasRoom{}, session.Atlas{}},
 	{"AtlasBoundary", encounter.AtlasBoundary{}, session.AtlasBoundary{}},
 	{"AtlasDoorway", encounter.AtlasDoorway{}, session.AtlasDoorway{}},
 	{"Status", encounter.Status{}, session.Status{}},
@@ -62,6 +68,24 @@ var omitted = map[string]string{
 	// including members they have never perceived and rooms they have never
 	// entered. The audience is a delivery rule, not story content.
 	"record.Entry.Audience": "delivery rule, not story content — naming it leaks unperceived members",
+
+	// The seam speaks ONE MAP (rpg-project#227). The composition keeps rooms
+	// and projects the absolute geometry out of them; by the time a map
+	// reaches a client the decomposition has done its job.
+	"encounter.Atlas.Rooms":  "the decomposition itself — folded into the flat Cells/Occluders/Boundaries",
+	"encounter.AtlasRoom.ID": "a room id, which is exactly what the one-map seam stops carrying",
+	"encounter.AtlasRoom.Origin": "an anchor exists to project room-local coordinates, and nothing " +
+		"on this side has one left to project",
+	"encounter.AtlasRoom.Width":  "a room's span; the map's extent is the extent of Cells",
+	"encounter.AtlasRoom.Height": "a room's span; the map's extent is the extent of Cells",
+
+	// A doorway's endpoints kept their meaning and lost their qualifier: on one
+	// map there is no second pair of From/To fields naming rooms to
+	// distinguish these from.
+	"encounter.AtlasDoorway.From":     "the source ROOM id; the doorway now carries only its two cells",
+	"encounter.AtlasDoorway.To":       "the destination ROOM id; same",
+	"encounter.AtlasDoorway.FromCell": "renamed to From, now that no room id competes for the name",
+	"encounter.AtlasDoorway.ToCell":   "renamed to To, for the same reason",
 }
 
 // TestEveryInnerFieldIsCarriedOrJustified is the completeness check.

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -60,8 +60,7 @@ func Example_theSession() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("  the hall is %dx%d on a %s grid\n",
-		atlas.Rooms[0].Width, atlas.Rooms[0].Height, atlas.Rooms[0].Grid)
+	fmt.Printf("  the map is %d cells on a %s grid\n", len(atlas.Cells), atlas.Grid)
 
 	// -- alice walks, and gets exactly as far as the world allows --
 	fmt.Println("-- alice walks toward the stairs --")
@@ -109,7 +108,7 @@ func Example_theSession() {
 
 	// Output:
 	// -- the party enters --
-	//   the hall is 8x8 on a square grid
+	//   the map is 64 cells on a square grid
 	// -- alice walks toward the stairs --
 	//   asked for 5 cells, walked 3
 	//     alice enters (2,1)

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -150,25 +150,18 @@ func (s *ReadTestSuite) TestAtlasProjectsTheWholeWorld() {
 
 	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
 	s.Require().NoError(err)
-	s.Require().Len(atlas.Rooms, 2)
+
+	s.Equal(session.GridHex, atlas.Grid, "the grid family must survive as the wire enum")
+	s.Len(atlas.Cells, 72, "both 6x6 rooms, every cell, once each")
+	s.Require().Len(atlas.Occluders, 1, "occluders are not optional decoration")
+	s.Require().Len(atlas.Boundaries, 1, "walls must survive the projection")
+	s.True(atlas.Boundaries[0].BlocksLineOfSight)
+	s.True(atlas.Boundaries[0].BlocksMovement)
+
 	s.Require().Len(atlas.Doorways, 1)
-
-	corridor := atlas.Rooms[0]
-	s.Equal("corridor", corridor.ID)
-	s.Equal(session.GridHex, corridor.Grid, "the grid family must survive as the wire enum")
-	s.Equal(6, corridor.Width)
-	s.Equal(6, corridor.Height)
-	s.NotEmpty(corridor.Cells, "absolute cells must be carried across")
-	s.Require().Len(corridor.Occluders, 1, "occluders are not optional decoration")
-	s.Require().Len(corridor.Boundaries, 1, "walls must survive the projection")
-	s.True(corridor.Boundaries[0].BlocksLineOfSight)
-	s.True(corridor.Boundaries[0].BlocksMovement)
-
 	gate := atlas.Doorways[0]
 	s.Equal("gate", gate.Connection)
-	s.Equal("corridor", gate.From)
-	s.Equal("vault", gate.To)
-	s.NotEqual(gate.FromCell, gate.ToCell, "the kissing pair is two distinct absolute cells")
+	s.NotEqual(gate.From, gate.To, "the kissing pair is two distinct absolute cells")
 }
 
 // TestGridProjectionCoversBothFamilies guards the enum mapping in both
@@ -178,7 +171,7 @@ func (s *ReadTestSuite) TestGridProjectionCoversBothFamilies() {
 	s.startWith(hexWorld(s.T()))
 	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
 	s.Require().NoError(err)
-	s.Equal(session.GridHex, atlas.Rooms[0].Grid)
+	s.Equal(session.GridHex, atlas.Grid)
 
 	square := newFakeSessions()
 	squareEnc := newFakeEncounters()
@@ -193,7 +186,7 @@ func (s *ReadTestSuite) TestGridProjectionCoversBothFamilies() {
 
 	atlas, err = mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sq"})
 	s.Require().NoError(err)
-	s.Equal(session.GridSquare, atlas.Rooms[0].Grid,
+	s.Equal(session.GridSquare, atlas.Grid,
 		"a square room must not be reported as hex")
 }
 

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -37,44 +37,44 @@ const (
 
 // Atlas is the static world map in dungeon-absolute space.
 //
+// ONE MAP. The composition underneath keeps rooms and projects the absolute
+// geometry out of them (rpg-project#227); by the time a map reaches here the
+// decomposition has done its job and is nobody else's business. What a client
+// renders is a set of cells, the ones that block sight, the walls between
+// cells, and the doorways — not a list of chambers with anchors and spans it
+// would have to reassemble.
+//
 // Construction truth: unchanged by movement, joins, exits, or endings. Cache
 // it per encounter rather than fetching it per frame.
+//
+// The INBOUND direction is deliberately different, and worth saying out loud
+// so the asymmetry is not read as an oversight: StartSessionInput.World is
+// authored content and still speaks rooms. Authoring is construction data,
+// and the one-map rule governs what a session SEES while it plays.
 type Atlas struct {
-	// Rooms is every room's absolute footprint, sorted by room ID.
-	Rooms []AtlasRoom `json:"rooms,omitempty"`
-
-	// Doorways is every connection's absolute endpoint pair, sorted by
-	// connection ID.
-	Doorways []AtlasDoorway `json:"doorways,omitempty"`
-}
-
-// AtlasRoom is one room's absolute-space footprint.
-type AtlasRoom struct {
-	// ID is the room's identifier.
-	ID string `json:"id"`
-
-	// Grid is the room's coordinate family.
+	// Grid is the coordinate family the whole map speaks. One value, not one
+	// per room: a field has a single grid family by law (W1), so a per-room
+	// grid was the same answer repeated.
 	Grid GridKind `json:"grid"`
 
-	// Origin is the room's dungeon-absolute anchor.
-	Origin spatial.Position `json:"origin"`
-
-	// Width is the room's horizontal dimension.
-	Width int `json:"width"`
-
-	// Height is the room's vertical dimension.
-	Height int `json:"height"`
-
-	// Cells is every cell of the room in dungeon-absolute space, occluded
-	// cells included: occlusion is walkability, not ownership.
+	// Cells is every cell of the map, sorted by coordinate. Occluded cells
+	// are included: occlusion is walkability, not ownership.
+	//
+	// Sorted by coordinate rather than concatenated room by room, so the
+	// flattening does not leak the grouping back through iteration order —
+	// a map that still came out room-by-room would be the old shape wearing
+	// a new type.
 	Cells []spatial.Position `json:"cells,omitempty"`
 
 	// Occluders is the subset of Cells that blocks line of sight, reported
-	// separately so a host can render them distinctly.
+	// separately so a host can render them distinctly. Sorted like Cells.
 	Occluders []spatial.Position `json:"occluders,omitempty"`
 
-	// Boundaries is the room's walls and barriers, both endpoints absolute.
+	// Boundaries is every wall and barrier on the map, sorted by endpoint.
 	Boundaries []AtlasBoundary `json:"boundaries,omitempty"`
+
+	// Doorways is every crossable cell pair, sorted by connection ID.
+	Doorways []AtlasDoorway `json:"doorways,omitempty"`
 }
 
 // AtlasBoundary is one wall or barrier crossing between adjacent cells.
@@ -92,23 +92,23 @@ type AtlasBoundary struct {
 	BlocksLineOfSight bool `json:"blocks_line_of_sight,omitempty"`
 }
 
-// AtlasDoorway is one connection's absolute endpoint pair. The two cells are
-// adjacent in absolute space, so crossing one is an ordinary step.
+// AtlasDoorway is one crossable pair of cells. The two are adjacent in
+// absolute space, which is what makes crossing one an ordinary step rather
+// than a jump between coordinate systems.
+//
+// It keeps an identifier and carries no room, because a doorway is a thing
+// with identity — a door that can be closed or locked is a capability still
+// ahead of this, and it will need to name one — while the rooms on either
+// side are the composition's own decomposition.
 type AtlasDoorway struct {
-	// Connection is the connection's identifier.
+	// Connection is the doorway's identifier.
 	Connection string `json:"connection"`
 
-	// From is the source room ID.
-	From string `json:"from"`
+	// From is one of the two cells, in dungeon-absolute space.
+	From spatial.Position `json:"from"`
 
-	// FromCell is the endpoint in From, in dungeon-absolute space.
-	FromCell spatial.Position `json:"from_cell"`
-
-	// To is the destination room ID.
-	To string `json:"to"`
-
-	// ToCell is the endpoint in To, in dungeon-absolute space.
-	ToCell spatial.Position `json:"to_cell"`
+	// To is the other, adjacent to From.
+	To spatial.Position `json:"to"`
 }
 
 // Status reports whether an encounter is still running.


### PR DESCRIPTION
Closes #1042. Second slice of the seam reshape (rpg-project#227).

Every coordinate on the Atlas was already dungeon-absolute. What it was not was ONE map —
it was a list of rooms, and room ids appeared on it in six places: which room owns a cell,
where each room is anchored, how wide and tall it is. None of that is needed to draw a
dungeon, and all of it is the concept the reshape removes from the seam.

```
before: Atlas{ Rooms []AtlasRoom{ID, Grid, Origin, Width, Height, Cells, Occluders, Boundaries}, Doorways }
after:  Atlas{ Grid, Cells, Occluders, Boundaries, Doorways }
        AtlasDoorway{ Connection, From (cell), To (cell) }
```

- **One `Grid`.** W1 gives a field a single coordinate family, so a per-room grid was one
  answer repeated.
- **`Origin`, `Width`, `Height` go with the rooms.** They exist to project room-local
  coordinates; nothing on this side has one left to project. A map's extent is the extent
  of its cells.
- **Doorways keep their identity and lose both room ids** — a doorway is a thing that door
  state and locks will one day need to name, and a connection id is not a room id.
- **The flat lists are SORTED by coordinate.** This is the half that is easy to skip:
  concatenating room by room leaves the grouping perfectly visible in the iteration order,
  so a client could recover the decomposition by looking for the seams, and would
  eventually depend on doing so.

## Forks this rests on

- **F1 (does Atlas keep rooms) — resolved per lean: flatten.** The evidence beyond the
  ruling is that the authoring dialect already replaced rooms with semantic REGIONS
  (`rpg-project/ideas/dungeon-builder/design.md`; #175/#180 closed), so the thing a
  renderer eventually wants to group by is arriving anyway and is not a room.
- **F5 — inbound stays room-shaped, deliberately.** `StartSessionInput.World` is authored
  content and keeps its room ids: authoring is construction data, and the one-map rule
  governs what a session SEES while it plays. The `Atlas` doc now states that asymmetry
  rather than leaving it to be discovered and read as an oversight.
- Not in this slice: Move crossing a doorway, Traverse retiring, the member and outcome
  projections, and the composition-side work (that is #1040, open in parallel).

## Verification

- Full `session` module suite green, workbench included; `gofmt -l` clean; `go mod tidy` a
  no-op; no lint findings in any file this PR touches.
- The converter's completeness check keeps working FOR the removed type rather than losing
  it: `encounter.AtlasRoom` is now paired against the flat `session.Atlas`, so the fields
  that survive still match by name and the four that describe a room *as a room* had to be
  justified in the omissions list. Dropping a field silently remains impossible.
- **The order pin is sensitive, and it took two tries to make it so.** Written first
  against `hexWorld`, it passed with the sorting deleted — that fixture's
  alphabetically-first room is also its leftmost, so concatenation is in coordinate order
  by accident. `backwardsWorld` anchors "alpha" to the RIGHT of "beta" so the two orders
  disagree, and the pin now fails without the sort and passes with it. Recording it because
  the near-miss is the interesting part: an order assertion over a fixture that is already
  in order is a test that cannot fail.
- The structural pin reads the Atlas types' own field names, so putting a room id back —
  which is exactly how this would regress, for a renderer that wants to chunk by chamber —
  is a failing test rather than a review catch.

— asset-pipeline agent, on behalf of KirkDiggler
