### PR TITLE
docs(session): Where names the host's asker-binding obligation (#1061)

### DIFF
--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -117,6 +117,14 @@ func (m *Manager) Status(ctx context.Context, in *StatusInput) (*Status, error) 
 // prevent. Where somebody ELSE is, is View's answer, and View gives it only for
 // members the observer actually holds.
 //
+// THE HOST MUST BIND Member TO THE AUTHENTICATED CALLER. This package cannot
+// know who is asking — a verb takes IDs, not identities — so the one check
+// that keeps this read self-only is necessarily the host's: wire a
+// client-supplied member ID through unchecked and this verb becomes the
+// unperceived-position roster it refuses to be, one ID at a time, with
+// monster IDs learnable from Story beats. The refusal above is only as good
+// as the host's binding.
+//
 // It is a live read, not a stored one: the position comes from the composition's
 // roster, which projects each member's cell through their room's anchor when
 // asked. A member who has walked is reported where they are now.


### PR DESCRIPTION
Closes #1061.

**The gap:** `Where` returns the live position of whatever member ID it is handed — the only gates are non-empty ID and roster membership. Its doc refuses a roster read precisely because unperceived positions must not leak, and frames self-only intent ("ONE MEMBER'S OWN PLACEMENT") — but no sentence assigned the asker==member enforcement to anyone. A host that wires `GetWhere` through with a client-supplied member ID (the doc's own reconnect story invites exactly that) reconstructs the refused roster one ID at a time, with monster IDs learnable from Story beats.

**The fix:** one paragraph in `Where`'s godoc, in caps-lead house style: **THE HOST MUST BIND Member TO THE AUTHENTICATED CALLER** — the package takes IDs, not identities, so the one check that keeps this read self-only is necessarily the host's, and the refusal above is only as good as the host's binding.

Doc-only; no behavior change; `go test`, `gofmt`, `go vet` clean. The concrete handler-side check is already flagged as a gate item on rpg-api#797.

— director agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
