### PR TITLE
fix(encounter)!: the outcome speaks one map, and old blobs fail loudly (#1068)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -159,7 +159,7 @@ behavior that decides *what to do to someone* is not.
 |---|---|
 | `encounter.go` | the aggregate: setup, verbs, `Pump`, member management |
 | `decider.go` | `Decider`, `Snapshot`, `Intent` and its three implementations |
-| `atlas.go` | the read projection — absolute coordinates appear only here |
+| `atlas.go` | the coordinate queries — `Atlas`, `Absolute`, `Locate` |
 | `field.go` | rooms, connections, and the per-verb output shapes |
 | `data.go` | `EncounterData` and the `ToData` / `LoadFromData` round trip |
 

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -188,11 +188,14 @@ func TestVaultChase(t *testing.T) {
 		}
 	}
 	require.Equal(t, vaultRoom, aliceOutcome.Room)
-	require.Equal(t, spatial.Position{X: 8, Y: 8}, aliceOutcome.Position)
+	// Dungeon-absolute (#1068): the vault is anchored at (10,0), so her
+	// vault-local (8,8) is (18,8) on the map — the same frame every other
+	// cell in this scene is reported in.
+	require.Equal(t, spatial.Position{X: 18, Y: 8}, aliceOutcome.Position)
 	// The goblin made it across the threshold too — the outcome reflects
 	// where it TRULY stands, in the vault, not its pre-chase corridor spot.
 	require.Equal(t, vaultRoom, goblinOutcome.Room, "beat 5: the outcome reflects the goblin's post-traverse room")
-	require.Equal(t, spatial.Position{X: 0, Y: 5}, goblinOutcome.Position)
+	require.Equal(t, spatial.Position{X: 10, Y: 5}, goblinOutcome.Position, "vault-local (0,5) anchored at (10,0)")
 
 	status, err := enc.Status()
 	require.NoError(t, err)

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -303,10 +303,14 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 					goblinOutcome = m
 				}
 			}
-			// The final ending position, projected too (#929 T4): it must
-			// agree with the live path's own last recorded entries.
-			outAlice := proj.project(string(alice), "outcome", aliceOutcome.Room, aliceOutcome.Position)
-			outGoblin := proj.project(string(goblin), "outcome", goblinOutcome.Room, goblinOutcome.Position)
+			// The final ending position (#929 T4): it must agree with the
+			// live path's own last recorded entries. Read back through
+			// Locate rather than projected, because the outcome now
+			// reports absolute cells itself (#1068) — and Locate is the
+			// stronger check anyway: a room-local cell here would resolve
+			// to the wrong room or to no room at all.
+			outAlice := proj.locate(string(alice), "outcome", aliceOutcome.Position)
+			outGoblin := proj.locate(string(goblin), "outcome", goblinOutcome.Position)
 			require.Equal(t, alicePath[len(alicePath)-1], outAlice, "the outcome's alice position matches her live projected path")
 			require.Equal(t, goblinPath[len(goblinPath)-1], outGoblin, "the outcome's goblin position matches its live projected path")
 		}

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -989,20 +989,25 @@ func refuseRoomLocalSightings(data intel.Data) error {
 			if holding.Channel != intel.Sight || len(holding.Payload) == 0 {
 				continue
 			}
-			var peek struct {
-				Room *string `json:"room"`
-			}
-			// A payload this module cannot parse at all is somebody else's:
-			// intel carries testimony for any channel a composition invents,
-			// and only the room key THIS one used to write is ours to
-			// recognize. Unreadable bytes are left to whoever wrote them.
+			// A payload this module cannot read as an object at all is
+			// somebody else's: intel carries testimony for any channel a
+			// composition invents, and only the room key THIS one used to
+			// write is ours to recognize. Unreadable bytes are left to
+			// whoever wrote them.
+			var peek map[string]json.RawMessage
 			if err := json.Unmarshal(holding.Payload, &peek); err != nil {
 				continue
 			}
-			if peek.Room != nil {
+			// PRESENCE of the key, not its value. Decoding "room" into a
+			// typed field let a null through as absent and a non-string
+			// through as unparseable (raised by Copilot on #1072, and both
+			// loaded clean before this) — and since this composition is the
+			// only writer of sight payloads, a payload naming a room AT ALL
+			// is not one it wrote today, whatever the name decodes to.
+			if room, named := peek["room"]; named {
 				return fmt.Errorf(
-					"load encounter intel: %q's sighting of %q names room %q — a room-local sight payload from before rpg-toolkit#1044, recreate the save: %w",
-					observer, subject, *peek.Room, ErrInvalidData)
+					"load encounter intel: %q's sighting of %q names a room (%s) — a room-local sight payload from before rpg-toolkit#1044, recreate the save: %w",
+					observer, subject, room, ErrInvalidData)
 			}
 		}
 	}

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -4,6 +4,7 @@
 package encounter
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -53,11 +54,30 @@ type OutcomeData struct {
 	Members []MemberOutcomeData `json:"members,omitempty"`
 }
 
-// MemberOutcomeData is a member's position when the encounter closed.
+// MemberOutcomeData is where a member stood when the encounter closed.
+//
+// Cell is DUNGEON-ABSOLUTE (rpg-toolkit#1068), mirroring the MemberOutcome it
+// persists — unlike MemberData above, which stays room-local because it is
+// placement to be restored into a spatial room rather than a report already
+// made.
+//
+// It is a pointer under a NEW key on purpose. This value changed frame without
+// changing type, and a bare pair of numbers cannot be told apart by
+// inspection, so a blob written before the flip would have loaded clean and
+// reported room-local cells as absolute ones — a party drawn in the wrong room
+// by a load that reported success. Renaming "position" to "cell" makes the old
+// dialect land nowhere, and its absence is then the signal: REQUIRED at load,
+// rejected by name, never defaulted to (0,0) — a legal cell that would invent
+// a placement. That is the same call RoomData.Origin makes for a missing
+// anchor, and this is Kirk's fail-loudly ruling (2026-08-17) for the one
+// persisted shape in this family that could be given a detectable one.
+//
+// Room stays: MemberOutcome still carries it. The composition keeps rooms, it
+// only stops speaking them in coordinates.
 type MemberOutcomeData struct {
-	ID       MemberID     `json:"id"`
-	Room     string       `json:"room"`
-	Position PositionData `json:"position"`
+	ID   MemberID      `json:"id"`
+	Room string        `json:"room"`
+	Cell *PositionData `json:"cell"`
 }
 
 // FieldData is the persistent representation of the encounter's field.
