### PR TITLE
feat(encounter)!: a room is a region — named cell sets, asked in one place (#1108)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -133,10 +133,9 @@ the contract rather than being coded defensively.
 - **Deterministic order.** Monsters act in stable `Members()` order.
 - **A decider error aborts the pump atomically.** No clock advance, no moves, no
   record beats. Return an error only when you genuinely cannot decide.
-- **A rejected step does not abort.** A cell no room owns, a cell in another
-  room with no doorway joining it to where you stand, or a step the spatial
-  rules refuse: each just means that monster fails to act this tick. Everything
-  else proceeds.
+- **A rejected step does not abort.** A cell no region owns, a wall between you
+  and it, or a step the spatial rules refuse: each just means that monster fails
+  to act this tick. Everything else proceeds.
 - **Sight refreshes once**, after all actions — then one tick beat, then the
   movement beats in decision order.
 - **A monster in a fight is not consulted.** `Pump` is the world thinking, and
@@ -195,14 +194,15 @@ other caller of the consult is a verb looking at a world something else changed.
 | `trigger.go` | `InitiativeRoller` and the classification that starts a fight |
 | `standing.go` | `Standing`, and the world noticing who is down |
 | `step.go` | one step on the map, and the one place that decides what one is |
-| `atlas.go` | the map reads — `Atlas` (the authored rooms in absolute space) and `Grid` |
+| `atlas.go` | the map reads — `Atlas` (every region's anchor and span, in absolute space) and `Grid` |
+| `region.go` | a room is a region: `RegionAt`, `MembersIn`, and the one ownership lookup |
 | `field.go` | rooms, connections, and the per-verb output shapes |
 | `data.go` | `EncounterData` and the `ToData` / `LoadFromData` round trip |
 
 ## Reading it
 
 Start with `doc.go` — it names the laws that bind this module (**C1–C8**, plus
-anchoring **W1–W5**) and points at the design contract in
+anchoring **W1–W6**) and points at the design contract in
 `docs/ideas/encounter/design.md`. Comments cite those laws by number, so `(C2)`
 in the source is pointing at a specific sentence.
 

--- a/rulebooks/dnd5e/encounter/arrival_test.go
+++ b/rulebooks/dnd5e/encounter/arrival_test.go
@@ -182,6 +182,40 @@ func (s *ArrivalSuite) TestAJoinDecidesTheEndingByTheSameRules() {
 	}
 }
 
