### PR TITLE
feat(encounter): one step on the map, decided in one place (#1059)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -194,7 +194,8 @@ other caller of the consult is a verb looking at a world something else changed.
 | `decider.go` | `Decider`, `Snapshot`, `Intent` and its three implementations |
 | `trigger.go` | `InitiativeRoller` and the classification that starts a fight |
 | `standing.go` | `Standing`, and the world noticing who is down |
-| `atlas.go` | the coordinate queries — `Atlas`, `Absolute`, `Locate` |
+| `step.go` | one step on the map, and the one place that decides what one is |
+| `atlas.go` | the coordinate queries — `Atlas`, `Absolute`, `Locate`, `Grid` |
 | `field.go` | rooms, connections, and the per-verb output shapes |
 | `data.go` | `EncounterData` and the `ToData` / `LoadFromData` round trip |
 

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -260,6 +260,40 @@ func (e *Encounter) Atlas() (Atlas, error) {
 	return Atlas{Rooms: rooms, Doorways: doorways}, nil
 }
 
+// Grid reports the field's coordinate family — GridShapeSquare or
+// GridShapeHex — in O(1).
+//
+// A FIELD fact, not a room one: W1 gives every room in a field the same family,
+// checked identically at Setup and Load (validateGridFamilies), so there is one
+// answer and every room agrees with it.
+//
+// It exists because the answer was only reachable through [Encounter.Atlas],
+// which enumerates every cell of every room to get there — measured at ~128MB
+// and tens of milliseconds at the legal field budget, unmemoized (Atlas's own
+// doc). A caller that needs the family and nothing else was paying the whole
+// map for one enum, on a per-request path (rpg-toolkit#1059 finding 2).
+//
+// WHO NEEDS IT: anything doing grid arithmetic of its own, and the reason that
+// is not merely a convenience is that the two families disagree about what one
+// step means. Chebyshev distance on axial hex coordinates agrees with cube
+// distance everywhere except the diagonals, so substituting one formula for the
+// other passes almost every fixture — a real, previously-shipped defect class.
+// The cure is to ask spatial for a grid of the right family, and this is how a
+// caller learns which one to ask for. SPAN IS NOT REPORTED and is not needed
+// for that: adjacency is Distance <= 1 in both families and neither Distance
+// consults the grid's dimensions.
+//
+// Returns ErrNoField if the field holds no rooms, which construction forbids —
+// but the zero GridShape IS GridShapeSquare, so answering "square" for a field
+// that cannot have one would be a wrong answer rather than an absent one.
+func (e *Encounter) Grid() (spatial.GridShape, error) {
+	if len(e.fieldInput) == 0 {
+		var unknown spatial.GridShape
+		return unknown, fmt.Errorf("grid: %w", ErrNoField)
+	}
+	return e.fieldInput[0].Grid, nil
+}
+
 // Absolute projects a room-local position into dungeon-absolute space.
 // Legal for ANY in-bounds position, whether occupied, occluded, or
 // empty — hosts project percept ghosts at cells nobody stands on (#929
@@ -327,17 +361,17 @@ func (e *Encounter) Absolute(in *AbsoluteInput) (*AbsoluteOutput, error) {
 // walkability, not ownership, and this function never consults
 // occluders.
 //
-// WARNING — the Locate→Move trap (#929 hardening round B): composing
-// Locate then Move is a natural host pattern ("where does this absolute
-// position land, then move the member there"), but Move is SAME-ROOM
-// ONLY — it applies LocateOutput.Position inside the member's OWN
-// current room, never inside LocateOutput.Room. If the member's current
-// room differs from LocateOutput.Room, Move silently misplaces the
-// member instead of erroring (Move's own doc comment has the concrete
-// example). Callers MUST compare LocateOutput.Room against the member's
-// current room before calling Move with LocateOutput.Position; use
-// Traverse when they differ. Doc-only for v0.3 — see Move's doc comment
-// for why the real fix is a follow-up, not made here.
+// DO NOT COMPOSE THIS WITH Move to walk somewhere (rpg-toolkit#1059).
+// It is a natural host pattern — "where does this absolute position
+// land, then move the member there" — and it is the Locate→Move trap
+// (#929 hardening round B): Move is SAME-ROOM ONLY and applies
+// LocateOutput.Position inside the member's OWN current room, never
+// inside LocateOutput.Room, so a cell in another room silently misplaces
+// the member instead of erroring. [Encounter.Step] is the verb that
+// pattern was reaching for: it takes the absolute cell directly and
+// decides same-room-or-doorway itself, in the one place that decision
+// belongs. Locate stays what it always was — the reverse bridge, for
+// asking WHICH ROOM a cell belongs to.
 func (e *Encounter) Locate(in *LocateInput) (*LocateOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("locate: %w", ErrNilInput)

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -22,14 +22,15 @@ import (
 // the walk that started the fight before the fight — an engine whose product
 // IS the narration cannot narrate backwards.
 //
-// The law is stated at [refreshSight]; these are its five guards. Setup ruled
+// The law is stated at [refreshSight]; these are its six guards. Setup ruled
 // it first (a scene records that it opened before it records a fight starting
 // inside it), and trigger detection then arrived at Move, Traverse, Pump and
 // Join. Two of the four (Traverse via TestTraverseBeatPinned, Join via
 // TestTombWatch) inverted the moment trigger detection moved inside
 // refreshSight; the other two were latent only because nothing asserted them.
-// All five are asserted here so a future verb inherits a guarded law rather
-// than a remembered one.
+// Step joined them with rpg-toolkit#1059 and inherits the law by writing the
+// obvious call. All six are asserted here so a future verb inherits a guarded
+// law rather than a remembered one.
 //
 // Every scene below uses the same set: a 12x12 room split by a wall across
 // y=6, open at either end. Nobody is in contact until the verb under test puts
@@ -136,6 +137,24 @@ func (s *BeatOrderTestSuite) TestTraverseBeforeItFights() {
 	s.Greater(out.Formed.Seq, out.Seq, "she goes through the door, THEN the fight starts")
 
 	s.Equal([]string{"scene-opened", "traversed", "bubble-formed"}, s.beatKinds(enc, alice))
+}
+
+// TestStepBeforeItFights pins the step verb's half, and it is the one that
+// matters most going forward: the seam walks a party one Step at a time, so
+// every player movement in the game reaches trigger detection through here.
+//
+// Alice starts behind the wall and steps out past its end, exactly as
+// TestMoveBeforeItFights does — same set, same cause, and the beat it writes
+// must be the same "moved". A step is not a new kind of event in the story.
+func (s *BeatOrderTestSuite) TestStepBeforeItFights() {
+	enc := s.blockedScene()
+
+	out, err := enc.Step(&encounter.StepInput{Member: alice, To: spatial.Position{X: 1, Y: 2}})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "stepping into the open puts her in contact")
+	s.Greater(out.Formed.Seq, out.Seq, "she steps, THEN the fight starts")
+
+	s.Equal([]string{"scene-opened", "moved", "bubble-formed"}, s.beatKinds(enc, alice))
 }
 
 // TestPumpBeforeItFights pins Pump's half, and Pump is the verb the whole

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -29,9 +29,9 @@
 // and Dissolve re-homes everyone to the tick. A fight also ENDS ITSELF when a
 // side runs out of members standing in it — [ByDefeat], with no caller, the
 // mirror of sight starting one. Everyone not in the fight keeps
-// free-roaming while it runs; everyone in it is the fight's alone — Move,
-// Traverse, and Pump are world-clock verbs and will not act for a fight
-// member. Which clock somebody is on is always askable, per member, via
+// free-roaming while it runs; everyone in it is the fight's alone — Step,
+// Move, Traverse, and Pump are world-clock verbs and will not act for a
+// fight member. Which clock somebody is on is always askable, per member, via
 // ClockOf.
 //
 // # Atomicity, and what R5 does and does not promise

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1421,6 +1421,116 @@ func (e *Encounter) moveMember(member *memberRecord, to spatial.Position) (spati
 	return currentPos, nil
 }
 
+// rosterIDs is every member of this encounter, in stable ID order.
+//
+// The refresh scope for every verb that changes what can be seen, and the
+// audience for every beat those verbs append. Sorted because determinism is
+// module law (C8) and because a beat's audience is persisted: an unstable
+// order would rewrite the blob on a save that changed nothing.
+func (e *Encounter) rosterIDs() []MemberID {
+	ids := make([]MemberID, 0, len(e.members))
+	for id := range e.members {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// appendMovementBeat records one executed step in the story and returns its
+// sequence number.
+//
+// ONE narration path for every movement this composition performs — the Move
+// verb, the Traverse verb, the Step verb, and every monster action inside a
+// Pump. A movement is reported TWICE, once as a typed output and once as a
+// beat, and a host reading both must be told the same cell; two copies of this
+// arithmetic is how those two answers drift apart.
+//
+// Cells are DUNGEON-ABSOLUTE (#1040). A room-local coordinate with no room
+// attached — which is exactly what the moved beat carried before — names
+// nowhere in a multi-room field: two members in different rooms could report
+// the same "position" and mean cells at opposite ends of the map. A crossing's
+// arrival cell is projected through the ARRIVAL room's anchor, which is a
+// different one from the room it left.
+//
+// CALL THIS BEFORE refreshSight. A verb's own beat precedes any beat its
+// consequences append — the law is stated at [Encounter.refreshSight].
+func (e *Encounter) appendMovementBeat(action executedAction, audience []MemberID, at uint64) (uint64, error) {
+	payload := map[string]interface{}{
+		"beat":     "moved",
+		"member":   string(action.member.ID),
+		"position": e.absoluteOf(action.toRoom, action.to),
+	}
+	if action.kind == actionTraverse {
+		// A crossing says so, and says which doorway carried it. The room key
+		// is NOT here with it: rooms are this composition's own business, and
+		// a caller that wants one asks Locate.
+		payload["beat"] = "traversed"
+		payload["connection"] = action.connection
+	}
+
+	beatBytes, _ := json.Marshal(payload)
+
+	appendOut, err := e.appendBeat(&record.AppendInput{
+		At:       at,
+		Audience: audience,
+		Tags:     map[string]string{"tag": "movement"},
+		Payload:  beatBytes,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return appendOut.Seq, nil
+}
+
+// firedReachedPosition evaluates every declared ReachedPosition ending against
+// where a member has just come to rest, closing the encounter if one fires.
+//
+// The cell is ROOM-LOCAL and the room is the member's CURRENT one, which is
+// correct for all three ways to arrive somewhere: a move never changes room, a
+// crossing has already mutated it to the arrival room, and the pump's actions
+// are one or the other. An ending is declared against a room and a local cell
+// (construction data, authored), so this is the one comparison that stays in
+// the composition's own frame.
+//
+// The member filter carries a rule that reads backwards until you know it:
+// EMPTY means any PLAYER member, not any member at all. A monster wandering
+// onto the tomb's exit tile does not end the scene — the party leaving does.
+// Naming a member explicitly overrides that, and then kind does not matter.
+//
+// Returns a DEEP COPY (mutation-proof): a caller holding the returned outcome
+// cannot reach into this encounter's own.
+func (e *Encounter) firedReachedPosition(member *memberRecord, local spatial.Position, at uint64) *Outcome {
+	for _, de := range e.endings {
+		trigger, ok := de.trigger.(TriggerReachedPosition)
+		if !ok {
+			continue // Not a ReachedPosition trigger
+		}
+		if trigger.Room != member.Room {
+			continue // Different room
+		}
+		if trigger.Position.X != local.X || trigger.Position.Y != local.Y {
+			continue // Different position
+		}
+		if trigger.Member != "" && trigger.Member != member.ID {
+			continue // Member filter doesn't match
+		}
+		if trigger.Member == "" && member.Kind != KindPlayer {
+			continue // Empty filter means players only
+		}
+
+		e.outcome = &Outcome{
+			Ending:  de.key,
+			At:      at,
+			Members: e.buildMemberOutcomes(),
+		}
+
+		members := make([]MemberOutcome, len(e.outcome.Members))
+		copy(members, e.outcome.Members)
+		return &Outcome{Ending: e.outcome.Ending, At: e.outcome.At, Members: members}
+	}
+	return nil
+}
+
 // Move executes a continuous movement within the same room for ANY
 // member — players move themselves; Pump routes monster intents through
 // the same path. Unfiltered ReachedPosition endings fire only for
@@ -1430,8 +1540,16 @@ func (e *Encounter) moveMember(member *memberRecord, to spatial.Position) (spati
 // not a member → spatial move rejection. On success, refreshes sight for all members,
 // records beat, and evaluates ReachedPosition endings.
 //
+// PREFER [Encounter.Step] (rpg-toolkit#1059). Step takes a cell on the
+// map, works out for itself whether that cell is inside the member's
+// room or through a doorway, and carries it out either way. Move
+// survives as the same-room MECHANISM it always was — Step and Pump both
+// route through it — and as the verb for a caller that genuinely holds a
+// room-local cell. New callers hold a map cell, and for them this verb
+// is a trap:
+//
 // WARNING — the Locate→Move trap (#929 hardening round B): Move is
-// SAME-ROOM ONLY. It interprets MoveInput.Position as local coordinates
+// SAME-ROOM ONLY. It interprets MoveInput.To as local coordinates
 // within the member's OWN current room — never the room Locate resolved.
 // Composing Locate then Move (a natural host pattern: "where does this
 // absolute position land, then move the member there") silently
@@ -1440,13 +1558,14 @@ func (e *Encounter) moveMember(member *memberRecord, to spatial.Position) (spati
 // answer came from, so it applies LocateOutput.Position as-is inside the
 // member's own room instead — e.g. an intended absolute target of (8,2)
 // in the OTHER room actually landing the member at local (2,2) in their
-// OWN room, no error. Callers MUST compare LocateOutput.Room against the
-// member's current room before feeding LocateOutput.Position to Move
-// (or Absolute's input, symmetrically); when they differ, use Traverse
-// instead — it is the cross-room verb. This is a doc-only ruling for
-// v0.3: the real fix is a verb input that carries the intended room and
-// rejects a mismatch, an API change filed as a follow-up rather than
-// made at the end of this wave.
+// OWN room, no error.
+//
+// That warning said the real fix was "a verb input that carries the
+// intended room and rejects a mismatch, an API change filed as a
+// follow-up". [Encounter.Step] IS that fix, arrived at from the other
+// direction: its input carries an ABSOLUTE cell, which cannot be
+// mis-attributed to a room because it already names exactly one. A
+// caller composing Locate and Move by hand should stop doing both.
 func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	// Validation order
 	if in == nil {
@@ -1485,39 +1604,19 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	// Get all member IDs for the refresh scope (v1: refresh everyone)
-	memberIDs := make([]MemberID, 0, len(e.members))
-	for id := range e.members {
-		memberIDs = append(memberIDs, id)
-	}
-	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
+	memberIDs := e.rosterIDs()
+	clockReadingForBeat := uint64(e.clock.ToData().HighWater)
 
 	// Record the movement beat BEFORE refreshing sight: the walk is the cause,
 	// anything trigger detection appends is its effect (see refreshSight).
-	clockReadingInt := e.clock.ToData().HighWater
-	clockReadingForBeat := uint64(clockReadingInt)
-	beatPayload := map[string]interface{}{
-		"beat":   "moved",
-		"member": string(in.Member),
-		// DUNGEON-ABSOLUTE (#1040). This beat carried the room-local cell and
-		// no room at all, which in a multi-room field named nowhere: two
-		// members in different rooms could report the same "position" and mean
-		// cells at opposite ends of the map.
-		"position": e.absoluteOf(member.Room, in.To),
-	}
-	beatBytes, _ := json.Marshal(beatPayload)
-
-	appendOut, err := e.appendBeat(&record.AppendInput{
-		At:       clockReadingForBeat,
-		Audience: memberIDs,
-		Tags:     map[string]string{"tag": "movement"},
-		Payload:  beatBytes,
-	})
+	seqNum, err := e.appendMovementBeat(executedAction{
+		member: member, kind: actionMove,
+		fromRoom: member.Room, from: currentPos,
+		toRoom: member.Room, to: in.To,
+	}, memberIDs, clockReadingForBeat)
 	if err != nil {
 		return nil, fmt.Errorf("move append beat: %w", err)
 	}
-
-	seqNum := appendOut.Seq
 
 	// Refresh sight for all members
 	intelDeltas, formed, err := e.refreshSight(memberIDs)
@@ -1526,57 +1625,7 @@ func (e *Encounter) Move(in *MoveInput) (*MoveOutput, error) {
 	}
 
 	// Evaluate ReachedPosition endings
-	var firedOutcome *Outcome
-	for _, de := range e.endings {
-		endingKey, trigger := de.key, de.trigger
-		reachedPosTrigger, ok := trigger.(TriggerReachedPosition)
-		if !ok {
-			continue // Not a ReachedPosition trigger
-		}
-
-		// Check if the ending fires
-		if reachedPosTrigger.Room != member.Room {
-			continue // Different room
-		}
-
-		if reachedPosTrigger.Position.X != in.To.X || reachedPosTrigger.Position.Y != in.To.Y {
-			continue // Different position
-		}
-
-		// Check member filter: empty = any player member; non-empty = specific member
-		if reachedPosTrigger.Member != "" && reachedPosTrigger.Member != in.Member {
-			continue // Member filter doesn't match
-		}
-
-		// Member filter passes (empty or matches) but we need to check kind
-		if reachedPosTrigger.Member == "" && member.Kind != KindPlayer {
-			continue // Empty filter means players only, but moved member is not player
-		}
-
-		// Ending fires! Build the outcome with all members' current positions
-		memberOutcomes := e.buildMemberOutcomes()
-
-		e.outcome = &Outcome{
-			Ending:  endingKey,
-			At:      clockReadingForBeat,
-			Members: memberOutcomes,
-		}
-		// Return a deep copy of the outcome (mutation-proof)
-		outcomeMembers := make([]MemberOutcome, len(e.outcome.Members))
-		for i, m := range e.outcome.Members {
-			outcomeMembers[i] = MemberOutcome{
-				ID:       m.ID,
-				Room:     m.Room,
-				Position: m.Position,
-			}
-		}
-		firedOutcome = &Outcome{
-			Ending:  e.outcome.Ending,
-			At:      e.outcome.At,
-			Members: outcomeMembers,
-		}
-		break
-	}
+	firedOutcome := e.firedReachedPosition(member, in.To, clockReadingForBeat)
 
 	return &MoveOutput{
 		Moved: struct {
@@ -1714,6 +1763,12 @@ func (e *Encounter) traverseMember(member *memberRecord, connectionID string) (t
 // checks (connection not found: ErrNoConnection; endpoint mismatch — wrong
 // room or wrong position, either rejects the same way: ErrBadPlacement).
 //
+// PREFER [Encounter.Step] for walking through a doorway (rpg-toolkit#1059):
+// a doorway's two endpoints are adjacent absolute cells (W3), so crossing one
+// is a step, and Step finds the doorway itself. Traverse survives as the
+// mechanism Step dispatches to, and as the verb for a caller that holds a
+// connection id rather than a cell.
+//
 // The clock is NOT advanced — traversal is an activity, not time (law T4).
 // Sight refreshes for ALL members in one refreshSight call: since
 // refreshSight scopes each observer's percept to members currently in
@@ -1762,96 +1817,29 @@ func (e *Encounter) Traverse(in *TraverseInput) (*TraverseOutput, error) {
 		return nil, fmt.Errorf("traverse: %w", err)
 	}
 
-	memberIDs := make([]MemberID, 0, len(e.members))
-	for id := range e.members {
-		memberIDs = append(memberIDs, id)
-	}
-	sort.Slice(memberIDs, func(i, j int) bool { return memberIDs[i] < memberIDs[j] })
+	memberIDs := e.rosterIDs()
+	clockReadingForBeat := uint64(e.clock.ToData().HighWater)
 
 	// Record the traversal beat BEFORE refreshing sight: walking through the
 	// doorway is the cause, anything trigger detection appends is its effect
 	// (see refreshSight). The clock is NOT advanced (law T4).
-	clockReadingInt := e.clock.ToData().HighWater
-	clockReadingForBeat := uint64(clockReadingInt)
-	beatPayload := map[string]interface{}{
-		"beat":       "traversed",
-		"member":     string(in.Member),
-		"connection": in.Connection,
-		// The arrival cell, DUNGEON-ABSOLUTE (#1040). The room key is gone
-		// with it: rooms are this composition's own business, and a caller
-		// that wants the arrival room asks Locate.
-		"position": e.absoluteOf(result.toRoom, result.toPos),
-	}
-	beatBytes, _ := json.Marshal(beatPayload)
-
-	appendOut, err := e.appendBeat(&record.AppendInput{
-		At:       clockReadingForBeat,
-		Audience: memberIDs,
-		Tags:     map[string]string{"tag": "movement"},
-		Payload:  beatBytes,
-	})
+	seqNum, err := e.appendMovementBeat(executedAction{
+		member: member, kind: actionTraverse, connection: in.Connection,
+		fromRoom: result.fromRoom, from: result.fromPos,
+		toRoom: result.toRoom, to: result.toPos,
+	}, memberIDs, clockReadingForBeat)
 	if err != nil {
 		return nil, fmt.Errorf("traverse append beat: %w", err)
 	}
-
-	seqNum := appendOut.Seq
 
 	intelDeltas, formed, err := e.refreshSight(memberIDs)
 	if err != nil {
 		return nil, fmt.Errorf("traverse refresh sight: %w", err)
 	}
 
-	// Evaluate ReachedPosition endings against the ARRIVAL room/position.
-	var firedOutcome *Outcome
-	for _, de := range e.endings {
-		endingKey, trigger := de.key, de.trigger
-		reachedPosTrigger, ok := trigger.(TriggerReachedPosition)
-		if !ok {
-			continue // Not a ReachedPosition trigger
-		}
-
-		if reachedPosTrigger.Room != result.toRoom {
-			continue // Different room
-		}
-
-		if reachedPosTrigger.Position.X != result.toPos.X || reachedPosTrigger.Position.Y != result.toPos.Y {
-			continue // Different position
-		}
-
-		// Check member filter: empty = any player member; non-empty = specific member
-		if reachedPosTrigger.Member != "" && reachedPosTrigger.Member != in.Member {
-			continue // Member filter doesn't match
-		}
-
-		// Member filter passes (empty or matches) but we need to check kind
-		if reachedPosTrigger.Member == "" && member.Kind != KindPlayer {
-			continue // Empty filter means players only, but traversing member is not player
-		}
-
-		// Ending fires! Build the outcome with all members' current positions
-		memberOutcomes := e.buildMemberOutcomes()
-
-		e.outcome = &Outcome{
-			Ending:  endingKey,
-			At:      clockReadingForBeat,
-			Members: memberOutcomes,
-		}
-		// Return a deep copy of the outcome (mutation-proof)
-		outcomeMembers := make([]MemberOutcome, len(e.outcome.Members))
-		for i, m := range e.outcome.Members {
-			outcomeMembers[i] = MemberOutcome{
-				ID:       m.ID,
-				Room:     m.Room,
-				Position: m.Position,
-			}
-		}
-		firedOutcome = &Outcome{
-			Ending:  e.outcome.Ending,
-			At:      e.outcome.At,
-			Members: outcomeMembers,
-		}
-		break
-	}
+	// Evaluate ReachedPosition endings against the ARRIVAL room/position —
+	// traverseMember has already moved member.Room to the arrival side.
+	firedOutcome := e.firedReachedPosition(member, result.toPos, clockReadingForBeat)
 
 	return &TraverseOutput{
 		Formed: formed,
@@ -2061,7 +2049,14 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 		}
 	}
 
-	// Single refreshSight for all members after all monster actions
+	// Single refreshSight for all members after all monster actions.
+	//
+	// Derived from the roster snapshot taken BEFORE phase 1, not from live
+	// membership: a contract-violating decider that removed itself mid-Decide
+	// still belongs in this tick's beat audience, because an exited member
+	// keeps Story access to the beats they were present for. This is why Pump
+	// does not share rosterIDs with the other verbs — every one of those reads
+	// a roster nothing has had a chance to change.
 	memberIDs := make([]MemberID, 0, len(allMembers))
 	for _, m := range allMembers {
 		memberIDs = append(memberIDs, m.ID)
@@ -2093,35 +2088,11 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 
 	// Then record a beat for each successful action, in decision order.
 	for _, action := range executed {
-		var beatPayload map[string]interface{}
-		switch action.kind {
-		case actionMove:
-			beatPayload = map[string]interface{}{
-				"beat":     "moved",
-				"member":   string(action.member.ID),
-				"position": e.absoluteOf(action.member.Room, action.to),
-			}
-		case actionTraverse:
-			beatPayload = map[string]interface{}{
-				"beat":       "traversed",
-				"member":     string(action.member.ID),
-				"connection": action.connection,
-				"position":   e.absoluteOf(action.toRoom, action.to),
-			}
-		}
-		beatBytes, _ := json.Marshal(beatPayload)
-
-		actionAppendOut, err := e.appendBeat(&record.AppendInput{
-			At:       newTickReading,
-			Audience: memberIDs,
-			Tags:     map[string]string{"tag": "movement"},
-			Payload:  beatBytes,
-		})
+		actionSeq, err := e.appendMovementBeat(action, memberIDs, newTickReading)
 		if err != nil {
 			return nil, fmt.Errorf("pump append %s beat: %w", action.kind, err)
 		}
-
-		seqs = append(seqs, actionAppendOut.Seq)
+		seqs = append(seqs, actionSeq)
 	}
 
 	intelDeltas, formed, err := e.refreshSight(memberIDs)
@@ -2131,60 +2102,15 @@ func (e *Encounter) Pump(in *PumpInput) (*PumpOutput, error) {
 
 	// Evaluate ReachedPosition endings, in decision order. For a
 	// traverse, action.member.Room is already the ARRIVAL room
-	// (traverseMember mutated it); for a move it's unchanged — either
-	// way action.member.Room is correct to check against.
+	// (traverseMember mutated it); for a move it is unchanged — either
+	// way the shared evaluation reads the room the action landed in.
+	//
+	// A monster never fires an UNFILTERED ending: the empty filter means "any
+	// player member", which firedReachedPosition enforces by kind, so a
+	// wandering goblin cannot end the scene by standing on the exit.
 	var firedOutcome *Outcome
 	for _, action := range executed {
-		for _, de := range e.endings {
-			endingKey, trigger := de.key, de.trigger
-			reachedPosTrigger, ok := trigger.(TriggerReachedPosition)
-			if !ok {
-				continue // Not a ReachedPosition trigger
-			}
-
-			if reachedPosTrigger.Room != action.member.Room {
-				continue // Different room
-			}
-
-			if reachedPosTrigger.Position.X != action.to.X || reachedPosTrigger.Position.Y != action.to.Y {
-				continue // Different position
-			}
-
-			// Check member filter: non-empty = specific member; empty = players only
-			// Monsters should never trigger an unfiltered (empty-filter) ending
-			if reachedPosTrigger.Member == "" {
-				continue // Empty filter means players only, but this member is a monster
-			}
-
-			if reachedPosTrigger.Member != action.member.ID {
-				continue // Member filter doesn't match
-			}
-
-			// Ending fires! Build the outcome with all members' current positions
-			memberOutcomes := e.buildMemberOutcomes()
-
-			e.outcome = &Outcome{
-				Ending:  endingKey,
-				At:      newTickReading,
-				Members: memberOutcomes,
-			}
-			// Return a deep copy of the outcome (mutation-proof)
-			outcomeMembers := make([]MemberOutcome, len(e.outcome.Members))
-			for i, m := range e.outcome.Members {
-				outcomeMembers[i] = MemberOutcome{
-					ID:       m.ID,
-					Room:     m.Room,
-					Position: m.Position,
-				}
-			}
-			firedOutcome = &Outcome{
-				Ending:  e.outcome.Ending,
-				At:      e.outcome.At,
-				Members: outcomeMembers,
-			}
-			break
-		}
-		if firedOutcome != nil {
+		if firedOutcome = e.firedReachedPosition(action.member, action.to, newTickReading); firedOutcome != nil {
 			break
 		}
 	}
@@ -2366,98 +2292,6 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 	}
 
 	return deltas, nil
-}
-
-// The two kinds of step the pump can carry out. Constants rather than
-// literals because they are matched in three places — built in stepTo, then
-// switched on for beats and for ending evaluation — and a typo in any one of
-// them silently drops a monster's action from a transcript.
-const (
-	actionMove     = "move"
-	actionTraverse = "traverse"
-)
-
-// executedAction is one monster action the pump actually carried out: a step
-// within a room, or a step through a doorway. Both come out of stepTo, which
-// is the only thing that builds one.
-type executedAction struct {
-	member     *memberRecord
-	kind       string // "move" or "traverse"
-	connection string // only meaningful for "traverse"
-	fromRoom   string // only meaningful for "traverse"; a move never changes room
-	from       spatial.Position
-	toRoom     string // only meaningful for "traverse"
-	to         spatial.Position
-}
-
-// stepTo executes one intended step to a DUNGEON-ABSOLUTE cell, which after
-// rpg-toolkit#1044 is the only kind of movement a decider can intend.
-//
-// The dispatch that used to be the decider's job lives here instead, and it is
-// the whole reason IntentTraverse could retire: W3 makes a doorway's two
-// endpoints ADJACENT ABSOLUTE CELLS, so "walk to the cell on the other side of
-// the doorway" and "walk to the cell next to me" are the same sentence. Which
-// of the two mechanisms carries it out is bookkeeping, and bookkeeping belongs
-// on this side of the seam.
-//
-// Every refusal is SILENT — reported as not-stepped, never as an error — which
-// is the contract a spatially-rejected move already had and the one
-// IntentTraverse documented for an illegal crossing. Three ways to be refused:
-// a cell no room owns (void is not floor), a cell in another room with no
-// doorway joining it to where the member stands, and the spatial rejections
-// the move or the crossing itself raises.
-func (e *Encounter) stepTo(member *memberRecord, to spatial.Position) (executedAction, bool) {
-	located, err := e.Locate(&LocateInput{Position: to})
-	if err != nil {
-		return executedAction{}, false
-	}
-
-	if located.Room == member.Room {
-		fromPos, moveErr := e.moveMember(member, located.Position)
-		if moveErr != nil {
-			return executedAction{}, false
-		}
-		return executedAction{
-			member: member, kind: actionMove, from: fromPos, to: located.Position,
-		}, true
-	}
-
-	connection, ok := e.doorwayFrom(member, to)
-	if !ok {
-		return executedAction{}, false
-	}
-	result, travErr := e.traverseMember(member, connection)
-	if travErr != nil {
-		return executedAction{}, false
-	}
-	return executedAction{
-		member: member, kind: actionTraverse, connection: connection,
-		fromRoom: result.fromRoom, from: result.fromPos,
-		toRoom: result.toRoom, to: result.toPos,
-	}, true
-}
-
-// doorwayFrom finds the connection joining where a member stands to the given
-// absolute cell, in either direction — a doorway is crossable both ways.
-//
-// Returns false when no connection joins the two, which is what makes a step
-// between rooms that merely TOUCH refuse: W2 lets two rooms share an edge
-// without a door, so absolute adjacency alone is not permission to cross.
-func (e *Encounter) doorwayFrom(member *memberRecord, to spatial.Position) (string, bool) {
-	local, err := e.cellOf(member)
-	if err != nil {
-		return "", false
-	}
-	from := e.absoluteOf(member.Room, local)
-
-	for _, c := range e.connectionsInput {
-		near := e.absoluteOf(c.From, c.FromPosition)
-		far := e.absoluteOf(c.To, c.ToPosition)
-		if (near == from && far == to) || (far == from && near == to) {
-			return c.ID, true
-		}
-	}
-	return "", false
 }
 
 // occluderEntity is an internal entity for blocking line of sight

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1468,7 +1468,18 @@ func (e *Encounter) appendMovementBeat(action executedAction, audience []MemberI
 		payload["connection"] = action.connection
 	}
 
-	beatBytes, _ := json.Marshal(payload)
+	// PROPAGATED, not discarded. Every movement beat in this module used to
+	// build its own payload and drop this error on the floor, which writes a
+	// nil payload into the story and calls it a success — a beat a host reads
+	// as an empty object rather than as a movement. It is unreachable in
+	// practice (the payload is two strings and a position of finite float64s,
+	// and construction refuses NaN and ±Inf), and it is one line here because
+	// the four verbs now share one writer. clocks.go and outcome.go already
+	// propagate theirs; this is the movement half catching up.
+	beatBytes, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("marshal %s beat: %w", action.kind, err)
+	}
 
 	appendOut, err := e.appendBeat(&record.AppendInput{
 		At:       at,

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -126,6 +126,19 @@ var (
 	// validateConnectionInputs Setup uses.
 	ErrBadConnection = errors.New("bad connection")
 
+	// ErrNoCrossing is returned by Step when the destination cell lies in
+	// ANOTHER room and no doorway joins it to the cell the member is standing
+	// on. The cell is real and the member simply cannot get there from here.
+	//
+	// Distinct from ErrBadPlacement on purpose, because the remedies differ:
+	// "that is not a cell" sends a caller back to its arithmetic, while "there
+	// is no way through" sends it back to the map. W2 lets two rooms share an
+	// edge without a door between them, so two absolutely-adjacent cells can be
+	// permanently unwalkable — a refusal a caller reading only the Atlas's
+	// CELLS cannot predict, since the doorway is in the doorway list or it is
+	// nowhere.
+	ErrNoCrossing = errors.New("no doorway joins those cells")
+
 	// ErrNoConnection is returned by Traverse when the given connection ID
 	// does not name any connection in this encounter — a runtime lookup
 	// miss, the ErrNotMember analogue for connections. Distinct from

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -427,6 +427,58 @@ type TraverseOutput struct {
 	Outcome *Outcome
 }
 
+// StepInput names who steps and which cell they step to.
+type StepInput struct {
+	// Member is the ID of the member stepping.
+	Member MemberID
+
+	// To is the destination cell, DUNGEON-ABSOLUTE — the same frame the Atlas
+	// draws, a Member's Position reports, and every movement beat speaks.
+	//
+	// A cell, not a room and a cell. Whether this one is inside the stepper's
+	// current room or through a doorway is decided here rather than by the
+	// caller, which is the whole point of the verb (rpg-toolkit#1059).
+	To spatial.Position
+}
+
+// StepOutput reports what the step actually did.
+type StepOutput struct {
+	// Stepped is the movement, in dungeon-absolute cells at both ends.
+	//
+	// From and To are projected through their OWN rooms' anchors, which for a
+	// crossing are two different ones — on the map that is simply two adjacent
+	// cells (W3), and a caller never learns there was an anchor involved.
+	Stepped struct {
+		Member MemberID
+		From   spatial.Position
+		To     spatial.Position
+	}
+
+	// Crossing names the doorway this step went through, or is empty when the
+	// step stayed inside one room.
+	//
+	// A doorway identifier is not a room: it is a thing on the map, and the
+	// Atlas carries the same ids. It is reported because "what happened" is
+	// genuinely two answers here, and a caller narrating a crossing ("she
+	// slips through the gate") should not have to re-derive which one it was
+	// from the geometry.
+	Crossing string
+
+	// IntelDeltas maps member IDs to their updated percepts after the step
+	// (SurveilOutput deltas from the refreshSight cycle).
+	IntelDeltas map[MemberID]*intel.SurveilOutput
+
+	// Seq is the sequence number of the recorded movement beat.
+	Seq uint64
+
+	// Outcome is the encounter outcome if an ending fired underfoot; nil
+	// otherwise.
+	Outcome *Outcome
+
+	// Formed is set when this step started a fight. Nil otherwise.
+	Formed *FormedBubble
+}
+
 // PumpInput contains no parameters; the pump is parameterless in wave 1.
 type PumpInput struct{}
 

--- a/rulebooks/dnd5e/encounter/step.go
+++ b/rulebooks/dnd5e/encounter/step.go
@@ -163,12 +163,14 @@ func (e *Encounter) Step(in *StepInput) (*StepOutput, error) {
 // of the two mechanisms carries it out is bookkeeping, and bookkeeping belongs
 // on this side of the seam.
 //
-// Three ways to be refused, and they are told apart because the remedies
+// Four ways to be refused, and they are told apart because the remedies
 // differ: a cell no room owns (void is not floor — ErrBadPlacement), a cell in
 // another room with no doorway joining it to where the member stands
-// (ErrNoCrossing — the cell is real and there is simply no way through), and
-// the spatial rejections the move or the crossing itself raises
-// (ErrBadPlacement).
+// (ErrNoCrossing — the cell is real and there is simply no way through), the
+// spatial rejections the move or the crossing itself raises (ErrBadPlacement),
+// and this composition being unable to say where the member is standing at all
+// (ErrNoField, from cellOf — an invariant break, not a caller mistake, and it
+// must not arrive wearing a doorway's name).
 func (e *Encounter) stepMember(member *memberRecord, to spatial.Position) (executedAction, error) {
 	located, err := e.Locate(&LocateInput{Position: to})
 	if err != nil {

--- a/rulebooks/dnd5e/encounter/step.go
+++ b/rulebooks/dnd5e/encounter/step.go
@@ -187,7 +187,18 @@ func (e *Encounter) stepMember(member *memberRecord, to spatial.Position) (execu
 		}, nil
 	}
 
-	connection, ok := e.doorwayFrom(member, to)
+	// Where the member stands, resolved BEFORE the doorway lookup so that a
+	// failure to answer that question is reported as itself. Folding it into
+	// the lookup let "this member is not placed in any room I know" come back
+	// as ErrNoCrossing — a refusal that names a door, for a member who has no
+	// position at all, sending whoever reads it to the map instead of to the
+	// roster.
+	local, cerr := e.cellOf(member)
+	if cerr != nil {
+		return executedAction{}, cerr
+	}
+
+	connection, ok := e.doorwayFrom(e.absoluteOf(member.Room, local), to)
 	if !ok {
 		return executedAction{}, fmt.Errorf(
 			"member %s: no doorway joins where they stand to %v: %w", member.ID, to, ErrNoCrossing)
@@ -223,19 +234,19 @@ func (e *Encounter) stepTo(member *memberRecord, to spatial.Position) (executedA
 	return action, true
 }
 
-// doorwayFrom finds the connection joining where a member stands to the given
-// absolute cell, in either direction — a doorway is crossable both ways.
+// doorwayFrom finds the connection joining two absolute cells, in either
+// direction — a doorway is crossable both ways.
 //
-// Returns false when no connection joins the two, which is what makes a step
-// between rooms that merely TOUCH refuse: W2 lets two rooms share an edge
-// without a door, so absolute adjacency alone is not permission to cross.
-func (e *Encounter) doorwayFrom(member *memberRecord, to spatial.Position) (string, bool) {
-	local, err := e.cellOf(member)
-	if err != nil {
-		return "", false
-	}
-	from := e.absoluteOf(member.Room, local)
-
+// Returns false when no connection joins the two, and that is the ONLY thing
+// it can mean. It used to take the member and read their cell itself, which
+// gave it a second way to answer false — the roster and the field disagreeing
+// about where somebody is — indistinguishable from the first at the call site.
+// A lookup with nothing to fail at cannot conflate anything.
+//
+// False is what makes a step between rooms that merely TOUCH refuse: W2 lets
+// two rooms share an edge without a door, so absolute adjacency alone is not
+// permission to cross.
+func (e *Encounter) doorwayFrom(from, to spatial.Position) (string, bool) {
 	for _, c := range e.connectionsInput {
 		near := e.absoluteOf(c.From, c.FromPosition)
 		far := e.absoluteOf(c.To, c.ToPosition)

--- a/rulebooks/dnd5e/encounter/step.go
+++ b/rulebooks/dnd5e/encounter/step.go
@@ -1,0 +1,247 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// step.go is ONE STEP ON THE MAP, and everything that decides what one is.
+//
+// A step names a DUNGEON-ABSOLUTE cell and nothing else. Whether that cell is
+// somewhere inside the stepper's own room or on the far side of a doorway is
+// this file's business to work out — off this composition's own connection
+// data, in one place, for every caller.
+//
+// It is one place because it was two (rpg-toolkit#1059). The session SDK
+// resolved a walk itself: locate each cell, compare rooms, scan the projected
+// Atlas doorway list, then choose between the Move verb and the Traverse verb.
+// The pump made the same decision here, off the raw connection inputs. The two
+// agreed only for as long as neither learned anything the other had not — and
+// the first rule that tells doorways apart, a locked door, a one-way door, a
+// doorway spanning more than one cell pair, would have had to land in both, in
+// lockstep, forever. Until it missed once, and a player walked somewhere a
+// monster could not follow.
+//
+// So there is one implementation, [Encounter.stepMember], and two ways in:
+// [Encounter.Step], the public verb a host walks a party with, and
+// [Encounter.stepTo], the silent one the pump moves monsters with. They differ
+// in whether a refusal is REPORTED or simply means the monster failed to act
+// this tick. They cannot differ in what is crossable.
+
+// The two kinds of step the composition can carry out. Constants rather than
+// literals because they are matched in several places — built in stepMember,
+// then switched on for beats and for the pump's output — and a typo in any one
+// of them silently drops an action from a transcript.
+const (
+	actionMove     = "move"
+	actionTraverse = "traverse"
+)
+
+// executedAction is one step that actually happened: a move within a room, or
+// a crossing through a doorway. Only [Encounter.stepMember] builds one.
+//
+// Every cell here is ROOM-LOCAL, because that is the frame the mechanisms
+// underneath work in. Rooms do not cross the seam, so anything that reports
+// one of these projects it through [Encounter.absoluteOf] first.
+type executedAction struct {
+	member     *memberRecord
+	kind       string // actionMove or actionTraverse
+	connection string // only meaningful for actionTraverse
+	fromRoom   string // the room departed; for a move, the member's own room
+	from       spatial.Position
+	toRoom     string // the room arrived in; for a move, the member's own room
+	to         spatial.Position
+}
+
+// Step moves a member ONE STEP to a dungeon-absolute cell, crossing a doorway
+// if that is what the cell turns out to be, and says what happened.
+//
+// This is the movement verb to reach for. [Encounter.Move] is same-room only
+// and takes a room-local cell, which is the composition's own bookkeeping and
+// the source of the Locate→Move trap documented on it; [Encounter.Traverse]
+// takes a connection id, which is the mechanism rather than the intent. Step
+// takes the one thing a caller actually has — a cell on the map — and works
+// the rest out.
+//
+// ONE STEP, not a walk. Walking is the seam's job, because anything that fires
+// because a member entered a PARTICULAR CELL can only be noticed by something
+// that visits each of them in turn; this verb is what such a loop calls.
+//
+// ADJACENCY IS NOT CHECKED, deliberately. Step is the reporting twin of the
+// silent stepTo the pump moves monsters with, and a decider's IntentMoveTo has
+// never carried an adjacency contract — the composition's Move accepts any
+// cell of the room. What "one step" means for a WALK is a rule about walking,
+// and it lives with the walk. The same goes for the zero-distance step
+// (rpg-toolkit#1060): stepping onto the cell you already occupy is a legal, if
+// pointless, placement here and is refused at the seam that knows it is a
+// phantom.
+//
+// Validation order (R5 atomicity): nil input → empty member → closed → not a
+// member → in a fight → the step itself. Returns ErrNilInput, ErrNoMember,
+// ErrClosed, ErrNotMember, ErrInBubble for a member mid-fight (free roam is a
+// world-clock verb), ErrBadPlacement for a cell no room owns or a placement
+// the field rejects, or ErrNoCrossing for a cell in another room with no
+// doorway joining it to where the member stands.
+func (e *Encounter) Step(in *StepInput) (*StepOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("step: %w", ErrNilInput)
+	}
+
+	if in.Member == "" {
+		return nil, fmt.Errorf("step: %w", ErrNoMember)
+	}
+
+	if e.outcome != nil {
+		return nil, fmt.Errorf("step: %w", ErrClosed)
+	}
+
+	member, ok := e.members[in.Member]
+	if !ok {
+		return nil, fmt.Errorf("step: %w", ErrNotMember)
+	}
+
+	// The same world-clock gate Move and Traverse carry. A member caught in a
+	// bubble acts through the fight's own turn structure — there is no in-fight
+	// movement verb yet, and until there is, a fight member cannot move at all
+	// rather than moving outside initiative.
+	bubble, err := e.bubbleFor(in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("step: %w", err)
+	}
+	if bubble != nil {
+		return nil, fmt.Errorf("step: member %q: %w", in.Member, ErrInBubble)
+	}
+
+	action, err := e.stepMember(member, in.To)
+	if err != nil {
+		return nil, fmt.Errorf("step: %w", err)
+	}
+
+	audience := e.rosterIDs()
+	at := uint64(e.clock.ToData().HighWater)
+
+	// The beat BEFORE the sight refresh: the step is the cause, anything
+	// trigger detection appends is its effect (the law is stated at
+	// refreshSight). A step narrates exactly as the verb whose mechanism
+	// carried it — "moved" within a room, "traversed" through a doorway — so a
+	// host reading the story cannot tell which verb produced a movement.
+	seq, err := e.appendMovementBeat(action, audience, at)
+	if err != nil {
+		return nil, fmt.Errorf("step append beat: %w", err)
+	}
+
+	intelDeltas, formed, err := e.refreshSight(audience)
+	if err != nil {
+		return nil, fmt.Errorf("step refresh sight: %w", err)
+	}
+
+	out := &StepOutput{
+		Crossing:    action.connection,
+		IntelDeltas: intelDeltas,
+		Seq:         seq,
+		Outcome:     e.firedReachedPosition(member, action.to, at),
+		Formed:      formed,
+	}
+	out.Stepped.Member = in.Member
+	out.Stepped.From = e.absoluteOf(action.fromRoom, action.from)
+	out.Stepped.To = e.absoluteOf(action.toRoom, action.to)
+	return out, nil
+}
+
+// stepMember executes one step to a DUNGEON-ABSOLUTE cell and says why not
+// when it cannot.
+//
+// THE ONE PLACE the same-room-or-through-a-doorway decision is made, for every
+// caller. The dispatch that used to be the decider's job lives here, and it is
+// the whole reason IntentTraverse could retire: W3 makes a doorway's two
+// endpoints ADJACENT ABSOLUTE CELLS, so "walk to the cell on the other side of
+// the doorway" and "walk to the cell next to me" are the same sentence. Which
+// of the two mechanisms carries it out is bookkeeping, and bookkeeping belongs
+// on this side of the seam.
+//
+// Three ways to be refused, and they are told apart because the remedies
+// differ: a cell no room owns (void is not floor — ErrBadPlacement), a cell in
+// another room with no doorway joining it to where the member stands
+// (ErrNoCrossing — the cell is real and there is simply no way through), and
+// the spatial rejections the move or the crossing itself raises
+// (ErrBadPlacement).
+func (e *Encounter) stepMember(member *memberRecord, to spatial.Position) (executedAction, error) {
+	located, err := e.Locate(&LocateInput{Position: to})
+	if err != nil {
+		return executedAction{}, err
+	}
+
+	if located.Room == member.Room {
+		fromPos, moveErr := e.moveMember(member, located.Position)
+		if moveErr != nil {
+			return executedAction{}, moveErr
+		}
+		return executedAction{
+			member: member, kind: actionMove,
+			fromRoom: member.Room, from: fromPos,
+			toRoom: member.Room, to: located.Position,
+		}, nil
+	}
+
+	connection, ok := e.doorwayFrom(member, to)
+	if !ok {
+		return executedAction{}, fmt.Errorf(
+			"member %s: no doorway joins where they stand to %v: %w", member.ID, to, ErrNoCrossing)
+	}
+
+	result, travErr := e.traverseMember(member, connection)
+	if travErr != nil {
+		return executedAction{}, travErr
+	}
+	return executedAction{
+		member: member, kind: actionTraverse, connection: connection,
+		fromRoom: result.fromRoom, from: result.fromPos,
+		toRoom: result.toRoom, to: result.toPos,
+	}, nil
+}
+
+// stepTo is the pump's way in: the same step, refused SILENTLY.
+//
+// Every refusal is reported as not-stepped rather than as an error, which is
+// the contract a spatially-rejected move already had and the one IntentTraverse
+// documented for an illegal crossing — a monster that cannot act simply does
+// not act this tick, and never aborts the pump.
+//
+// It decides nothing of its own. Sharing stepMember with the public verb is
+// what makes "what is crossable" a single answer: a rule added there reaches a
+// player's walk and a monster's pursuit in the same commit, and there is no
+// second copy left to forget it.
+func (e *Encounter) stepTo(member *memberRecord, to spatial.Position) (executedAction, bool) {
+	action, err := e.stepMember(member, to)
+	if err != nil {
+		return executedAction{}, false
+	}
+	return action, true
+}
+
+// doorwayFrom finds the connection joining where a member stands to the given
+// absolute cell, in either direction — a doorway is crossable both ways.
+//
+// Returns false when no connection joins the two, which is what makes a step
+// between rooms that merely TOUCH refuse: W2 lets two rooms share an edge
+// without a door, so absolute adjacency alone is not permission to cross.
+func (e *Encounter) doorwayFrom(member *memberRecord, to spatial.Position) (string, bool) {
+	local, err := e.cellOf(member)
+	if err != nil {
+		return "", false
+	}
+	from := e.absoluteOf(member.Room, local)
+
+	for _, c := range e.connectionsInput {
+		near := e.absoluteOf(c.From, c.FromPosition)
+		far := e.absoluteOf(c.To, c.ToPosition)
+		if (near == from && far == to) || (far == from && near == to) {
+			return c.ID, true
+		}
+	}
+	return "", false
+}

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -190,6 +190,32 @@ func (s *StepSuite) TestAStepThroughADoorwayIsACrossing() {
 	s.Equal(farSide, s.beatCell(beat))
 }
 
+// TestADoorwayIsCrossableBothWays pins the half a fixture will not reach by
+// accident: the way BACK.
+//
+// A connection is declared with a From room and a To room, and every scene in
+// this package walks it the declared way. Match only that direction and every
+// crossing test still passes while every door in the game becomes one-way —
+// caught here by a surviving mutant, which is exactly the "locked, one-way, or
+// wide doorway" rule #1059 says must land in one place rather than two.
+func (s *StepSuite) TestADoorwayIsCrossableBothWays() {
+	threshold := stepAbs(stepWestOrigin, stepDoorWestLocal)
+	farSide := stepAbs(stepEastOrigin, stepDoorEastLocal)
+
+	_, err := s.enc.Step(&encounter.StepInput{Member: alice, To: threshold})
+	s.Require().NoError(err)
+	_, err = s.enc.Step(&encounter.StepInput{Member: alice, To: farSide})
+	s.Require().NoError(err)
+
+	// And back through the same door, against the direction it was declared in.
+	out, err := s.enc.Step(&encounter.StepInput{Member: alice, To: threshold})
+	s.Require().NoError(err)
+	s.Equal(stepDoor, out.Crossing, "the same doorway carried her home")
+	s.Equal(farSide, out.Stepped.From)
+	s.Equal(threshold, out.Stepped.To)
+	s.Equal(threshold, s.standsAt(alice))
+}
+
 // TestAStepSpeaksTheMapAtBothEnds is the frame pin.
 //
 // Both chambers are anchored well away from the origin, so every cell has a

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -1,0 +1,471 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// step_test.go covers the composition's public step verb (rpg-toolkit#1059):
+// ONE cell, named in dungeon-absolute space, with the composition deciding
+// whether that cell is next door or through a door.
+//
+// The verb exists because the decision was being made twice. The session SDK
+// resolved a walk itself — locating each cell, comparing rooms, scanning the
+// projected doorway list, then choosing between Move and Traverse — while the
+// pump made the same decision here, off the raw connection list. Two
+// implementations of "what is crossable" is a defect waiting for the first
+// rule that distinguishes doorways from each other: a locked door, a one-way
+// door, a doorway wider than one cell pair. Whichever side learned it first
+// would let a player walk somewhere a monster could not follow, or the reverse.
+//
+// So the tests below are not only "does the verb work". The load-bearing one
+// is TestAStepAndAMonsterStepAgreeOnWhatIsCrossable, which drives the same
+// cell pair through both callers and asserts they answer the same way — a
+// property that now holds BY CONSTRUCTION, since both run stepMember.
+//
+// NOTHING IN THIS FILE IS ANCHORED AT THE ORIGIN, for pursuit_test.go's
+// reason: where a room sits at (0,0) its local coordinates and its absolute
+// ones are the same numbers, and a verb that answered in the wrong frame would
+// pass every assertion anyway.
+type StepSuite struct {
+	suite.Suite
+
+	enc *encounter.Encounter
+}
+
+func TestStepSuite(t *testing.T) {
+	suite.Run(t, new(StepSuite))
+}
+
+const (
+	stepWest = "west-chamber"
+	stepEast = "east-chamber"
+	stepDoor = "connecting-door"
+)
+
+// The two chambers touch along their whole shared edge and are joined at
+// exactly ONE cell pair. That is the fixture's whole point: W2 lets rooms
+// share an edge without a door, so absolute adjacency is not permission, and
+// every cell of the seam except the doorway's is an adjacent pair that must
+// refuse.
+var (
+	stepWestOrigin = spatial.Position{X: 20, Y: 10}
+	stepEastOrigin = spatial.Position{X: 26, Y: 10}
+
+	// The doorway, room-local on each side. Absolute: (25,13) and (26,13).
+	stepDoorWestLocal = spatial.Position{X: 5, Y: 3}
+	stepDoorEastLocal = spatial.Position{X: 0, Y: 3}
+)
+
+// abs projects a room-local cell the way the fixture's own anchors say it
+// should be — derived from the origins above rather than written out, so a
+// changed anchor cannot leave a stale literal passing.
+func stepAbs(origin, local spatial.Position) spatial.Position {
+	return local.Add(origin)
+}
+
+// stepField is the shared set, optionally with a decider driving the goblin.
+func stepField() encounter.FieldInput {
+	return encounter.FieldInput{
+		Rooms: []encounter.RoomInput{
+			{ID: stepWest, Width: 6, Height: 6, Origin: stepWestOrigin},
+			{ID: stepEast, Width: 6, Height: 6, Origin: stepEastOrigin},
+		},
+		Connections: []encounter.ConnectionInput{{
+			ID: stepDoor, From: stepWest, To: stepEast,
+			FromPosition: stepDoorWestLocal,
+			ToPosition:   stepDoorEastLocal,
+		}},
+	}
+}
+
+// SetupTest opens the set with alice alone in the west chamber, one cell north
+// of the threshold. Alone, so nothing forms a fight and each test's verb is
+// the only thing that happens.
+func (s *StepSuite) SetupTest() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: stepField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
+				Position: spatial.Position{X: 5, Y: 2}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	s.enc = enc
+}
+
+// standsAt reads a member's cell off the roster, which reports absolute.
+func (s *StepSuite) standsAt(id encounter.MemberID) spatial.Position {
+	members, err := s.enc.Members()
+	s.Require().NoError(err)
+	for _, m := range members {
+		if m.ID == id {
+			return m.Position
+		}
+	}
+	s.Require().Fail("no such member", string(id))
+	return spatial.Position{}
+}
+
+// lastBeat decodes the most recent story beat one member was told about.
+func (s *StepSuite) lastBeat(audience encounter.MemberID) map[string]any {
+	story, err := s.enc.Story(&encounter.StoryInput{Audience: audience})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(story)
+
+	var beat map[string]any
+	s.Require().NoError(json.Unmarshal(story[len(story)-1].Payload, &beat))
+	return beat
+}
+
+// beatCell reads a beat's position back as a Position, since JSON gives it
+// back as a map of floats.
+func (s *StepSuite) beatCell(beat map[string]any) spatial.Position {
+	raw, ok := beat["position"].(map[string]any)
+	s.Require().True(ok, "the beat carries a position")
+	return spatial.Position{X: raw["x"].(float64), Y: raw["y"].(float64)}
+}
+
+// TestAStepWithinARoomIsAMove is the ordinary case: a cell the walker's own
+// room owns, carried by the same mechanism the Move verb uses, narrated with
+// the same beat.
+//
+// "Narrated the same" is asserted rather than assumed because the step verb is
+// meant to REPLACE the seam's use of Move, and a host reading the story must
+// not be able to tell which verb produced a movement.
+func (s *StepSuite) TestAStepWithinARoomIsAMove() {
+	from := stepAbs(stepWestOrigin, spatial.Position{X: 5, Y: 2})
+	to := stepAbs(stepWestOrigin, spatial.Position{X: 4, Y: 2})
+
+	out, err := s.enc.Step(&encounter.StepInput{Member: alice, To: to})
+	s.Require().NoError(err)
+
+	s.Equal(alice, out.Stepped.Member)
+	s.Equal(from, out.Stepped.From, "where she was, on the map")
+	s.Equal(to, out.Stepped.To, "where she is, on the map")
+	s.Empty(out.Crossing, "no doorway was involved")
+	s.Equal(to, s.standsAt(alice), "and the roster agrees")
+
+	beat := s.lastBeat(alice)
+	s.Equal("moved", beat["beat"])
+	s.Equal(to, s.beatCell(beat))
+}
+
+// TestAStepThroughADoorwayIsACrossing is the same sentence one cell along.
+//
+// The step names a cell, exactly as the one above does; that this cell happens
+// to be on the far side of a doorway is the composition's business to notice.
+// This is what W3 bought — a doorway's two endpoints are adjacent absolute
+// cells, so "the cell next to me" and "the cell through that door" are written
+// identically.
+func (s *StepSuite) TestAStepThroughADoorwayIsACrossing() {
+	threshold := stepAbs(stepWestOrigin, stepDoorWestLocal)
+	farSide := stepAbs(stepEastOrigin, stepDoorEastLocal)
+
+	_, err := s.enc.Step(&encounter.StepInput{Member: alice, To: threshold})
+	s.Require().NoError(err)
+
+	out, err := s.enc.Step(&encounter.StepInput{Member: alice, To: farSide})
+	s.Require().NoError(err)
+
+	s.Equal(threshold, out.Stepped.From)
+	s.Equal(farSide, out.Stepped.To)
+	s.Equal(stepDoor, out.Crossing, "and the verb says which doorway carried it")
+	s.Equal(farSide, s.standsAt(alice))
+
+	beat := s.lastBeat(alice)
+	s.Equal("traversed", beat["beat"])
+	s.Equal(stepDoor, beat["connection"])
+	s.Equal(farSide, s.beatCell(beat))
+}
+
+// TestAStepSpeaksTheMapAtBothEnds is the frame pin.
+//
+// Both chambers are anchored well away from the origin, so every cell has a
+// local twin that is a DIFFERENT number. A verb reporting the room-local cell
+// — the frame the mechanisms underneath actually work in — would produce (4,2)
+// here instead of (24,12), and a host has nothing to check that against.
+func (s *StepSuite) TestAStepSpeaksTheMapAtBothEnds() {
+	local := spatial.Position{X: 4, Y: 2}
+	to := stepAbs(stepWestOrigin, local)
+
+	out, err := s.enc.Step(&encounter.StepInput{Member: alice, To: to})
+	s.Require().NoError(err)
+
+	s.NotEqual(local, out.Stepped.To, "the local cell is not the answer")
+
+	located, err := s.enc.Locate(&encounter.LocateInput{Position: out.Stepped.To})
+	s.Require().NoError(err)
+	s.Equal(stepWest, located.Room)
+	s.Equal(local, located.Position, "and the map cell resolves back to the local one")
+}
+
+// TestAStepIntoTheVoidIsRefused: void is not floor. The private twin skips
+// silently; this one has to SAY so, which is the whole reason it exists.
+func (s *StepSuite) TestAStepIntoTheVoidIsRefused() {
+	before := s.standsAt(alice)
+
+	_, err := s.enc.Step(&encounter.StepInput{Member: alice, To: spatial.Position{X: 500, Y: 500}})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrBadPlacement)
+	s.Equal(before, s.standsAt(alice), "and she did not move")
+}
+
+// TestAStepIntoATouchingRoomWithNoDoorwayIsRefused is W2's consequence.
+//
+// (25,12) and (26,12) are adjacent absolute cells in different rooms with
+// nothing joining them — the chambers share their whole edge and are joined at
+// one pair. A refusal for a cell that EXISTS needs its own name: "off the map"
+// and "no way through from here" are different mistakes, and a caller told the
+// wrong one goes looking for the wrong bug.
+func (s *StepSuite) TestAStepIntoATouchingRoomWithNoDoorwayIsRefused() {
+	before := s.standsAt(alice)
+	acrossTheSeam := stepAbs(stepEastOrigin, spatial.Position{X: 0, Y: 2})
+
+	// The premise: that cell is real, and it is next door.
+	located, err := s.enc.Locate(&encounter.LocateInput{Position: acrossTheSeam})
+	s.Require().NoError(err)
+	s.Require().Equal(stepEast, located.Room)
+
+	_, err = s.enc.Step(&encounter.StepInput{Member: alice, To: acrossTheSeam})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrNoCrossing)
+	s.NotErrorIs(err, encounter.ErrBadPlacement, "the cell is fine; there is just no door")
+	s.Equal(before, s.standsAt(alice))
+}
+
+// TestAStepAndAMonsterStepAgreeOnWhatIsCrossable is why this issue was filed.
+//
+// The same two cell pairs, asked twice: once as a player's step through the
+// public verb, once as a monster's intended step through the pump. One pair is
+// joined by the doorway and one is a bare seam between touching rooms, and the
+// two callers must answer identically on both.
+//
+// Before the step verb they could not have: the SDK scanned the projected
+// Atlas doorway list, the pump scanned the raw connection inputs, and the two
+// scans agreed only because neither had learned anything the other had not. A
+// locked door, a one-way door, or a doorway spanning more than one cell pair
+// would have had to land in both, in lockstep, forever.
+func (s *StepSuite) TestAStepAndAMonsterStepAgreeOnWhatIsCrossable() {
+	seamWest := stepAbs(stepWestOrigin, spatial.Position{X: 5, Y: 2})
+	seamEast := stepAbs(stepEastOrigin, spatial.Position{X: 0, Y: 2})
+	threshold := stepAbs(stepWestOrigin, stepDoorWestLocal)
+	farSide := stepAbs(stepEastOrigin, stepDoorEastLocal)
+
+	// A goblin standing on the bare seam, intending the cell across it.
+	refused := &onceStepDecider{to: seamEast}
+	enc := s.sceneWithMonster(spatial.Position{X: 5, Y: 2}, refused)
+	_, err := enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Require().True(refused.called, "the decider was consulted")
+	s.Equal(seamWest, s.whereIn(enc, goblin), "the monster did not cross a seam with no door")
+
+	// Alice, on the same cell, intending the same one: same answer.
+	_, err = s.enc.Step(&encounter.StepInput{Member: alice, To: seamEast})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrNoCrossing)
+
+	// And through the real doorway, both go.
+	crossed := &onceStepDecider{to: farSide}
+	enc = s.sceneWithMonster(stepDoorWestLocal, crossed)
+	_, err = enc.Pump(&encounter.PumpInput{})
+	s.Require().NoError(err)
+	s.Equal(farSide, s.whereIn(enc, goblin), "the monster went through the door")
+
+	_, err = s.enc.Step(&encounter.StepInput{Member: alice, To: threshold})
+	s.Require().NoError(err)
+	out, err := s.enc.Step(&encounter.StepInput{Member: alice, To: farSide})
+	s.Require().NoError(err)
+	s.Equal(farSide, out.Stepped.To, "and so did she")
+}
+
+// sceneWithMonster opens a second encounter on the same set with a goblin in
+// the west chamber and alice out of its sight in the east one, so nothing
+// forms a bubble before the pump under test runs.
+func (s *StepSuite) sceneWithMonster(at spatial.Position, decider encounter.Decider) *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: stepField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: stepEast,
+				Position: spatial.Position{X: 5, Y: 5}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: stepWest,
+				Position: at, Decider: decider},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// whereIn reads a member's absolute cell out of an encounter this suite does
+// not hold in its own field.
+func (s *StepSuite) whereIn(enc *encounter.Encounter, id encounter.MemberID) spatial.Position {
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	for _, m := range members {
+		if m.ID == id {
+			return m.Position
+		}
+	}
+	s.Require().Fail("no such member", string(id))
+	return spatial.Position{}
+}
+
+// TestAStepFiresAReachedPositionEnding — an ending underfoot closes the
+// encounter, and the step is what put a foot there.
+func (s *StepSuite) TestAStepFiresAReachedPositionEnding() {
+	target := spatial.Position{X: 4, Y: 2}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: stepField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
+				Position: spatial.Position{X: 5, Y: 2}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "found-it", Trigger: encounter.TriggerReachedPosition{Room: stepWest, Position: target}},
+		},
+	})
+	s.Require().NoError(err)
+
+	out, err := enc.Step(&encounter.StepInput{Member: alice, To: stepAbs(stepWestOrigin, target)})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Outcome)
+	s.Equal("found-it", out.Outcome.Ending)
+}
+
+// TestACrossingFiresAReachedPositionEndingOnTheFarSide is the same rule at the
+// arrival end of a doorway, which is the half a step verb could plausibly get
+// wrong: an ending declared in the room being ENTERED must be evaluated
+// against where the member landed, not where they left.
+func (s *StepSuite) TestACrossingFiresAReachedPositionEndingOnTheFarSide() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: stepField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
+				Position: stepDoorWestLocal},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "through", Trigger: encounter.TriggerReachedPosition{
+				Room: stepEast, Position: stepDoorEastLocal}},
+		},
+	})
+	s.Require().NoError(err)
+
+	out, err := enc.Step(&encounter.StepInput{
+		Member: alice, To: stepAbs(stepEastOrigin, stepDoorEastLocal)})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Outcome)
+	s.Equal("through", out.Outcome.Ending)
+}
+
+// TestAStepRefusesNilInput pins the caller-defect arm.
+func (s *StepSuite) TestAStepRefusesNilInput() {
+	_, err := s.enc.Step(nil)
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrNilInput)
+}
+
+// TestAStepRefusesAnEmptyMember mirrors Move: an unnamed member is a caller
+// defect distinct from a named one who is not here.
+func (s *StepSuite) TestAStepRefusesAnEmptyMember() {
+	_, err := s.enc.Step(&encounter.StepInput{To: spatial.Position{X: 24, Y: 12}})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrNoMember)
+}
+
+// TestAStepRefusesANonMember: somebody who is not in this encounter.
+func (s *StepSuite) TestAStepRefusesANonMember() {
+	_, err := s.enc.Step(&encounter.StepInput{
+		Member: core.EntityID("nobody"), To: spatial.Position{X: 24, Y: 12}})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrNotMember)
+}
+
+// TestAStepRefusesAClosedEncounter: a finished encounter does not move.
+func (s *StepSuite) TestAStepRefusesAClosedEncounter() {
+	_, err := s.enc.End(&encounter.EndInput{Ending: "withdrawn"})
+	s.Require().NoError(err)
+
+	_, err = s.enc.Step(&encounter.StepInput{
+		Member: alice, To: stepAbs(stepWestOrigin, spatial.Position{X: 4, Y: 2})})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrClosed)
+}
+
+// TestAStepRefusesAFightMember pins the world-clock gate Move and Traverse
+// both carry: free roam is a world-clock verb, and a member in a bubble acts
+// through the fight's own turn structure or not at all.
+//
+// It is asserted here rather than assumed because the step verb is the one the
+// seam will call for every walk — a gate it failed to inherit would let a
+// player stroll out of a fight.
+func (s *StepSuite) TestAStepRefusesAFightMember() {
+	// In sight of each other from first light, which starts the fight.
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: stepField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
+				Position: spatial.Position{X: 1, Y: 1}},
+			{ID: goblin, Kind: encounter.KindMonster, Room: stepWest,
+				Position: spatial.Position{X: 4, Y: 4}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.Step(&encounter.StepInput{
+		Member: alice, To: stepAbs(stepWestOrigin, spatial.Position{X: 2, Y: 1})})
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrInBubble)
+}
+
+// TestGridReportsTheFieldsFamily covers the cheap read the seam needs in place
+// of an Atlas call.
+//
+// Adjacency is grid-family arithmetic, and the family is a FIELD fact by law
+// (W1: one family per field). Getting it out of Atlas meant enumerating every
+// cell of every room — measured at ~128MB and tens of milliseconds at the
+// legal field budget — to read one enum.
+func (s *StepSuite) TestGridReportsTheFieldsFamily() {
+	shape, err := s.enc.Grid()
+	s.Require().NoError(err)
+	s.Equal(spatial.GridShapeSquare, shape)
+}
+
+// TestGridReportsAHexFieldAsHex is the discriminating half: square is the zero
+// value of GridShape, so a verb that returned nothing at all would pass the
+// square case.
+func (s *StepSuite) TestGridReportsAHexFieldAsHex() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: stepWest, Width: 6, Height: 6, Grid: spatial.GridShapeHex,
+				Origin: stepWestOrigin},
+		}},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
+				Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	shape, err := enc.Grid()
+	s.Require().NoError(err)
+	s.Equal(spatial.GridShapeHex, shape)
+}