@@ -264,9 +284,12 @@ func (e *Encounter) ToData() EncounterData {
 		}
 		for i, mo := range e.outcome.Members {
 			outcomeData.Members[i] = MemberOutcomeData{
-				ID:       mo.ID,
-				Room:     mo.Room,
-				Position: PositionData{X: mo.Position.X, Y: mo.Position.Y},
+				ID:   mo.ID,
+				Room: mo.Room,
+				// Always a fresh pointer, always written — RoomData.Origin's
+				// precedent — so presence itself is meaningful at load and two
+				// ToData calls never alias the same PositionData.
+				Cell: &PositionData{X: mo.Position.X, Y: mo.Position.Y},
 			}
 		}
 	}
@@ -580,12 +603,29 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		if data.Outcome.Ending == "abandoned" && len(data.Members) > 0 {
 			return nil, fmt.Errorf("load encounter: abandoned outcome with members present: %w: %w", ErrInvalidData, ErrNoMember)
 		}
+		origins := make(map[string]spatial.Position, len(roomInputs))
+		for _, ri := range roomInputs {
+			origins[ri.ID] = ri.Origin
+		}
 		for _, om := range data.Outcome.Members {
+			// A missing cell is how the pre-#1068 dialect announces itself:
+			// that blob's "position" key lands nowhere on today's shape, so
+			// the field arrives absent rather than wrong (MemberOutcomeData's
+			// doc comment). Checked FIRST, so the older mistake is named as
+			// itself instead of surfacing as an out-of-bounds (0,0).
+			if om.Cell == nil {
+				return nil, fmt.Errorf("load encounter: outcome member %q has no cell — a room-local outcome from before rpg-toolkit#1068, recreate the save: %w: %w", om.ID, ErrInvalidData, ErrBadPlacement)
+			}
 			_, ok := roomGrids[om.Room]
 			if !ok {
 				return nil, fmt.Errorf("load encounter: outcome member %q room %q not in field: %w: %w", om.ID, om.Room, ErrInvalidData, ErrBadPlacement)
 			}
-			if !roomGrids[om.Room].IsValidPosition(spatial.Position{X: om.Position.X, Y: om.Position.Y}) {
+			// The cell is absolute and the room's grid speaks local, so the
+			// bounds check is the projection run backwards. One check, two
+			// defects: a cell outside the field at all, and a cell that
+			// belongs to a room other than the one named beside it.
+			local := spatial.Position{X: om.Cell.X, Y: om.Cell.Y}.Subtract(origins[om.Room])
+			if !roomGrids[om.Room].IsValidPosition(local) {
 				return nil, fmt.Errorf("load encounter: outcome member %q position out of bounds: %w: %w", om.ID, ErrInvalidData, ErrBadPlacement)
 			}
 		}
@@ -684,6 +724,10 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 			}
 			onAClock[id] = struct{}{}
 		}
+	}
+
+	if err = refuseRoomLocalSightings(data.Intel); err != nil {
+		return nil, err
 	}
 
 	loadedIntel, err := intel.LoadIntel(data.Intel)
@@ -856,9 +900,13 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		}
 		for i, m := range data.Outcome.Members {
 			outcome.Members[i] = MemberOutcome{
-				ID:       m.ID,
-				Room:     m.Room,
-				Position: spatial.Position{X: m.Position.X, Y: m.Position.Y},
+				ID:   m.ID,
+				Room: m.Room,
+				// Stored and returned in the frame it was reported in — no
+				// re-derivation, so a reloaded outcome and the one the host
+				// already saw cannot disagree. Non-nil by R5: every cell was
+				// checked before construction began.
+				Position: spatial.Position{X: m.Cell.X, Y: m.Cell.Y},
 			}
 		}
 		e.outcome = outcome
@@ -900,6 +948,63 @@ func endingTriggerFromData(ed EndingData) Trigger {
 		}
 	case "external":
 		return TriggerExternal{}
