### PR TITLE
feat(dnd5e): an action has a price, and the sheet can pay it (#1091)

### DIFF
--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combatabilities"
@@ -66,20 +67,74 @@ func (c *Character) ExitCombat(_ context.Context, _ *ExitCombatInput) (*ExitComb
 // Sets 1 action, 1 bonus action, 1 reaction, and movement from input speed.
 // Returns the available abilities and actions for this turn.
 func (c *Character) StartTurn(_ context.Context, input *StartTurnInput) (*StartTurnOutput, error) {
-	c.actionEconomy = &ActionEconomyData{
-		TurnNumber:            input.TurnNumber,
-		ActionsRemaining:      1,
-		BonusActionsRemaining: 1,
-		ReactionsRemaining:    1,
-		MovementRemaining:     input.Speed,
-		Granted:               make(map[GrantedActionKey]int),
-	}
-	c.economyChanged()
+	c.seedTurn(input.TurnNumber, input.Speed)
 
 	return &StartTurnOutput{
 		Abilities: c.buildAvailableAbilities(),
 		Actions:   c.buildAvailableActions(),
 	}, nil
+}
+
+// seedTurn replaces the action economy with a full one for the given turn.
+//
+// Everything a turn grants is here and nothing else is: the three slots, the
+// movement the caller states (conditions modify speed, and that arithmetic
+// belongs above this), and an empty bank — capacity granted last turn is not
+// this turn's to spend. Shared by the turn-start verb and the freshness helper
+// so the two cannot drift into disagreeing about what a fresh turn looks like.
+func (c *Character) seedTurn(turnNumber, speed int) {
+	c.actionEconomy = &ActionEconomyData{
+		TurnNumber:            turnNumber,
+		ActionsRemaining:      1,
+		BonusActionsRemaining: 1,
+		ReactionsRemaining:    1,
+		MovementRemaining:     speed,
+		Granted:               make(map[GrantedActionKey]int),
+	}
+	c.economyChanged()
+}
+
+// RefreshForTurn fills a stale bank, so that the economy is observably full
+// when the character's turn begins.
+//
+// The stored TurnNumber is what makes this answerable without anybody
+// remembering: an economy left over from turn 3, asked about turn 4, is stale
+// and gets reseeded; asked about turn 3 again it is untouched, so a second
+// swing cannot refill what the first one spent. That is the whole rule, and it
+// is why this is safe to call at every ask rather than exactly once.
+//
+// Materialised at the first ask rather than pushed at the turn boundary: the
+// sheet may not have been loaded when the turn changed, and a bank that is
+// only correct if something remembered to announce the boundary is a bank that
+// is eventually wrong.
+//
+// A sheet that is not in combat has no turn to be stale and is left alone —
+// combat starts somewhere else, and inventing an economy here would put a
+// character in a fight nobody put them in.
+//
+// Nothing in this rulebook calls it yet. The door that pays an action's cost
+// is what will (rpg-toolkit#1091).
+func (c *Character) RefreshForTurn(
+	_ context.Context, input *RefreshForTurnInput,
+) (*RefreshForTurnOutput, error) {
+	if input == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "no turn to refresh for")
+	}
+	if c.actionEconomy == nil {
+		return &RefreshForTurnOutput{}, nil
+	}
+
+	// Any turn number that is not the stored one is stale, including one that
+	// went backwards. A bank left empty because a number moved the wrong way is
+	// a character who cannot act on their own turn, which is a worse failure
+	// than a bank refilled once too often.
+	if c.actionEconomy.TurnNumber == input.TurnNumber {
+		return &RefreshForTurnOutput{}, nil
+	}
+
+	c.seedTurn(input.TurnNumber, input.Speed)
+
+	return &RefreshForTurnOutput{Reseeded: true}, nil
 }
 
 // EndTurn resets action economy resources to 0 and clears granted capacity.

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -66,7 +66,15 @@ func (c *Character) ExitCombat(_ context.Context, _ *ExitCombatInput) (*ExitComb
 // StartTurn initializes the action economy for a new turn.
 // Sets 1 action, 1 bonus action, 1 reaction, and movement from input speed.
 // Returns the available abilities and actions for this turn.
+//
+// A call with no input is refused rather than dereferenced. The two turn verbs
+// answer the same way about the same mistake: [Character.RefreshForTurn] will
+// not reseed turn zero at zero speed either.
 func (c *Character) StartTurn(_ context.Context, input *StartTurnInput) (*StartTurnOutput, error) {
+	if input == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "no turn to start")
+	}
+
 	c.seedTurn(input.TurnNumber, input.Speed)
 
 	return &StartTurnOutput{

--- a/rulebooks/dnd5e/character/action_economy_types.go
+++ b/rulebooks/dnd5e/character/action_economy_types.go
@@ -112,6 +112,24 @@ type StartTurnOutput struct {
 	Actions   []AvailableAction
 }
 
+// RefreshForTurnInput provides input for filling a stale action economy.
+type RefreshForTurnInput struct {
+	// TurnNumber is the turn being acted in. An economy stored under any
+	// other number is stale.
+	TurnNumber int
+
+	// Speed is the movement to seed, in feet — the character's speed after
+	// whatever conditions have to say about it, which the caller computes.
+	Speed int
+}
+
+// RefreshForTurnOutput reports whether the bank was actually filled.
+type RefreshForTurnOutput struct {
+	// Reseeded is true when the economy was stale and has been replaced with a
+	// full one. False means it was already this turn's, and nothing moved.
+	Reseeded bool
+}
+
 // ActivateAbilityInput provides input for activating a combat ability or feature.
 type ActivateAbilityInput struct {
 	AbilityRef *core.Ref // which ability to activate

--- a/rulebooks/dnd5e/character/ledger.go
+++ b/rulebooks/dnd5e/character/ledger.go
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// A sheet is a [combat.Ledger].
+//
+// The gate spends from characters and monsters through one surface and is not
+// allowed to learn which it has — a monster's economy satisfies the same
+// interface from the combat package's own side. What differs is entirely below
+// this line: a monster's economy is built for a turn and discarded, while every
+// write here has to reach storage, which means every write here has to MARK
+// (#1087). A spend that does not dirty the sheet serializes perfectly and is
+// then dropped by the write-back.
+var _ combat.Ledger = (*Character)(nil)
+
+// grantedKeyFor is the one place the gate's cost vocabulary meets the sheet's
+// storage vocabulary.
+//
+// They are two vocabularies for a reason that is historical rather than good:
+// [combat.CapacityType] is what an action declares it consumes, and
+// [GrantedActionKey] is what the persisted economy files it under, and the two
+// were named independently — "attack" against "attacks", "flurry_strike"
+// against "flurry_strikes". The strings are in saved characters, so unifying
+// them is a migration rather than a rename.
+//
+// What matters is that the translation is TOTAL. The census's finding about
+// the older bridge (toToolkitActionEconomy) was that it carried three of five
+// keys, and the two it dropped went nowhere and reported nothing. A key with
+// no entry here is therefore not dropped: it is stored under its own name, so
+// the worst a missing alias can do is file a spend in a differently-spelled
+// drawer rather than lose it.
+var grantedKeyFor = map[combat.CapacityType]GrantedActionKey{
+	combat.CapacityAttack:        GrantedAttacks,
+	combat.CapacityOffHandAttack: GrantedOffHandStrikes,
+	combat.CapacityFlurryStrike:  GrantedFlurryStrikes,
+}
+
+// grantedKey translates a capacity into the key the sheet files it under.
+func grantedKey(key combat.CapacityType) GrantedActionKey {
+	if stored, ok := grantedKeyFor[key]; ok {
+		return stored
+	}
+
+	return GrantedActionKey(key)
+}
+
+// SlotsLeft reports the per-turn slots remaining.
+//
+// Only the three slots the sheet keeps can answer. Free and movement report
+// zero — free because a free action costs no slot and so can have no slot cost,
+// movement because the gate spends it as keyed capacity.
+//
+// Implements [combat.Ledger].
+func (c *Character) SlotsLeft(slot coreCombat.ActionType) int {
+	if c.actionEconomy == nil {
+		return 0
+	}
+
+	switch slot {
+	case coreCombat.ActionStandard:
+		return c.actionEconomy.ActionsRemaining
+	case coreCombat.ActionBonus:
+		return c.actionEconomy.BonusActionsRemaining
+	case coreCombat.ActionReaction:
+		return c.actionEconomy.ReactionsRemaining
+	case coreCombat.ActionFree, coreCombat.ActionMovement:
+		return 0
+	default:
+		return 0
+	}
+}
+
+// SpendSlots debits per-turn slots and marks the sheet.
+//
+// The gate checks affordability in full before calling this, which is what
+// makes a multi-currency payment atomic — see [combat.Pay].
+//
+// Implements [combat.Ledger].
+func (c *Character) SpendSlots(slot coreCombat.ActionType, n int) {
+	if c.actionEconomy == nil {
+		return
+	}
+
+	switch slot {
+	case coreCombat.ActionStandard:
+		c.actionEconomy.ActionsRemaining -= n
+	case coreCombat.ActionBonus:
+		c.actionEconomy.BonusActionsRemaining -= n
+	case coreCombat.ActionReaction:
+		c.actionEconomy.ReactionsRemaining -= n
+	case coreCombat.ActionFree, coreCombat.ActionMovement:
+		return
+	default:
+		return
+	}
+
+	c.economyChanged()
+}
+
+// CapacityLeft reports how much of a keyed capacity remains.
+//
+// Movement is the one capacity the persisted economy fields rather than keys,
+// so it is read from MovementRemaining; everything else comes out of the
+// Granted map. Both are the sheet's own state — this is a view over what is
+// saved, never a copy of it.
+//
+// Implements [combat.Ledger].
+func (c *Character) CapacityLeft(key combat.CapacityType) int {
+	if c.actionEconomy == nil || key == combat.CapacityNone {
+		return 0
+	}
+	if key == combat.CapacityMovement {
+		return c.actionEconomy.MovementRemaining
+	}
+
+	return c.actionEconomy.Granted[grantedKey(key)]
+}
+
+// SpendCapacity debits keyed capacity and marks the sheet.
+//
+// Implements [combat.Ledger].
+func (c *Character) SpendCapacity(key combat.CapacityType, n int) {
+	c.BankCapacity(key, -n)
+}
+
+// BankCapacity adds keyed capacity and marks the sheet.
+//
+// Adding rather than assigning is what lets an action taken twice in one turn
+// bank twice — the same reason [Character.GrantCapacity], which features spend
+// through, adds. The two write the same state: what a feature banked, the gate
+// can spend, and the other way round.
+//
+// Implements [combat.Ledger].
+func (c *Character) BankCapacity(key combat.CapacityType, n int) {
+	if c.actionEconomy == nil || key == combat.CapacityNone {
+		return
+	}
+
+	if key == combat.CapacityMovement {
+		c.actionEconomy.MovementRemaining += n
+		c.economyChanged()
+
+		return
+	}
+
+	if c.actionEconomy.Granted == nil {
+		c.actionEconomy.Granted = make(map[GrantedActionKey]int)
+	}
+	c.actionEconomy.Granted[grantedKey(key)] += n
+	c.economyChanged()
+}
+
+// PoolLeft reports the points remaining in a keyed pool.
+//
+// A pool the sheet does not have reports zero rather than erroring, because
+// zero is the answer that REFUSES a cost in it. A character with no ki must not
+// be able to pay for Flurry of Blows by not paying.
+//
+// Implements [combat.Ledger].
+func (c *Character) PoolLeft(key coreResources.ResourceKey) int {
+	return c.GetResource(key).Current()
+}
+
+// SpendPool debits a keyed pool.
+//
+// It spends through UseResource — the choke point every feature already spends
+// through, and the one that marks the sheet — rather than reaching into the
+// pool directly. UseResource can refuse, but not here: the gate checked
+// [Character.PoolLeft] for every pool in the profile before anything moved, so
+// by this point the points are known to be there. The same precedent sits in
+// the monster's turn loop, which ignores the error from an economy it has
+// already checked.
+//
+// Implements [combat.Ledger].
+func (c *Character) SpendPool(key coreResources.ResourceKey, n int) {
+	_ = c.UseResource(key, n)
+}

--- a/rulebooks/dnd5e/character/ledger_test.go
+++ b/rulebooks/dnd5e/character/ledger_test.go
@@ -1,0 +1,312 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// A sheet is a ledger. The gate spends from characters and monsters through
+// one surface and is not allowed to learn which it has — a monster's economy
+// satisfies the same interface from the combat package's own side.
+var _ combat.Ledger = (*Character)(nil)
+
+// SheetLedgerTestSuite pins the sheet's side of the gate: that the keyed view
+// reaches the state that is actually persisted, that a spend is a change the
+// sheet REPORTS (E0/#1087 — a spend that does not dirty is a spend the
+// write-back drops), and that a refused payment leaves the sheet exactly as
+// clean as it found it.
+type SheetLedgerTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+	bus events.EventBus
+}
+
+func TestSheetLedgerSuite(t *testing.T) {
+	suite.Run(t, new(SheetLedgerTestSuite))
+}
+
+func (s *SheetLedgerTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+// monk is a level-5 monk with ki: the only sheet in the fixture set that can
+// be charged in two currencies at once.
+func (s *SheetLedgerTestSuite) monk() *Data {
+	return &Data{
+		ID:               "gate-monk",
+		PlayerID:         "gate-player",
+		Name:             "Payer",
+		Level:            5,
+		ProficiencyBonus: 3,
+		RaceID:           races.Human,
+		ClassID:          classes.Monk,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 12,
+			abilities.DEX: 16,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 16,
+			abilities.CHA: 8,
+		},
+		HitPoints:    32,
+		MaxHitPoints: 32,
+		ArmorClass:   16,
+		Resources: map[coreResources.ResourceKey]RecoverableResourceData{
+			resources.Ki: {Current: 3, Maximum: 5, ResetType: coreResources.ResetShortRest},
+		},
+	}
+}
+
+// loaded returns the monk as it comes off storage and then in a turn, marked
+// clean — so whatever the test does next is the only thing that could have
+// dirtied it.
+func (s *SheetLedgerTestSuite) loaded() *Character {
+	char, err := LoadFromData(s.ctx, s.monk(), s.bus)
+	s.Require().NoError(err)
+
+	_, err = char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	return char
+}
+
+// A paid sheet says so. Without this the spend serializes perfectly and is
+// then discarded by the write-back, which is the failure #1087 was filed for.
+func (s *SheetLedgerTestSuite) TestPayingMarksTheSheetDirty() {
+	char := s.loaded()
+	s.Require().False(char.IsDirty())
+
+	profile := &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{coreCombat.ActionBonus: 1},
+		Pools: map[coreResources.ResourceKey]int{resources.Ki: 1},
+	}
+
+	s.Require().NoError(combat.Pay(char, profile))
+
+	s.True(char.IsDirty(), "a spend the sheet does not report is a spend that is lost")
+	s.Equal(0, char.GetActionEconomy().BonusActionsRemaining)
+	s.Equal(2, char.GetResource(resources.Ki).Current())
+}
+
+// Every currency dirties on its own — a profile that only spends a slot, only
+// spends capacity, or only banks capacity still has to reach storage.
+func (s *SheetLedgerTestSuite) TestEveryKindOfSpendMarksTheSheet() {
+	cases := map[string]*combat.SpendProfile{
+		"a slot": {
+			Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		},
+		"a pool": {
+			Pools: map[coreResources.ResourceKey]int{resources.Ki: 1},
+		},
+		"movement": {
+			Capacity: map[combat.CapacityType]int{combat.CapacityMovement: 10},
+		},
+		"a grant alone": {
+			Grants: map[combat.CapacityType]int{combat.CapacityAttack: 2},
+		},
+	}
+
+	for name, profile := range cases {
+		s.Run(name, func() {
+			char := s.loaded()
+			s.Require().NoError(combat.Pay(char, profile))
+			s.True(char.IsDirty())
+		})
+	}
+}
+
+// Spending capacity marks too, once there is capacity to spend.
+func (s *SheetLedgerTestSuite) TestSpendingBankedCapacityMarksTheSheet() {
+	char := s.loaded()
+	char.BankCapacity(combat.CapacityAttack, 1)
+	char.MarkClean()
+
+	s.Require().NoError(combat.Pay(char, &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	}))
+	s.True(char.IsDirty())
+}
+
+// Asking is free, in both senses: it moves nothing and it dirties nothing. A
+// clean sheet that answers a question and then reports itself dirty gets
+// written back over storage for no reason.
+func (s *SheetLedgerTestSuite) TestCanPayLeavesTheSheetClean() {
+	char := s.loaded()
+
+	profile := &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{coreCombat.ActionBonus: 1},
+		Pools: map[coreResources.ResourceKey]int{resources.Ki: 1},
+	}
+
+	s.True(combat.CanPay(char, profile))
+	s.False(char.IsDirty())
+	s.Equal(1, char.GetActionEconomy().BonusActionsRemaining)
+	s.Equal(3, char.GetResource(resources.Ki).Current())
+}
+
+// Atomicity on the real thing: the slot is affordable, the ki is not, and the
+// slot must survive. A sheet that is dirty afterwards is a sheet that half-paid.
+func (s *SheetLedgerTestSuite) TestARefusedPaymentChangesNothingOnTheSheet() {
+	char := s.loaded()
+
+	profile := &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		Pools: map[coreResources.ResourceKey]int{resources.Ki: 4},
+	}
+
+	s.False(combat.CanPay(char, profile))
+	s.Require().Error(combat.Pay(char, profile))
+
+	s.Equal(1, char.GetActionEconomy().ActionsRemaining)
+	s.Equal(3, char.GetResource(resources.Ki).Current())
+	s.False(char.IsDirty(), "nothing changed, so there is nothing to save")
+}
+
+// The other order, to pin that the check is complete before any write rather
+// than merely lucky about which currency it looks at first.
+func (s *SheetLedgerTestSuite) TestARefusedPaymentChangesNothingWhateverIsShort() {
+	char := s.loaded()
+	char.SpendSlots(coreCombat.ActionStandard, 1)
+	char.MarkClean()
+
+	profile := &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		Pools: map[coreResources.ResourceKey]int{resources.Ki: 1},
+	}
+
+	s.Require().Error(combat.Pay(char, profile))
+	s.Equal(3, char.GetResource(resources.Ki).Current())
+	s.False(char.IsDirty())
+}
+
+// A sheet that is not in combat has no economy, so it cannot pay — not even a
+// profile that only grants, which would otherwise land nowhere and report
+// success.
+func (s *SheetLedgerTestSuite) TestASheetOutOfCombatCannotPay() {
+	char, err := LoadFromData(s.ctx, s.monk(), s.bus)
+	s.Require().NoError(err)
+	char.MarkClean()
+	s.Require().False(char.InCombat())
+
+	profiles := []*combat.SpendProfile{
+		{Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1}},
+		{Grants: map[combat.CapacityType]int{combat.CapacityAttack: 2}},
+		{Pools: map[coreResources.ResourceKey]int{resources.Ki: 1}},
+	}
+
+	for _, profile := range profiles {
+		s.False(combat.CanPay(char, profile))
+		s.Require().Error(combat.Pay(char, profile))
+	}
+
+	s.False(char.IsDirty())
+	s.Equal(3, char.GetResource(resources.Ki).Current())
+}
+
+// Every declared capacity round-trips through the sheet. The census's finding
+// was that the bridge between the fielded economy and the persisted keyed one
+// carried three of five keys; a key the sheet cannot store is a grant that
+// disappears without an error, so the pin is over the whole vocabulary rather
+// than over the ones we happen to compile today.
+func (s *SheetLedgerTestSuite) TestEveryDeclaredCapacityRoundTripsThroughTheSheet() {
+	for _, key := range combat.CapacityTypes() {
+		char := s.loaded()
+
+		before := char.CapacityLeft(key)
+		char.BankCapacity(key, 3)
+		s.Require().Equalf(before+3, char.CapacityLeft(key), "banked %q", key)
+
+		char.SpendCapacity(key, 2)
+		s.Require().Equalf(before+1, char.CapacityLeft(key), "spent %q", key)
+	}
+}
+
+// A capacity the sheet has no name for is stored under its own key rather than
+// dropped. This is the rule that keeps the bridge total as the vocabulary grows.
+func (s *SheetLedgerTestSuite) TestAnUndeclaredCapacityIsStoredNotDropped() {
+	char := s.loaded()
+	future := combat.CapacityType("arcane_recovery_die")
+
+	char.BankCapacity(future, 2)
+	s.Equal(2, char.CapacityLeft(future))
+	s.True(char.IsDirty())
+
+	char.SpendCapacity(future, 2)
+	s.Equal(0, char.CapacityLeft(future))
+}
+
+// The keyed capacity view reaches the same storage the sheet already had, so a
+// gate spend and a feature grant are the same state rather than two.
+func (s *SheetLedgerTestSuite) TestTheKeyedViewIsTheStoredEconomy() {
+	char := s.loaded()
+
+	char.GrantCapacity(GrantedAttacks, 2)
+	s.Equal(2, char.CapacityLeft(combat.CapacityAttack), "the gate reads what a feature banked")
+
+	char.BankCapacity(combat.CapacityAttack, 1)
+	s.Equal(3, char.GetActionEconomy().Granted[GrantedAttacks], "and a feature reads what the gate banked")
+}
+
+// Movement is keyed capacity to the gate and a field on the sheet, and they
+// are one thing. What a path costs is the path's business — the profile only
+// ever says "spend this much".
+func (s *SheetLedgerTestSuite) TestMovementIsKeyedCapacityOverTheStoredField() {
+	char := s.loaded()
+	s.Require().Equal(30, char.CapacityLeft(combat.CapacityMovement))
+
+	s.Require().NoError(combat.Pay(char, &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{combat.CapacityMovement: 25},
+	}))
+
+	s.Equal(5, char.GetActionEconomy().MovementRemaining)
+	s.False(combat.CanPay(char, &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{combat.CapacityMovement: 10},
+	}))
+}
+
+// The three per-turn slots read from the three fields the sheet keeps, and a
+// slot the sheet does not keep reads as empty rather than as unlimited.
+func (s *SheetLedgerTestSuite) TestSlotsReadTheStoredEconomy() {
+	char := s.loaded()
+
+	s.Equal(1, char.SlotsLeft(coreCombat.ActionStandard))
+	s.Equal(1, char.SlotsLeft(coreCombat.ActionBonus))
+	s.Equal(1, char.SlotsLeft(coreCombat.ActionReaction))
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionFree))
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionMovement))
+
+	char.SpendSlots(coreCombat.ActionReaction, 1)
+	s.Equal(0, char.GetActionEconomy().ReactionsRemaining)
+	s.Equal(1, char.GetActionEconomy().ActionsRemaining)
+}
+
+// A pool the sheet does not have reads as empty, so a cost in it is refused
+// rather than charged to nothing.
+func (s *SheetLedgerTestSuite) TestAnAbsentPoolIsEmptyRatherThanFree() {
+	char := s.loaded()
+
+	s.Equal(3, char.PoolLeft(resources.Ki))
+	s.Equal(0, char.PoolLeft(coreResources.ResourceKey("sorcery_points")))
+
+	s.False(combat.CanPay(char, &combat.SpendProfile{
+		Pools: map[coreResources.ResourceKey]int{"sorcery_points": 1},
+	}))
+}

