### PR TITLE
feat(encounter)!: the canvas declares what void is — rock or sky, authored not assumed

### DIFF
--- a/rulebooks/dnd5e/encounter/arrival_test.go
+++ b/rulebooks/dnd5e/encounter/arrival_test.go
@@ -63,7 +63,7 @@ var (
 // arrivalField is two chambers with NO doorway and a fully sealed seam.
 func arrivalField() encounter.FieldInput {
 	return encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			{ID: arrivalVault, Width: 8, Height: 8, Origin: arrivalVaultOrigin,
 				Boundaries: squareSeamWall(7, 8)},

--- a/rulebooks/dnd5e/encounter/arrival_test.go
+++ b/rulebooks/dnd5e/encounter/arrival_test.go
@@ -63,6 +63,7 @@ var (
 // arrivalField is two chambers with NO doorway and a fully sealed seam.
 func arrivalField() encounter.FieldInput {
 	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			{ID: arrivalVault, Width: 8, Height: 8, Origin: arrivalVaultOrigin,
 				Boundaries: squareSeamWall(7, 8)},

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -28,7 +28,7 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
 				{ID: "atlas-r1", Width: 4, Height: 3, Origin: spatial.Position{X: 0, Y: 7},
@@ -68,7 +68,7 @@ func validAtlasVoidGapSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "gap-a", Width: 3, Height: 3, Origin: spatial.Position{X: 0, Y: 0}},
 				{ID: "gap-b", Width: 3, Height: 3, Origin: spatial.Position{X: 6, Y: 0}},
@@ -89,7 +89,7 @@ func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.Setu
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
 		},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -28,6 +28,7 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
 				{ID: "atlas-r1", Width: 4, Height: 3, Origin: spatial.Position{X: 0, Y: 7},
@@ -67,6 +68,7 @@ func validAtlasVoidGapSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "gap-a", Width: 3, Height: 3, Origin: spatial.Position{X: 0, Y: 0}},
 				{ID: "gap-b", Width: 3, Height: 3, Origin: spatial.Position{X: 6, Y: 0}},
@@ -87,7 +89,8 @@ func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.Setu
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "solo", Position: spatial.Position{X: 0, Y: 0}},

--- a/rulebooks/dnd5e/encounter/atlascost_test.go
+++ b/rulebooks/dnd5e/encounter/atlascost_test.go
@@ -20,7 +20,7 @@ import (
 func budgetField() encounter.FieldInput {
 	const dim = 1024
 	return encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			{ID: "a", Width: dim, Height: dim, Origin: spatial.Position{X: 0, Y: 0}},
 			{ID: "b", Width: dim, Height: dim, Origin: spatial.Position{X: dim, Y: 0}},

--- a/rulebooks/dnd5e/encounter/atlascost_test.go
+++ b/rulebooks/dnd5e/encounter/atlascost_test.go
@@ -20,6 +20,7 @@ import (
 func budgetField() encounter.FieldInput {
 	const dim = 1024
 	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			{ID: "a", Width: dim, Height: dim, Origin: spatial.Position{X: 0, Y: 0}},
 			{ID: "b", Width: dim, Height: dim, Origin: spatial.Position{X: dim, Y: 0}},

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -78,7 +78,7 @@ func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encoun
 func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{wallRoom()}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			// Both clear of the wall's span: they see each other at first light.
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 0, Y: 2}},
@@ -101,7 +101,7 @@ func (s *BeatOrderTestSuite) TestAStepThroughADoorwayBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -200,7 +200,7 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{wallRoom()}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 2}},
 			monster,

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -78,7 +78,7 @@ func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encoun
 func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			// Both clear of the wall's span: they see each other at first light.
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 0, Y: 2}},
@@ -101,6 +101,7 @@ func (s *BeatOrderTestSuite) TestAStepThroughADoorwayBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -199,7 +200,7 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{wallRoom()}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 2}},
 			monster,

--- a/rulebooks/dnd5e/encounter/canvas.go
+++ b/rulebooks/dnd5e/encounter/canvas.go
@@ -98,11 +98,11 @@ import (
 // interface to withhold half of it would be offering a door in order to lock
 // it.
 //
-// # It answers about the rock too
+// # It answers about the void too
 //
 // IsLineOfSightBlocked here is the CANVAS's answer, which since
 // rpg-toolkit#1116 counts the field's declared void: on a field whose void is
-// rock, a sightline crossing the space between two chambers is blocked, and a
+// opaque, a sightline crossing the space between two chambers is blocked, and a
 // caller reading this map is told so. That is the whole reason the declaration
 // lives on the map rather than in the sight loop — see [canvasRoom].
 //

--- a/rulebooks/dnd5e/encounter/canvas.go
+++ b/rulebooks/dnd5e/encounter/canvas.go
@@ -98,6 +98,14 @@ import (
 // interface to withhold half of it would be offering a door in order to lock
 // it.
 //
+// # It answers about the rock too
+//
+// IsLineOfSightBlocked here is the CANVAS's answer, which since
+// rpg-toolkit#1116 counts the field's declared void: on a field whose void is
+// rock, a sightline crossing the space between two chambers is blocked, and a
+// caller reading this map is told so. That is the whole reason the declaration
+// lives on the map rather than in the sight loop — see [canvasRoom].
+//
 // Returns ErrNoField when there is no canvas to hand out. Construction forbids
 // that — both seams compile one or fail — so it is reachable only through the
 // zero value, and a nil [spatial.Room] is not an absent answer but a wrong one
@@ -130,7 +138,7 @@ func (e *Encounter) Canvas() (spatial.Room, error) {
 // the room it stands in front of. The mutators are the only place this type
 // decides anything, and they are the only place it guards anything.
 type readOnlyRoom struct {
-	canvas *spatial.BasicRoom
+	canvas *canvasRoom
 }
 
 // readOnlyRoom must be a full spatial.Room: gamectx.WithRoom takes one.

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -95,7 +95,7 @@ func tombSeamWall(atLocalX, height, gapRow int) []spatial.Boundary {
 
 func tombField() encounter.FieldInput {
 	return encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			// The entrance walls itself off from the hall, all the way up its
 			// east edge except the doorway.
@@ -290,7 +290,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 			{"seq": 1, "audience": ["p1"], "tags": {"tag": "scene"},
 			 "payload": "eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}
 		]},
-		"field": {"canvas": {"void": "rock"}, "rooms": [{"id": "room1", "width": 5, "height": 5, "origin": {"x": 0, "y": 0}}]},
+		"field": {"canvas": {"void": "opaque"}, "rooms": [{"id": "room1", "width": 5, "height": 5, "origin": {"x": 0, "y": 0}}]},
 		"members": [{"id": "p1", "kind": "player", "room": "room1", "position": {"x": 2, "y": 2}}],
 		"endings": [{"key": "done", "kind": "external"}],
 		"ever_members": ["p1"],
@@ -329,7 +329,7 @@ func TestASquareFieldMustFitOneGrid(t *testing.T) {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5, Origin: origin}},
 			},
 			Members: []encounter.MemberInput{
@@ -361,7 +361,7 @@ func TestAHexFieldNeedsNoSuchLaw(t *testing.T) {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 					Origin: spatial.Position{X: -20, Y: -20}},
@@ -425,7 +425,7 @@ func TestABoundaryThatCannotBeDrawnIsRefusedAtConstruction(t *testing.T) {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "hall", Width: 6, Height: 6, Origin: spatial.Position{X: 4, Y: 4},
 						Boundaries: []spatial.Boundary{b}},

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -95,6 +95,7 @@ func tombSeamWall(atLocalX, height, gapRow int) []spatial.Boundary {
 
 func tombField() encounter.FieldInput {
 	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			// The entrance walls itself off from the hall, all the way up its
 			// east edge except the doorway.
@@ -289,7 +290,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 			{"seq": 1, "audience": ["p1"], "tags": {"tag": "scene"},
 			 "payload": "eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}
 		]},
-		"field": {"rooms": [{"id": "room1", "width": 5, "height": 5, "origin": {"x": 0, "y": 0}}]},
+		"field": {"canvas": {"void": "rock"}, "rooms": [{"id": "room1", "width": 5, "height": 5, "origin": {"x": 0, "y": 0}}]},
 		"members": [{"id": "p1", "kind": "player", "room": "room1", "position": {"x": 2, "y": 2}}],
 		"endings": [{"key": "done", "kind": "external"}],
 		"ever_members": ["p1"],
@@ -328,7 +329,8 @@ func TestASquareFieldMustFitOneGrid(t *testing.T) {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5, Origin: origin}},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5, Origin: origin}},
 			},
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 0, Y: 0}},
@@ -359,6 +361,7 @@ func TestAHexFieldNeedsNoSuchLaw(t *testing.T) {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 					Origin: spatial.Position{X: -20, Y: -20}},
@@ -422,6 +425,7 @@ func TestABoundaryThatCannotBeDrawnIsRefusedAtConstruction(t *testing.T) {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "hall", Width: 6, Height: 6, Origin: spatial.Position{X: 4, Y: 4},
 						Boundaries: []spatial.Boundary{b}},

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -62,7 +62,7 @@ func TestVaultChase(t *testing.T) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: corridorRoom, Width: 10, Height: 10, Boundaries: corridorWall},
 				// Anchored immediately east of the corridor (#929 T1): the

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -62,6 +62,7 @@ func TestVaultChase(t *testing.T) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: corridorRoom, Width: 10, Height: 10, Boundaries: corridorWall},
 				// Anchored immediately east of the corridor (#929 T1): the

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -30,7 +30,8 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: FieldInput{
-			Rooms: []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: CanvasInput{Void: VoidIsRock()},
+			Rooms:  []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []MemberInput{
 			{ID: "alice", Kind: KindPlayer, Room: "room-1", Position: spatial.Position{X: 2, Y: 2}},
@@ -72,7 +73,7 @@ func TestFormRejections(t *testing.T) {
 	newEnc := func() *Encounter {
 		enc, err := NewEncounter(&SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: FieldInput{Rooms: []RoomInput{
+			Field: FieldInput{Canvas: CanvasInput{Void: VoidIsRock()}, Rooms: []RoomInput{
 				{ID: "r1", Width: 8, Height: 8, Boundaries: sealedSeam(7, 8)},
 				{ID: "r2", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},
 			}},

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -30,7 +30,7 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: FieldInput{
-			Canvas: CanvasInput{Void: VoidIsRock()},
+			Canvas: CanvasInput{Void: VoidIsOpaque()},
 			Rooms:  []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []MemberInput{
@@ -73,7 +73,7 @@ func TestFormRejections(t *testing.T) {
 	newEnc := func() *Encounter {
 		enc, err := NewEncounter(&SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: FieldInput{Canvas: CanvasInput{Void: VoidIsRock()}, Rooms: []RoomInput{
+			Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque()}, Rooms: []RoomInput{
 				{ID: "r1", Width: 8, Height: 8, Boundaries: sealedSeam(7, 8)},
 				{ID: "r2", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},
 			}},

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -28,6 +28,7 @@ func (s *ClocksTestSuite) twoMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			// The goblin waits in the NEXT ROOM, which is how real content is
 			// authored and is the only way to open a scene that is not
 			// already a fight: sight is symmetric and unlimited within a room,
@@ -367,6 +368,7 @@ func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -697,7 +699,8 @@ func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
 		},
 		// Same room, so they see each other at first light and the fight
 		// forms — which is the state this test is about. The goblin's decider

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -28,7 +28,7 @@ func (s *ClocksTestSuite) twoMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			// The goblin waits in the NEXT ROOM, which is how real content is
 			// authored and is the only way to open a scene that is not
 			// already a fight: sight is symmetric and unlimited within a room,
@@ -368,7 +368,7 @@ func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -699,7 +699,7 @@ func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
 		},
 		// Same room, so they see each other at first light and the fight

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -90,6 +90,12 @@ func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
 		Field: encounter.FieldInput{
+			// The crypt is cut out of a mountain, so the space its two
+			// chambers do not cover is the rock they were cut from — stated
+			// rather than assumed (rpg-toolkit#1116). There IS such space:
+			// the ossuary is half the crypt's height, so the canvas's
+			// north-east corner — x 12..19, y 6..11 — belongs to no chamber.
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{
 					ID: cryptID, Width: cryptSize, Height: cryptSize,

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -90,12 +90,13 @@ func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
 		Field: encounter.FieldInput{
-			// The crypt is cut out of a mountain, so the space its two
-			// chambers do not cover is the rock they were cut from — stated
-			// rather than assumed (rpg-toolkit#1116). There IS such space:
+			// You cannot see across the space the crypt's two chambers do not
+			// cover — the fiction is the mountain they were cut from, and the
+			// declaration is the effect (rpg-toolkit#1116). There IS such
+			// space:
 			// the ossuary is half the crypt's height, so the canvas's
 			// north-east corner — x 12..19, y 6..11 — belongs to no chamber.
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{
 					ID: cryptID, Width: cryptSize, Height: cryptSize,

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -100,7 +100,7 @@ func vaultChaseHexSeamWall() []spatial.Boundary { return hexSeamWall(4, -2, 4, 1
 func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()
 	field := encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex,
 				Boundaries: vaultChaseHexSeamWall()},

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -100,6 +100,7 @@ func vaultChaseHexSeamWall() []spatial.Boundary { return hexSeamWall(4, -2, 4, 1
 func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()
 	field := encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex,
 				Boundaries: vaultChaseHexSeamWall()},

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -91,8 +91,28 @@ type MemberOutcomeData struct {
 // derived thing that is also stored is a second truth waiting to disagree.
 // Rooms hold the composition's own descriptions (mirroring RoomInput exactly).
 type FieldData struct {
+	// Canvas is what the field declared about its map — today, what the space
+	// between the authored chambers is made of (rpg-toolkit#1116). REQUIRED
+	// at load, and written by ToData without omitempty, for RoomData.Origin's
+	// reason: a declaration that persisted as absence could not be told apart
+	// from a blob written before there was one.
+	Canvas      CanvasData       `json:"canvas"`
 	Rooms       []RoomData       `json:"rooms"`
 	Connections []ConnectionData `json:"connections,omitempty"`
+}
+
+// CanvasData is the persistent representation of [CanvasInput].
+//
+// Void carries the declaration's own word ([VoidKind]), not an index into a
+// set: a wire form that meant "the second kind" would silently reinterpret
+// every old blob the day a third kind is added, which is RoomData.Grid's
+// reasoning applied to a younger sealed set. An absent or unknown word is
+// refused by name at load rather than defaulted — see voidFromData.
+//
+// Ambient light will land HERE when rpg-toolkit#1113 arrives, beside the void
+// it is a fact of the same species as.
+type CanvasData struct {
+	Void string `json:"void"`
 }
 
 // RoomData mirrors RoomInput exactly to persist construction inputs — true
@@ -251,6 +271,7 @@ func (e *Encounter) ToData() EncounterData {
 
 	// Deep-copy field from stored inputs
 	fieldData := FieldData{
+		Canvas:      CanvasData{Void: string(e.void.Kind())},
 		Rooms:       make([]RoomData, len(e.fieldInput)),
 		Connections: make([]ConnectionData, len(e.connectionsInput)),
 	}
@@ -581,6 +602,16 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	// (shape legality, W1, room legality, origin legality, W2, W3, and the
 	// existing bounds/occluder/self-connection checks) is enforced by
 	// buildValidRoomGrids/validateConnectionInputs, not duplicated here.
+
+	// What the space between the chambers is made of, resolved from the word
+	// the blob carries. Refused by name when absent or unknown — a guess here
+	// would load a party into a dungeon whose walls the host never authored
+	// (rpg-toolkit#1116; the standing no-migration precedent, #1053/#1068).
+	void, err := voidFromData(data.Field.Canvas.Void)
+	if err != nil {
+		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
+	}
+
 	roomInputs, err := convertRoomDataToRoomInput(data.Field.Rooms)
 	if err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
@@ -810,6 +841,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		endings:     nil,
 		retention:   normalizeRetention(data.Retention),
 		logFloor:    logFloorOf(data.Log),
+		void:        void,
 	}
 
 	// Compile the authored rooms into the canvas — the SAME compileCanvas
@@ -817,7 +849,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	// reloaded encounter's map is built by one implementation rather than a
 	// mirrored second one (#929 T2's shared-validator lesson, applied to
 	// construction).
-	e.canvas, err = compileCanvas(roomInputs)
+	e.canvas, err = compileCanvas(roomInputs, roomGrids, void)
 	if err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -73,6 +73,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
 					Occluders:  []spatial.Position{{X: 1, Y: 2}},
@@ -115,7 +116,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// because sight stopped at a room boundary. That makes the golden strictly
 	// richer: it is the one place the bubbles array and intel's holdings are
 	// pinned as exact bytes.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMywieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-3,"y":7}},{"id":"p1","kind":"player","cell":{"x":-10,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMywieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"rock"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-3,"y":7}},{"id":"p1","kind":"player","cell":{"x":-10,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
 	s.Equal(expected, string(bs))
 }
 
@@ -126,7 +127,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -170,6 +171,7 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
 				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: 0}},
@@ -223,6 +225,7 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 5, Y: 0}},
@@ -270,6 +273,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "square-room", Width: 5, Height: 5},
 				},
@@ -299,6 +303,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
 				},
@@ -346,6 +351,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0, Y: 1},
 					Occluders: []spatial.Position{{X: 3, Y: 3}}},
@@ -402,6 +408,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:        "crypt",
@@ -474,6 +481,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -569,6 +577,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -630,6 +639,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -700,6 +710,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -762,6 +773,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -823,6 +835,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -862,7 +875,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 		// renamed tag fails this where a decoded comparison would not.
 		// (log carries the opening beat: a fresh encounter is born with
 		// its first story entry; clock/intel marshal {} per leaf laws.)
-		expectedJSON := `{"clock":{"budgets":{"p1":0}},"intel":{},"log":{"next_seq":2,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":2,"y":2}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
+		expectedJSON := `{"clock":{"budgets":{"p1":0}},"intel":{},"log":{"next_seq":2,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}]},"field":{"canvas":{"void":"rock"},"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":2,"y":2}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -873,6 +886,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -935,7 +949,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		// blob written before the flip lands nowhere on today's shape and is
 		// refused by name rather than read in the wrong frame (see
 		// dialect_test.go).
-		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","cell":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
+		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","cell":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"canvas":{"void":"rock"},"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -946,6 +960,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -1014,6 +1029,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -1078,7 +1094,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		// first-light surveil would resurrect it to Current.
 		enc1, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
+			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
 			Members: []encounter.MemberInput{
 				{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
 				{ID: "goblin", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 5, Y: 5}},
@@ -1113,6 +1129,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -1187,6 +1204,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -1256,7 +1274,8 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
@@ -1290,6 +1309,7 @@ func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 				// playerA watches from the antechamber. Two monsters sharing
@@ -1351,7 +1371,7 @@ func (d *testDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 
 func validEncounterData() encounter.EncounterData {
 	return encounter.EncounterData{
-		Field: encounter.FieldData{Rooms: []encounter.RoomData{
+		Field: encounter.FieldData{Canvas: encounter.CanvasData{Void: "rock"}, Rooms: []encounter.RoomData{
 			{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 		}},
 		Members: []encounter.MemberData{
@@ -1456,6 +1476,7 @@ func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{
 					{X: 0, Y: 2}, {X: 4, Y: 2}, {X: 2, Y: 0}, {X: 2, Y: 4}, {X: 0, Y: 0}, {X: 4, Y: 4},
@@ -1475,6 +1496,7 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridTypeHex,
 					Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{{X: -5, Y: 4}}},
@@ -1495,6 +1517,7 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0},
 					Occluders: []encounter.PositionData{{X: 3, Y: 3}, {X: 3, Y: 3}}},
@@ -1516,7 +1539,8 @@ func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Rooms: []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
+			Canvas: encounter.CanvasData{Void: "rock"},
+			Rooms:  []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
 		},
 		Endings: []encounter.EndingData{
 			{Key: "dup", Kind: "reached_position", Room: "hall", Position: &encounter.PositionData{X: 4, Y: 4}},
@@ -1697,6 +1721,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 func connBoundsData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 4, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 4, Height: 3, Origin: &encounter.PositionData{X: 4, Y: 3}},
@@ -1834,6 +1859,7 @@ func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
 func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -1894,6 +1920,7 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 7}},
@@ -1923,6 +1950,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 func validHexAxialData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0},
 					Occluders: []encounter.PositionData{{X: 2, Y: 2}}},
@@ -2002,6 +2030,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 func validAnchoredHexData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 6, Y: -5}},
@@ -2134,6 +2163,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r-a", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r-b", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 20, Y: 20}},
@@ -2165,6 +2195,7 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0.5, Y: 1.5}},
 			},
@@ -2197,6 +2228,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 1e19, Y: 0}},
 				{ID: "r2", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 2e19, Y: 0}},
@@ -2233,6 +2265,7 @@ func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap
 func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 3, Y: 0}},
@@ -2264,6 +2297,7 @@ func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance
 func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 1000, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: math.MaxInt, Height: 5, Origin: &encounter.PositionData{X: 999, Y: 0}},
