### PR TITLE
feat(dnd5e): combat answers who is standing (#1074)

### DIFF
--- a/rulebooks/dnd5e/combat/is_down.go
+++ b/rulebooks/dnd5e/combat/is_down.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat
+
+// IsDown reports whether a combatant is down: at zero hit points, or below.
+//
+// This is a pull read of the sheet and nothing else. There is no stored down
+// flag, so the answer moves with the hit points — heal a combatant and it
+// stands again, and any route to zero (a weapon, a spell, a condition, a sheet
+// loaded from storage already at zero) is noticed at the next ask rather than
+// only at the moment it happens. ApplyDamageResult.DroppedToZero reports what
+// one blow did; IsDown reports where the combatant stands now.
+//
+// Below zero counts, and not only defensively: the two sheets in this rulebook
+// floor at zero today, but a combatant is defined by what it reports, and one
+// reporting -3 is not standing.
+//
+// Exceptions to the rule live here too. A monster with Undead Fortitude
+// (rpg-toolkit#977) reaches zero and is not down; when that answer is built it
+// changes this function, not its callers. That is the reason a composition
+// holding no hit points asks this question instead of comparing numbers itself.
+//
+// c must not be nil.
+func IsDown(c Combatant) bool {
+	return c.GetHitPoints() <= 0
+}

--- a/rulebooks/dnd5e/combat/is_down_test.go
+++ b/rulebooks/dnd5e/combat/is_down_test.go
@@ -1,0 +1,210 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	mock_combat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/mock"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// IsDownSuite pins the standing question against real sheets: every state a
+// test asserts on is reached by driving ApplyDamage (or the healing the sheet
+// listens for), never by hand-setting hit points, so the answer is a read of
+// what the sheet actually says.
+type IsDownSuite struct {
+	suite.Suite
+
+	ctx       context.Context
+	bus       events.EventBus
+	ctrl      *gomock.Controller
+	fighter   *character.Character
+	skeleton  *monster.Monster
+	fighterHP int
+}
+
+func TestIsDownSuite(t *testing.T) {
+	suite.Run(t, new(IsDownSuite))
+}
+
+func (s *IsDownSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.ctrl = gomock.NewController(s.T())
+	s.fighterHP = 12
+	s.fighter = s.createFighter()
+	s.skeleton = s.createSkeleton()
+}
+
+func (s *IsDownSuite) TearDownTest() {
+	if s.fighter != nil {
+		_ = s.fighter.Cleanup(s.ctx)
+	}
+	s.ctrl.Finish()
+}
+
+// createFighter loads a level 1 fighter attached to the bus, so the sheet
+// listens for healing the way a live sheet does.
+func (s *IsDownSuite) createFighter() *character.Character {
+	data := &character.Data{
+		ID:               "fighter-1",
+		PlayerID:         "player-1",
+		Name:             "Alice",
+		Level:            1,
+		ProficiencyBonus: 2,
+		RaceID:           races.Human,
+		ClassID:          classes.Fighter,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    s.fighterHP,
+		MaxHitPoints: s.fighterHP,
+		ArmorClass:   16,
+	}
+
+	char, err := character.LoadFromData(s.ctx, data, s.bus)
+	s.Require().NoError(err)
+	s.Require().NotNil(char)
+
+	return char
+}
+
+func (s *IsDownSuite) createSkeleton() *monster.Monster {
+	return monster.New(monster.Config{
+		ID:   "skeleton-1",
+		Name: "Skeleton",
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 10,
+			abilities.DEX: 14,
+			abilities.CON: 15,
+			abilities.INT: 6,
+			abilities.WIS: 8,
+			abilities.CHA: 5,
+		},
+		AC: 13,
+		HP: 13,
+	})
+}
+
+// hit drives real damage through the combatant's own ApplyDamage.
+func (s *IsDownSuite) hit(c combat.Combatant, amount int) *combat.ApplyDamageResult {
+	return c.ApplyDamage(s.ctx, &combat.ApplyDamageInput{
+		Instances: []combat.DamageInstance{{Amount: amount, Type: "slashing"}},
+	})
+}
+
+// An untouched sheet is standing — for a character and for a monster.
+func (s *IsDownSuite) TestUndamagedCombatantsAreStanding() {
+	s.Require().Positive(s.fighter.GetHitPoints())
+	s.Require().Positive(s.skeleton.GetHitPoints())
+
+	s.False(combat.IsDown(s.fighter), "an undamaged character is standing")
+	s.False(combat.IsDown(s.skeleton), "an undamaged monster is standing")
+}
+
+// Damage that leaves hit points behind leaves the combatant standing.
+func (s *IsDownSuite) TestDamagedButNotAtZeroIsStanding() {
+	result := s.hit(s.fighter, s.fighter.GetHitPoints()-1)
+	s.Require().Positive(result.CurrentHP, "this hit must leave the fighter above zero")
+	s.Require().False(result.DroppedToZero)
+
+	s.False(combat.IsDown(s.fighter))
+}
+
+// Exactly-lethal damage: the sheet lands on zero and the combatant reports down.
+func (s *IsDownSuite) TestCharacterAtZeroIsDown() {
+	result := s.hit(s.fighter, s.fighter.GetHitPoints())
+	s.Require().Zero(result.CurrentHP, "this hit must land the fighter exactly on zero")
+	s.Require().True(result.DroppedToZero)
+
+	s.True(combat.IsDown(s.fighter))
+}
+
+// The same question, asked of a monster: nothing about the answer is
+// character-specific.
+func (s *IsDownSuite) TestMonsterAtZeroIsDown() {
+	result := s.hit(s.skeleton, s.skeleton.GetHitPoints())
+	s.Require().Zero(result.CurrentHP)
+	s.Require().True(result.DroppedToZero)
+
+	s.True(combat.IsDown(s.skeleton))
+}
+
+// Overkill floors at zero on both real sheets, and down is still down.
+func (s *IsDownSuite) TestOverkillIsDown() {
+	result := s.hit(s.skeleton, s.skeleton.GetHitPoints()*3)
+	s.Require().Zero(result.CurrentHP, "the sheet floors overkill at zero")
+
+	s.True(combat.IsDown(s.skeleton))
+}
+
+// A combatant whose sheet reports below the floor is down. Neither real sheet
+// can produce this state — both floor at zero in ApplyDamage — so the reading
+// combatant is a stand-in for any future sheet that keeps negative hit points.
+// It pins the answer as "at or below zero", not "exactly zero".
+func (s *IsDownSuite) TestBelowZeroHitPointsIsDown() {
+	belowFloor := mock_combat.NewMockCombatant(s.ctrl)
+	belowFloor.EXPECT().GetHitPoints().Return(-7).AnyTimes()
+
+	s.True(combat.IsDown(belowFloor))
+}
+
+// The standing question is a pull read, not a stored flag: heal the sheet the
+// way the world heals it and the answer changes with the sheet.
+func (s *IsDownSuite) TestHealedCombatantStandsAgain() {
+	dropped := s.hit(s.fighter, s.fighter.GetHitPoints())
+	s.Require().Zero(dropped.CurrentHP)
+	s.Require().True(combat.IsDown(s.fighter), "the fighter must be down before healing")
+
+	healing := dnd5eEvents.HealingReceivedTopic.On(s.bus)
+	err := healing.Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: s.fighter.GetID(),
+		Amount:   5,
+		Roll:     5,
+		Source:   "potion",
+	})
+	s.Require().NoError(err)
+	s.Require().Positive(s.fighter.GetHitPoints(), "the healing must have reached the sheet")
+
+	s.False(combat.IsDown(s.fighter), "a healed combatant is standing again")
+}
+
+// And the reverse: a healed combatant taken back to zero reports down again on
+// the next ask. Any route to zero is noticed; nothing latches.
+func (s *IsDownSuite) TestDownAgainAfterHealingAndAnotherHit() {
+	s.hit(s.fighter, s.fighter.GetHitPoints())
+
+	healing := dnd5eEvents.HealingReceivedTopic.On(s.bus)
+	err := healing.Publish(s.ctx, dnd5eEvents.HealingReceivedEvent{
+		TargetID: s.fighter.GetID(),
+		Amount:   5,
+		Roll:     5,
+		Source:   "potion",
+	})
+	s.Require().NoError(err)
+	s.Require().False(combat.IsDown(s.fighter), "the fighter must be standing before the second hit")
+
+	again := s.hit(s.fighter, s.fighter.GetHitPoints())
+	s.Require().Zero(again.CurrentHP)
+
+	s.True(combat.IsDown(s.fighter))
+}


