### PR TITLE
fix(session): absent and corrupt character sheets report the right sentinels (#1057)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -290,7 +290,7 @@ func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.Reco
 // attach effects to. Two purposes, one stored sheet, and no shared bus between
 // them.
 func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolution.AttackProfile, error) {
-	data, err := m.fetchCharacterData(ctx, attacker)
+	data, err := m.fetchCharacterData(ctx, "attacker", attacker)
 	if err != nil {
 		return resolution.AttackProfile{}, err
 	}
@@ -345,7 +345,7 @@ func (m *Manager) castFor(
 			continue
 		}
 
-		data, err := m.fetchCharacterData(ctx, id)
+		data, err := m.fetchCharacterData(ctx, "participant", id)
 		if err != nil {
 			return nil, err
 		}

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -95,8 +95,15 @@ type AttackOutput struct {
 // every dirty sheet is written back.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
-// ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrBadAttack, ErrClosed, or
-// ErrSaveFailed with a populated report.
+// ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrNoSheet, ErrNoCharacter,
+// ErrBadCharacter, ErrBadRepository, ErrBadAttack, ErrClosed, or ErrSaveFailed
+// with a populated report.
+//
+// ErrNoCharacter and ErrBadCharacter mean here exactly what they mean
+// everywhere else in this package: the repository does not hold that sheet,
+// versus it holds bytes that will not reconstitute. A host branches on the
+// difference — re-check the ID, versus go and inspect storage — so the two are
+// worth reading off carefully.
 func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("attack: %w", ErrNilInput)
@@ -283,21 +290,14 @@ func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.Reco
 // attach effects to. Two purposes, one stored sheet, and no shared bus between
 // them.
 func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolution.AttackProfile, error) {
-	data, err := m.characters.GetCharacter(ctx, attacker)
+	data, err := m.fetchCharacterData(ctx, attacker)
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w", attacker, ErrBadCharacter)
-		}
 		return resolution.AttackProfile{}, err
-	}
-	if data == nil {
-		return resolution.AttackProfile{}, fmt.Errorf(
-			"attacker %q: GetCharacter reported success with no data: %w", attacker, ErrBadRepository)
 	}
 
 	loaded, err := character.Load(ctx, data)
 	if err != nil {
-		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %w", attacker, ErrNoCharacter, err)
+		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %w", attacker, ErrBadCharacter, err)
 	}
 
 	profile, err := resolution.AttackFromCharacter(loaded, &resolution.CharacterAttackInput{
@@ -345,16 +345,9 @@ func (m *Manager) castFor(
 			continue
 		}
 
-		data, err := m.characters.GetCharacter(ctx, id)
+		data, err := m.fetchCharacterData(ctx, id)
 		if err != nil {
-			if errors.Is(err, ErrNotFound) {
-				return nil, fmt.Errorf("participant %q: %w", id, ErrBadCharacter)
-			}
 			return nil, err
-		}
-		if data == nil {
-			return nil, fmt.Errorf(
-				"participant %q: GetCharacter reported success with no data: %w", id, ErrBadRepository)
 		}
 		cast = append(cast, resolution.Participant{Character: data})
 	}

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -5,6 +5,7 @@ package session_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -357,4 +358,101 @@ func (s *AttackTestSuite) TestASheetlessTargetIsRefusedByName() {
 		Session: "sess", Attacker: "alice", Target: "ogre",
 	})
 	s.ErrorIs(err, session.ErrNoSheet)
