### PR TITLE
feat(encounter): the killing blow notices its own kill (#1083)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -181,6 +181,11 @@ no `Pump` action, while staying on the map, in the roster, and recordable
 against. Answer only about the members you are asked about; a name that was not
 in the question is refused as a mis-wiring rather than ignored.
 
+`Record` asks too, after writing its own beat. It is the one verb whose beat can
+CHANGE who is standing, so the killing blow notices its own kill: the strike, the
+body, and the `ByDefeat` ending all land in that one call, in that order. Every
+other caller of the consult is a verb looking at a world something else changed.
+
 ## Contents
 
 | File | Holds |

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -43,7 +43,11 @@
 // It does NOT mean a verb's MUTATE phase is atomic. Join and Exit each perform
 // several fallible steps after their first mutation — refreshSight and
 // appendBeat both come after placement and member registration — so a failure
-// late in a verb can leave the in-memory encounter partially changed. The
+// late in a verb can leave the in-memory encounter partially changed. Record is
+// the same shape for the same reason: it consults Standing after appending its
+// outcome beat, because the beat is the cause the consult is reading (see
+// [Encounter.Record]), so a rulebook that cannot answer leaves an outcome
+// recorded and its consequences unworked. The
 // clock verbs are the same: Form moves members off the world clock one at a
 // time and Dissolve re-homes them one at a time, so a failure mid-verb can
 // leave a member between clocks — a state ClockOf reports as a defect rather

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -43,15 +43,18 @@
 // It does NOT mean a verb's MUTATE phase is atomic. Join and Exit each perform
 // several fallible steps after their first mutation — refreshSight and
 // appendBeat both come after placement and member registration — so a failure
-// late in a verb can leave the in-memory encounter partially changed. Record is
-// the same shape for the same reason: it consults Standing after appending its
-// outcome beat, because the beat is the cause the consult is reading (see
-// [Encounter.Record]), so a rulebook that cannot answer leaves an outcome
-// recorded and its consequences unworked. The
-// clock verbs are the same: Form moves members off the world clock one at a
+// late in a verb can leave the in-memory encounter partially changed.
+//
+// The clock verbs are the same: Form moves members off the world clock one at a
 // time and Dissolve re-homes them one at a time, so a failure mid-verb can
 // leave a member between clocks — a state ClockOf reports as a defect rather
 // than guessing (see its on-no-clock check).
+//
+// Record is the same shape for a reason worth naming, since the verb looks
+// atomic: it consults Standing AFTER appending its outcome beat, because that
+// beat is the cause the consult reads (see [Encounter.Record]). A rulebook that
+// cannot answer therefore leaves an outcome recorded and its consequences
+// unworked.
 //
 // That is safe because of how this module is used, not by accident: every
 // caller loads, acts, and saves, so a verb returning an error means the

--- a/rulebooks/dnd5e/encounter/killingblow_test.go
+++ b/rulebooks/dnd5e/encounter/killingblow_test.go
@@ -1,0 +1,436 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// killingblow_test.go is the death lane's coda (rpg-toolkit#1083): the swing
+// notices its own kill.
+//
+// D1 taught the world to notice who is down and D2 taught a fight to end when a
+// side runs out — both from the consult that hangs off a sight refresh. Record
+// does not refresh sight, so the one verb that WRITES the blow was the one verb
+// that could not see what it did: a party cleared the room, stood still, and was
+// in a fight with a corpse until somebody walked.
+//
+// The consult now runs in Record too, at the same one place noticing happens
+// (noticeDown). Nothing below asks for that, and nothing below mentions a hit
+// point — the rulebook is a fake driven by hand, exactly as D1 and D2 drive it.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type KillingBlowSuite struct {
+	deathScene
+}
+
+func TestKillingBlowSuite(t *testing.T) {
+	suite.Run(t, new(KillingBlowSuite))
+}
+
+// blow records one landed strike from alice at the goblin.
+//
+// The values are the ordinary ones a rulebook hands over. What they are does not
+// matter to a single assertion here — the composition never reads them, and the
+// death being noticed comes from the capability rather than from the amount.
+func (s *KillingBlowSuite) blow(enc *encounter.Encounter, target encounter.MemberID) (uint64, error) {
+	s.T().Helper()
+
+	out, err := enc.Record(&encounter.RecordInput{
+		Kind:    encounter.OutcomeStruck,
+		Actor:   alice,
+		Targets: []encounter.MemberID{target},
+		Values:  map[encounter.OutcomeValue]int{encounter.ValueAmount: 7},
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return out.Seq, nil
+}
+
+// apart is one room split by a solid wall, with alice and the goblin on opposite
+// sides of it and no fight anywhere.
+//
+// Free roam is the state the open scenes cannot be in: any co-located pair forms
+// a bubble at first light, so a wall is the only way to record an outcome
+// between two members who are not fighting.
+func (s *KillingBlowSuite) apart(standing encounter.Standing) *encounter.Encounter {
+	s.T().Helper()
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{},
+		Standing:   standing,
+		Retention:  encounter.RetentionUnbounded,
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: cryptID, Width: 12, Height: 12, Occluders: wallRow(6, 0, 11)},
+		}},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: cryptID, Position: spatial.Position{X: 2, Y: 2}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: cryptID, Position: spatial.Position{X: 2, Y: 10}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(encounter.ClockWorld, s.clockOf(enc, alice), "the wall keeps this scene quiet")
+
+	return enc
+}
+
+// countBeats reports how many of an audience's beats are of the given kind.
+func (s *KillingBlowSuite) countBeats(enc *encounter.Encounter, audience encounter.MemberID, kind string) int {
+	s.T().Helper()
+
+	n := 0
+	for _, k := range s.beatKindsOf(enc, audience) {
+		if k == kind {
+			n++
+		}
+	}
+
+	return n
+}
+
+// --- the swing notices ------------------------------------------------------
+
+// TestTheKillingBlowNoticesItsOwnKill is the coda, whole.
+//
+// The blow that drops the last monster is recorded, and the fight is over when
+// Record returns. Nobody walked, nobody ticked, nobody called Dissolve — the
+// party can stand perfectly still and the world still knows what they just did.
+func (s *KillingBlowSuite) TestTheKillingBlowNoticesItsOwnKill() {
+	down := &downList{}
+	enc := s.pair(down)
+	s.Require().Equal(encounter.ClockTurn, s.clockOf(enc, alice), "control: a fight is running")
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	s.Equal(encounter.ClockWorld, s.clockOf(enc, alice),
+		"the fight ended inside the verb that ended it")
+	s.Empty(enc.ToData().Bubbles, "a bubble exists only while a fight does")
+}
+
+// TestTheBeatOrderIsCauseThenEffect is the law this slice had to hold to be
+// allowed to exist: A VERB'S OWN BEAT PRECEDES ANY BEAT ITS CONSEQUENCES APPEND.
+//
+// The strike is the cause, the body is what it caused, and the ending is what
+// the body caused. All three land in one Record, in that order — which is the
+// whole gain over waiting for the next walk, where the strike and the death it
+// caused were separated by however long the party stood around.
+func (s *KillingBlowSuite) TestTheBeatOrderIsCauseThenEffect() {
+	down := &downList{}
+	enc := s.pair(down)
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	s.Equal([]string{"scene-opened", "bubble-formed", "struck", "down", "bubble-dissolved"},
+		s.beatKindsOf(enc, alice),
+		"the blow, then the body, then the ending the body explains")
+}
+
+// TestTheRecordedSeqIsTheOutcomeBeatNotTheLastOne pins which beat the caller is
+// told about, and the distinction now has teeth.
+//
+// Record appends up to three beats in a pass, and RecordOutput.Seq names ONE of
+// them: the outcome the caller handed over. A seam that echoed the last sequence
+// written would hand a client the ending's number and call it the strike's.
+func (s *KillingBlowSuite) TestTheRecordedSeqIsTheOutcomeBeatNotTheLastOne() {
+	down := &downList{}
+	enc := s.pair(down)
+
+	down.down = []encounter.MemberID{goblin}
+	seq, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: alice})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(story)
+
+	var named map[string]any
+	for i, entry := range story {
+		if entry.Seq == seq {
+			named = s.beatsOf(enc, alice)[i]
+		}
+	}
+	s.Require().NotNil(named, "the reported sequence is in the story")
+	s.Equal("struck", named["beat"], "and it is the beat the caller recorded")
+	s.Less(seq, story[len(story)-1].Seq, "with the consequences after it")
+}
+
+// TestASideStillStandingKeepsFighting is the rule's other half, and the one a
+// naive implementation gets wrong: the trigger is a SIDE being gone, not a body
+// being noticed. Drop one of two monsters and the fight goes on without it.
+func (s *KillingBlowSuite) TestASideStillStandingKeepsFighting() {
+	down := &downList{}
+	enc := s.trio(down)
+	s.Require().Equal([]encounter.MemberID{alice, goblin, wolf}, s.orderOf(enc, alice))
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	s.Equal(encounter.ClockTurn, s.clockOf(enc, alice), "the wolf is still standing")
+	s.Equal([]encounter.MemberID{alice, wolf}, s.orderOf(enc, alice),
+		"and the order closed over the body, mid-round")
+	s.Equal([]string{"scene-opened", "bubble-formed", "struck", "down", "transferred"},
+		s.beatKindsOf(enc, alice))
+}
+
+// --- what happens to the clock the recording swing was on -------------------
+
+// TestTheSpliceLeavesTheRoundWhereItWas pins the turn state a mid-round removal
+// leaves behind, DERIVED from the clock rather than assumed.
+//
+// A body leaving the order is the straggler's own machinery, and the round must
+// not restart because somebody fell — a fight where killing a monster rewound
+// the round would hand the party a free turn every time they landed a blow.
+func (s *KillingBlowSuite) TestTheSpliceLeavesTheRoundWhereItWas() {
+	down := &downList{}
+	enc := s.trio(down)
+
+	before, err := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
+	s.Require().NoError(err)
+	s.Require().Equal(alice, before.Active, "control: it is her turn")
+
+	down.down = []encounter.MemberID{goblin}
+	_, err = s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	after, err := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
+	s.Require().NoError(err)
+	s.Require().Equal([]encounter.MemberID{alice, wolf}, after.Order,
+		"control: the splice really happened, so what follows is about the splice")
+	s.Equal(before.Round, after.Round, "the round is where it was")
+	s.Equal(alice, after.Active, "and the turn is still hers")
+}
+
+// TestABodyRemovedOnItsOwnTurnLeavesSomebodyActive is the same removal at the
+// one moment it could strand a fight: the member being spliced is the member
+// whose turn it is.
+//
+// Whatever the answer is, it has to be SOMEBODY still in the order — a fight
+// whose active member is a body nobody can act for is a fight that cannot be
+// advanced, and EndTurn is the verb that would have to unstick it.
+func (s *KillingBlowSuite) TestABodyRemovedOnItsOwnTurnLeavesSomebodyActive() {
+	down := &downList{}
+	enc := s.trio(down)
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	before, err := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
+	s.Require().NoError(err)
+	s.Require().Equal(goblin, before.Active, "control: the goblin is up")
+
+	down.down = []encounter.MemberID{goblin}
+	_, err = s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	after, err := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal([]encounter.MemberID{alice, wolf}, after.Order)
+	s.Equal(wolf, after.Active,
+		"the turn passes to whoever stood behind the body, rather than rewinding to the top")
+	s.Equal(before.Round, after.Round, "and the round does not restart")
+
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: after.Active})
+	s.Require().NoError(err, "and the fight can still be advanced")
+}
+
+// TestTheEndingReHomesEverybodyTheFightHeld is the mid-turn dissolve seen from
+// the members' side. R6 says every member is on exactly one clock, and a fight
+// that ended inside a Record must not leave anybody between two.
+func (s *KillingBlowSuite) TestTheEndingReHomesEverybodyTheFightHeld() {
+	down := &downList{}
+	enc := s.pair(down)
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	for _, id := range []encounter.MemberID{alice, goblin} {
+		s.Equal(encounter.ClockWorld, s.clockOf(enc, id), "%q is home, not on no clock at all", id)
+	}
+
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().ErrorIs(err, encounter.ErrNoBubble, "there is no turn left to end")
+}
+
+// --- said once ---------------------------------------------------------------
+
+// TestTheSameDeathIsNotNarratedTwice is D1's story-ledger dedup holding across
+// the new call site, which is the thing that makes adding one SAFE.
+//
+// The consult now runs from two families of verb rather than one, so the same
+// body is asked about by the swing that made it and again by the next step
+// anybody takes. A client that heard about the death twice would render it
+// twice.
+func (s *KillingBlowSuite) TestTheSameDeathIsNotNarratedTwice() {
+	down := &downList{}
+	enc := s.pair(down)
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	// The fight is over, so the walk is hers — and the walk consults again.
+	_, err = enc.Move(&encounter.MoveInput{Member: alice, To: spatial.Position{X: 1, Y: 2}})
+	s.Require().NoError(err)
+
+	s.Equal(1, s.countBeats(enc, alice, "down"), "one body, told once")
+	s.Equal(1, s.countBeats(enc, alice, "bubble-dissolved"), "and one ending")
+}
+
+// TestRecordingAgainAfterTheDeathAddsOnlyTheOutcome is the same guard from the
+// caller's side: the killing blow stays recordable (ruled fork (a)), and a
+// second beat about a body already known does not re-narrate the death.
+func (s *KillingBlowSuite) TestRecordingAgainAfterTheDeathAddsOnlyTheOutcome() {
+	down := &downList{}
+	enc := s.pair(down)
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	_, err = s.blow(enc, goblin)
+	s.Require().NoError(err, "the killing blow is recordable against a body")
+
+	s.Equal([]string{"scene-opened", "bubble-formed", "struck", "down", "bubble-dissolved", "struck"},
+		s.beatKindsOf(enc, alice))
+}
+
+// --- and it invents nothing --------------------------------------------------
+
+// TestARecordWithNobodyDownAppendsOneBeat is the negative control every
+// assertion above leans on. The consult runs on EVERY Record, in a fight or out
+// of one, and a Record in a quiet world must look exactly as it did before this
+// slice.
+func (s *KillingBlowSuite) TestARecordWithNobodyDownAppendsOneBeat() {
+	enc := s.apart(&downList{})
+
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	s.Equal([]string{"scene-opened", "struck"}, s.beatKindsOf(enc, alice),
+		"one outcome in, one beat out")
+}
+
+// TestARecordOutsideAFightNoticesWithoutInventingAFight is the free-roam case,
+// which the new call site reaches for the first time: Record is legal against a
+// member who is in no bubble at all.
+//
+// The news is still news — a body is a body wherever it falls — but there is no
+// fight to end, no order to splice, and nothing here may invent either.
+func (s *KillingBlowSuite) TestARecordOutsideAFightNoticesWithoutInventingAFight() {
+	down := &downList{}
+	enc := s.apart(down)
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	s.Equal([]string{"scene-opened", "struck", "down"}, s.beatKindsOf(enc, alice),
+		"the body is news; the fight it was not in is not")
+	s.Equal(encounter.ClockWorld, s.clockOf(enc, goblin), "it was already home")
+}
+
+// TestRecordStillMovesNoClock is the half of "records and does nothing else"
+// that did NOT change, pinned because the doc around it did.
+//
+// A notice is not a tick. Every beat a Record writes carries the same clock
+// reading as the outcome that caused it, so a client reading the story sees one
+// moment rather than a fight aging by a beat every time somebody swings.
+func (s *KillingBlowSuite) TestRecordStillMovesNoClock() {
+	down := &downList{}
+	enc := s.pair(down)
+
+	down.down = []encounter.MemberID{goblin}
+	_, err := s.blow(enc, goblin)
+	s.Require().NoError(err)
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: alice})
+	s.Require().NoError(err)
+	s.Require().Len(story, 5)
+
+	at := story[2].At // the struck beat
+	for _, entry := range story[2:] {
+		s.Equal(at, entry.At, "beat at seq %d moved the clock", entry.Seq)
+	}
+}
+
+// --- the refusals both survive ----------------------------------------------
+
+// TestACallerStillCannotPushADownBeat is the refusal this slice was most likely
+// to erode, so it is re-pinned where the change is.
+//
+// Record now NOTICES a death, which is the composition asking the rulebook. That
+// is not the same thing as a caller declaring one, and the difference is the
+// whole reason OutcomeDown is refused: a caller who could push the beat would be
+// a second system deciding a fact the world already owns, and it would always
+// win, because it reaches the fact first.
+func (s *KillingBlowSuite) TestACallerStillCannotPushADownBeat() {
+	enc := s.pair(&downList{down: []encounter.MemberID{goblin}})
+
+	_, err := enc.Record(&encounter.RecordInput{Kind: encounter.OutcomeDown, Actor: alice})
+
+	s.Require().ErrorIs(err, encounter.ErrInvalidData,
+		"noticing a death is the composition asking; pushing one is still refused")
+}
+
+// TestTheRefusalsRunBeforeTheConsult keeps R5's promise where it is cheapest to
+// lose it: a verb rejected for its INPUT must not have asked the rulebook
+// anything, or a mis-typed kind would cost a repository read per member.
+func (s *KillingBlowSuite) TestTheRefusalsRunBeforeTheConsult() {
+	counted := &countingStanding{}
+	enc := s.pair(counted)
+	asked := counted.calls
+
+	_, err := enc.Record(&encounter.RecordInput{Kind: encounter.OutcomeStruck, Actor: "nobody"})
+	s.Require().ErrorIs(err, encounter.ErrNoMember)
+
+	s.Equal(asked, counted.calls, "a rejected verb asked nothing")
+}
+
+// --- the consult's own failures ---------------------------------------------
+
+// TestAStandingErrorAbortsTheRecording is the capability's contract reaching the
+// one verb that used never to consult it.
+//
+// A world that cannot find out who is standing does not half-act on a guess. The
+// error comes back and the caller's obligation is doc.go's — drop the encounter
+// unsaved — so nothing the consult would have done is in the world that gets
+// persisted.
+func (s *KillingBlowSuite) TestAStandingErrorAbortsTheRecording() {
+	rulebook := &brokenWhenTold{}
+	enc := s.pair(rulebook)
+
+	rulebook.broken = true
+	_, err := s.blow(enc, goblin)
+
+	s.Require().ErrorIs(err, errRulebookUnreachable)
+	s.Equal(encounter.ClockTurn, s.clockOf(enc, alice), "the fight is untouched")
+	s.Zero(s.countBeats(enc, alice, "down"), "and nothing was noticed on the way to the refusal")
+	s.Zero(s.countBeats(enc, alice, "bubble-dissolved"))
+}
+
+// TestAStrangerInTheAnswerAbortsTheRecording is the other half of the
+// capability's contract: an answer naming somebody who is not a member is a
+// rulebook defect, refused rather than ignored, and now refusable from Record.
+func (s *KillingBlowSuite) TestAStrangerInTheAnswerAbortsTheRecording() {
+	rulebook := &strangerWhenTold{}
+	enc := s.pair(rulebook)
+
+	rulebook.lying = true
+	_, err := s.blow(enc, goblin)
+
+	s.Require().ErrorIs(err, encounter.ErrNotMember)
+	s.Equal(encounter.ClockTurn, s.clockOf(enc, alice), "the fight is untouched")
+}

