### PR TITLE
fix(session): resolution and rulebook sentinels stop crossing the seam (#1066)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -230,20 +230,34 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 // The same reason translate exists for the composition's: a sentinel is not a
 // type in a signature, so the boundary test cannot see it, and a host that
 // matched on resolution.ErrBadParticipant would be coupled to a module we
-// intend to keep replaceable. Unrecognised errors pass through wrapped rather
-// than flattened — an error nobody anticipated is more useful with its own
-// message intact.
+// intend to keep replaceable.
+//
+// A translated error carries our sentinel ALONE, and the inner reason rides
+// along as TEXT. Every arm below used to wrap both — fmt.Errorf("%w: %w", ours,
+// theirs) — which reads like generosity and is the leak itself: it satisfies a
+// host matching on ours while leaving theirs just as matchable
+// (rpg-toolkit#1066). The %v keeps the account for whoever debugs it and hands
+// the host nothing to branch on but this package's vocabulary (S2).
+//
+// Unrecognised errors pass through UNCHANGED rather than being flattened, for
+// the reason translate's default arm does: it carries errors that ORIGINATED
+// WITH THE HOST — a failing Roller reaches the strike machine and comes back
+// out through here — and flattening those to protect the host from us would
+// break its matching on its own errors. The guarantee is instead that every
+// resolution sentinel this seam can REACH has an arm, and that guarantee is
+// mechanical: sentinels_test.go drives the refusals a caller can produce, and
+// translate_internal_test.go covers every arm below.
 func translateResolution(err error) error {
 	switch {
 	case errors.Is(err, resolution.ErrBadParticipant):
-		return fmt.Errorf("%w: %w", ErrBadCharacter, err)
+		return fmt.Errorf("%w: %v", ErrBadCharacter, err)
 	case errors.Is(err, resolution.ErrNoCombatant):
 		// Reachable when a member has no stored sheet — an authored monster
 		// standing in a world nobody spawned. Refused earlier by name, so this
 		// arm is the backstop rather than the path.
-		return fmt.Errorf("%w: %w", ErrNoSheet, err)
+		return fmt.Errorf("%w: %v", ErrNoSheet, err)
 	case errors.Is(err, resolution.ErrNilInput), errors.Is(err, resolution.ErrNoMachine):
-		return fmt.Errorf("%w: %w", ErrNilInput, err)
+		return fmt.Errorf("%w: %v", ErrNilInput, err)
 	default:
 		return err
 	}
@@ -289,6 +303,15 @@ func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.Reco
 // live character to read static facts off; resolution needs its own cast to
 // attach effects to. Two purposes, one stored sheet, and no shared bus between
 // them.
+//
+// Both refusals below keep the inner reason as TEXT rather than as a chain, the
+// way translateResolution's arms do. The second is the one that made it worth
+// saying: an empty main hand is refused by resolution, so its ErrBadAttack was
+// riding out under ours and a host could match on it (rpg-toolkit#1066). This
+// is not routed THROUGH translateResolution, deliberately — the compiler
+// answers everything the profile step refuses with ErrBadAttack, including the
+// resolution.ErrNilInput cases, and routing it would silently re-map those onto
+// a different sentinel than the one hosts have been given.
 func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolution.AttackProfile, error) {
 	data, err := m.fetchCharacterData(ctx, "attacker", attacker)
 	if err != nil {
@@ -297,14 +320,14 @@ func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolutio
 
 	loaded, err := character.Load(ctx, data)
 	if err != nil {
-		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %w", attacker, ErrBadCharacter, err)
+		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadCharacter, err)
 	}
 
 	profile, err := resolution.AttackFromCharacter(loaded, &resolution.CharacterAttackInput{
 		Slot: character.SlotMainHand,
 	})
 	if err != nil {
-		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %w", attacker, ErrBadAttack, err)
+		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadAttack, err)
 	}
 	return profile, nil
 }

