### PR TITLE
feat(session): a client can ask where it stands (#1050)

### DIFF
--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -23,6 +23,15 @@ type StatusInput struct {
 	Session string
 }
 
+// WhereInput asks where a member stands.
+type WhereInput struct {
+	// Session is the session to look inside.
+	Session string
+
+	// Member is the member whose own placement is being asked for.
+	Member string
+}
+
 // ViewInput asks what one member currently perceives.
 type ViewInput struct {
 	// Session is the session to look inside.
@@ -93,6 +102,51 @@ func (m *Manager) Status(ctx context.Context, in *StatusInput) (*Status, error) 
 	}
 
 	return projectStatus(enc, status), nil
+}
+
+// Where returns the cell a member stands on, in dungeon-absolute space.
+//
+// A client knows its own cell today only by remembering the last Move it made,
+// which holds until the moment it matters: a reconnect, a fresh tab, a second
+// device, a response it never received. This is the question asked directly.
+//
+// ONE MEMBER'S OWN PLACEMENT, and there is deliberately no read that returns
+// everybody's. A roster of positions would hand a client the cells of members
+// it has never perceived — around a corner, in a room it has not entered,
+// behind a door it has not opened — which is the one thing perception exists to
+// prevent. Where somebody ELSE is, is View's answer, and View gives it only for
+// members the observer actually holds.
+//
+// It is a live read, not a stored one: the position comes from the composition's
+// roster, which projects each member's cell through their room's anchor when
+// asked. A member who has walked is reported where they are now.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
+// ErrNoEncounter, or ErrNoMember if the member is not in this encounter.
+func (m *Manager) Where(ctx context.Context, in *WhereInput) (*WhereOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("where: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("where: %w", ErrNoMemberID)
+	}
+
+	enc, err := m.open(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("where: %w", err)
+	}
+
+	members, err := enc.Members()
+	if err != nil {
+		return nil, fmt.Errorf("where: %w", err)
+	}
+
+	for _, member := range members {
+		if string(member.ID) == in.Member {
+			return &WhereOutput{Position: member.Position}, nil
+		}
+	}
+	return nil, fmt.Errorf("where: %q: %w", in.Member, ErrNoMember)
 }
 
 // View returns what one member currently perceives.

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -141,8 +141,13 @@ func (m *Manager) Where(ctx context.Context, in *WhereInput) (*WhereOutput, erro
 		return nil, fmt.Errorf("where: %w", err)
 	}
 
+	// Converted once, at the boundary, and compared as the newtype it is —
+	// the same direction View and Story take a member id. Comparing the other
+	// way, by stringifying the composition's ID, would work today and would
+	// stop being checked the moment MemberID means anything more than a string.
+	want := encounter.MemberID(in.Member)
 	for _, member := range members {
-		if string(member.ID) == in.Member {
+		if member.ID == want {
 			return &WhereOutput{Position: member.Position}, nil
 		}
 	}

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -111,6 +111,13 @@ type AtlasDoorway struct {
 	To spatial.Position `json:"to"`
 }
 
+// WhereOutput is a member's own placement.
+type WhereOutput struct {
+	// Position is the cell they stand on, in dungeon-absolute space — the same
+	// coordinates the Atlas draws and every verb takes.
+	Position spatial.Position `json:"position"`
+}
+
 // Status reports whether an encounter is still running.
 type Status struct {
 	// Open reports whether the encounter is active.

--- a/rulebooks/dnd5e/session/where_test.go
+++ b/rulebooks/dnd5e/session/where_test.go
@@ -138,4 +138,7 @@ func (s *WhereSuite) TestItRefusesWhatItCannotAnswer() {
 
 	_, err = s.mgr.Where(ctx, &session.WhereInput{Session: "nope", Member: "alice"})
 	s.ErrorIs(err, session.ErrNoSession)
+
+	_, err = s.mgr.Where(ctx, &session.WhereInput{Member: "alice"})
+	s.ErrorIs(err, session.ErrNoSessionID, "an empty session id is refused before any load")
 }

--- a/rulebooks/dnd5e/session/where_test.go
+++ b/rulebooks/dnd5e/session/where_test.go
@@ -1,0 +1,141 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+// where_test.go pins the self-position read (rpg-toolkit#1050), the reshape's
+// last piece.
+//
+// It reuses offsetWorld, whose rooms are anchored at (40,20) and (46,20). That
+// is the whole reason these assertions mean anything: a Where that echoed the
+// stored room-local cell instead of projecting the live one would answer (1,1)
+// where the truth is (41,21), and in a world anchored at the origin those are
+// the same number.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type WhereSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	mgr        *session.Manager
+}
+
+func TestWhereSuite(t *testing.T) {
+	suite.Run(t, new(WhereSuite))
+}
+
+func (s *WhereSuite) SetupTest() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: offsetWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+}
+
+func (s *WhereSuite) where(member string) spatial.Position {
+	out, err := s.mgr.Where(context.Background(), &session.WhereInput{
+		Session: "sess", Member: member,
+	})
+	s.Require().NoError(err)
+	return out.Position
+}
+
+// TestAClientCanAskWhereItStands is the headline: the question answered
+// directly, rather than remembered from the last Move.
+func (s *WhereSuite) TestAClientCanAskWhereItStands() {
+	s.Equal(spatial.Position{X: 41, Y: 21}, s.where("alice"),
+		"hall-local (1,1), anchored at (40,20)")
+}
+
+// TestTheAnswerIsWhereTheyAreNow is the derive-don't-echo pin, and the case a
+// reconnecting client actually hits.
+//
+// The member walks, the client is told nothing (a fresh one would not have been
+// listening), and the read still answers correctly. An implementation that
+// reported the placement the world was CONSTRUCTED with — the obvious way to
+// get this wrong, since that is what the stored blob holds — passes the first
+// test in this file and fails this one.
+func (s *WhereSuite) TestTheAnswerIsWhereTheyAreNow() {
+	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 42, Y: 22}, {X: 43, Y: 22}},
+	})
+	s.Require().NoError(err)
+
+	s.Equal(spatial.Position{X: 43, Y: 22}, s.where("alice"), "where the walk left her")
+}
+
+// TestTheAnswerAgreesWithTheMap crosses the read against the other one a client
+// renders with. A cell that is not on the map is a member drawn outside the
+// dungeon.
+func (s *WhereSuite) TestTheAnswerAgreesWithTheMap() {
+	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
+	s.Require().NoError(err)
+
+	cells := map[spatial.Position]bool{}
+	for _, cell := range atlas.Cells {
+		cells[cell] = true
+	}
+
+	s.True(cells[s.where("alice")], "she stands on a cell the map contains")
+}
+
+// TestItSurvivesAReconnect: the read goes through the stored session like every
+// other verb, so a client that has lost everything can ask cold.
+//
+// A second Manager over the same repositories IS the reconnect — nothing of the
+// first one's memory carries over, which is the point of the seam holding no
+// session process.
+func (s *WhereSuite) TestItSurvivesAReconnect() {
+	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 42, Y: 22}},
+	})
+	s.Require().NoError(err)
+
+	reconnected, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	out, err := reconnected.Where(context.Background(), &session.WhereInput{
+		Session: "sess", Member: "alice",
+	})
+	s.Require().NoError(err)
+	s.Equal(spatial.Position{X: 42, Y: 22}, out.Position, "read cold from what was persisted")
+}
+
+// TestItRefusesWhatItCannotAnswer covers the three ways to ask badly.
+func (s *WhereSuite) TestItRefusesWhatItCannotAnswer() {
+	ctx := context.Background()
+
+	_, err := s.mgr.Where(ctx, nil)
+	s.ErrorIs(err, session.ErrNilInput)
+
+	_, err = s.mgr.Where(ctx, &session.WhereInput{Session: "sess"})
+	s.ErrorIs(err, session.ErrNoMemberID, "refused before the session is loaded")
+
+	_, err = s.mgr.Where(ctx, &session.WhereInput{Session: "sess", Member: "nobody"})
+	s.ErrorIs(err, session.ErrNoMember, "a member this encounter does not have")
+
+	_, err = s.mgr.Where(ctx, &session.WhereInput{Session: "nope", Member: "alice"})
+	s.ErrorIs(err, session.ErrNoSession)
+}


