### PR TITLE
feat(encounter)!: the decider surface speaks one map (#1044)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -72,13 +72,17 @@ percepts.
 
 ### You return an intent, not an action
 
-`Intent` is a sealed type — three today:
+`Intent` is a sealed type — two today:
 
 | Intent | Means |
 |---|---|
-| `IntentMoveTo{To}` | walk to a position in my current room |
-| `IntentTraverse{Connection}` | cross a connection I am standing on |
+| `IntentMoveTo{To}` | step to a cell on the map |
 | `IntentHold{}` | do nothing this tick |
+
+`To` is DUNGEON-ABSOLUTE, like everything else a decider is given. There is no
+separate intent for crossing a doorway: a doorway's two cells are adjacent in
+absolute space, so "step through the door" and "step next to me" are the same
+sentence, and the composition works out which mechanism carries it.
 
 You return what you *want*. The composition decides whether it happens and makes
 it happen. This is what keeps a decider testable: it is a pure function from a
@@ -129,9 +133,10 @@ the contract rather than being coded defensively.
 - **Deterministic order.** Monsters act in stable `Members()` order.
 - **A decider error aborts the pump atomically.** No clock advance, no moves, no
   record beats. Return an error only when you genuinely cannot decide.
-- **A rejected move does not abort.** A spatially illegal `IntentMoveTo`, or an
-  `IntentTraverse` naming an unknown connection or one you are not standing on,
-  just means that monster fails to act this tick. Everything else proceeds.
+- **A rejected step does not abort.** A cell no room owns, a cell in another
+  room with no doorway joining it to where you stand, or a step the spatial
+  rules refuse: each just means that monster fails to act this tick. Everything
+  else proceeds.
 - **Sight refreshes once**, after all actions — then one tick beat, then the
   move/traverse beats in decision order.
 - **A monster in a fight is not consulted.** `Pump` is the world thinking, and

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -47,7 +47,12 @@ func TestVaultChase(t *testing.T) {
 	// gate (static topology, given at construction) and its target
 	// (alice); it never reads encounter state directly — Snapshot +
 	// Holdings + its own construction-time config is all it gets (C2).
-	pursuit := &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice}
+	// The decider is built empty and handed the map once there is one to
+	// hand it: the doorways it needs are the Atlas's, and the Atlas comes
+	// from the encounter it is about to be part of. That ordering IS the
+	// point — a decider takes the same absolute map a host renders, not the
+	// composition's room-shaped topology (rpg-toolkit#1044).
+	pursuit := &pursuitDecider{target: alice}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
@@ -72,6 +77,10 @@ func TestVaultChase(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "beat 1: the corridor assembles")
+
+	atlas, err := enc.Atlas()
+	require.NoError(t, err, "beat 1: the map exists")
+	pursuit.doorways = atlas.Doorways
 
 	st, _ := seen(t, enc, alice, goblin)
 	require.Equal(t, intel.Current, st, "beat 1: alice sees the goblin across the open corridor")
@@ -99,7 +108,6 @@ func TestVaultChase(t *testing.T) {
 	// vault, which the goblin has never seen at all.
 	st, p := seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Held, st, "beat 2: the goblin's sight of alice fades — she left the room")
-	require.Equal(t, corridorRoom, p.Room, "beat 2: its ghost holds her LAST-SEEN room")
 	require.Equal(t, 9.0, p.X, "beat 2: at the threshold, not the far side it never saw")
 	require.Equal(t, 5.0, p.Y)
 	st, _ = seen(t, enc, alice, goblin)
@@ -119,15 +127,14 @@ func TestVaultChase(t *testing.T) {
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
-			goblin: &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice},
+			goblin: &pursuitDecider{doorways: atlas.Doorways, target: alice},
 		}})
 	require.NoError(t, err, "beat 3: the suspended chase crosses a process boundary")
 	enc = enc2 // the reload IS the encounter now
 
 	st, p = seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Held, st, "beat 3: the ghost survived the reload")
-	require.Equal(t, corridorRoom, p.Room, "beat 3: still at the threshold — loading never re-derives sight")
-	require.Equal(t, 9.0, p.X)
+	require.Equal(t, 9.0, p.X, "beat 3: still at the threshold — loading never re-derives sight")
 
 	// ---- Beat 4: the pursuit traverse ------------------------------------
 	// First pump: the goblin, still in the corridor, walks toward the
@@ -153,8 +160,7 @@ func TestVaultChase(t *testing.T) {
 	// her Current again, at (4,5), where she stopped in beat 2.
 	st, p = seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Current, st, "beat 4: the goblin holds alice Current again, having crossed the threshold")
-	require.Equal(t, vaultRoom, p.Room)
-	require.Equal(t, 4.0, p.X)
+	require.Equal(t, 14.0, p.X, "beat 4: vault-local (4,5), anchored at (10,0) — one map")
 	require.Equal(t, 5.0, p.Y)
 
 	// ---- Beat 5: sanctuary, in the far room ------------------------------

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -182,6 +182,13 @@ func beliefGrid(enc *encounter.Encounter, data encounter.EncounterData, who core
 	if r == nil {
 		return nil, nil
 	}
+	// The room's anchor, needed because sight payloads are dungeon-absolute
+	// while this pane draws a single room in its own local frame.
+	var origin spatial.Position
+	if r.Origin != nil {
+		origin = spatial.Position{X: r.Origin.X, Y: r.Origin.Y}
+	}
+
 	grid := blankGrid(r.Width, r.Height)
 	for _, o := range r.Occluders {
 		set(grid, o.X, o.Y, '#')
@@ -191,10 +198,13 @@ func beliefGrid(enc *encounter.Encounter, data encounter.EncounterData, who core
 		if err := json.Unmarshal(h.Payload, &p); err != nil {
 			continue
 		}
-		if p.Room != room {
+		// Sight payloads are dungeon-absolute; this pane draws ONE room, so
+		// bring them back into its local frame and skip anything outside it.
+		local := spatial.Position{X: p.X, Y: p.Y}.Subtract(origin)
+		if local.X < 0 || local.Y < 0 || int(local.X) >= r.Width || int(local.Y) >= r.Height {
 			continue
 		}
-		set(grid, p.X, p.Y, initialOf(string(h.Subject), h.Status == intel.Current))
+		set(grid, local.X, local.Y, initialOf(string(h.Subject), h.Status == intel.Current))
 	}
 	for _, m := range data.Members {
 		if m.ID == who {

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -88,16 +88,17 @@ func vaultChaseHexGate() encounter.ConnectionInput {
 // quirk (W3).
 func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()
-	pursuit := &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: alice}
+	field := encounter.FieldInput{
+		Rooms: []encounter.RoomInput{
+			{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
+			{ID: "vault", Width: 10, Height: 10, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: 3}},
+		},
+		Connections: []encounter.ConnectionInput{gate},
+	}
+	pursuit := &pursuitDecider{doorways: doorwaysFrom(field), target: alice}
 	return &encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{
-				{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
-				{ID: "vault", Width: 10, Height: 10, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: 3}},
-			},
-			Connections: []encounter.ConnectionInput{gate},
-		},
+		Field:      field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: "corridor", Position: spatial.Position{X: 1, Y: 1}},
 			// One hex-step from the gate's corridor-side endpoint (4,1) via
@@ -209,7 +210,9 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	// last sight of her, not the vault it has never seen.
 	st, p := seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Held, st, "beat 2: the goblin's sight of alice fades — she left the room")
-	require.Equal(t, "corridor", p.Room)
+	// The corridor is anchored at the origin, so the threshold's absolute
+	// cell is its local one — and the ghost is at the threshold, not the
+	// far side the goblin has never seen.
 	require.Equal(t, 4.0, p.X)
 	require.Equal(t, 1.0, p.Y)
 
@@ -226,7 +229,7 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
-			goblin: &pursuitDecider{connections: []encounter.ConnectionInput{vaultChaseHexGate()}, target: alice},
+			goblin: &pursuitDecider{doorways: doorwaysFrom(vaultChaseHexSetup().Field), target: alice},
 		}})
 	require.NoError(t, err, "the suspended chase crosses a process boundary")
 	enc = enc2
