### PR TITLE
feat(resolution)!: the world it loads needs to know who is standing

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -121,7 +121,7 @@ func (s *CharacterAttackTestSuite) mainHand() *CharacterAttackInput {
 // world puts the hero next to the wolf. Adjacency matters only to prone's
 // range predicate, which nobody here triggers.
 func (s *CharacterAttackTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -139,7 +139,7 @@ func (s *CharacterAttackTestSuite) world() encounter.EncounterData {
 func (s *CharacterAttackTestSuite) swingAt(
 	hero *character.Data, profile AttackProfile, roller *sequenceRoller,
 ) (*Output, error) {
-	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: roller,
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: roller,
 		World: s.world(),
 		Participants: []Participant{
 			{Character: hero},

--- a/rulebooks/dnd5e/resolution/contest_test.go
+++ b/rulebooks/dnd5e/resolution/contest_test.go
@@ -67,7 +67,7 @@ func (s *ContestTestSuite) wolfsKnockdown() *saves.SaveGate {
 }
 
 func (s *ContestTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -145,7 +145,7 @@ func (s *ContestTestSuite) contest(gate *saves.SaveGate, roller *scriptedRoller)
 }
 
 func (s *ContestTestSuite) resolve(hero *character.Data, machine Machine) *Output {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: hero}, {Monster: s.wolfData()}},
 		Machine:      machine,
@@ -252,14 +252,14 @@ func (s *ContestTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 		return &scriptedRoller{single: straightRoll, pair: []int{straightRoll, straightRoll}}
 	}
 
-	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero(s.raging())}, {Monster: s.wolfData()}},
 		Machine:      s.contest(s.wolfsKnockdown(), roller()),
 	})
 	s.Require().NoError(err)
 
-	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.wolfData()}, {Character: s.hero(s.raging())}},
 		Machine:      s.contest(s.wolfsKnockdown(), roller()),
