### PR TITLE
docs(ideas): the economy gate — where an action's cost lives (#1035)

### DIFF
--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -5,8 +5,8 @@
 trade-off conversation that happens *before* E1 freezes the spend vocabulary.
 **Decides:** nothing. The evidence is the [#1035 census][census] and its
 [supplement][supp] and [movement addendum][move]; this doc does not re-derive
-any of it. What it does is lay three shapes side by side and walk each one
-through the same four cases.
+any of it. What it does is lay four shapes side by side and walk each one
+through the same cases.
 
 **Verified against** `main` at `b3287ae`.
 
@@ -38,81 +38,130 @@ with two riders that shape everything below:
 > for that turn only if they have it. if they used it on their turn there is
 > nothing to pause for. if they do spend it it comes off their sheet.
 
-## Three shapes
+## Four shapes
 
 ```mermaid
 flowchart LR
     subgraph A["A — spend MACHINE"]
-        A1["Resolve(Input{Machine: Spend})"] --> A2["Spend machine\ndebits, then"] -->|Request| A3["Strike"]
+        A1["Resolve(Machine: Spend)"] --> A2["Spend debits"] -->|Request| A3["Strike"]
     end
     subgraph B["B — gate at the DOOR"]
-        B1["Resolve(Input{Cost, Machine})"] --> B2["door pays Cost"] --> B3["Strike"]
+        B1["Resolve(Cost, Machine)"] --> B2["door pays Cost"] --> B3["Strike"]
     end
     subgraph C["C — gate as a SERVICE"]
-        C1["Resolve(Input{Gate, Machine})"] --> C2["door consults Gate"] --> C3["Strike"]
-        C3 -.->|"at a reaction moment"| C4["consult Gate again"]
+        C1["Resolve(Gate, Machine)"] --> C2["door consults Gate"] --> C3["Strike"]
+        C3 -.->|"reaction moment"| C4["consult Gate again"]
+    end
+    subgraph D["D — ledger travels with the CAST"]
+        D1["Resolve(Participants)"] --> D2["Strike holds the sheets"]
+        D2 --> D3["combat.Pay(sheet, profile)"]
+        D2 -.->|"reaction moment"| D4["combat.CanPay(wizard's sheet)"]
     end
 ```
 
 - **(A) A spend machine wrapping the strike.** The census's F6-literal sketch:
   a machine whose steps are "debit, then `Request` the interaction below".
-  Costs nothing architecturally — a new machine over existing sealed steps is
-  priced "cheap and safe — cannot touch the bus" (`resolution/ARCHITECTURE.md:144`).
 - **(B) A gate at `Resolve`'s door.** A compiled cost profile rides `Input`
   beside the machine, and resolution debits before calling `Machine.Start`.
-  Cost and interaction become independent fields.
 - **(C) A gate as a service resolution can consult at any action moment.** The
-  same profile, reached through a capability on `Input` — consulted at the
-  door, and again wherever an action moment appears inside a resolution.
+  same profile, reached through a capability on `Input`.
+- **(D) The ledger travels with the cast.** No capability and no callback: the
+  gate is two pure functions in `combat` over sheets resolution *already holds*
+  — `CanPay(sheet, profile)` and `Pay(sheet, profile)`.
+
+Shape D came out of Kirk's push to keep the seam all-data:
+
+> I would like to find a way to keep it all data… holding out hope there is an
+> elegant solution.
+
+**D is not a fourth peer to A, B and C — it is a different axis.** A/B/C answer
+*where the debit is called from*; D answers *what the gate is made of*. Once the
+gate is pure functions over the cast's sheets, it can be called from a wrapping
+machine (A's site), from the door (B's site), or from inside a machine at a
+reaction moment (C's reach) — without any of them needing a capability. That is
+why it deserves its own section rather than a row in the table.
+
+### Why D is available at all — two verified facts
+
+1. **Resolution already holds every participant's sheet, mutably.** `castFor`
+   builds the cast from **every member of the encounter**, and the rule is
+   already "anyone whose effects might fire" rather than "the two swinging":
+
+   > EVERY member, not the two swinging: scope is the caller's and applicability
+   > is the effect's own predicate (ADR-0038). A bard three cells away whose
+   > Bless is running has to be in the room for their subscription to fire
+
+   (`session/attack.go:396-401`, loop at `:411-428`; law R3 at
+   `resolution/doc.go:36-41`). So "extend the cast to anyone who might react" is
+   **not an extension** — a wizard who is a member of the encounter is already
+   in the cast, with a mutable sheet, before any reaction is considered.
+
+2. **A machine already mutates those sheets mid-resolution, bus-free.** The
+   strike's damage phase reaches into the cast and writes the target's sheet:
+   `combatantFor(m.cast, m.in.TargetID)` (`resolution/strike.go:424`, helper at
+   `:624-634`) then `target.ApplyDamage(...)` — commented "**Bus-free, and the
+   only phase that is: applying damage is the sheet's own business and takes no
+   bus**" (`:443-448`). `character.ApplyDamage` marks the sheet dirty
+   (`character/character.go:767`), `Resolve` returns `dirtyCharacters(cast)`
+   (`resolve.go:294`, `:413-423`), and `session.saveDirty` writes them
+   (`session/attack.go:456-465`).
+
+   **The economy ledger is the same species as hit points**, and `Pay` would be
+   the second bus-free phase in exactly the category the first one established.
+
+The structural consequence: **D needs nothing new on `Input`**, so it never
+becomes "the first capability resolution consults" and never collides with
+`Input.Standing`'s "Carried, never consulted". On the ADR question below, **D
+is the only one of B/C/D that stays ADR-free**, and it is ADR-free for the same
+reason A is — it adds no vocabulary and no seam concept.
+
+## The cases
 
 ### Case (i) — the level-5 fighter's three swings
 
-One action buys two attacks; the third swing is refused. Two `Attack` verbs in
-one turn are two processes, so the bank lives on the sheet either way.
+One action buys two attacks; the third is refused. Two `Attack` verbs in one
+turn are two processes, so the bank lives on the sheet either way.
 
 | | |
 |---|---|
-| **A** | Spend machine reads the sheet, debits the action if the bank is empty, banks 2, spends 1, `Request`s the strike. Second call: bank non-empty, spend 1 only. Third: refused before the strike runs. |
-| **B** | Identical, except the arithmetic is at the door and the strike machine never learns economy exists. |
+| **A** | Spend machine reads the sheet, debits the action if the bank is empty, banks 2, spends 1, `Request`s the strike. |
+| **B** | Identical, arithmetic at the door; the strike never learns economy exists. |
 | **C** | Identical to B. |
+| **D** | Identical to whichever call site it is wired at — but the debit is `combat.Pay` on the cast's own sheet, so it rides out through `DirtyCharacters` with no new plumbing. |
 
-**Discriminates: nothing.** All three handle the headline case. Worth stating
-plainly — the case that motivated the issue does not choose the shape.
+**Discriminates: nothing.** Worth stating plainly — the case that motivated the
+issue does not choose the shape.
 
 ### Case (ii) — Dash: a spend with no machine behind it
 
-Dash spends an action and grants movement. There is no interaction to resolve:
-no roll, no target, no chain.
+Dash spends an action and grants movement. No roll, no target, no chain.
 
 | | |
 |---|---|
-| **A** | A "machine" whose entire body is a debit and a `Done`. Expressible, but it names a machine where there is no interaction — the vocabulary's own rule is that a machine's identity is its *yield-shape*, and this one yields nothing. |
-| **B** | Natural. `Cost` set, `Machine` nil (or trivially `Done`). Kirk's "a machine maybe doesn't have a cost" is the same independence read the other way. |
+| **A** | A "machine" whose entire body is a debit and a `Done`. Expressible, but it names a machine where there is no interaction — and the vocabulary's own rule is that a machine's "identity is its **yield-shape**". |
+| **B** | Natural. `Cost` set, `Machine` nil or trivial. Kirk's "a machine maybe doesn't have a cost" read the other way. |
 | **C** | Natural, same as B. |
+| **D** | **Honestly, no better than A or B.** A Dash verb still needs *something* to run; what D changes is that the cost is not pretending to be a machine — it is a function that something calls. The awkwardness is relocated, not dissolved. |
 
-**Discriminates: A.** Shape A conflates the cost with the interaction, so a
-cost without an interaction has to wear a machine's clothes. Note this case is
-currently hypothetical at the seam — there is no Dash verb in `session` — but
-it is the shape of every non-attack action in the catalogue (Dodge, Disengage,
-Help, Hide).
+**Discriminates: A (mildly).** Note the case is currently hypothetical at the
+seam — there is no Dash verb in `session` — but it is the shape of every
+non-attack action in the catalogue (Dodge, Disengage, Help, Hide).
 
 ### Case (iii) — the wizard's Shield
 
 A fighter swings at Aldric. Mid-resolution, after the roll and before damage,
-Aldric may cast Shield as a **reaction** — and only if he still has one.
-
-This case is already modelled as a nine-beat test,
-`play/interrupt/shieldscene_test.go`, with Aldric as audience and
-`["shield","decline"]` as options.
+Aldric may cast Shield as a **reaction** — and only if he still has one. Already
+modelled as a nine-beat test, `play/interrupt/shieldscene_test.go`.
 
 | | |
 |---|---|
-| **A** | The spend machine above the strike has already finished — it debited the *fighter's* action. The wizard's reaction is a **different actor's cost, discovered inside the interaction**. To express it, the strike machine would have to `Request` a spend machine for somebody else, which puts economy inside the strike — the exact thing the census argued the machine must never hold. |
-| **B** | **Cannot express it.** At the door, the actor is the fighter and the cost is the fighter's. The wizard's reaction is not knowable there: whether a window even opens depends on a fact discovered several steps into somebody else's resolution. |
-| **C** | The natural case. When the strike reaches a reaction moment, the spine consults the gate — *can Aldric afford Shield?* — **before** posing. No reaction, no window. If he answers "shield", the gate debits his reaction off his sheet. |
+| **A** | The spend machine above already finished; it debited the *fighter's* action. Reaching the wizard means the strike must `Request` a spend machine for somebody else — economy inside the strike, the thing the census said the machine must never hold. |
+| **B** | **Cannot express it.** At the door the actor is the fighter. Whether a window opens depends on a fact discovered several steps into somebody else's resolution. |
+| **C** | Works: the spine consults the gate before posing. Costs a consulted capability, and therefore an ADR. |
+| **D** | **Works, with nothing added.** At the reaction moment the strike already holds `m.cast`, and the wizard's sheet is in it (fact 1). `combat.CanPay(wizardSheet, shieldProfile)` is a pure read of data the machine has. No reaction, no window. On the answer, `combat.Pay` debits that same sheet and it rides out through `DirtyCharacters`. |
 
-**Discriminates: B (fails), A (only by breaking its own rule).** This is the
-case that separates the shapes, and Kirk's eligibility insight is what makes it
+**Discriminates: B fails; A only by breaking its own rule; C works but pays an
+ADR; D works for free.** Kirk's eligibility insight is what makes the case
 sharp:
 
 > the wizard spends their reaction for that turn only if they have it. if they
@@ -122,133 +171,206 @@ That is not a UI nicety — it decides whether the window exists. And the ledger
 cannot decide it: `interrupt.Pose` validates the audience and the option tokens
 and nothing else, because the module is deliberately "custody, not execution"
 and "never interprets an option, a choice, or a payload byte"
-(`play/interrupt/doc.go`). **So somebody must consult the economy before
-`Pose` is called.** Under C that somebody is the gate. Under A or B there is
-no one holding the question.
+(`play/interrupt/doc.go`). **So somebody must consult the economy before `Pose`
+is called** — and under D that somebody is the machine, reading its own input.
+
+**A second problem D dissolves that the others do not:** multiattack. If a
+fighter's two swings are two strikes inside one resolution, a wizard who spends
+Shield on the first must not be offered it on the second. Under D the later
+check reads the **same sheet instance** the earlier debit wrote, so the second
+window never opens. Under B or C the debit's visibility depends on whether the
+gate's writes are readable mid-resolution — which is a question D never has to
+ask.
 
 ### Case (iv) — suspension: the strike pauses and the process dies
 
-A window is open; the server restarts before anyone answers. Was the action
-spent?
+**There is no resume path today, and that has to be said before anything else
+about this case.** Nothing outside `play/interrupt` imports it — the only
+mention anywhere else in the repo is prose in `session/doc.go`, which records
+that the adapter was retired. `Answer` returns an envelope "for the rulebook to
+resume" and nothing calls it. So this case cannot be settled by reading code; it
+can only be reasoned about.
 
-Today the answer is clean and the same for all three: **nothing was spent**,
-because a failed resolution persists nothing — "a refused resolution leaves
-nothing on a bus and no half-written sheet" (`resolution/doc.go:82-85`), and
-`session.Attack` returns before `adopt`/`saveDirty` on any resolution error
-(`session/attack.go:213-215`). Failure refunds are free because failure writes
-nothing.
-
-Suspension is different from failure, and that is the open part:
+What *is* verified is the failure case, which is cleanly the same for all four:
+**nothing was spent**, because a failed resolution persists nothing — "a refused
+resolution leaves nothing on a bus and no half-written sheet"
+(`resolution/doc.go:82-85`) — and `session.Attack` returns before
+`adopt`/`saveDirty` on any resolution error (`session/attack.go:213-215`).
+Failure refunds are free because failure writes nothing.
 
 | | |
 |---|---|
-| **A / B** | The cost was paid before the interaction started. If a suspension persists the frozen resolution and the process later resumes *from the window* rather than from the top, the debit must have been persisted alongside the frozen payload — or it is lost on resume (free action) or re-applied (double charge). |
-| **C** | The fighter's door-cost has the identical problem. Aldric's reaction does not: under C it is debited **at the answer**, so a window that is never answered spent nothing, which is also the correct 5e reading. |
+| **A / B / C** | The actor's cost was paid before the interaction started. If a suspension persists the frozen resolution and resume continues *from the window* rather than from the top, that debit must have been persisted alongside the frozen payload, or it is lost on resume (free action) or re-applied (double charge). |
+| **D** | The actor's door-cost has the identical problem — D does not rescue it. What D does fix is the **reaction** half: the wizard's `Pay` happens at the *Answer* door, after a fresh load, so a window that is never answered spent nothing, and a reloaded sheet cannot be double-charged by a debit that was never written. |
 
-**Discriminates: partially.** Nobody escapes the door-cost-plus-suspension
-question; C removes it for the reaction half by paying later. Note this is
-wave-5-shaped, not hypothetical-forever: `Pose` is the sealed vocabulary's
-unbuilt fourth case, and the movement addendum found that the docs still
-promise it arrives with a walk machine that #964 never built
-(`ARCHITECTURE.md:96,162`, `resolution/doc.go:133-136`), while
-`session/doc.go:88-118` records reactions as the first honest producer.
+**Discriminates: partially, and the same way for all four.** The honest reading
+is that the actor's pre-suspension debit is a **suspension-contract** question,
+not an economy question: whatever freezes a resolution has to decide what
+travels with the frozen payload, and the debit is one more thing on that list.
+
+### Case (v) — the opportunity attack on a walk
+
+A creature leaves a threatened square; whoever threatens it may spend a reaction
+to swing. Two halves, and they are not equally ready.
+
+**The reactor side is door-computable, with one caveat.** Resolution builds an
+`interactionRoom` out of `Input.World` — "The positions are already here",
+because `EncounterData.Members` carries every member's room and position
+(`resolution/world.go:23-46`). So "who is adjacent to this path" is answerable
+from data the door already has. **The caveat is real:** that builder returns
+`nil` when the participants do not all share one room (`world.go:63-67`), and
+`castFor` passes *every* encounter member — so in a multi-room dungeon with the
+party spread out, no room is installed at all (`resolve.go:257-263`). Widening
+the cast makes this *more* likely, which is a cost D inherits rather than
+creates. Filed as a side-finding below.
+
+**The mover side is not ready at all, and D does not change that.** There is no
+in-fight movement verb and no walk machine: `encounter.Move` refuses a member in
+a bubble, saying in-fight movement "arrives with the resolution work"
+(`encounter/encounter.go:1469-1481`). **So D's OA story lands with the in-fight
+movement machine, not before it** — the same conclusion the movement addendum
+reached from the other direction.
+
+## Where this leaves the comparison
+
+Reading the cases rather than the intuition:
+
+| | (i) swings | (ii) Dash | (iii) Shield | (iv) suspension | ADR? |
+|---|---|---|---|---|---|
+| **A** machine | fine | awkward | only by breaking its own rule | door-cost open | no |
+| **B** door | fine | natural | **cannot express** | door-cost open | probably |
+| **C** service | fine | natural | works | door-cost open | probably, and after `Pose` |
+| **D** cast | fine | **no better than A/B** | works, nothing added | door-cost open; reaction half fixed | **no** |
+
+**What the evidence supports:** D gives C's reach at B's price, and it is the
+only shape besides A that adds no seam concept. It does *not* win case (ii), and
+it does *not* solve the suspension door-cost — no shape does. Its advantage is
+concentrated in case (iii) and in the multiattack visibility problem, and it
+gets there by using two mechanisms that already ship rather than by adding one.
+
+**What that does not settle:** D leaves the A-versus-B question open rather than
+answering it — the debit still has to be *called* from somewhere. That may be
+D's most useful property: it makes the call-site choice smaller and later,
+because moving a pure function call is a refactor, while moving a capability is
+a seam change.
+
+### D's honest cost — the cast-assembly obligation
+
+D is only correct while **everyone who might react is already in the cast.**
+Today that holds for encounter members and is not a new requirement (fact 1),
+but it has three edges worth naming:
+
+1. **It is paid for per verb.** `castFor` does a repository read per character
+   on every call (`session/attack.go:423-427`), and `standingSeam` does its own
+   on every consult. D adds no reads, but it makes the existing breadth
+   load-bearing for *correctness* rather than only for effects — a cast that was
+   merely generous becomes a cast that must be complete.
+2. **It collides with `interactionRoom`.** The wider the cast, the more likely
+   participants span rooms and the positional installer goes silent (case (v)).
+3. **A reactor who is not an encounter member cannot be reached at all.** Cast
+   membership is the roster; a monster with no stored sheet is skipped outright
+   (`session/attack.go:415-419`). Cross-encounter reactions are not expressible,
+   which is almost certainly fine and should be a stated limit rather than a
+   discovered one.
 
 ## The cross-cutting facts any shape must respect
 
 Established in the census and its addenda; cited, not re-argued.
 
-1. **The profile is compiled per actor, in the rulebook.** Class-dynamic cost —
-   Kirk's "maybe that cost is dynamic based on the class" — is the compiler's
-   business, following `AttackFromCharacter`. The machine holds no class table.
-   The repo has the anti-pattern three times: the monk hardcode
+1. **The profile is compiled per actor, in the rulebook.** Class-dynamic cost is
+   the compiler's business, following `AttackFromCharacter`. The machine holds no
+   class table. The repo has the anti-pattern three times: the monk hardcode
    (`character/action_economy.go:592-607`), the ref→resource switch (`:742-763`),
    and Dash's two constructors baking cost into object identity
    (`combatabilities/dash.go:29-41` vs `:43-55`).
-2. **The ledger is on the sheet.** Three verbs in one turn are three processes;
-   only persisted sheet state survives between them.
+2. **The ledger is on the sheet.** Three verbs in one turn are three processes.
 3. **Keyed, never fielded.** `combat.ActionEconomy` grew a named field per
-   feature; its persisted twin replaced them with `Granted map[GrantedActionKey]int`,
-   and the bridge between the two shapes maps only three of five keys.
-4. **Per-unit movement cost stays out of the profile.** "Spend N of capacity K";
-   what N is for a path is the path's business, or difficult terrain can never
-   be added.
+   feature; its persisted twin replaced them with a keyed map, and the bridge
+   between the two maps only three of five keys.
+4. **Per-unit movement cost stays out of the profile.**
 5. **The sealed vocabulary is `Gather | Pose | Request | Done`**, and extending
    it costs an ADR (ADR-0038).
 
-### Does B or C need an ADR? — honestly, probably yes, and not for the reason the census assumed
+### Does any shape need an ADR?
 
-The census said "no ADR" on the strength of the socket table: a new machine
-over existing steps is cheap. **That reasoning covers shape A only.**
+The census said "no ADR" on the strength of the socket table pricing a new
+machine as cheap. **That reasoning covers shape A only.**
 
 B and C do not add a step kind, so ADR-0038's stated trigger is not pulled. But
-they change what `resolution.Input` *means*, and there is a specific law in the
-way. R2 reads "**Everything at the seam is data.** No runtime object crosses
-into or out of [Resolve]" (`resolution/doc.go:34-36`). Four capabilities
-already ride `Input` — `Deciders`, `Initiative`, `Standing`, `Roller` — and the
-package rationalises them as pass-through rather than exceptions: `Standing`'s
-own field doc says "**Carried, never consulted.**"
+they change what `resolution.Input` *means*, and there is a law in the way. R2
+reads "**Everything at the seam is data.** No runtime object crosses into or out
+of [Resolve]" (`resolution/doc.go:34-36`). Four capabilities already ride
+`Input` — `Deciders`, `Initiative`, `Standing`, `Roller` — and the package
+rationalises them as pass-through rather than exceptions: `Standing`'s own field
+doc says "**Carried, never consulted.**" A cost gate under B or C would be the
+first capability resolution itself *consults*, which is a real change to the
+package's self-description.
 
-A cost gate would be **the first capability resolution itself consults.** That
-is a real change to the package's self-description, and under C it is consulted
-at a suspension point that does not exist yet. Calling that additive would be
-the kind of claim ADRs exist to stop. So: **A is ADR-free; B and C want one**,
-and C's would have to be written with `Pose` rather than before it.
+**D pulls neither trigger.** Pure functions in `combat` over sheets already in
+`Participants` add no step kind and no capability; the sheets are already data
+and already mutated in place. So: **A and D are ADR-free; B and C want one**, and
+C's would have to be written with `Pose` rather than before it.
 
 ## Open questions
 
-Front and centre, because these are the conversation.
-
-1. **Which shape?** Case (iii) is the discriminating one, and it is not a
-   corner case — it is wave 5. But choosing C now means designing a consult
-   point for a suspension mechanism nobody has built. Is it better to ship A or
-   B for v1 and pay a migration when reactions land, or to choose the shape
-   that survives reactions before writing the first debit?
-2. **One ledger behind the gate, or several?** Per-turn slots, granted
-   capacity, pools (ki) and slots have different cadences and, today, different
-   homes. Does the gate present one debit surface over all of them, or is
-   "spend an action" and "spend a ki" two verbs to the caller?
-3. **Pools and spell slots through the same system — genuinely unresolved.**
-   Ki is a keyed pool with a `ResetType`; a spell slot is keyed by *level* with
-   no reset field, and upcasting means a 3rd-level spell may eat a 5th-level
-   slot. Same gate, or a different one? Kirk's own read is that this is unclear,
-   and nothing in the code forces it either way yet.
+1. **Where is `Pay` called from — a wrapping machine (A's site) or the door
+   (B's site)?** Under D this is a smaller question than it looks, and it can be
+   answered later.
+2. **One ledger behind the gate, or several?** Per-turn slots, granted capacity,
+   pools and slots have different cadences and, today, different homes. One debit
+   surface, or several verbs to the caller?
+3. **Pools and spell slots through the same system — genuinely unresolved.** Ki
+   is a keyed pool with a `ResetType`; a spell slot is keyed by *level* with no
+   reset field, and upcasting means a 3rd-level spell may eat a 5th-level slot.
 4. **The eligibility read.** "Could Shield fire?" is the may-I-act question in
-   reaction clothes, and it is now two questions: the server needs it to decide
-   whether to open a window at all, and a client may want it to grey a button.
-   Same read, or does the server-side one stay internal?
-5. **Refunds.** 5e says no. Today the question does not arise, for a verified
-   reason: failure persists nothing. Suspension is where it becomes real — and
-   the honest answer may be that a suspended resolution must persist its debit
-   with its frozen payload, which makes the debit part of the suspension
-   contract rather than the economy's.
-6. **What does wave 5 need the gate to already be?** If the answer is "a thing
-   the interrupt spine can ask before posing", that is C, and it is worth
-   knowing now rather than after E1.
+   reaction clothes, and it is two questions: the server needs it to decide
+   whether to open a window, and a client may want it to grey a button.
+5. **What travels with a frozen resolution?** Case (iv) suggests the actor's
+   debit is part of the *suspension* contract rather than the economy's. Worth
+   settling when `Pose` is designed, not before.
+6. **Is the cast-assembly obligation acceptable as a correctness requirement?**
+   Under D a missing participant stops being a missed buff and becomes a missed
+   refusal.
 
 ## What each shape does to E1–E3
 
-E0 (dirty-marking) is ruling-independent and already dispatched.
+E0 (dirty-marking) is ruling-independent and already dispatched — and note it
+becomes **more** load-bearing under D, since every debit reaches storage through
+exactly that path.
 
-| | A | B | C |
-|---|---|---|---|
-| **E1** cost compiler | unchanged — profile compiled in the rulebook | unchanged | unchanged |
-| **E2** the spend | a `Spend` machine in resolution | a field on `Input` + a debit step at the door | a capability on `Input` + a consult at the door, and a second consult point reserved |
-| **E3** session one-liner | hands `Resolve` the spend machine | hands `Resolve` a cost beside the machine | hands `Resolve` a gate beside the machine |
+| | A | B | C | D |
+|---|---|---|---|---|
+| **E1** cost compiler | unchanged | unchanged | unchanged | unchanged |
+| **E2** the spend | a `Spend` machine | a field on `Input` + door debit | a capability on `Input` + two consult points | `combat.CanPay`/`Pay` + one call site |
+| **E3** session one-liner | hands `Resolve` the machine | hands `Resolve` a cost | hands `Resolve` a gate | **unchanged if the call site is a machine** |
 
-**E1 survives all three unchanged**, which is the useful result: the compiler
-and the profile are common ground, so E1 can proceed on the census's ruling
-while this conversation continues. What changes between shapes is E2 — where
-the debit happens — and E3's one line.
+**E1 survives all four shapes unchanged**, which is the useful result: the
+compiler and the profile are common ground, so E1 can proceed on the census's
+ruling while this conversation continues.
 
 ## What would make this doc wrong
 
-- If reactions turn out not to need an eligibility check before posing — if a
-  window may open and be refused at answer time — case (iii) stops
-  discriminating and B becomes as good as C.
-- If the per-actor profile cannot express a second actor's cost at all, then
-  no shape solves case (iii) and the reaction economy is a separate mechanism
-  from the action economy, which would be worth knowing before either is built.
-- If `Pose` arrives shaped so that a machine can consult supplied capabilities
-  directly, C stops being a distinct shape and becomes A with a longer reach.
+- If reactions turn out not to need an eligibility check before posing, case
+  (iii) stops discriminating and B becomes as good as C or D.
+- If a sheet in the cast cannot safely carry a debit across a `Request`
+  boundary — if a sub-machine gets a different instance — D's central claim
+  fails and it collapses into A.
+- If the cast cannot be guaranteed complete for reaction purposes, D is unsafe
+  in exactly the cases it was chosen for, and C's consult (which can go and ask)
+  becomes the honest answer.
+- If `Pose` arrives shaped so a machine can consult supplied capabilities
+  directly, C stops being distinct and becomes A with a longer reach.
+
+## Side-finding, filed separately
+
+**A multi-room cast silently disables prone's positional split.** `castFor`
+passes every encounter member (`session/attack.go:411-428`), and
+`interactionRoom` installs no room when participants span rooms
+(`resolution/world.go:63-67`, `resolve.go:257-263`). In a multi-room dungeon
+with the party spread out — the reference tomb's normal state — no room is
+installed for any strike, so prone's advantage-within-five-feet predicate has no
+positions to read. The behaviour is documented as intentional ("a machine that
+needs positions then refuses"), but the *combination* with pass-everyone-in
+means the refusal is the common case rather than the rare one. Not fixed here.
 
 — census-1035 agent, on behalf of KirkDiggler

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -254,24 +254,96 @@ D's most useful property: it makes the call-site choice smaller and later,
 because moving a pure function call is a refactor, while moving a capability is
 a seam change.
 
-### D's honest cost — the cast-assembly obligation
+### D's obligation, and Kirk's refinement of it — interested-by-declaration
 
 D is only correct while **everyone who might react is already in the cast.**
-Today that holds for encounter members and is not a new requirement (fact 1),
-but it has three edges worth naming:
+Today that holds for encounter members and is not a new requirement (fact 1) —
+but "pass literally everyone" is a blunt instrument, and Kirk's refinement is to
+narrow it by *relevance to the declared action*:
 
-1. **It is paid for per verb.** `castFor` does a repository read per character
-   on every call (`session/attack.go:423-427`), and `standingSeam` does its own
-   on every consult. D adds no reads, but it makes the existing breadth
-   load-bearing for *correctness* rather than only for effects — a cast that was
-   merely generous becomes a cast that must be complete.
-2. **It collides with `interactionRoom`.** The wider the cast, the more likely
-   participants span rooms and the positional installer goes silent (case (v)).
-3. **A reactor who is not an encounter member cannot be reached at all.** Cast
-   membership is the roster; a monster with no stored sheet is skipped outright
-   (`session/attack.go:415-419`). Cross-encounter reactions are not expressible,
-   which is almost certainly fine and should be a stated limit rather than a
-   discovered one.
+> what cast enters the input? what action is being taken? what can counter that
+> action? if it is an attack, a shield would go in because a shield can counter
+> that. the key is not shoving every possible thing into the input but only the
+> things that can have an effect on it.
+
+**The tension to clear first.** `castFor` passes the whole roster *precisely
+because* the session is not allowed to filter: "applicability is the effect's
+own predicate (ADR-0038)… deciding they are irrelevant here would be this
+package deciding a rule" (`session/attack.go:398-401`). So a narrower cast is
+legal **only if the relevance answer comes from the rulebook**, never from the
+seam. That is the whole design constraint, and it has a known solution shape.
+
+**The mechanism: a reaction declares its trigger as data.** The house pattern
+already exists twice, and both times it was invented to solve this exact class —
+"can this be answered before anything runs?":
+
+- **`SaveGate`** declares a contestable consequence's whole contest as data:
+  abilities, DC source, success semantics, recurrence. Its own doc says "**It is
+  data — content carries it, nothing here executes it**", and names the founding
+  complaint: "a stat block could carry a knockdown DC and be lying about whether
+  anything read it" (`saves/gate.go:160-173`, ADR-0039).
+- **`AttackProfile.Imposes`** declares the consequence itself as data, after
+  #1013 found the machine hardcoding prone — with #1014 adding the both-directions
+  validation, because "a consequence with no contest is as meaningless as a
+  contest with no consequence".
+
+A reaction-shaped feature would declare the same way: Shield as *reacts-to an
+attack against me*; an opportunity attack as *reacts-to a creature leaving my
+reach*; and the same declaration is what a hook like Bless already expresses
+implicitly through its chain subscription. **Cast assembly then becomes
+mechanical** — something like `combat.Interested(declaredAction, roster)`,
+scanning sheets for declared triggers that match the action about to be taken.
+The session hands over an action and a roster and decides nothing; the rulebook
+answers who is interested. R3 is not violated, it is *implemented*: applicability
+is still the effect's own predicate, only now the predicate is readable before
+the bus exists.
+
+**The failure modes are asymmetric, and that asymmetry is the load-bearing
+constraint.** Over-inclusion fails safe, by R3's own reasoning — "attaching a
+participant who turns out to be irrelevant costs correctness nothing"
+(`resolution/doc.go:36-41`): the sheet rides along, its predicates do not match,
+nothing fires. Under-inclusion fails **silent**: a wizard left out of the cast
+has a Shield that can never fire, no window ever opens, and *no error is ever
+produced* — the resolution looks entirely healthy. Nothing distinguishes "had no
+reaction" from "was never asked".
+
+So the filter has to be **closed by construction**: a reaction may exist *only*
+by declaring its trigger, so that the feature **is** its own index entry and
+there is no separate registry anybody can forget to update. That is the rule
+ownership already lives under — ADR-0006 keeps "a registry for definitions,
+entity-centric storage for ownership. No central who-has-what table", and a
+condition exists because it is on the sheet (`character/data.go:73`), not because
+a table says so. *(Honest caveat: the precedent transfers on the ownership half,
+not the routing half — `conditions.LoadJSON` still routes refs through a switch
+(`conditions/loader.go:28+`), which is a build-time registry of a different kind.
+#971 is in that neighbourhood.)*
+
+**What composes out of this.** The window's audience becomes the intersection of
+two data reads, which is Kirk's two insights joined:
+
+> audience = **interested** (declared trigger matches the action) ∩ **affordable**
+> (`CanPay` on the sheet the cast already holds)
+
+Both halves are door-readable, both are data, and D is intact — no capability,
+no callback. The same intersection is also exactly the list a client needs to
+render "you may react" prompts, which is open question 4 answered by
+construction rather than by a new read.
+
+**What it relieves, and what it does not.** Narrowing the cast reduces a cost
+that is real and already paid: `castFor` performs a repository read per
+character on every verb (`session/attack.go:423-427`), and `standingSeam` does
+its own per consult — a cost that scales with **roster size** rather than with
+the interaction, which is the wrong axis. It also reduces pressure on
+[#1090](https://github.com/KirkDiggler/rpg-toolkit/issues/1090), since a smaller
+cast spans rooms less often — but **it does not fix #1090**, whose real answer is
+the one-map position question rather than cast width. Do not let this section be
+read as closing that issue.
+
+**The honest cost: none of this exists yet.** No feature carries trigger data
+today, so `Interested` has nothing to scan and the filter cannot be built. **The
+whole-roster rule remains v1's honest behaviour** — over-inclusive, safe, and
+paid for — and this section is its designed successor, arriving with the
+reaction wave that gives it both its first declarations and its first caller.
 
 ## The cross-cutting facts any shape must respect
 
@@ -325,12 +397,21 @@ C's would have to be written with `Pose` rather than before it.
 4. **The eligibility read.** "Could Shield fire?" is the may-I-act question in
    reaction clothes, and it is two questions: the server needs it to decide
    whether to open a window, and a client may want it to grey a button.
+   Interested-by-declaration answers both with one intersection — is the read
+   the *same* one, or does the client's version want more (why not, not just
+   whether)?
 5. **What travels with a frozen resolution?** Case (iv) suggests the actor's
    debit is part of the *suspension* contract rather than the economy's. Worth
    settling when `Pose` is designed, not before.
-6. **Is the cast-assembly obligation acceptable as a correctness requirement?**
-   Under D a missing participant stops being a missed buff and becomes a missed
-   refusal.
+6. **Is "a reaction exists only by declaring its trigger" enforceable?** It is
+   what makes a narrowed cast safe, because under D a missing participant stops
+   being a missed buff and becomes a missed refusal — and an unfireable Shield
+   produces no error at all. Can the compiler or a test make an undeclared
+   reaction impossible, or is it a convention somebody eventually breaks?
+7. **Does the declared trigger vocabulary want to be sealed?** `DCSource` was
+   closed because 5e closed it (ADR-0039). Trigger shapes — attacked-by,
+   left-my-reach, ally-damaged, spell-cast-nearby — may or may not be a closed
+   set, and getting that wrong in either direction is expensive.
 
 ## What each shape does to E1–E3
 
@@ -357,7 +438,14 @@ ruling while this conversation continues.
   fails and it collapses into A.
 - If the cast cannot be guaranteed complete for reaction purposes, D is unsafe
   in exactly the cases it was chosen for, and C's consult (which can go and ask)
-  becomes the honest answer.
+  becomes the honest answer. This is the one that would hurt most, because
+  under-inclusion is silent: there is no failing test to write for a window that
+  never opened.
+- If a reaction's relevance turns out not to be declarable ahead of the
+  interaction — if "can this counter that?" genuinely needs the interaction's
+  intermediate state — then interested-by-declaration cannot be computed at the
+  door, and the whole-roster cast is not a v1 compromise but the permanent
+  answer.
 - If `Pose` arrives shaped so a machine can consult supplied capabilities
   directly, C stops being distinct and becomes A with a longer reach.
 

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -1,20 +1,22 @@
 # The economy gate: where an action's cost lives
 
 **Date:** 2026-08-18
-**Status:** open question space, now converged on a candidate. Kirk on the
-shape below: *"I can go along with this. I think it is a good foundation."* —
-**a foundation he can live with, not yet a formal ruling.** The open questions
-at the bottom are still open.
-**Where it converged:** shape **D**'s substance (the ledger travels with the
-cast, as data) + the **door** as the call site (paying a cost profile, not
-consulting a capability) + **doors debit, windows read** + casts assembled by
-**interested-by-declaration** + the **runner** owning both enforcement points so
-no machine ever spends + every answerer carrying an **ask/auto policy**, so
-**debits ride answers** whether they arrive synchronously or later.
-**Decides:** nothing formally. The evidence is the [#1035 census][census] and its
-[supplement][supp] and [movement addendum][move]; this doc does not re-derive
-any of it. What it does is lay four shapes side by side and walk each one
-through the same cases.
+**Status: DECIDED 2026-08-18.** Kirk: *"really happy with how this turned out I
+approve and am excited to get started on 1035."*
+**Decides:** the **foundation** — shape **D**'s substance (the ledger rides the
+cast as data; the gate is pure `CanPay`/`Pay` in `combat`) + casts assembled by
+**interested-by-declaration**, closed by construction + **machines yield, the
+runner spends**, the ledger denied to machines exactly as the bus is + **debits
+ride answers**, with *auto* a zero-latency window and *ask* a `Pose` plus an
+`Answer` door + **the door pays a compiled data profile** in v1, which is what
+keeps the whole thing ADR-free. Restated in full in *Decided* at the bottom.
+**Does not decide:** the eight open questions, each parked with the wave that
+owns it.
+The evidence is the [#1035 census][census] and its [supplement][supp] and
+[movement addendum][move]; this doc does not re-derive any of it. What it does is
+lay four shapes side by side and walk each one through the same cases — the
+argument is kept rather than collapsed, because a ruling is only as good as the
+reasoning that produced it.
 
 **Verified against** `main` at `b3287ae`.
 
@@ -579,6 +581,9 @@ C's would have to be written with `Pose` rather than before it.
 
 ## Open questions
 
+**All eight survive the ruling.** Each belongs to a wave that has not started —
+see *Decided* at the bottom.
+
 1. **~~Where is `Pay` called from?~~** Converged: the door, by the runner. What
    remains open underneath it is narrower — whether the runner's window
    enforcement rides `Pose` as its payload or needs its own shape, which is a
@@ -659,5 +664,62 @@ installed for any strike, so prone's advantage-within-five-feet predicate has no
 positions to read. The behaviour is documented as intentional ("a machine that
 needs positions then refuses"), but the *combination* with pass-everyone-in
 means the refusal is the common case rather than the rare one. Not fixed here.
+
+## Decided — 2026-08-18
+
+Kirk, ruling on the shape above:
+
+> really happy with how this turned out I approve and am excited to get started
+> on 1035.
+
+### The ruling — the foundation, in five parts
+
+1. **Shape D's substance.** The economy ledger rides the cast as data. The gate
+   is not a capability and not a callback: it is pure functions in `combat` —
+   `CanPay(sheet, profile)` / `Pay(sheet, profile)` — over sheets resolution
+   already holds. The ledger is the same species as hit points and reaches
+   storage the same way, through the dirty set.
+2. **Casts assembled by interested-by-declaration.** A reaction exists *only* by
+   declaring its trigger, so the feature is its own index entry and the filter is
+   **closed by construction** — because under-inclusion fails silent. This
+   arrives with the reaction wave that brings the first declarations; until then
+   **the whole-roster cast remains v1's honest behaviour**, over-inclusive and
+   safe.
+3. **Machines yield; the runner spends.** No machine touches the ledger. It is
+   denied to them by construction, exactly as ADR-0038 denies them the bus — keep
+   `Pay` where a machine cannot import it, and the denial is a compile error
+   rather than a review note.
+4. **Debits ride answers.** Every candidate surviving *interested ∩ affordable*
+   carries an answering policy. **auto ≡ decider**: a zero-latency window, posed
+   and answered in the same runner pass, debited inline. **ask**: a `Pose` window
+   debited at the `Answer` door. Nothing downstream needs to know which happened.
+5. **The door pays a compiled data profile.** In v1 the runner pays
+   `Input.Cost` before starting the machine — a *profile*, which is data, not a
+   capability it consults. That is what keeps R2 satisfied and the whole
+   foundation **ADR-free**.
+
+### What this ruling does not cover
+
+**The eight open questions above stay open.** Each is owned by the wave named
+beside it — the reaction wave, `Pose`'s design, spellcasting, the movement
+machine — and none of them is settled by this ruling. What is decided is the
+**foundation**: where the ledger lives, who may spend, and how a debit reaches
+storage. What is parked is everything that needs a caller which does not exist
+yet. A reader who takes this section as closing question 3 or question 7 has
+read it wrong.
+
+The falsifiers in *What would make this doc wrong* stand as written. A decided
+doc still names the observations that would overturn it, and if one of them
+lands, this section is what gets revisited.
+
+### Slice consequence
+
+> **E1** (the profile compiler and the gate functions, in `combat`) →
+> **E2** (the runner's door pays, in `resolution`) →
+> **E3** (`session` hands over the cost and flips `TestNothingSpendsYet`)
+
+E0 — economy and pool mutations marking the sheet dirty — is ruling-independent
+and already dispatched. It is also the slice everything else rests on: under this
+foundation, *every* debit reaches storage through exactly that path.
 
 — census-1035 agent, on behalf of KirkDiggler

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -1,9 +1,16 @@
 # The economy gate: where an action's cost lives
 
 **Date:** 2026-08-18
-**Status:** open question space. Nothing here is ratified. This is the
-trade-off conversation that happens *before* E1 freezes the spend vocabulary.
-**Decides:** nothing. The evidence is the [#1035 census][census] and its
+**Status:** open question space, now converged on a candidate. Kirk on the
+shape below: *"I can go along with this. I think it is a good foundation."* —
+**a foundation he can live with, not yet a formal ruling.** The open questions
+at the bottom are still open.
+**Where it converged:** shape **D**'s substance (the ledger travels with the
+cast, as data) + the **door** as the call site (paying a cost profile, not
+consulting a capability) + **doors debit, windows read** + casts assembled by
+**interested-by-declaration** + the **runner** owning both enforcement points so
+no machine ever spends.
+**Decides:** nothing formally. The evidence is the [#1035 census][census] and its
 [supplement][supp] and [movement addendum][move]; this doc does not re-derive
 any of it. What it does is lay four shapes side by side and walk each one
 through the same cases.
@@ -244,6 +251,90 @@ a bubble, saying in-fight movement "arrives with the resolution work"
 movement machine, not before it** — the same conclusion the movement addendum
 reached from the other direction.
 
+## The keystone: machines never touch the ledger — the runner does
+
+Everything above left one thing uncomfortable, and Kirk named it: under shape D
+the *machine* was doing the checking. That is the wrong hand on the lever, and
+the correction is the doc's closing move.
+
+> **A machine never spends. The runner owns both enforcement points.**
+
+**Point 1 — the door.** Resolution's loop pays `Input.Cost` before it starts the
+machine: a pure `combat.Pay` over the actor's sheet, which the runner already
+holds. A free action is simply a nil cost. **The machine starts already-paid and
+knows nothing about it** — it cannot tell a swing that cost an action from one
+that cost nothing, which is exactly the ignorance we want, because "what did
+this cost" is a rulebook question that was already answered by the compiler.
+
+**Point 2 — the window.** A machine reaching a reaction moment does not go
+looking for wizards. It **yields a step describing the moment**, and the runner
+interprets it: applies *interested* (declared triggers matching this action) ∩
+*affordable* (`CanPay` on the held sheet), and opens a window only for the
+survivors. **The machine never learns the wizard exists.**
+
+### Why this is not a new idea — it is ADR-0038's law applied twice
+
+The symmetry is exact, and it is the argument:
+
+| | ADR-0038 (shipped) | This doc (proposed) |
+|---|---|---|
+| what machines are denied | **the bus** | **the ledger** |
+| what they do instead | yield a step naming what they want | yield a step naming the moment |
+| who acts | the surface folds the chain | the runner pays / opens the window |
+| enforcement | by construction | the same construction |
+
+R6 is the law: "**A machine never sees the bus.** It yields steps; this package
+folds chains on its own bus and hands back results" (`resolution/doc.go:47-50`).
+And it is enforced structurally rather than by discipline — "a machine yields
+sealed steps and *cannot* reach the bus — `Gather`'s workings are unexported,
+and the strike machine does not even import the packages that could hand it one"
+(`ARCHITECTURE.md:69-72`). A machine also cannot *build* a step: "A machine
+cannot construct one directly — it calls a constructor in this package naming
+what it wants" (`step.go:37-42`).
+
+**The ledger joins the bus as a thing machines are structurally denied**, by the
+identical technique: keep `Pay` where a machine does not import it, and the
+denial is a compile error rather than a code-review note.
+
+### The runner already does this — verified, not asserted
+
+The claim that "the runner interprets yielded steps" is not aspirational. It is
+`drive`, the whole of it (`resolution/step.go:103-158`), called once from
+`Resolve` (`resolve.go:274`). Its own doc states the shape:
+
+> The loop is the whole driver: a machine yields, resolution acts, the machine
+> yields again. Nothing accumulates on the Go stack between yields, which is
+> what makes a suspension expressible later — the machine's own state is the
+> only state there is.
+
+The body is a type switch over the sealed set — `Done`, `Request`, `Gather`
+(`step.go:110-156`) — and the `Request` arm is the exact precedent for point 2:
+the machine yields a step *naming another interaction*, and **the runner is what
+actually runs it** (`step.go:126`), then feeds the outcome back into the
+machine's continuation. A machine that yields "there is a reaction moment here"
+and gets resumed with what happened is the same move, one case over.
+
+**And that case already exists in the sealed vocabulary.** `Pose` is named in
+ADR-0038's `Gather | Pose | Request | Done` and is simply unbuilt — "Pose waits
+for the walk machine" (`doc.go:133-136`), with reactions now the honest producer.
+So **point 2 needs no new step kind and therefore no ADR for the vocabulary** —
+it is the fourth case landing with the caller that forces it, which is precisely
+how the other three arrived.
+
+### What this settles, and what it costs
+
+It settles the call-site question this doc opened with. `Pay` is called **from
+the door, by the runner** — shape B's site, carrying shape D's substance (a pure
+function over a sheet the runner holds, not a capability it consults). The
+combination is why the R2 problem evaporates: there is nothing new on `Input`
+except **data** (a cost profile), and data at the seam is what R2 asks for rather
+than what it forbids.
+
+The cost is honest and small: `Input` grows a `Cost` field, and the runner grows
+two enforcement points. Neither is a vocabulary change. What it buys is that
+**no machine, present or future, can spend anything** — including machines
+written later by somebody who never read this doc.
+
 ## Where this leaves the comparison
 
 Reading the cases rather than the intuition:
@@ -261,11 +352,13 @@ it does *not* solve the suspension door-cost — no shape does. Its advantage is
 concentrated in case (iii) and in the multiattack visibility problem, and it
 gets there by using two mechanisms that already ship rather than by adding one.
 
-**What that does not settle:** D leaves the A-versus-B question open rather than
-answering it — the debit still has to be *called* from somewhere. That may be
-D's most useful property: it makes the call-site choice smaller and later,
-because moving a pure function call is a refactor, while moving a capability is
-a seam change.
+**What settles the rest:** D on its own leaves the A-versus-B question open —
+the debit still has to be *called* from somewhere. The keystone above answers it:
+**the door, by the runner.** That is B's call site carrying D's substance, and
+the pairing is what makes the R2 objection evaporate — `Input` grows a cost
+**profile**, which is data, and data at the seam is what R2 asks for rather than
+what it forbids. A capability would have been the violation; a struct field is
+not.
 
 ### D's obligation, and Kirk's refinement of it — interested-by-declaration
 
@@ -398,9 +491,10 @@ C's would have to be written with `Pose` rather than before it.
 
 ## Open questions
 
-1. **Where is `Pay` called from — a wrapping machine (A's site) or the door
-   (B's site)?** Under D this is a smaller question than it looks, and it can be
-   answered later.
+1. **~~Where is `Pay` called from?~~** Converged: the door, by the runner. What
+   remains open underneath it is narrower — whether the runner's window
+   enforcement rides `Pose` as its payload or needs its own shape, which is a
+   question for whoever designs `Pose` rather than for this doc.
 2. **One ledger behind the gate, or several?** Per-turn slots, granted capacity,
    pools and slots have different cadences and, today, different homes. One debit
    surface, or several verbs to the caller?

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -9,7 +9,8 @@ at the bottom are still open.
 cast, as data) + the **door** as the call site (paying a cost profile, not
 consulting a capability) + **doors debit, windows read** + casts assembled by
 **interested-by-declaration** + the **runner** owning both enforcement points so
-no machine ever spends.
+no machine ever spends + every answerer carrying an **ask/auto policy**, so
+**debits ride answers** whether they arrive synchronously or later.
 **Decides:** nothing formally. The evidence is the [#1035 census][census] and its
 [supplement][supp] and [movement addendum][move]; this doc does not re-derive
 any of it. What it does is lay four shapes side by side and walk each one
@@ -335,6 +336,93 @@ two enforcement points. Neither is a vocabulary change. What it buys is that
 **no machine, present or future, can spend anything** — including machines
 written later by somebody who never read this doc.
 
+### The sharpening: every answerer has a policy, and debits ride answers
+
+The keystone above says windows are opened by the runner and the debit happens
+at the answer. That quietly assumed a *human* answerer — and a monster taking an
+opportunity attack has no Answer verb to ride. **The doc left that gap unstated
+rather than open**, and Kirk closed it from an unexpected direction:
+
+> honestly, I think opportunity attack is going to be toggled to always do it or
+> always ask by the players.
+
+**A player toggled to always-take is structurally a monster decider.** Both are
+instant answerers. So the window machinery has **one case, not two**: every
+candidate surviving *interested ∩ affordable* carries an **answering policy**.
+
+| policy | what the runner does | when the debit lands |
+|---|---|---|
+| **ask** | opens a `Pose` window and suspends | on the `Answer` verb, later |
+| **auto** | answers synchronously, same runner pass | inline, in that pass |
+
+A monster decider is permanently *auto*. The player toggle is **choosing which
+kind of answerer you are** — and per reaction kind, not globally, because the
+same player may want opportunity attacks taken without asking and still want to
+be asked about Shield.
+
+**So the discipline sharpens.** "Doors debit, windows read" was almost right;
+the accurate rule is:
+
+> **Debits ride answers.** An answer may arrive synchronously (a policy or a
+> decider) or later (a human on the `Answer` verb). The debit rides it either
+> way, and nothing else needs to know which happened.
+
+### Verified: the interrupt module already anticipated this
+
+This is not a shape the ledger has to grow into — it was designed for it, and
+says so. The module doc:
+
+> Human and machine deciders are indistinguishable here: an auto-taken reaction
+> is an ordinary Pose answered immediately by composition.
+
+(`play/interrupt/doc.go:9-11`.) And the Shield scene has **a dedicated beat for
+exactly the auto-OA case** — beat 7 poses a window to a monster with options
+`["take-oa", "decline"]` and answers it in the same pass, commented "**NO queries
+between pose and answer**… the ledger cannot tell a policy answer from a human
+one" (`play/interrupt/shieldscene_test.go:135-161`).
+
+Two consequences follow, and both matter:
+
+1. **Auto is a zero-latency window, not the absence of a window.** The pose still
+   happens; it is simply answered before anyone can observe it open. Nothing
+   bypasses the interrupt spine.
+2. **The story records an auto-taken reaction exactly like an asked one**, and
+   not by convention — *by construction*, because the ledger cannot distinguish
+   them. The audit trail even survives the window's disappearance: `NextID`
+   persists across answers "so IDs are never reused within an encounter"
+   (`play/interrupt/data.go:31-37`), so a snapshot after everything resolved
+   still carries evidence of how many windows were posed.
+
+### What it buys, and Kirk's reason for wanting it
+
+**Suspension becomes the rare path.** Most opportunity-attack traffic resolves
+inline, in the pass that raised it, and the table never freezes. That is the
+motivation rather than a side effect: this is a **co-op game played in Discord**,
+where stopping four players to ask a fifth about an obvious stab is the
+difference between a fight and a queue. The machinery that *can* suspend is
+still there, unchanged, for the choices that deserve it.
+
+It also shrinks case (iv)'s blast radius. If most reactions never suspend, the
+open question about what travels with a frozen resolution applies to a much
+narrower set of moments than it first appeared to.
+
+### Named, not decided: where the policy lives
+
+Three candidates, and this doc does not pick:
+
+- **Supplied with the member, the way `Deciders` already are** — which has the
+  strongest precedent, since a decider *is* an answering policy for a monster,
+  and the parallel is exact.
+- **On the sheet**, persisted like the rest of the ledger.
+- **A host/table setting**, outside the rules entirely.
+
+Whichever it is, **capabilities are supplied, never defaulted** (#1036's law)
+applies with full force: a policy that silently defaults to *auto* would take
+reactions on a player's behalf without being asked, and one that silently
+defaults to *ask* would freeze the table Kirk is trying to keep moving. Neither
+is a safe guess, so it must be supplied.
+
+
 ## Where this leaves the comparison
 
 Reading the cases rather than the intuition:
@@ -515,7 +603,11 @@ C's would have to be written with `Pose` rather than before it.
    being a missed buff and becomes a missed refusal — and an unfireable Shield
    produces no error at all. Can the compiler or a test make an undeclared
    reaction impossible, or is it a convention somebody eventually breaks?
-7. **Does the declared trigger vocabulary want to be sealed?** `DCSource` was
+7. **Where does the answering policy live** — supplied with the member (the
+   `Deciders` precedent), on the sheet, or a host setting? And is *auto* allowed
+   to be a per-reaction-kind default a host sets once, or must every kind be
+   chosen explicitly?
+8. **Does the declared trigger vocabulary want to be sealed?** `DCSource` was
    closed because 5e closed it (ADR-0039). Trigger shapes — attacked-by,
    left-my-reach, ally-damaged, spell-cast-nearby — may or may not be a closed
    set, and getting that wrong in either direction is expensive.

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -1,0 +1,254 @@
+# The economy gate: where an action's cost lives
+
+**Date:** 2026-08-18
+**Status:** open question space. Nothing here is ratified. This is the
+trade-off conversation that happens *before* E1 freezes the spend vocabulary.
+**Decides:** nothing. The evidence is the [#1035 census][census] and its
+[supplement][supp] and [movement addendum][move]; this doc does not re-derive
+any of it. What it does is lay three shapes side by side and walk each one
+through the same four cases.
+
+**Verified against** `main` at `b3287ae`.
+
+[census]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326154182
+[supp]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326242250
+[move]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326344695
+
+## The question
+
+Nothing in the new stack spends anything yet, so the cost of an action has no
+home and no owner. Before the first spend exists we get to choose the shape
+rather than inherit it — and the shape is not obvious, because the cost of an
+action is three separable things: **where the cost is written down** (a
+profile, compiled per actor, because a monk's bonus strike and a rogue's Dash
+cost differently from the same nominal action), **who checks it can be paid**
+(before anything happens, or at the moment the thing happens), and **who
+debits the ledger** (and onto whose sheet). Kirk's framing puts it as a gate:
+
+> There's a gate to get into the machine and that gate has the cost. maybe more
+> than one cost. maybe that cost is dynamic based on the class… when an action
+> is going to be taken we should know what it cost and the action economy is
+> where that cost is paid from.
+
+with two riders that shape everything below:
+
+> A machine maybe doesn't have a cost and that's okay. it can just be taken.
+
+> Character shaped gates is really important. the wizard spends their reaction
+> for that turn only if they have it. if they used it on their turn there is
+> nothing to pause for. if they do spend it it comes off their sheet.
+
+## Three shapes
+
+```mermaid
+flowchart LR
+    subgraph A["A — spend MACHINE"]
+        A1["Resolve(Input{Machine: Spend})"] --> A2["Spend machine\ndebits, then"] -->|Request| A3["Strike"]
+    end
+    subgraph B["B — gate at the DOOR"]
+        B1["Resolve(Input{Cost, Machine})"] --> B2["door pays Cost"] --> B3["Strike"]
+    end
+    subgraph C["C — gate as a SERVICE"]
+        C1["Resolve(Input{Gate, Machine})"] --> C2["door consults Gate"] --> C3["Strike"]
+        C3 -.->|"at a reaction moment"| C4["consult Gate again"]
+    end
+```
+
+- **(A) A spend machine wrapping the strike.** The census's F6-literal sketch:
+  a machine whose steps are "debit, then `Request` the interaction below".
+  Costs nothing architecturally — a new machine over existing sealed steps is
+  priced "cheap and safe — cannot touch the bus" (`resolution/ARCHITECTURE.md:144`).
+- **(B) A gate at `Resolve`'s door.** A compiled cost profile rides `Input`
+  beside the machine, and resolution debits before calling `Machine.Start`.
+  Cost and interaction become independent fields.
+- **(C) A gate as a service resolution can consult at any action moment.** The
+  same profile, reached through a capability on `Input` — consulted at the
+  door, and again wherever an action moment appears inside a resolution.
+
+### Case (i) — the level-5 fighter's three swings
+
+One action buys two attacks; the third swing is refused. Two `Attack` verbs in
+one turn are two processes, so the bank lives on the sheet either way.
+
+| | |
+|---|---|
+| **A** | Spend machine reads the sheet, debits the action if the bank is empty, banks 2, spends 1, `Request`s the strike. Second call: bank non-empty, spend 1 only. Third: refused before the strike runs. |
+| **B** | Identical, except the arithmetic is at the door and the strike machine never learns economy exists. |
+| **C** | Identical to B. |
+
+**Discriminates: nothing.** All three handle the headline case. Worth stating
+plainly — the case that motivated the issue does not choose the shape.
+
+### Case (ii) — Dash: a spend with no machine behind it
+
+Dash spends an action and grants movement. There is no interaction to resolve:
+no roll, no target, no chain.
+
+| | |
+|---|---|
+| **A** | A "machine" whose entire body is a debit and a `Done`. Expressible, but it names a machine where there is no interaction — the vocabulary's own rule is that a machine's identity is its *yield-shape*, and this one yields nothing. |
+| **B** | Natural. `Cost` set, `Machine` nil (or trivially `Done`). Kirk's "a machine maybe doesn't have a cost" is the same independence read the other way. |
+| **C** | Natural, same as B. |
+
+**Discriminates: A.** Shape A conflates the cost with the interaction, so a
+cost without an interaction has to wear a machine's clothes. Note this case is
+currently hypothetical at the seam — there is no Dash verb in `session` — but
+it is the shape of every non-attack action in the catalogue (Dodge, Disengage,
+Help, Hide).
+
+### Case (iii) — the wizard's Shield
+
+A fighter swings at Aldric. Mid-resolution, after the roll and before damage,
+Aldric may cast Shield as a **reaction** — and only if he still has one.
+
+This case is already modelled as a nine-beat test,
+`play/interrupt/shieldscene_test.go`, with Aldric as audience and
+`["shield","decline"]` as options.
+
+| | |
+|---|---|
+| **A** | The spend machine above the strike has already finished — it debited the *fighter's* action. The wizard's reaction is a **different actor's cost, discovered inside the interaction**. To express it, the strike machine would have to `Request` a spend machine for somebody else, which puts economy inside the strike — the exact thing the census argued the machine must never hold. |
+| **B** | **Cannot express it.** At the door, the actor is the fighter and the cost is the fighter's. The wizard's reaction is not knowable there: whether a window even opens depends on a fact discovered several steps into somebody else's resolution. |
+| **C** | The natural case. When the strike reaches a reaction moment, the spine consults the gate — *can Aldric afford Shield?* — **before** posing. No reaction, no window. If he answers "shield", the gate debits his reaction off his sheet. |
+
+**Discriminates: B (fails), A (only by breaking its own rule).** This is the
+case that separates the shapes, and Kirk's eligibility insight is what makes it
+sharp:
+
+> the wizard spends their reaction for that turn only if they have it. if they
+> used it on their turn there is nothing to pause for.
+
+That is not a UI nicety — it decides whether the window exists. And the ledger
+cannot decide it: `interrupt.Pose` validates the audience and the option tokens
+and nothing else, because the module is deliberately "custody, not execution"
+and "never interprets an option, a choice, or a payload byte"
+(`play/interrupt/doc.go`). **So somebody must consult the economy before
+`Pose` is called.** Under C that somebody is the gate. Under A or B there is
+no one holding the question.
+
+### Case (iv) — suspension: the strike pauses and the process dies
+
+A window is open; the server restarts before anyone answers. Was the action
+spent?
+
+Today the answer is clean and the same for all three: **nothing was spent**,
+because a failed resolution persists nothing — "a refused resolution leaves
+nothing on a bus and no half-written sheet" (`resolution/doc.go:82-85`), and
+`session.Attack` returns before `adopt`/`saveDirty` on any resolution error
+(`session/attack.go:213-215`). Failure refunds are free because failure writes
+nothing.
+
+Suspension is different from failure, and that is the open part:
+
+| | |
+|---|---|
+| **A / B** | The cost was paid before the interaction started. If a suspension persists the frozen resolution and the process later resumes *from the window* rather than from the top, the debit must have been persisted alongside the frozen payload — or it is lost on resume (free action) or re-applied (double charge). |
+| **C** | The fighter's door-cost has the identical problem. Aldric's reaction does not: under C it is debited **at the answer**, so a window that is never answered spent nothing, which is also the correct 5e reading. |
+
+**Discriminates: partially.** Nobody escapes the door-cost-plus-suspension
+question; C removes it for the reaction half by paying later. Note this is
+wave-5-shaped, not hypothetical-forever: `Pose` is the sealed vocabulary's
+unbuilt fourth case, and the movement addendum found that the docs still
+promise it arrives with a walk machine that #964 never built
+(`ARCHITECTURE.md:96,162`, `resolution/doc.go:133-136`), while
+`session/doc.go:88-118` records reactions as the first honest producer.
+
+## The cross-cutting facts any shape must respect
+
+Established in the census and its addenda; cited, not re-argued.
+
+1. **The profile is compiled per actor, in the rulebook.** Class-dynamic cost —
+   Kirk's "maybe that cost is dynamic based on the class" — is the compiler's
+   business, following `AttackFromCharacter`. The machine holds no class table.
+   The repo has the anti-pattern three times: the monk hardcode
+   (`character/action_economy.go:592-607`), the ref→resource switch (`:742-763`),
+   and Dash's two constructors baking cost into object identity
+   (`combatabilities/dash.go:29-41` vs `:43-55`).
+2. **The ledger is on the sheet.** Three verbs in one turn are three processes;
+   only persisted sheet state survives between them.
+3. **Keyed, never fielded.** `combat.ActionEconomy` grew a named field per
+   feature; its persisted twin replaced them with `Granted map[GrantedActionKey]int`,
+   and the bridge between the two shapes maps only three of five keys.
+4. **Per-unit movement cost stays out of the profile.** "Spend N of capacity K";
+   what N is for a path is the path's business, or difficult terrain can never
+   be added.
+5. **The sealed vocabulary is `Gather | Pose | Request | Done`**, and extending
+   it costs an ADR (ADR-0038).
+
+### Does B or C need an ADR? — honestly, probably yes, and not for the reason the census assumed
+
+The census said "no ADR" on the strength of the socket table: a new machine
+over existing steps is cheap. **That reasoning covers shape A only.**
+
+B and C do not add a step kind, so ADR-0038's stated trigger is not pulled. But
+they change what `resolution.Input` *means*, and there is a specific law in the
+way. R2 reads "**Everything at the seam is data.** No runtime object crosses
+into or out of [Resolve]" (`resolution/doc.go:34-36`). Four capabilities
+already ride `Input` — `Deciders`, `Initiative`, `Standing`, `Roller` — and the
+package rationalises them as pass-through rather than exceptions: `Standing`'s
+own field doc says "**Carried, never consulted.**"
+
+A cost gate would be **the first capability resolution itself consults.** That
+is a real change to the package's self-description, and under C it is consulted
+at a suspension point that does not exist yet. Calling that additive would be
+the kind of claim ADRs exist to stop. So: **A is ADR-free; B and C want one**,
+and C's would have to be written with `Pose` rather than before it.
+
+## Open questions
+
+Front and centre, because these are the conversation.
+
+1. **Which shape?** Case (iii) is the discriminating one, and it is not a
+   corner case — it is wave 5. But choosing C now means designing a consult
+   point for a suspension mechanism nobody has built. Is it better to ship A or
+   B for v1 and pay a migration when reactions land, or to choose the shape
+   that survives reactions before writing the first debit?
+2. **One ledger behind the gate, or several?** Per-turn slots, granted
+   capacity, pools (ki) and slots have different cadences and, today, different
+   homes. Does the gate present one debit surface over all of them, or is
+   "spend an action" and "spend a ki" two verbs to the caller?
+3. **Pools and spell slots through the same system — genuinely unresolved.**
+   Ki is a keyed pool with a `ResetType`; a spell slot is keyed by *level* with
+   no reset field, and upcasting means a 3rd-level spell may eat a 5th-level
+   slot. Same gate, or a different one? Kirk's own read is that this is unclear,
+   and nothing in the code forces it either way yet.
+4. **The eligibility read.** "Could Shield fire?" is the may-I-act question in
+   reaction clothes, and it is now two questions: the server needs it to decide
+   whether to open a window at all, and a client may want it to grey a button.
+   Same read, or does the server-side one stay internal?
+5. **Refunds.** 5e says no. Today the question does not arise, for a verified
+   reason: failure persists nothing. Suspension is where it becomes real — and
+   the honest answer may be that a suspended resolution must persist its debit
+   with its frozen payload, which makes the debit part of the suspension
+   contract rather than the economy's.
+6. **What does wave 5 need the gate to already be?** If the answer is "a thing
+   the interrupt spine can ask before posing", that is C, and it is worth
+   knowing now rather than after E1.
+
+## What each shape does to E1–E3
+
+E0 (dirty-marking) is ruling-independent and already dispatched.
+
+| | A | B | C |
+|---|---|---|---|
+| **E1** cost compiler | unchanged — profile compiled in the rulebook | unchanged | unchanged |
+| **E2** the spend | a `Spend` machine in resolution | a field on `Input` + a debit step at the door | a capability on `Input` + a consult at the door, and a second consult point reserved |
+| **E3** session one-liner | hands `Resolve` the spend machine | hands `Resolve` a cost beside the machine | hands `Resolve` a gate beside the machine |
+
+**E1 survives all three unchanged**, which is the useful result: the compiler
+and the profile are common ground, so E1 can proceed on the census's ruling
+while this conversation continues. What changes between shapes is E2 — where
+the debit happens — and E3's one line.
+
+## What would make this doc wrong
+
+- If reactions turn out not to need an eligibility check before posing — if a
+  window may open and be refused at answer time — case (iii) stops
+  discriminating and B becomes as good as C.
+- If the per-actor profile cannot express a second actor's cost at all, then
+  no shape solves case (iii) and the reaction economy is a separate mechanism
+  from the action economy, which would be worth knowing before either is built.
+- If `Pose` arrives shaped so that a machine can consult supplied capabilities
+  directly, C stops being a distinct shape and becomes A with a longer reach.
+
+— census-1035 agent, on behalf of KirkDiggler

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -136,15 +136,28 @@ issue does not choose the shape.
 
 Dash spends an action and grants movement. No roll, no target, no chain.
 
+**First, a constraint that applies to all four** (caught in review of this doc):
+a nil `Machine` is refused — `Input.Validate` answers `ErrNoMachine`
+(`resolution/resolve.go:125-127`). But the error's own doc draws exactly the
+distinction this case needs: "**an interaction with nothing to resolve. Distinct
+from a machine that finishes immediately, which is legal**"
+(`resolution/errors.go:35-37`). So Dash gets a machine that starts and is
+immediately `Done` — already legal, already blessed — under *every* shape. "No
+machine at all" is not on the table for anyone without a contract change nobody
+has argued for.
+
 | | |
 |---|---|
-| **A** | A "machine" whose entire body is a debit and a `Done`. Expressible, but it names a machine where there is no interaction — and the vocabulary's own rule is that a machine's "identity is its **yield-shape**". |
-| **B** | Natural. `Cost` set, `Machine` nil or trivial. Kirk's "a machine maybe doesn't have a cost" read the other way. |
-| **C** | Natural, same as B. |
-| **D** | **Honestly, no better than A or B.** A Dash verb still needs *something* to run; what D changes is that the cost is not pretending to be a machine — it is a function that something calls. The awkwardness is relocated, not dissolved. |
+| **A** | The immediately-`Done` machine's entire body *is* the debit. Expressible, but it names a machine where there is no interaction — and the vocabulary's own rule is that a machine's "identity is its **yield-shape**", which here is empty. |
+| **B** | `Cost` set, machine trivially `Done`. The cost is a field; the empty machine is honest about being empty. Kirk's "a machine maybe doesn't have a cost" read the other way round. |
+| **C** | Same as B. |
+| **D** | Same as B, with the debit as a `combat.Pay` call rather than a field the door interprets. |
 
-**Discriminates: A (mildly).** Note the case is currently hypothetical at the
-seam — there is no Dash verb in `session` — but it is the shape of every
+**Discriminates: A, and only mildly.** The correction above shrinks this case's
+weight rather than growing it: every shape needs the same trivially-`Done`
+machine, so the only real difference is whether the *cost* has to pretend to be
+one (A) or can sit beside it (B/C/D). Note the case is currently hypothetical at
+the seam — there is no Dash verb in `session` — but it is the shape of every
 non-attack action in the catalogue (Dodge, Disengage, Help, Hide).
 
 ### Case (iii) — the wizard's Shield


### PR DESCRIPTION
## ✅ DECIDED 2026-08-18

**Kirk: _"really happy with how this turned out I approve and am excited to get started on 1035."_**

**The ruling — the foundation, in five parts:**

1. **Shape D's substance** — the ledger rides the cast as data; the gate is pure `CanPay`/`Pay` in `combat`, not a capability and not a callback.
2. **Casts by interested-by-declaration**, closed by construction (under-inclusion fails *silent*) — arriving with the reaction wave; **whole-roster remains v1's honest behaviour** until then.
3. **Machines yield, the runner spends** — the ledger denied to machines by construction, exactly as ADR-0038 denies them the bus.
4. **Debits ride answers** — *auto* is a zero-latency window, *ask* is a `Pose` plus an `Answer` door.
5. **The door pays a compiled data profile** in v1 — which is what keeps the whole foundation **ADR-free**.

**The eight open questions survive the ruling**, each owned by a wave that has not started (the reaction wave, `Pose`'s design, spellcasting, the movement machine). What is decided is where the ledger lives, who may spend, and how a debit reaches storage. **"What would make this doc wrong" is kept intact and still binding** — a decided doc still names its falsifiers.

**Slice consequence:** **E1** (profile compiler + gate functions, `combat`) → **E2** (the runner's door pays, `resolution`) → **E3** (`session` hands the cost, flips `TestNothingSpendsYet`). E0 is already dispatched and is what everything rests on, since every debit now reaches storage through it.

---

A brainstorm doc, in the register of [`resolution.md`](https://github.com/KirkDiggler/rpg-toolkit/blob/main/docs/ideas/session-sdk/resolution.md) (#975) — **options and open questions, not a design with leans.** The PR is the venue: comment inline and the doc changes.

## The question

Nothing in the new stack spends anything yet, so the cost of an action has no home and no owner. We get to choose the shape rather than inherit it — and it is not obvious, because "the cost of an action" is three separable things: **where the cost is written down**, **who checks it can be paid**, and **who debits the ledger, onto whose sheet**.

Kirk's framing is a gate into the machine that holds the cost — maybe more than one, maybe class-dynamic — with two riders that do a lot of work: *a machine may have no cost and that's fine*, and *character-shaped gates matter: the wizard spends their reaction only if they have it, and if they don't there is nothing to pause for.*

## Four shapes

- **(A)** a spend **machine** wrapping the strike
- **(B)** a gate at `Resolve`'s **door** — a cost profile rides `Input`
- **(C)** a gate as a **service** resolution consults at any action moment
- **(D)** the ledger travels with the **cast** — `combat.CanPay`/`Pay`, pure functions over sheets resolution already holds

**D is not a fourth peer.** A/B/C answer *where the debit is called from*; D answers *what the gate is made of*. It came from Kirk's push to keep the seam all-data, and two verified facts make it available:

1. **`castFor` already builds the cast from every encounter member**, and its own comment says the rule is "anyone whose effects might fire" — *"A bard three cells away whose Bless is running has to be in the room for their subscription to fire"*. So a wizard in the encounter is already in the cast with a mutable sheet; "extend the cast to anyone who might react" is **not an extension**.
2. **A machine already mutates those sheets mid-resolution, bus-free.** The strike reaches into the cast and calls `ApplyDamage` — *"Bus-free, and the only phase that is: applying damage is the sheet's own business and takes no bus"* — which flows out via `DirtyCharacters` to `session.saveDirty`. **The economy ledger is the same species as hit points.**

## The cases

| case | discriminates |
|---|---|
| the fighter's three swings | **nothing** — the case that motivated the issue does not choose the shape |
| **Dash** — a spend with no machine | mildly against A; **D is no better here** |
| **the wizard's Shield** | **the separating case** — B cannot express it; A only by breaking its own rule; C works but pays an ADR; **D works with nothing added** |
| **suspension** | **no shape solves the door-cost.** D fixes only the reaction half |
| **OA on a walk** | reactor side is door-computable; **mover side needs the in-fight movement machine first** |

**Shield is the one to read.** The interrupt ledger cannot decide eligibility — it is deliberately *"custody, not execution"* and *"never interprets an option, a choice, or a payload byte"* — so somebody must consult the economy **before `Pose` is called**. Under D that somebody is the machine, reading its own input. D also dissolves multiattack's double-Shield problem, because a later check reads the *same sheet instance* an earlier debit wrote.

## One correction to the census, made here rather than quietly

The census said "no ADR" on the strength of the socket table pricing a new machine as cheap. **That covers shape A only.** B and C would make the cost gate **the first capability resolution CONSULTS rather than carries** — and `Input.Standing`'s doc ("Carried, never consulted") is exactly how the package squares four capabilities with R2's "everything at the seam is data". **D pulls neither trigger.** So A and D are ADR-free; B and C are not.

## Stated honestly rather than sold

D does not win Dash, does not rescue the suspension door-cost, and its OA story lands with the movement machine. **There is no resume path in the repo at all today** — nothing outside `play/interrupt` imports it — so case (iv) is reasoned about, not read. D's cast-assembly obligation is named as its cost: a cast that was merely generous becomes a cast that must be *complete*.

## Kirk's refinement — interested-by-declaration

Shape D's cast-assembly obligation, narrowed: *not shoving every possible thing into the input, only the things that can have an effect on it.*

The tension it must clear is that `castFor` passes the whole roster **precisely because the session may not filter** — *"deciding they are irrelevant here would be this package deciding a rule"*. So a narrower cast is legal only if the relevance answer is the **rulebook's**.

The mechanism is the house pattern, already invented twice for this exact class of question: `SaveGate` declares a contest as data (*"It is data — content carries it, nothing here executes it"* — and its founding complaint was that *"a stat block could carry a knockdown DC and be lying about whether anything read it"*), and `AttackProfile.Imposes` declares the consequence as data after #1013 caught the machine hardcoding prone. A reaction declares its trigger the same way, and cast assembly becomes a rulebook scan — **R3 implemented rather than violated**, since applicability is still the effect's own predicate, only now readable before a bus exists.

**The load-bearing constraint is that the failure modes are asymmetric.** Over-inclusion fails safe, by R3's own reasoning (*"attaching a participant who turns out to be irrelevant costs correctness nothing"*). Under-inclusion fails **silent**: a wizard left out has a Shield that can never fire, no window ever opens, and no error is ever produced. So the filter must be **closed by construction** — a reaction exists *only* by declaring its trigger, so the feature **is** its own index entry and there is no registry to forget. That is the rule ownership already lives under (ADR-0006: *"entity-centric storage for ownership. No central who-has-what table"*), with the honest caveat that the precedent transfers on the ownership half, not the routing half.

Window audience then composes as **interested ∩ affordable** — Kirk's two insights joined, both halves door-readable data, D intact. It is also exactly the client's reaction-prompt list.

**Honest cost: none of this exists yet.** No feature carries trigger data, so the whole-roster rule stays v1's behaviour and this is its designed successor. It relieves a per-verb cost that scales with *roster size* rather than with the interaction, and reduces pressure on #1090 **without fixing it** — that issue's real answer is the one-map position question, not cast width.

## The keystone — machines never touch the ledger; the runner does

Kirk flagged that having the *machine* check the door felt off. He's right, and the correction closes the doc:

1. **The door.** Resolution's loop pays `Input.Cost` before `machine.Start` — a pure `combat.Pay` over the actor's held sheet; a free action is a nil cost. **The machine starts already-paid and knows nothing about it.**
2. **The window.** A machine reaching a reaction moment **yields a step describing the moment**; the runner applies *interested ∩ affordable* and opens a window only for survivors. **The machine never learns the wizard exists.**

**This is ADR-0038's law applied a second time**, and the symmetry is the argument. That ADR took the **bus** out of machines — R6: *"A machine never sees the bus. It yields steps; this package folds chains on its own bus and hands back results"* — enforced by construction rather than discipline: *"a machine yields sealed steps and cannot reach the bus… the strike machine does not even import the packages that could hand it one"*. **The ledger joins the bus as a thing machines are structurally denied**, by the identical technique: keep `Pay` where a machine cannot import it and the denial is a compile error, not a review note.

**The runner-interprets-steps claim is verified, not asserted.** It is `drive()` (`resolution/step.go:103-158`), called once from `Resolve` (`resolve.go:274`), a type switch over the sealed set — and its own doc says *"The loop is the whole driver: a machine yields, resolution acts, the machine yields again."* The **`Request` arm is the exact precedent**: a machine yields a step naming another interaction and **the runner is what runs it** (`step.go:126`), then resumes the machine with the outcome. A machine yielding "there is a reaction moment here" is the same move, one case over — and **`Pose` is already in the sealed vocabulary**, so this needs no new step kind and no ADR for it.

**This settles the call-site question the doc opened with:** `Pay` is called **from the door, by the runner** — shape B's site carrying shape D's substance. That pairing is why the R2 objection evaporates: `Input` grows a cost **profile**, which is data, and data at the seam is what R2 asks for rather than what it forbids. A capability would have been the violation; a struct field is not.

## The sharpening — every answerer has a policy; debits ride answers

Kirk: *opportunity attacks will be toggled to always-take or always-ask, per player.* The unification that falls out: **a player toggled to always-take is structurally a monster decider.** Both are instant answerers, so the window machinery has **one case, not two** — every candidate surviving *interested ∩ affordable* carries an **answering policy**:

| policy | runner | debit |
|---|---|---|
| **ask** | opens a `Pose` window, suspends | on the `Answer` verb, later |
| **auto** | answers synchronously, same pass | inline |

A monster decider is permanently *auto*; the player toggle is choosing which kind of answerer you are, **per reaction kind** (auto-OA while still being asked about Shield). This closes a gap the doc left *unstated*: "debit at the answer" quietly assumed a human answerer, and a monster's auto-OA has no `Answer` verb to ride. **The discipline sharpens to: debits ride answers** — synchronous or later, nothing else needs to know which.

**Verified, not proposed — `play/interrupt` already anticipated this and says so:** *"Human and machine deciders are indistinguishable here: an auto-taken reaction is an ordinary Pose answered immediately by composition."* And the Shield scene carries **a dedicated auto-OA beat** that poses and answers in one pass — *"NO queries between pose and answer… the ledger cannot tell a policy answer from a human one"*. So **auto is a zero-latency window, not the absence of one**: nothing bypasses the spine, and the story records an auto-taken reaction exactly like an asked one **by construction** rather than by convention. The audit trail even outlives the window, since `NextID` persists *"so IDs are never reused within an encounter"*.

**What it buys:** suspension becomes the rare path — most OA traffic resolves inline and the table never freezes, which is the point for a co-op game played in Discord. It also shrinks case (iv)'s blast radius.

**Named, not decided:** where the policy lives — supplied with the member (the `Deciders` precedent, and the parallel is exact), on the sheet, or a host setting. **Capabilities are supplied, never defaulted** (#1036) applies hard here: defaulting to *auto* takes reactions on a player's behalf unasked; defaulting to *ask* freezes the table. Neither is a safe guess.

## Slice impact

**E1 survives all four shapes unchanged** — compiler and cost profile are common ground — so E1 can proceed while this conversation runs. E0 is ruling-independent and already dispatched, and becomes *more* load-bearing under D, since every debit reaches storage through exactly that path.

## Side-finding (filed separately, not fixed here)

**A multi-room cast silently disables prone's positional split.** `castFor` passes every encounter member; `interactionRoom` installs no room when participants span rooms. In a multi-room dungeon with the party spread out — the reference tomb's normal state — no room is installed for any strike, so prone's advantage-within-five-feet predicate has no positions to read. Documented as intentional, but the combination makes the refusal the common case rather than the rare one.

## Evidence

Docs-only; no code touched. Cited to `main` at `b3287ae`; every verbatim quote swept with normalized matching (godoc prose wraps mid-phrase, so raw line greps false-negative — that bit us once already, and the sweep caught a capitalization slip in this round).

- [Census](https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326154182) · [Supplement](https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326242250) · [Movement addendum](https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326344695)

— census-1035 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
