### PR TITLE
fix(session): composition sentinels stop crossing the seam (#1058)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -119,7 +119,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 
 	roster, err := scope.enc.Members()
 	if err != nil {
-		return nil, fmt.Errorf("attack: %w", err)
+		return nil, fmt.Errorf("attack: %w", translate(err))
 	}
 	kinds := map[string]encounter.MemberKind{}
 	for _, member := range roster {

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -202,6 +202,14 @@ var (
 	// cannot be reconstituted is rejected at the door rather than persisted
 	// and discovered on the next verb — at which point the session would exist
 	// and be permanently unusable.
+	//
+	// It is also the TRANSLATION OF RECORD for a composition-side complaint
+	// about the world itself — a blob that cannot be loaded, or a field that
+	// does not hold the room somebody is standing in — for the reason
+	// ErrNoConnection is the translation of record for a refused crossing: an
+	// inner sentinel must never cross the boundary (S2). One sentinel covers
+	// both because the host's remedy is the same either way. The stored world
+	// is unusable, and the repair is upstream of anything a caller can retry.
 	ErrInvalidWorld = errors.New("invalid encounter data")
 
 	// ErrInBubble is returned when a member is asked to free-roam while they

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -333,7 +333,7 @@ func resolveWalk(
 	// version of this did, by asking gridFor to fetch its own.
 	atlas, err := enc.Atlas()
 	if err != nil {
-		return resolvedWalk{}, err
+		return resolvedWalk{}, translate(err)
 	}
 
 	grid, err := gridFrom(atlas, room)
@@ -355,7 +355,12 @@ func resolveWalk(
 
 		located, lerr := enc.Locate(&encounter.LocateInput{Position: cell})
 		if lerr != nil {
-			return resolvedWalk{}, fmt.Errorf("step %d of %d: no room owns (%v,%v): %w: %w",
+			// The composition's account of WHY is kept as text, not as a chain.
+			// Our sentinel is the one a caller matches on; wrapping theirs too
+			// would let a host match on encounter.ErrBadPlacement, which is the
+			// S2 leak the boundary test cannot see — and this is the refusal a
+			// routine pathing mistake actually reaches (rpg-toolkit#1058).
+			return resolvedWalk{}, fmt.Errorf("step %d of %d: no room owns (%v,%v): %w: %v",
 				i+1, len(path), cell.X, cell.Y, ErrBadPosition, lerr)
 		}
 
@@ -406,7 +411,7 @@ func doorwayBetween(atlas encounter.Atlas, from, to spatial.Position) (string, b
 func whereIs(enc *encounter.Encounter, member encounter.MemberID) (string, spatial.Position, error) {
 	members, err := enc.Members()
 	if err != nil {
-		return "", spatial.Position{}, err
+		return "", spatial.Position{}, translate(err)
 	}
 
 	for _, m := range members {

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -310,6 +310,37 @@ func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
 	s.NotErrorIs(err, session.ErrBadPosition, "and the cell exists; there is just no way through")
 }
 
+// TestAStepOntoNoCellUsesOurSentinelNotTheirs is
+// TestTrimmedStoryUsesOurSentinelNotTheirs' walk-shaped twin, and it covers the
+// leak channel a routine caller mistake reaches (rpg-toolkit#1058).
+//
+// Pathing one cell too far is arithmetic any client can get wrong — not corrupt
+// state and not a defect here. Until this test existed the refusal carried the
+// composition's own ErrBadPlacement alongside our ErrBadPosition, matchable by
+// errors.Is, so a host handling "off the map" would have been coupled to the
+// module this seam exists to keep replaceable — through the one channel the AST
+// boundary test cannot see.
+func (s *MoveTestSuite) TestAStepOntoNoCellUsesOurSentinelNotTheirs() {
+	s.startCorridor()
+
+	// The hall runs (0,0)-(7,7). Alice steps to its corner, then off the map.
+	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 0, Y: 0}, {X: -1, Y: -1}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadPosition, "the caller sees our vocabulary")
+	s.NotErrorIs(err, encounter.ErrBadPlacement,
+		"and must NOT be able to reach the composition's sentinel — a host that matched "+
+			"on it would break the day the composition is replaced")
+
+	// Demoting the inner error must cost its MESSAGE nothing: whoever debugs
+	// this still needs to know it was owned by no room rather than, say, a
+	// fractional hex cell.
+	s.Contains(err.Error(), "owned by no room",
+		"the composition's account of why survives, even though its sentinel does not")
+}
+
 func TestMoveSuite(t *testing.T) {
 	suite.Run(t, new(MoveTestSuite))
 }

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -301,8 +301,11 @@ func (m *Manager) loadWorldWithBaseline(
 // their error handling exactly as surely as leaking a struct would, and
 // nothing in CI would have said a word.
 //
-// Unrecognised errors pass through wrapped rather than being flattened, and
-// that is a deliberate limit rather than an oversight. The default arm carries
+// Unrecognised errors pass through UNCHANGED rather than being flattened. This
+// function adds nothing to them; the calling verb wraps what comes back with
+// its own prefix, which is where "view:" and "move:" come from.
+//
+// That limit is deliberate rather than an oversight. The default arm carries
 // errors that ORIGINATED WITH THE HOST as well as composition ones we did not
 // anticipate — a failing Roller comes back out through a composition verb — and
 // flattening those would break the host's matching on its own errors to protect

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -76,7 +76,7 @@ func (m *Manager) Atlas(ctx context.Context, in *AtlasInput) (*Atlas, error) {
 
 	atlas, err := enc.Atlas()
 	if err != nil {
-		return nil, fmt.Errorf("atlas: %w", err)
+		return nil, fmt.Errorf("atlas: %w", translate(err))
 	}
 
 	projected := projectAtlas(atlas)
@@ -98,7 +98,7 @@ func (m *Manager) Status(ctx context.Context, in *StatusInput) (*Status, error) 
 
 	status, err := enc.Status()
 	if err != nil {
-		return nil, fmt.Errorf("status: %w", err)
+		return nil, fmt.Errorf("status: %w", translate(err))
 	}
 
 	return projectStatus(enc, status), nil
@@ -138,7 +138,7 @@ func (m *Manager) Where(ctx context.Context, in *WhereInput) (*WhereOutput, erro
 
 	members, err := enc.Members()
 	if err != nil {
-		return nil, fmt.Errorf("where: %w", err)
+		return nil, fmt.Errorf("where: %w", translate(err))
 	}
 
 	// Converted once, at the boundary, and compared as the newtype it is —
@@ -281,7 +281,13 @@ func (m *Manager) loadWorldWithBaseline(
 		Initiative: m.initiative,
 	})
 	if err != nil {
-		return nil, 0, fmt.Errorf("%q: %w: %w", encID, ErrInvalidWorld, err)
+		// The reason is kept as TEXT, not as a chain. A blob this seam cannot
+		// reconstitute fails several modules deep — the composition's own
+		// validation, or a leaf's (clock, intel, record) underneath it — and
+		// every one of those is a module we intend to keep replaceable. %v
+		// hands whoever debugs it the whole account and hands a host nothing to
+		// match on but ours (S2).
+		return nil, 0, fmt.Errorf("%q: %w: %v", encID, ErrInvalidWorld, err)
 	}
 	return enc, world.Log.NextSeq, nil
 }
@@ -295,9 +301,20 @@ func (m *Manager) loadWorldWithBaseline(
 // their error handling exactly as surely as leaking a struct would, and
 // nothing in CI would have said a word.
 //
-// Unrecognised errors pass through wrapped rather than being flattened: an
-// error we did not anticipate is more useful with its own message intact than
-// re-labelled as something we do recognise.
+// Unrecognised errors pass through wrapped rather than being flattened, and
+// that is a deliberate limit rather than an oversight. The default arm carries
+// errors that ORIGINATED WITH THE HOST as well as composition ones we did not
+// anticipate — a failing Roller comes back out through a composition verb — and
+// flattening those would break the host's matching on its own errors to protect
+// it from ours. So the guarantee here is that every sentinel this seam can
+// reach has an arm, and the mechanical part of that guarantee lives in the
+// tests: sentinels_test.go over the refusals a caller can drive, and
+// translate_internal_test.go over every arm below (rpg-toolkit#1058).
+//
+// A translated error carries our sentinel ALONE. Wrapping both — fmt.Errorf(
+// "%w: %w", ours, theirs) — reads like generosity and is the leak itself: a
+// host can still match on theirs. Where the inner message is worth keeping, the
+// call site keeps it with %v, which is text rather than a chain.
 func translate(err error) error {
 	switch {
 	case errors.Is(err, encounter.ErrTrimmed):
@@ -312,6 +329,13 @@ func translate(err error) error {
 		return fmt.Errorf("%w", ErrNoConnection)
 	case errors.Is(err, encounter.ErrBadPlacement):
 		return fmt.Errorf("%w", ErrBadPosition)
+	case errors.Is(err, encounter.ErrNoField), errors.Is(err, encounter.ErrInvalidData):
+		// Both mean the stored world cannot answer: a field that is defective
+		// or does not hold the room somebody stands in, and a blob that cannot
+		// be reconstituted at all. One sentinel because the host's remedy is
+		// the same either way — this encounter's data is unusable, and the
+		// repair is upstream of anything a caller can retry.
+		return fmt.Errorf("%w", ErrInvalidWorld)
 	case errors.Is(err, encounter.ErrInBubble):
 		return fmt.Errorf("%w", ErrInBubble)
 	case errors.Is(err, encounter.ErrNoBubble):

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -1,0 +1,264 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+// sentinels_test.go is the sentinel-shaped sibling of boundary_test.go
+// (rpg-toolkit#1058).
+//
+// The AST boundary test reads exported SIGNATURES, and a sentinel error is not
+// a type in a signature — so an inner package can become part of the host's
+// contract through a channel that test never looks at. A host that matched on
+// encounter.ErrBadPlacement would be coupled to the module this seam exists to
+// keep replaceable, exactly as surely as if a struct had leaked, and nothing in
+// CI would have said a word.
+//
+// So every refusal this seam can be DRIVEN INTO is checked here against an
+// explicit list of the composition's own sentinels: our vocabulary must be
+// present, and none of theirs may be reachable through errors.Is.
+//
+// Reachability is the discipline that keeps this honest. A case belongs here
+// only if a caller or a stored blob can really produce it, which is why the
+// list of scenarios below reads like a list of mistakes rather than a list of
+// error values. The paths that exist but cannot be reached from a verb are
+// pinned one layer down, on translate itself, in translate_internal_test.go.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// compositionSentinels is every error value the composition exports, written
+// out rather than derived.
+//
+// Written out for the same reason boundary_test.go writes out its permitted
+// types: a rule like "anything named Err*" would be less typing and would
+// quietly cover values nobody weighed, while a list makes every future entry a
+// visible line in a diff. When the composition gains a sentinel, it is added
+// here — and if that addition turns this test red, a leak has been found rather
+// than a chore created.
+var compositionSentinels = map[string]error{
+	"encounter.ErrNilInput":      encounter.ErrNilInput,
+	"encounter.ErrNoMember":      encounter.ErrNoMember,
+	"encounter.ErrNotMember":     encounter.ErrNotMember,
+	"encounter.ErrNoEnding":      encounter.ErrNoEnding,
+	"encounter.ErrClosed":        encounter.ErrClosed,
+	"encounter.ErrNoField":       encounter.ErrNoField,
+	"encounter.ErrBadPlacement":  encounter.ErrBadPlacement,
+	"encounter.ErrBadConnection": encounter.ErrBadConnection,
+	"encounter.ErrNoConnection":  encounter.ErrNoConnection,
+	"encounter.ErrInBubble":      encounter.ErrInBubble,
+	"encounter.ErrNoBubble":      encounter.ErrNoBubble,
+	"encounter.ErrBadClock":      encounter.ErrBadClock,
+	"encounter.ErrInvalidData":   encounter.ErrInvalidData,
+	"encounter.ErrTrimmed":       encounter.ErrTrimmed,
+	"encounter.ErrNoInitiative":  encounter.ErrNoInitiative,
+}
+
+// SentinelSuite drives each reachable refusal and checks what a host can match
+// on afterwards.
+type SentinelSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	mgr        *session.Manager
+}
+
+func TestSentinelSuite(t *testing.T) { suite.Run(t, new(SentinelSuite)) }
+
+func (s *SentinelSuite) SetupTest() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+
+	// offsetWorld is the fixture with the most map in it: two rooms anchored
+	// away from the origin, a doorway between them, and endings on both sides.
+	// Anchoring matters here — a cell outside every room is a real coordinate
+	// rather than a negative number, which is the mistake a client actually
+	// makes.
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: offsetWorld(s.T()),
+	})
+	s.Require().NoError(err)
+}
+
+// refusedInOurVocabulary is the whole assertion of this file, in both
+// directions: the sentinel a host is documented to match on is present, and not
+// one of the composition's is.
+//
+// Asserting only the first half is what let this class of leak in. A refusal
+// can carry our sentinel and theirs at the same time — errors.Is walks the
+// whole chain — so the presence of ours proves nothing at all about what else
+// the host can reach.
+func (s *SentinelSuite) refusedInOurVocabulary(err error, want error) {
+	s.T().Helper()
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, want, "the host is answered in this package's vocabulary")
+	for name, inner := range compositionSentinels {
+		s.NotErrorIs(err, inner,
+			"a host can reach "+name+" through this refusal, and one that matched on it "+
+				"would break the day the composition is replaced (S2)")
+	}
+}
+
+// TestAWalkOffTheMap is the headline case, and the reason this file exists.
+//
+// Pathing to a cell no room owns is arithmetic any client can get wrong — not
+// corrupt state, not a defect in this package, just a route computed one cell
+// too far. It is therefore the leak a real host hits first.
+func (s *SentinelSuite) TestAWalkOffTheMap() {
+	// alice stands at absolute (41,21); the hall runs (40,20)-(45,25). She
+	// steps to its corner, then off the map entirely.
+	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 40, Y: 20}, {X: 39, Y: 19}},
+	})
+	s.refusedInOurVocabulary(err, session.ErrBadPosition)
+	s.Contains(err.Error(), "39",
+		"and the refusal still names the cell that was refused")
+}
+
+// TestAnEntryOffTheMap covers both doors into a session with the same mistake.
+//
+// Join and Spawn share one placement path, so a leak in it is a leak in both;
+// asserting through both is what proves the sharing is real rather than
+// remembered.
+func (s *SentinelSuite) TestAnEntryOffTheMap() {
+	nowhere := spatial.Position{X: 900, Y: 900}
+
+	_, joinErr := s.mgr.Join(context.Background(), &session.JoinInput{
+		Session: "sess", Member: "bob", Position: nowhere,
+	})
+	s.refusedInOurVocabulary(joinErr, session.ErrBadPosition)
+
+	_, spawnErr := s.mgr.Spawn(context.Background(), &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(), Position: nowhere,
+	})
+	s.refusedInOurVocabulary(spawnErr, session.ErrBadPosition)
+}
+
+// TestACorruptStoredWorld is the case every verb shares, because every verb
+// begins by loading.
+//
+// A blob whose member stands in a room the field does not declare is exactly
+// what a hand-edited or half-migrated store looks like, and the composition
+// refuses it in its own vocabulary — several sentinels deep. The host is
+// entitled to hear "the stored world is invalid" and nothing else: the leaves
+// underneath the composition (clock, intel, record) are replaceable too, and
+// they report through the same channel.
+func (s *SentinelSuite) TestACorruptStoredWorld() {
+	s.encounters.byID["world"].Members[0].Room = "nowhere"
+	ctx := context.Background()
+
+	_, err := s.mgr.Status(ctx, &session.StatusInput{Session: "sess"})
+	s.refusedInOurVocabulary(err, session.ErrInvalidWorld)
+
+	_, err = s.mgr.Where(ctx, &session.WhereInput{Session: "sess", Member: "alice"})
+	s.refusedInOurVocabulary(err, session.ErrInvalidWorld)
+
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 42, Y: 22}},
+	})
+	s.refusedInOurVocabulary(err, session.ErrInvalidWorld)
+
+	s.Contains(err.Error(), "nowhere",
+		"and the refusal still names the room the blob invented")
+}
+
+// TestAWorldThatWillNotLoad is the corrupt blob's twin at the OTHER door: the
+// same refusal, reached before anything is stored rather than after.
+//
+// A host authoring a world gets it wrong long before a store corrupts one, so
+// this is the first refusal most integrations meet — and the composition
+// answers it with several sentinels stacked, which is several ways to couple a
+// host to a module we intend to replace.
+func (s *SentinelSuite) TestAWorldThatWillNotLoad() {
+	broken := offsetWorld(s.T())
+	broken.Members[0].Room = "nowhere"
+
+	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "another", Encounter: "another-world", World: broken,
+	})
+	s.refusedInOurVocabulary(err, session.ErrInvalidWorld)
+	s.Contains(err.Error(), "nowhere",
+		"and the refusal still names the room the world invented")
+}
+
+// TestATrimmedStory is the case that already held, kept here so the list of
+// refusals is the list of refusals rather than a list of bugs once fixed.
+func (s *SentinelSuite) TestATrimmedStory() {
+	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "trimmed", Encounter: "trimmed-world", World: trimmedWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.mgr.Story(context.Background(),
+		&session.StoryInput{Session: "trimmed", Member: "alice", FromSeq: 1})
+	s.refusedInOurVocabulary(err, session.ErrStoryTrimmed)
+}
+
+// TestAMemberTheEncounterDoesNotHave covers the reads that ask the composition
+// about somebody by name.
+func (s *SentinelSuite) TestAMemberTheEncounterDoesNotHave() {
+	ctx := context.Background()
+
+	_, err := s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "nobody"})
+	s.refusedInOurVocabulary(err, session.ErrNoMember)
+
+	_, err = s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "nobody"})
+	s.refusedInOurVocabulary(err, session.ErrNoMember)
+
+	_, err = s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "nobody"})
+	s.refusedInOurVocabulary(err, session.ErrNoMember)
+}
+
+// TestAnEndingThatWasNeverDeclared and TestAClosedEncounter cover the write
+// verbs' own refusals, which already route through translate — regression
+// guards rather than new ground.
+func (s *SentinelSuite) TestAnEndingThatWasNeverDeclared() {
+	_, err := s.mgr.End(context.Background(), &session.EndInput{
+		Session: "sess", Ending: "never-declared",
+	})
+	s.refusedInOurVocabulary(err, session.ErrNoEnding)
+}
+
+func (s *SentinelSuite) TestAClosedEncounter() {
+	ctx := context.Background()
+
+	// Walked onto rather than declared: offsetWorld's endings both fire on a
+	// position, so the encounter is closed the way the game closes it.
+	out, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 42, Y: 21}, {X: 43, Y: 21}, {X: 44, Y: 21}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Outcome, "the walk ended the encounter")
+
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 44, Y: 22}},
+	})
+	s.refusedInOurVocabulary(err, session.ErrClosed)
+}
+
+// TestEndingATurnWhileFreeRoaming is the one refusal whose translation changes
+// the WORD as well as the package — the composition's "no bubble" is this
+// seam's "not in a fight" — so it also pins that translate is a mapping rather
+// than a rewrap.
+func (s *SentinelSuite) TestEndingATurnWhileFreeRoaming() {
+	_, err := s.mgr.EndTurn(context.Background(), &session.EndTurnInput{
+		Session: "sess", Member: "alice",
+	})
+	s.refusedInOurVocabulary(err, session.ErrNotInFight)
+}