### PR DESCRIPTION
First of two for #1059. This one gives the composition the verb; the session PR
that follows rewrites `Move` as a loop over it and deletes the seam's own copy of
the decision.

**The finding, restated in one line:** one step on the map was decided twice —
`session.resolveWalk` + `doorwayBetween` off the projected Atlas, and
`encounter.stepTo` + `doorwayFrom` off the raw connection inputs — so the first
rule that tells doorways apart (a locked door, a one-way door, a doorway wider
than one cell pair) had to land in both, in lockstep, or a player would walk
somewhere a monster could not follow.

## Census (verified against main b656d62, before any code)

| thing | where | what it was |
|---|---|---|
| `stepTo(member, absCell) (executedAction, bool)` | `encounter.go:2409` | private, **silent** dispatch: `Locate` → same room ? `moveMember` : `doorwayFrom` → `traverseMember`. Pump's only movement path, and the only builder of `executedAction`. |
| `doorwayFrom(member, absCell)` | `encounter.go:2446` | scans `connectionsInput`, projecting both endpoints through `absoluteOf`, either direction. |
| `Move` | `encounter.go:1450` | public, **same-room only**, takes a ROOM-LOCAL cell in the member's own room. Carries the documented Locate→Move trap. |
| `Traverse` | `encounter.go:1735` | public, takes a **connection id**. |
| `moveMember` / `traverseMember` | `1389` / `1625` | the two mechanisms, shared by the verbs and by `stepTo`. |
| callers outside this package | — | `session/move.go` (deleted by PR B) and `session/read_test.go:312`. Inside: ~59 `.Move(` and ~32 `.Traverse(` call sites, nearly all tests, plus `cmd/freeroam-workbench`. |