### PR DESCRIPTION
Death lane slice **D0** (tracker #959, ruled 2026-08-17). A combatant at zero hit points reports down; a combatant above zero reports standing.

```go
// package combat
func IsDown(c Combatant) bool
```

## Why this shape

**A pull read, not a stored flag.** `IsDown` reads `Combatant.GetHitPoints()` and nothing else. There is no down bit to keep in sync, so healing a combatant changes the answer with the sheet, and any route to zero — a weapon, a spell, a condition, a sheet loaded from storage already at zero — is noticed at the next ask rather than only at the moment it happens. That is deliberately the opposite of the pre-#1040 disease (a stored copy of a computable fact).

**No new methods on `Combatant`.** The census found `GetHitPoints() int` already on the interface (`combat/combatant.go:54-89`), implemented by `character.Character` (`character/character.go:727`) and `monster.Monster` (`monster/monster.go:126`). Both satisfy the question today; nothing was added to the interface, so nothing downstream has to implement anything.

**`<= 0`, not `== 0`.** Both real sheets floor at zero inside `ApplyDamage` (`character.go:762-765`, `monster.go:162-165`), so `== 0` would be correct-by-accident today and wrong for any sheet that ever keeps negative hit points. A combatant is what it reports; one reporting -7 is not standing.

**No `context`, no `error`.** The ruled downstream consumer is D1's port, `Standing(members []MemberID) (down []MemberID, err error)` (#1075) — no context in the ruled signature, and the question is a read of a number the sheet already holds. `c` must not be nil (documented); the package's closest analogue, `GetEffectiveAC`, does not nil-guard either.

**It does not preclude #977.** Undead Fortitude — a monster that reaches zero and is *not* down — changes this function, not its callers, exactly as `GetEffectiveAC` absorbs `EffectiveACCalculator` without reshaping anyone. Not implemented here, per the issue.

## Census findings

- `ApplyDamageResult.DroppedToZero` (already computed by both `ApplyDamage` implementations) reports what *one blow* did. It is an edge, not a state: it is false when a second hit lands on an already-downed target, and false for a sheet loaded at zero. `IsDown` is the standing question asked after the fact, which is why it could not simply be plumbed from the existing flag.
- `monster.IsAlive()` (`monster/monster.go:229`) is the same arithmetic, but monster-only and off the `Combatant` interface — it cannot answer for a character and no composition can reach it generically. Left untouched; `IsDown` is the interface-level answer.
- Healing never goes through a setter: it arrives on `HealingReceivedTopic` and the sheet's own handler applies it (`character.go:1182-1198`), attached by the sheet keeper. The healed test therefore heals the way the world heals, over the bus.
- New file `combat/is_down.go` — the package is file-per-concept (`ac.go`, `damage.go`, `healing.go`, `movement.go`).

## Test evidence

**RED first** (full output: the test landed before the function existed):

```
# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat_test [.../combat.test]
combat/is_down_test.go:120:17: undefined: combat.IsDown
combat/is_down_test.go:121:17: undefined: combat.IsDown
...
combat/is_down_test.go:204:27: too many errors
FAIL	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat [build failed]
```

**GREEN** — every state asserted on is reached by driving `ApplyDamage` on a real character and a real monster (and by real healing over the bus), never by hand-setting hit points. The one exception is the below-floor case, which no real sheet can produce; it uses the generated `MockCombatant` and says so in the test.

```
--- PASS: TestIsDownSuite (0.00s)
    --- PASS: TestIsDownSuite/TestUndamagedCombatantsAreStanding (0.00s)
    --- PASS: TestIsDownSuite/TestDamagedButNotAtZeroIsStanding (0.00s)
    --- PASS: TestIsDownSuite/TestCharacterAtZeroIsDown (0.00s)
    --- PASS: TestIsDownSuite/TestMonsterAtZeroIsDown (0.00s)
    --- PASS: TestIsDownSuite/TestOverkillIsDown (0.00s)
    --- PASS: TestIsDownSuite/TestBelowZeroHitPointsIsDown (0.00s)
    --- PASS: TestIsDownSuite/TestHealedCombatantStandsAgain (0.00s)
    --- PASS: TestIsDownSuite/TestDownAgainAfterHealingAndAnotherHit (0.00s)
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat	0.007s
```

The last two are the no-stored-flag pins: a fighter dropped to zero reports down, is healed over `HealingReceivedTopic`, and reports standing again; hit back to zero, it reports down again on the next ask. Nothing latches.

**Mutation check** (three boundary mutants, each run against the committed tests, all killed):

| mutant | result |
| --- | --- |
| `<= 0` → `< 0` | KILLED — 5 tests fail (both at-zero cases, overkill, both heal cases) |
| `<= 0` → `== 0` | KILLED — `TestBelowZeroHitPointsIsDown` fails |
| `<= 0` → `> 0` | KILLED — all 8 fail |

**Module gate**, from `rulebooks/dnd5e`: `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` all packages ok, `golangci-lint` 0 issues (pre-commit hook).

## gorelease

The parent `dnd5e` module has no gorelease CI job, so it was run by hand (base `v0.94.1`):

```
# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat
## compatible changes
IsDown: added

# summary
Suggested version: v0.95.0 (with tag rulebooks/dnd5e/v0.95.0)
```

Additive, as the issue requires — no breaking change to the module.

## Not in this slice

Undead Fortitude (#977). The encounter-side `Standing` capability (D1, #1075 — parallel, different module). The session wiring that supplies a real `Standing` backed by this function (D4).

Closes #1074

— fix-1074 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
