### PR TITLE
fix(session): the save report names the character writes that landed (#1056)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -365,16 +365,22 @@ func (m *Manager) saveDirty(ctx context.Context, scope *writeScope, out *resolut
 	// written before the failure is durable, and a caller told only about the
 	// failure would retry a write that already succeeded — which is the
 	// difference between repair and retry that the report exists to carry.
-	var written []string
+	//
+	// Every entry goes on the SCOPE rather than a local, so it outlives this
+	// call: the sheets are durable whether the next write succeeds or fails,
+	// and persist opens its report with them either way. Kept in a local, they
+	// were reported only when saveDirty itself failed — so a swing whose WORLD
+	// save failed named nothing at all, and the host retried a swing whose
+	// damage was already on disk (rpg-toolkit#1056).
 	for _, data := range out.DirtyCharacters {
 		if data == nil {
 			continue
 		}
 		if err := m.characters.SaveCharacter(ctx, data); err != nil {
-			report := SaveReport{Written: written, Failed: []string{"character:" + data.ID}}
+			report := SaveReport{Written: scope.written, Failed: []string{"character:" + data.ID}}
 			return &SaveError{Report: report, Err: fmt.Errorf("saving character: %w", err)}
 		}
-		written = append(written, "character:"+data.ID)
+		scope.written = append(scope.written, "character:"+data.ID)
 	}
 
 	for _, dirty := range out.DirtyMonsters {

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -106,11 +106,24 @@ func duelWorld(t fataler) *encounter.EncounterData {
 
 // duel wires the duel world to a manager whose events go nowhere.
 func (s *AttackTestSuite) duel(dice session.Roller) *session.Manager {
+	mgr, _ := s.breakableDuel(dice)
+	return mgr
+}
+
+// breakableDuel is the duel with its encounter store wrapped so a test can arm
+// the world save to fail.
+//
+// Unarmed the wrapper delegates, so every duel goes through ONE wiring path
+// rather than two that could drift. The failure is armed after StartSession
+// because the interesting moment is late: the swing has already made a damaged
+// sheet durable, and only the world save is left to fail.
+func (s *AttackTestSuite) breakableDuel(dice session.Roller) (*session.Manager, *failingEncounters) {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	encounters := &failingEncounters{fakeEncounters: s.encounters}
 
 	mgr, err := session.NewManager(&session.Config{
-		Dice: dice, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: dice, Sessions: s.sessions, Encounters: encounters,
 		Characters: s.characters, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -119,7 +132,7 @@ func (s *AttackTestSuite) duel(dice session.Roller) *session.Manager {
 		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
 	})
 	s.Require().NoError(err)
-	return mgr
+	return mgr, encounters
 }
 
 func (s *AttackTestSuite) swing(mgr *session.Manager) (*session.AttackOutput, error) {
@@ -195,6 +208,86 @@ func (s *AttackTestSuite) TestDamagePersists() {
 	s.Equal(before-out.Damage, s.characters.byID["bob"].HitPoints,
 		"the blow reached the stored sheet")
 	s.Equal(24, s.characters.byID["alice"].HitPoints, "and the swinger is untouched")
+}
+
+// TestASwingNamesTheSheetItWrote is the success half of S6 for the one verb
+// that writes a character.
+//
+// The report is the caller's only account of what this call made durable, and
+// a swing makes TWO things durable — the damaged sheet and the world that
+// records the blow. A report naming only the world describes a call that half
+// happened.
+//
+// The order is the order the writes really went in: sheets first, then the
+// world. Reading the report top to bottom retells the save.
+func (s *AttackTestSuite) TestASwingNamesTheSheetItWrote() {
+	mgr := s.duel(&sequenceDice{rolls: []int{15, 5}})
+
+	out, err := s.swing(mgr)
+	s.Require().NoError(err)
+	s.Require().True(out.Hit)
+
+	s.Equal([]string{"character:bob", "encounter:world"}, out.Saved.Written,
+		"the damaged sheet is durable and the report has to say so")
+	s.Empty(out.Saved.Failed)
+	s.False(out.Saved.Partial(), "a whole save is not a partial one")
+}
+
+// TestAMissNamesNoCharacterWrite is the negative control that gives the test
+// above its meaning.
+//
+// Nothing is dirtied by a miss, so nothing is written, and the report must be
+// derived from the writes that actually happened rather than from the fact
+// that a swing occurred. An implementation that named the target
+// unconditionally would satisfy the success pin and lie here.
+func (s *AttackTestSuite) TestAMissNamesNoCharacterWrite() {
+	mgr := s.duel(&sequenceDice{rolls: []int{2, 5}})
+
+	out, err := s.swing(mgr)
+	s.Require().NoError(err)
+	s.Require().False(out.Hit)
+
+	s.Equal([]string{"encounter:world"}, out.Saved.Written,
+		"a miss changed no sheet, so the report names no sheet")
+}
+
+// TestAFailedWorldSaveStillNamesTheSheetThatLanded is the reason this report
+// exists at all, and the bug it was written for (rpg-toolkit#1056).
+//
+// The sheet is written BEFORE the world, so a world save that fails leaves the
+// damage durable and the blow unrecorded. The report's own documented rule —
+// "nothing was written" is safe to retry — then decides what the host does
+// next, and it decides it from Written. An empty Written makes Partial() read
+// false, the host retries, the retry loads the already-damaged sheet and
+// applies the damage again: DOUBLE DAMAGE for one recorded swing, with nothing
+// in the stored world to betray it, because the beat lived only on the
+// encounter whose save failed.
+//
+// So the assertion is not cosmetic. Written naming the sheet is what turns this
+// into a repair.
+func (s *AttackTestSuite) TestAFailedWorldSaveStillNamesTheSheetThatLanded() {
+	mgr, encounters := s.breakableDuel(&sequenceDice{rolls: []int{15, 5}})
+	before := s.characters.byID["bob"].HitPoints
+
+	// Armed only now, so the session could be started.
+	encounters.saveErr = errBroken
+
+	out, err := s.swing(mgr)
+	s.Require().Error(err)
+	s.Nil(out)
+	s.Require().ErrorIs(err, session.ErrSaveFailed)
+	s.ErrorIs(err, errBroken, "the store's own failure survives")
+
+	var saved *session.SaveError
+	s.Require().ErrorAs(err, &saved, "the report must survive the error")
+	s.Equal([]string{"character:bob"}, saved.Report.Written,
+		"bob's damaged sheet is already durable — retrying the swing would damage him twice")
+	s.Equal([]string{"encounter:world"}, saved.Report.Failed,
+		"and the world that would have recorded the blow is what needs repair")
+	s.True(saved.Report.Partial(), "half a save is a repair, not a retry")
+
+	s.Equal(before-8, s.characters.byID["bob"].HitPoints,
+		"the write the report names really did land")
 }
 
 // TestNothingSpendsYet is the known gap, pinned so it cannot be mistaken for a

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -466,6 +466,21 @@ type writeScope struct {
 	// sheet, today — so a verb that changed only the world writes only the
 	// world. Writes stay proportional to what actually changed.
 	touched bool
+
+	// written names what this verb made durable BEFORE reaching persist —
+	// character sheets, today, which are the only aggregate a verb writes on
+	// its own (see [Manager.saveDirty]).
+	//
+	// It rides the scope for the same reason touched does: it is a fact the
+	// verb discovered on the way to the commit, and persist is the one place
+	// that turns facts into a report. Threading it through commit as a
+	// parameter would put a nil at every other call site — none of which
+	// writes a sheet — which reads as ceremony rather than as a decision.
+	//
+	// A verb that writes nothing early leaves this empty and its report is
+	// unchanged — the entries are added by whoever wrote, never by persist on
+	// their behalf.
+	written []string
 }
 
 // adopt replaces the scope's encounter with one loaded from a world that came
@@ -524,14 +539,24 @@ func (m *Manager) adopt(scope *writeScope, world encounter.EncounterData) error 
 // for this case is the fix, and it is not this wave's.
 func (m *Manager) persist(ctx context.Context, scope *writeScope) (SaveReport, *encounter.EncounterData, error) {
 	data := scope.enc.ToData()
+
+	// The report opens with what the verb already made durable rather than
+	// starting from nothing, which is the whole of rpg-toolkit#1056: a swing
+	// writes the damaged sheet before it gets here, so a world save that fails
+	// leaves a report claiming nothing landed while the damage is on disk. The
+	// host reads that as "safe to retry", retries, and the damage applies a
+	// second time. Copied rather than aliased so appending below cannot reach
+	// back into the scope.
+	report := SaveReport{Written: append([]string(nil), scope.written...)}
+
 	if err := m.encounters.SaveEncounter(ctx, scope.encounter, &data); err != nil {
-		report := SaveReport{Failed: []string{"encounter:" + scope.encounter}}
+		report.Failed = []string{"encounter:" + scope.encounter}
 		return report, nil, &SaveError{
 			Report: report,
 			Err:    fmt.Errorf("saving world: %w", err),
 		}
 	}
-	report := SaveReport{Written: []string{"encounter:" + scope.encounter}}
+	report.Written = append(report.Written, "encounter:"+scope.encounter)
 
 	if !scope.touched {
 		return report, &data, nil


### PR DESCRIPTION
Closes #1056

## The defect

S6 says a failure names its pieces — the report tells the caller what LANDED as well as what did not, because `SaveReport`'s own godoc documents "nothing was written" as safe to retry while a partial write is a repair. `Attack` broke that law in the exact scenario it was written for.

`saveDirty` writes the damaged character sheets and tracked them in a **local** `written` list, used only inside its own failure path and discarded on success. `commit` → `persist` then built a fresh report from scratch. So when `SaveCharacter` succeeded and `SaveEncounter` failed, the caller got `SaveReport{Failed: ["encounter:world"], Written: nil}` — `Partial()` false — while the damage was already durable.

**The consequence is double damage.** A hits B; B's damaged sheet is written; the world save fails. The host reads "nothing written" as a total failure and retries the swing. The retry loads the already-damaged sheet and applies fresh damage: two applications for one recorded swing, with nothing in stored state to betray it, because the beat lived only on the in-memory encounter whose save failed.

The success path had the same gap, quietly: `AttackOutput.Saved.Written` never named the sheet it had just written.

## The fix

Thread the entries instead of dropping them.

- `saveDirty` accumulates onto the `writeScope` rather than a local, so the receipts outlive the call — the sheets are durable whether the next write succeeds or fails.
- `persist` opens its report with `scope.written` on **both** arms, so the encounter-save failure now returns `Written: ["character:bob"], Failed: ["encounter:world"]` and `Partial()` reads true.

The scope carries it for the same reason it already carries `touched`: it is a fact the verb discovered on the way to the commit, and threading a parameter through `commit` would put a `nil` at every other call site, none of which writes a sheet. Verbs that write no character leave it empty and their reports are byte-for-byte what they were — Join, Exit, End, Move, Spawn and the turn verbs all still name only what they persist, and their existing report pins pass unchanged.

Neither the entry format (`"character:<id>"`) nor the save **order** changed: sheets before the world before the session record, which is the orphan-direction law.

## RED

Three tests through `Manager.Attack`, written and watched failing first:

```
=== RUN   TestAttackSuite/TestAFailedWorldSaveStillNamesTheSheetThatLanded
    attack_test.go:283:
        	Error:      	Not equal:
        	            	expected: []string{"character:bob"}
        	            	actual  : []string(nil)
        	Messages:   	bob's damaged sheet is already durable — retrying the swing would damage him twice
    attack_test.go:287:
        	Error:      	Should be true
        	Messages:   	half a save is a repair, not a retry
=== RUN   TestAttackSuite/TestASwingNamesTheSheetItWrote
    attack_test.go:230:
        	Error:      	Not equal:
        	            	expected: []string{"character:bob", "encounter:world"}
        	            	actual  : []string{"encounter:world"}
        	Messages:   	the damaged sheet is durable and the report has to say so
--- FAIL: TestAttackSuite (0.01s)
    --- FAIL: TestAttackSuite/TestAFailedWorldSaveStillNamesTheSheetThatLanded (0.00s)
    --- FAIL: TestAttackSuite/TestASwingNamesTheSheetItWrote (0.00s)
    --- PASS: TestAttackSuite/TestAMissNamesNoCharacterWrite (0.00s)
```

The third test — a miss names no character write — passes in RED by design: it is the negative control that makes the entry have to come from a write that actually happened rather than from the fact that a swing occurred. Note also that the failure test's final assertion (bob's stored HP really reduced) passed in RED: the damage genuinely was durable while the report claimed nothing landed, which is the double-damage scenario in one run.

## GREEN

```
--- PASS: TestAttackSuite (0.01s)
    --- PASS: TestAttackSuite/TestAFailedWorldSaveStillNamesTheSheetThatLanded (0.00s)
    --- PASS: TestAttackSuite/TestAMissNamesNoCharacterWrite (0.00s)
    --- PASS: TestAttackSuite/TestASwingNamesTheSheetItWrote (0.00s)
    --- PASS: TestAttackSuite/TestDamagePersists (0.00s)
    ... (15/15 in the attack suite)
--- PASS: TestAPartialCharacterSaveNamesWhatLanded (0.00s)
--- PASS: TestFightStartsSuite/TestAPartialSaveTellsTheCallerWhichHalfLanded (0.00s)
--- PASS: TestFightStartsSuite/TestATotalSaveFailureNamesOnlyWhatWasAttempted (0.00s)
--- PASS: TestFightStartsSuite/TestAWalkWritesOnlyTheEncounter (0.00s)
--- PASS: TestStartSessionSuite/TestSessionSaveFailureLeavesOnlyAnOrphan (0.00s)
--- PASS: TestWriteSuite (0.00s)   (Join / Exit / End report pins unchanged)

$ go test ./...
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session	0.050s
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session/cmd/session-workbench	0.006s

$ golangci-lint run ./...
0 issues.
```

`go fmt ./...`, `go mod tidy` and `go vet ./...` are clean; pre-commit hooks ran on the commit and passed.

## Mutation check

Two mutants, both killed:

- `persist` seeds its report from nothing (the original bug): kills both new tests.
- `persist` seeds only the **success** arm (the tempting half-fix): kills `TestAFailedWorldSaveStillNamesTheSheetThatLanded` alone, which is the arm that matters — proving the failure-path assertion is doing its own work rather than riding on the success one.

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