--- a/rulebooks/dnd5e/character/ledger_test.go
+++ b/rulebooks/dnd5e/character/ledger_test.go
@@ -239,18 +239,83 @@ func (s *SheetLedgerTestSuite) TestEveryDeclaredCapacityRoundTripsThroughTheShee
 	}
 }
 
-// A capacity the sheet has no name for is stored under its own key rather than
-// dropped. This is the rule that keeps the bridge total as the vocabulary grows.
-func (s *SheetLedgerTestSuite) TestAnUndeclaredCapacityIsStoredNotDropped() {
+// A capacity the sheet has no name for is stored under its OWN key rather than
+// dropped. This is the rule that keeps the bridge total as the vocabulary
+// grows, and reading back what you banked is not enough to show it: two keys
+// collapsed into one drawer round-trip perfectly right up until both are used.
+func (s *SheetLedgerTestSuite) TestAnUndeclaredCapacityIsStoredUnderItsOwnName() {
 	char := s.loaded()
 	future := combat.CapacityType("arcane_recovery_die")
+	otherFuture := combat.CapacityType("superiority_die")
 
 	char.BankCapacity(future, 2)
 	s.Equal(2, char.CapacityLeft(future))
 	s.True(char.IsDirty())
+	s.Equal(2, char.GetActionEconomy().Granted[GrantedActionKey("arcane_recovery_die")],
+		"the sheet files it under the capacity's own name")
+
+	char.BankCapacity(otherFuture, 5)
+	s.Equal(2, char.CapacityLeft(future), "and two unaliased capacities are two drawers")
+	s.Equal(5, char.CapacityLeft(otherFuture))
 
 	char.SpendCapacity(future, 2)
 	s.Equal(0, char.CapacityLeft(future))
+	s.Equal(5, char.CapacityLeft(otherFuture))
+}
+
+// A sheet with no economy reports nothing left, in every currency the economy
+// holds. Zero is what refuses a cost; anything else would let a character who
+// is not in a fight spend a turn they do not have. The pools are the exception
+// and deliberately so — they live on the sheet rather than in the turn, and a
+// ki point is there whether or not anyone is swinging.
+func (s *SheetLedgerTestSuite) TestASheetOutOfCombatHasNothingLeft() {
+	char, err := LoadFromData(s.ctx, s.monk(), s.bus)
+	s.Require().NoError(err)
+	s.Require().False(char.InCombat())
+
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionStandard))
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionBonus))
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionReaction))
+
+	for _, key := range combat.CapacityTypes() {
+		s.Equalf(0, char.CapacityLeft(key), "capacity %q", key)
+	}
+
+	s.Equal(3, char.PoolLeft(resources.Ki), "a pool is the sheet's, not the turn's")
+}
+
+// Writing to a sheet that has no economy writes nothing, and marks nothing —
+// there is no economy for the write to land in, and a sheet that reports itself
+// dirty over a write that did not happen gets saved over storage for no reason.
+func (s *SheetLedgerTestSuite) TestASheetOutOfCombatCannotBeWrittenTo() {
+	char, err := LoadFromData(s.ctx, s.monk(), s.bus)
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	char.SpendSlots(coreCombat.ActionStandard, 1)
+	char.BankCapacity(combat.CapacityAttack, 2)
+	char.SpendCapacity(combat.CapacityMovement, 5)
+
+	s.False(char.IsDirty())
+	s.Nil(char.GetActionEconomy())
+}
+
+// CapacityNone is what an action answers when it consumes no capacity. It is
+// not a drawer: nothing can be banked under it, and nothing read out of it.
+//
+// The second half is not redundant with the first. The economy comes back live
+// — that is documented, and the reason spends go through these methods — so a
+// caller CAN write a nameless key into it, and reading that back as capacity
+// would make "no capacity" into something spendable.
+func (s *SheetLedgerTestSuite) TestCapacityNoneIsNotADrawer() {
+	char := s.loaded()
+
+	char.BankCapacity(combat.CapacityNone, 3)
+	s.Empty(char.GetActionEconomy().Granted, "banking nothing banks nowhere")
+	s.False(char.IsDirty())
+
+	char.GetActionEconomy().Granted[GrantedActionKey("")] = 3
+	s.Equal(0, char.CapacityLeft(combat.CapacityNone))
 }
 
 // The keyed capacity view reaches the same storage the sheet already had, so a