+	}
+	return nil
+}
+
+// refuseRoomLocalSightings rejects a persisted sight payload written in the
+// dialect rpg-toolkit#1044 replaced.
+//
+// Intel round-trips payloads as opaque bytes and carries no version — that is
+// the leaf's whole contract, and it means nothing beneath this composition can
+// notice that stored bytes now mean something different. A sighting written
+// before sight payloads went dungeon-absolute carries a "room" key beside a
+// room-LOCAL cell; decoded through today's SightPayload it becomes an absolute
+// cell in some other room entirely, or in no room at all, and the load reports
+// success. Load never re-derives sight (see the reconstruction below — the
+// outcomes are already in intel), so nothing downstream corrects it either.
+//
+// Kirk's ruling, 2026-08-17: fail loudly, no migration. The only blobs in
+// existence are dev and workbench saves, so a stale one is refused by name and
+// recreated rather than silently reinterpreted.
+func refuseRoomLocalSightings(data intel.Data) error {
+	// Sorted, so a blob holding several stale sightings names the same one on
+	// every run — a rejection that moves under map iteration is a rejection
+	// nobody can write a test against.
+	observers := make([]core.EntityID, 0, len(data.Holdings))
+	for observer := range data.Holdings {
+		observers = append(observers, observer)
+	}
+	slices.Sort(observers)
+
+	for _, observer := range observers {
+		subjects := make([]intel.Subject, 0, len(data.Holdings[observer]))
+		for subject := range data.Holdings[observer] {
+			subjects = append(subjects, subject)
+		}
+		slices.Sort(subjects)
+
+		for _, subject := range subjects {
+			holding := data.Holdings[observer][subject]
+			if holding.Channel != intel.Sight || len(holding.Payload) == 0 {
+				continue
+			}
+			var peek struct {
+				Room *string `json:"room"`
+			}
+			// A payload this module cannot parse at all is somebody else's:
+			// intel carries testimony for any channel a composition invents,
+			// and only the room key THIS one used to write is ours to
+			// recognize. Unreadable bytes are left to whoever wrote them.
+			if err := json.Unmarshal(holding.Payload, &peek); err != nil {
+				continue
+			}
+			if peek.Room != nil {
+				return fmt.Errorf(
+					"load encounter intel: %q's sighting of %q names room %q — a room-local sight payload from before rpg-toolkit#1044, recreate the save: %w",
+					observer, subject, *peek.Room, ErrInvalidData)
+			}
+		}
 	}
 	return nil
 }

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -435,8 +435,9 @@ func (in *LoadEncounterInput) Validate() error {
 // field, member position out of bounds or non-integral (hex), ending trigger validity
 // (unknown room or unreachable position on a TriggerReachedPosition — #929 T3 Opus round
 // F5, the SAME validateEndingTriggers Setup uses), an abandoned outcome with members
-// still present, outcome member room/bounds checks, everMembers missing a current
-// member.
+// still present, outcome member cell PRESENCE (a missing cell is the pre-#1068
+// room-local dialect announcing itself — MemberOutcomeData's doc comment) then that
+// member's room and bounds, everMembers missing a current member.
 //
 // One check runs OUTSIDE this up-front pass, later, during member re-placement and
 // decider re-attachment (construction has already begun by then): a player member
@@ -462,6 +463,9 @@ func (in *LoadEncounterInput) Validate() error {
 // errors with "newencounter:" instead, at its own call sites.
 //
 // Leaf loaders (clock, intel, record) are called and their rejections are wrapped.
+// Intel gets one check of its own first, because it cannot make it itself: a stored
+// sight payload naming a room is a pre-#1044 room-local frame, and intel holds
+// payloads as opaque bytes by contract — see refuseRoomLocalSightings.
 // On success, the field is rebuilt via the same path Setup uses (no re-surveil),
 // and members are re-placed at persisted positions.
 func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -913,7 +913,14 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		// exists to exercise) and final member placements; the story
 		// carries all three beats (opening + the pump's tick + the
 		// closing move).
-		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","room":"room1","position":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
+		//
+		// The outcome member's key is "cell", not "position" (#1068): room1
+		// is anchored at the origin here, so the NUMBERS are unchanged and
+		// only the key moved — which is the entire point of the rename. A
+		// blob written before the flip lands nowhere on today's shape and is
+		// refused by name rather than read in the wrong frame (see
+		// dialect_test.go).
+		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","room":"room1","cell":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","room":"room1","position":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -1602,12 +1609,19 @@ func (s *DataTestSuite) TestLoadRejections() {
 		}, "abandoned outcome with members", encounter.ErrNoMember},
 		{"outcome member room missing", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
-				{ID: "ghost", Room: "nowhere", Position: encounter.PositionData{X: 1, Y: 1}}}}
+				{ID: "ghost", Room: "nowhere", Cell: &encounter.PositionData{X: 1, Y: 1}}}}
 		}, "outcome member", encounter.ErrBadPlacement},
 		{"outcome member out of bounds", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
-				{ID: "p1", Room: "r1", Position: encounter.PositionData{X: 999, Y: 999}}}}
+				{ID: "p1", Room: "r1", Cell: &encounter.PositionData{X: 999, Y: 999}}}}
 		}, "out of bounds", encounter.ErrBadPlacement},
+		{"outcome member missing cell", func(d *encounter.EncounterData) {
+			// Deletes the field from the wire path (nil), which is exactly what
+			// a pre-#1068 blob's room-local "position" key does on arrival —
+			// see dialect_test.go for that whole blob read end to end.
+			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
+				{ID: "p1", Room: "r1"}}}
+		}, "has no cell", encounter.ErrBadPlacement},
 		{"ever_members missing current member", func(d *encounter.EncounterData) {
 			d.EverMembers = nil
 		}, "ever_members", encounter.ErrNoMember},

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -47,12 +47,16 @@ func TestDialectSuite(t *testing.T) {
 
 var dialectOrigin = spatial.Position{X: 30, Y: 10}
 
-// closedBlob is one small scene, closed, saved: two members standing in plain
-// sight of each other in an off-origin room, so the blob carries both a sight
-// holding and an outcome — the two things this file ages.
+// closedBlob is one small scene, closed, saved: three members standing in
+// plain sight of one another in an off-origin room, so the blob carries sight
+// holdings and an outcome — the two things this file ages.
 //
-// Both are players on purpose. A player and a monster in sight of each other
-// start a fight, and a bubble in the blob is noise for a test about
+// Three rather than two so that ONE observer holds more than one sighting:
+// alice holds both bob and carl. With two members every observer's holdings
+// are a walk of length one, and the order they are walked in pins nothing.
+//
+// All three are players on purpose. A player and a monster in sight of each
+// other start a fight, and a bubble in the blob is noise for a test about
 // coordinates.
 func (s *DialectSuite) closedBlob() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
@@ -63,6 +67,7 @@ func (s *DialectSuite) closedBlob() encounter.EncounterData {
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 3}},
 			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 5}},
+			{ID: "carl", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 4, Y: 4}},
 		},
 		Endings:   []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 		Retention: encounter.RetentionUnbounded,
@@ -74,9 +79,12 @@ func (s *DialectSuite) closedBlob() encounter.EncounterData {
 
 	data := enc.ToData()
 	s.Require().NotNil(data.Outcome, "the scene closed, so the blob has an outcome to age")
-	s.Require().NotEmpty(data.Intel.Holdings, "the two of them are in plain sight, so somebody holds something")
+	s.Require().Len(data.Intel.Holdings, 3, "each of them is in plain sight of the other two")
 	return data
 }
