### PR TITLE
refactor(session): the walk speaks only absolute positions (#1059)

### DIFF
--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -186,27 +186,24 @@ func projectMember(in encounter.Member) Member {
 	}
 }
 
-// onMap projects a composition room-local cell into the one map this seam
-// speaks, by asking the composition rather than doing the arithmetic here.
+// onMap is gone (rpg-toolkit#1059), and its absence is the point.
 //
-// What is left for it to do keeps shrinking as the composition converges on
-// one map. Placement reads came back absolute at encounter v0.10.0, outcomes
-// at v0.13.0 (rpg-toolkit#1068); what remains is a walk — the room-local cells
-// the composition's own movement verbs take and report, which move.go
-// projects on the way out and on the way in. Asking Absolute means the seam
-// never learns what an origin is, which is the whole point of it living down
-// there.
-func onMap(enc *encounter.Encounter, room string, local spatial.Position) spatial.Position {
-	out, err := enc.Absolute(&encounter.AbsoluteInput{Room: room, Position: local})
-	if err != nil {
-		// Unreachable through any verb: an outcome names members the
-		// composition itself placed, in rooms it validated at construction.
-		// Returning the unprojected cell if that ever stops being true is
-		// wrong in a way a test can see, which a panic in a host would not be.
-		return local
-	}
-	return out.Position
-}
+// It projected a composition room-local cell onto the one map this seam
+// speaks, and what was left for it to do had been shrinking for three slices:
+// placement reads came back absolute at encounter v0.10.0, outcomes at v0.13.0
+// (rpg-toolkit#1068), and the last room-local cells anywhere near this package
+// were the ones the walk handed down to the composition's Move and read back
+// out of it. The step verb takes and reports absolute cells, so there is
+// nothing left to project.
+//
+// Its error path is why deleting it beats keeping it: an unprojectable cell
+// returned the cell UNPROJECTED, on the grounds that a wrong answer a test can
+// see beats a panic in a host. That fallback measurably masked a real bug —
+// after #1068, projectMemberOutcome would have anchored every outcome twice,
+// and every fixture hid it because their rooms sit far enough out that an
+// absolute cell is never also a legal local one, so the second projection was
+// refused and the refusal was swallowed (#1053, PR #1072's evidence). A helper
+// with no callers cannot swallow anything.
 
 // projectMemberOutcome carries the outcome's cell across unchanged.
 //

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.17.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0 h1:0OdQm7/dccn6P6LYZdeXCmpHIXigZ9J5cYs3Vy/TWR0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.16.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.17.0 h1:jEt9/1IXGFULEKWxJUbj388m51utDClG1WoT5mR7Xx8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.17.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0 h1:ua6yx4VVYHANoiQtf1vqO84e1ulli9ywss8G+5vnhj0=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0/go.mod h1:GpAKS7PrFBK2aUsHbAOJt/Z7djlDzmmlMuloyGq2XKs=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -5,9 +5,8 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
-	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
@@ -101,7 +100,7 @@ type MoveOutput struct {
 // Move walks a member along a path, one cell at a time.
 //
 // This is the first verb that does something the composition cannot do alone:
-// the composition's own Move is a single hop, and walking is what makes the
+// the composition's own Step is a single hop, and walking is what makes the
 // cells in between real. That matters beyond tidiness — anything that fires
 // because a member *entered a particular cell* can only be noticed by something
 // that visits each of them.
@@ -112,10 +111,20 @@ type MoveOutput struct {
 // that happened, happened, and it is exactly what the caller asked for up to
 // the point the world changed.
 //
-// Validation is complete before the first cell is entered (R5): a path with a
-// gap in it is rejected whole rather than walked up to the gap, because a
-// caller who mis-computed a route wants none of it rather than an arbitrary
-// prefix of it.
+// WHAT IS VALIDATED WHOLE, AND WHAT IS NOT (R5, narrowed deliberately by
+// rpg-toolkit#1059). A path that is not a WALK is rejected entire, before a
+// single cell is entered: a gap in it, a step of no distance, a first cell
+// nowhere near the walker. A caller who mis-computed a route wants none of it
+// rather than an arbitrary prefix of it, and those are the mistakes a route
+// computation actually makes.
+//
+// The two refusals that need the MAP — a cell no room owns, and a cell in the
+// next room with no doorway joining it — are raised by the composition as each
+// step is taken, because checking them in advance means the seam re-deciding
+// what is crossable, which is the duplication this walk exists without. The
+// caller sees no difference: a refused walk returns an error, and nothing is
+// persisted or published, because the encounter that moved in memory is
+// discarded unsaved.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrEmptyPath,
 // ErrBrokenPath for a path with a gap in it, ErrNoSession, ErrNoEncounter,
@@ -138,12 +147,11 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	walk, err := resolveWalk(scope.enc, encounter.MemberID(in.Member), in.Path)
-	if err != nil {
+	if err = validateWalk(scope.enc, encounter.MemberID(in.Member), in.Path); err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	// A downed member does not walk. Asked after the walk RESOLVES and before a single
+	// A downed member does not walk. Asked after the path is VALIDATED and before a single
 	// cell is entered, which is where R5 puts every other refusal: the path is
 	// validated whole first, so naming a member who is not here or a route that
 	// is not a walk still answers what it always answered, and a walk this
@@ -156,7 +164,7 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	res, err := m.runWalk(scope, in.Member, walk)
+	res, err := m.runWalk(scope, in.Member, in.Path)
 	if err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
@@ -187,51 +195,65 @@ type walkResult struct {
 // runWalk steps a member along a path, stopping at the first fight, the first
 // ending, or the last cell.
 //
-// IT DECIDES NONE OF THAT. Until rpg-toolkit#964 this loop held a game rule: it
-// read each step's perception delta, and a subject seen for the first time
-// stopped the walk and opened a window for the walker to answer. That was the
-// SDK deciding when an encounter begins — a rule, in the one package whose
-// charter is to hold none — and it was wrong twice over besides, because sight
-// is not the only way a fight starts and a walker is not the only one who can
-// see.
+// IT DECIDES NOTHING. It used to decide two things and both were wrong to hold
+// here. Until rpg-toolkit#964 it held a game rule: it read each step's
+// perception delta, and a subject seen for the first time stopped the walk and
+// opened a window for the walker to answer — the SDK deciding when an encounter
+// begins, in the one package whose charter is to hold no rules. Until
+// rpg-toolkit#1059 it held a mechanism: each step arrived pre-sorted into a
+// same-room move or a doorway crossing, resolved here off a projected map, and
+// executed through whichever of the composition's two verbs matched.
 //
-// The composition owns it now, at the one place all sight changes pass through,
-// and reports a formed bubble on the Move that caused it. This loop reads that
-// report exactly the way it already read Outcome: as news. The walk stops
-// because the walker is IN a fight and a fight member does not free-roam — the
-// composition would refuse the next step with ErrInBubble — so stopping is a
-// fact about the world rather than a policy about perception.
-func (m *Manager) runWalk(scope *writeScope, member string, walk resolvedWalk) (*walkResult, error) {
+// Both now belong to the composition, which owns the data each answer is made
+// of, and this loop reads what came back exactly the way it already read
+// Outcome: as news. The walk stops on a formed bubble because the walker is IN
+// a fight and a fight member does not free-roam — the composition would refuse
+// the next step with ErrInBubble — so stopping is a fact about the world rather
+// than a policy about perception.
+func (m *Manager) runWalk(scope *writeScope, member string, path []spatial.Position) (*walkResult, error) {
 	res := &walkResult{discovered: map[string]Discovery{}}
 
-	for i, step := range walk.steps {
-		moved, err := m.takeStep(scope, member, step)
+	for i, cell := range path {
+		stepped, err := scope.enc.Step(&encounter.StepInput{
+			Member: encounter.MemberID(member),
+			To:     cell,
+		})
 		if err != nil {
 			// Nothing is saved on a mid-walk rejection. The member has really
 			// moved in memory for the steps already taken, but that encounter is
 			// discarded unsaved, so the persisted world is untouched.
-			return nil, fmt.Errorf("step %d of %d: %w", i+1, len(walk.steps), translate(err))
+			return nil, refusedStep(i, len(path), cell, err)
 		}
 
-		// Reported from what the composition says happened, projected back —
-		// not echoed from the input. A step that landed somewhere other than
-		// where it was aimed is a thing worth being able to see.
+		// Read off what the composition says happened rather than off the
+		// input, and there is no projection left in between to get wrong: the
+		// answer arrives on the map already.
+		//
+		// The two are the same value TODAY, and a mutation swapping this for
+		// `cell` survives the whole suite because of it — a step lands exactly
+		// where it was aimed or it is refused, so no fixture can tell them
+		// apart. That is a statement about the composition's current contract,
+		// not a guarantee this loop is entitled to assume: the day a step can
+		// land somewhere other than where it was aimed (a shove, a slide, a
+		// door that opens onto a different cell than the one named), echoing
+		// the input reports a movement that did not happen, and reading the
+		// answer keeps being right without anyone noticing it had to change.
 		res.steps = append(res.steps, Step{
-			Position: onMap(scope.enc, step.room, moved.to),
-			Seq:      moved.Seq,
+			Position: stepped.Stepped.To,
+			Seq:      stepped.Seq,
 		})
-		mergeDiscoveries(res.discovered, projectDiscoveries(moved.IntelDeltas))
+		mergeDiscoveries(res.discovered, projectDiscoveries(stepped.IntelDeltas))
 
-		if moved.Outcome != nil {
+		if stepped.Outcome != nil {
 			// The encounter ended underfoot. Every remaining step is abandoned:
 			// a closed encounter refuses movement anyway, and attempting them
 			// would turn a clean stop into a rejection the caller must interpret.
-			res.outcome = projectOutcome(moved.Outcome)
+			res.outcome = projectOutcome(stepped.Outcome)
 			return res, nil
 		}
 
-		if moved.Formed != nil {
-			res.formed = projectFormed(moved.Formed)
+		if stepped.Formed != nil {
+			res.formed = projectFormed(stepped.Formed)
 			return res, nil
 		}
 	}
@@ -239,52 +261,25 @@ func (m *Manager) runWalk(scope *writeScope, member string, walk resolvedWalk) (
 	return res, nil
 }
 
-// stepResult is what one step produced, whichever mechanism carried it.
+// refusedStep says why a step the composition refused was refused, in this
+// package's vocabulary and the caller's own coordinates.
 //
-// The two composition verbs report the same news in different shapes, and this
-// is the small amount of translation that lets the walk loop treat a crossing
-// exactly like a step: same stop-on-ending, same stop-on-fight, same discovery
-// merge, same beat sequence.
-type stepResult struct {
-	to          spatial.Position
-	Seq         uint64
-	IntelDeltas map[encounter.MemberID]*intel.SurveilOutput
-	Outcome     *encounter.Outcome
-	Formed      *encounter.FormedBubble
-}
-
-// takeStep executes one resolved step: a move within the room, or a crossing
-// through the doorway the step named.
+// Our sentinel travels ALONE (S2, rpg-toolkit#1058): a host that could match on
+// encounter.ErrBadPlacement would be coupled to the module this seam exists to
+// keep replaceable, through the one channel the AST boundary test cannot see.
+// The composition's account of WHY survives as TEXT, because "owned by no room"
+// and "not an integral axial cell" are the difference between a typo and a
+// fractional coordinate for whoever has to debug it.
 //
-// Which of the two it is was decided during resolution, where the map was
-// already in hand; this only carries it out. Both are ONE step of a walk and
-// neither is time — the composition advances no clock for either.
-func (m *Manager) takeStep(scope *writeScope, member string, step walkStep) (stepResult, error) {
-	if step.connection == "" {
-		moved, err := scope.enc.Move(&encounter.MoveInput{
-			Member: encounter.MemberID(member),
-			To:     step.local,
-		})
-		if err != nil {
-			return stepResult{}, err
-		}
-		return stepResult{
-			to: moved.Moved.To, Seq: moved.Seq, IntelDeltas: moved.IntelDeltas,
-			Outcome: moved.Outcome, Formed: moved.Formed,
-		}, nil
+// An error the mapping does not recognise is wrapped once and not repeated.
+// Those are the HOST's own — a Standing or Initiative capability failing inside
+// the step — and a host matching on its own error must keep being able to.
+func refusedStep(i, n int, cell spatial.Position, err error) error {
+	ours := translate(err)
+	if errors.Is(ours, err) {
+		return fmt.Errorf("step %d of %d to (%v,%v): %w", i+1, n, cell.X, cell.Y, err)
 	}
-
-	crossed, err := scope.enc.Traverse(&encounter.TraverseInput{
-		Member:     encounter.MemberID(member),
-		Connection: step.connection,
-	})
-	if err != nil {
-		return stepResult{}, err
-	}
-	return stepResult{
-		to: crossed.Traversed.To, Seq: crossed.Seq, IntelDeltas: crossed.IntelDeltas,
-		Outcome: crossed.Outcome, Formed: crossed.Formed,
-	}, nil
+	return fmt.Errorf("step %d of %d to (%v,%v): %w: %v", i+1, n, cell.X, cell.Y, ours, err)
 }
 
 // projectFormed turns the composition's report of a started fight into the
@@ -303,77 +298,49 @@ func projectFormed(f *encounter.FormedBubble) *Formed {
 	return out
 }
 
-// walkStep is one resolved step of a path: where it lands in the composition's
-// own terms, and — when the step crosses a doorway — which doorway carries it.
-type walkStep struct {
-	room       string
-	local      spatial.Position
-	connection string // empty for an ordinary step within a room
-}
-
-// resolvedWalk is a path as the composition takes it: each step resolved to
-// the room it lands in and the cell within it, in order.
-type resolvedWalk struct {
-	steps []walkStep
-}
-
-// resolveWalk validates a path whole and resolves it ONCE.
+// validateWalk checks that a path IS a walk, whole, before a single cell is
+// entered.
 //
-// Two jobs in one pass, and they belong together. Validation must finish
-// before the first cell is entered (R5): a caller who mis-computed a route
-// wants none of it rather than an arbitrary prefix. Resolution turns each
-// dungeon-absolute cell into the room-local one the composition's Move takes.
-// Doing them separately located every cell twice and read the roster twice per
-// walk — and, worse, left two places free to disagree about which room a cell
-// belongs to.
+// What is left here after rpg-toolkit#1059 is exactly the part that is a rule
+// about WALKING rather than a fact about the map. A walk is a run of adjacent
+// cells starting next to the walker, and that can be decided from two things
+// this seam is entitled to know: where the walker stands, and which coordinate
+// family the field uses. Everything else a step needs — which room owns a cell,
+// whether a doorway joins two of them — the composition decides as the step is
+// taken, in the one place it is decided for monsters too.
 //
-// Adjacency is checked with a grid of the field's own family rather than a
-// hand-rolled distance, because the two families disagree about what "one
-// step" means and substituting one for the other is a real, previously-shipped
-// defect class: Chebyshev distance on axial hex coordinates agrees with cube
-// distance everywhere except the diagonals, so a wrong formula passes almost
-// every fixture. One grid answers for the whole path, including the step that
-// changes rooms — a field has a single family by law (W1), and adjacency in
-// both families survives translation, so an absolute pair is adjacent or not
-// regardless of which room's grid is asked.
+// It used to decide all of it, and the cost was not only duplication. It
+// fetched a whole Atlas per Move (documented O(total cells), measured ~128MB
+// and ~50-65ms at the legal field budget, unmemoized) to read one room's grid
+// and the doorway list; it located every cell of the path a second time; and it
+// hard-coded "a doorway is exactly one adjacent cell pair" into the walk loop,
+// where the first door that behaved differently would have had to be taught
+// twice.
+//
+// Adjacency is delegated to spatial's own grid rather than hand-rolled, because
+// the two families disagree about what "one step" means and substituting one
+// for the other is a real, previously-shipped defect class: Chebyshev distance
+// on axial hex coordinates agrees with cube distance everywhere except the
+// diagonals, so a wrong formula passes almost every fixture. ONE grid answers
+// for the whole path, including the step that changes rooms — a field has a
+// single family by law (W1), and adjacency in both families survives
+// translation, so an absolute pair is adjacent or not regardless of which
+// room's grid is asked.
 //
 // Adjacency is also not sufficient, in the other direction: a cell is adjacent
 // to ITSELF under every family's Distance <= 1, so the zero-distance step needs
 // refusing by name rather than falling out of the distance check
 // (rpg-toolkit#1060).
-//
-// A step MAY leave the room the walker is in, and that is the only way it may
-// leave: through a doorway joining the cell they stand on to the one they are
-// stepping to (rpg-toolkit#1048). Adjacency alone is not permission — W2 lets
-// two rooms touch without a door — so a cross-room step with no doorway is
-// refused with ErrNoCrossing, distinctly from a path that is not a walk at all.
-func resolveWalk(
-	enc *encounter.Encounter, member encounter.MemberID, path []spatial.Position,
-) (resolvedWalk, error) {
-	room, from, err := whereIs(enc, member)
+func validateWalk(enc *encounter.Encounter, member encounter.MemberID, path []spatial.Position) error {
+	here, err := standsAt(enc, member)
 	if err != nil {
-		return resolvedWalk{}, err
+		return err
 	}
 
-	// The map, fetched ONCE for the whole walk and used for both things this
-	// function needs it for: the grid to test adjacency with, and the doorway
-	// list to recognise a crossing. Building it twice is what the first
-	// version of this did, by asking gridFor to fetch its own.
-	atlas, err := enc.Atlas()
+	grid, err := gridOf(enc)
 	if err != nil {
-		return resolvedWalk{}, translate(err)
+		return err
 	}
-
-	grid, err := gridFrom(atlas, room)
-	if err != nil {
-		return resolvedWalk{}, err
-	}
-
-	walk := resolvedWalk{steps: make([]walkStep, 0, len(path))}
-	// Both frames are tracked: absolute to test adjacency and to describe a
-	// refusal in the coordinates the caller actually wrote, room-local because
-	// that is what the composition's verbs take.
-	here, hereRoom := onMap(enc, room, from), room
 
 	for i, cell := range path {
 		if cell == here {
@@ -392,117 +359,95 @@ func resolveWalk(
 			// genuinely at every step, and a walker may retrace their route as
 			// often as they like. It is zero DISTANCE that is the phantom, not
 			// a repeated cell.
-			return resolvedWalk{}, fmt.Errorf("step %d of %d: already standing on (%v,%v): %w",
+			return fmt.Errorf("step %d of %d: already standing on (%v,%v): %w",
 				i+1, len(path), cell.X, cell.Y, ErrBadPosition)
 		}
 
 		if !grid.IsAdjacent(here, cell) {
-			return resolvedWalk{}, fmt.Errorf("step %d from (%v,%v) to (%v,%v): %w",
+			return fmt.Errorf("step %d from (%v,%v) to (%v,%v): %w",
 				i+1, here.X, here.Y, cell.X, cell.Y, ErrBrokenPath)
 		}
 
-		located, lerr := enc.Locate(&encounter.LocateInput{Position: cell})
-		if lerr != nil {
-			// The composition's account of WHY is kept as text, not as a chain.
-			// Our sentinel is the one a caller matches on; wrapping theirs too
-			// would let a host match on encounter.ErrBadPlacement, which is the
-			// S2 leak the boundary test cannot see — and this is the refusal a
-			// routine pathing mistake actually reaches (rpg-toolkit#1058).
-			return resolvedWalk{}, fmt.Errorf("step %d of %d: no room owns (%v,%v): %w: %v",
-				i+1, len(path), cell.X, cell.Y, ErrBadPosition, lerr)
-		}
-
-		step := walkStep{room: located.Room, local: located.Position}
-		if located.Room != hereRoom {
-			// Another room: legal only through a doorway joining the cell the
-			// walker stands on to the one they are stepping to. Adjacency is
-			// not permission — W2 lets two rooms touch without a door between
-			// them, and that pair of cells is adjacent and unwalkable.
-			connection, ok := doorwayBetween(atlas, here, cell)
-			if !ok {
-				return resolvedWalk{}, fmt.Errorf(
-					"step %d from (%v,%v) to (%v,%v): %w",
-					i+1, here.X, here.Y, cell.X, cell.Y, ErrNoCrossing)
-			}
-			step.connection = connection
-		}
-
-		walk.steps = append(walk.steps, step)
-		here, hereRoom = cell, located.Room
+		here = cell
 	}
-	return walk, nil
+	return nil
 }
 
-// doorwayBetween finds the doorway joining two cells, in either direction — a
-// doorway is crossable both ways.
+// standsAt reports where a member is, on the map.
 //
-// Reads the Atlas, which is where doorways live in absolute space: a pair of
-// adjacent cells and the connection that joins them. The composition holds the
-// same fact in its own room-shaped terms, and this is the projection of it.
-func doorwayBetween(atlas encounter.Atlas, from, to spatial.Position) (string, bool) {
-	for _, doorway := range atlas.Doorways {
-		if (doorway.FromCell == from && doorway.ToCell == to) || (doorway.ToCell == from && doorway.FromCell == to) {
-			return doorway.Connection, true
-		}
-	}
-	return "", false
-}
-
-// whereIs locates a member: which room owns them, and which cell within it.
+// A ROSTER READ AND NOTHING ELSE. It used to serialize the whole aggregate —
+// clock, intel, log, field and endings — to read two floats, because the
+// composition's roster reported a room and no position; toolkit#933 fixed that,
+// and Members has carried each member's cell on the map ever since. What
+// remained until rpg-toolkit#1059 was the other half of the round trip: this
+// took the absolute cell the roster had just given it, Located it down to a
+// room and a room-local cell, and handed that to a caller who immediately
+// projected it back up to the identical absolute cell it started as — through a
+// helper whose error path silently returned the unprojected value.
 //
-// It used to serialize the whole aggregate — clock, intel, log, field and
-// endings — to read two floats, because the composition's roster reported a
-// room and no position. That was toolkit#933, and it has landed: Members now
-// carries each member's cell on the map, so this is a roster read and a
-// projection back down into the room-local terms the composition's own verbs
-// take.
-func whereIs(enc *encounter.Encounter, member encounter.MemberID) (string, spatial.Position, error) {
+// The answer was always right there in the row.
+func standsAt(enc *encounter.Encounter, member encounter.MemberID) (spatial.Position, error) {
 	members, err := enc.Members()
 	if err != nil {
-		return "", spatial.Position{}, translate(err)
+		return spatial.Position{}, translate(err)
 	}
 
 	for _, m := range members {
-		if m.ID != member {
-			continue
+		if m.ID == member {
+			return m.Position, nil
 		}
-		located, lerr := enc.Locate(&encounter.LocateInput{Position: m.Position})
-		if lerr != nil {
-			return "", spatial.Position{}, fmt.Errorf("%q stands at %v, which no room owns: %w",
-				member, m.Position, ErrBadPosition)
-		}
-		return located.Room, located.Position, nil
 	}
-	return "", spatial.Position{}, fmt.Errorf("%q: %w", member, ErrNoMember)
+	return spatial.Position{}, fmt.Errorf("%q: %w", member, ErrNoMember)
 }
 
-// gridFrom builds a grid matching a room's family and span, for adjacency
-// tests, from a map the caller already has.
+// adjacencySpan is the size the adjacency grid is built with, and it is
+// ARBITRARY on purpose.
 //
-// Takes the Atlas rather than fetching one: it is the caller that knows
-// whether it needs the map for anything else, and in resolveWalk's case it
-// does — the doorway list comes off the same fetch.
-func gridFrom(atlas encounter.Atlas, roomID string) (spatial.Grid, error) {
-	for _, room := range atlas.Rooms {
-		if room.ID != roomID {
-			continue
-		}
-		switch room.Grid {
-		case spatial.GridShapeHex:
-			return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{
-				SpanWidth:  float64(room.Width),
-				SpanHeight: float64(room.Height),
-			}), nil
-		case spatial.GridShapeSquare:
-			return spatial.NewSquareGrid(spatial.SquareGridConfig{
-				Width:  float64(room.Width),
-				Height: float64(room.Height),
-			}), nil
-		default:
-			return nil, fmt.Errorf("room %q: %w", roomID, ErrInvalidWorld)
-		}
+// A spatial.Grid is two things at once: a distance metric and a set of bounds.
+// This seam wants only the metric — adjacency is Distance <= 1 in every family,
+// and no family's Distance consults the grid's dimensions, so any span answers
+// identically for cells anywhere on the map (pinned by
+// TestTheAdjacencyGridIsSpanIndependent).
+//
+// The bounds are deliberately NOT this seam's business. Whether a cell exists
+// is the composition's answer, given by the step itself: a cell no room owns is
+// refused with ErrBadPosition when it is stepped on. Building this grid with a
+// real room's width and height would have looked more careful while checking
+// nothing — the walk crosses rooms, so the walker's own room's bounds are the
+// wrong bounds for half the path anyway.
+const adjacencySpan = 1
+
+// gridOf builds a grid to test adjacency with, matching the field's own
+// coordinate family.
+//
+// Asks the composition for the FAMILY and nothing else — an O(1) read (W1: one
+// family per field). The Atlas this used to come from enumerates every cell of
+// every room to answer, which is the per-Move cost rpg-toolkit#1059 finding 2
+// measured.
+func gridOf(enc *encounter.Encounter) (spatial.Grid, error) {
+	family, err := enc.Grid()
+	if err != nil {
+		return nil, translate(err)
 	}
-	return nil, fmt.Errorf("room %q: %w", roomID, ErrInvalidWorld)
+
+	switch family {
+	case spatial.GridShapeSquare:
+		return spatial.NewSquareGrid(spatial.SquareGridConfig{
+			Width:  adjacencySpan,
+			Height: adjacencySpan,
+		}), nil
+	case spatial.GridShapeHex:
+		return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{
+			SpanWidth:  adjacencySpan,
+			SpanHeight: adjacencySpan,
+		}), nil
+	default:
+		// Unreachable: the composition rejects every other family at both
+		// Setup and Load. Refused rather than defaulted to square, because a
+		// family we do not understand answered with one we do is a wrong
+		// answer dressed as a working one.
+		return nil, fmt.Errorf("unknown grid family: %w", ErrInvalidWorld)
+	}
 }
 
 // mergeDiscoveries folds one step's perception deltas into the walk's running

--- a/rulebooks/dnd5e/session/move_internal_test.go
+++ b/rulebooks/dnd5e/session/move_internal_test.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// move_internal_test.go pins the two claims that let the walk stop resolving
+// rooms for itself (rpg-toolkit#1059).
+//
+// Both are about what the seam NO LONGER needs to know, which is exactly the
+// kind of claim that is invisible from outside: the verb's behaviour is
+// identical either way, and only a test aimed at the reasoning can say why the
+// deletion was safe rather than lucky.
+
+// walkOrderAsGiven and walkEveryoneStanding are the two capabilities every
+// encounter needs, in their most boring form. The external test package has its
+// own; these tests are internal and cannot see them.
+type walkOrderAsGiven struct{}
+
+func (walkOrderAsGiven) RollInitiative(members []encounter.MemberID) ([]encounter.MemberID, error) {
+	return members, nil
+}
+
+type walkEveryoneStanding struct{}
+
+func (walkEveryoneStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberID, error) {
+	return nil, nil
+}
+
+// walkWorld is two rooms of DIFFERENT sizes, anchored away from the origin.
+// Different sizes on purpose: the grid this seam builds used to take the
+// walker's own room's span, so a fixture whose rooms agree could not tell a
+// span that mattered from one that never did.
+func walkWorld(t *testing.T, family spatial.GridShape) *encounter.Encounter {
+	t.Helper()
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: walkOrderAsGiven{}, Standing: walkEveryoneStanding{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: "hall", Width: 4, Height: 4, Grid: family, Origin: spatial.Position{X: 30, Y: 40}},
+			{ID: "annex", Width: 12, Height: 12, Grid: family, Origin: spatial.Position{X: 60, Y: 40}},
+		}},
+		Members: []encounter.MemberInput{{
+			ID: "alice", Kind: encounter.KindPlayer, Room: "hall",
+			Position: spatial.Position{X: 1, Y: 1},
+		}},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+	return enc
+}
+
+// TestTheAdjacencyGridIsSpanIndependent is the claim that lets gridOf ask the
+// composition for a FAMILY and nothing else.
+//
+// The seam used to fetch a whole Atlas per Move — documented O(total cells),
+// measured at ~128MB and tens of milliseconds at the legal field budget — and
+// the only thing it wanted from all that was one room's grid family and its
+// width and height. The width and height were never load-bearing: adjacency is
+// Distance <= 1 in every family, and no family's Distance consults the grid's
+// dimensions. Cells hundreds of units outside the span the grid was built with
+// therefore answer exactly as cells inside it do.
+//
+// If that ever stops being true, this test fails and gridOf has to start
+// carrying a real span again — which is the point of asserting it here rather
+// than trusting a comment.
+func TestTheAdjacencyGridIsSpanIndependent(t *testing.T) {
+	grid, err := gridOf(walkWorld(t, spatial.GridShapeSquare))
+	require.NoError(t, err)
+
+	// Far outside adjacencySpan, in both rooms and in the void between them.
+	require.True(t, grid.IsAdjacent(spatial.Position{X: 31, Y: 41}, spatial.Position{X: 32, Y: 42}),
+		"a diagonal step deep inside the hall")
+	require.True(t, grid.IsAdjacent(spatial.Position{X: 64, Y: 47}, spatial.Position{X: 65, Y: 47}),
+		"and one deep inside the annex, whose span is three times the hall's")
+	require.False(t, grid.IsAdjacent(spatial.Position{X: 31, Y: 41}, spatial.Position{X: 33, Y: 41}),
+		"two cells apart is still two cells apart")
+}
+
+// TestTheAdjacencyGridUsesCubeDistanceOnHex is the discriminating half, and it
+// is the reason gridOf asks for the family at all rather than hard-coding one
+// distance formula.
+//
+// Axial (1,1) is cube distance 2 from the origin — two steps, not one — while
+// Chebyshev distance calls it 1. Substituting the square formula for the hex
+// one passes almost every hex fixture and fails only on the diagonals, which is
+// a previously-shipped defect class in this codebase.
+func TestTheAdjacencyGridUsesCubeDistanceOnHex(t *testing.T) {
+	grid, err := gridOf(walkWorld(t, spatial.GridShapeHex))
+	require.NoError(t, err)
+
+	require.True(t, grid.IsAdjacent(spatial.Position{X: 30, Y: 40}, spatial.Position{X: 31, Y: 40}),
+		"one step east")
+	require.False(t, grid.IsAdjacent(spatial.Position{X: 30, Y: 40}, spatial.Position{X: 31, Y: 41}),
+		"axial (1,1) away is TWO hex steps, whatever Chebyshev says")
+}
+
+// TestStandsAtReadsTheRosterRow pins the round trip that finding 3 deleted.
+//
+// Asking where somebody is used to mean: read the roster (which already
+// carries a dungeon-absolute cell), Locate that cell down to a room and a
+// room-local one, then project it straight back up again through onMap. Two
+// composition queries and a silent-fallback helper to return the number the
+// first query already had.
+func TestStandsAtReadsTheRosterRow(t *testing.T) {
+	enc := walkWorld(t, spatial.GridShapeSquare)
+
+	at, err := standsAt(enc, "alice")
+	require.NoError(t, err)
+	require.Equal(t, spatial.Position{X: 31, Y: 41}, at,
+		"hall-local (1,1) through the hall's (30,40) anchor, as the roster already reported it")
+
+	members, err := enc.Members()
+	require.NoError(t, err)
+	require.Equal(t, members[0].Position, at, "which is the roster row itself, unmodified")
+}
+
+// TestStandsAtRefusesSomebodyWhoIsNotHere keeps the verb's own sentinel on the
+// path a caller can actually drive.
+func TestStandsAtRefusesSomebodyWhoIsNotHere(t *testing.T) {
+	_, err := standsAt(walkWorld(t, spatial.GridShapeSquare), "nobody")
+	require.ErrorIs(t, err, ErrNoMember)
+}

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -313,6 +313,54 @@ func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
 	s.NotErrorIs(err, session.ErrBadPosition, "and the cell exists; there is just no way through")
 }
 
+// TestAWalkComesBackThroughTheSameDoorway pins the direction a fixture will not
+// reach by accident: the way BACK.
+//
+// A connection is declared with a From room and a To room, and every crossing
+// scene in this package walks it the declared way. Match only that direction
+// and every crossing test still passes while every door in the game becomes
+// one-way — a surviving mutant found exactly that on the composition side
+// (rpg-toolkit#1102), and after #1059 this walk runs through the same code a
+// monster's pursuit does, so the two can no longer disagree about it.
+//
+// It runs on hexWorld rather than the offset world for a reason worth stating:
+// the offset world declares an ending ON the annex side of its doorway, so a
+// walk that crosses it closes the encounter on arrival and CANNOT step back.
+// A round trip needs a world with nothing underfoot at the far end.
+func (s *MoveTestSuite) TestAWalkComesBackThroughTheSameDoorway() {
+	ctx := context.Background()
+	_, err := s.mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "hex", Encounter: "hexworld", World: hexWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	// Out: the corridor is anchored at the origin, the vault at (6,0), and the
+	// gate joins corridor-local (2,0) to vault-local (-3,0) — absolute (2,0)
+	// and (3,0), one axial step apart.
+	out, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "hex", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 0}, {X: 2, Y: 0}, {X: 3, Y: 0}},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(out.Steps, 3, "the walk ran to the end: nothing here stops it")
+	s.Require().Nil(out.Outcome, "and nothing ended underfoot")
+	s.Equal(spatial.Position{X: 3, Y: 0}, out.Steps[2].Position, "the far side, in the vault")
+
+	// And back, against the direction the connection was declared in.
+	back, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "hex", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 0}},
+	})
+	s.Require().NoError(err, "a doorway is crossable both ways")
+	s.Require().Len(back.Steps, 1)
+	s.Equal(spatial.Position{X: 2, Y: 0}, back.Steps[0].Position)
+
+	where, err := s.mgr.Where(ctx, &session.WhereInput{Session: "hex", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(spatial.Position{X: 2, Y: 0}, where.Position,
+		"standing back on the corridor threshold, read cold")
+}
+
 // TestAStepOntoNoCellUsesOurSentinelNotTheirs is
 // TestTrimmedStoryUsesOurSentinelNotTheirs' walk-shaped twin, and it covers the
 // leak channel a routine caller mistake reaches (rpg-toolkit#1058).

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -344,6 +344,46 @@ func (s *MoveTestSuite) TestAStepOntoNoCellUsesOurSentinelNotTheirs() {
 		"the composition's account of why survives, even though its sentinel does not")
 }
 
+// TestAMidWalkRefusalMovesNobody guards the one thing that narrowed when the
+// walk stopped resolving the map for itself (rpg-toolkit#1059).
+//
+// "A cell no room owns" used to be caught while the path was being resolved,
+// before anybody moved. It is now caught as that step is TAKEN, because
+// catching it earlier means the seam deciding what the composition decides.
+// The caller must not be able to tell: a refused walk still moves nobody and
+// tells nobody, because the encounter that moved in memory is discarded
+// unsaved.
+//
+// So the assertions are about the WORLD, not the error. Alice is asked to take
+// a legal step and then step off the map; the legal one really does execute
+// against the in-memory encounter, and none of it may survive.
+func (s *MoveTestSuite) TestAMidWalkRefusalMovesNobody() {
+	s.startCorridor()
+	ctx := context.Background()
+
+	before, err := s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.stream.published = nil // setup beats predate the walk
+
+	// (1,1) → (0,0) is a real step. (-1,-1) is off the map.
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 0, Y: 0}, {X: -1, Y: -1}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrBadPosition)
+
+	where, err := s.mgr.Where(ctx, &session.WhereInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(spatial.Position{X: 1, Y: 1}, where.Position,
+		"she is where she started: the step that DID execute was discarded with the encounter")
+
+	after, err := s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Len(after, len(before), "no beat survived a walk that failed")
+	s.Empty(s.stream.published, "and nothing reached a client")
+}
+
 // TestAZeroDistanceStepIsRefused pins rpg-toolkit#1060: the cell the walker
 // already stands on is not a step.
 //

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -163,38 +163,6 @@ func (s *OneMapSuite) TestAWalkCrossesTheDoorway() {
 	s.Equal("beyond", out.Outcome.Ending)
 }
 
-// TestAWalkComesBackThroughTheSameDoorway pins the direction a fixture will
-// not reach by accident.
-//
-// A connection is declared with a From room and a To room, and every crossing
-// scene in this package walks it the declared way. The way BACK exercises the
-// other half of the doorway match, and after rpg-toolkit#1059 that match lives
-// in the composition — the same code a monster's pursuit runs through, so a
-// door that stopped working one way would stop working for everybody at once
-// rather than for one of them silently.
-func (s *OneMapSuite) TestAWalkComesBackThroughTheSameDoorway() {
-	ctx := context.Background()
-
-	// Out through the gate. The annex-side ending sits on (46,22), so the walk
-	// stops there — she is standing on the far side with the encounter closed
-	// for the party, which is not what this test is about. Take the route that
-	// crosses at (46,23) instead: same doorway is at (45,22)/(46,22), so step
-	// to the threshold, through, and back.
-	_, err := s.mgr.Move(ctx, &session.MoveInput{
-		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 42, Y: 22}, {X: 43, Y: 22}, {X: 44, Y: 22}, {X: 45, Y: 22}},
-	})
-	s.Require().NoError(err)
-
-	back, err := s.mgr.Move(ctx, &session.MoveInput{
-		Session: "sess", Member: "alice",
-		Path: []spatial.Position{{X: 46, Y: 22}},
-	})
-	s.Require().NoError(err, "through the gate")
-	s.Require().Len(back.Steps, 1)
-	s.Equal(spatial.Position{X: 46, Y: 22}, back.Steps[0].Position)
-}
-
 // TestACrossingReachesClientsAsACrossing: one map does not mean one narration.
 //
 // The step that changed rooms is still a distinguishable beat, so a client can

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -163,6 +163,38 @@ func (s *OneMapSuite) TestAWalkCrossesTheDoorway() {
 	s.Equal("beyond", out.Outcome.Ending)
 }
 
+// TestAWalkComesBackThroughTheSameDoorway pins the direction a fixture will
+// not reach by accident.
+//
+// A connection is declared with a From room and a To room, and every crossing
+// scene in this package walks it the declared way. The way BACK exercises the
+// other half of the doorway match, and after rpg-toolkit#1059 that match lives
+// in the composition — the same code a monster's pursuit runs through, so a
+// door that stopped working one way would stop working for everybody at once
+// rather than for one of them silently.
+func (s *OneMapSuite) TestAWalkComesBackThroughTheSameDoorway() {
+	ctx := context.Background()
+
+	// Out through the gate. The annex-side ending sits on (46,22), so the walk
+	// stops there — she is standing on the far side with the encounter closed
+	// for the party, which is not what this test is about. Take the route that
+	// crosses at (46,23) instead: same doorway is at (45,22)/(46,22), so step
+	// to the threshold, through, and back.
+	_, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 42, Y: 22}, {X: 43, Y: 22}, {X: 44, Y: 22}, {X: 45, Y: 22}},
+	})
+	s.Require().NoError(err)
+
+	back, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 46, Y: 22}},
+	})
+	s.Require().NoError(err, "through the gate")
+	s.Require().Len(back.Steps, 1)
+	s.Equal(spatial.Position{X: 46, Y: 22}, back.Steps[0].Position)
+}
+
 // TestACrossingReachesClientsAsACrossing: one map does not mean one narration.
 //
 // The step that changed rooms is still a distinguishable beat, so a client can