+// TestAnEndingIsOneCellNotOneColumn pins that the comparison is a CELL, both
+// axes, in both directions.
+//
+// The ending is compiled to a single absolute cell and an arrival is an
+// equality against it (compileEndings, firedReachedPosition). An equality that
+// dropped either axis would still pass every scene above, because each of them
+// arrives exactly on the tile — so the cells that matter here are the ones that
+// share ONE coordinate with it and miss on the other.
+func (s *ArrivalSuite) TestAnEndingIsOneCellNotOneColumn() {
+	near := []struct {
+		name string
+		cell spatial.Position
+	}{
+		{"same column, one row up", spatial.Position{X: arrivalTarget.X, Y: arrivalTarget.Y - 1}},
+		{"same row, one column back", spatial.Position{X: arrivalTarget.X - 1, Y: arrivalTarget.Y}},
+	}
+	for _, tc := range near {
+		s.Run(tc.name, func() {
+			enc := s.arrivalEncounter("", encounter.KindPlayer)
+			out, err := enc.Step(&encounter.StepInput{
+				Member: alice, To: tc.cell.Add(arrivalVaultOrigin)})
+			s.Require().NoError(err)
+			s.assertFired(false, out.Outcome != nil, enc)
+
+			// And from there, the tile itself still closes it — so the miss
+			// above was the cell, not the walk.
+			out, err = enc.Step(&encounter.StepInput{
+				Member: alice, To: arrivalTarget.Add(arrivalVaultOrigin)})
+			s.Require().NoError(err)
+			s.assertFired(true, out.Outcome != nil, enc)
+		})
+	}
+}
+
 // assertFired checks the ending and the encounter's own state agree: a fired
 // ending closes the encounter, and a closed encounter fired one.
 func (s *ArrivalSuite) assertFired(want, got bool, enc *encounter.Encounter) {

--- a/rulebooks/dnd5e/encounter/arrival_test.go
+++ b/rulebooks/dnd5e/encounter/arrival_test.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// arrival_test.go is ONE ENDING RULE, EVERY WAY IN (rpg-toolkit#1108).
+//
+// A ReachedPosition ending has been implemented twice before: #1059 found the
+// pair — encounter.go's firedReachedPosition and an inline copy inside Join —
+// and S0 deleted the copy. This file is what stops a third from growing back,
+// from the outside; the structural half of that pin lives in
+// oneplace_internal_test.go.
+//
+// The rules the trigger carries, all four:
+//
+//	R1  a PLAYER arrives, filter empty          -> fires
+//	R2  a MONSTER arrives, filter empty         -> does NOT fire (empty means players)
+//	R3  a MONSTER arrives, filter names it      -> fires (a named filter overrides kind)
+//	R4  a PLAYER arrives, filter names SOMEBODY ELSE -> does NOT fire
+//
+// The ways in: Step (a host walks somebody), Pump (a monster acts on its own
+// intel) and Join (somebody arrives mid-scene, possibly straight onto the
+// tile). Pump carries only the monster rules, because Pump only moves monsters
+// — stated rather than quietly skipped.
+//
+// The fixture seals the vault off from the annex where the watching player
+// stands. That is load-bearing rather than scenery: sight is geometry since S0,
+// a player who sees a monster starts a fight, and a member in a fight can
+// neither Step nor be Pumped. The wall is what keeps each case's arrival the
+// only thing happening.
+type ArrivalSuite struct {
+	suite.Suite
+}
+
+func TestArrivalSuite(t *testing.T) {
+	suite.Run(t, new(ArrivalSuite))
+}
+
+const (
+	arrivalVault = "vault"
+	arrivalAnnex = "annex"
+)
+
+var (
+	arrivalVaultOrigin = spatial.Position{X: 20, Y: 7}
+	arrivalAnnexOrigin = spatial.Position{X: 28, Y: 7}
+
+	// The ending tile, and the cell beside it a walker starts on — both
+	// room-local in the vault.
+	arrivalTarget = spatial.Position{X: 4, Y: 4}
+	arrivalStart  = spatial.Position{X: 3, Y: 4}
+)
+
+// arrivalField is two chambers with NO doorway and a fully sealed seam.
+func arrivalField() encounter.FieldInput {
+	return encounter.FieldInput{
+		Rooms: []encounter.RoomInput{
+			{ID: arrivalVault, Width: 8, Height: 8, Origin: arrivalVaultOrigin,
+				Boundaries: squareSeamWall(7, 8)},
+			{ID: arrivalAnnex, Width: 4, Height: 8, Origin: arrivalAnnexOrigin},
+		},
+	}
+}
+
+// arrivalEncounter opens a scene whose only ending is a ReachedPosition on the
+// vault's tile. dave always watches from the sealed annex, and is who "somebody
+// else" means. A walker is placed in the vault only when the case needs one to
+// move; Join's cases need the vault empty.
+func (s *ArrivalSuite) arrivalEncounter(filter encounter.MemberID, walker encounter.MemberKind) *encounter.Encounter {
+	members := []encounter.MemberInput{
+		{ID: dave, Kind: encounter.KindPlayer, Room: arrivalAnnex, Position: spatial.Position{X: 0, Y: 0}},
+	}
+	if walker != "" {
+		w := encounter.MemberInput{ID: alice, Kind: walker, Room: arrivalVault, Position: arrivalStart}
+		if walker == encounter.KindMonster {
+			w.Decider = &patrolDecider{positions: []spatial.Position{arrivalTarget.Add(arrivalVaultOrigin)}}
+		}
+		members = append(members, w)
+	}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field:   arrivalField(),
+		Members: members,
+		Endings: []encounter.EndingInput{
+			{Key: "found-it", Trigger: encounter.TriggerReachedPosition{
+				Room: arrivalVault, Position: arrivalTarget, Member: filter}},
+		},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// whoFilter names whose ID an ending's filter carries, resolved per path so
+// that "the arriver" means the member each path actually moves.
+type whoFilter int
+
+const (
+	filterNobody whoFilter = iota
+	filterTheArriver
+	filterSomebodyElse
+)
+
+// arrivalCases is the rule table every path below runs against.
+var arrivalCases = []struct {
+	name   string
+	kind   encounter.MemberKind
+	filter whoFilter
+	fires  bool
+}{
+	{"R1 player, unfiltered", encounter.KindPlayer, filterNobody, true},
+	{"R2 monster, unfiltered", encounter.KindMonster, filterNobody, false},
+	{"R3 monster, filtered to the arriver", encounter.KindMonster, filterTheArriver, true},
+	{"R4 player, filtered to somebody else", encounter.KindPlayer, filterSomebodyElse, false},
+}
+
+// filterID resolves a case's filter against whoever is arriving.
+func filterID(f whoFilter, arriver encounter.MemberID) encounter.MemberID {
+	switch f {
+	case filterTheArriver:
+		return arriver
+	case filterSomebodyElse:
+		return dave
+	case filterNobody:
+		return ""
+	}
+	return ""
+}
+
+// TestAStepDecidesTheEndingByTheSameRules — the host walks somebody onto the
+// tile.
+func (s *ArrivalSuite) TestAStepDecidesTheEndingByTheSameRules() {
+	for _, tc := range arrivalCases {
+		s.Run(tc.name, func() {
+			enc := s.arrivalEncounter(filterID(tc.filter, alice), tc.kind)
+			out, err := enc.Step(&encounter.StepInput{
+				Member: alice, To: arrivalTarget.Add(arrivalVaultOrigin)})
+			s.Require().NoError(err)
+			s.assertFired(tc.fires, out.Outcome != nil, enc)
+		})
+	}
+}
+
+// TestAPumpDecidesTheEndingByTheSameRules — a monster walks itself onto the
+// tile on its own intel. Only the monster rules apply.
+func (s *ArrivalSuite) TestAPumpDecidesTheEndingByTheSameRules() {
+	for _, tc := range arrivalCases {
+		if tc.kind != encounter.KindMonster {
+			continue
+		}
+		s.Run(tc.name, func() {
+			enc := s.arrivalEncounter(filterID(tc.filter, alice), tc.kind)
+			_, err := enc.Pump(&encounter.PumpInput{})
+			s.Require().NoError(err)
+			s.assertFired(tc.fires, !s.open(enc), enc)
+		})
+	}
+}
+
+// TestAJoinDecidesTheEndingByTheSameRules — somebody arrives mid-scene straight
+// onto the tile, which is the path that used to carry its own copy of the rule.
+func (s *ArrivalSuite) TestAJoinDecidesTheEndingByTheSameRules() {
+	for _, tc := range arrivalCases {
+		s.Run(tc.name, func() {
+			enc := s.arrivalEncounter(filterID(tc.filter, bob), "")
+			out, err := enc.Join(&encounter.JoinInput{
+				Member: bob, Kind: tc.kind,
+				Cell: arrivalTarget.Add(arrivalVaultOrigin),
+			})
+			s.Require().NoError(err)
+			s.assertFired(tc.fires, out.Outcome != nil, enc)
+		})
+	}
+}
+
+// assertFired checks the ending and the encounter's own state agree: a fired
+// ending closes the encounter, and a closed encounter fired one.
+func (s *ArrivalSuite) assertFired(want, got bool, enc *encounter.Encounter) {
+	s.Equal(want, got, "the ending")
+	s.Equal(want, !s.open(enc), "and the encounter's state must agree with it")
+}
+
+func (s *ArrivalSuite) open(enc *encounter.Encounter) bool {
+	status, err := enc.Status()
+	s.Require().NoError(err)
+	return status.Open
+}

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -11,60 +11,63 @@ import (
 )
 
 // Atlas is a deterministic, construction-time snapshot of the field
-// projected into dungeon-absolute space: every room's absolute cell set
+// projected into dungeon-absolute space: every region's absolute footprint
 // and occluders, and every connection's absolute doorway pair (#929 T3 —
 // the read surface promised by RoomInput.Origin's doc comment).
 type Atlas struct {
-	// Rooms is every room's absolute footprint, sorted by room ID (C8).
-	Rooms []AtlasRoom
+	// Regions is every region, sorted by region ID (C8).
+	Regions []AtlasRegion
 
 	// Doorways is every connection's absolute endpoint pair, sorted by
 	// connection ID (C8).
 	Doorways []AtlasDoorway
 }
 
-// AtlasRoom is one room's absolute-space footprint.
-type AtlasRoom struct {
-	// ID is the room's identifier.
-	ID string
+// AtlasRegion is one region: a NAMED SET OF CELLS, described rather than
+// enumerated (rpg-toolkit#1108).
+//
+// Grid, Origin, Width and Height ARE the cell set — they say exactly which
+// cells belong to this region, in the same terms the region's own grid uses to
+// decide it, and [Encounter.RegionAt] answers membership from them without
+// anybody building a list. A host that genuinely wants the cells (a renderer
+// laying out a floor) can walk that rectangle itself; every other caller was
+// paying for one.
+type AtlasRegion struct {
+	// ID is the region's identifier — the authored room's own ID.
+	ID RegionID
 
-	// Grid is the room's coordinate family (GridShapeSquare or GridShapeHex).
+	// Grid is the region's coordinate family (GridShapeSquare or GridShapeHex).
 	Grid spatial.GridShape
 
-	// Origin is the room's dungeon-absolute anchor (RoomInput.Origin).
+	// Origin is the region's dungeon-absolute anchor (RoomInput.Origin).
 	Origin spatial.Position
 
-	// Width is the room's horizontal dimension.
+	// Width is the region's horizontal dimension, in cells.
 	Width int
 
-	// Height is the room's vertical dimension.
+	// Height is the region's vertical dimension, in cells.
 	Height int
 
-	// Cells is every cell of the room, in dungeon-absolute space, in
-	// grid-iteration order (atlasCells) — always populated regardless of
-	// occupancy or occlusion: occlusion is walkability, not ownership
-	// (#929 T3 ruling 1).
-	Cells []spatial.Position
-
-	// Occluders is the room's line-of-sight-blocking cells, in
-	// dungeon-absolute space. Reported separately from Cells so a host
-	// can render them distinctly (#929 T3 ruling 1).
+	// Occluders is the region's line-of-sight-blocking cells, in
+	// dungeon-absolute space. An occluder is still a cell OF the region —
+	// occlusion is walkability, not ownership (#929 T3 ruling 1), and
+	// RegionAt names an occluded cell's region like any other.
 	Occluders []spatial.Position
 
-	// Boundaries is the room's walls (RoomInput.Boundaries), with both
+	// Boundaries is the region's walls (RoomInput.Boundaries), with both
 	// endpoints projected into dungeon-absolute space (#929 hardening round
 	// A) — the SAME projection compileCanvas registers them by, so what a
 	// host draws and what the encounter enforces are the same edges.
 	//
-	// An endpoint may belong to the room NEXT DOOR: a chamber walls its own
+	// An endpoint may belong to the region NEXT DOOR: a chamber walls its own
 	// edge by naming the cell beyond it, which is what makes a wall between
 	// two authored rooms expressible at all (rpg-toolkit#1106,
-	// RoomInput.Boundaries' doc comment). Grouping such a wall under the room
+	// RoomInput.Boundaries' doc comment). Grouping such a wall under the region
 	// that DECLARED it is construction truth reported faithfully, not a claim
-	// about which room the wall belongs to. In declaration order (RoomInput's own
-	// order, the same construction-truth ordering Occluders already
+	// about which region the wall belongs to. In declaration order (RoomInput's
+	// own order, the same construction-truth ordering Occluders already
 	// uses above) — deterministic given a fixed input (C8), though not
-	// independently sorted the way Rooms/Doorways are.
+	// independently sorted the way Regions/Doorways are.
 	Boundaries []AtlasBoundary
 }
 
@@ -86,18 +89,22 @@ type AtlasBoundary struct {
 }
 
 // AtlasDoorway is one connection's absolute endpoint pair.
+//
+// Both endpoint cells belong to their own regions and nothing sits between
+// them (W3) — a doorway is an opening in a wall, not a cell of its own. See
+// [Encounter.RegionAt] for what that means for somebody standing in one.
 type AtlasDoorway struct {
 	// Connection is the connection's identifier.
 	Connection string
 
-	// From is the source room ID.
-	From string
+	// From is the source region ID.
+	From RegionID
 
 	// FromCell is the connection's endpoint in From, in dungeon-absolute space.
 	FromCell spatial.Position
 
-	// To is the destination room ID.
-	To string
+	// To is the destination region ID.
+	To RegionID
 
 	// ToCell is the connection's endpoint in To, in dungeon-absolute space.
 	ToCell spatial.Position
@@ -110,69 +117,41 @@ type AtlasDoorway struct {
 // placing/moving a member or Pumping a tick never changes it (#929 T3
 // ruling 3).
 //
-// Deterministic (C8): Rooms sorted by room ID, Doorways sorted by
-// connection ID, each room's Cells in grid-iteration order (atlasCells'
-// Q-outer/R-inner nesting), each room's Boundaries in declaration order
-// (RoomInput's own order, same as Occluders — #929 hardening round A).
-// Copy-out: every returned slice is freshly allocated per call; mutating
-// the result never reaches internal state.
+// O(REGIONS + CONNECTIONS, rpg-toolkit#1108), and that is the whole point of
+// the shape it has. It used to enumerate every cell of every region: at the
+// legal field budget — four 1024x1024 rooms, a blob well under a kilobyte —
+// one call allocated 128 MB and took 43 ms, repeatably, because nothing was
+// memoized and every call redid it (measured again on the post-S0 shape:
+// 128.02 MB cold, 43.3 ms; 128.01 MB and 20.9 ms on a repeat call). #1059
+// found that cost paying for a caller who wanted the grid FAMILY and nothing
+// else, and added [Encounter.Grid] beside it; this is the other half of that
+// finding. A region reports what it IS — anchor, span, family — and
+// [Encounter.RegionAt] answers membership from that in O(regions) without
+// anybody building a list. The same field now measures 624 bytes and 8
+// microseconds per call (TestAtlasReportsRegionsWithoutEnumeratingThem).
 //
-// Cost: O(total cells across all rooms) by contract — Atlas enumerates
-// every cell of every room, via a make() sized exactly Width*Height per
-// room (atlasCells). This is BOUNDED, not merely documented:
-// maxRoomCells/maxFieldCells (encounter.go) reject an oversized room or
-// field at room legality — the shared path both NewEncounter and
-// LoadEncounter route through — before an Encounter exists to call Atlas
-// on. Before that bound existed, this comment claimed a legal-but-absurd
-// room would merely "allocate enormously" and that the wire "cannot
-// practically carry" one — both wrong (#929 T3 Opus round F1): a
-// 2^30 x 2^30 room, legal under maxRoomSpan's per-axis check alone,
-// PANICS atlasCells' make() (a 2^60-capacity argument), and the wire
-// carries the two integers that produce it in a few hundred bytes — not
-// impractically, trivially. Reject-never-crash is module law
-// (LoadEncounter's doc comment); this was the trust boundary.
+// Deterministic (C8): Regions sorted by region ID, Doorways sorted by
+// connection ID, each region's Boundaries and Occluders in declaration order
+// (RoomInput's own order — #929 hardening round A). Copy-out: every returned
+// slice is freshly allocated per call; mutating the result never reaches
+// internal state.
 //
-// Bounded is not the same as cheap (#929 hardening round I): at the
-// field budget — four 1024×1024 rooms, a legal field whose persisted
-// blob is well under a kilobyte (measured: 573 bytes) — a single Atlas()
-// call allocates on the order of 128 MB (measured via runtime.MemStats'
-// TotalAlloc delta: ~134 MB, i.e. exactly maxFieldCells cells at 16
-// bytes each, doubled by atlasCells' local enumeration plus its
-// Origin-projected copy) and takes tens of milliseconds (measured:
-// ~60-65ms cold, ~45-50ms on a repeat call), REPEATABLY — every call
-// redoes the same work, nothing is memoized internally. Hosts that call
-// Atlas() per request rather than per encounter will feel this; cache
-// the returned Atlas per encounter instead. Caching is trivially safe
-// here specifically because Atlas is pure construction-truth (ruling 3
-// above) — no live state can make a cached snapshot stale; only a
-// reload (LoadEncounter, which returns a new *Encounter) requires a
-// fresh call.
-//
-// Occluders are map data, not entities: every occluder cell is also an
-// AtlasRoom.Cells entry (AtlasRoom.Occluders is a SUBSET of
-// AtlasRoom.Cells — TestAtlasRoomCellsAndOccludersAreAbsolute), which is
-// why occluders must be integral in every family (encounter.go's
-// occluder-integrality check, #929 T3 Opus round F2). A MEMBER's
-// position is different in kind — an entity's position, not a map cell
-// — and on a fractional-tolerant square grid it may sit anywhere in a
-// room's continuous span, coinciding with no integer cell in
-// AtlasRoom.Cells at all; hex forbids fractional member positions entirely
-// (isIntegralAxialPosition), so this only affects square hosts (#929 T3
-// Opus round F4). The asymmetry — occluders must be integral, member
-// positions may be fractional — is deliberate: one is floor/blockage
-// data Atlas enumerates, the other is a live position Atlas never
-// touches.
+// Occluders are map data, not entities: an occluder cell is a cell OF its
+// region (RegionAt names it like any other), which is why occluders must be
+// integral in every family (encounter.go's occluder-integrality check, #929 T3
+// Opus round F2). A MEMBER's position is different in kind — an entity's
+// position, not a map cell — and on a fractional-tolerant square grid it may
+// sit anywhere in a region's continuous span, coinciding with no integer cell
+// at all; hex forbids fractional member positions entirely
+// (isIntegralAxialPosition), so this only affects square hosts (#929 T3 Opus
+// round F4). The asymmetry — occluders must be integral, member positions may
+// be fractional — is deliberate: one is floor/blockage data, the other is a
+// live position the Atlas never touches.
 func (e *Encounter) Atlas() (Atlas, error) {
 	roomsByID := make(map[string]RoomInput, len(e.fieldInput))
-	rooms := make([]AtlasRoom, len(e.fieldInput))
+	regions := make([]AtlasRegion, len(e.fieldInput))
 	for i, ri := range e.fieldInput {
 		roomsByID[ri.ID] = ri
-
-		local := atlasCells(ri.Grid, ri.Width, ri.Height)
-		cells := make([]spatial.Position, len(local))
-		for j, c := range local {
-			cells[j] = c.Add(ri.Origin)
-		}
 
 		occluders := make([]spatial.Position, len(ri.Occluders))
 		for j, o := range ri.Occluders {
@@ -189,20 +168,19 @@ func (e *Encounter) Atlas() (Atlas, error) {
 			}
 		}
 
-		rooms[i] = AtlasRoom{
+		regions[i] = AtlasRegion{
 			ID:         ri.ID,
 			Grid:       ri.Grid,
 			Origin:     ri.Origin,
 			Width:      ri.Width,
 			Height:     ri.Height,
-			Cells:      cells,
 			Occluders:  occluders,
 			Boundaries: boundaries,
 		}
 	}
 	// LOAD-BEARING: fieldInput is never sorted anywhere else — this sort is
-	// the only thing establishing C8 order for Rooms.
-	sort.Slice(rooms, func(i, j int) bool { return rooms[i].ID < rooms[j].ID })
+	// the only thing establishing C8 order for Regions.
+	sort.Slice(regions, func(i, j int) bool { return regions[i].ID < regions[j].ID })
 
 	doorways := make([]AtlasDoorway, len(e.connectionsInput))
 	for i, ci := range e.connectionsInput {
@@ -218,7 +196,7 @@ func (e *Encounter) Atlas() (Atlas, error) {
 	// both NewEncounter and LoadEncounter (encounter.go, data.go) before
 	// Atlas ever runs — but kept anyway so Atlas's own C8 determinism is
 	// self-contained rather than coupled to an invariant maintained in two
-	// OTHER files. Unlike the Rooms sort above (load-bearing: fieldInput is
+	// OTHER files. Unlike the Regions sort above (load-bearing: fieldInput is
 	// never pre-sorted), a future editor deleting this "redundant" sort
 	// would find no failing test today — exactly the trap this comment
 	// exists to prevent (#929 T3 fix round item 4; mutation evidence: the
@@ -226,7 +204,7 @@ func (e *Encounter) Atlas() (Atlas, error) {
 	// on any normally-constructed encounter).
 	sort.Slice(doorways, func(i, j int) bool { return doorways[i].Connection < doorways[j].Connection })
 
-	return Atlas{Rooms: rooms, Doorways: doorways}, nil
+	return Atlas{Regions: regions, Doorways: doorways}, nil
 }
 
 // Grid reports the field's coordinate family — GridShapeSquare or
@@ -237,10 +215,14 @@ func (e *Encounter) Atlas() (Atlas, error) {
 // answer and every room agrees with it.
 //
 // It exists because the answer was only reachable through [Encounter.Atlas],
-// which enumerates every cell of every room to get there — measured at ~128MB
-// and tens of milliseconds at the legal field budget, unmemoized (Atlas's own
-// doc). A caller that needs the family and nothing else was paying the whole
-// map for one enum, on a per-request path (rpg-toolkit#1059 finding 2).
+// which enumerated every cell of every room to get there — measured at ~128MB
+// and tens of milliseconds at the legal field budget, unmemoized. A caller that
+// needed the family and nothing else was paying the whole map for one enum, on
+// a per-request path (rpg-toolkit#1059 finding 2). The Atlas stopped
+// enumerating in rpg-toolkit#1108, which is the other half of that same
+// finding; this stays because O(1) is still the right cost for one enum, and
+// because a caller doing grid arithmetic should not have to read a map to
+// learn which arithmetic to do.
 //
 // WHO NEEDS IT: anything doing grid arithmetic of its own, and the reason that
 // is not merely a convenience is that the two families disagree about what one
@@ -261,39 +243,4 @@ func (e *Encounter) Grid() (spatial.GridShape, error) {
 		return unknown, fmt.Errorf("grid: %w", ErrNoField)
 	}
 	return e.fieldInput[0].Grid, nil
-}
-
-// atlasCells re-derives a room's local, integral cell coordinates for
-// Atlas. T1 deleted the original enumeration helper (roomLocalCells)
-// when W2 went interval-based (axisBounds' doc comment, encounter.go) —
-// this is a fresh implementation, not a resurrection, proven against
-// spatial's own IsValidPosition by TestAtlasCellsMatchIsValidPosition
-// (#929 T3 ruling 4).
-//
-// Built on axisBounds (encounter.go), the same min/max primitive W2
-// already trusts: enumerates every integer in
-// [axisBounds(shape,width).min, axisBounds(shape,width).max] crossed
-// with [axisBounds(shape,height).min, axisBounds(shape,height).max], Q
-// (X) outer, R (Y) inner — deterministic, grid-iteration order.
-func atlasCells(shape spatial.GridShape, width, height int) []spatial.Position {
-	qMin, qMax := axisBounds(shape, width)
-	rMin, rMax := axisBounds(shape, height)
-
-	// SAFE: (qMax-qMin+1)*(rMax-rMin+1) always equals width*height (both
-	// families — axisBounds' doc comment, encounter.go), and width*height is
-	// bounded by maxRoomCells at room legality (encounter.go) BEFORE any
-	// RoomInput reaches here — the only path to a RoomInput is
-	// buildValidRoomGrids, which every construction seam routes through.
-	// No redundant check here (#929 T3 Opus round F1 ruling): a future
-	// editor who relaxes maxRoomCells without reading this comment
-	// reintroduces the panic this bound exists to prevent — the
-	// doorway-sort lesson, applied to an allocation instead of an
-	// ordering invariant.
-	cells := make([]spatial.Position, 0, (qMax-qMin+1)*(rMax-rMin+1))
-	for q := qMin; q <= qMax; q++ {
-		for r := rMin; r <= rMax; r++ {
-			cells = append(cells, spatial.Position{X: float64(q), Y: float64(r)})
-		}
-	}
-	return cells
 }

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -222,6 +222,8 @@ func (s *EncounterTestSuite) TestAtlasRegionOccludersAndBoundariesAreAbsolute() 
 	s.Require().True(found, "atlas-r1 must be present")
 
 	s.Require().Equal(spatial.Position{X: 0, Y: 7}, r1.Origin, "the region's anchor is where its local (0,0) landed")
+	s.Require().Equal(4, r1.Width, "the span is the region's cell set, so the axes must not be swapped")
+	s.Require().Equal(3, r1.Height)
 	s.Require().Equal([]spatial.Position{{X: 1, Y: 8}}, r1.Occluders, "occluder must be offset by Origin too")
 
 	// The span means cells: local (0,0) and the far corner local (3,2) are

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -122,13 +122,19 @@ func bruteForceLocalCells(shape spatial.GridShape, width, height int) []spatial.
 	return cells
 }
 
-// TestAtlasCellsMatchIsValidPosition is the ruling-4 property test: for a
-// spread of dimension parities (odd, even, and 1xN thin rooms) across
-// both grid families, Atlas's room Cells (Origin zero, so absolute ==
-// local) must be EXACTLY the set spatial's own IsValidPosition accepts —
-// not a subset, not a superset. A one-cell span drift in the enumerator
-// fails this for some parity in the spread.
-func (s *EncounterTestSuite) TestAtlasCellsMatchIsValidPosition() {
+// TestRegionMembershipMatchesIsValidPosition is the ruling-4 property test,
+// asked of the thing that answers membership now (rpg-toolkit#1108). For a
+// spread of dimension parities (odd, even, and 1xN thin rooms) across both grid
+// families, the cells RegionAt claims for a region (Origin zero, so absolute ==
+// local) must be EXACTLY the set spatial's own IsValidPosition accepts — not a
+// subset, not a superset. A one-cell span drift fails this for some parity in
+// the spread.
+//
+// It used to compare Atlas's enumerated Cells against the same brute-force set.
+// The Atlas no longer enumerates, and this is the stronger question anyway: it
+// pins the lookup every verb in the module actually consults, rather than a
+// parallel enumerator that agreed with it.
+func (s *EncounterTestSuite) TestRegionMembershipMatchesIsValidPosition() {
 	dims := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	shapes := map[string]spatial.GridShape{"square": spatial.GridShapeSquare, "hex": spatial.GridShapeHex}
 
@@ -139,13 +145,15 @@ func (s *EncounterTestSuite) TestAtlasCellsMatchIsValidPosition() {
 					enc, err := encounter.NewEncounter(singleRoomSetup(shape, w, h))
 					s.Require().NoError(err)
 
-					atlas, err := enc.Atlas()
-					s.Require().NoError(err)
-					s.Require().Len(atlas.Rooms, 1)
-
-					got := make(map[spatial.Position]bool, len(atlas.Rooms[0].Cells))
-					for _, c := range atlas.Rooms[0].Cells {
-						got[c] = true
+					pad := w + h + 4 // generous — bigger than any valid span in either family
+					got := make(map[spatial.Position]bool)
+					for x := -pad; x <= pad; x++ {
+						for y := -pad; y <= pad; y++ {
+							cell := spatial.Position{X: float64(x), Y: float64(y)}
+							if _, owned := enc.RegionAt(cell); owned {
+								got[cell] = true
+							}
+						}
 					}
 
 					want := make(map[spatial.Position]bool)
@@ -154,14 +162,14 @@ func (s *EncounterTestSuite) TestAtlasCellsMatchIsValidPosition() {
 					}
 
 					s.Require().Equal(want, got,
-						"atlasCells must agree exactly with spatial's own IsValidPosition")
+						"RegionAt must agree exactly with spatial's own IsValidPosition")
 				})
 			}
 		}
 	}
 }
 
-// TestAtlasDeterministicOrdering pins C8: Rooms sorted by room ID and
+// TestAtlasDeterministicOrdering pins C8: Regions sorted by region ID and
 // Doorways sorted by connection ID, regardless of declaration order —
 // validAtlasOrderingSetup declares both scrambled.
 func (s *EncounterTestSuite) TestAtlasDeterministicOrdering() {
@@ -171,12 +179,12 @@ func (s *EncounterTestSuite) TestAtlasDeterministicOrdering() {
 	atlas, err := enc.Atlas()
 	s.Require().NoError(err)
 
-	gotRoomIDs := make([]string, len(atlas.Rooms))
-	for i, r := range atlas.Rooms {
-		gotRoomIDs[i] = r.ID
+	gotRegionIDs := make([]encounter.RegionID, len(atlas.Regions))
+	for i, r := range atlas.Regions {
+		gotRegionIDs[i] = r.ID
 	}
-	s.Require().Equal([]string{"atlas-r1", "atlas-r2", "atlas-r3", "atlas-r4"}, gotRoomIDs,
-		"Rooms must be sorted by ID regardless of declaration order")
+	s.Require().Equal([]encounter.RegionID{"atlas-r1", "atlas-r2", "atlas-r3", "atlas-r4"}, gotRegionIDs,
+		"Regions must be sorted by ID regardless of declaration order")
 
 	gotConnIDs := make([]string, len(atlas.Doorways))
 	for i, d := range atlas.Doorways {
@@ -186,23 +194,26 @@ func (s *EncounterTestSuite) TestAtlasDeterministicOrdering() {
 		"Doorways must be sorted by connection ID regardless of declaration order")
 }
 
-// TestAtlasRoomCellsAndOccludersAreAbsolute pins exact absolute values —
+// TestAtlasRegionOccludersAndBoundariesAreAbsolute pins exact absolute values —
 // local cell + Origin, element-wise — and would die under a sign-flipped
-// Add-vs-Subtract mutant inside Atlas itself (distinct from the same
-// mutant inside Absolute/Locate, pinned separately). Also pins
-// AtlasBoundary's absolute projection (#929 hardening round A): both
-// endpoints offset by Origin, independently — a mutant that projects only
-// From, or swaps From/To, changes one or both expected values here.
-func (s *EncounterTestSuite) TestAtlasRoomCellsAndOccludersAreAbsolute() {
+// Add-vs-Subtract mutant inside Atlas itself. Also pins AtlasBoundary's
+// absolute projection (#929 hardening round A): both endpoints offset by
+// Origin, independently — a mutant that projects only From, or swaps From/To,
+// changes one or both expected values here.
+//
+// The region's own footprint is pinned beside it through RegionAt rather than
+// through an enumerated cell list (rpg-toolkit#1108): the anchor and span the
+// region reports have to mean the cells it actually holds.
+func (s *EncounterTestSuite) TestAtlasRegionOccludersAndBoundariesAreAbsolute() {
 	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
 	s.Require().NoError(err)
 
 	atlas, err := enc.Atlas()
 	s.Require().NoError(err)
 
-	var r1 encounter.AtlasRoom
+	var r1 encounter.AtlasRegion
 	found := false
-	for _, r := range atlas.Rooms {
+	for _, r := range atlas.Regions {
 		if r.ID == "atlas-r1" {
 			r1 = r
 			found = true
@@ -210,15 +221,24 @@ func (s *EncounterTestSuite) TestAtlasRoomCellsAndOccludersAreAbsolute() {
 	}
 	s.Require().True(found, "atlas-r1 must be present")
 
-	s.Require().Contains(r1.Cells, spatial.Position{X: 0, Y: 7}, "local (0,0) projected through Origin")
-	s.Require().Contains(r1.Cells, spatial.Position{X: 3, Y: 9}, "local (3,2), the far corner, projected through Origin")
+	s.Require().Equal(spatial.Position{X: 0, Y: 7}, r1.Origin, "the region's anchor is where its local (0,0) landed")
 	s.Require().Equal([]spatial.Position{{X: 1, Y: 8}}, r1.Occluders, "occluder must be offset by Origin too")
 
-	// #929 T3 fix round item 3: an occluder's cell is floor AND blockage —
-	// it must appear in BOTH Cells and Occluders (ruling 1: occlusion is
-	// walkability, not ownership). This is the property hosts actually
-	// render by: floor from Cells, blockage layered from Occluders.
-	s.Require().Contains(r1.Cells, spatial.Position{X: 1, Y: 8}, "an occluded cell is still floor — it must appear in Cells too")
+	// The span means cells: local (0,0) and the far corner local (3,2) are
+	// both this region's, in absolute space, and RegionAt is what says so.
+	for _, cell := range []spatial.Position{{X: 0, Y: 7}, {X: 3, Y: 9}} {
+		got, owned := enc.RegionAt(cell)
+		s.Require().True(owned, "cell %v is floor", cell)
+		s.Require().Equal(encounter.RegionID("atlas-r1"), got, "cell %v", cell)
+	}
+
+	// #929 T3 fix round item 3: an occluder's cell is floor AND blockage
+	// (ruling 1: occlusion is walkability, not ownership). This is the
+	// property hosts render by — floor from the region's span, blockage
+	// layered from Occluders — and RegionAt is where it is now visible.
+	got, owned := enc.RegionAt(spatial.Position{X: 1, Y: 8})
+	s.Require().True(owned, "an occluded cell is still floor")
+	s.Require().Equal(encounter.RegionID("atlas-r1"), got)
 
 	// #929 hardening round A: local (0,0)-(1,0) projected through Origin
 	// (0,7) — BOTH endpoints offset, flags carried through unchanged.
@@ -283,15 +303,12 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 	atlas1, err := enc.Atlas()
 	s.Require().NoError(err)
 
-	for i := range atlas1.Rooms {
-		for j := range atlas1.Rooms[i].Cells {
-			atlas1.Rooms[i].Cells[j] = spatial.Position{X: -999, Y: -999}
+	for i := range atlas1.Regions {
+		for j := range atlas1.Regions[i].Occluders {
+			atlas1.Regions[i].Occluders[j] = spatial.Position{X: -999, Y: -999}
 		}
-		for j := range atlas1.Rooms[i].Occluders {
-			atlas1.Rooms[i].Occluders[j] = spatial.Position{X: -999, Y: -999}
-		}
-		for j := range atlas1.Rooms[i].Boundaries {
-			atlas1.Rooms[i].Boundaries[j] = encounter.AtlasBoundary{
+		for j := range atlas1.Regions[i].Boundaries {
+			atlas1.Regions[i].Boundaries[j] = encounter.AtlasBoundary{
 				From: spatial.Position{X: -999, Y: -999}, To: spatial.Position{X: -999, Y: -999},
 			}
 		}
@@ -304,16 +321,14 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 	atlas2, err := enc.Atlas()
 	s.Require().NoError(err)
 
-	var r1 encounter.AtlasRoom
-	for _, r := range atlas2.Rooms {
+	var r1 encounter.AtlasRegion
+	for _, r := range atlas2.Regions {
 		if r.ID == "atlas-r1" {
 			r1 = r
 		}
 	}
 	s.Require().Equal([]spatial.Position{{X: 1, Y: 8}}, r1.Occluders,
 		"mutating the first snapshot's Occluders must not corrupt internal state")
-	s.Require().Contains(r1.Cells, spatial.Position{X: 0, Y: 7},
-		"mutating the first snapshot's Cells must not corrupt internal state")
 	s.Require().Equal(spatial.Position{X: 3, Y: 8}, atlas2.Doorways[0].FromCell,
 		"mutating the first snapshot's Doorways must not corrupt internal state")
 	s.Require().Equal([]encounter.AtlasBoundary{
@@ -327,17 +342,13 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 // encounter's Atlas, captured before ToData/LoadEncounter and again after,
 // must be deep-equal (#929 T3 fix round item 2).
 //
-// This proves Cells ordering is DETERMINISTIC across a reload — not that
-// the order is any PARTICULAR order (#929 hardening round, test-gap
-// closure item 2 — corrects this comment's earlier "including Cells
-// ordering" claim, which overclaimed what a same-enumerator comparison
-// can show): both atlas1 and atlas2 are produced by calling the exact
-// SAME atlasCells enumerator, so a mutant that reordered atlasCells
-// itself (e.g. swapping its Q-outer/R-inner nesting to R-outer/Q-inner)
-// would reorder BOTH calls identically and still pass here. The exact,
-// intended order is pinned separately, against a hand-computed fixture
-// independent of atlasCells' own implementation, by
-// TestAtlasCellsExactOrder.
+// What it can show is that a reload changes NOTHING the Atlas reports — every
+// region's anchor, span, occluders and walls, and every doorway's endpoints,
+// come back identical. It cannot show that any of them is the INTENDED value,
+// since both sides are produced by the same code from the same construction
+// data; the intended values are pinned against hand-computed fixtures by
+// TestAtlasRegionOccludersAndBoundariesAreAbsolute and
+// TestAtlasDoorwaysAreAbsolute.
 func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 	enc1, err := encounter.NewEncounter(validAtlasOrderingSetup())
 	s.Require().NoError(err)
@@ -353,44 +364,20 @@ func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 	atlas2, err := enc2.Atlas()
 	s.Require().NoError(err)
 
-	s.Require().Equal(atlas1, atlas2, "Atlas must be identical after a ToData/LoadEncounter round trip — deterministic, though this alone cannot prove the order is the INTENDED one (see TestAtlasCellsExactOrder)")
+	s.Require().Equal(atlas1, atlas2, "Atlas must be identical after a ToData/LoadEncounter round trip")
 }
 
-// TestAtlasCellsExactOrder pins atlasCells' Q-outer/R-inner nesting order
-// exactly, against a fixture independent of atlasCells' own
-// implementation (#929 hardening round, test-gap closure item 2):
-// TestAtlasCellsMatchIsValidPosition only proves SET membership (both
-// sides are compared as maps), and TestAtlasIdenticalAfterReload only
-// proves the SAME enumerator is deterministic across two calls — neither
-// can catch a reordering that both calls agree on, such as swapping
-// atlasCells' outer/inner loop nesting. A small, hand-computed 2x3
-// square room (Origin zero, so absolute == local) makes the full
-// expected order easy to verify by inspection: Q outer over X∈[0,1], R
-// inner over Y∈[0,2].
-func (s *EncounterTestSuite) TestAtlasCellsExactOrder() {
-	enc, err := encounter.NewEncounter(singleRoomSetup(spatial.GridShapeSquare, 2, 3))
-	s.Require().NoError(err)
-
-	atlas, err := enc.Atlas()
-	s.Require().NoError(err)
-	s.Require().Len(atlas.Rooms, 1)
-
-	s.Require().Equal([]spatial.Position{
-		{X: 0, Y: 0}, {X: 0, Y: 1}, {X: 0, Y: 2},
-		{X: 1, Y: 0}, {X: 1, Y: 1}, {X: 1, Y: 2},
-	}, atlas.Rooms[0].Cells, "atlasCells must iterate Q (X) outer, R (Y) inner, in exactly this order")
-}
-
-// TestChamberOwnershipAtKissingDoorway pins the case that makes W2's
+// TestRegionOwnershipAtKissingDoorway pins the case that makes W2's
 // uniqueness meaningful: each doorway cell — immediately adjacent to a cell in
-// the OTHER chamber — belongs to its OWN chamber, not its neighbour's.
+// the OTHER region — belongs to its OWN region, not its neighbour's.
 //
 // It used to ask the Locate bridge, which is gone. The question survives it,
 // and it is asked the way it is asked now: a member standing on a cell is
-// reported in the chamber whose authored footprint holds it (rpg-toolkit#1106).
+// reported in the region whose cell set holds it (rpg-toolkit#1106, #1108).
 // The two members here stand one cell apart, on opposite sides of a doorway —
-// exactly the pair a room-membership answer has to get right.
-func (s *EncounterTestSuite) TestChamberOwnershipAtKissingDoorway() {
+// exactly the pair a membership answer has to get right, and the doorway
+// decision [Encounter.RegionAt] documents, seen from the roster.
+func (s *EncounterTestSuite) TestRegionOwnershipAtKissingDoorway() {
 	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
 	s.Require().NoError(err)
 
@@ -402,21 +389,21 @@ func (s *EncounterTestSuite) TestChamberOwnershipAtKissingDoorway() {
 		Member: "far", Kind: encounter.KindPlayer, Cell: spatial.Position{X: 4, Y: 8}})
 	s.Require().NoError(err)
 
-	rooms := map[encounter.MemberID]string{}
+	regions := map[encounter.MemberID]encounter.RegionID{}
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	for _, m := range members {
-		rooms[m.ID] = m.Room
+		regions[m.ID] = m.Region
 	}
-	s.Require().Equal("atlas-r1", rooms["near"], "the doorway cell in atlas-r1 belongs to atlas-r1, not atlas-r2")
-	s.Require().Equal("atlas-r2", rooms["far"], "the doorway cell in atlas-r2 belongs to atlas-r2, not atlas-r1")
+	s.Require().Equal(encounter.RegionID("atlas-r1"), regions["near"], "the doorway cell in atlas-r1 belongs to atlas-r1, not atlas-r2")
+	s.Require().Equal(encounter.RegionID("atlas-r2"), regions["far"], "the doorway cell in atlas-r2 belongs to atlas-r2, not atlas-r1")
 }
 
 // TestAnOccludedCellIsStillFloor pins ruling 1 in the terms that survive the
 // bridges: occlusion is walkability, not ownership. A member standing on an
-// occluder's own cell is reported in the chamber that owns it, exactly as one
-// on an empty cell is — the Atlas already reports occluders as a SUBSET of
-// Cells (TestAtlasRoomCellsAndOccludersAreAbsolute), and this is the runtime
+// occluder's own cell is reported in the region that owns it, exactly as one on
+// an empty cell is — RegionAt names an occluded cell like any other
+// (TestAtlasRegionOccludersAndBoundariesAreAbsolute), and this is the runtime
 // half of the same claim.
 func (s *EncounterTestSuite) TestAnOccludedCellIsStillFloor() {
 	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
@@ -431,7 +418,7 @@ func (s *EncounterTestSuite) TestAnOccludedCellIsStillFloor() {
 	s.Require().NoError(err)
 	for _, m := range members {
 		if m.ID == "onTheRubble" {
-			s.Require().Equal("atlas-r1", m.Room)
+			s.Require().Equal(encounter.RegionID("atlas-r1"), m.Region)
 			s.Require().Equal(spatial.Position{X: 1, Y: 8}, m.Position)
 			return
 		}

--- a/rulebooks/dnd5e/encounter/atlascost_test.go
+++ b/rulebooks/dnd5e/encounter/atlascost_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 // budgetField is the LARGEST LEGAL field: four 1024x1024 rooms, exactly
-// maxFieldCells (1<<22) cells between them, in a blob measured at 573 bytes.
-// The gap between what a field COSTS TO SAY and what it used to cost to READ is
-// the whole subject of the test below.
+// maxFieldCells (1<<22) cells between them — which the encounter below persists
+// in 601 bytes, measured. The gap between what a field COSTS TO SAY and what it
+// used to cost to READ is the whole subject of the test.
 func budgetField() encounter.FieldInput {
 	const dim = 1024
 	return encounter.FieldInput{

--- a/rulebooks/dnd5e/encounter/atlascost_test.go
+++ b/rulebooks/dnd5e/encounter/atlascost_test.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// budgetField is the LARGEST LEGAL field: four 1024x1024 rooms, exactly
+// maxFieldCells (1<<22) cells between them, in a blob measured at 573 bytes.
+// The gap between what a field COSTS TO SAY and what it used to cost to READ is
+// the whole subject of the test below.
+func budgetField() encounter.FieldInput {
+	const dim = 1024
+	return encounter.FieldInput{
+		Rooms: []encounter.RoomInput{
+			{ID: "a", Width: dim, Height: dim, Origin: spatial.Position{X: 0, Y: 0}},
+			{ID: "b", Width: dim, Height: dim, Origin: spatial.Position{X: dim, Y: 0}},
+			{ID: "c", Width: dim, Height: dim, Origin: spatial.Position{X: 0, Y: dim}},
+			{ID: "d", Width: dim, Height: dim, Origin: spatial.Position{X: dim, Y: dim}},
+		},
+	}
+}
+
+// TestAtlasReportsRegionsWithoutEnumeratingThem is the cost half of
+// rpg-toolkit#1108, pinned as a property rather than left as a claim in a doc
+// comment.
+//
+// The Atlas used to materialize every cell of every room. At this field —
+// legal, and small to say — one call allocated 128.02 MB and took 43.3 ms,
+// repeatably, because nothing memoized it (measured on the post-S0 shape, which
+// is where this slice starts). #1059 found that cost being paid by callers who
+// wanted the grid FAMILY and nothing else and added Encounter.Grid beside it;
+// this is the other half of the same finding.
+//
+// A region reports what it IS — anchor, span, family — and RegionAt answers
+// membership from that. So the report is O(regions), and a host that genuinely
+// wants cells walks a rectangle it was handed rather than one the module built
+// for it. The bound is deliberately loose (1 MB against a measured 624 bytes): this
+// is pinning an ORDER OF GROWTH, and a tight bound would fail on an unrelated
+// allocation without saying anything true.
+func TestAtlasReportsRegionsWithoutEnumeratingThem(t *testing.T) {
+	t.Run("a region describes its cells rather than listing them", func(t *testing.T) {
+		require.Equal(t,
+			[]string{"ID", "Grid", "Origin", "Width", "Height", "Occluders", "Boundaries"},
+			structFieldNames(encounter.AtlasRegion{}),
+			"an AtlasRegion is an anchor and a span; a cell list would be the enumeration this slice deleted")
+	})
+
+	t.Run("and reporting them costs O(regions), not O(cells)", func(t *testing.T) {
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: budgetField(),
+			Members: []encounter.MemberInput{
+				{ID: alice, Kind: encounter.KindPlayer, Room: "a", Position: spatial.Position{X: 1, Y: 1}},
+			},
+			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		})
+		require.NoError(t, err)
+
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		atlas, err := enc.Atlas()
+		runtime.ReadMemStats(&after)
+		require.NoError(t, err)
+		require.Len(t, atlas.Regions, 4)
+
+		allocated := after.TotalAlloc - before.TotalAlloc
+		t.Logf("Atlas at the legal field budget (%d cells): %d bytes allocated", 4*1024*1024, allocated)
+		require.Less(t, allocated, uint64(1<<20),
+			"one Atlas call allocated %d bytes for a 4-region field — an enumeration has grown back "+
+				"(it was 134,225,920 bytes before rpg-toolkit#1108)", allocated)
+	})
+}

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -200,8 +200,8 @@ func (s *CanvasSuite) TestTheWallIsAnAbsoluteEdgeNotARoomsBusiness() {
 	s.Equal(tombAt(tombHallOrigin, 0, tombDoorRow-1), want.to, "the far endpoint is the HALL's cell")
 
 	var found bool
-	for _, room := range atlas.Rooms {
-		for _, b := range room.Boundaries {
+	for _, region := range atlas.Regions {
+		for _, b := range region.Boundaries {
 			if b.From == want.from && b.To == want.to {
 				found = true
 				s.True(b.BlocksLineOfSight)

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -184,14 +184,14 @@ func TestVaultChase(t *testing.T) {
 			goblinOutcome = m
 		}
 	}
-	require.Equal(t, vaultRoom, aliceOutcome.Room)
+	require.Equal(t, encounter.RegionID(vaultRoom), aliceOutcome.Region)
 	// Dungeon-absolute (#1068): the vault is anchored at (10,0), so her
 	// vault-local (8,8) is (18,8) on the map — the same frame every other
 	// cell in this scene is reported in.
 	require.Equal(t, spatial.Position{X: 18, Y: 8}, aliceOutcome.Position)
 	// The goblin made it across the threshold too — the outcome reflects
 	// where it TRULY stands, in the vault, not its pre-chase corridor spot.
-	require.Equal(t, vaultRoom, goblinOutcome.Room, "beat 5: the outcome reflects the goblin's post-traverse room")
+	require.Equal(t, encounter.RegionID(vaultRoom), goblinOutcome.Region, "beat 5: the outcome reflects the region the goblin finished in")
 	require.Equal(t, spatial.Position{X: 10, Y: 5}, goblinOutcome.Position, "vault-local (0,5) anchored at (10,0)")
 
 	status, err := enc.Status()

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -375,8 +375,8 @@ const commands = `  step <name> <x> <y>   walk one cell (dungeon-absolute; the w
   exit <name>           a player heads back to town (carry-forward prints)
   end withdrew          the party calls the delve off (External ending)
   save <file> / load <file>   the ONE aggregate blob, round-tripped
-  atlas                 the dungeon in absolute space — rooms placed by
-                        origin, every doorway's kissing pair made visible
+  atlas                 the dungeon in absolute space — each region's anchor
+                        and span, every doorway's kissing pair made visible
   status | help | quit`
 
 func main() {

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -163,7 +163,7 @@ func worldGrid(data encounter.EncounterData, members []encounter.Member, room st
 	}
 	origin := roomOrigin(r)
 	for _, m := range members {
-		if m.Room != room {
+		if m.Region != room {
 			continue
 		}
 		local := m.Position.Subtract(origin)
@@ -308,6 +308,21 @@ func printStatus(enc *encounter.Encounter) {
 // own bounds (SquareGrid.Distance and AxialHexGrid.Distance's own
 // implementations), so any instance of the right family computes the
 // correct distance between two dungeon-absolute doorway cells (#929 T5).
+// regionExtent is the absolute rectangle a region covers, from the anchor and
+// span it reports — the arithmetic AtlasRegion's doc comment describes, which
+// is all the Atlas hands out now that it no longer enumerates cells
+// (rpg-toolkit#1108). Square regions start at their origin; hex spans are
+// origin-centred.
+func regionExtent(r encounter.AtlasRegion) (qMin, qMax, rMin, rMax float64) {
+	if r.Grid == spatial.GridShapeHex {
+		qMin = r.Origin.X - float64(r.Width/2)
+		rMin = r.Origin.Y - float64(r.Height/2)
+	} else {
+		qMin, rMin = r.Origin.X, r.Origin.Y
+	}
+	return qMin, qMin + float64(r.Width) - 1, rMin, rMin + float64(r.Height) - 1
+}
+
 func atlasDistanceGrid(family spatial.GridShape) spatial.Grid {
 	if family == spatial.GridShapeHex {
 		return spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 100000, SpanHeight: 100000})
@@ -328,18 +343,14 @@ func printAtlas(enc *encounter.Encounter) {
 		return
 	}
 	fmt.Println("  ATLAS — the dungeon in absolute space")
-	for _, r := range atlas.Rooms {
-		qMin, qMax, rMin, rMax := r.Cells[0].X, r.Cells[0].X, r.Cells[0].Y, r.Cells[0].Y
-		for _, c := range r.Cells {
-			qMin, qMax = min(qMin, c.X), max(qMax, c.X)
-			rMin, rMax = min(rMin, c.Y), max(rMax, c.Y)
-		}
-		fmt.Printf("    room %-10s origin (%g,%g)  %dx%d  absolute x:[%g,%g] y:[%g,%g]\n",
+	for _, r := range atlas.Regions {
+		qMin, qMax, rMin, rMax := regionExtent(r)
+		fmt.Printf("    region %-10s origin (%g,%g)  %dx%d  absolute x:[%g,%g] y:[%g,%g]\n",
 			r.ID, r.Origin.X, r.Origin.Y, r.Width, r.Height, qMin, qMax, rMin, rMax)
 	}
 	for _, d := range atlas.Doorways {
 		var family spatial.GridShape
-		for _, r := range atlas.Rooms {
+		for _, r := range atlas.Regions {
 			if r.ID == d.From {
 				family = r.Grid
 			}
@@ -539,7 +550,7 @@ func showView(enc *encounter.Encounter, who core.EntityID) {
 	room := ""
 	for _, m := range members {
 		if m.ID == who {
-			room = m.Room
+			room = m.Region
 		}
 	}
 	if room == "" {

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -71,11 +71,17 @@ type OutcomeData struct {
 // anchor, and this is Kirk's fail-loudly ruling (2026-08-17) for the one
 // persisted shape in this family that could be given a detectable one.
 //
-// Room stays: MemberOutcome still carries it. The composition keeps rooms, it
-// only stops speaking them in coordinates.
+// THE REGION IS NOT STORED (rpg-toolkit#1108). It used to be, as "room", and it
+// was the last derived spatial fact this module persisted: which region holds a
+// member is a function of their cell and the authored field, both of which are
+// in the blob already. A stored copy could only ever agree with them or lie, so
+// load validation had to check it — a whole branch existing to police a second
+// truth. It is re-derived at load through the same [regionAt] every live read
+// uses, which is why a reloaded outcome cannot disagree with the one the host
+// already saw. Blobs written with the old key still load: the key is ignored
+// and the value recomputed, which is the same answer unless it was wrong.
 type MemberOutcomeData struct {
 	ID   MemberID      `json:"id"`
-	Room string        `json:"room"`
 	Cell *PositionData `json:"cell"`
 }
 
@@ -300,8 +306,7 @@ func (e *Encounter) ToData() EncounterData {
 		}
 		for i, mo := range e.outcome.Members {
 			outcomeData.Members[i] = MemberOutcomeData{
-				ID:   mo.ID,
-				Room: mo.Room,
+				ID: mo.ID,
 				// Always a fresh pointer, always written — RoomData.Origin's
 				// precedent — so presence itself is meaningful at load and two
 				// ToData calls never alias the same PositionData.
@@ -626,8 +631,8 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		// chamber's footprint must hold it. One check, two defects — a cell
 		// outside the field entirely, and a cell in the space BETWEEN chambers,
 		// which the canvas spans but which is not floor.
-		if !ownedByAnyRoom(roomInputs, roomGrids, cell) {
-			return nil, fmt.Errorf("load encounter: member %q cell is owned by no room: %w: %w", m.ID, ErrInvalidData, ErrBadPlacement)
+		if _, owned := regionAt(roomInputs, roomGrids, cell); !owned {
+			return nil, fmt.Errorf("load encounter: member %q cell is owned by no region: %w: %w", m.ID, ErrInvalidData, ErrBadPlacement)
 		}
 	}
 
@@ -653,10 +658,6 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		if data.Outcome.Ending == "abandoned" && len(data.Members) > 0 {
 			return nil, fmt.Errorf("load encounter: abandoned outcome with members present: %w: %w", ErrInvalidData, ErrNoMember)
 		}
-		origins := make(map[string]spatial.Position, len(roomInputs))
-		for _, ri := range roomInputs {
-			origins[ri.ID] = ri.Origin
-		}
 		for _, om := range data.Outcome.Members {
 			// A missing cell is how the pre-#1068 dialect announces itself:
 			// that blob's "position" key lands nowhere on today's shape, so
@@ -666,17 +667,14 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 			if om.Cell == nil {
 				return nil, fmt.Errorf("load encounter: outcome member %q has no cell — a room-local outcome from before rpg-toolkit#1068, recreate the save: %w: %w", om.ID, ErrInvalidData, ErrBadPlacement)
 			}
-			_, ok := roomGrids[om.Room]
-			if !ok {
-				return nil, fmt.Errorf("load encounter: outcome member %q room %q not in field: %w: %w", om.ID, om.Room, ErrInvalidData, ErrBadPlacement)
-			}
-			// The cell is absolute and the room's grid speaks local, so the
-			// bounds check is the projection run backwards. One check, two
-			// defects: a cell outside the field at all, and a cell that
-			// belongs to a room other than the one named beside it.
-			local := spatial.Position{X: om.Cell.X, Y: om.Cell.Y}.Subtract(origins[om.Room])
-			if !roomGrids[om.Room].IsValidPosition(local) {
-				return nil, fmt.Errorf("load encounter: outcome member %q position out of bounds: %w: %w", om.ID, ErrInvalidData, ErrBadPlacement)
+			// Where they finished has to be floor — the SAME question, asked
+			// the SAME way, as for a live member above. This used to be an
+			// inline third implementation of region ownership, checking the
+			// cell against the region NAMED BESIDE IT in the blob; with the
+			// region derived rather than stored there is nothing to
+			// cross-check, only somewhere to be (rpg-toolkit#1108).
+			if _, owned := regionAt(roomInputs, roomGrids, spatial.Position{X: om.Cell.X, Y: om.Cell.Y}); !owned {
+				return nil, fmt.Errorf("load encounter: outcome member %q cell is owned by no region: %w: %w", om.ID, ErrInvalidData, ErrBadPlacement)
 			}
 		}
 	}
@@ -891,14 +889,20 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 			Members: make([]MemberOutcome, len(data.Outcome.Members)),
 		}
 		for i, m := range data.Outcome.Members {
+			cell := spatial.Position{X: m.Cell.X, Y: m.Cell.Y}
+			region, _ := regionAt(roomInputs, roomGrids, cell)
 			outcome.Members[i] = MemberOutcome{
-				ID:   m.ID,
-				Room: m.Room,
-				// Stored and returned in the frame it was reported in — no
-				// re-derivation, so a reloaded outcome and the one the host
-				// already saw cannot disagree. Non-nil by R5: every cell was
-				// checked before construction began.
-				Position: spatial.Position{X: m.Cell.X, Y: m.Cell.Y},
+				ID: m.ID,
+				// The region is DERIVED from the cell, through the same
+				// lookup every live read uses (rpg-toolkit#1108). Ownership
+				// was checked for every outcome cell before construction
+				// began (R5), so this cannot come back empty.
+				Region: region,
+				// The cell is stored and returned in the frame it was
+				// reported in — no re-derivation, so a reloaded outcome and
+				// the one the host already saw cannot disagree. Non-nil by
+				// R5: every cell was checked before construction began.
+				Position: cell,
 			}
 		}
 		e.outcome = outcome
@@ -917,27 +921,6 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	sort.Slice(e.connectionsInput, func(i, j int) bool { return e.connectionsInput[i].ID < e.connectionsInput[j].ID })
 
 	return e, nil
-}
-
-// ownedByAnyRoom reports whether some authored chamber's footprint holds an
-// absolute cell — the load-time twin of [Encounter.roomAt], which cannot be used
-// here because it is a method on an Encounter that does not exist yet (R5: the
-// blob is validated in full before anything is constructed).
-//
-// No integrality check, for roomAt's reason: the caller asks first, and names
-// that defect as itself.
-func ownedByAnyRoom(rooms []RoomInput, grids map[string]spatial.Grid, cell spatial.Position) bool {
-	for _, ri := range rooms {
-		local := cell.Subtract(ri.Origin)
-		grid, ok := grids[ri.ID]
-		if !ok {
-			continue
-		}
-		if grid.IsValidPosition(local) {
-			return true
-		}
-	}
-	return false
 }
 
 // endingTriggerFromData converts one persisted ending's Kind/Room/Position/

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -627,10 +627,12 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		}
 
 		// The cell is absolute and every room's grid speaks its own local
-		// frame, so the bounds check runs the compile backwards: some authored
-		// chamber's footprint must hold it. One check, two defects — a cell
-		// outside the field entirely, and a cell in the space BETWEEN chambers,
-		// which the canvas spans but which is not floor.
+		// frame, so the bounds check runs the compile backwards: some region
+		// must hold it. One check, two defects — a cell outside the field
+		// entirely, and a cell in the space BETWEEN regions, which the canvas
+		// spans but which is not floor. The SAME lookup the live verbs use
+		// (rpg-toolkit#1108); it used to be a twin that had to be kept in step
+		// by hand.
 		if _, owned := regionAt(roomInputs, roomGrids, cell); !owned {
 			return nil, fmt.Errorf("load encounter: member %q cell is owned by no region: %w: %w", m.ID, ErrInvalidData, ErrBadPlacement)
 		}

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -935,7 +935,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		// blob written before the flip lands nowhere on today's shape and is
 		// refused by name rather than read in the wrong frame (see
 		// dialect_test.go).
-		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","room":"room1","cell":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
+		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","cell":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -1559,9 +1559,9 @@ func (s *DataTestSuite) TestLoadRejections() {
 		{"member cell absent — the pre-#1106 room-local dialect", func(d *encounter.EncounterData) {
 			d.Members[0].Cell = nil
 		}, "before rpg-toolkit#1106", encounter.ErrBadPlacement},
-		{"member cell owned by no room", func(d *encounter.EncounterData) {
+		{"member cell owned by no region", func(d *encounter.EncounterData) {
 			d.Members[0].Cell = &encounter.PositionData{X: 99, Y: 99}
-		}, "owned by no room", encounter.ErrBadPlacement},
+		}, "owned by no region", encounter.ErrBadPlacement},
 		{"connection missing room", func(d *encounter.EncounterData) {
 			// FromPosition/ToPosition present (any value) so the ONLY
 			// defect this fixture carries is the unknown "to" room — #929
@@ -1624,20 +1624,20 @@ func (s *DataTestSuite) TestLoadRejections() {
 		{"abandoned outcome with members present", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "abandoned"}
 		}, "abandoned outcome with members", encounter.ErrNoMember},
-		{"outcome member room missing", func(d *encounter.EncounterData) {
+		// The "outcome member names a room the field does not have" case went
+		// with the field that carried it (rpg-toolkit#1108): the region is
+		// derived from the cell now, so the only way an outcome member can be
+		// somewhere impossible is by CELL, which is this case.
+		{"outcome member cell owned by no region", func(d *encounter.EncounterData) {
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
-				{ID: "ghost", Room: "nowhere", Cell: &encounter.PositionData{X: 1, Y: 1}}}}
-		}, "outcome member", encounter.ErrBadPlacement},
-		{"outcome member out of bounds", func(d *encounter.EncounterData) {
-			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
-				{ID: "p1", Room: "r1", Cell: &encounter.PositionData{X: 999, Y: 999}}}}
-		}, "out of bounds", encounter.ErrBadPlacement},
+				{ID: "p1", Cell: &encounter.PositionData{X: 999, Y: 999}}}}
+		}, "owned by no region", encounter.ErrBadPlacement},
 		{"outcome member missing cell", func(d *encounter.EncounterData) {
 			// Deletes the field from the wire path (nil), which is exactly what
 			// a pre-#1068 blob's room-local "position" key does on arrival —
 			// see dialect_test.go for that whole blob read end to end.
 			d.Outcome = &encounter.OutcomeData{Ending: "done", Members: []encounter.MemberOutcomeData{
-				{ID: "p1", Room: "r1"}}}
+				{ID: "p1"}}}
 		}, "has no cell", encounter.ErrBadPlacement},
 		{"ever_members missing current member", func(d *encounter.EncounterData) {
 			d.EverMembers = nil
@@ -1866,7 +1866,7 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
-		s.Require().Contains(err.Error(), "owned by no room")
+		s.Require().Contains(err.Error(), "owned by no region")
 	})
 
 	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
@@ -1880,7 +1880,7 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
-		s.Require().Contains(err.Error(), "owned by no room")
+		s.Require().Contains(err.Error(), "owned by no region")
 	})
 }
 

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -102,7 +102,18 @@
 //     the same vector — since a field's absolute frame only ever means
 //     "relative to the other rooms".
 //
-// Room and field size are allocation-bounded (a legal-but-absurd room or
-// field could otherwise demand an allocation Atlas cannot safely make);
-// see maxRoomCells/maxFieldCells for the exact figures and why.
+// A ROOM IS A REGION at runtime (#1108). Rooms remain how a dungeon is
+// AUTHORED — RoomInput, MemberInput.Room and TriggerReachedPosition.Room are
+// construction data and stay room-shaped — but what survives the compile onto
+// the canvas is a named set of cells: [Encounter.RegionAt] says which region
+// holds a cell, [Encounter.MembersIn] says who is standing in one, and
+// [Encounter.Atlas] reports each region's anchor and span instead of listing
+// its cells. Membership is DERIVED from a member's cell wherever it is
+// reported, never stored beside it.
+//
+// Room and field size are bounded (maxRoomCells/maxFieldCells): two individually
+// legal dimensions multiply into a cell count nothing could walk. The bound
+// guarded an Atlas allocation until #1108 stopped it enumerating; it now
+// guards the instruction a region report gives a host that wants the cells
+// itself. See maxRoomCells/maxFieldCells for the figures and the history.
 package encounter

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -85,7 +85,7 @@ type Encounter struct {
 
 	// roomGrids is each authored room's own grid, kept from construction so
 	// the field can answer which chamber owns an absolute cell without
-	// rebuilding one per call — see roomAt.
+	// rebuilding one per call — see regionAt.
 	roomGrids map[string]spatial.Grid
 
 	clock *clock.Tick
@@ -293,20 +293,26 @@ const (
 // EQUAL for both grid families: axisBounds' span always equals the
 // dimension itself, every parity, hex included — see axisBounds' doc
 // comment), and maxFieldCells bounds the SUM of every room's cell count
-// across one field. ALLOCATION-SAFETY bounds for Atlas, distinct in
-// PURPOSE from maxRoomSpan/maxAnchorCoord above (coordinate-OVERFLOW
-// defense): Atlas materializes every cell of every room by contract
-// (Atlas's doc comment), via a make() sized exactly Width*Height per
-// room. Two individually-legal integers under maxRoomSpan (up to 1<<30
-// each) multiply to up to 1<<60 — the amplification is exactly what
-// makes a SEPARATE bound necessary: a 2^30 x 2^30 room passes
-// maxRoomSpan's per-axis check cleanly but PANICS atlasCells' make()
-// (a 2^60-capacity argument), reachable from a persisted blob a few
-// hundred bytes long — two integers, no bulk data (#929 T3 Opus round
-// F1). Enforced HERE, in room legality — the shared path both
-// NewEncounter and LoadEncounter route through — not inside Atlas
-// itself: see the comment at atlasCells' allocation site (atlas.go) for
-// why no redundant check lives there.
+// across one field. Distinct in PURPOSE from maxRoomSpan/maxAnchorCoord
+// above (coordinate-OVERFLOW defense): this is the AMPLIFICATION bound.
+// Two individually-legal integers under maxRoomSpan (up to 1<<30 each)
+// multiply to up to 1<<60, so a 2^30 x 2^30 room passes maxRoomSpan's
+// per-axis check cleanly while describing a quintillion cells —
+// reachable from a persisted blob a few hundred bytes long, two
+// integers and no bulk data (#929 T3 Opus round F1).
+//
+// IT NO LONGER GUARDS AN ALLOCATION OF OURS, and that is worth saying
+// plainly rather than leaving the old reason standing. It was written
+// because Atlas materialized every cell of every room through a make()
+// sized Width*Height; rpg-toolkit#1108 stopped it enumerating, and
+// nothing in this module allocates per cell any more (both grid
+// families hold bounds only). What it guards now is the INSTRUCTION the
+// region report gives: an AtlasRegion states an anchor and a span and
+// leaves a host that genuinely wants the cells to walk that rectangle
+// itself, so the module must not hand out a legal region no caller can
+// walk. Enforced HERE, in room legality — the shared path both
+// NewEncounter and LoadEncounter route through — so a field is refused
+// before an Encounter exists to describe it.
 const (
 	maxRoomCells  = 1 << 20
 	maxFieldCells = 1 << 22
@@ -542,12 +548,15 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		// Occluders must be integral in EVERY family, not just hex (#929 T3
 		// Opus round F2 — the identical square-vs-hex asymmetry T1 already
 		// fixed for Origin: see isIntegralPosition's doc comment):
-		// AtlasRoom.Occluders must be a subset of AtlasRoom.Cells (Cells
-		// only enumerates INTEGER cells — atlasCells' doc comment), so a
-		// fractional occluder would appear in Occluders while absent from
-		// Cells, breaking the host contract "floor from Cells, blockage
-		// from Occluders". isIntegralPosition, not isIntegralAxialPosition
-		// — universal, not hex-only.
+		// an occluder is a CELL of its region, and a region's cells are
+		// the integer lattice points inside its anchor-plus-span
+		// (AtlasRegion's doc comment). A fractional occluder would be
+		// blockage reported at a point that is not one of the region's
+		// cells at all — undrawable under the host contract "floor from
+		// the span, blockage from Occluders", and indistinguishable from
+		// a member's position, which alone may be fractional on a square
+		// grid. isIntegralPosition, not isIntegralAxialPosition —
+		// universal, not hex-only.
 		//
 		// This is the ONLY reason left, as of #929 hardening round C: an
 		// earlier version of this comment ALSO cited the occluder entity
@@ -1309,8 +1318,8 @@ func (e *Encounter) buildMemberOutcomes() []MemberOutcome {
 		if !ok {
 			continue
 		}
-		room, _ := e.roomAt(cell)
-		outcomes = append(outcomes, MemberOutcome{ID: m.ID, Room: room, Position: cell})
+		region, _ := e.RegionAt(cell)
+		outcomes = append(outcomes, MemberOutcome{ID: m.ID, Region: region, Position: cell})
 	}
 	return outcomes
 }
@@ -1360,11 +1369,11 @@ func (e *Encounter) placementOf(record *memberRecord) (Member, error) {
 		return Member{}, err
 	}
 
-	room, _ := e.roomAt(cell)
+	region, _ := e.RegionAt(cell)
 	return Member{
 		ID:       record.ID,
 		Kind:     record.Kind,
-		Room:     room,
+		Region:   region,
 		Position: cell,
 	}, nil
 }
@@ -1377,44 +1386,6 @@ func (e *Encounter) cellOf(record *memberRecord) (spatial.Position, error) {
 		return spatial.Position{}, fmt.Errorf("member %q: not placed on the map: %w", record.ID, ErrNoField)
 	}
 	return cell, nil
-}
-
-// roomAt reports which authored chamber's footprint holds an absolute cell.
-//
-// The one question rooms still answer at runtime, and the reason they can be
-// deleted from every record that used to carry one: a member's chamber is a
-// fact about where they stand, so it is derived from where they stand.
-//
-// W2 (rooms never overlap) plus integral origins make ownership unique, so
-// iteration order never matters — at most one room's bounds check can pass.
-// Each room is asked with its OWN constructed grid, kept from construction, so
-// this answers exactly what the room itself would.
-//
-// NO INTEGRALITY CHECK HERE, deliberately. Hex forbids fractional cells
-// (isIntegralAxialPosition) and every way a cell reaches this function has
-// already asked: [Encounter.stepMember] and [Encounter.Join] check before they
-// ask, construction places from a room-local cell its own grid validated, and
-// the load seam has its own copy (ownedByAnyRoom) because it runs before an
-// Encounter exists. A check here would be a branch no input can take, which is
-// a branch no test can pin.
-//
-// False means no chamber owns the cell: void is not floor. Callers that place
-// or move somebody must treat that as a refusal; callers merely REPORTING a
-// member's chamber take the empty string, which cannot arise for a placed
-// member and is not worth an error return on a read path.
-func (e *Encounter) roomAt(cell spatial.Position) (string, bool) {
-	for _, ri := range e.fieldInput {
-		local := cell.Subtract(ri.Origin)
-		grid, ok := e.roomGrids[ri.ID]
-		if !ok {
-			continue
-		}
-		if !grid.IsValidPosition(local) {
-			continue
-		}
-		return ri.ID, true
-	}
-	return "", false
 }
 
 // roomOrigin is the construction-time anchor lookup compileCanvas and member
@@ -1439,7 +1410,7 @@ func (e *Encounter) Status() (*Status, error) {
 		for i, m := range e.outcome.Members {
 			members[i] = MemberOutcome{
 				ID:       m.ID,
-				Room:     m.Room,
+				Region:   m.Region,
 				Position: m.Position,
 			}
 		}
@@ -2126,7 +2097,7 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 	// map" and "somewhere a member can stand" are different questions, and
 	// this is the one that matters (the same check [Encounter.stepMember]
 	// makes for a step).
-	if _, owned := e.roomAt(in.Cell); !owned {
+	if _, owned := e.RegionAt(in.Cell); !owned {
 		return nil, fmt.Errorf("join: cell %v is not floor: %w", in.Cell, ErrBadPlacement)
 	}
 
@@ -2243,12 +2214,12 @@ func (e *Encounter) Exit(in *ExitInput) (*ExitOutput, error) {
 		return nil, fmt.Errorf("exit: %w", ErrNotMember)
 	}
 
-	// Get the exiting member's final cell, and the chamber it falls in.
+	// Get the exiting member's final cell, and the region it falls in.
 	finalCell, ok := e.canvas.GetEntityPosition(string(in.Member))
 	if !ok {
 		return nil, fmt.Errorf("exit: %w", ErrBadPlacement)
 	}
-	finalRoom, _ := e.roomAt(finalCell)
+	finalRegion, _ := e.RegionAt(finalCell)
 
 	// Capture the exiting member's holdings (carry-forward)
 	carry, err := e.intelLog.HeldBy(&intel.HeldByInput{Observer: in.Member})
@@ -2333,7 +2304,7 @@ func (e *Encounter) Exit(in *ExitInput) (*ExitOutput, error) {
 	return &ExitOutput{
 		Outcome: MemberOutcome{
 			ID:       in.Member,
-			Room:     finalRoom,
+			Region:   finalRegion,
 			Position: finalCell,
 		},
 		Carry:  carry,
@@ -2417,7 +2388,7 @@ func (e *Encounter) End(in *EndInput) (*EndOutput, error) {
 	for i, m := range e.outcome.Members {
 		outcomeMembers[i] = MemberOutcome{
 			ID:       m.ID,
-			Room:     m.Room,
+			Region:   m.Region,
 			Position: m.Position,
 		}
 	}

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1332,10 +1332,11 @@ func (e *Encounter) buildMemberOutcomes() []MemberOutcome {
 // endings to read two floats per member, once per frame in the worst case
 // (rpg-toolkit#933). A roster read should cost a roster read.
 //
-// Returns ErrNoField if a member's room or cell cannot be resolved, which
-// would mean the roster and the spatial field disagree about who is placed —
-// a defect worth surfacing rather than papering over with a zero position
-// that reads like the map's origin.
+// Returns ErrNoField if a member's cell cannot be resolved, which would mean
+// the roster and the canvas disagree about who is placed — a defect worth
+// surfacing rather than papering over with a zero position that reads like the
+// map's origin. Their REGION cannot fail separately: it is derived from the
+// cell (rpg-toolkit#1108), and a placed member's cell is always floor.
 func (e *Encounter) Members() ([]Member, error) {
 	// Sort by ID for stability
 	ids := make([]MemberID, 0, len(e.members))
@@ -1357,12 +1358,13 @@ func (e *Encounter) Members() ([]Member, error) {
 	return members, nil
 }
 
-// placementOf builds a member's read shape: the stored record plus where they
-// actually stand, projected into dungeon-absolute space.
+// placementOf builds a member's read shape: the stored record, the cell they
+// actually stand on, and the region that holds it.
 //
-// ONE projection path, used by every read that reports a member. Join and
-// Members answering the same question differently is the kind of drift that
-// stays invisible until two clients disagree about where somebody is.
+// ONE path, used by every read that reports a member — Members, MembersIn and
+// Join alike. Two of them answering the same question differently is the kind
+// of drift that stays invisible until two clients disagree about where
+// somebody is.
 func (e *Encounter) placementOf(record *memberRecord) (Member, error) {
 	cell, err := e.cellOf(record)
 	if err != nil {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -2595,7 +2595,7 @@ func (s *EncounterTestSuite) roomOf(enc *encounter.Encounter, id encounter.Membe
 	s.Require().NoError(err)
 	for _, m := range members {
 		if m.ID == id {
-			return m.Room
+			return m.Region
 		}
 	}
 	s.Require().Fail("no such member", string(id))
@@ -2709,7 +2709,7 @@ func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 	s.Equal("escaped", out.Outcome.Ending)
 	s.Require().Len(out.Outcome.Members, 1)
 	s.Equal(alice, out.Outcome.Members[0].ID)
-	s.Equal("room-b", out.Outcome.Members[0].Room)
+	s.Equal(encounter.RegionID("room-b"), out.Outcome.Members[0].Region)
 	s.Equal(spatial.Position{X: 10, Y: 5}, out.Outcome.Members[0].Position,
 		"room-b-local (0,5) anchored at (10,0) — the outcome speaks the dungeon map (#1068)")
 
@@ -2890,7 +2890,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 		// Assert: charlie joined
 		s.Equal(charlie, joinOut.Member.ID)
 		s.Equal(encounter.KindPlayer, joinOut.Member.Kind)
-		s.Equal(room1, joinOut.Member.Room)
+		s.Equal(encounter.RegionID(room1), joinOut.Member.Region)
 
 		// Assert: join beat recorded
 		s.Require().Greater(joinOut.Seq, uint64(0), "join should produce sequence number")
@@ -3091,7 +3091,7 @@ func (s *EncounterTestSuite) TestExitCarryForward() {
 
 		// Assert: exit outcome has alice's position
 		s.Equal(alice, exitOut.Outcome.ID)
-		s.Equal(room1, exitOut.Outcome.Room)
+		s.Equal(encounter.RegionID(room1), exitOut.Outcome.Region)
 		s.Equal(2.0, exitOut.Outcome.Position.X)
 		s.Equal(2.0, exitOut.Outcome.Position.Y)
 

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -27,6 +27,12 @@ var (
 	// ErrNotMember is returned when an entity is not a member of this encounter.
 	ErrNotMember = errors.New("not a member")
 
+	// ErrNoRegion is returned when [Encounter.MembersIn] is asked about a
+	// region the field does not have. An EMPTY region is an ordinary answer —
+	// "nobody has reached the tomb yet" is a fact worth reporting — so a
+	// mistyped region name must not be able to say it (rpg-toolkit#1108).
+	ErrNoRegion = errors.New("no such region")
+
 	// ErrNoEnding is returned when Setup or Load is called with zero
 	// endings, a declared ending's key is empty or the reserved
 	// "abandoned", a declared ending's key duplicates an earlier one in

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -55,18 +55,20 @@ func Example_theDungeon() {
 		return
 	}
 
-	// The static map, as construction truth: which cells each authored chamber
-	// claimed once it was placed, and where the doorway between them sits.
+	// The static map, as construction truth: where each authored chamber landed
+	// as a region, and where the doorway between them sits. A region says what
+	// it IS — anchor and span — rather than listing its cells; asking which
+	// region holds a particular cell is a question, not a list
+	// (rpg-toolkit#1108).
 	atlas, err := enc.Atlas()
 	if err != nil {
 		fmt.Println("atlas:", err)
 		return
 	}
 	fmt.Println("-- the map --")
-	for _, room := range atlas.Rooms {
-		first, last := room.Cells[0], room.Cells[len(room.Cells)-1]
-		fmt.Printf("%s: %d cells, (%g,%g) through (%g,%g)\n",
-			room.ID, len(room.Cells), first.X, first.Y, last.X, last.Y)
+	for _, region := range atlas.Regions {
+		fmt.Printf("%s: %dx%d, anchored at (%g,%g)\n",
+			region.ID, region.Width, region.Height, region.Origin.X, region.Origin.Y)
 	}
 	for _, d := range atlas.Doorways {
 		fmt.Printf("doorway %s: (%g,%g) -- (%g,%g), one cell apart\n",
@@ -82,7 +84,7 @@ func Example_theDungeon() {
 			return
 		}
 		for _, m := range members {
-			fmt.Printf("alice stands at (%g,%g), in the %s\n", m.Position.X, m.Position.Y, m.Room)
+			fmt.Printf("alice stands at (%g,%g), in the %s\n", m.Position.X, m.Position.Y, m.Region)
 		}
 	}
 
@@ -98,8 +100,8 @@ func Example_theDungeon() {
 
 	// Output:
 	// -- the map --
-	// hall: 64 cells, (0,0) through (7,7)
-	// vault: 64 cells, (8,0) through (15,7)
+	// hall: 8x8, anchored at (0,0)
+	// vault: 8x8, anchored at (8,0)
 	// doorway gate: (7,4) -- (8,4), one cell apart
 	// -- alice, at the threshold --
 	// alice stands at (7,4), in the hall

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -320,13 +320,18 @@ type Member struct {
 	ID   MemberID
 	Kind MemberKind
 
-	// Room is the authored chamber whose footprint holds Position — DERIVED,
-	// not stored. A member's cell is the canvas's to know and the authored
-	// footprints decide which chamber that cell falls in, so keeping a room
-	// label on the record would be a second truth every verb had to move in
-	// step with it (rpg-toolkit#1106; the dual state [memberRecord] already
-	// warns about, one field over).
-	Room string
+	// Region is the named cell set that holds Position — DERIVED, not stored.
+	// A member's cell is the canvas's to know and the authored footprints
+	// decide which region that cell falls in, so keeping a region label on the
+	// record would be a second truth every verb had to move in step with it
+	// (rpg-toolkit#1106; the dual state [memberRecord] already warns about, one
+	// field over).
+	//
+	// A member standing in a doorway is in the region whose cell is under their
+	// feet, and the member facing them one cell away is in the other — see
+	// [Encounter.RegionAt] for why this composition has no unnamed doorway cell
+	// to report instead (rpg-toolkit#1108).
+	Region RegionID
 
 	// Position is where the member stands, in DUNGEON-ABSOLUTE space —
 	// already projected through their room's origin, so it can be compared
@@ -388,8 +393,10 @@ type MemberOutcome struct {
 	// ID is the member's identifier.
 	ID MemberID
 
-	// Room is their room ID when the encounter closed.
-	Room string
+	// Region is the region they finished in — DERIVED from Position at the
+	// moment the encounter closed, exactly as [Member.Region] is, and for the
+	// same reason (rpg-toolkit#1108).
+	Region RegionID
 
 	// Position is the DUNGEON-ABSOLUTE cell they finished on
 	// (rpg-toolkit#1068) — the same frame Member.Position and every beat

--- a/rulebooks/dnd5e/encounter/oneplace_internal_test.go
+++ b/rulebooks/dnd5e/encounter/oneplace_internal_test.go
@@ -30,6 +30,12 @@ import (
 // So these two tests read. Each names one syntactic move a second
 // implementation of its rule cannot avoid making, and asserts that move happens
 // in exactly one function body. Neither checks style, and neither counts lines.
+//
+// The technique is the house's, not a new one: rulebooks/dnd5e/session's
+// boundary_test.go parses its own package to prove no inner type crosses the
+// seam, on the same reasoning — "the guarantee is mechanical rather than
+// aspirational ... instead of trusting that reviewers will spot a leaked type in
+// a diff two years from now".
 
 // TestRegionOwnershipIsAskedInOneFunction.
 //

--- a/rulebooks/dnd5e/encounter/oneplace_internal_test.go
+++ b/rulebooks/dnd5e/encounter/oneplace_internal_test.go
@@ -42,6 +42,11 @@ import (
 //
 // So: one Subtract, one region lookup. A second implementation has to subtract
 // an origin in order to exist, and this is the test it fails.
+//
+// If a legitimate second use ever appears — a delta between two cells for a
+// beat, say — the honest fix is to name it in the expected list, not to delete
+// the test. The point is that a second one becomes a decision somebody makes on
+// purpose rather than a copy that arrives unnoticed.
 func TestRegionOwnershipIsAskedInOneFunction(t *testing.T) {
 	callers := functionsWhoseBodyReads(t, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)

--- a/rulebooks/dnd5e/encounter/oneplace_internal_test.go
+++ b/rulebooks/dnd5e/encounter/oneplace_internal_test.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// oneplace_internal_test.go asks the SOURCE a question no behavioural test can
+// ask: is this decided in one place?
+//
+// Duplication is invisible to behaviour. Two implementations of one rule agree
+// on every fixture written while they still agree, which is why this package
+// has grown the same defect three times over: the walk resolved in the session
+// and again in the pump (#1059); the ReachedPosition ending decided in
+// firedReachedPosition and again inside Join (#1059, deleted by #1106); region
+// ownership answered by roomAt, by ownedByAnyRoom and by an inline copy in
+// outcome validation (#1108, this slice). Every one was found by reading, and
+// every one had a green suite while it stood.
+//
+// So these two tests read. Each names one syntactic move a second
+// implementation of its rule cannot avoid making, and asserts that move happens
+// in exactly one function body. Neither checks style, and neither counts lines.
+
+// TestRegionOwnershipIsAskedInOneFunction.
+//
+// Turning a dungeon-absolute cell into a room-local one is what asking "which
+// region owns this cell" requires, and spatial.Position.Subtract is the only
+// way this package says it. Every OTHER bounds check in the module takes a
+// room-local AUTHORING position — a connection's endpoint, an ending's target,
+// a member's placement — and asks a room grid about it in the frame it was
+// written in. None of them subtracts anything.
+//
+// So: one Subtract, one region lookup. A second implementation has to subtract
+// an origin in order to exist, and this is the test it fails.
+func TestRegionOwnershipIsAskedInOneFunction(t *testing.T) {
+	callers := functionsWhoseBodyReads(t, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "Subtract"
+	})
+
+	require.Equal(t, []string{"regionAt"}, callers,
+		"region ownership must be answered in exactly one place (rpg-toolkit#1108): a second "+
+			"function projecting an absolute cell into a room's local frame is a second answer "+
+			"to which region holds it")
+}
+
+// TestTheReachedPositionCellIsReadInOneFunction.
+//
+// A ReachedPosition ending is compiled once, at construction, into the single
+// absolute cell an arrival is compared against (compileEndings). Deciding the
+// ending means READING that cell — so anything but the one decider that reads
+// it is a second implementation of the ending rule, which is exactly what Join
+// carried until #1106 deleted it. compileEndings WRITES the field and is not a
+// reader; assignment targets are excluded for that reason.
+func TestTheReachedPositionCellIsReadInOneFunction(t *testing.T) {
+	readers := functionsWhoseBodyReads(t, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		return ok && sel.Sel.Name == "cell"
+	})
+
+	require.Equal(t, []string{"firedReachedPosition"}, readers,
+		"the compiled ending cell must be read in exactly one place (rpg-toolkit#1108, #1059): "+
+			"every arrival — Step, Pump, Join — decides the ending through that one function")
+}
+
+// functionsWhoseBodyReads parses this package's non-test source and returns the
+// sorted names of every function whose body READS a node the predicate accepts.
+// Nodes reached through the left-hand side of an assignment are writes and do
+// not count.
+//
+// Reads the files from disk rather than a go/types view because those files are
+// what a future editor changes and what a reviewer reads: a structural test
+// whose subject is the source itself explains its own failure.
+func functionsWhoseBodyReads(t *testing.T, match func(ast.Node) bool) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+	require.Contains(t, pkgs, "encounter", "the package must be parseable from its own directory")
+
+	written := map[ast.Node]bool{}
+	for _, file := range pkgs["encounter"].Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for _, lhs := range assign.Lhs {
+				ast.Inspect(lhs, func(inner ast.Node) bool {
+					written[inner] = true
+					return true
+				})
+			}
+			return true
+		})
+	}
+
+	names := map[string]bool{}
+	for _, file := range pkgs["encounter"].Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if n != nil && !written[n] && match(n) {
+					names[fn.Name.Name] = true
+				}
+				return true
+			})
+		}
+	}
+
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -107,29 +107,21 @@ func (s *PlacementSuite) TestTheRosterSaysWhereEverybodyStands() {
 		"and for the other room's anchor too")
 }
 
-// TestTheRosterAgreesWithTheMap crosses the roster against the static map, the
-// two reads a client renders together. A member reported at a cell the Atlas
-// does not contain is a member drawn outside the room they are standing in.
+// TestTheRosterAgreesWithTheMap crosses the roster against the map, the two
+// reads a client renders together. A member reported at a cell no region holds
+// is a member drawn outside the chamber they are standing in, and a member
+// whose reported region disagrees with the cell under them is the dual state
+// deriving it was supposed to end.
 func (s *PlacementSuite) TestTheRosterAgreesWithTheMap() {
 	members, err := s.enc.Members()
 	s.Require().NoError(err)
 
-	atlas, err := s.enc.Atlas()
-	s.Require().NoError(err)
-
-	cells := map[spatial.Position]string{}
-	for _, room := range atlas.Rooms {
-		for _, cell := range room.Cells {
-			cells[cell] = room.ID
-		}
-	}
-
 	for _, member := range members {
-		owner, ok := cells[member.Position]
-		s.Require().True(ok, "%s stands at %v, which is not a cell of any room on the map",
+		owner, ok := s.enc.RegionAt(member.Position)
+		s.Require().True(ok, "%s stands at %v, which is not a cell of any region on the map",
 			member.ID, member.Position)
-		s.Equal(member.Room, owner, "%s is reported in %q but their cell belongs to %q",
-			member.ID, member.Room, owner)
+		s.Equal(member.Region, owner, "%s is reported in %q but their cell belongs to %q",
+			member.ID, member.Region, owner)
 	}
 }
 

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -1176,7 +1176,7 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	s.Require().Len(members, 1)
-	s.Equal("room-b", members[0].Room)
+	s.Equal(encounter.RegionID("room-b"), members[0].Region)
 }
 
 // TestPumpReportsMovementOnTheMap is the discriminating probe for
@@ -1266,7 +1266,7 @@ func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	s.Require().Len(members, 1)
-	s.Equal(shrine, members[0].Room)
+	s.Equal(encounter.RegionID(shrine), members[0].Region)
 	s.Equal(out2.MonsterMoves[0].To, members[0].Position,
 		"where the pump says it went is where the field says it stands")
 }
@@ -1368,7 +1368,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenAWallIsInTheWay() {
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	s.Require().Len(members, 1)
-	s.Equal("room-a", members[0].Room, "the monster never left its chamber")
+	s.Equal(encounter.RegionID("room-a"), members[0].Region, "the monster never left its chamber")
 	s.Equal(spatial.Position{X: 3, Y: 2}, members[0].Position, "the monster's cell is unchanged")
 }
 
@@ -1423,7 +1423,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	s.Require().Len(members, 1)
-	s.Equal("room-a", members[0].Room, "the monster never left its chamber")
+	s.Equal(encounter.RegionID("room-a"), members[0].Region, "the monster never left its chamber")
 	s.Equal(spatial.Position{X: 9, Y: 5}, members[0].Position, "the monster's cell is unchanged")
 }
 
@@ -1465,7 +1465,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	s.Require().Len(members, 1)
-	s.Equal("room-a", members[0].Room, "the monster never moved — R5 atomicity")
+	s.Equal(encounter.RegionID("room-a"), members[0].Region, "the monster never moved — R5 atomicity")
 }
 
 // TestPumpPursuitAcrossConnection is the wave's integration pin: a
@@ -1641,14 +1641,14 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 			bOutcome = m
 		}
 	}
-	s.Equal("room-b", aOutcome.Room)
+	s.Equal(encounter.RegionID("room-b"), aOutcome.Region)
 	s.Equal(spatial.Position{X: 10, Y: 5}, aOutcome.Position,
 		"room-b-local (0,5) anchored at (10,0) — the outcome speaks the dungeon map (#1068)")
 	// The full-tick-then-evaluate law, made observable: zzz-goblin's
 	// ALREADY-APPLIED move is reflected in the outcome — its NEW
 	// position, not its pre-pump one. A revert-on-close implementation
 	// would show (3,3) here instead.
-	s.Equal("room-a", bOutcome.Room)
+	s.Equal(encounter.RegionID("room-a"), bOutcome.Region)
 	s.Equal(spatial.Position{X: 4, Y: 4}, bOutcome.Position,
 		"the outcome must reflect zzz-goblin's post-tick position, not its pre-tick one")
 

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -64,6 +64,11 @@ type RegionID = string
 // could stand in. A member in a doorway is therefore in the region whose cell
 // is under their feet, and the member facing them one cell away is in the
 // other. Pinned by TestAMemberInTheDoorwayStandsInTheRegionTheyStandOn.
+//
+// A host that wants "is this cell an opening" is asking a different question,
+// and [Encounter.Atlas] answers it: every doorway reports both endpoint cells
+// in absolute space. Standing in one is a fact about the doorway, not about
+// which region holds you.
 func (e *Encounter) RegionAt(cell spatial.Position) (RegionID, bool) {
 	return regionAt(e.fieldInput, e.roomGrids, cell)
 }

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// region.go is A ROOM IS A REGION (rpg-toolkit#1108).
+//
+// S0 made the field one canvas and left the authored chambers with exactly one
+// runtime job: saying which of them holds a given cell. This file gives that
+// job a name and a surface. A region is A NAMED SET OF CELLS — you ask it which
+// region holds a cell, or which members stand in one. It is not a coordinate
+// space, not a container, and not a visibility rule: a member's cell is the
+// canvas's to know, and their region is derived from it.
+//
+// ROOMS ARE STILL HOW A DUNGEON IS AUTHORED (Kirk's ruling on rpg-toolkit#1105:
+// "we author rooms; that they become one thing is after render"). RoomInput,
+// MemberInput.Room and TriggerReachedPosition.Room are construction data and
+// stay room-shaped. What changed is the word the RUNTIME answers in: after the
+// compile there is one map, and the authored chambers survive on it as named
+// regions over its cells.
+
+// RegionID names one region — the authored chamber's own ID (RoomInput.ID),
+// carried through the compile unchanged.
+//
+// An alias rather than a defined type, following MemberID: it exists to say
+// which of two strings a signature means, not to make callers convert.
+type RegionID = string
+
+// RegionAt reports which region holds a dungeon-absolute cell.
+//
+// TOTAL OVER FLOOR, AND ONLY OVER FLOOR: a cell is floor if and only if exactly
+// one region owns it. The canvas spans the field's whole bounding BOX, so
+// "on the map" and "somewhere a member can stand" are different questions, and
+// this answers the second one. False means the cell is void — the space between
+// or beside the authored chambers — which Step and Join refuse to place anybody
+// on.
+//
+// W2 (regions never overlap) plus integral origins make ownership unique, so
+// iteration order never matters: at most one region's bounds check can pass.
+//
+// A DOORWAY DOES NOT GET ITS OWN ANSWER, and that is a decision rather than an
+// omission. The old stack made a door's cell belong to no region on purpose —
+// its compiler puts a one-cell wall column between chambers and carves a floor
+// door cell into it, so there is a real cell between two regions to leave
+// unnamed. This composition has no such cell: a connection's two endpoints are
+// room-local cells OF THEIR OWN ROOMS (ConnectionInput's doc comment) and W3
+// makes them adjacent, so nothing sits between them. And a cell no region owns
+// is not floor here, so "belongs to no region" and "you cannot stand there"
+// would be the same sentence — an unnamed doorway would be a doorway nobody
+// could stand in. A member in a doorway is therefore in the region whose cell
+// is under their feet, and the member facing them one cell away is in the
+// other. Pinned by TestAMemberInTheDoorwayStandsInTheRegionTheyStandOn.
+//
+// NO INTEGRALITY CHECK, deliberately — the same rule regionAt states, one
+// layer down.
+func (e *Encounter) RegionAt(cell spatial.Position) (RegionID, bool) {
+	return regionAt(e.fieldInput, e.roomGrids, cell)
+}
+
+// MembersIn reports who is standing in a region, in the same stable order (and
+// with the same placement) [Encounter.Members] reports them.
+//
+// A ROSTER READ, filtered — deliberately built from the same projection every
+// other member read uses (placementOf), because Members and MembersIn
+// disagreeing about where somebody stands is the dual-state defect this
+// composition has paid for before.
+//
+// Returns ErrNoRegion for a region the field does not have. An EMPTY region is
+// an ordinary answer — nobody has reached the tomb yet is a fact worth
+// reporting — so a mistyped name must not be able to say it. Returns ErrNoField
+// if a member's cell cannot be resolved, for [Encounter.Members]' reason.
+func (e *Encounter) MembersIn(region RegionID) ([]Member, error) {
+	if _, ok := e.roomGrids[region]; !ok {
+		return nil, fmt.Errorf("members in %q: %w", region, ErrNoRegion)
+	}
+
+	all, err := e.Members()
+	if err != nil {
+		return nil, fmt.Errorf("members in %q: %w", region, err)
+	}
+
+	in := make([]Member, 0, len(all))
+	for _, m := range all {
+		if m.Region == region {
+			in = append(in, m)
+		}
+	}
+	return in, nil
+}
+
+// regionAt is THE region lookup — the one place this package turns a
+// dungeon-absolute cell into a room-local one to ask who owns it.
+//
+// A free function rather than a method because the load seam needs the same
+// answer before an Encounter exists (R5: a blob is validated in full before
+// anything is constructed). That used to be three implementations of one
+// question — [Encounter.roomAt], a load-time twin that said so in its own doc
+// comment, and an inline third inside outcome validation — which is the
+// dual-dispatch defect #1059 spent two PRs deleting for movement, grown back
+// around ownership. TestRegionOwnershipIsAskedInOneFunction is what keeps it
+// at one: spatial.Position.Subtract appears in exactly one function body in
+// this package, and a second lookup cannot exist without subtracting an origin.
+//
+// Each region is asked with its OWN constructed grid, kept from construction,
+// so this answers exactly what the authored room itself would.
+//
+// NO INTEGRALITY CHECK HERE, deliberately. Hex forbids fractional cells
+// (isIntegralAxialPosition) and every way a cell reaches this function has
+// already asked: [Encounter.stepMember] and [Encounter.Join] check before they
+// ask, construction places from a room-local cell its own grid validated, and
+// LoadEncounter checks the blob's cells before it gets here. A check here would
+// be a branch no input can take, which is a branch no test can pin.
+func regionAt(rooms []RoomInput, grids map[string]spatial.Grid, cell spatial.Position) (RegionID, bool) {
+	for _, ri := range rooms {
+		grid, ok := grids[ri.ID]
+		if !ok {
+			continue
+		}
+		if !grid.IsValidPosition(cell.Subtract(ri.Origin)) {
+			continue
+		}
+		return ri.ID, true
+	}
+	return "", false
+}

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -45,11 +45,11 @@ type RegionID = string
 // ownership unique, so iteration order never matters: at most one region's
 // bounds check can pass.
 //
-// It takes a POSITION, not only a cell, and answers for both. A square grid
-// tolerates a fractional position and a member may legitimately stand on one
-// (Atlas's doc comment on that asymmetry); such a member is in the region whose
-// span contains them, which is the same answer by the same rule. Hex forbids
-// fractional positions outright.
+// A SQUARE region is fractional-tolerant and a member may legitimately stand
+// between its cells (RoomInput.Grid's doc comment, and Atlas's on that
+// asymmetry); such a member is in the region whose span contains them, by the
+// same rule. A HEX region is not: a fractional axial position is not a cell at
+// all, and no region holds it — see regionAt.
 //
 // A DOORWAY DOES NOT GET ITS OWN ANSWER, and that is a decision rather than an
 // omission. The old stack made a door's cell belong to no region on purpose —
@@ -64,8 +64,7 @@ type RegionID = string
 // is under their feet, and the member facing them one cell away is in the
 // other. Pinned by TestAMemberInTheDoorwayStandsInTheRegionTheyStandOn.
 //
-// NO INTEGRALITY CHECK, deliberately — the same rule regionAt states, one
-// layer down.
+// The integrality rule is regionAt's, one layer down.
 func (e *Encounter) RegionAt(cell spatial.Position) (RegionID, bool) {
 	return regionAt(e.fieldInput, e.roomGrids, cell)
 }
@@ -107,29 +106,46 @@ func (e *Encounter) MembersIn(region RegionID) ([]Member, error) {
 // A free function rather than a method because the load seam needs the same
 // answer before an Encounter exists (R5: a blob is validated in full before
 // anything is constructed). That used to be three implementations of one
-// question — [Encounter.roomAt], a load-time twin that said so in its own doc
-// comment, and an inline third inside outcome validation — which is the
-// dual-dispatch defect #1059 spent two PRs deleting for movement, grown back
-// around ownership. TestRegionOwnershipIsAskedInOneFunction is what keeps it
+// question — Encounter.roomAt (gone with this slice), a load-time twin that
+// said so in its own doc comment, and an inline third inside outcome
+// validation — which is the dual-dispatch defect #1059 spent two PRs deleting
+// for movement, grown back around ownership. TestRegionOwnershipIsAskedInOneFunction is what keeps it
 // at one: spatial.Position.Subtract appears in exactly one function body in
 // this package, and a second lookup cannot exist without subtracting an origin.
 //
 // Each region is asked with its OWN constructed grid, kept from construction,
 // so this answers exactly what the authored room itself would.
 //
-// NO INTEGRALITY CHECK HERE, deliberately. Hex forbids fractional cells
-// (isIntegralAxialPosition) and every way a cell reaches this function has
-// already asked: [Encounter.stepMember] and [Encounter.Join] check before they
-// ask, construction places from a room-local cell its own grid validated, and
-// LoadEncounter checks the blob's cells before it gets here. A check here would
-// be a branch no input can take, which is a branch no test can pin.
+// THE INTEGRALITY CHECK IS HERE, and it did not used to be. While this was
+// Encounter.roomAt the check lived only at the verbs — every way a cell
+// reached it had already asked (Step, Join, and Load each name a fractional
+// axial cell as itself, which is a better error than "not floor"), so a check
+// here was a branch no input could take, which is a branch no test could pin.
+//
+// Making the question PUBLIC made that branch reachable. A hex grid's
+// IsValidPosition bounds-checks and nothing more (isIntegralAxialPosition's doc
+// comment says so, and tools/spatial's AxialHexGrid is where it is true), so
+// without this, RegionAt answered "yes, the hall holds it" for an axial
+// position Join refuses as not a cell — measured, before the fix:
+//
+//	RegionAt((3.5, -1.5)) on a hex field = ("only", true)
+//	Join at the same position: not an integral axial cell: bad placement
+//
+// Two answers to "is this floor" is exactly what this file exists to prevent,
+// so the predicate answers the question it claims to. HEX ONLY: square is
+// fractional-tolerant by design, and a square member standing between cells is
+// really in the region whose span holds them. (Found by Copilot on PR #1109.)
 func regionAt(rooms []RoomInput, grids map[string]spatial.Grid, cell spatial.Position) (RegionID, bool) {
 	for _, ri := range rooms {
 		grid, ok := grids[ri.ID]
 		if !ok {
 			continue
 		}
-		if !grid.IsValidPosition(cell.Subtract(ri.Origin)) {
+		local := cell.Subtract(ri.Origin)
+		if !isIntegralAxialPosition(grid, local) {
+			continue
+		}
+		if !grid.IsValidPosition(local) {
 			continue
 		}
 		return ri.ID, true

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -49,7 +49,8 @@ type RegionID = string
 // between its cells (RoomInput.Grid's doc comment, and Atlas's on that
 // asymmetry); such a member is in the region whose span contains them, by the
 // same rule. A HEX region is not: a fractional axial position is not a cell at
-// all, and no region holds it — see regionAt.
+// all, and no region holds it — the rule, and why it lives one layer down, are
+// regionAt's.
 //
 // A DOORWAY DOES NOT GET ITS OWN ANSWER, and that is a decision rather than an
 // omission. The old stack made a door's cell belong to no region on purpose —
@@ -63,8 +64,6 @@ type RegionID = string
 // could stand in. A member in a doorway is therefore in the region whose cell
 // is under their feet, and the member facing them one cell away is in the
 // other. Pinned by TestAMemberInTheDoorwayStandsInTheRegionTheyStandOn.
-//
-// The integrality rule is regionAt's, one layer down.
 func (e *Encounter) RegionAt(cell spatial.Position) (RegionID, bool) {
 	return regionAt(e.fieldInput, e.roomGrids, cell)
 }

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -53,10 +53,13 @@ type RegionID = string
 // regionAt's.
 //
 // A DOORWAY DOES NOT GET ITS OWN ANSWER, and that is a decision rather than an
-// omission. The old stack made a door's cell belong to no region on purpose —
-// its compiler puts a one-cell wall column between chambers and carves a floor
-// door cell into it, so there is a real cell between two regions to leave
-// unnamed. This composition has no such cell: a connection's two endpoints are
+// omission. The old top-level encounter module made a door's cell belong to no
+// region on purpose, and says so in its own words (encounter/knowledge.go's
+// doorPassageNeighbor: "the door's own cell belongs to NEITHER region ... doors
+// sit between two regions' tagged hex sets, never inside either"). That is a
+// fact about a compiler this composition does not have: it puts a one-cell wall
+// column between chambers and carves a floor door cell into it, so over there
+// a real cell sits between two regions with nothing to name it. This composition has no such cell: a connection's two endpoints are
 // room-local cells OF THEIR OWN ROOMS (ConnectionInput's doc comment) and W3
 // makes them adjacent, so nothing sits between them. And a cell no region owns
 // is not floor here, so "belongs to no region" and "you cannot stand there"

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -41,8 +41,15 @@ type RegionID = string
 // or beside the authored chambers — which Step and Join refuse to place anybody
 // on.
 //
-// W2 (regions never overlap) plus integral origins make ownership unique, so
-// iteration order never matters: at most one region's bounds check can pass.
+// W2 (rooms never overlap, so regions do not either) plus integral origins make
+// ownership unique, so iteration order never matters: at most one region's
+// bounds check can pass.
+//
+// It takes a POSITION, not only a cell, and answers for both. A square grid
+// tolerates a fractional position and a member may legitimately stand on one
+// (Atlas's doc comment on that asymmetry); such a member is in the region whose
+// span contains them, which is the same answer by the same rule. Hex forbids
+// fractional positions outright.
 //
 // A DOORWAY DOES NOT GET ITS OWN ANSWER, and that is a decision rather than an
 // omission. The old stack made a door's cell belong to no region on purpose —

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -4,6 +4,7 @@
 package encounter_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -217,6 +218,44 @@ func (s *RegionSuite) TestAStepChangesTheRegionAMemberIsIn() {
 	s.Equal(encounter.RegionID(tombHall), s.regionOf(alice))
 	s.Equal([]encounter.MemberID{carol}, s.idsIn(tombEntrance))
 	s.Equal([]encounter.MemberID{alice, bob, dave}, s.idsIn(tombHall))
+}
+
+// TestTheRegionIsDerivedAcrossPersistenceToo is the persistence half of the
+// same claim: nothing about a region is stored, at any point.
+//
+// An outcome used to carry a "room" key beside every member's cell — the last
+// derived spatial fact this module persisted, and load validation had a branch
+// whose whole job was policing the two against each other. The blob no longer
+// says it and the reloaded outcome still names it, because the cell and the
+// authored field say it between them (rpg-toolkit#1108).
+func (s *RegionSuite) TestTheRegionIsDerivedAcrossPersistenceToo() {
+	ended, err := s.enc.End(&encounter.EndInput{Ending: "withdrawn"})
+	s.Require().NoError(err)
+	s.Require().Len(ended.Outcome.Members, 4)
+
+	data := s.enc.ToData()
+
+	blob, err := json.Marshal(data.Outcome)
+	s.Require().NoError(err)
+	s.NotContains(string(blob), `"room"`, "an outcome member's region is derived, so it is not in the blob")
+	s.NotContains(string(blob), `"region"`, "and it did not come back under a new name either")
+
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+	s.Require().NoError(err)
+
+	status, err := reloaded.Status()
+	s.Require().NoError(err)
+	s.Require().NotNil(status.Outcome)
+
+	want := map[encounter.MemberID]encounter.RegionID{
+		alice: tombEntrance, carol: tombEntrance, bob: tombHall, dave: tombHall,
+	}
+	for _, mo := range status.Outcome.Members {
+		s.Equal(want[mo.ID], mo.Region, "%s finished in %q", mo.ID, want[mo.ID])
+	}
+	s.Require().Equal(ended.Outcome.Members, status.Outcome.Members,
+		"a reloaded outcome must be the outcome the host already saw")
 }
 
 // TestRegionAtAnswersExactlyWhatTheAuthoredGridWould, in both families. The

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -1,0 +1,311 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// regions_test.go is A ROOM IS A REGION (rpg-toolkit#1108).
+//
+// S0 made the field one canvas and left the authored chambers as construction
+// data with one runtime job: saying which of them holds a given cell. This
+// slice gives that job a name. A region is a NAMED SET OF CELLS — you ask it
+// which region holds a cell, or which members are standing in one — and it is
+// not a coordinate space, not a container, and not a visibility rule.
+//
+// The fixture is canvas_test.go's reference tomb, deliberately: three chambers
+// in a chain with two doorways, which is the shape that makes the doorway
+// question answerable rather than hypothetical.
+type RegionSuite struct {
+	suite.Suite
+
+	enc *encounter.Encounter
+}
+
+func TestRegionSuite(t *testing.T) {
+	suite.Run(t, new(RegionSuite))
+}
+
+// SetupTest opens the same tomb canvas_test.go opens, with the same four
+// members: alice ON the entrance's doorway cell, bob on the hall's side of that
+// same opening, carol and dave one row up with the seam wall between them.
+func (s *RegionSuite) SetupTest() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: tombField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
+				Position: spatial.Position{X: 5, Y: float64(tombDoorRow)}},
+			{ID: bob, Kind: encounter.KindPlayer, Room: tombHall,
+				Position: spatial.Position{X: 0, Y: float64(tombDoorRow)}},
+			{ID: carol, Kind: encounter.KindPlayer, Room: tombEntrance,
+				Position: spatial.Position{X: 5, Y: float64(tombDoorRow - 1)}},
+			{ID: dave, Kind: encounter.KindPlayer, Room: tombHall,
+				Position: spatial.Position{X: 0, Y: float64(tombDoorRow - 1)}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	s.enc = enc
+}
+
+// TestTheTombsThreeChambersAreRegions is the headline: the dungeon the stack
+// has to carry answers RegionAt for every cell it owns, and answers it with the
+// name the designer authored.
+func (s *RegionSuite) TestTheTombsThreeChambersAreRegions() {
+	chambers := []struct {
+		id            encounter.RegionID
+		origin        spatial.Position
+		width, height int
+	}{
+		{tombEntrance, tombEntranceOrigin, 6, 8},
+		{tombHall, tombHallOrigin, 10, 8},
+		{tombChamber, tombChamberOrigin, 12, 8},
+	}
+
+	for _, c := range chambers {
+		for x := 0; x < c.width; x++ {
+			for y := 0; y < c.height; y++ {
+				cell := tombAt(c.origin, x, y)
+				got, ok := s.enc.RegionAt(cell)
+				s.Require().True(ok, "cell %v is floor in %q", cell, c.id)
+				s.Require().Equal(c.id, got, "cell %v", cell)
+			}
+		}
+	}
+}
+
+// TestRegionAtIsTotalOverFloorAndSilentOverVoid pins the invariant the whole
+// slice rests on, swept over the canvas the field actually compiles onto: a
+// cell is floor if and only if exactly one region owns it.
+//
+// The tomb's canvas is its bounding box, so there ARE cells on it that no
+// chamber owns — the strip below and left of the chain, which the authored
+// rooms never reach. Those are the void S0 refuses to place anybody on, and
+// they are what "region membership is total over FLOOR" means as distinct from
+// "total over the canvas".
+func (s *RegionSuite) TestRegionAtIsTotalOverFloorAndSilentOverVoid() {
+	owners := 0
+	void := 0
+	for x := 0; x <= 30; x++ {
+		for y := 0; y <= 11; y++ {
+			cell := spatial.Position{X: float64(x), Y: float64(y)}
+			id, ok := s.enc.RegionAt(cell)
+
+			onFloor := y >= 4 && y <= 11 && x >= 3 && x <= 30
+			if !onFloor {
+				s.Require().False(ok, "cell %v is not floor", cell)
+				s.Require().Empty(id, "a cell no region owns is not named")
+				void++
+				continue
+			}
+			s.Require().True(ok, "cell %v is floor", cell)
+			s.Require().NotEmpty(id, "cell %v", cell)
+			owners++
+		}
+	}
+	s.Equal(6*8+10*8+12*8, owners, "every authored cell, once")
+	s.Positive(void, "and the fixture must actually contain void, or this pins nothing")
+}
+
+// TestAMemberInTheDoorwayStandsInTheRegionTheyStandOn is THE DOORWAY DECISION.
+//
+// The old stack made a door's own cell belong to NO region on purpose
+// (encounter/knowledge.go: "doors sit between two regions' tagged hex sets,
+// never inside either"). That is a fact about a canvas whose compiler puts a
+// one-cell WALL COLUMN between chambers and carves a floor door cell in it.
+//
+// This composition cannot express that cell. A connection's two endpoints are
+// room-LOCAL cells of their own rooms (ConnectionInput's doc comment: "the
+// position a member must stand on in each room to be at the doorway"), and W3
+// makes them ADJACENT absolute cells — there is nothing between them. And under
+// S0 a cell no room owns is not floor at all: Step and Join refuse it. So in
+// this model "belongs to no region" and "you cannot stand there" are the same
+// sentence, and a no-region doorway would be a doorway nobody could stand in.
+//
+// The answer here, therefore: a member in a doorway stands in the region whose
+// cell is under their feet. alice and bob are one cell apart in the same
+// opening and are in DIFFERENT regions — and they see each other, because sight
+// is geometry and region membership is not sight.
+func (s *RegionSuite) TestAMemberInTheDoorwayStandsInTheRegionTheyStandOn() {
+	entranceSide := tombAt(tombEntranceOrigin, 5, tombDoorRow)
+	hallSide := tombAt(tombHallOrigin, 0, tombDoorRow)
+	s.Require().Equal(float64(1), hallSide.X-entranceSide.X, "the two endpoints are adjacent (W3)")
+
+	got, ok := s.enc.RegionAt(entranceSide)
+	s.Require().True(ok, "the doorway cell is floor — somebody is standing on it")
+	s.Equal(encounter.RegionID(tombEntrance), got)
+
+	got, ok = s.enc.RegionAt(hallSide)
+	s.Require().True(ok)
+	s.Equal(encounter.RegionID(tombHall), got, "the far endpoint belongs to the hall, not to nobody")
+
+	s.Equal(encounter.RegionID(tombEntrance), s.regionOf(alice), "alice is IN the doorway")
+	s.Equal(encounter.RegionID(tombHall), s.regionOf(bob), "bob is one cell through it")
+
+	s.True(s.sees(alice, bob), "and they can see each other: the opening is open")
+	s.True(s.sees(bob, alice))
+}
+
+// TestMembersInReportsEachChambersRoster is the other half of the pair: given a
+// region, who is standing in it. The doorway pair lands on opposite sides of
+// this answer, which is the same decision the test above makes, read from the
+// other end.
+func (s *RegionSuite) TestMembersInReportsEachChambersRoster() {
+	s.Equal([]encounter.MemberID{alice, carol}, s.idsIn(tombEntrance))
+	s.Equal([]encounter.MemberID{bob, dave}, s.idsIn(tombHall))
+	s.Empty(s.idsIn(tombChamber), "nobody has reached the tomb yet, and that is an answer")
+}
+
+// TestMembersInCarriesTheSamePlacementEveryReadSpeaks — MembersIn is a roster
+// read, so it reports what Members reports, filtered. A parallel projection
+// here would be a second answer to "where is alice" (placementOf's rule).
+func (s *RegionSuite) TestMembersInCarriesTheSamePlacementEveryReadSpeaks() {
+	in, err := s.enc.MembersIn(tombEntrance)
+	s.Require().NoError(err)
+	s.Require().Len(in, 2)
+
+	all, err := s.enc.Members()
+	s.Require().NoError(err)
+	byID := map[encounter.MemberID]encounter.Member{}
+	for _, m := range all {
+		byID[m.ID] = m
+	}
+	for _, m := range in {
+		s.Equal(byID[m.ID], m, "MembersIn and Members must agree about %q", m.ID)
+	}
+}
+
+// TestMembersInRefusesARegionTheFieldDoesNotHave. A typo'd region name must not
+// read as "nobody is in the hall" — an empty roster is a real answer for a real
+// region (see the tomb chamber above), so an unknown one has to be an error.
+func (s *RegionSuite) TestMembersInRefusesARegionTheFieldDoesNotHave() {
+	_, err := s.enc.MembersIn("scullery")
+	s.Require().Error(err)
+	s.ErrorIs(err, encounter.ErrNoRegion)
+}
+
+// TestAStepChangesTheRegionAMemberIsIn pins that membership is DERIVED from the
+// cell rather than stored beside it: nothing tells the encounter that alice
+// changed chambers, and the encounter says she did.
+//
+// Bob steps out of the opening first, because he is standing in it. That is the
+// doorway decision showing up as a fact about the map rather than as a rule: an
+// opening is one cell wide on each side, both of them ordinary floor of their
+// own region, and two people cannot stand on one.
+func (s *RegionSuite) TestAStepChangesTheRegionAMemberIsIn() {
+	s.Require().Equal(encounter.RegionID(tombEntrance), s.regionOf(alice))
+
+	_, err := s.enc.Step(&encounter.StepInput{
+		Member: bob, To: tombAt(tombHallOrigin, 1, tombDoorRow),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.enc.Step(&encounter.StepInput{
+		Member: alice, To: tombAt(tombHallOrigin, 0, tombDoorRow),
+	})
+	s.Require().NoError(err)
+
+	s.Equal(encounter.RegionID(tombHall), s.regionOf(alice))
+	s.Equal([]encounter.MemberID{carol}, s.idsIn(tombEntrance))
+	s.Equal([]encounter.MemberID{alice, bob, dave}, s.idsIn(tombHall))
+}
+
+// TestRegionAtAnswersExactlyWhatTheAuthoredGridWould, in both families. The
+// region report no longer enumerates cells, so nothing else proves that what a
+// region CLAIMS to hold is what its own grid would accept — this does, by
+// sweeping a window wider than the field in each family and comparing against
+// the room's own bounds rule.
+func (s *RegionSuite) TestRegionAtAnswersExactlyWhatTheAuthoredGridWould() {
+	s.Run("square", func() {
+		origin := spatial.Position{X: 4, Y: 6}
+		enc := s.oneRoom(spatial.GridShapeSquare, 5, 3, origin)
+		for x := -4; x <= 14; x++ {
+			for y := -4; y <= 14; y++ {
+				cell := spatial.Position{X: float64(x), Y: float64(y)}
+				local := cell.Subtract(origin)
+				want := local.X >= 0 && local.X < 5 && local.Y >= 0 && local.Y < 3
+				_, ok := enc.RegionAt(cell)
+				s.Require().Equal(want, ok, "square cell %v (local %v)", cell, local)
+			}
+		}
+	})
+
+	s.Run("hex", func() {
+		// Hex spans are origin-CENTERED: [-dim/2, dim/2).
+		origin := spatial.Position{X: 3, Y: -2}
+		enc := s.oneRoom(spatial.GridShapeHex, 6, 4, origin)
+		for q := -10; q <= 10; q++ {
+			for r := -10; r <= 10; r++ {
+				cell := spatial.Position{X: float64(q), Y: float64(r)}
+				local := cell.Subtract(origin)
+				want := local.X >= -3 && local.X < 3 && local.Y >= -2 && local.Y < 2
+				_, ok := enc.RegionAt(cell)
+				s.Require().Equal(want, ok, "hex cell %v (local %v)", cell, local)
+			}
+		}
+	})
+}
+
+// oneRoom opens a single-region encounter of the given family, anchored away
+// from the origin so a local coordinate cannot pass as an absolute one.
+func (s *RegionSuite) oneRoom(shape spatial.GridShape, w, h int, origin spatial.Position) *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+			{ID: "only", Width: w, Height: h, Grid: shape, Origin: origin},
+		}},
+		Members: []encounter.MemberInput{
+			// Local (0,0) is a cell in both families: square rooms start
+			// there, hex rooms are centered on it.
+			{ID: alice, Kind: encounter.KindPlayer, Room: "only", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// regionOf reads a member's region off the roster.
+func (s *RegionSuite) regionOf(id core.EntityID) encounter.RegionID {
+	members, err := s.enc.Members()
+	s.Require().NoError(err)
+	for _, m := range members {
+		if m.ID == id {
+			return m.Region
+		}
+	}
+	s.Require().Fail("no such member", string(id))
+	return ""
+}
+
+// idsIn names who MembersIn reports, in the order it reports them.
+func (s *RegionSuite) idsIn(region encounter.RegionID) []encounter.MemberID {
+	members, err := s.enc.MembersIn(region)
+	s.Require().NoError(err)
+	ids := make([]encounter.MemberID, 0, len(members))
+	for _, m := range members {
+		ids = append(ids, m.ID)
+	}
+	return ids
+}
+
+// sees reports whether an observer holds anything on a subject.
+func (s *RegionSuite) sees(observer, subject core.EntityID) bool {
+	view, err := s.enc.View(&encounter.ViewInput{Member: observer})
+	s.Require().NoError(err)
+	for _, h := range view {
+		if string(h.Subject) == string(subject) {
+			return true
+		}
+	}
+	return false
+}

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -305,11 +305,15 @@ func (s *RegionSuite) TestTheRegionIsDerivedAcrossPersistenceToo() {
 		"a reloaded outcome must be the outcome the host already saw")
 }
 
-// TestRegionAtAnswersExactlyWhatTheAuthoredGridWould, in both families. The
-// region report no longer enumerates cells, so nothing else proves that what a
-// region CLAIMS to hold is what its own grid would accept — this does, by
-// sweeping a window wider than the field in each family and comparing against
-// the room's own bounds rule.
+// TestRegionAtAnswersExactlyWhatTheAuthoredGridWould, in both families, ANCHORED
+// AWAY FROM THE ORIGIN — which is the whole of what it adds.
+//
+// atlas_test.go's TestRegionMembershipMatchesIsValidPosition sweeps every
+// dimension parity against spatial's own IsValidPosition, and is the stronger
+// test of the bounds rule; its rooms sit at Origin zero, where a lookup that
+// forgot to project would pass anyway because local and absolute coincide.
+// This one sweeps a window wider than the field around a region anchored
+// somewhere else, in each family, so the projection is load-bearing.
 func (s *RegionSuite) TestRegionAtAnswersExactlyWhatTheAuthoredGridWould() {
 	s.Run("square", func() {
 		origin := spatial.Position{X: 4, Y: 6}

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -220,6 +220,53 @@ func (s *RegionSuite) TestAStepChangesTheRegionAMemberIsIn() {
 	s.Equal([]encounter.MemberID{alice, bob, dave}, s.idsIn(tombHall))
 }
 
+// TestReachingTheTombChamberClosesTheDelve is the issue's own done-when, in the
+// dungeon it names: an ending declared on a tile in the tomb chamber fires when
+// a player walks into that chamber.
+//
+// Worth having in the tomb's terms rather than only on a purpose-built fixture,
+// because the two seams are what make it a real walk: alice starts on the
+// hall's side of the tomb doorway and crosses into the chamber, which is one
+// ordinary step through a gap in a wall, and the ending is one cell equality
+// (arrival_test.go holds the rules that equality carries). The outcome then
+// reports every member's region, derived from where they each stand.
+func (s *RegionSuite) TestReachingTheTombChamberClosesTheDelve() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: tombField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: tombHall,
+				Position: spatial.Position{X: 9, Y: float64(tombDoorRow)}},
+			{ID: carol, Kind: encounter.KindPlayer, Room: tombEntrance,
+				Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "the-tomb", Trigger: encounter.TriggerReachedPosition{
+				Room: tombChamber, Position: spatial.Position{X: 0, Y: float64(tombDoorRow)}}},
+		},
+	})
+	s.Require().NoError(err)
+
+	theTomb := tombAt(tombChamberOrigin, 0, tombDoorRow)
+	got, ok := enc.RegionAt(theTomb)
+	s.Require().True(ok)
+	s.Require().Equal(encounter.RegionID(tombChamber), got, "the ending's tile is in the tomb chamber")
+
+	out, err := enc.Step(&encounter.StepInput{Member: alice, To: theTomb})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Outcome, "walking into the tomb chamber closes the delve")
+	s.Equal("the-tomb", out.Outcome.Ending)
+	s.Equal(tombDoor, out.Crossing, "and it was an ordinary step through the doorway")
+
+	finished := map[encounter.MemberID]encounter.RegionID{}
+	for _, mo := range out.Outcome.Members {
+		finished[mo.ID] = mo.Region
+	}
+	s.Equal(map[encounter.MemberID]encounter.RegionID{
+		alice: tombChamber, carol: tombEntrance,
+	}, finished, "the outcome names where each of them finished")
+}
+
 // TestTheRegionIsDerivedAcrossPersistenceToo is the persistence half of the
 // same claim: nothing about a region is stored, at any point.
 //

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -305,6 +305,59 @@ func (s *RegionSuite) TestTheRegionIsDerivedAcrossPersistenceToo() {
 		"a reloaded outcome must be the outcome the host already saw")
 }
 
+// TestAStaleRegionLabelInABlobCannotChangeTheAnswer is why dropping the
+// persisted "room" key is a quiet change rather than a dialect break.
+//
+// #1068 renamed a persisted field so old blobs would FAIL LOUDLY, and it was
+// right to: the coordinate FRAME had changed, so a blob written before the flip
+// meant something different from what it said, and silence would have been a
+// lie. Nothing like that is true here. The region was never information — it is
+// a function of the cell and the authored field, both still in the blob — so a
+// reader that ignores the old key cannot lose anything.
+//
+// This proves it rather than arguing it. The blob below is handed to
+// LoadEncounter with every outcome member labelled "tomb", which is wrong for
+// all four of them, and the encounter that comes back says where they actually
+// stood. A field whose value cannot change the answer was never load-bearing —
+// and a future reader tempted to "restore" it has to get past this test.
+func (s *RegionSuite) TestAStaleRegionLabelInABlobCannotChangeTheAnswer() {
+	ended, err := s.enc.End(&encounter.EndInput{Ending: "withdrawn"})
+	s.Require().NoError(err)
+
+	raw, err := json.Marshal(s.enc.ToData())
+	s.Require().NoError(err)
+
+	// Write the old key back in, with a value that is wrong for everybody.
+	var generic map[string]any
+	s.Require().NoError(json.Unmarshal(raw, &generic))
+	outcome, ok := generic["outcome"].(map[string]any)
+	s.Require().True(ok, "the fixture must have closed")
+	members, ok := outcome["members"].([]any)
+	s.Require().True(ok)
+	s.Require().Len(members, 4)
+	for _, m := range members {
+		m.(map[string]any)["room"] = tombChamber
+	}
+	tampered, err := json.Marshal(generic)
+	s.Require().NoError(err)
+	s.Require().Contains(string(tampered), `"room":"`+tombChamber+`"`,
+		"the stale label must actually be in the blob, or this test pins nothing")
+
+	var data encounter.EncounterData
+	s.Require().NoError(json.Unmarshal(tampered, &data))
+
+	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+	s.Require().NoError(err, "an unknown key is ignored, not a defect to refuse")
+
+	status, err := loaded.Status()
+	s.Require().NoError(err)
+	s.Require().NotNil(status.Outcome)
+	s.Equal(ended.Outcome.Members, status.Outcome.Members,
+		"the cells decide, so the reloaded outcome is the one the host already saw — "+
+			"nobody is in the tomb chamber, whatever the blob claimed")
+}
+
 // TestRegionAtAnswersExactlyWhatTheAuthoredGridWould, in both families, ANCHORED
 // AWAY FROM THE ORIGIN — which is the whole of what it adds.
 //

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -345,6 +345,42 @@ func (s *RegionSuite) TestRegionAtAnswersExactlyWhatTheAuthoredGridWould() {
 	})
 }
 
+// TestAFractionalHexPositionIsNotACell pins the answer to the question a public
+// predicate can be asked that an internal one could not.
+//
+// A hex grid's IsValidPosition bounds-checks and nothing else, so while this
+// lookup was internal the integrality rule lived at the verbs — every caller
+// asked first, and a check inside would have been unreachable. Making the
+// question public made it reachable: a host can hand RegionAt any position at
+// all. Before this was fixed, RegionAt answered ("only", true) for the axial
+// position below while Join refused the very same one as not a cell — two
+// answers to "is this floor", which is what region.go exists to prevent.
+//
+// Square is deliberately NOT covered by that rule: it is fractional-tolerant by
+// design, and a member standing between its cells really is in the region whose
+// span holds them.
+func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
+	hexOrigin := spatial.Position{X: 3, Y: -2}
+	hex := s.oneRoom(spatial.GridShapeHex, 6, 6, hexOrigin)
+
+	frac := spatial.Position{X: 3.5, Y: -1.5}
+	_, ok := hex.RegionAt(frac)
+	s.False(ok, "a fractional axial position is not a cell, so no region holds it")
+
+	_, err := hex.Join(&encounter.JoinInput{Member: bob, Kind: encounter.KindPlayer, Cell: frac})
+	s.Require().Error(err, "and the verbs agree — which is the whole point")
+	s.ErrorIs(err, encounter.ErrBadPlacement)
+
+	_, ok = hex.RegionAt(spatial.Position{X: 4, Y: -1})
+	s.True(ok, "the integral cell beside it is ordinary floor")
+
+	squareOrigin := spatial.Position{X: 4, Y: 6}
+	square := s.oneRoom(spatial.GridShapeSquare, 5, 3, squareOrigin)
+	got, ok := square.RegionAt(spatial.Position{X: 5.5, Y: 7.5})
+	s.True(ok, "square is fractional-tolerant by design")
+	s.Equal(encounter.RegionID("only"), got)
+}
+
 // oneRoom opens a single-region encounter of the given family, anchored away
 // from the origin so a local coordinate cannot pass as an absolute one.
 func (s *RegionSuite) oneRoom(shape spatial.GridShape, w, h int, origin spatial.Position) *encounter.Encounter {

--- a/rulebooks/dnd5e/encounter/step.go
+++ b/rulebooks/dnd5e/encounter/step.go
@@ -149,14 +149,14 @@ func (e *Encounter) Step(in *StepInput) (*StepOutput, error) {
 func (e *Encounter) stepMember(member *memberRecord, to spatial.Position) (executedAction, error) {
 	// Hex fields require integral axial cells (interim tools/spatial#926
 	// enforcement — see isIntegralAxialPosition). Asked BEFORE the floor
-	// question so a fractional cell is named as itself: roomAt refuses one too,
+	// question so a fractional cell is named as itself: regionAt refuses one too,
 	// but it would report it as "not floor", sending a caller to the map
 	// instead of to its arithmetic.
 	if !isIntegralAxialPosition(e.canvas.GetGrid(), to) {
 		return executedAction{}, fmt.Errorf("target is not an integral axial cell: %w", ErrBadPlacement)
 	}
 
-	if _, owned := e.roomAt(to); !owned {
+	if _, owned := e.RegionAt(to); !owned {
 		return executedAction{}, fmt.Errorf("cell %v is not floor: %w", to, ErrBadPlacement)
 	}
 

--- a/rulebooks/dnd5e/encounter/step.go
+++ b/rulebooks/dnd5e/encounter/step.go
@@ -149,9 +149,10 @@ func (e *Encounter) Step(in *StepInput) (*StepOutput, error) {
 func (e *Encounter) stepMember(member *memberRecord, to spatial.Position) (executedAction, error) {
 	// Hex fields require integral axial cells (interim tools/spatial#926
 	// enforcement — see isIntegralAxialPosition). Asked BEFORE the floor
-	// question so a fractional cell is named as itself: regionAt refuses one too,
-	// but it would report it as "not floor", sending a caller to the map
-	// instead of to its arithmetic.
+	// question so a fractional cell is named as itself: regionAt refuses one
+	// too, and refuses it by this very check (rpg-toolkit#1108), but it would
+	// report it as "not floor" — sending a caller to the map instead of to its
+	// arithmetic.
 	if !isIntegralAxialPosition(e.canvas.GetGrid(), to) {
 		return executedAction{}, fmt.Errorf("target is not an integral axial cell: %w", ErrBadPlacement)
 	}

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -252,7 +252,7 @@ func (s *StepSuite) roomOf(id encounter.MemberID) string {
 	s.Require().NoError(err)
 	for _, m := range members {
 		if m.ID == id {
-			return m.Room
+			return m.Region
 		}
 	}
 	s.Require().Fail("no such member", string(id))
@@ -283,7 +283,7 @@ func (s *StepSuite) TestAStepIntoTheWallBetweenTwoChambersIsRefused() {
 
 	// The premise: that cell is real floor, in the chamber next door — the
 	// refusal is about the wall, not about the destination.
-	s.Require().Equal(stepEast, s.roomAtCell(acrossTheSeam))
+	s.Require().Equal(encounter.RegionID(stepEast), s.regionAtCell(acrossTheSeam))
 
 	_, err := s.enc.Step(&encounter.StepInput{Member: alice, To: acrossTheSeam})
 	s.Require().Error(err)
@@ -291,19 +291,13 @@ func (s *StepSuite) TestAStepIntoTheWallBetweenTwoChambersIsRefused() {
 	s.Equal(before, s.standsAt(alice))
 }
 
-// roomAtCell names the authored chamber whose absolute footprint holds a cell,
-// read off the Atlas — construction truth, which is where rooms live now.
-func (s *StepSuite) roomAtCell(cell spatial.Position) string {
-	atlas, err := s.enc.Atlas()
-	s.Require().NoError(err)
-	for _, room := range atlas.Rooms {
-		for _, c := range room.Cells {
-			if c == cell {
-				return room.ID
-			}
-		}
-	}
-	return ""
+// regionAtCell names the region whose cell set holds a cell. It used to walk
+// the Atlas's enumerated cells to get there; the field answers it directly now
+// (rpg-toolkit#1108), which is the same question asked of the thing that owns
+// it rather than of a list.
+func (s *StepSuite) regionAtCell(cell spatial.Position) encounter.RegionID {
+	region, _ := s.enc.RegionAt(cell)
+	return region
 }
 
 // TestAStepAndAMonsterStepAgreeOnWhatIsCrossable is why this issue was filed.

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -263,7 +263,7 @@ func TestTombWatch(t *testing.T) {
 			kind = encounter.KindMonster
 		}
 		sequelMembers = append(sequelMembers, encounter.MemberInput{
-			ID: mo.ID, Kind: kind, Room: mo.Room, Position: mo.Position,
+			ID: mo.ID, Kind: kind, Room: mo.Region, Position: mo.Position,
 		})
 	}
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{


### PR DESCRIPTION
The authored chambers survive the compile as **regions**: named sets of cells you can ask about. `RegionAt` says which region holds a cell, `MembersIn` says who is standing in one, and the `Atlas` reports each region's anchor and span instead of listing its cells.

World-model wave slice **S1** (tracker #1105). Follows **S0 (#1106/#1107, merged, encounter v0.18.0)**, which made the canvas the primitive.

---

## The finding this rests on

The issue expected the duplicate to be in `TriggerReachedPosition`. **S0 already fixed that one** — it deleted Join's inline copy, and `compileEndings` now resolves an ending's authored room and local target into ONE absolute cell, so the decision is a coordinate equality with no region comparison left in it at all. Re-censused and stated plainly rather than re-reported as found.

**The live duplicate was region ownership itself, and there were three of it:**

| Where | Shape |
|---|---|
| `encounter.go:1405` `(*Encounter).roomAt` | `for ri := range fieldInput { grids[ri.ID].IsValidPosition(cell.Subtract(ri.Origin)) }` → `(string, bool)` |
| `data.go:929` `ownedByAnyRoom` | the same loop → `bool`. Its own doc comment called itself *"the load-time twin of Encounter.roomAt"* |
| `data.go:669-678` | an inline third, the named-region variant, checking an outcome cell against the room named beside it in the blob |

RED, run at `33c8f18` before anything was written:

```
--- FAIL: TestRegionOwnershipIsAskedInOneFunction
    expected: []string{"regionAt"}
    actual  : []string{"LoadEncounter", "ownedByAnyRoom", "roomAt"}
```

One `regionAt(rooms, grids, cell)` now, and the pin above is what keeps it at one.

---

## Census

Verified against `33c8f18`, tree clean. Plan at `/home/kirk/.claude/jobs/929a988a/tmp/fix-1108/plan.md`; RED transcripts at `red-evidence.txt` beside it.

**No compile is forced outside this module.** `session/go.mod` pins encounter `v0.17.0`, `resolution/go.mod` pins `v0.15.0`; no `go.work`, no `replace` anywhere in `rulebooks/`. **`Atlas` has zero consumers outside this module** — neither session nor resolution calls it.

**Three call sites inside the module were membership questions written the long way**: `placement_test.go:122` and `step_test.go:300` iterated `AtlasRoom.Cells` to ask which room held a cell, and `cmd/freeroam-workbench` scanned the whole cell list to recover a bounding box it was already handed. All three are `RegionAt` callers now.

**`spatial.Position.Subtract` appeared in production code at exactly three places** — the three implementations above. Every other `IsValidPosition` call in the package takes a room-LOCAL authoring position directly (a connection endpoint, an ending target, a member placement) and asks in the frame it was written in. That is what makes the structural pin precise rather than approximate.

---

## Conformance to the ruled shape

| Ruled (#1105, Kirk 2026-08-19) | Landed |
|---|---|
| (1) The canvas is the primitive | unchanged — this slice adds the read surface over it |
| (2) Walls are boundary edges | unchanged; no wall vocabulary touched |
| (3) `RoomInput` stays — rooms are how we AUTHOR | `RoomInput`, `MemberInput.Room`, `TriggerReachedPosition.Room`, `RoomData` all unchanged |
| (4) The floor mask is deferred | still deferred; nothing here forces it |

**The vocabulary line this slice draws: authoring says ROOM, runtime says REGION.** That is ruling 3 read one layer down — *"we author rooms; that they become one thing is after render"*. What a designer writes stays room-shaped; what the encounter answers with after the compile is a region. So `Atlas.Rooms`→`Regions`, `AtlasRoom`→`AtlasRegion`, `Member.Room`→`Member.Region`, `MemberOutcome.Room`→`Region`, and `RegionID` (an alias, following `MemberID` — it says which of two strings a signature means without making callers convert).

Shipping "region" on two verbs while the Atlas still said "room" would have been two words for one concept, which is how vocabulary drifts into two implementations.

---

## The doorway decision

**A member in a doorway is in the region whose cell is under their feet.** `RegionAt` is total over FLOOR: a cell is floor if and only if exactly one region owns it, doorway endpoints included.

The old stack made a door's own cell belong to no region *on purpose* — `encounter/knowledge.go:451-453`, verified still reading that way: *"the door's own cell belongs to NEITHER region ... doors sit between two regions' tagged hex sets, never inside either."*

**That is a fact about a compiler this composition does not have.** The old stack's canvas lays chambers out with a one-cell WALL COLUMN between them and carves a floor door cell into it — S0's own PR body measured the shipping tomb as entrance 0-5, wall column 6, hall 7-16. There is a real cell between two regions there to leave unnamed.

This composition cannot express that cell. A connection's two endpoints are room-LOCAL cells **of their own rooms** (`field.go`'s `ConnectionInput`: *"the position a member must stand on in each room to be at the doorway"*), and W3 makes them adjacent absolute cells — nothing sits between them. And under S0 a cell no room owns is not floor: `Step` and `Join` refuse it. So in this model **"belongs to no region" and "you cannot stand there" are the same sentence**, and an unnamed doorway cell would be a doorway nobody could stand in.

Not a rejection of the old stack's answer — an observation that it is un-instantiable here, and that the honest report is the one the model can actually make. Pinned three ways:

- `TestAMemberInTheDoorwayStandsInTheRegionTheyStandOn` — alice on the entrance's endpoint and bob one cell through it are in DIFFERENT regions, `MembersIn` splits them, **and they still see each other**, because sight is geometry and region membership is not sight.
- `TestRegionOwnershipAtKissingDoorway` — the same claim from the roster, on the atlas fixture.
- `TestRegionAtIsTotalOverFloorAndSilentOverVoid` — swept over the whole canvas bounding box, including the void strip the tomb's chain leaves in it.

**For S5:** this is the same warning S0's PR body left about a content compiler that maps regions to `RoomInput`s one-for-one. The authoring that works is rooms adjacent, seams walled with boundary edges, one edge left out for the doorway — which is what every fixture here uses.

---

## The Atlas measurement

Measured first-hand on the post-S0 shape rather than quoting #1059, at the legal field budget — four 1024×1024 rooms, `maxFieldCells` = 1<<22, which the fixture persists in 601 bytes (measured here, not carried over from S0's slightly different fixture):

```
BEFORE (33c8f18)                       AFTER
  cold:  128.02 MB   43.255256ms         624 bytes   7.985µs
  warm:  128.01 MB   20.899870ms         624 bytes   2.816µs
```

**134,225,920 bytes → 624 bytes.** `AtlasRegion` reports what a region IS — anchor, span, family — and `RegionAt` answers membership from that, so the report is O(regions) and a host that genuinely wants cells walks a rectangle it was handed rather than one the module built for it. `atlasCells` is deleted.

Pinned by `TestAtlasReportsRegionsWithoutEnumeratingThem`, in two halves: a shape assertion that `AtlasRegion` has no cell list, and an allocation bound of 1 MB at the field budget. The bound is deliberately loose against a measured 624 bytes — it is pinning an ORDER OF GROWTH, and a tight bound would fail on an unrelated allocation without saying anything true.

**Two comments that were true and stopped being true, corrected rather than left standing.** `maxRoomCells`/`maxFieldCells` existed as allocation-safety bounds for `atlasCells`' `make()`; nothing in the module allocates per cell any more (both grid families hold bounds only). They are KEPT, re-documented for what they guard now: the region report tells a host an anchor and a span and leaves it to walk them, so the module must not hand out a legal region no caller can walk. Likewise the occluder-integrality check, whose stated reason was "Occluders must be a subset of Cells".

---

## `MemberOutcomeData.Room` is deleted

The last derived spatial fact this module persisted. S0 deleted `MemberData.Room` on the argument that a member's chamber is a fact about where they stand; the outcome's copy survived it, and load validation carried a whole branch whose job was policing the stored region against the cell beside it.

It is re-derived at load through the same `regionAt` every live read uses. **Old blobs still load** — the `"room"` key is ignored and the value recomputed — so this is not a detectable break in the #1053 sense, just a smaller blob. The "outcome member names a room the field does not have" load case went with the field that carried it; the only way an outcome member can be somewhere impossible is now by CELL, which is the case that remains.

**Why this is a quiet change and #1068's rename was not — proven, not argued.** #1068 renamed a persisted field so old blobs would fail loudly, and it was right to: the coordinate FRAME had changed, so a blob written before the flip meant something different from what it said and silence would have been a lie. Nothing like that is true here. The region was never information.

`TestAStaleRegionLabelInABlobCannotChangeTheAnswer` hands `LoadEncounter` a blob with **every outcome member labelled `"tomb"`** — wrong for all four of them — and the encounter that comes back says where they actually stood. A field whose value cannot change the answer was never load-bearing, which is the entire justification for dropping it quietly. It also stops a future reader from "restoring" it: mutation `P4` does exactly that (field back, believed at load, written at save) and this test plus `TestTheRegionIsDerivedAcrossPersistenceToo` kill it.

---

## Test evidence

**RED first**, at `33c8f18`, in two parts (`red-evidence.txt`):

1. The region API does not exist — the external test package will not compile (`undefined: encounter.RegionID`, `has no field or method RegionAt`, …).
2. `TestRegionOwnershipIsAskedInOneFunction` reports three implementations, quoted above. `TestTheReachedPositionCellIsReadInOneFunction` **passes at base** — S0 had already collapsed it, and saying so is the honest report.

**New tests**

- `region.go` / `regions_test.go` — the tomb's three chambers as regions, `RegionAt` over every cell of each; totality over floor and silence over void; the doorway decision; `MembersIn` rosters, its agreement with `Members`, and its refusal of a region the field does not have; a step changing a member's region with nothing storing it; **`TestReachingTheTombChamberClosesTheDelve`** — the issue's done-when in the dungeon it names, a player crossing from the hall into the tomb chamber onto a declared tile; `RegionAt` against the authored grid in both families, anchored off-origin; and the region surviving a persistence round trip while the blob never carries it; and **`TestAStaleRegionLabelInABlobCannotChangeTheAnswer`** — see the persistence section.
- `arrival_test.go` — one ending rule, every way in: Step × 4 rules, Join × 4, Pump × 2 (Pump only moves monsters — stated rather than quietly skipped), plus `TestAnEndingIsOneCellNotOneColumn`.
- `oneplace_internal_test.go` — the two structural pins, which read the package's own source: `Subtract` in exactly one function body, `declaredEnding.cell` read in exactly one (assignment targets excluded, so `compileEndings` writing it does not count).
- `atlascost_test.go` — the shape and the cost.

**Converted rather than deleted:** `TestAtlasCellsMatchIsValidPosition` → `TestRegionMembershipMatchesIsValidPosition`, the same parity sweep (1..10 × 1..10 × both families) asked of the lookup every verb actually consults instead of a parallel enumerator. **Deleted:** `TestAtlasCellsExactOrder`, whose subject was `atlasCells`' loop nesting.

**GREEN**, from inside the module:

```
$ go test -count=1 ./...
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter          0.044s
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter/cmd/freeroam-workbench  0.003s

$ gofmt -l .      (clean)
$ go vet ./...    (clean)
$ golangci-lint run ./...   0 issues.
```

795 `=== RUN` lines. All CI checks green.

**Mutation testing: 24 of 24 killed.** Harness audited against an unmutated baseline first (reported PASS), and every restore is from an in-memory snapshot — never `git checkout --`.

- `regionAt` ×7 (everything is floor; origin added not subtracted; origin ignored; owned but unnamed; void is floor; integrality check dropped; integrality check widened to square)
- `MembersIn` ×3 (filter inverted; unknown region answers empty; reports everybody)
- `firedReachedPosition` ×4 (only X compared; member filter dropped; empty filter fires for monsters; first mismatch abandons the scan)
- `Atlas` ×4 (occluders unprojected; origin dropped; span swapped; sort dropped)
- load path ×4 (outcome floor check dropped; region not derived; member floor check dropped; **the persisted region label restored and believed** — the "a future reader puts the field back" scenario, killed by the two tests below)
- **the structural pins ×2** — both duplicates this slice deleted, reintroduced verbatim as new functions. `TestRegionOwnershipIsAskedInOneFunction` and `TestTheReachedPositionCellIsReadInOneFunction` each killed theirs, which is the evidence that the pins do the job they claim.

The first pass had three survivors, each a real hole, each fixed in the second commit: an ending compared on X alone passed every scene because every scene arrived exactly on the tile; the Atlas's 4×3 region could have its axes swapped unnoticed; a reloaded outcome's region could come back empty. Two mutants (`Subtract`→`Add`, origin ignored) are reported killed by the structural pin because it sees the edit — audited separately with the pins excluded, and both die behaviourally too.

---

## Copilot found a real defect, and it reproduces

> `RegionAt`/`regionAt` currently treat fractional axial (hex) positions as owned, because `spatial.AxialHexGrid.IsValidPosition` only bounds-checks and does not enforce integrality.

Verified before changing anything:

```
RegionAt((3.5, -1.5)) on a hex field = ("only", true)
Join at the same position: join: position is not an integral axial cell: bad placement
```

Two answers to "is this floor", which is the exact defect class this file exists to prevent — reached from the outside, on the very surface this slice adds.

**Why it was absent, and why that reasoning expired.** While the lookup was the internal `Encounter.roomAt`, every path to it had already asked: Step, Join and Load each name a fractional axial cell as itself, which is a better error than "not floor". A check inside was therefore a branch no input could take — and #1106's own mutation pass *deleted* that branch for being unpinnable, correctly, at the time. **Making the question public made the branch reachable, and therefore testable.**

Fixed at the predicate: the integrality check now lives in `regionAt`, **hex only** — square is fractional-tolerant by design (`RoomInput.Grid`'s doc comment) and a square member standing between cells really is in the region whose span holds them. `stepMember` keeps its own check first, because it names the defect as itself.

Copilot's second comment was the same finding seen from `step.go`, whose comment claimed `regionAt` would refuse a fractional cell. That claim was inherited from #1106 and was not true; it is true now, and says how. Both acknowledged in-thread.

Pinned by `TestAFractionalHexPositionIsNotACell`, mutation-tested two ways (check dropped; check widened to square) — both killed.

---

**gorelease**, base `v0.18.0`:

```
## incompatible changes
Atlas.Rooms: removed        AtlasRoom: removed
Member.Room: removed        MemberOutcome.Room: removed
MemberOutcomeData.Room: removed
## compatible changes
(*Encounter).MembersIn: added   (*Encounter).RegionAt: added
Atlas.Regions: added            AtlasRegion: added
ErrNoRegion: added              Member.Region: added
MemberOutcome.Region: added     RegionID: added
# summary
Suggested version: v0.19.0
```

**The `!` covers the READ-SURFACE RENAME, not a behaviour change.** Every incompatible entry is a field or type that changed its name (`Rooms`→`Regions`, `Room`→`Region`) or a derived one that stopped being persisted. No verb changed what it does, no rule changed what it decides, and nothing an existing caller passes IN changed shape — `RoomInput`, `MemberInput`, `TriggerReachedPosition` and the whole authoring dialect are untouched. The one behavioural change in the diff is a bug fix (fractional hex, below), and it makes a public predicate agree with the verbs rather than disagree.

**Graded breaking, against the issue's "additive".** The issue expected additive because it scoped the Atlas change as behaviour; a report that stops enumerating has to stop carrying the field it enumerated into, and leaving `Cells` present-but-empty would have been a silent lie. `v0.19.0` is the same number either way pre-1.0 (a minor bump carries a break below v1); the `!` in the title is what says so out loud. There is no installed base — zero `Atlas` consumers outside this module, and session/resolution pin older versions.

---

## Downstream flags — NOT this slice

`session` pins encounter `v0.17.0` and `resolution` pins `v0.15.0`, so nothing here breaks either today. What each will meet when it bumps, censused at this SHA:

**`session`: one mechanical rename, and one real DECISION.**

| Site | What it costs |
|---|---|
| `session/convert.go:62` `for _, room := range in.Rooms` | mechanical — `in.Regions` |
| `session/convert.go:65` `projectGrid(room.Grid)` | nothing — `AtlasRegion.Grid` is unchanged |
| **`session/convert.go:66` `out.Cells = append(out.Cells, room.Cells...)`** | **no source any more** |
| `session/convert.go:181` `projectMember`, `:216` `projectMemberOutcome` | **nothing** — both already drop the room label and carry only ID/Kind/Position, so `Member.Room`→`Region` and `MemberOutcome.Room`→`Region` cost session zero |

The third row is the one worth seeing before S3 starts. `session.Atlas.Cells []spatial.Position` (`json:"cells"`) is a client-facing wire field whose only source was `encounter.AtlasRoom.Cells`, and `projectAtlas`'s whole job is flattening the room-by-room map into one sorted cell list. When session bumps it must choose:

- **enumerate the regions itself** — which reinstates the O(total cells) cost one layer up, and puts a copy of `axisBounds`' span arithmetic in a second module, which is the "formula that could silently diverge" defect `validateConnectionInputs` already warns about; or
- **change its own wire shape to report regions** — which contradicts `session.Atlas`'s own stated design intent in its doc comment: *"what a client renders is a set of cells … not a list of chambers with anchors and spans it would have to reassemble."*

Neither is obviously right, and the caller that forces it (the web client's renderer) is not in this repo. Flagging it rather than pre-deciding it, per the house rule that a case lands with the caller that forces it. Session's own tests that assert on `atlas.Cells` — `atlasmap_test.go:126`, `read_test.go:156`, `onemap_test.go:305`, `example_session_test.go:63` — are where the decision will be felt.

**`resolution`**: unchanged by this slice. `world.go:63-64` reads `MemberData.Room`, which **S0** deleted; that is #1090/S3's subject and S0 already flagged it. Nothing here adds to it.

**`session/write.go:350`'s `place()`**: also S0's, not this slice's — it calls the deleted `Locate` and builds a `MemberInput{Room: …}`. S0's `JoinInput` reshape is what resolves it.

---

## Side-finding, flagged not fixed

`README.md`'s decider walkthrough still shows `Snapshot.Room` and `SightPayload.Room` in its example code. Both were deleted by **#1044**, so that sample has not compiled for two slices. Out of scope here — repairing it means rewriting the pursuer's "a percept in another room is out of reach" logic, which is a claim about sight that #1044 and S0 both changed. Worth its own issue. The lines this slice made wrong (the file table, the rejected-step bullet, the `W1–W5` pointer) are corrected.

Closes #1108.

— fix-1108 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