## What landed

**`Encounter.Step(*StepInput) (*StepOutput, error)`** — the error-reporting twin
of `stepTo`.

```go
type StepInput struct {
	Member MemberID
	To     spatial.Position // DUNGEON-ABSOLUTE
}

type StepOutput struct {
	Stepped struct {
		Member MemberID
		From   spatial.Position // absolute
		To     spatial.Position // absolute
	}
	Crossing    string // the doorway this step went through; empty within a room
	IntelDeltas map[MemberID]*intel.SurveilOutput
	Seq         uint64
	Outcome     *Outcome
	Formed      *FormedBubble
}
```

Guards mirror `Move` exactly (nil → empty member → closed → not a member → in a
fight), then the step, then the **same beat** — `moved` within a room,
`traversed` with its connection through a doorway, byte-identical payloads —
then `refreshSight`, then `ReachedPosition` endings. Beat before sight, which is
the cause-before-effect law stated at `refreshSight`; `beatorder_test.go` gains
its **sixth** guard for it.

**One implementation, not two.** `stepMember` is the whole decision, and both
ways in call it: `Step` reports its refusals, `stepTo` swallows them into the
pump's silent-skip contract. They cannot differ about what is crossable, and
`TestAStepAndAMonsterStepAgreeOnWhatIsCrossable` drives the same two cell pairs
through both callers to say so out loud.