@@ -2293,6 +2327,7 @@ func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint()
 func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "huge", Width: 1 << 30, Height: 1 << 30, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -2314,6 +2349,7 @@ func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 func (s *DataTestSuite) TestLoadOversizedRoomHeightRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "tall", Width: 5, Height: (1 << 30) + 1, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -2344,7 +2380,7 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 		}
 	}
 	data := encounter.EncounterData{
-		Field:   encounter.FieldData{Rooms: rooms},
+		Field:   encounter.FieldData{Canvas: encounter.CanvasData{Void: "rock"}, Rooms: rooms},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
@@ -2362,7 +2398,8 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 func validEndingTriggerData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Rooms: []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
+			Canvas: encounter.CanvasData{Void: "rock"},
+			Rooms:  []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
 		},
 		Endings: []encounter.EndingData{
 			{Key: "reach", Kind: "reached_position", Room: "hall", Position: &encounter.PositionData{X: 3, Y: 3}},
@@ -2410,7 +2447,8 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Rooms: []encounter.RoomData{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}}},
+			Canvas: encounter.CanvasData{Void: "rock"},
+			Rooms:  []encounter.RoomData{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}}},
 		},
 		Endings: []encounter.EndingData{
 			{Key: "reach", Kind: "reached_position", Room: "hall", Position: &encounter.PositionData{X: 1.5, Y: 0}},
@@ -2461,6 +2499,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
@@ -2521,6 +2560,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 func (s *DataTestSuite) TestLoadAnchoringSquareEndpointNotAdjacentDistance2() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 4, Y: 0}},
@@ -2582,6 +2622,7 @@ func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
 func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
+			Canvas: encounter.CanvasData{Void: "rock"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeGridless, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -2638,6 +2679,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2678,6 +2720,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2709,6 +2752,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2742,6 +2786,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2797,6 +2842,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 	s.Run("mutation 5: missing member-room validation", func() {
 		data := encounter.EncounterData{
 			Field: encounter.FieldData{
+				Canvas: encounter.CanvasData{Void: "rock"},
 				Rooms: []encounter.RoomData{
 					{ID: "room1", Width: 10, Height: 10},
 				},
@@ -2826,6 +2872,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -2900,6 +2947,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 10, Height: 10, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -73,7 +73,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
 					Occluders:  []spatial.Position{{X: 1, Y: 2}},
@@ -116,7 +116,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// because sight stopped at a room boundary. That makes the golden strictly
 	// richer: it is the one place the bubbles array and intel's holdings are
 	// pinned as exact bytes.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMywieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"rock"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-3,"y":7}},{"id":"p1","kind":"player","cell":{"x":-10,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMywieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-3,"y":7}},{"id":"p1","kind":"player","cell":{"x":-10,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
 	s.Equal(expected, string(bs))
 }
 
@@ -127,7 +127,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -171,7 +171,7 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
 				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: 0}},
@@ -225,7 +225,7 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 5, Y: 0}},
@@ -273,7 +273,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "square-room", Width: 5, Height: 5},
 				},
@@ -303,7 +303,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
 				},
@@ -351,7 +351,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0, Y: 1},
 					Occluders: []spatial.Position{{X: 3, Y: 3}}},
@@ -408,7 +408,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:        "crypt",
@@ -481,7 +481,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -577,7 +577,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -639,7 +639,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -710,7 +710,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -773,7 +773,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -835,7 +835,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -875,7 +875,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 		// renamed tag fails this where a decoded comparison would not.
 		// (log carries the opening beat: a fresh encounter is born with
 		// its first story entry; clock/intel marshal {} per leaf laws.)
-		expectedJSON := `{"clock":{"budgets":{"p1":0}},"intel":{},"log":{"next_seq":2,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}]},"field":{"canvas":{"void":"rock"},"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":2,"y":2}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
+		expectedJSON := `{"clock":{"budgets":{"p1":0}},"intel":{},"log":{"next_seq":2,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="}]},"field":{"canvas":{"void":"opaque"},"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":2,"y":2}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -886,7 +886,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -949,7 +949,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 		// blob written before the flip lands nowhere on today's shape and is
 		// refused by name rather than read in the wrong frame (see
 		// dialect_test.go).
-		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","cell":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"canvas":{"void":"rock"},"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
+		expectedJSON := `{"outcome":{"ending":"done","at":1,"members":[{"id":"p1","cell":{"x":0,"y":0}}]},"clock":{"budgets":{"p1":1},"driver_progress":{"world":1},"high_water":1},"intel":{},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"at":1,"audience":["p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"},{"seq":3,"at":1,"audience":["p1"],"tags":{"tag":"movement"},"payload":"eyJiZWF0IjoibW92ZWQiLCJtZW1iZXIiOiJwMSIsInBvc2l0aW9uIjp7IngiOjAsInkiOjB9fQ=="}]},"field":{"canvas":{"void":"opaque"},"rooms":[{"id":"room1","width":5,"height":5,"origin":{"x":0,"y":0}}]},"members":[{"id":"p1","kind":"player","cell":{"x":0,"y":0}}],"endings":[{"key":"done","kind":"reached_position","room":"room1","position":{"x":0,"y":0}}],"ever_members":["p1"],"retention":32}`
 		s.Equal(expectedJSON, string(jsonBytes))
 	})
 }
@@ -960,7 +960,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -1029,7 +1029,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         "room1",
@@ -1094,7 +1094,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		// first-light surveil would resurrect it to Current.
 		enc1, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
+			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
 			Members: []encounter.MemberInput{
 				{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
 				{ID: "goblin", Kind: encounter.KindMonster, Room: "crypt", Position: spatial.Position{X: 5, Y: 5}},
@@ -1129,7 +1129,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -1204,7 +1204,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -1274,7 +1274,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
@@ -1309,7 +1309,7 @@ func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 				// playerA watches from the antechamber. Two monsters sharing
@@ -1371,7 +1371,7 @@ func (d *testDecider) Decide(_ encounter.Snapshot) (encounter.Intent, error) {
 
 func validEncounterData() encounter.EncounterData {
 	return encounter.EncounterData{
-		Field: encounter.FieldData{Canvas: encounter.CanvasData{Void: "rock"}, Rooms: []encounter.RoomData{
+		Field: encounter.FieldData{Canvas: encounter.CanvasData{Void: "opaque"}, Rooms: []encounter.RoomData{
 			{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 		}},
 		Members: []encounter.MemberData{
@@ -1476,7 +1476,7 @@ func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{
 					{X: 0, Y: 2}, {X: 4, Y: 2}, {X: 2, Y: 0}, {X: 2, Y: 4}, {X: 0, Y: 0}, {X: 4, Y: 4},
@@ -1496,7 +1496,7 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridTypeHex,
 					Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{{X: -5, Y: 4}}},
@@ -1517,7 +1517,7 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0},
 					Occluders: []encounter.PositionData{{X: 3, Y: 3}, {X: 3, Y: 3}}},
@@ -1539,7 +1539,7 @@ func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms:  []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
 		},
 		Endings: []encounter.EndingData{
@@ -1721,7 +1721,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 func connBoundsData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 4, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 4, Height: 3, Origin: &encounter.PositionData{X: 4, Y: 3}},
@@ -1859,7 +1859,7 @@ func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
 func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -1920,7 +1920,7 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 7}},
@@ -1950,7 +1950,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 func validHexAxialData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0},
 					Occluders: []encounter.PositionData{{X: 2, Y: 2}}},
@@ -2030,7 +2030,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 func validAnchoredHexData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 6, Y: -5}},
@@ -2163,7 +2163,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r-a", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r-b", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 20, Y: 20}},
@@ -2195,7 +2195,7 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0.5, Y: 1.5}},
 			},
@@ -2228,7 +2228,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 1e19, Y: 0}},
 				{ID: "r2", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 2e19, Y: 0}},
@@ -2265,7 +2265,7 @@ func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap
 func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 3, Y: 0}},
@@ -2297,7 +2297,7 @@ func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance
 func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 1000, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: math.MaxInt, Height: 5, Origin: &encounter.PositionData{X: 999, Y: 0}},
@@ -2327,7 +2327,7 @@ func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint()
 func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "huge", Width: 1 << 30, Height: 1 << 30, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -2349,7 +2349,7 @@ func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 func (s *DataTestSuite) TestLoadOversizedRoomHeightRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "tall", Width: 5, Height: (1 << 30) + 1, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -2380,7 +2380,7 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 		}
 	}
 	data := encounter.EncounterData{
-		Field:   encounter.FieldData{Canvas: encounter.CanvasData{Void: "rock"}, Rooms: rooms},
+		Field:   encounter.FieldData{Canvas: encounter.CanvasData{Void: "opaque"}, Rooms: rooms},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
@@ -2398,7 +2398,7 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 func validEndingTriggerData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms:  []encounter.RoomData{{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}}},
 		},
 		Endings: []encounter.EndingData{
@@ -2447,7 +2447,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms:  []encounter.RoomData{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}}},
 		},
 		Endings: []encounter.EndingData{
@@ -2499,7 +2499,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
@@ -2560,7 +2560,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 func (s *DataTestSuite) TestLoadAnchoringSquareEndpointNotAdjacentDistance2() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "r2", Width: 3, Height: 3, Origin: &encounter.PositionData{X: 4, Y: 0}},
@@ -2622,7 +2622,7 @@ func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
 func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "rock"},
+			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeGridless, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -2679,7 +2679,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2720,7 +2720,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2752,7 +2752,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2786,7 +2786,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},
@@ -2842,7 +2842,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 	s.Run("mutation 5: missing member-room validation", func() {
 		data := encounter.EncounterData{
 			Field: encounter.FieldData{
-				Canvas: encounter.CanvasData{Void: "rock"},
+				Canvas: encounter.CanvasData{Void: "opaque"},
 				Rooms: []encounter.RoomData{
 					{ID: "room1", Width: 10, Height: 10},
 				},
@@ -2872,7 +2872,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     "crypt",
@@ -2947,7 +2947,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room1", Width: 10, Height: 10, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
 				},

--- a/rulebooks/dnd5e/encounter/defeat_internal_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_internal_test.go
@@ -48,7 +48,7 @@ func TestADecidedFightRefusesToCountAGhost(t *testing.T) {
 	rulebook := &oneDown{}
 	enc, err := NewEncounter(&SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: rulebook, Initiative: orderAsGiven{},
-		Field: FieldInput{Rooms: []RoomInput{{ID: "crypt", Width: 12, Height: 12}}},
+		Field: FieldInput{Canvas: CanvasInput{Void: VoidIsRock()}, Rooms: []RoomInput{{ID: "crypt", Width: 12, Height: 12}}},
 		Members: []MemberInput{
 			{ID: "alice", Kind: KindPlayer, Room: "crypt", Position: spatial.Position{X: 0, Y: 2}},
 			{ID: "goblin", Kind: KindMonster, Room: "crypt", Position: spatial.Position{X: 0, Y: 10}},

--- a/rulebooks/dnd5e/encounter/defeat_internal_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_internal_test.go
@@ -48,7 +48,7 @@ func TestADecidedFightRefusesToCountAGhost(t *testing.T) {
 	rulebook := &oneDown{}
 	enc, err := NewEncounter(&SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: rulebook, Initiative: orderAsGiven{},
-		Field: FieldInput{Canvas: CanvasInput{Void: VoidIsRock()}, Rooms: []RoomInput{{ID: "crypt", Width: 12, Height: 12}}},
+		Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque()}, Rooms: []RoomInput{{ID: "crypt", Width: 12, Height: 12}}},
 		Members: []MemberInput{
 			{ID: "alice", Kind: KindPlayer, Room: "crypt", Position: spatial.Position{X: 0, Y: 2}},
 			{ID: "goblin", Kind: KindMonster, Room: "crypt", Position: spatial.Position{X: 0, Y: 10}},

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -61,7 +61,7 @@ var dialectOrigin = spatial.Position{X: 30, Y: 10}
 func (s *DialectSuite) closedBlob() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Origin: dialectOrigin},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -61,7 +61,7 @@ var dialectOrigin = spatial.Position{X: 30, Y: 10}
 func (s *DialectSuite) closedBlob() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Origin: dialectOrigin},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -81,12 +81,19 @@ type Encounter struct {
 	// compiles into. The orchestrator that used to hold the rooms went with
 	// them: with one room there is nothing to orchestrate, and its connection
 	// registry described a crossing mechanism this composition no longer has.
-	canvas *spatial.BasicRoom
+	canvas *canvasRoom
 
 	// roomGrids is each authored room's own grid, kept from construction so
 	// the field can answer which chamber owns an absolute cell without
 	// rebuilding one per call — see regionAt.
 	roomGrids map[string]spatial.Grid
+
+	// void is what the field declared the space between its chambers is made
+	// of (rpg-toolkit#1116). Kept here because it is construction truth that
+	// has to persist; what READS it is the canvas, which was handed the same
+	// value at compile time. The canvas is the only thing that acts on it, so
+	// there is no second answer to keep in step — see [canvasRoom].
+	void Void
 
 	clock *clock.Tick
 	// bubbles are the localized initiative bubbles currently running. Zero or
@@ -746,7 +753,12 @@ func canvasSpan(shape spatial.GridShape, qMin, qMax, rMin, rMax int) (width, hei
 // compileCanvas turns the authored rooms into the one spatial room the
 // encounter runs on: a grid spanning the field's whole absolute footprint, with
 // every room's occluders and walls projected through its Origin and registered
-// there.
+// there, and the field's own declaration of what the space between them is made
+// of (rpg-toolkit#1116).
+//
+// The grids come in rather than being rebuilt because the canvas needs to know
+// which cells are FLOOR, and that is [regionAt]'s question — asked with each
+// room's own constructed grid, exactly as [Encounter.RegionAt] asks it.
 //
 // THIS IS WHERE A WALL BETWEEN TWO ROOMS BECOMES POSSIBLE. Registered on a
 // room's own grid, a boundary's endpoints both had to be cells of that room
@@ -762,7 +774,7 @@ func canvasSpan(shape spatial.GridShape, qMin, qMax, rMin, rMax int) (width, hei
 // Both seams run buildValidRoomGrids first, which is what lets this read the
 // family off rooms[0] alone: W1 gives every room in a field the same one, and a
 // mixed field never reaches here.
-func compileCanvas(rooms []RoomInput) (*spatial.BasicRoom, error) {
+func compileCanvas(rooms []RoomInput, grids map[string]spatial.Grid, void Void) (*canvasRoom, error) {
 	qMin, qMax, rMin, rMax := fieldAbsoluteBounds(rooms)
 	width, height, err := canvasSpan(rooms[0].Grid, qMin, qMax, rMin, rMax)
 	if err != nil {
@@ -802,7 +814,7 @@ func compileCanvas(rooms []RoomInput) (*spatial.BasicRoom, error) {
 		}
 	}
 
-	return canvas, nil
+	return &canvasRoom{BasicRoom: canvas, void: void, rooms: rooms, grids: grids}, nil
 }
 
 // gridShapeName renders a GridShape for W1's mixed-family defect message.
@@ -1139,6 +1151,15 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		}
 	}
 
+	// The field must say what its void is. Construction DATA rather than a
+	// capability, so it earns ErrNoField rather than a sentinel of its own —
+	// but the reason it is required is rpg-toolkit#1033's, unchanged: a
+	// default would be this module deciding what a dungeon is made of, in a
+	// field the author never wrote (rpg-toolkit#1116).
+	if in.Field.Canvas.Void == nil {
+		return nil, fmt.Errorf("newencounter: field does not say what its void is (FieldInput.Canvas.Void): %w", ErrNoField)
+	}
+
 	// Check rooms: unique non-empty IDs, recognized grid shape. roomGrids
 	// holds each room's constructed Grid, reused below for connection
 	// bounds validation and again in the room-construction loop so a
@@ -1190,6 +1211,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		retention:        normalizeRetention(in.Retention),
 		fieldInput:       deepCopyRoomInputs(in.Field.Rooms),
 		connectionsInput: connectionsInput,
+		void:             in.Field.Canvas.Void,
 	}
 
 	// Build clock and intel
@@ -1209,7 +1231,15 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	}
 
 	// Compile the authored rooms into the one canvas this encounter runs on.
-	e.canvas, err = compileCanvas(in.Field.Rooms)
+	//
+	// Fed e.fieldInput — the DEEP COPY made above — rather than the caller's
+	// own slice, because the canvas keeps it: it asks regionAt which cells are
+	// floor (rpg-toolkit#1116), and a canvas holding the caller's slice while
+	// [Encounter.RegionAt] holds the copy would be two answers to one question,
+	// diverging the moment a caller reused its RoomInputs. Load needs no such
+	// care — its roomInputs are freshly converted from the blob and alias
+	// nothing (LoadEncounter's own note, and TestAliasImmunityLoadEncounter).
+	e.canvas, err = compileCanvas(e.fieldInput, roomGrids, in.Field.Canvas.Void)
 	if err != nil {
 		return nil, fmt.Errorf("newencounter: %w", err)
 	}

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -814,7 +814,13 @@ func compileCanvas(rooms []RoomInput, grids map[string]spatial.Grid, void Void) 
 		}
 	}
 
-	return &canvasRoom{BasicRoom: canvas, void: void, rooms: rooms, grids: grids}, nil
+	return &canvasRoom{
+		BasicRoom: canvas,
+		void:      void,
+		rooms:     rooms,
+		grids:     grids,
+		hasVoid:   fieldHasVoid(rooms, width, height),
+	}, nil
 }
 
 // gridShapeName renders a GridShape for W1's mixed-family defect message.

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -49,7 +49,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -129,7 +129,7 @@ func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:        room1,
@@ -191,7 +191,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms:  []encounter.RoomInput{},
 			},
 			Members: []encounter.MemberInput{},
@@ -207,7 +207,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -223,7 +223,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -241,7 +241,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -259,7 +259,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -280,7 +280,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -303,7 +303,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		// First attempt: fails validation
 		setup1 := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{}},
+			Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{}},
 			Members: []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
 				{Key: "stairs", Trigger: encounter.TriggerExternal{}},
@@ -316,7 +316,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup2 := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -357,7 +357,7 @@ func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
 				{ID: "r2", Width: 3, Height: 9, Origin: spatial.Position{X: 10, Y: 0}, Occluders: []spatial.Position{{X: 1, Y: 3}}},
@@ -403,7 +403,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{
 					{X: 0, Y: 2}, // left edge
@@ -432,7 +432,7 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
 					Occluders: []spatial.Position{{X: -5, Y: 4}}},
@@ -458,7 +458,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}, {X: 3, Y: 3}}},
 			},
@@ -481,7 +481,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
 		Endings: []encounter.EndingInput{
@@ -575,7 +575,7 @@ func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 4, Height: 3},
 				{ID: "r2", Width: 4, Height: 3, Origin: spatial.Position{X: 4, Y: 3}},
@@ -645,7 +645,7 @@ func validRoomSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
 			},
@@ -731,7 +731,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
 				},
@@ -790,7 +790,7 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
 				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 7}},
@@ -829,7 +829,7 @@ func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
 					Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -903,7 +903,7 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Members: []encounter.MemberInput{
@@ -931,7 +931,7 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Members: []encounter.MemberInput{
@@ -978,7 +978,7 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
 				},
@@ -1038,7 +1038,7 @@ func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
@@ -1158,7 +1158,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "sq-a", Width: 5, Height: 5},
 				{ID: "sq-b", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: 5}},
@@ -1193,7 +1193,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
 				{ID: "r2", Width: 3, Height: 3, Origin: spatial.Position{X: 4, Y: 0}},
@@ -1229,7 +1229,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0.5, Y: 1.5}},
 			},
@@ -1262,7 +1262,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -1283,7 +1283,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() 
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -1305,7 +1305,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "square-first", Width: 5, Height: 5},
 				{ID: "hex-second", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
@@ -1341,7 +1341,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r-a", Width: 5, Height: 5},
 				{ID: "r-b", Width: 5, Height: 5, Origin: spatial.Position{X: 20, Y: 20}},
@@ -1374,7 +1374,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-r-b", Width: 4, Height: 4, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 0, Y: 4}},
@@ -1409,7 +1409,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDi
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
 				{ID: "r2", Width: 3, Height: 3, Origin: spatial.Position{X: 3, Y: 0}},
@@ -1446,7 +1446,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 1e19, Y: 0}},
 				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 2e19, Y: 0}},
@@ -1485,7 +1485,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisj
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 1000, Height: 5},
 				{ID: "r2", Width: math.MaxInt, Height: 5, Origin: spatial.Position{X: 999, Y: 0}},
@@ -1514,7 +1514,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -1537,7 +1537,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex(
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -1568,7 +1568,7 @@ func (s *EncounterTestSuite) TestSetupOversizedRoomHeightRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -1603,7 +1603,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 	}
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: rooms},
+		Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: rooms},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
@@ -1621,7 +1621,7 @@ func validEndingTriggerSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
 		Endings: []encounter.EndingInput{
@@ -1673,7 +1673,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Endings: []encounter.EndingInput{
@@ -1697,7 +1697,7 @@ func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
 				{ID: "vault", Width: 4, Height: 4, Origin: spatial.Position{X: 5, Y: 0}},
@@ -1761,7 +1761,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() 
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Endings: []encounter.EndingInput{
@@ -1783,7 +1783,7 @@ func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 					{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1838,7 +1838,7 @@ func (s *EncounterTestSuite) TestSetupBadPlacementSentinel() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},
@@ -1867,7 +1867,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
 				},
@@ -1924,7 +1924,7 @@ func (s *EncounterTestSuite) TestMembers() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},
@@ -1953,7 +1953,7 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -2043,7 +2043,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:        room1,
@@ -2108,7 +2108,7 @@ func (s *EncounterTestSuite) TestMoveSequentialConsistency() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -2165,7 +2165,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         room1,
@@ -2259,7 +2259,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
-					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2282,7 +2282,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
-					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2308,7 +2308,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
-					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2345,7 +2345,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
-					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2371,7 +2371,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
-					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2415,7 +2415,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
 				},
