### PR TITLE
feat(encounter)!: how far you can see is the rulebook's answer, per member (#1111)

### DIFF
--- a/rulebooks/dnd5e/encounter/README.md
+++ b/rulebooks/dnd5e/encounter/README.md
@@ -154,7 +154,7 @@ behavior that decides *what to do to someone* is not.
 
 ## Capabilities you must supply
 
-Two, both **required at `NewEncounter` and `LoadEncounter`**, both refused at
+Three, all **required at `NewEncounter` and `LoadEncounter`**, all refused at
 construction rather than guarded later:
 
 ```go
@@ -165,12 +165,34 @@ type InitiativeRoller interface {  // what order a fight goes in
 type Standing interface {          // who is down
     Standing(members []MemberID) (down []MemberID, err error)
 }
+
+type Sight interface {             // how far each member can see, in cells
+    Sight(members []MemberID) (map[MemberID]int, error)
+}
 ```
 
-They are the same move. This module cannot import the rulebook, so randomness
-and hit points are facts it **asks for**. Neither has a default: a nil meaning
-"unshuffled" or "everybody is fine" would be the composition deciding a rule it
-is not allowed to know.
+They are the same move. This module cannot import the rulebook, so randomness,
+hit points and light are facts it **asks for**. None has a default: a nil
+meaning "unshuffled", "everybody is fine" or "everyone sees this far" would be
+the composition deciding a rule it is not allowed to know — and the last of
+those three is a rule 5e does not even have, since sight is per-creature and
+per-light-source.
+
+`Sight` answers in **cells**, not feet. Cells are the only distance this module
+has; "a square is five feet" is a 5e rule, so 60-foot darkvision is `12` and the
+division is yours. Today an implementation may answer the same number for
+everybody — what is load-bearing is that the SHAPE is per member, so the real
+light model (bright, dim, dark, darkvision, blindness) lands later as a better
+**answer** rather than as a new mechanism.
+
+Two members answering differently is the point, and it means **A can see B
+without B seeing A**. Geometry stays mutual — `spatial` pins line of sight as a
+law — and what differs is reach. That is what makes 5e surprise producible: a
+monster with darkvision spots a player whose torch does not reach it, the bubble
+forms, and the player is in it unaware. This is not stealth
+([#1020](https://github.com/KirkDiggler/rpg-toolkit/issues/1020)), which
+contests whether an observer's percept holds a subject in plain view; it rides
+the same seam and neither has to know the other exists.
 
 `Standing` is a **pull**. Nothing pushes a death in, and nothing here remembers
 one — the composition asks at the choke point where it already asks about sight,
@@ -193,6 +215,7 @@ other caller of the consult is a verb looking at a world something else changed.
 | `decider.go` | `Decider`, `Snapshot`, `Intent` and its three implementations |
 | `trigger.go` | `InitiativeRoller` and the classification that starts a fight |
 | `standing.go` | `Standing`, and the world noticing who is down |
+| `sight.go` | `Sight`, and how far each member can see this refresh |
 | `step.go` | one step on the map, and the one place that decides what one is |
 | `atlas.go` | the map reads — `Atlas` (every region's anchor and span, in absolute space) and `Grid` |
 | `region.go` | a room is a region: `RegionAt`, `MembersIn`, and the one ownership lookup |

--- a/rulebooks/dnd5e/encounter/arrival_test.go
+++ b/rulebooks/dnd5e/encounter/arrival_test.go
@@ -88,7 +88,7 @@ func (s *ArrivalSuite) arrivalEncounter(filter encounter.MemberID, walker encoun
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field:   arrivalField(),
 		Members: members,
 		Endings: []encounter.EndingInput{

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -26,7 +26,7 @@ import (
 // all exercised by the same tests that already cover Cells/Occluders.
 func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
@@ -65,7 +65,7 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 // a point off in empty space (#929 T3 fix round item 5).
 func validAtlasVoidGapSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "gap-a", Width: 3, Height: 3, Origin: spatial.Position{X: 0, Y: 0}},
@@ -85,7 +85,7 @@ func validAtlasVoidGapSetup() *encounter.SetupInput {
 // IsValidPosition without any Origin arithmetic in the way.
 func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
 		},
@@ -360,7 +360,7 @@ func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 
 	data := enc1.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	atlas2, err := enc2.Atlas()

--- a/rulebooks/dnd5e/encounter/atlascost_test.go
+++ b/rulebooks/dnd5e/encounter/atlascost_test.go
@@ -56,7 +56,7 @@ func TestAtlasReportsRegionsWithoutEnumeratingThem(t *testing.T) {
 
 	t.Run("and reporting them costs O(regions), not O(cells)", func(t *testing.T) {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: budgetField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Room: "a", Position: spatial.Position{X: 1, Y: 1}},

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -77,7 +77,7 @@ func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encoun
 // that has not opened yet.
 func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			// Both clear of the wall's span: they see each other at first light.
@@ -99,7 +99,7 @@ func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 // and the story cannot tell this step apart from any other (rpg-toolkit#1106).
 func (s *BeatOrderTestSuite) TestAStepThroughADoorwayBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -198,7 +198,7 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 2}},

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -139,7 +139,7 @@ func tombAt(origin spatial.Position, x, y int) spatial.Position {
 // them. Nothing about rooms can tell them apart.
 func (s *CanvasSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -301,7 +301,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 		"the old blob still PARSES — that is exactly why the refusal has to be by name")
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data,
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data,
 	})
 	require.Error(t, err, "a room-local placement must not load as an absolute one")
 	require.ErrorIs(t, err, encounter.ErrInvalidData)
@@ -326,7 +326,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 func TestASquareFieldMustFitOneGrid(t *testing.T) {
 	setup := func(origin spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5, Origin: origin}},
 			},
@@ -357,7 +357,7 @@ func TestASquareFieldMustFitOneGrid(t *testing.T) {
 // and this check never rejects one.
 func TestAHexFieldNeedsNoSuchLaw(t *testing.T) {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 6, Height: 6, Grid: spatial.GridShapeHex,
@@ -393,7 +393,7 @@ func TestOccludersAreCompiledThroughTheirRoomsAnchor(t *testing.T) {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombHall,
@@ -420,7 +420,7 @@ func TestOccludersAreCompiledThroughTheirRoomsAnchor(t *testing.T) {
 func TestABoundaryThatCannotBeDrawnIsRefusedAtConstruction(t *testing.T) {
 	setup := func(b spatial.Boundary) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "hall", Width: 6, Height: 6, Origin: spatial.Position{X: 4, Y: 4},

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -60,7 +60,7 @@ func TestVaultChase(t *testing.T) {
 	// composition's room-shaped topology (rpg-toolkit#1044).
 	pursuit := &pursuitDecider{target: alice}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: corridorRoom, Width: 10, Height: 10, Boundaries: corridorWall},
@@ -133,7 +133,7 @@ func TestVaultChase(t *testing.T) {
 	// INTEL does — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: atlas.Doorways, target: alice},
 		}})
 	require.NoError(t, err, "beat 3: the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -28,7 +28,7 @@ import (
 // save. With it, the defect is loud: ErrInvalidData, never a guess.
 func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: FieldInput{
 			Rooms: []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
@@ -71,7 +71,7 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 func TestFormRejections(t *testing.T) {
 	newEnc := func() *Encounter {
 		enc, err := NewEncounter(&SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: FieldInput{Rooms: []RoomInput{
 				{ID: "r1", Width: 8, Height: 8, Boundaries: sealedSeam(7, 8)},
 				{ID: "r2", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -26,7 +26,7 @@ type ClocksTestSuite struct {
 // monster in one room.
 func (s *ClocksTestSuite) twoMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			// The goblin waits in the NEXT ROOM, which is how real content is
 			// authored and is the only way to open a scene that is not
@@ -138,7 +138,7 @@ func (s *ClocksTestSuite) TestABubbleRoundTripsAndIsReachedThroughItsMembers() {
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -192,7 +192,7 @@ func (s *ClocksTestSuite) TestAMemberOutsideTheFightKeepsFreeRoamingWhileItRuns(
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	fighting, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -226,7 +226,7 @@ func (s *ClocksTestSuite) TestMutatingTheReturnedOrderCannotCorruptTheEncounter(
 	data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -250,7 +250,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -266,7 +266,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -292,7 +292,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		data.Clock.Budgets["ghost"] = 0
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -306,7 +306,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -319,7 +319,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -339,7 +339,7 @@ func (s *ClocksTestSuite) TestABlobFromBeforeClockMembershipLoadsEveryoneOntoThe
 	data.Bubbles = nil
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	for _, id := range []core.EntityID{alice, goblin} {
@@ -365,7 +365,7 @@ const (
 // monster in one room, plus an external ending so closure is reachable.
 func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
@@ -410,7 +410,7 @@ func (s *ClocksTestSuite) assertR6(enc *encounter.Encounter, members ...core.Ent
 		s.Require().NoError(err, "member %q must be on exactly one clock", id)
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err, "the persisted shape must pass the trust boundary (R6)")
 }
 
@@ -695,7 +695,7 @@ func (s *ClocksTestSuite) TestAFightMemberCannotFreeRoam() {
 func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 	wanderer := &patrolDecider{positions: []spatial.Position{{X: 5, Y: 5}, {X: 6, Y: 5}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
 		},
@@ -767,7 +767,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAnIdleBubble() {
 	data.Bubbles = []clock.TurnData{{}}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrInvalidData)
 }
@@ -781,7 +781,7 @@ func (s *ClocksTestSuite) TestAMidFightBlobRoundTrips() {
 	s.Require().NoError(err)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	// Reached through a member of the fight — bob is exploring next door.

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -88,7 +88,7 @@ func goblinPatrol() *patrol {
 // someone launches the workbench by hand.
 func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
+		Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{
@@ -524,7 +524,7 @@ func main() {
 				continue
 			}
 			loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+				Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 					"goblin": goblinPatrol(),
 				}})
 			if err != nil {
@@ -588,4 +588,34 @@ type rollAllStanding struct{}
 
 func (rollAllStanding) Standing([]encounter.MemberID) ([]encounter.MemberID, error) {
 	return nil, nil
+}
+
+// torchAndDarkvision is the workbench's Sight capability, and it is the one
+// place in this module where the capability answers something a rulebook would
+// actually say (rpg-toolkit#1111).
+//
+// The party carries a torch: 40 feet of light, bright then dim, which is 8
+// cells. The goblin has darkvision: 60 feet, which is 12. Nothing about the
+// composition knows either of those sentences — it asks, and gets two numbers
+// — which is exactly the promise the capability makes. Swap this type for one
+// that reads a character sheet and the workbench gets a real light model with
+// no other line changing.
+//
+// The asymmetry is the demo. Walk the party far enough down the crypt and the
+// goblin sees them from a distance they cannot see back from: the bubble forms
+// spotted, and they enter it surprised.
+type torchAndDarkvision struct{}
+
+func (torchAndDarkvision) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	reach := make(map[encounter.MemberID]int, len(members))
+	for _, id := range members {
+		if id == "goblin" {
+			reach[id] = 12 // 60 feet of darkvision
+
+			continue
+		}
+		reach[id] = 8 // 40 feet of torchlight
+	}
+
+	return reach, nil
 }

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -109,7 +109,7 @@ func vaultChaseHexSetup() *encounter.SetupInput {
 	}
 	pursuit := &pursuitDecider{doorways: doorwaysFrom(field), target: alice}
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: "corridor", Position: spatial.Position{X: 1, Y: 1}},
@@ -293,7 +293,7 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	beforeReload := alicePath[len(alicePath)-1]
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: doorwaysFrom(vaultChaseHexSetup().Field), target: alice},
 		}})
 	require.NoError(t, err, "the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -416,6 +416,12 @@ type LoadEncounterInput struct {
 	// so a blob that comes back without one is as unusable as a Setup without
 	// one. Refused at the door, never guarded at the use site.
 	Standing Standing
+
+	// Sight reports how far each member can see, in cells. REQUIRED, exactly as
+	// it is on SetupInput: a loaded encounter consults it on its first sight
+	// refresh, so a blob that comes back without one is as unusable as a Setup
+	// without one. Refused at the door, never guarded at the use site.
+	Sight Sight
 }
 
 // Validate reports whether the input is usable. It checks only the input's own
@@ -435,6 +441,9 @@ func (in *LoadEncounterInput) Validate() error {
 	}
 	if in.Standing == nil {
 		return fmt.Errorf("load encounter: Standing is required: %w", ErrNoStanding)
+	}
+	if in.Sight == nil {
+		return fmt.Errorf("load encounter: Sight is required: %w", ErrNoSight)
 	}
 
 	return nil
@@ -797,6 +806,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		deciders:    make(map[MemberID]Decider),
 		initiative:  input.Initiative,
 		standing:    input.Standing,
+		sight:       input.Sight,
 		endings:     nil,
 		retention:   normalizeRetention(data.Retention),
 		logFloor:    logFloorOf(data.Log),

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -71,7 +71,7 @@ type DataTestSuite struct {
 // of the shift vector's own shape.
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
@@ -125,7 +125,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 // ending order changes which outcome the campaign receives.
 func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
@@ -138,7 +138,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	enc1, err := encounter.NewEncounter(setup)
 	s.Require().NoError(err)
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc1.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc1.ToData()})
 	s.Require().NoError(err)
 
 	out, err := enc2.Step(&encounter.StepInput{Member: "p1", To: spatial.Position{X: 3, Y: 3}})
@@ -168,7 +168,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 // origin simultaneously.
 func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
@@ -199,7 +199,7 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 	s.Require().NoError(err)
 
 	data2 := enc2.ToData()
@@ -242,7 +242,7 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 	}
 
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	got := enc.ToData().Field.Connections
@@ -268,7 +268,7 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 	s.Run("square", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "square-room", Width: 5, Height: 5},
@@ -288,7 +288,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Equal("", data1.Field.Rooms[0].Grid, "square is the zero value — omitted, not the literal \"square\"")
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -297,7 +297,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 
 	s.Run("hex", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
@@ -317,7 +317,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Equal(spatial.GridTypeHex, data1.Field.Rooms[0].Grid)
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -344,7 +344,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 // square grid starts at (0,0) — W5, rpg-toolkit#1106.
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0, Y: 1},
@@ -386,7 +386,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom
 	// was an encounter that became permanently unsavable).
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 }
 
@@ -400,7 +400,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 	s.Run("post-setup open encounter survives round-trip", func() {
 		// Create a simple encounter
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -451,7 +451,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 
 		// Load from data (without decider for goblin)
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Convert to data again
@@ -472,7 +472,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 	s.Run("mid-fade ghost survives reload still Held", func() {
 		// Create encounter with a wall that will cause a ghost to form
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -542,7 +542,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 
 		// Load and verify ghost is still there
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Get holdings - ghost should still be Held (not Current)
@@ -567,7 +567,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 func (s *DataTestSuite) TestRoundTripPostExit() {
 	s.Run("exited member persists in everMembers and can Story", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -613,7 +613,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 
 		// Load and verify everMembers includes the exited player
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Story should work for the exited member
@@ -628,7 +628,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 func (s *DataTestSuite) TestRoundTripClosed() {
 	s.Run("closed encounter with ending outcome round-trips", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -682,7 +682,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 
 		// Load and verify outcome matches
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		status2, _ := enc2.Status()
@@ -698,7 +698,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 func (s *DataTestSuite) TestPumpContinuesTick() {
 	s.Run("Pump continues tick sequence post-reload", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -747,7 +747,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 		s.Require().Equal(2, data1.Clock.HighWater, "precondition: two ticks persisted")
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 		s.Require().NoError(err)
 
 		out, err := enc2.Pump(&encounter.PumpInput{})
@@ -760,7 +760,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 func (s *DataTestSuite) TestMoveWorksPostReload() {
 	s.Run("Move works on reloaded encounter", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -802,7 +802,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 
 		// Load
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Move should work
@@ -821,7 +821,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 func (s *DataTestSuite) TestGoldenJSONOpen() {
 	s.Run("small open encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -871,7 +871,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 func (s *DataTestSuite) TestGoldenJSONClosed() {
 	s.Run("small closed encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -944,7 +944,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 func (s *DataTestSuite) TestAliasImmunityToData() {
 	s.Run("mutating ToData result doesn't affect aggregate", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1012,7 +1012,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 	s.Run("mutating caller's Data after LoadEncounter doesn't affect loaded aggregate", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1049,7 +1049,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 		// Load FIRST, then vandalize the caller's Data: the loaded
 		// aggregate must be untouched (load-side deep copy).
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err)
 
 		data.Members[0].ID = "mutated"
@@ -1077,7 +1077,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		// persisted holding says Held (a ghost). A load that re-runs
 		// first-light surveil would resurrect it to Current.
 		enc1, err := encounter.NewEncounter(&encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
 			Members: []encounter.MemberInput{
 				{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
@@ -1098,7 +1098,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		data.Intel.Holdings["playerA"]["goblin"] = holding
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err)
 
 		view, err := enc2.View(&encounter.ViewInput{Member: "playerA"})
@@ -1111,7 +1111,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 func (s *DataTestSuite) TestDeciderReattachment() {
 	s.Run("reload with decider resumes monster decision", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1165,7 +1165,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 			},
 		}
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 				encounter.MemberID("goblin"): decider,
 			}})
 		s.Require().NoError(err)
@@ -1185,7 +1185,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 	s.Run("reload without decider makes monster hold", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1234,7 +1234,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 
 		// Load WITHOUT goblin's decider
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Pump should succeed (goblin holds)
@@ -1254,7 +1254,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 // nil entry is equivalent to an absent one: the monster simply holds.
 func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
 		},
@@ -1271,7 +1271,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	data1 := enc1.ToData()
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 		}})
 	s.Require().NoError(err, "a present-but-nil reattachment entry must load, not reject")
@@ -1288,7 +1288,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 // same reattachment map: the real one decides normally, the nil one holds.
 func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
@@ -1315,7 +1315,7 @@ func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 
 	ratDecider := &testDecider{intent: encounter.IntentMoveTo{To: spatial.Position{X: 3, Y: 8}}}
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 			"rat":    ratDecider,
 		}})
@@ -1404,7 +1404,7 @@ func (s *DataTestSuite) TestLoadSquareOccluderFractionalRejected() {
 	data := validEncounterDataWithConnection()
 	data.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1443,7 +1443,7 @@ func (s *DataTestSuite) TestLoadNilInputRejected() {
 // call sites, so it is stated once rather than left implied by them.
 func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Data: validEncounterData(),
 	})
 	s.Require().NoError(err)
@@ -1465,7 +1465,7 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
@@ -1485,7 +1485,7 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide at Load either`)
 }
 
@@ -1503,7 +1503,7 @@ func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1524,7 +1524,7 @@ func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
 		},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -1648,7 +1648,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 			data := validEncounterData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().Contains(err.Error(), tc.fragment,
@@ -1662,7 +1662,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEncounterData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEncounterData()})
 	s.Require().NoError(err, "the valid base fixture must load")
 
 	// The valid CONNECTION base must also load. Since FromPosition{9,1} is
@@ -1674,7 +1674,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// it would silently swap the values — so the values are re-inspected,
 	// not just the absence of an error).
 	connEnc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEncounterDataWithConnection()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEncounterDataWithConnection()})
 	s.Require().NoError(err, "the valid connection base fixture must load")
 	connData := connEnc.ToData()
 	s.Require().Len(connData.Field.Connections, 1)
@@ -1725,7 +1725,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 4, Y: 0}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1734,7 +1734,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: 3}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1743,7 +1743,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: -1, Y: 0}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1752,7 +1752,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: -1}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1761,7 +1761,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 3, Y: 2}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 		s.Require().NoError(err, "the last valid cell must be accepted")
 	})
 }
@@ -1791,7 +1791,7 @@ func (s *DataTestSuite) TestLoadRoomValidation() {
 			data := validEncounterData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoField, tc.name)
@@ -1818,7 +1818,7 @@ func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
 	data.Field.Rooms[0].Origin = nil
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1851,19 +1851,19 @@ func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 	s.Run("positive Q, positive R within span accepted", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 1, Y: 1})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 1, Y: 1})})
 		s.Require().NoError(err)
 	})
 
 	s.Run("negative Q within span accepted — rejected under the old offset HexGrid", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -1, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -1, Y: 0})})
 		s.Require().NoError(err, "axial hex rooms are origin-centered; negative Q is ordinary, not a defect")
 	})
 
 	s.Run("Q at exactly +Width/2 rejected (upper bound exclusive)", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "owned by no region")
@@ -1871,13 +1871,13 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 
 	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -2, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -2, Y: 0})})
 		s.Require().NoError(err)
 	})
 
 	s.Run("Q beyond -Width/2 rejected", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "owned by no region")
@@ -1911,7 +1911,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
 }
 
@@ -1972,7 +1972,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 			data := validHexAxialData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			if tc.alsoErr != nil {
@@ -1984,7 +1984,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 	}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validHexAxialData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validHexAxialData()})
 	s.Require().NoError(err, "integral axial positions, including negative ones, must be accepted")
 }
 
@@ -2109,7 +2109,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 			data := validAnchoredHexData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
@@ -2121,7 +2121,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err, "the valid anchored base fixture must load")
 }
 
@@ -2147,7 +2147,7 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2176,7 +2176,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2209,7 +2209,7 @@ func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2250,7 +2250,7 @@ func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2276,7 +2276,7 @@ func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint()
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2300,7 +2300,7 @@ func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a 2^30 x 2^30 room from a persisted blob must REJECT, not panic")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2321,7 +2321,7 @@ func (s *DataTestSuite) TestLoadOversizedRoomHeightRejected() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2348,7 +2348,7 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2391,7 +2391,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 			data := validEndingTriggerData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoEnding, tc.name)
@@ -2401,7 +2401,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 	}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEndingTriggerData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validEndingTriggerData()})
 	s.Require().NoError(err, "a trigger naming a real room and in-bounds position must validate")
 }
 
@@ -2417,7 +2417,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 		},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -2432,14 +2432,14 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 // would not.
 func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 	enc1, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err)
 	data1 := enc1.ToData()
 	bs1, err := json.Marshal(data1.Field)
 	s.Require().NoError(err)
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1})
 	s.Require().NoError(err)
 	data2 := enc2.ToData()
 	bs2, err := json.Marshal(data2.Field)
@@ -2459,7 +2459,7 @@ func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 // Origins it didn't in v0.2.
 func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
@@ -2503,7 +2503,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 		}
 	}
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataPreCrossing})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataPreCrossing})
 	s.Require().NoError(err)
 
 	out2, err := enc2.Step(&encounter.StepInput{Member: "p1", To: farSide})
@@ -2538,7 +2538,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareEndpointNotAdjacentDistance2() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2569,7 +2569,7 @@ func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
 	s.Require().NoError(json.Unmarshal(hostile, &data))
 
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err, "a hand-edited blob with a non-kissing doorway must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2603,7 +2603,7 @@ func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 	s.Run("gridless grid string rejected regardless of member position", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
 		s.Require().Error(err, `a stored "gridless" grid string no longer loads`)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2613,7 +2613,7 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 
 	s.Run("still rejected for a position that would also be out of bounds", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField,
@@ -2626,7 +2626,7 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 	data := validEncounterData()
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			"p1": &spyDecider{},
 		}})
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
@@ -2636,7 +2636,7 @@ func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 func (s *DataTestSuite) TestMutation1ToDataAliases() {
 	s.Run("mutation 1: ToData aliases slices", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2676,7 +2676,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 	s.Run("mutation 2: wire tag renamed", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2707,7 +2707,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 func (s *DataTestSuite) TestMutation3StowawayField() {
 	s.Run("mutation 3: stowaway field in EncounterData", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2740,7 +2740,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 	s.Run("mutation 4: leaf data substitution (Intel/Log swapped)", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2773,7 +2773,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 
 		// Control: loading dataA verbatim, p1 holds p2.
 		ctrl, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataA})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataA})
 		s.Require().NoError(err)
 		ctrlView, err := ctrl.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2784,7 +2784,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		// is genuinely consumed, never re-derived from the field.
 		dataA.Intel = dataB.Intel
 		swapped, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataA})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: dataA})
 		s.Require().NoError(err)
 		swappedView, err := swapped.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2814,7 +2814,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 		}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().Error(err)
 		s.True(errors.Is(err, encounter.ErrInvalidData), "must validate member rooms exist")
 	})
@@ -2824,7 +2824,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 	s.Run("mutation 6: no re-surveil on load (ghost stays ghost)", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2877,7 +2877,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 
 		data := enc1.ToData()
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 
 		holdings2, _ := enc2.View(&encounter.ViewInput{Member: "playerA"})
 		var goblinStatusAfter intel.Status
@@ -2898,7 +2898,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 	s.Run("mutation 7: tick continuation (clock not reset)", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 10, Height: 10, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
@@ -2918,7 +2918,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 		tick1 := data1.Clock.HighWater
 
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		data2 := enc2.ToData()
 		tick2 := data2.Clock.HighWater
 

--- a/rulebooks/dnd5e/encounter/defeat_internal_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_internal_test.go
@@ -47,7 +47,7 @@ func (d *oneDown) Standing(members []MemberID) ([]MemberID, error) {
 func TestADecidedFightRefusesToCountAGhost(t *testing.T) {
 	rulebook := &oneDown{}
 	enc, err := NewEncounter(&SetupInput{
-		Standing: rulebook, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: rulebook, Initiative: orderAsGiven{},
 		Field: FieldInput{Rooms: []RoomInput{{ID: "crypt", Width: 12, Height: 12}}},
 		Members: []MemberInput{
 			{ID: "alice", Kind: KindPlayer, Room: "crypt", Position: spatial.Position{X: 0, Y: 2}},

--- a/rulebooks/dnd5e/encounter/defeat_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_test.go
@@ -376,7 +376,7 @@ func (s *DefeatSuite) TestOnlyTheDecidedFightEnds() {
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       data,
 		Initiative: orderAsGiven{},
-		Standing:   &downList{down: []encounter.MemberID{goblin}},
+		Sight:      everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -60,7 +60,7 @@ var dialectOrigin = spatial.Position{X: 30, Y: 10}
 // coordinates.
 func (s *DialectSuite) closedBlob() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Origin: dialectOrigin},
 		}},
@@ -89,7 +89,7 @@ const aRoomBearingSighting = `{"room":"hall","x":2,"y":5}`
 // load is the host's side of the seam: hand the loader a blob and see what it says.
 func (s *DialectSuite) load(data encounter.EncounterData) error {
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: data, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 	})
 	return err
 }

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -12,14 +12,15 @@
 // the map and in the roster, and stops acting: no turn, no side in a contact,
 // no tick action, and a beat in the story saying so.
 //
-// The composition holds no rules of its own that it could hold instead: two
+// The composition holds no rules of its own that it could hold instead: three
 // capabilities are SUPPLIED at construction and consulted during play, never
 // defaulted (rpg-toolkit#1033). InitiativeRoller says what order a fight goes
-// in; Standing says who is down. Both are the same move — this module cannot
-// import the rulebook (C1), so randomness and hit points are facts it asks for
-// rather than facts it knows. Neither has a default answer, because a default
-// would be this module quietly deciding a rule it is not allowed to know, and
-// both are refused at Setup AND Load rather than guarded where they are used.
+// in; Standing says who is down; Sight says how far each member can see. All
+// three are the same move — this module cannot import the rulebook (C1), so
+// randomness, hit points and light are facts it asks for rather than facts it
+// knows. None has a default answer, because a default would be this module
+// quietly deciding a rule it is not allowed to know, and all three are refused
+// at Setup AND Load rather than guarded where they are used.
 //
 // Every member is on exactly one clock (R6). The world tick is the default —
 // free roam is not a mode, it is where you are when no fight has pulled you

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -114,6 +114,11 @@ type Encounter struct {
 	// [Standing] for why it is asked rather than remembered, and why there is
 	// no default answer.
 	standing Standing
+
+	// sight reports how far each member can see. Required at both constructors
+	// — see [Sight] for why it is asked at every refresh rather than held, and
+	// why there is no default.
+	sight Sight
 	// endings holds declared endings in Setup order. Evaluation is
 	// deterministic (law C8), but NOT globally "first-declared-wins":
 	// for a single action (Step, Join) declaration order is
@@ -1089,6 +1094,16 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		return nil, fmt.Errorf("newencounter: %w", ErrNoStanding)
 	}
 
+	// Required for the third time, at the same door and by the same law: the
+	// sight consult runs at every refresh including first light, so an
+	// encounter that cannot ask how far its members can see cannot build a
+	// percept at all. Never defaulted — a number meaning "everyone sees this
+	// far" is a rule 5e does not have, since sight is per-creature and
+	// per-light-source (rpg-toolkit#1033, rpg-toolkit#1111).
+	if in.Sight == nil {
+		return nil, fmt.Errorf("newencounter: %w", ErrNoSight)
+	}
+
 	// Check ending keys: empty/reserved, and duplicate (#929 hardening
 	// round E — two endings sharing a key both used to load; End scans
 	// in declaration order, so a reached_position twin declared FIRST
@@ -1170,6 +1185,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		roomGrids:        roomGrids,
 		initiative:       in.Initiative,
 		standing:         in.Standing,
+		sight:            in.Sight,
 		endings:          nil,
 		retention:        normalizeRetention(in.Retention),
 		fieldInput:       deepCopyRoomInputs(in.Field.Rooms),
@@ -1621,16 +1637,19 @@ func (e *Encounter) firedReachedPosition(member *memberRecord, cell spatial.Posi
 // no clock advance, no moves, no record entries.
 //
 // WHAT PUMP DRIVES IN v1, stated plainly because the answer narrowed: members
-// on the WORLD clock. Under v1's sight model (rpg-toolkit#964) any monster a
-// player can see is in a bubble, and a bubble member is deliberately not
-// pumped — so in practice this verb moves the monsters NOBODY HAS SEEN YET.
+// on the WORLD clock. A bubble member is deliberately not pumped, and under
+// v1's sight model (rpg-toolkit#964) any monster a player could see was in a
+// bubble — so in practice this verb moved the monsters NOBODY HAD SEEN YET.
 // Free-roam monster behaviour is offscreen behaviour.
 //
-// That is a narrowing rather than the intent. It widens back when percept
-// production grows: asymmetric perception (#1020) lets a monster be watched
-// without a fight starting, and a faction model lets a visible creature be
-// non-hostile. Both change what forms a bubble, not what Pump does — see
-// classify's doc for the invariant. Pinned by
+// That was a narrowing rather than the intent, and it has started widening
+// back exactly where classify's doc said it would: in how percepts are
+// PRODUCED. rpg-toolkit#1111's per-member sight range makes the drop real, so
+// a monster CAN now be watched by a player it cannot see back without a fight
+// starting — and it keeps being pumped while that is true. #1020 widens it
+// further, and a faction model lets a visible creature be non-hostile. All of
+// them change what forms a bubble, not what Pump does — see classify's doc for
+// the invariant. Pinned by
 // TestPumpStopsMovingAMonsterOnceSeen.
 //
 // Semantics:
@@ -1945,6 +1964,17 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 	clockReading := uint64(clockReadingInt)
 	deltas := make(map[MemberID]*intel.SurveilOutput)
 
+	// Asked ONCE per refresh and never carried between them — see [Sight] for
+	// why remembering the answer would be the smallest possible version of the
+	// dual state the capability exists to avoid. Asked BEFORE the loop rather
+	// than inside it so that every observer in one refresh is bounded by the
+	// same reading of the world (C8), and so that a rulebook is consulted once
+	// per pass rather than once per member.
+	reach, err := e.sightNow()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, observerID := range observers {
 		if _, ok := e.members[observerID]; !ok {
 			continue // Skip if not found
@@ -1965,28 +1995,27 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 		// express (rpg-toolkit#1105/#1106). With one canvas and real walls it
 		// has nothing left to say, so it is gone and the geometry answers.
 		//
-		// NOTHING BOUNDS SIGHT BY DISTANCE YET, and that is a known gap rather
-		// than an oversight — measured, not guessed. The reference tomb ships
-		// with every doorway on one row (dungeonspec puts them at
-		// height/2), so its longest unobstructed sightline runs 29 cells,
-		// 145 feet, from the entrance to the far wall of the tomb; the
-		// skeleton-captain can see six of the entrance's forty-eight cells,
-		// from 100 to 125 feet away. Sight forms a bubble, so that is a FIGHT
-		// at 125 feet, in which neither side can move — there is no in-fight
-		// movement verb yet.
+		// AND BOUNDED BY A DISTANCE THIS MODULE WAS TOLD (rpg-toolkit#1111).
+		// The room label was quietly doing that job too: with it gone, the
+		// reference tomb's longest unobstructed run — three doorways on one
+		// row, 27 cells, 135 feet — was a sighting, and a sighting forms a
+		// fight. What was missing there was never a number this module could
+		// pick. It was a LIGHT model, and light is per-creature and
+		// per-light-source: the dwarf with darkvision and the human holding
+		// her torch answer differently on the same cell.
 		//
-		// What is missing there is a LIGHT model, not a range term. That
-		// sightline is a genuinely unobstructed run down three aligned
-		// doorways, and seeing along it is correct; what a crypt denies you is
-		// illumination, which this composition has never modelled. A distance
-		// cutoff would paper over that with a number instead of naming it.
+		// So the term is SUPPLIED, and supplied per member. [Sight] is asked
+		// how far each of them can see, this refresh, and the answer bounds
+		// what lands in the percept. The light model 5e states arrives later
+		// as a better ANSWER — with nothing here moving — which is exactly the
+		// promise [Standing] makes about hit points.
 		//
-		// So the range term is rpg-toolkit#1105's remaining half, and it lands
-		// with the caller that supplies it rather than as a default this module
-		// would be inventing (the argument [Standing] makes about answers this
-		// module is not allowed to decide for itself). Sight the other way is
-		// already better than it was: a member 35 feet down the hall is
-		// visible now, and was invisible under the room label.
+		// Two members can answer differently, so A may see B without B seeing
+		// A. That asymmetry is real and it is NOT rpg-toolkit#1020: geometry
+		// stays mutual (spatial v0.9.1 pins it), and what differs is reach.
+		// What it does do is give [Encounter.classify]'s spotted and drop arms
+		// their first producible input, and 5e surprise with them, without
+		// changing a line of how percepts are CONSUMED.
 		var percept []intel.Report
 		for _, otherMember := range e.members {
 			if otherMember.ID == observerID {
@@ -1996,6 +2025,13 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 			otherCell, ok := e.canvas.GetEntityPosition(string(otherMember.ID))
 			if !ok {
 				continue // Not placed
+			}
+
+			// Too far BEFORE too dark: the ray is the expensive question, and
+			// it is the second one 5e asks too. Strictly greater, because a
+			// member exactly at the edge of your sight is inside it.
+			if e.canvas.GetGrid().Distance(observerCell, otherCell) > float64(reach[observerID]) {
+				continue // Beyond how far this observer can see
 			}
 
 			if e.canvas.IsLineOfSightBlocked(observerCell, otherCell) {
@@ -2011,14 +2047,14 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 		}
 
 		// Surveil with the complete percept and current clock reading
-		out, err := e.intelLog.Surveil(&intel.SurveilInput{
+		out, serr := e.intelLog.Surveil(&intel.SurveilInput{
 			Observer: observerID,
 			Channel:  intel.Sight,
 			Percept:  percept,
 			At:       clockReading,
 		})
-		if err != nil {
-			return nil, fmt.Errorf("refreshsight surveil: %w", err)
+		if serr != nil {
+			return nil, fmt.Errorf("refreshsight surveil: %w", serr)
 		}
 		deltas[observerID] = out
 	}

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -2027,9 +2027,11 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 				continue // Not placed
 			}
 
-			// Too far BEFORE too dark: the ray is the expensive question, and
-			// it is the second one 5e asks too. Strictly greater, because a
-			// member exactly at the edge of your sight is inside it.
+			// Too far BEFORE blocked: both filters are geometric, and this
+			// one is arithmetic while the next one walks a ray. Order is a
+			// cost decision, not a correctness one — either filter alone
+			// drops the subject. Strictly greater, because a member exactly
+			// at the edge of your sight is inside it.
 			if e.canvas.GetGrid().Distance(observerCell, otherCell) > float64(reach[observerID]) {
 				continue // Beyond how far this observer can see
 			}

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -47,7 +47,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 	s.Run("two members clear line of sight", func() {
 		// Arrange: 10x10 room, alice at (2,2) player, goblin at (7,7) monster
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -126,7 +126,7 @@ func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 		// around now (spatial v0.9.1, see testwalls_test.go), so a fixture
 		// that wants sight blocked has to build something worth blocking.
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -187,7 +187,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no field", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{},
 			},
@@ -202,7 +202,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no endings", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -217,7 +217,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: reserved ending key", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -234,7 +234,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty ending key", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -251,7 +251,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty member ID", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -271,7 +271,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("validation order: duplicate member IDs", func() {
 		alice := core.EntityID("alice")
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -294,7 +294,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("atomicity: after error, valid setup works", func() {
 		// First attempt: fails validation
 		setup1 := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field:   encounter.FieldInput{Rooms: []encounter.RoomInput{}},
 			Members: []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
@@ -306,7 +306,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 		// Second attempt: valid
 		setup2 := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
@@ -346,7 +346,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 // all, so they stay disjoint (W2) regardless of their y overlap.
 func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -391,7 +391,7 @@ func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
 // interior one.
 func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{
@@ -419,7 +419,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 // this exact colliding pair must construct without error.
 func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
@@ -444,7 +444,7 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 // room-list defect vocabulary.
 func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}, {X: 3, Y: 3}}},
@@ -466,7 +466,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 // forever, the external ending having no other way to fire).
 func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
@@ -559,7 +559,7 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 // share no x value and so stay disjoint (W2) regardless of y.
 func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 4, Height: 3},
@@ -628,7 +628,7 @@ func (s *EncounterTestSuite) TestConnectionEndpointBoundsBoundaries() {
 // and one member — the base for TestSetupRoomValidation's one-defect rows.
 func validRoomSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
@@ -713,7 +713,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 	// Width=4, Height=3 => Q valid in [-2,2), R valid in [-1.5,1.5).
 	hexSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
@@ -771,7 +771,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 // hex-a's ([-5,4]), so the rooms stay disjoint (W2) regardless of R.
 func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
@@ -809,7 +809,7 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 // regardless of R.
 func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
@@ -882,7 +882,7 @@ func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 // Pump's IntentMoveTo, so this also covers decider-driven moves).
 func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -909,7 +909,7 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 // TestJoinHexIntegralAxial is Join's verb-seam counterpart.
 func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -955,7 +955,7 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 	gridlessSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
@@ -1014,7 +1014,7 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 // rooms are disjoint, touching only through the one declared doorway.
 func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
@@ -1133,7 +1133,7 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 // proves it independently for square's own distance formula).
 func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "sq-a", Width: 5, Height: 5},
@@ -1167,7 +1167,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 // in r2 projects to absolute (4,1) — Chebyshev distance 2, not 1.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance2() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
@@ -1202,7 +1202,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance
 // rejection pin that closes that hole.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0.5, Y: 1.5}},
@@ -1234,7 +1234,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 // message.
 func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
 		},
@@ -1254,7 +1254,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 // room legality's OWN message.
 func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
 		},
@@ -1275,7 +1275,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() 
 // direction.
 func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "square-first", Width: 5, Height: 5},
@@ -1310,7 +1310,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 // interval mins.
 func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r-a", Width: 5, Height: 5},
@@ -1342,7 +1342,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 // 1.
 func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
@@ -1376,7 +1376,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 // "close enough"; the strict `!= 1` correctly rejects it.
 func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDistance() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
@@ -1412,7 +1412,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDi
 // before W2 ever sees it, and specifically NOT with a W2 "overlap" message.
 func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 1e19, Y: 0}},
@@ -1450,7 +1450,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 // rejected — oversized, not evaluated for overlap at all.
 func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 1000, Height: 5},
@@ -1478,7 +1478,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisj
 // with maxRoomCells' message, never construct.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
 		},
@@ -1500,7 +1500,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 // an EXPLICIT hex room.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
 		},
@@ -1530,7 +1530,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex(
 // check alone would not.
 func (s *EncounterTestSuite) TestSetupOversizedRoomHeightRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
 		},
@@ -1565,7 +1565,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 		rooms[i] = encounter.RoomInput{ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024}
 	}
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field:   encounter.FieldInput{Rooms: rooms},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1582,7 +1582,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 // thing about (#929 T3 Opus round F5).
 func validEndingTriggerSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
@@ -1633,7 +1633,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerValidation() {
 // Opus round F5).
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -1656,7 +1656,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 // NOT over-reach.
 func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -1706,7 +1706,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 
 			data := enc.ToData()
 			_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 			s.Require().NoError(err, "%s must survive a ToData/LoadEncounter round trip", tc.name)
 		})
 	}
@@ -1719,7 +1719,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 // any room, not an edge case — the realistic hazard N2 names explicitly.
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() {
 	setup := &encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
@@ -1732,7 +1732,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() 
 
 	data := enc.ToData()
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "must survive a ToData/LoadEncounter round trip")
 }
 
@@ -1740,7 +1740,7 @@ func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 	s.Run("opening beat reaches all members via Story", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
@@ -1794,7 +1794,7 @@ func (s *EncounterTestSuite) TestSetupBadPlacementSentinel() {
 	s.Run("member placed in nonexistent room errors with ErrBadPlacement", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -1822,7 +1822,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 	s.Run("three members mutually visible all see each other", func() {
 		// Arrange: ONE room, THREE mutually visible members (alice, bob players; goblin monster)
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
@@ -1878,7 +1878,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 func (s *EncounterTestSuite) TestMembers() {
 	s.Run("returns stable order", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -1906,7 +1906,7 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 	s.Run("mover's vantage refreshes, others see mover at new position", func() {
 		// Arrange: alice and bob in clear sight
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1995,7 +1995,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		// A wall rather than the single pillar this fixture used to have —
 		// spatial v0.9.1 leans around a lone obstacle (see testwalls_test.go).
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2059,7 +2059,7 @@ func (s *EncounterTestSuite) TestMoveSequentialConsistency() {
 	s.Run("after sequential moves, spatial index remains valid (CanMoveEntityBetweenRooms-style)", func() {
 		// Arrange: alice in one room
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2115,7 +2115,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 	s.Run("player reaching ReachedPosition trigger fires the ending", func() {
 		// Arrange: alice is player, will reach stairs (no member filter = any player)
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2208,7 +2208,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 	s.Run("validation order and R5 atomicity", func() {
 		s.Run("nil input returns ErrNilInput", func() {
 			setup := &encounter.SetupInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2230,7 +2230,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("empty member ID returns ErrNoMember", func() {
 			setup := &encounter.SetupInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2255,7 +2255,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("closed encounter returns ErrClosed", func() {
 			setup := &encounter.SetupInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2291,7 +2291,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("not a member returns ErrNotMember", func() {
 			setup := &encounter.SetupInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2316,7 +2316,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("failed move leaves members unchanged", func() {
 			setup := &encounter.SetupInput{
-				Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
@@ -2359,7 +2359,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 	s.Run("mutating returned outcome does not affect internal state", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
@@ -2414,7 +2414,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 // (19,19).
 func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
@@ -2433,7 +2433,7 @@ func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 // an External ending (for testing End verb).
 func (s *EncounterTestSuite) newBasicEncounterWithExternalEnding() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
@@ -2504,7 +2504,7 @@ func (s *EncounterTestSuite) TestMoveSpatialRejectionAtomic() {
 // arrival-Current and T3 pins).
 func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				// room-a WALLS its east edge, leaving the doorway's row open.
@@ -2681,7 +2681,7 @@ func (s *EncounterTestSuite) holdingOf(
 // any other step's destination.
 func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -2723,7 +2723,7 @@ func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 // unfiltered ending's cell must NOT close the encounter, doorway or not.
 func (s *EncounterTestSuite) TestAMonsterCrossingOntoAnUnfilteredEndingDoesNotClose() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -2837,7 +2837,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 	s.Run("late joiner seen by and sees incumbents", func() {
 		// Arrange: setup with alice and bob
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -2994,7 +2994,7 @@ func (s *EncounterTestSuite) TestJoinValidation() {
 func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 	s.Run("join on stairs fires ReachedPosition ending", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3047,7 +3047,7 @@ func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 func (s *EncounterTestSuite) TestExitCarryForward() {
 	s.Run("exit carry-forward matches final state", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3143,7 +3143,7 @@ func (s *EncounterTestSuite) TestExitValidation() {
 func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 	s.Run("last member exit closes with abandoned ending", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3196,7 +3196,7 @@ func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 func (s *EncounterTestSuite) TestExitDepartedGhostFades() {
 	s.Run("remaining member's holdings persist after departure", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -3269,7 +3269,7 @@ func (s *EncounterTestSuite) TestEndExternalOnly() {
 
 	s.Run("End fires External endings", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
@@ -3407,7 +3407,7 @@ func (s *EncounterTestSuite) TestQueriesLivePostClose() {
 func (s *EncounterTestSuite) TestStoryForExitedMembers() {
 	s.Run("exited members can still read story", func() {
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -197,4 +197,12 @@ var (
 	// refused at construction rather than at the moment a body would have
 	// started a fight.
 	ErrNoStanding = errors.New("encounter: no standing capability")
+
+	// ErrNoSight indicates this module was not told, usably, how far somebody
+	// can see. Three ways to earn it: Setup or Load was given no Sight
+	// capability; the capability answered without covering a member it was
+	// asked about; or it answered with a negative distance. All three are the
+	// same defect seen from different sides — a sight range this module would
+	// have to invent, which rpg-toolkit#1033 forbids it to do.
+	ErrNoSight = errors.New("encounter: no sight capability")
 )

--- a/rulebooks/dnd5e/encounter/example_doorway_test.go
+++ b/rulebooks/dnd5e/encounter/example_doorway_test.go
@@ -59,7 +59,7 @@ func Example_theDoorway() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 7, Y: 4}},

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -31,7 +31,7 @@ func Example_theDungeon() {
 		ToPosition:   spatial.Position{X: 0, Y: 4},
 	}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -45,7 +45,7 @@ func Example_theTombWatch() {
 	// The crypt: a wall across y=6 from x=5 to x=7; alice enters at (2,6); a goblin
 	// stands at (6,10). One way out: the stairs at (11,11).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: "crypt", Width: 12, Height: 12,
@@ -88,7 +88,7 @@ func Example_theTombWatch() {
 	fmt.Println("-- the table saves and comes back tomorrow --")
 	data := enc.ToData()
 	enc, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	if err != nil {
 		fmt.Println("load:", err)
 		return

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -261,6 +261,15 @@ type SetupInput struct {
 	// standing" would be this module deciding a rule it is not allowed to know.
 	Standing Standing
 
+	// Sight reports how far each member can see, in cells (rpg-toolkit#1111).
+	// REQUIRED, for the same reason Standing is: the consult runs at every
+	// sight refresh including first light, so an encounter that cannot ask
+	// cannot build a percept. Refused at construction (ErrNoSight). There is no
+	// default — a number meaning "everyone sees this far" would be this module
+	// inventing a rule 5e does not have, since sight is per-creature and
+	// per-light-source.
+	Sight Sight
+
 	// Retention is how many story beats the encounter keeps. Older beats are
 	// trimmed after each append, so an encounter's blob does not grow without
 	// bound and a save does not rewrite the whole history.

--- a/rulebooks/dnd5e/encounter/killingblow_test.go
+++ b/rulebooks/dnd5e/encounter/killingblow_test.go
@@ -65,8 +65,8 @@ func (s *KillingBlowSuite) apart(standing encounter.Standing) *encounter.Encount
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Standing:   standing,
-		Retention:  encounter.RetentionUnbounded,
+		Sight:      everyoneSeesTheWholeMap{}, Standing: standing,
+		Retention: encounter.RetentionUnbounded,
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12, Occluders: wallRow(6, 0, 11)},
 		}},

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -29,7 +29,7 @@ const outcomeRoom = "yard"
 // other's sight, so nothing forms a fight before a test asks for one.
 func (s *OutcomeTestSuite) scene() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{
 			ID: outcomeRoom, Width: 12, Height: 12, Occluders: wallRow(6, 4, 8),
 		}}},

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -52,7 +52,7 @@ var gate = encounter.ConnectionInput{
 
 func (s *PlacementSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				// The hall walls its own east edge, leaving the gate's row
@@ -325,7 +325,7 @@ func (s *PlacementSuite) TestTheOutcomeSurvivesARoundTripStillAbsolute() {
 	s.Require().NoError(err)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: s.enc.ToData(), Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Data: s.enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -204,7 +204,7 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 // cleanup: an exited monster's decider must never be consulted again.
 func (s *PumpTestSuite) TestPumpDoesNotConsultExitedMonsterDecider() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -239,7 +239,7 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		}
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -338,7 +338,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 		// asymmetric perception (#1020) or a faction model, at which point
 		// this test should grow the positive case again.
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{{
 					ID: room1, Width: 10, Height: 10,
@@ -388,7 +388,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		errDecider := &errorDecider{err: deciderErr}
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -468,7 +468,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 // NEXT (successful) pump reports reading 1, not 2.
 func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -493,7 +493,7 @@ func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 // have moved — no partial mutation (R5).
 func (s *PumpTestSuite) TestPumpPartialAbort() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -538,7 +538,7 @@ func (s *PumpTestSuite) TestPumpPartialAbort() {
 func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	vandal := &vandalDecider{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -585,7 +585,7 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 		}
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -651,7 +651,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -722,7 +722,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 // this seam.
 func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 0, Y: 0}},
@@ -759,7 +759,7 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 		}
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -838,7 +838,7 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 		}
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -923,7 +923,7 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 		goblinID := core.EntityID("goblin")
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1003,7 +1003,7 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
 				Rooms: []encounter.RoomInput{
 					{
@@ -1095,7 +1095,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	spyB := &snapshotSpyDecider{}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
@@ -1146,7 +1146,7 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 5}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -1219,7 +1219,7 @@ func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
 	}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: cellar, Width: 10, Height: 10, Origin: spatial.Position{X: 40, Y: 20}},
@@ -1329,7 +1329,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenAWallIsInTheWay() {
 	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 2}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -1386,7 +1386,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	decider := &onceStepDecider{to: spatial.Position{X: 500, Y: 500}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -1438,7 +1438,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	deciderErr := errors.New("test decider error")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -1483,7 +1483,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	goblinID := core.EntityID("goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -1592,7 +1592,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	bID := core.EntityID("zzz-goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -1695,7 +1695,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("control: decision order and declaration order agree", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				{ID: aID, Kind: encounter.KindMonster, Room: room1,
@@ -1720,7 +1720,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				// Same decision order (aaa first, zzz second), but now each
@@ -1779,7 +1779,7 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 	decider := &reentrantSelfExitDecider{self: goblinID}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: aliceID, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -1828,7 +1828,7 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomWall()},
@@ -1920,7 +1920,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 	hidden := spatial.Position{X: 4, Y: 5}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: room1, Width: 10, Height: 10,

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -81,7 +81,7 @@ func (s *PursuitSuite) SetupTest() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			// Alice stands at the threshold; the goblin is across the room
@@ -212,7 +212,7 @@ func (s *PursuitSuite) freeRoamWith(decider encounter.Decider) {
 
 	data := s.enc.ToData()
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Data:     data,
 		Deciders: map[encounter.MemberID]encounter.Decider{hunter: decider},
 	})

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -40,7 +40,7 @@ func TestRegionSuite(t *testing.T) {
 // same opening, carol and dave one row up with the seam wall between them.
 func (s *RegionSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -232,7 +232,7 @@ func (s *RegionSuite) TestAStepChangesTheRegionAMemberIsIn() {
 // reports every member's region, derived from where they each stand.
 func (s *RegionSuite) TestReachingTheTombChamberClosesTheDelve() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombHall,
@@ -288,7 +288,7 @@ func (s *RegionSuite) TestTheRegionIsDerivedAcrossPersistenceToo() {
 	s.NotContains(string(blob), `"region"`, "and it did not come back under a new name either")
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	status, err := reloaded.Status()
@@ -347,7 +347,7 @@ func (s *RegionSuite) TestAStaleRegionLabelInABlobCannotChangeTheAnswer() {
 	s.Require().NoError(json.Unmarshal(tampered, &data))
 
 	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err, "an unknown key is ignored, not a defect to refuse")
 
 	status, err := loaded.Status()
@@ -438,7 +438,7 @@ func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
 // from the origin so a local coordinate cannot pass as an absolute one.
 func (s *RegionSuite) oneRoom(shape spatial.GridShape, w, h int, origin spatial.Position) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
 			{ID: "only", Width: w, Height: h, Grid: shape, Origin: origin},
 		}},

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -34,7 +34,7 @@ type RetentionTestSuite struct {
 // with the ending at (4,4).
 func (s *RetentionTestSuite) walkingEncounter(retention int) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
@@ -242,7 +242,7 @@ func (s *RetentionTestSuite) TestRetentionSurvivesReload() {
 	s.Equal(window, data.Retention, "retention is persisted, not inferred")
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().NoError(err)
 
 	// The reloaded encounter must still be trimming to the SAME window: keep
@@ -263,7 +263,7 @@ func (s *RetentionTestSuite) TestFloorSurvivesReload() {
 	s.generateBeats(enc, 40)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	_, err = reloaded.Story(&encounter.StoryInput{Audience: "p1", AfterSeq: 33})
@@ -283,7 +283,7 @@ func (s *RetentionTestSuite) TestUntrimmedEncounterHasNoFloor() {
 	s.generateBeats(enc, 5)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	for seq := uint64(1); seq <= 6; seq++ {

--- a/rulebooks/dnd5e/encounter/sight.go
+++ b/rulebooks/dnd5e/encounter/sight.go
@@ -1,0 +1,169 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Sight reports how far each of the given members can see, in cells. The
+// composition asks; the rulebook answers.
+//
+// Injected rather than held, exactly as [Standing] and [InitiativeRoller] are,
+// and for the same reason [Standing]'s doc gives with "hit points" swapped for
+// "light": this module's go.mod cannot import the rulebook (law C1), so how far
+// a creature can see is a fact it can only be TOLD. Member IDs in, one number
+// out per member — nothing here learns what a torch is, or what darkvision is,
+// or what a spell that puts out both is, and nothing here has to.
+//
+// # Per member, which is the whole design
+//
+// The question is "how far can THIS member see", never "how far can anyone
+// see". A flat range on [SetupInput] would have been cheaper and would have
+// been a rule 5e does not have: sight is per-creature and per-light-source, so
+// the dwarf with darkvision and the human holding her torch answer differently
+// while standing on the same cell. A single number could only ever have been
+// REPLACED by the real model, never grown into it — which is the difference
+// between a slice that pays for itself and one the next slice deletes
+// (rpg-toolkit#1111).
+//
+// # Today's answer is one number, and that is the point
+//
+// An implementation may return the same number for everybody, and the fixtures
+// in this module's own tests do. What is load-bearing is the SHAPE: the light
+// model 5e actually states — bright light, dim light, darkness, darkvision,
+// blindness, magical darkness — arrives as this capability returning a better
+// ANSWER, with nothing else in this module moving. That is the promise
+// [Standing] made and kept: rpg-toolkit#977's Undead Fortitude will change what
+// "down" means without the composition learning a thing about hit points, and
+// the light model will change what "can see" means without it learning a thing
+// about light.
+//
+// # Cells, not feet, and the conversion is yours
+//
+// The number is a count of CELLS on the map, because cells are the only
+// distance this module has: it measures with the grid's own metric, which is
+// Chebyshev on squares and cube distance on hexes. Feet are a 5e unit, and "a
+// square is five feet" is a 5e RULE — one this module is not allowed to know,
+// for the same reason it is not allowed to know what a hit point is. So 60-foot
+// darkvision is 12, and the division is the rulebook's, which is the side that
+// knows both halves. The conversion is exact rather than approximate:
+// Chebyshev is 5e's own "a diagonal costs five feet" measure.
+//
+// Zero is a legal answer and means blind — nothing but the cell underfoot,
+// which nobody is ever asked about. A negative is not a shorter answer; it is
+// not an answer, and it is refused (ErrNoSight).
+//
+// # It is a pull, and it is never remembered
+//
+// The composition stores no sight range, in memory or in its blob. It asks at
+// the choke point where percepts are built and uses the answer it gets, once,
+// for that refresh. The alternative — being handed a range at construction and
+// keeping it — recreates the dual state [Standing]'s doc describes: light the
+// torch and the character sheet says sixty feet while the composition still
+// says twenty.
+//
+// Being a pull is also what makes it COMPLETE. Every route to a changed range —
+// a torch lit, a torch dropped, a blindness spell, a light source another
+// creature is carrying, a rule nobody has written yet — is noticed at the next
+// refresh, without that route knowing this interface exists.
+//
+// # What an implementation owes
+//
+// Answer about the members you were asked about, and answer about ALL of them.
+// A name in the answer that was not in the question is a defect this module
+// refuses (ErrNotMember) rather than ignores, exactly as [Standing] does. A
+// member in the QUESTION missing from the answer is refused too (ErrNoSight),
+// and that half is stricter than [Standing]'s on purpose: absence from a
+// standing answer means "standing", but absence from this one means nothing at
+// all, and a member with no supplied range is a member whose sight this module
+// would have to invent. Inventing it is the thing rpg-toolkit#1033 forbids.
+//
+// The answer is asked for again rather than carried between refreshes. Carrying
+// it would be a cache, and a cache is the smallest possible version of the dual
+// state above.
+//
+// Errors abort whatever verb was running, atomically (R5), the same as
+// [InitiativeRoller]'s and [Standing]'s: a world that cannot find out how far
+// somebody can see does not half-build a percept on a guess.
+//
+// # The asymmetry this creates is real, and it is not stealth
+//
+// Two members can answer differently, so the dwarf may see the goblin from
+// forty feet while the goblin, in the dark, sees nothing back. Sight stays
+// symmetric in the GEOMETRIC sense — spatial v0.9.1 pins line of sight as a
+// mutual property over fuzzed rooms in every grid family, and this capability
+// does not touch that — and what differs is reach.
+//
+// That asymmetry is not rpg-toolkit#1020 and does not stand in for it. #1020 is
+// a Stealth contest against passive Perception, deciding whether an observer's
+// percept holds a subject that is in plain view; this decides how far a percept
+// extends. They compose on the same seam: #1020's per-observer answer rides
+// into [Encounter.rebuildPercepts] beside this one, filtering what survives the
+// range and the ray, and neither has to know the other exists.
+//
+// What the asymmetry DOES do, today, is make 5e surprise producible for the
+// first time. See [Encounter.classify]: the spotted and drop arms were written
+// against asymmetric sight and had no reachable input while every observer saw
+// the same distance. They have one now, and classification did not move.
+type Sight interface {
+	// Sight reports how far each of the given members can see, in cells. Every
+	// member asked about must appear in the answer, and nobody else may.
+	Sight(members []MemberID) (map[MemberID]int, error)
+}
+
+// sightNow asks the capability how far each member can see, right now, and
+// returns the answer keyed by member.
+//
+// The roster goes over SORTED, for C8's reason and [Encounter.standingNow]'s:
+// what a pass concludes must be a function of persisted data rather than of map
+// iteration order, and a capability handed its question in a different order
+// each time could answer differently each time. An empty roster is not a
+// question worth asking, and the capability is not called for one.
+//
+// The whole roster is asked about rather than only this refresh's observers,
+// which is the same choice [Encounter.standingNow] makes and for the same
+// reason: the question a rulebook receives should not depend on which verb
+// happens to be running. Every caller of [Encounter.rebuildPercepts] passes the
+// roster anyway.
+//
+// Three refusals, and each one exists to make a mis-wired capability LOOK like
+// a mis-wired capability rather than like a rule that silently never fires: a
+// stranger in the answer (ErrNotMember, exactly as [Standing] does), a member
+// the answer skipped (ErrNoSight), and a distance that is not one (ErrNoSight).
+// See [Sight] for why the second is stricter here than it is there.
+func (e *Encounter) sightNow() (map[MemberID]int, error) {
+	if len(e.members) == 0 {
+		return nil, nil
+	}
+
+	roster := make([]MemberID, 0, len(e.members))
+	for id := range e.members {
+		roster = append(roster, id)
+	}
+	sort.Slice(roster, func(i, j int) bool { return roster[i] < roster[j] })
+
+	reported, err := e.sight.Sight(roster)
+	if err != nil {
+		return nil, fmt.Errorf("sight: %w", err)
+	}
+
+	for id, cells := range reported {
+		if _, ok := e.members[id]; !ok {
+			return nil, fmt.Errorf("sight: reported a range for %q, who is not a member: %w", id, ErrNotMember)
+		}
+		if cells < 0 {
+			return nil, fmt.Errorf("sight: reported %d cells for %q, which is not a distance: %w", cells, id, ErrNoSight)
+		}
+	}
+
+	for _, id := range roster {
+		if _, ok := reported[id]; !ok {
+			return nil, fmt.Errorf("sight: did not say how far %q can see: %w", id, ErrNoSight)
+		}
+	}
+
+	return reported, nil
+}

--- a/rulebooks/dnd5e/encounter/sight_test.go
+++ b/rulebooks/dnd5e/encounter/sight_test.go
@@ -1,0 +1,513 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// sight_test.go is HOW FAR ANYONE CAN SEE (rpg-toolkit#1111), the second half
+// of rpg-toolkit#1105.
+//
+// rpg-toolkit#1106 took the blindfold off: the room-membership filter that had
+// been standing in for every wall the composition could not express is gone,
+// and sight is decided by geometry. What went with the filter was the only
+// thing bounding sight at all — the room label was quietly a range term, and
+// removing it left a viewer able to see to the far wall of the dungeon.
+//
+// The term comes back SUPPLIED and PER MEMBER. The composition asks the
+// rulebook how far each member can see and uses the answer; it never learns
+// what a torch is. Every test here holds one face of that:
+//
+//   - THE TERM BITES. A member beyond your range is not in your percept, and
+//     one inside it is — at the reference tomb's real scale, where the
+//     unobstructed run is 27 cells of 5 feet each.
+//   - IT IS ASKED, NOT REMEMBERED. Change the answer mid-scene and the next
+//     refresh honours it. A cache would pass every other test in this file.
+//   - IT IS SUPPLIED, NEVER DEFAULTED. Both constructors refuse a scene that
+//     did not say (rpg-toolkit#1033), and a rulebook that answers badly is
+//     refused by name rather than quietly rounded off.
+//   - GEOMETRY STILL DECIDES FIRST. A wall inside your range still blinds you.
+//     The distance term is a ceiling on sight, not a replacement for it.
+//   - AND SURPRISE CAME ALIVE. Two members can now answer differently, so a
+//     monster can see a player who cannot see back — the first producible
+//     input the spotted arm of trigger detection has ever had.
+//
+// The fixture is canvas_test.go's tomb, reused deliberately: it is the
+// reference tomb's shipping shape (chambers 6, 10 and 12 wide by 8 tall, both
+// doorways on one row), which is the geometry rpg-project#227 says this stack
+// has to carry.
+type SightSuite struct {
+	suite.Suite
+}
+
+func TestSightSuite(t *testing.T) {
+	suite.Run(t, new(SightSuite))
+}
+
+// darkvision is the range these scenes hand out when they want a real bound:
+// 12 cells, which is the 60 feet 5e gives a dwarf. The conversion is the
+// rulebook's, and writing it here rather than in the composition is the whole
+// point of the seam.
+const (
+	darkvision = 12 // 60 ft
+	torchlight = 4  // 20 ft of bright light
+)
+
+// The three cells this file measures against, on the one row where both
+// doorways sit — the tomb's only unobstructed run from end to end.
+//
+// Projected through the fixture's own anchors, never written absolute, so a
+// moved chamber cannot leave a stale literal passing (canvas_test.go's rule).
+func aliceCell() spatial.Position { return tombAt(tombEntranceOrigin, 0, tombDoorRow) }
+func bobCell() spatial.Position   { return tombAt(tombHallOrigin, 5, tombDoorRow) }
+func carolCell() spatial.Position { return tombAt(tombChamberOrigin, 11, tombDoorRow) }
+
+// cells is the map's own distance between two cells: Chebyshev, which is what
+// spatial's square grid measures and what 5e means by "a diagonal costs five
+// feet".
+func cells(from, to spatial.Position) int {
+	return int(math.Max(math.Abs(to.X-from.X), math.Abs(to.Y-from.Y)))
+}
+
+// theLongRow opens the tomb with alice, bob and carol strung out along the row
+// both doorways sit on, all players so that nothing forms a fight and the only
+// thing deciding percepts is sight.
+func (s *SightSuite) theLongRow(sight encounter.Sight) *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: tombField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
+				Position: spatial.Position{X: 0, Y: float64(tombDoorRow)}},
+			{ID: bob, Kind: encounter.KindPlayer, Room: tombHall,
+				Position: spatial.Position{X: 5, Y: float64(tombDoorRow)}},
+			{ID: carol, Kind: encounter.KindPlayer, Room: tombChamber,
+				Position: spatial.Position{X: 11, Y: float64(tombDoorRow)}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc
+}
+
+// held reports the observer's holding on a subject, and whether there is one at
+// all. A subject that faded out of the percept is still HELD — a ghost of where
+// it was last seen — so a test about sight has to read the status, not just the
+// presence.
+func (s *SightSuite) held(enc *encounter.Encounter, observer, subject core.EntityID) (intel.Holding, bool) {
+	view, err := enc.View(&encounter.ViewInput{Member: observer})
+	s.Require().NoError(err)
+	for _, h := range view {
+		if h.Subject == intel.Subject(subject) {
+			return h, true
+		}
+	}
+
+	return intel.Holding{}, false
+}
+
+// sees reports whether the observer is CURRENTLY seeing the subject — sustained
+// by a channel right now, rather than remembered from earlier.
+func (s *SightSuite) sees(enc *encounter.Encounter, observer, subject core.EntityID) bool {
+	h, ok := s.held(enc, observer, subject)
+
+	return ok && h.Status == intel.Current
+}
+
+// TestAMemberBeyondYourSightIsNotInYourPerceptAndOneInsideItIs is the slice in
+// one scene, at the tomb's real scale.
+//
+// alice stands at the mouth of the entrance. bob is 11 cells away down the
+// hall — 55 feet, which is what the longest sighting in this dungeon used to
+// be, back when the room label was the range term. carol is 27 cells away at
+// the far wall of the tomb chamber: 135 feet, the run rpg-toolkit#1106 opened
+// up and left unbounded.
+//
+// With 60 feet of darkvision supplied, alice sees the first and not the second.
+// Nothing about the wall changed — the second half of the test proves it, by
+// handing the same scene an unbounded answer and watching carol appear.
+func (s *SightSuite) TestAMemberBeyondYourSightIsNotInYourPerceptAndOneInsideItIs() {
+	near, far := cells(aliceCell(), bobCell()), cells(aliceCell(), carolCell())
+	s.Require().Less(near, darkvision, "the fixture's near pair must be INSIDE the supplied range")
+	s.Require().Greater(far, darkvision, "and its far pair must be BEYOND it")
+
+	enc := s.theLongRow(&sightList{fallback: darkvision})
+
+	s.True(s.sees(enc, alice, bob),
+		fmt.Sprintf("bob is %d ft away and alice can see %d ft", near*5, darkvision*5))
+	_, anyHolding := s.held(enc, alice, carol)
+	s.False(anyHolding,
+		fmt.Sprintf("carol is %d ft away, and a member beyond your sight is not in your percept", far*5))
+
+	// The same geometry, unbounded: carol is visible, so what excluded her
+	// above was the distance term and not a wall.
+	unbounded := s.theLongRow(&sightList{fallback: unlimitedSight})
+	s.True(s.sees(unbounded, alice, carol),
+		"the run down the tomb is unobstructed — only the range was hiding her")
+}
+
+// TestTheEdgeOfYourSightIsInsideIt pins the boundary, which is the one thing
+// about a range predicate that is worth a test of its own: a member standing at
+// EXACTLY the distance you can see is visible, and the first cell past it is
+// not.
+//
+// Written as a sweep across the edge rather than as one assertion, because a
+// range term is exactly the kind of code where the off-by-one is the whole bug
+// and every other test in this file passes with it.
+func (s *SightSuite) TestTheEdgeOfYourSightIsInsideIt() {
+	apart := cells(aliceCell(), bobCell())
+
+	for reach, want := range map[int]bool{
+		apart + 1: true,  // comfortably inside
+		apart:     true,  // exactly at the edge, which is inside it
+		apart - 1: false, // one cell short
+	} {
+		enc := s.theLongRow(&sightList{reach: map[encounter.MemberID]int{alice: reach}, fallback: unlimitedSight})
+		s.Equal(want, s.sees(enc, alice, bob),
+			fmt.Sprintf("bob is %d cells away and alice can see %d", apart, reach))
+	}
+}
+
+// TestSightIsStillGeometryFirst. The distance term is a CEILING on sight, not a
+// replacement for it: carol and dave are one cell apart with a wall between
+// them, which is well inside any range, and they are still blind to each other.
+//
+// This is canvas_test.go's pair, re-asked with the new term present, because a
+// range check written in the wrong place — instead of the ray rather than
+// before it — would pass every other test in this file.
+func (s *SightSuite) TestSightIsStillGeometryFirst() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: &sightList{fallback: darkvision}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: tombField(),
+		Members: []encounter.MemberInput{
+			{ID: carol, Kind: encounter.KindPlayer, Room: tombEntrance,
+				Position: spatial.Position{X: 5, Y: float64(tombDoorRow - 1)}},
+			{ID: dave, Kind: encounter.KindPlayer, Room: tombHall,
+				Position: spatial.Position{X: 0, Y: float64(tombDoorRow - 1)}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	adjacent := cells(tombAt(tombEntranceOrigin, 5, tombDoorRow-1), tombAt(tombHallOrigin, 0, tombDoorRow-1))
+	s.Require().Less(adjacent, darkvision, "they are close enough that range cannot be what blinds them")
+
+	_, ok := s.held(enc, carol, dave)
+	s.False(ok, "a wall inside your sight range still blinds you")
+}
+
+// TestTheConeStillNarrows is rpg-toolkit#1106's measurement, re-run with a
+// distance term in the way.
+//
+// A viewer backing away from an open doorway sees a shrinking slice of the
+// chamber beyond it, because the doorway frames the view. That is the effect
+// S0 measured (73% -> 44% -> 27% -> 18% of the far chamber at 1, 2, 4 and 8
+// cells back) and it is the thing a badly-placed range check would destroy, by
+// making distance rather than the doorway decide what is visible.
+//
+// So the range here is deliberately generous — every mark stays well inside it
+// — and the narrowing that remains is the doorway's alone.
+func (s *SightSuite) TestTheConeStillNarrows() {
+	// A rank of marks down the first column of the tomb chamber, one per row:
+	// the slice of the chamber a viewer in the hall can see.
+	marks := make([]encounter.MemberInput, 0, 8)
+	ids := make([]core.EntityID, 0, 8)
+	for y := 0; y < 8; y++ {
+		id := core.EntityID(fmt.Sprintf("mark-%d", y))
+		ids = append(ids, id)
+		marks = append(marks, encounter.MemberInput{
+			ID: id, Kind: encounter.KindPlayer, Room: tombChamber,
+			Position: spatial.Position{X: 1, Y: float64(y)},
+		})
+	}
+
+	// Far enough that the whole rank is inside it from every viewing position
+	// below: the doorway is the only thing that can narrow this.
+	const generous = 30
+
+	seenFrom := func(back int) int {
+		members := append([]encounter.MemberInput{{
+			ID: alice, Kind: encounter.KindPlayer, Room: tombHall,
+			Position: spatial.Position{X: float64(9 - back), Y: float64(tombDoorRow)},
+		}}, marks...)
+
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Sight: &sightList{fallback: generous}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field:   tombField(),
+			Members: members,
+			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		})
+		s.Require().NoError(err)
+
+		viewer := tombAt(tombHallOrigin, 9-back, tombDoorRow)
+		count := 0
+		for i, id := range ids {
+			s.Require().LessOrEqual(cells(viewer, tombAt(tombChamberOrigin, 1, i)), generous,
+				"the premise: every mark is inside the supplied range")
+			if s.sees(enc, alice, id) {
+				count++
+			}
+		}
+
+		return count
+	}
+
+	inTheDoorway, oneBack, fourBack := seenFrom(0), seenFrom(1), seenFrom(4)
+
+	s.Positive(inTheDoorway, "standing in the doorway she sees into the chamber")
+	s.LessOrEqual(oneBack, inTheDoorway, "and less of it from a step back")
+	s.Less(fourBack, inTheDoorway, "and strictly less from four cells back — the cone is still a cone")
+	s.LessOrEqual(fourBack, oneBack)
+}
+
+// TestHowFarSheCanSeeIsAskedAgainEveryTime is the only test here that can tell
+// a pull from a cache.
+//
+// Every other test in this file would pass against a composition that asked
+// once at construction and kept the number. This one puts the torch out
+// mid-scene: the rulebook's answer changes, nobody is rebuilt, and the very
+// next refresh honours it.
+//
+// bob does not vanish from alice's view — he becomes a GHOST, held at the cell
+// she last saw him in. That is intel's own model of memory and it is the right
+// answer: losing sight of somebody is not forgetting where they were.
+func (s *SightSuite) TestHowFarSheCanSeeIsAskedAgainEveryTime() {
+	rulebook := &sightList{fallback: darkvision}
+	enc := s.theLongRow(rulebook)
+
+	s.Require().True(s.sees(enc, alice, bob), "the torch is lit and bob is inside its light")
+
+	// The torch gutters out. Nothing is reconstructed; the rulebook simply
+	// answers differently the next time it is asked.
+	rulebook.reach = map[encounter.MemberID]int{alice: torchlight}
+
+	// Somebody else moves, which is all it takes for the world to look again.
+	_, err := enc.Step(&encounter.StepInput{Member: carol, To: tombAt(tombChamberOrigin, 10, tombDoorRow)})
+	s.Require().NoError(err)
+
+	s.Require().Greater(cells(aliceCell(), bobCell()), torchlight,
+		"the premise: bob is beyond the guttering torch")
+	s.False(s.sees(enc, alice, bob), "she cannot see that far any more")
+
+	ghost, ok := s.held(enc, alice, bob)
+	s.True(ok, "but she remembers where he was")
+	s.Equal(intel.Held, ghost.Status)
+
+	// And it goes both ways: bob's own answer never changed, so he still sees
+	// her. Two members, two ranges, one geometry.
+	s.True(s.sees(enc, bob, alice), "bob's eyes are as good as they were")
+}
+
+// TestTheConsultRunsAtEveryRefreshAndAsksAboutTheWholeRoster pins the shape of
+// the question rather than the answer: sorted, complete, and asked again.
+func (s *SightSuite) TestTheConsultRunsAtEveryRefreshAndAsksAboutTheWholeRoster() {
+	counter := &countingSight{}
+	enc := s.theLongRow(counter)
+
+	first := counter.calls
+	s.Require().Positive(first, "first light asks")
+	s.Require().Equal([]encounter.MemberID{alice, bob, carol}, counter.asked[0],
+		"the whole roster, sorted — a rulebook must not have to cope with a different question each verb")
+
+	_, err := enc.Step(&encounter.StepInput{Member: carol, To: tombAt(tombChamberOrigin, 10, tombDoorRow)})
+	s.Require().NoError(err)
+	s.Greater(counter.calls, first, "and every refresh asks again")
+}
+
+// TestTheFarSightedSpotTheShortSightedAndSurpriseThem is the finding this slice
+// did not set out to make.
+//
+// trigger.go has classified four contact cases since rpg-toolkit#964, and two
+// of them — the monster saw you and you did not see back, and its mirror — were
+// documented as having no producible input, because every observer saw exactly
+// as far as every other. A per-member range is that input. The goblin has
+// darkvision; alice has a torch; she walks into the range of the first and not
+// of the second, and the fight starts with her surprised.
+//
+// Not one line of classification changed, which is what its own godoc promised:
+// upgrades change how percepts are PRODUCED, never how they are consumed.
+//
+// This is not rpg-toolkit#1020 and does not stand in for it — no stealth is
+// contested here, and the geometry is as mutual as it ever was. What differs is
+// reach.
+func (s *SightSuite) TestTheFarSightedSpotTheShortSightedAndSurpriseThem() {
+	const goblin = core.EntityID("goblin")
+
+	scene := func(sight encounter.Sight) *encounter.Encounter {
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: tombField(),
+			Members: []encounter.MemberInput{
+				{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
+					Position: spatial.Position{X: 0, Y: float64(tombDoorRow)}},
+				{ID: goblin, Kind: encounter.KindMonster, Room: tombChamber,
+					Position: spatial.Position{X: 6, Y: float64(tombDoorRow)}},
+			},
+			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		})
+		s.Require().NoError(err)
+
+		return enc
+	}
+
+	goblinCell := tombAt(tombChamberOrigin, 6, tombDoorRow)
+	halfway := tombAt(tombHallOrigin, 5, tombDoorRow)
+	s.Require().Greater(cells(aliceCell(), goblinCell), darkvision,
+		"the premise: at the mouth of the tomb she is beyond even the goblin's eyes")
+	s.Require().Less(cells(halfway, goblinCell), darkvision,
+		"halfway down the hall she is inside them")
+	s.Require().Greater(cells(halfway, goblinCell), torchlight,
+		"and the goblin is still outside her torchlight")
+
+	s.Run("she is spotted, and surprised", func() {
+		enc := scene(&sightList{reach: map[encounter.MemberID]int{goblin: darkvision}, fallback: torchlight})
+
+		out, err := enc.Step(&encounter.StepInput{Member: alice, To: halfway})
+		s.Require().NoError(err)
+
+		s.Require().NotNil(out.Formed, "the goblin saw her, so there is a fight")
+		s.ElementsMatch([]encounter.MemberID{alice, goblin}, out.Formed.Order)
+		s.Equal([]encounter.MemberID{alice}, out.Formed.Surprised,
+			"she walked into a fight she could not see")
+
+		s.True(s.sees(enc, goblin, alice), "the goblin has her")
+		s.False(s.sees(enc, alice, goblin), "she does not have the goblin")
+	})
+
+	s.Run("with matching eyes nobody is surprised", func() {
+		enc := scene(&sightList{fallback: darkvision})
+
+		out, err := enc.Step(&encounter.StepInput{Member: alice, To: halfway})
+		s.Require().NoError(err)
+
+		s.Require().NotNil(out.Formed)
+		s.Empty(out.Formed.Surprised,
+			"the surprise came from the difference in reach, not from the fight")
+	})
+}
+
+// TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused. Both constructors, by
+// name.
+//
+// There is no default and there cannot be one: a number meaning "everyone sees
+// this far" is a rule 5e does not have, and picking one would be this module
+// deciding a rule it is not allowed to know — the argument Standing makes about
+// itself, and rpg-toolkit#1033's law.
+func TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused(t *testing.T) {
+	t.Run("setup", func(t *testing.T) {
+		_, err := encounter.NewEncounter(&encounter.SetupInput{
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: tombField(),
+			Members: []encounter.MemberInput{
+				{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
+					Position: spatial.Position{X: 0, Y: float64(tombDoorRow)}},
+			},
+			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, encounter.ErrNoSight)
+	})
+
+	t.Run("load", func(t *testing.T) {
+		enc, err := encounter.NewEncounter(&encounter.SetupInput{
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: tombField(),
+			Members: []encounter.MemberInput{
+				{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
+					Position: spatial.Position{X: 0, Y: float64(tombDoorRow)}},
+			},
+			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		})
+		require.NoError(t, err)
+
+		_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: enc.ToData(),
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, encounter.ErrNoSight)
+	})
+}
+
+// TestARulebookThatAnswersBadlyIsRefusedByName.
+//
+// Three shapes of wrong answer, all of them arriving MID-SCENE so the refusal
+// is asserted from an encounter that was already running — a mis-wired
+// capability has to look like a mis-wired capability, not like a rule that
+// silently never fires.
+func (s *SightSuite) TestARulebookThatAnswersBadlyIsRefusedByName() {
+	walk := func(enc *encounter.Encounter) error {
+		_, err := enc.Step(&encounter.StepInput{Member: carol, To: tombAt(tombChamberOrigin, 10, tombDoorRow)})
+
+		return err
+	}
+
+	s.Run("a range for somebody who is not a member", func() {
+		rulebook := &sightStrangerWhenTold{}
+		enc := s.theLongRow(rulebook)
+
+		rulebook.lying = true
+		err := walk(enc)
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNotMember)
+		s.Contains(err.Error(), "a-ghost", "the refusal names who")
+	})
+
+	s.Run("no range at all for somebody who is", func() {
+		rulebook := &sightSkippingWhenTold{}
+		enc := s.theLongRow(rulebook)
+
+		rulebook.skip = bob
+		err := walk(enc)
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNoSight)
+		s.Contains(err.Error(), string(bob), "the refusal names who was skipped")
+	})
+
+	s.Run("a range that is not a distance", func() {
+		rulebook := &sightBelowZero{who: bob, cells: 0}
+		enc := s.theLongRow(rulebook)
+
+		rulebook.cells = -1
+		err := walk(enc)
+		s.Require().Error(err)
+		s.ErrorIs(err, encounter.ErrNoSight)
+		s.Contains(err.Error(), string(bob))
+	})
+}
+
+// TestARulebookThatCannotAnswerAbortsTheVerb is R5: a world that cannot find
+// out how far somebody can see does not half-build a percept on a guess.
+func (s *SightSuite) TestARulebookThatCannotAnswerAbortsTheVerb() {
+	rulebook := &sightBrokenWhenTold{}
+	enc := s.theLongRow(rulebook)
+
+	rulebook.broken = true
+	_, err := enc.Step(&encounter.StepInput{Member: carol, To: tombAt(tombChamberOrigin, 10, tombDoorRow)})
+	s.Require().Error(err)
+	s.ErrorIs(err, errRulebookCannotSee, "the rulebook's own error survives the wrapping")
+}
+
+// TestBlindIsALegalAnswer. Zero cells is a rulebook saying "this one sees
+// nothing" — a creature in magical darkness, or blinded — and it is an answer
+// rather than a defect. Nobody is ever asked about the cell underfoot, so zero
+// means exactly what it says.
+func (s *SightSuite) TestBlindIsALegalAnswer() {
+	enc := s.theLongRow(&sightList{reach: map[encounter.MemberID]int{alice: 0}, fallback: unlimitedSight})
+
+	_, ok := s.held(enc, alice, bob)
+	s.False(ok, "she sees nothing at all")
+	s.True(s.sees(enc, bob, alice), "and the rest of the party is unaffected")
+}

--- a/rulebooks/dnd5e/encounter/standing_test.go
+++ b/rulebooks/dnd5e/encounter/standing_test.go
@@ -62,8 +62,8 @@ func (s *deathScene) scene(standing encounter.Standing, members ...encounter.Mem
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Standing:   standing,
-		Retention:  encounter.RetentionUnbounded,
+		Sight:      everyoneSeesTheWholeMap{}, Standing: standing,
+		Retention: encounter.RetentionUnbounded,
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
@@ -214,7 +214,7 @@ func (s *StandingSuite) TestALoadedEncounterAsksToo() {
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       saved,
 		Initiative: orderAsGiven{},
-		Standing:   down,
+		Sight:      everyoneSeesTheWholeMap{}, Standing: down,
 	})
 	s.Require().NoError(err)
 	s.Require().Equal([]encounter.MemberID{alice, goblin, wolf}, s.orderOf(enc, alice),
@@ -415,8 +415,8 @@ func (s *StandingSuite) TestTheStorySaysItOnce() {
 func (s *StandingSuite) TestAForgottenDeathIsToldAgain() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Standing:   &downList{down: []encounter.MemberID{goblin}},
-		Retention:  4,
+		Sight:      everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
+		Retention: 4,
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -101,7 +101,7 @@ func stepField() encounter.FieldInput {
 // the only thing that happens.
 func (s *StepSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -357,7 +357,7 @@ func (s *StepSuite) TestAStepAndAMonsterStepAgreeOnWhatIsCrossable() {
 // "nobody has seen anybody".
 func (s *StepSuite) sceneWithMonster(at spatial.Position, decider encounter.Decider) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: goblin, Kind: encounter.KindMonster, Room: stepWest,
@@ -388,7 +388,7 @@ func (s *StepSuite) whereIn(enc *encounter.Encounter, id encounter.MemberID) spa
 func (s *StepSuite) TestAStepFiresAReachedPositionEnding() {
 	target := spatial.Position{X: 4, Y: 2}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -412,7 +412,7 @@ func (s *StepSuite) TestAStepFiresAReachedPositionEnding() {
 // against where the member landed, not where they left.
 func (s *StepSuite) TestACrossingFiresAReachedPositionEndingOnTheFarSide() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -476,7 +476,7 @@ func (s *StepSuite) TestAStepRefusesAClosedEncounter() {
 func (s *StepSuite) TestAStepRefusesAFightMember() {
 	// In sight of each other from first light, which starts the fight.
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -512,7 +512,7 @@ func (s *StepSuite) TestGridReportsTheFieldsFamily() {
 // square case.
 func (s *StepSuite) TestGridReportsAHexFieldAsHex() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
 			{ID: stepWest, Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 				Origin: stepWestOrigin},

--- a/rulebooks/dnd5e/encounter/testsight_internal_test.go
+++ b/rulebooks/dnd5e/encounter/testsight_internal_test.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+// everyoneSeesTheWholeMap is the Sight capability the internal tests install.
+//
+// Nobody is ever bounded by distance: these tests are about clocks, not about
+// light, and the capability is required at construction so they have to say so.
+// The rulebook's real answer is the production consumer's business.
+type everyoneSeesTheWholeMap struct{}
+
+func (everyoneSeesTheWholeMap) Sight(members []MemberID) (map[MemberID]int, error) {
+	out := make(map[MemberID]int, len(members))
+	for _, id := range members {
+		out[id] = 1_000_000
+	}
+
+	return out, nil
+}

--- a/rulebooks/dnd5e/encounter/testsight_test.go
+++ b/rulebooks/dnd5e/encounter/testsight_test.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"errors"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// unlimitedSight is the range these tests hand out when light is not their
+// subject: further than the longest sightline any canvas in this package draws,
+// which is the reference tomb's 27 cells.
+const unlimitedSight = 1_000_000
+
+// everyoneSeesTheWholeMap is the Sight capability these tests install by
+// default.
+//
+// Nobody is ever bounded by distance, which is what every scene written before
+// sight had a distance term was already assuming. Installing it explicitly
+// rather than letting a nil mean it is the whole point of the capability being
+// required: a scene states what it believes about light out loud
+// (rpg-toolkit#1033 — capabilities are supplied, never defaulted).
+type everyoneSeesTheWholeMap struct{}
+
+func (everyoneSeesTheWholeMap) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	return sameForEveryone(members, unlimitedSight), nil
+}
+
+// sameForEveryone answers the same distance for every member asked about, which
+// is what a v1 rulebook with no light model does.
+func sameForEveryone(members []encounter.MemberID, cells int) map[encounter.MemberID]int {
+	out := make(map[encounter.MemberID]int, len(members))
+	for _, id := range members {
+		out[id] = cells
+	}
+
+	return out
+}
+
+// sightList reports a caller-set distance per member, and can be changed
+// MID-SCENE — which is how a test puts out a torch, or lights one, without
+// rebuilding the encounter. That is the only way to test a pull: if the
+// composition cached the answer, changing this would change nothing.
+//
+// It answers about exactly the members it was ASKED about, because that is what
+// a real implementation does. Anybody with no entry in reach gets fallback, so a
+// scene names only the members whose light it cares about.
+type sightList struct {
+	reach    map[encounter.MemberID]int
+	fallback int
+}
+
+func (s *sightList) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	out := make(map[encounter.MemberID]int, len(members))
+	for _, id := range members {
+		if cells, ok := s.reach[id]; ok {
+			out[id] = cells
+			continue
+		}
+		out[id] = s.fallback
+	}
+
+	return out, nil
+}
+
+// sightStrangerWhenTold is a rulebook that starts well-behaved and then answers
+// about somebody who is not in the encounter at all — the mis-wiring this
+// capability could arrive as, held here so the composition's refusal can be
+// asserted from a scene that was already running.
+type sightStrangerWhenTold struct {
+	lying bool
+}
+
+func (s *sightStrangerWhenTold) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	out := sameForEveryone(members, unlimitedSight)
+	if s.lying {
+		out["a-ghost"] = 4
+	}
+
+	return out, nil
+}
+
+// sightSkippingWhenTold is a rulebook that stops covering one of the members it
+// was asked about. Absence means nothing in a sight answer, so the composition
+// has nothing to fall back on and must say so.
+type sightSkippingWhenTold struct {
+	skip encounter.MemberID
+}
+
+func (s *sightSkippingWhenTold) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	out := sameForEveryone(members, unlimitedSight)
+	if s.skip != "" {
+		delete(out, s.skip)
+	}
+
+	return out, nil
+}
+
+// sightBelowZero answers with a number that is not a distance.
+type sightBelowZero struct {
+	who   encounter.MemberID
+	cells int
+}
+
+func (s *sightBelowZero) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	out := sameForEveryone(members, unlimitedSight)
+	out[s.who] = s.cells
+
+	return out, nil
+}
+
+// errRulebookCannotSee is what a rulebook that cannot answer looks like from the
+// composition's side — a content store that is down rather than a creature in
+// the dark.
+var errRulebookCannotSee = errors.New("the rulebook cannot say how far anyone can see")
+
+// sightBrokenWhenTold is a rulebook that starts well-behaved and then stops
+// answering, so the R5 arm can be driven from a scene that was already running.
+type sightBrokenWhenTold struct {
+	broken bool
+}
+
+func (s *sightBrokenWhenTold) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	if s.broken {
+		return nil, errRulebookCannotSee
+	}
+
+	return sameForEveryone(members, unlimitedSight), nil
+}
+
+// countingSight is everyoneSeesTheWholeMap that remembers what it was asked and
+// how often, which is how a test tells "the consult did not fire" from "the
+// consult found nothing to bound".
+type countingSight struct {
+	calls int
+	asked [][]encounter.MemberID
+}
+
+func (c *countingSight) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	c.calls++
+	c.asked = append(c.asked, append([]encounter.MemberID(nil), members...))
+
+	return sameForEveryone(members, unlimitedSight), nil
+}

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -56,7 +56,7 @@ func TestTombWatch(t *testing.T) {
 	// cannot get through.
 	goblinPatrol := &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
@@ -132,7 +132,7 @@ func TestTombWatch(t *testing.T) {
 	// does not — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}},
 		}})
 	require.NoError(t, err, "beat 4: the suspended scene crosses a process boundary")
@@ -267,7 +267,7 @@ func TestTombWatch(t *testing.T) {
 		})
 	}
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{
-		Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,

--- a/rulebooks/dnd5e/encounter/trigger.go
+++ b/rulebooks/dnd5e/encounter/trigger.go
@@ -45,25 +45,33 @@ const (
 	// decides in free roam — back away, sneak, or approach — with attacking
 	// from here counting as initiation.
 	//
-	// UNREACHABLE TODAY, and deliberately kept. Sight is symmetric: every
-	// percept is built from IsLineOfSightBlocked with no facing, stealth or
-	// perception input, and that predicate is symmetric BY LAW as of
-	// rpg-toolkit#1022 — spatial pins it as a property over fuzzed rooms in
-	// every grid family. So if the player sees the wolf, the wolf sees the
-	// player, and this case has no producible input.
+	// REACHABLE AS OF rpg-toolkit#1111, and it was not before — this comment
+	// said UNREACHABLE for three waves and had earned it.
 	//
-	// It was briefly reachable and nobody meant it to be, which is why the law
-	// exists: sight used to be one rasterized line, and Bresenham chose
-	// different cells by direction on square grids, so a wall corner could
-	// hide a player from a monster it did not hide the monster from. A
-	// one-sided ambush earned by ray-rounding rather than by anything in the
-	// fiction. Fixed in spatial v0.9.1, and asymmetry now arrives only where
-	// it is designed to.
+	// Sight's GEOMETRY is symmetric by law, and still is: every percept is
+	// built from IsLineOfSightBlocked with no facing, stealth or perception
+	// input, and spatial pins that predicate as mutual over fuzzed rooms in
+	// every grid family (rpg-toolkit#1022). While every observer ALSO saw
+	// exactly as far as every other, "the player sees the wolf" and "the wolf
+	// sees the player" were the same sentence and this arm had no producible
+	// input. [Sight] made the range per member, so they are two sentences now:
+	// the player with the lantern sees the wolf that cannot see her back.
 	//
-	// rpg-toolkit#1020 is that design and the prerequisite that makes this arm
-	// real. It stays because it is the documented shape rather than dead
-	// ceremony — what is NOT here is any behavior hanging off it, because
-	// unbuilt beats built-and-dead.
+	// It was briefly reachable BY ACCIDENT before that, and nobody meant it to
+	// be, which is why the geometric law exists: sight used to be one
+	// rasterized line, and Bresenham chose different cells by direction on
+	// square grids, so a wall corner could hide a player from a monster it did
+	// not hide the monster from. A one-sided ambush earned by ray-rounding
+	// rather than by anything in the fiction. Fixed in spatial v0.9.1, and
+	// asymmetry now arrives only where it is designed to — which is what
+	// rpg-toolkit#1111 is, and rpg-toolkit#1020 after it.
+	//
+	// WHAT IS STILL NOT HERE is any behaviour hanging off it. The
+	// classification is correct and nothing acts on it: no bubble forms, which
+	// is the right answer by itself — a creature that did not notice you starts
+	// no fight. The walk-stop and the choice it offers stay unbuilt, because
+	// the SHAPE of that offer is rpg-toolkit#1020's design and guessing it here
+	// would be the built-and-wrong this comment has always preferred to avoid.
 	contactDrop
 
 	// contactSpotted: the monster saw the player and the player did not see
@@ -99,12 +107,20 @@ type trigger struct {
 // written against asymmetric sight and does not move again. That is what makes
 // the next two versions cheap.
 //
-// v1, WHICH IS WHAT THIS IS: sight is symmetric line-of-sight, so any first
-// contact forms the bubble and the drop case has no producible input. Surprise
-// is computed correctly and is always empty, for the same reason — everyone
-// sees everyone, so nobody is unaware. Honest option C under B-prime's design,
-// not a compromise: the machinery is the permanent part and the percepts are
-// the part that grows.
+// v1 WAS symmetric line-of-sight, so any first contact formed the bubble, the
+// drop case had no producible input, and surprise — computed correctly the
+// whole time — was always empty, because everyone saw everyone and nobody could
+// be unaware. Honest option C under B-prime's design, not a compromise: the
+// machinery is the permanent part and the percepts are the part that grows.
+//
+// v1.5 IS WHAT THIS IS, and it is the invariant collecting. rpg-toolkit#1111
+// gave sight a distance term supplied PER MEMBER, so two observers can answer
+// differently: a monster with darkvision sees a player whose torch does not
+// reach it. Spotted and drop have inputs, and 5e surprise is producible and
+// real. NOT ONE LINE BELOW MOVED — the four-case table, the precedence law,
+// transition-only induction and awareness-based surprise were all written
+// against asymmetric sight, and they simply started firing. Pinned by
+// TestTheFarSightedSpotTheShortSightedAndSurpriseThem.
 //
 // THAT CLAIM WAS FALSE WHEN IT WAS FIRST WRITTEN, and the correction is worth
 // keeping rather than quietly editing away. Sight was symmetric by intent and
@@ -238,10 +254,12 @@ func (e *Encounter) classify(deltas map[MemberID]*intel.SurveilOutput, down map[
 		return e.formation(engaged, down)
 	}
 
-	// The drop arm classifies and then does nothing, because nothing can reach
-	// it (rpg-toolkit#1020) and a walk-stop built against an unreachable case
-	// would be untestable behavior shipped on faith. When #1020 lands, this is
-	// where the early stop attaches.
+	// The drop arm classifies and then does nothing. It is reachable now
+	// (rpg-toolkit#1111 — see contactDrop), and doing nothing is still the
+	// right amount: no bubble forms, which is correct on its own, and the
+	// walk-stop's shape — where the walk ends and what the player is offered —
+	// is rpg-toolkit#1020's design rather than something to guess here. When
+	// #1020 lands, this is where the early stop attaches.
 	_, _ = drops, dropBy
 
 	return &trigger{}, nil

--- a/rulebooks/dnd5e/encounter/trigger.go
+++ b/rulebooks/dnd5e/encounter/trigger.go
@@ -48,14 +48,18 @@ const (
 	// REACHABLE AS OF rpg-toolkit#1111, and it was not before — this comment
 	// said UNREACHABLE for three waves and had earned it.
 	//
-	// Sight's GEOMETRY is symmetric by law, and still is: every percept is
-	// built from IsLineOfSightBlocked with no facing, stealth or perception
-	// input, and spatial pins that predicate as mutual over fuzzed rooms in
-	// every grid family (rpg-toolkit#1022). While every observer ALSO saw
-	// exactly as far as every other, "the player sees the wolf" and "the wolf
-	// sees the player" were the same sentence and this arm had no producible
-	// input. [Sight] made the range per member, so they are two sentences now:
-	// the player with the lantern sees the wolf that cannot see her back.
+	// A percept is built from TWO filters, and only one of them is mutual.
+	// The geometric one is: IsLineOfSightBlocked takes no facing, stealth or
+	// perception input, and spatial pins it as mutual over fuzzed rooms in
+	// every grid family (rpg-toolkit#1022). It still is, and this slice did
+	// not touch it. The other is REACH, and it is per observer as of
+	// rpg-toolkit#1111 — see [Sight].
+	//
+	// While reach was the same for everybody, both filters were mutual, so
+	// "the player sees the wolf" and "the wolf sees the player" were one
+	// sentence and this arm had no producible input. They are two sentences
+	// now: the player with the lantern sees the wolf that cannot see her back,
+	// through geometry that is as mutual as it ever was.
 	//
 	// It was briefly reachable BY ACCIDENT before that, and nobody meant it to
 	// be, which is why the geometric law exists: sight used to be one


### PR DESCRIPTION
World-model slice **S2**, and the second half of #1105. Follows S0 (#1106, encounter v0.18.0 — the canvas became the primitive) and S1 (#1108, v0.19.0 — rooms became regions).

**The piece:** *how far you can see is the rulebook's answer, per member.*

Built to Kirk's ruling on #1111 (comment 5338377958): the distance term is a **per-member supplied capability**, mirroring `Standing`/`InitiativeRoller` — not a flat `SightRange` on Setup, and not the full bright/dim/dark light model yet.

---

## Census

Verified at `78227cd`, tree clean.

**The choke point is one function.** `rebuildPercepts` (`encounter.go:1942`) is the only producer of percepts in the module: `IsLineOfSightBlocked` has exactly one call site, `intelLog.Surveil` has exactly one, and every reader is downstream of `intelLog` — `View`, the monster decider's `Snapshot.Holdings`, and `classify`'s deltas. One consult covers all of them.

**Nothing outside is forced to compile.** `session` pins encounter v0.17.0, `resolution` pins v0.15.0; head is v0.19.0. No `go.work`, no `replace`, per-module CI.

**Persistence is untouched.** Capabilities are live objects and are absent from `EncounterData`, exactly as `Standing` and `InitiativeRoller` are. No dialect break, no blob change, no migration. The break is at construction only.

### The fixture cost, measured (the ~270 figure predates S0/S1)

Re-measured at `78227cd`: **265 `Standing:` sites** — 263 in `*_test.go`, 2 in `cmd/freeroam-workbench`. But the number that decides the approach is uniformity, and it is very high: deduplicated, those 265 sites are ~38 distinct line texts, and two of them cover 207:

```
165x  Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 42x  Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
```

Exactly **8 sites** use a non-default capability. The edit landed as one prefix insertion (`Sight: <double>,` in front of `Standing:`) applied to all of them mechanically.

**Asked whether a fixture chokepoint pays for itself this time: it does not, and I did not build one.**

1. A chokepoint means rewriting all 265 literals into helper calls — a strictly larger diff, to avoid a smaller one.
2. It would delete the property #1033's law exists to protect. A scene that writes `Sight: everyoneSeesTheWholeMap{}` is **stating out loud** that it believes light is not its subject. A helper that supplies it silently is a default wearing a different hat, and the next capability would arrive defaulted by construction.
3. It prices the wrong thing. A chokepoint is worth building when sites *differ*. These do not.

---

## Conformance to the ruled shape

| Ruled | Where |
|---|---|
| per-member supplied capability, `Standing`'s shape | `sight.go` — `Sight(members []MemberID) (map[MemberID]int, error)` |
| supplied at BOTH constructors, REQUIRED, refused by name | `encounter.go` (`ErrNoSight`), `data.go` `Validate` |
| never defaulted (#1033) | no default exists; `TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused` |
| roster-scoped; a stranger refused by name | `sightNow` → `ErrNotMember`, the whole roster asked, sorted (C8) — the exact `standingNow` mirror |
| consulted at the sight-refresh choke point | `rebuildPercepts`, once per refresh, before the observer loop |
| never cached | pinned by `TestHowFarSheCanSeeIsAskedAgainEveryTime` — the answer changes mid-scene and the next refresh honours it |
| godoc names the light model as the future ANSWER | `Sight`'s "Today's answer is one number, and that is the point", the way `Standing`'s doc names #977 |

### The one design call the ruling left open: cells, not feet

The module has **no notion of feet** — `grep` finds the word only in prose. Its only distance vocabulary is `spatial.Grid.Distance`, which returns cells. If the seam spoke feet, this module would have to hold *"a square is five feet"* to compare against the grid, and that is a 5e rule in a module whose whole basis is that it cannot know 5e rules (law C1). The rulebook already knows both halves, so the ÷5 belongs there: 60-foot darkvision is `12`. The conversion is exact rather than approximate — Chebyshev is 5e's own "a diagonal costs five feet" measure. Precedent: the old stack's `SightRange int` is in hexes too.

### Two derivations the ruling does not name

- **A member the answer SKIPPED is refused** (`ErrNoSight`), not just a stranger. `Standing`'s answer is a subset by nature — absence means "standing" — but absence here means nothing at all, and a member with no supplied range is a member whose sight this module would have to invent. That is exactly what #1033 forbids.
- **A negative answer is refused.** Zero already means blind, so a negative is not a shorter answer; it is not an answer.

---

## The finding this slice did not set out to make: surprise came alive

`trigger.go` has classified four contact cases since #964, and two of them — `contactSpotted` (the monster saw you and you did not see back) and `contactDrop` — were documented as having **no producible input**, because every observer saw exactly as far as every other. `formation` already computed `Surprised` and already said it was always empty for the same reason.

A per-member range is that input. A goblin with darkvision and a player with a torch, eleven cells apart: the goblin spots her, she cannot see back, the bubble forms **spotted**, and she enters it **surprised**. 5e surprise, produced.

**Not one line of `classify` moved**, which is precisely what its own godoc staked itself on: *"upgrades change how percepts are PRODUCED, never how they are consumed."* Pinned by `TestTheFarSightedSpotTheShortSightedAndSurpriseThem`, including the control — with matching eyes, nobody is surprised.

Those godoc claims are now **false**, so they are corrected rather than left standing (`trigger.go`'s `contactDrop` block, `classify`'s v1 paragraph, its drop arm, and `Pump`'s "any monster a player can see is in a bubble"). The drop arm still hangs no behaviour off itself: the classification is right, no bubble forms — which is correct on its own — and the walk-stop's shape is #1020's design rather than something to guess here.

## Nothing precludes #1020, and here is the seam it rides

The asymmetry above is **range**, not stealth. Geometry stays mutual — `spatial` v0.9.1 pins line of sight as a law over fuzzed rooms in every grid family, and this slice does not touch it.

#1020 is a per-observer answer to a different question: *does this observer's percept hold a subject that is in plain view?* It lands in the same loop in `rebuildPercepts`, beside this one:

```go
for _, otherMember := range e.members {
    if <too far — this slice> { continue }
    if <blocked by geometry> { continue }
    if <hidden from THIS observer — #1020> { continue }   // ← rides here
    percept = append(percept, ...)
}
```

Both are per-observer filters over the same candidate set, both are supplied capabilities consulted at the same choke point, and neither has to know the other exists. #1020's census found `play/intel` is already per-observer end to end; what it needed from the world model was a per-observer *production* seam, and this slice is one.

---

## Test evidence

RED first, behavioural, at the reference tomb's real scale — `canvas_test.go`'s fixture is the tomb's shipping shape (chambers 6/10/12 wide × 8 tall, both doorways on one row), whose unobstructed run is **27 cells = 135 ft**, exactly S0's measured maximum. Full RED transcript below.

| Test | Holds |
|---|---|
| `TestAMemberBeyondYourSightIsNotInYourPerceptAndOneInsideItIs` | bob at 55 ft is in alice's percept, carol at 135 ft is not, with 60 ft of darkvision supplied — and with an unbounded answer carol appears, so it was the range and not a wall |
| `TestTheEdgeOfYourSightIsInsideIt` | the boundary swept: exactly at your reach is inside it, one cell short is not |
| `TestSightIsStillGeometryFirst` | a wall one cell away still blinds you — the term is a ceiling on sight, not a replacement for it |
| `TestTheConeStillNarrows` | S0's cone survives: a viewer backing off an open doorway sees a shrinking rank of marks in the far chamber, with the range deliberately generous so the doorway is the only thing narrowing it |
| `TestHowFarSheCanSeeIsAskedAgainEveryTime` | the torch gutters mid-scene, nobody is rebuilt, and the next refresh honours it — bob becomes a `Held` ghost, and bob's own answer is unchanged so he still sees her |
| `TestTheConsultRunsAtEveryRefreshAndAsksAboutTheWholeRoster` | the question's shape: whole roster, sorted, asked again every refresh |
| `TestTheFarSightedSpotTheShortSightedAndSurpriseThem` | the finding above, with its control |
| `TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused` | Setup and Load, `ErrNoSight` |
| `TestARulebookThatAnswersBadlyIsRefusedByName` | a stranger (`ErrNotMember`), a skipped member (`ErrNoSight`), a negative (`ErrNoSight`) — all arriving mid-scene |
| `TestARulebookThatCannotAnswerAbortsTheVerb` | R5 |
| `TestBlindIsALegalAnswer` | zero cells is an answer, not a defect |

<details>
<summary>RED transcript (before the consult, the predicate and the refusals existed)</summary>

```
--- FAIL: TestSightSuite/TestAMemberBeyondYourSightIsNotInYourPerceptAndOneInsideItIs
        Should be false
        Messages: carol is 135 ft away, and a member beyond your sight is not in your percept
--- FAIL: TestSightSuite/TestARulebookThatAnswersBadlyIsRefusedByName/a_range_for_somebody_who_is_not_a_member
        An error is expected but got nil.
--- FAIL: TestSightSuite/TestARulebookThatAnswersBadlyIsRefusedByName/no_range_at_all_for_somebody_who_is
        An error is expected but got nil.
--- FAIL: TestSightSuite/TestARulebookThatAnswersBadlyIsRefusedByName/a_range_that_is_not_a_distance
        An error is expected but got nil.
--- FAIL: TestSightSuite/TestARulebookThatCannotAnswerAbortsTheVerb
        An error is expected but got nil.
--- FAIL: TestSightSuite/TestBlindIsALegalAnswer
        Should be false — she sees nothing at all
--- FAIL: TestSightSuite/TestHowFarSheCanSeeIsAskedAgainEveryTime
        Should be false — she cannot see that far any more
        expected: "held"  actual: "current"
--- FAIL: TestSightSuite/TestTheConsultRunsAtEveryRefreshAndAsksAboutTheWholeRoster
        "0" is not positive — first light asks
--- FAIL: TestSightSuite/TestTheFarSightedSpotTheShortSightedAndSurpriseThem/she_is_spotted,_and_surprised
        step: member "alice": already in a bubble        <- unbounded sight had already formed the fight at 110 ft
--- FAIL: TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused/setup
        An error is expected but got nil.
```

`TestSightIsStillGeometryFirst` and `TestTheConeStillNarrows` passed at RED, which is correct — they are regression guards on what S0 already built, held against the new term.
</details>

**Verification**, all from inside `rulebooks/dnd5e/encounter`: `gofmt -l` clean, `go vet ./...` clean, `go test -count=1 ./...` ok, `go test -race` ok, `golangci-lint run` **0 issues**.

### Mutation testing

Harness audited against an unmutated baseline first (green), each mutant restored from an **in-memory snapshot**, never `git checkout --`. Post-restore baseline re-verified green.

**11 of 12 killed.**

| Mutant | Verdict |
|---|---|
| range `>` → `>=` (the off-by-one) | killed — `TestTheEdgeOfYourSightIsInsideIt` |
| range `>` → `<` (inverted) | killed — 4+ suites |
| range predicate deleted | killed — 3 sight tests |
| stranger guard deleted | killed |
| negative guard deleted | killed |
| missing-member guard deleted | killed |
| capability error swallowed | killed |
| roster sorted the other way (C8) | killed |
| Setup refusal deleted | killed |
| Load refusal deleted | killed |
| the answer cached on the Encounter | killed — `TestDefeatSuite/TestSurvivorsFightAgain`, `TestJoinLateJoinerSeenByIncumbents` |
| range check moved to AFTER the ray | **SURVIVED — equivalent mutant** |

The survivor is honest: both arms `continue`, so swapping their order changes nothing observable, only cost. The code comment claims only that, and does not overclaim correctness.

**The off-by-one mutant survived the first round**, and that is the round's whole value: nothing in the original suite stood a member at exactly their own sight distance. `TestTheEdgeOfYourSightIsInsideIt` was written to kill it.

## gorelease

Run by hand from inside the module, base `encounter/v0.19.0`:

```
## compatible changes
ErrNoSight: added
LoadEncounterInput.Sight: added
SetupInput.Sight: added
Sight: added

# summary
Suggested version: v0.20.0 (with tag rulebooks/dnd5e/encounter/v0.20.0)
```

**It calls this compatible, and it is wrong** — its known blind spot for required inputs. Adding a field to a struct is not a Go API break, but every existing caller of `NewEncounter` and `LoadEncounter` now gets `ErrNoSight` at construction. The break is behavioural and at the door, and the `!` in the title carries it. Target: **v0.20.0**.

## Closes

- Closes #1111
- **Closes #1105.** The doorway blindfold went with S0, and sight is now geometry plus a supplied rule — which is exactly what that issue asked for. Both halves are in.

---

*Also: the workbench (`cmd/freeroam-workbench`) got a real capability rather than a stub, because it is the one place in this module that demos sight. `torchAndDarkvision` gives the party 40 feet of torchlight and the goblin 60 feet of darkvision, so walking the party down the crypt now shows the asymmetry live.*

— fix-1111 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