**`ErrNoCrossing`** (new sentinel) — the destination cell is real and in another
room, and no doorway joins it to where the member stands. Distinct from
`ErrBadPlacement` because the remedies differ: "that is not a cell" sends a
caller back to its arithmetic, "there is no way through" sends it back to the
map. W2 lets two rooms share an edge without a door, so absolutely-adjacent
cells can be permanently unwalkable.

**`Encounter.Grid() (spatial.GridShape, error)`** — the field's coordinate
family, O(1). This is finding 2's own prescription ("the fix is cheap
composition reads, not a field cache"). After the step verb the seam still owns
walk adjacency, adjacency needs the grid FAMILY, and the only way to get it was
`Atlas()` — measured at ~128MB and ~50–65ms at the legal field budget,
unmemoized, to read one enum. Span is deliberately not reported and is not
needed: adjacency is `Distance <= 1` in both families and neither `Distance`
consults the grid's dimensions.

**Shared bookkeeping.** `rosterIDs`,
`appendMovementBeat` and `firedReachedPosition` now serve `Move`, `Traverse`,
`Step` and `Pump` — the ending-evaluation block alone was three ~55-line copies.
`encounter.go` is **−155 lines** (179 added, 334 removed) as a result; the new
`step.go` is +258, over half of it documentation. Every existing test stayed
green through that refactor unchanged, which is the evidence it is
behaviour-preserving.

