### PR TITLE
feat(session)!: a walk crosses a doorway, and Traverse retires (#1048)

### DIFF
--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -265,15 +265,19 @@ func drive(out *bytes.Buffer) error {
 	fmt.Fprintf(out, "   delivered %d events\n", walked.Delivery.Events)
 
 	fmt.Fprintln(out, "\n== and through it, into something waiting ==")
-	crossed, err := mgr.Traverse(ctx, &session.TraverseInput{
-		Session: "crypt-run", Member: "alice", Connection: "gate",
+	// A doorway is a step. The antechamber's threshold is (5,1) and the
+	// vault's is (6,1): one cell apart on the map, so this is a one-step walk
+	// that happens to change rooms.
+	crossed, err := mgr.Move(ctx, &session.MoveInput{
+		Session: "crypt-run", Member: "alice",
+		Path: []spatial.Position{{X: 6, Y: 1}},
 	})
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "   %s (%v,%v) → %s (%v,%v)\n",
-		crossed.FromRoom, crossed.From.X, crossed.From.Y,
-		crossed.ToRoom, crossed.To.X, crossed.To.Y)
+	for _, step := range crossed.Steps {
+		fmt.Fprintf(out, "   alice steps through to (%v,%v)\n", step.Position.X, step.Position.Y)
+	}
 
 	// The doorway is where the fight starts, and the host is told in the same
 	// response that told it about the crossing. There is no window to answer

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
@@ -31,8 +31,8 @@ func TestWorkbenchRuns(t *testing.T) {
 		// names the rooms on either side (rpg-toolkit#1042).
 		"gate: (5,1) kisses (6,1)",
 		"one square map: 72 cells",
-		"alice enters (5,1)",              // the walk reached the doorway
-		"antechamber (5,1) → vault (0,1)", // and crossed it
+		"alice enters (5,1)",           // the walk reached the doorway
+		"alice steps through to (6,1)", // and crossed it — a doorway is a step
 
 		// A fight that starts itself, end to end. Each of these is a different
 		// claim, and any one regressing would leave the others still true:

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -149,8 +149,31 @@ var (
 	// leaves the party somewhere nobody chose.
 	ErrBrokenPath = errors.New("path is not a walk")
 
-	// ErrNoConnection is returned when a verb names a connection the encounter
-	// does not have.
+	// ErrNoCrossing is returned by Move when a step lands in another room and
+	// no doorway joins it to the cell the walker is standing on.
+	//
+	// Distinct from ErrBrokenPath, which means the two cells are not adjacent
+	// at all. These are different author mistakes: a broken path is arithmetic
+	// a caller can check against the map it already has, while two rooms may
+	// TOUCH without a door between them (W2 permits it), so a pair of cells can
+	// be perfectly adjacent and still have nothing to walk through. That second
+	// case is invisible to a client reading only the Atlas's cells — it is in
+	// the doorway list or it is nowhere — which is exactly why it earns a
+	// sentinel of its own rather than being folded into "not a walk".
+	//
+	// Distinct from ErrBadPosition too: "there is no cell there" and "there is
+	// no way there from here" send whoever reads them to different places.
+	ErrNoCrossing = errors.New("no doorway joins those cells")
+
+	// ErrNoConnection is the translation of a composition-side refusal to cross
+	// a doorway.
+	//
+	// No verb takes a connection id any more (rpg-toolkit#1048): a caller names
+	// cells, and this package finds the doorway joining them in the Atlas. So
+	// this can no longer be a caller's mistake — if it appears, this package
+	// derived a crossing the composition then rejected, which is a defect here
+	// rather than in the call. It stays as the translation of record so that an
+	// inner sentinel never crosses the boundary (S2).
 	ErrNoConnection = errors.New("no such connection")
 
 	// ErrBadPosition is returned when a target cell is out of bounds, or is

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -304,17 +304,21 @@ type resolvedWalk struct {
 // walk — and, worse, left two places free to disagree about which room a cell
 // belongs to.
 //
-// Adjacency is checked with the room's own grid rather than a hand-rolled
-// distance, because the two families disagree about what "one step" means and
-// substituting one for the other is a real, previously-shipped defect class:
-// Chebyshev distance on axial hex coordinates agrees with cube distance
-// everywhere except the diagonals, so a wrong formula passes almost every
-// fixture.
+// Adjacency is checked with a grid of the field's own family rather than a
+// hand-rolled distance, because the two families disagree about what "one
+// step" means and substituting one for the other is a real, previously-shipped
+// defect class: Chebyshev distance on axial hex coordinates agrees with cube
+// distance everywhere except the diagonals, so a wrong formula passes almost
+// every fixture. One grid answers for the whole path, including the step that
+// changes rooms — a field has a single family by law (W1), and adjacency in
+// both families survives translation, so an absolute pair is adjacent or not
+// regardless of which room's grid is asked.
 //
-// The restriction to one room is imposed now rather than later on purpose.
-// Loosening a rule is a compatible change; tightening one breaks every host
-// that was relying on the looser behaviour. If a walk should ever cross a
-// doorway, that can be granted; it could not be taken away.
+// A step MAY leave the room the walker is in, and that is the only way it may
+// leave: through a doorway joining the cell they stand on to the one they are
+// stepping to (rpg-toolkit#1048). Adjacency alone is not permission — W2 lets
+// two rooms touch without a door — so a cross-room step with no doorway is
+// refused with ErrNoCrossing, distinctly from a path that is not a walk at all.
 func resolveWalk(
 	enc *encounter.Encounter, member encounter.MemberID, path []spatial.Position,
 ) (resolvedWalk, error) {
@@ -323,16 +327,16 @@ func resolveWalk(
 		return resolvedWalk{}, err
 	}
 
-	grid, err := gridFor(enc, room)
+	// The map, fetched ONCE for the whole walk and used for both things this
+	// function needs it for: the grid to test adjacency with, and the doorway
+	// list to recognise a crossing. Building it twice is what the first
+	// version of this did, by asking gridFor to fetch its own.
+	atlas, err := enc.Atlas()
 	if err != nil {
 		return resolvedWalk{}, err
 	}
 
-	// The map, fetched once for the whole walk. gridFor already pays for it,
-	// so the doorway list is free — which is the practical half of why this
-	// package finds crossings here rather than asking the composition for a
-	// step verb. The other half is in resolveWalk's own doc.
-	atlas, err := enc.Atlas()
+	grid, err := gridFrom(atlas, room)
 	if err != nil {
 		return resolvedWalk{}, err
 	}
@@ -419,12 +423,13 @@ func whereIs(enc *encounter.Encounter, member encounter.MemberID) (string, spati
 	return "", spatial.Position{}, fmt.Errorf("%q: %w", member, ErrNoMember)
 }
 
-// gridFor builds a grid matching a room's family and span, for adjacency tests.
-func gridFor(enc *encounter.Encounter, roomID string) (spatial.Grid, error) {
-	atlas, err := enc.Atlas()
-	if err != nil {
-		return nil, err
-	}
+// gridFrom builds a grid matching a room's family and span, for adjacency
+// tests, from a map the caller already has.
+//
+// Takes the Atlas rather than fetching one: it is the caller that knows
+// whether it needs the map for anything else, and in resolveWalk's case it
+// does — the doorway list comes off the same fetch.
+func gridFrom(atlas encounter.Atlas, roomID string) (spatial.Grid, error) {
 	for _, room := range atlas.Rooms {
 		if room.ID != roomID {
 			continue

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -80,51 +82,12 @@ type MoveOutput struct {
 	Delivery DeliveryReport `json:"delivery"`
 }
 
-// TraverseInput moves a member through a connection into an adjoining room.
-type TraverseInput struct {
-	// Session is the session to act in.
-	Session string
-
-	// Member is the member crossing.
-	Member string
-
-	// Connection is the connection to cross.
-	Connection string
-}
-
-// TraverseOutput reports the crossing.
-type TraverseOutput struct {
-	// FromRoom is the room departed.
-	FromRoom string `json:"from_room"`
-
-	// From is where the member stood before crossing.
-	From spatial.Position `json:"from"`
-
-	// ToRoom is the room arrived in.
-	ToRoom string `json:"to_room"`
-
-	// To is where the member arrived.
-	To spatial.Position `json:"to"`
-
-	// Discovered is what changed in each observer's perception.
-	Discovered map[string]Discovery `json:"discovered,omitempty"`
-
-	// Seq is the story sequence of the recorded crossing.
-	Seq uint64 `json:"seq"`
-
-	// Outcome is present if an ending fired on arrival.
-	Outcome *Outcome `json:"outcome,omitempty"`
-
-	// Formed is present if walking through the doorway put the crosser in
-	// sight of the other side and a fight started.
-	Formed *Formed `json:"formed,omitempty"`
-
-	// Saved names what was persisted.
-	Saved SaveReport `json:"saved"`
-
-	// Delivery names what reached the event stream.
-	Delivery DeliveryReport `json:"delivery"`
-}
+// There were TraverseInput and TraverseOutput here, and a Traverse verb that
+// took a connection id and crossed it. All three retired with
+// rpg-toolkit#1048: a doorway's two cells are adjacent on the map, so crossing
+// one is a step, and Move takes steps. What the verb reported that a step does
+// not — which rooms were left and entered — was the room dialect this seam
+// stopped speaking two slices ago.
 
 // Move walks a member along a path, one cell at a time.
 //
@@ -190,58 +153,6 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 	}, nil
 }
 
-// Traverse moves a member through a connection into the adjoining room.
-//
-// Under world anchoring the two endpoint cells are adjacent in absolute space,
-// so a crossing is one ordinary step of the same size as any other — which is
-// why a client rendering the result cannot tell a doorway from a corridor.
-//
-// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
-// ErrNoEncounter, ErrNoMember, ErrNoConnection, ErrClosed, or ErrSaveFailed
-// with a populated report.
-func (m *Manager) Traverse(ctx context.Context, in *TraverseInput) (*TraverseOutput, error) {
-	if in == nil {
-		return nil, fmt.Errorf("traverse: %w", ErrNilInput)
-	}
-	if in.Member == "" {
-		return nil, fmt.Errorf("traverse: %w", ErrNoMemberID)
-	}
-	if in.Connection == "" {
-		return nil, fmt.Errorf("traverse: %w", ErrNoConnection)
-	}
-
-	scope, err := m.openForWrite(ctx, in.Session)
-	if err != nil {
-		return nil, fmt.Errorf("traverse: %w", err)
-	}
-
-	crossed, err := scope.enc.Traverse(&encounter.TraverseInput{
-		Member:     encounter.MemberID(in.Member),
-		Connection: in.Connection,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("traverse: %w", translate(err))
-	}
-
-	report, delivery, err := m.commit(ctx, scope)
-	if err != nil {
-		return nil, fmt.Errorf("traverse: %w", err)
-	}
-
-	return &TraverseOutput{
-		FromRoom:   crossed.Traversed.FromRoom,
-		From:       crossed.Traversed.From,
-		ToRoom:     crossed.Traversed.ToRoom,
-		To:         crossed.Traversed.To,
-		Discovered: projectDiscoveries(crossed.IntelDeltas),
-		Seq:        crossed.Seq,
-		Outcome:    projectOutcome(scope.enc, crossed.Outcome),
-		Formed:     projectFormed(crossed.Formed),
-		Saved:      report,
-		Delivery:   delivery,
-	}, nil
-}
-
 // walkResult is what one run of the walk produced.
 type walkResult struct {
 	steps      []Step
@@ -270,11 +181,8 @@ type walkResult struct {
 func (m *Manager) runWalk(scope *writeScope, member string, walk resolvedWalk) (*walkResult, error) {
 	res := &walkResult{discovered: map[string]Discovery{}}
 
-	for i, local := range walk.steps {
-		moved, err := scope.enc.Move(&encounter.MoveInput{
-			Member: encounter.MemberID(member),
-			To:     local,
-		})
+	for i, step := range walk.steps {
+		moved, err := m.takeStep(scope, member, step)
 		if err != nil {
 			// Nothing is saved on a mid-walk rejection. The member has really
 			// moved in memory for the steps already taken, but that encounter is
@@ -286,7 +194,7 @@ func (m *Manager) runWalk(scope *writeScope, member string, walk resolvedWalk) (
 		// not echoed from the input. A step that landed somewhere other than
 		// where it was aimed is a thing worth being able to see.
 		res.steps = append(res.steps, Step{
-			Position: onMap(scope.enc, walk.room, moved.Moved.To),
+			Position: onMap(scope.enc, step.room, moved.to),
 			Seq:      moved.Seq,
 		})
 		mergeDiscoveries(res.discovered, projectDiscoveries(moved.IntelDeltas))
@@ -308,6 +216,54 @@ func (m *Manager) runWalk(scope *writeScope, member string, walk resolvedWalk) (
 	return res, nil
 }
 
+// stepResult is what one step produced, whichever mechanism carried it.
+//
+// The two composition verbs report the same news in different shapes, and this
+// is the small amount of translation that lets the walk loop treat a crossing
+// exactly like a step: same stop-on-ending, same stop-on-fight, same discovery
+// merge, same beat sequence.
+type stepResult struct {
+	to          spatial.Position
+	Seq         uint64
+	IntelDeltas map[encounter.MemberID]*intel.SurveilOutput
+	Outcome     *encounter.Outcome
+	Formed      *encounter.FormedBubble
+}
+
+// takeStep executes one resolved step: a move within the room, or a crossing
+// through the doorway the step named.
+//
+// Which of the two it is was decided during resolution, where the map was
+// already in hand; this only carries it out. Both are ONE step of a walk and
+// neither is time — the composition advances no clock for either.
+func (m *Manager) takeStep(scope *writeScope, member string, step walkStep) (stepResult, error) {
+	if step.connection == "" {
+		moved, err := scope.enc.Move(&encounter.MoveInput{
+			Member: encounter.MemberID(member),
+			To:     step.local,
+		})
+		if err != nil {
+			return stepResult{}, err
+		}
+		return stepResult{
+			to: moved.Moved.To, Seq: moved.Seq, IntelDeltas: moved.IntelDeltas,
+			Outcome: moved.Outcome, Formed: moved.Formed,
+		}, nil
+	}
+
+	crossed, err := scope.enc.Traverse(&encounter.TraverseInput{
+		Member:     encounter.MemberID(member),
+		Connection: step.connection,
+	})
+	if err != nil {
+		return stepResult{}, err
+	}
+	return stepResult{
+		to: crossed.Traversed.To, Seq: crossed.Seq, IntelDeltas: crossed.IntelDeltas,
+		Outcome: crossed.Outcome, Formed: crossed.Formed,
+	}, nil
+}
+
 // projectFormed turns the composition's report of a started fight into the
 // SDK's own shape.
 func projectFormed(f *encounter.FormedBubble) *Formed {
@@ -324,11 +280,18 @@ func projectFormed(f *encounter.FormedBubble) *Formed {
 	return out
 }
 
-// resolvedWalk is a path as the composition takes it: the room being walked,
-// and the room-local cell for each step, in order.
+// walkStep is one resolved step of a path: where it lands in the composition's
+// own terms, and — when the step crosses a doorway — which doorway carries it.
+type walkStep struct {
+	room       string
+	local      spatial.Position
+	connection string // empty for an ordinary step within a room
+}
+
+// resolvedWalk is a path as the composition takes it: each step resolved to
+// the room it lands in and the cell within it, in order.
 type resolvedWalk struct {
-	room  string
-	steps []spatial.Position
+	steps []walkStep
 }
 
 // resolveWalk validates a path whole and resolves it ONCE.
@@ -365,26 +328,67 @@ func resolveWalk(
 		return resolvedWalk{}, err
 	}
 
-	// Both frames are tracked: the local one to ask the grid about adjacency,
-	// the absolute one to describe a refusal in the coordinates the caller
-	// actually wrote. A message that mixed them would send whoever reads it
-	// looking for a cell nobody named.
-	walk := resolvedWalk{room: room, steps: make([]spatial.Position, 0, len(path))}
-	previous, previousCell := from, onMap(enc, room, from)
+	// The map, fetched once for the whole walk. gridFor already pays for it,
+	// so the doorway list is free — which is the practical half of why this
+	// package finds crossings here rather than asking the composition for a
+	// step verb. The other half is in resolveWalk's own doc.
+	atlas, err := enc.Atlas()
+	if err != nil {
+		return resolvedWalk{}, err
+	}
+
+	walk := resolvedWalk{steps: make([]walkStep, 0, len(path))}
+	// Both frames are tracked: absolute to test adjacency and to describe a
+	// refusal in the coordinates the caller actually wrote, room-local because
+	// that is what the composition's verbs take.
+	here, hereRoom := onMap(enc, room, from), room
 
 	for i, cell := range path {
-		local, lerr := localTo(enc, room, cell)
-		if lerr != nil {
-			return resolvedWalk{}, fmt.Errorf("step %d of %d: %w", i+1, len(path), lerr)
-		}
-		if !grid.IsAdjacent(previous, local) {
+		if !grid.IsAdjacent(here, cell) {
 			return resolvedWalk{}, fmt.Errorf("step %d from (%v,%v) to (%v,%v): %w",
-				i+1, previousCell.X, previousCell.Y, cell.X, cell.Y, ErrBrokenPath)
+				i+1, here.X, here.Y, cell.X, cell.Y, ErrBrokenPath)
 		}
-		walk.steps = append(walk.steps, local)
-		previous, previousCell = local, cell
+
+		located, lerr := enc.Locate(&encounter.LocateInput{Position: cell})
+		if lerr != nil {
+			return resolvedWalk{}, fmt.Errorf("step %d of %d: no room owns (%v,%v): %w: %w",
+				i+1, len(path), cell.X, cell.Y, ErrBadPosition, lerr)
+		}
+
+		step := walkStep{room: located.Room, local: located.Position}
+		if located.Room != hereRoom {
+			// Another room: legal only through a doorway joining the cell the
+			// walker stands on to the one they are stepping to. Adjacency is
+			// not permission — W2 lets two rooms touch without a door between
+			// them, and that pair of cells is adjacent and unwalkable.
+			connection, ok := doorwayBetween(atlas, here, cell)
+			if !ok {
+				return resolvedWalk{}, fmt.Errorf(
+					"step %d from (%v,%v) to (%v,%v): %w",
+					i+1, here.X, here.Y, cell.X, cell.Y, ErrNoCrossing)
+			}
+			step.connection = connection
+		}
+
+		walk.steps = append(walk.steps, step)
+		here, hereRoom = cell, located.Room
 	}
 	return walk, nil
+}
+
+// doorwayBetween finds the doorway joining two cells, in either direction — a
+// doorway is crossable both ways.
+//
+// Reads the Atlas, which is where doorways live in absolute space: a pair of
+// adjacent cells and the connection that joins them. The composition holds the
+// same fact in its own room-shaped terms, and this is the projection of it.
+func doorwayBetween(atlas encounter.Atlas, from, to spatial.Position) (string, bool) {
+	for _, doorway := range atlas.Doorways {
+		if (doorway.FromCell == from && doorway.ToCell == to) || (doorway.ToCell == from && doorway.FromCell == to) {
+			return doorway.Connection, true
+		}
+	}
+	return "", false
 }
 
 // whereIs locates a member: which room owns them, and which cell within it.
@@ -413,30 +417,6 @@ func whereIs(enc *encounter.Encounter, member encounter.MemberID) (string, spati
 		return located.Room, located.Position, nil
 	}
 	return "", spatial.Position{}, fmt.Errorf("%q: %w", member, ErrNoMember)
-}
-
-// localTo resolves a map cell into the room-local cell the composition's verbs
-// take, refusing anything that is not in the given room.
-//
-// The refusal is the whole reason this is a named function rather than a call
-// to Locate. A walk is within one room, and after the reshape a caller CAN
-// write a path that leaves it — the coordinates no longer stop them. So the
-// rule that used to be enforced by the shape of the input has to be enforced
-// here instead, until the slice that makes a crossing an ordinary step.
-func localTo(enc *encounter.Encounter, room string, cell spatial.Position) (spatial.Position, error) {
-	located, err := enc.Locate(&encounter.LocateInput{Position: cell})
-	if err != nil {
-		// Both wrapped: the sentinel is what a caller matches on, and the
-		// composition's own error says WHICH way the cell was unusable —
-		// owned by nothing, off the grid, or not an integral cell.
-		return spatial.Position{}, fmt.Errorf(
-			"no room owns (%v,%v): %w: %w", cell.X, cell.Y, ErrBadPosition, err)
-	}
-	if located.Room != room {
-		return spatial.Position{}, fmt.Errorf(
-			"(%v,%v) is not in the room being walked: %w", cell.X, cell.Y, ErrBadPosition)
-	}
-	return located.Position, nil
 }
 
 // gridFor builds a grid matching a room's family and span, for adjacency tests.

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -252,46 +252,62 @@ func (s *MoveTestSuite) TestWalkPersists() {
 	s.Len(out.Steps, 1)
 }
 
-// TestTraverseCrossesTheDoorway pins the crossing and its projection.
-func (s *MoveTestSuite) TestTraverseCrossesTheDoorway() {
+// TestAWalkCrossesTheDoorway is what the two Traverse tests here became.
+//
+// hexWorld's gate joins corridor-local (2,0) — absolute (2,0), the corridor
+// being anchored at the origin — to vault-local (-3,0), absolute (3,0). One
+// Move walks alice to the threshold and through it, and the far side is just
+// the next cell in the path.
+func (s *MoveTestSuite) TestAWalkCrossesTheDoorway() {
 	ctx := context.Background()
 	_, err := s.mgr.StartSession(ctx, &session.StartSessionInput{
 		Session: "hex", Encounter: "hexworld", World: hexWorld(s.T()),
 	})
 	s.Require().NoError(err)
 
-	// Walk to the gate's own cell, then cross.
+	out, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "hex", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 0}, {X: 2, Y: 0}, {X: 3, Y: 0}},
+	})
+	s.Require().NoError(err, "the doorway is a step like any other")
+	s.Require().Len(out.Steps, 3, "two in the corridor, one through the gate")
+	s.Equal(spatial.Position{X: 3, Y: 0}, out.Steps[2].Position, "she is on the far side")
+	s.NotZero(out.Steps[2].Seq)
+}
+
+// TestAStepWithNoDoorwayIsRefused pins the sentinel that replaced
+// ErrNoConnection's role here.
+//
+// A caller can no longer name a connection, so "no such connection" is not a
+// mistake it can make. What it CAN do is name a cell in the next room with
+// nothing joining it to where the walker stands — and that has its own
+// refusal, because two rooms touching without a door is a thing W2 allows and
+// a client reading only the map's cells cannot see.
+func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
+	ctx := context.Background()
+	_, err := s.mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "hex", Encounter: "hexworld", World: hexWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	// Alice walks to the threshold itself.
 	_, err = s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
 		Path: []spatial.Position{{X: 1, Y: 0}, {X: 2, Y: 0}},
 	})
 	s.Require().NoError(err)
 
-	out, err := s.mgr.Traverse(ctx, &session.TraverseInput{
-		Session: "hex", Member: "alice", Connection: "gate",
-	})
-	s.Require().NoError(err)
-	s.Equal("corridor", out.FromRoom)
-	s.Equal("vault", out.ToRoom)
-	s.NotZero(out.Seq)
-}
-
-// TestTraverseRejectsUnknownConnection pins the sentinel translation.
-func (s *MoveTestSuite) TestTraverseRejectsUnknownConnection() {
-	ctx := context.Background()
-	_, err := s.mgr.StartSession(ctx, &session.StartSessionInput{
-		Session: "hex", Encounter: "hexworld", World: hexWorld(s.T()),
-	})
-	s.Require().NoError(err)
-
-	_, err = s.mgr.Traverse(ctx, &session.TraverseInput{
-		Session: "hex", Member: "alice", Connection: "not-a-door",
+	// (3,-1) is a vault cell and an axial neighbour of the threshold she is
+	// standing on — adjacent, in the next room, and joined to nothing. The
+	// doorway is at (3,0), one cell over.
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "hex", Member: "alice",
+		Path: []spatial.Position{{X: 3, Y: -1}},
 	})
 	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrNoConnection)
-
-	_, err = s.mgr.Traverse(ctx, &session.TraverseInput{Session: "hex", Member: "alice"})
-	s.ErrorIs(err, session.ErrNoConnection, "an empty connection is refused before loading")
+	s.ErrorIs(err, session.ErrNoCrossing)
+	s.NotErrorIs(err, session.ErrBrokenPath, "the cells ARE adjacent — that is the point")
+	s.NotErrorIs(err, session.ErrBadPosition, "and the cell exists; there is just no way through")
 }
 
 func TestMoveSuite(t *testing.T) {

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -61,6 +61,11 @@ func offsetWorld(t fataler) *encounter.EncounterData {
 			// report is exercised in the same scene.
 			{Key: "stairs", Trigger: encounter.TriggerReachedPosition{
 				Room: "hall", Position: spatial.Position{X: 4, Y: 1}}},
+			// And one on the FAR SIDE of the doorway, for the pin that a
+			// crossing is an ordinary step: an ending there must fire as the
+			// crossing lands, inside the same Move.
+			{Key: "beyond", Trigger: encounter.TriggerReachedPosition{
+				Room: "annex", Position: spatial.Position{X: 0, Y: 2}}},
 		},
 		Retention: encounter.RetentionUnbounded,
 	})
@@ -129,31 +134,62 @@ func (s *OneMapSuite) TestAJoinIsAnsweredInTheSameCellItWasAskedFor() {
 	s.Equal(spatial.Position{X: 41, Y: 21}, placements["alice"], "alice never moved from her cell")
 }
 
-// TestAWalkStillDoesNotCrossADoorway is the deliberate NON-change, pinned so
-// that the slice which makes a crossing an ordinary step has to come here and
-// change a test on purpose.
+// TestAWalkCrossesTheDoorway is what four slices of reshaping were for, and it
+// replaces the pin that used to say the opposite.
 //
-// Absolute coordinates make the crossing EXPRESSIBLE for the first time — the
-// far side of the doorway is simply the next cell along — and it is still
-// refused. That is the difference between changing a dialect and changing a
-// rule, and only one of them is happening in this slice.
-func (s *OneMapSuite) TestAWalkStillDoesNotCrossADoorway() {
-	ctx := context.Background()
-
-	// Alice walks to the threshold, which is allowed…
-	_, err := s.mgr.Move(ctx, &session.MoveInput{
+// TestAWalkStillDoesNotCrossADoorway stood here through #1046, refusing this
+// exact path so that the change would have to be made ON PURPOSE rather than
+// inherited when the coordinates stopped preventing it. This is that purpose:
+// one Move call, out of the hall, through the gate, into the annex.
+func (s *OneMapSuite) TestAWalkCrossesTheDoorway() {
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 42, Y: 21}, {X: 43, Y: 22}, {X: 44, Y: 22}, {X: 45, Y: 22}},
+		Path: []spatial.Position{
+			{X: 42, Y: 22}, {X: 43, Y: 22}, {X: 44, Y: 22}, {X: 45, Y: 22}, // the hall
+			{X: 46, Y: 22}, // through the doorway
+		},
 	})
-	s.Require().NoError(err, "the threshold is in her own room")
+	s.Require().NoError(err, "the doorway is a step like any other")
 
-	// …and then tries to step through it, which is not.
-	_, err = s.mgr.Move(ctx, &session.MoveInput{
-		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 46, Y: 22}},
+	s.Require().Len(out.Steps, 5)
+	s.Equal(spatial.Position{X: 45, Y: 22}, out.Steps[3].Position, "the threshold")
+	s.Equal(spatial.Position{X: 46, Y: 22}, out.Steps[4].Position, "the far side, in the annex")
+
+	// A crossing is a step, so an ending declared on the arrival cell fires as
+	// it lands — in THIS Move's own output, not on the next call.
+	s.Require().NotNil(out.Outcome, "the ending on the far side fired underfoot")
+	s.Equal("beyond", out.Outcome.Ending)
+}
+
+// TestACrossingReachesClientsAsACrossing: one map does not mean one narration.
+//
+// The step that changed rooms is still a distinguishable beat, so a client can
+// narrate a doorway differently from a corridor — which is the whole reason the
+// traversed event kind survives a reshape that removed rooms from everything
+// else a client sees.
+func (s *OneMapSuite) TestACrossingReachesClientsAsACrossing() {
+	stream := &fakeStream{}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: testCharacters(), Events: stream,
 	})
-	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrBadPosition, "the far side of a doorway is another room, and a walk is one room")
+	s.Require().NoError(err)
+
+	_, err = mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{
+			{X: 42, Y: 22}, {X: 43, Y: 22}, {X: 44, Y: 22}, {X: 45, Y: 22}, {X: 46, Y: 22},
+		},
+	})
+	s.Require().NoError(err)
+
+	kinds := map[session.EventKind]int{}
+	for _, e := range stream.published {
+		kinds[e.Kind]++
+	}
+	s.Positive(kinds[session.EventMoved], "the cells inside the hall are moves")
+	s.Positive(kinds[session.EventTraversed], "and the one through the gate is a crossing")
+	s.Zero(kinds[session.EventUnknown], "with nothing unnameable in between")
 }
 
 // TestARefusalIsDescribedInTheCallersOwnCoordinates.
@@ -179,12 +215,24 @@ func (s *OneMapSuite) TestARefusalIsDescribedInTheCallersOwnCoordinates() {
 // refusal names the same sentinel as the doorway case — both are "that is not
 // a cell you can walk to from here".
 func (s *OneMapSuite) TestAWalkIntoTheVoidIsRefused() {
-	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+	ctx := context.Background()
+
+	// To the hall's corner first: the void has to be ADJACENT for this to be
+	// the refusal under test. A cell far away is refused earlier, as a path
+	// that is not a walk, which is a different mistake and is checked first.
+	_, err := s.mgr.Move(ctx, &session.MoveInput{
 		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 900, Y: 900}},
+		Path: []spatial.Position{{X: 40, Y: 20}},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 39, Y: 19}},
 	})
 	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrBadPosition)