--- a/rulebooks/dnd5e/character/spend_profile.go
+++ b/rulebooks/dnd5e/character/spend_profile.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// The cost compilers: where an action's price stops being a class table and
+// becomes data.
+//
+// This is the only place in the economy that knows what a fighter is. The gate
+// charges a [combat.SpendProfile] and cannot tell a level-5 fighter's Attack
+// action from a level-1 fighter's — it sees a profile that banks two and a
+// profile that banks one. Everything class-dynamic lives on this side of that
+// line, and the line is what keeps the machinery that spends free of the
+// rulebook that prices.
+//
+// They live in this package rather than in combat for the plainest of reasons:
+// a compiler reads the SHEET, and combat cannot see a sheet — character imports
+// combat, so the dependency only runs one way. It is the same force that put
+// AttackFromCharacter in the resolution module: the compiler goes where the
+// sheet is, and hands back something neutral.
+//
+// The conventions follow that compiler's. A concrete sheet in, a neutral
+// profile out, nil refused by name, and only STATIC facts compiled — nothing
+// here asks what the character is standing next to.
+
+// CostOfAttack compiles what the Attack action costs this character.
+//
+// One action, and a bank of attacks to spend it on: 1 + whatever Extra Attack
+// grants at this class and level, which is the table
+// [Character.GetExtraAttacksCount] already keeps. A level-5 fighter's Attack
+// action buys two swings; a level-1 fighter's buys one; a level-20 fighter's
+// buys four.
+//
+// Note what it does NOT cost: the swings themselves. The action banks capacity
+// and [CostOfStrike] spends it, which is why the second swing needs no second
+// action and the third is refused without anybody counting to three.
+func CostOfAttack(c *Character) (*combat.SpendProfile, error) {
+	if c == nil {
+		return nil, rpgerr.New(rpgerr.CodeNil, "no character to price the Attack action for")
+	}
+
+	return &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{
+			coreCombat.ActionStandard: 1,
+		},
+		Grants: map[combat.CapacityType]int{
+			combat.CapacityAttack: 1 + c.GetExtraAttacksCount(),
+		},
+	}, nil
+}
+
+// CostOfStrike compiles what one swing costs this character: a single banked
+// attack and no slot at all.
+//
+// Those are the same two facts actions.Strike already declares about itself —
+// ActionFree, CapacityAttack — restated as a price the gate can charge instead
+// of a pair of accessors something has to interpret.
+//
+// The sheet is not read today. It is taken anyway, because the price of a swing
+// is a character question the moment anything makes it one, and a compiler that
+// has to grow a parameter is a compiler every caller has to be found for.
+func CostOfStrike(c *Character) (*combat.SpendProfile, error) {
+	if c == nil {
+		return nil, rpgerr.New(rpgerr.CodeNil, "no character to price a strike for")
+	}
+
+	return &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{
+			combat.CapacityAttack: 1,
+		},
+	}, nil
+}

--- a/rulebooks/dnd5e/character/spend_profile_test.go
+++ b/rulebooks/dnd5e/character/spend_profile_test.go
@@ -1,0 +1,175 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// CostCompilerTestSuite pins the one thing the gate is never allowed to know:
+// why a price is what it is. A level-5 fighter's Attack action buys two swings
+// and a level-1 fighter's buys one, and every number here is read off a real
+// sheet — the fixtures set a class and a level and nothing else, so a test
+// that passes because the economy was hand-seeded cannot exist.
+type CostCompilerTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+	bus events.EventBus
+}
+
+func TestCostCompilerSuite(t *testing.T) {
+	suite.Run(t, new(CostCompilerTestSuite))
+}
+
+func (s *CostCompilerTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+// sheetOf loads a real character of the given class and level. Nothing about
+// the action economy is set here: the compiler's answer has to come from the
+// class table, which is the whole point of compiling it per actor.
+func (s *CostCompilerTestSuite) sheetOf(class classes.Class, level int) *Character {
+	char, err := LoadFromData(s.ctx, &Data{
+		ID:               "cost-" + string(class),
+		PlayerID:         "cost-player",
+		Name:             "Priced",
+		Level:            level,
+		ProficiencyBonus: 2,
+		RaceID:           races.Human,
+		ClassID:          class,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    20,
+		MaxHitPoints: 20,
+		ArmorClass:   16,
+	}, s.bus)
+	s.Require().NoError(err)
+
+	return char
+}
+
+func (s *CostCompilerTestSuite) banked(class classes.Class, level int) int {
+	profile, err := CostOfAttack(s.sheetOf(class, level))
+	s.Require().NoError(err)
+	s.Require().NoError(profile.Validate())
+
+	return profile.Grants[combat.CapacityAttack]
+}
+
+// The headline case, from both ends.
+func (s *CostCompilerTestSuite) TestTheAttackActionBanksWhatTheClassTableSays() {
+	s.Equal(1, s.banked(classes.Fighter, 1), "a level-1 fighter's Attack action buys one swing")
+	s.Equal(2, s.banked(classes.Fighter, 5), "a level-5 fighter's Attack action buys two")
+	s.Equal(3, s.banked(classes.Fighter, 11))
+	s.Equal(4, s.banked(classes.Fighter, 20))
+}
+
+// Extra Attack is not a fighter feature, and the boundary is the level rather
+// than the class.
+func (s *CostCompilerTestSuite) TestOtherClassesArePricedByTheSameTable() {
+	s.Equal(1, s.banked(classes.Monk, 4))
+	s.Equal(2, s.banked(classes.Monk, 5))
+	s.Equal(2, s.banked(classes.Barbarian, 5))
+	s.Equal(2, s.banked(classes.Paladin, 5))
+	s.Equal(2, s.banked(classes.Ranger, 5))
+	s.Equal(1, s.banked(classes.Wizard, 20), "no Extra Attack at any level")
+}
+
+// The Attack action costs the action slot, and nothing else. It banks capacity
+// rather than spending it, which is why a fighter's second swing needs no
+// second action.
+func (s *CostCompilerTestSuite) TestTheAttackActionCostsExactlyOneActionSlot() {
+	profile, err := CostOfAttack(s.sheetOf(classes.Fighter, 5))
+	s.Require().NoError(err)
+
+	s.Equal(1, profile.Slots[coreCombat.ActionStandard])
+	s.Len(profile.Slots, 1)
+	s.Empty(profile.Capacity)
+	s.Empty(profile.Pools, "nothing in v1 prices an action in pool points")
+	s.Empty(profile.Requires, "nothing in v1 prices an action behind a precondition")
+}
+
+// A swing costs one banked attack and no slot — the same two facts
+// actions.Strike already declares about itself (ActionFree, CapacityAttack).
+func (s *CostCompilerTestSuite) TestAStrikeCostsOneBankedAttackAndNoSlot() {
+	profile, err := CostOfStrike(s.sheetOf(classes.Fighter, 5))
+	s.Require().NoError(err)
+	s.Require().NoError(profile.Validate())
+
+	s.Equal(1, profile.Capacity[combat.CapacityAttack])
+	s.Len(profile.Capacity, 1)
+	s.Empty(profile.Slots)
+	s.Empty(profile.Grants)
+}
+
+// No sheet, no price. The compilers refuse rather than compiling a default,
+// the way AttackFromCharacter refuses a nil character.
+func (s *CostCompilerTestSuite) TestCompilingWithoutASheetIsRefused() {
+	_, err := CostOfAttack(nil)
+	s.Require().Error(err)
+
+	_, err = CostOfStrike(nil)
+	s.Require().Error(err)
+}
+
+// Case (i) end to end: one action buys two swings, and the third is refused —
+// on a real sheet, through the gate, with nothing between the class table and
+// the bank but the profile.
+func (s *CostCompilerTestSuite) TestALevelFiveFighterSwingsTwiceAndNoMore() {
+	fighter := s.sheetOf(classes.Fighter, 5)
+	_, err := fighter.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+
+	attack, err := CostOfAttack(fighter)
+	s.Require().NoError(err)
+	s.Require().NoError(combat.Pay(fighter, attack))
+	s.Equal(2, fighter.CapacityLeft(combat.CapacityAttack))
+	s.Equal(0, fighter.SlotsLeft(coreCombat.ActionStandard))
+
+	strike, err := CostOfStrike(fighter)
+	s.Require().NoError(err)
+	s.Require().NoError(combat.Pay(fighter, strike))
+	s.Require().NoError(combat.Pay(fighter, strike))
+
+	s.False(combat.CanPay(fighter, strike), "the third swing has nothing left to spend")
+	s.Require().Error(combat.Pay(fighter, strike))
+
+	s.False(combat.CanPay(fighter, attack), "and the action that would bank more is gone")
+}
+
+// The level-1 fighter is the same walk with one swing in it.
+func (s *CostCompilerTestSuite) TestALevelOneFighterSwingsOnce() {
+	fighter := s.sheetOf(classes.Fighter, 1)
+	_, err := fighter.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+
+	attack, err := CostOfAttack(fighter)
+	s.Require().NoError(err)
+	s.Require().NoError(combat.Pay(fighter, attack))
+	s.Equal(1, fighter.CapacityLeft(combat.CapacityAttack))
+
+	strike, err := CostOfStrike(fighter)
+	s.Require().NoError(err)
+	s.Require().NoError(combat.Pay(fighter, strike))
+	s.False(combat.CanPay(fighter, strike))
+}

--- a/rulebooks/dnd5e/character/turn_refresh_test.go
+++ b/rulebooks/dnd5e/character/turn_refresh_test.go
@@ -209,6 +209,21 @@ func (s *TurnRefreshTestSuite) TestRefreshWithoutInputIsRefused() {
 	s.False(char.IsDirty())
 }
 
+// The turn-start verb refuses an empty call the same way the freshness helper
+// does. Two verbs over the same state answering the same mistake differently —
+// one with an error, one with a panic — is a difference a caller has to learn
+// rather than reason about.
+func (s *TurnRefreshTestSuite) TestStartingATurnWithoutInputIsRefused() {
+	char, err := LoadFromData(s.ctx, s.sheet(), s.bus)
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	_, err = char.StartTurn(s.ctx, nil)
+	s.Require().Error(err)
+	s.False(char.InCombat())
+	s.False(char.IsDirty())
+}
+
 // Nothing in this slice calls the helper in production: E2's door does. The
 // turn-start verb that exists today still works exactly as it did, and the two
 // agree about what a fresh turn looks like.

--- a/rulebooks/dnd5e/character/turn_refresh_test.go
+++ b/rulebooks/dnd5e/character/turn_refresh_test.go
@@ -1,0 +1,226 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// TurnRefreshTestSuite pins the observable rule the stored TurnNumber exists
+// for: the bank is full when your turn begins, and it gets there by being
+// noticed as stale at the first ask rather than by someone remembering to
+// call a turn-start verb. Nothing in this slice calls it — the door does, in
+// E2 — so what ships is the behaviour, tested directly.
+type TurnRefreshTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+	bus events.EventBus
+}
+
+func TestTurnRefreshSuite(t *testing.T) {
+	suite.Run(t, new(TurnRefreshTestSuite))
+}
+
+func (s *TurnRefreshTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+func (s *TurnRefreshTestSuite) sheet() *Data {
+	return &Data{
+		ID:               "refresh-fighter",
+		PlayerID:         "refresh-player",
+		Name:             "Fresh",
+		Level:            5,
+		ProficiencyBonus: 3,
+		RaceID:           races.Human,
+		ClassID:          classes.Fighter,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:    44,
+		MaxHitPoints: 44,
+		ArmorClass:   18,
+	}
+}
+
+// spent is a sheet that took its turn 1 and used all of it: no action, no
+// bonus, no reaction, no movement, and a bank that has been emptied. Marked
+// clean, so anything dirty afterwards came from the refresh.
+func (s *TurnRefreshTestSuite) spent() *Character {
+	char, err := LoadFromData(s.ctx, s.sheet(), s.bus)
+	s.Require().NoError(err)
+
+	_, err = char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+
+	char.SpendSlots(coreCombat.ActionStandard, 1)
+	char.SpendSlots(coreCombat.ActionBonus, 1)
+	char.SpendSlots(coreCombat.ActionReaction, 1)
+	char.SpendCapacity(combat.CapacityMovement, 30)
+	char.BankCapacity(combat.CapacityAttack, 2)
+	char.SpendCapacity(combat.CapacityAttack, 2)
+	char.MarkClean()
+
+	return char
+}
+
+// A new turn number finds a stale bank and fills it, and the sheet says so.
+func (s *TurnRefreshTestSuite) TestAStaleBankIsFullAgainAtTheNextTurn() {
+	char := s.spent()
+
+	out, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 2, Speed: 30})
+	s.Require().NoError(err)
+	s.True(out.Reseeded)
+
+	s.Equal(1, char.SlotsLeft(coreCombat.ActionStandard))
+	s.Equal(1, char.SlotsLeft(coreCombat.ActionBonus))
+	s.Equal(1, char.SlotsLeft(coreCombat.ActionReaction))
+	s.Equal(30, char.CapacityLeft(combat.CapacityMovement))
+	s.Equal(2, char.GetActionEconomy().TurnNumber)
+	s.True(char.IsDirty())
+}
+
+// The turn-granted bank does not carry across the boundary: attacks banked by
+// last turn's Attack action are not this turn's to spend.
+func (s *TurnRefreshTestSuite) TestTheNewTurnsBankIsEmptyOfLastTurnsGrants() {
+	char := s.spent()
+	char.BankCapacity(combat.CapacityAttack, 2)
+	char.BankCapacity(combat.CapacityFlurryStrike, 2)
+
+	_, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 2, Speed: 30})
+	s.Require().NoError(err)
+
+	s.Equal(0, char.CapacityLeft(combat.CapacityAttack))
+	s.Equal(0, char.CapacityLeft(combat.CapacityFlurryStrike))
+}
+
+// Mid-turn, the refresh is a no-op. This is the half that makes the helper
+// safe to call at every ask: a second swing must not refill the bank the first
+// one spent from.
+func (s *TurnRefreshTestSuite) TestTheSameTurnIsNeverReseeded() {
+	char := s.spent()
+
+	out, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+	s.False(out.Reseeded)
+
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionStandard))
+	s.Equal(0, char.CapacityLeft(combat.CapacityMovement))
+	s.False(char.IsDirty(), "a refresh that changed nothing is not something to save")
+}
+
+// Asking repeatedly within the turn stays a no-op — the freshness check reads
+// the stored turn number rather than remembering whether it has run.
+func (s *TurnRefreshTestSuite) TestRepeatedAsksWithinATurnChangeNothing() {
+	char := s.spent()
+
+	for i := 0; i < 3; i++ {
+		out, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 1, Speed: 30})
+		s.Require().NoError(err)
+		s.False(out.Reseeded)
+	}
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionStandard))
+	s.False(char.IsDirty())
+}
+
+// Reseeding twice for the same new turn fills the bank once. The second ask is
+// now the same-turn no-op, so a spend between the two survives.
+func (s *TurnRefreshTestSuite) TestReseedingHappensOncePerTurn() {
+	char := s.spent()
+
+	_, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 2, Speed: 30})
+	s.Require().NoError(err)
+	char.SpendSlots(coreCombat.ActionStandard, 1)
+
+	out, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 2, Speed: 30})
+	s.Require().NoError(err)
+	s.False(out.Reseeded)
+	s.Equal(0, char.SlotsLeft(coreCombat.ActionStandard), "the spend survived the second ask")
+}
+
+// Any turn number that is not the stored one is stale, including one that went
+// backwards. A bank left empty because a number moved the wrong way is a
+// character who cannot act on their own turn.
+func (s *TurnRefreshTestSuite) TestATurnNumberThatWentBackwardsIsStale() {
+	char := s.spent()
+	_, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 7, Speed: 30})
+	s.Require().NoError(err)
+	char.SpendSlots(coreCombat.ActionStandard, 1)
+	char.MarkClean()
+
+	out, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 3, Speed: 30})
+	s.Require().NoError(err)
+	s.True(out.Reseeded)
+	s.Equal(1, char.SlotsLeft(coreCombat.ActionStandard))
+	s.Equal(3, char.GetActionEconomy().TurnNumber)
+}
+
+// Movement is reseeded from the speed the caller states, not from the sheet's
+// base speed — conditions modify speed, and that arithmetic belongs above this.
+func (s *TurnRefreshTestSuite) TestMovementIsReseededFromTheStatedSpeed() {
+	char := s.spent()
+
+	_, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 2, Speed: 45})
+	s.Require().NoError(err)
+	s.Equal(45, char.CapacityLeft(combat.CapacityMovement))
+}
+
+// A sheet that is not in combat has no turn to be stale, so the refresh
+// declines rather than inventing an economy. Combat starts somewhere else.
+func (s *TurnRefreshTestSuite) TestASheetOutOfCombatIsNotReseeded() {
+	char, err := LoadFromData(s.ctx, s.sheet(), s.bus)
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	out, err := char.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+	s.False(out.Reseeded)
+	s.False(char.InCombat())
+	s.False(char.IsDirty())
+}
+
+// The freshness helper refuses a call with nothing in it rather than reseeding
+// to turn zero at zero speed.
+func (s *TurnRefreshTestSuite) TestRefreshWithoutInputIsRefused() {
+	char := s.spent()
+
+	_, err := char.RefreshForTurn(s.ctx, nil)
+	s.Require().Error(err)
+	s.Equal(1, char.GetActionEconomy().TurnNumber)
+	s.False(char.IsDirty())
+}
+
+// Nothing in this slice calls the helper in production: E2's door does. The
+// turn-start verb that exists today still works exactly as it did, and the two
+// agree about what a fresh turn looks like.
+func (s *TurnRefreshTestSuite) TestARefreshedTurnMatchesAStartedOne() {
+	started, err := LoadFromData(s.ctx, s.sheet(), s.bus)
+	s.Require().NoError(err)
+	_, err = started.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 4, Speed: 30})
+	s.Require().NoError(err)
+
+	refreshed := s.spent()
+	_, err = refreshed.RefreshForTurn(s.ctx, &RefreshForTurnInput{TurnNumber: 4, Speed: 30})
+	s.Require().NoError(err)
+
+	s.Equal(started.GetActionEconomy(), refreshed.GetActionEconomy())
+}

