### PR TITLE
feat(session)!: a second swing costs something (#1097)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -74,9 +74,11 @@ type AttackOutput struct {
 // which is its caller, and it earns its shape then. The same discipline
 // [DissolveCause] uses for defeat.
 //
-// Main hand, one-handed, melee. Two-handed grips and the off-hand swing are
-// the compiler's own named gaps and arrive with the economy that decides when
-// a second swing is allowed at all.
+// Main hand, one-handed, melee. Two-handed grips and the off-hand swing are the
+// compiler's own named gaps, and they did NOT arrive with the economy the way
+// this paragraph used to predict: the economy decides how many swings a turn
+// buys, and what a two-handed grip does to one is a question for whoever
+// compiles the attack rather than for whoever prices it.
 //
 // # A swing costs something, in a fight
 //

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -78,13 +78,22 @@ type AttackOutput struct {
 // the compiler's own named gaps and arrive with the economy that decides when
 // a second swing is allowed at all.
 //
-// # Nothing spends
+// # A swing costs something, in a fight
 //
-// A character can attack as many times in a turn as the caller asks. That is a
-// KNOWN GAP, not a ruling that attacks are free: the thing that spends is an
-// economy machine that sits above this one and does not exist. It is named at
-// the one place it will go — see the comment at the resolution call below —
-// and pinned by TestNothingSpendsYet so it cannot be mistaken for a decision.
+// A character in a fight pays for the swing before it is resolved: the first in
+// a turn takes the Attack action, and what that action banks is what the swings
+// after it spend. A level-1 fighter therefore gets one swing per turn and a
+// level-5 fighter gets two, and the swing after that is refused with
+// [ErrCannotAfford] naming the currency that ran out.
+//
+// The price is compiled here and charged by resolution's door, before the
+// machine starts — so a refused swing resolves nothing, damages nobody, and
+// writes nothing at all. See [Manager.priceSwing] for what a turn costs and
+// [costOfSwing] for how one price is made out of the rulebook's two.
+//
+// IN FREE ROAM IT COSTS NOTHING, which is a ruling rather than the old gap: the
+// action economy is a fight's economy, and a member on the world clock has no
+// turn to spend a turn's slots from. TestFreeRoamChargesNothing pins it.
 //
 // # How it runs, and why the order is not a style choice
 //
@@ -113,8 +122,8 @@ type AttackOutput struct {
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
 // ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrNoSheet, ErrNoCharacter,
-// ErrBadCharacter, ErrBadRepository, ErrBadAttack, ErrClosed, or ErrSaveFailed
-// with a populated report.
+// ErrBadCharacter, ErrBadRepository, ErrBadAttack, ErrCannotAfford, ErrBadCost,
+// ErrClosed, or ErrSaveFailed with a populated report.
 //
 // ErrNoCharacter and ErrBadCharacter mean here exactly what they mean
 // everywhere else in this package: the repository does not hold that sheet,
@@ -172,29 +181,37 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		}
 	}
 
-	profile, err := m.compileAttack(ctx, in.Attacker)
+	sheet, profile, err := m.compileAttack(ctx, in.Attacker)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
 	}
 
-	cast, err := m.castFor(ctx, scope, roster)
+	// THE ONE PLACE A SPEND GOES, and it is the place its own comment predicted.
+	// The economy turned out not to need a machine above this call: the ruling
+	// (docs/ideas/session-sdk/economy-gate.md) put the price on Input as DATA and
+	// the debit at resolution's door, so what belongs here is compiling what this
+	// actor's swing costs — which is a question about a sheet, and this is where
+	// the sheets are. Nothing persistent or wire-shaped assumed attacks were
+	// free, and nothing had to migrate.
+	price, err := m.priceSwing(ctx, scope, in.Attacker, sheet)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
 	}
 
