### PR TITLE
fix(session): a zero-distance step is refused, not recorded (#1060)

### DIFF
--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -176,8 +176,16 @@ var (
 	// inner sentinel never crosses the boundary (S2).
 	ErrNoConnection = errors.New("no such connection")
 
-	// ErrBadPosition is returned when a target cell is out of bounds, or is
-	// not a legal cell of its grid family.
+	// ErrBadPosition is returned when a target cell is out of bounds, is not a
+	// legal cell of its grid family, or is the cell the walker is already
+	// standing on.
+	//
+	// That last case shares the sentinel rather than earning its own because
+	// the remedy is the same one: the caller named a cell that cannot be
+	// stepped to, and must fix the cell. It is emphatically NOT ErrBrokenPath —
+	// a broken path has a gap in it, and whoever read "not a walk" about a
+	// zero-distance step would go hunting for arithmetic that is perfectly
+	// fine (rpg-toolkit#1060).
 	ErrBadPosition = errors.New("bad position")
 
 	// ErrNoSessionID is returned when a verb is given an empty session ID.

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -27,6 +27,12 @@ type MoveInput struct {
 	// Path is the cells to walk through, in order, each adjacent to the last
 	// and the first adjacent to where the member currently stands.
 	//
+	// ADJACENT, not merely within one cell: a step onto the cell the walker has
+	// just reached is refused with ErrBadPosition rather than recorded as a
+	// movement of no distance. Revisiting a cell is fine — a there-and-back
+	// walks genuinely both ways — so it is only the step that goes nowhere that
+	// is refused.
+	//
 	// A path, not a destination. The caller says where to walk; what actually
 	// happened comes back as Steps, which may be shorter. A single-cell path is
 	// the ordinary case and entirely legal.
@@ -110,8 +116,9 @@ type MoveOutput struct {
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrEmptyPath,
 // ErrBrokenPath for a path with a gap in it, ErrNoSession, ErrNoEncounter,
-// ErrNoMember, ErrClosed, ErrBadPosition for a cell no room owns OR a cell in
-// a room other than the walker's, or ErrSaveFailed with a populated report.
+// ErrNoMember, ErrClosed, ErrBadPosition for a cell no room owns OR a cell the
+// walker is already standing on, ErrNoCrossing for a step into another room
+// with no doorway joining it, or ErrSaveFailed with a populated report.
 func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("move: %w", ErrNilInput)
@@ -314,6 +321,11 @@ type resolvedWalk struct {
 // both families survives translation, so an absolute pair is adjacent or not
 // regardless of which room's grid is asked.
 //
+// Adjacency is also not sufficient, in the other direction: a cell is adjacent
+// to ITSELF under every family's Distance <= 1, so the zero-distance step needs
+// refusing by name rather than falling out of the distance check
+// (rpg-toolkit#1060).
+//
 // A step MAY leave the room the walker is in, and that is the only way it may
 // leave: through a doorway joining the cell they stand on to the one they are
 // stepping to (rpg-toolkit#1048). Adjacency alone is not permission — W2 lets
@@ -348,6 +360,26 @@ func resolveWalk(
 	here, hereRoom := onMap(enc, room, from), room
 
 	for i, cell := range path {
+		if cell == here {
+			// A step of zero distance is not a step (rpg-toolkit#1060). Nothing
+			// downstream would have caught it: every grid family reads
+			// adjacency as Distance <= 1, so zero passes the check below, and
+			// the composition's placement explicitly permits the mover's own
+			// cell. The no-op then went the whole way — a genuine `moved` beat
+			// recorded and persisted, sight refreshed, EventMoved fanned out to
+			// every client — for a movement that never happened, and free-roam
+			// has no movement budget to notice the discrepancy later.
+			//
+			// Compared against HERE, which advances with the walk, so [A,B,B]
+			// is caught at its second B rather than only at the path's first
+			// cell. [A,B,A] stays legal and must: a there-and-back moves
+			// genuinely at every step, and a walker may retrace their route as
+			// often as they like. It is zero DISTANCE that is the phantom, not
+			// a repeated cell.
+			return resolvedWalk{}, fmt.Errorf("step %d of %d: already standing on (%v,%v): %w",
+				i+1, len(path), cell.X, cell.Y, ErrBadPosition)
+		}
+
 		if !grid.IsAdjacent(here, cell) {
 			return resolvedWalk{}, fmt.Errorf("step %d from (%v,%v) to (%v,%v): %w",
 				i+1, here.X, here.Y, cell.X, cell.Y, ErrBrokenPath)

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -15,8 +15,8 @@ import (
 
 // MoveInput walks a member along a path of cells on the map.
 //
-// The path stays inside the room the walker is standing in — see Path — until
-// the slice that makes a doorway crossing an ordinary step.
+// The path may leave the room the walker is standing in, and a doorway is how
+// — see Path.
 type MoveInput struct {
 	// Session is the session to act in.
 	Session string
@@ -40,13 +40,16 @@ type MoveInput struct {
 	// Cells are DUNGEON-ABSOLUTE — the same coordinates the Atlas draws and
 	// every other verb speaks (rpg-project#227).
 	//
-	// A WALK STILL DOES NOT CROSS A DOORWAY. Absolute coordinates make a
-	// crossing expressible for the first time — the far side of a doorway is
-	// simply the next cell along — but expressible is not permitted: a path
-	// that leaves the walker's room is refused with ErrBadPosition, exactly
-	// as it was refused before, when it could not even be written down. That
-	// changes in its own slice, deliberately, so that a real behavior change
-	// is not smuggled in inside a change of dialect.
+	// A WALK CROSSES A DOORWAY, and a crossing is written like any other step:
+	// the far side is simply the next cell along (rpg-toolkit#1048, which is
+	// also where the Traverse verb went). Absolute coordinates made a crossing
+	// expressible, and that slice made it permitted.
+	//
+	// Adjacency is not permission, though. Two rooms may TOUCH without a door
+	// between them, so a step into the next room with no doorway joining it to
+	// the cell the walker stands on is refused with ErrNoCrossing — a refusal a
+	// client reading only the Atlas's cells cannot predict, since the doorway is
+	// in the doorway list or it is nowhere.
 	Path []spatial.Position
 }
 

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -22,6 +22,7 @@ type MoveTestSuite struct {
 	sessions   *fakeSessions
 	encounters *fakeEncounters
 	characters *fakeCharacters
+	stream     *fakeStream
 	mgr        *session.Manager
 }
 
@@ -29,9 +30,10 @@ func (s *MoveTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
+	s.stream = &fakeStream{}
 	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
-		Events: session.DiscardEvents{},
+		Events: s.stream,
 	})
 	s.Require().NoError(err)
 	s.mgr = mgr
@@ -339,6 +341,90 @@ func (s *MoveTestSuite) TestAStepOntoNoCellUsesOurSentinelNotTheirs() {
 	// fractional hex cell.
 	s.Contains(err.Error(), "owned by no room",
 		"the composition's account of why survives, even though its sentinel does not")
+}
+
+// TestAZeroDistanceStepIsRefused pins rpg-toolkit#1060: the cell the walker
+// already stands on is not a step.
+//
+// A step's only check was adjacency, and every grid family reads adjacency as
+// Distance <= 1 — so distance ZERO sailed through. The composition's own
+// placement then permits the mover's own cell, and the phantom went the whole
+// way: a genuine `moved` beat recorded and persisted, sight refreshed, and
+// EventMoved fanned out to every client, for a movement that never happened.
+// Free-roam has no movement budget, so no accounting layer downstream would
+// ever have caught the no-op.
+//
+// The assertion is therefore not only that it errors. What the defect produced
+// was a RECORD, so the record is what has to be absent: no beat, no delivery.
+func (s *MoveTestSuite) TestAZeroDistanceStepIsRefused() {
+	s.startCorridor()
+	ctx := context.Background()
+
+	before, err := s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.stream.published = nil // setup beats predate the walk
+
+	// Alice stands at (1,1). This asks her to step onto herself.
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 1}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadPosition)
+	s.NotErrorIs(err, session.ErrBrokenPath,
+		"a broken path has a GAP in it; this one has the opposite problem, and "+
+			"a caller told 'not a walk' would go looking for arithmetic that is fine")
+	s.Contains(err.Error(), "already standing on (1,1)",
+		"and the refusal names the cell, in the caller's own coordinates")
+
+	after, err := s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Len(after, len(before), "no beat was recorded for a movement that did not happen")
+	s.Empty(s.stream.published, "and nothing reached a client")
+}
+
+// TestARepeatedCellMidPathIsRefused is the same phantom one cell along, and it
+// is what stops the fix from being a comparison against where the walk began.
+//
+// "Where the walker stands" ADVANCES as the path resolves. [A,B,B] is a real
+// step followed by a phantom one, so a check against A alone waves the second
+// B straight through — the defect intact, one cell further in.
+func (s *MoveTestSuite) TestARepeatedCellMidPathIsRefused() {
+	s.startCorridor()
+	ctx := context.Background()
+
+	_, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 1}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadPosition)
+	s.Contains(err.Error(), "step 2 of 2", "and it names which step of the path")
+
+	// Refused WHOLE (R5). The legal first step is not taken either: validation
+	// finishes before the composition is touched, so alice never left (1,1).
+	where, err := s.mgr.Where(ctx, &session.WhereInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(spatial.Position{X: 1, Y: 1}, where.Position,
+		"a path refused whole leaves the walker exactly where she was")
+}
+
+// TestThereAndBackIsLegal is the negative control, and it is what keeps the
+// #1060 fix from turning into a rule about REPEATED CELLS.
+//
+// [B,A] visits A twice and moves genuinely at every step: out one cell and back
+// again is a walk, and a walker may retrace it as often as they like. Only a
+// step of zero DISTANCE is a phantom, so only that is refused.
+func (s *MoveTestSuite) TestThereAndBackIsLegal() {
+	s.startCorridor()
+
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 1, Y: 1}},
+	})
+	s.Require().NoError(err, "every step of a there-and-back is real movement")
+	s.Require().Len(out.Steps, 2, "both are walked, and both are recorded")
+	s.Equal(spatial.Position{X: 2, Y: 1}, out.Steps[0].Position)
+	s.Equal(spatial.Position{X: 1, Y: 1}, out.Steps[1].Position, "back where she started")
 }
 
 func TestMoveSuite(t *testing.T) {


### PR DESCRIPTION
`resolveWalk`'s only step validation was `grid.IsAdjacent(here, cell)`, and every
grid family implements adjacency as `Distance <= 1` — so distance ZERO passes. No
`from == to` comparison existed anywhere on the path, and downstream
`canPlaceEntityUnsafe` explicitly permits the mover's own cell, so a
`Path: [current-cell]` succeeded end to end.

## The phantom, measured

A throwaway probe on the unfixed code, asking alice to step from (1,1) onto
(1,1):

```
PROBE err=<nil>
PROBE steps=[{Position:(1, 1) Seq:2}]
PROBE saved={Written:[encounter:world] Failed:[]} delivery={Events:1 Failed:false}
PROBE beats before=1 after=2 (delta=1)
PROBE published kind=moved recipient=alice seq=2
PROBE alice is at (1, 1)
```

A genuine `moved` beat recorded and PERSISTED, sight refreshed, and `EventMoved`
fanned out to a client — for a movement that never happened. Free-roam has no
movement budget, so nothing downstream would ever have caught the no-op, and a
`ReachedPosition` ending declared on that cell would fire for standing still.

## The fix

One comparison in `resolveWalk`, ahead of the adjacency check and therefore
before the composition is touched at all — so the refusal costs the walk nothing
and R5 holds: the path is rejected whole, and a legal first step in `[B,B]` is
not taken either.

It is compared against `here`, the walker's cell AT THAT STEP, which advances as
the path resolves — not against where the walk began. That is what catches
`[A,B,B]`, whose second B is a phantom one cell in; a check against the origin
would wave it straight through.

### [A→B→A] stays legal, deliberately

A there-and-back visits A twice and MOVES GENUINELY at every step, and a walker
may retrace their route as often as they like. It is zero DISTANCE that is the
phantom, not a repeated cell — so the check is `cell == here` rather than "have I
been on this cell before", and `TestThereAndBackIsLegal` is the negative control
that stops the fix drifting into the second thing.

### ErrBadPosition, not ErrBrokenPath

The issue's lean, and the right one. `ErrBrokenPath` means the path has a GAP in
it; a zero-distance step has the opposite problem, and a caller told "not a walk"
would go hunting for arithmetic that is perfectly fine. `ErrBadPosition` already
covers "you named a cell that cannot be stepped to", and the remedy is the same:
fix the cell. Both sentinel docs now say which is which, and the test asserts the
discrimination rather than only the match.

The refusal names the step and the cell in the caller's own coordinates —
`step 2 of 2: already standing on (2,1): bad position` — matching the shape of
the sibling `ErrBadPosition` refusal beside it.

## RED

Watched failing before the fix. Both phantom cases SUCCEEDED, which is the defect
stated as a test:

```
--- FAIL: TestMoveSuite/TestAZeroDistanceStepIsRefused
    Error: An error is expected but got nil.
--- FAIL: TestMoveSuite/TestARepeatedCellMidPathIsRefused
    Error: An error is expected but got nil.
--- PASS: TestMoveSuite/TestThereAndBackIsLegal
```

The negative control passing in RED is the point: `[B,A]` was legal before this
change and stays legal after it.

Each refusal test asserts the ABSENCE OF SIDE EFFECTS as well as the sentinel,
because what the defect produced was a RECORD rather than merely a wrong return.
The zero-distance case pins that the story gains no beat and the stream carries
nothing; the mid-path case pins through `Where` that alice never left (1,1).

## GREEN

```
--- PASS: TestMoveSuite/TestAZeroDistanceStepIsRefused
--- PASS: TestMoveSuite/TestARepeatedCellMidPathIsRefused
--- PASS: TestMoveSuite/TestThereAndBackIsLegal
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session
```

Full module suite, `golangci-lint run ./...` (0 issues), `go fmt ./...` and
`go mod tidy` — all clean, no diff. Session module only; no `replace` directives,
no `go.work`.

Closes #1060

## Review follow-up

Copilot found a stale doc claim adjacent to this change, and it was right
(94c9f40, documentation only). `MoveInput.Path` still said "A WALK STILL DOES
NOT CROSS A DOORWAY" and that leaving the walker's room is refused with
`ErrBadPosition` — both untrue since fb0d704 (#1048) made a crossing an ordinary
step and retired `Traverse`. `TestAWalkCrossesTheDoorway` passes today, and
`TestAStepWithNoDoorwayIsRefused` pins the cross-room refusal as `ErrNoCrossing`
while explicitly asserting it is NOT `ErrBadPosition`.

Fixed here rather than deferred precisely because this PR adds an
`ErrBadPosition` paragraph to that same doc comment: a false `ErrBadPosition`
claim three paragraphs below a true one is worse than either alone.

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