--- a/rulebooks/dnd5e/session/start.go
+++ b/rulebooks/dnd5e/session/start.go
@@ -80,7 +80,12 @@ func (m *Manager) StartSession(ctx context.Context, in *StartSessionInput) (*Sta
 		Data:       *in.World,
 		Initiative: m.initiative,
 	}); err != nil {
-		return nil, fmt.Errorf("startsession: %w: %w", ErrInvalidWorld, err)
+		// The reason as TEXT, our sentinel as the only thing to match on. A
+		// blob that will not load fails several modules deep, and every one of
+		// those is replaceable underneath this seam (S2) — see
+		// loadWorldWithBaseline, which refuses the same way for the same
+		// reason.
+		return nil, fmt.Errorf("startsession: %w: %v", ErrInvalidWorld, err)
 	}
 
 	// Refuse to overwrite a session in progress. A miss is the expected path

--- a/rulebooks/dnd5e/session/translate_internal_test.go
+++ b/rulebooks/dnd5e/session/translate_internal_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// sentinels_test.go pins the refusals a caller can DRIVE this seam into. This
+// file pins the ones it cannot (rpg-toolkit#1058).
+//
+// Some composition sentinels arrive only through state no blob LoadEncounter
+// accepts can produce — Members reporting that the roster and the spatial field
+// disagree about who is placed, most concretely. There is no verb call that
+// reaches those today, and a test that faked one would be pinning the fake.
+// Testing translate directly is the honest version: it is where the mapping
+// lives, and an arm that is missing there is a leak the moment its path opens.
+func TestTranslateLetsNoCompositionSentinelThrough(t *testing.T) {
+	// Every arm translate carries, asserted in both directions. The second
+	// assertion is the load-bearing one: a translation that returned
+	// fmt.Errorf("%w: %w", ours, theirs) would satisfy the first and leak
+	// exactly as badly as no translation at all.
+	cases := []struct {
+		name  string
+		inner error
+		want  error
+	}{
+		{"trimmed story", encounter.ErrTrimmed, ErrStoryTrimmed},
+		{"empty member id", encounter.ErrNoMember, ErrNoMember},
+		{"not a member", encounter.ErrNotMember, ErrNoMember},
+		{"closed encounter", encounter.ErrClosed, ErrClosed},
+		{"undeclared ending", encounter.ErrNoEnding, ErrNoEnding},
+		{"unknown connection", encounter.ErrNoConnection, ErrNoConnection},
+		{"malformed connection", encounter.ErrBadConnection, ErrNoConnection},
+		{"bad placement", encounter.ErrBadPlacement, ErrBadPosition},
+		{"already in a fight", encounter.ErrInBubble, ErrInBubble},
+		{"not in a fight", encounter.ErrNoBubble, ErrNotInFight},
+		// The two the reads needed. Members fails with ErrNoField when the
+		// roster and the field disagree about who is placed, which is what
+		// Where, whereIs and Attack all read through; ErrInvalidData is what a
+		// blob that cannot be reconstituted carries.
+		{"defective field", encounter.ErrNoField, ErrInvalidWorld},
+		{"unreadable blob", encounter.ErrInvalidData, ErrInvalidWorld},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Wrapped, the way a composition verb really returns it, so the
+			// arms are exercised through errors.Is rather than by identity.
+			out := translate(fmt.Errorf("members: alice: %w", tc.inner))
+
+			require.ErrorIs(t, out, tc.want,
+				"the host is answered in this package's vocabulary")
+			require.NotErrorIs(t, out, tc.inner,
+				"and must not be able to reach the composition's sentinel — matching on it "+
+					"would couple every host to a module we intend to replace (S2)")
+		})
+	}
+}

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -329,11 +329,13 @@ func place(
 	// speaks one map, and a room id never has to appear in an input.
 	located, err := scope.enc.Locate(&encounter.LocateInput{Position: at})
 	if err != nil {
-		// Both wrapped: ErrBadPosition is what a caller matches on, and the
-		// composition's own error keeps WHY — owned by no room, off the grid,
-		// or not an integral cell — which is the difference between a typo
-		// and a fractional coordinate.
-		return nil, fmt.Errorf("no room owns %v: %w: %w", at, ErrBadPosition, err)
+		// ErrBadPosition is what a caller matches on, and the composition's own
+		// error keeps WHY — owned by no room, off the grid, or not an integral
+		// cell — which is the difference between a typo and a fractional
+		// coordinate. That account is kept as TEXT: wrapping it too would let a
+		// host match on encounter.ErrBadPlacement, which is the leak S2 exists
+		// to prevent and the one no AST test can see (rpg-toolkit#1058).
+		return nil, fmt.Errorf("no room owns %v: %w: %v", at, ErrBadPosition, err)
 	}
 
 	placed, err := scope.enc.Join(&encounter.JoinInput{
@@ -506,7 +508,7 @@ func (m *Manager) adopt(scope *writeScope, world encounter.EncounterData) error 
 		Initiative: m.initiative,
 	})
 	if err != nil {
-		return fmt.Errorf("%q: %w: %w", scope.encounter, ErrInvalidWorld, err)
+		return fmt.Errorf("%q: %w: %v", scope.encounter, ErrInvalidWorld, err)
 	}
 	scope.enc = enc
 	return nil


### PR DESCRIPTION
Closes #1058

## The S2 gap

`translate()`'s own comment names sentinels as exactly the channel the AST boundary test cannot see — a sentinel is not a type in a signature, so an inner package can become part of the host's contract through a door no test is watching. A host that matched on `encounter.ErrBadPlacement` would be coupled to the module this seam exists to keep replaceable, exactly as surely as if a struct had leaked, with CI green throughout.

Eight paths were skipping it.

## The paths

**The four the issue names.** `resolveWalk` wrapped `Locate`'s error with a SECOND `%w`, so `encounter.ErrBadPlacement` rode out alongside our `ErrBadPosition` — reachable by pathing one cell past the edge of the map, a routine caller mistake rather than corrupt state. `whereIs` returned `Members()`' errors raw. `Where` and `Status` passed the composition's through with only an `fmt.Errorf` prefix. `View`, sitting between them, translated.

**Four more of the same shape,** found by writing the allow-list test the issue asked for rather than by reading the diff:

| path | leaked | reachable by |
|---|---|---|
| `place()` (shared Join/Spawn placement) | `ErrBadPlacement` | joining or spawning at a cell no room owns |
| `loadWorldWithBaseline` | `ErrInvalidData`, `ErrBadPlacement`, + whatever leaf (clock/intel/record) reported | a corrupt stored blob, through **every** verb — all of them begin by loading |
| `StartSession`'s validation load | same | a host authoring a malformed world |
| `adopt` | same | defect-here path |
| `Attack`'s roster read, `Atlas`'s map read | `ErrNoField` (latent) | — |

## The fix

The issue's lean. Every composition call routes through `translate()`. `translate` gains one arm mapping `encounter.ErrNoField` and `encounter.ErrInvalidData` onto `ErrInvalidWorld`, which is now documented as the translation of record for a complaint about the world itself — modelled on `ErrNoConnection`'s doc, which already plays that role for a refused crossing.

Where an outer session sentinel already carries the meaning, the inner error is demoted from `%w` to `%v`: the message survives for whoever debugs it, the chain does not, so a host gets our vocabulary and only ours.

**The default arm still passes unrecognised errors through unchanged, deliberately** — it adds nothing, and the calling verb supplies the prefix. It carries errors that ORIGINATED with the host — a failing `Roller` comes back out through a composition verb — and flattening those to protect the host from us would break its matching on its own errors. The guarantee is instead that every sentinel this seam can reach has an arm, and that guarantee is mechanical, in the tests below.

## The tests

`sentinels_test.go` is the sentinel-shaped sibling of `TestNoInnerTypeCrossesTheBoundary`: an explicit, written-out list of the composition's sentinels (written out for the same reason `boundary_test.go` writes out its permitted types), and every refusal this seam can be driven into checked against all of it. Both directions per case — our sentinel present AND none of theirs reachable — because asserting only the first is what let this class in: `errors.Is` walks the whole chain, so ours being present says nothing about what else is.

The paths that exist but cannot be reached from a verb (`Members()` reporting that the roster and the spatial field disagree — no blob `LoadEncounter` accepts can produce it) are pinned one layer down, on `translate` itself, in `translate_internal_test.go`. A fake would only have pinned the fake.

## RED

Watched failing before the fix, each for the right reason:

```
--- FAIL: TestMoveSuite/TestAStepOntoNoCellUsesOurSentinelNotTheirs
    found: "bad placement"
    in chain: "move: step 2 of 2: no room owns (-1,-1): bad position: locate: position owned by no room: bad placement"
    Messages: and must NOT be able to reach the composition's sentinel — a host that
              matched on it would break the day the composition is replaced

--- FAIL: TestSentinelSuite/TestAWalkOffTheMap        (encounter.ErrBadPlacement)
--- FAIL: TestSentinelSuite/TestAnEntryOffTheMap      (encounter.ErrBadPlacement, via Join AND Spawn)
--- FAIL: TestSentinelSuite/TestACorruptStoredWorld   (encounter.ErrInvalidData + ErrBadPlacement, via Status, Where AND Move)
--- FAIL: TestSentinelSuite/TestAWorldThatWillNotLoad (encounter.ErrInvalidData + ErrBadPlacement, via StartSession)
--- FAIL: TestTranslateLetsNoCompositionSentinelThrough/defective_field
    expected: "invalid encounter data"  in chain: "members: alice: no field"
--- FAIL: TestTranslateLetsNoCompositionSentinelThrough/unreadable_blob
    expected: "invalid encounter data"  in chain: "members: alice: invalid encounter data"
```

`TestAClosedEncounter`, `TestATrimmedStory`, `TestAMemberTheEncounterDoesNotHave`, `TestAnEndingThatWasNeverDeclared` and `TestEndingATurnWhileFreeRoaming` were green from the start — regression guards, so the file reads as the list of refusals rather than a list of bugs once fixed.

## GREEN

```
--- PASS: TestTranslateLetsNoCompositionSentinelThrough (12 subtests)
--- PASS: TestSentinelSuite (9 subtests)
--- PASS: TestMoveSuite (12 subtests)
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session
```

Full module suite, plus `go vet`, `golangci-lint run ./...` (0 issues), `go fmt` and `go mod tidy` — all clean, no diff. Session module only; no `replace` directives, no `go.work`, hooks ran on the commit.

## Noted, not fixed

`translateResolution` wraps the resolution module's sentinels with `%w: %w` in every arm, so `resolution.ErrBadParticipant`, `ErrNoCombatant`, `ErrNilInput` and `ErrNoMachine` are host-matchable in exactly the way this PR closes for the composition. Same for `entities.go`'s `ErrBadCharacter`/`ErrBadRef` wraps over the dnd5e rulebook's errors. That is a different module's sentinels and a deliberate, documented choice in that function, so it wants its own issue rather than a drive-by here — the allow-list in `sentinels_test.go` is scoped to the composition and says so.

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