-	// THE ONE PLACE A SPEND WILL GO. An economy machine belongs above this
-	// call: it chooses what the actor is doing, spends the action or bonus
-	// action that buys it, and requests the strike below. Today nothing does,
-	// so nothing is spent — the strike runs directly. When the economy lands
-	// (its home is the combat package, whose ActionEconomy vocabulary already
-	// exists), the machine handed to Resolve becomes that one, and this line
-	// is where it changes. Nothing persistent or wire-shaped assumes attacks
-	// are free, so that change costs no migration.
+	// The readied sheet goes into the cast rather than the stored one: it is the
+	// sheet whose turn was just lit or refilled, and the door is about to charge
+	// exactly that bank. See swingPrice for why the two travel together.
+	cast, err := m.castFor(ctx, scope, roster, price.payer)
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
 	out, err := resolution.Resolve(ctx, &resolution.Input{
 		World:        scope.enc.ToData(),
 		Participants: cast,
 		Initiative:   m.initiative,
 		Standing:     scope.standing,
+		Cost:         price.cost,
 		Machine: resolution.NewStrike(&resolution.StrikeInput{
 			AttackerID: in.Attacker,
 			TargetID:   in.Target,
@@ -310,6 +327,20 @@ func reportUnrecorded(scope *writeScope, err error) error {
 // translate_internal_test.go covers every arm below.
 func translateResolution(err error) error {
 	switch {
+	case errors.Is(err, resolution.ErrCannotPay):
+		// The PLAYER-FACING one, and the reason it is not folded in with the two
+		// below. An actor who spent what they had is a fact about the game, and
+		// the gate's own refusal rides along as text so the message still names
+		// the currency that ran out — "action: 1 needed, 0 left" is what turns a
+		// refusal into something a client can say out loud.
+		return fmt.Errorf("%w: %v", ErrCannotAfford, err)
+	case errors.Is(err, resolution.ErrBadCost), errors.Is(err, resolution.ErrNoPayer):
+		// And the PROGRAMMER-FACING one. E2 split these deliberately and this
+		// seam keeps the split: a profile keyed to a currency no ledger holds, or
+		// a cost naming somebody who cannot be charged, is wiring that is wrong.
+		// Reporting it as "out of actions" would send whoever debugs it to a
+		// player's sheet to look for a bug that is in the code.
+		return fmt.Errorf("%w: %v", ErrBadCost, err)
 	case errors.Is(err, resolution.ErrBadParticipant):
 		return fmt.Errorf("%w: %v", ErrBadCharacter, err)
 	case errors.Is(err, resolution.ErrNoCombatant):
@@ -356,7 +387,7 @@ func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.Reco
 }
 
 // compileAttack turns the attacker's stored sheet into the neutral profile the
-// strike machine takes.
+// strike machine takes, and hands back the sheet it read it off.
 //
 // The sheet is loaded here as well as inside Resolve, and that is not a
 // duplicate to be optimised away: character.Load is bus-free, so this
@@ -364,6 +395,11 @@ func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.Reco
 // live character to read static facts off; resolution needs its own cast to
 // attach effects to. Two purposes, one stored sheet, and no shared bus between
 // them.
+//
+// THE LOADED SHEET COMES BACK OUT because the economy needs the same one. Its
+// turn is readied on this instance and its price compiled from what that leaves
+// ([Manager.priceSwing]), and loading a third copy to do it would ready a turn
+// on a sheet nobody hands over.
 //
 // Both refusals below keep the inner reason as TEXT rather than as a chain, the
 // way translateResolution's arms do. The second is the one that made it worth
@@ -373,24 +409,28 @@ func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.Reco
 // answers everything the profile step refuses with ErrBadAttack, including the
 // resolution.ErrNilInput cases, and routing it would silently re-map those onto
 // a different sentinel than the one hosts have been given.
-func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolution.AttackProfile, error) {
+func (m *Manager) compileAttack(
+	ctx context.Context, attacker string,
+) (*character.Character, resolution.AttackProfile, error) {
 	data, err := m.fetchCharacterData(ctx, "attacker", attacker)
 	if err != nil {
-		return resolution.AttackProfile{}, err
+		return nil, resolution.AttackProfile{}, err
 	}
 
 	loaded, err := character.Load(ctx, data)
 	if err != nil {
-		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadCharacter, err)
+		return nil, resolution.AttackProfile{},
+			fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadCharacter, err)
 	}
 
 	profile, err := resolution.AttackFromCharacter(loaded, &resolution.CharacterAttackInput{
 		Slot: character.SlotMainHand,
 	})
 	if err != nil {
-		return resolution.AttackProfile{}, fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadAttack, err)
+		return nil, resolution.AttackProfile{},
+			fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadAttack, err)
 	}
-	return profile, nil
+	return loaded, profile, nil
 }
 
 // castFor gathers every member of the encounter as a participant.
@@ -399,9 +439,14 @@ func (m *Manager) compileAttack(ctx context.Context, attacker string) (resolutio
 // is the effect's own predicate (ADR-0038). A bard three cells away whose
 // Bless is running has to be in the room for their subscription to fire, and
 // deciding they are irrelevant here would be this package deciding a rule.
-
+//
+// One member may arrive already in hand. The attacker's sheet has had its turn
+// readied by the time the cast is built (see [Manager.priceSwing]), and that
+// readying is state the stored copy does not have — so the readied sheet is
+// substituted rather than re-fetched. Passing nil means nobody was readied,
+// which is what free roam looks like.
 func (m *Manager) castFor(
-	ctx context.Context, scope *writeScope, roster []encounter.Member,
+	ctx context.Context, scope *writeScope, roster []encounter.Member, readied *character.Data,
 ) ([]resolution.Participant, error) {
 	npcs := map[string]*monster.Data{}
 	for i := range scope.data.NPCs {
@@ -417,6 +462,11 @@ func (m *Manager) castFor(
 				continue // content with no stored sheet contributes nothing
 			}
 			cast = append(cast, resolution.Participant{Monster: sheet})
+			continue
+		}
+
+		if readied != nil && readied.ID == id {
+			cast = append(cast, resolution.Participant{Character: readied})
 			continue
 		}
 

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -291,16 +291,33 @@ func (s *AttackTestSuite) TestAFailedWorldSaveStillNamesTheSheetThatLanded() {
 		"the write the report names really did land")
 }
 
-// TestNothingSpendsYet is the known gap, pinned so it cannot be mistaken for a
-// decision that attacks are free.
+// TestFreeRoamChargesNothing is TestNothingSpendsYet, flipped.
 //
-// A character may swing as many times in a turn as the caller asks, because
-// the thing that spends is an economy machine above this one and it does not
-// exist. The verb names the single place it will go. When it lands, THIS test
-// is the one that should fail — and its failure is the signal to write the
-// real economy assertions rather than to relax this one.
-func (s *AttackTestSuite) TestNothingSpendsYet() {
+// It used to pin a KNOWN GAP: nothing anywhere spent anything, a character could
+// swing as many times in a turn as the caller asked, and its failure was to be
+// the signal that the economy had landed. The economy has landed
+// (rpg-toolkit#1097), and the same three swings in the same scene still land —
+// which is now a RULING rather than a gap, and that is why the test is renamed
+// instead of deleted.
+//
+// The ruling is that the action economy is a FIGHT's economy. It is not this
+// package's invention: combat.Ledger opens with InCombat and refuses every
+// payment from a holder who is not in a fight, and a member on the world clock
+// has no turn to spend a turn's slots from. The duel below is free roam — two
+// characters standing next to each other, no bubble, no initiative order — so
+// the swing is passed no cost at all.
+//
+// EconomySuite is the other half, and neither test means much alone: the same
+// verb refuses a second swing the moment there is a fight to refuse it in. What
+// would make BOTH wrong is a swing charged where there is no economy to charge
+// it against, which the gate would refuse forever rather than once.
+func (s *AttackTestSuite) TestFreeRoamChargesNothing() {
 	mgr := s.duel(&sequenceDice{rolls: []int{15, 5, 15, 5, 15, 5}})
+
+	turn, err := mgr.Turn(context.Background(), &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal(session.ClockWorld, turn.Clock,
+		"the scene is free roam, which is the whole premise of this test")
 
 	for i := 0; i < 3; i++ {
 		out, err := s.swing(mgr)
@@ -310,7 +327,9 @@ func (s *AttackTestSuite) TestNothingSpendsYet() {
 
 	s.Equal(28-24, 4, "sanity: the fixture starts damaged, so HP is not clamped at max")
 	s.Less(s.characters.byID["bob"].HitPoints, 24,
-		"three unspent swings all landed — nothing anywhere is counting actions")
+		"three uncharged swings all landed — off the turn clock there is no economy")
+	s.Nil(s.characters.byID["alice"].ActionEconomy,
+		"and nothing lit one on her sheet: free roam is not a turn")
 }
 
 // TestAMonsterAttackerIsRefused pins v1's scope as a decision with a successor.

--- a/rulebooks/dnd5e/session/economy.go
+++ b/rulebooks/dnd5e/session/economy.go
@@ -1,0 +1,311 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
+)
+
+// The economy at this seam: what a swing costs, and whose turn it is bought in.
+//
+// The ruling this implements is docs/ideas/session-sdk/economy-gate.md. The
+// price is DATA compiled above resolution, the door charges it before the
+// machine runs, and no machine ever touches a ledger. What this file adds is the
+// only part that was left: somebody has to compile the price and say which turn
+// it is being paid in, and for a character swinging in a fight that somebody is
+// this package.
+
+// swingPrice is what one swing costs and the sheet that will be charged for it.
+//
+// The sheet travels WITH the price because the two are made together and must
+// not be separated. Readying a turn is a mutation — a cold sheet is lit, a stale
+// bank is refilled — and the price is compiled from the state that mutation
+// leaves behind. Handing the door the price while handing the cast the sheet as
+// it was stored would charge a bank nobody looked at.
+//
+// Both fields are nil in free roam, which is a price of nothing rather than a
+// missing one. See [Manager.priceSwing].
+type swingPrice struct {
+	// cost is what the door charges, or nil to charge nothing.
+	cost *resolution.Cost
+
+	// payer is the attacker's sheet with its turn readied, or nil when nothing
+	// readied it. It replaces the stored sheet in the cast.
+	payer *character.Data
+}
+
+// priceSwing works out what this swing costs its attacker, and readies the
+// sheet the door will charge for it.
+//
+// # Free roam charges nothing, and that is a ruling rather than a gap
+//
+// The action economy is a FIGHT's economy. That is not this package's opinion:
+// [combat.Ledger] opens with InCombat and refuses every payment from a holder
+// who is not in one, and a character on the world clock has no turn to spend a
+// turn's slots from. So a swing off the turn clock is passed no cost at all,
+// which is the same thing the verb did before this file existed.
+//
+// The alternative was tried on paper and is worse in a way worth recording: a
+// cost handed over in free roam is refused by the gate with "not in combat", so
+// every free-roam swing in the package — the duel every other test in this
+// suite is built on — would stop working. Charging nothing where there is no
+// economy is the honest reading of the same fact.
+//
+// # The turn number is the round, and it is READ rather than invented
+//
+// [resolution.Turn] declines to derive a turn number and says why: the world
+// carries per-bubble rounds and turning those into a turn number would be
+// resolution deciding what a turn is. THIS package is allowed to decide that,
+// because it is the one that projects the composition's clock to hosts already
+// ([Manager.Turn]).
+//
+// A member in a bubble acts exactly once per round — the order advances one
+// name per EndTurn and the round wraps when it comes back around — so the
+// round IS that member's turn number. Nothing is guessed.
+//
+// # Speed is the honest half-measure, and it is inert in v1
+//
+// [character.RefreshForTurnInput] wants the speed a turn seeds AFTER conditions
+// have had their say, and this package has no such number: it can read the
+// sheet's base walking speed and nothing else. So the seeded MovementRemaining
+// is wrong on any hasted or slowed character.
+//
+// It is shipped anyway, deliberately, because in v1 NOTHING READS IT: movement
+// costs nothing (the ruling's fork (d)), so no profile names CapacityMovement
+// and no path spends it. The day movement is charged, this is the line that has
+// to grow a real answer — a speed computed where conditions can be asked, which
+// is above this seam — and it must not be discovered then. It is named here
+// rather than left to be found.
+//
+// Returns ErrNoMember, ErrNoCharacter, ErrBadCharacter, ErrBadRepository, or
+// ErrBadCost.
+func (m *Manager) priceSwing(
+	ctx context.Context, scope *writeScope, attacker string, sheet *character.Character,
+) (*swingPrice, error) {
+	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(attacker)})
+	if err != nil {
+		return nil, translate(err)
+	}
+	if ClockKind(clock.Kind) != ClockTurn {
+		return &swingPrice{}, nil
+	}
+
+	if err := readyForTurn(ctx, sheet, clock.Round); err != nil {
+		return nil, fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadCost, err)
+	}
+
+	profile, err := costOfSwing(sheet)
+	if err != nil {
+		return nil, fmt.Errorf("attacker %q: %w: %v", attacker, ErrBadCost, err)
+	}
+
+	ready := sheet.ToData()
+	return &swingPrice{
+		cost: &resolution.Cost{
+			PayerID: attacker,
+			Profile: profile,
+			Turn: &resolution.Turn{
+				Number: clock.Round,
+				Speed:  sheet.GetSpeed(),
+			},
+		},
+		payer: ready,
+	}, nil
+}
+
+// readyForTurn puts a sheet into the turn it is about to act in.
+//
+// # This is the economy's ignition, and nothing else in the stack has one
+//
+// [character.RefreshForTurn] refills a STALE bank and refuses to create one:
+// handed a sheet that is not in combat it returns having done nothing, on the
+// stated grounds that "combat starts somewhere else, and inventing an economy
+// here would put a character in a fight nobody put them in". That is correct and
+// it leaves a hole, because until this change NOTHING in session, encounter or
+// resolution ever called [character.StartTurn] or wrote an ActionEconomy. Every
+// stored sheet in the stack is cold.
+//
+// A cost handed to the door for a cold sheet is therefore not refused once, it
+// is refused forever — the gate's very first question is InCombat. The economy
+// had a price, a door and a ledger, and no ignition.
+//
+// Combat starts somewhere else, and THIS IS SOMEWHERE ELSE: the fight is the
+// composition's bubble, and this package is the only layer that sees both the
+// bubble and the sheet. The composition holds no sheets; resolution holds sheets
+// and is forbidden from reading a turn out of the world it is handed
+// ([resolution.Turn]). So the seam that knows both is the one that lights it.
+//
+// # Lit at the first ask, not pushed at the boundary
+//
+// Which is [character.RefreshForTurn]'s own argument, reused: "the sheet may not
+// have been loaded when the turn changed, and a bank that is only correct if
+// something remembered to announce the boundary is a bank that is eventually
+// wrong". A fight can start on somebody else's walk; nothing loads every
+// combatant's sheet when it does.
+//
+// # And it runs BEFORE the price is compiled, which is not an ordering detail
+//
+// What a swing costs depends on what is banked, and the door refreshes AFTER the
+// caller compiled the price ([resolution.payAtTheDoor] finds the payer, then
+// refreshes, then charges). A price compiled against a pre-refresh bank is a
+// price for a bank that is about to be replaced: a level-5 fighter who swung
+// once last turn carries a banked attack into this one, would be priced as
+// though the bank could pay, and would then be refused by a door that had just
+// wiped it. So the refresh happens here, on the sheet this seam is about to hand
+// over, and the [resolution.Cost.Turn] passed alongside finds nothing left to do.
+func readyForTurn(ctx context.Context, sheet *character.Character, turn int) error {
+	// Speed is read once and used for whichever verb applies, so the two cannot
+	// seed different movement for the same turn.
+	speed := sheet.GetSpeed()
+
+	if !sheet.InCombat() {
+		_, err := sheet.StartTurn(ctx, &character.StartTurnInput{TurnNumber: turn, Speed: speed})
+		return err
+	}
+
+	_, err := sheet.RefreshForTurn(ctx, &character.RefreshForTurnInput{TurnNumber: turn, Speed: speed})
+	return err
+}
+
+// costOfSwing composes what ONE swing costs, out of the two prices the rulebook
+// compiles for it.
+//
+// # Why there are two prices and one payment
+//
+// The rulebook prices the two halves of 5e's attack separately, and correctly:
+// [character.CostOfAttack] is the ACTION, which costs a slot and BANKS
+// 1+ExtraAttacks swings, while [character.CostOfStrike] is one swing, which
+// costs a banked attack and no slot. That split is what makes Extra Attack a
+// table lookup instead of somebody counting to three.
+//
+// The door pays exactly one profile, so this seam has to say what a swing costs
+// as one price. Handing over [character.CostOfAttack] alone does not work — it
+// banks swings and never spends one, so a level-5 fighter's second Attack is
+// refused for want of an ACTION exactly like a level-1 fighter's, and Extra
+// Attack is granted capacity nothing can spend.
+//
+// # Nor can the two simply be concatenated
+//
+// A profile carrying Grants{attack:N} and Capacity{attack:1} together is refused
+// on its first use. [combat.Pay] checks affordability over EVERY currency before
+// anything moves and lands grants LAST, both deliberately — so the check asks
+// for a banked attack that the grant in the very same profile is about to
+// provide, and finds none. Atomicity is not negotiable and the grant cannot move
+// earlier, so the netting happens here instead.
+//
+// # What this does NOT do is read a class table
+//
+// The number of swings an Attack action buys is asked of the rulebook and never
+// derived. This function knows only that a strike is paid out of a bank, that an
+// action fills one, and that when the two arrive together the first swing comes
+// out of the grant rather than out of a bank nobody has yet.
+//
+// THAT SAID, this composition belongs upstream. It is 5e's rule about what
+// taking the Attack action and swinging means, and it lives here only because
+// this is the first caller that needed it — the same road CostOfAttack and
+// CostOfStrike travelled. When a second caller appears it should move next to
+// them as character.CostOfSwing, which is a move rather than a redesign.
+func costOfSwing(c *character.Character) (*combat.SpendProfile, error) {
+	strike, err := character.CostOfStrike(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// A bank the Attack action already filled pays for this swing outright.
+	// Asked of the gate rather than of the map, so that the question this seam
+	// asks is exactly the question the door will ask.
+	if combat.CanPay(c, strike) {
+		return strike, nil
+	}
+
+	action, err := character.CostOfAttack(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return asOnePayment(action, strike), nil
+}
+
+// asOnePayment folds a strike into the action that buys it.
+//
+// Every currency is carried, and the totality is the point rather than
+// tidiness. A cost keyed to something this merge dropped is not a cheaper
+// action, it is a FREE one, and nothing downstream would ever say so — which is
+// the same failure [combat.SpendProfile.Validate] exists to refuse and the same
+// reason the gate reads every field it declares. Slots and pools add, because
+// two prices in the same currency are owed together. Requirements take the
+// larger, because a precondition is a floor rather than a bill.
+//
+// Capacity and grants NET, and that is the whole reason this function exists:
+// the swing this payment buys is the first of the ones the action banks, so it
+// is paid out of the grant. What is left over stays banked for the swings after
+// it. A netting that reached zero must leave the key ABSENT rather than present
+// at zero — Validate refuses a grant of nothing as a cost that is not a cost —
+// which is why both loops drop non-positive entries rather than writing them.
+func asOnePayment(action, strike *combat.SpendProfile) *combat.SpendProfile {
+	wants := sum(action.Capacity, strike.Capacity)
+	banks := sum(action.Grants, strike.Grants)
+
+	merged := &combat.SpendProfile{
+		Slots:    sum(action.Slots, strike.Slots),
+		Pools:    sum(action.Pools, strike.Pools),
+		Requires: larger(action.Requires, strike.Requires),
+	}
+
+	for key, want := range wants {
+		if owed := want - banks[key]; owed > 0 {
+			merged.Capacity = put(merged.Capacity, key, owed)
+		}
+	}
+	for key, banked := range banks {
+		if left := banked - wants[key]; left > 0 {
+			merged.Grants = put(merged.Grants, key, left)
+		}
+	}
+
+	return merged
+}
+
+// sum adds two keyed-quantity maps, and returns nil when there is nothing in
+// either — an empty map and an absent one mean the same thing to the gate, and
+// nil is what a profile that names no cost in this currency looks like.
+func sum[K comparable](a, b map[K]int) map[K]int {
+	var out map[K]int
+	for key, n := range a {
+		out = put(out, key, n)
+	}
+	for key, n := range b {
+		out = put(out, key, out[key]+n)
+	}
+	return out
+}
+
+// larger keeps the stricter of two requirements per key.
+func larger[K comparable](a, b map[K]int) map[K]int {
+	var out map[K]int
+	for key, n := range a {
+		out = put(out, key, n)
+	}
+	for key, n := range b {
+		if n > out[key] {
+			out = put(out, key, n)
+		}
+	}
+	return out
+}
+
+// put writes a keyed quantity, allocating the map on first use.
+func put[K comparable](m map[K]int, key K, n int) map[K]int {
+	if m == nil {
+		m = make(map[K]int)
+	}
+	m[key] = n
+	return m
+}

--- a/rulebooks/dnd5e/session/economy.go
+++ b/rulebooks/dnd5e/session/economy.go
@@ -174,6 +174,13 @@ func (m *Manager) priceSwing(
 // though the bank could pay, and would then be refused by a door that had just
 // wiped it. So the refresh happens here, on the sheet this seam is about to hand
 // over, and the [resolution.Cost.Turn] passed alongside finds nothing left to do.
+//
+// This is the CALLER COMPENSATING FOR AN ORDERING IT CANNOT SEE, which is a
+// seam wart rather than a fact of nature — filed as rpg-toolkit#1100, whose
+// current lean is to move the refresh out of the door entirely now that this
+// slice shows the caller must do it anyway. Nothing is broken today and the
+// workaround is pinned; the next caller to compile a state-dependent price is
+// who would otherwise hit it fresh.
 func readyForTurn(ctx context.Context, sheet *character.Character, turn int) error {
 	// Speed is read once and used for whichever verb applies, so the two cannot
 	// seed different movement for the same turn.
@@ -226,6 +233,8 @@ func readyForTurn(ctx context.Context, sheet *character.Character, turn int) err
 // this is the first caller that needed it — the same road CostOfAttack and
 // CostOfStrike travelled. When a second caller appears it should move next to
 // them as character.CostOfSwing, which is a move rather than a redesign.
+// Filed as rpg-toolkit#1100 so it is a decision waiting on its second caller
+// rather than a note that decays into nobody's business.
 func costOfSwing(c *character.Character) (*combat.SpendProfile, error) {
 	strike, err := character.CostOfStrike(c)
 	if err != nil {

--- a/rulebooks/dnd5e/session/economy.go
+++ b/rulebooks/dnd5e/session/economy.go
@@ -111,6 +111,16 @@ func (m *Manager) priceSwing(
 		cost: &resolution.Cost{
 			PayerID: attacker,
 			Profile: profile,
+			// Handed over even though readyForTurn has already done it on the
+			// sheet below, and the redundancy is deliberate rather than
+			// forgotten. The door's refresh is the contract E2 built and this is
+			// its caller honouring it; finding the economy already filed under
+			// this turn, it does nothing. So a mutation that passes nil here
+			// changes no observable behaviour and no test can catch it — which
+			// is worth saying out loud, because the next reader to notice will
+			// otherwise conclude the field is dead and remove it. What it is is
+			// the backstop for the day this seam hands over a sheet it did not
+			// ready.
 			Turn: &resolution.Turn{
 				Number: clock.Round,
 				Speed:  sheet.GetSpeed(),

--- a/rulebooks/dnd5e/session/economy.go
+++ b/rulebooks/dnd5e/session/economy.go
@@ -152,6 +152,10 @@ func (m *Manager) priceSwing(
 // and is forbidden from reading a turn out of the world it is handed
 // ([resolution.Turn]). So the seam that knows both is the one that lights it.
 //
+// Stated as the rule it is: THE SESSION LIGHTS THE SHEET WHEN AN ACTOR ON THE
+// FIGHT CLOCK FIRST ACTS. Not when the bubble forms, because nothing loads the
+// sheets then; not for a free-roaming actor, because there is no turn to light.
+//
 // # Lit at the first ask, not pushed at the boundary
 //
 // Which is [character.RefreshForTurn]'s own argument, reused: "the sheet may not

--- a/rulebooks/dnd5e/session/economy_internal_test.go
+++ b/rulebooks/dnd5e/session/economy_internal_test.go
@@ -1,0 +1,114 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// economy_test.go drives the economy through the verb, which is where it has to
+// be right. This file pins the merge underneath it directly, for the two reasons
+// translate_internal_test.go exists: some of what asOnePayment guarantees has no
+// path from a caller today, and a promise that is only true for the profiles v1
+// happens to compile is not the promise the doc makes.
+//
+// The rulebook compiles exactly two profiles today, and between them they
+// exercise one shape: a slot cost, a grant, and a capacity cost smaller than the
+// grant. Pools, requirements, and a strike that costs MORE than its action banks
+// are all expressible and all unexercised — so a merge that silently dropped any
+// of them would ship green. That failure is the one combat.SpendProfile's own
+// doc names as the expensive one: a cost keyed to something nobody charges is
+// not a cheaper action, it is a free one.
+
+// TestASwingCostsMoreThanItsActionBanks is the case the netting exists to get
+// right in the other direction.
+//
+// An action that banks one swing cannot buy two, so the second is still owed
+// from the bank — and if the merge dropped the remainder, the profile would say
+// the action pays for both and the gate would charge for neither.
+func TestASwingCostsMoreThanItsActionBanks(t *testing.T) {
+	action := &combat.SpendProfile{
+		Slots:  map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		Grants: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	}
+	strike := &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{combat.CapacityAttack: 2},
+	}
+
+	merged := asOnePayment(action, strike)
+
+	require.NoError(t, merged.Validate(), "a merge must never produce a price the gate refuses")
+	require.Equal(t, 1, merged.Capacity[combat.CapacityAttack],
+		"one of the two swings came out of the grant; the other is still owed from the bank")
+	require.Empty(t, merged.Grants,
+		"and nothing is left banked — a grant of zero is a cost that is not a cost, "+
+			"which Validate refuses outright")
+	require.Equal(t, 1, merged.Slots[coreCombat.ActionStandard], "the action is still paid for")
+}
+
+// TestTheNettingLeavesNoZeroEntries is the trap this merge walks past on every
+// level-1 character.
+//
+// combat.SpendProfile.Validate refuses a grant or a cost of zero by name — "a
+// cost that is not a cost" — so a netting that wrote the key with a zero rather
+// than leaving it out would make the commonest case in the game unpayable, and
+// would report it as a malformed profile rather than as anything a player did.
+func TestTheNettingLeavesNoZeroEntries(t *testing.T) {
+	action := &combat.SpendProfile{
+		Slots:  map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		Grants: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	}
+	strike := &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	}
+
+	merged := asOnePayment(action, strike)
+
+	require.NoError(t, merged.Validate())
+	require.NotContains(t, merged.Grants, combat.CapacityAttack,
+		"the one swing the action banked is the one being taken, so nothing is left over")
+	require.NotContains(t, merged.Capacity, combat.CapacityAttack,
+		"and nothing is owed from a bank either — the grant paid for it")
+	require.Equal(t, 1, merged.Slots[coreCombat.ActionStandard])
+}
+
+// TestEveryCurrencySurvivesTheMerge is the totality claim, asserted rather than
+// described.
+//
+// Pools and requirements are the monk's and the monk is not v1, so nothing the
+// rulebook compiles today puts anything in either map. A merge that dropped them
+// would therefore pass every other test in this package and would be discovered
+// by whoever writes Flurry of Blows, at which point the bonus strike costs no ki
+// and nothing says so.
+func TestEveryCurrencySurvivesTheMerge(t *testing.T) {
+	const ki = coreResources.ResourceKey("ki")
+
+	action := &combat.SpendProfile{
+		Slots:    map[coreCombat.ActionType]int{coreCombat.ActionStandard: 1},
+		Pools:    map[coreResources.ResourceKey]int{ki: 1},
+		Requires: map[combat.CapacityType]int{combat.CapacityAttack: 1},
+	}
+	strike := &combat.SpendProfile{
+		Slots:    map[coreCombat.ActionType]int{coreCombat.ActionBonus: 1},
+		Pools:    map[coreResources.ResourceKey]int{ki: 2},
+		Requires: map[combat.CapacityType]int{combat.CapacityAttack: 3},
+	}
+
+	merged := asOnePayment(action, strike)
+
+	require.NoError(t, merged.Validate())
+	require.Equal(t, 1, merged.Slots[coreCombat.ActionStandard])
+	require.Equal(t, 1, merged.Slots[coreCombat.ActionBonus],
+		"two different slots are two different costs, not one")
+	require.Equal(t, 3, merged.Pools[ki],
+		"two prices in the same pool are owed together")
+	require.Equal(t, 3, merged.Requires[combat.CapacityAttack],
+		"a requirement is a floor rather than a bill, so the stricter one wins")
+}

--- a/rulebooks/dnd5e/session/economy_test.go
+++ b/rulebooks/dnd5e/session/economy_test.go
@@ -352,6 +352,41 @@ func (s *EconomySuite) TestANewTurnRefillsTheBank() {
 		"and the sheet is now filed under the turn it was refilled for")
 }
 
+// TestABankLeftOverFromLastTurnDoesNotMispriceThisOne is the ordering bug this
+// seam refreshes to avoid, and it is invisible from anywhere else.
+//
+// The door refreshes AFTER the caller has compiled the price: payAtTheDoor finds
+// the payer, then refreshes, then charges. So a price compiled against the bank
+// as STORED is a price for a bank that is about to be replaced.
+//
+// The scene is the one that makes it bite. A level-5 fighter takes one of her
+// two swings on turn one and stops, so the sheet is persisted with a banked
+// attack still on it. On turn two that bank is stale: the door is about to wipe
+// it and seed a fresh turn. A seam that priced from the stored bank would send
+// "spend one banked attack", the door would refresh the bank to empty, and the
+// swing would be refused — a fighter unable to attack on her own turn BECAUSE
+// she attacked on the last one, which is the worst-shaped bug in the file.
+//
+// So the refresh happens here, on the sheet this verb is about to hand over, and
+// the price is compiled from what it leaves. The assertion is deliberately plain
+// — the swing works — because the failure it guards is a refusal that would look
+// exactly like the economy working.
+func (s *EconomySuite) TestABankLeftOverFromLastTurnDoesNotMispriceThisOne() {
+	s.fightScene(5, 1, 1, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err, "one swing of the two Extra Attack bought")
+	s.Require().Equal(1, s.storedEconomy().Granted["attacks"],
+		"and the other is still banked, which is the state that makes this case real")
+
+	s.nextTurn()
+
+	_, err = s.swing()
+	s.Require().NoError(err,
+		"a fresh turn buys a fresh swing — a bank left over from last turn must not "+
+			"price this one against capacity the door is about to wipe")
+}
+
 // TestTheTurnIsLitOnceAndSpentFromThereafter pins the ignition itself.
 //
 // Nothing in this stack put a character in combat before rpg-toolkit#1097:

--- a/rulebooks/dnd5e/session/economy_test.go
+++ b/rulebooks/dnd5e/session/economy_test.go
@@ -1,0 +1,379 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// EconomySuite is what rpg-toolkit#1097 bought: a swing that costs something.
+//
+// It is the other half of TestFreeRoamChargesNothing, and the two are the whole
+// ruling between them — the action economy is a FIGHT's economy, so the same
+// verb charges nothing on the world clock and refuses a second swing on the turn
+// clock. Neither test means much without the other.
+//
+// EVERY SCENE HERE IS A REAL FIGHT, driven through the session's own verbs: a
+// skeleton arrives in plain sight, the composition forms a bubble, and the
+// swings below are swings inside it. Nothing constructs an action economy by
+// hand — if the seam stopped lighting one, these tests would fail rather than
+// pass against a fixture that did the lighting for it.
+type EconomySuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+	mgr        *session.Manager
+}
+
+func TestEconomySuite(t *testing.T) { suite.Run(t, new(EconomySuite)) }
+
+// skeletonAC is what the catalog skeleton defends with, and the reason the
+// scenes below can script a miss: a d20 of 1 totals 6 against it.
+const skeletonAC = 13
+
+// fightScene puts an armed fighter of the given level in a hall and drops a
+// skeleton next to her, which starts a fight.
+//
+// The level is the parameter because it is the only thing the cases differ in —
+// Extra Attack is a class table, and asserting it at this seam means asserting
+// that the seam ASKED, rather than that it counted.
+//
+// A MISS IS THE DEFAULT SCRIPT, and that is a scene requirement rather than
+// squeamishness: this fixture's fighter deals 8 and the catalog skeleton holds
+// 13, so two landed blows drop it, the last monster falling ends the fight, and
+// alice is back on the world clock — where swings are free and the case under
+// test has quietly stopped existing. Rolls of 1 keep the fight running so the
+// economy is what the refusal is about.
+//
+// The rolls given are the SWINGS' rolls. Forming the bubble rolls initiative
+// first — one die per member — and those are prepended here rather than left for
+// every caller to remember, because a scene whose scripted 15 silently became an
+// initiative roll reads as a miss nobody can explain. The first swing asserts it
+// got the die it asked for, so this stops being true loudly rather than quietly.
+func (s *EconomySuite) fightScene(level int, rolls ...int) {
+	alice := armedFighter("alice")
+	alice.Level = level
+
+	s.mgr, s.sessions, s.encounters, s.characters = aFight(s.T(), alice, rolls)
+}
+
+// aFight puts one armed fighter in a plain hall and drops a catalog skeleton
+// next to her, which starts a fight.
+//
+// A package-level function rather than a suite method because two suites need
+// the same scene: this file's economy pins, and sentinels_test.go, whose whole
+// job is to check what a host can match on when a refusal really happens. A
+// second arrangement of the same fixture is a second thing to drift.
+//
+// It asserts the bubble for its callers. A scene that quietly formed none would
+// leave every member on the world clock, where nothing is charged — so every
+// economy claim built on it would pass by testing nothing at all.
+func aFight(
+	t fataler, alice *character.Data, rolls []int,
+) (*session.Manager, *fakeSessions, *fakeEncounters, *fakeCharacters) {
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	characters := newFakeCharacters(alice)
+
+	// initiativeRolls is one die per member of the bubble the spawn forms.
+	const initiativeRolls = 2
+	scripted := append(make([]int, initiativeRolls), rolls...)
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: &sequenceDice{rolls: scripted}, Sessions: sessions, Encounters: encounters,
+		Characters: characters, Events: session.DiscardEvents{},
+	})
+	if err != nil {
+		t.Fatalf("building manager: %v", err)
+	}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: encOrderAsGiven{},
+		Standing:   encEveryoneStanding{},
+		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: encounter.MemberID(alice.ID), Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	if err != nil {
+		t.Fatalf("building the hall: %v", err)
+	}
+	data := enc.ToData()
+
+	ctx := context.Background()
+	if _, err := mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &data,
+	}); err != nil {
+		t.Fatalf("starting the session: %v", err)
+	}
+
+	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skeleton", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	if err != nil {
+		t.Fatalf("spawning the skeleton: %v", err)
+	}
+	if spawned.Formed == nil {
+		t.Fatalf("arriving in plain sight of %s must start a fight", alice.ID)
+	}
+
+	turn, err := mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: alice.ID})
+	if err != nil {
+		t.Fatalf("asking what %s is waiting on: %v", alice.ID, err)
+	}
+	if turn.Clock != session.ClockTurn {
+		t.Fatalf("%s is on the %s clock, where nothing costs anything", alice.ID, turn.Clock)
+	}
+	if turn.Round != 1 {
+		t.Fatalf("a fight starts in round 1, not %d", turn.Round)
+	}
+
+	return mgr, sessions, encounters, characters
+}
+
+func (s *EconomySuite) swing() (*session.AttackOutput, error) {
+	return s.mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "skeleton",
+	})
+}
+
+// nextTurn takes the fight all the way round to alice again.
+//
+// Both ends are ended deliberately: a round advances when the order comes back
+// around, so ending only alice's turn leaves the round where it was and the
+// bank exactly as spent.
+func (s *EconomySuite) nextTurn() {
+	s.T().Helper()
+	ctx := context.Background()
+
+	for _, who := range []string{"alice", "skeleton"} {
+		_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: who})
+		s.Require().NoError(err, "ending %s's turn", who)
+	}
+
+	turn, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal(2, turn.Round, "the fight really came back around")
+}
+
+// storedSkeleton reads the NPC's hit points back out of the session record.
+func (s *EconomySuite) storedSkeleton() int {
+	s.T().Helper()
+	for _, npc := range s.sessions.byID["sess"].NPCs {
+		if npc.ID == "skeleton" {
+			return npc.HitPoints
+		}
+	}
+	s.FailNow("no skeleton in the record")
+	return 0
+}
+
+// storedEconomy reads alice's persisted action economy.
+func (s *EconomySuite) storedEconomy() *character.ActionEconomyData {
+	s.T().Helper()
+	stored, ok := s.characters.byID["alice"]
+	s.Require().True(ok, "alice must be in the repository")
+	return stored.ActionEconomy
+}
+
+func (s *EconomySuite) story() []session.StoryEntry {
+	s.T().Helper()
+	out, err := s.mgr.Story(context.Background(), &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	return out
+}
+
+// TestALevel1FightersSecondSwingIsRefused is the headline, and the thing
+// rpg-toolkit#1035 was opened to make true.
+//
+// One action, one swing, and the second ask is refused BY NAME rather than
+// silently ignored or quietly resolved. The currency is in the message because a
+// refusal a client cannot explain reads to a player as a bug: "action: 1 needed,
+// 0 left" is the difference between "you can't do that" and "you have already
+// taken your action this turn".
+func (s *EconomySuite) TestALevel1FightersSecondSwingIsRefused() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	first, err := s.swing()
+	s.Require().NoError(err, "the Attack action buys the first swing")
+	s.Require().Equal(15, first.Roll, "the swing got the die the scene scripted for it")
+	s.Require().Equal(skeletonAC, first.Against, "and resolved against the skeleton's own armour class")
+	s.True(first.Hit, "15 + 3 STR + 2 proficiency beats it")
+
+	_, err = s.swing()
+	s.Require().Error(err, "and there is nothing left to buy a second")
+	s.ErrorIs(err, session.ErrCannotAfford)
+	s.Contains(err.Error(), "action",
+		"the refusal names the currency that ran out")
+	s.Contains(err.Error(), "alice",
+		"and who ran out of it")
+}
+
+// TestTheRefusalIsOursAndNotResolutions is the #1058/#1066 law reaching the
+// economy.
+//
+// resolution.ErrCannotPay is the gate's word for this and it must not be the
+// host's: a client that branched on it would be coupled to the module the strike
+// machine lives in, through the one channel boundary_test.go cannot see. The
+// reason still travels — as TEXT, which is what the assertion above about the
+// currency is really checking — and only the sentinel is ours alone.
+func (s *EconomySuite) TestTheRefusalIsOursAndNotResolutions() {
+	s.fightScene(1, 1, 1, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err)
+	_, err = s.swing()
+	s.Require().Error(err)
+
+	s.ErrorIs(err, session.ErrCannotAfford, "the host is answered in this package's vocabulary")
+	s.NotErrorIs(err, resolution.ErrCannotPay,
+		"and cannot reach resolution's, which would couple it to a module we intend to replace")
+	s.NotErrorIs(err, resolution.ErrBadCost)
+	s.NotErrorIs(err, resolution.ErrNoPayer)
+	s.NotErrorIs(err, session.ErrBadCost,
+		"an actor who ran out is not a malformed price, and the two must not be one sentinel")
+}
+
+// TestExtraAttackBuysASecondSwing pins the class table at the seam.
+//
+// A level-5 fighter's Attack action banks two swings, so the second lands and
+// the third is refused — and the SAME code produced the level-1 case above,
+// which is the actual claim. Nothing here counts to two; it asks the rulebook
+// what the action bought and spends that.
+func (s *EconomySuite) TestExtraAttackBuysASecondSwing() {
+	s.fightScene(5, 1, 1, 1, 1, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err, "swing 1, bought by the Attack action")
+	_, err = s.swing()
+	s.Require().NoError(err, "swing 2, bought by Extra Attack")
+
+	_, err = s.swing()
+	s.Require().Error(err, "swing 3 has nothing left")
+	s.ErrorIs(err, session.ErrCannotAfford)
+	s.Contains(err.Error(), "action",
+		"and it is the action that ran out — the bank was emptied by the swing before")
+}
+
+// TestARefusedSwingWritesNothing is the #1056 shape asked of the economy.
+//
+// E2 refuses at the door — before the machine starts, before any damage exists —
+// so this is the clean case that shape was named for: there is nothing to undo
+// because nothing was done. A refusal that had persisted a sheet, or recorded a
+// beat for a swing that never happened, would leave a host holding a story about
+// an attack nobody made.
+//
+// All three stores are checked rather than one. The skeleton's hit points are
+// the world, the story is the transcript, and alice's own economy is the sheet —
+// and it is the third that could plausibly have moved, since the refused payment
+// runs against a sheet this verb had already readied.
+func (s *EconomySuite) TestARefusedSwingWritesNothing() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err)
+
+	hpBefore := s.storedSkeleton()
+	storyBefore := len(s.story())
+	economyBefore := *s.storedEconomy()
+
+	_, err = s.swing()
+	s.Require().ErrorIs(err, session.ErrCannotAfford)
+
+	s.Equal(hpBefore, s.storedSkeleton(), "a refused swing damaged nobody")
+	s.Len(s.story(), storyBefore, "and recorded no beat")
+	s.Equal(economyBefore, *s.storedEconomy(),
+		"and did not spend, refill or otherwise touch the sheet it was refused against")
+
+	var saved *session.SaveError
+	s.False(errors.As(err, &saved),
+		"nothing was written, so there is no partial save to report and no repair to do")
+}
+
+// TestTheFirstSwingSurvivesTheRefusal is the other half of writing nothing:
+// what DID happen stays happened.
+//
+// The obvious wrong implementation rolls the swing back on the way out, or
+// re-runs the verb and overwrites it. The blow that landed is durable and the
+// beat that recorded it is in the transcript, and a refusal arriving after them
+// changes neither.
+func (s *EconomySuite) TestTheFirstSwingSurvivesTheRefusal() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	first, err := s.swing()
+	s.Require().NoError(err)
+	s.Require().True(first.Hit)
+	s.Require().Equal(8, first.Damage, "15 + 3 STR + 2 proficiency lands; the die scripted to 5 plus 3 deals 8")
+
+	_, err = s.swing()
+	s.Require().ErrorIs(err, session.ErrCannotAfford)
+
+	s.Equal(13-8, s.storedSkeleton(), "the blow that landed is still on the stored sheet")
+	s.NotEmpty(s.story(), "and its beat is still in the story")
+}
+
+// TestANewTurnRefillsTheBank is the pin that keeps this a TURN economy rather
+// than a session-long one.
+//
+// It is the failure the whole turn-marker question exists to prevent: a bank
+// that is charged and never refilled gives every character exactly one action
+// for the entire game, which would look like a working economy in the test above
+// and be unplayable in a fight. The refill runs through the door's own refresh,
+// keyed on the round the composition reports.
+func (s *EconomySuite) TestANewTurnRefillsTheBank() {
+	s.fightScene(1, 1, 1, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err)
+	_, err = s.swing()
+	s.Require().ErrorIs(err, session.ErrCannotAfford, "spent, on turn one")
+
+	s.nextTurn()
+
+	_, err = s.swing()
+	s.Require().NoError(err, "a new turn buys a new swing")
+	s.Equal(2, s.storedEconomy().TurnNumber,
+		"and the sheet is now filed under the turn it was refilled for")
+}
+
+// TestTheTurnIsLitOnceAndSpentFromThereafter pins the ignition itself.
+//
+// Nothing in this stack put a character in combat before rpg-toolkit#1097:
+// character.RefreshForTurn refuses to create an economy by design, so a cold
+// sheet handed to the gate is refused forever rather than once. This seam lights
+// it, and the assertion that matters is the SECOND one — a sheet re-lit on every
+// ask would look identical on the first swing and would make the economy
+// unspendable, since every swing would arrive at a freshly full bank.
+func (s *EconomySuite) TestTheTurnIsLitOnceAndSpentFromThereafter() {
+	s.fightScene(1, 1, 1, 1, 1)
+
+	s.Nil(s.storedEconomy(), "a stored sheet starts cold: no economy at all")
+
+	_, err := s.swing()
+	s.Require().NoError(err)
+
+	lit := s.storedEconomy()
+	s.Require().NotNil(lit, "the swing lit the turn it was paid in")
+	s.Equal(1, lit.TurnNumber, "filed under the round the composition reported")
+	s.Zero(lit.ActionsRemaining, "and the action it cost is spent")
+
+	_, err = s.swing()
+	s.ErrorIs(err, session.ErrCannotAfford,
+		"a second ask must not re-light the turn — that would refill the bank it just spent")
+}

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -307,6 +307,41 @@ var (
 	// semantics for.
 	ErrBadAttack = errors.New("attack cannot be made")
 
+	// ErrCannotAfford is returned when an actor cannot pay for what they
+	// declared: a second swing in a turn that bought only one, a level-5
+	// fighter's third, an action after the action was spent.
+	//
+	// THIS IS A FACT ABOUT THE GAME, not about the code, and that is the whole
+	// reason it is separate from ErrBadCost. A player who has run out of actions
+	// has done nothing wrong and needs to hear a different sentence from the one
+	// a developer needs to hear, so the two are never merged — E2 split them at
+	// the door for the same reason and this seam keeps the split rather than
+	// flattening it on the way out (rpg-toolkit#1097).
+	//
+	// The message NAMES THE CURRENCY that ran out — "action: 1 needed, 0 left" —
+	// because a refusal a client cannot explain is a refusal that reads as a bug.
+	// A host may show it or match the sentinel and say it in its own words.
+	//
+	// It is a FIGHT's refusal. The action economy exists only in combat, so a
+	// member on the world clock is charged nothing and can never see this.
+	ErrCannotAfford = errors.New("action cannot be paid for")
+
+	// ErrBadCost is returned when a price could not be charged to anybody: a
+	// profile keyed to a currency no ledger holds, or a cost naming a payer this
+	// cast cannot charge.
+	//
+	// The programmer-facing half of the split ErrCannotAfford describes. This one
+	// means content or wiring is wrong — the remedy is to go and look at the
+	// code, not at a player's sheet — and reporting it as "out of actions" would
+	// send whoever debugs it to exactly the wrong place.
+	//
+	// Not reachable from a well-formed call today: this package compiles the only
+	// prices it charges, and it names the attacker, who is always in the cast. It
+	// exists so that the day something else compiles one, the failure has a name
+	// that is not a lie. Its translation is pinned in translate_internal_test.go
+	// rather than in sentinels_test.go for exactly that reason.
+	ErrBadCost = errors.New("cost cannot be charged")
+
 	// ErrFrozen, ErrNoWindow, ErrNotAudience, ErrNotOffered and ErrNoWindowID
 	// lived here. Every one of them described an open interrupt window, and
 	// nothing in this module opens one (rpg-toolkit#964 slice 2) — a sentinel

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.95.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.8.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -16,12 +16,12 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.95.0 h1:IsL2wyRwRmuePZsr3J1zydORSo0udTwM5iWdJy4IfwU=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.95.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0 h1:0OdQm7/dccn6P6LYZdeXCmpHIXigZ9J5cYs3Vy/TWR0=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.8.0 h1:r9xXC60bRnLBVcS5QG49dxsTMwHJJt4Xto0fJygApE8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.8.0/go.mod h1:5EFMIuZeoyC7YVYEN5v0jJ52sqmu0i07SKdJBmLRS6c=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0 h1:ua6yx4VVYHANoiQtf1vqO84e1ulli9ywss8G+5vnhj0=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0/go.mod h1:GpAKS7PrFBK2aUsHbAOJt/Z7djlDzmmlMuloyGq2XKs=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -99,6 +99,15 @@ var resolutionSentinels = map[string]error{
 	"resolution.ErrBadAttack":             resolution.ErrBadAttack,
 	"resolution.ErrNoCombatant":           resolution.ErrNoCombatant,
 	"resolution.ErrRecurrenceUnsupported": resolution.ErrRecurrenceUnsupported,
+	// The economy's three, added with the slice that made them reachable
+	// (rpg-toolkit#1097). ErrCannotPay is the one a PLAYER produces — a second
+	// swing in a turn that bought one — and it is driven for real below. The
+	// other two are wiring being wrong rather than an actor running out, and
+	// they are here for the reason the whole list is written out: an unlisted
+	// sentinel reaching a host is a leak whether or not anybody wrote an arm.
+	"resolution.ErrCannotPay": resolution.ErrCannotPay,
+	"resolution.ErrBadCost":   resolution.ErrBadCost,
+	"resolution.ErrNoPayer":   resolution.ErrNoPayer,
 }
 
 // refSentinels is core's identifier vocabulary — what a malformed ref is
@@ -457,6 +466,35 @@ func (s *SentinelSuite) TestADownedActorIsRefusedInOurWords() {
 	})
 	s.refusedInOurVocabulary(swingErr, session.ErrDowned)
 	s.Contains(swingErr.Error(), "alice", "and the refusal still names who could not act")