+}
+
+// duelAmong wires a manager whose world holds the named players and whose
+// character repository holds exactly the sheets given.
+//
+// The two lists are independent on purpose. Every test below turns on a member
+// the roster HAS and the repository does NOT — a state only a host can produce,
+// and the one the character sentinels exist to describe.
+func (s *AttackTestSuite) duelAmong(members []string, sheets ...*character.Data) *session.Manager {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(sheets...)
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	placed := make([]encounter.MemberInput, 0, len(members))
+	for i, id := range members {
+		placed = append(placed, encounter.MemberInput{
+			ID: encounter.MemberID(id), Kind: encounter.KindPlayer, Room: "hall",
+			Position: spatial.Position{X: float64(i + 1), Y: 1},
+		})
+	}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: encOrderAsGiven{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members:    placed,
+		Endings:    []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention:  encounter.RetentionUnbounded,
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &data,
+	})
+	s.Require().NoError(err)
+	return mgr
+}
+
+// unreadableFighter is a stored sheet that EXISTS and cannot be reconstituted.
+//
+// The malformed condition blob is what makes it unreadable, and it bites only
+// on the path under test: character.Load — what compileAttack uses — is STRICT
+// and fails the whole load, while the lenient character.LoadFromData that Join
+// uses drops the blob and carries on (pinned by
+// TestACorruptConditionIsDroppedRatherThanRejected). So this fixture is corrupt
+// exactly where the sentinel under test is chosen.
+func unreadableFighter(id string) *character.Data {
+	sheet := armedFighter(id)
+	sheet.Conditions = []json.RawMessage{json.RawMessage(`{"ref":"nonsense","x":`)}
+	return sheet
+}
+
+// The three tests below pin one contract: ABSENT and CORRUPT are different
+// answers, and Attack must give the same ones every other verb gives.
+//
+// errors.go defines ErrNoCharacter as "the repository does not hold it" and
+// ErrBadCharacter as "stored data exists but cannot be reconstituted", and
+// loadCharacter has always honoured that. Attack did not: it carried its own
+// copies of the fetch, and they mapped the pair backwards (rpg-toolkit#1057).
+// A host branching on these does opposite repairs — re-check the ID versus go
+// inspect storage — so the two must never be swapped. Each test asserts the
+// sentinel it wants AND denies the other, because an implementation returning
+// both would satisfy a one-sided assertion while telling the host nothing.
+
+func (s *AttackTestSuite) TestAnAbsentAttackerSheetIsAbsentRatherThanCorrupt() {
+	mgr := s.duelAmong([]string{"alice", "bob"}, armedFighter("bob"))
+
+	_, err := s.swing(mgr)
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNoCharacter, "the repository does not hold alice at all")
+	s.NotErrorIs(err, session.ErrBadCharacter, "absent is not corrupt")
+}
+
+func (s *AttackTestSuite) TestAnUnreadableAttackerSheetIsCorruptRatherThanAbsent() {
+	mgr := s.duelAmong([]string{"alice", "bob"}, unreadableFighter("alice"), armedFighter("bob"))
+
+	_, err := s.swing(mgr)
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadCharacter, "alice's bytes are there and cannot be read")
+	s.NotErrorIs(err, session.ErrNoCharacter, "corrupt is not absent")
+}
+
+// TestAnAbsentBystanderSheetIsAbsentRatherThanCorrupt covers the castFor path:
+// a member who is neither swinging nor being swung at still joins the cast,
+// because applicability is an effect's own predicate (ADR-0038). Their sheet
+// being absent is the same failure as the attacker's and must read the same way.
+func (s *AttackTestSuite) TestAnAbsentBystanderSheetIsAbsentRatherThanCorrupt() {
+	mgr := s.duelAmong([]string{"alice", "bob", "carol"}, armedFighter("alice"), armedFighter("bob"))
+
+	_, err := s.swing(mgr)
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNoCharacter, "carol is in the roster and not in the repository")
+	s.NotErrorIs(err, session.ErrBadCharacter, "absent is not corrupt")
 }

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -455,4 +455,9 @@ func (s *AttackTestSuite) TestAnAbsentBystanderSheetIsAbsentRatherThanCorrupt() 
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrNoCharacter, "carol is in the roster and not in the repository")
 	s.NotErrorIs(err, session.ErrBadCharacter, "absent is not corrupt")
+
+	// The role noun earns its keep here more than anywhere else: the host asked
+	// alice to swing at bob and gets back a complaint about carol, who it never
+	// named. "participant" is the word that explains why she was read at all.
+	s.Contains(err.Error(), `participant "carol"`, "say which part the missing member was playing")
 }

--- a/rulebooks/dnd5e/session/entities.go
+++ b/rulebooks/dnd5e/session/entities.go
@@ -57,6 +57,37 @@ func newCallBus() events.EventBus {
 	return events.NewEventBus()
 }
 
+// fetchCharacterData reads one stored sheet and checks that the repository kept
+// its side of the contract.
+//
+// The fetch-and-validate half of loading a character, factored out because
+// three call sites need it and only one of them goes on to reconstitute
+// anything. Its whole job is the vocabulary: ErrNoCharacter when the repository
+// does not hold the ID, ErrBadRepository when it reports success with no data.
+//
+// It exists as ONE function because it used to exist as three, and the copies
+// disagreed. compileAttack and castFor each reported an ABSENT sheet as a
+// corrupt one (rpg-toolkit#1057), so the same package answered the same
+// question two different ways depending on which verb a host called. A sentinel
+// a host branches on cannot be restated per call site and stay honest.
+func (m *Manager) fetchCharacterData(ctx context.Context, id string) (*character.Data, error) {
+	data, err := m.characters.GetCharacter(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("character %q: %w", id, ErrNoCharacter)
+		}
+		return nil, fmt.Errorf("character %q: %w", id, err)
+	}
+	if data == nil {
+		// A repository reporting success with no data has violated its
+		// contract. Guessing in either direction — treating it as absent, or
+		// carrying a nil into a loader — is worse than saying so.
+		return nil, fmt.Errorf(
+			"character %q: GetCharacter reported success with no data: %w", id, ErrBadRepository)
+	}
+	return data, nil
+}
+
 // loadCharacter reconstitutes a player character and attaches its features and
 // conditions to the call's bus.
 //
