### PR TITLE
fix(dnd5e): an economy or pool spend marks the sheet dirty (#1087)

### DIFF
--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -26,10 +26,33 @@ func (c *Character) InCombat() bool {
 	return c.actionEconomy != nil
 }
 
+// economyChanged records that a write landed on c.actionEconomy.
+//
+// The economy is persisted — ToData writes it to Data.ActionEconomy and Load
+// restores it — but serializing is not saving: resolution keeps only the
+// sheets that report IsDirty() and session writes back only those. An economy
+// mutation that skips this is a spend that serializes perfectly and is then
+// discarded (#1087).
+//
+// Each writer calls this for itself rather than trusting a caller to, with two
+// exceptions documented where they live: checkPostStrikeGrants, whose only
+// caller marks after it returns, and restoreActionType, which undoes a spend
+// that already marked. The load path is a third: it seeds the economy from
+// stored data, so the sheet already matches storage.
+func (c *Character) economyChanged() {
+	c.dirty = true
+}
+
 // ExitCombat clears the action economy entirely, removing combat state.
 // Call this when the encounter ends, not between turns.
 func (c *Character) ExitCombat(_ context.Context, _ *ExitCombatInput) (*ExitCombatOutput, error) {
-	c.actionEconomy = nil
+	// Guarded so that leaving combat twice is not a second change: an economy
+	// that was already absent has nothing to write.
+	if c.actionEconomy != nil {
+		c.actionEconomy = nil
+		c.economyChanged()
+	}
+
 	return &ExitCombatOutput{}, nil
 }
 
@@ -45,6 +68,7 @@ func (c *Character) StartTurn(_ context.Context, input *StartTurnInput) (*StartT
 		MovementRemaining:     input.Speed,
 		Granted:               make(map[GrantedActionKey]int),
 	}
+	c.economyChanged()
 
 	return &StartTurnOutput{
 		Abilities: c.buildAvailableAbilities(),
@@ -61,6 +85,7 @@ func (c *Character) EndTurn(_ context.Context, _ *EndTurnInput) (*EndTurnOutput,
 		c.actionEconomy.ReactionsRemaining = 0
 		c.actionEconomy.MovementRemaining = 0
 		c.actionEconomy.Granted = make(map[GrantedActionKey]int)
+		c.economyChanged()
 	}
 	return &EndTurnOutput{}, nil
 }
@@ -154,6 +179,7 @@ func (c *Character) GrantCapacity(key GrantedActionKey, amount int) {
 		c.actionEconomy.Granted = make(map[GrantedActionKey]int)
 	}
 	c.actionEconomy.Granted[key] += amount
+	c.economyChanged()
 }
 
 // HasGranted returns whether the character has any remaining capacity for the given key.