+
+// aRoomBearingSighting is one payload in the dialect #1044 replaced.
+const aRoomBearingSighting = `{"room":"hall","x":2,"y":5}`
 
 // load is the host's side of the seam: hand the loader a blob and see what it says.
 func (s *DialectSuite) load(data encounter.EncounterData) error {
@@ -106,7 +114,7 @@ func (s *DialectSuite) TestARoomBearingSightPayloadIsRefused() {
 	// composition is the only writer of sight payloads, so a payload that
 	// names a room AT ALL is not one it wrote today.
 	for _, payload := range []string{
-		`{"room":"hall","x":2,"y":5}`,
+		aRoomBearingSighting,
 		`{"room":null,"x":32,"y":15}`,
 		`{"room":7,"x":32,"y":15}`,
 	} {
@@ -139,6 +147,57 @@ func (s *DialectSuite) TestARoomLocalOutcomeIsRefused() {
 	s.ErrorIs(err, encounter.ErrBadPlacement)
 	s.Contains(err.Error(), "alice", "the refusal names the member it could not place")
 	s.Contains(err.Error(), "room-local", "and says what is wrong with the blob")
+}
+
+// TestAnotherChannelsPayloadIsNotOurs pins the guard's NARROWNESS, which is a
+// policy rather than an oversight.
+//
+// Intel carries testimony for any channel a composition cares to invent, and
+// the room key this one used to write is the only thing in those bytes that is
+// ours to recognize. A holding on some other channel is left alone whatever it
+// says — including saying "room", which in another channel's vocabulary might
+// mean something entirely reasonable.
+func (s *DialectSuite) TestAnotherChannelsPayloadIsNotOurs() {
+	data := s.closedBlob()
+	holding := data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")]
+	holding.Channel = intel.Channel("hearsay")
+	holding.CurrentVia = []intel.Channel{intel.Channel("hearsay")}
+	holding.Payload = []byte(aRoomBearingSighting)
+	data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")] = holding
+
+	s.Require().NoError(s.load(data),
+		"a channel this composition never writes is not this composition's business")
+}
+
+// TestTheRefusalNamesTheSameSightingEveryTime.
+//
+// Go randomizes map iteration, so a guard that walked its holdings in map
+// order would name a different stale sighting from one run to the next: a
+// rejection nobody can write a test against, and a bug report nobody can
+// reproduce. Sorted, the answer is alice's sighting of bob every time —
+// first observer, first subject — and both orderings have to hold for that
+// to be true.
+func (s *DialectSuite) TestTheRefusalNamesTheSameSightingEveryTime() {
+	data := s.closedBlob()
+	for observer, subjects := range data.Intel.Holdings {
+		for subject, holding := range subjects {
+			holding.Payload = []byte(aRoomBearingSighting)
+			data.Intel.Holdings[observer][subject] = holding
+		}
+	}
+
+	first := s.load(data)
+	s.Require().Error(first)
+	s.Contains(first.Error(), `"alice"`, "the first observer")
+	s.Contains(first.Error(), `"bob"`, "and their first subject")
+
+	// Fifty runs: an unsorted walk would have to pick the same one out of six
+	// holdings fifty times running to slip through here.
+	for i := range 50 {
+		again := s.load(data)
+		s.Require().Error(again)
+		s.Require().Equal(first.Error(), again.Error(), "run %d named a different sighting", i)
+	}
 }
 
 // agedOutcome rewrites a fresh blob's outcome members back into the wire shape

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -100,20 +100,30 @@ func (s *DialectSuite) TestTodaysBlobLoads() {
 // hall-local (2,5) would render at absolute (2,5): a cell in a different room,
 // or no room at all.
 func (s *DialectSuite) TestARoomBearingSightPayloadIsRefused() {
-	data := s.closedBlob()
+	// The KEY is what marks the dialect, whatever it holds. Decoding "room"
+	// into a typed field would let a null through as absent and a non-string
+	// through as unparseable (raised by Copilot on #1072) — and this
+	// composition is the only writer of sight payloads, so a payload that
+	// names a room AT ALL is not one it wrote today.
+	for _, payload := range []string{
+		`{"room":"hall","x":2,"y":5}`,
+		`{"room":null,"x":32,"y":15}`,
+		`{"room":7,"x":32,"y":15}`,
+	} {
+		s.Run(payload, func() {
+			data := s.closedBlob()
+			holding := data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")]
+			holding.Payload = []byte(payload)
+			data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")] = holding
 
-	aged, err := json.Marshal(map[string]any{"room": "hall", "x": 2, "y": 5})
-	s.Require().NoError(err)
-	holding := data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")]
-	holding.Payload = aged
-	data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")] = holding
-
-	err = s.load(data)
-	s.Require().Error(err, "a room-local sighting must not load")
-	s.ErrorIs(err, encounter.ErrInvalidData)
-	s.Contains(err.Error(), "alice", "the refusal names whose holding it is")
-	s.Contains(err.Error(), "bob", "and who it is about")
-	s.Contains(err.Error(), "room-local", "and says what is wrong with it")
+			err := s.load(data)
+			s.Require().Error(err, "a sighting that names a room must not load")
+			s.ErrorIs(err, encounter.ErrInvalidData)
+			s.Contains(err.Error(), "alice", "the refusal names whose holding it is")
+			s.Contains(err.Error(), "bob", "and who it is about")
+			s.Contains(err.Error(), "room-local", "and says what is wrong with it")
+		})
+	}
 }
 
 // TestARoomLocalOutcomeIsRefused.

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -1,0 +1,176 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// dialect_test.go pins what happens to a save written before this composition
+// spoke one map (rpg-toolkit#1053, #1068).
+//
+// Kirk's ruling, 2026-08-17: FAIL LOUDLY. Nothing real exists to migrate — the
+// only blobs in the world are dev and workbench saves — so a blob written in
+// the room-local dialect is REFUSED at load with a clear error, never quietly
+// reinterpreted. The cost of the alternative is not a crash: it is a party
+// rendered at cells that belong to some other room, in a load that reported
+// success.
+//
+// Two dialects are detectable, and both are checked here:
+//
+//   - a sight payload carrying a "room" key, which is what every payload
+//     looked like before #1044 made them dungeon-absolute;
+//   - an outcome member carrying "position" instead of "cell", which is the
+//     shape #1068 replaced. A bare pair of numbers cannot be told apart by
+//     inspection, which is exactly why the new wire key is a different NAME:
+//     the old one no longer lands anywhere, and its absence is the signal.
+//
+// The room here is anchored at (30,10) so that the two frames are different
+// numbers. A room at the origin would make the whole distinction invisible.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type DialectSuite struct {
+	suite.Suite
+}
+
+func TestDialectSuite(t *testing.T) {
+	suite.Run(t, new(DialectSuite))
+}
+
+var dialectOrigin = spatial.Position{X: 30, Y: 10}
+
+// closedBlob is one small scene, closed, saved: two members standing in plain
+// sight of each other in an off-origin room, so the blob carries both a sight
+// holding and an outcome — the two things this file ages.
+//
+// Both are players on purpose. A player and a monster in sight of each other
+// start a fight, and a bubble in the blob is noise for a test about
+// coordinates.
+func (s *DialectSuite) closedBlob() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: "hall", Width: 8, Height: 8, Origin: dialectOrigin},
+		}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 3}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 5}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.End(&encounter.EndInput{Ending: "done"})
+	s.Require().NoError(err)
+
+	data := enc.ToData()
+	s.Require().NotNil(data.Outcome, "the scene closed, so the blob has an outcome to age")
+	s.Require().NotEmpty(data.Intel.Holdings, "the two of them are in plain sight, so somebody holds something")
+	return data
+}
+
+// load is the host's side of the seam: hand the loader a blob and see what it says.
+func (s *DialectSuite) load(data encounter.EncounterData) error {
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: data, Initiative: orderAsGiven{},
+	})
+	return err
+}
+
+// TestTodaysBlobLoads is the control. Every refusal below is only meaningful if
+// the dialect the composition writes today is the one it accepts.
+func (s *DialectSuite) TestTodaysBlobLoads() {
+	s.Require().NoError(s.load(s.closedBlob()))
+}
+
+// TestARoomBearingSightPayloadIsRefused.
+//
+// Intel holds opaque bytes and never reads them — that is the leaf's whole
+// contract — so nothing beneath this composition can notice that a stored
+// payload means something different than it used to. A stale sighting at
+// hall-local (2,5) would render at absolute (2,5): a cell in a different room,
+// or no room at all.
+func (s *DialectSuite) TestARoomBearingSightPayloadIsRefused() {
+	data := s.closedBlob()
+
+	aged, err := json.Marshal(map[string]any{"room": "hall", "x": 2, "y": 5})
+	s.Require().NoError(err)
+	holding := data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")]
+	holding.Payload = aged
+	data.Intel.Holdings[core.EntityID("alice")][intel.Subject("bob")] = holding
+
+	err = s.load(data)
+	s.Require().Error(err, "a room-local sighting must not load")
+	s.ErrorIs(err, encounter.ErrInvalidData)
+	s.Contains(err.Error(), "alice", "the refusal names whose holding it is")
+	s.Contains(err.Error(), "bob", "and who it is about")
+	s.Contains(err.Error(), "room-local", "and says what is wrong with it")
+}
+
+// TestARoomLocalOutcomeIsRefused.
+//
+// The old outcome shape is a room plus a room-local "position". Loading it
+// against the new field would leave the outcome's cell nil — an absent
+// placement reading as the map's origin, which is a legal cell — so absence is
+// checked and named rather than defaulted, the same call RoomData.Origin makes.
+func (s *DialectSuite) TestARoomLocalOutcomeIsRefused() {
+	err := s.load(s.agedOutcome(s.closedBlob()))
+	s.Require().Error(err, "a room-local outcome must not load")
+	s.ErrorIs(err, encounter.ErrInvalidData)
+	s.ErrorIs(err, encounter.ErrBadPlacement)
+	s.Contains(err.Error(), "alice", "the refusal names the member it could not place")
+	s.Contains(err.Error(), "room-local", "and says what is wrong with the blob")
+}
+
+// agedOutcome rewrites a fresh blob's outcome members back into the wire shape
+// #1068 replaced — the room-LOCAL "position" key — by editing the marshalled
+// bytes, because the current Go type has nowhere to put one.
+//
+// Going through JSON is the point rather than an inconvenience: this is
+// exactly the path a host takes with a save written by the old code, unknown
+// keys silently dropped and all. Building the aged blob by transforming
+// today's keeps the fixture honest as the rest of the shape moves on.
+func (s *DialectSuite) agedOutcome(data encounter.EncounterData) encounter.EncounterData {
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	var blob map[string]json.RawMessage
+	s.Require().NoError(json.Unmarshal(raw, &blob))
+
+	var outcome map[string]any
+	s.Require().NoError(json.Unmarshal(blob["outcome"], &outcome))
+
+	members, ok := outcome["members"].([]any)
+	s.Require().True(ok, "the blob's outcome lists its members")
+	for _, entry := range members {
+		member, isObject := entry.(map[string]any)
+		s.Require().True(isObject)
+		cell, hasCell := member["cell"].(map[string]any)
+		s.Require().True(hasCell, "today's outcome carries a cell, which is what ages into a position")
+		delete(member, "cell")
+		member["position"] = map[string]any{
+			"x": cell["x"].(float64) - dialectOrigin.X,
+			"y": cell["y"].(float64) - dialectOrigin.Y,
+		}
+	}
+
+	outcomeRaw, err := json.Marshal(outcome)
+	s.Require().NoError(err)
+	blob["outcome"] = outcomeRaw
+
+	agedRaw, err := json.Marshal(blob)
+	s.Require().NoError(err)
+
+	var aged encounter.EncounterData
+	s.Require().NoError(json.Unmarshal(agedRaw, &aged))
+	return aged
+}

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -59,8 +59,12 @@
 //   - W3 (doorways kiss) — a connection's two endpoints, once anchored to
 //     their rooms' origins, are adjacent absolute cells.
 //   - W4 (projection is a read) — rules and verbs stay room-local; absolute