@@ -2470,7 +2470,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2489,7 +2489,7 @@ func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 func (s *EncounterTestSuite) newBasicEncounterWithExternalEnding() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2561,7 +2561,7 @@ func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Enco
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				// room-a WALLS its east edge, leaving the doorway's row open.
 				// With one canvas and no wall the two chambers share an open
@@ -2739,7 +2739,7 @@ func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -2782,7 +2782,7 @@ func (s *EncounterTestSuite) TestAMonsterCrossingOntoAnUnfilteredEndingDoesNotCl
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -2897,7 +2897,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3055,7 +3055,7 @@ func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3109,7 +3109,7 @@ func (s *EncounterTestSuite) TestExitCarryForward() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3206,7 +3206,7 @@ func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3260,7 +3260,7 @@ func (s *EncounterTestSuite) TestExitDepartedGhostFades() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3334,7 +3334,7 @@ func (s *EncounterTestSuite) TestEndExternalOnly() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},
@@ -3473,7 +3473,7 @@ func (s *EncounterTestSuite) TestStoryForExitedMembers() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -49,6 +49,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -128,6 +129,7 @@ func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:        room1,
@@ -189,7 +191,8 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Rooms: []encounter.RoomInput{},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Rooms:  []encounter.RoomInput{},
 			},
 			Members: []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
@@ -204,6 +207,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -219,6 +223,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -236,6 +241,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -253,6 +259,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -273,6 +280,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -295,7 +303,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		// First attempt: fails validation
 		setup1 := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field:   encounter.FieldInput{Rooms: []encounter.RoomInput{}},
+			Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{}},
 			Members: []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
 				{Key: "stairs", Trigger: encounter.TriggerExternal{}},
@@ -308,6 +316,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 		setup2 := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "room-1", Width: 10, Height: 10},
 				},
@@ -348,6 +357,7 @@ func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
 				{ID: "r2", Width: 3, Height: 9, Origin: spatial.Position{X: 10, Y: 0}, Occluders: []spatial.Position{{X: 1, Y: 3}}},
@@ -393,6 +403,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{
 					{X: 0, Y: 2}, // left edge
@@ -421,6 +432,7 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
 					Occluders: []spatial.Position{{X: -5, Y: 4}}},
@@ -446,6 +458,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}, {X: 3, Y: 3}}},
 			},
@@ -468,7 +481,8 @@ func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: "dup", Trigger: encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 4, Y: 4}}},
@@ -561,6 +575,7 @@ func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 4, Height: 3},
 				{ID: "r2", Width: 4, Height: 3, Origin: spatial.Position{X: 4, Y: 3}},
@@ -630,6 +645,7 @@ func validRoomSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5},
 			},
@@ -715,6 +731,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
 				},
@@ -773,6 +790,7 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
 				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 7}},
@@ -811,6 +829,7 @@ func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
 					Occluders: []spatial.Position{{X: 2, Y: 2}}},
@@ -884,7 +903,8 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-room", Position: spatial.Position{X: 0, Y: 0}},
@@ -911,7 +931,8 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-room", Position: spatial.Position{X: 0, Y: 0}},
@@ -957,6 +978,7 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeGridless},
 				},
@@ -1016,6 +1038,7 @@ func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
@@ -1135,6 +1158,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "sq-a", Width: 5, Height: 5},
 				{ID: "sq-b", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: 5}},
@@ -1169,6 +1193,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
 				{ID: "r2", Width: 3, Height: 3, Origin: spatial.Position{X: 4, Y: 0}},
@@ -1204,6 +1229,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0.5, Y: 1.5}},
 			},
@@ -1236,7 +1262,8 @@ func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1256,7 +1283,8 @@ func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() 
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1277,6 +1305,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "square-first", Width: 5, Height: 5},
 				{ID: "hex-second", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
@@ -1312,6 +1341,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r-a", Width: 5, Height: 5},
 				{ID: "r-b", Width: 5, Height: 5, Origin: spatial.Position{X: 20, Y: 20}},
@@ -1344,6 +1374,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-r-b", Width: 4, Height: 4, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 0, Y: 4}},
@@ -1378,6 +1409,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDi
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 3, Height: 3},
 				{ID: "r2", Width: 3, Height: 3, Origin: spatial.Position{X: 3, Y: 0}},
@@ -1414,6 +1446,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 1e19, Y: 0}},
 				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 2e19, Y: 0}},
@@ -1452,6 +1485,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisj
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 1000, Height: 5},
 				{ID: "r2", Width: math.MaxInt, Height: 5, Origin: spatial.Position{X: 999, Y: 0}},
@@ -1480,7 +1514,8 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1502,7 +1537,8 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex(
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1532,7 +1568,8 @@ func (s *EncounterTestSuite) TestSetupOversizedRoomHeightRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1566,7 +1603,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 	}
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field:   encounter.FieldInput{Rooms: rooms},
+		Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: rooms},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
@@ -1584,7 +1621,8 @@ func validEndingTriggerSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 3, Y: 3}}},
@@ -1635,7 +1673,8 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "hall", Position: spatial.Position{X: 1.5, Y: 0}}},
@@ -1658,6 +1697,7 @@ func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
 				{ID: "vault", Width: 4, Height: 4, Origin: spatial.Position{X: 5, Y: 0}},
@@ -1721,7 +1761,8 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() 
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "crypt", Position: spatial.Position{X: -2, Y: -2}}},
@@ -1742,6 +1783,7 @@ func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 					{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1796,6 +1838,7 @@ func (s *EncounterTestSuite) TestSetupBadPlacementSentinel() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},
@@ -1824,6 +1867,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
 				},
@@ -1880,6 +1924,7 @@ func (s *EncounterTestSuite) TestMembers() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},
@@ -1908,6 +1953,7 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -1997,6 +2043,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:        room1,
@@ -2061,6 +2108,7 @@ func (s *EncounterTestSuite) TestMoveSequentialConsistency() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -2117,6 +2165,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:         room1,
@@ -2210,6 +2259,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2232,6 +2282,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2257,6 +2308,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2293,6 +2345,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2318,6 +2371,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 			setup := &encounter.SetupInput{
 				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 				Field: encounter.FieldInput{
+					Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 					Rooms: []encounter.RoomInput{
 						{ID: room1, Width: 10, Height: 10},
 					},
@@ -2361,6 +2415,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 20, Height: 20},
 				},
@@ -2415,7 +2470,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2434,7 +2489,7 @@ func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 func (s *EncounterTestSuite) newBasicEncounterWithExternalEnding() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
 			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
@@ -2506,6 +2561,7 @@ func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Enco
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				// room-a WALLS its east edge, leaving the doorway's row open.
 				// With one canvas and no wall the two chambers share an open