### PR DESCRIPTION
Closes #1050, and closes the remaining half of #933.

The reads on this seam were `Atlas`, `Status`, `View` and `Story`, and none of them answers
"where am I". `View` structurally cannot: the composition builds each observer's percept
from the OTHER members in the room and skips self, which is correct — you do not perceive
yourself, you are simply somewhere.

So a client knew its own cell by remembering the last `Move` it made, which holds right up
until the moment it matters: a reconnect, a fresh tab, a second device, a response that
never arrived.

```
Where(WhereInput{Session, Member}) → WhereOutput{Position}
```

Dungeon-absolute, like everything else this seam speaks, and a LIVE read: the cell comes
from the composition's roster, so a member who has walked is reported where they are now
rather than where the stored blob first placed them.

## Self only, as a rule

There is deliberately no read that returns everybody's positions. A roster of placements
would hand a client the cells of members it has never perceived — around a corner, in a
room it has not entered, behind a door it has not opened — which is the one thing
perception exists to prevent. Where somebody ELSE is, is `View`'s answer, and `View` gives
it only for members the observer actually holds. The doc says so, so the next person who
wants "just give me all the positions" meets the reason before the request rather than
after the implementation.

## Verification

- Full `session` suite green, workbench included; `gofmt` clean; `go mod tidy` a no-op; no
  lint findings in touched files.
- The pins reuse `offsetWorld` (rooms at (40,20) and (46,20)) for the usual reason: a
  `Where` that echoed the stored room-local cell would answer (1,1) where the truth is
  (41,21), and in a world anchored at the origin those are the same number.
- **Derive-don't-echo is pinned twice, not once.** `TestTheAnswerIsWhereTheyAreNow` walks
  the member first, so an implementation reporting the placement the world was CONSTRUCTED
  with — the obvious way to get this wrong, since that is exactly what the stored blob
  holds — passes the simple case and fails this one. `TestItSurvivesAReconnect` then asks
  through a SECOND Manager over the same repositories, which is what a reconnect actually
  is once the seam holds no session process.
- **Sensitivity checked by mutation.** Rewriting `Where` to read `ToData().Members`' stored
  room-local position — the plausible wrong implementation, not a strawman — fails four of
  the five pins.

## This completes the seam reshape

Slices 1a (#1040), 1b (#1044), 2 (#1042), 3 (#1046), 4 (#1048) and this one. The seam
speaks ONE MAP end to end: every position a caller hands in or reads back is a
dungeon-absolute cell, no room id crosses during play, a doorway crossing is an ordinary
step, and a client can now ask where it stands.

The one deliberate asymmetry, stated wherever it shows: `StartSessionInput.World` is
authored content and still speaks rooms. Authoring is construction data; the one-map rule
governs what a session sees while it plays.

— asset-pipeline agent, on behalf of KirkDiggler
