### PR TITLE
feat(session)!: the seam speaks one map to the last frame (#1053)

### DIFF
--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -109,7 +109,7 @@ func before(a, b spatial.Position) bool {
 	return a.Y < b.Y
 }
 
-func projectStatus(enc *encounter.Encounter, in *encounter.Status) *Status {
+func projectStatus(in *encounter.Status) *Status {
 	if in == nil {
 		return nil
 	}
@@ -124,7 +124,7 @@ func projectStatus(enc *encounter.Encounter, in *encounter.Status) *Status {
 		Members: make([]MemberOutcome, 0, len(in.Outcome.Members)),
 	}
 	for _, m := range in.Outcome.Members {
-		outcome.Members = append(outcome.Members, projectMemberOutcome(enc, m))
+		outcome.Members = append(outcome.Members, projectMemberOutcome(m))
 	}
 	out.Outcome = outcome
 	return out
@@ -189,9 +189,11 @@ func projectMember(in encounter.Member) Member {
 // onMap projects a composition room-local cell into the one map this seam
 // speaks, by asking the composition rather than doing the arithmetic here.
 //
-// Placement reads already come back absolute (encounter v0.10.0), and this is
-// for the two shapes that do not: an outcome's member list, which the
-// composition still reports in its own terms. Asking Absolute means the seam
+// What is left for it to do keeps shrinking as the composition converges on
+// one map. Placement reads came back absolute at encounter v0.10.0, outcomes
+// at v0.13.0 (rpg-toolkit#1068); what remains is a walk — the room-local cells
+// the composition's own movement verbs take and report, which move.go
+// projects on the way out and on the way in. Asking Absolute means the seam
 // never learns what an origin is, which is the whole point of it living down
 // there.
 func onMap(enc *encounter.Encounter, room string, local spatial.Position) spatial.Position {
@@ -206,17 +208,25 @@ func onMap(enc *encounter.Encounter, room string, local spatial.Position) spatia
 	return out.Position
 }
 
-func projectMemberOutcome(enc *encounter.Encounter, in encounter.MemberOutcome) MemberOutcome {
+// projectMemberOutcome carries the outcome's cell across unchanged.
+//
+// It used to project one: an outcome was the last shape the composition still
+// reported room-local, so the seam re-asked for an absolute cell through
+// Absolute. Encounter v0.13.0 reports the outcome on the dungeon map itself
+// (rpg-toolkit#1068), and the same anchoring applied twice would put every
+// member off by their room's origin — in the one report a host reads after
+// there is nothing left to check it against.
+func projectMemberOutcome(in encounter.MemberOutcome) MemberOutcome {
 	return MemberOutcome{
 		ID:       string(in.ID),
-		Position: onMap(enc, in.Room, in.Position),
+		Position: in.Position,
 	}
 }
 
 // projectOutcome converts a bare outcome. projectStatus has its own inline
 // copy of this walk because it must also handle the nil-Status case; this one
 // serves the verbs that return an outcome directly.
-func projectOutcome(enc *encounter.Encounter, in *encounter.Outcome) *Outcome {
+func projectOutcome(in *encounter.Outcome) *Outcome {
 	if in == nil {
 		return nil
 	}
@@ -226,7 +236,7 @@ func projectOutcome(enc *encounter.Encounter, in *encounter.Outcome) *Outcome {
 		Members: make([]MemberOutcome, 0, len(in.Members)),
 	}
 	for _, m := range in.Members {
-		out.Members = append(out.Members, projectMemberOutcome(enc, m))
+		out.Members = append(out.Members, projectMemberOutcome(m))
 	}
 	return out
 }

--- a/rulebooks/dnd5e/session/convert_test.go
+++ b/rulebooks/dnd5e/session/convert_test.go
@@ -84,7 +84,7 @@ var omitted = map[string]string{
 	// the composition's own decomposition, and a caller that wanted it would
 	// be reconstructing the frame the reshape removed.
 	"encounter.Member.Room":        "a room id; the seam reports the cell instead",
-	"encounter.MemberOutcome.Room": "a room id; Position is projected onto the map instead",
+	"encounter.MemberOutcome.Room": "a room id; the composition's own bookkeeping — Position already names the cell on the map",
 
 	// A doorway's endpoints kept their meaning and lost their qualifier: on one
 	// map there is no second pair of From/To fields naming rooms to

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.10.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.13.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.10.0 h1:yHUQxaqN66Eh8ZHWY1FA/+xXB8JDXOof4Up9pPETfrY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.10.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.13.0 h1:95b9sOvtPK3J+ix1zr7hnB8vp/o0ZXFTbhDgbq9D3cc=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.13.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2 h1:I8cobvZ+E2lk5no782XSFCoODqt3l+LLgJaKUkBz1WU=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.7.2/go.mod h1:akIVBXf3LdfHmcKlliUngpzKWWCZOl6DWpK9CPFetPo=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -213,7 +213,7 @@ func (m *Manager) runWalk(scope *writeScope, member string, walk resolvedWalk) (
 			// The encounter ended underfoot. Every remaining step is abandoned:
 			// a closed encounter refuses movement anyway, and attempting them
 			// would turn a clean stop into a rejection the caller must interpret.
-			res.outcome = projectOutcome(scope.enc, moved.Outcome)
+			res.outcome = projectOutcome(moved.Outcome)
 			return res, nil
 		}
 

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -14,6 +14,7 @@ package session_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -261,4 +262,160 @@ func (s *OneMapSuite) TestNothingOnThePlaySurfaceNamesARoom() {
 	// half that is about rooms specifically.
 	s.NotContains(fieldsOf(session.Member{}), "Room")
 	s.Contains(fieldsOf(session.Member{}), "Position")
+}
+
+// TestASightingIsReportedOnTheMap is #1053's own case, and the last frame this
+// seam had left to converge.
+//
+// A sighting's payload is opaque bytes here — the session hands them through
+// without reading them, because intel's testimony is the composition's
+// encoding, not this package's — so the pin decodes them the way a client
+// does. Two halves, and both matter: the cell is the one the Atlas names for
+// that spot, and there is no room key to reinterpret it by. A payload carrying
+// hall-local (2,1) would put bob at a cell no room in this world contains,
+// while looking exactly as plausible.
+func (s *OneMapSuite) TestASightingIsReportedOnTheMap() {
+	ctx := context.Background()
+	bobsCell := spatial.Position{X: 42, Y: 21} // hall-local (2,1)
+
+	_, err := s.mgr.Join(ctx, &session.JoinInput{
+		Session: "sess", Member: "bob", Position: bobsCell,
+	})
+	s.Require().NoError(err)
+
+	seen, err := s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+
+	var payload map[string]any
+	for _, sighting := range seen {
+		if sighting.Subject != "bob" {
+			continue
+		}
+		s.Require().NoError(json.Unmarshal(sighting.Payload, &payload))
+	}
+	s.Require().NotNil(payload, "alice and bob share an open hall in plain sight")
+
+	s.Equal(map[string]any{"x": float64(42), "y": float64(21)}, payload,
+		"bob's cell on the dungeon map — hall-local (2,1) anchored at (40,20)")
+	s.NotContains(payload, "room", "a sighting names no room; there is one map")
+
+	atlas, err := s.mgr.Atlas(ctx, &session.AtlasInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Contains(atlas.Cells, bobsCell,
+		"the sighted cell is a cell of the map the same client renders")
+}
+
+// TestASightingAndAPlacementAgree crosses the two reads a client puts on
+// screen together. Where bob IS and where alice SEES bob are answered by
+// different paths — a join's own report and an intel payload — and a client
+// draws them on one canvas.
+func (s *OneMapSuite) TestASightingAndAPlacementAgree() {
+	ctx := context.Background()
+	joined, err := s.mgr.Join(ctx, &session.JoinInput{
+		Session: "sess", Member: "bob", Position: spatial.Position{X: 43, Y: 22},
+	})
+	s.Require().NoError(err)
+
+	seen, err := s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+
+	var sighted spatial.Position
+	found := false
+	for _, sighting := range seen {
+		if sighting.Subject != "bob" {
+			continue
+		}
+		var payload struct {
+			X float64 `json:"x"`
+			Y float64 `json:"y"`
+		}
+		s.Require().NoError(json.Unmarshal(sighting.Payload, &payload))
+		sighted, found = spatial.Position{X: payload.X, Y: payload.Y}, true
+	}
+	s.Require().True(found)
+
+	s.Equal(joined.Member.Position, sighted,
+		"the cell bob joined at is the cell alice sees him on")
+}
+
+// The two tests below are the pins the rest of this file cannot carry, and
+// they exist because the mistake they guard against is INVISIBLE in every
+// other world here.
+//
+// The hall above is six cells wide and anchored at (40,20), so an absolute
+// cell there is never also a legal room-local one. Anchor a cell twice in that
+// world and the composition refuses the second projection as out of bounds,
+// the seam's fallback hands the cell back untouched, and a wrong calculation
+// produces a right answer. Anchor the room near the origin instead and the
+// overlap is real — (7,6) is both a cell on the map and a cell inside the room
+// — so the second anchoring succeeds and lands somewhere else entirely, in the
+// one report a host reads after the encounter is over.
+
+// shallowAnchoredWorld is one 10x10 room anchored at (2,3) — close enough to
+// the origin that its ABSOLUTE cells overlap its own room-local ones.
+func shallowAnchoredWorld(t fataler) *encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: encOrderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: "hall", Width: 10, Height: 10, Origin: spatial.Position{X: 2, Y: 3}},
+		}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 3}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "stairs", Trigger: encounter.TriggerReachedPosition{
+				Room: "hall", Position: spatial.Position{X: 5, Y: 3}}},
+		},
+		Retention: encounter.RetentionUnbounded,
+	})
+	if err != nil {
+		t.Fatalf("building the shallow-anchored world: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
+// shallowSession starts a session on that world. Alice stands at absolute
+// (4,6) — hall-local (2,3) — and the stairs are at absolute (7,6).
+func (s *OneMapSuite) shallowSession() *session.Manager {
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: sessions, Encounters: encounters,
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "shallow", Encounter: "shallow-world", World: shallowAnchoredWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	return mgr
+}
+
+// TestAnOutcomeIsNotAnchoredTwice: the ending's own member list.
+func (s *OneMapSuite) TestAnOutcomeIsNotAnchoredTwice() {
+	out, err := s.shallowSession().Move(context.Background(), &session.MoveInput{
+		Session: "shallow", Member: "alice",
+		Path: []spatial.Position{{X: 5, Y: 6}, {X: 6, Y: 6}, {X: 7, Y: 6}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Outcome, "the stairs are underfoot")
+	s.Require().Len(out.Outcome.Members, 1)
+
+	s.Equal(spatial.Position{X: 7, Y: 6}, out.Outcome.Members[0].Position,
+		"the cell she finished on — anchoring it a second time would say (9,9)")
+}
+
+// TestAnExitIsNotAnchoredTwice: the leaver's own report, which the composition
+// builds on its own path and which reaches a client through the same
+// converter. Two shapes carry an outcome across this seam, and a pin on one
+// says nothing about the other.
+func (s *OneMapSuite) TestAnExitIsNotAnchoredTwice() {
+	left, err := s.shallowSession().Exit(context.Background(), &session.ExitInput{
+		Session: "shallow", Member: "alice",
+	})
+	s.Require().NoError(err)
+
+	s.Equal(spatial.Position{X: 4, Y: 6}, left.Outcome.Position,
+		"the cell she left from — anchoring it a second time would say (6,9)")
 }

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -101,7 +101,7 @@ func (m *Manager) Status(ctx context.Context, in *StatusInput) (*Status, error) 
 		return nil, fmt.Errorf("status: %w", translate(err))
 	}
 
-	return projectStatus(enc, status), nil
+	return projectStatus(status), nil
 }
 
 // Where returns the cell a member stands on, in dungeon-absolute space.

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -221,7 +221,7 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 		Character:  projectCharacter(ch),
 		Discovered: projectDiscoveries(placed.IntelDeltas),
 		Seq:        placed.Seq,
-		Outcome:    projectOutcome(scope.enc, placed.Outcome),
+		Outcome:    projectOutcome(placed.Outcome),
 		Formed:     projectFormed(placed.Formed),
 		Saved:      report,
 		Delivery:   delivery,
@@ -302,7 +302,7 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 		NPC:        projectMonster(sheet),
 		Discovered: projectDiscoveries(placed.IntelDeltas),
 		Seq:        placed.Seq,
-		Outcome:    projectOutcome(scope.enc, placed.Outcome),
+		Outcome:    projectOutcome(placed.Outcome),
 		Formed:     projectFormed(placed.Formed),
 		Saved:      report,
 		Delivery:   delivery,
@@ -382,10 +382,10 @@ func (m *Manager) Exit(ctx context.Context, in *ExitInput) (*ExitOutput, error) 
 	}
 
 	return &ExitOutput{
-		Outcome:  projectMemberOutcome(scope.enc, left.Outcome),
+		Outcome:  projectMemberOutcome(left.Outcome),
 		Carry:    projectSightings(left.Carry),
 		Seq:      left.Seq,
-		Closed:   projectOutcome(scope.enc, left.Closed),
+		Closed:   projectOutcome(left.Closed),
 		Saved:    report,
 		Delivery: delivery,
 	}, nil
@@ -416,7 +416,7 @@ func (m *Manager) End(ctx context.Context, in *EndInput) (*EndOutput, error) {
 		return nil, fmt.Errorf("end: %w", err)
 	}
 
-	outcome := projectOutcome(scope.enc, &ended.Outcome)
+	outcome := projectOutcome(&ended.Outcome)
 	return &EndOutput{Outcome: *outcome, Saved: report, Delivery: delivery}, nil
 }
 


### PR DESCRIPTION
Closes #1053. The session half of the closing flip — #1072 landed the encounter half and was tagged `rulebooks/dnd5e/encounter/v0.13.0`, and this is the pin bump that makes the seam speak one dialect end to end.

## What changed

**The pin**, `encounter v0.10.0 → v0.13.0`. One bump, three flips this seam had been reporting behind:

| version | flip |
|---|---|
| v0.11.0 | sight payloads are dungeon-absolute and carry no room (#1044) |
| v0.12.0 | the pump's monster moves are dungeon-absolute (#1062) |
| v0.13.0 | the outcome is dungeon-absolute, and old blobs are refused at load (#1068) |

**The sighting** is #1053's own case. What one member sees of another used to arrive as `{"room":"hall","x":2,"y":1}` — a cell resolvable only by knowing about rooms, which is the one thing this seam exists to stop handing out. It now arrives as `{"x":42,"y":21}`: the cell the Atlas names for that spot, with no room to reinterpret it by.

**The outcome** moves the other way. `projectMemberOutcome` used to re-ask the composition for an absolute cell through `Absolute`, because an outcome was the last shape still reported room-local. It is not now, and anchoring the same cell twice puts every member off by their room's origin. `onMap` itself stays — a walk's steps still come back room-local from the composition's own movement verbs, and `move.go` still projects them. With the outcome no longer needing it, `projectStatus` and `projectOutcome` no longer need the composition at all, so the `*encounter.Encounter` argument comes off both.

## Evidence

Both directions of RED, run against `origin/main` with only the new pins added — the production code exactly as main holds it.

**RED at the committed v0.10.0 pin** — the sighting is reported in the composition's own frame, with a room key to prove it:

```
--- FAIL: TestOneMapSuite/TestASightingIsReportedOnTheMap
        expected: map[string]interface {}{"x":42, "y":21}
        actual  : map[string]interface {}{"room":"hall", "x":2, "y":1}
        Messages: bob's cell on the dungeon map — hall-local (2,1) anchored at (40,20)
        Messages: a sighting names no room; there is one map

--- FAIL: TestOneMapSuite/TestASightingAndAPlacementAgree
        expected: spatial.Position{X:43, Y:22}
        actual  : spatial.Position{X:3, Y:2}
        Messages: the cell bob joined at is the cell alice sees him on
```

**RED with the pin bumped to v0.13.0 and the converter left alone** — the double anchoring this PR exists to prevent:

```
--- FAIL: TestOneMapSuite/TestAnOutcomeIsNotAnchoredTwice
        expected: spatial.Position{X:7, Y:6}
        actual  : spatial.Position{X:9, Y:9}
        Messages: the cell she finished on — anchoring it a second time would say (9,9)

--- FAIL: TestOneMapSuite/TestAnExitIsNotAnchoredTwice
        expected: spatial.Position{X:4, Y:6}
        actual  : spatial.Position{X:6, Y:9}
        Messages: the cell she left from — anchoring it a second time would say (6,9)
```

That second pair needed a new world to be visible at all, and the reason is worth recording. `onMap` swallows `Absolute`'s out-of-bounds error and hands the cell back unprojected. In this file's existing hall — six cells wide, anchored at (40,20) — an absolute cell is never ALSO a legal room-local one, so a second projection is refused and wrong arithmetic produces a right answer. `shallowAnchoredWorld` anchors a 10×10 room at (2,3) instead, where the frames genuinely overlap: (7,6) is both a cell on the map and a cell inside the room, so the second anchoring succeeds and lands somewhere else. Both verbs that report an outcome are pinned, because `Exit` builds the leaver's own report on its own path and a pin on `Move` says nothing about it.

**GREEN**

```
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session                   0.059s
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session/cmd/session-workbench
golangci-lint run ./...  →  0 issues.
gofmt -l .               →  (clean)
go mod tidy              →  only the encounter line moved
```

## Notes

No `replace` directive and no `go.work` is committed. The two halves were developed against a local override in a throwaway copy outside the repository, which is how this could be written and rehearsed before #1072 was tagged — and why it is only opened now that v0.13.0 exists to pin.

`TestNothingOnThePlaySurfaceNamesARoom` already guarded the types; these pins guard the values that travel through them, which is where the room was still leaking.

— rpg-toolkit implementer agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
