### PR TITLE
fix(encounter)!: Pump's monster moves speak dungeon-absolute (#1062)

### DIFF
--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -154,7 +154,12 @@ func TestVaultChase(t *testing.T) {
 	require.Equal(t, goblin, pumpOut2.MonsterTraverses[0].Member)
 	require.Equal(t, corridorRoom, pumpOut2.MonsterTraverses[0].FromRoom)
 	require.Equal(t, vaultRoom, pumpOut2.MonsterTraverses[0].ToRoom)
-	require.Equal(t, spatial.Position{X: 0, Y: 5}, pumpOut2.MonsterTraverses[0].To)
+	// The arrival cell on the MAP: vault-local (0,5) through the vault's
+	// (10,0) anchor. The same cell the traversed beat carries — one
+	// movement cannot be reported in two frames (rpg-toolkit#1062).
+	require.Equal(t, spatial.Position{X: 10, Y: 5}, pumpOut2.MonsterTraverses[0].To)
+	require.Equal(t, spatial.Position{X: 9, Y: 5}, pumpOut2.MonsterTraverses[0].From,
+		"the departure cell is the corridor-side threshold, on the map")
 
 	// It's in her room now — this pump's own refreshSight already shows
 	// her Current again, at (4,5), where she stopped in beat 2.

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -428,7 +428,10 @@ func main() {
 			}
 			fmt.Printf("  tick %d", out.Tick)
 			for _, mv := range out.MonsterMoves {
-				fmt.Printf("; %s prowls (%g,%g)->(%g,%g)", mv.Member, mv.From.X, mv.From.Y, mv.To.X, mv.To.Y)
+				// Absolute cells, same as the atlas above prints — a prowl in
+				// the ossuary (anchored at (12,0)) reads on the same map as
+				// one in the crypt (rpg-toolkit#1062).
+				fmt.Printf("; %s prowls (%g,%g)->(%g,%g) on the map", mv.Member, mv.From.X, mv.From.Y, mv.To.X, mv.To.Y)
 			}
 			fmt.Println()
 			if out.Outcome != nil {

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -148,6 +148,25 @@ func (p *continuityProjector) project(member, verb, room string, pos spatial.Pos
 	return out.Position
 }
 
+// locate is project's sibling for a position the composition ALREADY
+// reports in dungeon-absolute space — a pump's monster move or doorway
+// crossing (rpg-toolkit#1062). It resolves the cell back to its owning
+// room through Locate (project's exact inverse), writes the SAME
+// transcript row project would have written for that room-local cell,
+// and returns the absolute position unchanged.
+//
+// Reading the reported cell back through Locate is what makes a
+// room-local value visible: a room-local cell either resolves to the
+// WRONG room or to no room at all, and the transcript row says which.
+func (p *continuityProjector) locate(member, verb string, absolute spatial.Position) spatial.Position {
+	p.t.Helper()
+	out, err := p.enc.Locate(&encounter.LocateInput{Position: absolute})
+	require.NoError(p.t, err, "%s %s: the reported cell must be an absolute cell some room owns", member, verb)
+	p.transcript = append(p.transcript, fmt.Sprintf("%s %s: %s(%g,%g) -> absolute(%g,%g)",
+		member, verb, out.Room, out.Position.X, out.Position.Y, absolute.X, absolute.Y))
+	return absolute
+}
+
 // TestVaultChaseAbsoluteContinuity is the wave's payoff scene (#929 T4):
 // W2 + W3 + the local/absolute bridge, proven as ONE property — a
 // member's path, projected into dungeon-absolute space, is continuous
@@ -249,15 +268,22 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	pumpOut1, err := enc.Pump(&encounter.PumpInput{})
 	require.NoError(t, err, "beat 4: the pursuit resumes")
 	require.Len(t, pumpOut1.MonsterMoves, 1, "beat 4: the goblin steps toward the threshold")
+	// The pump reports where it walked on the MAP — no room needed to read
+	// it, and no arithmetic to redo (rpg-toolkit#1062). The corridor is
+	// anchored at the origin, so this one cell reads the same either way;
+	// the crossing below is where the two frames part company.
 	require.Equal(t, spatial.Position{X: 4, Y: 1}, pumpOut1.MonsterMoves[0].To)
-	goblinPath = append(goblinPath, proj.project(string(goblin), "move", "corridor", pumpOut1.MonsterMoves[0].To))
+	goblinPath = append(goblinPath, proj.locate(string(goblin), "move", pumpOut1.MonsterMoves[0].To))
 
 	pumpOut2, err := enc.Pump(&encounter.PumpInput{})
 	require.NoError(t, err, "beat 4: the goblin follows her through")
 	require.Len(t, pumpOut2.MonsterTraverses, 1, "beat 4: the goblin traverses the gate")
 	require.Equal(t, "vault", pumpOut2.MonsterTraverses[0].ToRoom)
-	require.Equal(t, spatial.Position{X: -5, Y: -2}, pumpOut2.MonsterTraverses[0].To)
-	goblinPath = append(goblinPath, proj.project(string(goblin), "arrive via gate", "vault", pumpOut2.MonsterTraverses[0].To))
+	// vault-local (-5,-2) through the vault's (10,3) anchor: the same
+	// absolute cell alice's own Traverse projected to, and the same cell
+	// the traversed beat carries.
+	require.Equal(t, spatial.Position{X: 5, Y: 1}, pumpOut2.MonsterTraverses[0].To)
+	goblinPath = append(goblinPath, proj.locate(string(goblin), "arrive via gate", pumpOut2.MonsterTraverses[0].To))
 
 	// ---- Beat 5: sanctuary ------------------------------------------------
 	for _, to := range []spatial.Position{{X: -3, Y: -2}, {X: -2, Y: -2}} {

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -2156,6 +2156,16 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 
 	// Build the output, splitting executed actions by kind (each output
 	// slice preserves the SAME relative order it had in executed).
+	//
+	// Every cell is projected through the SAME absoluteOf the beats above
+	// used, and for the same reason (rpg-toolkit#1062): one movement is
+	// reported twice — once as a typed output, once as a beat — and a host
+	// reading both must be told the same cell. An executedAction carries
+	// room-local cells because that is what spatial hands back; a room-local
+	// cell is this composition's own bookkeeping, and rooms do not cross the
+	// seam. A move's cells belong to member.Room (a move never changes it);
+	// a crossing's belong to two DIFFERENT rooms, each side projected
+	// through its own anchor.
 	var outputMoves []struct {
 		Member MemberID
 		From   spatial.Position
@@ -2175,7 +2185,11 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 				Member MemberID
 				From   spatial.Position
 				To     spatial.Position
-			}{Member: action.member.ID, From: action.from, To: action.to})
+			}{
+				Member: action.member.ID,
+				From:   e.absoluteOf(action.member.Room, action.from),
+				To:     e.absoluteOf(action.member.Room, action.to),
+			})
 		case actionTraverse:
 			outputTraverses = append(outputTraverses, struct {
 				Member   MemberID
@@ -2183,7 +2197,13 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 				From     spatial.Position
 				ToRoom   string
 				To       spatial.Position
-			}{Member: action.member.ID, FromRoom: action.fromRoom, From: action.from, ToRoom: action.toRoom, To: action.to})
+			}{
+				Member:   action.member.ID,
+				FromRoom: action.fromRoom,
+				From:     e.absoluteOf(action.fromRoom, action.from),
+				ToRoom:   action.toRoom,
+				To:       e.absoluteOf(action.toRoom, action.to),
+			})
 		}
 	}
 

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -418,7 +418,20 @@ type PumpOutput struct {
 	// Tick is the exploration clock's reading after the advance.
 	Tick uint64
 
-	// MonsterMoves contains the successful same-room moves executed by monsters during this pump.
+	// MonsterMoves contains the successful same-room moves executed by monsters
+	// during this pump.
+	//
+	// From and To are DUNGEON-ABSOLUTE — already projected through the room's
+	// origin, so they can be compared with any other absolute coordinate this
+	// composition reports (a [Member]'s Position, an Atlas cell, the position
+	// on this move's own "moved" beat) without the caller redoing the
+	// arithmetic. They are also the frame the decider named the step in: what
+	// the pump reports back is the cell that was asked for.
+	//
+	// No room field, deliberately: an absolute cell does not need one, and
+	// carrying a composition-internal room ID beside a position is the dialect
+	// the seam reshape exists to remove (rpg-toolkit#1062). To recover the
+	// room-local cell, pass the position to [Encounter.Locate].
 	MonsterMoves []struct {
 		Member MemberID
 		From   spatial.Position
@@ -430,6 +443,12 @@ type PumpOutput struct {
 	// doorway. A step that could not be taken does not appear here: a cell in
 	// another room with no doorway joining it to where the monster stands is
 	// silently skipped, matching MonsterMoves' spatial-rejection contract.
+	//
+	// From and To are DUNGEON-ABSOLUTE, exactly as MonsterMoves' are — and here
+	// the two sides are projected through DIFFERENT anchors, since a crossing's
+	// departure cell belongs to FromRoom and its arrival cell to ToRoom. On the
+	// map the pair is simply two adjacent cells (W3), which is the whole point:
+	// a crossing reads like an ordinary step.
 	MonsterTraverses []struct {
 		Member   MemberID
 		FromRoom string

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -1164,13 +1164,159 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	s.Equal("room-a", out.MonsterTraverses[0].FromRoom)
 	s.Equal(spatial.Position{X: 9, Y: 5}, out.MonsterTraverses[0].From)
 	s.Equal("room-b", out.MonsterTraverses[0].ToRoom)
-	s.Equal(spatial.Position{X: 0, Y: 5}, out.MonsterTraverses[0].To)
+	// The arrival cell as the decider named it: room-b's local (0,5) is
+	// (10,5) on the map, and what the pump reports is the cell the decider
+	// asked for, not a room-local one it would have to re-anchor.
+	s.Equal(spatial.Position{X: 10, Y: 5}, out.MonsterTraverses[0].To)
 	s.Empty(out.MonsterMoves, "this is a traverse, not a move")
 
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	s.Require().Len(members, 1)
 	s.Equal("room-b", members[0].Room)
+}
+
+// TestPumpReportsMovementOnTheMap is the discriminating probe for
+// rpg-toolkit#1062: NEITHER room is anchored at the origin, so a room-local
+// coordinate and its absolute one differ in every single assertion below.
+//
+// Every other fixture in this file anchors room-a at (0,0), which made a
+// room-local report indistinguishable from an absolute one for a same-room
+// move and for a crossing's departure cell — the frame was pinned by
+// coincidence, not by a test. Here the coincidence is gone: the prowler
+// walks within a room anchored at (40,20) and then crosses into one anchored
+// at (50,20), and the pump's report is checked against BOTH the map and the
+// beat that describes the same movement.
+//
+// The beat cross-check is the point. Pump reports one movement twice — once
+// as a typed output a host reads, once as a beat a host renders — and the two
+// must be the same cell. They were not: the beat projected and the output did
+// not, so a host that trusted both drew the monster in two places the moment a
+// room stopped sitting at the origin.
+func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
+	prowler := core.EntityID("prowler")
+	const (
+		cellar = "cellar"
+		shrine = "shrine"
+	)
+
+	// cellar occupies absolute x:[40,49], shrine x:[50,59] — disjoint (W2) —
+	// and the door's endpoints, cellar-local (9,5) and shrine-local (0,5),
+	// land on absolute (49,25) and (50,25): adjacent cells (W3).
+	door := encounter.ConnectionInput{
+		ID: "cellar-door", From: cellar, To: shrine,
+		FromPosition: spatial.Position{X: 9, Y: 5},
+		ToPosition:   spatial.Position{X: 0, Y: 5},
+	}
+	// Both steps are named in absolute space, which is the only space a
+	// decider has spoken since rpg-toolkit#1044: walk to the threshold, then
+	// walk to the cell beyond it.
+	patrol := &patrolDecider{positions: []spatial.Position{
+		{X: 49, Y: 25}, {X: 50, Y: 25},
+	}}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{
+				{ID: cellar, Width: 10, Height: 10, Origin: spatial.Position{X: 40, Y: 20}},
+				{ID: shrine, Width: 10, Height: 10, Origin: spatial.Position{X: 50, Y: 20}},
+			},
+			Connections: []encounter.ConnectionInput{door},
+		},
+		Members: []encounter.MemberInput{
+			// cellar-local (3,5) — absolute (43,25).
+			{ID: prowler, Kind: encounter.KindMonster, Room: cellar,
+				Position: spatial.Position{X: 3, Y: 5}, Decider: patrol},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	// ---- The same-room move ------------------------------------------------
+	out1, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(out1.MonsterMoves, 1)
+	s.Equal(prowler, out1.MonsterMoves[0].Member)
+	s.Equal(spatial.Position{X: 43, Y: 25}, out1.MonsterMoves[0].From,
+		"it departs from (43,25) on the map — cellar-local (3,5) is not an answer without the room")
+	s.Equal(spatial.Position{X: 49, Y: 25}, out1.MonsterMoves[0].To,
+		"and arrives at the cell the decider named, in the frame the decider named it")
+	s.Equal(out1.MonsterMoves[0].To, s.movedBeatPosition(enc, prowler, out1.Seqs),
+		"the moved beat and the typed output describe ONE movement")
+
+	// ---- The crossing ------------------------------------------------------
+	out2, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().Len(out2.MonsterTraverses, 1)
+	s.Equal(prowler, out2.MonsterTraverses[0].Member)
+	s.Equal(cellar, out2.MonsterTraverses[0].FromRoom)
+	s.Equal(shrine, out2.MonsterTraverses[0].ToRoom)
+	s.Equal(spatial.Position{X: 49, Y: 25}, out2.MonsterTraverses[0].From,
+		"the departure cell is the cellar-side threshold, projected through the CELLAR's anchor")
+	s.Equal(spatial.Position{X: 50, Y: 25}, out2.MonsterTraverses[0].To,
+		"and the arrival cell through the SHRINE's — the two sides of a doorway have different anchors")
+	s.Equal(out2.MonsterTraverses[0].To, s.traversedBeatPosition(enc, prowler, out2.Seqs),
+		"the traversed beat and the typed output describe ONE crossing")
+
+	// And the map agrees with both: Members() has spoken absolute since the
+	// seam reshape, so a host comparing a move's destination against a member's
+	// position must find them equal without redoing any arithmetic.
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	s.Require().Len(members, 1)
+	s.Equal(shrine, members[0].Room)
+	s.Equal(out2.MonsterTraverses[0].To, members[0].Position,
+		"where the pump says it went is where the field says it stands")
+}
+
+// movedBeatPosition reads the position off the "moved" beat this member
+// recorded among the given seqs — the beat half of the one-movement-one-frame
+// claim TestPumpReportsMovementOnTheMap makes.
+func (s *PumpTestSuite) movedBeatPosition(
+	enc *encounter.Encounter, member core.EntityID, seqs []uint64,
+) spatial.Position {
+	return s.beatPosition(enc, member, seqs, "moved")
+}
+
+// traversedBeatPosition is movedBeatPosition's sibling for a doorway crossing.
+func (s *PumpTestSuite) traversedBeatPosition(
+	enc *encounter.Encounter, member core.EntityID, seqs []uint64,
+) spatial.Position {
+	return s.beatPosition(enc, member, seqs, "traversed")
+}
+
+// beatPosition finds the one beat of the given kind naming this member within
+// seqs and returns the position it carries, failing the test if there is not
+// exactly one.
+func (s *PumpTestSuite) beatPosition(
+	enc *encounter.Encounter, member core.EntityID, seqs []uint64, kind string,
+) spatial.Position {
+	s.T().Helper()
+	wanted := make(map[uint64]bool, len(seqs))
+	for _, seq := range seqs {
+		wanted[seq] = true
+	}
+	story, err := enc.Story(&encounter.StoryInput{Audience: member, AfterSeq: 0})
+	s.Require().NoError(err)
+
+	var found []spatial.Position
+	for _, entry := range story {
+		if !wanted[entry.Seq] {
+			continue
+		}
+		var beat struct {
+			Beat     string           `json:"beat"`
+			Member   string           `json:"member"`
+			Position spatial.Position `json:"position"`
+		}
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		if beat.Beat == kind && beat.Member == string(member) {
+			found = append(found, beat.Position)
+		}
+	}
+	s.Require().Len(found, 1, "expected exactly one %q beat for %s in this pump", kind, member)
+	return found[0]
 }
 
 // TestPumpDoesNotAbortWhenNoDoorwayJoinsTheStep pins the silent skip for the
@@ -1402,7 +1548,9 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	s.Equal(goblinID, out2.MonsterTraverses[0].Member)
 	s.Equal("room-a", out2.MonsterTraverses[0].FromRoom)
 	s.Equal("room-b", out2.MonsterTraverses[0].ToRoom)
-	s.Equal(spatial.Position{X: 0, Y: 5}, out2.MonsterTraverses[0].To)
+	// room-b is anchored at (10,0), so the arrival cell on the map is
+	// (10,5) — the same cell the traversed beat carries.
+	s.Equal(spatial.Position{X: 10, Y: 5}, out2.MonsterTraverses[0].To)
 
 	// The monster arrives in alice's room and, since THIS pump's own
 	// refreshSight ran AFTER the traverse, already holds her Current.


### PR DESCRIPTION
One movement, reported twice in two different frames. `Pump` records a `"moved"` beat through `absoluteOf` and then copies the SAME action's cells raw into `PumpOutput.MonsterMoves` — and `stepTo` stores what spatial hands back, which is room-local per `Locate`'s contract. So a host reading the beat and a host reading the typed output were told two different places, and neither struct's doc said which frame it was in.

`MonsterMoves` has no room field to reconstruct the absolute cell from, which is what makes this a defect rather than a dialect: a room-local coordinate with no room attached cannot be resolved to anywhere in a multi-room field. Every other position at this seam has been dungeon-absolute since the reshape — `Member.Position`, every beat, Atlas cells, the doorway endpoints, and the intent a decider names in the first place. These two outputs were the exception.

## The ruling this enforces

Rooms are composition-internal, and everything the composition REPORTS speaks absolute (rpg-project#227, one map at the seam). So the fix is the projection, not a room field:

- A **move**'s cells project through `member.Room` — a move never changes it, and it is the same room the beat already used.
- A **crossing**'s project through two DIFFERENT anchors: departure through `FromRoom`, arrival through `ToRoom`. On the map that leaves them simply two adjacent cells (W3) — a crossing reads like an ordinary step, which is the whole point of W3.

Both struct docs now declare the frame in `Member.Position`'s own words, and say where the room-local cell went (`Locate`, the exact inverse).

**`FromRoom`/`ToRoom` stay.** They are composition-internal room IDs, and #1053's question about them is real — but nothing outside this module consumes them today (`session` does not reference `Pump` at all; the workbench reads only `MonsterMoves`), so removing them is a separate decision and not this PR's.

## RED, watched before the fix

The existing tests pinned room-local as intent and were flipped first:

```
--- FAIL: TestVaultChase
    chase_test.go:160: expected: {X:10, Y:5}   actual: {X:0, Y:5}
--- FAIL: TestVaultChaseAbsoluteContinuity
    continuity_test.go:285: expected: {X:5, Y:1}   actual: {X:-5, Y:-2}
--- FAIL: TestPumpTestSuite/TestAnIntendedStepCrossesADoorway
    pump_test.go:1170: expected: {X:10, Y:5}   actual: {X:0, Y:5}
--- FAIL: TestPumpTestSuite/TestPumpPursuitAcrossConnection
    pump_test.go:1553: expected: {X:10, Y:5}   actual: {X:0, Y:5}
```

The continuity chase's own `Locate` round-trip is worth calling out: reading the reported cell back put the goblin in the CORRIDOR, a room it had just left through the gate.

`TestPumpReportsMovementOnTheMap` is the new discriminating probe, and it exists because every other fixture in the file anchors its first room at (0,0) — the frame was pinned by coincidence, not by a test. NEITHER of its rooms sits at the origin (cellar at (40,20), shrine at (50,20)), so a same-room move and a crossing's departure cell differ in every assertion. It failed six ways:

```
--- FAIL: TestPumpTestSuite/TestPumpReportsMovementOnTheMap
    pump_test.go:1241: expected {X:43,Y:25}  actual {X:3,Y:5}
        it departs from (43,25) on the map — cellar-local (3,5) is not an answer without the room
    pump_test.go:1243: expected {X:49,Y:25}  actual {X:9,Y:5}
        and arrives at the cell the decider named, in the frame the decider named it
    pump_test.go:1245: expected {X:9,Y:5}    actual {X:49,Y:25}
        the moved beat and the typed output describe ONE movement
    ...
    pump_test.go:1269: expected {X:0,Y:5}    actual {X:50,Y:25}
        where the pump says it went is where the field says it stands
```

The sharpest two are the ones it cross-checks against each other: the typed output said (9,5) while the `"moved"` beat for that same step said (49,25), and where the pump said the monster went was 40 cells from where `Members()` said it stood.

## GREEN

```
=== go test ===
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter	0.051s
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter/cmd/freeroam-workbench	0.005s
=== golangci-lint ===
0 issues.
```

`go fmt`, `go vet` and `go mod tidy` are all clean (no diffs). The hex continuity test's pinned transcript is byte-identical after the fix — the story it tells did not change, only which side of the seam does the arithmetic.

The workbench's pump line moves with them: an ossuary prowl (anchored at (12,0)) now prints on the same map its own atlas dump does.

## Why the `!`

A behavior change to the values of a public output type — a host reading `MonsterMoves` gets different numbers for the same movement. On v0.x the tagger maps breaking to minor, so encounter goes v0.11.0 → v0.12.0, which is the right bump for this.

Closes #1062

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