--- a/rulebooks/dnd5e/session/entities.go
+++ b/rulebooks/dnd5e/session/entities.go
@@ -105,6 +105,14 @@ func (m *Manager) fetchCharacterData(ctx context.Context, role, id string) (*cha
 // The returned character is for this call only. It is never stored on the
 // manager (S1), never held across a suspension, and never returned to the host
 // (S2) — the host named an ID and gets data back, not an object.
+//
+// The loader's own reason is kept as TEXT. The rulebook answers a sheet it
+// cannot reconstitute through rpgerr rather than through sentinel values, so
+// there is nothing for a host to match on TODAY — which is exactly why this
+// reads %v rather than %w. A chain that leaks nothing only because the module
+// underneath happens not to export a sentinel is a leak waiting on somebody
+// else's commit, and S2 is not a promise this package gets to delegate
+// (rpg-toolkit#1066).
 func (m *Manager) loadCharacter(
 	ctx context.Context, bus events.EventBus, id string,
 ) (*character.Character, error) {
@@ -115,7 +123,7 @@ func (m *Manager) loadCharacter(
 
 	ch, err := character.LoadFromData(ctx, data, bus)
 	if err != nil {
-		return nil, fmt.Errorf("character %q: %w: %w", id, ErrBadCharacter, err)
+		return nil, fmt.Errorf("character %q: %w: %v", id, ErrBadCharacter, err)
 	}
 	return ch, nil
 }
@@ -146,11 +154,19 @@ func instantiate(id string, ref string) (*monster.Data, error) {
 	}
 	parsed, err := core.ParseString(ref)
 	if err != nil {
-		// The parse error is carried, not swallowed. core.ParseString reports
-		// WHICH segment was wrong and why, and a caller staring at a bad ref
-		// wants that far more than the string it already passed in. The
-		// sentinel stays first so errors.Is keeps working.
-		return nil, fmt.Errorf("%q: %w: %w", ref, ErrBadRef, err)
+		// The parse error is carried as TEXT, not swallowed and not chained.
+		// core.ParseString reports WHICH segment was wrong and why, and a
+		// caller staring at a bad ref wants that far more than the string it
+		// already passed in — so the message survives in full.
+		//
+		// What does not survive is the chain. A ref crosses this seam as a
+		// STRING, so parsing it with core is an implementation detail, and
+		// carrying core.ErrTooFewSegments out to the host made that detail
+		// matchable — the same leak the composition's and resolution's
+		// sentinels had (rpg-toolkit#1066). ErrBadRef is the whole vocabulary
+		// a caller needs: the ref is not a well-formed module:type:id, and the
+		// text says which part offended.
+		return nil, fmt.Errorf("%q: %w: %v", ref, ErrBadRef, err)
 	}
 	if parsed.Module != refs.Module || parsed.Type != refs.TypeMonsters {
 		return nil, fmt.Errorf("%q: %w", ref, ErrNoLoader)

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -14,14 +14,22 @@ package session_test
 // CI would have said a word.
 //
 // So every refusal this seam can be DRIVEN INTO is checked here against an
-// explicit list of the composition's own sentinels: our vocabulary must be
-// present, and none of theirs may be reachable through errors.Is.
+// explicit list of the sentinels the modules underneath export: our vocabulary
+// must be present, and none of theirs may be reachable through errors.Is.
+//
+// THE COMPOSITION IS NOT THE ONLY MODULE UNDERNEATH. This file was scoped to
+// encounter's sentinels when it was written, and said so — which left the same
+// leak open one module over for a swing, and one more for a ref
+// (rpg-toolkit#1066). The lists below are now every module a verb can be
+// refused BY, because a list that covers one of them reads like a guarantee and
+// is not one.
 //
 // Reachability is the discipline that keeps this honest. A case belongs here
 // only if a caller or a stored blob can really produce it, which is why the
 // list of scenarios below reads like a list of mistakes rather than a list of
 // error values. The paths that exist but cannot be reached from a verb are
-// pinned one layer down, on translate itself, in translate_internal_test.go.
+// pinned one layer down, on the translations themselves, in
+// translate_internal_test.go.
 
 import (
 	"context"
@@ -29,8 +37,10 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -61,6 +71,67 @@ var compositionSentinels = map[string]error{
 	"encounter.ErrTrimmed":       encounter.ErrTrimmed,
 	"encounter.ErrNoInitiative":  encounter.ErrNoInitiative,
 }
+
+// resolutionSentinels is every error value the resolution module exports.
+//
+// Resolution is where a swing actually happens, and it is under S2 for the same
+// reason the composition is: the day the strike machine is replaced, a host
+// that branched on resolution.ErrBadParticipant breaks. translateResolution
+// exists to keep that from being possible, and this list is what makes the
+// claim mechanical rather than remembered.
+//
+// Written out whole rather than reduced to the four translateResolution names,
+// because the arms are the answer to a question this list asks: an unlisted
+// resolution error reaching a host is a leak whether or not anybody wrote an
+// arm for it.
+var resolutionSentinels = map[string]error{
+	"resolution.ErrNilInput":              resolution.ErrNilInput,
+	"resolution.ErrNoInitiative":          resolution.ErrNoInitiative,
+	"resolution.ErrNoRoller":              resolution.ErrNoRoller,
+	"resolution.ErrNoMachine":             resolution.ErrNoMachine,
+	"resolution.ErrBadParticipant":        resolution.ErrBadParticipant,
+	"resolution.ErrBadStep":               resolution.ErrBadStep,
+	"resolution.ErrNoSaver":               resolution.ErrNoSaver,
+	"resolution.ErrBadGate":               resolution.ErrBadGate,
+	"resolution.ErrBadWorld":              resolution.ErrBadWorld,
+	"resolution.ErrBadAttack":             resolution.ErrBadAttack,
+	"resolution.ErrNoCombatant":           resolution.ErrNoCombatant,
+	"resolution.ErrRecurrenceUnsupported": resolution.ErrRecurrenceUnsupported,
+}
+
+// refSentinels is core's identifier vocabulary — what a malformed ref is
+// refused with underneath ErrBadRef.
+//
+// This is the third list, and it is the one whose OWNER is worth stating.
+// ErrBadCharacter and ErrBadRef both sit over the rulebook modules the entity
+// loaders call into, and of those only the ref parser answers with sentinel
+// VALUES: character and monster report through rpgerr's codes, which are not
+// reachable by errors.Is at all. So the matchable set underneath the loaders is
+// core's, and listing it is what this file can actually assert.
+//
+// A ref crosses this seam as a STRING (S2 keeps core.Ref off the surface), so
+// which parser reads it is an implementation detail — and a host that matched
+// on core.ErrTooFewSegments would be coupled to that detail through the one
+// channel the boundary test cannot see. When character or monster grows a
+// sentinel of its own, it is added here and this file will say whether it
+// escapes.
+var refSentinels = map[string]error{
+	"core.ErrEmptyString":       core.ErrEmptyString,
+	"core.ErrInvalidFormat":     core.ErrInvalidFormat,
+	"core.ErrEmptyComponent":    core.ErrEmptyComponent,
+	"core.ErrInvalidCharacters": core.ErrInvalidCharacters,
+	"core.ErrTooManySegments":   core.ErrTooManySegments,
+	"core.ErrTooFewSegments":    core.ErrTooFewSegments,
+}
+
+// innerSentinels is the three lists as one: everything a refusal is checked
+// against, whichever module produced it.
+//
+// One collection rather than three call sites, so a new module underneath this
+// seam is covered by every scenario in this file the moment its list is added
+// here — which is the opposite of how the resolution and ref leaks survived
+// rpg-toolkit#1058.
+var innerSentinels = []map[string]error{compositionSentinels, resolutionSentinels, refSentinels}
 
 // SentinelSuite drives each reachable refusal and checks what a host can match
 // on afterwards.
@@ -96,7 +167,7 @@ func (s *SentinelSuite) SetupTest() {
 
 // refusedInOurVocabulary is the whole assertion of this file, in both
 // directions: the sentinel a host is documented to match on is present, and not
-// one of the composition's is.
+// one of the inner modules' is.
 //
 // Asserting only the first half is what let this class of leak in. A refusal
 // can carry our sentinel and theirs at the same time — errors.Is walks the
@@ -106,11 +177,47 @@ func (s *SentinelSuite) refusedInOurVocabulary(err error, want error) {
 	s.T().Helper()
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, want, "the host is answered in this package's vocabulary")
-	for name, inner := range compositionSentinels {
-		s.NotErrorIs(err, inner,
-			"a host can reach "+name+" through this refusal, and one that matched on it "+
-				"would break the day the composition is replaced (S2)")
+	for _, module := range innerSentinels {
+		for name, inner := range module {
+			s.NotErrorIs(err, inner,
+				"a host can reach "+name+" through this refusal, and one that matched on it "+
+					"would break the day that module is replaced (S2)")
+		}
 	}
+}
+
+// armedDuel rewires this suite onto a world where a swing means something.
+//
+// The map fixture in SetupTest is the wrong shape for one: its cast carries no
+// weapon, and its rooms are anchored to make PATHING mistakes real rather than
+// to put two people within reach of each other. duelWorld is already the
+// smallest world a strike resolves in, so the swings below are the same swings
+// attack_test.go pins rather than a second arrangement that could drift from
+// them.
+//
+// The character repository is the parameter because every case here turns on
+// what the host stored — an empty hand, one sheet under two names — which is
+// the only part of a duel these refusals differ in.
+func (s *SentinelSuite) armedDuel(chars *fakeCharacters) *session.Manager {
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Characters: chars, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	return mgr
+}
+
+func (s *SentinelSuite) swing(mgr *session.Manager) error {
+	s.T().Helper()
+	_, err := mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "bob",
+	})
+	return err
 }
 
 // TestAWalkOffTheMap is the headline case, and the reason this file exists.
@@ -261,4 +368,73 @@ func (s *SentinelSuite) TestEndingATurnWhileFreeRoaming() {
 		Session: "sess", Member: "alice",
 	})
 	s.refusedInOurVocabulary(err, session.ErrNotInFight)
+}
+
+// TestASwingWithAnEmptyHand is the resolution module's headline case, and the
+// reason the second list above exists.
+//
+// A character with nothing in the main hand is refused rather than falling back
+// to an unarmed strike, which makes this the first refusal any host meets that
+// comes from the rules rather than from the map — a party member who unequipped
+// and forgot, or a sheet seeded without a weapon. The compiler asks resolution
+// to read the attack off the sheet, resolution says it cannot, and its sentinel
+// rode out under ours.
+func (s *SentinelSuite) TestASwingWithAnEmptyHand() {
+	mgr := s.armedDuel(newFakeCharacters(dwarfCharacter("alice"), armedFighter("bob")))
+
+	err := s.swing(mgr)
+	s.refusedInOurVocabulary(err, session.ErrBadAttack)
+	s.Contains(err.Error(), "alice",
+		"and the refusal still names who could not swing")
+}
+
+// TestOneSheetStoredUnderTwoNames drives the resolution module's own validation
+// — the arm translateResolution was written for.
+//
+// The roster holds two members and the repository answers both with the same
+// sheet, which is a seeding mistake rather than corruption: the bytes are
+// valid, and only their identity is wrong. Resolution refuses because two
+// sheets under one ID would attach twice and be written back once, and the host
+// is entitled to hear that in this package's vocabulary — its own character
+// data is what needs looking at.
+func (s *SentinelSuite) TestOneSheetStoredUnderTwoNames() {
+	chars := newFakeCharacters(armedFighter("alice"))
+	chars.byID["bob"] = armedFighter("alice")
+
+	err := s.swing(s.armedDuel(chars))
+	s.refusedInOurVocabulary(err, session.ErrBadCharacter)
+}
+
+// TestASwingWithAnUnreadableSheet is the loader's own refusal on the swing
+// path, kept here as the case that guards the OTHER wrap in the compiler.
+//
+// The rulebook answers this one through rpgerr rather than a sentinel value, so
+// there is nothing for a host to match on today and this case was green from
+// the start. It is here because that is a property of the character module this
+// package does not control: the day a sentinel appears underneath the strict
+// load, this scenario is what notices.
+func (s *SentinelSuite) TestASwingWithAnUnreadableSheet() {
+	mgr := s.armedDuel(newFakeCharacters(unreadableFighter("alice"), armedFighter("bob")))
+
+	err := s.swing(mgr)
+	s.refusedInOurVocabulary(err, session.ErrBadCharacter)
+}
+
+// TestASpawnNamingAMalformedRef is the third module and the second door.
+//
+// A ref crosses this seam as a string, so getting one wrong is the most
+// ordinary mistake a host can make — a bare "skeleton" where the catalog wanted
+// "dnd5e:monsters:skeleton". The parser underneath answers in core's
+// vocabulary, and a host that matched on core.ErrTooFewSegments would be
+// coupled to the fact that this package parses refs with core at all.
+func (s *SentinelSuite) TestASpawnNamingAMalformedRef() {
+	_, err := s.mgr.Spawn(context.Background(), &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: "skeleton",
+		Position: spatial.Position{X: 42, Y: 22},
+	})
+	s.refusedInOurVocabulary(err, session.ErrBadRef)
+	s.Contains(err.Error(), "skeleton",
+		"and the refusal still names the ref it could not read")
+	s.Contains(err.Error(), "segments",
+		"and still says what was wrong with it")
 }

