### PR TITLE
feat(encounter)!: the world notices who is down (#1075)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -153,12 +153,42 @@ are wave-4 work (see `docs/ideas/session-sdk/plan.md`). Worth knowing before
 choosing a first task — behavior that decides *where to be* is buildable now,
 behavior that decides *what to do to someone* is not.
 
+## Capabilities you must supply
+
+Two, both **required at `NewEncounter` and `LoadEncounter`**, both refused at
+construction rather than guarded later:
+
+```go
+type InitiativeRoller interface {  // what order a fight goes in
+    RollInitiative(members []MemberID) ([]MemberID, error)
+}
+
+type Standing interface {          // who is down
+    Standing(members []MemberID) (down []MemberID, err error)
+}
+```
+
+They are the same move. This module cannot import the rulebook, so randomness
+and hit points are facts it **asks for**. Neither has a default: a nil meaning
+"unshuffled" or "everybody is fine" would be the composition deciding a rule it
+is not allowed to know.
+
+`Standing` is a **pull**. Nothing pushes a death in, and nothing here remembers
+one — the composition asks at the choke point where it already asks about sight,
+so every route to zero is noticed without that route knowing this interface
+exists. A member reported down is on no side of a contact, has no turn, and gets
+no `Pump` action, while staying on the map, in the roster, and recordable
+against. Answer only about the members you are asked about; a name that was not
+in the question is refused as a mis-wiring rather than ignored.
+
 ## Contents
 
 | File | Holds |
 |---|---|
 | `encounter.go` | the aggregate: setup, verbs, `Pump`, member management |
 | `decider.go` | `Decider`, `Snapshot`, `Intent` and its three implementations |
+| `trigger.go` | `InitiativeRoller` and the classification that starts a fight |
+| `standing.go` | `Standing`, and the world noticing who is down |
 | `atlas.go` | the coordinate queries — `Atlas`, `Absolute`, `Locate` |
 | `field.go` | rooms, connections, and the per-verb output shapes |
 | `data.go` | `EncounterData` and the `ToData` / `LoadFromData` round trip |

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -26,7 +26,7 @@ import (
 // all exercised by the same tests that already cover Cells/Occluders.
 func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
@@ -65,7 +65,7 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 // a point off in empty space (#929 T3 fix round item 5).
 func validAtlasVoidGapSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "gap-a", Width: 3, Height: 3, Origin: spatial.Position{X: 0, Y: 0}},
@@ -85,7 +85,7 @@ func validAtlasVoidGapSetup() *encounter.SetupInput {
 // IsValidPosition without any Origin arithmetic in the way.
 func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
 		},
@@ -346,7 +346,7 @@ func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 
 	data := enc1.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	atlas2, err := enc2.Atlas()
@@ -465,7 +465,7 @@ func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripFractionalSquare() {
 func (s *EncounterTestSuite) TestLocateAbsoluteRoundTripExactAtExtremeOrigin() {
 	const extreme = (1 << 30) - 8
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "extreme", Width: 10, Height: 10, Origin: spatial.Position{X: extreme, Y: -extreme}},

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -76,8 +76,8 @@ func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encoun
 // that has not opened yet.
 func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			// Both clear of the wall's span: they see each other at first light.
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 0, Y: 2}},
@@ -110,7 +110,7 @@ func (s *BeatOrderTestSuite) TestMoveBeforeItFights() {
 // room: the traversed beat is the cause, the fight is the effect.
 func (s *BeatOrderTestSuite) TestTraverseBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10},
@@ -186,8 +186,8 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 2}},
 			monster,

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -54,7 +54,7 @@ func TestVaultChase(t *testing.T) {
 	// composition's room-shaped topology (rpg-toolkit#1044).
 	pursuit := &pursuitDecider{target: alice}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: corridorRoom, Width: 10, Height: 10},