--- a/rulebooks/dnd5e/combat/action_economy_ledger.go
+++ b/rulebooks/dnd5e/combat/action_economy_ledger.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat
+
+import (
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+)
+
+// ActionEconomy is a [Ledger].
+//
+// This is the economy a monster's turn is driven from: the caller builds one,
+// hands it to the monster's action loop, and drops it when the turn ends. It
+// keeps its capacity in named fields rather than a map, which is exactly the
+// shape the persisted twin moved away from — so the keyed methods below are a
+// VIEW over those fields rather than a second copy of them. A keyed write that
+// the named accessors could not see would be a spend the surrounding code
+// overwrites without noticing.
+//
+// It holds no pools, and says so honestly: [ActionEconomy.PoolLeft] answers
+// zero for everything, so a profile that costs ki is refused rather than
+// charged to nothing.
+var _ Ledger = (*ActionEconomy)(nil)
+
+// InCombat reports whether there is an economy here at all.
+//
+// An economy that does not exist is not in combat, and the nil receiver is
+// deliberate: a caller holding a *ActionEconomy it never built gets a refusal
+// from the gate rather than a panic.
+func (ae *ActionEconomy) InCombat() bool {
+	return ae != nil
+}
+
+// SlotsLeft reports the per-turn slots remaining.
+//
+// Only the three slots this economy keeps can answer. Free and movement report
+// zero — free because a free action costs no slot and so can have no slot cost,
+// movement because it is keyed capacity here rather than a slot.
+func (ae *ActionEconomy) SlotsLeft(slot coreCombat.ActionType) int {
+	if ae == nil {
+		return 0
+	}
+
+	switch slot {
+	case coreCombat.ActionStandard:
+		return ae.ActionsRemaining
+	case coreCombat.ActionBonus:
+		return ae.BonusActionsRemaining
+	case coreCombat.ActionReaction:
+		return ae.ReactionsRemaining
+	case coreCombat.ActionFree, coreCombat.ActionMovement:
+		return 0
+	default:
+		return 0
+	}
+}
+
+// SpendSlots debits per-turn slots. The gate checks affordability in full
+// first, so this cannot fail; a slot this economy does not keep is not
+// reachable through the gate, because the profile that named it would not have
+// validated.
+func (ae *ActionEconomy) SpendSlots(slot coreCombat.ActionType, n int) {
+	if ae == nil {
+		return
+	}
+
+	switch slot {
+	case coreCombat.ActionStandard:
+		ae.ActionsRemaining -= n
+	case coreCombat.ActionBonus:
+		ae.BonusActionsRemaining -= n
+	case coreCombat.ActionReaction:
+		ae.ReactionsRemaining -= n
+	case coreCombat.ActionFree, coreCombat.ActionMovement:
+	default:
+	}
+}
+
+// CapacityLeft reports how much of a keyed capacity remains, reading the field
+// that has always held it.
+func (ae *ActionEconomy) CapacityLeft(key CapacityType) int {
+	if ae == nil {
+		return 0
+	}
+
+	switch key {
+	case CapacityAttack:
+		return ae.AttacksRemaining
+	case CapacityMovement:
+		return ae.MovementRemaining
+	case CapacityOffHandAttack:
+		return ae.OffHandAttacksRemaining
+	case CapacityFlurryStrike:
+		return ae.FlurryStrikesRemaining
+	case CapacityNone:
+		return 0
+	default:
+		return 0
+	}
+}
+
+// SpendCapacity debits keyed capacity, writing the field that has always held
+// it.
+func (ae *ActionEconomy) SpendCapacity(key CapacityType, n int) {
+	ae.BankCapacity(key, -n)
+}
+
+// BankCapacity adds keyed capacity. Adding rather than assigning is what lets
+// an action taken twice in one turn bank twice — the fielded setters this
+// economy also carries (SetAttacks and friends) assign, which is why the
+// Attack ability had to know what was already there.
+func (ae *ActionEconomy) BankCapacity(key CapacityType, n int) {
+	if ae == nil {
+		return
+	}
+
+	switch key {
+	case CapacityAttack:
+		ae.AttacksRemaining += n
+	case CapacityMovement:
+		ae.MovementRemaining += n
+	case CapacityOffHandAttack:
+		ae.OffHandAttacksRemaining += n
+	case CapacityFlurryStrike:
+		ae.FlurryStrikesRemaining += n
+	case CapacityNone:
+	default:
+	}
+}
+
+// PoolLeft reports zero for every pool, because this economy has none.
+//
+// That is not a gap to be filled later with a silent zero: a cost in a pool
+// nobody holds must be REFUSED, and reporting nothing left is how the gate
+// refuses it.
+func (ae *ActionEconomy) PoolLeft(_ coreResources.ResourceKey) int {
+	return 0
+}
+
+// SpendPool cannot happen: the gate checks [ActionEconomy.PoolLeft] first and
+// every answer is zero, so every pool cost is refused before anything is spent.
+func (ae *ActionEconomy) SpendPool(_ coreResources.ResourceKey, _ int) {
+}

--- a/rulebooks/dnd5e/combat/action_economy_ledger.go
+++ b/rulebooks/dnd5e/combat/action_economy_ledger.go
@@ -138,7 +138,18 @@ func (ae *ActionEconomy) PoolLeft(_ coreResources.ResourceKey) int {
 	return 0
 }
 
-// SpendPool cannot happen: the gate checks [ActionEconomy.PoolLeft] first and
-// every answer is zero, so every pool cost is refused before anything is spent.
+// SpendPool does nothing, because there is nothing here to take.
+//
+// Through the gate it is unreachable: [ActionEconomy.PoolLeft] answers zero for
+// everything, so a pool cost is refused before anything is spent. A caller
+// reaching past the gate to spend directly gets the honest result of spending
+// from a pool that does not exist — nothing moves, and PoolLeft still reports
+// zero, exactly as it did before. Nothing is quietly consumed and nothing
+// quietly succeeds; the read and the write agree.
+//
+// It cannot refuse out loud instead: [Ledger]'s debit methods take no error
+// return by design, because a debit that could fail after the check has passed
+// is a debit that could leave half a payment behind. An economy that wants
+// pools grows them here rather than growing an error path.
 func (ae *ActionEconomy) SpendPool(_ coreResources.ResourceKey, _ int) {
 }

