### PR TITLE
feat(session)!: joins, walks and outcomes speak one map (#1046)

### DIFF
--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -198,12 +198,14 @@ func drive(out *bytes.Buffer) error {
 
 	joined, err := mgr.Join(ctx, &session.JoinInput{
 		Session: "crypt-run", Member: "bob",
-		Room: "antechamber", Position: spatial.Position{X: 1, Y: 2},
+		// A cell on the map. The antechamber is anchored at the origin, so
+		// this one reads the same either way; the vault below does not.
+		Position: spatial.Position{X: 1, Y: 2},
 	})
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "   bob joins the %s\n", joined.Member.Room)
+	fmt.Fprintf(out, "   bob joins at (%v,%v)\n", joined.Member.Position.X, joined.Member.Position.Y)
 
 	// The sheet came back derived, not echoed. Speed is not a field of the
 	// stored data at all — a dwarf's 25 comes from reconstituting the
@@ -224,8 +226,10 @@ func drive(out *bytes.Buffer) error {
 	// is why SpawnOutput carries Formed at all.
 	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
 		Session: "crypt-run", ID: "skel-1",
-		Ref:  refs.Monsters.Skeleton().String(),
-		Room: "vault", Position: spatial.Position{X: 4, Y: 5},
+		Ref: refs.Monsters.Skeleton().String(),
+		// The vault is anchored at (6,0), so its local (4,5) is (10,5) on
+		// the map — and the map is what this seam speaks.
+		Position: spatial.Position{X: 10, Y: 5},
 	})
 	if err != nil {
 		return err
@@ -284,7 +288,9 @@ func drive(out *bytes.Buffer) error {
 	}
 
 	fmt.Fprintln(out, "\n== and she cannot simply walk away ==")
-	vaultPath := []spatial.Position{{X: 1, Y: 1}, {X: 1, Y: 2}}
+	// Cells on the map: alice arrived at the vault's (0,1) local, which is
+	// (6,1) with the vault anchored at (6,0). She tries to step deeper in.
+	vaultPath := []spatial.Position{{X: 7, Y: 1}, {X: 7, Y: 2}}
 	_, err = mgr.Move(ctx, &session.MoveInput{
 		Session: "crypt-run", Member: "alice", Path: vaultPath,
 	})
@@ -319,7 +325,7 @@ func drive(out *bytes.Buffer) error {
 	}
 	final := make([]string, 0, len(ended.Outcome.Members))
 	for _, m := range ended.Outcome.Members {
-		final = append(final, fmt.Sprintf("%s in %s at (%v,%v)", m.ID, m.Room, m.Position.X, m.Position.Y))
+		final = append(final, fmt.Sprintf("%s at (%v,%v)", m.ID, m.Position.X, m.Position.Y))
 	}
 	sort.Strings(final)
 	fmt.Fprintf(out, "   ended by %q\n", ended.Outcome.Ending)

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
@@ -41,7 +41,7 @@ func TestWorkbenchRuns(t *testing.T) {
 		"bob walks on regardless, 1 step(s)",            // while everyone not in it carries on
 
 		`ended by "withdraw"`,
-		"alice in vault at (0,1)", // she is where the fight stopped her, and it persisted
+		"alice at (6,1)", // she is where the fight stopped her, and it persisted
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("workbench output missing %q\nfull output:\n%s", want, got)

--- a/rulebooks/dnd5e/session/conditions_test.go
+++ b/rulebooks/dnd5e/session/conditions_test.go
@@ -145,7 +145,7 @@ func (s *ConditionsTestSuite) TestAVerbLeavesTheCharacterStoreUntouched() {
 		before := s.storedBytes("bob")
 		_, err := s.mgr.Join(ctx, &session.JoinInput{
 			Session: "sess", Member: "bob",
-			Room: "hall", Position: spatial.Position{X: 0, Y: 0},
+			Position: spatial.Position{X: 0, Y: 0},
 		})
 		s.Require().NoError(err)
 		s.Equal(string(before), string(s.storedBytes("bob")))
@@ -262,7 +262,7 @@ func (s *ConditionsTestSuite) TestACharacterTheSDKCannotFullyLoadIsStillNotDamag
 
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "dave",
-		Room: "hall", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 0, Y: 0},
 	})
 	s.Require().NoError(err, "the unreadable condition does not fail the join — that is the trap")
 

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -109,7 +109,7 @@ func before(a, b spatial.Position) bool {
 	return a.Y < b.Y
 }
 