+}
+
+// TestASecondSwingInOneTurn is the economy's refusal, driven for real.
+//
+// This is the most ORDINARY mistake on the list. Every other case here is a
+// caller getting something wrong — a route off the map, a malformed ref, one
+// sheet stored under two names — and this one is a player doing exactly what
+// the game invites them to do and being told they have already acted. It will be
+// the refusal a host sees most often by a wide margin, which makes it the one a
+// leaked sentinel would hurt through most.
+//
+// The scene is a real fight rather than the duel the rest of this file uses,
+// because free roam charges nothing and the refusal has no path there. See
+// aFight in economy_test.go.
+func (s *SentinelSuite) TestASecondSwingInOneTurn() {
+	mgr, _, _, _ := aFight(s.T(), armedFighter("alice"), []int{1, 1, 1, 1})
+	ctx := context.Background()
+
+	_, err := mgr.Attack(ctx, &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "skeleton",
+	})
+	s.Require().NoError(err, "the first swing is bought by the Attack action")
+
+	_, err = mgr.Attack(ctx, &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "skeleton",
+	})
+	s.refusedInOurVocabulary(err, session.ErrCannotAfford)
+	s.Contains(err.Error(), "action",
+		"and the refusal still names the currency that ran out")
 }
 
 // TestASpawnNamingAMalformedRef is the third module and the second door.