--- a/rulebooks/dnd5e/combat/action_economy_ledger_test.go
+++ b/rulebooks/dnd5e/combat/action_economy_ledger_test.go
@@ -1,0 +1,148 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// The economy a monster's turn is driven from is a ledger. Monsters take no
+// gated action in v1, but the gate must not be shaped so that they never can:
+// a monster holds a caller-supplied *ActionEconomy where a character holds a
+// persisted sheet, and the gate is not allowed to know which it has.
+var _ combat.Ledger = (*combat.ActionEconomy)(nil)
+
+type ActionEconomyLedgerTestSuite struct {
+	suite.Suite
+}
+
+func TestActionEconomyLedgerSuite(t *testing.T) {
+	suite.Run(t, new(ActionEconomyLedgerTestSuite))
+}
+
+// An economy that does not exist is not in combat, so the gate refuses it
+// rather than dereferencing it.
+func (s *ActionEconomyLedgerTestSuite) TestNilEconomyIsNotInCombat() {
+	var economy *combat.ActionEconomy
+	s.False(economy.InCombat())
+	s.False(combat.CanPay(economy, &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+	}))
+}
+
+func (s *ActionEconomyLedgerTestSuite) TestNewEconomyIsInCombat() {
+	s.True(combat.NewActionEconomy().InCombat())
+}
+
+// The three per-turn slots read and write the three fields that have always
+// held them.
+func (s *ActionEconomyLedgerTestSuite) TestSlotsAreTheThreeFields() {
+	economy := combat.NewActionEconomy()
+
+	s.Equal(1, economy.SlotsLeft(coreCombat.ActionStandard))
+	s.Equal(1, economy.SlotsLeft(coreCombat.ActionBonus))
+	s.Equal(1, economy.SlotsLeft(coreCombat.ActionReaction))
+
+	economy.SpendSlots(coreCombat.ActionBonus, 1)
+	s.Equal(0, economy.BonusActionsRemaining)
+	s.Equal(1, economy.ActionsRemaining)
+	s.Equal(1, economy.ReactionsRemaining)
+}
+
+// A slot this economy does not keep reads as nothing left, so any cost keyed
+// to it is refused rather than quietly granted.
+func (s *ActionEconomyLedgerTestSuite) TestUnknownSlotHasNothingLeft() {
+	economy := combat.NewActionEconomy()
+	s.Equal(0, economy.SlotsLeft(coreCombat.ActionFree))
+	s.Equal(0, economy.SlotsLeft(coreCombat.ActionMovement))
+}
+
+// The keyed view and the named fields are one piece of state, not two. This is
+// the half of the census's lossy-bridge finding that is testable here: a
+// keyed write that the fielded accessors cannot see is a spend that legacy
+// code will overwrite.
+func (s *ActionEconomyLedgerTestSuite) TestKeyedCapacityIsTheFieldedCapacity() {
+	economy := combat.NewActionEconomy()
+
+	economy.BankCapacity(combat.CapacityAttack, 2)
+	s.Equal(2, economy.AttacksRemaining)
+
+	economy.BankCapacity(combat.CapacityOffHandAttack, 1)
+	s.Equal(1, economy.OffHandAttacksRemaining)
+
+	economy.BankCapacity(combat.CapacityFlurryStrike, 2)
+	s.Equal(2, economy.FlurryStrikesRemaining)
+
+	economy.SetMovement(30)
+	s.Equal(30, economy.CapacityLeft(combat.CapacityMovement))
+
+	economy.SpendCapacity(combat.CapacityMovement, 10)
+	s.Equal(20, economy.MovementRemaining)
+}
+
+// Every declared capacity round-trips. A key the ledger cannot store is a
+// grant that vanishes and a cost that is free, and neither reports anything.
+func (s *ActionEconomyLedgerTestSuite) TestEveryDeclaredCapacityRoundTrips() {
+	for _, key := range combat.CapacityTypes() {
+		economy := combat.NewActionEconomy()
+
+		economy.BankCapacity(key, 3)
+		s.Require().Equalf(3, economy.CapacityLeft(key), "banked %q", key)
+
+		economy.SpendCapacity(key, 2)
+		s.Require().Equalf(1, economy.CapacityLeft(key), "spent %q", key)
+	}
+}
+
+// A capacity this economy has no field for never reaches it: the profile that
+// named it does not validate, so the gate refuses before anything is charged.
+// That is what closing the vocabulary buys — a fielded ledger cannot store a
+// key it was never told about, and the alternative to refusing is a grant that
+// evaporates without a word.
+func (s *ActionEconomyLedgerTestSuite) TestAnUndeclaredCapacityNeverReachesTheEconomy() {
+	economy := combat.NewActionEconomy()
+	future := combat.CapacityType("arcane_recovery_die")
+
+	s.Equal(0, economy.CapacityLeft(future))
+
+	profile := &combat.SpendProfile{
+		Grants: map[combat.CapacityType]int{future: 2},
+	}
+	s.False(combat.CanPay(economy, profile))
+	s.Require().Error(combat.Pay(economy, profile))
+	s.Equal(0, economy.CapacityLeft(future))
+}
+
+// An economy holds no pools, so a pool cost is refused rather than charged to
+// nothing. A monster with no ki cannot pay for Flurry of Blows by not paying.
+func (s *ActionEconomyLedgerTestSuite) TestNoPoolsMeansAPoolCostIsRefused() {
+	economy := combat.NewActionEconomy()
+	s.Equal(0, economy.PoolLeft("ki"))
+
+	s.False(combat.CanPay(economy, &combat.SpendProfile{
+		Pools: map[coreResources.ResourceKey]int{"ki": 1},
+	}))
+}
+
+// The shape a monster's turn actually takes: one action-costing profile paid
+// out of the economy the caller handed in.
+func (s *ActionEconomyLedgerTestSuite) TestAMonstersEconomyPaysForAnAction() {
+	economy := combat.NewActionEconomy()
+	profile := &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+	}
+
+	s.True(combat.CanPay(economy, profile))
+	s.Require().NoError(combat.Pay(economy, profile))
+	s.Equal(0, economy.ActionsRemaining)
+
+	s.False(combat.CanPay(economy, profile))
+	s.Require().Error(combat.Pay(economy, profile))
+}

--- a/rulebooks/dnd5e/combat/capacity.go
+++ b/rulebooks/dnd5e/combat/capacity.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2024 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat
+
+// CapacityType identifies what capacity an action consumes.
+//
+// This is the toolkit's cost vocabulary. An action declares what it draws from
+// (actions.Action.CapacityType), a compiled [SpendProfile] keys its costs,
+// grants and requirements by it, and [Ledger] is where those keys are read and
+// written. It is deliberately keyed rather than fielded: the action economy
+// grew a named field per feature once already, and the persisted twin had to
+// replace them with a map when the bridge between the two turned out to carry
+// three of the five keys that existed.
+//
+// It lived in turn_manager.go until #1091 — beside a TurnManager that nothing
+// outside its own tests has referenced in a long time — which made a live
+// vocabulary look like part of a dead type. The move changed no identifier and
+// no value.
+//
+// The set is closed on purpose: [SpendProfile.Validate] refuses a key that is
+// not in it, because a capacity no ledger has agreed to store is a grant that
+// vanishes and a cost that is free, and neither reports anything. Growing it is
+// a constant here plus whatever each ledger needs to hold it — and the
+// round-trip tests fail until every ledger does.
+type CapacityType string
+
+// CapacityType constants for different action capacity requirements.
+const (
+	// CapacityNone means the action has no capacity requirement.
+	CapacityNone CapacityType = ""
+
+	// CapacityAttack means the action consumes one attack from AttacksRemaining.
+	CapacityAttack CapacityType = "attack"
+
+	// CapacityMovement means the action consumes movement from MovementRemaining.
+	CapacityMovement CapacityType = "movement"
+
+	// CapacityOffHandAttack means the action consumes one off-hand attack.
+	CapacityOffHandAttack CapacityType = "off_hand_attack"
+
+	// CapacityFlurryStrike means the action consumes one flurry strike.
+	CapacityFlurryStrike CapacityType = "flurry_strike"
+)
+
+// capacities is the closed set, as a set. CapacityNone is not in it: "no
+// capacity" is the answer an action gives about itself, not a currency
+// anything can hold.
+var capacities = map[CapacityType]struct{}{
+	CapacityAttack:        {},
+	CapacityMovement:      {},
+	CapacityOffHandAttack: {},
+	CapacityFlurryStrike:  {},
+}
+
+// CapacityTypes returns every capacity a profile may name and every capacity a
+// ledger must be able to hold. Callers get a fresh slice, so the vocabulary
+// cannot be edited by reading it.
+//
+// It exists so a ledger implementation can be pinned TOTAL rather than trusted
+// to be: a test walks this list rather than the keys the rulebook happens to
+// compile today, and a new member breaks every ledger that cannot store it.
+func CapacityTypes() []CapacityType {
+	return []CapacityType{
+		CapacityAttack,
+		CapacityMovement,
+		CapacityOffHandAttack,
+		CapacityFlurryStrike,
+	}
+}
+
+// IsCapacity reports whether a key names a capacity that can be held.
+func IsCapacity(key CapacityType) bool {
+	_, ok := capacities[key]
+	return ok
+}

--- a/rulebooks/dnd5e/combat/gate.go
+++ b/rulebooks/dnd5e/combat/gate.go
@@ -1,0 +1,179 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat
+
+import (
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+)
+
+// Ledger is the account an action is paid out of.
+//
+// Both halves of a fight's cast hold one, and neither holds it the same way: a
+// character's is persisted on the sheet and reaches storage only if the sheet
+// reports itself dirty, while a monster's is a plain [ActionEconomy] its caller
+// hands to the turn and throws away after. The gate is not allowed to tell them
+// apart. Monsters take no gated action in v1 — but a signature that could not
+// accept one would have to be replaced rather than extended on the day they do.
+//
+// Every method is over state the holder already has. Nothing here takes a
+// context, a bus or a repository: paying is arithmetic on a sheet the runner is
+// already holding, which is what lets the gate stay somewhere a machine cannot
+// reach it.
+type Ledger interface {
+	// InCombat reports whether there is an economy to spend from at all.
+	//
+	// A holder that is not in combat refuses every payment, including one that
+	// only grants. A grant with nowhere to land is worse than a refusal: the
+	// caller is told the action was paid for and the capacity is simply gone.
+	InCombat() bool
+
+	// SlotsLeft reports how many of a per-turn slot remain. Only the three
+	// slots a turn holds — action, bonus action, reaction — can answer;
+	// anything else reports nothing left rather than unlimited, so a cost
+	// keyed to it is refused instead of granted for free.
+	SlotsLeft(slot coreCombat.ActionType) int
+
+	// CapacityLeft reports how much of a keyed capacity remains. Every member
+	// of [CapacityTypes] must answer, and must answer about the same state the
+	// holder persists — a keyed view over a private copy is a spend that the
+	// next write-back discards.
+	CapacityLeft(key CapacityType) int
+
+	// PoolLeft reports the points remaining in a keyed pool. A pool the holder
+	// does not have reports zero, which refuses a cost in it; a monster with no
+	// ki must not be able to pay for Flurry of Blows by not paying.
+	PoolLeft(key coreResources.ResourceKey) int
+
+	// SpendSlots debits per-turn slots. The gate calls it only after a
+	// complete affordability check, so it takes no error return and must not
+	// refuse — see [Pay] on why that is what makes a multi-currency debit
+	// atomic.
+	SpendSlots(slot coreCombat.ActionType, n int)
+
+	// SpendCapacity debits keyed capacity, under the same contract as
+	// [Ledger.SpendSlots].
+	SpendCapacity(key CapacityType, n int)
+
+	// SpendPool debits a keyed pool, under the same contract as
+	// [Ledger.SpendSlots].
+	SpendPool(key coreResources.ResourceKey, n int)
+
+	// BankCapacity ADDS keyed capacity rather than assigning it, so an action
+	// taken twice in one turn banks twice.
+	BankCapacity(key CapacityType, n int)
+}
+
+// CanPay reports whether this ledger could pay this profile right now, without
+// paying it.
+//
+// It is a pure read — no debit, no mark, nothing the caller has to undo — which
+// is what makes it usable at a reaction moment: a wizard who has already spent
+// their reaction has no Shield window to be offered, and asking must not be the
+// thing that spends it. It answers from the same check [Pay] runs, so there is
+// no state in which one says yes and the other refuses.
+//
+// A nil profile is a free action and is always payable.
+func CanPay(l Ledger, p *SpendProfile) bool {
+	return check(l, p) == nil
+}
+
+// Pay debits every currency the profile names, or none of them.
+//
+// ATOMIC IS THE POINT. The whole affordability check runs first, over every
+// currency, and only then does anything move — so a bonus strike that needs a
+// bonus action AND a ki point cannot take the bonus action and then discover
+// there is no ki. That is why [Ledger]'s debit methods return no error: by the
+// time one is called the check has already passed, and a debit that could
+// refuse would put a partial payment back on the table.
+//
+// A refused payment is indistinguishable from one that was never attempted. On
+// a character's sheet that includes the dirty flag: nothing moved, so there is
+// nothing to save, and the sheet stays exactly as clean as it was found.
+//
+// What Pay does NOT do is decide whether the action should happen. It charges a
+// price. Whether there was a target, whether the machine can run, whether the
+// swing hits — all of that is somebody else's, and all of it happens after.
+func Pay(l Ledger, p *SpendProfile) error {
+	if err := check(l, p); err != nil {
+		return err
+	}
+
+	if p == nil {
+		return nil
+	}
+
+	for slot, amount := range p.Slots {
+		l.SpendSlots(slot, amount)
+	}
+	for key, amount := range p.Capacity {
+		l.SpendCapacity(key, amount)
+	}
+	for key, amount := range p.Pools {
+		l.SpendPool(key, amount)
+	}
+
+	// Grants land last so a profile that spends and banks the same capacity —
+	// a hypothetical action that trades one attack for two — nets out the same
+	// way whichever order the maps happen to iterate in.
+	for key, amount := range p.Grants {
+		l.BankCapacity(key, amount)
+	}
+
+	return nil
+}
+
+// check is the affordability question, asked in full. Both gate functions go
+// through it, so they cannot drift apart, and [Pay] runs it to completion
+// before touching anything.
+func check(l Ledger, p *SpendProfile) error {
+	if l == nil {
+		return rpgerr.New(rpgerr.CodeNil, "no ledger to pay from")
+	}
+	if p == nil {
+		return nil
+	}
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if p.movesNothing() {
+		return nil
+	}
+	if !l.InCombat() {
+		return rpgerr.New(rpgerr.CodeInvalidState,
+			"no action economy to pay from: not in combat")
+	}
+
+	for slot, amount := range p.Slots {
+		if l.SlotsLeft(slot) < amount {
+			return rpgerr.ResourceExhaustedf("%s: %d needed, %d left",
+				slot, amount, l.SlotsLeft(slot))
+		}
+	}
+	for key, amount := range p.Capacity {
+		if l.CapacityLeft(key) < amount {
+			return rpgerr.ResourceExhaustedf("%s: %d needed, %d left",
+				key, amount, l.CapacityLeft(key))
+		}
+	}
+	for key, amount := range p.Pools {
+		if l.PoolLeft(key) < amount {
+			return rpgerr.ResourceExhaustedf("%s: %d needed, %d left",
+				key, amount, l.PoolLeft(key))
+		}
+	}
+
+	// Requirements are read against the same state the costs were, before
+	// anything is spent. A precondition asks what was true when the action was
+	// declared, not what is left after paying for it.
+	for key, amount := range p.Requires {
+		if l.CapacityLeft(key) < amount {
+			return rpgerr.PrerequisiteNotMetf("%s: %d needed, %d present",
+				key, amount, l.CapacityLeft(key))
+		}
+	}
+
+	return nil
+}