@@ -234,7 +237,7 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 
 	st, p = seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Held, st, "beat 3: the ghost survived the reload")
-	require.Equal(t, "corridor", p.Room)
+	require.Equal(t, 4.0, p.X, "beat 3: still at the threshold — loading never re-derives sight")
 
 	// Re-project alice's CURRENT position on the reloaded encounter — it
 	// must be identical to her last pre-reload position (distance 0,

--- a/rulebooks/dnd5e/encounter/decider.go
+++ b/rulebooks/dnd5e/encounter/decider.go
@@ -10,9 +10,9 @@ import (
 
 // Intent represents a decision made by a decider in response to their
 // Snapshot. The anti-wall-hack contract: a decider receives ONLY its own
-// Snapshot (own room, own position, own holdings), never the full
-// encounter state or another member's live truth. Intent is a sealed
-// type (unexported marker method).
+// Snapshot (its own cell and its own holdings), never the full encounter
+// state or another member's live truth. Intent is a sealed type
+// (unexported marker method).
 type Intent interface {
 	isIntent()
 }
@@ -69,7 +69,7 @@ type Snapshot struct {
 }
 
 // Decider is the interface for monster intelligence. A decider receives ONLY
-// its own Snapshot (own room, own position, own holdings — never another
+// its own Snapshot (its own cell and its own holdings — never another
 // member's live truth) and returns an Intent representing what the monster
 // wants to do, or an error that aborts the pump atomically. The anti-wall-
 // hack contract is structural: Decide receives exactly what the monster

--- a/rulebooks/dnd5e/encounter/decider.go
+++ b/rulebooks/dnd5e/encounter/decider.go
@@ -17,9 +17,17 @@ type Intent interface {
 	isIntent()
 }
 
-// IntentMoveTo represents a decision to move to a specific position.
+// IntentMoveTo represents a decision to step to a specific cell.
 type IntentMoveTo struct {
-	// To is the target position the member intends to move to.
+	// To is the cell the member intends to step to, in DUNGEON-ABSOLUTE
+	// space — the same frame Snapshot.Position and every sight payload
+	// speak, so a decider can compare where it stands with where it last
+	// saw something and subtract one from the other (rpg-toolkit#1044).
+	//
+	// A cell in the room the member is already in, or the far side of a
+	// doorway they are standing at: both are ordinary steps, and the
+	// composition decides which mechanism carries them out. An unreachable
+	// or unowned cell is skipped in silence rather than aborting the pump.
 	To spatial.Position
 }
 
@@ -32,36 +40,27 @@ type IntentHold struct{}
 // isIntent marks IntentHold as an Intent.
 func (i IntentHold) isIntent() {}
 
-// IntentTraverse represents a decision to cross a connection into the room
-// on its other side. Preconditions match the Traverse verb exactly: the
-// decider's own Snapshot.Room/Position (see Snapshot) must be standing
-// exactly on one of the named connection's two endpoints. An illegal
-// traverse intent (unknown connection, or not at the threshold) does not
-// abort the pump — it follows the same silent-skip contract Pump already
-// applies to a spatially-rejected IntentMoveTo: no beat, no room/position
-// change for that member, everything else in the pump proceeds normally.
-type IntentTraverse struct {
-	// Connection is the ID of the connection to traverse.
-	Connection string
-}
+// There was an IntentTraverse here, naming a connection to cross. It retired
+// with rpg-toolkit#1044: an intent now names a CELL in dungeon-absolute space,
+// and W3 makes a doorway's two endpoints adjacent absolute cells — so crossing
+// one is an ordinary intended step, and which mechanism carries it out is the
+// composition's bookkeeping rather than a decision a monster makes. See stepTo.
 
-// isIntent marks IntentTraverse as an Intent.
-func (i IntentTraverse) isIntent() {}
-
-// Snapshot is a decider's complete input: their OWN current placement
-// (room and position) plus their OWN held intel. The anti-wall-hack
-// contract (C2) extends to placement, not just holdings — a decider
-// learns where IT stands, never where any other member stands except
-// through Holdings' sighted percepts. Static field topology (e.g. a
-// connections list, for a pursuit decider that needs to know where the
-// doors are) is NOT part of Snapshot; give it to a decider at
-// construction time instead — Snapshot itself carries only what changes
-// tick to tick.
+// Snapshot is a decider's complete input: where it stands, plus its OWN held
+// intel. The anti-wall-hack contract (C2) extends to placement, not just
+// holdings — a decider learns where IT stands, never where any other member
+// stands except through Holdings' sighted percepts. Static field topology is
+// NOT part of Snapshot; give it to a decider at construction time instead —
+// Snapshot carries only what changes tick to tick.
 type Snapshot struct {
-	// Room is the decider's own current room ID.
-	Room string
-
-	// Position is the decider's own current position within Room.
+	// Position is where the decider stands, in DUNGEON-ABSOLUTE space.
+	//
+	// There was a Room beside this, and the position was local to it. Both
+	// halves were needed then and neither is now (rpg-toolkit#1044): a
+	// decider that knows its own cell on the map, and reads its targets'
+	// cells on the same map, has nothing left to reconcile. Keeping the room
+	// would keep the frame the reshape exists to remove — and it was never
+	// really identity a monster needed, only the key to a coordinate system.
 	Position spatial.Position
 
 	// Holdings is the decider's own held intel — exactly what HeldBy

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1582,8 +1582,8 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 }
 
 // traverseResult holds the outcome of a successful cross-room move via
-// traverseMember — shared by the Traverse verb and Pump's IntentTraverse
-// executor.
+// traverseMember — shared by the Traverse verb and the doorway half of
+// stepTo, which is how a monster's intended step crosses one.
 type traverseResult struct {
 	fromRoom string
 	fromPos  spatial.Position
@@ -1603,10 +1603,11 @@ type traverseResult struct {
 // Shared by the Traverse verb (which owns the nil/closed/member-lookup
 // guards and propagates this function's error as its own public
 // contract — ErrNoConnection or ErrBadPlacement, already correctly
-// wrapped here) and Pump's phase-2 IntentTraverse executor (which owns
-// Pump's silent-skip-on-failure semantics: ANY error returned here is
-// treated exactly like a spatially-rejected IntentMoveTo — the monster
-// simply fails to act this tick, no abort).
+// wrapped here) and by stepTo, which calls it when a monster's intended
+// step lands on the far side of a doorway. stepTo owns Pump's
+// silent-skip-on-failure semantics: ANY error returned here means the
+// monster simply fails to act this tick, exactly as a refused move does,
+// and never aborts the pump.
 func (e *Encounter) traverseMember(member *memberRecord, connectionID string) (traverseResult, error) {
 	var conn *ConnectionInput
 	for i := range e.connectionsInput {
@@ -1881,13 +1882,14 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 // Semantics:
 //   - Tick advances by exactly 1 (via clock.Advance with displacement 1).
 //   - Monsters act in deterministic order (stable Members() order, filtered to KindMonster).
-//   - Each decider receives exactly its own Snapshot: own room, own position,
-//     own holdings (anti-wall-hack contract C2 — placement included, not just sight).
-//   - IntentHold means do nothing; IntentMoveTo executes via the same-room managed
-//     seam; IntentTraverse executes via traverseMember (the Traverse verb's own
-//     mechanics, shared — see its doc comment).
-//   - A spatial rejection of a monster's move, or an illegal traverse intent
-//     (unknown connection, or not at the threshold), does NOT abort the pump; the
+//   - Each decider receives exactly its own Snapshot: its own cell on the map and
+//     its own holdings (anti-wall-hack contract C2 — placement included, not just
+//     sight).
+//   - IntentHold means do nothing; IntentMoveTo names a cell in dungeon-absolute
+//     space and executes through stepTo, which moves the monster within its room
+//     or carries it through a doorway, whichever the cell turns out to be.
+//   - A refused step does NOT abort the pump — a cell no room owns, a cell in
+//     another room with no doorway from here, or a spatial rejection all mean the
 //     monster simply fails to act. Only a decider error aborts.
 //   - After all monster actions: ONE refreshSight for all members, ONE tick beat
 //     (stamped with the new clock reading), then move/traverse beats in

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -19,10 +19,16 @@ import (
 // SightPayload is the composition-owned encoding of a sighted member's position —
 // the payload of every sight-channel intel report. Hosts decode it to render what
 // a player sees; intel itself never interprets it.
+//
+// DUNGEON-ABSOLUTE, and carrying no room (rpg-toolkit#1044). A sighted member is
+// somewhere on the map, and the chamber they happen to be standing in is this
+// composition's own bookkeeping. It matters most here of all the projections,
+// because this is the payload a DECIDER reads: a monster comparing a target's
+// position against its own needs both in one frame, and the two used to be in
+// different ones for every room whose origin is not (0,0).
 type SightPayload struct {
-	Room string  `json:"room"`
-	X    float64 `json:"x"`
-	Y    float64 `json:"y"`
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
 }
 
 // declaredEnding pairs an ending key with its trigger, in Setup order.
@@ -1962,13 +1968,16 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 			return nil, fmt.Errorf("pump held_by: %w", err)
 		}
 
-		intent, err := decider.Decide(Snapshot{Room: m.Room, Position: ownPos, Holdings: ownHoldings})
+		intent, err := decider.Decide(Snapshot{
+			Position: e.absoluteOf(m.Room, ownPos),
+			Holdings: ownHoldings,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("pump decide: %w", err)
 		}
 
 		switch intent.(type) {
-		case IntentMoveTo, IntentTraverse:
+		case IntentMoveTo:
 			planned = append(planned, plannedAction{memberID: m.ID, intent: intent})
 		}
 	}
@@ -1985,19 +1994,11 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 
 	newTickReading := uint64(e.clock.ToData().HighWater)
 
-	// executedAction is built in PLANNED (decision) order regardless of
-	// kind, so beats and ending evaluation below stay in the same
-	// deterministic per-monster order the deciders were consulted in
-	// (C8) — not "all moves then all traverses".
-	type executedAction struct {
-		member     *memberRecord
-		kind       string // "move" or "traverse"
-		connection string // only meaningful for "traverse"
-		fromRoom   string // only meaningful for "traverse"; a move never changes room
-		from       spatial.Position
-		toRoom     string // only meaningful for "traverse"
-		to         spatial.Position
-	}
+	// executedAction (declared at package scope, beside stepTo which builds
+	// one) is collected in PLANNED (decision) order regardless of kind, so
+	// beats and ending evaluation below stay in the same deterministic
+	// per-monster order the deciders were consulted in (C8) — not "all moves
+	// then all crossings".
 	var executed []executedAction
 
 	for _, p := range planned {
@@ -2016,28 +2017,9 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 			// the pump otherwise proceeds normally.
 			continue
 		}
-		switch intent := p.intent.(type) {
-		case IntentMoveTo:
-			// Spatial rejection does not abort the pump; the monster
-			// simply fails to move and no beat is recorded for it.
-			fromPos, moveErr := e.moveMember(member, intent.To)
-			if moveErr == nil {
-				executed = append(executed, executedAction{
-					member: member, kind: "move", from: fromPos, to: intent.To,
-				})
-			}
-		case IntentTraverse:
-			// An illegal traverse (unknown connection, or not at the
-			// threshold) does not abort the pump either — same silent-skip
-			// contract as a spatially-rejected move (see traverseMember's
-			// doc comment).
-			result, travErr := e.traverseMember(member, intent.Connection)
-			if travErr == nil {
-				executed = append(executed, executedAction{
-					member: member, kind: "traverse", connection: intent.Connection,
-					fromRoom: result.fromRoom, from: result.fromPos,
-					toRoom: result.toRoom, to: result.toPos,
-				})
+		if intent, ok := p.intent.(IntentMoveTo); ok {
+			if action, stepped := e.stepTo(member, intent.To); stepped {
+				executed = append(executed, action)
 			}
 		}
 	}
@@ -2076,13 +2058,13 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 	for _, action := range executed {
 		var beatPayload map[string]interface{}
 		switch action.kind {
-		case "move":
+		case actionMove:
 			beatPayload = map[string]interface{}{
 				"beat":     "moved",
 				"member":   string(action.member.ID),
 				"position": e.absoluteOf(action.member.Room, action.to),
 			}
-		case "traverse":
+		case actionTraverse:
 			beatPayload = map[string]interface{}{
 				"beat":       "traversed",
 				"member":     string(action.member.ID),
@@ -2186,13 +2168,13 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 	}
 	for _, action := range executed {
 		switch action.kind {
-		case "move":
+		case actionMove:
 			outputMoves = append(outputMoves, struct {
 				Member MemberID
 				From   spatial.Position
 				To     spatial.Position
 			}{Member: action.member.ID, From: action.from, To: action.to})
-		case "traverse":
+		case actionTraverse:
 			outputTraverses = append(outputTraverses, struct {
 				Member   MemberID
 				FromRoom string
@@ -2304,11 +2286,8 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 			}
 
 			// Add to percept
-			pos := SightPayload{
-				Room: otherMember.Room,
-				X:    otherPos.X,
-				Y:    otherPos.Y,
-			}
+			absolute := e.absoluteOf(otherMember.Room, otherPos)
+			pos := SightPayload{X: absolute.X, Y: absolute.Y}
 			payload, _ := json.Marshal(pos)
 			percept = append(percept, intel.Report{
 				Subject: intel.Subject(otherMember.ID),
@@ -2330,6 +2309,98 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 	}
 
 	return deltas, nil
+}
+
+// The two kinds of step the pump can carry out. Constants rather than
+// literals because they are matched in three places — built in stepTo, then
+// switched on for beats and for ending evaluation — and a typo in any one of
+// them silently drops a monster's action from a transcript.
+const (
+	actionMove     = "move"
+	actionTraverse = "traverse"
+)
+
+// executedAction is one monster action the pump actually carried out: a step
+// within a room, or a step through a doorway. Both come out of stepTo, which
+// is the only thing that builds one.
+type executedAction struct {
+	member     *memberRecord
+	kind       string // "move" or "traverse"
+	connection string // only meaningful for "traverse"
+	fromRoom   string // only meaningful for "traverse"; a move never changes room
+	from       spatial.Position
+	toRoom     string // only meaningful for "traverse"
+	to         spatial.Position
+}
+
+// stepTo executes one intended step to a DUNGEON-ABSOLUTE cell, which after
+// rpg-toolkit#1044 is the only kind of movement a decider can intend.
+//
+// The dispatch that used to be the decider's job lives here instead, and it is
+// the whole reason IntentTraverse could retire: W3 makes a doorway's two
+// endpoints ADJACENT ABSOLUTE CELLS, so "walk to the cell on the other side of
+// the doorway" and "walk to the cell next to me" are the same sentence. Which
+// of the two mechanisms carries it out is bookkeeping, and bookkeeping belongs
+// on this side of the seam.
+//
+// Every refusal is SILENT — reported as not-stepped, never as an error — which
+// is the contract a spatially-rejected move already had and the one
+// IntentTraverse documented for an illegal crossing. Three ways to be refused:
+// a cell no room owns (void is not floor), a cell in another room with no
+// doorway joining it to where the member stands, and the spatial rejections
+// the move or the crossing itself raises.
+func (e *Encounter) stepTo(member *memberRecord, to spatial.Position) (executedAction, bool) {
+	located, err := e.Locate(&LocateInput{Position: to})
+	if err != nil {
+		return executedAction{}, false
+	}
+
+	if located.Room == member.Room {
+		fromPos, moveErr := e.moveMember(member, located.Position)
+		if moveErr != nil {
+			return executedAction{}, false
+		}
+		return executedAction{
+			member: member, kind: actionMove, from: fromPos, to: located.Position,
+		}, true
+	}
+
+	connection, ok := e.doorwayFrom(member, to)
+	if !ok {
+		return executedAction{}, false
+	}
+	result, travErr := e.traverseMember(member, connection)
+	if travErr != nil {
+		return executedAction{}, false
+	}
+	return executedAction{
+		member: member, kind: actionTraverse, connection: connection,
+		fromRoom: result.fromRoom, from: result.fromPos,
+		toRoom: result.toRoom, to: result.toPos,
+	}, true
+}
+
+// doorwayFrom finds the connection joining where a member stands to the given
+// absolute cell, in either direction — a doorway is crossable both ways.
+//
+// Returns false when no connection joins the two, which is what makes a step
+// between rooms that merely TOUCH refuse: W2 lets two rooms share an edge
+// without a door, so absolute adjacency alone is not permission to cross.
+func (e *Encounter) doorwayFrom(member *memberRecord, to spatial.Position) (string, bool) {
+	local, err := e.cellOf(member)
+	if err != nil {
+		return "", false
+	}
+	from := e.absoluteOf(member.Room, local)
+
+	for _, c := range e.connectionsInput {
+		near := e.absoluteOf(c.From, c.FromPosition)
+		far := e.absoluteOf(c.To, c.ToPosition)
+		if (near == from && far == to) || (far == from && near == to) {
+			return c.ID, true
+		}
+	}
+	return "", false
 }
 
 // occluderEntity is an internal entity for blocking line of sight

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -100,7 +100,6 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 		var payload encounter.SightPayload
 		err = json.Unmarshal(holding.Payload, &payload)
 		s.Require().NoError(err)
-		s.Equal(room1, payload.Room)
 		s.Equal(7.0, payload.X)
 		s.Equal(7.0, payload.Y)
 
@@ -2677,7 +2676,6 @@ func (s *EncounterTestSuite) TestTraverseGhostAtThreshold() {
 
 	var aliceSeen encounter.SightPayload
 	s.Require().NoError(json.Unmarshal(bobAfter[0].Payload, &aliceSeen))
-	s.Equal("room-a", aliceSeen.Room, "ghost holds alice's LAST-SEEN room")
 	s.Equal(9.0, aliceSeen.X, "ghost holds alice at the DEPARTURE endpoint, not the arrival one")
 	s.Equal(5.0, aliceSeen.Y)
 }
@@ -2698,8 +2696,10 @@ func (s *EncounterTestSuite) TestTraverseArrivalCurrent() {
 
 	var aliceSeen encounter.SightPayload
 	s.Require().NoError(json.Unmarshal(goblinView[0].Payload, &aliceSeen))
-	s.Equal("room-b", aliceSeen.Room)
-	s.Equal(0.0, aliceSeen.X)
+	// room-b is anchored at (10,0), so her local (0,5) arrival cell is
+	// (10,5) on the map — the projection is what makes this assertion mean
+	// "the arrival endpoint" rather than "somewhere called zero".
+	s.Equal(10.0, aliceSeen.X)
 	s.Equal(5.0, aliceSeen.Y)
 }
 

--- a/rulebooks/dnd5e/encounter/example_traverse_test.go
+++ b/rulebooks/dnd5e/encounter/example_traverse_test.go
@@ -19,6 +19,11 @@ import (
 // Example_theTombWatch (sight, the ghost, save/reload, the ending);
 // this one shows what tomb watch predates: the room boundary itself.
 // Reuses tell() from example_tombwatch_test.go (same package).
+//
+// Every position printed here is DUNGEON-ABSOLUTE (rpg-toolkit#1044), which
+// is why alice's arrival reads as (8,4) rather than the vault-local (0,4) she
+// stands on: the vault is anchored at (8,0), and one map is what a decider —
+// and a reader — gets to work in.
 func Example_theTraverse() {
 	// Two rooms, one gate: alice starts exactly at the hall's threshold;
 	// the goblin, across the hall, can see her but not yet follow.
@@ -43,7 +48,13 @@ func Example_theTraverse() {
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 7, Y: 4}},
 			{ID: "goblin", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 4},
-				Decider: &pursuitDecider{connections: []encounter.ConnectionInput{gate}, target: "alice"}},
+				Decider: &pursuitDecider{doorways: doorwaysFrom(encounter.FieldInput{
+					Rooms: []encounter.RoomInput{
+						{ID: "hall", Width: 8, Height: 8},
+						{ID: "vault", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},
+					},
+					Connections: []encounter.ConnectionInput{gate},
+				}), target: "alice"}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: "done", Trigger: encounter.TriggerExternal{}},
@@ -95,5 +106,5 @@ func Example_theTraverse() {
 	// -- alice slips through the gate --
 	// goblin holds a GHOST of alice at last-seen (7,4)
 	// -- the goblin gives chase, and follows her through --
-	// goblin sees alice at (0,4)
+	// goblin sees alice at (8,4)
 }

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -425,11 +425,11 @@ type PumpOutput struct {
 		To     spatial.Position
 	}
 
-	// MonsterTraverses contains the successful cross-room traverses executed by
-	// monsters during this pump (IntentTraverse). An illegal traverse intent
-	// (unknown connection, or the monster not at its threshold) does not appear
-	// here — it is silently skipped, matching MonsterMoves' spatial-rejection
-	// contract.
+	// MonsterTraverses contains the doorway crossings monsters made during this
+	// pump — an intended step whose cell turned out to be on the far side of a
+	// doorway. A step that could not be taken does not appear here: a cell in
+	// another room with no doorway joining it to where the monster stands is
+	// silently skipped, matching MonsterMoves' spatial-rejection contract.
 	MonsterTraverses []struct {
 		Member   MemberID
 		FromRoom string

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -107,36 +107,66 @@ func (s *snapshotSpyDecider) Decide(snap encounter.Snapshot) (encounter.Intent, 
 	return encounter.IntentHold{}, nil
 }
 
-// onceTraverseDecider intends IntentTraverse{Connection} on its first
-// call, then holds forever after — a minimal fixture for pinning a
-// single traverse attempt's success or failure.
-type onceTraverseDecider struct {
-	connection string
-	called     bool
+// doorwaysFrom projects a field's connections into absolute cell pairs — the
+// same thing Atlas.Doorways carries.
+//
+// For fixtures that must hand a decider its map BEFORE the encounter that
+// would produce one exists. chase_test.go does it the other way round, taking
+// the real Atlas after construction, which is what a host would do; this is
+// the same arithmetic for the cases where ordering makes that awkward.
+func doorwaysFrom(field encounter.FieldInput) []encounter.AtlasDoorway {
+	origin := map[string]spatial.Position{}
+	for _, room := range field.Rooms {
+		origin[room.ID] = room.Origin
+	}
+
+	out := make([]encounter.AtlasDoorway, 0, len(field.Connections))
+	for _, c := range field.Connections {
+		out = append(out, encounter.AtlasDoorway{
+			Connection: c.ID,
+			From:       c.From,
+			FromCell:   c.FromPosition.Add(origin[c.From]),
+			To:         c.To,
+			ToCell:     c.ToPosition.Add(origin[c.To]),
+		})
+	}
+	return out
 }
 
-func (t *onceTraverseDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
+// onceStepDecider intends one step to a fixed absolute cell, then holds
+// forever after — a minimal fixture for pinning a single attempt's success or
+// failure, whether the cell is next door or through a door.
+type onceStepDecider struct {
+	to     spatial.Position
+	called bool
+}
+
+func (t *onceStepDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 	if t.called {
 		return encounter.IntentHold{}, nil
 	}
 	t.called = true
-	return encounter.IntentTraverse{Connection: t.connection}, nil
+	return encounter.IntentMoveTo{To: t.to}, nil
 }
 
-// pursuitDecider is constructed with the field's static connection
-// topology and a target subject to chase — it never reads encounter
-// state directly; Snapshot + Holdings + its own construction-time config
-// is all it gets (C2 extended to placement, not just sight). Logic: if it
-// currently holds a percept of the target, and it is standing EXACTLY
-// where that percept places them (its own room and position match), that
-// cell is either a connection endpoint in this room — traverse through
-// it — or nowhere useful — hold. Otherwise, if the percept's room matches
-// its own current room, walk toward the held position. A percept in a
-// DIFFERENT room is out of this simple pursuer's reach (it does not
-// cross-room-pathfind); it holds until circumstances change.
+// pursuitDecider walks toward the last place it saw its target.
+//
+// It is worth comparing against what this fixture used to be. It read a room
+// id off the percept, compared it with its own room and held if they differed;
+// then, if it happened to be standing exactly where the percept placed its
+// target, it scanned a room-local connection list for an endpoint matching
+// BOTH its room and its cell, and chose between two different intent types.
+// Every one of those steps existed to reconcile two coordinate systems.
+//
+// In one frame (rpg-toolkit#1044) it subtracts one cell from another and steps.
+// It crosses a doorway without knowing what a doorway is: the far side is
+// simply the next cell along. The only thing it still needs told is where the
+// doorways ARE — because a doorway is the one adjacency that is not implied by
+// the coordinates — and it takes that as the Atlas, the same absolute map a
+// host renders, rather than as the composition's room-shaped topology.
 type pursuitDecider struct {
-	connections []encounter.ConnectionInput
-	target      core.EntityID
+	doorways []encounter.AtlasDoorway
+	target   core.EntityID
 }
 
 func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
@@ -149,23 +179,23 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 			return nil, err
 		}
 
-		if snap.Room != seen.Room {
-			return encounter.IntentHold{}, nil
+		here := snap.Position
+		there := spatial.Position{X: seen.X, Y: seen.Y}
+		if here != there {
+			return encounter.IntentMoveTo{To: there}, nil
 		}
 
-		if snap.Position.X == seen.X && snap.Position.Y == seen.Y {
-			for _, c := range p.connections {
-				if c.From == snap.Room && c.FromPosition.X == snap.Position.X && c.FromPosition.Y == snap.Position.Y {
-					return encounter.IntentTraverse{Connection: c.ID}, nil
-				}
-				if c.To == snap.Room && c.ToPosition.X == snap.Position.X && c.ToPosition.Y == snap.Position.Y {
-					return encounter.IntentTraverse{Connection: c.ID}, nil
-				}
+		// Standing where it last saw them, and they are not here: the only
+		// place left to look is through the door it is standing in.
+		for _, d := range p.doorways {
+			if d.FromCell == here {
+				return encounter.IntentMoveTo{To: d.ToCell}, nil
 			}
-			return encounter.IntentHold{}, nil
+			if d.ToCell == here {
+				return encounter.IntentMoveTo{To: d.FromCell}, nil
+			}
 		}
-
-		return encounter.IntentMoveTo{To: spatial.Position{X: seen.X, Y: seen.Y}}, nil
+		return encounter.IntentHold{}, nil
 	}
 	return encounter.IntentHold{}, nil
 }
@@ -339,8 +369,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 		_, err = enc.Pump(&encounter.PumpInput{})
 		s.Require().NoError(err)
 
-		s.Equal(room1, spy.capturedSnap.Room, "its own room")
-		s.Equal(spatial.Position{X: 6, Y: 5}, spy.capturedSnap.Position, "its own position")
+		s.Equal(spatial.Position{X: 6, Y: 5}, spy.capturedSnap.Position, "its own cell, on the map")
 
 		// THE PIN: alice exists one cell away and does not appear. The
 		// snapshot is built from what this member holds, not from the
@@ -539,7 +568,10 @@ func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	s.Require().Len(goblinView, 1)
 	var p encounter.SightPayload
 	s.Require().NoError(json.Unmarshal(goblinView[0].Payload, &p))
-	s.Equal(room1, p.Room, "the vandal's scribbles must not reach encounter state")
+	// The rat, where the fixture placed it — room1 is anchored at the origin,
+	// so its local cell is its cell on the map.
+	s.Equal(6.0, p.X, "the vandal's scribbles must not reach encounter state")
+	s.Equal(6.0, p.Y)
 }
 
 func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
@@ -1033,6 +1065,20 @@ var twoRoomDoor = encounter.ConnectionInput{
 	ToPosition:   spatial.Position{X: 0, Y: 5},
 }
 
+// twoRoomField is the field most of this file's two-room fixtures build:
+// room-a at the origin, room-b anchored immediately east of it, joined at
+// the doorway above. Absolute footprints x:[0,9] and x:[10,19] (W2), and
+// the doorway's cells (9,5) and (10,5) are adjacent (W3).
+func twoRoomField() encounter.FieldInput {
+	return encounter.FieldInput{
+		Rooms: []encounter.RoomInput{
+			{ID: "room-a", Width: 10, Height: 10},
+			{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
+		},
+		Connections: []encounter.ConnectionInput{twoRoomDoor},
+	}
+}
+
 // TestPumpSnapshotIsOwnPlacement pins that each monster's Snapshot
 // carries ITS OWN room/position — never another member's (Task 3, item
 // 2). Two monsters in DIFFERENT rooms each get a spy decider; if Pump
@@ -1063,13 +1109,16 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	_, err = enc.Pump(&encounter.PumpInput{})
 	s.Require().NoError(err)
 
+	// Absolute cells, so the two snapshots are distinguishable by position
+	// alone — which is the whole assertion now that a snapshot no longer
+	// names a room. room-b is anchored at (10,0), so its goblin's local
+	// (7,8) is (17,8) on the map: a snapshot built in the wrong frame, or
+	// from the wrong member, lands somewhere else.
 	s.Require().Len(spyA.snapshots, 1)
-	s.Equal("room-a", spyA.snapshots[0].Room, "goblin-a's snapshot must name ITS OWN room")
-	s.Equal(spatial.Position{X: 2, Y: 3}, spyA.snapshots[0].Position, "goblin-a's snapshot must be ITS OWN position")
+	s.Equal(spatial.Position{X: 2, Y: 3}, spyA.snapshots[0].Position, "goblin-a's snapshot must be ITS OWN cell")
 
 	s.Require().Len(spyB.snapshots, 1)
-	s.Equal("room-b", spyB.snapshots[0].Room, "goblin-b's snapshot must name ITS OWN room")
-	s.Equal(spatial.Position{X: 7, Y: 8}, spyB.snapshots[0].Position, "goblin-b's snapshot must be ITS OWN position")
+	s.Equal(spatial.Position{X: 17, Y: 8}, spyB.snapshots[0].Position, "goblin-b's snapshot must be ITS OWN cell")
 }
 
 // TestPumpIntentTraverseSuccess pins that a monster standing at a
@@ -1081,7 +1130,9 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 // PUMP is).
 func (s *PumpTestSuite) TestPumpIntentTraverseSuccess() {
 	goblinID := core.EntityID("goblin")
-	decider := &onceTraverseDecider{connection: "door1"}
+	// The cell on the far side of the doorway: room-b's local (0,5), anchored
+	// at (10,0). One step from the threshold, on the map.
+	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 5}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
@@ -1127,7 +1178,9 @@ func (s *PumpTestSuite) TestPumpIntentTraverseSuccess() {
 // unchanged.
 func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
 	goblinID := core.EntityID("goblin")
-	decider := &onceTraverseDecider{connection: "door1"}
+	// The far side of the doorway again — but this goblin does not stand at
+	// the near side, so nothing joins where it is to where it is going.
+	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 5}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
@@ -1182,7 +1235,9 @@ func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
 // position change.
 func (s *PumpTestSuite) TestPumpIntentTraverseUnknownConnectionDoesNotAbort() {
 	goblinID := core.EntityID("goblin")
-	decider := &onceTraverseDecider{connection: "no-such-door"}
+	// A cell no room owns: void is not floor, and stepping into it is the
+	// third way stepTo refuses in silence.
+	decider := &onceStepDecider{to: spatial.Position{X: 500, Y: 500}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
@@ -1292,7 +1347,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 		Members: []encounter.MemberInput{
 			{ID: aliceID, Kind: encounter.KindPlayer, Room: "room-a", Position: spatial.Position{X: 9, Y: 5}},
 			{ID: goblinID, Kind: encounter.KindMonster, Room: "room-a", Position: spatial.Position{X: 8, Y: 5},
-				Decider: &pursuitDecider{connections: []encounter.ConnectionInput{twoRoomDoor}, target: aliceID}},
+				Decider: &pursuitDecider{doorways: doorwaysFrom(twoRoomField()), target: aliceID}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1323,8 +1378,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	s.Equal(intel.Held, goblinView[0].Status, "alice left the room — goblin's sight of her fades")
 	var ghostSeen encounter.SightPayload
 	s.Require().NoError(json.Unmarshal(goblinView[0].Payload, &ghostSeen))
-	s.Equal("room-a", ghostSeen.Room, "the ghost holds alice's LAST-SEEN room")
-	s.Equal(9.0, ghostSeen.X, "the ghost holds alice at the THRESHOLD, her last-seen position")
+	s.Equal(9.0, ghostSeen.X, "the ghost holds alice at the THRESHOLD, her last-seen cell")
 	s.Equal(5.0, ghostSeen.Y)
 
 	// Stage 2: pump — goblin walks toward the ghost's last-seen position.
@@ -1351,8 +1405,8 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	s.Equal(intel.Current, goblinView[0].Status, "the monster holds alice Current again, having crossed the threshold")
 	var aliceSeen encounter.SightPayload
 	s.Require().NoError(json.Unmarshal(goblinView[0].Payload, &aliceSeen))
-	s.Equal("room-b", aliceSeen.Room)
-	s.Equal(3.0, aliceSeen.X)
+	// room-b is anchored at (10,0), so her local (3,5) is (13,5) on the map.
+	s.Equal(13.0, aliceSeen.X)
 	s.Equal(5.0, aliceSeen.Y)
 
 	// Also verify via Story that the chase left the expected trail.
@@ -1400,7 +1454,8 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 			// aaa-goblin is AT the threshold, ready to traverse onto the
 			// filtered ending below.
 			{ID: aID, Kind: encounter.KindMonster, Room: "room-a",
-				Position: spatial.Position{X: 9, Y: 5}, Decider: &onceTraverseDecider{connection: "door1"}},
+				Position: spatial.Position{X: 9, Y: 5},
+				Decider:  &onceStepDecider{to: spatial.Position{X: 10, Y: 5}}},
 			// zzz-goblin has an unrelated same-room move queued.
 			{ID: bID, Kind: encounter.KindMonster, Room: "room-a",
 				Position: spatial.Position{X: 3, Y: 3}, Decider: &patrolDecider{positions: []spatial.Position{{X: 4, Y: 4}}}},
@@ -1633,7 +1688,7 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 			{
 				ID: goblinID, Kind: encounter.KindMonster, Room: room1,
 				Position: spatial.Position{X: 9, Y: 5},
-				Decider:  &traverseThenWander{connection: "door"},
+				Decider:  &crossThenWander{through: spatial.Position{X: 10, Y: 5}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
@@ -1664,16 +1719,16 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 	s.Empty(second.MonsterTraverses, "and not the world's to walk through doors either")
 }
 
-// traverseThenWander goes through its connection once, then shuffles.
-type traverseThenWander struct {
-	connection string
-	gone       bool
+// crossThenWander steps through a doorway once, then shuffles east.
+type crossThenWander struct {
+	through spatial.Position
+	gone    bool
 }
 
-func (t *traverseThenWander) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
+func (t *crossThenWander) Decide(snap encounter.Snapshot) (encounter.Intent, error) {
 	if !t.gone {
 		t.gone = true
-		return encounter.IntentTraverse{Connection: t.connection}, nil
+		return encounter.IntentMoveTo{To: t.through}, nil
 	}
 
 	return encounter.IntentMoveTo{To: spatial.Position{X: snap.Position.X + 1, Y: snap.Position.Y}}, nil

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -1121,14 +1121,19 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	s.Equal(spatial.Position{X: 17, Y: 8}, spyB.snapshots[0].Position, "goblin-b's snapshot must be ITS OWN cell")
 }
 
-// TestPumpIntentTraverseSuccess pins that a monster standing at a
-// connection's threshold, deciding IntentTraverse, actually crosses:
-// room changes, the "traversed" beat is recorded, PumpOutput.MonsterTraverses
-// reflects it (and MonsterMoves does not), and the clock still advances
-// by exactly 1 — Pump's own tick is unconditional regardless of what a
-// monster does within it (traversal itself is not time, law T4, but the
-// PUMP is).
-func (s *PumpTestSuite) TestPumpIntentTraverseSuccess() {
+// TestAnIntendedStepCrossesADoorway pins the crossing as what it now is: a
+// monster standing at the threshold names the cell on the far side, and the
+// composition carries it through the door.
+//
+// There is no traverse intent to decide any more (rpg-toolkit#1044) — the same
+// IntentMoveTo that walks a monster across a room walks it through a doorway,
+// because W3 makes the far side an adjacent cell on the map. What the pump
+// reports is unchanged: the room changes, the "traversed" beat is recorded,
+// PumpOutput.MonsterTraverses reflects it (and MonsterMoves does not), and the
+// clock still advances by exactly 1 — Pump's own tick is unconditional
+// regardless of what a monster does within it (a crossing itself is not time,
+// law T4, but the PUMP is).
+func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	goblinID := core.EntityID("goblin")
 	// The cell on the far side of the doorway: room-b's local (0,5), anchored
 	// at (10,0). One step from the threshold, on the map.
@@ -1168,15 +1173,16 @@ func (s *PumpTestSuite) TestPumpIntentTraverseSuccess() {
 	s.Equal("room-b", members[0].Room)
 }
 
-// TestPumpIntentTraverseIllegalDoesNotAbort pins that an illegal traverse
-// intent (decider names a REAL connection but the monster isn't AT its
-// threshold) follows the SAME silent-skip contract Pump already
-// established for a spatially-rejected IntentMoveTo (traverseMember's own
-// doc comment): the pump does NOT abort — the clock still advances, the
-// tick beat is still recorded, refreshSight still runs — but no
-// "traversed" beat is recorded and the monster's room/position are
-// unchanged.
-func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
+// TestPumpDoesNotAbortWhenNoDoorwayJoinsTheStep pins the silent skip for the
+// crossing that is not available: the monster names a cell in the next room
+// while standing nowhere near the door between them.
+//
+// Same contract Pump already gave a spatially-rejected step, and the reason it
+// must hold is the pump, not the monster: an error here would abort the tick
+// for every OTHER monster in the encounter. So the pump does NOT abort — the
+// clock still advances, the tick beat is still recorded, refreshSight still
+// runs — but no "traversed" beat is recorded and the monster has not moved.
+func (s *PumpTestSuite) TestPumpDoesNotAbortWhenNoDoorwayJoinsTheStep() {
 	goblinID := core.EntityID("goblin")
 	// The far side of the doorway again — but this goblin does not stand at
 	// the near side, so nothing joins where it is to where it is going.
@@ -1203,7 +1209,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
 	beforeClock := enc.ToData().Clock.HighWater
 
 	out, err := enc.Pump(&encounter.PumpInput{})
-	s.Require().NoError(err, "an illegal traverse intent must not abort the pump")
+	s.Require().NoError(err, "a step with no doorway to carry it must not abort the pump")
 
 	afterClock := enc.ToData().Clock.HighWater
 	s.Equal(beforeClock+1, afterClock, "clock still advances — matches IntentMoveTo's spatial-rejection contract")
@@ -1227,13 +1233,14 @@ func (s *PumpTestSuite) TestPumpIntentTraverseIllegalDoesNotAbort() {
 	s.Equal(3.0, data.Members[0].Position.Y)
 }
 
-// TestPumpIntentTraverseUnknownConnectionDoesNotAbort pins that an
-// IntentTraverse naming an unknown connection (a decider bug) follows the
-// SAME silent-skip contract as an illegal-position traverse:
-// traverseMember's ErrNoConnection is treated identically to its
-// ErrBadPlacement by Pump's phase-2 executor — no abort, no beat, no
-// position change.
-func (s *PumpTestSuite) TestPumpIntentTraverseUnknownConnectionDoesNotAbort() {
+// TestPumpDoesNotAbortWhenTheCellIsNowhere pins the third silent skip, and the
+// one that changed shape: a decider used to be able to name a connection that
+// did not exist, and now it can name a CELL that does not — void is not floor.
+//
+// Treated identically to the other two by stepTo — no abort, no beat, no
+// movement — which is what keeps one monster's bad arithmetic from costing
+// every other monster its tick.
+func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	goblinID := core.EntityID("goblin")
 	// A cell no room owns: void is not floor, and stepping into it is the
 	// third way stepTo refuses in silence.
@@ -1259,7 +1266,7 @@ func (s *PumpTestSuite) TestPumpIntentTraverseUnknownConnectionDoesNotAbort() {
 	beforeClock := enc.ToData().Clock.HighWater
 
 	out, err := enc.Pump(&encounter.PumpInput{})
-	s.Require().NoError(err, "an unknown-connection traverse intent must not abort the pump")
+	s.Require().NoError(err, "a step into a cell no room owns must not abort the pump")
 
 	afterClock := enc.ToData().Clock.HighWater
 	s.Equal(beforeClock+1, afterClock, "clock still advances")
@@ -1424,9 +1431,9 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 }
 
 // TestPumpFullTickThenEvaluateAcrossTraverse pins full-tick-then-evaluate
-// as law, now that IntentTraverse raises its stakes (a fired ending
-// during phase-2 execution would otherwise need to REVERT a room
-// mutation, not just a same-room position). Two monsters decide in the
+// as law, and a doorway crossing is what raises its stakes: a fired ending
+// during phase-2 execution would otherwise need to REVERT a room mutation,
+// not just a same-room position. Two monsters decide in the
 // SAME pump: "aaa-goblin" (decides first — Members() stable order sorts
 // its ID before "zzz-goblin") traverses onto a FILTERED ending naming
 // it; "zzz-goblin" has an unrelated same-room move queued. The shipped

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -1,0 +1,218 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// pursuit_test.go is rpg-toolkit#1044's payoff pin: a monster hunts a player
+// through a doorway while NEITHER ROOM SITS AT THE ORIGIN.
+//
+// That is the entire design of the fixture. Everywhere else in this package a
+// corridor is anchored at (0,0), which makes its local coordinates and its
+// absolute ones the same numbers — so a decider reasoning in the wrong frame,
+// a snapshot built in the wrong frame, and a sight payload projected in the
+// wrong frame all agree with the right ones, and every assertion passes.
+// Anchor both rooms away from the origin and there is no frame a mistake can
+// hide in.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type PursuitSuite struct {
+	suite.Suite
+
+	enc *encounter.Encounter
+}
+
+func TestPursuitSuite(t *testing.T) {
+	suite.Run(t, new(PursuitSuite))
+}
+
+const (
+	hunted  = core.EntityID("alice")
+	hunter  = core.EntityID("goblin")
+	westID  = "west"
+	eastID  = "east"
+	gateway = "gateway"
+)
+
+// Both rooms are 6x6 and neither is anchored at the origin. The doorway joins
+// west-local (5,3) — absolute (25,13) — to east-local (0,3) — absolute
+// (26,13). Adjacent (W3), footprints disjoint (W2), and no coordinate in this
+// field is its own local twin.
+var (
+	westOrigin = spatial.Position{X: 20, Y: 10}
+	eastOrigin = spatial.Position{X: 26, Y: 10}
+
+	westThreshold = spatial.Position{X: 25, Y: 13}
+	eastThreshold = spatial.Position{X: 26, Y: 13}
+)
+
+func (s *PursuitSuite) SetupTest() {
+	field := encounter.FieldInput{
+		Rooms: []encounter.RoomInput{
+			{ID: westID, Width: 6, Height: 6, Origin: westOrigin},
+			{ID: eastID, Width: 6, Height: 6, Origin: eastOrigin},
+		},
+		Connections: []encounter.ConnectionInput{{
+			ID: gateway, From: westID, To: eastID,
+			FromPosition: spatial.Position{X: 5, Y: 3},
+			ToPosition:   spatial.Position{X: 0, Y: 3},
+		}},
+	}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field:      field,
+		Members: []encounter.MemberInput{
+			// Alice stands at the threshold; the goblin is across the room
+			// with a clear line to her, so first light makes them mutual.
+			{ID: hunted, Kind: encounter.KindPlayer, Room: westID,
+				Position: spatial.Position{X: 5, Y: 3}},
+			{ID: hunter, Kind: encounter.KindMonster, Room: westID,
+				Position: spatial.Position{X: 1, Y: 3},
+				Decider:  &pursuitDecider{doorways: doorwaysFrom(field), target: hunted}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	s.enc = enc
+}
+
+// sightOf decodes what one member currently believes about another.
+func (s *PursuitSuite) sightOf(observer, subject core.EntityID) (string, spatial.Position) {
+	status, payload := seen(s.T(), s.enc, observer, subject)
+	_ = subject
+	return string(status), spatial.Position{X: payload.X, Y: payload.Y}
+}
+
+// TestTheHuntCrossesTheDoorwayWithoutKnowingItIsOne is the whole slice in one
+// scene.
+//
+// The decider is told a target and a list of doorway cell pairs, and nothing
+// else — no rooms, no local coordinates, no traverse intent. It compares two
+// absolute cells, subtracts, and steps. Crossing the threshold happens because
+// the far side is the next cell along, which is W3 stated as geometry rather
+// than as a special case.
+func (s *PursuitSuite) TestTheHuntCrossesTheDoorwayWithoutKnowingItIsOne() {
+	status, at := s.sightOf(hunter, hunted)
+	s.Require().Equal("current", status, "first light: the goblin sees her across the room")
+	s.Equal(westThreshold, at, "and sees her ON THE MAP, at the west room's threshold cell")
+
+	// Contact started a fight, as it must — sight is what forms a bubble, and
+	// nobody asked for one. The party disengages, which returns both to the
+	// world clock and touches nothing either of them knows: the goblin keeps
+	// its sighting, which is what makes the hunt possible at all.
+	_, err := s.enc.Dissolve(&encounter.DissolveInput{Member: hunted})
+	s.Require().NoError(err, "the fight ends by decision, and the memory of it does not")
+
+	// She slips through. The goblin's sight of her fades to a ghost holding
+	// her last-seen cell — the near side of the doorway, never the far side
+	// it has not seen.
+	_, err = s.enc.Traverse(&encounter.TraverseInput{Member: hunted, Connection: gateway})
+	s.Require().NoError(err)
+
+	status, ghost := s.sightOf(hunter, hunted)
+	s.Require().Equal("held", status, "she left the room; the sighting becomes a memory")
+	s.Equal(westThreshold, ghost, "the ghost stands where she was last seen")
+
+	// First pump: the goblin walks to the ghost's cell — inside its own room,
+	// so this is an ordinary move.
+	first, err := s.enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(first.MonsterMoves, 1, "it walks toward the last place it saw her")
+	s.Empty(first.MonsterTraverses, "no doorway crossed yet — it was not standing at one")
+
+	// Second pump: standing where she vanished, the only place left to look
+	// is through the door. The SAME intent type carries it — there is no
+	// traverse intent any more — and the composition works out that the cell
+	// it named is on the other side of a doorway.
+	second, err := s.enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(second.MonsterTraverses, 1, "the hunt follows her through")
+	s.Empty(second.MonsterMoves, "the crossing is the whole of this tick's movement")
+	s.Equal(hunter, second.MonsterTraverses[0].Member)
+	s.Equal(westID, second.MonsterTraverses[0].FromRoom)
+	s.Equal(eastID, second.MonsterTraverses[0].ToRoom)
+
+	// And it can see her again, in the room it has just entered.
+	status, found := s.sightOf(hunter, hunted)
+	s.Equal("current", status, "the hunt closes: she is in sight again")
+	s.Equal(eastThreshold, found, "at the far side of the doorway, on the same map")
+}
+
+// TestAStepIntoTheVoidIsRefusedInSilence and its sibling below pin the two
+// ways stepTo declines without complaining. Both matter because the pump must
+// survive a decider that asks for something impossible: an error would abort
+// the tick for every other monster in the encounter.
+func (s *PursuitSuite) TestAStepIntoTheVoidIsRefusedInSilence() {
+	decider := &onceStepDecider{to: spatial.Position{X: 500, Y: 500}}
+	s.freeRoamWith(decider)
+
+	out, err := s.enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err, "an impossible step is not an error")
+	s.True(decider.called, "and the refusal happened in stepTo, not by never being asked")
+	s.Empty(out.MonsterMoves)
+	s.Empty(out.MonsterTraverses)
+	s.Equal(spatial.Position{X: 21, Y: 13}, s.whereIs(hunter), "so nobody moved")
+}
+
+// TestAStepIntoTheNextRoomWithoutADoorwayIsRefused is the case W2 makes
+// possible and coordinates alone cannot rule out: two rooms may TOUCH without
+// a door between them, so an absolutely-adjacent cell is not automatically a
+// step you may take.
+func (s *PursuitSuite) TestAStepIntoTheNextRoomWithoutADoorwayIsRefused() {
+	// The east room's cell one row ABOVE the doorway: adjacent to the west
+	// room's own (25,12) in absolute space, and joined to nothing.
+	decider := &onceStepDecider{to: spatial.Position{X: 26, Y: 12}}
+	s.freeRoamWith(decider)
+
+	out, err := s.enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err, "an unjoined crossing is not an error either")
+	s.True(decider.called, "and it really was asked")
+	s.Empty(out.MonsterTraverses, "there is no doorway there to cross")
+	s.Empty(out.MonsterMoves, "and it is not a move — the cell is in another room")
+	s.Equal(spatial.Position{X: 21, Y: 13}, s.whereIs(hunter), "so the goblin stayed put")
+}
+
+// freeRoamWith puts the hunter back on the world clock with the given decider,
+// which is what a refusal pin needs before it means anything.
+//
+// Both halves are load-bearing. The DISSOLVE matters because first light
+// starts a fight and Pump only consults world-clock monsters — without it a
+// "nobody moved" assertion passes because nobody was ever asked, which is a
+// test that cannot fail. Both refusal pins therefore also assert the decider
+// was called. The RELOAD is how a decider is swapped at all: they are
+// behavior, re-registered at load, never persisted.
+func (s *PursuitSuite) freeRoamWith(decider encounter.Decider) {
+	_, err := s.enc.Dissolve(&encounter.DissolveInput{Member: hunter})
+	s.Require().NoError(err)
+
+	data := s.enc.ToData()
+	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Initiative: orderAsGiven{},
+		Data:       data,
+		Deciders:   map[encounter.MemberID]encounter.Decider{hunter: decider},
+	})
+	s.Require().NoError(err)
+	s.enc = enc
+}
+
+// whereIs is the member's cell on the map, read from the roster.
+func (s *PursuitSuite) whereIs(member core.EntityID) spatial.Position {
+	members, err := s.enc.Members()
+	s.Require().NoError(err)
+	for _, m := range members {
+		if m.ID == member {
+			return m.Position
+		}
+	}
+	s.Require().Fail("not a member", "%s", member)
+	return spatial.Position{}
+}

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -88,7 +88,6 @@ func (s *PursuitSuite) SetupTest() {
 // sightOf decodes what one member currently believes about another.
 func (s *PursuitSuite) sightOf(observer, subject core.EntityID) (string, spatial.Position) {
 	status, payload := seen(s.T(), s.enc, observer, subject)
-	_ = subject
 	return string(status), spatial.Position{X: payload.X, Y: payload.Y}
 }
 


### PR DESCRIPTION
Closes #1044. Third slice of the seam reshape (rpg-project#227), and the half of #1040 that
was deliberately split off.

#1040 made placement reads and movement beats absolute. It left everything a DECIDER
touches alone, because those pieces move together or not at all — and Kirk ruled the
alternative ("B seems like a non starter") so ruling A stands: **the decider surface goes
absolute with the payloads.**

## What changes

- **`SightPayload` is `{X, Y}`, dungeon-absolute.** The room id is gone. This is the
  payload a decider reads to find its target, so it matters more than any other
  projection: a monster comparing a target's cell with its own needs both in one frame,
  and they were in different ones for every room whose origin is not (0,0).
- **`Snapshot` is `{Position, Holdings}`**, position absolute; `Room` retires with the
  frame it was the key to.
- **`IntentMoveTo.To` is absolute**, translated by `Pump` through `Locate`.
- **`IntentTraverse` retires.** W3 makes a doorway's two endpoints adjacent absolute
  cells, so crossing one is an ordinary intended step; the new `stepTo` decides which
  mechanism carries it out. Three refusals stay SILENT, as the spatially-rejected move
  and the illegal traverse both already were: a cell no room owns, a cell in another room
  with no doorway from here, and the rejections the move or crossing itself raises. An
  error would abort the tick for every other monster in the encounter.

## The fixture is the argument

`pursuitDecider` used to read a room id off the percept, compare it with its own room and
hold if they differed; then, if it happened to stand exactly where the percept placed its
target, scan a room-local connection list for an endpoint matching BOTH its room and its
cell, and choose between two intent types. Every step of that existed to reconcile two
coordinate systems.

It now subtracts one cell from another and steps — and **crosses a doorway without knowing
what a doorway is**. The one thing it still needs told is where the doorways ARE, since
that is the single adjacency the coordinates do not imply, and it takes that as
`Atlas.Doorways`: the same absolute map a host renders, handed over after construction,
rather than the composition's room-shaped topology. The census predicted this; it is
pleasant that it fell out rather than had to be forced.

## Verification

- Full `encounter` module suite green, workbench included; `gofmt` clean; `go mod tidy` a
  no-op; the two new `goconst` findings my change would have introduced (`"move"` and
  `"traverse"` reaching three occurrences) are gone — they are constants now, which they
  should have been: the kind is built in one place and switched on in two more.
- **`pursuit_test.go` anchors BOTH rooms away from the origin**, which is the point of it.
  Everywhere else in this package a corridor sits at (0,0), so local and absolute are the
  same numbers and a wrong-frame decider, snapshot or payload agrees with a right one.
  In this fixture no coordinate is its own local twin.
- **Sensitivity checked by mutation.** Stop projecting sight payloads → the hunt pin fails.
  Stop projecting snapshots → the hunt pin AND `TestPumpSnapshotIsOwnPlacement` fail.
- The two refusal pins assert the decider **was called** before asserting nobody moved.
  Without that they were vacuous: first light starts a fight, Pump only consults
  world-clock monsters, and "nobody moved" passes when nobody was asked. They dissolve the
  bubble first, and say so in the helper's doc.

## Known duplication, flagged rather than fixed

`stepTo`'s dispatch — locate the cell, same room means move, another room means find the
doorway — is the same decomposition the SEAM will need when `session.Move` crosses a
doorway (slice 4). Two implementations at two layers, because the module boundary is real:
the seam cannot call an unexported helper. If slice 4 wants it shared, the shape would be
an exported step verb on the composition, and that is a decision for that slice rather
than a thing to invent here.

— asset-pipeline agent, on behalf of KirkDiggler