@@ -454,6 +480,7 @@ func (c *Character) executeStrike() (*ExecuteActionOutput, error) {
 
 	c.actionEconomy.Granted[GrantedAttacks]--
 	c.checkPostStrikeGrants()
+	c.economyChanged()
 
 	return &ExecuteActionOutput{
 		Success:   true,
@@ -474,6 +501,7 @@ func (c *Character) executeOffHandStrike() (*ExecuteActionOutput, error) {
 	}
 
 	c.actionEconomy.Granted[GrantedOffHandStrikes]--
+	c.economyChanged()
 
 	return &ExecuteActionOutput{
 		Success:   true,
@@ -494,6 +522,7 @@ func (c *Character) executeFlurryStrike() (*ExecuteActionOutput, error) {
 	}
 
 	c.actionEconomy.Granted[GrantedFlurryStrikes]--
+	c.economyChanged()
 
 	return &ExecuteActionOutput{
 		Success:   true,
@@ -533,6 +562,7 @@ func (c *Character) executeUnarmedStrike() (*ExecuteActionOutput, error) {
 
 	c.actionEconomy.Granted[GrantedMartialArtsBonus]--
 	c.actionEconomy.BonusActionsRemaining--
+	c.economyChanged()
 
 	return &ExecuteActionOutput{
 		Success:   true,
@@ -578,6 +608,7 @@ func (c *Character) executeMove(distance int) (*ExecuteActionOutput, error) {
 	}
 
 	c.actionEconomy.MovementRemaining -= distance
+	c.economyChanged()
 
 	return &ExecuteActionOutput{
 		Success:   true,
@@ -589,6 +620,10 @@ func (c *Character) executeMove(distance int) (*ExecuteActionOutput, error) {
 // checkPostStrikeGrants checks for post-main-hand-strike grants.
 // After a main-hand strike, monks get a martial arts bonus strike
 // and two-weapon fighters get an off-hand strike.
+//
+// It writes granted capacity but does not call economyChanged: its only caller,
+// executeStrike, marks once for the decrement and these grants together. A
+// second caller has to mark for itself.
 func (c *Character) checkPostStrikeGrants() {
 	// Monk: grant martial arts bonus if bonus action available and not already granted
 	if c.classID == classes.Monk &&
@@ -609,6 +644,10 @@ func (c *Character) checkPostStrikeGrants() {
 
 // toToolkitActionEconomy converts ActionEconomyData to the toolkit's combat.ActionEconomy.
 // This bridges our serializable data with the toolkit's combat ability system.
+//
+// It only reads: the value it returns is a detached copy that the ability
+// mutates, and fromToolkitActionEconomy is what puts the result back on the
+// sheet. Nothing here dirties anything.
 func (c *Character) toToolkitActionEconomy() *combat.ActionEconomy {
 	ae := &combat.ActionEconomy{
 		ActionsRemaining:      c.actionEconomy.ActionsRemaining,
@@ -633,6 +672,10 @@ func (c *Character) toToolkitActionEconomy() *combat.ActionEconomy {
 
 // fromToolkitActionEconomy syncs the toolkit's combat.ActionEconomy back to ActionEconomyData.
 // Called after a combat ability modifies the toolkit ActionEconomy.
+//
+// This is where a whole ability activation lands on the sheet at once — the
+// slot it spent and the capacity it granted — so it is where that activation
+// becomes something to save.
 func (c *Character) fromToolkitActionEconomy(ae *combat.ActionEconomy) {
 	c.actionEconomy.ActionsRemaining = ae.ActionsRemaining
 	c.actionEconomy.BonusActionsRemaining = ae.BonusActionsRemaining
@@ -649,6 +692,8 @@ func (c *Character) fromToolkitActionEconomy(ae *combat.ActionEconomy) {
 	if ae.FlurryStrikesRemaining > 0 {
 		c.actionEconomy.Granted[GrantedFlurryStrikes] = ae.FlurryStrikesRemaining
 	}
+
+	c.economyChanged()
 }
 
 // --- Helper methods ---
@@ -701,10 +746,21 @@ func (c *Character) consumeActionType(actionType coreCombat.ActionType) {
 		c.actionEconomy.BonusActionsRemaining--
 	case coreCombat.ActionReaction:
 		c.actionEconomy.ReactionsRemaining--
+	default:
+		// A free action costs no slot, so nothing was written and the sheet
+		// has nothing new to save.
+		return
 	}
+
+	c.economyChanged()
 }
 
 // restoreActionType increments the appropriate action economy counter (rollback).
+//
+// It does not need to mark the sheet dirty — the consumeActionType it undoes
+// already did — and deliberately does not mark it clean again. A feature whose
+// Activate failed may have moved its own persisted state before it errored, and
+// one redundant write costs less than one lost spend.
 func (c *Character) restoreActionType(actionType coreCombat.ActionType) {
 	switch actionType {
 	case coreCombat.ActionStandard:

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -16,6 +16,12 @@ import (
 )
 
 // GetActionEconomy returns the current action economy data, or nil if not in combat.
+//
+// The economy comes back live, not copied — the same shape as GetResource, and
+// the same warning. Reading it is free; writing through it moves persisted
+// state without the sheet noticing, and the write is then dropped by the next
+// write-back. Spend through the methods on this file, which mark the sheet
+// dirty (#1087).
 func (c *Character) GetActionEconomy() *ActionEconomyData {
 	return c.actionEconomy
 }
@@ -747,8 +753,16 @@ func (c *Character) consumeActionType(actionType coreCombat.ActionType) {
 	case coreCombat.ActionReaction:
 		c.actionEconomy.ReactionsRemaining--
 	default:
-		// A free action costs no slot, so nothing was written and the sheet
-		// has nothing new to save.
+		// Nothing to spend, so nothing to save. A free action costs no slot by
+		// definition; any OTHER type never reaches here at all, because
+		// activateFeature gates on canUseAbilityByActionType, which recognises
+		// exactly the four types above and refuses the rest.
+		//
+		// The two free features that ship say the same thing from the other
+		// side: Reckless Attack's change to the sheet is a condition, and the
+		// condition site marks it, while Action Surge cannot reach its spend
+		// through this path at all — its CanActivate demands an ActionEconomy
+		// that activateFeature does not supply.
 		return
 	}
 

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -802,11 +802,14 @@ func (c *Character) IsDirty() bool {
 	return c.dirty
 }
 
-// poolChanged records that a write landed on a persisted resource pool.
+// poolChanged records that a write landed on the resource pools or on the state
+// that moves with them.
 //
 // GetResourceData feeds Data.Resources, so a spent ki point or a restored hit
 // die is state ToData writes — and, like the action economy, state that only
-// reaches storage if the sheet reports IsDirty() (#1087).
+// reaches storage if the sheet reports IsDirty() (#1087). The rests call it for
+// everything they touch at once, hit points and death saves included, because a
+// rest is one change to the sheet rather than three.
 //
 // The load paths deliberately do not call this: loadResources and
 // LoadResourceData rebuild pools at the values they were read from, so the

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -409,6 +409,11 @@ func (c *Character) SpendHitDice(ctx context.Context, input *SpendHitDiceInput) 
 		return nil, rpgerr.Wrapf(err, "failed to use hit dice")
 	}
 
+	// The pool moved, and says so for itself rather than leaning on the healing
+	// below: the hit points only get marked if the sheet's keeper is on this
+	// bus, and the spent die is persisted either way.
+	c.poolChanged()
+
 	// Publish healing event (character's onHealingReceived will handle HP update)
 	healingTopic := dnd5eEvents.HealingReceivedTopic.On(c.bus)
 	err = healingTopic.Publish(ctx, dnd5eEvents.HealingReceivedEvent{
@@ -468,6 +473,10 @@ func (c *Character) LongRest(ctx context.Context) error {
 		}
 	}
 
+	// Covers all three writes above — hit points, death saves, pools — in one
+	// place, because a rest is one change to the sheet.
+	c.poolChanged()
+
 	// Publish RestEvent for conditions to react (e.g., RagingCondition removes itself)
 	restTopic := dnd5eEvents.RestTopic.On(c.bus)
 	err := restTopic.Publish(ctx, dnd5eEvents.RestEvent{
@@ -495,6 +504,13 @@ func (c *Character) ShortRest(ctx context.Context) error {
 			resource.RestoreToFull()
 		}
 	}
+
+	// Unconditional rather than only when a pool actually moved: the rest event
+	// published below also reaches resources and conditions that restore or
+	// remove themselves, and a rest that changed nothing costs one redundant
+	// write while a rest that changed something silently would cost the party
+	// its ki.
+	c.poolChanged()
 
 	// Publish RestEvent for conditions to react (e.g., RagingCondition removes itself)
 	restTopic := dnd5eEvents.RestTopic.On(c.bus)
@@ -786,6 +802,20 @@ func (c *Character) IsDirty() bool {
 	return c.dirty
 }
 
+// poolChanged records that a write landed on a persisted resource pool.
+//
+// GetResourceData feeds Data.Resources, so a spent ki point or a restored hit
+// die is state ToData writes — and, like the action economy, state that only
+// reaches storage if the sheet reports IsDirty() (#1087).
+//
+// The load paths deliberately do not call this: loadResources and
+// LoadResourceData rebuild pools at the values they were read from, so the
+// sheet already matches storage, and marking there would make every loaded
+// sheet write itself back over what it was read from.
+func (c *Character) poolChanged() {
+	c.dirty = true
+}
+
 // MarkClean marks the character as saved (not dirty).
 // Implements combat.Combatant interface.
 func (c *Character) MarkClean() {
@@ -802,6 +832,11 @@ var emptyResource = combat.NewRecoverableResource(combat.RecoverableResourceConf
 // GetResource returns the resource for the given key.
 // If the resource doesn't exist, returns an empty resource (not nil).
 // Use IsEmpty() to check if the resource exists and has uses available.
+//
+// The pool comes back live, not copied. Reading it is free; spending through it
+// mutates the sheet without the sheet noticing, and the spend is then dropped
+// on the next write-back. Spend through UseResource, which marks the sheet
+// dirty (#1087).
 func (c *Character) GetResource(key coreResources.ResourceKey) *combat.RecoverableResource {
 	if c.resources == nil {
 		return emptyResource
@@ -818,6 +853,7 @@ func (c *Character) AddResource(key coreResources.ResourceKey, resource *combat.
 		c.resources = make(map[coreResources.ResourceKey]*combat.RecoverableResource)
 	}
 	c.resources[key] = resource
+	c.poolChanged()
 }
 
 // IsResourceAvailable implements coreResources.ResourceAccessor.
@@ -844,7 +880,16 @@ func (c *Character) UseResource(key coreResources.ResourceKey, amount int) error
 	if !ok {
 		return rpgerr.Newf(rpgerr.CodeNotFound, "resource %s not found", key)
 	}
-	return r.Use(amount)
+	if err := r.Use(amount); err != nil {
+		return err
+	}
+
+	// The choke point every feature spend goes through — rage charges, ki for
+	// Flurry of Blows, Patient Defense, Step of the Wind — so this one line is
+	// what makes those spends survive the write-back.
+	c.poolChanged()
+
+	return nil
 }
 
 // GetResourceData returns serializable resource data for persistence
@@ -866,6 +911,10 @@ func (c *Character) GetResourceData() map[coreResources.ResourceKey]RecoverableR
 
 // LoadResourceData loads resources from serialized data and applies them to the event bus.
 // Resources are applied so they subscribe to rest events for automatic recovery.
+//
+// A load path, so it does not mark the sheet dirty: the pools come back at the
+// values they were read from, and a sheet that reported itself dirty for
+// having been read would write those values straight back over storage.
 func (c *Character) LoadResourceData(
 	ctx context.Context,
 	bus events.EventBus,

--- a/rulebooks/dnd5e/character/economy_dirty_test.go
+++ b/rulebooks/dnd5e/character/economy_dirty_test.go
@@ -210,7 +210,7 @@ func (s *EconomyDirtyTestSuite) TestTheUnarmedStrikeMarks() {
 func (s *EconomyDirtyTestSuite) TestARefusedUnarmedStrikeLeavesTheSheetClean() {
 	char := s.inCombat()
 	char.GrantCapacity(GrantedMartialArtsBonus, 1)
-	char.GetActionEconomy().BonusActionsRemaining = 0
+	char.actionEconomy.BonusActionsRemaining = 0
 	char.MarkClean()
 
 	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.UnarmedStrike()})
@@ -343,6 +343,25 @@ func (s *EconomyDirtyTestSuite) TestAFailedFeatureActivationLeavesTheSheetDirty(
 
 	s.Equal(1, char.GetActionEconomy().ActionsRemaining, "the slot was given back")
 	s.True(char.IsDirty(), "but the sheet is not assumed to be untouched")
+}
+
+// A free action costs no slot, so activating a feature that takes one writes
+// nothing to the economy — and a sheet with nothing written has nothing to
+// save. (The free features that ship do change the sheet, but through other
+// sites: Reckless Attack applies a condition, which marks.)
+func (s *EconomyDirtyTestSuite) TestActivatingAFreeFeatureLeavesTheSheetClean() {
+	char := s.inCombat()
+	char.features = append(char.features, &stubFeature{actionType: coreCombat.ActionFree})
+	before := *char.GetActionEconomy()
+
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{AbilityRef: stubFeatureRef})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.Equal(before.ActionsRemaining, char.GetActionEconomy().ActionsRemaining)
+	s.Equal(before.BonusActionsRemaining, char.GetActionEconomy().BonusActionsRemaining)
+	s.Equal(before.ReactionsRemaining, char.GetActionEconomy().ReactionsRemaining)
+	s.False(char.IsDirty(), "no slot moved, so there is nothing to write")
 }
 
 func (s *EconomyDirtyTestSuite) TestAnUnknownAbilityLeavesTheSheetClean() {

--- a/rulebooks/dnd5e/character/economy_dirty_test.go
+++ b/rulebooks/dnd5e/character/economy_dirty_test.go
@@ -1,0 +1,502 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combatabilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// EconomyDirtyTestSuite pins the half of the round-trip that serialization
+// alone does not buy: a sheet whose action economy or resource pool moved has
+// to SAY so, or the write-back never happens.
+//
+// ToData has always serialized the economy (Data.ActionEconomy) and the pools
+// (Data.Resources), but resolution.dirtyCharacters keeps only the sheets that
+// report IsDirty() and session.saveDirty writes only what that returns. Before
+// #1087 the flag was set at four sites, all hit points or conditions — so a
+// spend performed on a loaded sheet inside a resolution was serialized
+// perfectly and then dropped on the floor. Every test here fails for a sheet
+// that mutates quietly.
+//
+// The other half is no less load-bearing: a sheet that was loaded and NOT
+// touched must stay clean, or the write-back clobbers stored state with a
+// re-serialization of what it just read.
+type EconomyDirtyTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+	bus events.EventBus
+}
+
+func TestEconomyDirtySuite(t *testing.T) {
+	suite.Run(t, new(EconomyDirtyTestSuite))
+}
+
+func (s *EconomyDirtyTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+// sheet is a level-3 monk mid-encounter: ki to spend, hit dice to spend, and
+// no action economy yet (the encounter seeds that at the turn boundary).
+func (s *EconomyDirtyTestSuite) sheet() *Data {
+	return &Data{
+		ID:               "economy-monk",
+		PlayerID:         "economy-player",
+		Name:             "Spender",
+		Level:            3,
+		ProficiencyBonus: 2,
+		RaceID:           races.Human,
+		ClassID:          classes.Monk,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 12,
+			abilities.DEX: 16,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 16,
+			abilities.CHA: 8,
+		},
+		HitPoints:    18,
+		MaxHitPoints: 24,
+		ArmorClass:   16,
+		Resources: map[coreResources.ResourceKey]RecoverableResourceData{
+			resources.Ki:      {Current: 3, Maximum: 3, ResetType: coreResources.ResetShortRest},
+			resources.HitDice: {Current: 3, Maximum: 3, ResetType: coreResources.ResetLongRest},
+		},
+	}
+}
+
+// loaded returns the sheet as it comes off storage: clean, with the combat
+// abilities a monk brings to a turn. Load does not rebuild those (they come
+// from the class, not the save), so the fixture adds them the way a caller
+// would — before marking clean, so the sheet under test starts where a freshly
+// loaded one does.
+func (s *EconomyDirtyTestSuite) loaded() *Character {
+	char, err := Load(s.ctx, s.sheet())
+	s.Require().NoError(err)
+	s.Require().NoError(char.AddCombatAbility(combatabilities.NewAttack("attack-1")))
+	s.Require().NoError(char.AddCombatAbility(combatabilities.NewDash("dash-1")))
+	char.MarkClean()
+
+	return char
+}
+
+// inCombat is a loaded sheet that has been given a turn, then marked clean —
+// so that whatever the test does next is the only thing that could have
+// dirtied it.
+func (s *EconomyDirtyTestSuite) inCombat() *Character {
+	char := s.loaded()
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	return char
+}
+
+// --- The no-clobber half ---
+
+func (s *EconomyDirtyTestSuite) TestALoadedSheetIsClean() {
+	char, err := Load(s.ctx, s.sheet())
+	s.Require().NoError(err)
+
+	s.False(char.IsDirty(), "a sheet that was only read back has nothing to write")
+	s.Equal(3, char.GetResource(resources.Ki).Current(), "and it came back at its stored ki")
+}
+
+func (s *EconomyDirtyTestSuite) TestAttachingASheetLeavesItClean() {
+	char := s.loaded()
+	s.Require().NoError(Attach(s.ctx, char, s.bus))
+
+	s.False(char.IsDirty(), "putting a sheet on a bus changes nothing about the sheet")
+}
+
+func (s *EconomyDirtyTestSuite) TestReadingTheEconomyLeavesTheSheetClean() {
+	char := s.inCombat()
+
+	s.True(char.InCombat())
+	s.NotNil(char.GetActionEconomy())
+	s.False(char.HasGranted(GrantedAttacks))
+	s.NotEmpty(char.AvailableAbilities())
+	s.NotEmpty(char.AvailableActions())
+
+	s.False(char.IsDirty(), "asking a sheet what it can do is not a spend")
+}
+
+// --- Action economy: every write-site marks ---
+
+func (s *EconomyDirtyTestSuite) TestStartTurnMarks() {
+	char := s.loaded()
+
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+
+	s.True(char.IsDirty(), "a seeded turn is economy state that has to be written down")
+}
+
+// The bridge is the site the issue names: activating a combat ability spends
+// and grants inside a detached toolkit economy, and fromToolkitActionEconomy
+// syncs it back onto the sheet. A mutation that lands through there must not
+// escape marking.
+func (s *EconomyDirtyTestSuite) TestActivatingAnAbilityMarksThroughTheBridge() {
+	char := s.inCombat()
+	hitPoints := char.GetHitPoints()
+
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{
+		AbilityRef: refs.CombatAbilities.Attack(),
+	})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.Equal(0, char.GetActionEconomy().ActionsRemaining, "the action slot was spent")
+	s.Equal(hitPoints, char.GetHitPoints(), "and no hit point moved")
+	s.True(char.IsDirty(), "an economy-only change still needs saving")
+}
+
+func (s *EconomyDirtyTestSuite) TestStrikingMarks() {
+	char := s.inCombat()
+	_, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{AbilityRef: refs.CombatAbilities.Attack()})
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.Strike()})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.True(char.IsDirty(), "a spent attack is a spend")
+}
+
+func (s *EconomyDirtyTestSuite) TestARefusedStrikeLeavesTheSheetClean() {
+	char := s.inCombat()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.Strike()})
+	s.Require().NoError(err)
+	s.Require().False(out.Success, "no attack was granted, so there is nothing to spend")
+
+	s.False(char.IsDirty(), "a refused action wrote nothing, so there is nothing to save")
+}
+
+func (s *EconomyDirtyTestSuite) TestTheUnarmedStrikeMarks() {
+	char := s.inCombat()
+	char.GrantCapacity(GrantedMartialArtsBonus, 1)
+	char.MarkClean()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.UnarmedStrike()})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.True(char.IsDirty(), "the granted strike and the bonus action that paid for it both moved")
+}
+
+func (s *EconomyDirtyTestSuite) TestARefusedUnarmedStrikeLeavesTheSheetClean() {
+	char := s.inCombat()
+	char.GrantCapacity(GrantedMartialArtsBonus, 1)
+	char.GetActionEconomy().BonusActionsRemaining = 0
+	char.MarkClean()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.UnarmedStrike()})
+	s.Require().NoError(err)
+	s.Require().False(out.Success)
+
+	s.False(char.IsDirty())
+}
+
+func (s *EconomyDirtyTestSuite) TestTheOffHandStrikeMarks() {
+	char := s.inCombat()
+	char.GrantCapacity(GrantedOffHandStrikes, 1)
+	char.MarkClean()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.OffHandStrike()})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.True(char.IsDirty())
+}
+
+func (s *EconomyDirtyTestSuite) TestTheFlurryStrikeMarks() {
+	char := s.inCombat()
+	char.GrantCapacity(GrantedFlurryStrikes, 1)
+	char.MarkClean()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.FlurryStrike()})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.True(char.IsDirty())
+}
+
+func (s *EconomyDirtyTestSuite) TestMovingMarks() {
+	char := s.inCombat()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+		ActionRef: refs.Actions.Move(),
+		Distance:  10,
+	})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.Equal(20, char.GetActionEconomy().MovementRemaining)
+	s.True(char.IsDirty(), "movement spent off a persisted budget has to be written down")
+}
+
+func (s *EconomyDirtyTestSuite) TestARefusedMoveLeavesTheSheetClean() {
+	char := s.inCombat()
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{
+		ActionRef: refs.Actions.Move(),
+		Distance:  100,
+	})
+	s.Require().NoError(err)
+	s.Require().False(out.Success, "100ft is over a 30ft budget")
+
+	s.False(char.IsDirty())
+}
+
+func (s *EconomyDirtyTestSuite) TestGrantingCapacityMarks() {
+	char := s.inCombat()
+
+	char.GrantCapacity(GrantedAttacks, 2)
+
+	s.True(char.IsDirty(), "granted capacity is persisted on the sheet")
+}
+
+func (s *EconomyDirtyTestSuite) TestGrantingCapacityOutOfCombatLeavesTheSheetClean() {
+	char := s.loaded()
+
+	char.GrantCapacity(GrantedAttacks, 2)
+
+	s.False(char.IsDirty(), "there is no economy to grant into, so nothing was written")
+}
+
+func (s *EconomyDirtyTestSuite) TestEndTurnMarks() {
+	char := s.inCombat()
+
+	_, err := char.EndTurn(s.ctx, &EndTurnInput{})
+	s.Require().NoError(err)
+
+	s.True(char.IsDirty(), "a turn that ended zeroed four persisted counters")
+}
+
+func (s *EconomyDirtyTestSuite) TestExitCombatMarks() {
+	char := s.inCombat()
+
+	_, err := char.ExitCombat(s.ctx, &ExitCombatInput{})
+	s.Require().NoError(err)
+
+	s.True(char.IsDirty(), "the economy went from stored to absent, which is a change")
+}
+
+func (s *EconomyDirtyTestSuite) TestExitCombatOutOfCombatLeavesTheSheetClean() {
+	char := s.loaded()
+
+	_, err := char.ExitCombat(s.ctx, &ExitCombatInput{})
+	s.Require().NoError(err)
+
+	s.False(char.IsDirty(), "nil to nil is not a change")
+}
+
+// activateFeature is the other economy write path: it spends the slot itself
+// rather than going through the bridge. The stub feature costs an action and
+// touches nothing else, so the mark can only have come from that spend.
+func (s *EconomyDirtyTestSuite) TestActivatingAFeatureMarksTheSlotItSpends() {
+	char := s.inCombat()
+	char.features = append(char.features, &stubFeature{actionType: coreCombat.ActionStandard})
+
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{AbilityRef: stubFeatureRef})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.Equal(0, char.GetActionEconomy().ActionsRemaining)
+	s.True(char.IsDirty())
+}
+
+// A feature whose Activate fails is rolled back to the same counters it
+// started with — and the sheet stays dirty on purpose. A failed Activate may
+// have moved feature state before it errored, and one redundant write is
+// cheaper than one lost spend.
+func (s *EconomyDirtyTestSuite) TestAFailedFeatureActivationLeavesTheSheetDirty() {
+	char := s.inCombat()
+	char.features = append(char.features, &stubFeature{actionType: coreCombat.ActionStandard, failActivate: true})
+
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{AbilityRef: stubFeatureRef})
+	s.Require().NoError(err)
+	s.Require().False(out.Success)
+
+	s.Equal(1, char.GetActionEconomy().ActionsRemaining, "the slot was given back")
+	s.True(char.IsDirty(), "but the sheet is not assumed to be untouched")
+}
+
+func (s *EconomyDirtyTestSuite) TestAnUnknownAbilityLeavesTheSheetClean() {
+	char := s.inCombat()
+
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{AbilityRef: refs.Features.Rage()})
+	s.Require().NoError(err)
+	s.Require().False(out.Success)
+
+	s.False(char.IsDirty())
+}
+
+// --- Resource pools: every write-site marks ---
+
+func (s *EconomyDirtyTestSuite) TestSpendingAPoolMarksWithoutTouchingHitPoints() {
+	char := s.loaded()
+	hitPoints := char.GetHitPoints()
+
+	s.Require().NoError(char.UseResource(resources.Ki, 1))
+
+	s.Equal(2, char.GetResource(resources.Ki).Current())
+	s.Equal(hitPoints, char.GetHitPoints(), "no hit point moved")
+	s.True(char.IsDirty(), "a ki-shaped spend is the whole reason Data.Resources exists")
+}
+
+func (s *EconomyDirtyTestSuite) TestSpendingAPoolThatIsNotThereLeavesTheSheetClean() {
+	char := s.loaded()
+
+	s.Require().Error(char.UseResource(resources.RageCharges, 1))
+
+	s.False(char.IsDirty(), "nothing was spent, so nothing needs saving")
+}
+
+func (s *EconomyDirtyTestSuite) TestSpendingMorePoolThanRemainsLeavesTheSheetClean() {
+	char := s.loaded()
+
+	s.Require().Error(char.UseResource(resources.Ki, 99))
+
+	s.Equal(3, char.GetResource(resources.Ki).Current())
+	s.False(char.IsDirty())
+}
+
+func (s *EconomyDirtyTestSuite) TestAddingAPoolMarks() {
+	char := s.loaded()
+
+	char.AddResource(resources.RageCharges, combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+		ID:      string(resources.RageCharges),
+		Maximum: 2,
+	}))
+
+	s.True(char.IsDirty(), "a pool the sheet did not have is a pool ToData now writes")
+}
+
+// The sheet holds the bus but its keeper was never applied, so nothing is
+// listening for the healing this publishes. What is left is the hit-dice pool
+// moving — which has to mark on its own, not by leaning on the healing
+// handler that happens to mark alongside it inside an encounter.
+func (s *EconomyDirtyTestSuite) TestSpendingHitDiceMarksOnItsOwn() {
+	char := s.loaded()
+	char.bus = s.bus
+
+	out, err := char.SpendHitDice(s.ctx, &SpendHitDiceInput{Count: 1})
+	s.Require().NoError(err)
+	s.Require().Equal(2, out.Remaining)
+
+	s.True(char.IsDirty(), "the hit-dice pool moved")
+}
+
+func (s *EconomyDirtyTestSuite) TestAShortRestMarks() {
+	char := s.loaded()
+	char.bus = s.bus
+	s.Require().NoError(char.UseResource(resources.Ki, 2))
+	char.MarkClean()
+
+	s.Require().NoError(char.ShortRest(s.ctx))
+
+	s.Equal(3, char.GetResource(resources.Ki).Current())
+	s.True(char.IsDirty(), "restored pools are as persisted as spent ones")
+}
+
+func (s *EconomyDirtyTestSuite) TestALongRestMarks() {
+	char := s.loaded()
+	char.bus = s.bus
+
+	s.Require().NoError(char.LongRest(s.ctx))
+
+	s.Equal(char.GetMaxHitPoints(), char.GetHitPoints())
+	s.True(char.IsDirty())
+}
+
+// --- The four sites that already marked still mark ---
+
+func (s *EconomyDirtyTestSuite) TestDamageStillMarks() {
+	char := s.loaded()
+
+	char.ApplyDamage(s.ctx, &combat.ApplyDamageInput{
+		Instances: []combat.DamageInstance{{Amount: 3}},
+	})
+
+	s.True(char.IsDirty(), "the hit-point site is unchanged by #1087")
+}
+
+// The condition and healing sites keep their own pins in sheet_keeper_test.go.
+
+// --- End to end ---
+
+// The point of the whole slice: a spend on a loaded sheet is both reported as
+// needing a save and present in what gets saved.
+func (s *EconomyDirtyTestSuite) TestASpendOnALoadedSheetSurvivesToData() {
+	char := s.inCombat()
+	s.Require().NoError(char.UseResource(resources.Ki, 1))
+
+	out, err := char.ExecuteAction(s.ctx, &ExecuteActionInput{ActionRef: refs.Actions.Move(), Distance: 15})
+	s.Require().NoError(err)
+	s.Require().True(out.Success)
+
+	s.Require().True(char.IsDirty(), "so resolution keeps it in DirtyCharacters")
+
+	data := char.ToData()
+	s.Require().NotNil(data.ActionEconomy)
+	s.Equal(15, data.ActionEconomy.MovementRemaining, "and this is what gets written")
+	s.Equal(2, data.Resources[resources.Ki].Current)
+}
+
+// --- Stub feature ---
+
+var stubFeatureRef = &core.Ref{Module: "dnd5e", Type: "features", ID: "stub-economy-feature"}
+
+// stubFeature costs an action economy slot and does nothing else, so a test
+// using it can attribute a dirty sheet to the slot and to nothing else.
+type stubFeature struct {
+	actionType   coreCombat.ActionType
+	failActivate bool
+}
+
+func (f *stubFeature) GetID() string            { return stubFeatureRef.ID }
+func (f *stubFeature) GetType() core.EntityType { return features.EntityTypeFeature }
+func (f *stubFeature) Ref() *core.Ref           { return stubFeatureRef }
+func (f *stubFeature) Name() string             { return "Stub" }
+
+func (f *stubFeature) ActionType() coreCombat.ActionType { return f.actionType }
+
+func (f *stubFeature) CanActivate(_ context.Context, _ core.Entity, _ features.FeatureInput) error {
+	return nil
+}
+
+func (f *stubFeature) Activate(_ context.Context, _ core.Entity, _ features.FeatureInput) error {
+	if f.failActivate {
+		return rpgerr.New(rpgerr.CodeInternal, "stub feature refuses to activate")
+	}
+
+	return nil
+}
+
+func (f *stubFeature) ToJSON() (json.RawMessage, error) {
+	return json.Marshal(map[string]any{"ref": stubFeatureRef})
+}


