### PR TITLE
feat(encounter): the canvas is readable — hand out the map, not a description of it

### DIFF
--- a/rulebooks/dnd5e/encounter/canvas.go
+++ b/rulebooks/dnd5e/encounter/canvas.go
@@ -113,8 +113,20 @@ var _ spatial.Room = readOnlyRoom{}
 
 // PlaceEntity refuses. Use [Encounter.Join], which also refreshes sight and
 // writes the beat.
+//
+// A NIL ENTITY IS REFUSED RATHER THAN DEREFERENCED. [spatial.BasicRoom] answers
+// a nil entity with "entity cannot be nil", so a view that panicked on one
+// would be strictly worse than the room it stands in front of — and a view of a
+// read-only thing has no business being the harder of the two to call. What is
+// refused here does not depend on the entity, so the answer is the same
+// refusal, with the nil named rather than dereferenced.
 func (r readOnlyRoom) PlaceEntity(entity core.Entity, pos spatial.Position) error {
-	return fmt.Errorf("canvas: PlaceEntity(%q, (%g,%g)): %w", entity.GetID(), pos.X, pos.Y, ErrReadOnly)
+	id := "<nil>"
+	if entity != nil {
+		id = entity.GetID()
+	}
+
+	return fmt.Errorf("canvas: PlaceEntity(%q, (%g,%g)): %w", id, pos.X, pos.Y, ErrReadOnly)
 }
 
 // MoveEntity refuses. Use [Encounter.Step], which decides what a step is