--- a/rulebooks/dnd5e/session/translate_internal_test.go
+++ b/rulebooks/dnd5e/session/translate_internal_test.go
@@ -89,6 +89,18 @@ func TestTranslateResolutionLetsNoResolutionSentinelThrough(t *testing.T) {
 		// before the strike runs, so this arm is the one that catches a
 		// combatant the cast turned out not to hold.
 		{"combatant not in the cast", resolution.ErrNoCombatant, ErrNoSheet},
+		// Driven for real in sentinels_test.go: a second swing in a turn that
+		// bought one. The PLAYER-facing arm, and the only one of the economy's
+		// three a caller can reach.
+		{"an actor who has run out", resolution.ErrCannotPay, ErrCannotAfford},
+		// The economy's programmer-facing pair, unreachable because this package
+		// compiles the only prices it charges and names an attacker who is always
+		// in the cast. They are kept APART from the arm above deliberately: E2
+		// split them at the door so that a malformed profile could never reach a
+		// client as "out of actions", and flattening them here would undo that
+		// split one layer further out (rpg-toolkit#1097).
+		{"a price nobody could be charged", resolution.ErrBadCost, ErrBadCost},
+		{"a payer this cast cannot charge", resolution.ErrNoPayer, ErrBadCost},
 		// Defects here rather than in the call, and unreachable for that
 		// reason.
 		{"no input at all", resolution.ErrNilInput, ErrNilInput},


### PR DESCRIPTION
Economy wave slice **E3**, the last. The session compiles what a swing costs its attacker, hands it to resolution's door as data, and translates the refusal into its own vocabulary. A level-1 fighter's second swing in a turn is now refused by name.

Foundation: `docs/ideas/session-sdk/economy-gate.md` (DECIDED, including its dated correction). Consumes E1 (#1092) and E2 (#1096). Pins bumped: resolution v0.8.0 → v0.9.0, dnd5e v0.95.0 → v0.96.0. No replace directives.

## Census — three things the spec assumed that did not hold

Everything below is probe-verified against `origin/main` @ 401884f, not inferred.

**1. The economy foundation had no ignition.** `character.InCombat()` is `actionEconomy != nil`, and grepping session + encounter + resolution finds **no caller of `StartTurn` and no writer of `ActionEconomy` anywhere**. Every stored sheet in the stack is cold, the `armedFighter` fixture included. `RefreshForTurn` does not help — it returns early on a nil economy *by design* ("combat starts somewhere else, and inventing an economy here would put a character in a fight nobody put them in"):

```
PROBE fresh InCombat=false
PROBE CanPay(before refresh)=false  pay=no action economy to pay from: not in combat
PROBE RefreshForTurn(1,30) out={Reseeded:false} -> InCombat=false
PROBE CanPay(after refresh)=false
PROBE StartTurn -> InCombat=true ;  CanPay(after StartTurn)=true
```

So the consequence the issue asked to be checked is worse than "one action per session": a cost passed to a cold sheet is refused at the gate's very first question, forever, for everyone. E1 built the price, E2 built the door, and nothing lit the sheet.

**2. `CostOfAttack` alone cannot produce the done-when.** It costs an action and *banks* 1+ExtraAttacks; it never spends a banked swing. Hand it over on its own and a level-5 fighter's second Attack is refused for want of an ACTION exactly like a level-1 fighter's — Extra Attack becomes granted capacity nothing can spend. Concatenating the two profiles fails too: `combat.Pay` checks every currency **before** anything moves and lands grants **last**, both deliberately, so the check asks for a banked attack that the grant in the same profile is about to provide.

So the session asks E1 for both prices and nets them — reading no class table, which is the line that matters. Measured, before any of it was built; this probe output **is** the issue's done-when:

```
level=1  extraAttacks=0
  swing1  Slots{action:1}                  pay=nil                        (action=0 bank=0)
  swing2  Slots{action:1}                  pay=action: 1 needed, 0 left
  swing3  Slots{action:1}                  pay=action: 1 needed, 0 left
  next turn reseeded=true;  swing after new turn pay=nil

level=5  extraAttacks=1
  swing1  Slots{action:1} Grants{attack:1}  pay=nil                        (action=0 bank=1)
  swing2  Capacity{attack:1}                pay=nil                        (action=0 bank=0)
  swing3  Slots{action:1} Grants{attack:1}  pay=action: 1 needed, 0 left
  swing4  Slots{action:1} Grants{attack:1}  pay=action: 1 needed, 0 left
  next turn reseeded=true;  swing after new turn pay=nil
```

Level-1 gets one swing and the second is refused; level-5 gets two and the third is refused; both refill on a new turn. Note the grants map is OMITTED rather than written as zero for the level-1 case — `Validate` refuses a grant of nothing as "a cost that is not a cost", so writing the key would make the commonest character in the game unpayable and report it as a malformed profile.

**3. The turn marker *is* honestly supplyable.** `Move` forms a bubble, `Turn` reports `Round`, and a member in a bubble acts exactly once per round — verified end to end: round 1 → alice, ogre → `RoundWrapped:true` → round 2. So the round **is** that member's turn number, read off the composition rather than invented. The issue's fallback ("pass nil and document it") was not needed.

## The turn-marker and refill decision

**The session lights the turn, at the first ask, keyed on the bubble's round.**

Combat starts somewhere else, and this is somewhere else: the fight is the composition's bubble, and the session is the only layer that sees both the bubble and the sheet. The composition holds no sheets; resolution holds sheets and is explicitly forbidden from reading a turn out of the world it is handed (`resolution.Turn`'s own doc). Lighting it lazily rather than pushing at the boundary is `RefreshForTurn`'s own argument reused — a fight can start on somebody else's walk, and nothing loads every combatant's sheet when it does.

**Does the bank refill?** Yes, and it is pinned (`TestANewTurnRefillsTheBank`): after the fight comes back around, the sheet is refiled under round 2 and the fighter swings again. Verified rather than assumed, because a bank that is charged and never refilled would look like a working economy in the refusal test and be unplayable in a real fight.

**Speed is the honest half-measure.** `RefreshForTurnInput.Speed` wants speed *after* conditions and this seam has only base walking speed. It ships anyway because in v1 **nothing reads it**: movement costs nothing (ruled fork (d)), no profile names `CapacityMovement`, nothing spends it. The day movement is charged, that line needs a real answer computed where conditions can be asked — named in the code rather than left to be discovered.

**Ordering, which is not a detail — and is filed as #1100.** The door refreshes *after* the caller has compiled the price. A price compiled against the bank as stored is a price for a bank about to be replaced: a level-5 fighter who swings once on turn 1 carries a banked attack into turn 2, would be priced "spend a banked attack", and would be refused by a door that had just wiped it — a fighter unable to attack on her own turn *because* she attacked on the last one. So the refresh happens on the sheet this seam hands over, and the price is compiled from what it leaves. Pinned by `TestABankLeftOverFromLastTurnDoesNotMispriceThisOne`. Nothing is broken today, but the workaround is the caller compensating for an ordering it cannot see, and the next caller to compile a state-dependent price hits it fresh — so it is filed as **#1100**, whose current lean is to move the refresh out of the door entirely now that this slice shows the caller must do it anyway. Cited in the code at the site that compensates.

## Free roam charges nothing — the one place this bends the issue's letter

The issue asked to rewrite `TestNothingSpendsYet` **keeping its scene**. Its scene is the duel, and the duel is on the **world clock**: `duelWorld`'s members are adjacent at StartSession and no bubble forms — only a `Move` into contact forms one. There are 35 attack call sites across `attack_test.go`, `attackevents_test.go`, `sentinels_test.go` and `death_test.go`, and every one is free roam.

So "keep the scene and assert refusals" is only satisfiable by gating free roam, which refuses all 35 — shipping the verb broken in its only exercised scene.

**This trade was put to the director before it was built, and ruled.** The ruling, recorded here rather than left in session chat: take B1, because it is not merely the pragmatic option but the ruled position — fork (d)'s reasoning was that the economy is a fight concept in v1, `combat.Ledger`'s own first question is `InCombat`, and 5e itself does not track actions outside combat. The issue's "keep its scene" bends to its intent, and the old free-roam duel stays alive as an explicit pin rather than being deleted: a bent scene that is still asserted beats a scene that is gone. The ignition point (fork A) was ruled the same way — the session lights the sheet when an actor on the fight clock first acts, and `RefreshForTurn` is NOT to be taught to seed, because its refusal is correct.

The ruling taken, then: **the action economy is a fight's economy.** That is not an invention here — `combat.Ledger` opens with `InCombat` and refuses every payment from a holder who is not in one, and a member on the world clock has no turn to spend a turn's slots from. So the scene is kept and the test is renamed for what it now claims (`TestFreeRoamChargesNothing`, a ruling rather than a gap), and the real economy pins land in `EconomySuite` in a real fight. Neither test means much alone; together they are the ruling.

Worth noting for whoever reads `death_test.go` next: it swings alice three times in a formed bubble and is still green, legitimately — the killing blow drops the last monster, the fight ends, and alice is back on the world clock. Verified, not assumed.

## Sentinel vocabulary added

- **`ErrCannotAfford`** — player-facing. An actor who spent what they had. The message names the currency: `action cannot be paid for: ... "alice": action: 1 needed, 0 left`.
- **`ErrBadCost`** — programmer-facing. A profile keyed to a currency no ledger holds, or a payer this cast cannot charge.

Kept apart because E2 split them at the door for exactly this reason: a malformed profile must never reach a client as "out of actions". `resolution.ErrCannotPay`, `ErrBadCost` and `ErrNoPayer` are added to `sentinels_test.go`'s explicit allow-list (extended, never loosened), and the refusal is driven for real there — `TestASecondSwingInOneTurn`, the most ordinary mistake on that list by a wide margin. The two unreachable arms are pinned one layer down in `translate_internal_test.go`, as that file's own convention requires.

## What the flipped test now claims

`TestNothingSpendsYet` → **`TestFreeRoamChargesNothing`**: same duel, same three swings, and they still land — but as a ruling about where the economy exists, with an added assertion that nothing lit an economy on her sheet. Its failure used to be the signal that the economy had arrived; it has arrived.

## Tests

New `EconomySuite` (8 pins, every scene a real fight driven through the session's own verbs — spawn, bubble, swing, EndTurn — with nothing constructing an economy by hand):

- a level-1 fighter's second swing refused by name, currency and actor in the message
- the refusal is ours and not resolution's (`ErrCannotAfford` yes; `ErrCannotPay`/`ErrBadCost`/`ErrNoPayer` no; and not our own `ErrBadCost` either)
- Extra Attack buys a level-5 fighter a second swing; the third is refused
- a refused swing writes nothing — world, story and the attacker's own economy all unchanged, and no `SaveError` to repair from
- the first swing survives the refusal (damage durable, beat in the story)
- a new turn refills the bank, and the sheet is refiled under it
- a bank left over from last turn does not misprice this one
- the turn is lit once and spent from thereafter (a re-light on every ask would refill what it just spent)

New `economy_internal_test.go` (3 pins on the merge itself: a strike costing more than its action banks, the netting leaving no zero entries — `Validate` refuses a grant of zero, which is every level-1 character — and every currency surviving the merge, including the pools and requirements v1 never compiles).

**RED path**: the three headline pins were written first against the fight scene and failed with "An error is expected but got nil" (evidence in `red-evidence.txt`), which is the honest failure — the scene formed correctly and nothing was being charged.

`go test -count=1 ./...` from inside the module: green. `gofmt`, `go vet`, `golangci-lint run ./...`: 0 issues.

## Mutation testing

15 mutations across the translation, refusal, pricing and ignition paths. **Harness audited with an unmutated baseline first** — it reports SURVIVED on unedited source, so the kills below are real rather than a harness that fails everything.

**14 killed, 1 survived.** The first pass killed 12; both survivors were real gaps rather than equivalents and are now closed by the two tests named above (the merge's totality, and the stale-bank ordering).

The one that remains — passing `nil` for `Cost.Turn` at the door — is an **equivalent mutant**: `readyForTurn` has already filed the sheet under this turn, so the door's refresh finds nothing to do and no test can distinguish the two. It is documented in place rather than papered over, because the next reader to notice would otherwise remove the field as dead. It is kept as the contract E2 built and as the backstop for the day this seam hands over a sheet it did not ready.

Mutants killed include: the free-roam gate inverted (24 tests), the turn never lit (19), the turn re-lit on every ask (10), the turn never refreshed (2), `costOfSwing` always returning the strike (19) or the unnetted action (10), grants not netted (10), the slot cost dropped (10), unpaid capacity dropped (1), no cost at all (11), the readied sheet not reaching the cast (20), and all three translation leaks (`%w: %w` on either arm, and the two sentinels collapsed into one).

## gorelease

```
## compatible changes
ErrBadCost: added
ErrCannotAfford: added

# summary
Suggested version: v0.17.0 (with tag rulebooks/dnd5e/session/v0.17.0)
```

As predicted, it sees only the two added sentinels and misses the behavioural break entirely — a host relying on unlimited swings in a fight now gets refusals. The `!` in the title carries what the tool cannot.

## Named here, owned elsewhere — #1098

The census exposed a third thing that is **not** E3's business and is **not** caused by this slice: a free-roam swing neither costs anything nor starts a fight. Filed as **#1098**, where it was narrowed and then ruled.

The sharpening matters, because the gap is not where it first looked. `duelWorld`'s two members are **both `KindPlayer`**, and `sidesInContactOrder` partitions by kind — so two players are never on opposing sides and no adjacency or line of sight will ever form a bubble between them. Player-versus-monster is already covered by sight forming the fight (#964/#1021); player-versus-player is structurally outside the fight system, which is why those 35 swings are unlimited by construction rather than by oversight.

Kirk has ruled both halves on #1098:

- **PvP: no**, scoped precisely — refuse `Attack{Attacker: player, Target: player}` by name at the seam, while friendly fire stays legal, because an area effect names a point and an area rather than a member. "Sides" does not need to learn about parties; kind stays the partition. When it lands, `duelWorld` stops being a valid scene and the 35 call sites move to a player-vs-monster world — a bigger mechanical change than the refusal itself.
- **A swing at an unseen monster IS initiation: yes** — but unreachable today, because sight is currently symmetric, so anything a player can see already sees them and a bubble has formed before any swing. The build belongs with **#1020** (asymmetric perception), where the case first becomes reachable and testable, and the composition owns formation there as it does everywhere.

E3 charges fight-clock actors only; PvP swings being free is a consequence of that gap and closes when the refusal lands.

## Follow-up named, not done here

`costOfSwing`'s composition is 5e's rule about what taking the Attack action and swinging means, and it belongs next to `CostOfAttack`/`CostOfStrike` in the rulebook rather than at this seam. It lives here because this is the first caller that needed it — the same road those two travelled — and the code says so, citing **#1100**, which carries this alongside the ordering wart. When a second caller appears it is a move rather than a redesign.

Closes #1097

— fix-1097 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