--- a/rulebooks/dnd5e/combat/gate_test.go
+++ b/rulebooks/dnd5e/combat/gate_test.go
@@ -201,6 +201,37 @@ func (s *GateTestSuite) TestNilProfileIsFree() {
 	s.Zero(ledger.writes)
 }
 
+// A profile that moves nothing is payable by anyone, in combat or out. There
+// is nothing to take and nowhere for it to fail to land, so refusing it would
+// mean a free action needs a turn to happen in.
+func (s *GateTestSuite) TestAProfileThatMovesNothingIsPayableOutOfCombat() {
+	ledger := newSpyLedger()
+	ledger.inCombat = false
+
+	s.True(combat.CanPay(ledger, &combat.SpendProfile{}))
+	s.Require().NoError(combat.Pay(ledger, &combat.SpendProfile{}))
+
+	s.True(combat.CanPay(ledger, nil))
+	s.Require().NoError(combat.Pay(ledger, nil))
+
+	s.Zero(ledger.writes)
+}
+
+// No ledger, no payment — including for a free action. A caller that reached
+// the gate without an actor is a caller with a bug, and answering "yes, that
+// was free" would hide it.
+func (s *GateTestSuite) TestWithoutALedgerNothingIsPayable() {
+	profile := &combat.SpendProfile{
+		Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+	}
+
+	s.False(combat.CanPay(nil, profile))
+	s.Require().Error(combat.Pay(nil, profile))
+
+	s.False(combat.CanPay(nil, nil))
+	s.Require().Error(combat.Pay(nil, nil))
+}
+
 // A ledger that is not in combat has no economy to spend from, and that has to
 // refuse even a profile that only GRANTS — otherwise the grant lands nowhere
 // and the caller is told it succeeded.
@@ -257,6 +288,21 @@ func (s *GateTestSuite) TestMalformedProfilesAreRefused() {
 		},
 		"zero slot cost": {
 			Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 0},
+		},
+		"zero capacity cost": {
+			Capacity: map[combat.CapacityType]int{combat.CapacityAttack: 0},
+		},
+		"zero grant": {
+			Grants: map[combat.CapacityType]int{combat.CapacityAttack: 0},
+		},
+		"zero requirement": {
+			Requires: map[combat.CapacityType]int{combat.CapacityAttack: 0},
+		},
+		"zero pool cost": {
+			Pools: map[coreResources.ResourceKey]int{"ki": 0},
+		},
+		"negative requirement": {
+			Requires: map[combat.CapacityType]int{combat.CapacityAttack: -1},
 		},
 		"negative capacity cost": {
 			Capacity: map[combat.CapacityType]int{combat.CapacityAttack: -1},

--- a/rulebooks/dnd5e/combat/gate_test.go
+++ b/rulebooks/dnd5e/combat/gate_test.go
@@ -1,0 +1,297 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// spyLedger is a ledger that counts writes, so "a refused payment changed
+// nothing" can be asserted as NOTHING WAS WRITTEN rather than inferred from a
+// state comparison that a compensating pair of writes would pass.
+type spyLedger struct {
+	inCombat bool
+	slots    map[coreCombat.ActionType]int
+	capacity map[combat.CapacityType]int
+	pools    map[coreResources.ResourceKey]int
+
+	writes int
+}
+
+func newSpyLedger() *spyLedger {
+	return &spyLedger{
+		inCombat: true,
+		slots:    map[coreCombat.ActionType]int{},
+		capacity: map[combat.CapacityType]int{},
+		pools:    map[coreResources.ResourceKey]int{},
+	}
+}
+
+func (l *spyLedger) InCombat() bool { return l.inCombat }
+
+func (l *spyLedger) SlotsLeft(slot coreCombat.ActionType) int { return l.slots[slot] }
+
+func (l *spyLedger) CapacityLeft(key combat.CapacityType) int { return l.capacity[key] }
+
+func (l *spyLedger) PoolLeft(key coreResources.ResourceKey) int { return l.pools[key] }
+
+func (l *spyLedger) SpendSlots(slot coreCombat.ActionType, n int) {
+	l.writes++
+	l.slots[slot] -= n
+}
+
+func (l *spyLedger) SpendCapacity(key combat.CapacityType, n int) {
+	l.writes++
+	l.capacity[key] -= n
+}
+
+func (l *spyLedger) SpendPool(key coreResources.ResourceKey, n int) {
+	l.writes++
+	l.pools[key] -= n
+}
+
+func (l *spyLedger) BankCapacity(key combat.CapacityType, n int) {
+	l.writes++
+	l.capacity[key] += n
+}
+
+// GateTestSuite pins the gate's two pure functions: what they read, what they
+// write, and — the property the whole slice turns on — that a refused payment
+// is indistinguishable from one that was never attempted.
+type GateTestSuite struct {
+	suite.Suite
+}
+
+func TestGateSuite(t *testing.T) {
+	suite.Run(t, new(GateTestSuite))
+}
+
+// mixed is a profile that costs three different currencies at once. Nothing in
+// v1 compiles one — it is what the ki-spending monk's bonus strike will be —
+// and it exists here because atomicity is only observable across currencies.
+func (s *GateTestSuite) mixed() *combat.SpendProfile {
+	return &combat.SpendProfile{
+		Slots:    map[coreCombat.ActionType]int{coreCombat.ActionBonus: 1},
+		Capacity: map[combat.CapacityType]int{combat.CapacityFlurryStrike: 1},
+		Pools:    map[coreResources.ResourceKey]int{"ki": 2},
+	}
+}
+
+// A payment that cannot be met in one currency spends nothing in the others.
+// The pool is short by one; the slot and the capacity are both affordable and
+// both must survive untouched.
+func (s *GateTestSuite) TestPayIsAtomicAcrossCurrencies() {
+	ledger := newSpyLedger()
+	ledger.slots[coreCombat.ActionBonus] = 1
+	ledger.capacity[combat.CapacityFlurryStrike] = 1
+	ledger.pools["ki"] = 1
+
+	s.False(combat.CanPay(ledger, s.mixed()))
+
+	err := combat.Pay(ledger, s.mixed())
+	s.Require().Error(err)
+
+	s.Zero(ledger.writes, "a refused payment must not write")
+	s.Equal(1, ledger.slots[coreCombat.ActionBonus])
+	s.Equal(1, ledger.capacity[combat.CapacityFlurryStrike])
+	s.Equal(1, ledger.pools["ki"])
+}
+
+// The affordable case debits every currency exactly once.
+func (s *GateTestSuite) TestPayDebitsEveryCurrency() {
+	ledger := newSpyLedger()
+	ledger.slots[coreCombat.ActionBonus] = 1
+	ledger.capacity[combat.CapacityFlurryStrike] = 3
+	ledger.pools["ki"] = 3
+
+	s.True(combat.CanPay(ledger, s.mixed()))
+	s.Require().NoError(combat.Pay(ledger, s.mixed()))
+
+	s.Equal(0, ledger.slots[coreCombat.ActionBonus])
+	s.Equal(2, ledger.capacity[combat.CapacityFlurryStrike])
+	s.Equal(1, ledger.pools["ki"])
+}
+
+// CanPay is a read. Asking whether an action is affordable must never be the
+// reason it stops being affordable.
+func (s *GateTestSuite) TestCanPayWritesNothing() {
+	ledger := newSpyLedger()
+	ledger.slots[coreCombat.ActionBonus] = 1
+	ledger.capacity[combat.CapacityFlurryStrike] = 1
+	ledger.pools["ki"] = 2
+
+	s.True(combat.CanPay(ledger, s.mixed()))
+	s.True(combat.CanPay(ledger, s.mixed()))
+
+	s.Zero(ledger.writes)
+	s.Equal(1, ledger.slots[coreCombat.ActionBonus])
+	s.Equal(1, ledger.capacity[combat.CapacityFlurryStrike])
+	s.Equal(2, ledger.pools["ki"])
+}
+
+// Banked capacity is added to what is already there, not assigned over it: a
+// second Attack action in one turn (Action Surge) banks more attacks rather
+// than resetting the bank to the same number.
+func (s *GateTestSuite) TestGrantsBankOnTopOfWhatIsThere() {
+	ledger := newSpyLedger()
+	ledger.slots[coreCombat.ActionStandard] = 2
+	ledger.capacity[combat.CapacityAttack] = 1
+
+	profile := &combat.SpendProfile{
+		Slots:  map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		Grants: map[combat.CapacityType]int{combat.CapacityAttack: 2},
+	}
+
+	s.Require().NoError(combat.Pay(ledger, profile))
+	s.Equal(3, ledger.capacity[combat.CapacityAttack])
+	s.Equal(1, ledger.slots[coreCombat.ActionStandard])
+}
+
+// A requirement is read and never debited. This is the monk's shape — the
+// bonus strike needs the Attack action to have happened, and needs it to still
+// be there afterwards for the second strike.
+func (s *GateTestSuite) TestRequirementsAreCheckedAndNotSpent() {
+	ledger := newSpyLedger()
+	ledger.slots[coreCombat.ActionBonus] = 1
+	ledger.capacity[combat.CapacityAttack] = 1
+
+	profile := &combat.SpendProfile{
+		Slots:    map[coreCombat.ActionType]int{coreCombat.ActionBonus: 1},
+		Requires: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	}
+
+	s.True(combat.CanPay(ledger, profile))
+	s.Require().NoError(combat.Pay(ledger, profile))
+
+	s.Equal(0, ledger.slots[coreCombat.ActionBonus])
+	s.Equal(1, ledger.capacity[combat.CapacityAttack], "a requirement is not a cost")
+}
+
+// An unmet requirement refuses the whole payment, and refuses it the same way
+// an unaffordable cost does: nothing written.
+func (s *GateTestSuite) TestUnmetRequirementRefusesAndWritesNothing() {
+	ledger := newSpyLedger()
+	ledger.slots[coreCombat.ActionBonus] = 1
+
+	profile := &combat.SpendProfile{
+		Slots:    map[coreCombat.ActionType]int{coreCombat.ActionBonus: 1},
+		Requires: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	}
+
+	s.False(combat.CanPay(ledger, profile))
+	s.Require().Error(combat.Pay(ledger, profile))
+	s.Zero(ledger.writes)
+	s.Equal(1, ledger.slots[coreCombat.ActionBonus])
+}
+
+// A free action is a nil cost — the doc's own phrasing. It is always payable
+// and moves nothing.
+func (s *GateTestSuite) TestNilProfileIsFree() {
+	ledger := newSpyLedger()
+
+	s.True(combat.CanPay(ledger, nil))
+	s.Require().NoError(combat.Pay(ledger, nil))
+	s.Zero(ledger.writes)
+}
+
+// A ledger that is not in combat has no economy to spend from, and that has to
+// refuse even a profile that only GRANTS — otherwise the grant lands nowhere
+// and the caller is told it succeeded.
+func (s *GateTestSuite) TestNotInCombatPaysNothing() {
+	ledger := newSpyLedger()
+	ledger.inCombat = false
+
+	profile := &combat.SpendProfile{
+		Grants: map[combat.CapacityType]int{combat.CapacityAttack: 2},
+	}
+
+	s.False(combat.CanPay(ledger, profile))
+	s.Require().Error(combat.Pay(ledger, profile))
+	s.Zero(ledger.writes)
+}
+
+// A malformed profile is refused rather than partly honoured. Each of these
+// names a cost the ledger has no way to charge, and silently charging nothing
+// is how an action becomes free by accident.
+func (s *GateTestSuite) TestMalformedProfilesAreRefused() {
+	rich := func() *spyLedger {
+		l := newSpyLedger()
+		l.slots[coreCombat.ActionStandard] = 9
+		l.slots[coreCombat.ActionBonus] = 9
+		l.capacity[combat.CapacityAttack] = 9
+		l.pools["ki"] = 9
+		return l
+	}
+
+	cases := map[string]*combat.SpendProfile{
+		"capacity keyed to none": {
+			Capacity: map[combat.CapacityType]int{combat.CapacityNone: 1},
+		},
+		"grant keyed to none": {
+			Grants: map[combat.CapacityType]int{combat.CapacityNone: 1},
+		},
+		"requirement keyed to none": {
+			Requires: map[combat.CapacityType]int{combat.CapacityNone: 1},
+		},
+		"capacity outside the vocabulary": {
+			Capacity: map[combat.CapacityType]int{combat.CapacityType("arcane_recovery_die"): 1},
+		},
+		"grant outside the vocabulary": {
+			Grants: map[combat.CapacityType]int{combat.CapacityType("arcane_recovery_die"): 1},
+		},
+		"slot keyed to free": {
+			Slots: map[coreCombat.ActionType]int{coreCombat.ActionFree: 1},
+		},
+		"slot keyed to movement": {
+			Slots: map[coreCombat.ActionType]int{coreCombat.ActionMovement: 1},
+		},
+		"pool with no key": {
+			Pools: map[coreResources.ResourceKey]int{"": 1},
+		},
+		"zero slot cost": {
+			Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 0},
+		},
+		"negative capacity cost": {
+			Capacity: map[combat.CapacityType]int{combat.CapacityAttack: -1},
+		},
+		"negative grant": {
+			Grants: map[combat.CapacityType]int{combat.CapacityAttack: -1},
+		},
+		"negative pool cost": {
+			Pools: map[coreResources.ResourceKey]int{"ki": -1},
+		},
+	}
+
+	for name, profile := range cases {
+		s.Run(name, func() {
+			ledger := rich()
+			s.False(combat.CanPay(ledger, profile))
+			s.Require().Error(combat.Pay(ledger, profile))
+			s.Zero(ledger.writes)
+		})
+	}
+}
+
+// CanPay and Pay answer from the same check, so there is no state in which one
+// says yes and the other refuses.
+func (s *GateTestSuite) TestCanPayAndPayAgree() {
+	for available := 0; available <= 2; available++ {
+		ledger := newSpyLedger()
+		ledger.slots[coreCombat.ActionStandard] = available
+
+		profile := &combat.SpendProfile{
+			Slots: map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		}
+
+		can := combat.CanPay(ledger, profile)
+		err := combat.Pay(ledger, profile)
+		s.Equal(can, err == nil, "available=%d", available)
+	}
+}