@@ -71,18 +102,9 @@ func newCallBus() events.EventBus {
 func (m *Manager) loadCharacter(
 	ctx context.Context, bus events.EventBus, id string,
 ) (*character.Character, error) {
-	data, err := m.characters.GetCharacter(ctx, id)
+	data, err := m.fetchCharacterData(ctx, id)
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil, fmt.Errorf("character %q: %w", id, ErrNoCharacter)
-		}
-		return nil, fmt.Errorf("character %q: %w", id, err)
-	}
-	if data == nil {
-		// A repository reporting success with no data has violated its
-		// contract. Guessing in either direction — treating it as absent, or
-		// carrying a nil into LoadFromData — is worse than saying so.
-		return nil, fmt.Errorf("character %q: %w", id, ErrBadRepository)
+		return nil, err
 	}
 
 	ch, err := character.LoadFromData(ctx, data, bus)

--- a/rulebooks/dnd5e/session/entities.go
+++ b/rulebooks/dnd5e/session/entities.go
@@ -70,20 +70,26 @@ func newCallBus() events.EventBus {
 // corrupt one (rpg-toolkit#1057), so the same package answered the same
 // question two different ways depending on which verb a host called. A sentinel
 // a host branches on cannot be restated per call site and stay honest.
-func (m *Manager) fetchCharacterData(ctx context.Context, id string) (*character.Data, error) {
+//
+// role names the part the member is playing — "attacker", "participant",
+// plain "character" — and is the one thing a call site still gets to say for
+// itself. The sentinel is not negotiable; which member of the roster the host
+// should go look at is local knowledge, and castFor in particular reaches for
+// sheets the host never named.
+func (m *Manager) fetchCharacterData(ctx context.Context, role, id string) (*character.Data, error) {
 	data, err := m.characters.GetCharacter(ctx, id)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return nil, fmt.Errorf("character %q: %w", id, ErrNoCharacter)
+			return nil, fmt.Errorf("%s %q: %w", role, id, ErrNoCharacter)
 		}
-		return nil, fmt.Errorf("character %q: %w", id, err)
+		return nil, fmt.Errorf("%s %q: %w", role, id, err)
 	}
 	if data == nil {
 		// A repository reporting success with no data has violated its
 		// contract. Guessing in either direction — treating it as absent, or
 		// carrying a nil into a loader — is worse than saying so.
 		return nil, fmt.Errorf(
-			"character %q: GetCharacter reported success with no data: %w", id, ErrBadRepository)
+			"%s %q: GetCharacter reported success with no data: %w", role, id, ErrBadRepository)
 	}
 	return data, nil
 }
