### PR TITLE
feat(resolution): the door charges what the action costs (#1094)

### DIFF
--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -299,6 +299,40 @@ what it wants" (`step.go:37-42`).
 identical technique: keep `Pay` where a machine does not import it, and the
 denial is a compile error rather than a code-review note.
 
+> **Correction — 2026-08-18, from E2's census ([#1094][e2], PR [#1096][e2pr]).**
+> The paragraph above and the *enforcement* row of the table are **wrong about
+> the ledger**, and the difference matters because it is the difference between
+> a guarantee and a habit.
+>
+> The bus's denial is structural and stays structural: `Gather`'s workings are
+> unexported and a machine cannot construct a step at all, so reaching the bus
+> is a compile error. **The ledger has no equivalent seal**, and the reason is
+> shape D itself. `drive` hands the machine `*Participants`
+> (`resolution/step.go:103`), the `*character.Character` values in it satisfy
+> `combat.Ledger` (`character/ledger.go:21`), and `combat.Pay` is an ordinary
+> exported function in a package anything may import. So "keep `Pay` where a
+> machine does not import it" describes no achievable arrangement: **the sheets
+> are the ledger, and the machine already holds them** — which is the same fact
+> D was chosen for, working against the denial rather than for it.
+>
+> **What E2 ships is the checkable half**, and `resolution/doc.go` says that
+> rather than repeating the claim above: the runner pays, no machine in the
+> package reads or writes an economy, and both are held by review and by test
+> rather than by the compiler. It becomes structural only behind a **read-only
+> cast view** — a change to *what a machine is handed*, not to where the debit
+> is called from — which is now a **named gap** rather than a property anyone
+> may rely on.
+>
+> **No falsifier fired and the ruling is unaffected.** The door still pays, the
+> runner still spends, and nothing in E2 needed the structural denial to be
+> true — it needed only that no machine *does* spend, which is what was built.
+> The correction lands here rather than in a side note because this doc's own
+> practice is to name what would overturn it: a DECIDED record carrying a false
+> load-bearing claim is worse than one carrying a dated correction.
+
+[e2]: https://github.com/KirkDiggler/rpg-toolkit/issues/1094
+[e2pr]: https://github.com/KirkDiggler/rpg-toolkit/pull/1096
+
 ### The runner already does this — verified, not asserted
 
 The claim that "the runner interprets yielded steps" is not aspirational. It is
@@ -688,7 +722,11 @@ Kirk, ruling on the shape above:
 3. **Machines yield; the runner spends.** No machine touches the ledger. It is
    denied to them by construction, exactly as ADR-0038 denies them the bus — keep
    `Pay` where a machine cannot import it, and the denial is a compile error
-   rather than a review note.
+   rather than a review note. **Corrected 2026-08-18** — see the
+   correction above the *runner already does this* section. The ledger's denial
+   is a checkable discipline rather than a compile error, and stays one until a
+   read-only cast view exists. The ruling — no machine spends — stands exactly
+   as written; only its claimed enforcement mechanism was wrong.
 4. **Debits ride answers.** Every candidate surviving *interested ∩ affordable*
    carries an answering policy. **auto ≡ decider**: a zero-latency window, posed
    and answered in the same runner pass, debited inline. **ask**: a `Pose` window

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -726,8 +726,9 @@ Kirk, ruling on the shape above:
    rather than a review note. **Corrected 2026-08-18** — see the
    correction above the *runner already does this* section. The ledger's denial
    is a checkable discipline rather than a compile error, and stays one until
-   the read-only cast view of [#1095][gap] exists. The ruling — no machine spends — stands exactly
-   as written; only its claimed enforcement mechanism was wrong.
+   the read-only cast view of [#1095][gap] exists. The ruling — no machine
+   spends — stands exactly as written; only its claimed enforcement mechanism
+   was wrong.
 4. **Debits ride answers.** Every candidate surviving *interested ∩ affordable*
    carries an answering policy. **auto ≡ decider**: a zero-latency window, posed
    and answered in the same runner pass, debited inline. **ask**: a `Pose` window

--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -320,8 +320,8 @@ denial is a compile error rather than a code-review note.
 > package reads or writes an economy, and both are held by review and by test
 > rather than by the compiler. It becomes structural only behind a **read-only
 > cast view** — a change to *what a machine is handed*, not to where the debit
-> is called from — which is now a **named gap** rather than a property anyone
-> may rely on.
+> is called from — which is now a **named gap filed as [#1095][gap]** rather
+> than a property anyone may rely on.
 >
 > **No falsifier fired and the ruling is unaffected.** The door still pays, the
 > runner still spends, and nothing in E2 needed the structural denial to be
@@ -332,6 +332,7 @@ denial is a compile error rather than a code-review note.
 
 [e2]: https://github.com/KirkDiggler/rpg-toolkit/issues/1094
 [e2pr]: https://github.com/KirkDiggler/rpg-toolkit/pull/1096
+[gap]: https://github.com/KirkDiggler/rpg-toolkit/issues/1095
 
 ### The runner already does this — verified, not asserted
 
@@ -724,8 +725,8 @@ Kirk, ruling on the shape above:
    `Pay` where a machine cannot import it, and the denial is a compile error
    rather than a review note. **Corrected 2026-08-18** — see the
    correction above the *runner already does this* section. The ledger's denial
-   is a checkable discipline rather than a compile error, and stays one until a
-   read-only cast view exists. The ruling — no machine spends — stands exactly
+   is a checkable discipline rather than a compile error, and stays one until
+   the read-only cast view of [#1095][gap] exists. The ruling — no machine spends — stands exactly
    as written; only its claimed enforcement mechanism was wrong.
 4. **Debits ride answers.** Every candidate surviving *interested ∩ affordable*
    carries an answering policy. **auto ≡ decider**: a zero-latency window, posed

--- a/rulebooks/dnd5e/resolution/cost.go
+++ b/rulebooks/dnd5e/resolution/cost.go
@@ -1,0 +1,192 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// Cost is what an interaction costs the actor who declared it, compiled.
+//
+// It is DATA, and under R2 that is what lets it exist at all. A gate resolution
+// consulted would be the first capability this package reads rather than
+// carries; a price it is handed is a struct field, and the difference is the
+// whole reason the economy needed no vocabulary change to arrive
+// (docs/ideas/session-sdk/economy-gate.md).
+//
+// The price is compiled ABOVE this package, by whoever knows what a fighter is
+// — character.CostOfAttack and character.CostOfStrike today. By the time a
+// profile reaches the door the class table is gone, and a level-5 fighter's
+// Attack action is indistinguishable from a level-1 fighter's except in the
+// number it banks.
+//
+// A nil *Cost is a free action: nothing is looked up, nothing is refreshed, and
+// nothing is charged. That is the shipped semantics of the gate one layer down
+// ("a machine maybe doesn't have a cost and that's okay"), and it is what every
+// Resolve in this package did before the door existed.
+type Cost struct {
+	// PayerID names the participant whose sheet is charged. REQUIRED whenever a
+	// cost is present — a price nobody pays is a free action wearing a cost's
+	// clothes, and nothing downstream would ever say so.
+	//
+	// It must name a CHARACTER in the cast. A monster is refused by name rather
+	// than charged: monster.Monster keeps no economy, it is handed one for the
+	// duration of a turn and it is thrown away after, so there is nothing on
+	// that sheet to debit. Monsters take no gated action in v1 — the session
+	// refuses them at Attack — and this refusal is what keeps the day they do
+	// from being a silent free swing.
+	PayerID string
+
+	// Profile is the price, compiled. Nil charges nothing.
+	Profile *combat.SpendProfile
+
+	// Turn is the turn the payer is acting in, so a bank left over from an
+	// earlier one can be refilled before it is charged. Nil refreshes nothing
+	// and charges the bank exactly as it was stored.
+	//
+	// Nil is a legal statement rather than a missing capability, and the
+	// difference from rpg-toolkit#1033's roller is that nil INVENTS nothing: a
+	// caller who omits it gets the stored bank, and once that bank is empty
+	// they get a refusal. The failure is loud and it is never a free action,
+	// which is what makes the omission safe to allow. What this package will
+	// not do is guess a turn — see [Turn] for why neither half is derivable
+	// here.
+	Turn *Turn
+}
+
+// Turn is which turn the payer is acting in, and what a fresh one grants them.
+//
+// It is not initiative order and not the encounter's clock: it is the marker
+// character.RefreshForTurn compares against the economy stored on the sheet.
+// An economy filed under any other number is stale and gets replaced with a
+// full one; filed under this one it is left exactly as it is, so a second swing
+// cannot refill what the first spent. That is what makes the refresh safe to
+// ask for at every door rather than exactly once at a turn boundary nobody
+// announces.
+//
+// BOTH HALVES ARE SUPPLIED BECAUSE NEITHER IS DERIVABLE HERE, and the
+// derivations that look available are wrong:
+//
+//   - The world carries no per-character turn number. [Input.World] holds
+//     per-bubble rounds (clock.TurnData's Order, ActiveIdx and Round), and a
+//     member on the world clock has no bubble at all. Turning that into a turn
+//     number would be this package deciding what a turn is.
+//   - character.Character's own speed accessor answers the BASE walking speed,
+//     before conditions have their say, while the refresh wants the speed a
+//     turn actually seeds. Reading it here would put a right-looking wrong
+//     number on every hasted, slowed or unarmored-moving sheet — the shape of
+//     failure rpg-toolkit#1033 exists to remember.
+type Turn struct {
+	// Number is the turn being acted in. An economy stored under any other
+	// number is stale.
+	Number int
+
+	// Speed is the movement a fresh turn seeds, in feet — the payer's speed
+	// after whatever conditions have to say about it, which the caller computes.
+	Speed int
+}
+
+// validate reports whether this cost names a price somebody could be charged.
+//
+// It runs with the rest of [Input.Validate], before the world is loaded and
+// before a sheet is attached, because a malformed price is a caller or a
+// content defect rather than an actor who ran out — and the two must not reach
+// a client as the same refusal.
+//
+// What it deliberately does not require is a price at all. A nil cost never
+// reaches here, and a nil profile is a free action: that is the gate's shipped
+// semantics one layer down, not a default invented at this seam.
+func (c *Cost) validate() error {
+	if c == nil {
+		return nil
+	}
+
+	if c.PayerID == "" {
+		return fmt.Errorf("%w: no payer named", ErrBadCost)
+	}
+
+	if err := c.Profile.Validate(); err != nil {
+		// Both are wrapped: this package's sentinel is what a caller matches on,
+		// and the gate's own structured error is what says which key was wrong.
+		return fmt.Errorf("%w: %w", ErrBadCost, err)
+	}
+
+	return nil
+}
+
+// payAtTheDoor charges the actor, and charges them before the machine runs.
+//
+// This is the runner's enforcement point. The machine starts already-paid and
+// is never told: it cannot tell a swing that cost an action from one that cost
+// nothing, which is the ignorance the ruling asks for, because what an action
+// costs was answered by whoever compiled the profile one layer up.
+//
+// The order inside is not arbitrary:
+//
+//   - The payer is found FIRST. A cost naming somebody who cannot be charged is
+//     a caller defect, and it should not refill anybody's bank on its way to
+//     being refused.
+//   - The refresh comes NEXT, because a bank left over from an earlier turn has
+//     to be full before it is asked to pay. It is safe to ask at every door: an
+//     economy already filed under this turn is left exactly as it is, so a
+//     second swing cannot refill what the first one spent.
+//   - The charge comes LAST, and it is all-or-none by the gate's own
+//     construction — a bonus strike that needs a bonus action and a ki point
+//     cannot take the action and then discover there is no ki.
+func payAtTheDoor(ctx context.Context, cost *Cost, cast *Participants) error {
+	if cost == nil {
+		return nil
+	}
+
+	payer, err := ledgerFor(cast, cost.PayerID)
+	if err != nil {
+		return err
+	}
+
+	if cost.Turn != nil {
+		if _, refreshErr := payer.RefreshForTurn(ctx, &character.RefreshForTurnInput{
+			TurnNumber: cost.Turn.Number,
+			Speed:      cost.Turn.Speed,
+		}); refreshErr != nil {
+			return fmt.Errorf("resolution: refresh %q for turn %d: %w",
+				cost.PayerID, cost.Turn.Number, refreshErr)
+		}
+	}
+
+	if err := combat.Pay(payer, cost.Profile); err != nil {
+		return fmt.Errorf("%w: %q: %w", ErrCannotPay, cost.PayerID, err)
+	}
+
+	return nil
+}
+
+// ledgerFor finds the sheet a cost is charged to.
+//
+// The concrete character comes back rather than a combat.Ledger, and both
+// reasons matter: the refresh is a character's own verb, and a nil *Character
+// inside a non-nil interface would sail past the gate's nil check as a ledger
+// that exists and answers nothing.
+func ledgerFor(cast *Participants, id string) (*character.Character, error) {
+	if ch, ok := cast.Character(id); ok {
+		return ch, nil
+	}
+
+	if _, ok := cast.Monster(id); ok {
+		// Named rather than dereferenced, and named separately from "was not
+		// passed in", because the two want different fixes. A monster keeps no
+		// economy: one is handed to it for the duration of a turn by whoever
+		// runs that turn, and it is thrown away after. Monsters take no gated
+		// action in v1, and this is what keeps the day they do from arriving as
+		// a silently free one.
+		return nil, fmt.Errorf(
+			"%w: %q is a monster, whose economy belongs to whoever runs its turn rather than to its sheet",
+			ErrNoPayer, id)
+	}
+
+	return nil, fmt.Errorf("%w: %q was not passed in", ErrNoPayer, id)
+}

--- a/rulebooks/dnd5e/resolution/cost.go
+++ b/rulebooks/dnd5e/resolution/cost.go
@@ -98,9 +98,10 @@ type Turn struct {
 // content defect rather than an actor who ran out — and the two must not reach
 // a client as the same refusal.
 //
-// What it deliberately does not require is a price at all. A nil cost never
-// reaches here, and a nil profile is a free action: that is the gate's shipped
-// semantics one layer down, not a default invented at this seam.
+// What it deliberately does not require is a price at all. A nil cost reaches
+// this method and leaves it legal, and so does a nil profile: both are free
+// actions, which is the gate's shipped semantics one layer down rather than a
+// default invented at this seam.
 func (c *Cost) validate() error {
 	if c == nil {
 		return nil

--- a/rulebooks/dnd5e/resolution/cost.go
+++ b/rulebooks/dnd5e/resolution/cost.go
@@ -50,12 +50,16 @@ type Cost struct {
 	// and charges the bank exactly as it was stored.
 	//
 	// Nil is a legal statement rather than a missing capability, and the
-	// difference from rpg-toolkit#1033's roller is that nil INVENTS nothing: a
-	// caller who omits it gets the stored bank, and once that bank is empty
-	// they get a refusal. The failure is loud and it is never a free action,
-	// which is what makes the omission safe to allow. What this package will
-	// not do is guess a turn — see [Turn] for why neither half is derivable
-	// here.
+	// difference from rpg-toolkit#1033's roller is that nil INVENTS nothing.
+	// THE FAILURE DIRECTION IS THE WHOLE ARGUMENT FOR ALLOWING IT: forgetting
+	// this field yields refusals, never free actions. A caller who omits it
+	// gets the bank exactly as stored, and once that bank is empty every ask is
+	// refused — loudly, and pointing at the missing wiring. #1033's nil failed
+	// the other way, quietly becoming real randomness that looked like a
+	// working capability.
+	//
+	// What this package will not do is guess a turn — see [Turn] for why
+	// neither half of one is derivable here.
 	Turn *Turn
 }
 

--- a/rulebooks/dnd5e/resolution/cost_test.go
+++ b/rulebooks/dnd5e/resolution/cost_test.go
@@ -1,0 +1,544 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// CostTestSuite drives the door: what an action costs is paid before the
+// machine runs, and a resolution that cannot be paid for never starts one.
+type CostTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestCostSuite(t *testing.T) {
+	suite.Run(t, new(CostTestSuite))
+}
+
+func (s *CostTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+const (
+	// bankedAttacks is what the Attack action left behind for a swing to spend.
+	bankedAttacks = 1
+
+	// heroBaseSpeed is the Human walking speed this hero's race gives them, and
+	// therefore the number a door that read the SHEET instead of the caller
+	// would seed movement with.
+	heroBaseSpeed = 30
+
+	// suppliedSpeed is deliberately not heroBaseSpeed. Every refresh in this
+	// suite states it, so an assertion on movement tells the two sources apart.
+	suppliedSpeed = 25
+
+	firstTurn = 1
+	nextTurn  = 2
+)
+
+// economy is a turn's worth of action economy, filed under a turn number, with
+// whatever the Attack action has already banked.
+func (s *CostTestSuite) economy(turn, actions, banked int) *character.ActionEconomyData {
+	granted := map[character.GrantedActionKey]int{}
+	if banked > 0 {
+		granted[character.GrantedAttacks] = banked
+	}
+
+	return &character.ActionEconomyData{
+		TurnNumber:            turn,
+		ActionsRemaining:      actions,
+		BonusActionsRemaining: 1,
+		ReactionsRemaining:    1,
+		MovementRemaining:     heroBaseSpeed,
+		Granted:               granted,
+	}
+}
+
+// hero is a level-1 human fighter with a longsword they know how to use. A nil
+// economy is a character who is not in a fight.
+func (s *CostTestSuite) hero(econ *character.ActionEconomyData) *character.Data {
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Grog",
+		Level:    1,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:           14,
+		MaxHitPoints:        14,
+		ArmorClass:          14,
+		ProficiencyBonus:    2,
+		WeaponProficiencies: []proficiencies.Weapon{proficiencies.WeaponSimple, proficiencies.WeaponMartial},
+		Inventory: []character.InventoryItemData{
+			{Type: shared.EquipmentTypeWeapon, ID: string(weapons.Longsword), Quantity: 1},
+		},
+		EquipmentSlots: character.EquipmentSlots{character.SlotMainHand: string(weapons.Longsword)},
+		ActionEconomy:  econ,
+	}
+}
+
+func (s *CostTestSuite) load(data *character.Data) *character.Character {
+	c, err := character.Load(s.ctx, data)
+	s.Require().NoError(err)
+
+	return c
+}
+
+// attackCost and strikeCost come from the REAL compilers rather than a
+// hand-built profile, so the two halves of the economy meet here as they will
+// in the session: the rulebook prices the action, the door charges it.
+func (s *CostTestSuite) attackCost(data *character.Data) *combat.SpendProfile {
+	profile, err := character.CostOfAttack(s.load(data))
+	s.Require().NoError(err)
+
+	return profile
+}
+
+func (s *CostTestSuite) strikeCost(data *character.Data) *combat.SpendProfile {
+	profile, err := character.CostOfStrike(s.load(data))
+	s.Require().NoError(err)
+
+	return profile
+}
+
+func (s *CostTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+// witnessMachine records that it was driven, then gets out of the way. The
+// evidence a refused resolution has to leave is negative — nothing ran — so the
+// pin needs something that would have said otherwise.
+type witnessMachine struct {
+	inner   Machine
+	started bool
+}
+
+func (m *witnessMachine) Start(ctx context.Context, cast *Participants) (Step, error) {
+	m.started = true
+
+	return m.inner.Start(ctx, cast)
+}
+
+// countingRoller is the other half of that evidence: a strike that starts rolls
+// its attack, so a count of zero says the machine never got that far. Every
+// answer is a miss, which keeps a resolution that DOES run away from the damage
+// phase and its sheet writes.
+type countingRoller struct {
+	rolls int
+}
+
+func (r *countingRoller) Roll(_ context.Context, _ int) (int, error) {
+	r.rolls++
+
+	return missRoll, nil
+}
+
+func (r *countingRoller) RollN(_ context.Context, count, _ int) ([]int, error) {
+	r.rolls += count
+
+	out := make([]int, count)
+	for i := range out {
+		out[i] = missRoll
+	}
+
+	return out, nil
+}
+
+// swing drives the real strike machine — this hero's own longsword against the
+// catalog wolf — with the door's cost in front of it.
+//
+// Input.Roller is a separate, ordinary roller: it reconstitutes effects at
+// attach time, and letting it share the counting one would put rolls nobody
+// asked about into the evidence.
+func (s *CostTestSuite) swing(
+	hero *character.Data, cost *Cost, roller *countingRoller,
+) (*Output, *witnessMachine, error) {
+	profile, err := AttackFromCharacter(s.load(hero), &CharacterAttackInput{Slot: character.SlotMainHand})
+	s.Require().NoError(err)
+
+	machine := &witnessMachine{inner: NewStrike(&StrikeInput{
+		AttackerID: heroID,
+		TargetID:   wolfID,
+		Attack:     profile,
+		Roller:     roller,
+	})}
+
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
+		World:        s.world(),
+		Participants: []Participant{{Character: hero}, {Monster: monsters.NewWolf(wolfID).ToData()}},
+		Machine:      machine,
+		Cost:         cost,
+	})
+
+	return out, machine, err
+}
+
+// declare runs a cost against a machine that starts and is immediately Done —
+// the shape the ruling gives an action with no interaction behind it. The
+// Attack action is exactly that: it banks swings rather than making one, and
+// ErrNoMachine's own doc blesses the form ("distinct from a machine that
+// finishes immediately, which is legal").
+func (s *CostTestSuite) declare(hero *character.Data, cost *Cost) (*Output, error) {
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
+		World:        s.world(),
+		Participants: []Participant{{Character: hero}, {Monster: monsters.NewWolf(wolfID).ToData()}},
+		Machine:      &captureMachine{},
+		Cost:         cost,
+	})
+}
+
+func (s *CostTestSuite) thisTurn() *Turn {
+	return &Turn{Number: firstTurn, Speed: suppliedSpeed}
+}
+
+// ---------------------------------------------------------------------------
+// THE HEADLINE: a swing nobody can pay for never happens.
+// ---------------------------------------------------------------------------
+
+// The hero is in combat with an action in hand, but the Attack action was never
+// taken — so there is no banked swing for this strike to spend. The refusal has
+// to arrive before the machine does anything, and both halves of the evidence
+// say it did.
+func (s *CostTestSuite) TestAnActorWhoCannotPayNeverStartsTheMachine() {
+	hero := s.hero(s.economy(firstTurn, 1, 0))
+	roller := &countingRoller{}
+
+	out, machine, err := s.swing(hero, &Cost{
+		PayerID: heroID,
+		Profile: s.strikeCost(hero),
+		Turn:    s.thisTurn(),
+	}, roller)
+
+	s.Require().ErrorIs(err, ErrCannotPay)
+	s.Require().Nil(out, "a refused resolution hands back nothing to store")
+	s.Require().False(machine.started, "the machine never started")
+	s.Require().Zero(roller.rolls, "a strike that started would have rolled its attack")
+}
+
+// A paid swing that MISSES still costs what it cost. The attacker's sheet comes
+// back dirty with nothing on it but the spend, which is the whole reason the
+// economy had to mark (#1087): a miss changes nothing else, so without the mark
+// the debit would serialize perfectly and then be dropped by the write-back.
+func (s *CostTestSuite) TestAPaidStrikeSpendsTheBankEvenWhenItMisses() {
+	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
+	roller := &countingRoller{}
+
+	out, machine, err := s.swing(hero, &Cost{
+		PayerID: heroID,
+		Profile: s.strikeCost(hero),
+		Turn:    s.thisTurn(),
+	}, roller)
+
+	s.Require().NoError(err)
+	s.Require().True(machine.started)
+
+	outcome, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok, "a strike produces a StrikeOutcome")
+	s.Require().False(outcome.Hit, "a 4 plus the hero's +5 does not reach the wolf's AC 13")
+
+	s.Require().Len(out.DirtyCharacters, 1, "the attacker is dirty on a miss, and dirty for the economy alone")
+	spent := out.DirtyCharacters[0]
+	s.Require().Equal(heroID, spent.ID)
+	s.Require().Equal(bankedAttacks-1, spent.ActionEconomy.Granted[character.GrantedAttacks],
+		"exactly one swing off the bank")
+	s.Require().Equal(hero.HitPoints, spent.HitPoints, "and nothing else about the attacker moved")
+	s.Require().Empty(out.DirtyMonsters, "a miss takes no hit points")
+}
+
+// A nil cost is a free action: the door looks nobody up, refreshes nothing and
+// charges nothing, and the sheet comes back exactly as clean as it went in.
+// Every other suite in this package is the wider version of this pin — none of
+// them passes a cost, and none of them changed.
+func (s *CostTestSuite) TestANilCostChargesNothing() {
+	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
+
+	out, machine, err := s.swing(hero, nil, &countingRoller{})
+
+	s.Require().NoError(err)
+	s.Require().True(machine.started, "a free action still runs")
+	s.Require().Empty(out.DirtyCharacters, "nothing was spent, so there is nothing to save")
+}
+
+// ---------------------------------------------------------------------------
+// One turn, one action — and the turn after.
+// ---------------------------------------------------------------------------
+
+// The end-to-end shape of the economy through the door: a fighter's Attack
+// action costs the action and banks a swing, a second one in the same turn is
+// refused, and a new turn refills the bank on the way in.
+//
+// The sheet travels the way a host would carry it — what came back dirty is
+// what goes in next — so the refusal is against state that was actually written
+// rather than against a fixture edited between calls.
+func (s *CostTestSuite) TestTwoActionsInOneTurnAndTheSecondIsRefused() {
+	cost := func(sheet *character.Data, turn int) *Cost {
+		return &Cost{
+			PayerID: heroID,
+			Profile: s.attackCost(sheet),
+			Turn:    &Turn{Number: turn, Speed: suppliedSpeed},
+		}
+	}
+
+	hero := s.hero(s.economy(firstTurn, 1, 0))
+
+	first, err := s.declare(hero, cost(hero, firstTurn))
+	s.Require().NoError(err)
+	s.Require().Len(first.DirtyCharacters, 1)
+
+	spent := first.DirtyCharacters[0]
+	s.Require().Zero(spent.ActionEconomy.ActionsRemaining, "the action is gone")
+	s.Require().Equal(1, spent.ActionEconomy.Granted[character.GrantedAttacks],
+		"and a level-1 fighter's Attack action banks exactly one swing")
+
+	_, err = s.declare(spent, cost(spent, firstTurn))
+	s.Require().ErrorIs(err, ErrCannotPay, "a second Attack action in the same turn has no action to pay with")
+
+	third, err := s.declare(spent, cost(spent, nextTurn))
+	s.Require().NoError(err, "a new turn refills the bank at the door")
+
+	refreshed := third.DirtyCharacters[0].ActionEconomy
+	s.Require().Equal(nextTurn, refreshed.TurnNumber)
+	s.Require().Zero(refreshed.ActionsRemaining, "one seeded by the refresh, one spent by the door")
+	s.Require().Equal(1, refreshed.Granted[character.GrantedAttacks],
+		"the reseed empties the bank and the grant fills it again")
+}
+
+// A refused payment leaves the caller's sheet byte-identical. The turn stated
+// here is the one the economy is already filed under, so the refresh is on its
+// write-nothing path and the refusal is the only thing that could have written.
+func (s *CostTestSuite) TestARefusedPaymentWritesNothingBack() {
+	hero := s.hero(s.economy(firstTurn, 1, 0))
+
+	before, err := json.Marshal(hero)
+	s.Require().NoError(err)
+
+	out, _, err := s.swing(hero, &Cost{
+		PayerID: heroID,
+		Profile: s.strikeCost(hero),
+		Turn:    s.thisTurn(),
+	}, &countingRoller{})
+	s.Require().ErrorIs(err, ErrCannotPay)
+	s.Require().Nil(out, "nothing comes back, so nothing reaches storage")
+
+	after, err := json.Marshal(hero)
+	s.Require().NoError(err)
+	s.Require().JSONEq(string(before), string(after), "the sheet the caller handed over is untouched")
+}
+
+// ---------------------------------------------------------------------------
+// Who can be charged.
+// ---------------------------------------------------------------------------
+
+// A monster in the cast is refused BY NAME rather than nil-dereferenced or
+// silently let through. monster.Monster keeps no economy — it is handed one for
+// a turn and it is thrown away after — so there is nothing on that sheet to
+// debit, and the message says that rather than pretending the wolf was never
+// passed in.
+func (s *CostTestSuite) TestACostNamingAMonsterIsRefusedByName() {
+	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
+
+	out, machine, err := s.swing(hero, &Cost{
+		PayerID: wolfID,
+		Profile: s.strikeCost(hero),
+		Turn:    s.thisTurn(),
+	}, &countingRoller{})
+
+	s.Require().ErrorIs(err, ErrNoPayer)
+	s.Require().Contains(err.Error(), wolfID)
+	s.Require().Contains(err.Error(), "monster", "the refusal says which of the two ways it failed")
+	s.Require().Nil(out)
+	s.Require().False(machine.started)
+}
+
+func (s *CostTestSuite) TestACostNamingSomebodyNotPassedInIsRefused() {
+	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
+
+	out, machine, err := s.swing(hero, &Cost{
+		PayerID: "ghost",
+		Profile: s.strikeCost(hero),
+		Turn:    s.thisTurn(),
+	}, &countingRoller{})
+
+	s.Require().ErrorIs(err, ErrNoPayer)
+	s.Require().Contains(err.Error(), "ghost")
+	s.Require().Nil(out)
+	s.Require().False(machine.started)
+}
+
+// Out of combat is a refusal, not a free swing. The refresh does not rescue it:
+// a sheet with no economy has no turn to be stale, and inventing one here would
+// put a character in a fight nobody put them in.
+func (s *CostTestSuite) TestAnActorWithNoEconomyIsRefusedRatherThanChargedNothing() {
+	hero := s.hero(nil)
+
+	out, machine, err := s.swing(hero, &Cost{
+		PayerID: heroID,
+		Profile: s.strikeCost(hero),
+		Turn:    s.thisTurn(),
+	}, &countingRoller{})
+
+	s.Require().ErrorIs(err, ErrCannotPay)
+	s.Require().Nil(out)
+	s.Require().False(machine.started)
+}
+
+// ---------------------------------------------------------------------------
+// A cost that is not a price.
+// ---------------------------------------------------------------------------
+
+func (s *CostTestSuite) TestACostThatNamesNoPayerIsRefused() {
+	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
+
+	out, machine, err := s.swing(hero, &Cost{Profile: s.strikeCost(hero)}, &countingRoller{})
+
+	s.Require().ErrorIs(err, ErrBadCost)
+	s.Require().Nil(out)
+	s.Require().False(machine.started)
+}
+
+// A price keyed to a currency no ledger holds is refused as a MALFORMED cost,
+// not as an actor who ran out. E3 translates these to a client, and a caller
+// told "you are out of actions" about a typo would go looking at the wrong
+// sheet.
+func (s *CostTestSuite) TestACostKeyedToACurrencyNoLedgerHoldsIsRefused() {
+	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
+
+	out, machine, err := s.swing(hero, &Cost{
+		PayerID: heroID,
+		Profile: &combat.SpendProfile{
+			Capacity: map[combat.CapacityType]int{combat.CapacityType("sword-swings"): 1},
+		},
+	}, &countingRoller{})
+
+	s.Require().ErrorIs(err, ErrBadCost)
+	s.Require().NotErrorIs(err, ErrCannotPay)
+	s.Require().Nil(out)
+	s.Require().False(machine.started)
+}
+
+// The refusal comes out of Validate, so it lands before the world is loaded.
+// The world here is one this package cannot make sense of, and the malformed
+// cost has to beat it to the answer.
+func (s *CostTestSuite) TestAMalformedCostIsRefusedBeforeTheWorldIsLoaded() {
+	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
+
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
+		World:        encounter.EncounterData{},
+		Participants: []Participant{{Character: hero}},
+		Machine:      &captureMachine{},
+		Cost:         &Cost{Profile: s.strikeCost(hero)},
+	})
+
+	s.Require().ErrorIs(err, ErrBadCost)
+	s.Require().Nil(out)
+}
+
+// ---------------------------------------------------------------------------
+// The turn marker.
+// ---------------------------------------------------------------------------
+
+// A bank left over from last turn is refilled on the way in, which is what makes
+// materialise-at-first-ask work with no turn-start signal to listen for.
+//
+// The movement assertion is the pin that matters: the speed seeded is the one
+// the CALLER stated, and it is deliberately not this hero's base 30 — a door
+// that read the sheet's own accessor would answer 30 here and be wrong for
+// anyone hasted, slowed or unarmored-moving.
+func (s *CostTestSuite) TestTheDoorRefillsAStaleBankFromTheSuppliedTurn() {
+	hero := s.hero(s.economy(firstTurn, 0, 0))
+
+	out, err := s.declare(hero, &Cost{
+		PayerID: heroID,
+		Profile: s.attackCost(hero),
+		Turn:    &Turn{Number: nextTurn, Speed: suppliedSpeed},
+	})
+	s.Require().NoError(err, "the spent bank was refilled before it was charged")
+
+	refreshed := out.DirtyCharacters[0].ActionEconomy
+	s.Require().Equal(nextTurn, refreshed.TurnNumber)
+	s.Require().Zero(refreshed.ActionsRemaining, "one seeded, one spent")
+	s.Require().Equal(suppliedSpeed, refreshed.MovementRemaining,
+		"the supplied speed, not the sheet's base speed")
+}
+
+// No turn stated, no turn invented. The bank is charged exactly as it was
+// stored, and an actor who spent their action last turn is refused rather than
+// quietly handed a fresh one.
+func (s *CostTestSuite) TestWithoutATurnTheBankIsChargedExactlyAsStored() {
+	hero := s.hero(s.economy(firstTurn, 0, 0))
+
+	_, err := s.declare(hero, &Cost{PayerID: heroID, Profile: s.attackCost(hero)})
+
+	s.Require().ErrorIs(err, ErrCannotPay)
+}
+
+// A free action does not go through the door at all, so a stale bank stays
+// stale: the refresh is something a cost brings with it, not something every
+// resolution does to whoever happens to be in the cast.
+func (s *CostTestSuite) TestAFreeActionNeverRefreshesTheBank() {
+	hero := s.hero(s.economy(firstTurn, 0, 0))
+
+	out, err := s.declare(hero, nil)
+
+	s.Require().NoError(err)
+	s.Require().Empty(out.DirtyCharacters, "no cost, no door")
+}
+
+// A cost with a payer and a turn but no price refreshes and charges nothing.
+// The door's trigger is the cost being present, not the profile being non-nil —
+// which is what lets a caller say "this actor is acting now, and it is free"
+// without the two statements having to travel separately.
+func (s *CostTestSuite) TestACostWithNoProfileRefreshesAndChargesNothing() {
+	hero := s.hero(s.economy(firstTurn, 0, 0))
+
+	out, err := s.declare(hero, &Cost{
+		PayerID: heroID,
+		Turn:    &Turn{Number: nextTurn, Speed: suppliedSpeed},
+	})
+	s.Require().NoError(err)
+
+	refreshed := out.DirtyCharacters[0].ActionEconomy
+	s.Require().Equal(nextTurn, refreshed.TurnNumber)
+	s.Require().Equal(1, refreshed.ActionsRemaining, "refilled, and nothing taken back out")
+}

--- a/rulebooks/dnd5e/resolution/cost_test.go
+++ b/rulebooks/dnd5e/resolution/cost_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
@@ -254,6 +257,12 @@ func (s *CostTestSuite) TestAnActorWhoCannotPayNeverStartsTheMachine() {
 	s.Require().Nil(out, "a refused resolution hands back nothing to store")
 	s.Require().False(machine.started, "the machine never started")
 	s.Require().Zero(roller.rolls, "a strike that started would have rolled its attack")
+
+	// The sentinel is what E3 matches on; the gate's own message is what says
+	// WHICH currency ran out, and it has to survive being wrapped or the
+	// translation on the other side has nothing to say.
+	s.Require().Contains(err.Error(), heroID, "the refusal names who could not pay")
+	s.Require().Contains(err.Error(), string(combat.CapacityAttack), "and what they were short of")
 }
 
 // A paid swing that MISSES still costs what it cost. The attacker's sheet comes
@@ -453,6 +462,7 @@ func (s *CostTestSuite) TestACostKeyedToACurrencyNoLedgerHoldsIsRefused() {
 
 	s.Require().ErrorIs(err, ErrBadCost)
 	s.Require().NotErrorIs(err, ErrCannotPay)
+	s.Require().Contains(err.Error(), "sword-swings", "and it names the key nobody holds")
 	s.Require().Nil(out)
 	s.Require().False(machine.started)
 }
@@ -541,4 +551,55 @@ func (s *CostTestSuite) TestACostWithNoProfileRefreshesAndChargesNothing() {
 	refreshed := out.DirtyCharacters[0].ActionEconomy
 	s.Require().Equal(nextTurn, refreshed.TurnNumber)
 	s.Require().Equal(1, refreshed.ActionsRemaining, "refilled, and nothing taken back out")
+}
+
+// raging is a condition that subscribes on attach and can be heard afterwards,
+// which is what makes it a probe for whether anything survived.
+func (s *CostTestSuite) raging() json.RawMessage {
+	raw, err := (&conditions.RagingCondition{
+		CharacterID: heroID,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "rage",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// R5 holds on the refusal path too: the payment is refused AFTER every sheet
+// attached, so every subscription those attachments granted has to come back
+// off. The hero's Raging joins the saving-throw chain on the way in, and after
+// the refusal that chain answers nobody.
+//
+// Asserted on the bus rather than on the teardown call, so the pin survives a
+// change to which mechanism does the work — the same shape
+// TestAFailedResolutionLeavesNothingOnTheBus uses for the attach path.
+func (s *CostTestSuite) TestARefusedPaymentLeavesNothingOnTheBus() {
+	inner := events.NewEventBus()
+
+	hero := s.hero(s.economy(firstTurn, 1, 0))
+	hero.Conditions = []json.RawMessage{s.raging()}
+
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
+		World:        s.world(),
+		Participants: []Participant{{Character: hero}, {Monster: monsters.NewWolf(wolfID).ToData()}},
+		Machine:      &captureMachine{},
+		Cost:         &Cost{PayerID: heroID, Profile: s.strikeCost(hero), Turn: s.thisTurn()},
+	}, newSurface(inner))
+
+	s.Require().ErrorIs(err, ErrCannotPay)
+	s.Require().Nil(out)
+
+	event := &dnd5eEvents.SavingThrowChainEvent{SaverID: heroID, Ability: abilities.STR, DC: saveDifficulty}
+	chain := events.NewStagedChain[*dnd5eEvents.SavingThrowChainEvent](combat.ModifierStages)
+
+	modified, err := dnd5eEvents.SavingThrowChain.On(inner).PublishWithChain(s.ctx, event, chain)
+	s.Require().NoError(err)
+
+	folded, err := modified.Execute(s.ctx, event)
+	s.Require().NoError(err)
+
+	s.Require().False(folded.HasAdvantage(),
+		"the hero's Raging attached before the refusal and does not answer this chain")
 }

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -54,6 +54,29 @@
 //     conditions — silently. It buys nothing when the bus dies with the call
 //     anyway.
 //
+// # The door pays
+//
+// [Input.Cost] is what an interaction costs the actor who declared it, and this
+// package charges it before [Machine.Start] runs. A resolution nobody can pay
+// for never starts a machine and writes nothing; a nil cost is a free action,
+// which is what every Resolve was before the door existed.
+//
+// The runner spends and machines yield. That is the same move R6 makes about
+// the bus — a machine names what it wants and this package acts — so no machine
+// here reads or writes an economy, and a machine cannot tell a swing that cost
+// an action from one that cost nothing. What it cost was answered by whoever
+// compiled the profile.
+//
+// It is a discipline rather than R6's guarantee, and the difference is worth
+// being exact about. A machine cannot reach the bus BY CONSTRUCTION: [Gather]'s
+// workings are unexported and a machine cannot build a step at all. The ledger
+// has no such seal — [Participants] hands a machine the same
+// [character.Character] values the gate spends from, and the gate is an
+// ordinary exported function in a package anyone may import. Sealing it would
+// mean changing what a machine is handed rather than where the debit is called
+// from. Recorded here so nobody reads "the runner spends" as a compiler-checked
+// claim it is not.
+//
 // # Where this sits on the migration
 //
 // [ADR-0038]'s end state is one sentence of its Consequences: combat and

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -74,8 +74,8 @@
 // [character.Character] values the gate spends from, and the gate is an
 // ordinary exported function in a package anyone may import. Sealing it would
 // mean changing what a machine is handed rather than where the debit is called
-// from. Recorded here so nobody reads "the runner spends" as a compiler-checked
-// claim it is not.
+// from, which is rpg-toolkit#1095. Recorded here so nobody reads "the runner
+// spends" as a compiler-checked claim it is not.
 //
 // # Where this sits on the migration
 //

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -68,6 +68,25 @@ var (
 	// ErrNoCombatant indicates a strike naming somebody who was not passed in.
 	ErrNoCombatant = errors.New("resolution: combatant is not a participant")
 
+	// ErrBadCost indicates a cost that does not describe a price anybody could
+	// be charged — one that names no payer, or one whose profile is keyed to a
+	// currency no ledger holds. Refused at the door before the world is loaded,
+	// and kept distinct from ErrCannotPay on purpose: a malformed declaration is
+	// content or wiring being wrong, and translating it into "you are out of
+	// actions" would send a caller looking at the wrong sheet.
+	ErrBadCost = errors.New("resolution: invalid cost")
+
+	// ErrNoPayer indicates a cost naming somebody this cast cannot charge —
+	// an ID that was not passed in, or a monster, whose economy belongs to
+	// whoever runs its turn rather than to its sheet.
+	ErrNoPayer = errors.New("resolution: payer has no ledger in this cast")
+
+	// ErrCannotPay indicates an actor who cannot afford what they declared: no
+	// economy to spend from, not enough of a currency, or a precondition the
+	// ledger does not hold. The gate's own refusal is wrapped rather than
+	// replaced, so which currency ran out survives the crossing.
+	ErrCannotPay = errors.New("resolution: cost cannot be paid")
+
 	// ErrRecurrenceUnsupported indicates a gate asking for a repeat save this
 	// package cannot yet run. Refusing is the point: treating "save again at
 	// the end of each of your turns" as a single save would produce a

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -70,10 +70,13 @@ var (
 
 	// ErrBadCost indicates a cost that does not describe a price anybody could
 	// be charged — one that names no payer, or one whose profile is keyed to a
-	// currency no ledger holds. Refused at the door before the world is loaded,
-	// and kept distinct from ErrCannotPay on purpose: a malformed declaration is
-	// content or wiring being wrong, and translating it into "you are out of
-	// actions" would send a caller looking at the wrong sheet.
+	// currency no ledger holds. Refused at the door before the world is loaded.
+	//
+	// Kept distinct from [ErrCannotPay] on purpose, and this is the whole reason
+	// there are two: A MALFORMED PROFILE MUST NOT REACH A PLAYER AS "OUT OF
+	// ACTIONS". One is content or wiring being wrong and wants a developer; the
+	// other is an actor who spent what they had and wants a different verb. A
+	// single sentinel would send the first one looking at the wrong sheet.
 	ErrBadCost = errors.New("resolution: invalid cost")
 
 	// ErrNoPayer indicates a cost naming somebody this cast cannot charge —

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1 h1:QsAh+YZleaj52aSdawrIx1q2skRhPcPNKiP1wr2++HA=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.94.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0 h1:dB16IaDoSN+m3aFXD+t/3fNuYP43n6kvwBZa3ljtzbI=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.15.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -81,6 +81,17 @@ type Input struct {
 	// Machine is the interaction to run.
 	Machine Machine
 
+	// Cost is what this interaction costs the actor who declared it. NIL IS A
+	// FREE ACTION and is the common case today — only a caller that compiled a
+	// price passes one.
+	//
+	// It is paid HERE, before the machine starts, and the machine is never told:
+	// it cannot tell a swing that cost an action from one that cost nothing,
+	// which is the ignorance the ruling asks for, because what an action costs
+	// was already answered by whoever compiled the profile. See [Cost], and
+	// "The door pays" in this package's doc.
+	Cost *Cost
+
 	// Initiative orders a fight that starts while this interaction runs.
 	// REQUIRED.
 	//
@@ -158,7 +169,10 @@ func (in *Input) Validate() error {
 		seen[p.ID()] = struct{}{}
 	}
 
-	return nil
+	// Last, because it is the only clause that talks about somebody in the cast
+	// above: a cost names a payer, and whether the cast is one-sheet-per-ID is
+	// the question that has to be settled before naming anybody in it.
+	return in.Cost.validate()
 }
 
 // Output is everything the interaction produced. All of it is data (R2).
@@ -269,6 +283,16 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		// error path's silence is how leaks become normal.
 		_ = surf.teardown(ctx)
 		return nil, err
+	}
+
+	// THE DOOR PAYS, AND IT PAYS BEFORE THE MACHINE RUNS. A resolution nobody
+	// can pay for never starts one, which is R5's clean case and is only true
+	// while there is still nothing to undo. The teardown is joined rather than
+	// swallowed the way the attach failure above swallows it: everything
+	// attached successfully here, so a subscription outliving a refused
+	// interaction is a leak rather than the tail of a half-finished attach.
+	if payErr := payAtTheDoor(ctx, in.Cost, cast); payErr != nil {
+		return nil, errors.Join(payErr, surf.teardown(ctx))
 	}
 
 	outcome, runErr := drive(ctx, surf, in.Machine, cast)


### PR DESCRIPTION
Economy wave slice **E2**: *the runner's door pays*. Foundation ruled by Kirk on #1089's `docs/ideas/session-sdk/economy-gate.md`; E0 (#1088, v0.95.1) and E1 (#1092, v0.96.0) are in. E1 built the price and the gate and nothing called either — this is their one v1 caller.

*A strike nobody can pay for never rolls a die, and a swing that misses still costs what it cost.*

## Census

Three findings shaped the build. All three went to the director before building.

**A turn marker has no honest source inside resolution, so it is supplied or absent.** `RefreshForTurn` wants a turn number and a speed, and neither is derivable here. The world carries per-bubble *rounds* — `EncounterData.Bubbles` is `clock.TurnData{Order, ActiveIdx, Round}` — and a member on the world clock has no bubble at all, so turning that into `ActionEconomyData.TurnNumber` would be this package deciding what a turn is. And `Character.GetSpeed()` is documented as the **base** walking speed "before condition modifiers" (`character/character.go:136-138`), while `RefreshForTurnInput.Speed` is documented as the speed "after whatever conditions have to say about it, **which the caller computes**". Reading it at the door would be a #1033-shaped silent default: a right-looking number that is wrong for anyone hasted, slowed or unarmored-moving. So the marker rides in as data, and a test pins it with a supplied speed of **25** against a hero whose race gives 30 — a door that read the sheet would answer 30 and be caught.

**The ledger is NOT denied to machines by construction, and this PR does not claim it is.** The design record's keystone says the ledger "joins the bus as a thing machines are structurally denied… a compile error rather than a review note" (`economy-gate.md:298-300`). That is not achievable at this seam. The bus's denial works because `Gather`'s workings are unexported and a machine cannot construct a step at all; a sheet in the cast has no equivalent seal — `drive` hands the machine `*Participants`, whose `*character.Character` values satisfy `combat.Ledger`, and the gate is an ordinary exported function in an importable package. Sealing it means changing *what a machine is handed*, not where the debit is called from. So `doc.go` states the checkable half (the runner pays; no machine here touches an economy) and records the gap by name, rather than shipping a godoc claiming a compiler check that does not exist — which is exactly the overclaim Copilot caught on #1092.

**And the design record is corrected rather than left wrong.** At the director's direction this PR carries a dated amendment to `docs/ideas/session-sdk/economy-gate.md`: the keystone paragraph and the *enforcement* row of its table get a correction note distinguishing the bus's denial (structural, and staying structural) from the ledger's (a checkable discipline until a read-only cast view exists), and the ruling's own restatement in *Decided* gets a pointer so a reader of only that section is not left with the corrected claim. No falsifier fired and the ruling is unaffected — the door still pays and the runner still spends; E2 never needed the structural denial to be true, only that no machine *does* spend. A DECIDED doc carrying a false load-bearing claim is worse than one carrying a dated correction, and the falsifiers section is why that correction belongs in the doc itself.

**A monster payer has no ledger to charge.** `monster.Monster` keeps no economy: `TakeTurn` drives a caller-supplied `*combat.ActionEconomy` (`monster/monster.go:429-492`) and throws it away, and there is no accessor. So a cost naming a monster in the cast is refused **by name** and the message says why, rather than nil-dereferencing or folding into "was not passed in". Monsters take no gated action in v1; this is what keeps the day they do from arriving as a silently free one.

## Conformance to the ruled shape

| ruled | built |
|---|---|
| cost rides `Input` as data | `Input.Cost *Cost` — the ruling's own field name |
| payer + `*combat.SpendProfile` | `Cost{PayerID, Profile}`, one struct rather than loose fields |
| **nil cost is a free action** | nil never reaches the door; a nil `Profile` charges nothing |
| the door, not the machine | between `attachAll` and `drive` in `resolveOn` |
| machines never see the ledger | no machine in this package reads or writes one — but see the census finding above on *by construction* |
| the ledger is in the cast | `Participants.Character(payerID)`; the dirty mark rides out through the existing `dirtyCharacters` |
| don't preclude monsters | refused by name at one call site, with the reason in the message |
| `RefreshForTurn` at the door, before paying | yes, and only when the caller states a turn |
| turn marker rides as data | `Cost.Turn *Turn{Number, Speed}` |
| a refusal refuses the whole resolution | before `drive`; nil `Output`, sheet byte-identical, surface torn down |
| resolution's own sentinel vocabulary | `ErrBadCost` / `ErrNoPayer` / `ErrCannotPay`, wrapping the gate's error |
| additive | gorelease agrees, below |

**On `Cost.Turn` riding the cost rather than `Input`.** The refresh is payer-scoped — the door refills one bank, the payer's — so a turn on `Input` would imply everyone. Nil is a legal statement rather than a missing capability, and the difference from #1033's roller is that nil **invents nothing**: it charges the bank exactly as stored, and a caller who forgets it gets a *refusal* once the bank empties rather than a free action. The failure direction is what makes the omission safe to allow.

**On three sentinels rather than one.** The split is for E3's benefit. A malformed profile must not reach a client as "you are out of actions", so a cost naming no payer or keyed to a currency no ledger holds is `ErrBadCost`, raised in `Input.Validate` — before the world is loaded and before a sheet is attached. By the time the door runs, the only failures left are affordability and state. The gate's own error is wrapped rather than replaced, so *which* currency ran out survives the crossing, and there are tests on both halves.

**On the nil-cost legality, stated deliberately.** `Validate` does **not** require a cost, and that is not a #1033-style silent default. #1033 was a nil that silently became a real capability — randomness — producing a right-looking wrong answer with nothing to observe. A nil cost produces the behaviour every `Resolve` in this package already had; the 105 pre-existing tests are the pin that it still does (two mutants that break it are killed by `TestCharacterAttackSuite`, not by anything added here), and E3's flip of `TestNothingSpendsYet` is the guard that the one caller which *should* pay does.

## Test evidence

16 new cases in `cost_test.go`, driving the **real** strike machine over a hero's own longsword and the catalog wolf. Full `go test -count=1 ./...` green (121 tests), `gofmt` clean, `go vet` clean, `golangci-lint` 0 issues.

**RED was behavioural, not a compile error.** The types and the sentinels landed first with no door behind them, so every test compiled and failed against today's free-swing behaviour: **13 failed, 2 passed** — and the two that passed are exactly the two no-change pins (a nil cost charges nothing; a free action never refreshes).

The pins the issue asked for:

- **Refused before the machine starts.** A hero in combat whose Attack action was never taken has no banked swing. The strike is wrapped in a machine that records being driven, and its roller counts rolls: after the refusal, `started` is false and the roll count is **zero**.
- **A paid strike that MISSES still comes back dirty**, with the bank one lower than it went in and hit points untouched — economy-only dirt, which is E0's whole point.
- **Nil cost = free.** Broad no-change, plus an explicit case: the swing runs and no sheet comes back dirty.
- **Two Resolves, one turn, then the next.** The profile comes from the real `character.CostOfAttack` over a loaded sheet, and the sheet travels the way a host carries it — what came back dirty goes in next. First pays the action and banks one swing (a level-1 fighter's); second is `ErrCannotPay`; a third with the next turn number refreshes and pays, coming back with the turn advanced, the action spent, and the bank refilled by the grant after the reseed emptied it.
- **A refused pay leaves the sheet clean.** JSON snapshot before and after is byte-identical, and the output is nil so nothing reaches storage. The turn stated is the one the economy is already filed under, so the refresh is on its write-nothing path and the refusal is the only thing that could have written.

Plus: a payer with no economy at all is refused rather than charged nothing (and the refresh does not invent a fight nobody put them in); a monster payer and an absent payer are each refused by name; a malformed cost beats an unloadable world to the answer, which is how "before anything loads" is observed; and **R5 holds on the refusal path** — a raging hero joins the saving-throw chain on the way in, and after the refusal that chain answers nobody.

### Mutation testing

**29 mutants over the door's branches, in two waves. 28 killed, 1 survivor.**

Wave 1 (21) covers `Cost.validate`, `payAtTheDoor`, `ledgerFor` and the call site; wave 2 (8) covers the branches wave 1 did not reach — an ignored payer lookup, a nil ledger handed onward, the charge and the refresh swapped, a cost with no price skipping the door, an empty cast. The headline mutant is the door moved *after* `drive`: killed by three tests, including the one that counts rolls.

Two audit notes, because a mutation run is only worth what its harness is:

- **The first run reported 21/21 killed and was measuring nothing.** The harness ran `go test ./...` from the worktree root, where the resolution module is not the main module, so every run failed at setup and every mutant looked dead. The harness now refuses to report until an unmutated baseline runs green from the same directory, and the numbers above are from the corrected run.
- **The one survivor is unreachable by construction, and the alternative is worse.** `RefreshForTurn` returns an error only for a nil input, and the call site builds that input inline two lines above — so discarding the error passes every test. Keeping it handled is the honest shape: the day that verb grows a second failure mode, a swallowed error is a debit that silently did not happen. Recorded rather than papered over, and deliberately not "fixed" by a comment claiming it cannot happen.

Two gaps were found by *reading* for mutants before running any, and are the second commit: R5 was unpinned on the refusal path (a door that skipped the teardown passed the entire suite), and the gate's own message was crossing unobserved (the refusal now has to name the payer and the capacity, derived from `combat.CapacityAttack` rather than spelled out).

## gorelease

No CI job for this module, so run by hand from `rulebooks/dnd5e/resolution`:

```
# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution
## compatible changes
Cost: added
ErrBadCost: added
ErrCannotPay: added
ErrNoPayer: added
Input.Cost: added
Turn: added

# summary
Suggested version: v0.9.0 (with tag rulebooks/dnd5e/resolution/v0.9.0)
```

The `rulebooks/dnd5e` pin moves v0.94.1 → v0.96.0 for E1's gate; the encounter pin is untouched and there are no replace directives. No session or encounter changes — E3 is where the refusal reaches the wire with its translation. The one non-module path in the diff is the design-record amendment above, which the tagger's `has_changes` guard ignores.

Closes #1094

— fix-1094 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