--- a/rulebooks/dnd5e/combat/spend_profile.go
+++ b/rulebooks/dnd5e/combat/spend_profile.go
@@ -44,6 +44,17 @@ import (
 // field the gate did not read would be a profile that could lie about what it
 // costs.
 //
+// # What Requires is, and what it is not
+//
+// [SpendProfile.Requires] is THE PRECONDITION SHAPE THE GATE CAN EVALUATE
+// TODAY: a keyed quantity the ledger must already hold. It is not a general
+// predicate language and must not be read as one. A precondition that needs to
+// ask something the ledger does not keep — a declared trigger, a condition on
+// the board, a fact about who is adjacent to whom — is a different shape, and
+// deciding whether that vocabulary should be sealed is rpg-toolkit#1035's open
+// question 8, deliberately left open. It arrives with the caller that forces
+// it, the way every other shape in this package did.
+//
 // A nil *SpendProfile is a free action. So is an empty one.
 type SpendProfile struct {
 	// Slots is the per-turn cost in action, bonus action or reaction — the
@@ -69,10 +80,17 @@ type SpendProfile struct {
 	Pools map[coreResources.ResourceKey]int
 
 	// Requires is keyed capacity that must be PRESENT and is never spent — a
-	// precondition rather than a price. The monk's bonus strike is the shape:
-	// it needs the Attack action to have happened, which the sheet already
-	// records by banking capacity for it, and it must still be there for the
-	// second strike. Expressible and unexercised in v1 — see the type doc.
+	// precondition rather than a price.
+	//
+	// It needs no new state, and that is the reason it is shaped this way. The
+	// monk's bonus strike wants to know whether the Attack action was taken
+	// this turn, and the sheet ALREADY RECORDS THAT as banked capacity: the
+	// post-strike grant files it the moment the swing lands. So a requirement
+	// reads evidence the ledger keeps for its own reasons, rather than asking
+	// the ledger to remember something extra on a precondition's behalf.
+	//
+	// What it is not is a predicate vocabulary — see the type doc.
+	// Expressible and unexercised in v1.
 	Requires map[CapacityType]int
 }
 

--- a/rulebooks/dnd5e/combat/spend_profile.go
+++ b/rulebooks/dnd5e/combat/spend_profile.go
@@ -105,21 +105,14 @@ func (p *SpendProfile) Validate() error {
 		}
 	}
 
-	for name, costs := range map[string]map[CapacityType]int{
-		"capacity cost": p.Capacity,
-		"grant":         p.Grants,
-		"requirement":   p.Requires,
-	} {
-		for key, amount := range costs {
-			if !IsCapacity(key) {
-				return rpgerr.Newf(rpgerr.CodeInvalidArgument,
-					"%s keyed to %q, which no ledger holds", name, key)
-			}
-			if amount <= 0 {
-				return rpgerr.Newf(rpgerr.CodeInvalidArgument,
-					"%s of %d for %q is not a cost", name, amount, key)
-			}
-		}
+	if err := validateCapacities("capacity cost", p.Capacity); err != nil {
+		return err
+	}
+	if err := validateCapacities("grant", p.Grants); err != nil {
+		return err
+	}
+	if err := validateCapacities("requirement", p.Requires); err != nil {
+		return err
 	}
 
 	for key, amount := range p.Pools {
@@ -129,6 +122,24 @@ func (p *SpendProfile) Validate() error {
 		if amount <= 0 {
 			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
 				"pool cost of %d for %q is not a cost", amount, key)
+		}
+	}
+
+	return nil
+}
+
+// validateCapacities checks one of the three keyed-capacity maps. They have
+// identical rules and different names, and the name is what makes the error
+// say which map was wrong.
+func validateCapacities(name string, costs map[CapacityType]int) error {
+	for key, amount := range costs {
+		if !IsCapacity(key) {
+			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"%s keyed to %q, which no ledger holds", name, key)
+		}
+		if amount <= 0 {
+			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"%s of %d for %q is not a cost", name, amount, key)
 		}
 	}
 

--- a/rulebooks/dnd5e/combat/spend_profile.go
+++ b/rulebooks/dnd5e/combat/spend_profile.go
@@ -1,0 +1,161 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat
+
+import (
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+)
+
+// SpendProfile is what one action costs one actor: the price, compiled.
+//
+// It is DATA, and that is the whole design. A profile is compiled per actor by
+// the rulebook — a level-5 fighter's Attack action banks two swings and a
+// level-1 fighter's banks one — and by the time it reaches [Pay] the class
+// table is gone. The gate charges a price; it never learns why the price is
+// what it is. Nothing here executes, subscribes, or reaches a bus.
+//
+// # Keyed, never fielded
+//
+// Every currency is a map. The action economy already learned this the
+// expensive way: it grew a named field per feature (AttacksRemaining, then
+// OffHandAttacksRemaining, then FlurryStrikesRemaining) while its persisted
+// twin moved to a keyed map, and the bridge between the two silently carried
+// three of five keys. A profile with a field per capacity would rebuild that
+// bridge, one feature at a time.
+//
+// # What is deliberately not here
+//
+// The per-unit cost of movement. A profile says "spend 25 feet"; what a
+// particular path across a particular room costs is the path's business, and
+// the profile is compiled before anyone has chosen one.
+//
+// # Expressible and unexercised
+//
+// [SpendProfile.Pools] and [SpendProfile.Requires] are the monk's, and the monk
+// is not v1. Nothing this rulebook compiles today emits either one. They are
+// here because the gate that will charge a ki point, or refuse a bonus strike
+// from someone who did not take the Attack action, must not need a different
+// shape than the gate that charges an action — and because the alternative to
+// carrying them is discovering the shape after there are call sites. They are
+// checked and charged exactly like the currencies that do get compiled: a
+// field the gate did not read would be a profile that could lie about what it
+// costs.
+//
+// A nil *SpendProfile is a free action. So is an empty one.
+type SpendProfile struct {
+	// Slots is the per-turn cost in action, bonus action or reaction — the
+	// three slots a turn actually holds. A free action has no entry here
+	// rather than an entry costing nothing, and movement is not a slot: it is
+	// keyed capacity, because movement is spent in feet across a turn rather
+	// than taken once.
+	Slots map[coreCombat.ActionType]int
+
+	// Capacity is the keyed capacity this action consumes: one banked attack
+	// for a swing, feet of movement for a step.
+	Capacity map[CapacityType]int
+
+	// Grants is the keyed capacity this action banks. The Attack action's
+	// entire effect on the economy is here — it buys 1+ExtraAttacks attacks —
+	// and it ADDS to whatever is already banked, so a second Attack action in
+	// one turn (Action Surge) buys more swings rather than resetting the bank
+	// to the same number.
+	Grants map[CapacityType]int
+
+	// Pools is the cost in keyed resource points: ki, sorcery points, a
+	// feature's charges. Expressible and unexercised in v1 — see the type doc.
+	Pools map[coreResources.ResourceKey]int
+
+	// Requires is keyed capacity that must be PRESENT and is never spent — a
+	// precondition rather than a price. The monk's bonus strike is the shape:
+	// it needs the Attack action to have happened, which the sheet already
+	// records by banking capacity for it, and it must still be there for the
+	// second strike. Expressible and unexercised in v1 — see the type doc.
+	Requires map[CapacityType]int
+}
+
+// Validate reports whether this profile names a price anything could actually
+// charge.
+//
+// It refuses rather than trims, and it refuses before any currency has moved,
+// because the failure it exists for is silent: a cost keyed to something no
+// ledger holds is not an expensive action, it is a FREE one, and nothing
+// downstream would ever say so. Three ways to write one:
+//
+//   - a key outside the closed capacity vocabulary, [CapacityNone] included
+//   - a slot that is not one of the three a turn holds
+//   - an amount that is zero or negative, which is a cost that is not a cost
+//
+// A nil profile is a free action and validates.
+func (p *SpendProfile) Validate() error {
+	if p == nil {
+		return nil
+	}
+
+	for slot, amount := range p.Slots {
+		if !isTurnSlot(slot) {
+			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"slot cost keyed to %q, which is not one of the turn's three slots", slot)
+		}
+		if amount <= 0 {
+			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"slot cost of %d for %q is not a cost", amount, slot)
+		}
+	}
+
+	for name, costs := range map[string]map[CapacityType]int{
+		"capacity cost": p.Capacity,
+		"grant":         p.Grants,
+		"requirement":   p.Requires,
+	} {
+		for key, amount := range costs {
+			if !IsCapacity(key) {
+				return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"%s keyed to %q, which no ledger holds", name, key)
+			}
+			if amount <= 0 {
+				return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"%s of %d for %q is not a cost", name, amount, key)
+			}
+		}
+	}
+
+	for key, amount := range p.Pools {
+		if key == "" {
+			return rpgerr.New(rpgerr.CodeInvalidArgument, "pool cost with no pool named")
+		}
+		if amount <= 0 {
+			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"pool cost of %d for %q is not a cost", amount, key)
+		}
+	}
+
+	return nil
+}
+
+// movesNothing reports whether paying this profile would touch the ledger at
+// all. A free action is payable by anyone, in combat or out of it, because
+// there is nothing to take and nowhere for it to fail to land.
+func (p *SpendProfile) movesNothing() bool {
+	return len(p.Slots) == 0 &&
+		len(p.Capacity) == 0 &&
+		len(p.Grants) == 0 &&
+		len(p.Pools) == 0 &&
+		len(p.Requires) == 0
+}
+
+// isTurnSlot reports whether an action type is one of the three per-turn slots
+// a ledger keeps. Free is the absence of a slot cost rather than a slot that
+// costs nothing, and movement is keyed capacity rather than a slot.
+func isTurnSlot(slot coreCombat.ActionType) bool {
+	switch slot {
+	case coreCombat.ActionStandard, coreCombat.ActionBonus, coreCombat.ActionReaction:
+		return true
+	case coreCombat.ActionFree, coreCombat.ActionMovement:
+		return false
+	default:
+		return false
+	}
+}

--- a/rulebooks/dnd5e/combat/spend_profile_test.go
+++ b/rulebooks/dnd5e/combat/spend_profile_test.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combat_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// kiFlurry is the profile v1 never compiles and the type must already hold: a
+// pool cost and a precondition, side by side with the currencies that do get
+// compiled. It is a package-level declaration on purpose — if either field
+// stops existing, or stops being keyed, this file stops building, which is the
+// pin. Nothing exercises it as content; the shape is what ships.
+var kiFlurry = &combat.SpendProfile{
+	Slots:    map[coreCombat.ActionType]int{coreCombat.ActionBonus: 1},
+	Pools:    map[coreResources.ResourceKey]int{"ki": 1},
+	Requires: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	Grants:   map[combat.CapacityType]int{combat.CapacityFlurryStrike: 2},
+}
+
+// SpendProfileTestSuite pins the profile's shape rather than any content: that
+// every currency is a map keyed by an existing vocabulary, and that a profile
+// nobody can charge is refused before it can be half-charged.
+type SpendProfileTestSuite struct {
+	suite.Suite
+}
+
+func TestSpendProfileSuite(t *testing.T) {
+	suite.Run(t, new(SpendProfileTestSuite))
+}
+
+// The ki-shaped profile validates. Expressible means expressible — a shape the
+// type can hold but the gate would refuse is not a shape that ships.
+func (s *SpendProfileTestSuite) TestPoolCostAndPreconditionAreLegal() {
+	s.Require().NoError(kiFlurry.Validate())
+}
+
+// A nil profile is a free action, and free actions are legal.
+func (s *SpendProfileTestSuite) TestNilProfileValidates() {
+	var free *combat.SpendProfile
+	s.Require().NoError(free.Validate())
+}
+
+// The empty profile is the same thing spelled differently.
+func (s *SpendProfileTestSuite) TestEmptyProfileValidates() {
+	s.Require().NoError((&combat.SpendProfile{}).Validate())
+}
+
+// The per-turn slots are exactly the three the sheet keeps. Movement is not a
+// slot — it is keyed capacity — and free is the absence of a slot cost rather
+// than a slot that costs nothing.
+func (s *SpendProfileTestSuite) TestOnlyTheThreeTurnSlotsAreSlots() {
+	legal := []coreCombat.ActionType{
+		coreCombat.ActionStandard,
+		coreCombat.ActionBonus,
+		coreCombat.ActionReaction,
+	}
+	for _, slot := range legal {
+		profile := &combat.SpendProfile{Slots: map[coreCombat.ActionType]int{slot: 1}}
+		s.Require().NoErrorf(profile.Validate(), "slot %q", slot)
+	}
+
+	illegal := []coreCombat.ActionType{
+		coreCombat.ActionFree,
+		coreCombat.ActionMovement,
+		coreCombat.ActionType("nonsense"),
+		coreCombat.ActionType(""),
+	}
+	for _, slot := range illegal {
+		profile := &combat.SpendProfile{Slots: map[coreCombat.ActionType]int{slot: 1}}
+		s.Require().Errorf(profile.Validate(), "slot %q", slot)
+	}
+}
+
+// Every declared capacity is a legal key for a cost, a grant and a
+// requirement. A vocabulary member the profile cannot name is a spend that has
+// nowhere to be written down.
+func (s *SpendProfileTestSuite) TestEveryDeclaredCapacityIsALegalKey() {
+	for _, key := range combat.CapacityTypes() {
+		s.Require().NoErrorf(
+			(&combat.SpendProfile{Capacity: map[combat.CapacityType]int{key: 1}}).Validate(),
+			"cost keyed %q", key,
+		)
+		s.Require().NoErrorf(
+			(&combat.SpendProfile{Grants: map[combat.CapacityType]int{key: 1}}).Validate(),
+			"grant keyed %q", key,
+		)
+		s.Require().NoErrorf(
+			(&combat.SpendProfile{Requires: map[combat.CapacityType]int{key: 1}}).Validate(),
+			"requirement keyed %q", key,
+		)
+	}
+}
+
+// CapacityNone is the answer an action gives when it consumes no capacity. It
+// is not a currency, so it cannot be a key.
+func (s *SpendProfileTestSuite) TestCapacityNoneIsNotACurrency() {
+	s.NotContains(combat.CapacityTypes(), combat.CapacityNone)
+}