Two places deliberately **not** shared, because sharing them would have changed
behaviour:

- **Pump keeps its own roster build.** Its audience comes from the snapshot
  taken *before* phase 1, so a contract-violating decider that removed itself
  mid-`Decide` still belongs in that tick's beat audience — an exited member
  keeps Story access to the beats they were present for. Every other verb reads
  a roster nothing has had a chance to change. Noted in the code where it
  differs.
- **Pump's ending evaluation DOES share it.** Its filter rule looked different
  (`if trigger.Member == "" { continue }` versus Move's `... && member.Kind !=
  KindPlayer`) but is identical in effect, because phase 1 filters `planned` to
  `KindMonster`. Verified before merging the two, not assumed.

### What happened to `Traverse` and `Move` — both stay

`Move` and `Traverse` are not rival dispatchers; they are the two **mechanisms**
`stepMember` dispatches between, and after PR B the decision lives in
`stepMember` alone. Deleting them would mean rewriting ~91 in-package call sites
and the freeroam workbench for no safety gained — the no-backcompat law makes
that free, but free is not the same as worth doing.

What they got instead is honest documentation. `Move`'s WARNING already said the
real fix for the Locate→Move trap was "a verb input that carries the intended
room and rejects a mismatch, an API change filed as a follow-up". **`Step` is
that fix**, arrived at from the other direction: an absolute cell cannot be
mis-attributed to a room because it already names exactly one. Both verbs, and
`Locate`'s own copy of the warning, now point at `Step` as the verb to prefer.

## Tests

New suite `step_test.go` (16 tests) — nothing in it is anchored at the origin,
for `pursuit_test.go`'s reason: where a room sits at (0,0) its local coordinates
and its absolute ones are the same numbers, and a verb answering in the wrong
frame passes anyway. Two 6×6 chambers at (20,10) and (26,10), touching along
their whole shared edge, joined at exactly one cell pair.

- `TestAStepWithinARoomIsAMove` — `moved` beat, empty `Crossing`, absolute ends
- `TestAStepThroughADoorwayIsACrossing` — `traversed` beat + connection
- `TestADoorwayIsCrossableBothWays` — **added because a mutant survived**, below
- `TestAStepSpeaksTheMapAtBothEnds` — the reported cell is not the local twin,
  and `Locate` resolves it back
- `TestAStepIntoTheVoidIsRefused` — `ErrBadPlacement`, and she did not move
- `TestAStepIntoATouchingRoomWithNoDoorwayIsRefused` — `ErrNoCrossing`, asserted
  NOT `ErrBadPlacement`, with the cell's existence checked as the premise
- `TestAStepAndAMonsterStepAgreeOnWhatIsCrossable` — the headline
- `TestAStepFiresAReachedPositionEnding` / `...OnTheFarSide` — both ends of a
  doorway
- `TestAStepRefusesNilInput` / `AnEmptyMember` / `ANonMember` /
  `AClosedEncounter` / `AFightMember`
- `TestGridReportsTheFieldsFamily` / `...AHexFieldAsHex` — square is the zero
  value of `GridShape`, so the hex case is the discriminating one
- `beatorder_test.go`: `TestStepBeforeItFights`

RED first, captured at
`red-evidence.txt`: `s.enc.Step undefined (type *encounter.Encounter has no
field or method Step)`, `undefined: encounter.StepInput` — build failed, 15
tests unrunnable, before a line of `step.go` existed.

```
go test -count=1 ./...   ok (0.030s)
go test -count=1 -race ./...  ok (1.129s)
go vet ./...             clean
gofmt -l .               clean
golangci-lint run ./...  0 issues
```

## Mutation testing

Harness audited against an unmutated baseline first (baseline GREEN, refuses to
mutate otherwise), 17 mutants over the new decision branches. **First sweep:
15/16 killed** (M17 was added later, with the review fix it covers). The
survivor is worth reading:

> **M4 — doorway crossable one way only.** Narrowing `doorwayFrom`'s match to
> `near == from && far == to` — dropping the reverse-direction clause — survived
> the entire suite. Every crossing scene in this package walks a connection the
> way it was declared, so matching one direction turns every door in the game
> one-way and nothing notices. That is precisely the "locked, one-way, or wide
> doorway" class this issue says must live in one place.

Killed by `TestADoorwayIsCrossableBothWays`. Second sweep: **16/16, no
survivors.**

**Final sweep after the review fixes: 16/17.** The one survivor is M17 —
replacing `stepMember`'s `if cerr != nil { return ..., cerr }` (the guard added
for Copilot's finding) with a silent zero value. It survives because the state
`cellOf` guards, the roster and the spatial field disagreeing about where
somebody is placed, is unreachable through any public verb. That is what an
unreachable branch looks like under mutation, and it is why that fix is
described below as a structural guarantee rather than a live bug fixed.

One process note, because it cost real time: the first harness reverted mutants
with `git checkout --`, which silently deleted the just-written test that killed
M4 and made the next sweep report it surviving again. The harness now snapshots
the single file in memory and restores that.

## gorelease

```
# github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter
## compatible changes
(*Encounter).Grid: added
(*Encounter).Step: added
ErrNoCrossing: added
StepInput: added
StepOutput: added

# summary
Suggested version: v0.17.0 (with tag rulebooks/dnd5e/encounter/v0.17.0)
```

Additive across the board — hence `feat(encounter):` rather than `feat!`. No
exported signature changed, no behaviour changed for any existing caller: the
`Move`/`Traverse`/`Pump` refactor is internal and their own tests pin it
unchanged.

## Review

Copilot raised two, both verified empirically and both fixed in
`review(encounter): a missing door and a missing member are different answers`
(replies in-thread):

1. **`doorwayFrom` collapsed `cellOf` failures into `ErrNoCrossing`.** Correct,
   and the fix makes it impossible rather than merely correct: `doorwayFrom` now
   takes the two ABSOLUTE cells and has exactly one way to answer false — no
   door — while `stepMember` resolves where the member stands first and returns
   that error as itself. The conflated state is unreachable through any public
   verb (mutant M17, above), so this is a structural guarantee. The `stepTo`
   sibling Copilot also flagged keeps collapsing deliberately: the pump's
   contract is that any refusal means the monster silently fails to act.
2. **`appendMovementBeat` discarded its `json.Marshal` error.** Half-right:
   "like other beat writers do" is true of `clocks.go`, `outcome.go` and
   `standing.go` and false of the other seven Marshal sites in the module,
   including the three `moved`/`traversed` writers this helper replaced
   verbatim. Taken anyway, because consolidating four verbs into one writer made
   it a one-line fix for all of them. Unreachable in practice — the payload is
   two strings and two `float64`s, and construction refuses NaN and ±Inf — but a
   nil payload can no longer be written into the story AS A SUCCESS.

## Follows in PR B (session)

`Move` becomes a loop over `Step`; `resolveWalk`, `doorwayBetween`, `takeStep`
and `whereIs` are deleted along with the `Atlas()`-per-`Move` call and
`convert.go`'s `onMap`, whose only two callers are the lines going away.

— fix-1059 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