--- a/rulebooks/dnd5e/encounter/outcome.go
+++ b/rulebooks/dnd5e/encounter/outcome.go
@@ -42,6 +42,13 @@ const (
 	// thing, and the first one would always win because it reaches the fact
 	// first. Record's switch is therefore the CALLER-WRITABLE subset of this
 	// enum rather than all of it — pushing this kind gets ErrInvalidData.
+	//
+	// [Encounter.Record] performing that ask itself (rpg-toolkit#1083) SHARPENS
+	// this refusal rather than softening it. The verb a caller uses to report a
+	// blow is now the verb that finds out what the blow did — so a caller gets
+	// the down beat it wanted, in the same call, and still cannot write one. The
+	// beat says what the rulebook answered; it has never said what a caller
+	// claimed, and a kind here would be the only way to change that.
 	OutcomeDown OutcomeKind = "down"
 )
 
@@ -112,22 +119,72 @@ type RecordOutput struct {
 // (rpg-toolkit#966). One transcript is the product; a rule that resolves
 // somewhere else still has to land in it.
 //
-// It records and does NOTHING ELSE. No sight refresh, no trigger detection, no
-// clock movement — the beat is the whole effect. That is what makes the
-// ordering law hold for free: the rule at [Encounter.refreshSight] is that a
-// verb's own beat precedes any beat its consequences append, and an outcome IS
-// a consequence, of whatever the caller did to produce it. Its beat therefore
-// lands after that verb's, because the caller records it after, and nothing
-// here can reorder them.
-//
 // The audience is every current member, at the current clock reading — the
 // same convention the clock beats use. An outcome is not secret: a fight is
 // localized but visible, and a client that learned about a strike only from
 // the striker's own response could not render the scene the party is in.
 //
+// # It records, and then the world notices what it recorded
+//
+// This verb used to record and do NOTHING ELSE, and that sentence was worth the
+// emphasis it carried. Two thirds of it still hold exactly: no sight refresh, no
+// trigger detection, no clock movement. What it now also does is run the
+// standing consult — [Encounter.noticeDown], the one place noticing happens —
+// after its own beat.
+//
+// THE REASON IS THE ONE THING THAT MAKES THIS VERB DIFFERENT from the others
+// that reach that consult. A walk cannot change who is standing; a recorded
+// outcome can, because the blow this beat describes is the blow that took
+// somebody to zero. Every other consult site is a verb LOOKING at a world
+// somebody else changed. This one is the change. Leaving it out meant a killing
+// blow landed, persisted, and left the world not knowing — no down beat, no
+// [ByDefeat] ending, the turn order still holding a body — until whatever verb
+// next happened to refresh sight. A party that cleared the room and stood still
+// was in a fight with a corpse (rpg-toolkit#1083).
+//
+// NOTICING IS NOT "SOMETHING ELSE", and that is an argument rather than an
+// exception carved for convenience. It is the same consult, at the same choke
+// point, under the same discipline: the composition ASKS and the rulebook
+// answers (C1), the answer is pulled and never remembered, and the story is the
+// ledger that keeps the news from being told twice. Record is not growing a
+// second mechanism for death — it is joining the list of verbs that reach the
+// first one, which is exactly what "one place" is for. The alternative on offer
+// was a caller pushing the beat in, and that is a different thing entirely: see
+// [OutcomeDown], which is still refused, for why.
+//
+// # The order in one pass
+//
+// The recorded outcome lands FIRST, then whatever the consult makes of it: the
+// strike, then the body, then the ending the body explains. That is
+// [Encounter.refreshSight]'s law — a verb's own beat precedes any beat its
+// consequences append — held inside one verb, the same way
+// [Encounter.noticeDown] holds it inside one pass. The caller's beat is still
+// the cause. What is new is that its effects can arrive in the same breath
+// instead of at whatever ran next.
+//
+// [RecordOutput.Seq] is therefore the OUTCOME beat and never the last one
+// written. A caller asked for one thing to be recorded and is told where that
+// thing landed.
+//
+// The consult runs for EVERY kind rather than only for [OutcomeStruck]. Which
+// outcomes can drop somebody is a rulebook fact and this module cannot import
+// the rulebook (C1) — a Record that decided for itself which of its beats were
+// worth looking after would be encoding that rule, and would miss the first
+// route to zero nobody has written yet.
+//
+// # On error
+//
 // Errors: ErrNilInput, ErrClosed, ErrNoMember (empty or unknown actor, unknown
 // target), ErrInvalidData (a kind or value name this composition does not
-// know).
+// know), and anything the [Standing] capability answers with — including
+// ErrNotMember for an answer naming a stranger.
+//
+// The input refusals all run before anything is appended, so a rejected input
+// costs the rulebook nothing. The consult does not: it runs after the beat, so a
+// Record that fails there leaves the in-memory encounter holding an outcome
+// whose consequences were never worked out. That is R5's documented limit rather
+// than a hole in it, and the caller's obligation is doc.go's whole answer to it
+// — drop the encounter unsaved.
 func (e *Encounter) Record(in *RecordInput) (*RecordOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("record: %w", ErrNilInput)
@@ -205,6 +262,13 @@ func (e *Encounter) Record(in *RecordInput) (*RecordOutput, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("record: %w", err)
+	}
+
+	// And now the world finds out what that beat just changed. AFTER the append,
+	// never before: the outcome is the cause, and a down beat ahead of the strike
+	// that explains it would be a story told backwards. See the godoc.
+	if _, nerr := e.noticeDown(); nerr != nil {
+		return nil, fmt.Errorf("record: %w", nerr)
 	}
 
 	return &RecordOutput{Seq: appended.Seq}, nil

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -183,11 +183,17 @@ func (s *OutcomeTestSuite) TestRefusalsAreCheckedAgainstTheRoster() {
 // cause-before-effect law (see refreshSight).
 //
 // An outcome is a CONSEQUENCE — of a walk, an arrival, whatever produced it —
-// so it lands after that verb's own beat. Record holds that for free by doing
-// nothing but record: no sight refresh, no trigger detection, no clock
-// movement, so there is nothing it could append first and nothing it could
-// reorder. This pins both halves: the order, and the "nothing else" that makes
-// the order structural rather than a habit.
+// so it lands after that verb's own beat. Record holds that by appending its own
+// beat FIRST and refreshing no sight, detecting no trigger and moving no clock,
+// so there is nothing it could append ahead of the outcome and nothing it could
+// reorder.
+//
+// Nobody is down in this scene, so the standing consult Record now runs
+// (rpg-toolkit#1083) finds nothing to say and the beat list is the same list it
+// always was. That is the point of leaving this pin exactly as it was written:
+// the news a consult has none of must cost the story nothing. killingblow_test.go
+// owns the scene where there IS news, and pins that it lands after the outcome
+// rather than before it.
 func (s *OutcomeTestSuite) TestTheOutcomeLandsAfterTheVerbThatCausedIt() {
 	enc := s.scene()
 

--- a/rulebooks/dnd5e/encounter/standing.go
+++ b/rulebooks/dnd5e/encounter/standing.go
@@ -125,6 +125,14 @@ func (e *Encounter) standingNow() (map[MemberID]bool, error) {
 // light, which calls applyTrigger directly so its scene-opened beat can land
 // first. A scene can open with a body already on the floor.
 //
+// [Encounter.Record] reaches this function DIRECTLY rather than through
+// applyTrigger, and the difference is the point (rpg-toolkit#1083). Record
+// refreshes no sight, so it has no deltas to classify and no fight to start —
+// what it has is a beat that may have just changed the answer this function
+// pulls. Every other caller looks at a world something else changed; that one is
+// the change. Calling applyTrigger from it would mean synthesising an empty
+// delta map to satisfy a classification nobody asked for.
+//
 // # The order inside one pass
 //
 // Two passes over the fallen, sorted: ALL the news, then everything the news

--- a/rulebooks/dnd5e/encounter/standing_test.go
+++ b/rulebooks/dnd5e/encounter/standing_test.go
@@ -518,8 +518,14 @@ func (s *StandingSuite) TestACorpseIsStillOnTheMapAndInTheRoster() {
 // TestNobodyCanPushADownBeatIn is the census's rejected shape, refused
 // structurally. Down arrives by the composition ASKING, at the choke point
 // where it already asks about sight; a caller that could push the beat in would
-// be a second system deciding the same thing, and Record's own doc is that it
-// records and does nothing else.
+// be a second system deciding the same thing, and the first one would always
+// win, because it reaches the fact first.
+//
+// Record itself now performs that ask (rpg-toolkit#1083), which is why the
+// refusal is worth re-reading rather than assuming: a caller gets the down beat
+// it would have pushed, in the same call it recorded the blow, and still cannot
+// write one. The beat says what the rulebook answered. It has never said what a
+// caller claimed.
 func (s *StandingSuite) TestNobodyCanPushADownBeatIn() {
 	enc := s.pair(&downList{})
 

--- a/rulebooks/dnd5e/encounter/teststanding_test.go
+++ b/rulebooks/dnd5e/encounter/teststanding_test.go
@@ -3,7 +3,11 @@
 
 package encounter_test
 
-import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+import (
+	"errors"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
 
 // everyoneStanding is the Standing capability these tests install by default.
 //
@@ -59,6 +63,36 @@ func (s *strangerWhenTold) Standing([]encounter.MemberID) ([]encounter.MemberID,
 	if s.lying {
 		return []encounter.MemberID{"a-ghost"}, nil
 	}
+
+	return nil, nil
+}
+
+// errRulebookUnreachable is what a rulebook that cannot answer looks like from
+// the composition's side — a store that is down rather than a member at zero.
+var errRulebookUnreachable = errors.New("the rulebook cannot say who is standing")
+
+// brokenWhenTold is a rulebook that starts well-behaved and then stops
+// answering, so the R5 arm can be driven from a scene that was already running.
+type brokenWhenTold struct {
+	broken bool
+}
+
+func (b *brokenWhenTold) Standing([]encounter.MemberID) ([]encounter.MemberID, error) {
+	if b.broken {
+		return nil, errRulebookUnreachable
+	}
+
+	return nil, nil
+}
+
+// countingStanding is everyoneStanding that remembers being asked, which is how
+// a test tells "the consult did not fire" from "the consult found nobody".
+type countingStanding struct {
+	calls int
+}
+
+func (c *countingStanding) Standing([]encounter.MemberID) ([]encounter.MemberID, error) {
+	c.calls++
 
 	return nil, nil
 }


### PR DESCRIPTION
The death lane's coda (#1083, tracker #959). D1 taught the world to notice who is down; D2 taught a fight to end when a side runs out. Both hang off the standing consult, which every sight-refreshing verb reaches and `Record` did not — so the one verb that WRITES the blow was the one verb that could not see what it did.

A killing blow landed, persisted, and left the world not knowing: no down beat, no `ByDefeat` ending, the turn order still holding a body, until somebody happened to walk. **A party that cleared the room and stood still was in a fight with a corpse.**

## The change

Six lines of code. `Record` calls `noticeDown` after appending its own beat:

```go
	// And now the world finds out what that beat just changed. AFTER the append,
	// never before: the outcome is the cause, and a down beat ahead of the strike
	// that explains it would be a story told backwards.
	if _, nerr := e.noticeDown(); nerr != nil {
		return nil, fmt.Errorf("record: %w", nerr)
	}
```

Directly rather than through `applyTrigger`, and that is the point: `Record` refreshes no sight, so it has no deltas to classify and no fight to start. Reaching `applyTrigger` would mean synthesising an empty delta map to satisfy a classification nobody asked for. `noticeDown` already contains D1's story-ledger dedup and D2's decided-check-before-splice, so both arrive unchanged.

Beat order falls out of the placement: **struck → down → bubble-dissolved**, all in one call.

## The doc tension, argued rather than footnoted

`Record`'s godoc said it "records and does NOTHING ELSE" — the sentence that rejected push-via-Record and that `OutcomeDown`'s refusal leans on. That sentence has been rewritten, not deleted, and the argument is in the source:

- **Two thirds of it still hold exactly.** No sight refresh, no trigger detection, no clock movement. Pinned by `TestRecordStillMovesNoClock` (every beat a Record writes carries the same clock reading) and by `TestARecordWithNobodyDownAppendsOneBeat`.
- **Noticing is not "something else."** It is the same consult, at the same choke point, under the same discipline: the composition ASKS and the rulebook answers (C1), the answer is pulled and never remembered, the story is the ledger that keeps news from repeating. `Record` is not growing a second mechanism for death — it is joining the list of verbs that reach the first one, which is what "one place" is for.
- **What makes this verb different is why it had to change.** A walk cannot change who is standing. A recorded outcome can: the blow this beat describes is the blow that took somebody to zero. Every other consult site is a verb LOOKING at a world something else changed. This one is the change.
- **Both refusals survive unchanged.** `OutcomeDown` is still `ErrInvalidData` from a caller (`TestACallerStillCannotPushADownBeat`), and its own doc gains the sharpened reading: a caller now GETS the down beat it would have pushed, in the same call it recorded the blow, and still cannot write one. The beat says what the rulebook answered; it has never said what a caller claimed.

`doc.go`'s R5 paragraph gains `Record` to the list of verbs with fallible steps after their first mutation (alongside Join, Exit, Form, Dissolve) — the consult runs after the beat, so a rulebook that cannot answer leaves an outcome recorded and its consequences unworked, and the caller's obligation is the one doc.go already states: drop the encounter unsaved.

## Tests — 16 new, `killingblow_test.go`

RED first: **12 of the 16 failed against `main`**; the four that did not are the negative controls and refusals that must not move (`…AppendsOneBeat`, `…StillCannotPushADownBeat`, `…RefusalsRunBeforeTheConsult`, `…SpliceLeavesTheRoundWhereItWas`, the last of which gained a `Require` on the spliced order so it can no longer pass by the consult not firing).

The swing notices:
- `TestTheKillingBlowNoticesItsOwnKill` — the fight is over when `Record` returns; nobody walked, nobody ticked, nobody called `Dissolve`.
- `TestTheBeatOrderIsCauseThenEffect` — `scene-opened, bubble-formed, struck, down, bubble-dissolved`.
- `TestTheRecordedSeqIsTheOutcomeBeatNotTheLastOne` — `RecordOutput.Seq` names the caller's beat, derived from the story, with the consequences after it.
- `TestASideStillStandingKeepsFighting` — one of two monsters down: splice, no dissolve, `ClockTurn` intact.

The clock the recording swing was on:
- `TestTheSpliceLeavesTheRoundWhereItWas` — the round does not restart and the turn stays with the actor.
- `TestABodyRemovedOnItsOwnTurnLeavesSomebodyActive` — the body falls on ITS OWN turn: the turn passes to whoever stood behind it (`wolf`), the round holds, and `EndTurn` still advances the fight.
- `TestTheEndingReHomesEverybodyTheFightHeld` — R6 after a mid-turn dissolve: everyone on the world clock, nobody between two, and `EndTurn` answers `ErrNoBubble`.

Said once, and inventing nothing:
- `TestTheSameDeathIsNotNarratedTwice` — Record-notice then Move-notice: one down beat, one ending.
- `TestRecordingAgainAfterTheDeathAddsOnlyTheOutcome` — the killing blow stays recordable (fork (a)) and adds only its own beat.
- `TestARecordOutsideAFightNoticesWithoutInventingAFight` — free-roam Record (a member in no bubble at all, reachable for the first time from this call site): the body is news, the fight it was not in is not.

The consult's own failures, reaching `Record` for the first time:
- `TestAStandingErrorAbortsTheRecording` — R5's arm; the fight is untouched and nothing was noticed on the way to the refusal.
- `TestAStrangerInTheAnswerAbortsTheRecording` — `ErrNotMember` through `Record`.
- `TestTheRefusalsRunBeforeTheConsult` — a rejected INPUT asks the rulebook nothing (a counting capability), so a mis-typed kind costs no repository reads.

`outcome_test.go`'s `TestTheOutcomeLandsAfterTheVerbThatCausedIt` is left asserting exactly what it always asserted, with its comment corrected: nobody is down in that scene, so a consult with no news costs the story nothing.

## Evidence

```
$ go test -count=1 ./...
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter/cmd/freeroam-workbench

$ gofmt -l . && go vet ./...        # clean
$ golangci-lint run ./...           # 0 issues
$ gorelease -base v0.15.0
Suggested version: v0.15.1
```

**gorelease says v0.15.1 because the exported API surface does not move** — no signature, no input, no constructor changes. The title is `feat(encounter):` anyway, which mints **v0.16.0**: the observable behavior of a verb changed, and a consumer needs to know. No `!` — this is D2's shape exactly (#1080 added a self-dissolve at an existing consult site and was a plain `feat`), and here the consult reaches one more site.

## Follow-on

The session side is #1083's other half and lands in a separate PR against this module's new tag. One finding worth flagging early: `resolution` does not mutate the sheets handed to it (`dirtyMonsters` returns a fresh `*monster.Data`), so at session `Attack`'s current `Record` call site the standing seam still reads PRE-swing hit points. That PR moves `saveDirty` above `Record` — the sheets are the truth, so they have to be written before the composition is asked.

— fix-1083 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