@@ -102,7 +108,7 @@ func (m *Manager) fetchCharacterData(ctx context.Context, id string) (*character
 func (m *Manager) loadCharacter(
 	ctx context.Context, bus events.EventBus, id string,
 ) (*character.Character, error) {
-	data, err := m.fetchCharacterData(ctx, id)
+	data, err := m.fetchCharacterData(ctx, "character", id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #1057

## The defect

`session/errors.go` defines the two character sentinels precisely: **`ErrNoCharacter` = absent** ("the character repository does not hold it") and **`ErrBadCharacter` = corrupt** ("stored data exists but cannot be reconstituted"). `loadCharacter` has always honoured that.

`compileAttack` and `castFor` did not. Each carried its own copy of the `GetCharacter` fetch, and the copies mapped the pair **backwards**:

| failure | `loadCharacter` (Join) | `compileAttack` / `castFor` (Attack) |
|---|---|---|
| repository `ErrNotFound` | `ErrNoCharacter` ✅ | `ErrBadCharacter` ❌ |
| `character.Load` fails | — | `ErrNoCharacter` ❌ |

So the same package answered the same question two opposite ways depending on which verb a host called. A host branches on these to pick a repair — absent means re-check the ID (`NOT_FOUND`), corrupt means go inspect storage (`INTERNAL`) — so Attack sent it to the wrong one every time, and rpg-api#797's error table inherited the misleading codes.

## The fix

The duplication is the root cause, so the fix removes it rather than patching the mapping in place. The fetch-and-validate half of `loadCharacter` is now `fetchCharacterData` in `entities.go`, called from all three sites. The inversion has nowhere left to live.

- `entities.go` — new `fetchCharacterData`: `ErrNoCharacter` on repository `ErrNotFound`, `ErrBadRepository` when the repository reports success with no data. `loadCharacter` now calls it.
- `attack.go` — `compileAttack` and `castFor` call the helper; `compileAttack`'s `character.Load` failure now correctly reports `ErrBadCharacter`.
- `attack.go` — `Attack`'s godoc `Returns` list now names the character sentinels it can actually produce: `ErrNoSheet`, `ErrNoCharacter`, `ErrBadCharacter`, `ErrBadRepository`.

Three tests pin the contract, each asserting the sentinel it wants **and** denying the other — an implementation returning both would satisfy a one-sided assertion while telling the host nothing.

The corrupt-sheet fixture is worth a note: it uses a malformed condition blob, which fails only the **strict** `character.Load` that `compileAttack` uses. The lenient `LoadFromData` behind Join drops the blob and carries on (pinned by `TestACorruptConditionIsDroppedRatherThanRejected`). So the fixture is corrupt exactly where the sentinel under test is chosen.

## Evidence

### RED — production files at `1d71386`, new tests in place

```
--- FAIL: TestAttackSuite/TestAnAbsentAttackerSheetIsAbsentRatherThanCorrupt
        Error:      	Target error should be in err chain:
            	            	expected: "no such character"
            	            	in chain: "attack: attacker \"alice\": character data could not be loaded"
        Messages:   	the repository does not hold alice at all
        Error:      	Target error should not be in err chain:
            	            	found: "character data could not be loaded"
        Messages:   	absent is not corrupt

--- FAIL: TestAttackSuite/TestAnAbsentBystanderSheetIsAbsentRatherThanCorrupt
        Error:      	Target error should be in err chain:
            	            	expected: "no such character"
            	            	in chain: "attack: participant \"carol\": character data could not be loaded"
        Messages:   	carol is in the roster and not in the repository
        Error:      	Target error should not be in err chain:
            	            	found: "character data could not be loaded"
        Messages:   	absent is not corrupt

--- FAIL: TestAttackSuite/TestAnUnreadableAttackerSheetIsCorruptRatherThanAbsent
        Error:      	Target error should be in err chain:
            	            	expected: "character data could not be loaded"
            	            	in chain: "attack: attacker \"alice\": no such character: failed to load condition 0: ..."
        Messages:   	alice's bytes are there and cannot be read
        Error:      	Target error should not be in err chain:
            	            	found: "no such character"
        Messages:   	corrupt is not absent

FAIL	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session	0.024s
```

Three failures, all three the new tests, each failing on exactly the inversion and nothing else. Note the third: the attacker's sheet **is** in the repository and fails to load, and the old code called that "no such character".

### GREEN — with the fix

```
$ go test ./...
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session	0.032s
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session/cmd/session-workbench	0.004s

$ go test -run TestAttackSuite -v ./...
--- PASS: TestAttackSuite (0.00s)
    --- PASS: TestAttackSuite/TestAnAbsentAttackerSheetIsAbsentRatherThanCorrupt (0.00s)
    --- PASS: TestAttackSuite/TestAnAbsentBystanderSheetIsAbsentRatherThanCorrupt (0.00s)
    --- PASS: TestAttackSuite/TestAnUnreadableAttackerSheetIsCorruptRatherThanAbsent (0.00s)

$ golangci-lint run ./...
0 issues.

$ go fmt ./... && go mod tidy   # no diff
```

## Review follow-up (80f638d)

Copilot caught that folding the three fetches into one also folded away the **role noun** each site used for the member it was reading. It was slightly worse than reported: `compileAttack` ended up disagreeing with itself, saying `character "alice"` for the absent case and `attacker "alice"` for the corrupt case two lines below.

`fetchCharacterData` now takes the role noun from its caller. The **sentinel** stays the helper's alone — restating that per call site is what caused #1057 — while **which part the member was playing** is local knowledge and returns to the call sites. Messages are now exactly what they were before the extraction:

```
attack: attacker "alice": no such character
attack: participant "carol": no such character
attack: attacker "alice": character data could not be loaded: ...
```

The bystander test pins the noun, because that is where it carries real information: the host named alice and bob, and gets back a complaint about carol. Tests and lint re-verified green after the change. (The RED capture above predates this commit and was not re-run for it — the failures it shows are the sentinel inversion, which that commit does not touch.)

## Provenance

The implementation is a predecessor Opus agent's work, interrupted by a power loss before it could run a single test or commit. Its tree was recovered and committed as-is first, then **RED was reconstructed** by reverting `attack.go` and `entities.go` to `1d71386` with the new tests in place — the failures above are from that reconstructed run, not from the original session. They reproduce the predecessor's own capture byte-for-byte.

Scope is the `session` module only. No `replace` directives, no `go.work`, no drive-by fixes — the known cosmetic `castFor` doc-comment collision at `attack.go:312-318` is deliberately left untouched.

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