@@ -311,7 +311,7 @@ func (s *ContestTestSuite) TestTheDCComesFromTheGate() {
 		Recurrence: saves.RecurrenceNone,
 	}
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
 		Machine: NewContest(&ContestInput{
@@ -334,7 +334,7 @@ func (s *ContestTestSuite) TestARecurringGateIsRefused() {
 	gate := saves.NewSaveGate(abilities.STR, 11)
 	gate.Recurrence = saves.RecurrenceEndOfTurn
 
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
 		Machine:      s.contest(gate, &scriptedRoller{single: straightRoll}),
@@ -347,7 +347,7 @@ func (s *ContestTestSuite) TestARecurringGateIsRefused() {
 
 func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	s.Run("no gate", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine: NewContest(&ContestInput{
@@ -359,7 +359,7 @@ func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	})
 
 	s.Run("an invalid gate", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine: NewContest(&ContestInput{
@@ -372,7 +372,7 @@ func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	})
 
 	s.Run("no consequence", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine:      NewContest(&ContestInput{Gate: s.wolfsKnockdown(), SaverID: heroID}),
@@ -381,7 +381,7 @@ func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	})
 
 	s.Run("a saver who is not a participant", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine: NewContest(&ContestInput{
@@ -425,7 +425,7 @@ func (s *ContestTestSuite) TestTheImpositionStepSaysWhatItDoes() {
 // contest rolls anything — rather than a description reading "unknown" and a
 // contest that imposes something nobody can name.
 func (s *ContestTestSuite) TestAConsequenceWithNoRefIsRefused() {
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
 		Machine: NewContest(&ContestInput{

--- a/rulebooks/dnd5e/resolution/damage_custody_test.go
+++ b/rulebooks/dnd5e/resolution/damage_custody_test.go
@@ -62,7 +62,7 @@ func (s *DamageCustodyTestSuite) biteOnBus(
 	attack, err := AttackFromMonsterAction(data.Actions[0])
 	s.Require().NoError(err)
 
-	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.roomWith(encounter.MemberID(wolfID), encounter.MemberID(target.ID)),
 		Participants: []Participant{{Monster: data}, {Monster: target}},
 		Machine: NewStrike(&StrikeInput{
@@ -164,7 +164,7 @@ func (s *DamageCustodyTestSuite) TestTypesAreGroupedSeparatelyThroughTheFold() {
 // Real content, and the case a synthetic subscriber cannot pin: a raging
 // barbarian takes half from the wolf's piercing bite.
 func (s *DamageCustodyTestSuite) TestARagingTargetsResistanceReadsTheEventsDamageType() {
-	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -188,7 +188,7 @@ func (s *DamageCustodyTestSuite) TestARagingTargetsResistanceReadsTheEventsDamag
 	}).ToJSON()
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: world.ToData(),
 		Participants: []Participant{
 			{Character: s.ragingHero(raging)},
@@ -295,7 +295,7 @@ func (s *DamageCustodyTestSuite) addFlatOnBus(bus events.EventBus, amount int, t
 // it keeps a character's AC chain out of the arithmetic under test, and the
 // damage fold is the same fold whoever is swinging.
 func (s *DamageCustodyTestSuite) roomWith(attacker, target encounter.MemberID) encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},

--- a/rulebooks/dnd5e/resolution/declared_consequence_test.go
+++ b/rulebooks/dnd5e/resolution/declared_consequence_test.go
@@ -63,7 +63,7 @@ func (s *DeclaredConsequenceTestSuite) biteProfile() AttackProfile {
 // world places the hero and the wolf three cells apart — far enough that
 // prone's range predicate stays out of these cases.
 func (s *DeclaredConsequenceTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -106,7 +106,7 @@ func (s *DeclaredConsequenceTestSuite) hero() *character.Data {
 }
 
 func (s *DeclaredConsequenceTestSuite) resolve(machine Machine) (*Output, error) {
-	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.hero()},

--- a/rulebooks/dnd5e/resolution/effective_ac_test.go
+++ b/rulebooks/dnd5e/resolution/effective_ac_test.go
@@ -98,7 +98,7 @@ func (s *EffectiveACTestSuite) defenseStyle() json.RawMessage {
 }
 
 func (s *EffectiveACTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -120,7 +120,7 @@ func (s *EffectiveACTestSuite) biteAt(hero *character.Data, roll int) StrikeOutc
 	attack, err := AttackFromMonsterAction(data.Actions[0])
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: hero}, {Monster: data}},
 		Machine: NewStrike(&StrikeInput{
@@ -188,7 +188,7 @@ func (s *EffectiveACTestSuite) TestAMonsterTargetStillReportsItsStatBlockAC() {
 	attack, err := AttackFromMonsterAction(data.Actions[0])
 	s.Require().NoError(err)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -200,7 +200,7 @@ func (s *EffectiveACTestSuite) TestAMonsterTargetStillReportsItsStatBlockAC() {
 	})
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        enc.ToData(),
 		Participants: []Participant{{Monster: data}, {Monster: second}},
 		Machine: NewStrike(&StrikeInput{

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -20,6 +20,18 @@ var (
 	// seemed fine. Refused at the door instead.
 	ErrNoRoller = errors.New("resolution: no roller")
 
+	// ErrNoStanding indicates an interaction given no way to find out who is
+	// standing. The composition requires one to load at all, the same way it
+	// requires an initiative roller.
+	//
+	// Nothing in this package consults it. The world is loaded here and read
+	// back out as data, and no verb that refreshes sight runs in between — so
+	// this is a capability carried ACROSS rather than used, exactly like
+	// Deciders. Carried rather than invented, because a package that answered
+	// "nobody is down" on the caller's behalf would be deciding a rule it
+	// cannot see (rpg-toolkit#1079).
+	ErrNoStanding = errors.New("resolution: no standing capability")
+
 	// ErrNoMachine indicates an interaction with nothing to resolve. Distinct
 	// from a machine that finishes immediately, which is legal.
 	ErrNoMachine = errors.New("resolution: no machine")

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0 h1:j0VBbyFOEbM+UrfaDYdvuPDQ2L7b4IVVjEzMtJMg5Dc=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.9.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0 h1:dB16IaDoSN+m3aFXD+t/3fNuYP43n6kvwBZa3ljtzbI=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -105,8 +105,14 @@ type Input struct {
 
 	// Roller is used to reconstitute effects that need one — a monster's Undead
 	// Fortitude, for instance, which rolls when it is triggered rather than
-	// when it is loaded. Nil takes the default roller. It is not the machine's
-	// roller: a machine that rolls carries its own.
+	// when it is loaded. REQUIRED. It is not the machine's roller: a machine
+	// that rolls carries its own.
+	//
+	// It used to say "nil takes the default roller", and that stopped being
+	// true when rpg-toolkit#1033 refused the default — a nil silently became
+	// real randomness, which put unreproducible rolls into results that looked
+	// fine. Validate has answered ErrNoRoller ever since; only this line had
+	// not caught up.
 	Roller dice.Roller
 }
 

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -91,6 +91,18 @@ type Input struct {
 	// what the caller supplied, the way Deciders one field up are handed over.
 	Initiative encounter.InitiativeRoller
 
+	// Standing reports which members are down. REQUIRED.
+	//
+	// Carried, never consulted. This package loads the world and reads it back
+	// out as data; no verb that refreshes sight runs in between, so nothing
+	// here ever asks the question. The composition still refuses to load
+	// without one (rpg-toolkit#1077), and answering on the caller's behalf —
+	// "nobody is down" — would be this package deciding a rule about hit
+	// points it holds none of. So it is handed over, the way Deciders and
+	// Initiative above are handed over, and the caller that owns the sheets
+	// owns the answer (rpg-toolkit#1079).
+	Standing encounter.Standing
+
 	// Roller is used to reconstitute effects that need one — a monster's Undead
 	// Fortitude, for instance, which rolls when it is triggered rather than
 	// when it is loaded. Nil takes the default roller. It is not the machine's
@@ -117,6 +129,9 @@ func (in *Input) Validate() error {
 	// by putting untestable randomness into a result that looks fine.
 	if in.Initiative == nil {
 		return ErrNoInitiative
+	}
+	if in.Standing == nil {
+		return ErrNoStanding
 	}
 	if in.Roller == nil {
 		return ErrNoRoller
@@ -221,6 +236,7 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		Data:       in.World,
 		Deciders:   in.Deciders,
 		Initiative: in.Initiative,
+		Standing:   in.Standing,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("resolution: load world: %w", err)

--- a/rulebooks/dnd5e/resolution/resolve_test.go
+++ b/rulebooks/dnd5e/resolution/resolve_test.go
@@ -69,7 +69,7 @@ func (s *ResolveTestSuite) SetupTest() {
 // world is a two-member encounter, already normalised by a load/save cycle so
 // that "unchanged" can be asserted literally.
 func (s *ResolveTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -213,7 +213,7 @@ func (s *ResolveTestSuite) outcomeOf(out *Output) SaveOutcome {
 // own predicate decided it applied. This single assertion is ADR-0038 end to
 // end.
 func (s *ResolveTestSuite) TestRagingBarbarianGetsAdvantageOnAStrengthSave() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -235,7 +235,7 @@ func (s *ResolveTestSuite) TestRagingBarbarianGetsAdvantageOnAStrengthSave() {
 // The control that makes the headline mean something: the same barbarian, the
 // same save, no condition — a straight roll.
 func (s *ResolveTestSuite) TestTheSameBarbarianWithoutRageRollsStraight() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian()}},
 		Machine:      s.save(abilities.STR),
@@ -250,7 +250,7 @@ func (s *ResolveTestSuite) TestTheSameBarbarianWithoutRageRollsStraight() {
 
 // The second effect, on a different chain, through the same machinery.
 func (s *ResolveTestSuite) TestDodgingGrantsAdvantageOnADexteritySave() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.dodging())}},
 		Machine:      s.save(abilities.DEX),
@@ -265,7 +265,7 @@ func (s *ResolveTestSuite) TestDodgingGrantsAdvantageOnADexteritySave() {
 // Applicability is the effect's own predicate, never resolution's. Raging is
 // attached for a DEX save exactly as it is for a STR save, and declines.
 func (s *ResolveTestSuite) TestRagingDeclinesADexteritySaveOnItsOwn() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.DEX),
@@ -283,7 +283,7 @@ func (s *ResolveTestSuite) TestRagingDeclinesADexteritySaveOnItsOwn() {
 // R3. A participant nobody expected to matter is passed in, attaches, and folds
 // nothing. Pass-everyone-in costs correctness nothing.
 func (s *ResolveTestSuite) TestAnIrrelevantParticipantAttachesAndFoldsNothing() {
-	alone, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	alone, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -291,7 +291,7 @@ func (s *ResolveTestSuite) TestAnIrrelevantParticipantAttachesAndFoldsNothing() 
 	s.Require().NoError(err)
 
 	s.SetupTest()
-	together, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	together, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.barbarian(s.raging())},
@@ -313,7 +313,7 @@ func (s *ResolveTestSuite) TestAnIrrelevantParticipantAttachesAndFoldsNothing() 
 // caller happened to list participants in. Without this, a resumed suspension
 // could attach into a differently-ordered world.
 func (s *ResolveTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
-	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.barbarian(s.raging())},
@@ -324,7 +324,7 @@ func (s *ResolveTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 	s.Require().NoError(err)
 
 	s.SetupTest()
-	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Monster: s.skeleton()},
@@ -345,7 +345,7 @@ func (s *ResolveTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 func (s *ResolveTestSuite) TestNothingSurvivesTheCall() {
 	inner := events.NewEventBus()
 
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -376,7 +376,7 @@ func (s *ResolveTestSuite) TestTheWorldRoundTripsUnchanged() {
 	before, err := json.Marshal(world)
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        world,
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -411,7 +411,7 @@ func (s *ResolveTestSuite) TestTheWorldRoundTripsUnchanged() {
 func (s *ResolveTestSuite) TestAMonstersActionsSurviveResolution() {
 	machine := &captureMachine{}
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.skeleton()}},
 		Machine:      machine,
@@ -433,7 +433,7 @@ func (s *ResolveTestSuite) TestAMonstersActionsSurviveResolution() {
 // A save changes nobody, so nobody comes back dirty. The point is that dirty
 // means dirty rather than "was present".
 func (s *ResolveTestSuite) TestASaveLeavesNobodyDirty() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.barbarian(s.raging())},
@@ -456,13 +456,13 @@ func (s *ResolveTestSuite) TestNilInputRejected() {
 }
 
 func (s *ResolveTestSuite) TestMissingMachineRejected() {
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(), World: s.world()})
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(), World: s.world()})
 	s.Require().ErrorIs(err, ErrNoMachine)
 }
 
 func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 	s.Run("empty", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{}},
 			Machine:      s.save(abilities.STR),
@@ -471,7 +471,7 @@ func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 	})
 
 	s.Run("both a character and a monster", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.barbarian(), Monster: s.skeleton()}},
 			Machine:      s.save(abilities.STR),
@@ -480,7 +480,7 @@ func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 	})
 
 	s.Run("the same id twice", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.barbarian()}, {Character: s.barbarian(s.raging())}},
 			Machine:      s.save(abilities.STR),
@@ -492,7 +492,7 @@ func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 // Rolling a save for someone who was not passed in would silently drop their
 // modifier and every effect they carry, and still return a plausible number.
 func (s *ResolveTestSuite) TestASaverWhoIsNotAParticipantIsRefused() {
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.skeleton()}},
 		Machine:      NewSave(&SaveInput{SaverID: "nobody", Ability: abilities.STR, DC: saveDifficulty}),
@@ -503,7 +503,7 @@ func (s *ResolveTestSuite) TestASaverWhoIsNotAParticipantIsRefused() {
 func (s *ResolveTestSuite) TestAMonsterCanSucceedOnASavingThrow() {
 	s.roller.single = 11
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.wolf()}},
 		Machine: NewSave(&SaveInput{
@@ -524,7 +524,7 @@ func (s *ResolveTestSuite) TestAMonsterCanSucceedOnASavingThrow() {
 func (s *ResolveTestSuite) TestAMonsterCanFailASavingThrowWithANegativeModifier() {
 	s.roller.single = 10
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.wolf()}},
 		Machine: NewSave(&SaveInput{
@@ -563,6 +563,14 @@ func TestResolveSuite(t *testing.T) {
 //
 // Exactly ONE literal in this suite was relying on that default when it was
 // removed — the surface it was protecting was almost entirely imaginary.
+//
+// Standing joins them for the first reason rather than the second. The
+// composition grew a required standing capability (rpg-toolkit#1077) and this
+// package kept calling LoadEncounter without one, so against encounter v0.15.0
+// every Resolve failed at the door — found, again, by the session seam adopting
+// the new pin (rpg-toolkit#1079), and again because nothing here loads a world
+// that requires one. The default this refuses is the tempting one: answering
+// "nobody is down" on the caller's behalf, from a package holding no hit points.
 func TestCapabilitiesAreSuppliedNeverDefaulted(t *testing.T) {
 	machine := NewSave(&SaveInput{
 		SaverID: "x", Ability: abilities.CON, DC: 10, Roller: dice.NewRoller(),
@@ -573,15 +581,77 @@ func TestCapabilitiesAreSuppliedNeverDefaulted(t *testing.T) {
 		require.ErrorIs(t, err, ErrNoInitiative)
 	})
 
+	t.Run("no standing", func(t *testing.T) {
+		err := (&Input{Machine: machine, Initiative: orderAsGiven{}, Roller: dice.NewRoller()}).Validate()
+		require.ErrorIs(t, err, ErrNoStanding)
+	})
+
 	t.Run("no roller", func(t *testing.T) {
-		err := (&Input{Machine: machine, Initiative: orderAsGiven{}}).Validate()
+		err := (&Input{Machine: machine, Initiative: orderAsGiven{}, Standing: everyoneStanding{}}).Validate()
 		require.ErrorIs(t, err, ErrNoRoller)
 	})
 
-	t.Run("both supplied", func(t *testing.T) {
+	t.Run("all supplied", func(t *testing.T) {
 		err := (&Input{
-			Machine: machine, Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+			Machine: machine, Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		}).Validate()
 		require.NoError(t, err)
 	})
+}
+
+// countingStanding answers like everyoneStanding and remembers being asked.
+type countingStanding struct{ asks int }
+
+func (c *countingStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberID, error) {
+	c.asks++
+
+	return nil, nil
+}
+
+// TestTheStandingCapabilityIsCarriedAndNeverAsked pins both halves of what this
+// field is for, and they pull in opposite directions.
+//
+// CARRIED: the world underneath refuses to load without one, so a Resolve that
+// succeeds at all is proof the capability reached LoadEncounter. Drop the
+// pass-through and this fails at the door rather than in an assertion.
+//
+// NEVER ASKED: nothing here refreshes sight, so the count must stay zero. That
+// is the claim the field's doc makes, and it is the one that would rot silently
+// — a later change that started consulting it would be this package answering a
+// question about hit points, which is the thing it must not do. Asserting the
+// zero is how that stays a decision rather than a coincidence.
+func TestTheStandingCapabilityIsCarriedAndNeverAsked(t *testing.T) {
+	world, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+
+	counter := &countingStanding{}
+	out, err := Resolve(context.Background(), &Input{
+		Initiative: orderAsGiven{}, Standing: counter, Roller: dice.NewRoller(),
+		World: world.ToData(),
+		Participants: []Participant{{Character: &character.Data{
+			ID: heroID, PlayerID: "player-1", Name: "Grog", Level: 1,
+			ClassID: classes.Barbarian, RaceID: races.Human,
+			AbilityScores: shared.AbilityScores{
+				abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+				abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+			},
+			HitPoints: 14, MaxHitPoints: 14, ProficiencyBonus: 2,
+		}}},
+		Machine: NewSave(&SaveInput{
+			SaverID: heroID, Ability: abilities.CON, DC: 10, Roller: dice.NewRoller(),
+		}),
+	})
+
+	require.NoError(t, err, "the world loads, which it cannot do without the capability")
+	require.NotNil(t, out)
+	require.Zero(t, counter.asks, "and this package never asks who is standing")
 }

--- a/rulebooks/dnd5e/resolution/strictness_test.go
+++ b/rulebooks/dnd5e/resolution/strictness_test.go
@@ -63,7 +63,7 @@ func (s *StrictnessTestSuite) SetupTest() {
 // world is a two-member encounter: the hero, and a second character whose sheet
 // is the corrupt one.
 func (s *StrictnessTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -129,7 +129,7 @@ func (s *StrictnessTestSuite) save() Machine {
 // error says which participant and which blob. The legacy path resolved it
 // happily, one effect short, and returned a sheet to persist in that state.
 func (s *StrictnessTestSuite) TestAnUnroutableConditionFailsTheResolution() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.sheet(heroID, unroutable)}},
 		Machine:      s.save(),
@@ -144,7 +144,7 @@ func (s *StrictnessTestSuite) TestAnUnroutableConditionFailsTheResolution() {
 // The control that makes the refusal mean something: the same sheet, the same
 // machine, a condition this build does know — and the resolution runs.
 func (s *StrictnessTestSuite) TestTheSameSheetWithAReadableConditionResolves() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.sheet(heroID, s.raging(heroID))}},
 		Machine:      s.save(),
@@ -165,7 +165,7 @@ func (s *StrictnessTestSuite) TestTheSameSheetWithAReadableConditionResolves() {
 func (s *StrictnessTestSuite) TestAFailedResolutionLeavesNothingOnTheBus() {
 	inner := events.NewEventBus()
 
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.sheet(heroID, s.raging(heroID))},
@@ -205,7 +205,7 @@ func (s *StrictnessTestSuite) TestAnUnroutableMonsterTraitFailsTheResolution() {
 		},
 	}
 
-	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -217,7 +217,7 @@ func (s *StrictnessTestSuite) TestAnUnroutableMonsterTraitFailsTheResolution() {
 	})
 	s.Require().NoError(err)
 
-	out, resolveErr := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, resolveErr := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: world.ToData(),
 		Participants: []Participant{
 			{Character: s.sheet(heroID)},
@@ -266,7 +266,7 @@ func (b *refusingBus) Publish(ctx context.Context, topic events.Topic, event any
 func (s *StrictnessTestSuite) TestAnAttachThatFailsFailsTheResolution() {
 	bus := &refusingBus{inner: events.NewEventBus(), failOn: 1}
 
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.sheet(heroID, s.raging(heroID))}},
 		Machine:      s.save(),

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -104,7 +104,7 @@ func (s *StrikeTestSuite) wolfBite() monster.ActionData {
 // hero; otherwise it stands three cells away — the two sides of prone's range
 // split.
 func (s *StrikeTestSuite) world(secondWolfAt spatial.Position) encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -194,7 +194,7 @@ func (s *StrikeTestSuite) strike(attacker string, roller *scriptedRoller) Machin
 func (s *StrikeTestSuite) resolve(
 	world encounter.EncounterData, hero *character.Data, machine Machine,
 ) (*Output, error) {
-	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Character: hero},
@@ -328,7 +328,7 @@ func (s *StrikeTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 		return &scriptedRoller{single: hitRoll, pair: []int{hitRoll, hitRoll}}
 	}
 
-	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Character: s.hero(s.raging())},
@@ -339,7 +339,7 @@ func (s *StrikeTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 	})
 	s.Require().NoError(err)
 
-	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Monster: s.wolf(secondWolfID)},
@@ -423,7 +423,7 @@ func (s *StrikeTestSuite) TestTheStrikeRunsInPieces() {
 // strikeMachine.afterDamage: the topic is an instruction to one listener and a
 // notification to another, which is slice 2's classification to make.
 func (s *StrikeTestSuite) TestAMonsterTargetTakesItsDamageOnce() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: s.world(spatial.Position{X: 5, Y: 4}),
 		Participants: []Participant{
 			{Character: s.hero()},
@@ -514,7 +514,7 @@ func (s *StrikeTestSuite) resolveWith(
 		second = secondWolf[0]
 	}
 
-	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Character: hero},
@@ -650,7 +650,7 @@ func (s *StrikeTestSuite) TestASkeletonSwingsItsShortsword() {
 	s.Require().NoError(err)
 	s.Require().Nil(attack.Gate, "a plain weapon declares no rider")
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -662,7 +662,7 @@ func (s *StrikeTestSuite) TestASkeletonSwingsItsShortsword() {
 	})
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		World: enc.ToData(),
 		Participants: []Participant{
 			{Character: s.hero()},

--- a/rulebooks/dnd5e/resolution/testrollers_test.go
+++ b/rulebooks/dnd5e/resolution/testrollers_test.go
@@ -14,3 +14,16 @@ type orderAsGiven struct{}
 func (orderAsGiven) RollInitiative(members []encounter.MemberID) ([]encounter.MemberID, error) {
 	return members, nil
 }
+
+// everyoneStanding is the deterministic Standing every fixture wires.
+//
+// The composition requires one to load at all (rpg-toolkit#1077), and this
+// package never consults it — it carries the caller's capability across a
+// round trip through the world. So the fixtures hand over the one answer that
+// changes nothing, and any test that came to depend on a different one would
+// be testing a question this package does not ask.
+type everyoneStanding struct{}
+
+func (everyoneStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberID, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Prerequisite for the death lane's last slice (#1079). Small, and found the only way it could have been found.

## The break it fixes

encounter v0.15.0 requires a `Standing` at both constructors (#1075 / PR #1077). This package calls `LoadEncounter` **itself** — `resolve.go:220` — so the moment a consumer's build graph contains encounter v0.15.0, resolution's own literal is validated against the new required field and every `Resolve` fails at the door:

```
attack: resolution: load world: load encounter: Standing is required: encounter: no standing capability
```

That is #1033's Initiative story one release later, and it fails the same way for the same structural reason: **nothing in this package loads a world that requires the capability**, so nothing here could notice. The downstream seam adopting the pin is where it surfaces. Now stated in `TestCapabilitiesAreSuppliedNeverDefaulted`'s doc rather than left as folklore.

## Carried, never consulted — and why that is the right shape

`Resolve` loads the world and reads exactly one thing back off it (`enc.ToData()`, line 271). No verb that refreshes sight runs in between, so **nothing here ever asks who is standing**. The consult belongs to the composition's own choke points, where sight already flows; keeping resolution out of that business is what the R-series laws are for, and this field does not change that.

So it is a capability handed **across** a round trip, treated exactly like `Deciders` and `Initiative` already are.

**The tempting alternative is refused deliberately.** Resolution could have defaulted a no-op "everybody is standing" and required nothing of its callers. That is precisely the silent capability default #1033 killed — a nil `Roller` quietly becoming real randomness, so a caller who forgot to wire dice got a result that passed every assertion and could not be reproduced — and the same class #1036 tracks in the machine inputs. A load that never consults a capability still may not invent its answer, least of all a package that holds no hit points and cannot. `Input.Standing` is REQUIRED, refused in `Validate`, with its own sentinel.

## API changes

| Change | Notes |
|---|---|
| `Input.Standing` | new **required** field |
| `ErrNoStanding` | new sentinel, beside `ErrNoInitiative` |
| encounter pin | v0.9.0 → **v0.15.0** |

## Evidence

**RED first, two stages**, both captured with `go build` at exit 0 so every failure is behavioural rather than a compile error. Full transcript in the branch's evidence file; the shape of it:

**Stage 1 — the break itself.** encounter pinned to v0.15.0 and the FIXTURE worlds supplied (`SetupInput` grew the same required field), nothing on resolution's own `Input`. **60 failing tests**, every one of them the same line:

```
resolution: load world: load encounter: Standing is required: encounter: no standing capability
```

**Stage 2 — declarations only.** The field, the sentinel, the `Validate` arm, every `Input` literal supplying it, and both new tests present. The ONE thing withheld is the pass-through into `LoadEncounter`, so what is left failing is exactly the line this PR adds. The validation half goes green while the world still cannot load:

```
--- PASS: TestCapabilitiesAreSuppliedNeverDefaulted/no_standing
--- FAIL: TestTheStandingCapabilityIsCarriedAndNeverAsked
    Received unexpected error:
    resolution: load world: load encounter: Standing is required: encounter: no standing capability
    Messages: the world loads, which it cannot do without the capability
    ... 69 subtests still failing
```

Order stated rather than overclaimed: the defect surfaced first in the **session** module — its suite green except every Attack-driven test — because that is the only place it can surface. The two stages above re-run that same failure isolated inside the module that owns the fix.

**GREEN.** `TestTheStandingCapabilityIsCarriedAndNeverAsked` then holds both halves at once, and they pull in opposite directions:

- **carried** — the world underneath refuses to load without one, so a `Resolve` that succeeds at all is proof the capability reached `LoadEncounter`. Dropping the pass-through is a mutant that fails **81** assertions across the suite.
- **never asked** — a counting capability records **zero** consults. That is the claim the field's doc makes, and it is the one that would rot silently: a later change that started consulting it would be this package answering a question about hit points.

| Check | Result |
|---|---|
| `go test -count=1 ./...` | **exit 0** |
| `golangci-lint run ./...` | **0 issues** |
| `gofmt -l .` / `go vet ./...` | clean |
| repo pre-commit hook | passed |

**The sanctioned fixture pass:** 60 construction sites across 8 test files, `Standing: everyoneStanding{}` beside every `Initiative: orderAsGiven{}`, then `gofmt`. One new fake, deliberately dumb — this package never consults the capability, so a fixture that answered anything interesting would be testing a question nobody asks.

**`gorelease -base v0.7.2`**, run **by hand**: `compat.yml` has no job for this module — it gates `play/{clock,intel,record,interrupt}`, `rulebooks/dnd5e/encounter` and `rulebooks/dnd5e/session` only — so there is no CI check to read this off.

```
## compatible changes
ErrNoStanding: added
Input.Standing: added

# summary
Suggested version: v0.8.0 (with tag rulebooks/dnd5e/resolution/v0.8.0)
```

Both changes reported *compatible*, and that is the tool's **blind spot** rather than a verdict: a newly-required struct field is not a type break, but every existing caller now gets `ErrNoStanding` from `Validate`. The `!` in the title is what carries the bump. The suggested version is the one wanted, for the wrong reason — the same note #1077 wrote about the same blind spot.

## Review round

One Copilot comment, and it was right about something older than this PR. `Input.Roller`'s doc still said *"Nil takes the default roller"* although `Validate` has returned `ErrNoRoller` since #1033 removed that default. It sat directly above the field this PR adds, so a reader arriving at `Standing` would have read the two neighbours as disagreeing about whether capabilities are optional here — the one thing this module is emphatic about. Fixed, with a line saying when it stopped being optional and why, so the correction is not silently re-litigated later.

## Sequencing

This must merge and tag before **#1082** (which closes #1079) can go green — that PR pins `resolution v0.8.0` and cannot resolve it until the tag exists. No other module is affected: `session` is the only consumer, and it is the one waiting.

— fix-1079 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
