### PR TITLE
feat(session): the swing notices its own kill (#1083)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -86,13 +86,30 @@ type AttackOutput struct {
 // the one place it will go — see the comment at the resolution call below —
 // and pinned by TestNothingSpendsYet so it cannot be mistaken for a decision.
 //
-// # How it runs
+// # How it runs, and why the order is not a style choice
 //
 // The world goes into resolution as data and a different world comes back, so
 // the scope adopts the returned one before anything else touches it
-// ([Manager.adopt] carries that invariant). The outcome is then recorded on the
-// world the interaction produced — a consequence lands after its cause — and
-// every dirty sheet is written back.
+// ([Manager.adopt] carries that invariant). Every dirty sheet is then written
+// back, and only THEN is the outcome recorded on the world the interaction
+// produced — a consequence landing after its cause.
+//
+// THE SHEETS GO FIRST, and that is the whole of this seam's half of
+// rpg-toolkit#1083. The composition's Record now consults who is standing, which
+// it does by asking [standingSeam] — and that seam answers out of the two stores
+// this verb writes: the session record for NPCs, the host's repository for
+// characters. Neither is current until [Manager.saveDirty] has run.
+// [resolution] does not mutate what it is handed (its dirtyMonsters builds a
+// fresh sheet), so recording first would ask the world about PRE-SWING hit
+// points and the killing blow would be invisible to its own beat — which is the
+// exact defect #1083 exists to close, reproduced one layer up.
+//
+// The cost is stated rather than hidden: a Record that fails now fails with the
+// damage already durable. That is rpg-toolkit#1056's shape, so it is answered
+// the way #1056 was — the refusal carries a [SaveError] naming the sheets that
+// landed and the world that did not, and TestASwingThatCannotRecordStillNamesTheSheetItWrote
+// is what keeps that true. A caller told only "it failed" would retry a swing
+// whose damage is on disk.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
 // ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrNoSheet, ErrNoCharacter,
@@ -207,13 +224,15 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		return nil, fmt.Errorf("attack: %w", err)
 	}
 
-	recorded, err := scope.enc.Record(recordFor(in, struck))
-	if err != nil {
-		return nil, fmt.Errorf("attack: %w", translate(err))
-	}
-
 	if err := m.saveDirty(ctx, scope, out); err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
+	}
+
+	// And now the beat, on a world whose sheets say what the swing did — see the
+	// godoc for why this is not the other way round.
+	recorded, err := scope.enc.Record(recordFor(in, struck))
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", reportUnrecorded(scope, translate(err)))
 	}
 
 	report, delivery, err := m.commit(ctx, scope)
@@ -232,6 +251,38 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		Saved:    report,
 		Delivery: delivery,
 	}, nil
+}
+
+// reportUnrecorded turns a failure AFTER the sheets landed into one a caller can
+// repair from, and leaves every other failure exactly as it was.
+//
+// This is rpg-toolkit#1056's rule reaching one more call site. Recording is the
+// last fallible step before the commit, and since the sheets are now written
+// ahead of it (see [Manager.Attack]), a bare error would say "nothing happened"
+// about a swing whose damage is durable. The host reads that as safe to retry,
+// retries, and applies the damage twice.
+//
+// The world is named as FAILED because that is what a caller has to act on: the
+// sheets describe a blow the persisted world has no beat for. It was never
+// attempted rather than attempted and refused, and the repair is the same either
+// way — which is why it is reported the same way persist reports its own
+// world-save failure rather than given a vocabulary of its own.
+//
+// Nothing written means nothing to report, and the plain error is the better
+// answer: a report of an empty ledger is noise, and wrapping would hand a host
+// ErrSaveFailed for a verb that saved nothing.
+func reportUnrecorded(scope *writeScope, err error) error {
+	if len(scope.written) == 0 {
+		return err
+	}
+
+	return &SaveError{
+		Report: SaveReport{
+			Written: append([]string(nil), scope.written...),
+			Failed:  []string{"encounter:" + scope.encounter},
+		},
+		Err: err,
+	}
 }
 
 // translateResolution maps the resolution module's sentinels onto this