### PR DESCRIPTION
Economy wave slice **E0**, and the prerequisite for every other one.

The census correction #1035 filed under "the state already round-trips" is true for serialization and false for write-back. `ToData` deep-copies the economy and `GetResourceData` feeds `Data.Resources`, but `Character.dirty` was set at exactly four sites — all hit points or conditions (`character.go:767, 1137, 1174, 1195`). `resolution.dirtyCharacters` keeps only the sheets that report `IsDirty()`, and `session.saveDirty` writes only what that returns. So an action spent or a ki point burned on a loaded sheet inside a resolution serialized perfectly and was then dropped on the floor. Invisible until something spends, which is exactly what the rest of the wave is about to make happen.

## Census — every write to `c.actionEconomy`

| Site | Write | Disposition |
|---|---|---|
| `ExitCombat` | `c.actionEconomy = nil` | **marks**, guarded on it having been non-nil (nil→nil is not a change) |
| `StartTurn` | seeds a fresh `ActionEconomyData` | **marks** |
| `EndTurn` | zeroes four counters, fresh `Granted` map | **marks**, inside the nil guard |
| `GrantCapacity` | creates `Granted`, `Granted[key] += amount` | **marks**, after the nil guard |
| `executeStrike` | `Granted[GrantedAttacks]--` | **marks** |
| `executeOffHandStrike` | `Granted[GrantedOffHandStrikes]--` | **marks** |
| `executeFlurryStrike` | `Granted[GrantedFlurryStrikes]--` | **marks** |
| `executeUnarmedStrike` | granted capacity **and** the bonus-action slot | **marks** |
| `executeMove` | `MovementRemaining -= distance` | **marks** |
| `fromToolkitActionEconomy` | the bridge write-back the issue names | **marks** — a whole ability activation lands here at once |
| `consumeActionType` | one of three slot counters | **marks** in the three writing cases; a free action writes nothing and returns |
| `checkPostStrikeGrants` | grants martial-arts / off-hand strike | **exception, documented in place**: its only caller, `executeStrike`, marks once for the decrement and these grants together |
| `restoreActionType` | rollback increment | **exception, documented in place**: the `consumeActionType` it undoes already marked, and the sheet deliberately stays dirty (below) |
| `toToolkitActionEconomy` | — | **exception**: pure read, returns a detached copy |
| `GetActionEconomy` | returns the **live** `*ActionEconomyData` | **exception, documented in place**: a read that lends out a writable pointer, so writing through it escapes marking. Filed as a pure read in my first pass; Copilot caught it. Same hatch as `GetResource`, same warning, and not closed by copying — callers write through it today and the change would break them with no compile error. |
| `load.go:250-258` `char.actionEconomy = &aeCopy` | seeds from stored data | **exception**: load path |