-func projectStatus(in *encounter.Status) *Status {
+func projectStatus(enc *encounter.Encounter, in *encounter.Status) *Status {
 	if in == nil {
 		return nil
 	}
@@ -124,11 +124,7 @@ func projectStatus(in *encounter.Status) *Status {
 		Members: make([]MemberOutcome, 0, len(in.Outcome.Members)),
 	}
 	for _, m := range in.Outcome.Members {
-		outcome.Members = append(outcome.Members, MemberOutcome{
-			ID:       string(m.ID),
-			Room:     m.Room,
-			Position: m.Position,
-		})
+		outcome.Members = append(outcome.Members, projectMemberOutcome(enc, m))
 	}
 	out.Outcome = outcome
 	return out
@@ -184,24 +180,43 @@ func projectStory(in []record.Entry) []StoryEntry {
 
 func projectMember(in encounter.Member) Member {
 	return Member{
-		ID:   string(in.ID),
-		Kind: MemberKind(in.Kind),
-		Room: in.Room,
+		ID:       string(in.ID),
+		Kind:     MemberKind(in.Kind),
+		Position: in.Position,
 	}
 }
 
-func projectMemberOutcome(in encounter.MemberOutcome) MemberOutcome {
+// onMap projects a composition room-local cell into the one map this seam
+// speaks, by asking the composition rather than doing the arithmetic here.
+//
+// Placement reads already come back absolute (encounter v0.10.0), and this is
+// for the two shapes that do not: an outcome's member list, which the
+// composition still reports in its own terms. Asking Absolute means the seam
+// never learns what an origin is, which is the whole point of it living down
+// there.
+func onMap(enc *encounter.Encounter, room string, local spatial.Position) spatial.Position {
+	out, err := enc.Absolute(&encounter.AbsoluteInput{Room: room, Position: local})
+	if err != nil {
+		// Unreachable through any verb: an outcome names members the
+		// composition itself placed, in rooms it validated at construction.
+		// Returning the unprojected cell if that ever stops being true is
+		// wrong in a way a test can see, which a panic in a host would not be.
+		return local
+	}
+	return out.Position
+}
+
+func projectMemberOutcome(enc *encounter.Encounter, in encounter.MemberOutcome) MemberOutcome {
 	return MemberOutcome{
 		ID:       string(in.ID),
-		Room:     in.Room,
-		Position: in.Position,
+		Position: onMap(enc, in.Room, in.Position),
 	}
 }
 
 // projectOutcome converts a bare outcome. projectStatus has its own inline
 // copy of this walk because it must also handle the nil-Status case; this one
 // serves the verbs that return an outcome directly.
-func projectOutcome(in *encounter.Outcome) *Outcome {
+func projectOutcome(enc *encounter.Encounter, in *encounter.Outcome) *Outcome {
 	if in == nil {
 		return nil
 	}
@@ -211,7 +226,7 @@ func projectOutcome(in *encounter.Outcome) *Outcome {
 		Members: make([]MemberOutcome, 0, len(in.Members)),
 	}
 	for _, m := range in.Members {
-		out.Members = append(out.Members, projectMemberOutcome(m))
+		out.Members = append(out.Members, projectMemberOutcome(enc, m))
 	}
 	return out
 }

--- a/rulebooks/dnd5e/session/convert_test.go
+++ b/rulebooks/dnd5e/session/convert_test.go
@@ -54,6 +54,7 @@ var projectedPairs = []struct {
 	{"AtlasDoorway", encounter.AtlasDoorway{}, session.AtlasDoorway{}},
 	{"Status", encounter.Status{}, session.Status{}},
 	{"Outcome", encounter.Outcome{}, session.Outcome{}},
+	{"Member", encounter.Member{}, session.Member{}},
 	{"MemberOutcome", encounter.MemberOutcome{}, session.MemberOutcome{}},
 	{"Sighting", intel.Holding{}, session.Sighting{}},
 	{"StoryEntry", record.Entry{}, session.StoryEntry{}},
@@ -78,6 +79,12 @@ var omitted = map[string]string{
 		"on this side has one left to project",
 	"encounter.AtlasRoom.Width":  "a room's span; the map's extent is the extent of Cells",
 	"encounter.AtlasRoom.Height": "a room's span; the map's extent is the extent of Cells",
+
+	// Placement answers a cell, not a chamber (rpg-toolkit#1046). The room is
+	// the composition's own decomposition, and a caller that wanted it would
+	// be reconstructing the frame the reshape removed.
+	"encounter.Member.Room":        "a room id; the seam reports the cell instead",
+	"encounter.MemberOutcome.Room": "a room id; Position is projected onto the map instead",
 
 	// A doorway's endpoints kept their meaning and lost their qualifier: on one
 	// map there is no second pair of From/To fields naming rooms to

--- a/rulebooks/dnd5e/session/entities_test.go
+++ b/rulebooks/dnd5e/session/entities_test.go
@@ -51,7 +51,7 @@ func (s *EntitiesTestSuite) SetupSubTest() { s.SetupTest() }
 func (s *EntitiesTestSuite) joinBob() (*session.JoinOutput, error) {
 	return s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 }
 
@@ -92,7 +92,7 @@ func (s *EntitiesTestSuite) TestSpeedIsDerivedRatherThanDefaulted() {
 
 	humanOut, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "human-one",
-		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+		Position: spatial.Position{X: 7, Y: 0},
 	})
 	s.Require().NoError(err)
 
@@ -107,7 +107,7 @@ func (s *EntitiesTestSuite) TestSpeedIsDerivedRatherThanDefaulted() {
 func (s *EntitiesTestSuite) TestJoiningAPlayerWithNoCharacterIsRejected() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "nobody",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrNoCharacter)
@@ -132,7 +132,7 @@ func (s *EntitiesTestSuite) TestJoiningAPlayerWithNoCharacterIsRejected() {
 func (s *EntitiesTestSuite) TestARejectedJoinPlacesNobody() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "nobody",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.Require().Error(err)
 
@@ -161,7 +161,7 @@ func (s *EntitiesTestSuite) TestSpawnedContentNeverConsultsTheCharacterRepositor
 
 	out, err := s.mgr.Spawn(context.Background(), &session.SpawnInput{
 		Session: "sess", ID: "ogre-7", Ref: refs.Monsters.Skeleton().String(),
-		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+		Position: spatial.Position{X: 7, Y: 0},
 	})
 	s.Require().NoError(err, "content that lives in code needs no stored sheet")
 	s.Require().NotNil(out.NPC)
@@ -177,7 +177,7 @@ func (s *EntitiesTestSuite) TestSpawnedContentNeverConsultsTheCharacterRepositor
 func (s *EntitiesTestSuite) TestAMonsterCannotJoin() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "ogre-7",
-		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+		Position: spatial.Position{X: 7, Y: 0},
 	})
 	s.ErrorIs(err, session.ErrNoCharacter)
 }
@@ -202,7 +202,7 @@ func (s *EntitiesTestSuite) TestEveryPlayerJoinConsultsTheRepository() {
 
 	_, err = s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "carol",
-		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+		Position: spatial.Position{X: 7, Y: 0},
 	})
 	s.Require().NoError(err)
 	s.Greater(s.characters.loads, first, "a second join must load again, not reuse")
@@ -221,7 +221,7 @@ func (s *EntitiesTestSuite) TestARepositoryReportingSuccessWithNoDataIsRejected(
 
 	_, err = mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrBadRepository)
@@ -247,7 +247,7 @@ func (s *EntitiesTestSuite) TestACorruptConditionIsDroppedRatherThanRejected() {
 
 	out, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "corrupt-one",
-		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+		Position: spatial.Position{X: 7, Y: 0},
 	})
 
 	s.Require().NoError(err, "upstream currently swallows this; if that changes, so must this test")
@@ -306,7 +306,7 @@ func BenchmarkJoinPlayer(b *testing.B) {
 
 		if _, err := mgr.Join(ctx, &session.JoinInput{
 			Session: "sess", Member: "bob",
-			Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+			Position: spatial.Position{X: 6, Y: 0},
 		}); err != nil {
 			b.Fatalf("join: %v", err)
 		}
@@ -322,7 +322,7 @@ func BenchmarkSpawnMonster(b *testing.B) {
 
 		if _, err := mgr.Spawn(ctx, &session.SpawnInput{
 			Session: "sess", ID: "ogre-7", Ref: refs.Monsters.Skeleton().String(),
-			Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+			Position: spatial.Position{X: 6, Y: 0},
 		}); err != nil {
 			b.Fatalf("spawn: %v", err)
 		}

--- a/rulebooks/dnd5e/session/events_test.go
+++ b/rulebooks/dnd5e/session/events_test.go
@@ -269,7 +269,7 @@ func (s *EventsTestSuite) TestKindsComeFromTheBeatNotTheTag() {
 	s.stream.published = nil
 	_, err = s.mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "erin",
-		Room: "corridor", Position: spatial.Position{X: 3, Y: 3},
+		Position: spatial.Position{X: 3, Y: 3},
 	})
 	s.Require().NoError(err)
 	joined := s.kinds()

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -51,7 +51,7 @@ func Example_theSession() {
 
 	if _, err := mgr.Join(ctx, &session.JoinInput{
 		Session: "tomb-run", Member: "bob",
-		Room: "hall", Position: spatial.Position{X: 1, Y: 3},
+		Position: spatial.Position{X: 1, Y: 3},
 	}); err != nil {
 		panic(err)
 	}

--- a/rulebooks/dnd5e/session/fight_starts_test.go
+++ b/rulebooks/dnd5e/session/fight_starts_test.go
@@ -475,7 +475,7 @@ func (s *FightStartsTestSuite) TestAPartialSaveTellsTheCallerWhichHalfLanded() {
 
 	_, err := mgr.Spawn(context.Background(), &session.SpawnInput{
 		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
-		Room: "hall", Position: spatial.Position{X: 6, Y: 6},
+		Position: spatial.Position{X: 6, Y: 6},
 	})
 	s.Require().Error(err, "the spawned sheet had to be written to the session")
 	s.Require().ErrorIs(err, session.ErrSaveFailed, "the condition is matchable")

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0 h1:j0VBbyFOEbM+UrfaDYdvuPDQ2L7b4IVVjEzMtJMg5Dc=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.10.0 h1:yHUQxaqN66Eh8ZHWY1FA/+xXB8JDXOof4Up9pPETfrY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.10.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2 h1:I8cobvZ+E2lk5no782XSFCoODqt3l+LLgJaKUkBz1WU=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2/go.mod h1:akIVBXf3LdfHmcKlliUngpzKWWCZOl6DWpK9CPFetPo=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -165,11 +165,12 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	if err := validatePath(scope.enc, encounter.MemberID(in.Member), in.Path); err != nil {
+	walk, err := resolveWalk(scope.enc, encounter.MemberID(in.Member), in.Path)
+	if err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	res, err := m.runWalk(scope, in.Member, in.Path)
+	res, err := m.runWalk(scope, in.Member, walk)
 	if err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
@@ -266,20 +267,10 @@ type walkResult struct {
 // because the walker is IN a fight and a fight member does not free-roam — the
 // composition would refuse the next step with ErrInBubble — so stopping is a
 // fact about the world rather than a policy about perception.
-func (m *Manager) runWalk(scope *writeScope, member string, path []spatial.Position) (*walkResult, error) {
+func (m *Manager) runWalk(scope *writeScope, member string, walk resolvedWalk) (*walkResult, error) {
 	res := &walkResult{discovered: map[string]Discovery{}}
 
-	room, _, err := whereIs(scope.enc, encounter.MemberID(member))
-	if err != nil {
-		return nil, err
-	}
-
-	for i, cell := range path {
-		local, err := localTo(scope.enc, room, cell)
-		if err != nil {
-			return nil, fmt.Errorf("step %d of %d: %w", i+1, len(path), err)
-		}
-
+	for i, local := range walk.steps {
 		moved, err := scope.enc.Move(&encounter.MoveInput{
 			Member: encounter.MemberID(member),
 			To:     local,
@@ -288,14 +279,14 @@ func (m *Manager) runWalk(scope *writeScope, member string, path []spatial.Posit
 			// Nothing is saved on a mid-walk rejection. The member has really
 			// moved in memory for the steps already taken, but that encounter is
 			// discarded unsaved, so the persisted world is untouched.
-			return nil, fmt.Errorf("step %d of %d: %w", i+1, len(path), translate(err))
+			return nil, fmt.Errorf("step %d of %d: %w", i+1, len(walk.steps), translate(err))
 		}
 
 		// Reported from what the composition says happened, projected back —
 		// not echoed from the input. A step that landed somewhere other than
 		// where it was aimed is a thing worth being able to see.
 		res.steps = append(res.steps, Step{
-			Position: onMap(scope.enc, room, moved.Moved.To),
+			Position: onMap(scope.enc, walk.room, moved.Moved.To),
 			Seq:      moved.Seq,
 		})
 		mergeDiscoveries(res.discovered, projectDiscoveries(moved.IntelDeltas))
@@ -333,7 +324,22 @@ func projectFormed(f *encounter.FormedBubble) *Formed {
 	return out
 }
 
-// validatePath rejects a path that is not a walk, before any of it is walked.
+// resolvedWalk is a path as the composition takes it: the room being walked,
+// and the room-local cell for each step, in order.
+type resolvedWalk struct {
+	room  string
+	steps []spatial.Position
+}
+
+// resolveWalk validates a path whole and resolves it ONCE.
+//
+// Two jobs in one pass, and they belong together. Validation must finish
+// before the first cell is entered (R5): a caller who mis-computed a route
+// wants none of it rather than an arbitrary prefix. Resolution turns each
+// dungeon-absolute cell into the room-local one the composition's Move takes.
+// Doing them separately located every cell twice and read the roster twice per
+// walk — and, worse, left two places free to disagree about which room a cell
+// belongs to.
 //
 // Adjacency is checked with the room's own grid rather than a hand-rolled
 // distance, because the two families disagree about what "one step" means and
@@ -342,34 +348,43 @@ func projectFormed(f *encounter.FormedBubble) *Formed {
 // everywhere except the diagonals, so a wrong formula passes almost every
 // fixture.
 //
-// The restriction is imposed now rather than later on purpose. Loosening a rule
-// is a compatible change; tightening one breaks every host that was relying on
-// the looser behaviour. If a path should ever be allowed to teleport, that can
-// be granted; it could not be taken away.
-func validatePath(enc *encounter.Encounter, member encounter.MemberID, path []spatial.Position) error {
+// The restriction to one room is imposed now rather than later on purpose.
+// Loosening a rule is a compatible change; tightening one breaks every host
+// that was relying on the looser behaviour. If a walk should ever cross a
+// doorway, that can be granted; it could not be taken away.
+func resolveWalk(
+	enc *encounter.Encounter, member encounter.MemberID, path []spatial.Position,
+) (resolvedWalk, error) {
 	room, from, err := whereIs(enc, member)
 	if err != nil {
-		return err
+		return resolvedWalk{}, err
 	}
 
 	grid, err := gridFor(enc, room)
 	if err != nil {
-		return err
+		return resolvedWalk{}, err
 	}
 
-	previous := from
+	// Both frames are tracked: the local one to ask the grid about adjacency,
+	// the absolute one to describe a refusal in the coordinates the caller
+	// actually wrote. A message that mixed them would send whoever reads it
+	// looking for a cell nobody named.
+	walk := resolvedWalk{room: room, steps: make([]spatial.Position, 0, len(path))}
+	previous, previousCell := from, onMap(enc, room, from)
+
 	for i, cell := range path {
-		local, err := localTo(enc, room, cell)
-		if err != nil {
-			return fmt.Errorf("step %d of %d: %w", i+1, len(path), err)
+		local, lerr := localTo(enc, room, cell)
+		if lerr != nil {
+			return resolvedWalk{}, fmt.Errorf("step %d of %d: %w", i+1, len(path), lerr)
 		}
 		if !grid.IsAdjacent(previous, local) {
-			return fmt.Errorf("step %d from (%v,%v) to (%v,%v): %w",
-				i+1, previous.X, previous.Y, cell.X, cell.Y, ErrBrokenPath)
+			return resolvedWalk{}, fmt.Errorf("step %d from (%v,%v) to (%v,%v): %w",
+				i+1, previousCell.X, previousCell.Y, cell.X, cell.Y, ErrBrokenPath)
 		}
-		previous = local
+		walk.steps = append(walk.steps, local)
+		previous, previousCell = local, cell
 	}
-	return nil
+	return walk, nil
 }
 
 // whereIs locates a member: which room owns them, and which cell within it.
@@ -411,7 +426,11 @@ func whereIs(enc *encounter.Encounter, member encounter.MemberID) (string, spati
 func localTo(enc *encounter.Encounter, room string, cell spatial.Position) (spatial.Position, error) {
 	located, err := enc.Locate(&encounter.LocateInput{Position: cell})
 	if err != nil {
-		return spatial.Position{}, fmt.Errorf("no room owns (%v,%v): %w", cell.X, cell.Y, ErrBadPosition)
+		// Both wrapped: the sentinel is what a caller matches on, and the
+		// composition's own error says WHICH way the cell was unusable —
+		// owned by nothing, off the grid, or not an integral cell.
+		return spatial.Position{}, fmt.Errorf(
+			"no room owns (%v,%v): %w: %w", cell.X, cell.Y, ErrBadPosition, err)
 	}
 	if located.Room != room {
 		return spatial.Position{}, fmt.Errorf(

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -11,7 +11,10 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
-// MoveInput walks a member along a path within their current room.
+// MoveInput walks a member along a path of cells on the map.
+//
+// The path stays inside the room the walker is standing in — see Path — until
+// the slice that makes a doorway crossing an ordinary step.
 type MoveInput struct {
 	// Session is the session to act in.
 	Session string
@@ -143,8 +146,9 @@ type TraverseOutput struct {
 // prefix of it.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrEmptyPath,
-// ErrBrokenPath, ErrNoSession, ErrNoEncounter, ErrNoMember, ErrClosed,
-// ErrBadPosition, or ErrSaveFailed with a populated report.
+// ErrBrokenPath for a path with a gap in it, ErrNoSession, ErrNoEncounter,
+// ErrNoMember, ErrClosed, ErrBadPosition for a cell no room owns OR a cell in
+// a room other than the walker's, or ErrSaveFailed with a populated report.
 func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("move: %w", ErrNilInput)

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -25,12 +25,23 @@ type MoveInput struct {
 	// A path, not a destination. The caller says where to walk; what actually
 	// happened comes back as Steps, which may be shorter. A single-cell path is
 	// the ordinary case and entirely legal.
+	//
+	// Cells are DUNGEON-ABSOLUTE — the same coordinates the Atlas draws and
+	// every other verb speaks (rpg-project#227).
+	//
+	// A WALK STILL DOES NOT CROSS A DOORWAY. Absolute coordinates make a
+	// crossing expressible for the first time — the far side of a doorway is
+	// simply the next cell along — but expressible is not permitted: a path
+	// that leaves the walker's room is refused with ErrBadPosition, exactly
+	// as it was refused before, when it could not even be written down. That
+	// changes in its own slice, deliberately, so that a real behavior change
+	// is not smuggled in inside a change of dialect.
 	Path []spatial.Position
 }
 
 // Step is one cell actually entered.
 type Step struct {
-	// Position is the cell entered.
+	// Position is the cell entered, in dungeon-absolute space.
 	Position spatial.Position `json:"position"`
 
 	// Seq is the story sequence of the recorded step.
@@ -219,7 +230,7 @@ func (m *Manager) Traverse(ctx context.Context, in *TraverseInput) (*TraverseOut
 		To:         crossed.Traversed.To,
 		Discovered: projectDiscoveries(crossed.IntelDeltas),
 		Seq:        crossed.Seq,
-		Outcome:    projectOutcome(crossed.Outcome),
+		Outcome:    projectOutcome(scope.enc, crossed.Outcome),
 		Formed:     projectFormed(crossed.Formed),
 		Saved:      report,
 		Delivery:   delivery,
@@ -254,10 +265,20 @@ type walkResult struct {
 func (m *Manager) runWalk(scope *writeScope, member string, path []spatial.Position) (*walkResult, error) {
 	res := &walkResult{discovered: map[string]Discovery{}}
 
+	room, _, err := whereIs(scope.enc, encounter.MemberID(member))
+	if err != nil {
+		return nil, err
+	}
+
 	for i, cell := range path {
+		local, err := localTo(scope.enc, room, cell)
+		if err != nil {
+			return nil, fmt.Errorf("step %d of %d: %w", i+1, len(path), err)
+		}
+
 		moved, err := scope.enc.Move(&encounter.MoveInput{
 			Member: encounter.MemberID(member),
-			To:     cell,
+			To:     local,
 		})
 		if err != nil {
 			// Nothing is saved on a mid-walk rejection. The member has really
@@ -266,14 +287,20 @@ func (m *Manager) runWalk(scope *writeScope, member string, path []spatial.Posit
 			return nil, fmt.Errorf("step %d of %d: %w", i+1, len(path), translate(err))
 		}
 
-		res.steps = append(res.steps, Step{Position: moved.Moved.To, Seq: moved.Seq})
+		// Reported from what the composition says happened, projected back —
+		// not echoed from the input. A step that landed somewhere other than
+		// where it was aimed is a thing worth being able to see.
+		res.steps = append(res.steps, Step{
+			Position: onMap(scope.enc, room, moved.Moved.To),
+			Seq:      moved.Seq,
+		})
 		mergeDiscoveries(res.discovered, projectDiscoveries(moved.IntelDeltas))
 
 		if moved.Outcome != nil {
 			// The encounter ended underfoot. Every remaining step is abandoned:
 			// a closed encounter refuses movement anyway, and attempting them
 			// would turn a clean stop into a rejection the caller must interpret.
-			res.outcome = projectOutcome(moved.Outcome)
+			res.outcome = projectOutcome(scope.enc, moved.Outcome)
 			return res, nil
 		}
 
@@ -328,32 +355,65 @@ func validatePath(enc *encounter.Encounter, member encounter.MemberID, path []sp
 
 	previous := from
 	for i, cell := range path {
-		if !grid.IsAdjacent(previous, cell) {
+		local, err := localTo(enc, room, cell)
+		if err != nil {
+			return fmt.Errorf("step %d of %d: %w", i+1, len(path), err)
+		}
+		if !grid.IsAdjacent(previous, local) {
 			return fmt.Errorf("step %d from (%v,%v) to (%v,%v): %w",
 				i+1, previous.X, previous.Y, cell.X, cell.Y, ErrBrokenPath)
 		}
-		previous = cell
+		previous = local
 	}
 	return nil
 }
 
-// whereIs locates a member: which room, and which cell within it.
+// whereIs locates a member: which room owns them, and which cell within it.
 //
-// Read out of a snapshot rather than a query, because the composition's
-// Members() reports a member's room but not their position — the ergonomics gap
-// already filed as toolkit#933. A snapshot is heavier than the question
-// deserves, but it is the only source of truth for a member's current cell, and
-// it runs once per walk rather than once per step.
-//
-// When #933 lands this becomes a direct lookup and the snapshot goes away.
+// It used to serialize the whole aggregate — clock, intel, log, field and
+// endings — to read two floats, because the composition's roster reported a
+// room and no position. That was toolkit#933, and it has landed: Members now
+// carries each member's cell on the map, so this is a roster read and a
+// projection back down into the room-local terms the composition's own verbs
+// take.
 func whereIs(enc *encounter.Encounter, member encounter.MemberID) (string, spatial.Position, error) {
-	for _, m := range enc.ToData().Members {
+	members, err := enc.Members()
+	if err != nil {
+		return "", spatial.Position{}, err
+	}
+
+	for _, m := range members {
 		if m.ID != member {
 			continue
 		}
-		return m.Room, spatial.Position{X: m.Position.X, Y: m.Position.Y}, nil
+		located, lerr := enc.Locate(&encounter.LocateInput{Position: m.Position})
+		if lerr != nil {
+			return "", spatial.Position{}, fmt.Errorf("%q stands at %v, which no room owns: %w",
+				member, m.Position, ErrBadPosition)
+		}
+		return located.Room, located.Position, nil
 	}
 	return "", spatial.Position{}, fmt.Errorf("%q: %w", member, ErrNoMember)
+}
+
+// localTo resolves a map cell into the room-local cell the composition's verbs
+// take, refusing anything that is not in the given room.
+//
+// The refusal is the whole reason this is a named function rather than a call
+// to Locate. A walk is within one room, and after the reshape a caller CAN
+// write a path that leaves it — the coordinates no longer stop them. So the
+// rule that used to be enforced by the shape of the input has to be enforced
+// here instead, until the slice that makes a crossing an ordinary step.
+func localTo(enc *encounter.Encounter, room string, cell spatial.Position) (spatial.Position, error) {
+	located, err := enc.Locate(&encounter.LocateInput{Position: cell})
+	if err != nil {
+		return spatial.Position{}, fmt.Errorf("no room owns (%v,%v): %w", cell.X, cell.Y, ErrBadPosition)
+	}
+	if located.Room != room {
+		return spatial.Position{}, fmt.Errorf(
+			"(%v,%v) is not in the room being walked: %w", cell.X, cell.Y, ErrBadPosition)
+	}
+	return located.Position, nil
 }
 
 // gridFor builds a grid matching a room's family and span, for adjacency tests.

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+// onemap_test.go pins that the seam's typed surface speaks one map
+// (rpg-toolkit#1046): a caller hands in cells, reads back cells, and never
+// names a room while playing.
+//
+// Every fixture here anchors its room AWAY from the origin. A room at (0,0)
+// makes local and absolute the same numbers, which is why the rest of this
+// package's move and join tests pass unchanged through this reshape — they
+// cannot tell the two frames apart, and neither could a bug.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type OneMapSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	mgr        *session.Manager
+}
+
+func TestOneMapSuite(t *testing.T) {
+	suite.Run(t, new(OneMapSuite))
+}
+
+// offsetWorld is a single 6x6 room anchored at (40,20), plus a second room
+// beyond it so that "a cell in another room" is a thing a path can name.
+//
+// The doorway joins hall-local (5,2) — absolute (45,22) — to annex-local (0,2)
+// — absolute (46,22).
+func offsetWorld(t fataler) *encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: "hall", Width: 6, Height: 6, Origin: spatial.Position{X: 40, Y: 20}},
+				{ID: "annex", Width: 6, Height: 6, Origin: spatial.Position{X: 46, Y: 20}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "gate", From: "hall", To: "annex",
+				FromPosition: spatial.Position{X: 5, Y: 2},
+				ToPosition:   spatial.Position{X: 0, Y: 2},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{
+			// Fires where the walk below ends, so the outcome's own placement
+			// report is exercised in the same scene.
+			{Key: "stairs", Trigger: encounter.TriggerReachedPosition{
+				Room: "hall", Position: spatial.Position{X: 4, Y: 1}}},
+		},
+		Retention: encounter.RetentionUnbounded,
+	})
+	if err != nil {
+		t.Fatalf("building the offset world: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
+func (s *OneMapSuite) SetupTest() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: offsetWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+}
+
+// TestAJoinIsAnsweredInTheSameCellItWasAskedFor is the slice's headline case.
+//
+// One cell goes in, and every surface that mentions the joiner afterwards
+// answers with the same cell: the join's own report, the steps of a later
+// walk, and the ending's final placement. A seam that projected in some places
+// and not others would satisfy any single one of these.
+func (s *OneMapSuite) TestAJoinIsAnsweredInTheSameCellItWasAskedFor() {
+	ctx := context.Background()
+	arrival := spatial.Position{X: 41, Y: 21} // hall-local (1,1)
+
+	joined, err := s.mgr.Join(ctx, &session.JoinInput{
+		Session: "sess", Member: "bob", Position: arrival,
+	})
+	s.Require().NoError(err)
+	s.Equal(arrival, joined.Member.Position, "the join answers the cell it was given")
+
+	// He walks two cells east, still inside the hall.
+	walked, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "bob",
+		Path: []spatial.Position{{X: 42, Y: 21}, {X: 43, Y: 21}},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(walked.Steps, 2)
+	s.Equal(spatial.Position{X: 42, Y: 21}, walked.Steps[0].Position)
+	s.Equal(spatial.Position{X: 43, Y: 21}, walked.Steps[1].Position, "walked on the map, reported on it")
+
+	// One more step lands on the stairs and closes the encounter, so the
+	// outcome reports where everybody finished — on the map as well.
+	ended, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "bob",
+		Path: []spatial.Position{{X: 44, Y: 21}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(ended.Outcome, "the stairs are underfoot")
+
+	placements := map[string]spatial.Position{}
+	for _, m := range ended.Outcome.Members {
+		placements[m.ID] = m.Position
+	}
+	s.Equal(spatial.Position{X: 44, Y: 21}, placements["bob"], "bob finished on the stairs")
+	s.Equal(spatial.Position{X: 41, Y: 21}, placements["alice"], "alice never moved from her cell")
+}
+
+// TestAWalkStillDoesNotCrossADoorway is the deliberate NON-change, pinned so
+// that the slice which makes a crossing an ordinary step has to come here and
+// change a test on purpose.
+//
+// Absolute coordinates make the crossing EXPRESSIBLE for the first time — the
+// far side of the doorway is simply the next cell along — and it is still
+// refused. That is the difference between changing a dialect and changing a
+// rule, and only one of them is happening in this slice.
+func (s *OneMapSuite) TestAWalkStillDoesNotCrossADoorway() {
+	ctx := context.Background()
+
+	// Alice walks to the threshold, which is allowed…
+	_, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 42, Y: 21}, {X: 43, Y: 22}, {X: 44, Y: 22}, {X: 45, Y: 22}},
+	})
+	s.Require().NoError(err, "the threshold is in her own room")
+
+	// …and then tries to step through it, which is not.
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 46, Y: 22}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadPosition, "the far side of a doorway is another room, and a walk is one room")
+}
+
+// TestAWalkIntoTheVoidIsRefused: a cell no room owns is not a step, and the
+// refusal names the same sentinel as the doorway case — both are "that is not
+// a cell you can walk to from here".
+func (s *OneMapSuite) TestAWalkIntoTheVoidIsRefused() {
+	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 900, Y: 900}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadPosition)
+}
+
+// TestNothingOnThePlaySurfaceNamesARoom checks the claim structurally rather
+// than by reading the diff.
+//
+// The types are the contract: a room id cannot come back through an input a
+// caller fills in or an output a client renders, because there is nowhere to
+// put one. Authoring is deliberately not on this list — StartSessionInput
+// carries an authored world, which is construction data and still speaks
+// rooms.
+func (s *OneMapSuite) TestNothingOnThePlaySurfaceNamesARoom() {
+	for _, shape := range []any{
+		session.JoinInput{}, session.SpawnInput{}, session.MoveInput{},
+		session.Member{}, session.MemberOutcome{}, session.Step{},
+		session.Atlas{}, session.AtlasDoorway{},
+	} {
+		for _, field := range fieldsOf(shape) {
+			s.NotEqual("Room", field, "%T still names a room", shape)
+			s.NotEqual("FromRoom", field, "%T still names a room", shape)
+			s.NotEqual("ToRoom", field, "%T still names a room", shape)
+		}
+	}
+
+	// And the composition's own room-shaped types are not reachable from here
+	// either, which the boundary test already guards — this only states the
+	// half that is about rooms specifically.
+	s.NotContains(fieldsOf(session.Member{}), "Room")
+	s.Contains(fieldsOf(session.Member{}), "Position")
+}

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -156,6 +156,25 @@ func (s *OneMapSuite) TestAWalkStillDoesNotCrossADoorway() {
 	s.ErrorIs(err, session.ErrBadPosition, "the far side of a doorway is another room, and a walk is one room")
 }
 
+// TestARefusalIsDescribedInTheCallersOwnCoordinates.
+//
+// A broken path is reported with the cell the caller wrote, at both ends. The
+// message used to mix frames — the "from" was room-local and the "to" was
+// absolute — which in this world differs by (40,20) and would send whoever
+// read it looking for a cell nobody named.
+func (s *OneMapSuite) TestARefusalIsDescribedInTheCallersOwnCoordinates() {
+	// Alice stands at (41,21). A jump three cells away is not a walk.
+	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 44, Y: 24}},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, session.ErrBrokenPath)
+
+	s.Contains(err.Error(), "from (41,21)", "the cell she stands on, on the map")
+	s.Contains(err.Error(), "to (44,24)", "the cell the caller asked for, as the caller wrote it")
+}
+
 // TestAWalkIntoTheVoidIsRefused: a cell no room owns is not a step, and the
 // refusal names the same sentinel as the doorway case — both are "that is not
 // a cell you can walk to from here".

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -49,8 +49,8 @@ type StoryInput struct {
 	FromSeq uint64
 }
 
-// Atlas returns the session's static world map: every room's absolute
-// footprint and every doorway's kissing pair.
+// Atlas returns the session's static world map: one set of cells, the ones
+// that block sight, the walls between them, and every doorway's kissing pair.
 //
 // Construction truth — unchanged by movement, joins, exits or endings — so a
 // host should fetch it once per session rather than per frame.

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -92,7 +92,7 @@ func (m *Manager) Status(ctx context.Context, in *StatusInput) (*Status, error) 
 		return nil, fmt.Errorf("status: %w", err)
 	}
 
-	return projectStatus(status), nil
+	return projectStatus(enc, status), nil
 }
 
 // View returns what one member currently perceives.

--- a/rulebooks/dnd5e/session/spawn_test.go
+++ b/rulebooks/dnd5e/session/spawn_test.go
@@ -55,7 +55,7 @@ func (s *SpawnTestSuite) SetupSubTest() { s.SetupTest() }
 
 func (s *SpawnTestSuite) spawn(id, ref string, at spatial.Position) (*session.SpawnOutput, error) {
 	return s.mgr.Spawn(context.Background(), &session.SpawnInput{
-		Session: "sess", ID: id, Ref: ref, Room: "vault", Position: at,
+		Session: "sess", ID: id, Ref: ref, Position: at,
 	})
 }
 
@@ -187,15 +187,17 @@ func (s *SpawnTestSuite) TestTheSpawnedSheetSurvivesAProcessRestart() {
 // apply to the other — so this asserts a placement rule through BOTH doors and
 // fails if either stops enforcing it.
 func (s *SpawnTestSuite) TestBothEntryVerbsEnforceTheSamePlacementRules() {
-	nowhere := "no-such-room"
+	// A cell in the void. Naming a room that does not exist used to be the way
+	// to be refused; on one map the equivalent is a cell no room owns, which
+	// is a better test anyway — it is the mistake a real caller can actually
+	// make, since a client works in coordinates rather than room ids.
+	nowhere := spatial.Position{X: 900, Y: 900}
 
 	_, joinErr := s.mgr.Join(context.Background(), &session.JoinInput{
-		Session: "sess", Member: "bob",
-		Room: nowhere, Position: spatial.Position{X: 0, Y: 0},
+		Session: "sess", Member: "bob", Position: nowhere,
 	})
 	_, spawnErr := s.mgr.Spawn(context.Background(), &session.SpawnInput{
-		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
-		Room: nowhere, Position: spatial.Position{X: 0, Y: 0},
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(), Position: nowhere,
 	})
 
 	// The SENTINEL, not merely "an error". A Spawn with its own placement
@@ -262,11 +264,11 @@ func (s *SpawnTestSuite) TestADuplicateArrivalIsRejectedButMisreported() {
 	s.Len(s.storedNPCs(), 1, "and the refused duplicate stored no second sheet")
 
 	_, joinErr := s.mgr.Join(context.Background(), &session.JoinInput{
-		Session: "sess", Member: "bob", Room: "vault", Position: spatial.Position{X: 2, Y: 0},
+		Session: "sess", Member: "bob", Position: spatial.Position{X: 8, Y: 0},
 	})
 	s.Require().NoError(joinErr)
 	_, joinErr = s.mgr.Join(context.Background(), &session.JoinInput{
-		Session: "sess", Member: "bob", Room: "vault", Position: spatial.Position{X: 3, Y: 0},
+		Session: "sess", Member: "bob", Position: spatial.Position{X: 8, Y: 1},
 	})
 	s.Require().Error(joinErr, "and the same holds through the other door")
 	s.ErrorIs(joinErr, session.ErrNoMember)

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -178,10 +178,8 @@ type MemberOutcome struct {
 	// ID is the member's identifier.
 	ID string `json:"id"`
 
-	// Room is the room they were in.
-	Room string `json:"room"`
-
-	// Position is where they stood within it.
+	// Position is the cell they stood on when it ended, in dungeon-absolute
+	// space — the same frame every other position on this seam speaks.
 	Position spatial.Position `json:"position"`
 }
 
@@ -407,8 +405,13 @@ type Member struct {
 	// Kind categorises the member.
 	Kind MemberKind `json:"kind"`
 
-	// Room is the room the member currently occupies.
-	Room string `json:"room"`
+	// Position is the cell they stand on, in dungeon-absolute space.
+	//
+	// It replaced a room id, and the swap is the reshape in one field: which
+	// chamber somebody is in is the composition's own decomposition, while
+	// where they STAND is the thing a client renders, a rule measures, and
+	// another member walks toward.
+	Position spatial.Position `json:"position"`
 }
 
 // CharacterState is what a loaded character reports about itself.

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -18,7 +18,7 @@ import "github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 // Everything here is also proto-shaped by construction: flat structs, string
 // enums, no interfaces, nothing whose meaning varies by another field's value.
 
-// GridKind names a room's coordinate family.
+// GridKind names the map's coordinate family.
 //
 // A string rather than a mirror of spatial's iota. The composition already
 // persists grid this way for the same reason: an iota is an in-process

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -329,7 +329,11 @@ func place(
 	// speaks one map, and a room id never has to appear in an input.
 	located, err := scope.enc.Locate(&encounter.LocateInput{Position: at})
 	if err != nil {
-		return nil, fmt.Errorf("no room owns %v: %w", at, ErrBadPosition)
+		// Both wrapped: ErrBadPosition is what a caller matches on, and the
+		// composition's own error keeps WHY — owned by no room, off the grid,
+		// or not an integral cell — which is the difference between a typo
+		// and a fractional coordinate.
+		return nil, fmt.Errorf("no room owns %v: %w: %w", at, ErrBadPosition, err)
 	}
 
 	placed, err := scope.enc.Join(&encounter.JoinInput{

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -25,10 +25,10 @@ type JoinInput struct {
 	// produce it. A "dnd5e:characters:..." ref would claim otherwise.
 	Member string
 
-	// Room is the room to place them in.
-	Room string
-
-	// Position is where within that room.
+	// Position is the cell to place them on, in dungeon-absolute space —
+	// the same coordinates the Atlas and every other verb speak. Which room
+	// owns that cell is worked out here; a caller places somebody on the map,
+	// not in a chamber (rpg-project#227).
 	Position spatial.Position
 }
 
@@ -82,10 +82,8 @@ type SpawnInput struct {
 	// rejected rather than guessed at.
 	Ref string
 
-	// Room is the room to place it in.
-	Room string
-
-	// Position is where within that room.
+	// Position is the cell to place it on, in dungeon-absolute space. See
+	// JoinInput.Position.
 	Position spatial.Position
 }
 
@@ -208,7 +206,7 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 		return nil, fmt.Errorf("join: %w", err)
 	}
 
-	placed, err := place(scope, in.Member, KindPlayer, in.Room, in.Position)
+	placed, err := place(scope, in.Member, KindPlayer, in.Position)
 	if err != nil {
 		return nil, fmt.Errorf("join: %w", err)
 	}
@@ -223,7 +221,7 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 		Character:  projectCharacter(ch),
 		Discovered: projectDiscoveries(placed.IntelDeltas),
 		Seq:        placed.Seq,
-		Outcome:    projectOutcome(placed.Outcome),
+		Outcome:    projectOutcome(scope.enc, placed.Outcome),
 		Formed:     projectFormed(placed.Formed),
 		Saved:      report,
 		Delivery:   delivery,
@@ -286,7 +284,7 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 		return nil, fmt.Errorf("spawn: %w", err)
 	}
 
-	placed, err := place(scope, in.ID, KindMonster, in.Room, in.Position)
+	placed, err := place(scope, in.ID, KindMonster, in.Position)
 	if err != nil {
 		return nil, fmt.Errorf("spawn: %w", err)
 	}
@@ -304,7 +302,7 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 		NPC:        projectMonster(sheet),
 		Discovered: projectDiscoveries(placed.IntelDeltas),
 		Seq:        placed.Seq,
-		Outcome:    projectOutcome(placed.Outcome),
+		Outcome:    projectOutcome(scope.enc, placed.Outcome),
 		Formed:     projectFormed(placed.Formed),
 		Saved:      report,
 		Delivery:   delivery,
@@ -323,14 +321,23 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 // Setup and Load were made to share one validator so that a single mutation
 // kills the pins on both. Same reasoning, one layer up.
 func place(
-	scope *writeScope, id string, kind MemberKind, room string, at spatial.Position,
+	scope *writeScope, id string, kind MemberKind, at spatial.Position,
 ) (*encounter.JoinOutput, error) {
+	// The one place a cell becomes a room. The composition's verbs are
+	// room-local by law, so somebody has to resolve an absolute cell to the
+	// chamber that owns it; doing it HERE means every caller of this seam
+	// speaks one map, and a room id never has to appear in an input.
+	located, err := scope.enc.Locate(&encounter.LocateInput{Position: at})
+	if err != nil {
+		return nil, fmt.Errorf("no room owns %v: %w", at, ErrBadPosition)
+	}
+
 	placed, err := scope.enc.Join(&encounter.JoinInput{
 		Member: encounter.MemberInput{
 			ID:       encounter.MemberID(id),
 			Kind:     encounter.MemberKind(kind),
-			Room:     room,
-			Position: at,
+			Room:     located.Room,
+			Position: located.Position,
 		},
 	})
 	if err != nil {
@@ -369,10 +376,10 @@ func (m *Manager) Exit(ctx context.Context, in *ExitInput) (*ExitOutput, error) 
 	}
 
 	return &ExitOutput{
-		Outcome:  projectMemberOutcome(left.Outcome),
+		Outcome:  projectMemberOutcome(scope.enc, left.Outcome),
 		Carry:    projectSightings(left.Carry),
 		Seq:      left.Seq,
-		Closed:   projectOutcome(left.Closed),
+		Closed:   projectOutcome(scope.enc, left.Closed),
 		Saved:    report,
 		Delivery: delivery,
 	}, nil
@@ -403,7 +410,7 @@ func (m *Manager) End(ctx context.Context, in *EndInput) (*EndOutput, error) {
 		return nil, fmt.Errorf("end: %w", err)
 	}
 
-	outcome := projectOutcome(&ended.Outcome)
+	outcome := projectOutcome(scope.enc, &ended.Outcome)
 	return &EndOutput{Outcome: *outcome, Saved: report, Delivery: delivery}, nil
 }
 

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -185,9 +185,9 @@ type EndOutput struct {
 // somewhere with no visible connection to the join that caused it.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
-// ErrNoEncounter, ErrNoCharacter, ErrBadCharacter, ErrClosed if the encounter
-// has already ended, or
-// ErrSaveFailed with a populated report.
+// ErrNoEncounter, ErrNoCharacter, ErrBadCharacter, ErrBadPosition if no room
+// owns the cell they were placed on, ErrClosed if the encounter has already
+// ended, or ErrSaveFailed with a populated report.
 func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("join: %w", ErrNilInput)
@@ -245,9 +245,9 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 // simply does not act on its own.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoRef, ErrBadRef,
-// ErrNoLoader, ErrUnknownContent, ErrNoSession, ErrNoEncounter, ErrClosed,
-// or ErrSaveFailed with a populated
-// report.
+// ErrNoLoader, ErrUnknownContent, ErrNoSession, ErrNoEncounter,
+// ErrBadPosition if no room owns the cell, ErrClosed, or ErrSaveFailed with a
+// populated report.
 func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("spawn: %w", ErrNilInput)

--- a/rulebooks/dnd5e/session/write_test.go
+++ b/rulebooks/dnd5e/session/write_test.go
@@ -52,12 +52,15 @@ func (s *WriteTestSuite) TestJoinPersistsTheNewMember() {
 
 	out, err := s.mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.Require().NoError(err)
 	s.Equal("bob", out.Member.ID)
 	s.Equal(session.KindPlayer, out.Member.Kind)
-	s.Equal("vault", out.Member.Room)
+	// The cell he was placed on, reported back on the map rather than as a
+	// room he would have to look up. The vault is anchored at (6,0), so this
+	// number only exists if the projection happened.
+	s.Equal(spatial.Position{X: 6, Y: 0}, out.Member.Position)
 	s.Equal([]string{"encounter:world"}, out.Saved.Written)
 
 	// The proof: a fresh read sees him.
@@ -74,7 +77,7 @@ func (s *WriteTestSuite) TestJoinPersistsTheNewMember() {
 func (s *WriteTestSuite) TestJoinReportsWhoNoticed() {
 	out, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Room: "corridor", Position: spatial.Position{X: 1, Y: 0},
+		Position: spatial.Position{X: 1, Y: 0},
 	})
 	s.Require().NoError(err)
 	s.NotEmpty(out.Discovered,
@@ -88,7 +91,7 @@ func (s *WriteTestSuite) TestExitCarriesKnowledgeOut() {
 	out, err := s.mgr.Exit(ctx, &session.ExitInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
 	s.Equal("alice", out.Outcome.ID)
-	s.Equal("corridor", out.Outcome.Room)
+	s.Equal(spatial.Position{X: 0, Y: 0}, out.Outcome.Position, "where she stood when she left")
 	s.Equal([]string{"encounter:world"}, out.Saved.Written)
 
 	// And she is really gone, not merely reported gone.
@@ -123,7 +126,7 @@ func (s *WriteTestSuite) TestClosedEncounterRefusesChanges() {
 
 	_, err = s.mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.ErrorIs(err, session.ErrClosed)
 
@@ -210,7 +213,7 @@ func (s *WriteTestSuite) TestFailedSaveIsReportedNotSwallowed() {
 
 	out, err := mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrSaveFailed)
@@ -236,13 +239,13 @@ func (s *WriteTestSuite) TestStaleWorldIsNotResurrected() {
 
 	_, err = s.mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Room: "vault", Position: spatial.Position{X: 0, Y: 0},
+		Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.Require().NoError(err)
 
 	_, err = other.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "carol",
-		Room: "vault", Position: spatial.Position{X: 1, Y: 0},
+		Position: spatial.Position{X: 7, Y: 0},
 	})
 	s.Require().NoError(err)
 
@@ -257,7 +260,7 @@ func (s *WriteTestSuite) TestStaleWorldIsNotResurrected() {
 // TestJoinOnUnknownSession pins the load failures reach the write verbs too.
 func (s *WriteTestSuite) TestJoinOnUnknownSession() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
-		Session: "nope", Member: "bob", Room: "vault",
+		Session: "nope", Member: "bob", Position: spatial.Position{X: 6, Y: 0},
 	})
 	s.ErrorIs(err, session.ErrNoSession)
 }


### PR DESCRIPTION
Closes #1046. Fourth slice of the seam reshape (rpg-project#227), and the seam's typed
surface catching up to the composition.

| before | after |
|---|---|
| `JoinInput{Member, Room, Position}` | `JoinInput{Member, Position}` |
| `SpawnInput{ID, Ref, Room, Position}` | `SpawnInput{ID, Ref, Position}` |
| `MoveInput.Path` room-local | absolute |
| `MoveOutput.Steps[].Position` room-local, no room | absolute |
| `Member{ID, Kind, Room}` | `Member{ID, Kind, Position}` |
| `MemberOutcome{ID, Room, Position}` | `MemberOutcome{ID, Position}` |

Bumps `encounter` to v0.10.0, which is what makes it possible: placement reads come back
absolute, so the seam stops doing arithmetic it should never have owned. Resolving a cell
to a room happens in exactly two places — `place()` for the entry verbs and `localTo()`
for the walk — both by asking the composition's `Locate`, so a room id never appears in an
input and this package still never learns what an origin is.

`whereIs` also stops serializing the whole aggregate to read two floats. Its doc said
"when #933 lands this becomes a direct lookup and the snapshot goes away" — #933 landed in
encounter v0.10.0, so it has, and the doc now says so instead of predicting it.

## The deliberate non-change

**A walk still does not cross a doorway.** Absolute coordinates make a crossing
*expressible* for the first time — the far side is simply the next cell along — and it is
still refused, with `ErrBadPosition`. `TestAWalkStillDoesNotCrossADoorway` pins that, so
the slice which makes a crossing an ordinary step has to come here and change a test ON
PURPOSE rather than inherit the behavior because a dialect changed underneath it.

`StartSessionInput.World` also stays room-shaped (F5): authoring is construction data, and
the one-map rule governs what a session sees while it plays.

## Forks and leans this rests on

- **F5 — inbound authoring stays room-shaped**, per lean, stated in the docs and in the
  structural pin's own comment so the asymmetry is not read as an oversight.
- The room ids dropped from `Member` and `MemberOutcome` are recorded as justified
  omissions in the converter's completeness check, which now also covers `Member` — it did
  not before, so the pair is new coverage rather than a weakened guard.

## Verification

- Full `session` module suite green, workbench included; `gofmt` clean; `go mod tidy` a
  no-op; no lint findings in any file this PR touches.
- **New pins anchor their world at (40,20)**, so local and absolute are different numbers
  everywhere. That is not decoration: every existing move and join test in this package
  passes unchanged through this reshape, because their rooms sit at (0,0) and cannot tell
  the two frames apart.
- The headline pin follows ONE cell through four surfaces — the join's report, two walked
  steps, and the ending's placement list — because a seam that projected in some places
  and not others satisfies any single assertion.
- **Sensitivity checked by mutation.** Drop the same-room rule in `localTo` → the doorway
  pin fails. Report `moved.Moved.To` unprojected → the join-to-outcome pin fails.
- One fixture correction worth noting: a bulk rewrite of join sites also caught the
  authored-world builder in `events_test.go`, which must keep its room ids. Restored, and
  the subsequent edits target `session.JoinInput`/`SpawnInput` literals specifically.

— asset-pipeline agent, on behalf of KirkDiggler