--- a/rulebooks/dnd5e/session/translate_internal_test.go
+++ b/rulebooks/dnd5e/session/translate_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 )
 
 // sentinels_test.go pins the refusals a caller can DRIVE this seam into. This
@@ -60,6 +61,51 @@ func TestTranslateLetsNoCompositionSentinelThrough(t *testing.T) {
 			require.NotErrorIs(t, out, tc.inner,
 				"and must not be able to reach the composition's sentinel — matching on it "+
 					"would couple every host to a module we intend to replace (S2)")
+		})
+	}
+}
+
+// TestTranslateResolutionLetsNoResolutionSentinelThrough is the same table over
+// the swing's translation (rpg-toolkit#1066).
+//
+// One of these arms IS reachable from Attack and is driven there, in
+// sentinels_test.go, where a real host mistake produces it. The rest are not:
+// a member with no stored sheet is refused by name before the strike runs, and
+// Attack always builds an input and always hands over a machine, so
+// ErrNoCombatant, ErrNilInput and ErrNoMachine have no path from a verb. They
+// keep their arms because an unmapped sentinel is a leak the moment its path
+// opens, and this is where that promise is checkable without a fake standing in
+// for the module that would have produced it.
+func TestTranslateResolutionLetsNoResolutionSentinelThrough(t *testing.T) {
+	cases := []struct {
+		name  string
+		inner error
+		want  error
+	}{
+		// Driven for real in sentinels_test.go: one stored sheet answering to
+		// two member IDs.
+		{"one sheet under two ids", resolution.ErrBadParticipant, ErrBadCharacter},
+		// The backstop: a member with no stored sheet is refused by name
+		// before the strike runs, so this arm is the one that catches a
+		// combatant the cast turned out not to hold.
+		{"combatant not in the cast", resolution.ErrNoCombatant, ErrNoSheet},
+		// Defects here rather than in the call, and unreachable for that
+		// reason.
+		{"no input at all", resolution.ErrNilInput, ErrNilInput},
+		{"nothing to resolve", resolution.ErrNoMachine, ErrNilInput},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := translateResolution(fmt.Errorf("resolution: attach character %q: %w", "alice", tc.inner))
+
+			require.ErrorIs(t, out, tc.want,
+				"the host is answered in this package's vocabulary")
+			require.NotErrorIs(t, out, tc.inner,
+				"and must not be able to reach the resolution module's sentinel — matching on "+
+					"it would couple every host to the module the strike machine lives in (S2)")
+			require.Contains(t, out.Error(), tc.inner.Error(),
+				"while the reason itself survives as text, for whoever debugs it")
 		})
 	}
 }