-//     coordinates appear only in query outputs (Atlas, Absolute, Locate),
-//     never in a rule's own logic.
+//     coordinates appear only where this module REPORTS a cell, never in a
+//     rule's own logic. That set has grown as the seam converged on one map:
+//     the coordinate queries it started as (Atlas, Absolute, Locate), then
+//     placement reads and movement beats (#1040), sight payloads (#1044),
+//     the pump's monster moves (#1062), and finally the outcome (#1068).
+//     Everything a caller is told a cell for now speaks the same one.
 //   - W5 (anchors are construction data) — Origin's LEGALITY (bounds,
 //     integrality) is validated identically at Setup and Load, never
 //     derived or inferred; PRESENCE is structurally Load-only — Origin is

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1195,7 +1195,7 @@ func (e *Encounter) buildMemberOutcomes() []MemberOutcome {
 		if !ok {
 			continue
 		}
-		outcomes = append(outcomes, MemberOutcome{ID: m.ID, Room: m.Room, Position: mPos})
+		outcomes = append(outcomes, MemberOutcome{ID: m.ID, Room: m.Room, Position: e.absoluteOf(m.Room, mPos)})
 	}
 	return outcomes
 }
@@ -2754,9 +2754,14 @@ func (e *Encounter) Exit(in *ExitInput) (*ExitOutput, error) {
 
 	return &ExitOutput{
 		Outcome: MemberOutcome{
-			ID:       in.Member,
-			Room:     member.Room,
-			Position: finalPos,
+			ID:   in.Member,
+			Room: member.Room,
+			// Exit builds its own outcome rather than going through
+			// buildMemberOutcomes, so it needs the SAME projection explicitly:
+			// flipping only the shared path would leave the leaver's own
+			// report — the one thing they are handed on the way out — in the
+			// frame everything else stopped speaking.
+			Position: e.absoluteOf(member.Room, finalPos),
 		},
 		Carry:  carry,
 		Seq:    seqNum,

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -2179,7 +2179,8 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 		s.Equal(spatial.Position{X: 19, Y: 19}, aliceOutcome.Position, "alice should be at ending position")
 
 		s.Equal(goblin, goblinOutcome.ID)
-		s.Equal(spatial.Position{X: 10, Y: 10}, goblinOutcome.Position, "goblin should remain at original position")
+		s.Equal(spatial.Position{X: 30, Y: 10}, goblinOutcome.Position,
+			"goblin should remain at original position — room2-local (10,10) anchored at (20,0)")
 
 		// Assert: encounter is now closed
 		status, err := enc.Status()
@@ -2788,7 +2789,8 @@ func (s *EncounterTestSuite) TestTraverseEndingFiresOnArrival() {
 	s.Require().Len(out.Outcome.Members, 1)
 	s.Equal(alice, out.Outcome.Members[0].ID)
 	s.Equal("room-b", out.Outcome.Members[0].Room)
-	s.Equal(spatial.Position{X: 0, Y: 5}, out.Outcome.Members[0].Position)
+	s.Equal(spatial.Position{X: 10, Y: 5}, out.Outcome.Members[0].Position,
+		"room-b-local (0,5) anchored at (10,0) — the outcome speaks the dungeon map (#1068)")
 
 	status, err := enc.Status()
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -105,7 +105,11 @@ var (
 	// checks — room lookup miss, out-of-bounds position, non-integral
 	// (hex) position — which mirror NewEncounter's identical member
 	// checks and used to carry only ErrInvalidData (#929 hardening
-	// round F).
+	// round F) — plus, outcome-only, a MISSING cell, which has no Setup
+	// analogue for the same structural reason RoomData.Origin's absence
+	// does not: an outcome's position is a plain value in memory and a
+	// pointer on the wire, so only Load can tell a blob that omitted it
+	// (the pre-#1068 room-local dialect) from one that declared (0,0).
 	ErrBadPlacement = errors.New("bad placement")
 
 	// ErrBadConnection is returned when a connection's ID is empty or

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -314,7 +314,7 @@ type Outcome struct {
 	Members []MemberOutcome
 }
 
-// MemberOutcome is a member's position when the encounter closed.
+// MemberOutcome is where a member stood when the encounter closed.
 type MemberOutcome struct {
 	// ID is the member's identifier.
 	ID MemberID
@@ -322,7 +322,16 @@ type MemberOutcome struct {
 	// Room is their room ID when the encounter closed.
 	Room string
 
-	// Position is their position within the room.
+	// Position is the DUNGEON-ABSOLUTE cell they finished on
+	// (rpg-toolkit#1068) — the same frame Member.Position and every beat
+	// speak, projected through the same absoluteOf.
+	//
+	// This was the last room-local report on the surface, and the worst place
+	// for one to survive: an outcome is read AFTER the encounter is over, when
+	// a host has no roster call and no further beats left to cross-check it
+	// against. A party that finished in a room anchored anywhere but the
+	// origin was reported at cells belonging to whatever room happens to sit
+	// there.
 	Position spatial.Position
 }
 

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -218,3 +218,108 @@ func (s *PlacementSuite) TestTheDoorwayKissesInAbsoluteSpace() {
 	s.Equal(float64(1), doorway.ToCell.X-doorway.FromCell.X, "one step apart on the dungeon map")
 	s.Equal(doorway.FromCell.Y, doorway.ToCell.Y)
 }
+
+// TestTheOutcomeSpeaksAbsolute (rpg-toolkit#1068) closes the last room-local
+// report on this surface.
+//
+// An outcome is the one placement report a host reads AFTER the encounter is
+// over, when it has nothing left to cross-check against — no roster call, no
+// further beats. It carried a room-local cell while every other read had
+// already flipped, so a party that finished in a room anchored anywhere but
+// the origin was drawn at cells belonging to whatever room happens to sit
+// there.
+func (s *PlacementSuite) TestTheOutcomeSpeaksAbsolute() {
+	ended, err := s.enc.End(&encounter.EndInput{Ending: "done"})
+	s.Require().NoError(err)
+
+	placed := map[encounter.MemberID]spatial.Position{}
+	for _, m := range ended.Outcome.Members {
+		placed[m.ID] = m.Position
+	}
+	s.Require().Len(placed, 2)
+	s.Equal(spatial.Position{X: 32, Y: 13}, placed["alice"], "hall-local (2,3) anchored at (30,10)")
+	s.Equal(spatial.Position{X: 43, Y: 11}, placed["ogre"], "vault-local (5,1) anchored at (38,10)")
+
+	s.Equal(s.absolute("hall", spatial.Position{X: 2, Y: 3}), placed["alice"],
+		"the outcome and the projection bridge must agree")
+	s.Equal(s.absolute("vault", spatial.Position{X: 5, Y: 1}), placed["ogre"],
+		"and for the other room's anchor too")
+}
+
+// TestTheOutcomeAgreesWithTheRoster is the cross-check that makes the flip
+// mean something: the last thing a host hears about where somebody stands must
+// be the same cell as the last roster read, not the same numbers in a
+// different frame.
+func (s *PlacementSuite) TestTheOutcomeAgreesWithTheRoster() {
+	roster, err := s.enc.Members()
+	s.Require().NoError(err)
+	standing := map[encounter.MemberID]spatial.Position{}
+	for _, m := range roster {
+		standing[m.ID] = m.Position
+	}
+
+	ended, err := s.enc.End(&encounter.EndInput{Ending: "done"})
+	s.Require().NoError(err)
+
+	for _, m := range ended.Outcome.Members {
+		s.Equal(standing[m.ID], m.Position, "%s finished where the roster last put them", m.ID)
+	}
+}
+
+// TestAClosedEncounterKeepsAnsweringAbsolute: Status re-reads the stored
+// outcome rather than rebuilding it, so it is its own path and its own pin.
+func (s *PlacementSuite) TestAClosedEncounterKeepsAnsweringAbsolute() {
+	_, err := s.enc.End(&encounter.EndInput{Ending: "done"})
+	s.Require().NoError(err)
+
+	status, err := s.enc.Status()
+	s.Require().NoError(err)
+	s.Require().NotNil(status.Outcome)
+
+	placed := map[encounter.MemberID]spatial.Position{}
+	for _, m := range status.Outcome.Members {
+		placed[m.ID] = m.Position
+	}
+	s.Equal(spatial.Position{X: 32, Y: 13}, placed["alice"])
+	s.Equal(spatial.Position{X: 43, Y: 11}, placed["ogre"])
+}
+
+// TestAnExitReportsAbsolutePlacement. Exit builds its departing member's
+// outcome itself — from the spatial room, not from buildMemberOutcomes — so
+// projecting the shared path and leaving this one alone would flip everything
+// except the report the leaver actually gets.
+func (s *PlacementSuite) TestAnExitReportsAbsolutePlacement() {
+	left, err := s.enc.Exit(&encounter.ExitInput{Member: "alice"})
+	s.Require().NoError(err)
+
+	s.Equal(spatial.Position{X: 32, Y: 13}, left.Outcome.Position,
+		"hall-local (2,3) anchored at (30,10)")
+	s.Equal(s.absolute("hall", spatial.Position{X: 2, Y: 3}), left.Outcome.Position)
+}
+
+// TestTheOutcomeSurvivesARoundTripStillAbsolute.
+//
+// Persistence is where a frame flip goes wrong quietly: a loader that stores
+// the cell it was given and hands it back unchanged passes every live test in
+// this file and still returns a different frame after a save/load, because the
+// blob was written in one dialect and read in another.
+func (s *PlacementSuite) TestTheOutcomeSurvivesARoundTripStillAbsolute() {
+	_, err := s.enc.End(&encounter.EndInput{Ending: "done"})
+	s.Require().NoError(err)
+
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: s.enc.ToData(), Initiative: orderAsGiven{},
+	})
+	s.Require().NoError(err)
+
+	status, err := reloaded.Status()
+	s.Require().NoError(err)
+	s.Require().NotNil(status.Outcome)
+
+	placed := map[encounter.MemberID]spatial.Position{}
+	for _, m := range status.Outcome.Members {
+		placed[m.ID] = m.Position
+	}
+	s.Equal(spatial.Position{X: 32, Y: 13}, placed["alice"], "still on the dungeon map after a save")
+	s.Equal(spatial.Position{X: 43, Y: 11}, placed["ogre"])
+}

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -1647,7 +1647,8 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 		}
 	}
 	s.Equal("room-b", aOutcome.Room)
-	s.Equal(spatial.Position{X: 0, Y: 5}, aOutcome.Position)
+	s.Equal(spatial.Position{X: 10, Y: 5}, aOutcome.Position,
+		"room-b-local (0,5) anchored at (10,0) — the outcome speaks the dungeon map (#1068)")
 	// The full-tick-then-evaluate law, made observable: zzz-goblin's
 	// ALREADY-APPLIED move is reflected in the outcome — its NEW
 	// position, not its pre-pump one. A revert-on-close implementation


### PR DESCRIPTION
Closes #1068. Half of the closing flip of the one-map seam reshape — the encounter half. #1053's session pin bump follows in its own PR, for the reason spelled out under **Why this is two PRs** below.

## What changed

`MemberOutcome.Position` was the last room-local report on this surface, and the worst place for one to survive: an outcome is read AFTER the encounter is over, when a host has no roster call and no further beats left to check it against. A party that finished in a room anchored anywhere but the origin was reported at cells belonging to whatever room happens to sit there.

It now projects through the same `absoluteOf` every other report uses — from `buildMemberOutcomes` (Status, Move, Traverse, Pump, End) and from `Exit`, which builds the leaver's own report separately and would otherwise have been the one shape left behind.

## The ruling this implements

> **Kirk's ruling on old persisted blobs (2026-08-17): FAIL LOUDLY.** No migration — nothing real exists to migrate (dev/workbench saves only). When the pin bump lands, `LoadEncounter` must REJECT old-dialect data rather than silently reading room-local coordinates as absolute: a sight payload carrying a `"room"` key is refused at load with a clear error. Same ruling governs #1068's MemberOutcome flip — and since a bare position is not shape-detectable, the new outcome shape should change detectably (e.g. drop/rename the room-bearing field) so an old blob fails parse loudly by name instead of rendering wrong.

Two dialects are detectable, and both are now refused by name:

**The outcome.** `MemberOutcomeData`'s cell moved from `"position"` to `"cell"`, and is REQUIRED — a pointer, `RoomData.Origin`'s precedent. A bare pair of numbers cannot be told apart by inspection, so the wire KEY carries the signal: an old blob's `"position"` lands nowhere on today's shape, and its absence is named at load rather than defaulting to (0,0), a legal cell that would invent a placement. `Room` stays on both the runtime and wire shapes: the composition keeps rooms, it only stops speaking them in coordinates.

**Sight payloads.** A payload carrying a `"room"` key — every payload written before #1044 — is refused at load. Intel round-trips payloads as opaque bytes with no version field (that is the leaf's contract), and load never re-derives sight, so nothing beneath or after this composition could have noticed a stale frame. This half serves #1053, which is why the guard lands here rather than with the pin bump.

Also corrects W4's own statement of itself in `doc.go`: absolute coordinates stopped being confined to Atlas/Absolute/Locate at #1040, and the law's parenthetical never caught up.

## Why this is two PRs

Session's committed `go.mod` must pin a PUBLISHED encounter, and no override may be committed. Session cannot pin a version that does not exist yet, so the pin bump is a second PR against the tag this one produces.

It is not only a versioning technicality — the two halves genuinely conflict. Session's `projectMemberOutcome` projects the outcome through `Absolute`, which is correct against every published encounter and becomes a double anchoring the moment this PR is tagged. Measured, with session's code unchanged and encounter local:

```
--- FAIL: TestOneMapSuite/TestAnOutcomeIsNotAnchoredTwice
    Error:    Not equal:
              expected: spatial.Position{X:7, Y:6}
              actual  : spatial.Position{X:9, Y:9}
    Messages: the cell she finished on — anchoring it a second time would say (9,9)
```

So the sequence is: merge this, tag encounter `v0.13.0`, then session bumps `v0.10.0 → v0.13.0` and drops the second projection, closing #1053. That PR is written and rehearsed against a local override already (whole session suite green) — it is waiting on the tag, not on the work.

## Version expectation

`fix(encounter)!:` on a v0.x module is a MINOR bump by the tagger's own rule (semver 4: "anything MAY change at any time"), so **encounter v0.12.0 → v0.13.0**. Only `rulebooks/dnd5e/encounter/**` is touched, and the tagger's nested-module excludes (#917) keep the parent `rulebooks/dnd5e` out of it — no phantom bump expected.

## Evidence

**RED** — the seven new pins, before the change:

```
--- FAIL: TestDialectSuite/TestARoomBearingSightPayloadIsRefused
--- FAIL: TestDialectSuite/TestARoomLocalOutcomeIsRefused
--- FAIL: TestPlacementSuite/TestAClosedEncounterKeepsAnsweringAbsolute
--- FAIL: TestPlacementSuite/TestAnExitReportsAbsolutePlacement
--- FAIL: TestPlacementSuite/TestTheOutcomeAgreesWithTheRoster
--- FAIL: TestPlacementSuite/TestTheOutcomeSpeaksAbsolute
--- FAIL: TestPlacementSuite/TestTheOutcomeSurvivesARoundTripStillAbsolute
```

with `TestDialectSuite/TestTodaysBlobLoads` — the control — green throughout, so every refusal below is a refusal of the OLD dialect and not of loading in general.

Sample failure, showing the frame rather than a nil:

```
Error: Not equal:
       expected: spatial.Position{X:43, Y:11}
       actual  : spatial.Position{X:5, Y:1}
Messages: and for the other room's anchor too
```

Every new fixture anchors its rooms away from the origin. A room at (0,0) makes local and absolute the same numbers, which is exactly how this module's existing suites went green through #1040 without noticing anything had moved.

**GREEN**

```
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter          0.053s
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter/cmd/freeroam-workbench
golangci-lint run ./...  →  0 issues.
gofmt -l .               →  (clean)
go mod tidy              →  (no diff)
```

**Six existing tests changed, each an honest frame update rather than a loosened assertion:** `chase_test.go` (vault anchored at (10,0), so (8,8) → (18,8)), `continuity_test.go` (the outcome is read back through `Locate` now instead of projected — the stronger check, since a room-local cell would resolve to the wrong room or to none), `encounter_test.go` ×2, `pump_test.go`, and the closed golden in `data_test.go` (`"position"` → `"cell"`; room1 sits at the origin there, so the NUMBERS are unchanged and only the key moved, which is the whole point of the rename).

## Review round

Copilot found a real hole in the sight guard and it was worse than described. The guard decoded `"room"` into a `*string`, so `{"room":null,…}` read as absent, and `{"room":7,…}` failed to decode at all — and the decode-failure branch is a deliberate pass, since intel carries testimony for any channel a composition invents and bytes this module cannot read belong to whoever wrote them. Both loaded clean; I reproduced both before touching anything:

```
--- FAIL: TestDialectSuite/TestARoomBearingSightPayloadIsRefused/{"room":null,"x":32,"y":15}
        Error: An error is expected but got nil.
--- FAIL: TestDialectSuite/TestARoomBearingSightPayloadIsRefused/{"room":7,"x":32,"y":15}
        Error: An error is expected but got nil.
```

Fixed in 1069a21: the guard peeks into `map[string]json.RawMessage` and refuses on PRESENCE of the key rather than its value — the right rule independent of the null case, since this composition is the only writer of sight payloads. All three payloads are subtests of the same case now, so the rule is pinned rather than the one example.

## Mutation check

Eight mutants over the changed production code. The first run left two alive, and both were claims written in the guard's own doc comments that no test held — widening the guard past the sight channel was unobservable because nothing constructed a holding on another channel, and dropping either sort pinned nothing because with two members every observer held exactly one subject. `closedBlob` grew a third member so an ordering exists to check, and both claims are pinned now (the determinism pin loads the same blob fifty times and requires the same message).

```
M1 buildMemberOutcomes stops projecting              caught by TestVaultChase
M2 Exit stops projecting                             caught by TestPlacementSuite
M3 the sight guard never refuses                     caught by TestDialectSuite
M4 the outcome bounds check forgets the origin       caught by TestDialectSuite
M5 a missing cell is not named                       caught by TestDataSuite
M6 the guard looks at every channel, not just sight  caught by TestDialectSuite
M7 the guard stops sorting its subjects              caught by TestDialectSuite
M8 the guard stops sorting its observers             caught by TestDialectSuite
```

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)