@@ -126,7 +126,7 @@ func TestVaultChase(t *testing.T) {
 	// INTEL does — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: atlas.Doorways, target: alice},
 		}})
 	require.NoError(t, err, "beat 3: the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -28,7 +28,7 @@ import (
 // save. With it, the defect is loud: ErrInvalidData, never a guess.
 func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: FieldInput{
 			Rooms: []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -71,7 +71,7 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 func TestFormRejections(t *testing.T) {
 	newEnc := func() *Encounter {
 		enc, err := NewEncounter(&SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: FieldInput{Rooms: []RoomInput{
 				{ID: "r1", Width: 8, Height: 8},
 				{ID: "r2", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -26,7 +26,7 @@ type ClocksTestSuite struct {
 // monster in one room.
 func (s *ClocksTestSuite) twoMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			// The goblin waits in the NEXT ROOM, which is how real content is
 			// authored and is the only way to open a scene that is not
@@ -136,7 +136,7 @@ func (s *ClocksTestSuite) TestABubbleRoundTripsAndIsReachedThroughItsMembers() {
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -188,7 +188,7 @@ func (s *ClocksTestSuite) TestAMemberOutsideTheFightKeepsFreeRoamingWhileItRuns(
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	fighting, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -222,7 +222,7 @@ func (s *ClocksTestSuite) TestMutatingTheReturnedOrderCannotCorruptTheEncounter(
 	data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -246,7 +246,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -262,7 +262,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -288,7 +288,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		data.Clock.Budgets["ghost"] = 0
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -302,7 +302,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -315,7 +315,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -335,7 +335,7 @@ func (s *ClocksTestSuite) TestABlobFromBeforeClockMembershipLoadsEveryoneOntoThe
 	data.Bubbles = nil
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	for _, id := range []core.EntityID{alice, goblin} {
@@ -361,7 +361,7 @@ const (
 // monster in one room, plus an external ending so closure is reachable.
 func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10},
@@ -406,7 +406,7 @@ func (s *ClocksTestSuite) assertR6(enc *encounter.Encounter, members ...core.Ent
 		s.Require().NoError(err, "member %q must be on exactly one clock", id)
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err, "the persisted shape must pass the trust boundary (R6)")
 }
 
@@ -690,7 +690,7 @@ func (s *ClocksTestSuite) TestAFightMemberCannotFreeRoam() {
 func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 	wanderer := &patrolDecider{positions: []spatial.Position{{X: 5, Y: 5}, {X: 6, Y: 5}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
 		},
@@ -762,7 +762,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAnIdleBubble() {
 	data.Bubbles = []clock.TurnData{{}}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrInvalidData)
 }
@@ -776,7 +776,7 @@ func (s *ClocksTestSuite) TestAMidFightBlobRoundTrips() {
 	s.Require().NoError(err)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	// Reached through a member of the fight — bob is exploring next door.

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -82,7 +82,7 @@ func goblinPatrol() *patrol {
 // someone launches the workbench by hand.
 func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: rollOrderAsGiven{},
+		Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{
@@ -507,7 +507,7 @@ func main() {
 				continue
 			}
 			loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Initiative: rollOrderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+				Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 					"goblin": goblinPatrol(),
 				}})
 			if err != nil {
@@ -556,4 +556,14 @@ type rollOrderAsGiven struct{}
 
 func (rollOrderAsGiven) RollInitiative(members []encounter.MemberID) ([]encounter.MemberID, error) {
 	return members, nil
+}
+
+// rollAllStanding is the workbench's Standing capability: nobody is ever down.
+// The workbench drives free roam and sight, not damage — nothing in it can take
+// a member to zero — so the honest answer is that everyone is on their feet,
+// said out loud because the capability is required.
+type rollAllStanding struct{}
+
+func (rollAllStanding) Standing([]encounter.MemberID) ([]encounter.MemberID, error) {
+	return nil, nil
 }

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -97,8 +97,8 @@ func vaultChaseHexSetup() *encounter.SetupInput {
 	}
 	pursuit := &pursuitDecider{doorways: doorwaysFrom(field), target: alice}
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      field,
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: "corridor", Position: spatial.Position{X: 1, Y: 1}},
 			// One hex-step from the gate's corridor-side endpoint (4,1) via
@@ -247,7 +247,7 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	beforeReload := alicePath[len(alicePath)-1]
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: doorwaysFrom(vaultChaseHexSetup().Field), target: alice},
 		}})
 	require.NoError(t, err, "the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -412,6 +412,9 @@ func (in *LoadEncounterInput) Validate() error {
 	if in.Initiative == nil {
 		return fmt.Errorf("load encounter: Initiative is required: %w", ErrNoInitiative)
 	}
+	if in.Standing == nil {
+		return fmt.Errorf("load encounter: Standing is required: %w", ErrNoStanding)
+	}
 
 	return nil
 }
@@ -756,6 +759,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		everMembers: make(map[MemberID]bool),
 		deciders:    make(map[MemberID]Decider),
 		initiative:  input.Initiative,
+		standing:    input.Standing,
 		endings:     nil,
 		retention:   normalizeRetention(data.Retention),
 		logFloor:    logFloorOf(data.Log),

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -389,6 +389,12 @@ type LoadEncounterInput struct {
 	// guarded where it is used — a nil roller is an error returned at the
 	// door, not a branch taken deep inside a verb.
 	Initiative InitiativeRoller
+
+	// Standing reports which members are down. REQUIRED, exactly as it is on
+	// SetupInput: a loaded encounter consults it on its first sight refresh,
+	// so a blob that comes back without one is as unusable as a Setup without
+	// one. Refused at the door, never guarded at the use site.
+	Standing Standing
 }
 
 // Validate reports whether the input is usable. It checks only the input's own

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -71,7 +71,7 @@ type DataTestSuite struct {
 // of the shift vector's own shape.
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
@@ -114,8 +114,8 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 // ending order changes which outcome the campaign receives.
 func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -127,7 +127,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	enc1, err := encounter.NewEncounter(setup)
 	s.Require().NoError(err)
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: enc1.ToData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc1.ToData()})
 	s.Require().NoError(err)
 
 	out, err := enc2.Move(&encounter.MoveInput{Member: "p1", To: spatial.Position{X: 3, Y: 3}})
@@ -157,7 +157,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 // origin simultaneously.
 func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
@@ -188,7 +188,7 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data1})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 	s.Require().NoError(err)
 
 	data2 := enc2.ToData()
@@ -231,7 +231,7 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 	}
 
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	got := enc.ToData().Field.Connections
@@ -257,7 +257,7 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 	s.Run("square", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "square-room", Width: 5, Height: 5},
@@ -277,7 +277,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Equal("", data1.Field.Rooms[0].Grid, "square is the zero value — omitted, not the literal \"square\"")
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -286,7 +286,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 
 	s.Run("hex", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
@@ -306,7 +306,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Equal(spatial.GridTypeHex, data1.Field.Rooms[0].Grid)
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -330,7 +330,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 // so they stay disjoint (W2) regardless of y.
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}}},
@@ -371,7 +371,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom
 	// was an encounter that became permanently unsavable).
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 }
 
@@ -385,7 +385,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 	s.Run("post-setup open encounter survives round-trip", func() {
 		// Create a simple encounter
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -436,7 +436,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 
 		// Load from data (without decider for goblin)
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Convert to data again
@@ -457,7 +457,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 	s.Run("mid-fade ghost survives reload still Held", func() {
 		// Create encounter with a wall that will cause a ghost to form
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -527,7 +527,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 
 		// Load and verify ghost is still there
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Get holdings - ghost should still be Held (not Current)
@@ -552,7 +552,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 func (s *DataTestSuite) TestRoundTripPostExit() {
 	s.Run("exited member persists in everMembers and can Story", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -598,7 +598,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 
 		// Load and verify everMembers includes the exited player
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Story should work for the exited member
@@ -613,7 +613,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 func (s *DataTestSuite) TestRoundTripClosed() {
 	s.Run("closed encounter with ending outcome round-trips", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -667,7 +667,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 
 		// Load and verify outcome matches
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		status2, _ := enc2.Status()
@@ -683,7 +683,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 func (s *DataTestSuite) TestPumpContinuesTick() {
 	s.Run("Pump continues tick sequence post-reload", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -732,7 +732,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 		s.Require().Equal(2, data1.Clock.HighWater, "precondition: two ticks persisted")
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		out, err := enc2.Pump(&encounter.PumpInput{})
@@ -745,7 +745,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 func (s *DataTestSuite) TestMoveWorksPostReload() {
 	s.Run("Move works on reloaded encounter", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -787,7 +787,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 
 		// Load
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Move should work
@@ -806,7 +806,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 func (s *DataTestSuite) TestGoldenJSONOpen() {
 	s.Run("small open encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -856,7 +856,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 func (s *DataTestSuite) TestGoldenJSONClosed() {
 	s.Run("small closed encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -929,7 +929,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 func (s *DataTestSuite) TestAliasImmunityToData() {
 	s.Run("mutating ToData result doesn't affect aggregate", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -997,7 +997,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 	s.Run("mutating caller's Data after LoadEncounter doesn't affect loaded aggregate", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1034,7 +1034,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 		// Load FIRST, then vandalize the caller's Data: the loaded
 		// aggregate must be untouched (load-side deep copy).
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err)
 
 		data.Members[0].ID = "mutated"
@@ -1062,8 +1062,8 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		// persisted holding says Held (a ghost). A load that re-runs
 		// first-light surveil would resurrect it to Current.
 		enc1, err := encounter.NewEncounter(&encounter.SetupInput{
-			Initiative: orderAsGiven{},
-			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
 			Members: []encounter.MemberInput{
 				{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
 				{ID: "goblin", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 5, Y: 5}},
@@ -1083,7 +1083,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		data.Intel.Holdings["playerA"]["goblin"] = holding
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err)
 
 		view, err := enc2.View(&encounter.ViewInput{Member: "playerA"})
@@ -1096,7 +1096,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 func (s *DataTestSuite) TestDeciderReattachment() {
 	s.Run("reload with decider resumes monster decision", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1150,7 +1150,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 			},
 		}
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 				encounter.MemberID("goblin"): decider,
 			}})
 		s.Require().NoError(err)
@@ -1170,7 +1170,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 	s.Run("reload without decider makes monster hold", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1219,7 +1219,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 
 		// Load WITHOUT goblin's decider
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Pump should succeed (goblin holds)
@@ -1239,7 +1239,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 // nil entry is equivalent to an absent one: the monster simply holds.
 func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
 		},
@@ -1256,7 +1256,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	data1 := enc1.ToData()
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 		}})
 	s.Require().NoError(err, "a present-but-nil reattachment entry must load, not reject")
@@ -1273,7 +1273,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 // same reattachment map: the real one decides normally, the nil one holds.
 func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 10, Height: 10},
@@ -1300,7 +1300,7 @@ func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 
 	ratDecider := &testDecider{intent: encounter.IntentMoveTo{To: spatial.Position{X: 3, Y: 8}}}
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 			"rat":    ratDecider,
 		}})
@@ -1389,7 +1389,7 @@ func (s *DataTestSuite) TestLoadSquareOccluderFractionalRejected() {
 	data := validEncounterDataWithConnection()
 	data.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1428,8 +1428,8 @@ func (s *DataTestSuite) TestLoadNilInputRejected() {
 // call sites, so it is stated once rather than left implied by them.
 func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{},
-		Data:       validEncounterData(),
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Data: validEncounterData(),
 	})
 	s.Require().NoError(err)
 	s.Require().NotNil(enc)
@@ -1450,7 +1450,7 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
@@ -1470,7 +1470,7 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide at Load either`)
 }
 
@@ -1488,7 +1488,7 @@ func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1509,7 +1509,7 @@ func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
 		},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -1631,7 +1631,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 			data := validEncounterData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Initiative: orderAsGiven{}, Data: data})
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().Contains(err.Error(), tc.fragment,
@@ -1645,7 +1645,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: validEncounterData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEncounterData()})
 	s.Require().NoError(err, "the valid base fixture must load")
 
 	// The valid CONNECTION base must also load. Since FromPosition{9,1} is
@@ -1657,7 +1657,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// it would silently swap the values — so the values are re-inspected,
 	// not just the absence of an error).
 	connEnc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: validEncounterDataWithConnection()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEncounterDataWithConnection()})
 	s.Require().NoError(err, "the valid connection base fixture must load")
 	connData := connEnc.ToData()
 	s.Require().Len(connData.Field.Connections, 1)
@@ -1708,7 +1708,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 4, Y: 0}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1717,7 +1717,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: 3}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1726,7 +1726,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: -1, Y: 0}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1735,7 +1735,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: -1}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1744,7 +1744,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 3, Y: 2}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err, "the last valid cell must be accepted")
 	})
 }
@@ -1774,7 +1774,7 @@ func (s *DataTestSuite) TestLoadRoomValidation() {
 			data := validEncounterData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Initiative: orderAsGiven{}, Data: data})
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoField, tc.name)
@@ -1801,7 +1801,7 @@ func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
 	data.Field.Rooms[0].Origin = nil
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1834,19 +1834,19 @@ func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 	s.Run("positive Q, positive R within span accepted", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 1, Y: 1})})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 1, Y: 1})})
 		s.Require().NoError(err)
 	})
 
 	s.Run("negative Q within span accepted — rejected under the old offset HexGrid", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -1, Y: 0})})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -1, Y: 0})})
 		s.Require().NoError(err, "axial hex rooms are origin-centered; negative Q is ordinary, not a defect")
 	})
 
 	s.Run("Q at exactly +Width/2 rejected (upper bound exclusive)", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "out of bounds")
@@ -1854,13 +1854,13 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 
 	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -2, Y: 0})})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -2, Y: 0})})
 		s.Require().NoError(err)
 	})
 
 	s.Run("Q beyond -Width/2 rejected", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "out of bounds")
@@ -1894,7 +1894,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
 }
 
@@ -1955,7 +1955,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 			data := validHexAxialData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Initiative: orderAsGiven{}, Data: data})
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			if tc.alsoErr != nil {
@@ -1967,7 +1967,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 	}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: validHexAxialData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validHexAxialData()})
 	s.Require().NoError(err, "integral axial positions, including negative ones, must be accepted")
 }
 
@@ -2092,7 +2092,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 			data := validAnchoredHexData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Initiative: orderAsGiven{}, Data: data})
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
@@ -2104,7 +2104,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err, "the valid anchored base fixture must load")
 }
 
@@ -2130,7 +2130,7 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2159,7 +2159,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2192,7 +2192,7 @@ func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2233,7 +2233,7 @@ func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2259,7 +2259,7 @@ func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint()
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2283,7 +2283,7 @@ func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a 2^30 x 2^30 room from a persisted blob must REJECT, not panic")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2304,7 +2304,7 @@ func (s *DataTestSuite) TestLoadOversizedRoomHeightRejected() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2331,7 +2331,7 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2374,7 +2374,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 			data := validEndingTriggerData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Initiative: orderAsGiven{}, Data: data})
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoEnding, tc.name)
@@ -2384,7 +2384,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 	}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: validEndingTriggerData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEndingTriggerData()})
 	s.Require().NoError(err, "a trigger naming a real room and in-bounds position must validate")
 }
 
@@ -2400,7 +2400,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 		},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -2415,14 +2415,14 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 // would not.
 func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 	enc1, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err)
 	data1 := enc1.ToData()
 	bs1, err := json.Marshal(data1.Field)
 	s.Require().NoError(err)
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data1})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 	s.Require().NoError(err)
 	data2 := enc2.ToData()
 	bs2, err := json.Marshal(data2.Field)
@@ -2442,7 +2442,7 @@ func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 // Origins it didn't in v0.2.
 func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
@@ -2481,7 +2481,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 		}
 	}
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: dataPreTraverse})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataPreTraverse})
 	s.Require().NoError(err)
 
 	out2, err := enc2.Traverse(&encounter.TraverseInput{Member: "p1", Connection: "gate"})
@@ -2516,7 +2516,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareEndpointNotAdjacentDistance2() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2547,7 +2547,7 @@ func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
 	s.Require().NoError(json.Unmarshal(hostile, &data))
 
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a hand-edited blob with a non-kissing doorway must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2581,7 +2581,7 @@ func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 	s.Run("gridless grid string rejected regardless of member position", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
 		s.Require().Error(err, `a stored "gridless" grid string no longer loads`)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2591,7 +2591,7 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 
 	s.Run("still rejected for a position that would also be out of bounds", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField,
@@ -2604,7 +2604,7 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 	data := validEncounterData()
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			"p1": &spyDecider{},
 		}})
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
@@ -2614,7 +2614,7 @@ func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 func (s *DataTestSuite) TestMutation1ToDataAliases() {
 	s.Run("mutation 1: ToData aliases slices", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2654,7 +2654,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 	s.Run("mutation 2: wire tag renamed", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2685,7 +2685,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 func (s *DataTestSuite) TestMutation3StowawayField() {
 	s.Run("mutation 3: stowaway field in EncounterData", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2718,7 +2718,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 	s.Run("mutation 4: leaf data substitution (Intel/Log swapped)", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2751,7 +2751,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 
 		// Control: loading dataA verbatim, p1 holds p2.
 		ctrl, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: dataA})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataA})
 		s.Require().NoError(err)
 		ctrlView, err := ctrl.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2762,7 +2762,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		// is genuinely consumed, never re-derived from the field.
 		dataA.Intel = dataB.Intel
 		swapped, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: dataA})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataA})
 		s.Require().NoError(err)
 		swappedView, err := swapped.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2793,7 +2793,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 		}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().Error(err)
 		s.True(errors.Is(err, encounter.ErrInvalidData), "must validate member rooms exist")
 	})
@@ -2803,7 +2803,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 	s.Run("mutation 6: no re-surveil on load (ghost stays ghost)", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2856,7 +2856,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 
 		data := enc1.ToData()
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 
 		holdings2, _ := enc2.View(&encounter.ViewInput{Member: "playerA"})
 		var goblinStatusAfter intel.Status
@@ -2877,7 +2877,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 	s.Run("mutation 7: tick continuation (clock not reset)", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 10, Height: 10, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2897,7 +2897,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 		tick1 := data1.Clock.HighWater
 
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		data2 := enc2.ToData()
 		tick2 := data2.Clock.HighWater
 

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -60,7 +60,7 @@ var dialectOrigin = spatial.Position{X: 30, Y: 10}
 // coordinates.
 func (s *DialectSuite) closedBlob() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Origin: dialectOrigin},
 		}},
@@ -89,7 +89,7 @@ const aRoomBearingSighting = `{"room":"hall","x":2,"y":5}`
 // load is the host's side of the seam: hand the loader a blob and see what it says.
 func (s *DialectSuite) load(data encounter.EncounterData) error {
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: data, Initiative: orderAsGiven{},
+		Data: data, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 	})
 	return err
 }

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -8,7 +8,18 @@
 // and tools/spatial: it surveils percepts into intel, lets deciders act on
 // their own intel, and appends the story to record.
 // Members exit, encounters close; player activity pumps the clock, the world
-// thinks on the tick.
+// thinks on the tick. A member the rulebook reports down keeps their place on
+// the map and in the roster, and stops acting: no turn, no side in a contact,
+// no tick action, and a beat in the story saying so.
+//
+// The composition holds no rules of its own that it could hold instead: two
+// capabilities are SUPPLIED at construction and consulted during play, never
+// defaulted (rpg-toolkit#1033). InitiativeRoller says what order a fight goes
+// in; Standing says who is down. Both are the same move — this module cannot
+// import the rulebook (C1), so randomness and hit points are facts it asks for
+// rather than facts it knows. Neither has a default answer, because a default
+// would be this module quietly deciding a rule it is not allowed to know, and
+// both are refused at Setup AND Load rather than guarded where they are used.
 //
 // Every member is on exactly one clock (R6). The world tick is the default —
 // free roam is not a mode, it is where you are when no fight has pulled you

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -64,6 +64,10 @@ type Encounter struct {
 	// one; trigger detection refuses to start a fight without it rather than
 	// dropping the fight silently.
 	initiative InitiativeRoller
+	// standing reports who is down. Required at both constructors — see
+	// [Standing] for why it is asked rather than remembered, and why there is
+	// no default answer.
+	standing Standing
 	// endings holds declared endings in Setup order. Evaluation is
 	// deterministic (law C8), but NOT globally "first-declared-wins":
 	// for a single action (Move, Traverse, Join) declaration order is
@@ -903,6 +907,15 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		return nil, fmt.Errorf("newencounter: %w", ErrNoInitiative)
 	}
 
+	// Required for the same reason, one layer down: the standing consult runs
+	// from first light too — a scene can open with a body already on the floor
+	// — and an encounter that cannot ask would start fights with corpses and
+	// walk them around the map. Refused at the door; never guarded at the use
+	// site, and never defaulted (rpg-toolkit#1033).
+	if in.Standing == nil {
+		return nil, fmt.Errorf("newencounter: %w", ErrNoStanding)
+	}
+
 	// Check ending keys: empty/reserved, and duplicate (#929 hardening
 	// round E — two endings sharing a key both used to load; End scans
 	// in declaration order, so a reached_position twin declared FIRST
@@ -984,6 +997,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		everMembers:      make(map[MemberID]bool),
 		deciders:         make(map[MemberID]Decider),
 		initiative:       in.Initiative,
+		standing:         in.Standing,
 		endings:          nil,
 		retention:        normalizeRetention(in.Retention),
 		fieldInput:       deepCopyRoomInputs(in.Field.Rooms),
@@ -1919,6 +1933,23 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		return nil, fmt.Errorf("pump members: %w", err)
 	}
 
+	// Who is down, asked before anything is planned: a body has no action to
+	// take, so its decider is not consulted at all rather than consulted and
+	// discarded (a decider is behaviour, and running a corpse's behaviour is
+	// the second census defect — Pump had no standing filter and dead monsters
+	// kept patrolling).
+	//
+	// This is the SECOND consult in a Pump — refreshSight runs another at the
+	// end, through noticeDown, which is what narrates and splices. Deliberate,
+	// both ways round: the answer is not carried forward because carrying it
+	// is a cache ([Standing]), and the narration cannot happen here because a
+	// down beat appended before Pump's own tick beat would break the ordering
+	// law refreshSight states.
+	down, err := e.standingNow()
+	if err != nil {
+		return nil, fmt.Errorf("pump standing: %w", err)
+	}
+
 	type plannedAction struct {
 		memberID MemberID
 		intent   Intent
@@ -1927,6 +1958,10 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 
 	for _, m := range allMembers {
 		if m.Kind != KindMonster {
+			continue
+		}
+
+		if down[m.ID] {
 			continue
 		}
 

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -47,7 +47,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 	s.Run("two members clear line of sight", func() {
 		// Arrange: 10x10 room, alice at (2,2) player, goblin at (7,7) monster
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -126,7 +126,7 @@ func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 		// around now (spatial v0.9.1, see testwalls_test.go), so a fixture
 		// that wants sight blocked has to build something worth blocking.
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -187,7 +187,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no field", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{},
 			},
@@ -202,7 +202,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no endings", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -217,7 +217,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: reserved ending key", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -234,7 +234,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty ending key", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -251,7 +251,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty member ID", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -271,7 +271,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("validation order: duplicate member IDs", func() {
 		alice := core.EntityID("alice")
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -294,9 +294,9 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("atomicity: after error, valid setup works", func() {
 		// First attempt: fails validation
 		setup1 := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
-			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{}},
-			Members:    []encounter.MemberInput{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field:   encounter.FieldInput{Rooms: []encounter.RoomInput{}},
+			Members: []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
 				{Key: "stairs", Trigger: encounter.TriggerExternal{}},
 			},
@@ -306,7 +306,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 		// Second attempt: valid
 		setup2 := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -346,7 +346,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 // all, so they stay disjoint (W2) regardless of their y overlap.
 func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -391,7 +391,7 @@ func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
 // interior one.
 func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{
@@ -419,7 +419,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 // this exact colliding pair must construct without error.
 func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
@@ -444,7 +444,7 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 // room-list defect vocabulary.
 func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}, {X: 3, Y: 3}}},
@@ -466,7 +466,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 // forever, the external ending having no other way to fire).
 func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
@@ -559,7 +559,7 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 // share no x value and so stay disjoint (W2) regardless of y.
 func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 4, Height: 3},
@@ -628,7 +628,7 @@ func (s *EncounterTestSuite) TestConnectionEndpointBoundsBoundaries() {
 // and one member — the base for TestSetupRoomValidation's one-defect rows.
 func validRoomSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
@@ -713,7 +713,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 	// Width=4, Height=3 => Q valid in [-2,2), R valid in [-1.5,1.5).
 	hexSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
@@ -771,7 +771,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 // hex-a's ([-5,4]), so the rooms stay disjoint (W2) regardless of R.
 func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
@@ -809,7 +809,7 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 // regardless of R.
 func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
@@ -882,7 +882,7 @@ func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 // Pump's IntentMoveTo, so this also covers decider-driven moves).
 func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -909,7 +909,7 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 // TestJoinHexIntegralAxial is Join's verb-seam counterpart.
 func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -951,7 +951,7 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 	gridlessSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
@@ -1010,7 +1010,7 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 // rooms are disjoint, touching only through the one declared doorway.
 func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
@@ -1129,7 +1129,7 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 // proves it independently for square's own distance formula).
 func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "sq-a", Width: 5, Height: 5},
@@ -1163,7 +1163,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 // in r2 projects to absolute (4,1) — Chebyshev distance 2, not 1.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance2() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
@@ -1198,7 +1198,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance
 // rejection pin that closes that hole.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0.5, Y: 1.5}},
@@ -1230,7 +1230,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 // message.
 func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
 		},
@@ -1250,7 +1250,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 // room legality's OWN message.
 func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
 		},
@@ -1271,7 +1271,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() 
 // direction.
 func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "square-first", Width: 5, Height: 5},
@@ -1306,7 +1306,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 // interval mins.
 func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r-a", Width: 5, Height: 5},
@@ -1338,7 +1338,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 // 1.
 func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
@@ -1372,7 +1372,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 // "close enough"; the strict `!= 1` correctly rejects it.
 func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDistance() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
@@ -1408,7 +1408,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDi
 // before W2 ever sees it, and specifically NOT with a W2 "overlap" message.
 func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 1e19, Y: 0}},
@@ -1446,7 +1446,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 // rejected — oversized, not evaluated for overlap at all.
 func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 1000, Height: 5},
@@ -1474,7 +1474,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisj
 // with maxRoomCells' message, never construct.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
 		},
@@ -1496,7 +1496,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 // an EXPLICIT hex room.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
 		},
@@ -1526,7 +1526,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex(
 // check alone would not.
 func (s *EncounterTestSuite) TestSetupOversizedRoomHeightRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
 		},
@@ -1561,9 +1561,9 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 		rooms[i] = encounter.RoomInput{ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024}
 	}
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: rooms},
-		Endings:    []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field:   encounter.FieldInput{Rooms: rooms},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1578,7 +1578,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 // thing about (#929 T3 Opus round F5).
 func validEndingTriggerSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
@@ -1629,7 +1629,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerValidation() {
 // Opus round F5).
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -1652,7 +1652,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 // NOT over-reach.
 func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -1702,7 +1702,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 
 			data := enc.ToData()
 			_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Initiative: orderAsGiven{}, Data: data})
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().NoError(err, "%s must survive a ToData/LoadEncounter round trip", tc.name)
 		})
 	}
@@ -1715,7 +1715,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 // any room, not an edge case — the realistic hazard N2 names explicitly.
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() {
 	setup := &encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -1728,7 +1728,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() 
 
 	data := enc.ToData()
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "must survive a ToData/LoadEncounter round trip")
 }
 
@@ -1736,7 +1736,7 @@ func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 	s.Run("opening beat reaches all members via Story", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -1790,7 +1790,7 @@ func (s *EncounterTestSuite) TestSetupBadPlacementSentinel() {
 	s.Run("member placed in nonexistent room errors with ErrBadPlacement", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -1818,7 +1818,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 	s.Run("three members mutually visible all see each other", func() {
 		// Arrange: ONE room, THREE mutually visible members (alice, bob players; goblin monster)
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
@@ -1874,7 +1874,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 func (s *EncounterTestSuite) TestMembers() {
 	s.Run("returns stable order", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -1902,7 +1902,7 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 	s.Run("mover's vantage refreshes, others see mover at new position", func() {
 		// Arrange: alice and bob in clear sight
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1991,7 +1991,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		// A wall rather than the single pillar this fixture used to have —
 		// spatial v0.9.1 leans around a lone obstacle (see testwalls_test.go).
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2055,7 +2055,7 @@ func (s *EncounterTestSuite) TestMoveSequentialConsistency() {
 	s.Run("after sequential moves, spatial index remains valid (CanMoveEntityBetweenRooms-style)", func() {
 		// Arrange: alice in one room
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2111,7 +2111,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 	s.Run("player reaching ReachedPosition trigger fires the ending", func() {
 		// Arrange: alice is player, will reach stairs (no member filter = any player)
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2201,7 +2201,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 	s.Run("validation order and R5 atomicity", func() {
 		s.Run("nil input returns ErrNilInput", func() {
 			setup := &encounter.SetupInput{
-				Initiative: orderAsGiven{},
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2223,7 +2223,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("empty member ID returns ErrNoMember", func() {
 			setup := &encounter.SetupInput{
-				Initiative: orderAsGiven{},
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2248,7 +2248,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("closed encounter returns ErrClosed", func() {
 			setup := &encounter.SetupInput{
-				Initiative: orderAsGiven{},
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2284,7 +2284,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("not a member returns ErrNotMember", func() {
 			setup := &encounter.SetupInput{
-				Initiative: orderAsGiven{},
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2309,7 +2309,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("failed move leaves members unchanged", func() {
 			setup := &encounter.SetupInput{
-				Initiative: orderAsGiven{},
+				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2352,7 +2352,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 	s.Run("mutating returned outcome does not affect internal state", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
@@ -2407,8 +2407,8 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 // (19,19).
 func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2426,8 +2426,8 @@ func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 // an External ending (for testing End verb).
 func (s *EncounterTestSuite) newBasicEncounterWithExternalEnding() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2497,7 +2497,7 @@ func (s *EncounterTestSuite) TestMoveSpatialRejectionAtomic() {
 // arrival-Current and T3 pins).
 func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -2573,7 +2573,7 @@ func (s *EncounterTestSuite) TestTraverseValidation() {
 		// the connection doesn't touch at all. Proves room membership is
 		// checked, not just coordinate equality.
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-a", Width: 10, Height: 10},
@@ -2760,7 +2760,7 @@ func (s *EncounterTestSuite) TestTraverseOwnView() {
 // like Move firing endings at a movement target.
 func (s *EncounterTestSuite) TestTraverseEndingFiresOnArrival() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -2803,7 +2803,7 @@ func (s *EncounterTestSuite) TestTraverseEndingFiresOnArrival() {
 // NOT close the encounter.
 func (s *EncounterTestSuite) TestTraverseMonsterOnUnfilteredEndingDoesNotClose() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -2910,7 +2910,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 	s.Run("late joiner seen by and sees incumbents", func() {
 		// Arrange: setup with alice and bob
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3085,7 +3085,7 @@ func (s *EncounterTestSuite) TestJoinValidation() {
 func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 	s.Run("join on stairs fires ReachedPosition ending", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3141,7 +3141,7 @@ func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 func (s *EncounterTestSuite) TestExitCarryForward() {
 	s.Run("exit carry-forward matches final state", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3237,7 +3237,7 @@ func (s *EncounterTestSuite) TestExitValidation() {
 func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 	s.Run("last member exit closes with abandoned ending", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3290,7 +3290,7 @@ func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 func (s *EncounterTestSuite) TestExitDepartedGhostFades() {
 	s.Run("remaining member's holdings persist after departure", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3363,7 +3363,7 @@ func (s *EncounterTestSuite) TestEndExternalOnly() {
 
 	s.Run("End fires External endings", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -3509,7 +3509,7 @@ func (s *EncounterTestSuite) TestQueriesLivePostClose() {
 func (s *EncounterTestSuite) TestStoryForExitedMembers() {
 	s.Run("exited members can still read story", func() {
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -179,4 +179,10 @@ var (
 	// detection runs from first light, so every encounter needs one — refused
 	// at construction rather than at the moment a fight would have started.
 	ErrNoInitiative = errors.New("encounter: no initiative roller")
+
+	// ErrNoStanding indicates Setup or Load was given no Standing capability.
+	// The consult runs from first light, so every encounter needs one —
+	// refused at construction rather than at the moment a body would have
+	// started a fight.
+	ErrNoStanding = errors.New("encounter: no standing capability")
 )

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -27,7 +27,7 @@ func Example_theDungeon() {
 		ToPosition:   spatial.Position{X: 0, Y: 4},
 	}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -45,7 +45,7 @@ func Example_theTombWatch() {
 	// The crypt: a wall across y=6 from x=5 to x=7; alice enters at (2,6); a goblin
 	// stands at (6,10). One way out: the stairs at (11,11).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: "crypt", Width: 12, Height: 12,
@@ -88,7 +88,7 @@ func Example_theTombWatch() {
 	fmt.Println("-- the table saves and comes back tomorrow --")
 	data := enc.ToData()
 	enc, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	if err != nil {
 		fmt.Println("load:", err)
 		return

--- a/rulebooks/dnd5e/encounter/example_traverse_test.go
+++ b/rulebooks/dnd5e/encounter/example_traverse_test.go
@@ -33,7 +33,7 @@ func Example_theTraverse() {
 		ToPosition:   spatial.Position{X: 0, Y: 4},
 	}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -204,6 +204,14 @@ type SetupInput struct {
 	// without it (ErrNoInitiative).
 	Initiative InitiativeRoller
 
+	// Standing reports which members are down (rpg-toolkit#1075). REQUIRED,
+	// for the same reason Initiative is: the consult runs from first light, so
+	// an encounter that cannot ask who is standing would start fights with
+	// bodies and walk them around the map. Setup refuses without it
+	// (ErrNoStanding). There is no default — a nil meaning "everyone is
+	// standing" would be this module deciding a rule it is not allowed to know.
+	Standing Standing
+
 	// Retention is how many story beats the encounter keeps. Older beats are
 	// trimmed after each append, so an encounter's blob does not grow without
 	// bound and a save does not rewrite the whole history.

--- a/rulebooks/dnd5e/encounter/outcome.go
+++ b/rulebooks/dnd5e/encounter/outcome.go
@@ -31,6 +31,18 @@ const (
 
 	// OutcomeMissed is an attack that did not.
 	OutcomeMissed OutcomeKind = "missed"
+
+	// OutcomeDown is a member the rulebook reports out of the fight — the
+	// minimal death beat ruled on rpg-toolkit#959: this kind, and who.
+	//
+	// NOT ACCEPTABLE TO [Encounter.Record], deliberately, and it is the only
+	// kind that is not. Down is something the composition NOTICES, by asking
+	// [Standing] at the choke point where it already asks about sight; a caller
+	// that could push the beat in would be a second system deciding the same
+	// thing, and the first one would always win because it reaches the fact
+	// first. Record's switch is therefore the CALLER-WRITABLE subset of this
+	// enum rather than all of it — pushing this kind gets ErrInvalidData.
+	OutcomeDown OutcomeKind = "down"
 )
 
 // OutcomeValue names one number a rulebook outcome carries.

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -29,7 +29,7 @@ const outcomeRoom = "yard"
 // other's sight, so nothing forms a fight before a test asks for one.
 func (s *OutcomeTestSuite) scene() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{
 			ID: outcomeRoom, Width: 12, Height: 12, Occluders: wallRow(6, 4, 8),
 		}}},

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -52,7 +52,7 @@ var gate = encounter.ConnectionInput{
 
 func (s *PlacementSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8, Origin: hallOrigin},
@@ -308,7 +308,7 @@ func (s *PlacementSuite) TestTheOutcomeSurvivesARoundTripStillAbsolute() {
 	s.Require().NoError(err)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: s.enc.ToData(), Initiative: orderAsGiven{},
+		Data: s.enc.ToData(), Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -204,8 +204,8 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 // cleanup: an exited monster's decider must never be consulted again.
 func (s *PumpTestSuite) TestPumpDoesNotConsultExitedMonsterDecider() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
@@ -239,7 +239,7 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		}
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -339,7 +339,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 		// asymmetric perception (#1020) or a faction model, at which point
 		// this test should grow the positive case again.
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{{
 					ID: room1, Width: 10, Height: 10,
@@ -389,7 +389,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		errDecider := &errorDecider{err: deciderErr}
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -470,8 +470,8 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 // NEXT (successful) pump reports reading 1, not 2.
 func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
@@ -495,8 +495,8 @@ func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 // have moved — no partial mutation (R5).
 func (s *PumpTestSuite) TestPumpPartialAbort() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			// "aaa-goblin" sorts before "zzz-goblin": it decides (and
@@ -540,8 +540,8 @@ func (s *PumpTestSuite) TestPumpPartialAbort() {
 func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	vandal := &vandalDecider{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			// The vandal's victim is a MONSTER peer, not a player. Two
@@ -587,7 +587,7 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 		}
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -654,7 +654,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -726,8 +726,8 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 // this seam.
 func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 0, Y: 0}},
 		},
@@ -762,7 +762,7 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 		}
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -842,7 +842,7 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 		}
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -928,7 +928,7 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 		goblinID := core.EntityID("goblin")
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1009,7 +1009,7 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Initiative: orderAsGiven{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1089,7 +1089,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	spyB := &snapshotSpyDecider{}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1140,7 +1140,7 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 5}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1216,7 +1216,7 @@ func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
 	}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: cellar, Width: 10, Height: 10, Origin: spatial.Position{X: 40, Y: 20}},
@@ -1335,7 +1335,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenNoDoorwayJoinsTheStep() {
 	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 5}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1393,7 +1393,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	decider := &onceStepDecider{to: spatial.Position{X: 500, Y: 500}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1445,7 +1445,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	deciderErr := errors.New("test decider error")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1489,7 +1489,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	goblinID := core.EntityID("goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1597,7 +1597,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	bID := core.EntityID("zzz-goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10},
@@ -1698,8 +1698,8 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("control: decision order and declaration order agree", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Initiative: orderAsGiven{},
-			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				{ID: aID, Kind: encounter.KindMonster, Room: room1,
 					Position: spatial.Position{X: 5, Y: 5}, Decider: &patrolDecider{positions: []spatial.Position{posA}}},
@@ -1723,8 +1723,8 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Initiative: orderAsGiven{},
-			Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				// Same decision order (aaa first, zzz second), but now each
 				// monster's landing position fires the OTHER declared ending.
@@ -1782,8 +1782,8 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 	decider := &reentrantSelfExitDecider{self: goblinID}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: aliceID, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: goblinID, Kind: encounter.KindMonster, Room: room1,
@@ -1831,7 +1831,7 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10},
@@ -1921,7 +1921,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 	hidden := spatial.Position{X: 4, Y: 5}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: room1, Width: 10, Height: 10,

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -68,8 +68,8 @@ func (s *PursuitSuite) SetupTest() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      field,
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: field,
 		Members: []encounter.MemberInput{
 			// Alice stands at the threshold; the goblin is across the room
 			// with a clear line to her, so first light makes them mutual.
@@ -195,9 +195,9 @@ func (s *PursuitSuite) freeRoamWith(decider encounter.Decider) {
 
 	data := s.enc.ToData()
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{},
-		Data:       data,
-		Deciders:   map[encounter.MemberID]encounter.Decider{hunter: decider},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Data:     data,
+		Deciders: map[encounter.MemberID]encounter.Decider{hunter: decider},
 	})
 	s.Require().NoError(err)
 	s.enc = enc

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -34,8 +34,8 @@ type RetentionTestSuite struct {
 // with the ending at (4,4).
 func (s *RetentionTestSuite) walkingEncounter(retention int) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -242,7 +242,7 @@ func (s *RetentionTestSuite) TestRetentionSurvivesReload() {
 	s.Equal(window, data.Retention, "retention is persisted, not inferred")
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	// The reloaded encounter must still be trimming to the SAME window: keep
@@ -263,7 +263,7 @@ func (s *RetentionTestSuite) TestFloorSurvivesReload() {
 	s.generateBeats(enc, 40)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	_, err = reloaded.Story(&encounter.StoryInput{Audience: "p1", AfterSeq: 33})
@@ -283,7 +283,7 @@ func (s *RetentionTestSuite) TestUntrimmedEncounterHasNoFloor() {
 	s.generateBeats(enc, 5)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	for seq := uint64(1); seq <= 6; seq++ {

--- a/rulebooks/dnd5e/encounter/standing.go
+++ b/rulebooks/dnd5e/encounter/standing.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+// Standing reports which of the given members are down — out of the fight,
+// however the rulebook decides that. The composition asks; the rulebook
+// answers.
+//
+// Injected rather than held, exactly as [Decider] and [InitiativeRoller] are,
+// and for the same reason [InitiativeRoller]'s doc gives with "randomness"
+// swapped for "hit points": this module's go.mod cannot import the rulebook
+// (law C1), so defeat is a fact it can only be TOLD. Member IDs in, member IDs
+// out — nothing here learns what a hit point is, and nothing here has to.
+//
+// # It is a pull, and that is the whole design
+//
+// The composition stores no down flag, in memory or in its blob. It asks at
+// every choke point where the answer could matter, and acts on the answer it
+// gets. The alternative — being pushed a "this one is down" event and
+// remembering it — recreates the dual state the seam reshape spent #1040
+// removing: heal a character and the sheet says four hit points while the
+// composition still says down. There is one source of truth for defeat and it
+// is not this package.
+//
+// Being a pull is also what makes it COMPLETE. Every route to zero — a strike,
+// a hazard, a rule nobody has written yet — is noticed at the next consult,
+// without that route knowing this interface exists.
+//
+// # What an implementation owes
+//
+// Answer about the members you were asked about. The composition hands over its
+// current roster, and a name in the answer that was not in the question is a
+// defect it refuses (ErrNotMember) rather than ignores — a mis-wired capability
+// must look like a mis-wired capability, not like a rule that silently never
+// fires. Order does not matter and duplicates are harmless.
+//
+// Errors abort whatever verb was running, atomically (R5), the same as
+// [InitiativeRoller]'s: a world that cannot find out who is standing does not
+// half-act on a guess.
+type Standing interface {
+	// Standing reports which of the given members are down. Returning none is
+	// the ordinary answer.
+	Standing(members []MemberID) (down []MemberID, err error)
+}

--- a/rulebooks/dnd5e/encounter/standing.go
+++ b/rulebooks/dnd5e/encounter/standing.go
@@ -3,6 +3,14 @@
 
 package encounter
 
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/record"
+)
+
 // Standing reports which of the given members are down — out of the fight,
 // however the rulebook decides that. The composition asks; the rulebook
 // answers.
@@ -15,13 +23,13 @@ package encounter
 //
 // # It is a pull, and that is the whole design
 //
-// The composition stores no down flag, in memory or in its blob. It asks at
-// every choke point where the answer could matter, and acts on the answer it
-// gets. The alternative — being pushed a "this one is down" event and
-// remembering it — recreates the dual state the seam reshape spent #1040
-// removing: heal a character and the sheet says four hit points while the
-// composition still says down. There is one source of truth for defeat and it
-// is not this package.
+// The composition stores no down flag, in memory or in its blob. It asks at the
+// choke points where the answer could matter and acts on the answer it gets.
+// The alternative — being pushed a "this one is down" event and remembering it
+// — recreates the dual state the seam reshape spent rpg-toolkit#1040 removing:
+// heal a character and the sheet says four hit points while the composition
+// still says down. There is one source of truth for defeat and it is not this
+// package.
 //
 // Being a pull is also what makes it COMPLETE. Every route to zero — a strike,
 // a hazard, a rule nobody has written yet — is noticed at the next consult,
@@ -35,6 +43,10 @@ package encounter
 // must look like a mis-wired capability, not like a rule that silently never
 // fires. Order does not matter and duplicates are harmless.
 //
+// The answer is asked for again rather than carried between consults, including
+// twice within one [Encounter.Pump]. Carrying it would be a cache, and a cache
+// is the smallest possible version of the dual state above.
+//
 // Errors abort whatever verb was running, atomically (R5), the same as
 // [InitiativeRoller]'s: a world that cannot find out who is standing does not
 // half-act on a guess.
@@ -42,4 +54,190 @@ type Standing interface {
 	// Standing reports which of the given members are down. Returning none is
 	// the ordinary answer.
 	Standing(members []MemberID) (down []MemberID, err error)
+}
+
+// standingNow asks the capability who is down, right now, and returns the
+// answer as a set.
+//
+// The roster goes over SORTED, for C8's reason: what a pass concludes must be a
+// function of persisted data rather than of map iteration order, and a
+// capability handed its question in a different order each time could answer
+// differently each time. An empty roster is not a question worth asking, and
+// the capability is not called for one.
+func (e *Encounter) standingNow() (map[MemberID]bool, error) {
+	if len(e.members) == 0 {
+		return nil, nil
+	}
+
+	roster := make([]MemberID, 0, len(e.members))
+	for id := range e.members {
+		roster = append(roster, id)
+	}
+	sort.Slice(roster, func(i, j int) bool { return roster[i] < roster[j] })
+
+	reported, err := e.standing.Standing(roster)
+	if err != nil {
+		return nil, fmt.Errorf("standing: %w", err)
+	}
+
+	down := make(map[MemberID]bool, len(reported))
+	for _, id := range reported {
+		if _, ok := e.members[id]; !ok {
+			return nil, fmt.Errorf("standing: reported %q down, who is not a member: %w", id, ErrNotMember)
+		}
+		down[id] = true
+	}
+
+	return down, nil
+}
+
+// noticeDown is the world noticing, and it is the one place that happens.
+//
+// It pulls the standing answer, tells the story about anybody the story has not
+// been told about yet, takes them out of whatever fight they were in, and hands
+// the down set to [Encounter.applyTrigger], which has to classify contact
+// knowing who is a body and who is an enemy.
+//
+// Placement: [Encounter.applyTrigger] is reached from [Encounter.refreshSight]
+// — the choke point sight already flows through, so Move, Traverse, Pump, Join
+// and Exit all pass here by writing the obvious call — and from Setup's first
+// light, which calls applyTrigger directly so its scene-opened beat can land
+// first. A scene can open with a body already on the floor.
+//
+// # The order inside one pass
+//
+// Per member, sorted: the beat, then the transfer that beat explains. Cause
+// immediately before effect, which is the same law [Encounter.refreshSight]
+// states for verbs, applied inside one.
+//
+// # Why the STORY is the ledger
+//
+// The consult runs at every sight refresh, so something has to decide whether a
+// body is news. Nothing in this module can remember: doc.go's contract is that
+// every caller loads, acts and saves, so an Encounter lives for one verb and an
+// in-memory ledger would be empty on every call. That leaves persisted state,
+// and a persisted down flag is exactly the dual state [Standing] exists to
+// avoid.
+//
+// So the ledger is the STORY — the module's own persisted narration, and the
+// same trick logFloor already plays (derived from the log rather than stored
+// beside it, so it cannot drift out of agreement with the entries it
+// describes). "Has the story already said this?" is a question with one answer,
+// and no second thing to keep true.
+//
+// The cost, stated rather than hidden: the story has a retention window, so a
+// down beat can age out of it, and the next consult will say it again. That is
+// accepted. The obvious fix is to remember, and remembering is the disease.
+func (e *Encounter) noticeDown() (map[MemberID]bool, error) {
+	down, err := e.standingNow()
+	if err != nil {
+		return nil, err
+	}
+	if len(down) == 0 {
+		return down, nil
+	}
+
+	told, err := e.storyToldDown()
+	if err != nil {
+		return nil, err
+	}
+
+	fallen := make([]MemberID, 0, len(down))
+	for id := range down {
+		fallen = append(fallen, id)
+	}
+	sort.Slice(fallen, func(i, j int) bool { return fallen[i] < fallen[j] })
+
+	for _, id := range fallen {
+		if !told[id] {
+			if berr := e.appendDownBeat(id); berr != nil {
+				return nil, berr
+			}
+		}
+
+		// Out of the fight. A body keeps no turn, and the order closes over
+		// the gap rather than holding it open — Transfer is the mid-round
+		// removal a straggler leaving already used, and it prunes the bubble
+		// if it empties.
+		//
+		// The world clock, not nowhere: R6 says every member is on exactly one
+		// clock, and ruled fork (a) on rpg-toolkit#959 says a body is still a
+		// member — on the map, in the roster, recordable, carried by Exit.
+		bubble, berr := e.bubbleFor(id)
+		if berr != nil {
+			return nil, fmt.Errorf("standing bubble %q: %w", id, berr)
+		}
+		if bubble == nil {
+			continue
+		}
+		if _, terr := e.Transfer(&TransferInput{Member: id, To: ClockWorld}); terr != nil {
+			return nil, fmt.Errorf("standing transfer %q: %w", id, terr)
+		}
+	}
+
+	return down, nil
+}
+
+// storyToldDown reads back which members the RETAINED story already reports
+// down. See noticeDown for why this is the ledger.
+func (e *Encounter) storyToldDown() (map[MemberID]bool, error) {
+	entries, err := e.story.All(&record.AllInput{Tags: map[string]string{"tag": "outcome"}})
+	if err != nil {
+		return nil, fmt.Errorf("standing story: %w", err)
+	}
+
+	told := make(map[MemberID]bool)
+	for _, entry := range entries {
+		var beat struct {
+			Beat   string `json:"beat"`
+			Member string `json:"member"`
+		}
+		// A payload this pass cannot read is not this pass's business. Every
+		// beat this module writes is a JSON object and decodes here (unknown
+		// keys are ignored), so the skip is for a shape that could only come
+		// from a hand-edited blob — and refusing every verb over one is worse
+		// than not counting it as a death already told.
+		if json.Unmarshal(entry.Payload, &beat) != nil {
+			continue
+		}
+		if beat.Beat == string(OutcomeDown) && beat.Member != "" {
+			told[MemberID(beat.Member)] = true
+		}
+	}
+
+	return told, nil
+}
+
+// appendDownBeat writes the minimal death beat: the kind, and who.
+//
+// Ruled fork (d) on rpg-toolkit#959 — everything a client needs to render a
+// death, and nothing about hit points, which is a separate decision with its
+// own case (census S3). Tag "outcome" and the current clock reading put it in
+// the same family, with the same audience rule, as the struck and missed beats
+// a client reads beside it.
+func (e *Encounter) appendDownBeat(id MemberID) error {
+	payload, err := json.Marshal(map[string]string{
+		"beat":   string(OutcomeDown),
+		"member": string(id),
+	})
+	if err != nil {
+		return fmt.Errorf("standing beat payload: %w", err)
+	}
+
+	memberIDs := make([]MemberID, 0, len(e.members))
+	for mid := range e.members {
+		memberIDs = append(memberIDs, mid)
+	}
+	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
+
+	if _, aerr := e.appendBeat(&record.AppendInput{
+		At:       uint64(e.clock.ToData().HighWater),
+		Audience: memberIDs,
+		Tags:     map[string]string{"tag": "outcome"},
+		Payload:  payload,
+	}); aerr != nil {
+		return fmt.Errorf("standing append beat: %w", aerr)
+	}
+
+	return nil
 }

--- a/rulebooks/dnd5e/encounter/standing.go
+++ b/rulebooks/dnd5e/encounter/standing.go
@@ -50,6 +50,25 @@ import (
 // Errors abort whatever verb was running, atomically (R5), the same as
 // [InitiativeRoller]'s: a world that cannot find out who is standing does not
 // half-act on a guess.
+//
+// # What being down governs today, and what it does not
+//
+// It governs the three things the death census (rpg-toolkit#959) named: a down
+// member is on no side of a contact, so they neither start a fight nor join
+// one; they take no turn, because they are spliced out of the order; and they
+// take no [Encounter.Pump] action, because their decider is not consulted.
+//
+// It does NOT gate the caller-driven verbs. A down member can still be walked
+// by [Encounter.Move] and still be the actor on an [Encounter.Record]. Both are
+// the same gap seen twice: the swing stops because the TURN ORDER stops, and
+// free roam has no turn order. Deliberate for this slice — the alternative is a
+// refusal shape nobody has ruled on, and an unbuilt refusal beats a built-and-
+// wrong one. The session supplies the real capability in the death lane's D4
+// slice, which is where that call belongs.
+//
+// It also does not end a fight. A bubble whose whole living side is down keeps
+// running here; self-dissolution is D2's ruling (ByDefeat), and this slice
+// deliberately stops short of it.
 type Standing interface {
 	// Standing reports which of the given members are down. Returning none is
 	// the ordinary answer.

--- a/rulebooks/dnd5e/encounter/standing_test.go
+++ b/rulebooks/dnd5e/encounter/standing_test.go
@@ -1,0 +1,525 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// standing_test.go is death lane slice D1 (rpg-toolkit#1075): the world
+// notices who is down.
+//
+// Three live defects the death census named, one suite. A corpse could start a
+// fight, because sides were partitioned by Kind alone. A corpse could keep
+// walking, because Pump had no standing filter. A downed character could keep
+// swinging, because nothing took them out of the turn order. None of the three
+// is a rule this module is allowed to know — the composition cannot import the
+// rulebook (law C1) — so every scene below installs a FAKE Standing and drives
+// it by hand. Member IDs in, member IDs out; not one of these tests mentions a
+// hit point, and neither does the package.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type StandingSuite struct {
+	suite.Suite
+}
+
+func TestStandingSuite(t *testing.T) {
+	suite.Run(t, new(StandingSuite))
+}
+
+const cryptID = "crypt"
+
+// wolf is this suite's third body. alice, bob and goblin come from
+// encounter_test.go.
+const wolf = encounter.MemberID("wolf")
+
+// scene is the shared set: one open 12x12 room with alice, the goblin, and
+// (when asked for) the wolf standing in plain sight of each other.
+//
+// Plain sight is deliberate. Everywhere a corpse is expected to change nothing,
+// the control is a scene that WOULD have fought — so a test that stops seeing a
+// bubble is seeing the standing rule and not a sightline.
+//
+// Retention is unbounded because most of these tests read the story, and a
+// window would make "what the story says" a question about trimming.
+// TestAForgottenDeathIsToldAgain sets its own, on purpose.
+func (s *StandingSuite) scene(standing encounter.Standing, members ...encounter.MemberInput) *encounter.Encounter {
+	s.T().Helper()
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Standing:   standing,
+		Retention:  encounter.RetentionUnbounded,
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: cryptID, Width: 12, Height: 12},
+		}},
+		Members: members,
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc
+}
+
+// pair is alice and a goblin in plain sight of each other, the goblin pacing
+// between two cells so a tick has something to show.
+func (s *StandingSuite) pair(standing encounter.Standing) *encounter.Encounter {
+	s.T().Helper()
+
+	return s.scene(standing,
+		encounter.MemberInput{ID: alice, Kind: encounter.KindPlayer, Room: cryptID,
+			Position: spatial.Position{X: 0, Y: 2}},
+		encounter.MemberInput{ID: goblin, Kind: encounter.KindMonster, Room: cryptID,
+			Position: spatial.Position{X: 0, Y: 10},
+			Decider: &patrolDecider{positions: []spatial.Position{
+				{X: 1, Y: 10}, {X: 0, Y: 10},
+			}}},
+	)
+}
+
+// trio adds the wolf, so a fight has an order long enough for a gap in the
+// middle of it to be visible.
+func (s *StandingSuite) trio(standing encounter.Standing) *encounter.Encounter {
+	s.T().Helper()
+
+	return s.scene(standing,
+		encounter.MemberInput{ID: alice, Kind: encounter.KindPlayer, Room: cryptID,
+			Position: spatial.Position{X: 0, Y: 2}},
+		encounter.MemberInput{ID: goblin, Kind: encounter.KindMonster, Room: cryptID,
+			Position: spatial.Position{X: 0, Y: 10}},
+		encounter.MemberInput{ID: wolf, Kind: encounter.KindMonster, Room: cryptID,
+			Position: spatial.Position{X: 2, Y: 10}},
+	)
+}
+
+func (s *StandingSuite) clockOf(enc *encounter.Encounter, id encounter.MemberID) encounter.ClockKind {
+	s.T().Helper()
+
+	out, err := enc.ClockOf(&encounter.ClockOfInput{Member: id})
+	s.Require().NoError(err)
+
+	return out.Kind
+}
+
+func (s *StandingSuite) orderOf(enc *encounter.Encounter, id encounter.MemberID) []encounter.MemberID {
+	s.T().Helper()
+
+	out, err := enc.ClockOf(&encounter.ClockOfInput{Member: id})
+	s.Require().NoError(err)
+
+	return out.Order
+}
+
+func (s *StandingSuite) positionOf(enc *encounter.Encounter, id encounter.MemberID) spatial.Position {
+	s.T().Helper()
+
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	for _, m := range members {
+		if m.ID == id {
+			return m.Position
+		}
+	}
+	s.Require().Fail("no such member", "%q is not in the roster", id)
+
+	return spatial.Position{}
+}
+
+// beatKindsOf reads one audience's whole retained story as its list of beat
+// kinds — the shape the beat-order law is asserted in.
+func (s *StandingSuite) beatKindsOf(enc *encounter.Encounter, audience encounter.MemberID) []string {
+	s.T().Helper()
+
+	kinds := make([]string, 0)
+	for _, beat := range s.beatsOf(enc, audience) {
+		kinds = append(kinds, beat["beat"].(string))
+	}
+
+	return kinds
+}
+
+func (s *StandingSuite) beatsOf(enc *encounter.Encounter, audience encounter.MemberID) []map[string]any {
+	s.T().Helper()
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: audience})
+	s.Require().NoError(err)
+
+	beats := make([]map[string]any, 0, len(story))
+	for _, entry := range story {
+		var beat map[string]any
+		s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+		beats = append(beats, beat)
+	}
+
+	return beats
+}
+
+// --- construction is total ------------------------------------------------
+
+// TestSetupRefusesAnEncounterThatCannotAskWhoIsDown is the #1021 precedent
+// applied to hit points: an encounter consults Standing from first light, so
+// one that cannot ask is a misconfiguration, and it is refused at the door
+// rather than guarded at the use site. There is no nil-means-everyone-standing
+// — a default would be this module deciding a rule it is not allowed to know.
+func (s *StandingSuite) TestSetupRefusesAnEncounterThatCannotAskWhoIsDown() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: cryptID, Width: 12, Height: 12},
+		}},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: cryptID, Position: spatial.Position{X: 0, Y: 2}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+
+	s.Require().ErrorIs(err, encounter.ErrNoStanding)
+}
+
+// TestLoadRefusesAnEncounterThatCannotAskWhoIsDown is the other door. A loaded
+// encounter runs the same consult on its first sight refresh, and a blob is
+// exactly as capable of arriving without a capability as a Setup is.
+func (s *StandingSuite) TestLoadRefusesAnEncounterThatCannotAskWhoIsDown() {
+	saved := s.pair(&downList{}).ToData()
+
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:       saved,
+		Initiative: orderAsGiven{},
+	})
+
+	s.Require().ErrorIs(err, encounter.ErrNoStanding)
+}
+
+// TestALoadedEncounterAsksToo proves the capability is actually wired through
+// Load rather than merely demanded by it — the blob comes back mid-fight and
+// the reloaded encounter drops the body out of the order on its next consult.
+func (s *StandingSuite) TestALoadedEncounterAsksToo() {
+	saved := s.trio(&downList{}).ToData()
+
+	down := &downList{down: []encounter.MemberID{goblin}}
+	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:       saved,
+		Initiative: orderAsGiven{},
+		Standing:   down,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal([]encounter.MemberID{alice, goblin, wolf}, s.orderOf(enc, alice),
+		"the blob was saved mid-fight, with all three in the order")
+
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Equal([]encounter.MemberID{alice, wolf}, s.orderOf(enc, alice),
+		"the reloaded encounter asked, and the fight closed over the gap")
+}
+
+// --- a corpse cannot start or join a fight --------------------------------
+
+// TestACorpseStartsNoFight is the first of the three census defects:
+// sidesInContactOrder partitioned by Kind alone, so a dead monster in view was
+// still a monster in view, and sight started a fight with it.
+func (s *StandingSuite) TestACorpseStartsNoFight() {
+	fighting := s.pair(&downList{})
+	s.Require().Equal(encounter.ClockTurn, s.clockOf(fighting, alice),
+		"control: standing, in plain sight, first light starts the fight")
+
+	quiet := s.pair(&downList{down: []encounter.MemberID{goblin}})
+
+	s.Equal(encounter.ClockWorld, s.clockOf(quiet, alice), "a body in view is not an enemy in view")
+	s.Equal(encounter.ClockWorld, s.clockOf(quiet, goblin), "and it is on no turn order of its own")
+}
+
+// TestADownPlayerStartsNoFightEither pins the same rule from the other side. A
+// filter that only ever ran over monsters would pass every test above and
+// still let an unconscious character walk into a wolf and start a fight.
+func (s *StandingSuite) TestADownPlayerStartsNoFightEither() {
+	quiet := s.pair(&downList{down: []encounter.MemberID{alice}})
+
+	s.Equal(encounter.ClockWorld, s.clockOf(quiet, alice))
+	s.Equal(encounter.ClockWorld, s.clockOf(quiet, goblin))
+}
+
+// TestACorpseDoesNotJoinAFightAlreadyRunning is the straggler path's other
+// half. A monster in contact with a live fight transfers into it at the end of
+// the order; a body lying beside one is never swept in, tick after tick.
+func (s *StandingSuite) TestACorpseDoesNotJoinAFightAlreadyRunning() {
+	down := &downList{down: []encounter.MemberID{wolf}}
+	enc := s.trio(down)
+
+	s.Require().Equal([]encounter.MemberID{alice, goblin}, s.orderOf(enc, alice),
+		"the fight formed without the body")
+	s.Equal(encounter.ClockWorld, s.clockOf(enc, wolf))
+
+	_, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Equal([]encounter.MemberID{alice, goblin}, s.orderOf(enc, alice),
+		"and a tick beside a running fight does not sweep it in")
+	s.Equal(encounter.ClockWorld, s.clockOf(enc, wolf))
+}
+
+// --- a downed character stops swinging ------------------------------------
+
+// TestADownMemberLeavesTheTurnOrder is the second census defect: nothing took a
+// downed character out of the order, so the fight kept handing them turns and
+// the SDK kept letting them swing (#845, reproduced on the new stack).
+//
+// The gap closes rather than being held open — mid-round order splicing is the
+// same machinery a straggler leaving uses — and the body lands on the world
+// clock, because R6 says every member is on exactly one clock and a corpse is
+// still a member.
+func (s *StandingSuite) TestADownMemberLeavesTheTurnOrder() {
+	down := &downList{}
+	enc := s.trio(down)
+	s.Require().Equal([]encounter.MemberID{alice, goblin, wolf}, s.orderOf(enc, alice))
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Equal([]encounter.MemberID{alice, wolf}, s.orderOf(enc, alice),
+		"the order closes over the body, mid-round")
+	s.Equal(encounter.ClockWorld, s.clockOf(enc, goblin),
+		"which leaves it on the world clock — present, not gone")
+}
+
+// TestTheFightGoesOnWithoutIt pins what the splice must NOT do: end the fight.
+// A bubble holding one live side is still a fight in this slice; self-dissolve
+// when a whole side is down is D2's ruling (ByDefeat), not this one's.
+func (s *StandingSuite) TestTheFightGoesOnWithoutIt() {
+	down := &downList{}
+	enc := s.trio(down)
+
+	down.down = []encounter.MemberID{goblin, wolf}
+	_, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Equal(encounter.ClockTurn, s.clockOf(enc, alice),
+		"every monster is down and alice is STILL in a fight — D2 is what ends it")
+	s.Equal([]encounter.MemberID{alice}, s.orderOf(enc, alice))
+}
+
+// --- a corpse does not walk -----------------------------------------------
+
+// TestACorpseDoesNotWalk is the third census defect: Pump consulted every
+// monster's decider with no standing filter, so a dead goblin kept patrolling.
+//
+// The second half is the pull itself. Nothing is rebuilt and nothing is told
+// that the goblin recovered — the capability's answer simply changes, and the
+// next tick moves it again. A composition that cached the first answer passes
+// the first half of this test and fails here.
+func (s *StandingSuite) TestACorpseDoesNotWalk() {
+	down := &downList{down: []encounter.MemberID{goblin}}
+	enc := s.pair(down)
+	fell := s.positionOf(enc, goblin)
+
+	// It is on the WORLD clock, which is the only place Pump thinks for
+	// anybody — so the tick below skipping it is the standing filter and not
+	// the bubble filter that was already there.
+	s.Require().Equal(encounter.ClockWorld, s.clockOf(enc, goblin))
+
+	out, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Empty(out.MonsterMoves, "a body has nowhere to be")
+	s.Equal(fell, s.positionOf(enc, goblin), "and is still where it fell")
+
+	down.down = nil
+	out, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Require().Len(out.MonsterMoves, 1, "the rulebook says it is standing, so it walks")
+	s.NotEqual(fell, s.positionOf(enc, goblin))
+}
+
+// --- the story says so ----------------------------------------------------
+
+// TestTheStorySaysWhoIsDown is ruled fork (d): a minimal beat, kind and who.
+// It is everything a client needs to render a death; what the wire says about
+// hit points is a separate decision with its own case (census S3).
+func (s *StandingSuite) TestTheStorySaysWhoIsDown() {
+	enc := s.pair(&downList{down: []encounter.MemberID{goblin}})
+
+	var found []map[string]any
+	for _, beat := range s.beatsOf(enc, alice) {
+		if beat["beat"] == "down" {
+			found = append(found, beat)
+		}
+	}
+
+	s.Require().Len(found, 1)
+	s.Equal("goblin", found[0]["member"], "kind, and who")
+}
+
+// TestTheStorySaysItOnce is what makes the beat a beat rather than a status
+// line. The consult runs at every sight refresh — every walk, every tick — and
+// a body is news exactly once.
+func (s *StandingSuite) TestTheStorySaysItOnce() {
+	enc := s.pair(&downList{down: []encounter.MemberID{goblin}})
+
+	for i := 0; i < 3; i++ {
+		_, err := enc.Pump(&encounter.PumpInput{})
+		s.Require().NoError(err)
+	}
+
+	downs := 0
+	for _, kind := range s.beatKindsOf(enc, alice) {
+		if kind == "down" {
+			downs++
+		}
+	}
+
+	s.Equal(1, downs, "three ticks over a body, one down beat")
+}
+
+// TestAForgottenDeathIsToldAgain pins the accepted cost of holding NO state.
+//
+// There is no down flag anywhere in this module and none in the blob: the
+// composition asks the rulebook who is down, and asks its own STORY whether it
+// has already said so. The story is the only memory involved, and the story has
+// a retention window — so when the window forgets the down beat, the next
+// consult says it again.
+//
+// Pinned rather than left to be discovered, because the obvious "fix" is to
+// remember it, and remembering it is the dual state this whole shape exists to
+// avoid (heal a character and the sheet says four hit points while the
+// composition still says down).
+func (s *StandingSuite) TestAForgottenDeathIsToldAgain() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Standing:   &downList{down: []encounter.MemberID{goblin}},
+		Retention:  4,
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: cryptID, Width: 12, Height: 12},
+		}},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: cryptID, Position: spatial.Position{X: 0, Y: 2}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: cryptID, Position: spatial.Position{X: 0, Y: 10}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	// Every down beat ever appended, by sequence — the retained story holds at
+	// most one at a time, so it has to be collected as the ticks go by.
+	told := map[uint64]bool{}
+	collect := func() {
+		story, serr := enc.Story(&encounter.StoryInput{Audience: alice})
+		s.Require().NoError(serr)
+		for _, entry := range story {
+			var beat map[string]any
+			s.Require().NoError(json.Unmarshal(entry.Payload, &beat))
+			if beat["beat"] == "down" {
+				told[entry.Seq] = true
+			}
+		}
+	}
+
+	collect()
+	for i := 0; i < 8; i++ {
+		_, perr := enc.Pump(&encounter.PumpInput{})
+		s.Require().NoError(perr)
+		collect()
+	}
+
+	s.Greater(len(told), 1, "the story forgot the body, so the world noticed it again")
+}
+
+// --- beat order -----------------------------------------------------------
+
+// TestTheSceneOpensThenNoticesThenFights holds the beat-order law where the new
+// beat meets it: A VERB'S OWN BEAT PRECEDES ANY BEAT ITS CONSEQUENCES APPEND.
+//
+// The scene opens; the world notices the goblin is down; the fight that the
+// remaining wolf starts comes last. Noticing precedes the fight because it
+// DECIDES the fight — a bubble-formed beat naming a body would be a story that
+// contradicts the beat two lines above it.
+func (s *StandingSuite) TestTheSceneOpensThenNoticesThenFights() {
+	enc := s.trio(&downList{down: []encounter.MemberID{goblin}})
+
+	s.Equal([]string{"scene-opened", "down", "bubble-formed"}, s.beatKindsOf(enc, alice))
+	s.Equal([]encounter.MemberID{alice, wolf}, s.orderOf(enc, alice),
+		"and the fight is the two who could have one")
+}
+
+// TestThePumpTicksThenNotices is the same law at the verb where a body most
+// often appears: the tick is the cause, everything the world notices inside it
+// is the effect, and the transfer out of the fight follows the notice that
+// caused it.
+func (s *StandingSuite) TestThePumpTicksThenNotices() {
+	down := &downList{}
+	enc := s.trio(down)
+	s.Require().Equal([]string{"scene-opened", "bubble-formed"}, s.beatKindsOf(enc, alice))
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+
+	s.Equal([]string{"scene-opened", "bubble-formed", "tick", "down", "transferred"},
+		s.beatKindsOf(enc, alice))
+}
+
+// --- the body stays --------------------------------------------------------
+
+// TestACorpseIsStillOnTheMapAndInTheRoster is ruled fork (a), whole. A member
+// the rulebook reports down is never removed: the killing blow stays
+// recordable (Record validates targets against the roster), Members still
+// reports where the body lies, and Exit carries it forward — a TPK must not
+// close a dungeon as "abandoned" because the roster emptied itself.
+func (s *StandingSuite) TestACorpseIsStillOnTheMapAndInTheRoster() {
+	enc := s.pair(&downList{down: []encounter.MemberID{goblin}})
+
+	s.Equal(spatial.Position{X: 0, Y: 10}, s.positionOf(enc, goblin),
+		"still on the map, at the cell it fell on")
+
+	_, err := enc.Record(&encounter.RecordInput{
+		Kind:    encounter.OutcomeStruck,
+		Actor:   alice,
+		Targets: []encounter.MemberID{goblin},
+		Values:  map[encounter.OutcomeValue]int{encounter.ValueAmount: 7},
+	})
+	s.Require().NoError(err, "the killing blow is recordable against a body")
+
+	out, err := enc.Exit(&encounter.ExitInput{Member: goblin})
+	s.Require().NoError(err, "and the body is carried out, not vanished")
+	s.Equal(goblin, out.Outcome.ID)
+}
+
+// --- the capability is a seam, not a back door -----------------------------
+
+// TestNobodyCanPushADownBeatIn is the census's rejected shape, refused
+// structurally. Down arrives by the composition ASKING, at the choke point
+// where it already asks about sight; a caller that could push the beat in would
+// be a second system deciding the same thing, and Record's own doc is that it
+// records and does nothing else.
+func (s *StandingSuite) TestNobodyCanPushADownBeatIn() {
+	enc := s.pair(&downList{})
+
+	_, err := enc.Record(&encounter.RecordInput{Kind: encounter.OutcomeDown, Actor: alice})
+
+	s.Require().ErrorIs(err, encounter.ErrInvalidData)
+}
+
+// TestADownAnswerNamingAStrangerIsRefused holds the capability to its contract.
+// The composition asks about ITS roster; an answer naming somebody else is a
+// rulebook defect, and a defect this module cannot act on is one it refuses
+// rather than ignores — silently dropping the name would make a mis-wired
+// Standing look like a rule that simply does not fire.
+//
+// The refusal is atomic (R5): the tick that raised it moved nothing.
+func (s *StandingSuite) TestADownAnswerNamingAStrangerIsRefused() {
+	rulebook := &strangerWhenTold{}
+	enc := s.pair(rulebook)
+	before := s.positionOf(enc, goblin)
+
+	rulebook.lying = true
+	_, err := enc.Pump(&encounter.PumpInput{})
+
+	s.Require().ErrorIs(err, encounter.ErrNotMember)
+	s.Equal(before, s.positionOf(enc, goblin), "and nothing moved on the way to the refusal")
+}

--- a/rulebooks/dnd5e/encounter/teststanding_internal_test.go
+++ b/rulebooks/dnd5e/encounter/teststanding_internal_test.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+// everyoneStanding is the Standing capability the internal tests install.
+//
+// Nobody is ever down: these tests are about clocks, not about hit points, and
+// the capability is required at construction so they have to say so. The
+// rulebook's real answer is the production consumer's business.
+type everyoneStanding struct{}
+
+func (everyoneStanding) Standing([]MemberID) ([]MemberID, error) {
+	return nil, nil
+}

--- a/rulebooks/dnd5e/encounter/teststanding_test.go
+++ b/rulebooks/dnd5e/encounter/teststanding_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+
+// everyoneStanding is the Standing capability these tests install by default.
+//
+// Nobody is ever down, which is what every scene written before death existed
+// was already assuming. Installing it explicitly rather than letting a nil mean
+// it is the whole point of the capability being required: a scene states what
+// it believes about hit points out loud (rpg-toolkit#1033 — capabilities are
+// supplied, never defaulted).
+type everyoneStanding struct{}
+
+func (everyoneStanding) Standing([]encounter.MemberID) ([]encounter.MemberID, error) {
+	return nil, nil
+}
+
+// downList reports a caller-set roster down, and can be changed MID-SCENE —
+// which is how a test drops somebody, or stands them back up, without
+// rebuilding the encounter. That is the only way to test a pull: if the
+// composition cached the answer, changing this would change nothing.
+//
+// It answers only about members it was ASKED about, because that is what a real
+// implementation does — the composition hands over its roster and the rulebook
+// reports on those. A name that has since left the encounter is not in the
+// question and is not in the answer.
+type downList struct {
+	down []encounter.MemberID
+}
+
+func (d *downList) Standing(members []encounter.MemberID) ([]encounter.MemberID, error) {
+	asked := make(map[encounter.MemberID]bool, len(members))
+	for _, id := range members {
+		asked[id] = true
+	}
+
+	var down []encounter.MemberID
+	for _, id := range d.down {
+		if asked[id] {
+			down = append(down, id)
+		}
+	}
+
+	return down, nil
+}
+
+// strangerWhenTold is a rulebook that starts well-behaved and then answers with
+// somebody who is not in the encounter at all — the mis-wiring D4 could arrive
+// as, held here so the composition's refusal can be asserted from a scene that
+// was already running.
+type strangerWhenTold struct {
+	lying bool
+}
+
+func (s *strangerWhenTold) Standing([]encounter.MemberID) ([]encounter.MemberID, error) {
+	if s.lying {
+		return []encounter.MemberID{"a-ghost"}, nil
+	}
+
+	return nil, nil
+}

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -56,7 +56,7 @@ func TestTombWatch(t *testing.T) {
 	// cannot get through.
 	goblinPatrol := &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
@@ -132,7 +132,7 @@ func TestTombWatch(t *testing.T) {
 	// does not — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}},
 		}})
 	require.NoError(t, err, "beat 4: the suspended scene crosses a process boundary")
@@ -262,7 +262,7 @@ func TestTombWatch(t *testing.T) {
 		})
 	}
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{},
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,

--- a/rulebooks/dnd5e/encounter/trigger.go
+++ b/rulebooks/dnd5e/encounter/trigger.go
@@ -164,7 +164,7 @@ type trigger struct {
 // PLAYER has been watching the whole time and is plainly not surprised, while
 // FirstContact-only surprise would say they were, because the player's own
 // first contact happened long ago and is not in this delta.
-func (e *Encounter) classify(deltas map[MemberID]*intel.SurveilOutput) (*trigger, error) {
+func (e *Encounter) classify(deltas map[MemberID]*intel.SurveilOutput, down map[MemberID]bool) (*trigger, error) {
 	sawFirst := func(observer, subject MemberID) bool {
 		delta, ok := deltas[observer]
 		if !ok || delta == nil {
@@ -179,7 +179,7 @@ func (e *Encounter) classify(deltas map[MemberID]*intel.SurveilOutput) (*trigger
 		return false
 	}
 
-	players, monsters := e.sidesInContactOrder()
+	players, monsters := e.sidesInContactOrder(down)
 
 	var (
 		engaged = map[MemberID]bool{}
@@ -214,7 +214,7 @@ func (e *Encounter) classify(deltas map[MemberID]*intel.SurveilOutput) (*trigger
 	}
 
 	if len(engaged) > 0 {
-		return e.formation(engaged)
+		return e.formation(engaged, down)
 	}
 
 	// The drop arm classifies and then does nothing, because nothing can reach
@@ -232,7 +232,7 @@ func (e *Encounter) classify(deltas map[MemberID]*intel.SurveilOutput) (*trigger
 // other leave the world clock and everybody else keeps exploring. Stragglers
 // join later through the same classification, which is what makes a fight
 // grow rather than start twice.
-func (e *Encounter) formation(engaged map[MemberID]bool) (*trigger, error) {
+func (e *Encounter) formation(engaged map[MemberID]bool, down map[MemberID]bool) (*trigger, error) {
 	form := make([]MemberID, 0, len(engaged))
 	for id := range engaged {
 		form = append(form, id)
@@ -266,7 +266,7 @@ func (e *Encounter) formation(engaged map[MemberID]bool) (*trigger, error) {
 
 	surprised := make([]MemberID, 0, len(form))
 	for _, id := range form {
-		unaware, err := e.unawareOfOpposition(id)
+		unaware, err := e.unawareOfOpposition(id, down)
 		if err != nil {
 			return nil, err
 		}
@@ -281,7 +281,7 @@ func (e *Encounter) formation(engaged map[MemberID]bool) (*trigger, error) {
 // unawareOfOpposition reports whether this member's CURRENT view holds nobody
 // from the other side — which is exactly 5e's surprise condition, read at
 // formation rather than inferred from whatever triggered it.
-func (e *Encounter) unawareOfOpposition(id MemberID) (bool, error) {
+func (e *Encounter) unawareOfOpposition(id MemberID, down map[MemberID]bool) (bool, error) {
 	member, ok := e.members[id]
 	if !ok {
 		return false, nil
@@ -303,6 +303,11 @@ func (e *Encounter) unawareOfOpposition(id MemberID) (bool, error) {
 		if !ok {
 			continue
 		}
+		// A body in view is not opposition in view. Watching a corpse is not
+		// what stops you being surprised by the thing that is still standing.
+		if down[other.ID] {
+			continue
+		}
 		if other.Kind != member.Kind {
 			return false, nil
 		}
@@ -311,13 +316,24 @@ func (e *Encounter) unawareOfOpposition(id MemberID) (bool, error) {
 	return true, nil
 }
 
-// sidesInContactOrder returns the players and the monsters, each sorted.
+// sidesInContactOrder returns the STANDING players and the STANDING monsters,
+// each sorted.
+//
+// Down members are on neither side, which is the census defect this closes: the
+// partition used to be by Kind alone, so a dead monster was still a monster and
+// sight started a fight with it. A corpse can neither start a fight nor be
+// pulled into one already running, from either side of the roster — a member
+// who is not on a side is in no pair, and a pair is the only thing that forms
+// or joins a bubble.
 //
 // Sorted because e.members is a map and C8 requires that what a pass concludes
 // be a function of persisted data rather than of iteration order — the same
 // reason buildMemberOutcomes sorts.
-func (e *Encounter) sidesInContactOrder() (players, monsters []MemberID) {
+func (e *Encounter) sidesInContactOrder(down map[MemberID]bool) (players, monsters []MemberID) {
 	for id, member := range e.members {
+		if down[id] {
+			continue
+		}
 		switch member.Kind {
 		case KindPlayer:
 			players = append(players, id)
@@ -343,7 +359,16 @@ func (e *Encounter) sidesInContactOrder() (players, monsters []MemberID) {
 // checkCombatEntry, reached from Move AND AddMonster); this sits at the one
 // place all of them already pass through.
 func (e *Encounter) applyTrigger(deltas map[MemberID]*intel.SurveilOutput) (*FormedBubble, error) {
-	verdict, err := e.classify(deltas)
+	// The world notices who is down BEFORE it works out who is fighting whom.
+	// Both halves of that order matter: a body must not be classified as an
+	// enemy, and the beat saying so must not land after a bubble-formed beat
+	// it contradicts (rpg-toolkit#1075).
+	down, err := e.noticeDown()
+	if err != nil {
+		return nil, err
+	}
+
+	verdict, err := e.classify(deltas, down)
 	if err != nil {
 		return nil, err
 	}

--- a/rulebooks/dnd5e/encounter/trigger.go
+++ b/rulebooks/dnd5e/encounter/trigger.go
@@ -144,6 +144,21 @@ type trigger struct {
 // watching" without anything forming — cannot arise: the step that created the
 // watching was itself classified, and either formed a bubble or was a drop.
 //
+// STANDING IS THE ONE HOLE IN THAT INDUCTION, and it is worth stating rather
+// than discovering. A down member is on no side (see sidesInContactOrder), so
+// awareness created while they were down was classified as nothing — and if
+// they were later reported standing again, that awareness is already Refreshed
+// rather than FirstContact and will never trigger. A revived monster could
+// stand in plain sight of a player and start no fight until somebody moves.
+//
+// Left open on purpose. Ruled fork (b) on rpg-toolkit#959 is that zero hit
+// points has no exit in v1 — death saves are deferred — so recovery is not a
+// path anything can currently take, and building against it would be untestable
+// behaviour shipped on faith. It is the same call contactDrop above documents
+// for the same reason. When recovery becomes real, the fix belongs where the
+// invariant says it does: in how percepts are PRODUCED, not in how they are
+// consumed here.
+//
 // # Precedence
 //
 // Within one pass, any spotted or mutual pair forms the bubble, and the drop's


### PR DESCRIPTION
Closes #1075. Death lane slice **D1**, encounter module only. The four forks were ruled on #959 on 2026-08-17 and this implements them as written.

## What it does

```go
// package encounter — the composition asks; the rulebook answers.
type Standing interface {
    Standing(members []MemberID) (down []MemberID, err error)
}
```

Member IDs in, member IDs out. **Law C1 holds** — encounter's `go.mod` still cannot import the rulebook, and nothing in this diff learns what a hit point is. The whole suite drives a test-supplied fake.

A member the rulebook reports down is on **no side of a contact**, has **no turn**, gets **no `Pump` action**, and the story says so — while staying on the map, in the roster, recordable against, and carried by `Exit`.

## The three live defects this closes

| Census defect | Was | Now |
|---|---|---|
| **A corpse can start a fight** | `sidesInContactOrder` partitioned by `Kind` alone, so a dead monster was still a monster in view | down members are on neither side, so they are in no pair, so they neither form nor join a bubble |
| **A corpse keeps walking** | `Pump` had no standing filter | phase 1 skips a down monster before its decider is consulted at all |
| **A downed character keeps swinging** (#845, reproduced on the new stack) | nothing took them out of the order | the order splices over them mid-round and they land on the world clock |

The third one closes **structurally rather than by a gate**: there is no HP check in `Record`, because there cannot be one here. It is not their turn any more, so the seam above has nothing to offer them. Stated plainly because the honest corollary is below.

## Design — a pull, and no state anywhere

Consulted at **`applyTrigger`**, which is what every `refreshSight` reaches (Move, Traverse, Pump, Join, Exit) **and** what Setup's first light calls directly — the census said `refreshSight`, and `applyTrigger` is the choke point on the far side of it that Setup also crosses. A scene can open with a body already on the floor.

Per pass, in this order: pull → beat → splice → classify. Both halves of that order matter — a body must not be classified as an enemy, and the beat saying so must not land after a `bubble-formed` beat it contradicts.

**No stored down flag, in memory or in the blob.** `EncounterData` is byte-for-byte unchanged; the only persistence-file change is `LoadEncounterInput`, which is the live-objects half. The pull is the truth.

**Why the ledger is the story.** Something has to decide whether a body is news, because the consult runs at every sight refresh. Nothing here can remember: `doc.go`'s contract is that every caller loads, acts and saves, so an `Encounter` lives for exactly one verb and an in-memory ledger would be empty on every call. That leaves persisted state — and a persisted down flag is precisely the dual state this shape exists to avoid (heal a character and the sheet says 4 HP while the composition still says down). So the ledger is the **story**, the module's own persisted narration, which is the same trick `logFloor` already plays: derived from the log rather than stored beside it, so it cannot drift out of agreement with the entries it describes.

**The accepted cost, pinned rather than hidden:** the story has a retention window, so a down beat can age out and the next consult will say it again. `TestAForgottenDeathIsToldAgain` pins that, because the obvious "fix" is to remember, and remembering is the disease.

## API changes

| Change | Why |
|---|---|
| `SetupInput.Standing` **required** | The consult runs from first light. **BREAKING.** |
| `LoadEncounterInput.Standing` **required** | Same consult on the first sight refresh; `ErrNoStanding` from `Validate` |
| `ErrNoStanding` | New sentinel, beside `ErrNoInitiative` |
| `OutcomeDown` (`"down"`) | New `OutcomeKind`. **Not acceptable to `Record`** — see below |
| `Standing` | The capability |

`Record`'s switch stays `{struck, missed}`, so pushing `OutcomeDown` gets `ErrInvalidData`. That is the census's rejected push-via-`Record` shape refused **structurally**: down is something the composition notices, and a caller that could push it in would be a second system deciding the same thing. `TestNobodyCanPushADownBeatIn` pins it.

An answer naming somebody who is not a member is refused with `ErrNotMember` rather than ignored, so a mis-wired `Standing` at D4 looks like a mis-wired capability instead of a rule that silently never fires.

## The beat

`{"beat":"down","member":"goblin"}`, tag `outcome`, audience every current member. Ruled fork (d): kind and who, nothing else. Tag `outcome` puts it in the same family as `struck`/`missed`, so D4's `kindOf` reads one tag family rather than two.

## Evidence

**RED first.** Two stages, both captured before any production behaviour existed — stage 1 the capability not existing at all, stage 2 declarations only (interface, both fields, sentinel, kind) with nothing consulting them, so every failure is behavioural:

```
--- FAIL: TestStandingSuite/TestACorpseStartsNoFight
    Error:    Not equal:
              expected: "world"
              actual  : "turn"
    Messages: a body in view is not an enemy in view
--- FAIL: TestStandingSuite/TestADownMemberLeavesTheTurnOrder
    expected: []core.EntityID{"alice", "wolf"}
    actual  : []core.EntityID{"alice", "goblin", "wolf"}
--- FAIL: TestStandingSuite/TestTheStorySaysWhoIsDown
--- FAIL: TestStandingSuite/TestThePumpTicksThenNotices
    ... 15 of 17 failing
```

The two that did not fail are guard rails that must stay green throughout (`TestACorpseIsStillOnTheMapAndInTheRoster`, `TestNobodyCanPushADownBeatIn`).

| Check | Result |
|---|---|
| `go test -count=1 ./...` | **exit 0 — 724 pass, 0 fail** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |

**Mutation-tested, six mutants, six kills, each by a named pin** — and the round is worth reading, because two mutants did not compile the first time (a build failure is not a killed mutant) and one **survived**: moving the notice after *classification* changed nothing, because `form` runs later still. Restated so the notice landed after the formation, it died to `TestTheSceneOpensThenNoticesThenFights`.

| Mutant | Killed by |
|---|---|
| `sidesInContactOrder` stops excluding the down | `TestACorpseStartsNoFight` + 4 others |
| Pump's standing filter stops filtering | `TestACorpseDoesNotWalk` |
| the splice out of the fight is removed | `TestADownMemberLeavesTheTurnOrder` + 3 others |
| the down beat is appended at every consult | `TestTheStorySaysItOnce` |
| an answer naming a stranger is ignored | `TestADownAnswerNamingAStrangerIsRefused` |
| the notice runs after the formation | `TestTheSceneOpensThenNoticesThenFights` |

**`gorelease -base v0.13.0`** reports every change as *compatible* and suggests v0.14.0:

```
## compatible changes
ErrNoStanding: added
LoadEncounterInput.Standing: added
OutcomeDown: added
SetupInput.Standing: added
Standing: added
```

That is the tool's **blind spot**, not a verdict: a newly-required struct field is not a type break, but every existing caller now gets `ErrNoStanding` at construction. The `!` in the title is what carries the bump. The suggested version happens to be the one we want anyway — for the wrong reason.

## The sanctioned fixture pass

**244 construction sites across 19 files** (18 test files + the workbench), mirroring #1021's own pass. Purely mechanical: `Standing: everyoneStanding{},` beside every `Initiative:`, then `gofmt`. Two fakes carry the suite — `everyoneStanding` (nobody is ever down, which is what every scene written before death existed was already assuming) and `downList`, which is mutable so a scene can drop somebody or stand them back up **without rebuilding the encounter**. That mutability is the only way to test a pull: if the answer were cached, changing it would change nothing.

## Deliberately deferred

- **D2 — the bubble does not self-dissolve when a whole side is down.** `ByDefeat()` is D2's ruling and is not here. `TestTheFightGoesOnWithoutIt` pins the interim state honestly: every monster down, alice still in a fight. One emergent exception worth naming — if *every* member of a bubble goes down the bubble drains and `dropBubbleIfIdle` prunes the husk, which is a consequence of splicing rather than D2 arriving early.
- **D4 — no real rulebook wiring.** No `combat.IsDown` anywhere; the session supplies the real capability in its own slice.
- **The caller-driven verbs are not gated.** A down member can still be walked by `Move` and still be the actor on a `Record` — the same gap seen twice, because the swing stops when the *turn order* stops and free roam has no turn order. Deliberate: the alternative is a refusal shape nobody has ruled on, and an unbuilt refusal beats a built-and-wrong one. Written onto `Standing`'s own doc so a reader hits it in the IDE rather than in a bug report.

## One hole, stated rather than discovered

The standing filter opens an exception in `classify`'s transition induction, and it is now written into `classify`'s doc beside the induction it qualifies. Awareness created while a member was down was classified as nothing; if they are later reported standing again, that awareness is already `Refreshed` rather than `FirstContact` and will never trigger — so a revived monster could stand in plain sight and start no fight until something moves.

Left open on purpose. Ruled fork (b) gives zero hit points **no exit in v1**, so recovery is not a path anything can currently take, and building against it would be untestable behaviour shipped on faith — the same call `contactDrop` documents for the same reason. When recovery becomes real the fix belongs where the invariant says: in how percepts are *produced*, not in how they are consumed.

## Adoption

Neither downstream module is broken today — both pin released versions (`session` v0.13.0, `resolution` v0.9.0). Each adopts at its next bump by supplying a `Standing`; for `session` that bump **is** D4.

— fix-1075 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