@@ -384,6 +435,12 @@ func (m *Manager) castFor(
 // they are folded into it and the record is marked touched. This is the first
 // verb in the package that writes a character at all — damage has to persist —
 // and the no-clobber pin gained a row for it rather than losing its guard.
+//
+// IT RUNS BEFORE THE OUTCOME IS RECORDED, and that is a correctness ordering
+// rather than a convenience: the composition's Record consults who is standing,
+// [standingSeam] answers out of exactly these two stores, and a consult run
+// against sheets this verb has not written back yet is a consult about a world
+// that no longer exists. See [Manager.Attack].
 func (m *Manager) saveDirty(ctx context.Context, scope *writeScope, out *resolution.Output) error {
 	// The report names what LANDED as well as what did not (S6). A sheet
 	// written before the failure is durable, and a caller told only about the

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -52,10 +52,10 @@ func TestDeathSuite(t *testing.T) { suite.Run(t, new(DeathTestSuite)) }
 // each side of it.
 //
 // The wall is the fixture's whole reason for existing. Bob has to be able to
-// take an ordinary step WITHOUT joining the fight on the other side — his walk
-// is what refreshes sight, and a refresh is the only thing that notices a body
-// (see TestTheSwingIsNotWhatNotices). A gap anywhere in the column and he sees
-// the skeleton, contact forms, and the scene stops being the one under test.
+// take an ordinary step WITHOUT joining the fight on the other side, so the
+// scenes that ask what a SECOND player's walk does can ask it. A gap anywhere in
+// the column and he sees the skeleton, contact forms, and the scene stops being
+// the one under test.
 //
 // Unbounded retention because the story is the ledger the composition reads
 // back to decide whether a death is news (rpg-toolkit#1077). A window that
@@ -174,8 +174,12 @@ func (s *DeathTestSuite) payloadOf(event session.Event) map[string]any {
 	return beat
 }
 
-// dropTheSkeleton is the scene up to the moment of death, with nobody having
-// looked yet.
+// dropTheSkeleton swings until the skeleton is at zero, and is the whole scene.
+//
+// It used to be "the scene up to the moment of death, with nobody having looked
+// yet", and the change of description is the change of behavior: the killing
+// blow is now the moment the world looks (rpg-toolkit#1083). Nothing after this
+// helper has to walk, tick, or ask.
 func (s *DeathTestSuite) dropTheSkeleton() {
 	s.startCrypt()
 	s.spawnSkeleton()
@@ -186,46 +190,46 @@ func (s *DeathTestSuite) dropTheSkeleton() {
 	s.Require().Zero(s.storedHP("skeleton"), "the blows really landed on the stored sheet")
 }
 
-// TestTheSwingIsNotWhatNotices is the honest shape of this slice, pinned first
-// because it is the part that surprises.
+// TestTheSwingNoticesItsOwnKill is this suite's opening pin, FLIPPED.
 //
-// The skeleton is at zero and NOTHING has said so. Recording an outcome is not
-// a sight refresh — the composition consults who is standing from refreshSight,
-// which Move, Traverse, Join, Exit and Pump reach and Record does not — so a
-// killing blow lands, persists, and leaves the world not yet knowing.
+// It used to say the opposite and said so by name: recording an outcome was not
+// a sight refresh, so a killing blow landed, persisted, and left the world not
+// knowing — no downed event, no ending, the turn order still holding a body —
+// until somebody walked. A party that cleared the room and stood still was in a
+// fight with a corpse.
 //
-// It is pinned rather than hidden because the fix is not here: it would be a
-// consult inside the composition's own Record, which is a change to a module
-// this slice only consumes. What this seam owes is that the news arrives the
-// moment anything looks, which is the next test.
-func (s *DeathTestSuite) TestTheSwingIsNotWhatNotices() {
+// rpg-toolkit#1083 put the standing consult inside the composition's own Record,
+// and this seam moved to meet it: the sheets the swing changed are written back
+// BEFORE the outcome is recorded, because the capability answering the
+// composition's question reads those sheets (see Manager.Attack).
+//
+// So the whole scene is one verb. Nobody walks, nobody ticks, nobody asks.
+func (s *DeathTestSuite) TestTheSwingNoticesItsOwnKill() {
 	s.dropTheSkeleton()
 
-	s.Empty(s.eventsOfKind(session.EventDowned),
-		"the blow is recorded; nobody has noticed it yet")
-	s.Empty(s.eventsOfKind(session.EventFightEnded),
-		"and a fight nobody has looked at has not ended")
+	s.NotEmpty(s.eventsOfKind(session.EventDowned),
+		"the blow is recorded, and the same call notices what the blow did")
+	s.NotEmpty(s.eventsOfKind(session.EventFightEnded),
+		"and the fight it ended is over")
 
 	turn, err := s.mgr.Turn(context.Background(), &session.TurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
-	s.Equal(session.ClockTurn, turn.Clock, "alice is still in a fight with a downed skeleton")
+	s.Equal(session.ClockWorld, turn.Clock,
+		"alice is free-roaming, and the party never had to move to find out")
 }
 
-// TestTheNextSightRefreshSaysDowned is the headline: the world looks, and the
-// stream carries the death.
+// TestEveryMemberHearsTheDeath is the headline: the stream carries the death, on
+// the swing that caused it.
 //
-// Bob is behind a solid wall and takes one step for reasons of his own. That is
-// enough — the consult is not scoped to whoever moved, so a member downed
-// anywhere on the map is noticed by anybody's refresh.
+// The audience is not scoped to whoever swung — a member downed anywhere on the
+// map is news to everybody, including bob, who is behind a solid wall and did
+// nothing at all.
 //
 // The event kind is EventDowned while the beat inside it still says "down":
 // that asymmetry is the ruling, and asserting both here is what would notice if
 // either half drifted.
-func (s *DeathTestSuite) TestTheNextSightRefreshSaysDowned() {
+func (s *DeathTestSuite) TestEveryMemberHearsTheDeath() {
 	s.dropTheSkeleton()
-	s.stream.published = nil
-
-	s.bobSteps()
 
 	down := s.eventsOfKind(session.EventDowned)
 	s.Require().Len(down, 3, "every member hears it: alice, bob, and the skeleton's own audience")
@@ -240,16 +244,27 @@ func (s *DeathTestSuite) TestTheNextSightRefreshSaysDowned() {
 	s.Equal(map[string]bool{"alice": true, "bob": true, "skeleton": true}, heard)
 }
 
-// TestTheLastOneDownedEndsTheFightByDefeat is the slice's own sentence.
+// TestTheDeathIsNotAnnouncedTwice is the story-ledger dedup surviving the trip
+// to a client, which is the thing that makes a second consult site SAFE.
 //
-// Nobody called Dissolve. The only verb in this scene is bob's step, and the
-// ending is delivered by that step's own fan-out — which is what the reset
-// before it makes assertable rather than merely true.
-func (s *DeathTestSuite) TestTheLastOneDownedEndsTheFightByDefeat() {
+// The swing notices, and then bob takes an ordinary step that consults again. A
+// table that heard the skeleton fall twice would render it twice.
+func (s *DeathTestSuite) TestTheDeathIsNotAnnouncedTwice() {
 	s.dropTheSkeleton()
-	s.stream.published = nil
+	s.Require().Len(s.eventsOfKind(session.EventDowned), 3)
 
 	s.bobSteps()
+
+	s.Len(s.eventsOfKind(session.EventDowned), 3, "one body, announced once")
+	s.Len(s.eventsOfKind(session.EventFightEnded), 3, "and one ending")
+}
+
+// TestTheLastOneDownedEndsTheFightByDefeat is the slice's own sentence.
+//
+// Nobody called Dissolve, and nobody walked either. The only verb in this scene
+// is alice's swing, and the ending rides out on that swing's own fan-out.
+func (s *DeathTestSuite) TestTheLastOneDownedEndsTheFightByDefeat() {
+	s.dropTheSkeleton()
 
 	ended := s.eventsOfKind(session.EventFightEnded)
 	s.Require().NotEmpty(ended, "the last one down ends the fight")
@@ -265,6 +280,33 @@ func (s *DeathTestSuite) TestTheLastOneDownedEndsTheFightByDefeat() {
 	s.Equal(session.ClockWorld, turn.Clock, "alice is free-roaming again, and nobody asked for that")
 }
 
+// TestTheBeatOrderReachesTheClientAsCauseThenEffect is the composition's
+// ordering law arriving where a table actually reads it.
+//
+// The strike, the body, the ending — in that order, in one response's worth of
+// events. A client renders in sequence order, so an ending delivered ahead of
+// the death that caused it would narrate the fight as won before anybody fell.
+func (s *DeathTestSuite) TestTheBeatOrderReachesTheClientAsCauseThenEffect() {
+	s.dropTheSkeleton()
+
+	var kinds []session.EventKind
+	for _, event := range s.stream.published {
+		if event.Recipient != "alice" {
+			continue
+		}
+		switch event.Kind {
+		case session.EventStruck, session.EventDowned, session.EventFightEnded:
+			kinds = append(kinds, event.Kind)
+		default:
+		}
+	}
+
+	s.Require().GreaterOrEqual(len(kinds), 3)
+	s.Equal([]session.EventKind{session.EventDowned, session.EventFightEnded}, kinds[len(kinds)-2:],
+		"the last strike, then the body, then the ending the body explains")
+	s.Equal(session.EventStruck, kinds[len(kinds)-3])
+}
+
 // TestTheEncounterOutlivesTheFight is ruled fork (c) surviving the seam, and
 // ruled fork (a) with it.
 //
@@ -274,7 +316,6 @@ func (s *DeathTestSuite) TestTheLastOneDownedEndsTheFightByDefeat() {
 // answerable by Where, and walkable past.
 func (s *DeathTestSuite) TestTheEncounterOutlivesTheFight() {
 	s.dropTheSkeleton()
-	s.bobSteps()
 
 	ctx := context.Background()
 
@@ -290,19 +331,27 @@ func (s *DeathTestSuite) TestTheEncounterOutlivesTheFight() {
 
 // TestTheSurvivorWalksAgain is the consequence a player actually feels.
 //
-// Alice was refused every free-roam verb with ErrInBubble while the fight ran
-// (rpg-toolkit#1024). The fight is over, so the walk is hers again — and this
-// is the assertion that would fail if the ending were narrated without
-// actually re-homing anyone.
+// Alice is refused every free-roam verb with ErrInBubble while the fight runs
+// (rpg-toolkit#1024). Her own killing blow ends it, so the walk is hers on the
+// very next call — and this is the assertion that would fail if the ending were
+// narrated without actually re-homing anyone.
+//
+// The control moved. It used to sit AFTER the killing blow, because the fight
+// outlived it; it now has to sit before, which is the whole change stated as a
+// scene rather than as a claim.
 func (s *DeathTestSuite) TestTheSurvivorWalksAgain() {
-	s.dropTheSkeleton()
+	s.startCrypt()
+	s.spawnSkeleton()
 
 	_, blocked := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
 	})
-	s.Require().ErrorIs(blocked, session.ErrInBubble, "the world has not looked yet")
+	s.Require().ErrorIs(blocked, session.ErrInBubble, "control: mid-fight, she is not free to walk")
 
-	s.bobSteps()
+	for i := 0; i < 3 && s.storedHP("skeleton") > 0; i++ {
+		s.aliceSwings()
+	}
+	s.Require().Zero(s.storedHP("skeleton"))
 
 	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
@@ -312,14 +361,15 @@ func (s *DeathTestSuite) TestTheSurvivorWalksAgain() {
 
 // TestNothingReachesAClientUnnamed is the whole scene's guard rail.
 //
-// Two new beats arrive on this path — the death and the ending — and either one
-// reaching a client as EventUnknown would leave a table unable to narrate the
-// moment the fight was won.
+// Three beats now leave one Attack — the strike, the death, and the ending — and
+// any of them reaching a client as EventUnknown would leave a table unable to
+// narrate the moment the fight was won.
+//
+// It is also the answer to the question rpg-toolkit#1083 asked of this seam:
+// whether the new call site needs new vocabulary. It does not. The beats are the
+// same kinds kindOf already names; only the verb they arrive on changed.
 func (s *DeathTestSuite) TestNothingReachesAClientUnnamed() {
 	s.dropTheSkeleton()
-	s.stream.published = nil
-
-	s.bobSteps()
 
 	s.Require().NotEmpty(s.stream.published)
 	for _, event := range s.stream.published {
@@ -347,6 +397,97 @@ func (s *DeathTestSuite) duelAtZero() {
 		s.Require().NoError(err)
 	}
 	s.Require().Zero(s.characters.byID["alice"].HitPoints, "alice is down")
+}
+
+// TestTheKillingBlowNoticesACHARACTERToo is the other store's half of the same
+// ordering, and it is the half that could rot silently.
+//
+// The seam answers about monsters out of the session record — aliased, so a
+// sheet this verb folded in is what the next consult reads — and about players
+// out of the HOST'S REPOSITORY, which is only current once SaveCharacter has run.
+// A version of Attack that folded the NPC sheets early and left the character
+// write where it was would pass every skeleton scene above and fail here.
+//
+// Two characters, because Attack compiles character attackers only: bob is the
+// only thing in this package that can drive alice to zero.
+func (s *DeathTestSuite) TestTheKillingBlowNoticesACHARACTERToo() {
+	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	s.stream.published = nil
+
+	for i := 0; i < 4 && s.characters.byID["alice"].HitPoints > 0; i++ {
+		_, aerr := s.mgr.Attack(context.Background(), &session.AttackInput{
+			Session: "sess", Attacker: "bob", Target: "alice",
+		})
+		s.Require().NoError(aerr)
+	}
+	s.Require().Zero(s.characters.byID["alice"].HitPoints)
+
+	down := s.eventsOfKind(session.EventDowned)
+	s.Require().NotEmpty(down, "the blow that dropped her is the blow that says so")
+	s.Equal("alice", s.payloadOf(down[0])["member"])
+}
+
+// brokenAfterWriting is a repository that answers reads until something is
+// written to it, and then stops — the shape of a store that goes away
+// mid-verb, at the one moment this verb now has something durable to lose.
+type brokenAfterWriting struct {
+	*fakeCharacters
+	wrote bool
+}
+
+var errStoreWentAway = errors.New("the character store went away")
+
+func (b *brokenAfterWriting) SaveCharacter(ctx context.Context, data *character.Data) error {
+	b.wrote = true
+
+	return b.fakeCharacters.SaveCharacter(ctx, data)
+}
+
+func (b *brokenAfterWriting) GetCharacter(ctx context.Context, id string) (*character.Data, error) {
+	if b.wrote {
+		return nil, errStoreWentAway
+	}
+
+	return b.fakeCharacters.GetCharacter(ctx, id)
+}
+
+// TestASwingThatCannotRecordStillNamesTheSheetItWrote is rpg-toolkit#1056's
+// lesson held against the new ordering, and it is why that ordering needed a
+// guard rather than just a comment.
+//
+// The sheets are now written BEFORE the outcome is recorded, so a Record that
+// fails has damage already on disk. A caller told only "it failed" would retry a
+// swing whose damage landed — which is the difference between repair and retry
+// that the report exists to carry.
+func (s *DeathTestSuite) TestASwingThatCannotRecordStillNamesTheSheetItWrote() {
+	chars := &brokenAfterWriting{
+		fakeCharacters: newFakeCharacters(armedFighter("alice"), armedFighter("bob")),
+	}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: chars, Events: s.stream,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "bob", Target: "alice",
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, errStoreWentAway, "the host's own failure is not flattened into ours")
+
+	var reported *session.SaveError
+	s.Require().ErrorAs(err, &reported,
+		"a swing that wrote a sheet and then failed reports what it wrote")
+	s.NotEmpty(reported.Report.Written, "and names it, so the caller repairs rather than retries")
+	s.Contains(reported.Report.Failed, "encounter:world", "while the world it describes did not land")
 }
 
 // TestADownedActorCannotSwing is rpg-toolkit#845 refused by name.

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -174,6 +174,24 @@ func (s *DeathTestSuite) payloadOf(event session.Event) map[string]any {
 	return beat
 }
 
+// swingUntilTheSkeletonFalls is alice hitting it until it stops standing.
+//
+// The bound is a runaway guard and nothing more — it is deliberately far above
+// the three swings this fixture's deterministic damage actually takes, so a
+// change to the weapon, the dice or the catalog's hit points moves the number of
+// iterations and moves no test. What holds the scene honest is the assertion
+// after the loop: if the skeleton is not at zero, this fails saying so rather
+// than letting a half-dead monster into a scene about death.
+func (s *DeathTestSuite) swingUntilTheSkeletonFalls() {
+	s.T().Helper()
+
+	const runaway = 25
+	for i := 0; i < runaway && s.storedHP("skeleton") > 0; i++ {
+		s.aliceSwings()
+	}
+	s.Require().Zero(s.storedHP("skeleton"), "the blows really landed on the stored sheet")
+}
+
 // dropTheSkeleton swings until the skeleton is at zero, and is the whole scene.
 //
 // It used to be "the scene up to the moment of death, with nobody having looked
@@ -183,11 +201,7 @@ func (s *DeathTestSuite) payloadOf(event session.Event) map[string]any {
 func (s *DeathTestSuite) dropTheSkeleton() {
 	s.startCrypt()
 	s.spawnSkeleton()
-
-	for i := 0; i < 3 && s.storedHP("skeleton") > 0; i++ {
-		s.aliceSwings()
-	}
-	s.Require().Zero(s.storedHP("skeleton"), "the blows really landed on the stored sheet")
+	s.swingUntilTheSkeletonFalls()
 }
 
 // TestTheSwingNoticesItsOwnKill is this suite's opening pin, FLIPPED.
@@ -348,10 +362,7 @@ func (s *DeathTestSuite) TestTheSurvivorWalksAgain() {
 	})
 	s.Require().ErrorIs(blocked, session.ErrInBubble, "control: mid-fight, she is not free to walk")
 
-	for i := 0; i < 3 && s.storedHP("skeleton") > 0; i++ {
-		s.aliceSwings()
-	}
-	s.Require().Zero(s.storedHP("skeleton"))
+	s.swingUntilTheSkeletonFalls()
 
 	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.95.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.8.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.95.0 h1:IsL2wyRwRmuePZsr3J1zydORSo0udTwM5iWdJy4IfwU=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.95.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0 h1:dB16IaDoSN+m3aFXD+t/3fNuYP43n6kvwBZa3ljtzbI=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0 h1:0OdQm7/dccn6P6LYZdeXCmpHIXigZ9J5cYs3Vy/TWR0=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.8.0 h1:r9xXC60bRnLBVcS5QG49dxsTMwHJJt4Xto0fJygApE8=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.8.0/go.mod h1:5EFMIuZeoyC7YVYEN5v0jJ52sqmu0i07SKdJBmLRS6c=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -278,9 +278,9 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 	// load-bearing is that the error stops the verb, and that is pinned
 	// separately.
 	//
-	// The lesson holds where it is about persistence ALONE. It stops holding the
-	// moment something reads back what was written, which is the shape both
-	// exceptions below and in Attack turn out to be — see the next comment.
+	// The lesson holds where the ordering is about persistence ALONE. It stops
+	// holding the moment something READS BACK what was written inside the same
+	// verb — which is what the exception below is, and what Attack's is too.
 	//
 	// The order is still chosen: there is no reason to touch the world when
 	// the call is already doomed.

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -278,6 +278,10 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 	// load-bearing is that the error stops the verb, and that is pinned
 	// separately.
 	//
+	// The lesson holds where it is about persistence ALONE. It stops holding the
+	// moment something reads back what was written, which is the shape both
+	// exceptions below and in Attack turn out to be — see the next comment.
+	//
 	// The order is still chosen: there is no reason to touch the world when
 	// the call is already doomed.
 	sheet, err := instantiate(in.ID, in.Ref)
@@ -286,8 +290,8 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 	}
 
 	// THE SHEET IS RECORDED BEFORE THE PLACEMENT, and here the ordering IS
-	// load-bearing — the one exception to the paragraph above, which is why it
-	// is stated separately rather than folded into it.
+	// load-bearing — an exception to the paragraph above, which is why it is
+	// stated separately rather than folded into it.
 	//
 	// Arriving refreshes sight, and every sight refresh asks who is standing
 	// (rpg-toolkit#1079). That consult reads the session's own sheets, so a
@@ -298,6 +302,15 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 	//
 	// Nothing durable changes by moving it: a failed placement returns before
 	// the commit and the whole scope is dropped, sheet and all.
+	//
+	// It stopped being the ONLY exception at rpg-toolkit#1083, and the second one
+	// names what the two have in common. [Manager.Attack] must write its damaged
+	// sheets BEFORE it records the outcome, because recording now runs the same
+	// standing consult and it reads the same sheets — and there the write really
+	// is durable, so that ordering has a cost the paragraph above says cannot
+	// exist. The rule underneath both: ordering against persistence is free only
+	// while nothing READS BACK what was written inside the same verb. A consult
+	// is a read-back.
 	scope.data.NPCs = append(scope.data.NPCs, *sheet)
 	scope.touched = true
 


### PR DESCRIPTION
Closes #1083. The seam half of the death lane's coda; the composition half is **#1085**, which this needs merged and tagged — see *Sequencing* at the bottom.

## What it does

*Alice's swing drops the last skeleton. The `downed` event, the `defeat` ending and alice's freedom to walk all arrive on that swing's own response. Nobody moves, nobody ticks, nobody calls `Dissolve`.*

`TestTheSwingIsNotWhatNotices` is flipped and renamed. It used to pin the honest gap by name:

> The skeleton is at zero and NOTHING has said so. […] a killing blow lands, persists, and leaves the world not yet knowing.

It now reads `TestTheSwingNoticesItsOwnKill`, and the pin it replaced is quoted in the new one's godoc rather than deleted.

## The census finding that made this more than a pin flip

**#1085 alone does not close the issue at this seam.** `resolution` does not mutate the sheets it is handed — `castFor` passes `&scope.data.NPCs[i]`, but `loadMonster` copies fields out of `Data` and `dirtyMonsters` returns `m.ToData()`, a fresh `*monster.Data`. The damaged sheet reaches the session record and the character repository only in `saveDirty`, which ran **after** `Record`. So the composition's new consult would have asked `standingSeam` about **pre-swing hit points** and found everybody standing — the exact defect #1083 exists to close, reproduced one layer up.

Verified rather than reasoned: with #1085's encounter wired in by a local `replace` and no session change, the entire suite including `TestTheSwingIsNotWhatNotices` stayed green.

So `saveDirty` moves above `Record`:

```go
	if err := m.saveDirty(ctx, scope, out); err != nil {
		return nil, fmt.Errorf("attack: %w", err)
	}

	// And now the beat, on a world whose sheets say what the swing did — see the
	// godoc for why this is not the other way round.
	recorded, err := scope.enc.Record(recordFor(in, struck))
```

The sheets are the truth, and this seam is the only thing that knows where they live — so they have to be written before the composition is asked. `Attack`'s and `saveDirty`'s godocs both carry the argument; `Attack`'s "How it runs" section is retitled "How it runs, and why the order is not a style choice".

## The cost of that ordering, paid rather than noted

A `Record` that fails now fails with the damage **already durable**. That is rpg-toolkit#1056's shape — a caller told only "it failed" retries a swing whose damage is on disk and applies it twice — so it is answered the way #1056 was:

```go
func reportUnrecorded(scope *writeScope, err error) error {
	if len(scope.written) == 0 {
		return err
	}
	return &SaveError{
		Report: SaveReport{Written: …, Failed: []string{"encounter:" + scope.encounter}},
		Err:    err,
	}
}
```

The world is named FAILED because that is what a caller has to act on: the sheets describe a blow the persisted world has no beat for, and the repair is identical to `persist`'s own world-save failure — which is why it gets that vocabulary rather than a new one. Nothing written means nothing to report and the plain error stands, so a host is never handed `ErrSaveFailed` for a verb that saved nothing. `SaveError.Unwrap` returns both, so `errors.Is` on the underlying reason keeps working.

Pinned by `TestASwingThatCannotRecordStillNamesTheSheetItWrote`, driven by a repository that answers reads until something is written to it and then stops.

## A claim in `write.go` that this change falsifies

`write.go` stated a general lesson and gave it one exception:

> in a load-act-save verb, ordering with respect to PERSISTENCE is never load-bearing before the commit

with the spawn's sheet-before-placement as "the one exception". `saveDirty`-before-`Record` is a second, and a stronger one — the write there is *durable*, so it has exactly the cost the claim says cannot exist. Rather than quietly adding a second exception, both comments now name what the two have in common:

> ordering against persistence is free only while nothing READS BACK what was written inside the same verb. A consult is a read-back.

Worth having in the file rather than in a PR body, because the next verb that adds a consult will hit it.

## `kindOf` needed nothing — asked, not assumed

The issue expected this and the census confirms it: `"down"` → `EventDowned` and `"bubble-dissolved"` → `EventFightEnded` have been in `kindOf` since D4. Only the verb they arrive on changed. `TestNothingReachesAClientUnnamed` is now the mechanical check, run against the swing's own fan-out and with its godoc saying that is what it answers.

## Tests

RED first, against #1085's encounter via a local `replace`: **8 failed**, and the two that did not are guards that must hold either way (`TestNothingReachesAClientUnnamed`, `TestTheEncounterOutlivesTheFight`). All 22 in the suite pass now.

| Test | Claims |
|---|---|
| `TestTheSwingNoticesItsOwnKill` | the flip: downed + fight-ended on the killing blow, alice on `ClockWorld`, nothing walked |
| `TestEveryMemberHearsTheDeath` | all three recipients on the swing's fan-out; `EventDowned` outside, `"down"` in the payload — the #1084 translation, both halves |
| `TestTheBeatOrderReachesTheClientAsCauseThenEffect` | struck → downed → fight-ended, in delivery order, for one recipient |
| `TestTheDeathIsNotAnnouncedTwice` | the story-ledger dedup surviving to a client: bob steps afterwards and the counts do not move |
| `TestTheLastOneDownedEndsTheFightByDefeat` | cause `"defeat"`, everyone the fight held, on the swing rather than on a walk |
| `TestTheKillingBlowNoticesACHARACTERToo` | the **repository** half of the ordering, which the skeleton scenes cannot see — a version that folded NPC sheets early and left the character write where it was passes every scene above and fails this one |
| `TestASwingThatCannotRecordStillNamesTheSheetItWrote` | the #1056 guard on the new ordering |
| `TestTheSurvivorWalksAgain` | the `ErrInBubble` control moved to mid-fight, because the fight no longer outlives the blow — the change stated as a scene rather than a claim |

`dropTheSkeleton`'s own doc changed with its meaning ("the scene up to the moment of death, with nobody having looked yet" → the whole scene), and `cryptWorld`'s comment no longer points at a test that does not exist.

## Evidence

Run with `-modfile=local.go.mod` carrying a `replace` onto #1085's encounter (no `replace` is committed anywhere):

```
$ go test -count=1 ./...
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session/cmd/session-workbench

$ gofmt -l . && go vet ./...        # clean
$ golangci-lint run ./...           # 0 issues
$ gorelease -base v0.15.0
Suggested version: v0.15.1
```

**gorelease says v0.15.1 because the exported API surface does not move.** The title is `feat(session):`, which mints **v0.16.0**: `Attack`'s observable behavior changed and a host needs to know. **No `!`** — nothing new is refused, no signature moved, and the ordering change makes the events arrive *earlier* in strictly the same sequence. The one error-path change is additive: `SaveError.Unwrap` keeps the underlying sentinel matchable, so a host branching on `ErrClosed` or a standing failure branches on it exactly as before and now also learns what landed. That is the distinction from D4 (#1082), which took `!` because verbs started refusing.

## Sequencing — RESOLVED, and CI is green

#1085 merged (main `5b411b6`) and auto-tagged **`encounter v0.16.0`**, so the pin this branch already named now resolves and `go mod tidy` added the sums. Everything above was originally verified through a local `replace` in an alternate modfile; it has been re-run on the **real pins with no replace anywhere**, and that run is what CI is reading:

At `0685e90`:

| Check | Result |
|---|---|
| `test-changed (rulebooks/dnd5e/session)` | **pass** |
| `gorelease-dnd5e-session` | **pass** |
| `ci-status` and every other check | **pass** — 10 pass, 0 fail |
| merge state | `MERGEABLE` / `CLEAN` |
| local `gofmt` / `go build` / `go vet` / `golangci-lint` | clean, 0 issues |
| local `go test -count=1 ./...` | ok — `TestDeathSuite` 22/22 |

`gorelease -base v0.15.0` on the real pins now suggests **v0.16.0**, which is the version wanted — and it is a sharper verdict than the local-replace run, which said v0.15.1. The difference is the point: this module's own exported API does not move, so gorelease had nothing to see until the dependency's real minor bump was in front of it. The title's `feat(session):` and gorelease now agree without either being talked into it.

Worth naming, as the same closing on this lane's D4 (#1082) did: `gorelease-dnd5e-session` had never actually EXECUTED on this PR before now — it died at module resolution alongside the tests — so this is its first genuine run, and it agrees with the hand-run above.

— fix-1083 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