--- a/rulebooks/dnd5e/combat/turn_manager.go
+++ b/rulebooks/dnd5e/combat/turn_manager.go
@@ -47,27 +47,6 @@ type AbilityInfo struct {
 	ActionType coreCombat.ActionType
 }
 
-// CapacityType identifies what capacity an action consumes.
-type CapacityType string
-
-// CapacityType constants for different action capacity requirements.
-const (
-	// CapacityNone means the action has no capacity requirement.
-	CapacityNone CapacityType = ""
-
-	// CapacityAttack means the action consumes one attack from AttacksRemaining.
-	CapacityAttack CapacityType = "attack"
-
-	// CapacityMovement means the action consumes movement from MovementRemaining.
-	CapacityMovement CapacityType = "movement"
-
-	// CapacityOffHandAttack means the action consumes one off-hand attack.
-	CapacityOffHandAttack CapacityType = "off_hand_attack"
-
-	// CapacityFlurryStrike means the action consumes one flurry strike.
-	CapacityFlurryStrike CapacityType = "flurry_strike"
-)
-
 // ActionInfo provides metadata about an available action.
 type ActionInfo struct {
 	// ID is the unique identifier of this action instance.


### PR DESCRIPTION
Economy wave slice **E1**: the cost vocabulary and the gate's pure functions. Foundation ruled by Kirk on #1089's `docs/ideas/session-sdk/economy-gate.md`; evidence base is #1035's census, supplement and movement addendum. E0 (#1087/#1088) is in.

*A level-5 fighter's Attack action buys two swings, a level-1 fighter's buys one, and the machinery that charges for it never learns what a fighter is.* Nothing calls any of it yet — E2's door does.

## Census

Three findings changed the plan. All three were sent to the director before building.

**The capacity enum is neither dead nor two-member.** The brief described a stranded two-member enum in a dead file. Against `83172c1` `combat.CapacityType` has **five** members and is live outside the file it lives in: `actions.Action` carries `CapacityType()` on the interface (`actions/action.go:34`) and Strike/Move/FlurryStrike/OffHandStrike/MartialArtsBonusStrike each return one; `character/character.go:730` copies it onto `combat.ActionInfo`; `combat/turn_manager_queries.go:100-118` switches on it. What *is* dead is `TurnManager` itself — no non-test reference in the repo. **Rescue = relocate the enum verbatim to `combat/capacity.go`.** Pure in-package move: no identifier, no value, no import changed.

**There are two capacity vocabularies, and the persisted one is the other one.** The gate's cost vocabulary is `combat.CapacityType` (what an action declares). The ledger's *storage* vocabulary is `character.GrantedActionKey` — `attacks` / `off_hand_strikes` / `flurry_strikes` / `martial_arts_bonus` / `off_hand_attack`, different strings, different membership, and the one persisted in JSON on `ActionEconomyData.Granted`. Movement is not in `Granted` at all; it is the `MovementRemaining` field. Unifying them changes stored key strings, which is a migration rather than a rename — out of an additive slice's scope. **So the profile speaks `CapacityType`, and the sheet's ledger carries one translation that is total by construction:** three legacy aliases, movement to its field, and any other key filed under its own name. That replaces the lossy-3-of-5 pattern of `toToolkitActionEconomy` (`character/action_economy.go:657-678`) with a bridge that cannot drop anything, pinned by a test over the whole vocabulary and by two undeclared keys that must not collide.

**The module graph forbids the compiler and the reseed from living in `combat`.** `character` imports `combat`; `go list -deps ./combat` confirms the reverse does not hold. `CostOfAttack` reads `GetExtraAttacksCount()` off `*character.Character` and the freshness helper reads `ActionEconomyData.TurnNumber` — both `character` types. **This is the one deviation from the ruled placement, and it is not optional**; it is the same force that put `AttackFromCharacter` in the `resolution` module, and inside the parent module the compiler goes where the sheet is. The profile, the ledger interface and the gate do land in `combat` as ruled.

**What `x` is.** `monster.Monster` has no persisted economy: it drives a caller-supplied `*combat.ActionEconomy` (`monster/monster.go:429-492`) and prices actions with its own `ActionCost` enum. A character holds `*ActionEconomyData`. Two different ledger types, so the gate names neither — `x` is `combat.Ledger`, implemented natively by `*combat.ActionEconomy` (monsters get it for free, today) and by `*character.Character`. `PoolLeft` answers zero for the monster's economy, so a ki cost is honestly refused rather than silently free.

## Conformance to the ruled shape

| ruled | built |
|---|---|
| keyed, never fielded | five keyed maps, no per-currency field |
| grants keyed, Attack banks `1+ExtraAttacks` | `Grants map[CapacityType]int` |
| pools expressible, unexercised | `Pools map[ResourceKey]int` — typed, validated, charged; no v1 compiler emits one |
| preconditions expressible, unexercised | `Requires map[CapacityType]int` — see note below |
| rescue the enum, don't mint a vocabulary | relocated verbatim, no new members |
| no per-unit movement cost in the profile | the profile only ever says "spend N"; what a path costs is the path's |
| gate pure, bus-free, atomic all-or-none | complete precheck, then infallible writes |
| `Pay` marks the sheet dirty | through `economyChanged` and `UseResource`, E0's own choke points |
| reseed off `ActionEconomyData.TurnNumber` | `RefreshForTurn`, no production caller |
| additive only | gorelease agrees, below |
| profile + gate in `combat` | yes |
| compiler + reseed in `combat` | **no — `character`, forced by the module graph** |

**On the precondition shape.** A precondition is a keyed capacity requirement that is **checked and never spent**, not a declared-trigger predicate. The gate evaluates everything the profile carries, because a field the gate did not read would be exactly the "stat block that could be lying about whether anything read it" the doc cites against `SaveGate`'s predecessor — and a trigger vocabulary would have to be sealed, which the doc's open question 8 explicitly declines to do. The monk's took-Attack-this-turn is expressible in it the way the sheet already records that fact (`checkPostStrikeGrants` banks `martial_arts_bonus` after a strike) — which is the reason the shape needs **no new state**: a requirement reads evidence the ledger keeps for its own reasons rather than asking it to remember something on a precondition's behalf.

**Director-blessed with a scope constraint**, now in the godoc: `Requires` is *the precondition shape the gate can evaluate today*, not a predicate language. Anything that has to ask what the ledger does not keep — a declared trigger, a condition on the board, who is adjacent to whom — is a different shape, and whether that vocabulary should be sealed is #1035's open question 8, deliberately left open. It arrives with the caller that forces it.

One naming note: `Character.GrantCapacity` already exists with a `GrantedActionKey` signature, so the `Ledger`'s banking method is `BankCapacity`.

## What lands

- `combat/capacity.go` — the relocated vocabulary, now **closed**: `SpendProfile.Validate` refuses a key outside it, because a capacity no ledger agreed to store is a grant that vanishes and a cost that is free, and neither reports anything. `CapacityTypes()` exists so a ledger can be pinned *total* rather than trusted to be.
- `combat/spend_profile.go` — `SpendProfile{Slots, Capacity, Grants, Pools, Requires}` + `Validate`. Nil is a free action.
- `combat/gate.go` — `Ledger`, `CanPay`, `Pay`. Both gate functions answer from one `check`, so they cannot drift apart.
- `combat/action_economy_ledger.go` — `*ActionEconomy` implements `Ledger` as a *view* over its named fields, not a second copy.
- `character/ledger.go` — `*Character` implements `Ledger`; the one total translation lives here.
- `character/spend_profile.go` — `CostOfAttack`, `CostOfStrike`. Conventions mirror `AttackFromCharacter`: concrete sheet in, neutral profile out, nil refused by name, static facts only.
- `character/action_economy.go` — `RefreshForTurn` + `seedTurn`, shared with `StartTurn` so the two cannot disagree about what a fresh turn looks like.

## Test evidence

61 new cases across six suites (subtests counted individually), all green; full `go test -count=1 ./...` green for the module, `go vet` clean, `golangci-lint` 0 issues, `gofmt` clean.

The pins the issue asked for: a level-5 fighter's compiled Attack profile banks 2 and a level-1 banks 1 — plus level 11 → 3, level 20 → 4, monk 4 → 1, monk 5 → 2, wizard 20 → 1 — every one from a real sheet through `LoadFromData`, with nothing set on the economy by hand. Multi-currency `Pay` is atomic (a spy ledger counts writes, so "nothing changed" is *nothing was written* rather than a state compare a compensating pair of writes would pass). A paid sheet reports `IsDirty()`, per currency. `CanPay` writes nothing and dirties nothing. A pool cost and a precondition are expressible as a package-level declaration that stops compiling if either field stops existing. The reseed refills exactly at a turn boundary and never mid-turn, including that a spend between two asks in the same turn survives. And case (i) end to end: one action, two swings, third refused.

**Mutation testing** — 54 mutants over the new marks and branches, run in two waves plus fixes. Wave 1 found five survivors; three were real gaps, now closed by the second commit: a **zero** cost was only refused for slots (capacity and pools were pinned by negatives, which a `< 0` catches equally well); an unaliased capacity round-trip proved nothing, because a translation returning the empty key for everything agrees with itself; and the nil-economy guards on the reads and writes were unpinned because the gate refuses out-of-combat before reading anything. Wave 2 added 13 more and found two further gaps (a nil ledger, and a profile that moves nothing being payable out of combat). Every mutant now dies. The two that appear as survivors in the raw logs were my own defects — one a no-op rewrite, one killed by a build failure from an unused import rather than by a test; both were corrected and killed by name.

## gorelease

`gorelease -base v0.95.1` from `rulebooks/dnd5e` — **compatible changes only**, nothing incompatible:

```
# .../rulebooks/dnd5e/character
## compatible changes
(*Character).BankCapacity/CapacityLeft/PoolLeft/RefreshForTurn/SlotsLeft/
SpendCapacity/SpendPool/SpendSlots: added
CostOfAttack, CostOfStrike, RefreshForTurnInput, RefreshForTurnOutput: added

# .../rulebooks/dnd5e/combat
## compatible changes
(*ActionEconomy).BankCapacity/CapacityLeft/InCombat/PoolLeft/SlotsLeft/
SpendCapacity/SpendPool/SpendSlots: added
CanPay, CapacityTypes, IsCapacity, Ledger, Pay, SpendProfile: added

# summary
Suggested version: v0.96.0 (with tag rulebooks/dnd5e/v0.96.0)
```

## Review round

Copilot raised two, both verified against the code before acting.

**`(*ActionEconomy).SpendPool` has an empty body → silent free spend.** Half taken. The doc claimed the call "cannot happen", which is true through the gate and false for anyone reaching past it — an overclaiming comment is exactly what this codebase least wants, so it is rewritten. The behaviour stands: failing fast would mean panicking, because `Ledger`'s debit methods take no error return *by design* — that is what makes the debit atomic, and a debit that can refuse after the check passed is one that can leave half a payment behind. And the outcome is not a free spend: the economy holds no pools, so `PoolLeft` reports zero before and after, and the read and the write agree.

**`StartTurn` dereferences its input without a nil check.** Taken. The panic predates this PR — but the *asymmetry* is mine, because this PR added `RefreshForTurn` over the same state and that one refuses nil with a structured error. `StartTurn` now does too, pinned by a test that a refused start leaves the sheet out of combat and unmarked, and mutation-checked. Scoped to the verb this diff already touched: `ActivateAbility` and `ExecuteAction` have the same shape and belong on their own issue rather than riding an economy slice.

No resolution, session or encounter changes — those modules pin published versions and cannot see this yet.

Closes #1091

— fix-1091 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