The rejecting branches in the execute helpers return *before* mutating, so a refused strike or an over-budget move leaves the sheet clean without any extra care.

## Census — every write to `Data.Resources`-backed pool state

| Site | Write | Disposition |
|---|---|---|
| `UseResource` | `r.Use(amount)` | **marks** on success — the choke point Rage, Flurry of Blows, Patient Defense and Step of the Wind all spend through |
| `SpendHitDice` | `hitDiceResource.Use(count)` | **marks** on its own, rather than leaning on the healing event it publishes (that only marks if the sheet's keeper is on the bus) |
| `LongRest` | hit points to max, death saves cleared, long/short-rest pools restored | **marks** — LongRest was moving hit points without marking either, so that goes with it |
| `ShortRest` | short-rest pools restored | **marks**, unconditionally (below) |
| `AddResource` | adds a pool to the map | **marks** |
| `LoadResourceData` | rebuilds pools from stored data | **exception, documented in place**: load path |
| `loadResources` (`load.go:406`) | same, on the pure `Load` path | **exception**: load path |
| `GetResource` | returns the **live** `*RecoverableResource` | **exception**: read accessor, and the one real escape hatch. Mutating through the returned pointer skips marking. No in-repo caller does — only `Current()`/`Maximum()`/`IsEmpty()`, plus `SpendHitDice`, which marks. Its doc now says to spend through `UseResource`. |
| `RecoverableResource.onRest` | bus-driven self-restore | **exception by containment**: the only `RestTopic` publishers are `Character.LongRest`/`ShortRest`, both of which mark. `conditions/raging.go` subscribes, never publishes. |
| `Character.ActivateCombatAbility`, `conditions/fighting_style_protection.go`, `combat/attack.go` | drive a **caller-supplied** economy | **exception**: never touch `c.actionEconomy` |
| `features/second_wind.go`, `features/action_surge.go` | spend a feature-owned resource | **out of E0 scope**: persisted through `Data.Features`, not `Data.Resources`. Belongs to #972/#987. Second Wind is covered incidentally — it costs a bonus action, and `consumeActionType` marks. Action Surge is not, but cannot reach its spend through this path either: it is a FREE action, and its `CanActivate` demands an `ActionEconomy` that `activateFeature` never supplies, so it fails before mutating. Reckless Attack, the other free feature, marks through the condition site. |

Adjacent and not touched: `EquipItem`/`UnequipItem` mutate the persisted inventory without marking — the same defect wearing an inventory face, and #972/#987's, not E0's.

### Two judgement calls, both toward over-saving

- **`restoreActionType` leaves the sheet dirty.** A feature whose `Activate` failed may have moved its own persisted state before it errored, and the rollback cannot know. One redundant write costs less than one lost spend.
- **`ShortRest` marks unconditionally**, even when no pool moved. The rest event it publishes also reaches resources and conditions that restore or remove themselves, which `Character` cannot observe.

## Does anything reset dirty?

`MarkClean()` is the only reset. Its non-test callers are the OLD top-level `encounter` module (`hydration.go:241/256`), which is a separate module pinning a released `rulebooks/dnd5e`. The new stack reads `IsDirty()` and never clears it. Nothing on the load path sets or clears it, so a loaded-untouched sheet stays clean — which the new tests pin.

## Spurious writes

- `Load` → `loadResources` and a direct `char.actionEconomy = &aeCopy`; neither routes through a marked function.
- `Attach` / `SheetKeeper.Apply` → `resource.Apply` subscribes to the bus without touching a value.
- `Draft.initializeClassResources` writes `char.resources[...]` directly, not via `AddResource`.
- No `go.work`, no `replace` anywhere: `session`, `resolution` and `rulebooks/dnd5e/encounter` pin released versions, so nothing downstream sees this until a release.

## Test evidence

New file `character/economy_dirty_test.go`, 31 cases (30 at RED, plus the free-action pin the mutation pass called for). Mutations are driven through real public paths (`StartTurn`, `ActivateAbility`, `ExecuteAction`, `UseResource`, the rests, `SpendHitDice`) on a sheet built by `Load`, so the load path is exercised for real rather than simulated.

**RED, before the production change — 18 failing:**

```
--- FAIL: TestEconomyDirtySuite/TestStartTurnMarks
        Messages:   	a seeded turn is economy state that has to be written down
--- FAIL: TestEconomyDirtySuite/TestActivatingAnAbilityMarksThroughTheBridge
        Messages:   	an economy-only change still needs saving
--- FAIL: TestEconomyDirtySuite/TestSpendingAPoolMarksWithoutTouchingHitPoints
        Messages:   	a ki-shaped spend is the whole reason Data.Resources exists
--- FAIL: TestEconomyDirtySuite/TestMovingMarks
        Messages:   	movement spent off a persisted budget has to be written down
```

...plus `TestStrikingMarks`, `TestTheUnarmedStrikeMarks`, `TestTheOffHandStrikeMarks`, `TestTheFlurryStrikeMarks`, `TestEndTurnMarks`, `TestExitCombatMarks`, `TestGrantingCapacityMarks`, `TestActivatingAFeatureMarksTheSlotItSpends`, `TestAFailedFeatureActivationLeavesTheSheetDirty`, `TestAddingAPoolMarks`, `TestSpendingHitDiceMarksOnItsOwn`, `TestAShortRestMarks`, `TestALongRestMarks`, `TestASpendOnALoadedSheetSurvivesToData`.

The **12 no-clobber cases were green before the change and stayed green after** — that is the point of them: a loaded sheet, an attached sheet, a sheet that was only asked what it can do, a refused strike, a refused unarmed strike, a refused move, an over-budget pool spend, a pool that isn't there, an unknown ability, `GrantCapacity` out of combat, `ExitCombat` out of combat, and the free-action feature. `TestDamageStillMarks` pins the first of the four existing sites; the condition and healing sites keep their own pins in `sheet_keeper_test.go`.

**Mutation-tested.** Each of the 16 new marks was deleted in turn and the suite re-run; all 16 were killed by a named test, as were both exception guards (`ExitCombat`'s nil check → `TestExitCombatOutOfCombatLeavesTheSheetClean`). One survivor turned up on the first pass — `consumeActionType`'s no-slot branch, because nothing that ships takes a free action and mutates the economy — and now has a stub-feature pin, `TestActivatingAFreeFeatureLeavesTheSheetClean`.

**GREEN:**

```
$ gofmt -l .          # (no output)
$ go vet ./...        # clean
$ go test -count=1 ./...
27 packages ok, 0 FAIL
$ golangci-lint run ./...
0 issues.
```

## gorelease

The parent `dnd5e` module has no gorelease CI job, so this was run by hand:

```
$ gorelease -base v0.95.0
# summary
Suggested version: v0.95.1 (with tag rulebooks/dnd5e/v0.95.1)
```

Patch-shaped: no exported API changed, only behaviour behind existing methods. Hence `fix(dnd5e):`. (Run on the first commit; the follow-up is a test, three doc comments and one comment rewrite, none of which touch the API surface.)

Closes #1087

— fix-1087 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