--- a/rulebooks/dnd5e/encounter/canvas.go
+++ b/rulebooks/dnd5e/encounter/canvas.go
@@ -53,6 +53,18 @@ import (
 // and this IS the map; there is no version of "the same world, copied" that
 // stays the same world.
 //
+// AND A FAITHFUL COPY IS NOT MERELY WORSE, IT IS NOT AVAILABLE. Entities and
+// their cells can be read back off a [spatial.Room], but its REGISTERED
+// BOUNDARIES cannot: nothing on Room or [spatial.BoundaryAwareRoom] lists them,
+// and the only way to ask is GetBoundary, one adjacent pair at a time — so
+// recovering a canvas's walls means probing every adjacent pair on it, through
+// an interface this deliberately does not return (see below). Any snapshot
+// built with what a caller actually has is therefore a room with NO WALLS,
+// which is exactly the defect this exists to end, reintroduced one layer down.
+// Pinned by TestTheCanvasIsTheLiveMapNotACopy, and measured: the snapshot
+// mutant fails that test AND the sight test, and the sight failure is the one
+// that matters.
+//
 // # Which is why it refuses to be written to
 //
 // Placing, moving or removing an entity here would move a member behind every
@@ -82,8 +94,9 @@ import (
 // offer, and its reading half is already answered here: IsLineOfSightBlocked
 // consults the registered boundaries, and a caller that wants the walls
 // themselves has [Encounter.Atlas], which reports every one of them in absolute
-// space. Adding the interface to withhold half of it would be offering a door
-// in order to lock it.
+// space and in construction terms rather than a pair at a time. Adding the
+// interface to withhold half of it would be offering a door in order to lock
+// it.
 //
 // Returns ErrNoField when there is no canvas to hand out. Construction forbids
 // that — both seams compile one or fail — so it is reachable only through the
@@ -100,10 +113,22 @@ func (e *Encounter) Canvas() (spatial.Room, error) {
 // readOnlyRoom is the live canvas with its three mutators refusing.
 //
 // Every read delegates to the room itself rather than to a copy of it, which is
-// what makes [Encounter.Canvas] live. The reads are safe to pass straight
-// through: spatial's own GetAllEntities and GetEntitiesAt already copy out
-// their containers, and [spatial.Grid] has no mutating method, so nothing
-// reachable from here is a second way in.
+// what makes [Encounter.Canvas] live. Two things were checked before passing
+// them straight through, rather than assumed: spatial's own GetAllEntities and
+// GetEntitiesAt build fresh containers, so neither hands back a map or slice
+// that writes through to the room's own; and every method on [spatial.Grid] is
+// a query (GetShape, IsValidPosition, GetDimensions, Distance, GetNeighbors,
+// IsAdjacent, GetLineOfSight, GetPositionsInRange), so handing out the grid
+// hands out no way to change it.
+//
+// The pass-throughs behave EXACTLY as the room does, which is the invariant
+// worth stating because it also decides what not to do. CanPlaceEntity takes an
+// entity and spatial dereferences it without a nil check — measured:
+// BasicRoom.CanPlaceEntity(nil, an occupied cell) panics, and on an empty cell
+// it returns true because the loop never runs. That is spatial's behaviour, not
+// this view's, and guarding it HERE would make the view answer differently from
+// the room it stands in front of. The mutators are the only place this type
+// decides anything, and they are the only place it guards anything.
 type readOnlyRoom struct {
 	canvas *spatial.BasicRoom
 }
@@ -120,6 +145,10 @@ var _ spatial.Room = readOnlyRoom{}
 // read-only thing has no business being the harder of the two to call. What is
 // refused here does not depend on the entity, so the answer is the same
 // refusal, with the nil named rather than dereferenced.
+//
+// This is the ONLY mutator that can meet a nil: MoveEntity and RemoveEntity
+// take an entity ID by string, so there is nothing to dereference in either.
+// Checked rather than fixed here and left to be discovered there.
 func (r readOnlyRoom) PlaceEntity(entity core.Entity, pos spatial.Position) error {
 	id := "<nil>"
 	if entity != nil {

--- a/rulebooks/dnd5e/encounter/canvas.go
+++ b/rulebooks/dnd5e/encounter/canvas.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// canvas.go is THE MAP, HANDED OUT TO BE READ (rpg-toolkit#1114).
+//
+// Since #1106 this composition has held exactly one map and published only
+// DESCRIPTIONS of it: [Encounter.Atlas]'s regions and walls, a [Member]'s cell,
+// [Encounter.RegionAt]'s name for a cell. Each is correct and none of them is
+// the map, so a caller with a question the descriptions do not answer — "is
+// there a wall between these two cells" — had to build a map out of them.
+//
+// That reconstruction is a second implementation of the field's geometry, and
+// rpg-toolkit#1090's slice measured what it costs. The one that exists today,
+// in `rulebooks/dnd5e/resolution`, carries its own copy of grid construction
+// with a comment promising it "tracks encounter.buildRoomGrid rather than
+// choosing for itself" — and has no walls and no occluders in it at all, so the
+// first rule to ask it about line of sight would be told nothing blocks while
+// this module says otherwise. A promise in a comment is not a mechanism.
+//
+// So the map is handed out instead of described. What that costs is stated in
+// [Encounter.Canvas]'s own doc: it is the LIVE room, so it goes out behind a
+// view that refuses every write.
+
+// Canvas returns the map this encounter runs on, to READ.
+//
+// One spatial room spanning the whole dungeon, in dungeon-absolute cells — the
+// canvas the authored rooms compiled into (#1106), with every wall registered
+// as an absolute boundary edge and every occluder and member placed on it. It
+// answers what a room answers: where somebody stands, what the distance between
+// two cells is, whether a sightline is blocked, who is within a radius.
+//
+// # It is the live map, and that is the point
+//
+// Not a snapshot. A member who steps is at their new cell the next time this
+// room is asked, through a value obtained before the step. A copy would be
+// cheaper to reason about and would be the wrong thing: the caller this exists
+// for installs it as the world an interaction's rules read positions out of,
+// and a rule reading a stale world gives a WRONG answer rather than no answer.
+//
+// This is the one place this module hands out live internal state rather than
+// copying out, and it is deliberate rather than an oversight in a module whose
+// every other read is copy-out ([Encounter.Atlas]'s "every returned slice is
+// freshly allocated per call"). The difference is that those describe the map
+// and this IS the map; there is no version of "the same world, copied" that
+// stays the same world.
+//
+// # Which is why it refuses to be written to
+//
+// Placing, moving or removing an entity here would move a member behind every
+// verb's back: no sight refresh, no beat in the story, and a blob that
+// disagrees with the world the next load builds. So the returned room refuses
+// all three with ErrReadOnly, NAMING the method refused.
+//
+// Refusing rather than quietly doing nothing is the whole design of it. A no-op
+// mutator reports success and changes nothing, which is the defect shape this
+// composition has spent several slices deleting — a silent fallback that makes
+// broken wiring look like working wiring. A caller that genuinely needs to move
+// somebody has [Encounter.Step] and [Encounter.Join], which are the verbs that
+// know what else has to happen.
+//
+// The type system would say this better than a runtime error does, and it
+// cannot yet: the consumer seam is `gamectx.WithRoom`, which takes a full
+// `spatial.Room`, so anything handed to it must carry the mutators whether or
+// not they can be honoured. Narrowing that seam to a read-only interface is a
+// change to a third module and is worth doing; until then the refusal is loud,
+// immediate, and asserted in canvasread_test.go.
+//
+// # Boundaries are readable, not registrable
+//
+// The returned value is a [spatial.Room] and NOT a [spatial.BoundaryAwareRoom],
+// which is a decision rather than an omission. That interface's writing half —
+// RegisterBoundary, RemoveBoundary — is exactly what a read-only view must not
+// offer, and its reading half is already answered here: IsLineOfSightBlocked
+// consults the registered boundaries, and a caller that wants the walls
+// themselves has [Encounter.Atlas], which reports every one of them in absolute
+// space. Adding the interface to withhold half of it would be offering a door
+// in order to lock it.
+//
+// Returns ErrNoField when there is no canvas to hand out. Construction forbids
+// that — both seams compile one or fail — so it is reachable only through the
+// zero value, and a nil [spatial.Room] is not an absent answer but a wrong one
+// that panics at the first read. [Encounter.Grid] refuses on the same grounds.
+func (e *Encounter) Canvas() (spatial.Room, error) {
+	if e.canvas == nil {
+		return nil, fmt.Errorf("canvas: %w", ErrNoField)
+	}
+
+	return readOnlyRoom{canvas: e.canvas}, nil
+}
+
+// readOnlyRoom is the live canvas with its three mutators refusing.
+//
+// Every read delegates to the room itself rather than to a copy of it, which is
+// what makes [Encounter.Canvas] live. The reads are safe to pass straight
+// through: spatial's own GetAllEntities and GetEntitiesAt already copy out
+// their containers, and [spatial.Grid] has no mutating method, so nothing
+// reachable from here is a second way in.
+type readOnlyRoom struct {
+	canvas *spatial.BasicRoom
+}
+
+// readOnlyRoom must be a full spatial.Room: gamectx.WithRoom takes one.
+var _ spatial.Room = readOnlyRoom{}
+
+// PlaceEntity refuses. Use [Encounter.Join], which also refreshes sight and
+// writes the beat.
+func (r readOnlyRoom) PlaceEntity(entity core.Entity, pos spatial.Position) error {
+	return fmt.Errorf("canvas: PlaceEntity(%q, (%g,%g)): %w", entity.GetID(), pos.X, pos.Y, ErrReadOnly)
+}
+
+// MoveEntity refuses. Use [Encounter.Step], which decides what a step is
+// allowed to cross and reports what happened.
+func (r readOnlyRoom) MoveEntity(entityID string, newPos spatial.Position) error {
+	return fmt.Errorf("canvas: MoveEntity(%q, (%g,%g)): %w", entityID, newPos.X, newPos.Y, ErrReadOnly)
+}
+
+// RemoveEntity refuses. Use [Encounter.Exit], which records where they stood on
+// the way out.
+func (r readOnlyRoom) RemoveEntity(entityID string) error {
+	return fmt.Errorf("canvas: RemoveEntity(%q): %w", entityID, ErrReadOnly)
+}
+
+func (r readOnlyRoom) GetID() string            { return r.canvas.GetID() }
+func (r readOnlyRoom) GetType() core.EntityType { return r.canvas.GetType() }
+func (r readOnlyRoom) GetGrid() spatial.Grid    { return r.canvas.GetGrid() }
+
+func (r readOnlyRoom) GetEntitiesAt(pos spatial.Position) []core.Entity {
+	return r.canvas.GetEntitiesAt(pos)
+}
+
+func (r readOnlyRoom) GetEntityPosition(entityID string) (spatial.Position, bool) {
+	return r.canvas.GetEntityPosition(entityID)
+}
+
+func (r readOnlyRoom) GetAllEntities() map[string]core.Entity {
+	return r.canvas.GetAllEntities()
+}
+
+func (r readOnlyRoom) GetEntitiesInRange(center spatial.Position, radius float64) []core.Entity {
+	return r.canvas.GetEntitiesInRange(center, radius)
+}
+
+func (r readOnlyRoom) IsPositionOccupied(pos spatial.Position) bool {
+	return r.canvas.IsPositionOccupied(pos)
+}
+
+func (r readOnlyRoom) CanPlaceEntity(entity core.Entity, pos spatial.Position) bool {
+	return r.canvas.CanPlaceEntity(entity, pos)
+}
+
+func (r readOnlyRoom) GetPositionsInRange(center spatial.Position, radius float64) []spatial.Position {
+	return r.canvas.GetPositionsInRange(center, radius)
+}
+
+func (r readOnlyRoom) GetLineOfSight(from, to spatial.Position) []spatial.Position {
+	return r.canvas.GetLineOfSight(from, to)
+}
+
+func (r readOnlyRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
+	return r.canvas.IsLineOfSightBlocked(from, to)
+}

--- a/rulebooks/dnd5e/encounter/canvasread_test.go
+++ b/rulebooks/dnd5e/encounter/canvasread_test.go
@@ -1,0 +1,243 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// canvasread_test.go is THE MAP, HANDED OUT TO BE READ (rpg-toolkit#1114).
+//
+// The composition has held one canvas since #1106 and told nobody. Everything
+// it published about the map was a DESCRIPTION of it — the Atlas's regions and
+// walls, a Member's cell, a region name — each correct, none of them the thing
+// itself. A caller that needed to ask the map a question had to rebuild one out
+// of those descriptions, and rpg-toolkit#1090's slice found what that costs: a
+// reconstruction is a second implementation of the field's geometry, kept in
+// step by a comment rather than by the compiler, and the copy that exists today
+// has no walls in it at all.
+//
+// So the map is handed out. READ-ONLY, because it is the live one: what this
+// returns is the encounter's own room, not a snapshot of it, and a caller that
+// could place or move an entity on it would be moving members behind every
+// verb's back — sight would not refresh, no beat would be written, and the
+// blob would disagree with the world the next load produced.
+//
+// Three claims, and each of them is a way that could go wrong:
+//
+//   - IT IS LIVE. A snapshot would satisfy every read in this file except one,
+//     and would quietly answer yesterday's question forever.
+//   - IT REFUSES TO BE WRITTEN, BY NAME. A no-op mutator is worse than an
+//     absent one: it reports success and changes nothing, which is the failure
+//     shape this composition has paid for repeatedly.
+//   - IT AGREES WITH THE ENCOUNTER ABOUT SIGHT. That is the question the
+//     caller this exists for actually asks, and the walls are the half a
+//     reconstruction gets wrong.
+type CanvasReadSuite struct {
+	suite.Suite
+
+	enc *encounter.Encounter
+}
+
+func TestCanvasReadSuite(t *testing.T) {
+	suite.Run(t, new(CanvasReadSuite))
+}
+
+// SetupTest opens the reference tomb from canvas_test.go — three walled
+// chambers, two doorways on one row, pillars in the hall. The walls are the
+// point: a map with nothing in the way agrees with any other map.
+func (s *CanvasReadSuite) SetupTest() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: tombField(),
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
+				Position: spatial.Position{X: 5, Y: float64(tombDoorRow)}},
+			{ID: bob, Kind: encounter.KindPlayer, Room: tombHall,
+				Position: spatial.Position{X: 0, Y: float64(tombDoorRow)}},
+			{ID: carol, Kind: encounter.KindPlayer, Room: tombEntrance,
+				Position: spatial.Position{X: 5, Y: float64(tombDoorRow - 1)}},
+			{ID: dave, Kind: encounter.KindPlayer, Room: tombHall,
+				Position: spatial.Position{X: 0, Y: float64(tombDoorRow - 1)}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	s.enc = enc
+}
+
+func (s *CanvasReadSuite) canvas() spatial.Room {
+	canvas, err := s.enc.Canvas()
+	s.Require().NoError(err)
+	s.Require().NotNil(canvas)
+
+	return canvas
+}
+
+// THE CANVAS IS THE LIVE MAP, and this is the test a snapshot fails.
+//
+// The canvas is taken FIRST, then a member walks, and then the canvas taken
+// before the walk is asked where they are. A copy would still be holding the
+// old cell and would answer confidently — which is why "returns the map" and
+// "returns a picture of the map" cannot be told apart by any other read in this
+// file.
+//
+// It matters because of what the caller is: an interaction installs this as the
+// world its rules read positions out of, and a rule reading a stale world gives
+// a wrong answer rather than no answer.
+func (s *CanvasReadSuite) TestTheCanvasIsTheLiveMapNotACopy() {
+	before := s.canvas()
+
+	from, ok := before.GetEntityPosition(string(bob))
+	s.Require().True(ok)
+
+	to := tombAt(tombHallOrigin, 1, tombDoorRow)
+	out, err := s.enc.Step(&encounter.StepInput{Member: bob, To: to})
+	s.Require().NoError(err)
+	s.Require().Equal(to, out.Stepped.To)
+	s.Require().NotEqual(from, to, "the fixture has to actually move somebody")
+
+	now, ok := before.GetEntityPosition(string(bob))
+	s.Require().True(ok, "bob is still on the map")
+	s.Equal(to, now, "the canvas taken before the step reports where bob is NOW")
+}
+
+// A REFUSAL, BY NAME, AND A REAL ONE. Both halves are asserted, because either
+// on its own is a defect wearing the other's clothes: an error that did not
+// actually prevent the write would be a lie, and a silent prevention would be
+// the no-op this composition keeps deleting.
+func (s *CanvasReadSuite) TestTheCanvasRefusesEveryWrite() {
+	canvas := s.canvas()
+	empty := tombAt(tombChamberOrigin, 4, 4)
+
+	s.Run("place", func() {
+		err := canvas.PlaceEntity(&readOnlyProbe{id: "intruder"}, empty)
+		s.Require().ErrorIs(err, encounter.ErrReadOnly)
+		s.Require().ErrorContains(err, "PlaceEntity", "the refusal names the verb refused")
+
+		_, placed := canvas.GetEntityPosition("intruder")
+		s.False(placed, "and nothing was placed")
+	})
+
+	s.Run("move", func() {
+		was, ok := canvas.GetEntityPosition(string(alice))
+		s.Require().True(ok)
+
+		err := canvas.MoveEntity(string(alice), empty)
+		s.Require().ErrorIs(err, encounter.ErrReadOnly)
+		s.Require().ErrorContains(err, "MoveEntity")
+
+		now, ok := canvas.GetEntityPosition(string(alice))
+		s.Require().True(ok)
+		s.Equal(was, now, "and alice did not move")
+	})
+
+	s.Run("remove", func() {
+		err := canvas.RemoveEntity(string(alice))
+		s.Require().ErrorIs(err, encounter.ErrReadOnly)
+		s.Require().ErrorContains(err, "RemoveEntity")
+
+		_, stillThere := canvas.GetEntityPosition(string(alice))
+		s.True(stillThere, "and alice is still on the map")
+	})
+}
+
+// A refused write must not reach the ENCOUNTER either — the reads above are
+// taken through the same view that refused, so on their own they would pass for
+// a view that wrote to a copy of the world and hid it.
+func (s *CanvasReadSuite) TestARefusedWriteNeverReachesTheEncounter() {
+	canvas := s.canvas()
+
+	members, err := s.enc.Members()
+	s.Require().NoError(err)
+
+	_ = canvas.PlaceEntity(&readOnlyProbe{id: "intruder"}, tombAt(tombChamberOrigin, 4, 4))
+	_ = canvas.MoveEntity(string(alice), tombAt(tombChamberOrigin, 5, 5))
+	_ = canvas.RemoveEntity(string(dave))
+
+	after, err := s.enc.Members()
+	s.Require().NoError(err)
+	s.Equal(members, after, "the roster and every cell in it are untouched")
+}
+
+// SIGHT AGREES, which is the question the caller this exists for asks.
+//
+// The encounter decides who sees whom on this canvas — within reach, and the
+// ray unblocked (rebuildPercepts) — and the fixture gives everybody unlimited
+// reach, so a sighting IS "the geometry admits it". Asking the handed-out map
+// the same question about every pair has to give the same answer, and the tomb
+// has walls and pillars in it so that both answers occur.
+func (s *CanvasReadSuite) TestTheCanvasAnswersSightTheWayTheEncounterDoes() {
+	canvas := s.canvas()
+
+	members, err := s.enc.Members()
+	s.Require().NoError(err)
+	s.Require().Len(members, 4)
+
+	blocked, clear := 0, 0
+	for _, observer := range members {
+		for _, subject := range members {
+			if observer.ID == subject.ID {
+				continue
+			}
+
+			isBlocked := canvas.IsLineOfSightBlocked(observer.Position, subject.Position)
+			s.Equal(!isBlocked, s.holds(observer.ID, subject.ID),
+				"the handed-out map and the encounter disagree about whether %s can see %s",
+				observer.ID, subject.ID)
+
+			if isBlocked {
+				blocked++
+			} else {
+				clear++
+			}
+		}
+	}
+
+	s.Positive(blocked, "the tomb's walls block somebody")
+	s.Positive(clear, "and the doorway lets somebody through")
+}
+
+// holds reports whether an observer holds anything at all on a subject —
+// canvas_test.go's helper, which belongs to its own suite.
+func (s *CanvasReadSuite) holds(observer, subject core.EntityID) bool {
+	view, err := s.enc.View(&encounter.ViewInput{Member: observer})
+	s.Require().NoError(err)
+	for _, h := range view {
+		if h.Subject == intel.Subject(subject) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// An encounter with no canvas says so rather than handing back a nil map.
+// Construction forbids one — both seams compile a canvas or fail — so this is
+// only reachable through the zero value, which is exactly the case [Grid] and
+// [Atlas] answer for too: a nil spatial.Room is not an absent answer, it is a
+// wrong one that panics at the first read.
+func TestACanvaslessEncounterSaysSo(t *testing.T) {
+	canvas, err := (&encounter.Encounter{}).Canvas()
+	require.ErrorIs(t, err, encounter.ErrNoField)
+	require.Nil(t, canvas)
+}
+
+// readOnlyProbe is something to try to place. It is deliberately not a
+// spatial.Placeable: what is under test is the refusal, which happens before
+// anything about the entity is consulted.
+type readOnlyProbe struct {
+	id string
+}
+
+func (p *readOnlyProbe) GetID() string            { return p.id }
+func (p *readOnlyProbe) GetType() core.EntityType { return "probe" }

--- a/rulebooks/dnd5e/encounter/canvasread_test.go
+++ b/rulebooks/dnd5e/encounter/canvasread_test.go
@@ -128,6 +128,16 @@ func (s *CanvasReadSuite) TestTheCanvasRefusesEveryWrite() {
 		s.False(placed, "and nothing was placed")
 	})
 
+	s.Run("a nil entity is refused, not dereferenced", func() {
+		// spatial.BasicRoom answers a nil entity with "entity cannot be nil".
+		// A view in front of it that panicked instead would be harder to call
+		// than the thing it protects, which is backwards for a read-only view.
+		var err error
+		s.Require().NotPanics(func() { err = canvas.PlaceEntity(nil, empty) })
+		s.Require().ErrorIs(err, encounter.ErrReadOnly)
+		s.Require().ErrorContains(err, "PlaceEntity")
+	})
+
 	s.Run("move", func() {
 		was, ok := canvas.GetEntityPosition(string(alice))
 		s.Require().True(ok)
@@ -233,8 +243,9 @@ func TestACanvaslessEncounterSaysSo(t *testing.T) {
 }
 
 // readOnlyProbe is something to try to place. It is deliberately not a
-// spatial.Placeable: what is under test is the refusal, which happens before
-// anything about the entity is consulted.
+// spatial.Placeable: the refusal never reaches spatial's placement rules, so
+// nothing about whether this entity COULD be placed is ever consulted. Its ID
+// is read, to name it in the refusal.
 type readOnlyProbe struct {
 	id string
 }

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -112,6 +112,12 @@
 // its cells. Membership is DERIVED from a member's cell wherever it is
 // reported, never stored beside it.
 //
+// AND THE CANVAS ITSELF IS READABLE (#1114). Everything above DESCRIBES the
+// map; [Encounter.Canvas] hands out the map, to read. It is the live room
+// rather than a snapshot, so it goes out behind a view that refuses every
+// write by name — see its own doc for why a copy is not an option and why a
+// silent no-op would be worse than a refusal.
+//
 // Room and field size are bounded (maxRoomCells/maxFieldCells): two individually
 // legal dimensions multiply into a cell count nothing could walk. The bound
 // guarded an Atlas allocation until #1108 stopped it enumerating; it now

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -205,4 +205,8 @@ var (
 	// same defect seen from different sides — a sight range this module would
 	// have to invent, which rpg-toolkit#1033 forbids it to do.
 	ErrNoSight = errors.New("encounter: no sight capability")
+
+	// ErrReadOnly indicates an attempt to write to the map through the
+	// read-only view [Encounter.Canvas] hands out.
+	ErrReadOnly = errors.New("encounter: the canvas is read-only")
 )


### PR DESCRIPTION
Everything this module publishes about its map is a **description** of the map. `Encounter.Canvas` hands out the map.

Prepares **S3** (#1114 / #1090), which installs this as the world an interaction's rules read positions out of. Follows S0 (#1107, v0.18.0), S1 (#1109, v0.19.0), S2 (#1112, v0.20.0).

---

## Why this exists, and it is not tidiness

Since #1106 there has been exactly one canvas, and nothing could get at it. What is published — `Atlas`'s regions and walls, a `Member`'s cell, `RegionAt`'s name for a cell — is each correct and none of it is the map. So a caller with a question the descriptions do not answer (*"is there a wall between these two cells"*) has to **build a map out of them**, which is a second implementation of the field's geometry kept in step by a comment.

**One such reconstruction is live today, and it is already silently wrong.** `rulebooks/dnd5e/resolution`'s `interactionRoom` builds the room that every position-reading rule consults, and it registers **no walls and no occluders at all** — it only ever placed members on a bare grid. It also carries its own copy of grid construction, under a comment promising it *"tracks encounter.buildRoomGrid rather than choosing for itself"*, with nothing keeping that true.

Nothing has caught it because the rules that read that room today ask about distance (prone's within-five-feet, Protection's) and about a radius (Sneak Attack's). **The first rule to ask it a line-of-sight question gets "nothing blocks" while this module says otherwise** — a wrong answer, from a divergence that has been sitting there since the room was introduced.

The alternative to this PR was for S3 to fix that by *porting the projection loops too* — `fieldAbsoluteBounds`, `roomAbsoluteBounds`, `axisBounds`, `canvasSpan`, `buildRoomGrid`, plus occluder and wall projection. The slice whose stated job is deleting one copy of a formula would have landed five more.

**And it is what makes "one world, always installed" literally true.** S3's sentence is about a world, not a faithful reproduction of one. With this, resolution installs *the* encounter's map; without it, it installs a replica that agrees with the map because a test says so.

## The design decision, and why it went the way it did

**Read-only WRAPPER satisfying `spatial.Room`, with the mutators refusing loudly by name.** The alternative — a narrower read interface at the consumer seam — is better, and is not available from here.

Censused first, as directed:

- **`gamectx.WithRoom(ctx context.Context, room spatial.Room)`** (`rulebooks/dnd5e/gamectx/room.go:24`) takes the **full** `spatial.Room`: 20 methods, three of them mutators. `Room` and `RequireRoom` hand it back the same way. So anything installed through that seam must carry `PlaceEntity`/`MoveEntity`/`RemoveEntity` whether or not it can honour them.
- **`gamectx` is in a third module** (`rulebooks/dnd5e`, v0.96.0) and **this module cannot import it** — law C1, the same rule that makes `Standing` and `Sight` injected capabilities. So there is no way for the returned type to be named in terms a narrowed `gamectx` would define, even if `gamectx` were narrowed today.

**Narrowing it is feasible and worth doing, and I checked rather than assuming.** All four production readers use read methods only — `prone.go:286` and `fighting_style_protection.go:152` (`GetEntityPosition`, `GetGrid`), `sneak_attack.go:228` (`GetEntityPosition`, `GetEntitiesInRange`), `opportunity_attack.go:168` → `isLeavingMyThreatRange` (`GetEntityPosition`, `GetGrid`). So a `gamectx` read interface would compile against every existing consumer; narrowing `WithRoom`'s **parameter** is even source-compatible, since a `spatial.Room` satisfies any subset. Only the **return** types of `Room`/`RequireRoom` are a break, and only for a caller reaching for a mutator — of which there are none. That is a `rulebooks/dnd5e` change and its own PR; worth filing.

Until then the refusal is a runtime one, and it is made as loud as a runtime refusal can be: it names the method, names the entity, carries `ErrReadOnly`, and it **actually refuses** — both halves asserted, because either alone is the other's defect wearing a disguise.

**Filed as #1119** with that census, so it does not live only in this PR body.

**Not a `BoundaryAwareRoom`**, deliberately. That interface's writing half (`RegisterBoundary`, `RemoveBoundary`) is exactly what a read-only view must not offer, and its reading half is already answered: `IsLineOfSightBlocked` consults the registered boundaries, and `Atlas` reports every wall in absolute space. Adding the interface in order to withhold half of it would be offering a door so it can be locked.

## Live, not a snapshot — and a snapshot is not merely worse, it is impossible

`Canvas` returns the encounter's own room. A member who steps is at their new cell the next time the room is asked, through a value taken *before* the step.

This is the one place the module hands out live internal state, in a package whose every other read copies out (`Atlas`: *"every returned slice is freshly allocated per call"*). The difference is that those **describe** the map and this **is** the map — there is no version of "the same world, copied" that stays the same world.

It turns out to be sharper than a preference. **A faithful snapshot is not available to a caller.** Entities and their cells read back off a `spatial.Room`; the registered *boundaries* do not. Nothing on `Room` or `BoundaryAwareRoom` **lists** them — the only way to ask is `GetBoundary(from, to)`, one adjacent pair at a time — so recovering a canvas's walls means probing every adjacent pair on it, through an interface `Canvas` deliberately does not return. Any snapshot built with what a caller actually has is therefore a room with **no walls**: precisely the defect at the top of this PR, reintroduced one layer down.

Mutation N1 is the proof rather than the argument: the snapshot implementation fails the liveness test **and** the sight test, and the sight failure is the one that matters. That reasoning now lives in `canvas.go`'s own doc comment, not only here — it is the reason this accessor exists.

## RED first

`Canvas` was implemented the naive way — `return e.canvas, nil` — before the view existed. It compiles, and it genuinely is the live map, so the liveness and sight claims **passed**. What failed is the read-only half, behaviourally: a caller placed, moved and removed entities on the encounter's own world and every write landed.

```
--- FAIL: TestCanvasReadSuite/TestARefusedWriteNeverReachesTheEncounter
--- FAIL: TestCanvasReadSuite/TestTheCanvasRefusesEveryWrite
--- PASS: TestCanvasReadSuite/TestTheCanvasIsTheLiveMapNotACopy
--- PASS: TestCanvasReadSuite/TestTheCanvasAnswersSightTheWayTheEncounterDoes
--- PASS: TestACanvaslessEncounterSaysSo
```

Transcript at `/home/kirk/.claude/jobs/929a988a/tmp/fix-1114a/red-evidence.txt`.

## Tests

`canvasread_test.go`, on `canvas_test.go`'s reference-tomb fixture — three walled chambers, two doorways on one row, pillars in the hall. The walls are the point: a map with nothing in the way agrees with any other map.

| Test | Claim |
|---|---|
| `TestTheCanvasIsTheLiveMapNotACopy` | a canvas taken **before** a `Step` reports where the member is **now** |
| `TestTheCanvasRefusesEveryWrite` | each mutator returns `ErrReadOnly` **naming the method**, and the write did not happen |
| `TestARefusedWriteNeverReachesTheEncounter` | the roster and every cell in it are untouched — read through `Members()`, not through the view that refused |
| `TestTheCanvasAnswersSightTheWayTheEncounterDoes` | every ordered pair agrees with the encounter's own sightings, with both answers occurring |
| `TestACanvaslessEncounterSaysSo` | the zero value returns `ErrNoField`, not a nil room that panics on first read |

`TestARefusedWriteNeverReachesTheEncounter` is separate from the refusal test on purpose: reading the result back through the same view that refused would also pass for a view that wrote to a hidden copy.

## Mutation testing — 9/9 killed

Baseline audited unmutated first; `canvas.go` snapshotted **in memory** and restored from the snapshot, never `git checkout --`.

| | Mutant | Killed by |
|---|---|---|
| N1 | `Canvas` hands out a snapshot | liveness **and** sight (see above) |
| N2 | `PlaceEntity` silently no-ops | the refusal test |
| N3 | `MoveEntity` passes through to the live canvas | refusal + alice actually moved |
| N4 | `RemoveEntity` passes through | refusal + the roster changed |
| N5 | the refusal does not name the method | `ErrorContains` |
| N6 | `IsLineOfSightBlocked` always answers "clear" | the sight agreement |
| N7 | the missing-canvas guard is dropped | `TestACanvaslessEncounterSaysSo` |
| N8 | `GetEntityPosition` answers one cell off | liveness |
| N9 | `PlaceEntity` dereferences a nil entity | the nil subtest (added after Copilot found the bug) |

Harness and full output at `/home/kirk/.claude/jobs/929a988a/tmp/fix-1114a/`.

## Copilot review

Two comments, both on the same line, both verified before acting on, both real.

1. **`PlaceEntity(nil, …)` panicked.** `spatial.BasicRoom` guards nil explicitly and answers `"entity cannot be nil"`; the view dereferenced it. Probed rather than reasoned about:

```
=== view (read-only wrapper) ===
VIEW PANICKED: runtime error: invalid memory address or nil pointer dereference
=== underlying spatial.BasicRoom, for comparison ===
BasicRoom returned: entity cannot be nil
```

   A view standing in front of a room has no business being harder to call than the room — the more so for a read-only one, whose likeliest caller is somebody poking at a value they were told not to write to. Fixed in `53c0cbd`: the nil is **named** in the refusal rather than dereferenced, since what is refused does not depend on the entity. Pinned by a subtest asserting `NotPanics` *and* the refusal, and by mutation N9.

2. **A test comment overclaimed** — it said the refusal happens "before anything about the entity is consulted", while `GetID()` is read to name it. Narrowed to what is true.

## A self-audit, because two claims in this slice ran ahead of the code

Copilot caught one comment here overclaiming, and a claim in the sibling PR (#1115) had the same shape. Two of a kind is a pattern rather than a slip, so every factual claim in this PR's code comments was re-checked against a command rather than against memory. Three were narrowed in `82ade1f`:

- *"nothing reachable from here is a second way in"* was a universal over a surface I had checked two members of. It now names the two that were verified — `GetAllEntities` and `GetEntitiesAt` build fresh containers; every method on `spatial.Grid` is a query — and states the invariant that decides the rest.
- The sibling mutators are now named as **checked**: `MoveEntity` and `RemoveEntity` take an ID by string, so neither can meet a nil. That was the right answer, but it had been left implicit.
- The boundary claim was tightened as above.

One measurement fell out of it, and it is deliberately **not** fixed here: `spatial.BasicRoom.CanPlaceEntity(nil, an occupied cell)` panics, and on an empty cell returns `true` because the loop never runs. This view passes that method straight through, so it behaves exactly as the room does. Guarding it here would make the view answer *differently* from the room it fronts, which is the opposite of what a faithful read-only view should do — it belongs in `tools/spatial`, and is noted here rather than smuggled in.

## Verification

From inside the module:

```
gofmt -l .           (clean)
go vet ./...         (clean)
go test -count=1     ok  rulebooks/dnd5e/encounter        (full suite, not just the new file)
golangci-lint run    0 issues
```

**gorelease, by hand:**

```
$ gorelease -base v0.20.0
## compatible changes
(*Encounter).Canvas: added
ErrReadOnly: added

Suggested version: v0.21.0 (with tag rulebooks/dnd5e/encounter/v0.21.0)
```

**Graded honestly, and this time "compatible" is the whole truth** — unlike the S3 PR beside it, where the surface grew while behaviour broke. Nothing existing moves: no signature changes, no behaviour changes, no persisted shape touched, and the full suite passes untouched. Additive, `feat(encounter):` without the `!`, **v0.21.0**.

## What comes next

**#1115** (S3) re-pins to v0.21.0 and installs this, deleting its reconstruction — the span arithmetic, the family branch, the occluder and wall registration, and the differential test that existed to keep a copy honest. Its CI stays red on module `resolution` until this merges and tags, which is the ordinary A-then-B shape here (#1081/#1082, #1085/#1086, #1102/#1103).

**#1119** narrows `gamectx.WithRoom`/`Room`/`RequireRoom` to a read-only interface, so the compiler says no where this PR can only say it at runtime.

Closes #1117

— fix-1114 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