@@ -2683,6 +2739,7 @@ func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -2725,6 +2782,7 @@ func (s *EncounterTestSuite) TestAMonsterCrossingOntoAnUnfilteredEndingDoesNotCl
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -2839,6 +2897,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -2996,6 +3055,7 @@ func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3049,6 +3109,7 @@ func (s *EncounterTestSuite) TestExitCarryForward() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3145,6 +3206,7 @@ func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3198,6 +3260,7 @@ func (s *EncounterTestSuite) TestExitDepartedGhostFades() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -3271,6 +3334,7 @@ func (s *EncounterTestSuite) TestEndExternalOnly() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},
@@ -3409,6 +3473,7 @@ func (s *EncounterTestSuite) TestStoryForExitedMembers() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{ID: room1, Width: 10, Height: 10},
 				},

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -94,6 +94,15 @@ var (
 	// single grid of its family (W6, rpg-toolkit#1106): the canvas the rooms
 	// compile into is one grid, and a square field reaching a negative cell
 	// has no such grid — see canvasSpan, whose message names the remedy.
+	//
+	// And when the field does not say what its VOID is (rpg-toolkit#1116) —
+	// at Setup, a nil [CanvasInput.Void]; at Load, a blob whose canvas.void is
+	// absent or carries a word this build does not know. Field construction
+	// DATA, which is what this sentinel is for; the capability sentinels
+	// (ErrNoSight, ErrNoStanding) are for injected behaviour, not world facts.
+	// Both messages name the declaration and the two are worded apart, because
+	// "never declared" and "declared something I do not know" send whoever
+	// reads them to different places — see [Void] and voidFromData.
 	ErrNoField = errors.New("no field")
 
 	// ErrBadPlacement is returned when a placement or position is bad in

--- a/rulebooks/dnd5e/encounter/example_doorway_test.go
+++ b/rulebooks/dnd5e/encounter/example_doorway_test.go
@@ -47,6 +47,7 @@ func Example_theDoorway() {
 	wall := squareSeamWall(7, 8, 4)
 
 	field := encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Boundaries: wall},
 			// Anchored immediately east of the hall (#929 T1): the gate's

--- a/rulebooks/dnd5e/encounter/example_doorway_test.go
+++ b/rulebooks/dnd5e/encounter/example_doorway_test.go
@@ -47,7 +47,7 @@ func Example_theDoorway() {
 	wall := squareSeamWall(7, 8, 4)
 
 	field := encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Boundaries: wall},
 			// Anchored immediately east of the hall (#929 T1): the gate's

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -33,7 +33,7 @@ func Example_theDungeon() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},
 				// Anchored immediately east of the hall (#929 T1): the

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -33,6 +33,7 @@ func Example_theDungeon() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 8, Height: 8},
 				// Anchored immediately east of the hall (#929 T1): the

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -47,6 +47,7 @@ func Example_theTombWatch() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{{
 				ID: "crypt", Width: 12, Height: 12,
 				Occluders: wallRow(6, 5, 7),

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -47,7 +47,7 @@ func Example_theTombWatch() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
 				ID: "crypt", Width: 12, Height: 12,
 				Occluders: wallRow(6, 5, 7),

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -150,8 +150,14 @@ type ConnectionInput struct {
 	ToPosition spatial.Position
 }
 
-// FieldInput describes the layout of rooms and connections.
+// FieldInput describes the layout of rooms and connections, and what the
+// canvas they compile onto is made of.
 type FieldInput struct {
+	// Canvas is what this field DECLARES about the map its rooms compile
+	// onto — today, what the space between them is made of. REQUIRED: see
+	// [Void] for why this module is not allowed to pick (rpg-toolkit#1116).
+	Canvas CanvasInput
+
 	// Rooms is the list of rooms in this field.
 	Rooms []RoomInput
 

--- a/rulebooks/dnd5e/encounter/killingblow_test.go
+++ b/rulebooks/dnd5e/encounter/killingblow_test.go
@@ -67,7 +67,7 @@ func (s *KillingBlowSuite) apart(standing encounter.Standing) *encounter.Encount
 		Initiative: orderAsGiven{},
 		Sight:      everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12, Occluders: wallRow(6, 0, 11)},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/killingblow_test.go
+++ b/rulebooks/dnd5e/encounter/killingblow_test.go
@@ -67,7 +67,7 @@ func (s *KillingBlowSuite) apart(standing encounter.Standing) *encounter.Encount
 		Initiative: orderAsGiven{},
 		Sight:      everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12, Occluders: wallRow(6, 0, 11)},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -30,7 +30,7 @@ const outcomeRoom = "yard"
 func (s *OutcomeTestSuite) scene() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{
 			ID: outcomeRoom, Width: 12, Height: 12, Occluders: wallRow(6, 4, 8),
 		}}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -30,7 +30,7 @@ const outcomeRoom = "yard"
 func (s *OutcomeTestSuite) scene() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{
 			ID: outcomeRoom, Width: 12, Height: 12, Occluders: wallRow(6, 4, 8),
 		}}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -54,6 +54,7 @@ func (s *PlacementSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				// The hall walls its own east edge, leaving the gate's row
 				// open: with one canvas the two chambers would otherwise share

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -54,7 +54,7 @@ func (s *PlacementSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				// The hall walls its own east edge, leaving the gate's row
 				// open: with one canvas the two chambers would otherwise share

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -205,7 +205,7 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 func (s *PumpTestSuite) TestPumpDoesNotConsultExitedMonsterDecider() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
@@ -241,6 +241,7 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -340,6 +341,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{{
 					ID: room1, Width: 10, Height: 10,
 					// A wall down x=5 rather than one cell of it: spatial
@@ -390,6 +392,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -469,7 +472,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
@@ -494,7 +497,7 @@ func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 func (s *PumpTestSuite) TestPumpPartialAbort() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			// "aaa-goblin" sorts before "zzz-goblin": it decides (and
@@ -539,7 +542,7 @@ func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	vandal := &vandalDecider{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			// The vandal's victim is a MONSTER peer, not a player. Two
@@ -587,6 +590,7 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -653,6 +657,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -723,7 +728,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 0, Y: 0}},
 		},
@@ -761,6 +766,7 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -840,6 +846,7 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -925,6 +932,7 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -1005,6 +1013,7 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -1077,6 +1086,7 @@ func twoRoomSealedWall() []spatial.Boundary { return squareSeamWall(9, 10) }
 // the doorway's cells (9,5) and (10,5) are adjacent (W3).
 func twoRoomField() encounter.FieldInput {
 	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 			{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1097,6 +1107,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1148,6 +1159,7 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1221,6 +1233,7 @@ func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: cellar, Width: 10, Height: 10, Origin: spatial.Position{X: 40, Y: 20}},
 				{ID: shrine, Width: 10, Height: 10, Origin: spatial.Position{X: 50, Y: 20}},
@@ -1331,6 +1344,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenAWallIsInTheWay() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1388,6 +1402,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1440,6 +1455,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1485,6 +1501,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1594,6 +1611,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1696,7 +1714,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 	s.Run("control: decision order and declaration order agree", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				{ID: aID, Kind: encounter.KindMonster, Room: room1,
 					Position: spatial.Position{X: 5, Y: 5}, Decider: &patrolDecider{positions: []spatial.Position{posA}}},
@@ -1721,7 +1739,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				// Same decision order (aaa first, zzz second), but now each
 				// monster's landing position fires the OTHER declared ending.
@@ -1780,7 +1798,7 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: aliceID, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: goblinID, Kind: encounter.KindMonster, Room: room1,
@@ -1830,6 +1848,7 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1922,6 +1941,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{{
 				ID: room1, Width: 10, Height: 10,
 				// A short wall, positioned so that alice is visible from the

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -205,7 +205,7 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 func (s *PumpTestSuite) TestPumpDoesNotConsultExitedMonsterDecider() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
@@ -241,7 +241,7 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -341,7 +341,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{{
 					ID: room1, Width: 10, Height: 10,
 					// A wall down x=5 rather than one cell of it: spatial
@@ -392,7 +392,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -472,7 +472,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: core.EntityID("goblin"), Kind: encounter.KindMonster, Room: room1,
@@ -497,7 +497,7 @@ func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 func (s *PumpTestSuite) TestPumpPartialAbort() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			// "aaa-goblin" sorts before "zzz-goblin": it decides (and
@@ -542,7 +542,7 @@ func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	vandal := &vandalDecider{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			// The vandal's victim is a MONSTER peer, not a player. Two
@@ -590,7 +590,7 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -657,7 +657,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -728,7 +728,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 0, Y: 0}},
 		},
@@ -766,7 +766,7 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -846,7 +846,7 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -932,7 +932,7 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -1013,7 +1013,7 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
 						ID:     room1,
@@ -1086,7 +1086,7 @@ func twoRoomSealedWall() []spatial.Boundary { return squareSeamWall(9, 10) }
 // the doorway's cells (9,5) and (10,5) are adjacent (W3).
 func twoRoomField() encounter.FieldInput {
 	return encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 			{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1107,7 +1107,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomSealedWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1159,7 +1159,7 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1233,7 +1233,7 @@ func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: cellar, Width: 10, Height: 10, Origin: spatial.Position{X: 40, Y: 20}},
 				{ID: shrine, Width: 10, Height: 10, Origin: spatial.Position{X: 50, Y: 20}},
@@ -1344,7 +1344,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenAWallIsInTheWay() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1402,7 +1402,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1455,7 +1455,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1501,7 +1501,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1611,7 +1611,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-a", Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: "room-b", Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1714,7 +1714,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 	s.Run("control: decision order and declaration order agree", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				{ID: aID, Kind: encounter.KindMonster, Room: room1,
 					Position: spatial.Position{X: 5, Y: 5}, Decider: &patrolDecider{positions: []spatial.Position{posA}}},
@@ -1739,7 +1739,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				// Same decision order (aaa first, zzz second), but now each
 				// monster's landing position fires the OTHER declared ending.
@@ -1798,7 +1798,7 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: aliceID, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
 			{ID: goblinID, Kind: encounter.KindMonster, Room: room1,
@@ -1848,7 +1848,7 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomWall()},
 				{ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}},
@@ -1941,7 +1941,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
 				ID: room1, Width: 10, Height: 10,
 				// A short wall, positioned so that alice is visible from the

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -68,6 +68,7 @@ func pursuitSeamWall() []spatial.Boundary { return squareSeamWall(5, 6, 3) }
 
 func (s *PursuitSuite) SetupTest() {
 	field := encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			{ID: westID, Width: 6, Height: 6, Origin: westOrigin,
 				Boundaries: pursuitSeamWall()},

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -68,7 +68,7 @@ func pursuitSeamWall() []spatial.Boundary { return squareSeamWall(5, 6, 3) }
 
 func (s *PursuitSuite) SetupTest() {
 	field := encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			{ID: westID, Width: 6, Height: 6, Origin: westOrigin,
 				Boundaries: pursuitSeamWall()},

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -439,7 +439,7 @@ func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
 func (s *RegionSuite) oneRoom(shape spatial.GridShape, w, h int, origin spatial.Position) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: "only", Width: w, Height: h, Grid: shape, Origin: origin},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -439,7 +439,7 @@ func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
 func (s *RegionSuite) oneRoom(shape spatial.GridShape, w, h int, origin spatial.Position) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
 			{ID: "only", Width: w, Height: h, Grid: shape, Origin: origin},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -35,7 +35,7 @@ type RetentionTestSuite struct {
 func (s *RetentionTestSuite) walkingEncounter(retention int) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -35,7 +35,7 @@ type RetentionTestSuite struct {
 func (s *RetentionTestSuite) walkingEncounter(retention int) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
 		},

--- a/rulebooks/dnd5e/encounter/standing_test.go
+++ b/rulebooks/dnd5e/encounter/standing_test.go
@@ -64,7 +64,7 @@ func (s *deathScene) scene(standing encounter.Standing, members ...encounter.Mem
 		Initiative: orderAsGiven{},
 		Sight:      everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
 		Members: members,
@@ -178,7 +178,7 @@ func (s *deathScene) beatsOf(enc *encounter.Encounter, audience encounter.Member
 func (s *StandingSuite) TestSetupRefusesAnEncounterThatCannotAskWhoIsDown() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
 		Members: []encounter.MemberInput{
@@ -417,7 +417,7 @@ func (s *StandingSuite) TestAForgottenDeathIsToldAgain() {
 		Initiative: orderAsGiven{},
 		Sight:      everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
 		Retention: 4,
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/standing_test.go
+++ b/rulebooks/dnd5e/encounter/standing_test.go
@@ -64,7 +64,7 @@ func (s *deathScene) scene(standing encounter.Standing, members ...encounter.Mem
 		Initiative: orderAsGiven{},
 		Sight:      everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
 		Members: members,
@@ -178,7 +178,7 @@ func (s *deathScene) beatsOf(enc *encounter.Encounter, audience encounter.Member
 func (s *StandingSuite) TestSetupRefusesAnEncounterThatCannotAskWhoIsDown() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
 		Members: []encounter.MemberInput{
@@ -417,7 +417,7 @@ func (s *StandingSuite) TestAForgottenDeathIsToldAgain() {
 		Initiative: orderAsGiven{},
 		Sight:      everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
 		Retention: 4,
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -83,7 +83,7 @@ func stepSeamWall() []spatial.Boundary { return squareSeamWall(5, 6, int(stepDoo
 // stepField is the shared set, optionally with a decider driving the goblin.
 func stepField() encounter.FieldInput {
 	return encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 		Rooms: []encounter.RoomInput{
 			{ID: stepWest, Width: 6, Height: 6, Origin: stepWestOrigin,
 				Boundaries: stepSeamWall()},
@@ -514,7 +514,7 @@ func (s *StepSuite) TestGridReportsTheFieldsFamily() {
 func (s *StepSuite) TestGridReportsAHexFieldAsHex() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: stepWest, Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 				Origin: stepWestOrigin},
 		}},

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -83,6 +83,7 @@ func stepSeamWall() []spatial.Boundary { return squareSeamWall(5, 6, int(stepDoo
 // stepField is the shared set, optionally with a decider driving the goblin.
 func stepField() encounter.FieldInput {
 	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 		Rooms: []encounter.RoomInput{
 			{ID: stepWest, Width: 6, Height: 6, Origin: stepWestOrigin,
 				Boundaries: stepSeamWall()},
@@ -513,7 +514,7 @@ func (s *StepSuite) TestGridReportsTheFieldsFamily() {
 func (s *StepSuite) TestGridReportsAHexFieldAsHex() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()}, Rooms: []encounter.RoomInput{
 			{ID: stepWest, Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 				Origin: stepWestOrigin},
 		}},

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -58,7 +58,7 @@ func TestTombWatch(t *testing.T) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
 				Occluders: wallRow(6, 5, 7),
@@ -270,7 +270,7 @@ func TestTombWatch(t *testing.T) {
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
 				Occluders: wallRow(6, 5, 7),

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -58,6 +58,7 @@ func TestTombWatch(t *testing.T) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
 				Occluders: wallRow(6, 5, 7),
@@ -269,6 +270,7 @@ func TestTombWatch(t *testing.T) {
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsRock()},
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
 				Occluders: wallRow(6, 5, 7),

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -228,9 +228,10 @@ type canvasRoom struct {
 // whether it belongs in tools/spatial — and this is one derived bit, computed
 // from numbers already in hand, never stored and never persisted. The measured
 // case for it: on a twenty-chamber field whose rooms tile their canvas exactly,
-// a sight refresh under rock cost 109 ms against open's 26 ms, all of it spent
-// proving there was no void to find. With this it is open's number, because
-// there is nothing to look for.
+// deleting this check costs a sight refresh 121 ms against open's 30 ms — 4.0x,
+// and 46.7 MB of allocation against 24.2 MB — every byte of it spent proving
+// there was no void to find. With it, parity. Re-runnable: see
+// voidcost_internal_test.go.
 func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 	var floor int64
 	for _, r := range rooms {
@@ -285,13 +286,15 @@ func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 // because the shape of the cost is not the shape it looks like. Scanning the
 // ray is arithmetic, and the spatial call it can skip rasterizes, walks
 // boundaries, walks blocking entities and then walks a lean lane per neighbour.
-// So finding rock EARLY returns before any of that: on a twenty-chamber field
-// with gaps, a refresh cost 17 ms under rock against 28 ms under open, and the
-// reference tomb's shape 46 us against 77 us. The price is paid by rays that
-// never leave the floor, which run the scan in full and then delegate anyway:
-// one forty-by-forty chamber with a void margin and forty members measured
-// 3.7 ms against 2.7 ms. That is the honest worst case, and it is the one to
-// beat if a caller ever forces the floor mask.
+// So finding rock EARLY returns before any of that: a twenty-chamber field with
+// gaps refreshed sight 1.6-1.7x FASTER under rock than under open, and the
+// reference tomb's shape 1.4-1.6x faster. The price is paid by rays that never
+// leave the floor, which run the scan in full and then delegate anyway: one
+// forty-by-forty chamber with a void margin and forty members measured 1.34x
+// SLOWER. That is the honest worst case, and it is the one to beat if a caller
+// ever forces the floor mask. Ratios rather than times because the times move
+// with the machine and the ratios did not; both are in
+// voidcost_internal_test.go, which is where they are re-runnable.
 func (c *canvasRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
 	if c.hasVoid && c.void.blocksSight() {
 		for _, cell := range spatial.CanonicalBoundaryRay(c.GetGrid(), from, to) {

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -38,10 +38,25 @@ import (
 // the material would have been this file holding a fact about a world — the
 // same overreach as deciding the default in the first place, one layer up.
 //
-// So the cases are [VoidOpaque] and [VoidClear], for what a sightline does when
-// it crosses. The fiction stays in these comments, where it is an ILLUSTRATION
-// of a mechanic rather than a definition of one, and in the content that
-// authors the field.
+// So the cases are [VoidOpaque] and [VoidTransparent], for what a sightline does
+// when it crosses. The fiction stays in these comments, where it is an
+// ILLUSTRATION of a mechanic rather than a definition of one, and in the content
+// that authors the field.
+//
+// He corrected the second name too, and the correction is worth keeping because
+// it is a finer point than the first: the pair was briefly VoidOpaque and
+// VoidClear, and he said "transparant i think matches opaque better". Both words
+// name an effect, so the first rule was already satisfied — what was wrong was
+// that "clear" is colloquial where "opaque" is precise, and a sealed set whose
+// members are drawn from two registers reads as two separate decisions rather
+// than one axis with two ends. Opaque and transparent are the same word's two
+// directions.
+//
+// TWO NAME CORRECTIONS IN ONE REVIEW IS THE PATTERN, not an accident of taste.
+// A composition that may not hold fiction has to be read for fiction, and the
+// place it hides is in names that feel merely descriptive — which is why both
+// of these survived writing, testing and a full mutation battery before anybody
+// noticed them.
 
 // CanvasInput is what the field DECLARES about its own canvas — the world facts
 // no rule can derive and this module is not allowed to pick.
@@ -77,9 +92,9 @@ const (
 	// mechanic.
 	VoidOpaque VoidKind = "opaque"
 
-	// VoidClear does not: you can see straight across, and still not walk it.
+	// VoidTransparent does not: you can see straight across, and still not walk it.
 	// An open-air ruin, a ship's deck, a rooftop, the gap over a chasm.
-	VoidClear VoidKind = "clear"
+	VoidTransparent VoidKind = "transparent"
 )
 
 // Void is what the space between the authored chambers does to a sightline: a
@@ -89,7 +104,7 @@ const (
 //
 // "Can you see across the space between two rooms" is not a 5e rule this
 // composition could derive. It is a fact about THIS world — a tomb's void is
-// opaque, an open-air ruin's or a ship's deck is clear — and a fact about the
+// opaque, an open-air ruin's or a ship's deck is transparent — and a fact about
 // world arrives as construction data. There is no correct default, which is exactly
 // what rpg-toolkit#1033's capabilities-supplied-never-defaulted law is about:
 // a default here would be this module quietly deciding what a dungeon is made
@@ -130,8 +145,8 @@ const (
 //
 // A bool would answer today's question and could never be grown into the next
 // one. A chasm you can see across and FALL INTO is a third case, and it is not
-// [VoidClear] with a footnote — it is a different thing that happens to share
-// one of clear's two answers while differing on a third nobody has asked for
+// [VoidTransparent] with a footnote — it is a different thing that happens to share
+// one of transparent's two answers while differing on a third nobody has asked
 // yet. Sealing the set the way [DissolveCause] is
 // sealed makes that structural: the unexported method means a third case cannot
 // be declared outside this package, so adding one means editing this file, and
@@ -171,15 +186,15 @@ type voidOpaque struct{}
 func (voidOpaque) Kind() VoidKind    { return VoidOpaque }
 func (voidOpaque) blocksSight() bool { return true }
 
-// VoidIsClear declares that you can see straight across the space between the
+// VoidIsTransparent declares that you can see straight across the space between the
 // authored chambers, and still cannot walk it. An open-air ruin, a ship's deck,
 // a rooftop — somewhere the gap is a drop rather than a barrier.
-func VoidIsClear() Void { return voidClear{} }
+func VoidIsTransparent() Void { return voidTransparent{} }
 
-type voidClear struct{}
+type voidTransparent struct{}
 
-func (voidClear) Kind() VoidKind    { return VoidClear }
-func (voidClear) blocksSight() bool { return false }
+func (voidTransparent) Kind() VoidKind    { return VoidTransparent }
+func (voidTransparent) blocksSight() bool { return false }
 
 // voidFromData resolves the persisted word back to the declaration it names.
 //
@@ -194,8 +209,8 @@ func voidFromData(name string) (Void, error) {
 	switch VoidKind(name) {
 	case VoidOpaque:
 		return VoidIsOpaque(), nil
-	case VoidClear:
-		return VoidIsClear(), nil
+	case VoidTransparent:
+		return VoidIsTransparent(), nil
 	case "":
 		return nil, fmt.Errorf("field does not say what its void is (canvas.void): %w", ErrNoField)
 	default:
@@ -230,7 +245,7 @@ type canvasRoom struct {
 
 	// hasVoid is whether this field has any cell no chamber owns — see
 	// fieldHasVoid. Purely a cost decision: where there is no void, opaque and
-	// clear MEAN THE SAME THING, and the scan below can only ever run to the
+	// transparent MEAN THE SAME THING, and the scan below can only ever run to
 	// end of the ray and find nothing.
 	hasVoid bool
 }
@@ -250,7 +265,7 @@ type canvasRoom struct {
 // whether it belongs in tools/spatial — and this is one derived bit, computed
 // from numbers already in hand, never stored and never persisted. The measured
 // case for it: on a twenty-chamber field whose rooms tile their canvas exactly,
-// deleting this check costs a sight refresh 121 ms against clear's 30 ms — 4.0x,
+// deleting this check costs a sight refresh 121 ms against transparent's 30 ms —
 // and 46.7 MB of allocation against 24.2 MB — every byte of it spent proving
 // there was no void to find. With it, parity. Re-runnable: see
 // voidcost_internal_test.go.
@@ -296,9 +311,9 @@ func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 // until a caller forces it — this one does not, because the question already
 // has an implementation.
 //
-// Under [VoidClear] this is spatial's answer unchanged, which is the honest
+// Under [VoidTransparent] this is spatial's answer unchanged, which is the honest
 // shape of "the declaration decides": there is nothing to add to a sightline
-// crossing a clear gap. Under opaque on a field with NO void it is spatial's
+// crossing a transparent gap. Under opaque on a field with NO void it is spatial's
 // answer unchanged too, and for a better reason than speed: a field whose chambers
 // tile their canvas exactly has nothing for either declaration to be about, so
 // the two mean the same thing and cost the same (fieldHasVoid, pinned by
@@ -309,7 +324,7 @@ func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 // ray is arithmetic, and the spatial call it can skip rasterizes, walks
 // boundaries, walks blocking entities and then walks a lean lane per neighbour.
 // So finding void EARLY returns before any of that: a twenty-chamber field with
-// gaps refreshed sight 1.6-1.7x FASTER under opaque than under clear, and the
+// gaps refreshed sight 1.6-1.7x FASTER under opaque than under transparent, and
 // reference tomb's shape 1.4-1.6x faster. The price is paid by rays that never
 // leave the floor, which run the scan in full and then delegate anyway: one
 // forty-by-forty chamber with a void margin and forty members measured 1.34x

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -1,0 +1,256 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// void.go is THE CANVAS DECLARES WHAT VOID IS (rpg-toolkit#1116).
+//
+// The canvas spans the field's whole bounding BOX, and the authored chambers
+// are only the part of it somebody drew. Everything else — the gap between two
+// chambers, the strip beside a short one, the margin outside them all — is
+// void: on the map, and owned by nobody.
+//
+// Until this file, void was UNWALKABLE BUT TRANSPARENT. [Encounter.Step]
+// refused a cell no region owns while percept building checked only distance
+// and line of sight, so a sight ray crossed empty canvas as if it were open
+// air. That is neither rock nor sky. It is what fell out of nobody deciding,
+// and it decided something: two chambers with a gap between them saw each other
+// through solid nothing unless a complete wall-edge chain had been authored
+// along the seam.
+//
+// So the field says which it is, and Kirk ruled how (2026-08-19): "seems like
+// we have some very specific choices and these choices could be configured on
+// the canvas." Authored data, required, never defaulted.
+
+// CanvasInput is what the field DECLARES about its own canvas — the world facts
+// no rule can derive and this module is not allowed to pick.
+//
+// A struct with one field today, and a struct on purpose. "Is the space between
+// the chambers stone or sky" is the first of a species: facts that are true of
+// THIS dungeon, that arrive as construction data because there is nowhere else
+// they could come from. AMBIENT LIGHT IS THE NEXT ONE (rpg-toolkit#1113) —
+// "this dungeon is dark" is the same kind of sentence as "this dungeon is cut
+// out of rock", and it belongs beside it rather than in a second mechanism
+// invented for it. That is the slot this type exists to hold open.
+//
+// It is not a place for anything DERIVABLE. The canvas's dimensions, its grid
+// family, which cells are floor: all of those the authored rooms already say,
+// and a field that could state them twice would be a field that could state
+// them differently.
+type CanvasInput struct {
+	// Void is what the space between the authored chambers is made of.
+	// REQUIRED — see [Void] for why there is no default to fall back on.
+	Void Void
+}
+
+// VoidKind names what void is made of, in the form the story and the blob carry
+// it. See [Void].
+type VoidKind string
+
+const (
+	// VoidRock is stone: the chambers were cut out of a mountain, and what
+	// was not cut is still there.
+	VoidRock VoidKind = "rock"
+
+	// VoidOpen is sky: the chambers stand in the open, and what is not floor
+	// is the air above a courtyard, a deck, or a rooftop.
+	VoidOpen VoidKind = "open"
+)
+
+// Void is what the space between the authored chambers is made of: a closed
+// set, sealed the way [DissolveCause] is and for the same reason.
+//
+// # Why it is declared rather than decided here
+//
+// "Is the space between two rooms stone or sky" is not a 5e rule this
+// composition could derive. It is a fact about THIS world — a tomb's void is
+// rock, an open-air ruin's or a ship's deck is sky — and a fact about the world
+// arrives as construction data. There is no correct default, which is exactly
+// what rpg-toolkit#1033's capabilities-supplied-never-defaulted law is about:
+// a default here would be this module quietly deciding what a dungeon is made
+// of, in a field the author never wrote. So [CanvasInput.Void] is required, and
+// a field without one is refused at construction (ErrNoField) rather than
+// silently given the answer that happened to be cheapest.
+//
+// # What each answer does, and what neither does
+//
+// Both are UNWALKABLE, and that half does not vary: void is not floor under any
+// declaration, because floor is what the authored chambers own. A member cannot
+// step into the gap in an open-air ruin any more than into the rock of a tomb —
+// [Encounter.Step] and [Encounter.Join] refuse a cell no region owns, and this
+// declaration does not touch that. What varies is what SIGHT does with it:
+// [VoidRock] stops a sightline, [VoidOpen] does not.
+//
+// Rock stops it EXACTLY AS A WALL DOES, which is the point rather than an
+// implementation note: a boundary edge is a hard block on the direct canonical
+// ray (tools/spatial's IsLineOfSightBlocked checks boundaries on that ray alone,
+// deliberately, and lets occluding ENTITIES be leaned around). Rock void is
+// checked on the same ray, by the same rule, so "the rock face at the edge of
+// the room" and "a wall somebody drew there" cannot answer differently. That is
+// Kirk's ruling on rpg-toolkit#1105 fork 2 — walls are boundary edges — kept
+// true for the walls nobody had to draw.
+//
+// # What it does NOT change
+//
+// Occluders and boundaries inside a chamber are untouched: still authored,
+// still carrying BlocksMovement and BlocksLineOfSight independently, so "rock I
+// placed" and "a low altar you can see over" both stay expressible. Kirk's
+// point on the ruling was that both should be deliberate — "if I wanted rock, I
+// could place it and set it to block LoS. I could put an obstacle that does
+// not. I can have both but should be deliberate" — and what this slice changes
+// is that the DEFAULT is deliberate too.
+//
+// # Why a sealed set rather than a bool
+//
+// A bool would answer today's question and could never be grown into the next
+// one. A chasm you can see across and fall into is a third case, and it is not
+// "transparent" with a footnote — it is a different thing that happens to share
+// one of transparency's answers. Sealing the set the way [DissolveCause] is
+// sealed makes that structural: the unexported method means a third case cannot
+// be declared outside this package, so adding one means editing this file, and
+// editing this file means having the caller that forces it in hand. It also
+// makes the zero value USELESS rather than plausible — a nil Void is obviously
+// absent, where a false bool is a legal-looking answer nobody wrote.
+//
+// The set is deliberately not asked whether void is WALKABLE. Both cases answer
+// the same way today, so a predicate for it would be a branch no field could
+// take and no test could pin — it lands with the case that needs it.
+type Void interface {
+	// Kind names which void this is: the word the blob carries, and the word
+	// an error quotes back.
+	Kind() VoidKind
+
+	// blocksSight reports whether a sightline crossing void is stopped by it.
+	//
+	// Unexported, which SEALS the set — see the type's godoc. It is the only
+	// question this module asks a Void, so the sealing method is a real one
+	// rather than a marker: a third case cannot be added without answering
+	// it.
+	blocksSight() bool
+}
+
+// VoidIsRock declares that the space between the authored chambers is stone:
+// opaque, and not floor. The reference tomb's answer, and every dungeon cut out
+// of a mountain.
+//
+// A function rather than a package-level variable so nothing can reassign what
+// it means at runtime — [ByDecision]'s reasoning, and the save gate's before
+// it.
+func VoidIsRock() Void { return voidRock{} }
+
+type voidRock struct{}
+
+func (voidRock) Kind() VoidKind    { return VoidRock }
+func (voidRock) blocksSight() bool { return true }
+
+// VoidIsOpen declares that the space between the authored chambers is sky:
+// transparent, and still not floor. An open-air ruin, a ship's deck, a rooftop —
+// somewhere you can see clear across the gap and still cannot walk out over it.
+func VoidIsOpen() Void { return voidOpen{} }
+
+type voidOpen struct{}
+
+func (voidOpen) Kind() VoidKind    { return VoidOpen }
+func (voidOpen) blocksSight() bool { return false }
+
+// voidFromData resolves the persisted word back to the declaration it names.
+//
+// Two refusals, both by name and both loud, per the standing precedent
+// (rpg-toolkit#1053/#1068: fail loudly, no migration). An ABSENT word is a blob
+// written before the field declared anything, and loading it under a guess
+// would put a party in a dungeon whose walls the host never authored. An
+// UNKNOWN word is a blob from a dialect this build does not speak — a kind
+// somebody added and this binary has never heard of — and the honest answer to
+// that is not to pick the nearest one.
+func voidFromData(name string) (Void, error) {
+	switch VoidKind(name) {
+	case VoidRock:
+		return VoidIsRock(), nil
+	case VoidOpen:
+		return VoidIsOpen(), nil
+	case "":
+		return nil, fmt.Errorf("field does not say what its void is (canvas.void): %w", ErrNoField)
+	default:
+		return nil, fmt.Errorf("field declares void %q, which this build does not know (canvas.void): %w", name, ErrNoField)
+	}
+}
+
+// canvasRoom is the canvas, plus what the field declared its void to be.
+//
+// The declaration lives ON THE MAP rather than in the sight loop, and that is
+// the load-bearing choice in this slice. rpg-toolkit#1118 hands the canvas out
+// to be READ — a rule installed on it asks it about line of sight directly — so
+// a void rule that lived in [Encounter.rebuildPercepts] would tell that caller
+// nothing stands between two cells while this module refuses to let them see
+// each other. Two answers to one question is the defect #1118 exists to end,
+// and it would have been reintroduced one layer down. Pinned by
+// TestTheHandedOutCanvasAnswersTheSameWay.
+//
+// It EMBEDS the room rather than reimplementing it: every other read, every
+// mutator, and the grid itself are spatial's, unchanged. One method is
+// overridden, and it is the one the declaration is about.
+type canvasRoom struct {
+	*spatial.BasicRoom
+
+	void Void
+
+	// rooms and grids are the SAME slices and maps the encounter holds, so
+	// asking this room what is floor and asking [Encounter.RegionAt] are one
+	// question — see IsLineOfSightBlocked.
+	rooms []RoomInput
+	grids map[string]spatial.Grid
+}
+
+// IsLineOfSightBlocked reports whether sight between two cells is blocked,
+// counting rock void as the wall it is.
+//
+// THE ROCK IS CHECKED FIRST AND CHECKED HARD. tools/spatial's own rule treats a
+// boundary edge as an unconditional block on the direct canonical ray while
+// letting an occluding ENTITY be leaned around, because a boundary is a wall
+// drawn on an edge with no extent to lean past. A rock face is that same thing,
+// so it is asked the same way: [spatial.CanonicalBoundaryRay] — the very
+// rasterization spatial checks boundaries along, not a second one — and any
+// cell on it that no region owns stops the line. Sharing the ray is what makes
+// "the rock at the edge of the chamber" and "a wall somebody drew there"
+// evaluate over identical cells rather than merely similar ones.
+//
+// That is a guarantee about the CODE, and no fixture found here can stand in
+// for it — stated because it was measured rather than assumed. Over eight void
+// layouts (a gap column, offset and ragged rooms, an L, a checkerboard, a
+// staircase, comb teeth, and a hex pair; 340 floor cells) the raw
+// GetLineOfSight visits a DIFFERENT SET of cells depending on which end it is
+// asked from in roughly a quarter of ordered pairs — Bresenham's known
+// direction dependence, alive on square grids and absent on hex — and yet the
+// "does this ray cross void" answer came out the same both ways for every
+// single pair. So swapping the canonical ray for the raw one is a mutant no
+// test in this package kills. It is still wrong: the canonicalization is what
+// keeps this rule pinned to the boundary rule as spatial's rasterization
+// changes, rather than pinned to it by coincidence today.
+//
+// Floor is asked through [regionAt], the one function in this package that
+// turns an absolute cell into an owner. Not a copy of the rule and not a mask
+// beside it: a second answer to "is this floor" is exactly what region.go
+// exists to prevent, and rpg-toolkit#1105's ruling (4) deferred the floor mask
+// until a caller forces it — this one does not, because the question already
+// has an implementation.
+//
+// Under [VoidOpen] this is spatial's answer unchanged, which is the honest
+// shape of "the declaration decides": there is nothing to add to a sightline
+// crossing open sky.
+func (c *canvasRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
+	if c.void.blocksSight() {
+		for _, cell := range spatial.CanonicalBoundaryRay(c.GetGrid(), from, to) {
+			if _, floor := regionAt(c.rooms, c.grids, cell); !floor {
+				return true
+			}
+		}
+	}
+
+	return c.BasicRoom.IsLineOfSightBlocked(from, to)
+}

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -18,60 +18,79 @@ import (
 //
 // Until this file, void was UNWALKABLE BUT TRANSPARENT. [Encounter.Step]
 // refused a cell no region owns while percept building checked only distance
-// and line of sight, so a sight ray crossed empty canvas as if it were open
-// air. That is neither rock nor sky. It is what fell out of nobody deciding,
-// and it decided something: two chambers with a gap between them saw each other
-// through solid nothing unless a complete wall-edge chain had been authored
-// along the seam.
+// and line of sight, so a sight ray crossed empty canvas freely. That is not a
+// decision anybody made; it is what fell out of nobody making one, and it
+// decided something anyway: two chambers with a gap between them saw each other
+// through the gap unless a complete wall-edge chain had been authored along the
+// seam.
 //
 // So the field says which it is, and Kirk ruled how (2026-08-19): "seems like
 // we have some very specific choices and these choices could be configured on
 // the canvas." Authored data, required, never defaulted.
+//
+// # The names say what void DOES, not what it is made of
+//
+// Kirk again, reviewing this file: "the isrock is very specific do we need to
+// call it rock. isBlockedLOS or maybe isblocked." He is right, and the reason
+// is the rule this whole composition runs on. Stone, a ship's hull, the air
+// over a chasm, the vacuum outside a skyship: those are four fictions and ONE
+// mechanic, and the mechanic is all this module can know. Naming the case for
+// the material would have been this file holding a fact about a world — the
+// same overreach as deciding the default in the first place, one layer up.
+//
+// So the cases are [VoidOpaque] and [VoidClear], for what a sightline does when
+// it crosses. The fiction stays in these comments, where it is an ILLUSTRATION
+// of a mechanic rather than a definition of one, and in the content that
+// authors the field.
 
 // CanvasInput is what the field DECLARES about its own canvas — the world facts
 // no rule can derive and this module is not allowed to pick.
 //
-// A struct with one field today, and a struct on purpose. "Is the space between
-// the chambers stone or sky" is the first of a species: facts that are true of
-// THIS dungeon, that arrive as construction data because there is nowhere else
-// they could come from. AMBIENT LIGHT IS THE NEXT ONE (rpg-toolkit#1113) —
-// "this dungeon is dark" is the same kind of sentence as "this dungeon is cut
-// out of rock", and it belongs beside it rather than in a second mechanism
-// invented for it. That is the slot this type exists to hold open.
+// A struct with one field today, and a struct on purpose. "Can you see across
+// the space between the chambers" is the first of a species: facts that are
+// true of THIS dungeon, that arrive as construction data because there is
+// nowhere else they could come from. AMBIENT LIGHT IS THE NEXT ONE
+// (rpg-toolkit#1113) — "this dungeon is dark" is the same kind of sentence, and
+// it belongs beside this one rather than in a second mechanism invented for it.
+// That is the slot this type exists to hold open.
 //
 // It is not a place for anything DERIVABLE. The canvas's dimensions, its grid
 // family, which cells are floor: all of those the authored rooms already say,
 // and a field that could state them twice would be a field that could state
 // them differently.
 type CanvasInput struct {
-	// Void is what the space between the authored chambers is made of.
-	// REQUIRED — see [Void] for why there is no default to fall back on.
+	// Void is what the space between the authored chambers does to a
+	// sightline. REQUIRED — see [Void] for why there is no default to fall
+	// back on.
 	Void Void
 }
 
-// VoidKind names what void is made of, in the form the story and the blob carry
-// it. See [Void].
+// VoidKind names what void does to a sightline, in the form the story and the
+// blob carry it. See [Void].
 type VoidKind string
 
 const (
-	// VoidRock is stone: the chambers were cut out of a mountain, and what
-	// was not cut is still there.
-	VoidRock VoidKind = "rock"
+	// VoidOpaque stops a sightline: you cannot see across the space between
+	// the chambers. Stone is the obvious fiction for it — a tomb cut from a
+	// mountain, with what was not cut still there — but a hull, a curtain
+	// wall, or a bank of fog are the same mechanic, and this module knows the
+	// mechanic.
+	VoidOpaque VoidKind = "opaque"
 
-	// VoidOpen is sky: the chambers stand in the open, and what is not floor
-	// is the air above a courtyard, a deck, or a rooftop.
-	VoidOpen VoidKind = "open"
+	// VoidClear does not: you can see straight across, and still not walk it.
+	// An open-air ruin, a ship's deck, a rooftop, the gap over a chasm.
+	VoidClear VoidKind = "clear"
 )
 
-// Void is what the space between the authored chambers is made of: a closed
-// set, sealed the way [DissolveCause] is and for the same reason.
+// Void is what the space between the authored chambers does to a sightline: a
+// closed set, sealed the way [DissolveCause] is and for the same reason.
 //
 // # Why it is declared rather than decided here
 //
-// "Is the space between two rooms stone or sky" is not a 5e rule this
+// "Can you see across the space between two rooms" is not a 5e rule this
 // composition could derive. It is a fact about THIS world — a tomb's void is
-// rock, an open-air ruin's or a ship's deck is sky — and a fact about the world
-// arrives as construction data. There is no correct default, which is exactly
+// opaque, an open-air ruin's or a ship's deck is clear — and a fact about the
+// world arrives as construction data. There is no correct default, which is exactly
 // what rpg-toolkit#1033's capabilities-supplied-never-defaulted law is about:
 // a default here would be this module quietly deciding what a dungeon is made
 // of, in a field the author never wrote. So [CanvasInput.Void] is required, and
@@ -82,36 +101,38 @@ const (
 //
 // Both are UNWALKABLE, and that half does not vary: void is not floor under any
 // declaration, because floor is what the authored chambers own. A member cannot
-// step into the gap in an open-air ruin any more than into the rock of a tomb —
+// step into the gap in an open-air ruin any more than into the stone of a tomb —
 // [Encounter.Step] and [Encounter.Join] refuse a cell no region owns, and this
-// declaration does not touch that. What varies is what SIGHT does with it:
-// [VoidRock] stops a sightline, [VoidOpen] does not.
+// declaration does not touch that. SIGHT is the only thing the declaration
+// decides, which is why the cases are named for it.
 //
-// Rock stops it EXACTLY AS A WALL DOES, which is the point rather than an
-// implementation note: a boundary edge is a hard block on the direct canonical
-// ray (tools/spatial's IsLineOfSightBlocked checks boundaries on that ray alone,
-// deliberately, and lets occluding ENTITIES be leaned around). Rock void is
-// checked on the same ray, by the same rule, so "the rock face at the edge of
-// the room" and "a wall somebody drew there" cannot answer differently. That is
+// OPAQUE STOPS A SIGHTLINE EXACTLY AS A WALL DOES, which is the point rather
+// than an implementation note: a boundary edge is a hard block on the direct
+// canonical ray (tools/spatial's IsLineOfSightBlocked checks boundaries on that
+// ray alone, deliberately, and lets occluding ENTITIES be leaned around).
+// Opaque void is checked on the same ray, by the same rule, so the edge of the
+// floor and a wall somebody drew along it cannot answer differently. That is
 // Kirk's ruling on rpg-toolkit#1105 fork 2 — walls are boundary edges — kept
 // true for the walls nobody had to draw.
 //
 // # What it does NOT change
 //
 // Occluders and boundaries inside a chamber are untouched: still authored,
-// still carrying BlocksMovement and BlocksLineOfSight independently, so "rock I
-// placed" and "a low altar you can see over" both stay expressible. Kirk's
-// point on the ruling was that both should be deliberate — "if I wanted rock, I
-// could place it and set it to block LoS. I could put an obstacle that does
-// not. I can have both but should be deliberate" — and what this slice changes
-// is that the DEFAULT is deliberate too.
+// still carrying BlocksMovement and BlocksLineOfSight independently, so a
+// blocker somebody placed and a low altar you can see over both stay
+// expressible. Kirk's point on the ruling was that both should be deliberate —
+// in his words, "if I wanted rock, I could place it and set it to block LoS. I
+// could put an obstacle that does not. I can have both but should be
+// deliberate" — and what this slice changes is that the DEFAULT is deliberate
+// too.
 //
 // # Why a sealed set rather than a bool
 //
 // A bool would answer today's question and could never be grown into the next
-// one. A chasm you can see across and fall into is a third case, and it is not
-// "transparent" with a footnote — it is a different thing that happens to share
-// one of transparency's answers. Sealing the set the way [DissolveCause] is
+// one. A chasm you can see across and FALL INTO is a third case, and it is not
+// [VoidClear] with a footnote — it is a different thing that happens to share
+// one of clear's two answers while differing on a third nobody has asked for
+// yet. Sealing the set the way [DissolveCause] is
 // sealed makes that structural: the unexported method means a third case cannot
 // be declared outside this package, so adding one means editing this file, and
 // editing this file means having the caller that forces it in hand. It also
@@ -135,29 +156,30 @@ type Void interface {
 	blocksSight() bool
 }
 
-// VoidIsRock declares that the space between the authored chambers is stone:
-// opaque, and not floor. The reference tomb's answer, and every dungeon cut out
-// of a mountain.
+// VoidIsOpaque declares that you cannot see across the space between the
+// authored chambers, and cannot walk it either. The reference tomb's answer,
+// where the fiction is the stone the chambers were cut from — and equally a
+// hull, a curtain wall, or a fog bank, which is why the name is the effect.
 //
 // A function rather than a package-level variable so nothing can reassign what
 // it means at runtime — [ByDecision]'s reasoning, and the save gate's before
 // it.
-func VoidIsRock() Void { return voidRock{} }
+func VoidIsOpaque() Void { return voidOpaque{} }
 
-type voidRock struct{}
+type voidOpaque struct{}
 
-func (voidRock) Kind() VoidKind    { return VoidRock }
-func (voidRock) blocksSight() bool { return true }
+func (voidOpaque) Kind() VoidKind    { return VoidOpaque }
+func (voidOpaque) blocksSight() bool { return true }
 
-// VoidIsOpen declares that the space between the authored chambers is sky:
-// transparent, and still not floor. An open-air ruin, a ship's deck, a rooftop —
-// somewhere you can see clear across the gap and still cannot walk out over it.
-func VoidIsOpen() Void { return voidOpen{} }
+// VoidIsClear declares that you can see straight across the space between the
+// authored chambers, and still cannot walk it. An open-air ruin, a ship's deck,
+// a rooftop — somewhere the gap is a drop rather than a barrier.
+func VoidIsClear() Void { return voidClear{} }
 
-type voidOpen struct{}
+type voidClear struct{}
 
-func (voidOpen) Kind() VoidKind    { return VoidOpen }
-func (voidOpen) blocksSight() bool { return false }
+func (voidClear) Kind() VoidKind    { return VoidClear }
+func (voidClear) blocksSight() bool { return false }
 
 // voidFromData resolves the persisted word back to the declaration it names.
 //
@@ -170,10 +192,10 @@ func (voidOpen) blocksSight() bool { return false }
 // that is not to pick the nearest one.
 func voidFromData(name string) (Void, error) {
 	switch VoidKind(name) {
-	case VoidRock:
-		return VoidIsRock(), nil
-	case VoidOpen:
-		return VoidIsOpen(), nil
+	case VoidOpaque:
+		return VoidIsOpaque(), nil
+	case VoidClear:
+		return VoidIsClear(), nil
 	case "":
 		return nil, fmt.Errorf("field does not say what its void is (canvas.void): %w", ErrNoField)
 	default:
@@ -207,8 +229,8 @@ type canvasRoom struct {
 	grids map[string]spatial.Grid
 
 	// hasVoid is whether this field has any cell no chamber owns — see
-	// fieldHasVoid. Purely a cost decision: where there is no void, rock and
-	// open MEAN THE SAME THING, and the scan below can only ever run to the
+	// fieldHasVoid. Purely a cost decision: where there is no void, opaque and
+	// clear MEAN THE SAME THING, and the scan below can only ever run to the
 	// end of the ray and find nothing.
 	hasVoid bool
 }
@@ -228,7 +250,7 @@ type canvasRoom struct {
 // whether it belongs in tools/spatial — and this is one derived bit, computed
 // from numbers already in hand, never stored and never persisted. The measured
 // case for it: on a twenty-chamber field whose rooms tile their canvas exactly,
-// deleting this check costs a sight refresh 121 ms against open's 30 ms — 4.0x,
+// deleting this check costs a sight refresh 121 ms against clear's 30 ms — 4.0x,
 // and 46.7 MB of allocation against 24.2 MB — every byte of it spent proving
 // there was no void to find. With it, parity. Re-runnable: see
 // voidcost_internal_test.go.
@@ -242,17 +264,17 @@ func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 }
 
 // IsLineOfSightBlocked reports whether sight between two cells is blocked,
-// counting rock void as the wall it is.
+// counting opaque void as the wall it is.
 //
-// THE ROCK IS CHECKED FIRST AND CHECKED HARD. tools/spatial's own rule treats a
+// THE VOID IS CHECKED FIRST AND CHECKED HARD. tools/spatial's own rule treats a
 // boundary edge as an unconditional block on the direct canonical ray while
 // letting an occluding ENTITY be leaned around, because a boundary is a wall
-// drawn on an edge with no extent to lean past. A rock face is that same thing,
+// drawn on an edge with no extent to lean past. Opaque void is that same thing,
 // so it is asked the same way: [spatial.CanonicalBoundaryRay] — the very
 // rasterization spatial checks boundaries along, not a second one — and any
 // cell on it that no region owns stops the line. Sharing the ray is what makes
-// "the rock at the edge of the chamber" and "a wall somebody drew there"
-// evaluate over identical cells rather than merely similar ones.
+// the edge of the floor and a wall somebody drew along it evaluate over
+// identical cells rather than merely similar ones.
 //
 // That is a guarantee about the CODE, and no fixture found here can stand in
 // for it — stated because it was measured rather than assumed. Over eight void
@@ -274,20 +296,20 @@ func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 // until a caller forces it — this one does not, because the question already
 // has an implementation.
 //
-// Under [VoidOpen] this is spatial's answer unchanged, which is the honest
+// Under [VoidClear] this is spatial's answer unchanged, which is the honest
 // shape of "the declaration decides": there is nothing to add to a sightline
-// crossing open sky. Under rock on a field with NO void it is spatial's answer
-// unchanged too, and for a better reason than speed: a field whose chambers
+// crossing a clear gap. Under opaque on a field with NO void it is spatial's
+// answer unchanged too, and for a better reason than speed: a field whose chambers
 // tile their canvas exactly has nothing for either declaration to be about, so
 // the two mean the same thing and cost the same (fieldHasVoid, pinned by
-// TestRockCostsNothingWhereThereIsNoVoid).
+// TestOpaqueCostsNothingWhereThereIsNoVoid).
 //
 // WHERE THERE IS VOID, THIS IS USUALLY CHEAPER THAN NOT DOING IT — measured,
 // because the shape of the cost is not the shape it looks like. Scanning the
 // ray is arithmetic, and the spatial call it can skip rasterizes, walks
 // boundaries, walks blocking entities and then walks a lean lane per neighbour.
-// So finding rock EARLY returns before any of that: a twenty-chamber field with
-// gaps refreshed sight 1.6-1.7x FASTER under rock than under open, and the
+// So finding void EARLY returns before any of that: a twenty-chamber field with
+// gaps refreshed sight 1.6-1.7x FASTER under opaque than under clear, and the
 // reference tomb's shape 1.4-1.6x faster. The price is paid by rays that never
 // leave the floor, which run the scan in full and then delegate anyway: one
 // forty-by-forty chamber with a void margin and forty members measured 1.34x

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -205,6 +205,39 @@ type canvasRoom struct {
 	// question — see IsLineOfSightBlocked.
 	rooms []RoomInput
 	grids map[string]spatial.Grid
+
+	// hasVoid is whether this field has any cell no chamber owns — see
+	// fieldHasVoid. Purely a cost decision: where there is no void, rock and
+	// open MEAN THE SAME THING, and the scan below can only ever run to the
+	// end of the ray and find nothing.
+	hasVoid bool
+}
+
+// fieldHasVoid reports whether any cell of the canvas belongs to no chamber.
+//
+// ARITHMETIC, NOT ENUMERATION, and that distinction is the whole reason this is
+// allowed to exist. W2 makes the chambers disjoint and W6 makes them fit, so
+// the union of their footprints has exactly the cell count their sum does, and
+// the canvas is void-free precisely when that sum fills it. Both grid families
+// count the same way: an AxialHexGrid of Width x Height holds Width*Height
+// integer (Q,R) pairs, exactly as a square grid holds Width*Height cells.
+//
+// THIS IS NOT THE FLOOR MASK, which Kirk's ruling (4) on rpg-toolkit#1105
+// deferred until a caller forces one. A mask is a per-cell structure with two
+// unanswered questions riding on it — computed per load or persisted, and
+// whether it belongs in tools/spatial — and this is one derived bit, computed
+// from numbers already in hand, never stored and never persisted. The measured
+// case for it: on a twenty-chamber field whose rooms tile their canvas exactly,
+// a sight refresh under rock cost 109 ms against open's 26 ms, all of it spent
+// proving there was no void to find. With this it is open's number, because
+// there is nothing to look for.
+func fieldHasVoid(rooms []RoomInput, width, height int) bool {
+	var floor int64
+	for _, r := range rooms {
+		floor += int64(r.Width) * int64(r.Height)
+	}
+
+	return int64(width)*int64(height) != floor
 }
 
 // IsLineOfSightBlocked reports whether sight between two cells is blocked,
@@ -242,9 +275,25 @@ type canvasRoom struct {
 //
 // Under [VoidOpen] this is spatial's answer unchanged, which is the honest
 // shape of "the declaration decides": there is nothing to add to a sightline
-// crossing open sky.
+// crossing open sky. Under rock on a field with NO void it is spatial's answer
+// unchanged too, and for a better reason than speed: a field whose chambers
+// tile their canvas exactly has nothing for either declaration to be about, so
+// the two mean the same thing and cost the same (fieldHasVoid, pinned by
+// TestRockCostsNothingWhereThereIsNoVoid).
+//
+// WHERE THERE IS VOID, THIS IS USUALLY CHEAPER THAN NOT DOING IT — measured,
+// because the shape of the cost is not the shape it looks like. Scanning the
+// ray is arithmetic, and the spatial call it can skip rasterizes, walks
+// boundaries, walks blocking entities and then walks a lean lane per neighbour.
+// So finding rock EARLY returns before any of that: on a twenty-chamber field
+// with gaps, a refresh cost 17 ms under rock against 28 ms under open, and the
+// reference tomb's shape 46 us against 77 us. The price is paid by rays that
+// never leave the floor, which run the scan in full and then delegate anyway:
+// one forty-by-forty chamber with a void margin and forty members measured
+// 3.7 ms against 2.7 ms. That is the honest worst case, and it is the one to
+// beat if a caller ever forces the floor mask.
 func (c *canvasRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
-	if c.void.blocksSight() {
+	if c.hasVoid && c.void.blocksSight() {
 		for _, cell := range spatial.CanonicalBoundaryRay(c.GetGrid(), from, to) {
 			if _, floor := regionAt(c.rooms, c.grids, cell); !floor {
 				return true

--- a/rulebooks/dnd5e/encounter/void_test.go
+++ b/rulebooks/dnd5e/encounter/void_test.go
@@ -1,0 +1,363 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// void_test.go is WHAT THE SPACE BETWEEN THE CHAMBERS IS MADE OF
+// (rpg-toolkit#1116).
+//
+// The canvas spans the field's whole bounding box, so a field of two chambers
+// with a gap between them has cells no chamber owns. Until this slice those
+// cells were unwalkable but TRANSPARENT — Step refused them and a sight ray
+// sailed straight through — which is neither rock nor sky, but what fell out of
+// nobody deciding. Kirk ruled that the canvas DECLARES it, as authored data,
+// required and never defaulted: "seems like we have some very specific choices
+// and these choices could be configured on the canvas."
+//
+// The fixture is the smallest thing that can tell the two answers apart: two
+// four-by-four chambers with ONE COLUMN OF VOID between them, and a member on
+// each side of it standing on the same row. Two cells apart, in plain sight of
+// each other across a strip of nothing.
+//
+//	x: 0  1  2  3  |  4  |  5  6  7  8
+//	         west  | void|  east
+//	west's brenna at (3,1)      east's kade at (5,1)
+//
+// Nothing about the two declarations differs except the one word each field
+// says about that column.
+type VoidSuite struct {
+	suite.Suite
+}
+
+func TestVoidSuite(t *testing.T) {
+	suite.Run(t, new(VoidSuite))
+}
+
+const (
+	voidWest = "west"
+	voidEast = "east"
+
+	brenna = core.EntityID("brenna")
+	kade   = core.EntityID("kade")
+)
+
+var (
+	voidWestOrigin = spatial.Position{X: 0, Y: 0} // cells x 0..3
+	voidEastOrigin = spatial.Position{X: 5, Y: 0} // cells x 5..8, leaving column 4 void
+
+	brennaCell = spatial.Position{X: 3, Y: 1}
+	kadeCell   = spatial.Position{X: 5, Y: 1}
+	theGapCell = spatial.Position{X: 4, Y: 1}
+)
+
+// gappedField is two chambers with a column of void between them, declaring
+// what that column is made of.
+func gappedField(void encounter.Void) encounter.FieldInput {
+	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: void},
+		Rooms: []encounter.RoomInput{
+			{ID: voidWest, Width: 4, Height: 4, Origin: voidWestOrigin},
+			{ID: voidEast, Width: 4, Height: 4, Origin: voidEastOrigin},
+		},
+	}
+}
+
+// gapped opens the fixture with one member in each chamber, both players so
+// that nothing forms a fight and sight is the only thing under test.
+func (s *VoidSuite) gapped(void encounter.Void) *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: gappedField(void),
+		Members: []encounter.MemberInput{
+			{ID: brenna, Kind: encounter.KindPlayer, Room: voidWest,
+				Position: spatial.Position{X: 3, Y: 1}},
+			{ID: kade, Kind: encounter.KindPlayer, Room: voidEast,
+				Position: spatial.Position{X: 0, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc
+}
+
+// sees reports whether an observer holds anything at all on a subject.
+func (s *VoidSuite) sees(enc *encounter.Encounter, observer, subject core.EntityID) bool {
+	view, err := enc.View(&encounter.ViewInput{Member: observer})
+	s.Require().NoError(err)
+	for _, h := range view {
+		if h.Subject == intel.Subject(subject) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestRockVoidBlocksSightBetweenChambers is the slice, from the tomb's side.
+//
+// One column of rock stands between brenna and kade, and it is not a wall
+// anybody drew: it is the space the authored chambers left, which this field
+// declared is stone. Neither of them sees the other, and that is the same
+// answer a wall would give — because it IS the same answer. Rock is rock.
+func (s *VoidSuite) TestRockVoidBlocksSightBetweenChambers() {
+	enc := s.gapped(encounter.VoidIsRock())
+
+	s.False(s.sees(enc, brenna, kade), "a column of rock stands between them")
+	s.False(s.sees(enc, kade, brenna), "from either side — geometry is mutual")
+}
+
+// TestOpenVoidDoesNotBlockSightBetweenChambers is the same slice from the
+// ruined-courtyard side, and it is the half that shows the declaration is a
+// CHOICE rather than a new rule.
+//
+// Identical geometry, identical members, identical distance. The only thing
+// that changed is the word the field says about that column, and the answer
+// inverts.
+func (s *VoidSuite) TestOpenVoidDoesNotBlockSightBetweenChambers() {
+	enc := s.gapped(encounter.VoidIsOpen())
+
+	s.True(s.sees(enc, brenna, kade), "the gap is open sky; they are two cells apart in plain view")
+	s.True(s.sees(enc, kade, brenna), "from either side")
+}
+
+// TestOpenVoidIsStillNotFloor pins the half of the ruling that does NOT vary:
+// both declarations are unwalkable. Open means you can SEE across the gap, not
+// that you can walk out over it.
+func (s *VoidSuite) TestOpenVoidIsStillNotFloor() {
+	for _, tc := range []struct {
+		name string
+		void encounter.Void
+	}{
+		{"rock", encounter.VoidIsRock()},
+		{"open", encounter.VoidIsOpen()},
+	} {
+		s.Run(tc.name, func() {
+			enc := s.gapped(tc.void)
+			_, err := enc.Step(&encounter.StepInput{Member: brenna, To: theGapCell})
+			s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+			s.Contains(err.Error(), "not floor")
+		})
+	}
+}
+
+// TestRockVoidDoesNotBlockSightWithinAChamber is the false-positive guard.
+//
+// A rule that blocked every ray would pass the rock test above and be useless.
+// Two members in the SAME chamber, on a ray that never leaves its floor, see
+// each other under exactly the declaration that blinded the pair across the
+// gap.
+func (s *VoidSuite) TestRockVoidDoesNotBlockSightWithinAChamber() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: gappedField(encounter.VoidIsRock()),
+		Members: []encounter.MemberInput{
+			{ID: brenna, Kind: encounter.KindPlayer, Room: voidWest,
+				Position: spatial.Position{X: 0, Y: 0}},
+			{ID: kade, Kind: encounter.KindPlayer, Room: voidWest,
+				Position: spatial.Position{X: 3, Y: 3}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	s.True(s.sees(enc, brenna, kade), "corner to corner of one chamber, over its own floor")
+	s.True(s.sees(enc, kade, brenna))
+}
+
+// TestTheHandedOutCanvasAnswersTheSameWay is the dual-state guard, and it is
+// the reason this rule lives on the map rather than in the sight loop.
+//
+// rpg-toolkit#1118 hands the canvas out to be READ, so a rule installed on it
+// asks it about line of sight directly. If void opacity were a filter inside
+// rebuildPercepts, that caller would be told nothing stands between two cells
+// while this module refuses to let them see each other — which is exactly the
+// defect #1118 exists to end, reintroduced one layer down.
+func (s *VoidSuite) TestTheHandedOutCanvasAnswersTheSameWay() {
+	rock, err := s.gapped(encounter.VoidIsRock()).Canvas()
+	s.Require().NoError(err)
+	s.True(rock.IsLineOfSightBlocked(brennaCell, kadeCell), "the map itself says rock is in the way")
+
+	open, err := s.gapped(encounter.VoidIsOpen()).Canvas()
+	s.Require().NoError(err)
+	s.False(open.IsLineOfSightBlocked(brennaCell, kadeCell), "and that open sky is not")
+}
+
+// TestAFieldMustSayWhatItsVoidIs is the ruling's "required, never defaulted".
+//
+// There is no answer this module is allowed to pick. A tomb's void is rock and
+// an open-air ruin's is sky, and which one THIS world is made of is not a 5e
+// rule the composition could derive — it is a fact about the world, which makes
+// it construction data (rpg-toolkit#1033's law, applied to the map).
+func (s *VoidSuite) TestAFieldMustSayWhatItsVoidIs() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Rooms: []encounter.RoomInput{{ID: voidWest, Width: 4, Height: 4}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Contains(err.Error(), "Canvas.Void", "the refusal names the declaration that is missing")
+}
+
+// TestTheDeclarationSurvivesASave round-trips both answers.
+//
+// It is construction truth, so it persists with the rooms it is a fact about —
+// and a reloaded encounter that guessed instead would be a different dungeon
+// from the one that was saved.
+func (s *VoidSuite) TestTheDeclarationSurvivesASave() {
+	for _, tc := range []struct {
+		name    string
+		void    encounter.Void
+		kind    encounter.VoidKind
+		blocked bool
+	}{
+		{"rock", encounter.VoidIsRock(), encounter.VoidRock, true},
+		{"open", encounter.VoidIsOpen(), encounter.VoidOpen, false},
+	} {
+		s.Run(tc.name, func() {
+			data := s.gapped(tc.void).ToData()
+			s.Equal(string(tc.kind), data.Field.Canvas.Void, "the blob carries the word")
+
+			back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+				Data:  data,
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			})
+			s.Require().NoError(err)
+
+			canvas, err := back.Canvas()
+			s.Require().NoError(err)
+			s.Equal(tc.blocked, canvas.IsLineOfSightBlocked(brennaCell, kadeCell),
+				"the reloaded map is made of what the saved one was")
+		})
+	}
+}
+
+// TestAnOldBlobIsRefusedByName is the standing precedent (#1053/#1068): fail
+// loudly, no migration, no default.
+//
+// A blob written before this slice has no canvas declaration at all. Loading it
+// under a guess would put a party in a dungeon whose walls the host never
+// authored, so it is refused, and the refusal names what is missing.
+func (s *VoidSuite) TestAnOldBlobIsRefusedByName() {
+	data := s.gapped(encounter.VoidIsRock()).ToData()
+
+	raw, err := json.Marshal(data)
+	s.Require().NoError(err)
+
+	var blob map[string]any
+	s.Require().NoError(json.Unmarshal(raw, &blob))
+	field, _ := blob["field"].(map[string]any)
+	s.Require().NotNil(field)
+	delete(field, "canvas")
+
+	raw, err = json.Marshal(blob)
+	s.Require().NoError(err)
+
+	var old encounter.EncounterData
+	s.Require().NoError(json.Unmarshal(raw, &old))
+
+	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:  old,
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Contains(err.Error(), "canvas.void", "the refusal names the field the blob does not carry")
+	s.Contains(err.Error(), "does not say what its void is",
+		"and says the word is ABSENT — a blob that never declared is a different story from one "+
+			"declaring a word this build does not know, and the two must not read the same")
+}
+
+// TestAnUnknownVoidIsRefusedByName closes the other end of the wire: a word
+// this module does not know is not a third kind of void, it is a blob from a
+// dialect this build does not speak.
+func (s *VoidSuite) TestAnUnknownVoidIsRefusedByName() {
+	data := s.gapped(encounter.VoidIsRock()).ToData()
+	data.Field.Canvas.Void = "lava"
+
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:  data,
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Contains(err.Error(), "lava", "the refusal quotes the word it does not know")
+	s.Contains(err.Error(), "does not know", "and says it is UNKNOWN rather than absent")
+}
+
+// TestTheCanvasKeepsItsOwnCopyOfTheChambers is the alias guard this slice makes
+// necessary.
+//
+// The canvas now asks which cells are FLOOR, and the chambers are what answer.
+// Handed the caller's own slice it would answer out of a thing the caller can
+// still edit, while [Encounter.RegionAt] answered out of the deep copy Setup
+// takes — two answers to one question, diverging silently the moment somebody
+// reused their RoomInputs to build a second encounter.
+//
+// SHIFTING west one cell east is the way to see it, and the choice of field
+// matters: [regionAt] asks each room's constructed GRID whether a local cell is
+// in bounds, so Width and Height are spent at construction and editing them
+// afterwards changes nothing. ORIGIN is the one it still reads on every call —
+// measured, not assumed, by mutating this call site back to the caller's slice
+// and watching a Width-based version of this test go on passing. Shifted, west
+// claims the gap column, the column stops being void, and the rock stops
+// blocking.
+func (s *VoidSuite) TestTheCanvasKeepsItsOwnCopyOfTheChambers() {
+	field := gappedField(encounter.VoidIsRock())
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: field,
+		Members: []encounter.MemberInput{
+			{ID: brenna, Kind: encounter.KindPlayer, Room: voidWest,
+				Position: spatial.Position{X: 3, Y: 1}},
+			{ID: kade, Kind: encounter.KindPlayer, Room: voidEast,
+				Position: spatial.Position{X: 0, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	canvas, err := enc.Canvas()
+	s.Require().NoError(err)
+	s.Require().True(canvas.IsLineOfSightBlocked(brennaCell, kadeCell), "rock, before anybody touches anything")
+
+	field.Rooms[0].Origin = spatial.Position{X: 1, Y: 0} // west now covers x 1..4 — in the CALLER's slice
+
+	s.True(canvas.IsLineOfSightBlocked(brennaCell, kadeCell),
+		"the encounter's map is not the caller's to redraw after the fact")
+
+	_, floor := enc.RegionAt(theGapCell)
+	s.False(floor, "and RegionAt says the same thing the canvas does")
+}
+
+// TestNobodySeesOutOfSolidRock is the endpoint half of the rule, and the reason
+// the ray is walked from end to end rather than through its middle.
+//
+// A member is never on a void cell — [Encounter.Step] and [Encounter.Join]
+// refuse one — but the canvas rpg-toolkit#1118 hands out takes any two cells a
+// caller cares to name, and the honest answer for a cell inside the rock is
+// that nothing sees out of it. Under an open sky the same cell is just a place
+// nobody can stand, and the sightline across it is clear.
+func (s *VoidSuite) TestNobodySeesOutOfSolidRock() {
+	rock, err := s.gapped(encounter.VoidIsRock()).Canvas()
+	s.Require().NoError(err)
+	s.True(rock.IsLineOfSightBlocked(theGapCell, brennaCell), "the gap cell IS the rock")
+	s.True(rock.IsLineOfSightBlocked(brennaCell, theGapCell), "from either end")
+
+	open, err := s.gapped(encounter.VoidIsOpen()).Canvas()
+	s.Require().NoError(err)
+	s.False(open.IsLineOfSightBlocked(theGapCell, brennaCell), "open air is nothing to see through")
+	s.False(open.IsLineOfSightBlocked(brennaCell, theGapCell))
+}

--- a/rulebooks/dnd5e/encounter/void_test.go
+++ b/rulebooks/dnd5e/encounter/void_test.go
@@ -21,7 +21,7 @@ import (
 // The canvas spans the field's whole bounding box, so a field of two chambers
 // with a gap between them has cells no chamber owns. Until this slice those
 // cells were unwalkable but TRANSPARENT — Step refused them and a sight ray
-// sailed straight through — which is neither rock nor sky, but what fell out of
+// sailed straight through — which is not a decision anybody made, but what fell
 // nobody deciding. Kirk ruled that the canvas DECLARES it, as authored data,
 // required and never defaulted: "seems like we have some very specific choices
 // and these choices could be configured on the canvas."
@@ -106,43 +106,44 @@ func (s *VoidSuite) sees(enc *encounter.Encounter, observer, subject core.Entity
 	return false
 }
 
-// TestRockVoidBlocksSightBetweenChambers is the slice, from the tomb's side.
+// TestOpaqueVoidBlocksSightBetweenChambers is the slice, from the tomb's side.
 //
-// One column of rock stands between brenna and kade, and it is not a wall
+// One column of void stands between brenna and kade, and it is not a wall
 // anybody drew: it is the space the authored chambers left, which this field
-// declared is stone. Neither of them sees the other, and that is the same
-// answer a wall would give — because it IS the same answer. Rock is rock.
-func (s *VoidSuite) TestRockVoidBlocksSightBetweenChambers() {
-	enc := s.gapped(encounter.VoidIsRock())
+// declared you cannot see through. Neither of them sees the other, and that is
+// the same answer a wall would give — because it IS the same answer, checked on
+// the same ray by the same rule.
+func (s *VoidSuite) TestOpaqueVoidBlocksSightBetweenChambers() {
+	enc := s.gapped(encounter.VoidIsOpaque())
 
-	s.False(s.sees(enc, brenna, kade), "a column of rock stands between them")
+	s.False(s.sees(enc, brenna, kade), "a column of opaque void stands between them")
 	s.False(s.sees(enc, kade, brenna), "from either side — geometry is mutual")
 }
 
-// TestOpenVoidDoesNotBlockSightBetweenChambers is the same slice from the
+// TestClearVoidDoesNotBlockSightBetweenChambers is the same slice from the
 // ruined-courtyard side, and it is the half that shows the declaration is a
 // CHOICE rather than a new rule.
 //
 // Identical geometry, identical members, identical distance. The only thing
 // that changed is the word the field says about that column, and the answer
 // inverts.
-func (s *VoidSuite) TestOpenVoidDoesNotBlockSightBetweenChambers() {
-	enc := s.gapped(encounter.VoidIsOpen())
+func (s *VoidSuite) TestClearVoidDoesNotBlockSightBetweenChambers() {
+	enc := s.gapped(encounter.VoidIsClear())
 
-	s.True(s.sees(enc, brenna, kade), "the gap is open sky; they are two cells apart in plain view")
+	s.True(s.sees(enc, brenna, kade), "the gap is clear; they are two cells apart in plain view")
 	s.True(s.sees(enc, kade, brenna), "from either side")
 }
 
-// TestOpenVoidIsStillNotFloor pins the half of the ruling that does NOT vary:
+// TestClearVoidIsStillNotFloor pins the half of the ruling that does NOT vary:
 // both declarations are unwalkable. Open means you can SEE across the gap, not
 // that you can walk out over it.
-func (s *VoidSuite) TestOpenVoidIsStillNotFloor() {
+func (s *VoidSuite) TestClearVoidIsStillNotFloor() {
 	for _, tc := range []struct {
 		name string
 		void encounter.Void
 	}{
-		{"rock", encounter.VoidIsRock()},
-		{"open", encounter.VoidIsOpen()},
+		{"opaque", encounter.VoidIsOpaque()},
+		{"clear", encounter.VoidIsClear()},
 	} {
 		s.Run(tc.name, func() {
 			enc := s.gapped(tc.void)
@@ -153,16 +154,16 @@ func (s *VoidSuite) TestOpenVoidIsStillNotFloor() {
 	}
 }
 
-// TestRockVoidDoesNotBlockSightWithinAChamber is the false-positive guard.
+// TestOpaqueVoidDoesNotBlockSightWithinAChamber is the false-positive guard.
 //
-// A rule that blocked every ray would pass the rock test above and be useless.
+// A rule that blocked every ray would pass the opaque test above and be useless.
 // Two members in the SAME chamber, on a ray that never leaves its floor, see
 // each other under exactly the declaration that blinded the pair across the
 // gap.
-func (s *VoidSuite) TestRockVoidDoesNotBlockSightWithinAChamber() {
+func (s *VoidSuite) TestOpaqueVoidDoesNotBlockSightWithinAChamber() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: gappedField(encounter.VoidIsRock()),
+		Field: gappedField(encounter.VoidIsOpaque()),
 		Members: []encounter.MemberInput{
 			{ID: brenna, Kind: encounter.KindPlayer, Room: voidWest,
 				Position: spatial.Position{X: 0, Y: 0}},
@@ -186,19 +187,19 @@ func (s *VoidSuite) TestRockVoidDoesNotBlockSightWithinAChamber() {
 // while this module refuses to let them see each other — which is exactly the
 // defect #1118 exists to end, reintroduced one layer down.
 func (s *VoidSuite) TestTheHandedOutCanvasAnswersTheSameWay() {
-	rock, err := s.gapped(encounter.VoidIsRock()).Canvas()
+	opaque, err := s.gapped(encounter.VoidIsOpaque()).Canvas()
 	s.Require().NoError(err)
-	s.True(rock.IsLineOfSightBlocked(brennaCell, kadeCell), "the map itself says rock is in the way")
+	s.True(opaque.IsLineOfSightBlocked(brennaCell, kadeCell), "the map itself says something is in the way")
 
-	open, err := s.gapped(encounter.VoidIsOpen()).Canvas()
+	clear, err := s.gapped(encounter.VoidIsClear()).Canvas()
 	s.Require().NoError(err)
-	s.False(open.IsLineOfSightBlocked(brennaCell, kadeCell), "and that open sky is not")
+	s.False(clear.IsLineOfSightBlocked(brennaCell, kadeCell), "and that a clear gap is not")
 }
 
 // TestAFieldMustSayWhatItsVoidIs is the ruling's "required, never defaulted".
 //
-// There is no answer this module is allowed to pick. A tomb's void is rock and
-// an open-air ruin's is sky, and which one THIS world is made of is not a 5e
+// There is no answer this module is allowed to pick. A tomb's void is opaque
+// and an open-air ruin's is clear, and which one THIS world is is not a 5e
 // rule the composition could derive — it is a fact about the world, which makes
 // it construction data (rpg-toolkit#1033's law, applied to the map).
 func (s *VoidSuite) TestAFieldMustSayWhatItsVoidIs() {
@@ -225,8 +226,8 @@ func (s *VoidSuite) TestTheDeclarationSurvivesASave() {
 		kind    encounter.VoidKind
 		blocked bool
 	}{
-		{"rock", encounter.VoidIsRock(), encounter.VoidRock, true},
-		{"open", encounter.VoidIsOpen(), encounter.VoidOpen, false},
+		{"opaque", encounter.VoidIsOpaque(), encounter.VoidOpaque, true},
+		{"clear", encounter.VoidIsClear(), encounter.VoidClear, false},
 	} {
 		s.Run(tc.name, func() {
 			data := s.gapped(tc.void).ToData()
@@ -253,7 +254,7 @@ func (s *VoidSuite) TestTheDeclarationSurvivesASave() {
 // under a guess would put a party in a dungeon whose walls the host never
 // authored, so it is refused, and the refusal names what is missing.
 func (s *VoidSuite) TestAnOldBlobIsRefusedByName() {
-	data := s.gapped(encounter.VoidIsRock()).ToData()
+	data := s.gapped(encounter.VoidIsOpaque()).ToData()
 
 	raw, err := json.Marshal(data)
 	s.Require().NoError(err)
@@ -285,7 +286,7 @@ func (s *VoidSuite) TestAnOldBlobIsRefusedByName() {
 // this module does not know is not a third kind of void, it is a blob from a
 // dialect this build does not speak.
 func (s *VoidSuite) TestAnUnknownVoidIsRefusedByName() {
-	data := s.gapped(encounter.VoidIsRock()).ToData()
+	data := s.gapped(encounter.VoidIsOpaque()).ToData()
 	data.Field.Canvas.Void = "lava"
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
@@ -312,10 +313,9 @@ func (s *VoidSuite) TestAnUnknownVoidIsRefusedByName() {
 // afterwards changes nothing. ORIGIN is the one it still reads on every call —
 // measured, not assumed, by mutating this call site back to the caller's slice
 // and watching a Width-based version of this test go on passing. Shifted, west
-// claims the gap column, the column stops being void, and the rock stops
-// blocking.
+// claims the gap column, the column stops being void, and it stops blocking.
 func (s *VoidSuite) TestTheCanvasKeepsItsOwnCopyOfTheChambers() {
-	field := gappedField(encounter.VoidIsRock())
+	field := gappedField(encounter.VoidIsOpaque())
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: field,
@@ -331,7 +331,7 @@ func (s *VoidSuite) TestTheCanvasKeepsItsOwnCopyOfTheChambers() {
 
 	canvas, err := enc.Canvas()
 	s.Require().NoError(err)
-	s.Require().True(canvas.IsLineOfSightBlocked(brennaCell, kadeCell), "rock, before anybody touches anything")
+	s.Require().True(canvas.IsLineOfSightBlocked(brennaCell, kadeCell), "blocked, before anybody touches anything")
 
 	field.Rooms[0].Origin = spatial.Position{X: 1, Y: 0} // west now covers x 1..4 — in the CALLER's slice
 
@@ -342,24 +342,24 @@ func (s *VoidSuite) TestTheCanvasKeepsItsOwnCopyOfTheChambers() {
 	s.False(floor, "and RegionAt says the same thing the canvas does")
 }
 
-// TestNobodySeesOutOfSolidRock is the endpoint half of the rule, and the reason
+// TestNobodySeesOutOfOpaqueVoid is the endpoint half of the rule, and the reason
 // the ray is walked from end to end rather than through its middle.
 //
 // A member is never on a void cell — [Encounter.Step] and [Encounter.Join]
 // refuse one — but the canvas rpg-toolkit#1118 hands out takes any two cells a
-// caller cares to name, and the honest answer for a cell inside the rock is
-// that nothing sees out of it. Under an open sky the same cell is just a place
-// nobody can stand, and the sightline across it is clear.
-func (s *VoidSuite) TestNobodySeesOutOfSolidRock() {
-	rock, err := s.gapped(encounter.VoidIsRock()).Canvas()
+// caller cares to name, and the honest answer for a cell inside opaque void is
+// that nothing sees out of it. Under a clear declaration the same cell is just
+// a place nobody can stand, and the sightline across it is unobstructed.
+func (s *VoidSuite) TestNobodySeesOutOfOpaqueVoid() {
+	opaque, err := s.gapped(encounter.VoidIsOpaque()).Canvas()
 	s.Require().NoError(err)
-	s.True(rock.IsLineOfSightBlocked(theGapCell, brennaCell), "the gap cell IS the rock")
-	s.True(rock.IsLineOfSightBlocked(brennaCell, theGapCell), "from either end")
+	s.True(opaque.IsLineOfSightBlocked(theGapCell, brennaCell), "the gap cell IS the thing in the way")
+	s.True(opaque.IsLineOfSightBlocked(brennaCell, theGapCell), "from either end")
 
-	open, err := s.gapped(encounter.VoidIsOpen()).Canvas()
+	clear, err := s.gapped(encounter.VoidIsClear()).Canvas()
 	s.Require().NoError(err)
-	s.False(open.IsLineOfSightBlocked(theGapCell, brennaCell), "open air is nothing to see through")
-	s.False(open.IsLineOfSightBlocked(brennaCell, theGapCell))
+	s.False(clear.IsLineOfSightBlocked(theGapCell, brennaCell), "a clear gap is nothing to see through")
+	s.False(clear.IsLineOfSightBlocked(brennaCell, theGapCell))
 }
 
 // blocked keeps the compiler from optimizing away the calls the allocation
@@ -394,17 +394,17 @@ func (s *VoidSuite) canvasOf(field encounter.FieldInput) spatial.Room {
 	return canvas
 }
 
-// TestRockCostsNothingWhereThereIsNoVoid pins the short-circuit, and pins it as
+// TestOpaqueCostsNothingWhereThereIsNoVoid pins the short-circuit, and pins it as
 // ALLOCATIONS rather than as a stopwatch, so it says something true on a busy
 // machine (atlascost_test.go's rule: pin an order of growth, loosely).
 //
-// A field whose chambers tile their canvas exactly has no void, so rock and
-// open are the same world described two ways — and a rock declaration must not
-// buy a per-ray scan for a thing that cannot be there. Where there IS void the
+// A field whose chambers tile their canvas exactly has no void, so opaque and
+// clear are the same world described two ways — and an opaque declaration must
+// not buy a per-ray scan for a thing that cannot be there. Where there IS void the
 // scan is real work and shows up here as real allocation, which is what gives
 // this test teeth: without that half it would pass on a version that never
 // scanned at all.
-func (s *VoidSuite) TestRockCostsNothingWhereThereIsNoVoid() {
+func (s *VoidSuite) TestOpaqueCostsNothingWhereThereIsNoVoid() {
 	const from, to = 0, 3
 
 	measure := func(canvas spatial.Room) float64 {
@@ -413,13 +413,13 @@ func (s *VoidSuite) TestRockCostsNothingWhereThereIsNoVoid() {
 		return testing.AllocsPerRun(200, func() { blocked = canvas.IsLineOfSightBlocked(a, b) })
 	}
 
-	tiled := measure(s.canvasOf(contiguousField(encounter.VoidIsRock())))
-	s.Equal(measure(s.canvasOf(contiguousField(encounter.VoidIsOpen()))), tiled,
-		"no void to look for, so rock allocates exactly what open does")
+	tiled := measure(s.canvasOf(contiguousField(encounter.VoidIsOpaque())))
+	s.Equal(measure(s.canvasOf(contiguousField(encounter.VoidIsClear()))), tiled,
+		"no void to look for, so opaque allocates exactly what clear does")
 
-	gappedOpen := measure(s.canvasOf(gappedField(encounter.VoidIsOpen())))
-	gappedRock := measure(s.canvasOf(gappedField(encounter.VoidIsRock())))
-	s.Greater(gappedRock, gappedOpen,
+	gappedClear := measure(s.canvasOf(gappedField(encounter.VoidIsClear())))
+	gappedOpaque := measure(s.canvasOf(gappedField(encounter.VoidIsOpaque())))
+	s.Greater(gappedOpaque, gappedClear,
 		"and where there IS void, the scan is real work on a ray that never finds any — "+
 			"which is what makes the line above a measurement rather than a tautology")
 }

--- a/rulebooks/dnd5e/encounter/void_test.go
+++ b/rulebooks/dnd5e/encounter/void_test.go
@@ -361,3 +361,65 @@ func (s *VoidSuite) TestNobodySeesOutOfSolidRock() {
 	s.False(open.IsLineOfSightBlocked(theGapCell, brennaCell), "open air is nothing to see through")
 	s.False(open.IsLineOfSightBlocked(brennaCell, theGapCell))
 }
+
+// blocked keeps the compiler from optimizing away the calls the allocation
+// measurement below is counting.
+var blocked bool
+
+// contiguousField is two chambers that TOUCH: their footprints tile the canvas
+// exactly, so the field has no void at all and neither declaration has anything
+// to be about.
+func contiguousField(void encounter.Void) encounter.FieldInput {
+	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: void},
+		Rooms: []encounter.RoomInput{
+			{ID: voidWest, Width: 4, Height: 4, Origin: spatial.Position{X: 0, Y: 0}},
+			{ID: voidEast, Width: 4, Height: 4, Origin: spatial.Position{X: 4, Y: 0}},
+		},
+	}
+}
+
+// canvasOf opens a field with nobody in it and hands back its map.
+func (s *VoidSuite) canvasOf(field encounter.FieldInput) spatial.Room {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field:   field,
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	canvas, err := enc.Canvas()
+	s.Require().NoError(err)
+
+	return canvas
+}
+
+// TestRockCostsNothingWhereThereIsNoVoid pins the short-circuit, and pins it as
+// ALLOCATIONS rather than as a stopwatch, so it says something true on a busy
+// machine (atlascost_test.go's rule: pin an order of growth, loosely).
+//
+// A field whose chambers tile their canvas exactly has no void, so rock and
+// open are the same world described two ways — and a rock declaration must not
+// buy a per-ray scan for a thing that cannot be there. Where there IS void the
+// scan is real work and shows up here as real allocation, which is what gives
+// this test teeth: without that half it would pass on a version that never
+// scanned at all.
+func (s *VoidSuite) TestRockCostsNothingWhereThereIsNoVoid() {
+	const from, to = 0, 3
+
+	measure := func(canvas spatial.Room) float64 {
+		a := spatial.Position{X: from, Y: 1}
+		b := spatial.Position{X: to, Y: 1}
+		return testing.AllocsPerRun(200, func() { blocked = canvas.IsLineOfSightBlocked(a, b) })
+	}
+
+	tiled := measure(s.canvasOf(contiguousField(encounter.VoidIsRock())))
+	s.Equal(measure(s.canvasOf(contiguousField(encounter.VoidIsOpen()))), tiled,
+		"no void to look for, so rock allocates exactly what open does")
+
+	gappedOpen := measure(s.canvasOf(gappedField(encounter.VoidIsOpen())))
+	gappedRock := measure(s.canvasOf(gappedField(encounter.VoidIsRock())))
+	s.Greater(gappedRock, gappedOpen,
+		"and where there IS void, the scan is real work on a ray that never finds any — "+
+			"which is what makes the line above a measurement rather than a tautology")
+}

--- a/rulebooks/dnd5e/encounter/void_test.go
+++ b/rulebooks/dnd5e/encounter/void_test.go
@@ -120,30 +120,30 @@ func (s *VoidSuite) TestOpaqueVoidBlocksSightBetweenChambers() {
 	s.False(s.sees(enc, kade, brenna), "from either side — geometry is mutual")
 }
 
-// TestClearVoidDoesNotBlockSightBetweenChambers is the same slice from the
+// TestTransparentVoidDoesNotBlockSightBetweenChambers is the same slice from the
 // ruined-courtyard side, and it is the half that shows the declaration is a
 // CHOICE rather than a new rule.
 //
 // Identical geometry, identical members, identical distance. The only thing
 // that changed is the word the field says about that column, and the answer
 // inverts.
-func (s *VoidSuite) TestClearVoidDoesNotBlockSightBetweenChambers() {
-	enc := s.gapped(encounter.VoidIsClear())
+func (s *VoidSuite) TestTransparentVoidDoesNotBlockSightBetweenChambers() {
+	enc := s.gapped(encounter.VoidIsTransparent())
 
-	s.True(s.sees(enc, brenna, kade), "the gap is clear; they are two cells apart in plain view")
+	s.True(s.sees(enc, brenna, kade), "the gap is transparent; they are two cells apart in plain view")
 	s.True(s.sees(enc, kade, brenna), "from either side")
 }
 
-// TestClearVoidIsStillNotFloor pins the half of the ruling that does NOT vary:
+// TestTransparentVoidIsStillNotFloor pins the half of the ruling that does NOT vary:
 // both declarations are unwalkable. Open means you can SEE across the gap, not
 // that you can walk out over it.
-func (s *VoidSuite) TestClearVoidIsStillNotFloor() {
+func (s *VoidSuite) TestTransparentVoidIsStillNotFloor() {
 	for _, tc := range []struct {
 		name string
 		void encounter.Void
 	}{
 		{"opaque", encounter.VoidIsOpaque()},
-		{"clear", encounter.VoidIsClear()},
+		{"transparent", encounter.VoidIsTransparent()},
 	} {
 		s.Run(tc.name, func() {
 			enc := s.gapped(tc.void)
@@ -191,15 +191,15 @@ func (s *VoidSuite) TestTheHandedOutCanvasAnswersTheSameWay() {
 	s.Require().NoError(err)
 	s.True(opaque.IsLineOfSightBlocked(brennaCell, kadeCell), "the map itself says something is in the way")
 
-	clear, err := s.gapped(encounter.VoidIsClear()).Canvas()
+	transparent, err := s.gapped(encounter.VoidIsTransparent()).Canvas()
 	s.Require().NoError(err)
-	s.False(clear.IsLineOfSightBlocked(brennaCell, kadeCell), "and that a clear gap is not")
+	s.False(transparent.IsLineOfSightBlocked(brennaCell, kadeCell), "and that a transparent gap is not")
 }
 
 // TestAFieldMustSayWhatItsVoidIs is the ruling's "required, never defaulted".
 //
 // There is no answer this module is allowed to pick. A tomb's void is opaque
-// and an open-air ruin's is clear, and which one THIS world is is not a 5e
+// and an open-air ruin's is transparent, and which one THIS world is is not a 5e
 // rule the composition could derive — it is a fact about the world, which makes
 // it construction data (rpg-toolkit#1033's law, applied to the map).
 func (s *VoidSuite) TestAFieldMustSayWhatItsVoidIs() {
@@ -227,7 +227,7 @@ func (s *VoidSuite) TestTheDeclarationSurvivesASave() {
 		blocked bool
 	}{
 		{"opaque", encounter.VoidIsOpaque(), encounter.VoidOpaque, true},
-		{"clear", encounter.VoidIsClear(), encounter.VoidClear, false},
+		{"transparent", encounter.VoidIsTransparent(), encounter.VoidTransparent, false},
 	} {
 		s.Run(tc.name, func() {
 			data := s.gapped(tc.void).ToData()
@@ -348,7 +348,7 @@ func (s *VoidSuite) TestTheCanvasKeepsItsOwnCopyOfTheChambers() {
 // A member is never on a void cell — [Encounter.Step] and [Encounter.Join]
 // refuse one — but the canvas rpg-toolkit#1118 hands out takes any two cells a
 // caller cares to name, and the honest answer for a cell inside opaque void is
-// that nothing sees out of it. Under a clear declaration the same cell is just
+// that nothing sees out of it. Under a transparent declaration the same cell is
 // a place nobody can stand, and the sightline across it is unobstructed.
 func (s *VoidSuite) TestNobodySeesOutOfOpaqueVoid() {
 	opaque, err := s.gapped(encounter.VoidIsOpaque()).Canvas()
@@ -356,10 +356,10 @@ func (s *VoidSuite) TestNobodySeesOutOfOpaqueVoid() {
 	s.True(opaque.IsLineOfSightBlocked(theGapCell, brennaCell), "the gap cell IS the thing in the way")
 	s.True(opaque.IsLineOfSightBlocked(brennaCell, theGapCell), "from either end")
 
-	clear, err := s.gapped(encounter.VoidIsClear()).Canvas()
+	transparent, err := s.gapped(encounter.VoidIsTransparent()).Canvas()
 	s.Require().NoError(err)
-	s.False(clear.IsLineOfSightBlocked(theGapCell, brennaCell), "a clear gap is nothing to see through")
-	s.False(clear.IsLineOfSightBlocked(brennaCell, theGapCell))
+	s.False(transparent.IsLineOfSightBlocked(theGapCell, brennaCell), "a transparent gap is nothing to see through")
+	s.False(transparent.IsLineOfSightBlocked(brennaCell, theGapCell))
 }
 
 // blocked keeps the compiler from optimizing away the calls the allocation
@@ -399,7 +399,8 @@ func (s *VoidSuite) canvasOf(field encounter.FieldInput) spatial.Room {
 // machine (atlascost_test.go's rule: pin an order of growth, loosely).
 //
 // A field whose chambers tile their canvas exactly has no void, so opaque and
-// clear are the same world described two ways — and an opaque declaration must
+// transparent are the same world described two ways — and an opaque declaration
+// must
 // not buy a per-ray scan for a thing that cannot be there. Where there IS void the
 // scan is real work and shows up here as real allocation, which is what gives
 // this test teeth: without that half it would pass on a version that never
@@ -414,12 +415,12 @@ func (s *VoidSuite) TestOpaqueCostsNothingWhereThereIsNoVoid() {
 	}
 
 	tiled := measure(s.canvasOf(contiguousField(encounter.VoidIsOpaque())))
-	s.Equal(measure(s.canvasOf(contiguousField(encounter.VoidIsClear()))), tiled,
-		"no void to look for, so opaque allocates exactly what clear does")
+	s.Equal(measure(s.canvasOf(contiguousField(encounter.VoidIsTransparent()))), tiled,
+		"no void to look for, so opaque allocates exactly what transparent does")
 
-	gappedClear := measure(s.canvasOf(gappedField(encounter.VoidIsClear())))
+	gappedTransparent := measure(s.canvasOf(gappedField(encounter.VoidIsTransparent())))
 	gappedOpaque := measure(s.canvasOf(gappedField(encounter.VoidIsOpaque())))
-	s.Greater(gappedOpaque, gappedClear,
+	s.Greater(gappedOpaque, gappedTransparent,
 		"and where there IS void, the scan is real work on a ray that never finds any — "+
 			"which is what makes the line above a measurement rather than a tautology")
 }

--- a/rulebooks/dnd5e/encounter/voidcost_internal_test.go
+++ b/rulebooks/dnd5e/encounter/voidcost_internal_test.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// voidcost_internal_test.go is WHAT THE ROCK COSTS (rpg-toolkit#1116).
+//
+// [canvasRoom.IsLineOfSightBlocked] scans the ray for cells no chamber owns,
+// and Copilot's review of PR #1124 asked the obvious question: that scan is
+// O(rayLen x rooms) inside percept building's O(members^2) loop. These
+// benchmarks are the answer, and they are here rather than in a comment because
+// every number quoted in that method's godoc — and the case for the floor mask
+// rpg-toolkit#1105's ruling (4) deferred — has to stay re-runnable:
+//
+//	go test -run XXX -bench BenchmarkSight -benchtime 30x .
+//
+// One run on an AMD 7945HX. Absolute times move with whatever else the machine
+// is doing; the RATIOS held across repeats, and they are the finding:
+//
+//	tomb-shaped, 3 chambers, 8 members     open   84us  rock   53us   1.4-1.6x FASTER
+//	20 chambers with gaps, 60 members      open 31.7ms  rock 18.9ms   1.6-1.7x FASTER
+//	one 40x40 chamber, void margin, 40     open  3.1ms  rock  4.1ms   1.34x slower
+//	20 chambers, canvas tiled, NO void     open 29.7ms  rock 29.6ms   parity
+//
+// Where there IS void, rock is FASTER, which is not the intuition: the scan is
+// arithmetic, and the spatial call it returns before rasterizes, walks
+// boundaries, walks blocking entities and then walks a lean lane per neighbour.
+// Finding rock early skips all of that. The price is paid by rays that never
+// leave the floor, which scan in full and delegate anyway — the third row, and
+// the honest worst case. That 1.34x is the number to beat if a caller ever
+// forces the floor mask rpg-toolkit#1105's ruling (4) deferred.
+//
+// The fourth row is the one that was bad, and is the reason fieldHasVoid
+// exists. Deleting its check from IsLineOfSightBlocked and re-running that pair
+// measures rock at 121ms against open's 30ms — 4.0x, and 46.7 MB of allocation
+// against 24.2 MB — every byte of it spent proving there was no void to find on
+// a field where rock and open mean the same thing.
+// TestRockCostsNothingWhereThereIsNoVoid pins the fix as allocations, so it
+// holds without a stopwatch.
+
+type benchSight struct{ cells int }
+
+func (b benchSight) Sight(members []MemberID) (map[MemberID]int, error) {
+	out := make(map[MemberID]int, len(members))
+	for _, m := range members {
+		out[m] = b.cells
+	}
+	return out, nil
+}
+
+type benchStanding struct{}
+
+func (benchStanding) Standing(_ []MemberID) ([]MemberID, error) { return nil, nil }
+
+type benchRoller struct{}
+
+func (benchRoller) RollInitiative(members []MemberID) ([]MemberID, error) { return members, nil }
+
+// benchField lays `rooms` chambers of dim x dim in a row, `stride` apart:
+// stride == dim makes them tile the canvas with no void at all, stride == dim+1
+// leaves a one-cell gap between each pair. `anchor` shifts the whole field off
+// the canvas origin, which is how a single-chamber field gets a void margin.
+func benchField(rooms, dim, stride, anchor int, void Void) FieldInput {
+	ri := make([]RoomInput, rooms)
+	for i := range ri {
+		ri[i] = RoomInput{ID: fmt.Sprintf("r%d", i), Width: dim, Height: dim,
+			Origin: spatial.Position{X: float64(anchor + i*stride), Y: float64(anchor)}}
+	}
+	return FieldInput{Canvas: CanvasInput{Void: void}, Rooms: ri}
+}
+
+// benchSightRefresh times one full percept rebuild over the whole roster, which
+// is the loop the scan actually runs inside.
+func benchSightRefresh(b *testing.B, rooms, dim, stride, anchor, members int, void Void) {
+	b.Helper()
+
+	mi := make([]MemberInput, members)
+	for i := range mi {
+		mi[i] = MemberInput{ID: MemberID(fmt.Sprintf("m%d", i)), Kind: KindPlayer,
+			Room:     fmt.Sprintf("r%d", i%rooms),
+			Position: spatial.Position{X: float64(i % dim), Y: float64((i / dim) % dim)}}
+	}
+
+	enc, err := NewEncounter(&SetupInput{
+		Sight: benchSight{1 << 20}, Standing: benchStanding{}, Initiative: benchRoller{},
+		Field:   benchField(rooms, dim, stride, anchor, void),
+		Members: mi,
+		Endings: []EndingInput{{Key: "done", Trigger: TriggerExternal{}}},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	roster := enc.rosterIDs()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := enc.rebuildPercepts(roster); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The reference tomb's shape: three chambers in a chain, a party of eight.
+func BenchmarkSightTombOpen(b *testing.B) { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsOpen()) }
+func BenchmarkSightTombRock(b *testing.B) { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsRock()) }
+
+// Chambers with gaps between them — the case rock exists for.
+func BenchmarkSightGappedOpen(b *testing.B) { benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsOpen()) }
+func BenchmarkSightGappedRock(b *testing.B) { benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsRock()) }
+
+// One chamber with a void margin and nobody ever looking across it: the scan
+// runs in full, finds nothing, and delegates anyway. The worst case.
+func BenchmarkSightMarginOpen(b *testing.B) { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsOpen()) }
+func BenchmarkSightMarginRock(b *testing.B) { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsRock()) }
+
+// Chambers that tile their canvas exactly: no void, so nothing to look for.
+func BenchmarkSightNoVoidOpen(b *testing.B) { benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsOpen()) }
+func BenchmarkSightNoVoidRock(b *testing.B) { benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsRock()) }

--- a/rulebooks/dnd5e/encounter/voidcost_internal_test.go
+++ b/rulebooks/dnd5e/encounter/voidcost_internal_test.go
@@ -24,10 +24,10 @@ import (
 // One run on an AMD 7945HX. Absolute times move with whatever else the machine
 // is doing; the RATIOS held across repeats, and they are the finding:
 //
-//	tomb-shaped, 3 chambers, 8 members   clear   84us  opaque   53us  1.4-1.6x FASTER
-//	20 chambers with gaps, 60 members    clear 31.7ms  opaque 18.9ms  1.6-1.7x FASTER
-//	one 40x40 chamber, void margin, 40   clear  3.1ms  opaque  4.1ms  1.34x slower
-//	20 chambers, canvas tiled, NO void   clear 29.7ms  opaque 29.6ms  parity
+//	tomb-shaped, 3 chambers, 8 members   transparent   84us  opaque   53us  1.4-1.6x FASTER
+//	20 chambers with gaps, 60 members    transparent 31.7ms  opaque 18.9ms  1.6-1.7x FASTER
+//	one 40x40 chamber, void margin, 40   transparent  3.1ms  opaque  4.1ms  1.34x slower
+//	20 chambers, canvas tiled, NO void   transparent 29.7ms  opaque 29.6ms  parity
 //
 // Where there IS void, opaque is FASTER, which is not the intuition: the scan is
 // arithmetic, and the spatial call it returns before rasterizes, walks
@@ -39,9 +39,9 @@ import (
 //
 // The fourth row is the one that was bad, and is the reason fieldHasVoid
 // exists. Deleting its check from IsLineOfSightBlocked and re-running that pair
-// measures opaque at 121ms against clear's 30ms — 4.0x, and 46.7 MB of allocation
+// measures opaque at 121ms against transparent's 30ms — 4.0x, and 46.7 MB of
 // against 24.2 MB — every byte of it spent proving there was no void to find on
-// a field where opaque and clear mean the same thing.
+// a field where opaque and transparent mean the same thing.
 // TestOpaqueCostsNothingWhereThereIsNoVoid pins the fix as allocations, so it
 // holds without a stopwatch.
 
@@ -110,22 +110,30 @@ func benchSightRefresh(b *testing.B, rooms, dim, stride, anchor, members int, vo
 }
 
 // The reference tomb's shape: three chambers in a chain, a party of eight.
-func BenchmarkSightTombClear(b *testing.B)  { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsClear()) }
+func BenchmarkSightTombTransparent(b *testing.B) {
+	benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsTransparent())
+}
 func BenchmarkSightTombOpaque(b *testing.B) { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsOpaque()) }
 
 // Chambers with gaps between them — the case an opaque declaration exists for.
-func BenchmarkSightGappedClear(b *testing.B) { benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsClear()) }
+func BenchmarkSightGappedTransparent(b *testing.B) {
+	benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsTransparent())
+}
 func BenchmarkSightGappedOpaque(b *testing.B) {
 	benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsOpaque())
 }
 
 // One chamber with a void margin and nobody ever looking across it: the scan
 // runs in full, finds nothing, and delegates anyway. The worst case.
-func BenchmarkSightMarginClear(b *testing.B)  { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsClear()) }
+func BenchmarkSightMarginTransparent(b *testing.B) {
+	benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsTransparent())
+}
 func BenchmarkSightMarginOpaque(b *testing.B) { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsOpaque()) }
 
 // Chambers that tile their canvas exactly: no void, so nothing to look for.
-func BenchmarkSightNoVoidClear(b *testing.B) { benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsClear()) }
+func BenchmarkSightNoVoidTransparent(b *testing.B) {
+	benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsTransparent())
+}
 func BenchmarkSightNoVoidOpaque(b *testing.B) {
 	benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsOpaque())
 }

--- a/rulebooks/dnd5e/encounter/voidcost_internal_test.go
+++ b/rulebooks/dnd5e/encounter/voidcost_internal_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
-// voidcost_internal_test.go is WHAT THE ROCK COSTS (rpg-toolkit#1116).
+// voidcost_internal_test.go is WHAT OPAQUE VOID COSTS (rpg-toolkit#1116).
 //
 // [canvasRoom.IsLineOfSightBlocked] scans the ray for cells no chamber owns,
 // and Copilot's review of PR #1124 asked the obvious question: that scan is
@@ -24,25 +24,25 @@ import (
 // One run on an AMD 7945HX. Absolute times move with whatever else the machine
 // is doing; the RATIOS held across repeats, and they are the finding:
 //
-//	tomb-shaped, 3 chambers, 8 members     open   84us  rock   53us   1.4-1.6x FASTER
-//	20 chambers with gaps, 60 members      open 31.7ms  rock 18.9ms   1.6-1.7x FASTER
-//	one 40x40 chamber, void margin, 40     open  3.1ms  rock  4.1ms   1.34x slower
-//	20 chambers, canvas tiled, NO void     open 29.7ms  rock 29.6ms   parity
+//	tomb-shaped, 3 chambers, 8 members   clear   84us  opaque   53us  1.4-1.6x FASTER
+//	20 chambers with gaps, 60 members    clear 31.7ms  opaque 18.9ms  1.6-1.7x FASTER
+//	one 40x40 chamber, void margin, 40   clear  3.1ms  opaque  4.1ms  1.34x slower
+//	20 chambers, canvas tiled, NO void   clear 29.7ms  opaque 29.6ms  parity
 //
-// Where there IS void, rock is FASTER, which is not the intuition: the scan is
+// Where there IS void, opaque is FASTER, which is not the intuition: the scan is
 // arithmetic, and the spatial call it returns before rasterizes, walks
 // boundaries, walks blocking entities and then walks a lean lane per neighbour.
-// Finding rock early skips all of that. The price is paid by rays that never
+// Finding void early skips all of that. The price is paid by rays that never
 // leave the floor, which scan in full and delegate anyway — the third row, and
 // the honest worst case. That 1.34x is the number to beat if a caller ever
 // forces the floor mask rpg-toolkit#1105's ruling (4) deferred.
 //
 // The fourth row is the one that was bad, and is the reason fieldHasVoid
 // exists. Deleting its check from IsLineOfSightBlocked and re-running that pair
-// measures rock at 121ms against open's 30ms — 4.0x, and 46.7 MB of allocation
+// measures opaque at 121ms against clear's 30ms — 4.0x, and 46.7 MB of allocation
 // against 24.2 MB — every byte of it spent proving there was no void to find on
-// a field where rock and open mean the same thing.
-// TestRockCostsNothingWhereThereIsNoVoid pins the fix as allocations, so it
+// a field where opaque and clear mean the same thing.
+// TestOpaqueCostsNothingWhereThereIsNoVoid pins the fix as allocations, so it
 // holds without a stopwatch.
 
 type benchSight struct{ cells int }
@@ -110,18 +110,22 @@ func benchSightRefresh(b *testing.B, rooms, dim, stride, anchor, members int, vo
 }
 
 // The reference tomb's shape: three chambers in a chain, a party of eight.
-func BenchmarkSightTombOpen(b *testing.B) { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsOpen()) }
-func BenchmarkSightTombRock(b *testing.B) { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsRock()) }
+func BenchmarkSightTombClear(b *testing.B)  { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsClear()) }
+func BenchmarkSightTombOpaque(b *testing.B) { benchSightRefresh(b, 3, 10, 11, 0, 8, VoidIsOpaque()) }
 
-// Chambers with gaps between them — the case rock exists for.
-func BenchmarkSightGappedOpen(b *testing.B) { benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsOpen()) }
-func BenchmarkSightGappedRock(b *testing.B) { benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsRock()) }
+// Chambers with gaps between them — the case an opaque declaration exists for.
+func BenchmarkSightGappedClear(b *testing.B) { benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsClear()) }
+func BenchmarkSightGappedOpaque(b *testing.B) {
+	benchSightRefresh(b, 20, 20, 21, 0, 60, VoidIsOpaque())
+}
 
 // One chamber with a void margin and nobody ever looking across it: the scan
 // runs in full, finds nothing, and delegates anyway. The worst case.
-func BenchmarkSightMarginOpen(b *testing.B) { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsOpen()) }
-func BenchmarkSightMarginRock(b *testing.B) { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsRock()) }
+func BenchmarkSightMarginClear(b *testing.B)  { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsClear()) }
+func BenchmarkSightMarginOpaque(b *testing.B) { benchSightRefresh(b, 1, 40, 40, 1, 40, VoidIsOpaque()) }
 
 // Chambers that tile their canvas exactly: no void, so nothing to look for.
-func BenchmarkSightNoVoidOpen(b *testing.B) { benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsOpen()) }
-func BenchmarkSightNoVoidRock(b *testing.B) { benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsRock()) }
+func BenchmarkSightNoVoidClear(b *testing.B) { benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsClear()) }
+func BenchmarkSightNoVoidOpaque(b *testing.B) {
+	benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsOpaque())
+}


### PR DESCRIPTION
World-model wave slice, ruled on #1116. Void was **unwalkable but transparent**; now the field says which it is.

Closes #1116.

## Census (verified at `776451d`, executor-run)

| Claim | Where |
|---|---|
| Void is unwalkable | `stepMember` asks `RegionAt`; a cell no region owns is `ErrBadPlacement` "not floor" (`step.go:156-165`), and `Join` the same (`encounter.go:2131+`) |
| Void is transparent | `rebuildPercepts` filters on exactly two things — `Distance > reach` and `canvas.IsLineOfSightBlocked` (`encounter.go:2035-2042`). The canvas spans the field's bounding BOX; cells no region owns carry no entity and no edge, so a ray crosses them freely. Nothing consults region membership for sight — that filter died in #1106 |
| A boundary edge is the stronger primitive | `tools/spatial/room.go:533-550`: boundaries are a hard block on the direct canonical ray; occluding ENTITIES can be leaned around |
| The canvas is handed out live | #1118's `readOnlyRoom` delegates `IsLineOfSightBlocked` straight through — so a void rule living in the sight loop would make the handed-out map disagree with the encounter |
| Sealed-set precedent | `DissolveCause` (`dissolve.go:23-95`): `Kind()` reader + unexported method + constructor functions, nil zero value |
| Required-construction-data precedent | `RoomData.Origin` — absent is refused by name, `ToData` always writes it, no `omitempty` |
| Blast radius | **162** `FieldInput{` literals and **24** `FieldData{` literals across 26 test files; **0** in non-test code. `session` pins v0.17.0 and `resolution` v0.21.0, so neither moves in this PR |

**No contradiction with any ruling**, checked before building: ruling (2) *walls are boundary edges* — opaque void is made to behave exactly as a boundary does, on the same ray, rather than adding a wall vocabulary; ruling (4) *the floor mask is deferred* — not forced here, and a mask would not answer this question anyway (it makes `IsValidPosition` false off-floor, which spatial's LoS does not consult). Region ownership already answers "is this floor", so this reuses `regionAt` and leaves `TestRegionOwnershipIsAskedInOneFunction`'s one-function invariant intact.

## The ruled shape, point by point

- **Required, never defaulted.** `FieldInput.Canvas.Void`; nil at Setup and absent-or-unknown at Load are both refused with `ErrNoField`, and the two refusals are **worded apart** ("does not say what its void is" vs "declares void %q, which this build does not know") because they send whoever reads them to different places.
- **Named for the EFFECT, not the material — twice** (Kirk on review: *"the isrock is very specific do we need to call it rock. isBlockedLOS or maybe isblocked."*). `VoidOpaque`/`VoidTransparent`, wire `"opaque"`/`"transparent"`. Stone, a ship's hull, the air over a chasm, hard vacuum are four fictions and one mechanic, and the mechanic is all this module can know — naming the case for the material was the same overreach as defaulting the declaration, one layer up. Landed **before** merge because `CanvasData` persists those strings: free now, a stored-dialect break after. The fiction stays in the docs, reframed throughout so it reads as illustration rather than definition; what survives is Kirk's own quoted words and sentences explicitly labelled as fiction.

  Then Kirk corrected the *second* name as well — *"transparant i think matches opaque better"* — and that one is a finer point: both words already named an effect, so the first rule was satisfied; what was wrong is that "clear" is colloquial where "opaque" is precise, and a sealed set drawn from two registers reads as two decisions rather than one axis with two ends. **Two name corrections in one review is the pattern, not an accident of taste** — a composition that may not hold fiction has to be *read* for fiction, and where it hides is in names that feel merely descriptive, which is how both survived writing, tests and a full mutation battery before anybody noticed. That is recorded in the godoc rather than left in a PR thread.
- **Sealed set, not a bool.** `Void` is an interface with `Kind() VoidKind` and an unexported `blocksSight()`. The unexported method both seals the set and answers the only question the module asks, so it is a real method rather than a marker — a third case (a chasm) cannot be added without answering it, and cannot be declared outside the package at all.
- **Shaped so ambient light can join it.** `CanvasInput` is a struct with one field today. #1113's "this dungeon is dark" is the same species of authored world fact and lands beside `Void`, in `CanvasInput` and in `CanvasData`, rather than needing a second mechanism.
- **Rock and open, both unwalkable.** Only sight varies; the floor check is untouched. The set is deliberately *not* asked whether void is walkable — both cases answer the same today, so the predicate would be a branch no field could take.
- **Occluders do not change.** No authored occluder or boundary moved.

## Where the rule lives, and why it matters

On the **map**, not in the sight loop. `canvasRoom` embeds the spatial room and overrides one method; `Encounter.Canvas()` therefore inherits the answer with no second implementation. Had this been a filter in `rebuildPercepts`, a rule installed on the handed-out canvas would be told nothing stands between two cells while this module refused to let them see each other — the exact dual state #1118 exists to end, one layer down. Pinned by `TestTheHandedOutCanvasAnswersTheSameWay`.

The override walks `spatial.CanonicalBoundaryRay` — the very rasterization spatial checks boundaries along — and asks `regionAt`. So opaque void blocks exactly as a wall does: hard, on the direct ray, no leaning past it.

## Test evidence

**RED, in two stages.** (1) `go vet` → `undefined: encounter.Void`. (2) declaration wired and persisting, nothing acting on it — the honest measurement of the gap:

```
--- FAIL: TestVoidSuite/TestOpaqueVoidBlocksSightBetweenChambers
--- FAIL: TestVoidSuite/TestTheHandedOutCanvasAnswersTheSameWay
--- FAIL: TestVoidSuite/TestTheDeclarationSurvivesASave/opaque
```

Three failures saying one thing: the declaration was accepted, persisted and read back, and a sightline still went straight through the gap. (Names as they read now — the run predates the rename below.)

**The fixtures' meaning is preserved under an opaque declaration — verified, not assumed.** Sweeping all 162 + 24 literals produced **four** failures, every one mechanical: three golden JSON strings, one hand-written pre-#1106 blob, and the workbench demo dungeon needing to state its choice. **No behavioural failure anywhere**, across the sight-heavy suites (`canvas_test`, `pump_test`, `tombwatch`, `pursuit`, `chase`). Checkable: `git diff HEAD~1 -- '*_test.go'` filtered for declaration inserts and JSON canvas keys leaves only gofmt realignment — **no assertion was changed**.

**Mutation, 15 mutants, baseline audited unmutated first, 14 killed:**

```
M1  opaque stops blocking sight                    killed  TestOpaqueVoidBlocksSightBetweenChambers, TestNobodySeesOutOfOpaqueVoid, ...
M2  transparent starts blocking sight                   killed  TestTransparentVoidDoesNotBlockSightBetweenChambers, ...
M3  the declaration is not consulted             killed  TestTransparentVoidDoesNotBlockSightBetweenChambers, ...
M4  floor blocks instead of void                 killed  TestCanvasSuite/TestThroughTheDoorway..., TestCanvasReadSuite, ...
M5  spatial's own answer discarded               killed  Example_theDoorway, TestArrivalSuite, ...
M6  the declaration is not required at Setup     killed  TestAFieldMustSayWhatItsVoidIs
M7  absent not told apart from unknown           killed  TestAnOldBlobIsRefusedByName
M8  ToData always writes opaque                    killed  TestTheDeclarationSurvivesASave/transparent
M9  opaque persists under the wrong word           killed  TestDataSuite/TestGoldenJSON*
M10 canonical ray swapped for the raw one        SURVIVED (see below)
M11 the ray's first cell is skipped              killed  TestNobodySeesOutOfOpaqueVoid
M12 the no-void short-circuit never fires        killed  TestOpaqueCostsNothingWhereThereIsNoVoid
M13 every field treated as void-free             killed  TestOpaqueVoidBlocksSightBetweenChambers, ...
M14 every field treated as having void           killed  TestOpaqueCostsNothingWhereThereIsNoVoid
M15 the void test is inverted                    killed  TestOpaqueVoidBlocksSightBetweenChambers, ...
```

M7 and M11 survived a first round and are killed by tests added because of it — the absent/unknown wording assertions, and `TestNobodySeesOutOfOpaqueVoid` (nothing sees out of a cell inside opaque void; the endpoints are on the ray).

**M10 survives, and it is stated in the godoc rather than papered over.** Over eight void layouts (gap column, offset and ragged rooms, an L, a checkerboard, a staircase, comb teeth, a hex pair; 340 floor cells) the raw `GetLineOfSight` visits a **different set of cells depending on which end it is asked from in roughly a quarter of ordered pairs** on square grids — Bresenham's known direction dependence, absent on hex — and yet the "does this ray cross void" answer came out identical both ways for every single pair. So no fixture in this package can distinguish the canonical ray from the raw one. It is still the right call: the canonicalization is what keeps this rule pinned to the boundary rule *as spatial's rasterization changes*, rather than pinned to it by coincidence today.

**An alias defect this slice created, found and fixed.** The canvas now keeps the room list (it asks `regionAt` what is floor), so Setup feeds it `e.fieldInput` — the deep copy — not the caller's slice, or the canvas and `Encounter.RegionAt` would be two answers to one question. `TestTheCanvasKeepsItsOwnCopyOfTheChambers` pins it, and its first version was a **surviving mutant**: it mutated `Width`, which `regionAt` never reads (dimensions are spent on the constructed grid). It mutates `Origin` now, which is the field still read on every call, and it kills the mutant.

## Cost, measured — and one regression Copilot found and this fixes

The void scan is `O(rayLen x rooms)` inside percept building's `O(members^2)` loop, which Copilot flagged. Measured with a benchmark that **ships on this branch** (`voidcost_internal_test.go`, `go test -run XXX -bench BenchmarkSight -benchtime 30x .`) so every number here is re-runnable. Absolute times move with machine load, so the ratios are the finding — those held across repeats:

| field | opaque vs clear |
|---|---|
| reference-tomb shape, 3 chambers, 8 members | **1.4-1.6x faster** |
| 20 chambers with gaps, 60 members | **1.6-1.7x faster** |
| one 40x40 chamber, void margin, 40 members | 1.34x slower (**the worst case**) |
| 20 chambers tiling their canvas exactly — **no void** | ~~4.0x slower~~ → **parity** |

Where there IS void the scan is a net **speedup**, which is not the intuition: scanning the ray is arithmetic, and the `spatial` call it returns before rasterizes, walks boundaries, walks blocking entities and then walks a lean lane per neighbour. The price is paid by rays that never leave the floor.

The real regression was the last row — a field whose chambers tile their canvas exactly, where the scan can only run to the end of every ray and find nothing: **121 ms against open's 30 ms, 46.7 MB of allocation against 24.2 MB**. There **opaque and clear mean the same thing**, so the fix is to notice that. `fieldHasVoid` is arithmetic on numbers already in hand: W2 makes the chambers disjoint and W6 makes them fit, so the canvas is void-free exactly when their cell counts sum to its own (and both families count the same way — an `AxialHexGrid` of WxH holds WxH integer (Q,R) pairs). One derived bit, computed at compile time, never stored, never persisted.

**Not the floor mask.** Kirk deferred that on #1105 (ruling 4) until a caller forces one, because two questions ride on it — computed per load vs persisted, and whether it belongs in `tools/spatial`. A boolean raises neither. The 1.34x is the number that would justify the mask if a caller ever forces it, and it is recorded in `canvasRoom.IsLineOfSightBlocked`'s godoc beside the harness that produced it.

Pinned by `TestOpaqueCostsNothingWhereThereIsNoVoid` as **allocations** rather than a stopwatch, with the has-void half measured too so it cannot pass on a version that never scans at all.

## Gates

- `gofmt -l` clean, `go vet ./...` clean, `go test -count=1 ./...` green (both packages), run from inside the module.
- `golangci-lint` at CI's pinned **v2.2.1**, invoked the way CI invokes it for this module (`--config=../.golangci.yml` from the module dir): **0 issues**.
- `gorelease -base v0.21.0`: **"compatible changes"**, suggested `v0.22.0`. That is its known blind spot — a newly REQUIRED struct field is source-compatible by its analysis, while in fact **every existing caller now fails at construction until it declares**. The `!` in the title carries the break; the real version is a minor bump on a v0 module either way.

## Not in this slice

A read accessor for the declaration (`Atlas` does not report it; the blob does, and no caller has forced one), and any consumer update — `session` and `resolution` pin older tags and move when they upgrade, per the no-backcompat-baggage ruling.

— fix-1116 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