+	s.ErrorIs(err, session.ErrBadPosition, "no room owns that cell")
+	s.NotErrorIs(err, session.ErrNoCrossing, "and it is not a doorway problem — there is nothing there")
 }
 
 // TestNothingOnThePlaySurfaceNamesARoom checks the claim structurally rather

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -236,10 +236,15 @@ const (
 	// EventMoved reports that a member stepped to a new cell.
 	EventMoved EventKind = "moved"
 
-	// EventTraversed reports that a member crossed a connection into another
-	// room. Distinct from EventMoved even though both are one step in absolute
-	// space, because a client may want to narrate a doorway differently from a
-	// corridor.
+	// EventTraversed reports that a member's step carried them through a
+	// doorway.
+	//
+	// Distinct from EventMoved even though both are one step of the same size
+	// on the same map — and it stayed distinct through the reshape that took
+	// rooms off everything else a client sees, because ONE MAP DOES NOT MEAN
+	// ONE NARRATION. A client renders a doorway differently from a corridor,
+	// and the composition still knows which happened; collapsing them would
+	// make a client re-derive it from the geometry.
 	EventTraversed EventKind = "traversed"
 
 	// EventJoined reports that a member entered the encounter.


### PR DESCRIPTION
Closes #1048. Fifth slice of the seam reshape (rpg-project#227), and the one the previous
four were clearing the way for: **on one map, walking through a doorway is walking.**

Since #1046 a caller hands `Move` a path of dungeon-absolute cells, and W3 guarantees a
doorway's two endpoints are adjacent absolute cells. So the path was already well-formed;
it was only refused. Now it walks.

`resolveWalk` classifies each step while the map is already in hand — same room is a move,
another room is a crossing through the doorway joining those two cells, no doorway is a
refusal — and `takeStep` carries out whichever it turned out to be. The walk loop is
unchanged around it, which is the point: **a crossing is a step.** Stop-on-ending,
stop-on-fight, the per-step sight refresh, and the beat sequence all behave exactly as they
do inside a room, and a crossing costs no extra clock.

`Traverse`, `TraverseInput` and `TraverseOutput` are **deleted, not deprecated**. A verb
whose whole job was "cross this connection" has nothing to do once a step can do it, and
the connection id it took is a room-shaped identifier this seam stopped speaking two slices
ago.

## The three parked forks, resolved per lean

- **F3 — `EventTraversed` SURVIVES.** One map does not mean one narration: a client renders
  a doorway differently from a corridor, the composition still records a `traversed` beat,
  and `kindOf` has mapped it since #1039. `TestACrossingReachesClientsAsACrossing` pins that
  a single Move produces both kinds and nothing unknown. Its doc now says WHY it survived a
  reshape that took rooms off everything else a client sees.
- **F4 — a step between touching-but-unconnected rooms gets `ErrNoCrossing`**, its own
  sentinel. W2 lets two rooms touch without a door, so those cells are perfectly adjacent
  and unwalkable — an authoring mistake invisible to a client reading only the Atlas's
  cells, which is precisely why it should not be folded into "not a walk".
- **F7 — a cell no room owns refuses distinctly**, as `ErrBadPosition`. "There is no cell
  there" and "there is no way there from here" send whoever reads them to different places.

**Refusal ORDER turned out to matter and is deliberate:** not-a-walk first (arithmetic a
caller can check against the map it already has), then no-such-cell, then no-way-through.
That ordering makes `ErrBadPosition` mean the interesting case — an ADJACENT cell that no
room owns — and the void pin had to be rewritten to walk to the hall's corner first,
because a cell far away is refused earlier as a broken path.

## The step-verb question, answered: two implementations, deliberately

`stepTo` in the composition (from #1044) does the same "locate → move or cross" dispatch
this seam now needs, and sharing one implementation is normally the right call. Not here:

1. **W4 says absolute coordinates appear only in query outputs, never in a verb's own
   logic.** An exported composition `Step` taking an absolute cell would be the first verb
   to take one — a change to a stated law, which deserves to be made deliberately rather
   than as a side effect of a seam convenience.
2. **They are not two copies of a fact.** The seam reads `Atlas.Doorways` — the published,
   already-tested absolute projection — while Pump reads the composition's own connections.
   Both derive from the same construction data; the Atlas IS its projection.
3. **It is free.** `resolveWalk` fetches the Atlas once and uses it for both the adjacency
   grid and the doorway list, so recognising a crossing costs nothing extra per walk.
   (It was not free when this was first written — the map was built twice. Copilot caught
   the comment claiming otherwise; 5bc69e2 made the claim true.)
4. The genuinely shared part is a ten-line pair match.

If a third caller appears, or W4 is revisited, the exported step verb is the shape — and
that is a decision for whoever has the forcing case.

## Verification

- Full `session` suite green, workbench included; `gofmt` clean; `go mod tidy` a no-op; no
  lint findings in touched files. `localTo` went with the change (`resolveWalk` locates
  directly now) rather than lingering unused.
- `TestAWalkStillDoesNotCrossADoorway` is **replaced** by `TestAWalkCrossesTheDoorway`,
  which is what that pin existed for. The far-side ending fires as the crossing lands, in
  that Move's own output.
- **Sensitivity checked by mutation — and the first mutant was wrong in a way worth
  recording.** Changing `if !ok` to `if ok || true` made EVERY cross-room step refuse, so
  the three crossing pins failed and the refusal pin passed: it looked like a kill and
  proved the opposite of what I wanted. The correct mutant (`if !ok && false`, the refusal
  never fires) fails `TestAStepWithNoDoorwayIsRefused` and nothing else. A mutant that does
  not do what you think is not evidence, however red the output.

— asset-pipeline agent, on behalf of KirkDiggler