@@ -406,6 +438,32 @@ func (s *OneMapSuite) TestAnOutcomeIsNotAnchoredTwice() {
 
 	s.Equal(spatial.Position{X: 7, Y: 6}, out.Outcome.Members[0].Position,
 		"the cell she finished on — anchoring it a second time would say (9,9)")
+}
+
+// TestAWalkIsNotAnchoredTwice is the standing probe (#1072) aimed at the walk
+// itself rather than at what it ends in.
+//
+// Every OTHER fixture in this package anchors its rooms far enough out that an
+// absolute cell is never also a legal room-local one — which means a step
+// reported through one anchoring too many produces a cell no room owns, and
+// the projection refuses rather than answering wrongly. Anchor shallowly and
+// the overlap is real: (7,6) is both a cell on the map and a cell inside the
+// room, so a second anchoring SUCCEEDS and lands somewhere else entirely.
+//
+// The walk path is where that mattered longest: it was the last place a
+// room-local cell crossed this seam in either direction.
+func (s *OneMapSuite) TestAWalkIsNotAnchoredTwice() {
+	out, err := s.shallowSession().Move(context.Background(), &session.MoveInput{
+		Session: "shallow", Member: "alice",
+		Path: []spatial.Position{{X: 5, Y: 6}, {X: 6, Y: 6}},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(out.Steps, 2)
+
+	s.Equal(spatial.Position{X: 5, Y: 6}, out.Steps[0].Position,
+		"the cell asked for — anchoring it a second time would say (7,9)")
+	s.Equal(spatial.Position{X: 6, Y: 6}, out.Steps[1].Position,
+		"and the next one, which would say (8,9)")
 }
 
 // TestAnExitIsNotAnchoredTwice: the leaver's own report, which the composition

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -144,22 +144,16 @@ func (m *Manager) Where(ctx context.Context, in *WhereInput) (*WhereOutput, erro
 		return nil, fmt.Errorf("where: %w", err)
 	}
 
-	members, err := enc.Members()
+	// The same roster read the walk uses to find its starting cell. Converted
+	// once, at the boundary, and compared as the newtype it is — the same
+	// direction View and Story take a member id. Comparing the other way, by
+	// stringifying the composition's ID, would work today and would stop being
+	// checked the moment MemberID means anything more than a string.
+	at, err := standsAt(enc, encounter.MemberID(in.Member))
 	if err != nil {
-		return nil, fmt.Errorf("where: %w", translate(err))
+		return nil, fmt.Errorf("where: %w", err)
 	}
-
-	// Converted once, at the boundary, and compared as the newtype it is —
-	// the same direction View and Story take a member id. Comparing the other
-	// way, by stringifying the composition's ID, would work today and would
-	// stop being checked the moment MemberID means anything more than a string.
-	want := encounter.MemberID(in.Member)
-	for _, member := range members {
-		if member.ID == want {
-			return &WhereOutput{Position: member.Position}, nil
-		}
-	}
-	return nil, fmt.Errorf("where: %q: %w", in.Member, ErrNoMember)
+	return &WhereOutput{Position: at}, nil
 }
 
 // View returns what one member currently perceives.
@@ -349,6 +343,13 @@ func translate(err error) error {
 		return fmt.Errorf("%w", ErrNoEnding)
 	case errors.Is(err, encounter.ErrNoConnection), errors.Is(err, encounter.ErrBadConnection):
 		return fmt.Errorf("%w", ErrNoConnection)
+	case errors.Is(err, encounter.ErrNoCrossing):
+		// Checked BEFORE ErrBadPlacement below, though the two cannot both
+		// match: the ordering states the distinction rather than relying on it.
+		// A cell in the next room with no doorway is not a bad position — the
+		// cell is real, and a caller told "off the map" would go looking for
+		// arithmetic that is fine.
+		return fmt.Errorf("%w", ErrNoCrossing)
 	case errors.Is(err, encounter.ErrBadPlacement):
 		return fmt.Errorf("%w", ErrBadPosition)
 	case errors.Is(err, encounter.ErrNoField), errors.Is(err, encounter.ErrInvalidData):

--- a/rulebooks/dnd5e/session/translate_internal_test.go
+++ b/rulebooks/dnd5e/session/translate_internal_test.go
@@ -38,6 +38,12 @@ func TestTranslateLetsNoCompositionSentinelThrough(t *testing.T) {
 		{"closed encounter", encounter.ErrClosed, ErrClosed},
 		{"undeclared ending", encounter.ErrNoEnding, ErrNoEnding},
 		{"unknown connection", encounter.ErrNoConnection, ErrNoConnection},
+		// The step verb's own refusal (rpg-toolkit#1059): the destination cell
+		// is real, in the next room, and nothing joins it to where the walker
+		// stands. It arrives through Move and MUST NOT arrive as ErrBadPosition
+		// — "off the map" and "no way through" send a caller to different
+		// places, and the walk's own test drives exactly this one.
+		{"no doorway", encounter.ErrNoCrossing, ErrNoCrossing},
 		{"malformed connection", encounter.ErrBadConnection, ErrNoConnection},
 		{"bad placement", encounter.ErrBadPlacement, ErrBadPosition},
 		{"already in a fight", encounter.ErrInBubble, ErrInBubble},


### PR DESCRIPTION
Second of two for #1059, and the one Kirk's ruling is about: *"the session should
only know and speak the absolute positioning."* Builds on #1102, which gave the
composition the step verb.

**#1102 has merged and tagged `encounter v0.17.0`, so this is now green on its
own terms.** The `go.sum` line that was unwritable until the version existed is
in (`chore(session): go.sum for encounter v0.17.0`), and everything below was
re-verified against the REAL published module — no workspace, no `replace`.

For the record of what the earlier red meant: `go.mod` here requires
`encounter v0.17.0`, which #1102 is what auto-tags, so `go mod tidy` and
`gorelease` could not run and CI failed on exactly one cause —
`unknown revision rulebooks/dnd5e/encounter/v0.17.0` — in `test-changed`,
`gorelease-dnd5e-session` and the `ci-status` roll-up. I read both real logs at
the time and nothing else was failing.

## The three findings, closed

| finding | what it was | what it is |
|---|---|---|
| **1. Dual dispatch** | `resolveWalk` + `doorwayBetween` + `takeStep` (move.go:322, 389) re-implemented `stepTo`/`doorwayFrom` off a different data source — the seam scanned the projected Atlas doorway list, the composition scanned raw `connectionsInput`. | Gone. `runWalk` calls `enc.Step` per cell. Crossing rules live in one place, read once, where the data is owned. A locked or one-way door now lands for a player's walk and a monster's pursuit in the same commit, because it lands in the same function. |
| **2. Per-Move Atlas** | `enc.Atlas()` on every Move (move.go:334) — documented O(total cells), measured ~128MB and ~50–65ms at the legal field budget, unmemoized — for two facts. | Gone. The doorway list is not the seam's business any more, and the grid family comes from `enc.Grid()`, the O(1) read #1102 added for exactly this. |
| **3. `whereIs` round trip** | Read the roster (which already carries a dungeon-absolute cell), `Locate` it down to a room and a room-local cell, hand that back — and `resolveWalk` immediately `onMap`ed it to the identical absolute cell it started as. | `standsAt` returns `m.Position`. One query, no projection, no silent fallback in the walker's own position. `Where` now shares it: the roster row IS the answer. |

## Kirk's law — the remaining-`Room` table

Every room name and room-local coordinate in the session's own reasoning is
gone. TWO code sites still name a room, plus one comment and one Atlas fetch
that the rider's neighbouring finding is about; each is a different kind of
thing, and none of them is the walk:

| where | what | verdict |
|---|---|---|
| `move.go:376`, `415-431`, `474` (`hereRoom`, `located.Room`, `whereIs`) | the walk written in room-local terms and translated back | **DELETED** |
| `convert.go:199` `onMap` | the last room-local projection at this seam | **DELETED — no callers left.** Its two callers were the two lines above |
| `write.go:357, 372` `place()`: `Locate(at)` → `Join(MemberInput{Room: located.Room, Position: located.Position})` | **survives — filed as #1101.** Entry placement, not the walk. `MemberInput` is room-shaped by construction, and it is also Setup's and Load's input type, where room-shaped is CORRECT: authoring is construction data, which the one-map ruling says explicitly. Removing this room means giving the composition an absolute-cell ENTRY verb — a second public API, squarely outside "give the composition a public absolute-cell STEP verb" | justified |
| `convert.go:62` `for _, room := range in.Rooms` in `projectAtlas` | **survives.** This IS the one-map projection point: the composition answers room-by-room because rooms are how it holds a field together, and this is where that stops being anybody else's problem | justified |
| `read.go:77` `enc.Atlas()` in the Map read | **survives.** Finding 2 is the per-MOVE cost. A verb whose job is to hand back the map is entitled to fetch the map | justified |
| `repositories.go:138` | a comment naming `spatial.BoundaryAwareRoom` | not a room |

`move.go` and `read.go` now contain the identifier `Room` zero times. The word
"room" still appears in their prose, explaining to a reader what a doorway is
and why a cell can be unwalkable — that is the map being described, not the
walk reasoning in rooms.

## What the walk still decides, and what it stopped deciding

`validateWalk` keeps exactly the part that is a rule about WALKING: a walk is a
run of adjacent cells starting next to the walker, plus the zero-distance
refusal (#1070/#1060), decided from two things this seam is entitled to know —
where the walker stands, and the field's coordinate family.

`adjacencySpan` is a named constant of `1`, and the honesty is the point: a
`spatial.Grid` is a distance metric AND a set of bounds, and this seam wants only
the metric.

Dropping the span the old `gridFrom` passed is behaviour-preserving, and that is
a checked claim rather than an assumed one. `IsAdjacent` is `Distance <= 1` in
both families (`square_grid.go:71`, `hex_grid.go:362`); `SquareGrid.Distance` is
`max(|dx|,|dy|)` and `AxialHexGrid.Distance` is `axialToCube` then cube distance
— **neither reads `dimensions` at all**. So the room width and height the seam
used to fetch a whole Atlas for could not have changed a single answer, at any
coordinate, ever. `TestTheAdjacencyGridIsSpanIndependent` pins it at cells
hundreds of units outside the span rather than leaving it to a comment, and
every pre-existing hex and diagonal walk test re-passing on a 1×1 grid is the
second, independent confirmation.

The bounds were never this seam's business anyway — the walk crosses rooms, so
the walker's own room's bounds (which is what `gridFrom` passed) are the wrong
bounds for half the path, and whether a cell EXISTS is the composition's answer,
given by the step itself.

### The narrowing, stated plainly

**Whole-path pre-validation shrinks, and this is inherent to the ruled shape.**
"A cell no room owns" and "no doorway joins these" used to be caught while the
path was resolved, before anybody moved. Pre-checking them requires precisely
the `Locate` + doorway-list dual dispatch being deleted, so they are now raised
by `Step` as each cell is taken. Adjacency, zero-distance and broken-path stay
whole-path pre-checks — those are the mistakes a route computation actually
makes.

The caller cannot tell: a refused walk returns an error, moves nobody and tells
nobody, because the encounter that moved in memory is discarded unsaved.
`TestAMidWalkRefusalMovesNobody` asserts that about the WORLD rather than about
the error — she is still where she started on a fresh read, no beat survived, no
event reached a client. `Move`'s doc comment now says which half is validated
whole and which is not, instead of the flat R5 claim that is no longer true.

**One refusal-ordering change falls out of it.** A DOWNED member handed a path
containing an unwalkable cell now gets `ErrDowned` where they used to get
`ErrBadPosition`, because `refuseIfDown` sits after validation and validation no
longer looks at the map. Nothing pinned the old order, and the new one is the
better answer: a body does not walk, whatever the route said.

## The rider — the silent fallbacks

`onMap` is not made loud, it is **deleted**, which is the stronger version: a
helper with no callers cannot swallow anything. Its error path returned the cell
UNPROJECTED, and #1053/#1072 demonstrated that swallowing measurably masked a
real bug rather than hypothetically risking one. `convert.go` keeps a comment
where it stood saying so, because the reason it is gone is worth more than the
absence.

`TestAWalkIsNotAnchoredTwice` adds the standing probe (#1072's
`shallowAnchoredWorld`) to the walk path itself — the last place a room-local
cell crossed this seam in either direction. Every other fixture anchors far
enough out that a double projection lands on no cell at all and is refused;
shallow anchoring is the only place a second anchoring SUCCEEDS and lands
somewhere wrong.

`encounter.absoluteOf`'s fallback survives, in the composition, where it is the
projection used by beats and reports. Out of scope here and worth its own look.

## Tests

RED first, in two stages, both captured.

**Behavioural RED** — `translate_internal_test.go` gains the `ErrNoCrossing` row
before the arm existed:

```
--- FAIL: TestTranslateLetsNoCompositionSentinelThrough/no_doorway
    Error: Target error should be in err chain:
           expected: "no doorway joins those cells"
           in chain: "members: alice: no doorway joins those cells"
```

— the composition's own sentinel passing straight through to a host, which is
the S2 leak the AST boundary test cannot see (#1058).

**Compile RED** — `move_internal_test.go` against internals that did not exist:
`undefined: gridOf` ×2, `undefined: standsAt` ×2, build failed.

New:
- `TestTheAdjacencyGridIsSpanIndependent` — the claim that lets `gridOf` ask for
  a family and nothing else. Two rooms of DIFFERENT sizes on purpose: a fixture
  whose rooms agree cannot tell a span that mattered from one that never did
- `TestTheAdjacencyGridUsesCubeDistanceOnHex` — axial (1,1) is TWO hex steps
- `TestStandsAtReadsTheRosterRow` / `...RefusesSomebodyWhoIsNotHere`
- `TestAMidWalkRefusalMovesNobody` — the narrowing's observable half
- `TestAWalkIsNotAnchoredTwice` — the shallow-anchor probe on the walk
- `TestAWalkComesBackThroughTheSameDoorway` — the direction a fixture will not
  reach by accident. #1102's own mutation sweep found this gap on the
  composition side; this is the seam-level twin. It runs on `hexWorld`, NOT the
  offset world, and the reason is Copilot's catch below: the offset world
  declares an ending on the far side of its doorway, so a walk that crosses it
  closes the encounter on arrival and can never step back
- `translate_internal_test.go`: the `encounter.ErrNoCrossing → ErrNoCrossing` row

Every pre-existing walk pin stayed green unchanged — adjacency, diagonals, hex
cube distance, zero-distance, repeated cells, broken paths rejected whole,
ending-underfoot, crossings, `ErrNoCrossing`, the sentinel-leak tests, and the
refusal messages in the caller's own coordinates.

```
go vet ./...             clean
gofmt -l .               clean
go test -count=1 ./...        ok
go test -count=1 -race ./...  ok (1.24s)
golangci-lint run ./...  0 issues
```

All run against the PUBLISHED `encounter v0.17.0` with no workspace and no
`replace`. They were run first against #1102's branch through a `GOWORK`
workspace while the tag did not exist, and the results are identical.

## Mutation testing

Harness audited against an unmutated baseline first (it refuses to mutate a red
baseline), and restores mutants from an in-memory snapshot rather than
`git checkout` — the latter ate an uncommitted test earlier in this work and
made a killed mutant report as surviving. 14 mutants: **12 killed, 2 survivors,
both explained.**

Killed: zero-distance permitted, adjacency never checked, `here` not advancing
with the walk, square field given a hex metric, hex field given a square metric,
the refusal wrapping the composition's error (the S2 leak — killed by
`TestDeathSuite`), an ending underfoot not stopping the walk, a formed fight not
stopping the walk, `standsAt` answering the origin, the translation arm removed,
the path not validated before the walk, the step's sequence not reported.

**Survivor B9 — `Position: cell` instead of `stepped.Stepped.To`.** The two are
the same value today: a step lands exactly where it was aimed or it is refused,
so no fixture can tell an echoed input from the composition's answer. The code
now says that instead of claiming a guarantee the tests do not give, and keeps
reading the answer — the day a step can land somewhere else (a shove, a slide, a
door opening onto a different cell), echoing the input reports a movement that
did not happen, and reading the answer keeps being right without anyone noticing
it had to change.

**Survivor B14 — `gridOf`'s default arm returning a square grid instead of
refusing.** Unreachable: the composition rejects every family but square and hex
at both Setup and Load, so no test can drive an unknown one. The arm stays,
refusing rather than defaulting, because a family we do not understand answered
with one we do is a wrong answer dressed as a working one.

## Review

Copilot raised one, and it was right: `TestAWalkComesBackThroughTheSameDoorway`
as first written asserted a FORWARD crossing under a name promising a
bidirectional one. `offsetWorld` declares `{Key: "beyond", ReachedPosition{annex,
(0,2)}}` — absolute (46,22), the far side of the gate — so the crossing fires it,
the encounter closes, and the return step was unreachable. Moved to `hexWorld`,
whose only ending is `TriggerExternal`, with `Outcome == nil` asserted so the
world cannot quietly stop the walk again.

Then checked it is load-bearing rather than merely passing, by narrowing the
composition's doorway match to the declared direction only:

```
--- FAIL: TestMoveSuite/TestAWalkComesBackThroughTheSameDoorway
    move: step 1 of 1 to (2,0): no doorway joins those cells: ...
    Messages: a doorway is crossable both ways
```

## gorelease

```
# summary
Suggested version: v0.18.0 (with tag rulebooks/dnd5e/session/v0.18.0)
```

**No API-change section at all** — gorelease found nothing added, removed or
altered on the exported surface. That matches the mechanical check made while
the tag did not yet exist: a diff of the exported declarations in all three
touched non-test files (`move.go`, `read.go`, `convert.go`) between
`origin/main` and this branch is empty. `MoveInput`, `Step`, `MoveOutput` and
`Where` are byte-identical; everything deleted was unexported.

The suggested bump is a MINOR one anyway, driven by the go.mod requirement
moving from `encounter v0.16.0` to `v0.17.0` rather than by anything on this
module's surface.

Hence `refactor(session):` and NOT `feat(session)!:`. There is no break to mark
and no feature to announce: the surface is unchanged, no sentinel changed
meaning, and the two behavioural changes above (where a map-level refusal is
raised, and `ErrDowned` winning over it) are not observable through the API.

Closes #1059. Entry placement, the one room translation left at this seam,
is #1101.

## Sequencing — RESOLVED, and CI is green

#1102 merged and auto-tagged `encounter v0.17.0`, so the prerequisite exists and
`go mod tidy` added the sums (`chore(session): go.sum for encounter v0.17.0`).
Everything above was originally verified through a `GOWORK` workspace
`replace` pointing at #1102's branch; it has now been re-run on the **real pin
with no replace anywhere** — `grep -c '^replace' go.mod` is 0, there is no
`go.work` in the tree, and `GOWORK` is unset — and that run is what CI is
reading:

| Check | Result |
|---|---|
| `test-changed (rulebooks/dnd5e/session, 1.25.x)` | **pass** |
| `gorelease-dnd5e-session` | **pass** |
| `ci-status` and every other check | **pass** — 10 pass, 8 skipping, 0 fail |
| local `go vet` / `go test -count=1` / `-race` / `golangci-lint` | clean, 0 issues |

`gorelease -base=v0.17.0` on the real pin runs with no diagnostics and reports
**no API-change section at all**, suggesting v0.18.0 — the minor coming from the
`encounter v0.16.0 → v0.17.0` requirement, not from this module's surface. That
agrees with the hand-run exported-declaration diff above, which was empty.

Worth naming, the same way #1082 named it: `test-changed` and
`gorelease-dnd5e-session` had never actually EXECUTED on this PR before the tidy
— they died at module resolution — so this is their first genuine run.

One thing that is NOT a property of this branch and cost twenty minutes:
`proxy.golang.org` served 404 for `.info` and `.mod` well after the tag existed
on origin, while its own `@latest` already reported v0.17.0 with the right hash.
`go mod tidy` cannot write `go.sum` in that window. Resolved with
`GOPRIVATE='github.com/KirkDiggler/*' go mod tidy`, which goes straight to the
VCS; the module zip is deterministic, so the sums it wrote are the ones the
proxy later published — confirmed by CI passing on exactly those lines.

— fix-1059 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