### PR DESCRIPTION

#1065 closed the S2 sentinel leak for the composition's sentinels and named two
more it deliberately left open. This closes those.

## The leak, one module over

A sentinel is not a type in a signature, so `TestNoInnerTypeCrossesTheBoundary`
cannot see one. `translateResolution` existed precisely because of that — and
then wrapped BOTH errors in every arm, `fmt.Errorf("%w: %w", ours, theirs)`,
which satisfies a host matching on ours while leaving theirs exactly as
matchable. The same shape sat in `compileAttack` and in both entity loaders.

Live today, not latent:

| path | leaked | reached by |
|---|---|---|
| `compileAttack`'s profile step | `resolution.ErrBadAttack` | a character with nothing in the main hand |
| `translateResolution` (ErrBadParticipant arm) | `resolution.ErrBadParticipant` | one stored sheet answering to two member IDs |
| `instantiate` | `core.ErrTooFewSegments` and its five siblings | `Spawn` with a bare `"skeleton"` for a ref |

`translateResolution`'s other three arms and `loadCharacter`'s wrap are the same
change on paths a verb cannot drive: a member with no stored sheet is refused by
name before the strike runs, and `Attack` always builds an input and always
hands over a machine.

## The fix

The issue's lean, and #1065's: the session-owned outer sentinel stays `%w`, the
inner error is demoted to `%v`. The message survives in full for whoever debugs
it — "nothing equipped in \"main_hand\"", "expected 3 segments, got 1" — and the
chain does not, so a host gets this package's vocabulary and only ours. No
mapping changed: which session sentinel answers which inner error is exactly
what it was before (#1057 settled that), and only matchability moved.

`compileAttack` is deliberately NOT routed through `translateResolution`. The
compiler answers everything the profile step refuses with `ErrBadAttack`,
`resolution.ErrNilInput` cases included; routing it would quietly re-map those
onto a different sentinel than hosts have been given.

`loadCharacter`'s demotion leaks nothing today — the rulebook answers through
rpgerr codes rather than sentinel values, so there is nothing to match on. That
is the reason to make it `%v` rather than a reason to skip it: a chain that is
safe only because another module has not exported a sentinel yet is a leak
waiting on somebody else's commit.

## The default arm stays a pass-through

Unrecognised errors still return unchanged. That arm carries errors that
ORIGINATED WITH THE HOST — a failing `Roller` reaches the strike machine through
both `Input.Roller` and `StrikeInput.Roller` and comes back out through here —
and flattening those to protect the host from us would break its matching on its
own errors. `start.go`'s `ErrSaveFailed` wraps are the same case and are
untouched for the same reason.

The guarantee is the one #1065 stated: every inner sentinel this seam can REACH
has an arm, made mechanical by the tests rather than by review. Of resolution's
eight unmapped sentinels, none has a path from a verb: `ErrBadWorld` cannot be
reached because `Attack` reads the roster through `Members()` first and refuses
a world of that shape as `ErrInvalidWorld`; `ErrNoRoller` and `ErrNoInitiative`
are supplied on every call; and the save-gate vocabulary is unreachable while v1
compiles character weapon strikes only.

## The tests

`sentinels_test.go` was scoped to the composition and said so, which is what let
this survive. It now carries three lists — `compositionSentinels`,
`resolutionSentinels`, `refSentinels` — collected into one `innerSentinels`, so
every scenario in the file is checked against all of them and a fourth module
underneath this seam is covered the moment its list is added.

Three new scenarios, each a mistake a host really makes: an empty hand, one
sheet stored under two names, a bare ref at `Spawn`. A fourth, an unreadable
sheet on the swing path, was green from the start and stays as the guard for the
loader wrap the rulebook does not yet make matchable.
`translate_internal_test.go` gains the table over `translateResolution`'s arms,
in the same both-directions shape as the composition's.

## RED

Watched failing before the fix, seven assertions, each for the right reason:

```
--- FAIL: TestSentinelSuite/TestASwingWithAnEmptyHand
    found: "resolution: unreadable attack"
    in chain: "attack: attacker \"alice\": attack cannot be made: resolution:
               unreadable attack: nothing equipped in \"main_hand\""

--- FAIL: TestSentinelSuite/TestOneSheetStoredUnderTwoNames
    found: "resolution: bad participant"
    in chain: "attack: character data could not be loaded: resolution: bad
               participant: \"alice\" appears twice"

--- FAIL: TestSentinelSuite/TestASpawnNamingAMalformedRef
    found: "too few segments in identifier"
    in chain: "spawn: \"skeleton\": malformed ref: failed to parse identifier
               \"skeleton\": too few segments in identifier: expected 3
               segments, got 1"

--- FAIL: TestTranslateResolutionLetsNoResolutionSentinelThrough/one_sheet_under_two_ids
--- FAIL: TestTranslateResolutionLetsNoResolutionSentinelThrough/combatant_not_in_the_cast
--- FAIL: TestTranslateResolutionLetsNoResolutionSentinelThrough/no_input_at_all
--- FAIL: TestTranslateResolutionLetsNoResolutionSentinelThrough/nothing_to_resolve
```

## GREEN

```
--- PASS: TestSentinelSuite (13 subtests)
--- PASS: TestTranslateResolutionLetsNoResolutionSentinelThrough (4 subtests)
--- PASS: TestTranslateLetsNoCompositionSentinelThrough (12 subtests)
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session
```

Full module suite, `go vet`, `golangci-lint run ./...` (0 issues), `go fmt` and
`go mod tidy` — all clean, no diff. Session module only; no `replace`
directives, no `go.work`.

Closes #1066

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
