### PR TITLE
fix(encounter)!: a prop says what it is and what it does — you walked through pillars

### DIFF
--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -48,11 +48,19 @@ type AtlasRegion struct {
 	// Height is the region's vertical dimension, in cells.
 	Height int
 
-	// Occluders is the region's line-of-sight-blocking cells, in
-	// dungeon-absolute space. An occluder is still a cell OF the region —
-	// occlusion is walkability, not ownership (#929 T3 ruling 1), and
-	// RegionAt names an occluded cell's region like any other.
-	Occluders []spatial.Position
+	// Props is the things standing in this region, in dungeon-absolute
+	// space and in declaration order. A prop's cell is still a cell OF the
+	// region — what a prop blocks is not ownership (#929 T3 ruling 1), and
+	// [Encounter.RegionAt] names an occupied cell's region like any other,
+	// whichever way its flags are set.
+	//
+	// EACH ONE SAYS WHICH THING IT IS (rpg-toolkit#1128). These used to be
+	// bare positions, so a host could draw blockage but could not draw a
+	// ROOM: a pillar, a statue and a bone pile were the same cell, which the
+	// multi-room census (rpg-project#227) recorded as the reason authored
+	// content could not land. See [PropInput] for why the ref is opaque and
+	// why both flags are the author's to set.
+	Props []AtlasProp
 
 	// Boundaries is the region's walls (RoomInput.Boundaries), with both
 	// endpoints projected into dungeon-absolute space (#929 hardening round
@@ -65,10 +73,30 @@ type AtlasRegion struct {
 	// RoomInput.Boundaries' doc comment). Grouping such a wall under the region
 	// that DECLARED it is construction truth reported faithfully, not a claim
 	// about which region the wall belongs to. In declaration order (RoomInput's
-	// own order, the same construction-truth ordering Occluders already
+	// own order, the same construction-truth ordering Props already
 	// uses above) — deterministic given a fixed input (C8), though not
 	// independently sorted the way Regions/Doorways are.
 	Boundaries []AtlasBoundary
+}
+
+// AtlasProp is one authored thing standing in a region, as the map reports it:
+// what it is, where it stands in dungeon-absolute space, and what it does to a
+// step and to a sightline. See [PropInput] for the authoring side.
+type AtlasProp struct {
+	// Ref is content's identifier for this thing, carried through the
+	// compile unchanged and never interpreted by this module.
+	Ref string
+
+	// At is where it stands, in dungeon-absolute space.
+	At spatial.Position
+
+	// BlocksMovement is whether a member can end a step on this cell.
+	BlocksMovement bool
+
+	// BlocksLineOfSight is whether it obstructs a sightline — subject to
+	// spatial's lane rule, so one cell of it obstructs nothing on its own
+	// ([PropInput]).
+	BlocksLineOfSight bool
 }
 
 // AtlasBoundary is one wall or barrier crossing, with both endpoints
@@ -131,21 +159,21 @@ type AtlasDoorway struct {
 // microseconds per call (TestAtlasReportsRegionsWithoutEnumeratingThem).
 //
 // Deterministic (C8): Regions sorted by region ID, Doorways sorted by
-// connection ID, each region's Boundaries and Occluders in declaration order
+// connection ID, each region's Boundaries and Props in declaration order
 // (RoomInput's own order — #929 hardening round A). Copy-out: every returned
 // slice is freshly allocated per call; mutating the result never reaches
 // internal state.
 //
-// Occluders are map data, not entities: an occluder cell is a cell OF its
-// region (RegionAt names it like any other), which is why occluders must be
-// integral in every family (encounter.go's occluder-integrality check, #929 T3
+// Props are map data, not entities: a prop's cell is a cell OF its region
+// (RegionAt names it like any other), which is why a prop's cell must be
+// integral in every family (encounter.go's prop-integrality check, #929 T3
 // Opus round F2). A MEMBER's position is different in kind — an entity's
 // position, not a map cell — and on a fractional-tolerant square grid it may
 // sit anywhere in a region's continuous span, coinciding with no integer cell
 // at all; hex forbids fractional member positions entirely
 // (isIntegralAxialPosition), so this only affects square hosts (#929 T3 Opus
-// round F4). The asymmetry — occluders must be integral, member positions may
-// be fractional — is deliberate: one is floor/blockage data, the other is a
+// round F4). The asymmetry — a prop's cell must be integral, member positions
+// may be fractional — is deliberate: one is floor/blockage data, the other is a
 // live position the Atlas never touches.
 func (e *Encounter) Atlas() (Atlas, error) {
 	roomsByID := make(map[string]RoomInput, len(e.fieldInput))
@@ -153,9 +181,14 @@ func (e *Encounter) Atlas() (Atlas, error) {
 	for i, ri := range e.fieldInput {
 		roomsByID[ri.ID] = ri
 
-		occluders := make([]spatial.Position, len(ri.Occluders))
-		for j, o := range ri.Occluders {
-			occluders[j] = o.Add(ri.Origin)
+		props := make([]AtlasProp, len(ri.Props))
+		for j, p := range ri.Props {
+			props[j] = AtlasProp{
+				Ref:               p.Ref,
+				At:                p.At.Add(ri.Origin),
+				BlocksMovement:    *p.BlocksMovement,
+				BlocksLineOfSight: *p.BlocksLineOfSight,
+			}
 		}
 
 		boundaries := make([]AtlasBoundary, len(ri.Boundaries))
@@ -174,7 +207,7 @@ func (e *Encounter) Atlas() (Atlas, error) {
 			Origin:     ri.Origin,
 			Width:      ri.Width,
 			Height:     ri.Height,
-			Occluders:  occluders,
+			Props:      props,
 			Boundaries: boundaries,
 		}
 	}

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -23,7 +23,7 @@ import (
 // versa) produces a wrong, non-accidental-match absolute value. atlas-r1
 // also carries one boundary (#929 hardening round A) so AtlasRoom.Boundaries
 // projection, copy-out, reload survival, and live-state independence are
-// all exercised by the same tests that already cover Cells/Occluders.
+// all exercised by the same tests that already cover Cells/Props.
 func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
@@ -32,7 +32,7 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 			Rooms: []encounter.RoomInput{
 				{ID: "atlas-r3", Width: 4, Height: 3, Origin: spatial.Position{X: 9950, Y: 7}},
 				{ID: "atlas-r1", Width: 4, Height: 3, Origin: spatial.Position{X: 0, Y: 7},
-					Occluders: []spatial.Position{{X: 1, Y: 1}},
+					Props: []encounter.PropInput{rubble(1, 1)},
 					// (0,2)-(1,2): the far row from atlas-p1's Y=0 move path
 					// below (TestAtlasUnaffectedByLiveState moves it (0,0) to
 					// (3,0)) — a movement-blocking boundary on that row would
@@ -197,7 +197,7 @@ func (s *EncounterTestSuite) TestAtlasDeterministicOrdering() {
 		"Doorways must be sorted by connection ID regardless of declaration order")
 }
 
-// TestAtlasRegionOccludersAndBoundariesAreAbsolute pins exact absolute values —
+// TestAtlasRegionPropsAndBoundariesAreAbsolute pins exact absolute values —
 // local cell + Origin, element-wise — and would die under a sign-flipped
 // Add-vs-Subtract mutant inside Atlas itself. Also pins AtlasBoundary's
 // absolute projection (#929 hardening round A): both endpoints offset by
@@ -207,7 +207,7 @@ func (s *EncounterTestSuite) TestAtlasDeterministicOrdering() {
 // The region's own footprint is pinned beside it through RegionAt rather than
 // through an enumerated cell list (rpg-toolkit#1108): the anchor and span the
 // region reports have to mean the cells it actually holds.
-func (s *EncounterTestSuite) TestAtlasRegionOccludersAndBoundariesAreAbsolute() {
+func (s *EncounterTestSuite) TestAtlasRegionPropsAndBoundariesAreAbsolute() {
 	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
 	s.Require().NoError(err)
 
@@ -227,7 +227,8 @@ func (s *EncounterTestSuite) TestAtlasRegionOccludersAndBoundariesAreAbsolute() 
 	s.Require().Equal(spatial.Position{X: 0, Y: 7}, r1.Origin, "the region's anchor is where its local (0,0) landed")
 	s.Require().Equal(4, r1.Width, "the span is the region's cell set, so the axes must not be swapped")
 	s.Require().Equal(3, r1.Height)
-	s.Require().Equal([]spatial.Position{{X: 1, Y: 8}}, r1.Occluders, "occluder must be offset by Origin too")
+	s.Require().Equal([]encounter.AtlasProp{absoluteRubble(1, 8)}, r1.Props,
+		"a prop's cell must be offset by Origin too")
 
 	// The span means cells: local (0,0) and the far corner local (3,2) are
 	// both this region's, in absolute space, and RegionAt is what says so.
@@ -237,10 +238,10 @@ func (s *EncounterTestSuite) TestAtlasRegionOccludersAndBoundariesAreAbsolute() 
 		s.Require().Equal(encounter.RegionID("atlas-r1"), got, "cell %v", cell)
 	}
 
-	// #929 T3 fix round item 3: an occluder's cell is floor AND blockage
+	// #929 T3 fix round item 3: a prop's cell is floor AND blockage
 	// (ruling 1: occlusion is walkability, not ownership). This is the
 	// property hosts render by — floor from the region's span, blockage
-	// layered from Occluders — and RegionAt is where it is now visible.
+	// layered from Props — and RegionAt is where it is now visible.
 	got, owned := enc.RegionAt(spatial.Position{X: 1, Y: 8})
 	s.Require().True(owned, "an occluded cell is still floor")
 	s.Require().Equal(encounter.RegionID("atlas-r1"), got)
@@ -299,7 +300,7 @@ func (s *EncounterTestSuite) TestAtlasUnaffectedByLiveState() {
 // TestAtlasCopyOutImmunity mutates every slice a returned Atlas exposes
 // and re-fetches — the second Atlas must be unaffected, proving nothing
 // aliases internal storage (MUTATION-PROOF: verified by temporarily
-// aliasing Occluders directly to fieldInput and observing this fail,
+// aliasing Props directly to fieldInput and observing this fail,
 // per #929 T3 mutation-evidence protocol).
 func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
@@ -309,8 +310,8 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 	s.Require().NoError(err)
 
 	for i := range atlas1.Regions {
-		for j := range atlas1.Regions[i].Occluders {
-			atlas1.Regions[i].Occluders[j] = spatial.Position{X: -999, Y: -999}
+		for j := range atlas1.Regions[i].Props {
+			atlas1.Regions[i].Props[j].At = spatial.Position{X: -999, Y: -999}
 		}
 		for j := range atlas1.Regions[i].Boundaries {
 			atlas1.Regions[i].Boundaries[j] = encounter.AtlasBoundary{
@@ -332,8 +333,8 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 			r1 = r
 		}
 	}
-	s.Require().Equal([]spatial.Position{{X: 1, Y: 8}}, r1.Occluders,
-		"mutating the first snapshot's Occluders must not corrupt internal state")
+	s.Require().Equal([]encounter.AtlasProp{absoluteRubble(1, 8)}, r1.Props,
+		"mutating the first snapshot's Props must not corrupt internal state")
 	s.Require().Equal(spatial.Position{X: 3, Y: 8}, atlas2.Doorways[0].FromCell,
 		"mutating the first snapshot's Doorways must not corrupt internal state")
 	s.Require().Equal([]encounter.AtlasBoundary{
@@ -348,11 +349,11 @@ func (s *EncounterTestSuite) TestAtlasCopyOutImmunity() {
 // must be deep-equal (#929 T3 fix round item 2).
 //
 // What it can show is that a reload changes NOTHING the Atlas reports — every
-// region's anchor, span, occluders and walls, and every doorway's endpoints,
+// region's anchor, span, props and walls, and every doorway's endpoints,
 // come back identical. It cannot show that any of them is the INTENDED value,
 // since both sides are produced by the same code from the same construction
 // data; the intended values are pinned against hand-computed fixtures by
-// TestAtlasRegionOccludersAndBoundariesAreAbsolute and
+// TestAtlasRegionPropsAndBoundariesAreAbsolute and
 // TestAtlasDoorwaysAreAbsolute.
 func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 	enc1, err := encounter.NewEncounter(validAtlasOrderingSetup())
@@ -404,27 +405,48 @@ func (s *EncounterTestSuite) TestRegionOwnershipAtKissingDoorway() {
 	s.Require().Equal(encounter.RegionID("atlas-r2"), regions["far"], "the doorway cell in atlas-r2 belongs to atlas-r2, not atlas-r1")
 }
 
-// TestAnOccludedCellIsStillFloor pins ruling 1 in the terms that survive the
-// bridges: occlusion is walkability, not ownership. A member standing on an
-// occluder's own cell is reported in the region that owns it, exactly as one on
-// an empty cell is — RegionAt names an occluded cell like any other
-// (TestAtlasRegionOccludersAndBoundariesAreAbsolute), and this is the runtime
-// half of the same claim.
-func (s *EncounterTestSuite) TestAnOccludedCellIsStillFloor() {
+// TestAPropsCellIsStillFloor pins ruling 1 in the terms that survive the
+// bridges: WHAT A PROP BLOCKS IS NOT OWNERSHIP. RegionAt names a prop's cell
+// like any other (TestAtlasRegionPropsAndBoundariesAreAbsolute), and this is
+// the runtime half of the same claim.
+//
+// The two halves came apart in rpg-toolkit#1128 and are worth keeping apart.
+// This test used to assert that a member could be PLACED on a prop's cell, and
+// read that as proof the cell was floor — which held only because every prop
+// was hardcoded walk-through, so the assertion could not have failed for any
+// reason at all. Now a prop says whether it blocks movement, and the fixture's
+// rubble is solid: the cell is still floor, still owned by atlas-r1, and
+// nobody may stand on it. Ownership is the map's answer; blockage is the
+// prop's.
+func (s *EncounterTestSuite) TestAPropsCellIsStillFloor() {
 	enc, err := encounter.NewEncounter(validAtlasOrderingSetup())
 	s.Require().NoError(err)
 
-	// atlas-r1's occluder is local (1,1), absolute (1,8).
+	// atlas-r1's prop is local (1,1), absolute (1,8).
+	onTheRubble := spatial.Position{X: 1, Y: 8}
+
+	region, floor := enc.RegionAt(onTheRubble)
+	s.Require().True(floor, "a prop stands ON the floor; it is not a hole in it")
+	s.Require().Equal(encounter.RegionID("atlas-r1"), region,
+		"and the region that owns the cell owns it whatever is standing there")
+
 	_, err = enc.Join(&encounter.JoinInput{
-		Member: "onTheRubble", Kind: encounter.KindPlayer, Cell: spatial.Position{X: 1, Y: 8}})
-	s.Require().NoError(err, "an occluder must not bar a placement — it blocks sight, not floor")
+		Member: "onTheRubble", Kind: encounter.KindPlayer, Cell: onTheRubble})
+	s.Require().ErrorIs(err, encounter.ErrBadPlacement,
+		"solid rubble is somewhere you cannot stand — which is blockage, not ownership")
+
+	// The cell one step over is the control: same region, nothing on it.
+	beside := spatial.Position{X: 2, Y: 8}
+	_, err = enc.Join(&encounter.JoinInput{
+		Member: "besideIt", Kind: encounter.KindPlayer, Cell: beside})
+	s.Require().NoError(err)
 
 	members, err := enc.Members()
 	s.Require().NoError(err)
 	for _, m := range members {
-		if m.ID == "onTheRubble" {
+		if m.ID == "besideIt" {
 			s.Require().Equal(encounter.RegionID("atlas-r1"), m.Region)
-			s.Require().Equal(spatial.Position{X: 1, Y: 8}, m.Position)
+			s.Require().Equal(beside, m.Position)
 			return
 		}
 	}

--- a/rulebooks/dnd5e/encounter/atlascost_test.go
+++ b/rulebooks/dnd5e/encounter/atlascost_test.go
@@ -50,7 +50,7 @@ func budgetField() encounter.FieldInput {
 func TestAtlasReportsRegionsWithoutEnumeratingThem(t *testing.T) {
 	t.Run("a region describes its cells rather than listing them", func(t *testing.T) {
 		require.Equal(t,
-			[]string{"ID", "Grid", "Origin", "Width", "Height", "Occluders", "Boundaries"},
+			[]string{"ID", "Grid", "Origin", "Width", "Height", "Props", "Boundaries"},
 			structFieldNames(encounter.AtlasRegion{}),
 			"an AtlasRegion is an anchor and a span; a cell list would be the enumeration this slice deleted")
 	})

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -57,7 +57,7 @@ const beatOrderRoom = "hall"
 func wallRoom() encounter.RoomInput {
 	return encounter.RoomInput{
 		ID: beatOrderRoom, Width: 12, Height: 12,
-		Occluders: wallRow(6, 4, 8),
+		Props: wallRow(6, 4, 8),
 	}
 }
 

--- a/rulebooks/dnd5e/encounter/canvas.go
+++ b/rulebooks/dnd5e/encounter/canvas.go
@@ -22,7 +22,7 @@ import (
 // rpg-toolkit#1090's slice measured what it costs. The one that exists today,
 // in `rulebooks/dnd5e/resolution`, carries its own copy of grid construction
 // with a comment promising it "tracks encounter.buildRoomGrid rather than
-// choosing for itself" — and has no walls and no occluders in it at all, so the
+// choosing for itself" — and has no walls and no props in it at all, so the
 // first rule to ask it about line of sight would be told nothing blocks while
 // this module says otherwise. A promise in a comment is not a mechanism.
 //
@@ -34,7 +34,7 @@ import (
 //
 // One spatial room spanning the whole dungeon, in dungeon-absolute cells — the
 // canvas the authored rooms compiled into (#1106), with every wall registered
-// as an absolute boundary edge and every occluder and member placed on it. It
+// as an absolute boundary edge and every prop and member placed on it. It
 // answers what a room answers: where somebody stands, what the distance between
 // two cells is, whether a sightline is blocked, who is within a radius.
 //

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -105,9 +105,7 @@ func tombField() encounter.FieldInput {
 			// carries the pillars the reference tomb puts there.
 			{ID: tombHall, Width: 10, Height: 8, Origin: tombHallOrigin,
 				Boundaries: tombSeamWall(9, 8, tombDoorRow),
-				Occluders: []spatial.Position{
-					{X: 2, Y: 1}, {X: 2, Y: 6}, {X: 6, Y: 1}, {X: 6, Y: 6},
-				}},
+				Props:      []encounter.PropInput{rubble(2, 1), rubble(2, 6), rubble(6, 1), rubble(6, 6)}},
 			{ID: tombChamber, Width: 12, Height: 8, Origin: tombChamberOrigin},
 		},
 		Connections: []encounter.ConnectionInput{
@@ -375,23 +373,23 @@ func TestAHexFieldNeedsNoSuchLaw(t *testing.T) {
 	require.NoError(t, err, "a hex field anchored deep in the negative quadrant is ordinary")
 }
 
-// TestOccludersAreCompiledThroughTheirRoomsAnchor is the occluder half of the
+// TestPropsAreCompiledThroughTheirRoomsAnchor is the prop half of the
 // compile, pinned where it is observable: a sightline.
 //
-// The Atlas reports occluders absolute too, but it computes that projection
+// The Atlas reports props absolute too, but it computes that projection
 // itself, from the same construction data — so an Atlas assertion cannot tell
 // whether the CANVAS got them right. This one can: the blocking column sits in
 // a chamber anchored well away from the origin, and the two members are placed
-// so that an unprojected occluder would land in a different chamber entirely
+// so that an unprojected prop would land in a different chamber entirely
 // and block nothing.
-func TestOccludersAreCompiledThroughTheirRoomsAnchor(t *testing.T) {
+func TestPropsAreCompiledThroughTheirRoomsAnchor(t *testing.T) {
 	// A pillar wall three cells tall at hall-local x=5, y=2..4 — absolute
 	// x=14, y=6..8 through the hall's (9,4) anchor. Unprojected it would sit
 	// at (5,2..4), which is entrance floor and nowhere near the pair below.
 	field := tombField()
 	for i := range field.Rooms {
 		if field.Rooms[i].ID == tombHall {
-			field.Rooms[i].Occluders = wallColumn(5, 2, 4)
+			field.Rooms[i].Props = wallColumn(5, 2, 4)
 		}
 	}
 

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -86,6 +86,20 @@ func goblinPatrol() *patrol {
 // main_test.go, both tell the story) — a future W-law addition that
 // invalidates this fixture now fails CI instead of surfacing only when
 // someone launches the workbench by hand.
+// solidPillar is a chunk of rubble the workbench draws as '#': solid to walk
+// into and solid to look through, which is what its two-cell runs were always
+// meant to be. Before rpg-toolkit#1128 a room's contents could not say either,
+// and this pane's '#' was drawing a thing you could stand inside.
+func solidPillar(x, y float64) encounter.PropInput {
+	blocks := true
+	return encounter.PropInput{
+		Ref:               "workbench:props:rubble",
+		At:                spatial.Position{X: x, Y: y},
+		BlocksMovement:    &blocks,
+		BlocksLineOfSight: &blocks,
+	}
+}
+
 func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
@@ -100,7 +114,9 @@ func dungeonSetup() *encounter.SetupInput {
 			Rooms: []encounter.RoomInput{
 				{
 					ID: cryptID, Width: cryptSize, Height: cryptSize,
-					Occluders: []spatial.Position{{X: 6, Y: 6}, {X: 5, Y: 6}},
+					Props: []encounter.PropInput{
+						solidPillar(6, 6), solidPillar(5, 6),
+					},
 				},
 				{
 					// Anchored immediately east of the crypt (#929): the
@@ -114,8 +130,8 @@ func dungeonSetup() *encounter.SetupInput {
 					// room "crypt" and room "ossuary" overlap at absolute
 					// cell (0, 0): no field`) until this fix.
 					ID: ossuaryID, Width: ossuaryW, Height: ossuaryH,
-					Origin:    spatial.Position{X: 12, Y: 0},
-					Occluders: []spatial.Position{{X: 4, Y: 3}},
+					Origin: spatial.Position{X: 12, Y: 0},
+					Props:  []encounter.PropInput{solidPillar(4, 3)},
 				},
 			},
 			Connections: []encounter.ConnectionInput{
@@ -165,8 +181,8 @@ func worldGrid(data encounter.EncounterData, members []encounter.Member, room st
 		return nil
 	}
 	grid := blankGrid(r.Width, r.Height)
-	for _, o := range r.Occluders {
-		set(grid, o.X, o.Y, '#')
+	for _, o := range r.Props {
+		set(grid, o.At.X, o.At.Y, '#')
 	}
 	origin := roomOrigin(r)
 	for _, m := range members {
@@ -206,8 +222,8 @@ func beliefGrid(
 	origin := roomOrigin(r)
 
 	grid := blankGrid(r.Width, r.Height)
-	for _, o := range r.Occluders {
-		set(grid, o.X, o.Y, '#')
+	for _, o := range r.Props {
+		set(grid, o.At.X, o.At.Y, '#')
 	}
 	for _, h := range view {
 		var p encounter.SightPayload

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -141,13 +141,51 @@ type CanvasData struct {
 // spatial ever reordered it. Grid omits when empty (the square zero value)
 // so pre-v0.2 blobs and square-only encounters keep byte-identical output.
 type RoomData struct {
-	ID         string         `json:"id"`
-	Width      int            `json:"width"`
-	Height     int            `json:"height"`
-	Grid       string         `json:"grid,omitempty"`
-	Occluders  []PositionData `json:"occluders,omitempty"`
+	ID     string `json:"id"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+	Grid   string `json:"grid,omitempty"`
+
+	// Props are the room's authored things (rpg-toolkit#1128). Written
+	// under a NEW key, and Occluders below is why.
+	Props []PropData `json:"props,omitempty"`
+
+	// Occluders is a TOMBSTONE: the key this room's contents used to be
+	// written under, kept solely so a blob carrying it is refused by name.
+	//
+	// Renaming was not enough on its own, and that is the whole reason this
+	// field exists. The precedent (rpg-toolkit#1053/#1068, Kirk's
+	// fail-loudly ruling) is that a changed shape gets a detectable name so
+	// the old dialect lands nowhere — but "lands nowhere" only SIGNALS
+	// anything for a REQUIRED field, whose absence is then the defect.
+	// A room's contents are optional: a chamber with nothing in it is
+	// ordinary. So an old blob would have loaded clean as a room with no
+	// props, silently dropping every blocker somebody authored — a party
+	// walking through pillars in a dungeon whose load reported success.
+	// That is the exact failure mode MemberOutcomeData.Cell's rename exists
+	// to prevent, and here it needs a positive check rather than an absent
+	// one.
+	//
+	// json.RawMessage rather than the old type because nothing decodes it:
+	// the only question asked is whether the key was present at all.
+	Occluders json.RawMessage `json:"occluders,omitempty"`
+
 	Boundaries []BoundaryData `json:"boundaries,omitempty"`
 	Origin     *PositionData  `json:"origin"`
+}
+
+// PropData is the persistent representation of a [PropInput].
+//
+// BOTH FLAGS ARE POINTERS HERE TOO, and for the input's reason rather than a
+// mechanical mirror of it: a persisted false and a persisted nothing are
+// different facts, and a blob that lost the difference would reload a coffin
+// as decoration. Required at load, refused by name, never defaulted — the
+// same call RoomData.Origin makes for a missing anchor.
+type PropData struct {
+	Ref               string       `json:"ref"`
+	At                PositionData `json:"at"`
+	BlocksMovement    *bool        `json:"blocks_movement"`
+	BlocksLineOfSight *bool        `json:"blocks_line_of_sight"`
 }
 
 // PositionData is the persistent representation of spatial.Position.
@@ -400,7 +438,7 @@ func (e *Encounter) ToData() EncounterData {
 			Width:      ri.Width,
 			Height:     ri.Height,
 			Grid:       gridShapeToData(ri.Grid),
-			Occluders:  make([]PositionData, len(ri.Occluders)),
+			Props:      make([]PropData, len(ri.Props)),
 			Boundaries: make([]BoundaryData, len(ri.Boundaries)),
 			// Always a fresh pointer, always written — even the zero value
 			// (no omitempty, RoomData's own doc comment) — so a declared
@@ -409,8 +447,16 @@ func (e *Encounter) ToData() EncounterData {
 			Origin: &PositionData{X: ri.Origin.X, Y: ri.Origin.Y},
 		}
 
-		for j, occ := range ri.Occluders {
-			rd.Occluders[j] = PositionData{X: occ.X, Y: occ.Y}
+		for j, p := range ri.Props {
+			// Fresh pointers, never the input's own: two ToData calls must
+			// not alias one bool, for RoomData.Origin's reason.
+			blocksMovement, blocksSight := *p.BlocksMovement, *p.BlocksLineOfSight
+			rd.Props[j] = PropData{
+				Ref:               p.Ref,
+				At:                PositionData{X: p.At.X, Y: p.At.Y},
+				BlocksMovement:    &blocksMovement,
+				BlocksLineOfSight: &blocksSight,
+			}
 		}
 
 		for j, b := range ri.Boundaries {
@@ -1242,19 +1288,48 @@ func convertRoomDataToRoomInput(rooms []RoomData) ([]RoomInput, error) {
 		if rd.Origin == nil {
 			return nil, fmt.Errorf("room %q missing origin: %w", rd.ID, ErrNoField)
 		}
+		// The tombstone, checked before anything is built from this room —
+		// see RoomData.Occluders for why a rename alone would have loaded
+		// this blob clean and thrown its blockers away.
+		if len(rd.Occluders) > 0 {
+			return nil, fmt.Errorf(
+				"room %q carries occluders, a dialect this build does not speak: "+
+					"a room's contents are props now, and each says its ref and what it "+
+					"blocks (rpg-toolkit#1128): %w", rd.ID, ErrNoField)
+		}
 
 		ri := RoomInput{
 			ID:         rd.ID,
 			Width:      rd.Width,
 			Height:     rd.Height,
 			Grid:       shape,
-			Occluders:  make([]spatial.Position, len(rd.Occluders)),
+			Props:      make([]PropInput, len(rd.Props)),
 			Boundaries: make([]spatial.Boundary, len(rd.Boundaries)),
 			Origin:     spatial.Position{X: rd.Origin.X, Y: rd.Origin.Y},
 		}
 
-		for j, pd := range rd.Occluders {
-			ri.Occluders[j] = spatial.Position{X: pd.X, Y: pd.Y}
+		for j, pd := range rd.Props {
+			// REQUIRED at load, both of them, by name. A persisted prop that
+			// does not say what it blocks is a blob from before this module
+			// asked — loading it under a guess would put a party in a room
+			// whose blockers the host never authored (PropData).
+			if pd.BlocksMovement == nil {
+				return nil, fmt.Errorf("room %q prop %q does not say whether it blocks_movement: %w",
+					rd.ID, pd.Ref, ErrNoField)
+			}
+			if pd.BlocksLineOfSight == nil {
+				return nil, fmt.Errorf("room %q prop %q does not say whether it blocks_line_of_sight: %w",
+					rd.ID, pd.Ref, ErrNoField)
+			}
+			// Fresh pointers again: a loaded RoomInput must not alias the
+			// caller's EncounterData (snapshot immunity, both directions).
+			blocksMovement, blocksSight := *pd.BlocksMovement, *pd.BlocksLineOfSight
+			ri.Props[j] = PropInput{
+				Ref:               pd.Ref,
+				At:                spatial.Position{X: pd.At.X, Y: pd.At.Y},
+				BlocksMovement:    &blocksMovement,
+				BlocksLineOfSight: &blocksSight,
+			}
 		}
 
 		for j, bd := range rd.Boundaries {

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -1420,7 +1420,7 @@ func validEncounterDataWithConnection() encounter.EncounterData {
 // TestLoadSquarePropFractionalRejected is the Load-seam counterpart to
 // encounter_test.go's TestSetupSquarePropFractionalRejected (#929 T3
 // Opus round F2).
-func (s *DataTestSuite) TestLoadSquareOccluderFractionalRejected() {
+func (s *DataTestSuite) TestLoadSquarePropCellFractionalRejected() {
 	data := validEncounterDataWithConnection()
 	data.Field.Rooms[0].Props[0].At = encounter.PositionData{X: 2.5, Y: 2}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
@@ -1473,7 +1473,7 @@ func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 // TestLoadPropOnBoundaryCellAccepted is the Load-seam counterpart to
 // encounter_test.go's TestSetupPropOnBoundaryCellAccepted (#929 T3
 // trailing round N2).
-func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
+func (s *DataTestSuite) TestLoadPropOnBoundaryCellAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
 			Canvas: encounter.CanvasData{Void: "opaque"},
@@ -1485,13 +1485,13 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
-	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal at Load too")
+	s.Require().NoError(err, "a prop on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
 // TestLoadPropIDCrossRoomCollisionAccepted is the Load-seam counterpart
 // to encounter_test.go's TestSetupPropIDCrossRoomCollisionAccepted
 // (#929 hardening round C).
-func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
+func (s *DataTestSuite) TestLoadPropIDCrossRoomCollisionAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
 			Canvas: encounter.CanvasData{Void: "opaque"},
@@ -1506,13 +1506,13 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
-	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide at Load either`)
+	s.Require().NoError(err, `room "r" prop (-5,4) and room "r-" prop (5,4) must not collide at Load either`)
 }
 
 // TestLoadDuplicatePropRejected is the Load-seam counterpart to
 // encounter_test.go's TestSetupDuplicatePropRejected (#929 hardening
 // round D).
-func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
+func (s *DataTestSuite) TestLoadTwoPropsOnOneCellRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
 			Canvas: encounter.CanvasData{Void: "opaque"},

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -24,7 +24,7 @@ type DataTestSuite struct {
 }
 
 // TestGoldenJSONRich pins the tags the two small goldens cannot see:
-// occluders, boundaries, connections, a member-filtered ending, an
+// props, boundaries, connections, a member-filtered ending, an
 // External ending, intel-free monsters in a second room, and non-zero
 // clock/At fields. Eleven tag renames survived the small goldens
 // because omitempty hid these fields (T6 review).
@@ -37,7 +37,7 @@ type DataTestSuite struct {
 // zero value) — unaffected by this rewrite. Every position below is
 // re-derived for crypt's (Width=8,Height=8 => Q,R valid [-4,4)) and hall's
 // (Width=6,Height=6 => Q,R valid [-3,3)) origin-centered spans: crypt's
-// occluder, boundary (still an axial-neighbor pair, ΔR=1), member p1, and
+// prop, boundary (still an axial-neighbor pair, ΔR=1), member p1, and
 // the "guarded" ending's position are distinct in-bounds cells; door1's
 // endpoints are each room's own boundary cell (an interior cell can never
 // kiss anything) — FromPosition (3,0) is crypt's max-Q edge, ToPosition
@@ -76,7 +76,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
-					Occluders:  []spatial.Position{{X: 1, Y: 2}},
+					Props:      []encounter.PropInput{rubble(1, 2)},
 					Boundaries: []spatial.Boundary{{From: spatial.Position{X: -2, Y: -2}, To: spatial.Position{X: -2, Y: -1}, BlocksMovement: true, BlocksLineOfSight: true}},
 				},
 				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -3, Y: 7}},
@@ -116,7 +116,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// because sight stopped at a room boundary. That makes the golden strictly
 	// richer: it is the one place the bubbles array and intel's holdings are
 	// pinned as exact bytes.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMywieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","occluders":[{"x":1,"y":2}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-3,"y":7}},{"id":"p1","kind":"player","cell":{"x":-10,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMywieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","props":[{"ref":"test:props:rubble","at":{"x":1,"y":2},"blocks_movement":true,"blocks_line_of_sight":true}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-3,"y":7}},{"id":"p1","kind":"player","cell":{"x":-10,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
 	s.Equal(expected, string(bs))
 }
 
@@ -354,7 +354,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: 0, Y: 1},
-					Occluders: []spatial.Position{{X: 3, Y: 3}}},
+					Props: []encounter.PropInput{rubble(3, 3)}},
 				{ID: "r2", Width: 5, Height: 5, Origin: spatial.Position{X: 5, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{
@@ -371,7 +371,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 
 	setup.Field.Rooms[0].ID = "VANDALIZED"
 	setup.Field.Rooms[0].Width = 999
-	setup.Field.Rooms[0].Occluders[0] = spatial.Position{X: 4, Y: 4}
+	setup.Field.Rooms[0].Props[0].At = spatial.Position{X: 4, Y: 4}
 	setup.Field.Connections[0].ID = "VANDALIZED"
 	setup.Field.Connections[0].From = "VANDALIZED"
 	setup.Field.Connections[0].FromPosition = spatial.Position{X: 4, Y: 4}
@@ -381,7 +381,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	s.Require().Len(data.Field.Rooms, 2)
 	s.Equal("r1", data.Field.Rooms[0].ID, "the snapshot must not see the caller's vandalism")
 	s.Equal(5, data.Field.Rooms[0].Width)
-	s.Equal(encounter.PositionData{X: 3, Y: 3}, data.Field.Rooms[0].Occluders[0])
+	s.Equal(encounter.PositionData{X: 3, Y: 3}, data.Field.Rooms[0].Props[0].At)
 
 	s.Require().Len(data.Field.Connections, 1)
 	s.Equal("door1", data.Field.Connections[0].ID, "the snapshot must not see the caller's vandalism")
@@ -411,10 +411,10 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
-						ID:        "crypt",
-						Width:     10,
-						Height:    10,
-						Occluders: wallColumn(5, 3, 7),
+						ID:     "crypt",
+						Width:  10,
+						Height: 10,
+						Props:  wallColumn(5, 3, 7),
 						Boundaries: []spatial.Boundary{
 							{
 								From:              spatial.Position{X: 3, Y: 3},
@@ -493,7 +493,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 						// still reads the same three ways: blocked at first
 						// light, open once playerA steps to (4,1), blocked
 						// again once the goblin ducks behind it.
-						Occluders:  wallRow(3, 3, 5),
+						Props:      wallRow(3, 3, 5),
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -589,7 +589,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 						// world's to pump. Co-located and visible would be
 						// a fight at first light (rpg-toolkit#964), and a
 						// fight monster's decider is never consulted.
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						Props:      []encounter.PropInput{rubble(5, 5)},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -651,7 +651,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 						// world's to pump. Co-located and visible would be
 						// a fight at first light (rpg-toolkit#964), and a
 						// fight monster's decider is never consulted.
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						Props:      []encounter.PropInput{rubble(5, 5)},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -722,7 +722,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 						// world's to pump. Co-located and visible would be
 						// a fight at first light (rpg-toolkit#964), and a
 						// fight monster's decider is never consulted.
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						Props:      []encounter.PropInput{rubble(5, 5)},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -785,7 +785,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 						// world's to pump. Co-located and visible would be
 						// a fight at first light (rpg-toolkit#964), and a
 						// fight monster's decider is never consulted.
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						Props:      []encounter.PropInput{rubble(5, 5)},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -841,7 +841,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 						ID:         "room1",
 						Width:      5,
 						Height:     5,
-						Occluders:  []spatial.Position{},
+						Props:      []encounter.PropInput{},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -892,7 +892,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 						ID:         "room1",
 						Width:      5,
 						Height:     5,
-						Occluders:  []spatial.Position{},
+						Props:      []encounter.PropInput{},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -966,7 +966,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 						ID:         "room1",
 						Width:      5,
 						Height:     5,
-						Occluders:  []spatial.Position{},
+						Props:      []encounter.PropInput{},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -1035,7 +1035,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 						ID:         "room1",
 						Width:      5,
 						Height:     5,
-						Occluders:  []spatial.Position{},
+						Props:      []encounter.PropInput{},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -1141,7 +1141,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 						// world's to pump. Co-located and visible would be
 						// a fight at first light (rpg-toolkit#964), and a
 						// fight monster's decider is never consulted.
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						Props:      []encounter.PropInput{rubble(5, 5)},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -1216,7 +1216,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 						// world's to pump. Co-located and visible would be
 						// a fight at first light (rpg-toolkit#964), and a
 						// fight monster's decider is never consulted.
-						Occluders:  []spatial.Position{{X: 5, Y: 5}},
+						Props:      []encounter.PropInput{rubble(5, 5)},
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -1390,8 +1390,8 @@ func validEncounterData() encounter.EncounterData {
 // and ToPosition{0,7} valid ONLY in r2: same-sized rooms and equal From/To
 // positions would make a check that validates an endpoint against the WRONG
 // room (or a From/To transposition in convertConnectionDataToConnectionInput)
-// invisible. r1 carries an occluder at (2,2) and r2 an occluder at (1,3), so
-// both the from- and to-side "endpoint on occluder" rows have something to hit.
+// invisible. r1 carries a prop at (2,2) and r2 a prop at (1,3), so
+// both the from- and to-side "endpoint on prop" rows have something to hit.
 //
 // #929 T2: mirrors encounter_test.go's validConnSetup exactly (its own
 // comment explains the geometry in full) — FromPosition sits on r1's own
@@ -1404,10 +1404,10 @@ func validEncounterDataWithConnection() encounter.EncounterData {
 	d := validEncounterData()
 	d.Field.Rooms[0].Width = 10
 	d.Field.Rooms[0].Height = 4
-	d.Field.Rooms[0].Occluders = []encounter.PositionData{{X: 2, Y: 2}}
+	d.Field.Rooms[0].Props = []encounter.PropData{rubbleData(2, 2)}
 	d.Field.Rooms = append(d.Field.Rooms, encounter.RoomData{
 		ID: "r2", Width: 3, Height: 9, Origin: &encounter.PositionData{X: 10, Y: 0},
-		Occluders: []encounter.PositionData{{X: 1, Y: 3}},
+		Props: []encounter.PropData{rubbleData(1, 3)},
 	})
 	d.Field.Connections = []encounter.ConnectionData{
 		{ID: "c1", From: "r1", To: "r2",
@@ -1417,12 +1417,12 @@ func validEncounterDataWithConnection() encounter.EncounterData {
 	return d
 }
 
-// TestLoadSquareOccluderFractionalRejected is the Load-seam counterpart to
-// encounter_test.go's TestSetupSquareOccluderFractionalRejected (#929 T3
+// TestLoadSquarePropFractionalRejected is the Load-seam counterpart to
+// encounter_test.go's TestSetupSquarePropFractionalRejected (#929 T3
 // Opus round F2).
 func (s *DataTestSuite) TestLoadSquareOccluderFractionalRejected() {
 	data := validEncounterDataWithConnection()
-	data.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
+	data.Field.Rooms[0].Props[0].At = encounter.PositionData{X: 2.5, Y: 2}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
 	s.Require().Error(err)
@@ -1470,17 +1470,15 @@ func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 	s.Require().NotNil(enc)
 }
 
-// TestLoadOccluderOnBoundaryCellAccepted is the Load-seam counterpart to
-// encounter_test.go's TestSetupOccluderOnBoundaryCellAccepted (#929 T3
+// TestLoadPropOnBoundaryCellAccepted is the Load-seam counterpart to
+// encounter_test.go's TestSetupPropOnBoundaryCellAccepted (#929 T3
 // trailing round N2).
 func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
 			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
-				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{
-					{X: 0, Y: 2}, {X: 4, Y: 2}, {X: 2, Y: 0}, {X: 2, Y: 4}, {X: 0, Y: 0}, {X: 4, Y: 4},
-				}},
+				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0}, Props: []encounter.PropData{rubbleData(0, 2), rubbleData(4, 2), rubbleData(2, 0), rubbleData(2, 4), rubbleData(0, 0), rubbleData(4, 4)}},
 			},
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
@@ -1490,8 +1488,8 @@ func (s *DataTestSuite) TestLoadOccluderOnBoundaryCellAccepted() {
 	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
-// TestLoadOccluderIDCrossRoomCollisionAccepted is the Load-seam counterpart
-// to encounter_test.go's TestSetupOccluderIDCrossRoomCollisionAccepted
+// TestLoadPropIDCrossRoomCollisionAccepted is the Load-seam counterpart
+// to encounter_test.go's TestSetupPropIDCrossRoomCollisionAccepted
 // (#929 hardening round C).
 func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 	data := encounter.EncounterData{
@@ -1499,9 +1497,9 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridTypeHex,
-					Origin: &encounter.PositionData{X: 0, Y: 0}, Occluders: []encounter.PositionData{{X: -5, Y: 4}}},
+					Origin: &encounter.PositionData{X: 0, Y: 0}, Props: []encounter.PropData{rubbleData(-5, 4)}},
 				{ID: "r-", Width: 12, Height: 10, Grid: spatial.GridTypeHex,
-					Origin: &encounter.PositionData{X: 1000, Y: 0}, Occluders: []encounter.PositionData{{X: 5, Y: 4}}},
+					Origin: &encounter.PositionData{X: 1000, Y: 0}, Props: []encounter.PropData{rubbleData(5, 4)}},
 			},
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
@@ -1511,8 +1509,8 @@ func (s *DataTestSuite) TestLoadOccluderIDCrossRoomCollisionAccepted() {
 	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide at Load either`)
 }
 
-// TestLoadDuplicateOccluderRejected is the Load-seam counterpart to
-// encounter_test.go's TestSetupDuplicateOccluderRejected (#929 hardening
+// TestLoadDuplicatePropRejected is the Load-seam counterpart to
+// encounter_test.go's TestSetupDuplicatePropRejected (#929 hardening
 // round D).
 func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 	data := encounter.EncounterData{
@@ -1520,7 +1518,7 @@ func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "hall", Width: 5, Height: 5, Origin: &encounter.PositionData{X: 0, Y: 0},
-					Occluders: []encounter.PositionData{{X: 3, Y: 3}, {X: 3, Y: 3}}},
+					Props: []encounter.PropData{rubbleData(3, 3), rubbleData(3, 3)}},
 			},
 		},
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
@@ -1530,7 +1528,7 @@ func (s *DataTestSuite) TestLoadDuplicateOccluderRejected() {
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
-	s.Require().Contains(err.Error(), "duplicate occluder")
+	s.Require().Contains(err.Error(), "two props at")
 }
 
 // TestLoadDuplicateEndingKeyRejected is the Load-seam counterpart to
@@ -1623,14 +1621,14 @@ func (s *DataTestSuite) TestLoadRejections() {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 99, Y: 99}
 		}, "to-position out of bounds", encounter.ErrBadConnection},
-		{"connection from-position on occluder", func(d *encounter.EncounterData) {
+		{"connection from-position on a prop", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].FromPosition = &encounter.PositionData{X: 2, Y: 2}
-		}, "from-position on occluder", encounter.ErrBadConnection},
-		{"connection to-position on occluder", func(d *encounter.EncounterData) {
+		}, "from-position on prop", encounter.ErrBadConnection},
+		{"connection to-position on a prop", func(d *encounter.EncounterData) {
 			*d = validEncounterDataWithConnection()
 			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 1, Y: 3}
-		}, "to-position on occluder", encounter.ErrBadConnection},
+		}, "to-position on prop", encounter.ErrBadConnection},
 		{"connection missing from_position", func(d *encounter.EncounterData) {
 			// Deletes the field from the wire path (nil), not a zero-valued
 			// position — a missing endpoint must never silently default to
@@ -1943,7 +1941,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 }
 
 // validHexAxialData returns a fresh EncounterData with two hex rooms
-// joined by one connection, a member, and an occluder — the Load-seam
+// joined by one connection, a member, and a prop — the Load-seam
 // counterpart to encounter_test.go's validHexAxialSetup, mirrored exactly
 // (its own comment explains the geometry). Every position is integral
 // axial, including a negative one (gate.ToPosition).
@@ -1953,7 +1951,7 @@ func validHexAxialData() encounter.EncounterData {
 			Canvas: encounter.CanvasData{Void: "opaque"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0},
-					Occluders: []encounter.PositionData{{X: 2, Y: 2}}},
+					Props: []encounter.PropData{rubbleData(2, 2)}},
 				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 1}},
 			},
 			Connections: []encounter.ConnectionData{{
@@ -1988,11 +1986,11 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 		{"connection to-position fractional", func(d *encounter.EncounterData) {
 			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: -1.5, Y: -1}
 		}, encounter.ErrBadConnection, "not an integral axial cell"},
-		{"occluder position fractional", func(d *encounter.EncounterData) {
-			// #929 T3 Opus round F2: occluder integrality is now universal
+		{"prop cell fractional", func(d *encounter.EncounterData) {
+			// #929 T3 Opus round F2: prop integrality is now universal
 			// (isIntegralPosition), not hex-only — see the Setup-seam
 			// counterpart in encounter_test.go's TestSetupHexIntegralAxial.
-			d.Field.Rooms[0].Occluders[0] = encounter.PositionData{X: 2.5, Y: 2}
+			d.Field.Rooms[0].Props[0].At = encounter.PositionData{X: 2.5, Y: 2}
 		}, encounter.ErrNoField, "not a representable integral cell"},
 	}
 	for _, tc := range cases {
@@ -2681,7 +2679,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
-					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
+					{ID: "room1", Width: 5, Height: 5, Props: []encounter.PropInput{}, Boundaries: []spatial.Boundary{}},
 				},
 				Connections: []encounter.ConnectionInput{},
 			},
@@ -2722,7 +2720,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
-					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
+					{ID: "room1", Width: 5, Height: 5, Props: []encounter.PropInput{}, Boundaries: []spatial.Boundary{}},
 				},
 				Connections: []encounter.ConnectionInput{},
 			},
@@ -2754,7 +2752,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
-					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
+					{ID: "room1", Width: 5, Height: 5, Props: []encounter.PropInput{}, Boundaries: []spatial.Boundary{}},
 				},
 				Connections: []encounter.ConnectionInput{},
 			},
@@ -2788,7 +2786,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
-					{ID: "room1", Width: 5, Height: 5, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
+					{ID: "room1", Width: 5, Height: 5, Props: []encounter.PropInput{}, Boundaries: []spatial.Boundary{}},
 				},
 				Connections: []encounter.ConnectionInput{},
 			},
@@ -2884,7 +2882,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 						// still reads the same three ways — blocked at first
 						// light, open once playerA steps to (4,1), blocked
 						// again once the goblin ducks to (5,6).
-						Occluders:  wallRow(3, 3, 5),
+						Props:      wallRow(3, 3, 5),
 						Boundaries: []spatial.Boundary{},
 					},
 				},
@@ -2949,7 +2947,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
-					{ID: "room1", Width: 10, Height: 10, Occluders: []spatial.Position{}, Boundaries: []spatial.Boundary{}},
+					{ID: "room1", Width: 10, Height: 10, Props: []encounter.PropInput{}, Boundaries: []spatial.Boundary{}},
 				},
 				Connections: []encounter.ConnectionInput{},
 			},

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -174,7 +174,7 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 	out := make([]RoomInput, len(rooms))
 	for i, r := range rooms {
 		rc := r
-		rc.Occluders = append([]spatial.Position(nil), r.Occluders...)
+		rc.Props = append([]PropInput(nil), r.Props...)
 		rc.Boundaries = append([]spatial.Boundary(nil), r.Boundaries...)
 		out[i] = rc
 	}
@@ -567,55 +567,72 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 		}
 		grids[r.ID] = buildRoomGrid(r.Grid, r.Width, r.Height)
 
-		// Occluders must be integral in EVERY family, not just hex (#929 T3
-		// Opus round F2 — the identical square-vs-hex asymmetry T1 already
-		// fixed for Origin: see isIntegralPosition's doc comment):
-		// an occluder is a CELL of its region, and a region's cells are
-		// the integer lattice points inside its anchor-plus-span
-		// (AtlasRegion's doc comment). A fractional occluder would be
+		// A PROP MUST SAY WHAT IT IS AND WHAT IT DOES (rpg-toolkit#1128,
+		// and rpg-toolkit#1033's law behind it). All four blocking
+		// combinations are real content, so no zero value could stand in
+		// for a missing answer without inventing a wall nobody drew or
+		// removing one somebody did — the flags are pointers precisely so
+		// absence is absence, and both are refused here rather than
+		// silently taken (the argument [Void]'s doc comment makes for
+		// sealing itself, one type over).
+		//
+		// A prop's cell must be integral in EVERY family, not just hex
+		// (#929 T3 Opus round F2 — the identical square-vs-hex asymmetry
+		// T1 already fixed for Origin: see isIntegralPosition's doc
+		// comment): a prop is a CELL of its region, and a region's cells
+		// are the integer lattice points inside its anchor-plus-span
+		// ([AtlasRegion]'s doc comment). A fractional one would be
 		// blockage reported at a point that is not one of the region's
 		// cells at all — undrawable under the host contract "floor from
-		// the span, blockage from Occluders", and indistinguishable from
-		// a member's position, which alone may be fractional on a square
+		// the span, blockage from Props", and indistinguishable from a
+		// member's position, which alone may be fractional on a square
 		// grid. isIntegralPosition, not isIntegralAxialPosition —
 		// universal, not hex-only.
 		//
-		// This is the ONLY reason left, as of #929 hardening round C: an
-		// earlier version of this comment ALSO cited the occluder entity
-		// ID (built below) truncating fractional coordinates to int as a
-		// second, "reinforcing" reason — that claim was itself wrong in a
-		// way integrality could never have fixed: truncation makes
-		// coordinate-based IDs collide only WITHIN one room's own
-		// occluders, but the old ID scheme concatenated the ROOM ID too
-		// (occluder-<room>-<int(X)>-<int(Y)>), and room IDs are arbitrary,
-		// unrestricted strings — "r" with occluder (-5,4) and "r-" with
-		// occluder (5,4) both produced "occluder-r--5-4" regardless of
-		// integrality, a genuine CROSS-room collision on a legal field.
-		// The entity ID is index-based now (room's declaration index,
-		// occluder's index within it — see the occluder-placement loop
-		// below), which can never collide on ANY input, integral or not.
-		// Duplicate occluder positions are a room-list defect too (#929
-		// hardening round D), not something left to spatial's own voice:
-		// before the occluder entity ID went index-based (hardening round
-		// C), a duplicate coordinate happened to collide on the OLD
+		// Integrality is the ONLY reason left, as of #929 hardening round
+		// C: an earlier version of this comment ALSO cited the prop
+		// entity ID (built below) truncating fractional coordinates to
+		// int as a second, "reinforcing" reason — that claim was itself
+		// wrong in a way integrality could never have fixed: truncation
+		// makes coordinate-based IDs collide only WITHIN one room's own
+		// props, but the old ID scheme concatenated the ROOM ID too
+		// (occluder-<room>-<int(X)>-<int(Y)>), and room IDs are
+		// arbitrary, unrestricted strings — "r" with a prop at (-5,4) and
+		// "r-" with one at (5,4) both produced "occluder-r--5-4"
+		// regardless of integrality, a genuine CROSS-room collision on a
+		// legal field. The entity ID is index-based now (room's
+		// declaration index, prop's index within it — see the
+		// prop-placement loop below), which can never collide on ANY
+		// input, integral or not. Duplicate prop cells are a room-list
+		// defect too (#929 hardening round D), not something left to
+		// spatial's own voice: before the ID went index-based (hardening
+		// round C), a duplicate coordinate happened to collide on the OLD
 		// coordinate-derived ID and got rejected as "entity ... already
 		// indexed" — spatial's vocabulary, not ours, and an accident of
 		// that ID scheme, not a real "no duplicate cells" rule (spatial
 		// freely allows two DIFFERENT entities to share a position). The
-		// index-based ID fixed the cross-room collision but also
-		// silently REMOVED that accidental duplicate-catch — two
-		// occluders at the same cell now place without error. Caught
-		// explicitly here instead: same room-list defect vocabulary
-		// every other room check uses.
-		seenOccluders := make(map[spatial.Position]bool, len(r.Occluders))
-		for _, occ := range r.Occluders {
-			if !isIntegralPosition(occ) {
-				return nil, fmt.Errorf("room %q occluder (%g,%g) is not a representable integral cell: %w", r.ID, occ.X, occ.Y, ErrNoField)
+		// index-based ID fixed the cross-room collision but also silently
+		// REMOVED that accidental duplicate-catch — two props at the same
+		// cell now place without error. Caught explicitly here instead:
+		// same room-list defect vocabulary every other room check uses.
+		seenProps := make(map[spatial.Position]bool, len(r.Props))
+		for _, p := range r.Props {
+			if p.Ref == "" {
+				return nil, fmt.Errorf("room %q has a prop at (%g,%g) with no ref: %w", r.ID, p.At.X, p.At.Y, ErrNoField)
 			}
-			if seenOccluders[occ] {
-				return nil, fmt.Errorf("room %q has duplicate occluder (%g,%g): %w", r.ID, occ.X, occ.Y, ErrNoField)
+			if p.BlocksMovement == nil {
+				return nil, fmt.Errorf("room %q prop %q does not say whether it blocks_movement: %w", r.ID, p.Ref, ErrNoField)
 			}
-			seenOccluders[occ] = true
+			if p.BlocksLineOfSight == nil {
+				return nil, fmt.Errorf("room %q prop %q does not say whether it blocks_line_of_sight: %w", r.ID, p.Ref, ErrNoField)
+			}
+			if !isIntegralPosition(p.At) {
+				return nil, fmt.Errorf("room %q prop %q at (%g,%g) is not a representable integral cell: %w", r.ID, p.Ref, p.At.X, p.At.Y, ErrNoField)
+			}
+			if seenProps[p.At] {
+				return nil, fmt.Errorf("room %q has two props at (%g,%g): %w", r.ID, p.At.X, p.At.Y, ErrNoField)
+			}
+			seenProps[p.At] = true
 		}
 	}
 
@@ -762,7 +779,7 @@ func canvasSpan(shape spatial.GridShape, qMin, qMax, rMin, rMax int) (width, hei
 
 // compileCanvas turns the authored rooms into the one spatial room the
 // encounter runs on: a grid spanning the field's whole absolute footprint, with
-// every room's occluders and walls projected through its Origin and registered
+// every room's props and walls projected through its Origin and registered
 // there, and the field's own declaration of what the space between them is made
 // of (rpg-toolkit#1116).
 //
@@ -798,14 +815,21 @@ func compileCanvas(rooms []RoomInput, grids map[string]spatial.Grid, void Void, 
 	})
 
 	for roomIdx, ri := range rooms {
-		// Occluder entity IDs stay index-based — the room's declaration index
-		// and the occluder's index within it. Room IDs are arbitrary strings,
-		// and a coordinate- or ID-derived key collides on legal fields (#929
-		// hardening round C). A pair of slice indices cannot.
-		for occIdx, pos := range ri.Occluders {
-			occluder := &occluderEntity{id: fmt.Sprintf("occluder-%d-%d", roomIdx, occIdx)}
-			if perr := canvas.PlaceEntity(occluder, pos.Add(ri.Origin)); perr != nil {
-				return nil, fmt.Errorf("occluder placement: %w: %w", ErrBadPlacement, perr)
+		// Prop entity IDs stay index-based — the room's declaration index
+		// and the prop's index within it. Room IDs are arbitrary strings, and
+		// a coordinate- or ID-derived key collides on legal fields (#929
+		// hardening round C); the authored REF cannot be one either, since
+		// four pillars in a hall legitimately share one (rpg-toolkit#1128).
+		// A pair of slice indices cannot collide on any input.
+		for propIdx, p := range ri.Props {
+			prop := &propEntity{
+				id:                fmt.Sprintf("prop-%d-%d", roomIdx, propIdx),
+				ref:               p.Ref,
+				blocksMovement:    *p.BlocksMovement,
+				blocksLineOfSight: *p.BlocksLineOfSight,
+			}
+			if perr := canvas.PlaceEntity(prop, p.At.Add(ri.Origin)); perr != nil {
+				return nil, fmt.Errorf("prop placement: %w: %w", ErrBadPlacement, perr)
 			}
 		}
 
@@ -1007,14 +1031,14 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 			return fmt.Errorf("connection %q to-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
 		}
 
-		for _, occ := range fromRoom.Occluders {
-			if occ.X == c.FromPosition.X && occ.Y == c.FromPosition.Y {
-				return fmt.Errorf("connection %q from-position on occluder: %w", c.ID, ErrBadConnection)
+		for _, prop := range fromRoom.Props {
+			if prop.At.X == c.FromPosition.X && prop.At.Y == c.FromPosition.Y {
+				return fmt.Errorf("connection %q from-position on prop %q: %w", c.ID, prop.Ref, ErrBadConnection)
 			}
 		}
-		for _, occ := range toRoom.Occluders {
-			if occ.X == c.ToPosition.X && occ.Y == c.ToPosition.Y {
-				return fmt.Errorf("connection %q to-position on occluder: %w", c.ID, ErrBadConnection)
+		for _, prop := range toRoom.Props {
+			if prop.At.X == c.ToPosition.X && prop.At.Y == c.ToPosition.Y {
+				return fmt.Errorf("connection %q to-position on prop %q: %w", c.ID, prop.Ref, ErrBadConnection)
 			}
 		}
 
@@ -1198,7 +1222,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 
 	// Check connections: unique non-empty IDs, endpoints resolve to distinct
 	// declared rooms, endpoints in bounds (per the room's own grid) and off
-	// any occluder.
+	// any prop.
 	if err = validateConnectionInputs(in.Field.Rooms, roomGrids, in.Field.Connections); err != nil {
 		return nil, fmt.Errorf("newencounter: %w", err)
 	}
@@ -2128,34 +2152,46 @@ func (e *Encounter) rebuildPercepts(observers []MemberID) (map[MemberID]*intel.S
 	return deltas, nil
 }
 
-// occluderEntity is an internal entity for blocking line of sight
-type occluderEntity struct {
-	id string
+// propEntity is one authored [PropInput] as the canvas holds it.
+//
+// BOTH ANSWERS ARE CARRIED, NOT DECIDED (rpg-toolkit#1128). Its predecessor
+// answered true to sight and false to movement unconditionally, which made
+// every authored thing transparent to walk through and opaque to look through —
+// the inverse of a pillar, a statue and a coffin alike. What a prop blocks is
+// the author's to say, and this type's only job is to say it back to spatial.
+type propEntity struct {
+	id                string
+	ref               string
+	blocksMovement    bool
+	blocksLineOfSight bool
 }
 
-// GetID returns the occluder's ID
-func (o *occluderEntity) GetID() string {
-	return o.id
+// GetID returns the prop's index-derived entity ID — see compileCanvas for why
+// it is not the ref.
+func (p *propEntity) GetID() string {
+	return p.id
 }
 
-// GetType returns "occluder"
-func (o *occluderEntity) GetType() core.EntityType {
-	return core.EntityType("occluder")
+// GetType returns "prop"
+func (p *propEntity) GetType() core.EntityType {
+	return core.EntityType("prop")
 }
 
 // GetSize returns 1 (single-cell entity)
-func (o *occluderEntity) GetSize() int {
+func (p *propEntity) GetSize() int {
 	return 1
 }
 
-// BlocksLineOfSight returns true for occluders
-func (o *occluderEntity) BlocksLineOfSight() bool {
-	return true
+// BlocksLineOfSight reports what the author declared. Subject to spatial's lane
+// rule either way: one cell of it obstructs nothing on its own ([PropInput]).
+func (p *propEntity) BlocksLineOfSight() bool {
+	return p.blocksLineOfSight
 }
 
-// BlocksMovement returns false for occluders
-func (o *occluderEntity) BlocksMovement() bool {
-	return false
+// BlocksMovement reports what the author declared. True refuses an arrival on
+// this cell, which is what a step is ([PropInput]).
+func (p *propEntity) BlocksMovement() bool {
+	return p.blocksMovement
 }
 
 // Join adds a new member to the encounter. The ambient field is always there

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -167,14 +167,35 @@ type Encounter struct {
 }
 
 // deepCopyRoomInputs snapshots the caller's room descriptions — the
-// persistence source must never alias caller-owned slices (T6 review
+// persistence source must never alias caller-owned state (T6 review
 // M4: a caller editing its SetupInput after construction silently
 // corrupted ToData and made the encounter unsavable).
+//
+// COPYING THE SLICE IS NOT ENOUGH FOR PROPS, and that is why they are copied
+// element-wise here rather than with an append like the boundaries beside them.
+// A [PropInput] holds its two blocking answers as POINTERS ([PropInput]'s doc
+// comment: absence has to be absence), so a copied element still points at the
+// caller's bools, and a caller flipping one after construction would change what
+// ToData writes while the running encounter — which dereferenced them once, at
+// compileCanvas — went on behaving the other way. That is the T6 defect exactly,
+// reintroduced one indirection down, and it survived the mutation battery on
+// rpg-toolkit#1128 until this loop was written.
 func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 	out := make([]RoomInput, len(rooms))
 	for i, r := range rooms {
 		rc := r
-		rc.Props = append([]PropInput(nil), r.Props...)
+		rc.Props = make([]PropInput, len(r.Props))
+		for j, p := range r.Props {
+			rc.Props[j] = p
+			if p.BlocksMovement != nil {
+				blocksMovement := *p.BlocksMovement
+				rc.Props[j].BlocksMovement = &blocksMovement
+			}
+			if p.BlocksLineOfSight != nil {
+				blocksSight := *p.BlocksLineOfSight
+				rc.Props[j].BlocksLineOfSight = &blocksSight
+			}
+		}
 		rc.Boundaries = append([]spatial.Boundary(nil), r.Boundaries...)
 		out[i] = rc
 	}

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -382,7 +382,7 @@ func validConnSetup() *encounter.SetupInput {
 // (TestSetupHexIntegralAxial's sibling row), with the universal
 // isRepresentableInteger message, not the hex-specific one. One-defect:
 // validConnSetup's r1.Props[0] is the ONLY thing mutated.
-func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
+func (s *EncounterTestSuite) TestSetupSquarePropCellFractionalRejected() {
 	setup := validConnSetup()
 	setup.Field.Rooms[0].Props[0].At = spatial.Position{X: 2.5, Y: 2}
 	_, err := encounter.NewEncounter(setup)
@@ -399,7 +399,7 @@ func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
 // sight (field.go's doc comment), not placement — a boundary cell,
 // including a corner, is exactly as legal a prop cell as an
 // interior one.
-func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
+func (s *EncounterTestSuite) TestSetupPropOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
@@ -411,7 +411,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	}
 	_, err := encounter.NewEncounter(setup)
-	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal")
+	s.Require().NoError(err, "a prop on a room's boundary cell, including a corner, must be legal")
 }
 
 // TestSetupPropIDCrossRoomCollisionAccepted pins the hardening round's
@@ -421,7 +421,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 // "prop-r--5-4" — a genuine cross-room ID collision on a field that is
 // otherwise entirely legal under W1/W2/W3. The ID is index-based now, so
 // this exact colliding pair must construct without error.
-func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
+func (s *EncounterTestSuite) TestSetupPropIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
@@ -436,7 +436,7 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	}
 	_, err := encounter.NewEncounter(setup)
-	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide`)
+	s.Require().NoError(err, `room "r" prop (-5,4) and room "r-" prop (5,4) must not collide`)
 }
 
 // TestSetupDuplicatePropRejected pins the hardening round's item D:
@@ -447,7 +447,7 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 // switched to an index-based ID and, as a side effect, removed even
 // that accidental catch. Rejected explicitly now, in the module's own
 // room-list defect vocabulary.
-func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
+func (s *EncounterTestSuite) TestSetupTwoPropsOnOneCellRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -122,7 +122,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 }
 
 func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
-	s.Run("occluder blocks both directions", func() {
+	s.Run("a wall blocks both directions", func() {
 		// Arrange: alice and goblin separated by a WALL — a pillar is leaned
 		// around now (spatial v0.9.1, see testwalls_test.go), so a fixture
 		// that wants sight blocked has to build something worth blocking.
@@ -132,10 +132,10 @@ func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
-						ID:        room1,
-						Width:     10,
-						Height:    10,
-						Occluders: wallColumn(4, 0, 9),
+						ID:     room1,
+						Width:  10,
+						Height: 10,
+						Props:  wallColumn(4, 0, 9),
 					},
 				},
 				Connections: []encounter.ConnectionInput{},
@@ -335,7 +335,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 }
 
 // validConnSetup returns a fresh SetupInput with two DELIBERATELY
-// mismatched rooms — r1 is 10x4 (occluder at (2,2)), r2 is 3x9 (occluder
+// mismatched rooms — r1 is 10x4 (prop at (2,2)), r2 is 3x9 (prop
 // at (1,3)) — and one fully valid connection between them, with
 // FromPosition{9,1} valid ONLY in r1 and ToPosition{0,7} valid ONLY in r2.
 // Same-sized rooms and equal From/To positions would make a check that
@@ -359,8 +359,8 @@ func validConnSetup() *encounter.SetupInput {
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
-				{ID: "r1", Width: 10, Height: 4, Occluders: []spatial.Position{{X: 2, Y: 2}}},
-				{ID: "r2", Width: 3, Height: 9, Origin: spatial.Position{X: 10, Y: 0}, Occluders: []spatial.Position{{X: 1, Y: 3}}},
+				{ID: "r1", Width: 10, Height: 4, Props: []encounter.PropInput{rubble(2, 2)}},
+				{ID: "r2", Width: 3, Height: 9, Origin: spatial.Position{X: 10, Y: 0}, Props: []encounter.PropInput{rubble(1, 3)}},
 			},
 			Connections: []encounter.ConnectionInput{
 				{ID: "c1", From: "r1", To: "r2",
@@ -375,29 +375,29 @@ func validConnSetup() *encounter.SetupInput {
 	}
 }
 
-// TestSetupSquareOccluderFractionalRejected pins F2 (#929 T3 Opus round):
-// occluder integrality is universal now, not hex-only — a fractional
-// occluder on a SQUARE room (previously accepted outright, before this
+// TestSetupSquarePropFractionalRejected pins F2 (#929 T3 Opus round):
+// prop integrality is universal now, not hex-only — a fractional
+// prop on a SQUARE room (previously accepted outright, before this
 // fix) must reject exactly like a fractional hex one
 // (TestSetupHexIntegralAxial's sibling row), with the universal
 // isRepresentableInteger message, not the hex-specific one. One-defect:
-// validConnSetup's r1.Occluders[0] is the ONLY thing mutated.
+// validConnSetup's r1.Props[0] is the ONLY thing mutated.
 func (s *EncounterTestSuite) TestSetupSquareOccluderFractionalRejected() {
 	setup := validConnSetup()
-	setup.Field.Rooms[0].Occluders[0] = spatial.Position{X: 2.5, Y: 2}
+	setup.Field.Rooms[0].Props[0].At = spatial.Position{X: 2.5, Y: 2}
 	_, err := encounter.NewEncounter(setup)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Require().Contains(err.Error(), "not a representable integral cell")
 }
 
-// TestSetupOccluderOnBoundaryCellAccepted pins N2's over-tightening sweep
-// (#929 T3 trailing round): every occluder in every EXISTING fixture sits
-// on an interior cell, so a mutant that rejected a boundary-cell occluder
-// (plausible: "occluders should be interior only") survived the suite
-// with zero failures until this row was added. Occluders block line of
+// TestSetupPropOnBoundaryCellAccepted pins N2's over-tightening sweep
+// (#929 T3 trailing round): every prop in every EXISTING fixture sits
+// on an interior cell, so a mutant that rejected a boundary-cell prop
+// (plausible: "props should be interior only") survived the suite
+// with zero failures until this row was added. Props block line of
 // sight (field.go's doc comment), not placement — a boundary cell,
-// including a corner, is exactly as legal an occluder position as an
+// including a corner, is exactly as legal a prop cell as an
 // interior one.
 func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
@@ -405,14 +405,7 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
-				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{
-					{X: 0, Y: 2}, // left edge
-					{X: 4, Y: 2}, // right edge
-					{X: 2, Y: 0}, // top edge
-					{X: 2, Y: 4}, // bottom edge
-					{X: 0, Y: 0}, // corner
-					{X: 4, Y: 4}, // corner
-				}},
+				{ID: "hall", Width: 5, Height: 5, Props: []encounter.PropInput{rubble(0, 2), rubble(4, 2), rubble(2, 0), rubble(2, 4), rubble(0, 0), rubble(4, 4)}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -421,11 +414,11 @@ func (s *EncounterTestSuite) TestSetupOccluderOnBoundaryCellAccepted() {
 	s.Require().NoError(err, "an occluder on a room's boundary cell, including a corner, must be legal")
 }
 
-// TestSetupOccluderIDCrossRoomCollisionAccepted pins the hardening round's
-// fix (#929 item C): the occluder entity ID used to concatenate room ID
-// and truncated coordinates (occluder-<room>-<int(X)>-<int(Y)>), so room
-// "r" with occluder (-5,4) and room "r-" with occluder (5,4) both produced
-// "occluder-r--5-4" — a genuine cross-room ID collision on a field that is
+// TestSetupPropIDCrossRoomCollisionAccepted pins the hardening round's
+// fix (#929 item C): the prop entity ID used to concatenate room ID
+// and truncated coordinates (prop-<room>-<int(X)>-<int(Y)>), so room
+// "r" with prop (-5,4) and room "r-" with prop (5,4) both produced
+// "prop-r--5-4" — a genuine cross-room ID collision on a field that is
 // otherwise entirely legal under W1/W2/W3. The ID is index-based now, so
 // this exact colliding pair must construct without error.
 func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
@@ -435,9 +428,9 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
-					Occluders: []spatial.Position{{X: -5, Y: 4}}},
+					Props: []encounter.PropInput{rubble(-5, 4)}},
 				{ID: "r-", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
-					Origin: spatial.Position{X: 1000, Y: 0}, Occluders: []spatial.Position{{X: 5, Y: 4}}},
+					Origin: spatial.Position{X: 1000, Y: 0}, Props: []encounter.PropInput{rubble(5, 4)}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -446,11 +439,11 @@ func (s *EncounterTestSuite) TestSetupOccluderIDCrossRoomCollisionAccepted() {
 	s.Require().NoError(err, `room "r" occluder (-5,4) and room "r-" occluder (5,4) must not collide`)
 }
 
-// TestSetupDuplicateOccluderRejected pins the hardening round's item D:
-// two occluders at the SAME cell used to escape module validation
+// TestSetupDuplicatePropRejected pins the hardening round's item D:
+// two props at the SAME cell used to escape module validation
 // entirely and reject only in spatial's own voice ("entity ... already
 // indexed") as an accident of the old coordinate-derived entity ID —
-// see TestSetupOccluderIDCrossRoomCollisionAccepted's fix, which
+// see TestSetupPropIDCrossRoomCollisionAccepted's fix, which
 // switched to an index-based ID and, as a side effect, removed even
 // that accidental catch. Rejected explicitly now, in the module's own
 // room-list defect vocabulary.
@@ -460,7 +453,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
-				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 3, Y: 3}, {X: 3, Y: 3}}},
+				{ID: "hall", Width: 5, Height: 5, Props: []encounter.PropInput{rubble(3, 3), rubble(3, 3)}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -468,7 +461,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateOccluderRejected() {
 	_, err := encounter.NewEncounter(setup)
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
-	s.Require().Contains(err.Error(), "duplicate occluder")
+	s.Require().Contains(err.Error(), "two props at")
 }
 
 // TestSetupDuplicateEndingKeyRejected pins hardening round item E: two
@@ -527,12 +520,12 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 		{"connection to-position out of bounds", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].ToPosition = spatial.Position{X: 99, Y: 99}
 		}, "to-position out of bounds"},
-		{"connection from-position on occluder", func(in *encounter.SetupInput) {
+		{"connection from-position on a prop", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].FromPosition = spatial.Position{X: 2, Y: 2}
-		}, "from-position on occluder"},
-		{"connection to-position on occluder", func(in *encounter.SetupInput) {
+		}, "from-position on prop"},
+		{"connection to-position on a prop", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].ToPosition = spatial.Position{X: 1, Y: 3}
-		}, "to-position on occluder"},
+		}, "to-position on prop"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -810,7 +803,7 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 }
 
 // validHexAxialSetup returns a fresh SetupInput with two hex rooms joined
-// by one connection, a member, and an occluder — every position integral
+// by one connection, a member, and a prop — every position integral
 // axial, including a negative one (gate.ToPosition). The base for
 // TestSetupHexIntegralAxial's one-defect rows: interim tools/spatial#926
 // enforcement (isIntegralAxialPosition) rejects a fractional X or Y at
@@ -832,7 +825,7 @@ func validHexAxialSetup() *encounter.SetupInput {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
-					Occluders: []spatial.Position{{X: 2, Y: 2}}},
+					Props: []encounter.PropInput{rubble(2, 2)}},
 				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 1}},
 			},
 			Connections: []encounter.ConnectionInput{{
@@ -851,7 +844,7 @@ func validHexAxialSetup() *encounter.SetupInput {
 // TestSetupHexIntegralAxial pins the interim tools/spatial#926
 // enforcement at the Setup seam: a fractional X or Y is rejected for
 // every position kind a hex room accepts externally — member, both
-// connection endpoints, and an occluder — each with the error class its
+// connection endpoints, and a prop — each with the error class its
 // existing defect family already uses. Load-seam counterpart:
 // TestLoadHexIntegralAxial in data_test.go.
 func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
@@ -870,12 +863,12 @@ func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 		{"connection to-position fractional", func(in *encounter.SetupInput) {
 			in.Field.Connections[0].ToPosition = spatial.Position{X: -1.5, Y: -1}
 		}, encounter.ErrBadConnection, "not an integral axial cell"},
-		{"occluder position fractional", func(in *encounter.SetupInput) {
-			// #929 T3 Opus round F2: occluder integrality is now universal
+		{"prop cell fractional", func(in *encounter.SetupInput) {
+			// #929 T3 Opus round F2: prop integrality is now universal
 			// (isIntegralPosition), not hex-only (isIntegralAxialPosition) —
 			// the message matches Origin's ("not a representable integral
 			// cell"), not the hex-specific connection/member wording.
-			in.Field.Rooms[0].Occluders[0] = spatial.Position{X: 2.5, Y: 2}
+			in.Field.Rooms[0].Props[0].At = spatial.Position{X: 2.5, Y: 2}
 		}, encounter.ErrNoField, "not a representable integral cell"},
 	}
 	for _, tc := range cases {
@@ -1688,7 +1681,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 
 // validTriggerAcceptanceFieldSetup is the rich SQUARE-family fixture for
 // TestSetupEndingTriggerMustAccept (#929 T3 trailing round N2): a kissing
-// pair (hall/vault, connected, hall carries an occluder) plus an isolated
+// pair (hall/vault, connected, hall carries a prop) plus an isolated
 // room (annex, no connection at all) — exercising every must-accept shape
 // a TriggerReachedPosition can legally target. A rejection-only test
 // suite proves a validator rejects; this fixture is what proves it does
@@ -1699,7 +1692,7 @@ func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
-				{ID: "hall", Width: 5, Height: 5, Occluders: []spatial.Position{{X: 2, Y: 2}}},
+				{ID: "hall", Width: 5, Height: 5, Props: []encounter.PropInput{rubble(2, 2)}},
 				{ID: "vault", Width: 4, Height: 4, Origin: spatial.Position{X: 5, Y: 0}},
 				{ID: "annex", Width: 3, Height: 3, Origin: spatial.Position{X: 1000, Y: 1000}},
 			},
@@ -2046,10 +2039,10 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
 					{
-						ID:        room1,
-						Width:     20,
-						Height:    20,
-						Occluders: wallRow(10, 7, 13),
+						ID:     room1,
+						Width:  20,
+						Height: 20,
+						Props:  wallRow(10, 7, 13),
 					},
 				},
 			},

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -60,12 +60,15 @@ var (
 	// ErrNoField is returned when Setup is called without rooms, or when a
 	// declared room is itself defective — empty or duplicate ID, an
 	// unrecognized-or-no-longer-supported grid shape value (gridless
-	// included — RoomData's doc comment in data.go), a non-integral
-	// occluder position in ANY family, not just hex (#929 T3 Opus round
-	// F2), a duplicate occluder position within one room (#929 hardening
-	// round D — previously escaped module validation and rejected only
-	// in spatial's own voice, an accident of the pre-index-based
-	// occluder entity ID), non-positive OR oversized Width/Height
+	// included — RoomData's doc comment in data.go), a prop with no ref or
+	// with either blocking answer left unsaid (rpg-toolkit#1128 —
+	// [PropInput]), a non-integral prop cell in ANY family, not just hex
+	// (#929 T3 Opus round F2), two props on one cell within one room (#929
+	// hardening round D — previously escaped module validation and
+	// rejected only in spatial's own voice, an accident of the
+	// pre-index-based prop entity ID), a room carrying the retired
+	// `occluders` key at load (RoomData.Occluders), non-positive OR
+	// oversized Width/Height
 	// (maxRoomSpan), a
 	// per-room or field-total cell count exceeding maxRoomCells/
 	// maxFieldCells (allocation safety for Atlas — #929 T3 Opus round F1),
@@ -142,7 +145,7 @@ var (
 	// ErrBadConnection is returned when a connection's ID is empty or
 	// duplicated, its From/To names an unknown room or itself, an
 	// endpoint lies outside its room's bounds, is non-integral (hex
-	// rooms only), or sits on an occluder position — or (W3) its two
+	// rooms only), or sits on a prop's cell — or (W3) its two
 	// endpoints, once anchored to their rooms' Origin, are not adjacent
 	// absolute cells — or, Load-only, since ConnectionInput's endpoints
 	// are plain values and can't be absent the way ConnectionData's

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -50,7 +50,7 @@ func Example_theTombWatch() {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
 				ID: "crypt", Width: 12, Height: 12,
-				Occluders: wallRow(6, 5, 7),
+				Props: wallRow(6, 5, 7),
 			}},
 		},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -59,10 +59,11 @@ type RoomInput struct {
 	// benefit, since the composition never renders a grid itself.
 	Grid spatial.GridShape
 
-	// Occluders are room-local positions that block line of sight, compiled
-	// onto the canvas at construction: each one is registered at
-	// Occluders[i] + Origin, in the dungeon's own absolute frame.
-	Occluders []spatial.Position
+	// Props are the things standing in this room that are not creatures —
+	// room-local at authoring, compiled onto the canvas at construction, each
+	// one registered at Props[i].At + Origin in the dungeon's own absolute
+	// frame. See [PropInput].
+	Props []PropInput
 
 	// Boundaries are the walls this room draws, as edges between adjacent
 	// cells — room-local at authoring, compiled through Origin onto the
@@ -124,6 +125,91 @@ type RoomInput struct {
 	// (RoomData.Origin, #929 T2) because it is construction truth, and Atlas
 	// still reports each authored room's absolute footprint from it.
 	Origin spatial.Position
+}
+
+// PropInput is one thing standing in a room that is not a creature: a pillar,
+// a coffin, an altar, a bank of candles.
+//
+// IT SAYS WHAT IT IS AND WHAT IT DOES, and until rpg-toolkit#1128 it said
+// neither. A room's contents were bare cells called occluders, and the module
+// decided their behaviour for them: every one blocked line of sight, none
+// blocked movement, both hardcoded. That is the inverse of nearly everything a
+// dungeon contains. Measured before the fix, on a chamber with a coffin across
+// the middle: a member stood INSIDE the coffin, stepped out through its far
+// side, and could not see the wight beyond it. A pillar you can walk through is
+// not a pillar.
+//
+// # The ref is opaque, and that is the point
+//
+// [PropInput.Ref] is content's word for what this is — "dnd5e:props:pillar" —
+// and nothing in this module ever reads it. It exists so the map can say WHICH
+// thing is where: the multi-room census (rpg-project#227) recorded that "a
+// pillar and a statue are the same cell", and a client that cannot tell them
+// apart cannot draw the room. Behaviour comes from the two flags, never from
+// the ref; a module that switched on ref strings would be holding a fact about
+// a world, which is the overreach [Void]'s doc comment is about.
+//
+// # Both answers are required, neither is defaulted
+//
+// The flags are pointers because a prop must SAY what it does. This is
+// rpg-toolkit#1033's capabilities-supplied-never-defaulted law, and [Void]'s
+// own argument applied one type over: a nil pointer is obviously absent, where
+// a false bool is a legal-looking answer nobody wrote. All four combinations
+// are real content, so there is no combination the zero value could safely
+// stand for:
+//
+//   - both — a pillar, a statue: go round it, cannot see past it.
+//   - movement only — the reference tomb's coffin, a low altar: seen over,
+//     not walked through. Authored `blocks_los: false`.
+//   - sight only — a curtain, a fog bank: walked through blind.
+//   - neither — candles, a rug: present, drawn, in nobody's way.
+//
+// The old top-level encounter module's authoring dialect carries the same two
+// flags as pointers (dungeonspec's ObstacleEntry) with a documented nil-means-
+// true default. The default is what this drops: a blocker nobody declared is a
+// wall nobody drew.
+//
+// # What a movement-blocking prop denies
+//
+// A PLACE TO STAND, not a path. [Encounter.Step] deliberately does not check
+// adjacency — that is a rule about walking and it lives with the walk
+// ([StepOutput.Doors]' doc comment) — so a step is a placement question, and a
+// solid prop refuses to be stood on (ErrBadPlacement). A seam that walks a path
+// cell by cell asks once per cell and gets the wall it expects. A prop is not a
+// [spatial.Boundary]: a wall is an edge BETWEEN cells and stops a crossing, a
+// prop occupies a cell and stops an arrival.
+//
+// # Sight, and why one prop is not a wall
+//
+// A LONE PROP BLOCKS NOBODY even with BlocksLineOfSight set, and that is
+// spatial v0.9.1's rule rather than this module's: sight is a LANE, blocked
+// only when the direct lane and every lane from a neighbour closer to the
+// target are obstructed, so a viewer leans around a single occupied cell
+// exactly as they would at the table (testwalls_test.go's own finding, and
+// rpg-toolkit#1022 behind it). Occluding ENTITIES can be leaned around;
+// boundary EDGES cannot. So a prop that must genuinely stop a sightline needs
+// width — or it wants to be a wall.
+type PropInput struct {
+	// Ref is content's identifier for this thing, e.g.
+	// "dnd5e:props:pillar". REQUIRED and never inspected here — see the
+	// type's doc comment.
+	Ref string
+
+	// At is where it stands, ROOM-LOCAL, compiled to At + the room's Origin
+	// on the canvas. Must be an integral cell in every grid family: a prop
+	// is a cell OF its region, and a region's cells are integral
+	// ([AtlasRegion.Props]).
+	At spatial.Position
+
+	// BlocksMovement is whether a member can end a step on this cell.
+	// REQUIRED — a nil pointer is refused at construction (ErrNoField), and
+	// there is no default. See the type's doc comment.
+	BlocksMovement *bool
+
+	// BlocksLineOfSight is whether a sightline is obstructed by it — subject
+	// to the lane rule, so one cell of it obstructs nothing on its own.
+	// REQUIRED, for the same reason and with the same refusal.
+	BlocksLineOfSight *bool
 }
 
 // ConnectionInput describes a connection between two rooms: a bidirectional

--- a/rulebooks/dnd5e/encounter/killingblow_test.go
+++ b/rulebooks/dnd5e/encounter/killingblow_test.go
@@ -68,7 +68,7 @@ func (s *KillingBlowSuite) apart(standing encounter.Standing) *encounter.Encount
 		Sight:      everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
-			{ID: cryptID, Width: 12, Height: 12, Occluders: wallRow(6, 0, 11)},
+			{ID: cryptID, Width: 12, Height: 12, Props: wallRow(6, 0, 11)},
 		}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: cryptID, Position: spatial.Position{X: 2, Y: 2}},

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -31,7 +31,7 @@ func (s *OutcomeTestSuite) scene() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{
-			ID: outcomeRoom, Width: 12, Height: 12, Occluders: wallRow(6, 4, 8),
+			ID: outcomeRoom, Width: 12, Height: 12, Props: wallRow(6, 4, 8),
 		}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: outcomeRoom, Position: spatial.Position{X: 6, Y: 2}},

--- a/rulebooks/dnd5e/encounter/props_test.go
+++ b/rulebooks/dnd5e/encounter/props_test.go
@@ -210,7 +210,7 @@ func (s *PropsSuite) TestTheMapSaysWHICHThingIsWhere() {
 	s.Require().NoError(err)
 	s.Require().Len(atlas.Regions, 1)
 	props := atlas.Regions[0].Props
-	s.Require().Len(props, 2, "declaration order, the ordering Occluders already promised")
+	s.Require().Len(props, 2, "declaration order, the ordering a room's contents have always promised")
 
 	s.Equal("dnd5e:props:statue-reaper", props[0].Ref)
 	s.Equal(propAbs(1, 1), props[0].At, "absolute, like everything else the map reports")

--- a/rulebooks/dnd5e/encounter/props_test.go
+++ b/rulebooks/dnd5e/encounter/props_test.go
@@ -1,0 +1,326 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// props_test.go is A PROP IS A THING, NOT A HOLE IN THE SIGHTLINE
+// (rpg-toolkit#1128).
+//
+// What a room could place used to be a bare cell, and the module decided for it:
+// every one blocked sight and none blocked movement, hardcoded. That is the
+// inverse of nearly everything a dungeon contains — measured on main, a member
+// stood inside a coffin, walked out through the far side of it, and could not
+// see the wight beyond. A pillar you can walk through is not a pillar.
+//
+// So a prop now says what it is (a ref the module never reads) and what it does
+// (two flags, independent, REQUIRED). The four combinations are all real, and
+// this file walks each of them as a scene rather than asserting on fields:
+//
+//	blocks both    — a pillar, a statue: you go round it and you cannot see past
+//	blocks movement— the reference tomb's coffin, a low altar: see over, not through
+//	blocks sight   — a curtain, a fog bank: walk through it blind
+//	blocks neither — candles, a rug: there, and in nobody's way
+//
+// The tomb's coffin is authored `blocks_los: false` and is the case this exists
+// for: void.go promised "a low altar you can see over" stayed expressible, and
+// it was the one thing that was not.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type PropsSuite struct {
+	suite.Suite
+}
+
+func TestPropsSuite(t *testing.T) {
+	suite.Run(t, new(PropsSuite))
+}
+
+// The chamber is anchored away from the origin so a projection that forgets to
+// project is as visible here as one that projects the wrong way — the lesson
+// placement_test.go's fixtures are built on.
+var propsOrigin = spatial.Position{X: 20, Y: 10}
+
+const (
+	// The run is THREE CELLS TALL on purpose. spatial v0.9.1 lets a viewer
+	// lean around a single occupied cell, so a lone prop blocks nothing and a
+	// fixture built on one would be asserting the opposite of what it claims
+	// (testwalls_test.go's own finding).
+	propRunTop = 3
+	propRunLen = 3
+
+	propAtX = 5
+
+	delver = core.EntityID("delve")
+	beyond = core.EntityID("wight")
+)
+
+func propTrue() *bool  { t := true; return &t }
+func propFalse() *bool { f := false; return &f }
+
+// propAbs is a chamber-local cell in the dungeon's absolute frame.
+func propAbs(x, y float64) spatial.Position {
+	return spatial.Position{X: x, Y: y}.Add(propsOrigin)
+}
+
+// chamber is one room with a three-cell run of the same prop standing across
+// the middle of it, a player on each side, and nothing else to explain a
+// result.
+func (s *PropsSuite) chamber(ref string, blocksMovement, blocksSight *bool) *encounter.Encounter {
+	props := make([]encounter.PropInput, 0, propRunLen)
+	for y := propRunTop; y < propRunTop+propRunLen; y++ {
+		props = append(props, encounter.PropInput{
+			Ref:               ref,
+			At:                spatial.Position{X: propAtX, Y: float64(y)},
+			BlocksMovement:    blocksMovement,
+			BlocksLineOfSight: blocksSight,
+		})
+	}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{
+				ID: "crypt", Width: 12, Height: 8, Origin: propsOrigin, Props: props,
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: delver, Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 2, Y: 4}},
+			{ID: beyond, Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 8, Y: 4}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc
+}
+
+func (s *PropsSuite) sees(enc *encounter.Encounter, observer, subject core.EntityID) bool {
+	view, err := enc.View(&encounter.ViewInput{Member: observer})
+	s.Require().NoError(err)
+	for _, h := range view {
+		if h.Subject != intel.Subject(subject) {
+			continue
+		}
+		for _, via := range h.CurrentVia {
+			if via == intel.Sight {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// standsOn reports whether the delver can end a step on the prop's own cell.
+//
+// ONTO, not THROUGH, and the distinction is the module's rather than this
+// test's: [Encounter.Step] deliberately does not check adjacency, because that
+// is a rule about walking and it lives with the walk (StepOutput.Doors' own doc
+// comment). So a step is a placement question, and what a movement-blocking
+// prop denies is a place to stand. A seam that walks a path cell by cell asks
+// this once per cell and gets the wall it expects.
+func (s *PropsSuite) standsOn(enc *encounter.Encounter) error {
+	_, err := enc.Step(&encounter.StepInput{Member: delver, To: propAbs(propAtX, 4)})
+	return err
+}
+
+// TestAPillarIsSolidAndOpaque — the ordinary case, and the one main got least
+// wrong: it did block sight. It just did not stop anybody.
+func (s *PropsSuite) TestAPillarIsSolidAndOpaque() {
+	enc := s.chamber("dnd5e:props:pillar", propTrue(), propTrue())
+
+	s.False(s.sees(enc, delver, beyond), "stone between them")
+	s.False(s.sees(enc, beyond, delver), "and geometry is mutual")
+	s.Require().ErrorIs(s.standsOn(enc), encounter.ErrBadPlacement,
+		"a pillar is not somewhere to stand")
+}
+
+// TestTheTombsCoffinIsSolidAndSeenOver is the case this whole issue is about:
+// `{ ref: dnd5e:props:coffin, at: [6, 3], blocks_los: false }`, straight out of
+// reference-tomb.yaml.
+func (s *PropsSuite) TestTheTombsCoffinIsSolidAndSeenOver() {
+	enc := s.chamber("dnd5e:props:coffin", propTrue(), propFalse())
+
+	s.True(s.sees(enc, delver, beyond), "she can see clean over a coffin")
+	s.True(s.sees(enc, beyond, delver), "and he over her")
+	s.Require().ErrorIs(s.standsOn(enc), encounter.ErrBadPlacement,
+		"and neither of them can stand in it")
+}
+
+// TestACurtainIsPassedThroughBlind — the other asymmetry, which nothing could
+// say before either.
+func (s *PropsSuite) TestACurtainIsPassedThroughBlind() {
+	enc := s.chamber("dnd5e:props:curtain", propFalse(), propTrue())
+
+	s.False(s.sees(enc, delver, beyond), "she cannot see through it")
+	s.Require().NoError(s.standsOn(enc), "but she can walk into it")
+}
+
+// TestCandlesAreThereAndInNobodysWay — a prop that blocks nothing is still a
+// prop. It has a ref, it is on the map, and the client draws it.
+func (s *PropsSuite) TestCandlesAreThereAndInNobodysWay() {
+	enc := s.chamber("dnd5e:props:candles", propFalse(), propFalse())
+
+	s.True(s.sees(enc, delver, beyond), "candles hide nobody")
+	s.Require().NoError(s.standsOn(enc), "and stop nobody")
+
+	atlas, err := enc.Atlas()
+	s.Require().NoError(err)
+	s.Require().Len(atlas.Regions, 1)
+	s.Require().Len(atlas.Regions[0].Props, propRunLen,
+		"and they are on the map, which is the whole reason a prop that does nothing exists")
+}
+
+// TestTheMapSaysWHICHThingIsWhere — identity, the half rpg-project#227 recorded
+// as "a pillar and a statue are the same cell".
+func (s *PropsSuite) TestTheMapSaysWHICHThingIsWhere() {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{
+				ID: "tomb", Width: 12, Height: 8, Origin: propsOrigin,
+				Props: []encounter.PropInput{
+					{Ref: "dnd5e:props:statue-reaper", At: spatial.Position{X: 1, Y: 1},
+						BlocksMovement: propTrue(), BlocksLineOfSight: propTrue()},
+					{Ref: "dnd5e:props:altar", At: spatial.Position{X: 9, Y: 3},
+						BlocksMovement: propTrue(), BlocksLineOfSight: propFalse()},
+				},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: delver, Kind: encounter.KindPlayer, Room: "tomb", Position: spatial.Position{X: 4, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	atlas, err := enc.Atlas()
+	s.Require().NoError(err)
+	s.Require().Len(atlas.Regions, 1)
+	props := atlas.Regions[0].Props
+	s.Require().Len(props, 2, "declaration order, the ordering Occluders already promised")
+
+	s.Equal("dnd5e:props:statue-reaper", props[0].Ref)
+	s.Equal(propAbs(1, 1), props[0].At, "absolute, like everything else the map reports")
+	s.True(props[0].BlocksLineOfSight)
+
+	s.Equal("dnd5e:props:altar", props[1].Ref)
+	s.Equal(propAbs(9, 3), props[1].At)
+	s.False(props[1].BlocksLineOfSight, "you can see over an altar, and the map says so")
+}
+
+// TestAPropMustSayWhatItDoes — #1033's law. A bare false is a legal-looking
+// answer nobody wrote (void.go's argument for sealing Void), so absence has to
+// be absence.
+func (s *PropsSuite) TestAPropMustSayWhatItDoes() {
+	build := func(p encounter.PropInput) error {
+		_, err := encounter.NewEncounter(&encounter.SetupInput{
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+				Rooms: []encounter.RoomInput{{
+					ID: "crypt", Width: 12, Height: 8, Origin: propsOrigin,
+					Props: []encounter.PropInput{p},
+				}},
+			},
+			Members: []encounter.MemberInput{
+				{ID: delver, Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 2, Y: 4}},
+			},
+			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		})
+		return err
+	}
+
+	at := spatial.Position{X: 5, Y: 4}
+
+	s.Run("no movement answer", func() {
+		err := build(encounter.PropInput{Ref: "dnd5e:props:pillar", At: at, BlocksLineOfSight: propTrue()})
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Contains(err.Error(), "blocks_movement")
+	})
+
+	s.Run("no sight answer", func() {
+		err := build(encounter.PropInput{Ref: "dnd5e:props:pillar", At: at, BlocksMovement: propTrue()})
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Contains(err.Error(), "blocks_line_of_sight")
+	})
+
+	s.Run("no name", func() {
+		err := build(encounter.PropInput{At: at, BlocksMovement: propTrue(), BlocksLineOfSight: propTrue()})
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Contains(err.Error(), "ref")
+	})
+}
+
+// TestAPropSurvivesASave — the ref and both answers, or the reload is a
+// different dungeon.
+func (s *PropsSuite) TestAPropSurvivesASave() {
+	enc := s.chamber("dnd5e:props:coffin", propTrue(), propFalse())
+
+	data := enc.ToData()
+	s.Require().Len(data.Field.Rooms, 1)
+	s.Require().Len(data.Field.Rooms[0].Props, propRunLen)
+	s.Equal("dnd5e:props:coffin", data.Field.Rooms[0].Props[0].Ref)
+	s.Require().NotNil(data.Field.Rooms[0].Props[0].BlocksMovement)
+	s.True(*data.Field.Rooms[0].Props[0].BlocksMovement)
+	s.Require().NotNil(data.Field.Rooms[0].Props[0].BlocksLineOfSight)
+	s.False(*data.Field.Rooms[0].Props[0].BlocksLineOfSight)
+
+	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{},
+	})
+	s.Require().NoError(err)
+
+	s.True(s.sees(back, delver, beyond), "still seen over after a reload")
+	_, err = back.Step(&encounter.StepInput{Member: delver, To: propAbs(propAtX, 4)})
+	s.Require().ErrorIs(err, encounter.ErrBadPlacement, "and still solid")
+}
+
+// TestAnOldBlobsOccludersAreRefusedLoudly — the #1053/#1068 precedent. A room
+// whose walls were occluders must not load as a room with none: that is a party
+// dropped into a dungeon whose blockers silently vanished, reported as success.
+func (s *PropsSuite) TestAnOldBlobsOccludersAreRefusedLoudly() {
+	enc := s.chamber("dnd5e:props:pillar", propTrue(), propTrue())
+
+	raw, err := json.Marshal(enc.ToData())
+	s.Require().NoError(err)
+
+	var generic map[string]any
+	s.Require().NoError(json.Unmarshal(raw, &generic))
+
+	field, _ := generic["field"].(map[string]any)
+	rooms, _ := field["rooms"].([]any)
+	s.Require().NotEmpty(rooms)
+	room, _ := rooms[0].(map[string]any)
+
+	// Rewind the room to the dialect that had no answers in it.
+	delete(room, "props")
+	room["occluders"] = []any{map[string]any{"x": 25.0, "y": 13.0}}
+
+	rewound, err := json.Marshal(generic)
+	s.Require().NoError(err)
+
+	var data encounter.EncounterData
+	s.Require().NoError(json.Unmarshal(rewound, &data))
+
+	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Contains(err.Error(), "occluders",
+		"named, so whoever holds the blob knows which dialect it is written in")
+}

--- a/rulebooks/dnd5e/encounter/props_test.go
+++ b/rulebooks/dnd5e/encounter/props_test.go
@@ -324,3 +324,105 @@ func (s *PropsSuite) TestAnOldBlobsOccludersAreRefusedLoudly() {
 	s.Contains(err.Error(), "occluders",
 		"named, so whoever holds the blob knows which dialect it is written in")
 }
+
+// TestAPersistedPropMustSayWhatItDoesToo — the load seam's half of
+// TestAPropMustSayWhatItDoes.
+//
+// Construction refusing a nil answer proves nothing about LOAD, which builds
+// its rooms from a blob rather than from a caller's struct. A blob written by a
+// build that did not ask is exactly the case the required-at-load rule exists
+// for, and it is reachable by hand-editing JSON, which is what a stored
+// encounter IS. Both mutants that defaulted a missing persisted answer survived
+// the battery until this test existed.
+func (s *PropsSuite) TestAPersistedPropMustSayWhatItDoesToo() {
+	loadWith := func(mutate func(*encounter.RoomData)) error {
+		enc := s.chamber("dnd5e:props:pillar", propTrue(), propTrue())
+		data := enc.ToData()
+		mutate(&data.Field.Rooms[0])
+		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+			Initiative: orderAsGiven{},
+		})
+		return err
+	}
+
+	s.Run("no movement answer", func() {
+		err := loadWith(func(r *encounter.RoomData) { r.Props[0].BlocksMovement = nil })
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Contains(err.Error(), "blocks_movement")
+		s.Contains(err.Error(), "dnd5e:props:pillar", "named, so the blob's owner can find it")
+	})
+
+	s.Run("no sight answer", func() {
+		err := loadWith(func(r *encounter.RoomData) { r.Props[0].BlocksLineOfSight = nil })
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Contains(err.Error(), "blocks_line_of_sight")
+	})
+}
+
+// TestEditingTheSetupAfterwardsCannotChangeTheSavedDungeon is T6 review M4's
+// guarantee, asked of a field the caller holds by POINTER.
+//
+// deepCopyRoomInputs promised the persistence source never aliases caller-owned
+// state, and copying the Props slice looked like it kept that promise — the
+// elements are copied, after all. But a prop's two answers are pointers, so the
+// copies pointed straight back at the caller's bools: flipping one afterwards
+// rewrote what ToData would save, while the running encounter kept behaving the
+// way it was built. A promise in a comment is not a mechanism, and this is the
+// mechanism.
+func (s *PropsSuite) TestEditingTheSetupAfterwardsCannotChangeTheSavedDungeon() {
+	solid := true
+	setup := &encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{
+				ID: "crypt", Width: 12, Height: 8, Origin: propsOrigin,
+				Props: []encounter.PropInput{{
+					Ref:               "dnd5e:props:pillar",
+					At:                spatial.Position{X: 5, Y: 4},
+					BlocksMovement:    &solid,
+					BlocksLineOfSight: &solid,
+				}},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: delver, Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 2, Y: 4}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	}
+
+	enc, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err)
+
+	// The caller changes its mind about its own struct, after the fact.
+	solid = false
+
+	data := enc.ToData()
+	s.Require().Len(data.Field.Rooms[0].Props, 1)
+	s.Require().NotNil(data.Field.Rooms[0].Props[0].BlocksMovement)
+	s.True(*data.Field.Rooms[0].Props[0].BlocksMovement,
+		"the dungeon was built with a solid pillar and saves one")
+	s.Require().NotNil(data.Field.Rooms[0].Props[0].BlocksLineOfSight)
+	s.True(*data.Field.Rooms[0].Props[0].BlocksLineOfSight)
+
+	// And the encounter that is actually running never wavered.
+	_, err = enc.Step(&encounter.StepInput{Member: delver, To: propAbs(5, 4)})
+	s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+}
+
+// TestASavedPropIsNotAliasedByTheSnapshot — snapshot immunity, the direction
+// ToData's own doc comment promises: "mutating the returned EncounterData will
+// not affect this Encounter".
+func (s *PropsSuite) TestASavedPropIsNotAliasedByTheSnapshot() {
+	enc := s.chamber("dnd5e:props:coffin", propTrue(), propFalse())
+
+	first := enc.ToData()
+	*first.Field.Rooms[0].Props[0].BlocksMovement = false
+	*first.Field.Rooms[0].Props[0].BlocksLineOfSight = true
+
+	second := enc.ToData()
+	s.True(*second.Field.Rooms[0].Props[0].BlocksMovement,
+		"a second snapshot must not carry the first one's edits")
+	s.False(*second.Field.Rooms[0].Props[0].BlocksLineOfSight)
+}

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -347,7 +347,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 					// A wall down x=5 rather than one cell of it: spatial
 					// v0.9.1 leans around a lone obstacle, so a fixture that
 					// wants sight blocked builds a wall (testwalls_test.go).
-					Occluders: wallColumn(5, 4, 6),
+					Props: wallColumn(5, 4, 6),
 				}},
 			},
 			Members: []encounter.MemberInput{
@@ -1517,7 +1517,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	})
 	s.Require().NoError(err)
 
-	// Precondition: goblin sees alice Current (adjacent, no occluders).
+	// Precondition: goblin sees alice Current (adjacent, no props).
 	goblinView, err := enc.View(&encounter.ViewInput{Member: goblinID})
 	s.Require().NoError(err)
 	s.Require().Len(goblinView, 1)
@@ -1948,7 +1948,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 				// goblin where she starts and hidden where she ends up. It
 				// was a single pillar until spatial v0.9.1, which leans
 				// around one — see testwalls_test.go.
-				Occluders: wallColumn(5, 4, 6),
+				Props: wallColumn(5, 4, 6),
 			}},
 		},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/encounter/testwalls_test.go
+++ b/rulebooks/dnd5e/encounter/testwalls_test.go
@@ -6,6 +6,7 @@ package encounter_test
 import (
 	"reflect"
 
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
@@ -27,26 +28,71 @@ import (
 // and reading one of them now ("the pillar blocks sight") tells you something
 // the engine no longer believes.
 //
+// A pillar still STOPS you, mind — a prop declares movement and sight
+// separately (rpg-toolkit#1128), and leaning around one is a fact about the
+// sightline, not about walking through it.
+//
 // The width is not decoration either. A wall must be wide enough that the
 // neighbour lanes are obstructed too, which means covering the cells a viewer
 // would lean toward, not just the one on the centre line.
 
-// wallRow returns a horizontal run of occluder cells at the given row,
-// inclusive of both ends.
-func wallRow(y, fromX, toX int) []spatial.Position {
-	out := make([]spatial.Position, 0, toX-fromX+1)
+// rubble is one cell of a fixture wall: solid to walk into and solid to look
+// through, which is what every caller of wallRow and wallColumn has always
+// meant by "wall".
+//
+// Both answers are stated because a prop has to state them (rpg-toolkit#1128).
+// Before that, a fixture like this got the opposite of what it asked for on the
+// movement axis — the module hardcoded every placed thing as walk-through — and
+// no test noticed, because none of them tried to walk into one.
+func rubble(x, y int) encounter.PropInput {
+	solid := true
+	return encounter.PropInput{
+		Ref:               "test:props:rubble",
+		At:                spatial.Position{X: float64(x), Y: float64(y)},
+		BlocksMovement:    &solid,
+		BlocksLineOfSight: &solid,
+	}
+}
+
+// rubbleData is rubble as it persists — the PropData half, for fixtures that
+// build a blob directly rather than saving one.
+func rubbleData(x, y float64) encounter.PropData {
+	solid := true
+	return encounter.PropData{
+		Ref:               "test:props:rubble",
+		At:                encounter.PositionData{X: x, Y: y},
+		BlocksMovement:    &solid,
+		BlocksLineOfSight: &solid,
+	}
+}
+
+// absoluteRubble is rubble as the map reports it: the same thing, at a
+// dungeon-absolute cell, with the flags it was authored with.
+func absoluteRubble(x, y float64) encounter.AtlasProp {
+	return encounter.AtlasProp{
+		Ref:               "test:props:rubble",
+		At:                spatial.Position{X: x, Y: y},
+		BlocksMovement:    true,
+		BlocksLineOfSight: true,
+	}
+}
+
+// wallRow returns a horizontal run of wall cells at the given row, inclusive of
+// both ends.
+func wallRow(y, fromX, toX int) []encounter.PropInput {
+	out := make([]encounter.PropInput, 0, toX-fromX+1)
 	for x := fromX; x <= toX; x++ {
-		out = append(out, spatial.Position{X: float64(x), Y: float64(y)})
+		out = append(out, rubble(x, y))
 	}
 	return out
 }
 
-// wallColumn returns a vertical run of occluder cells in the given column,
+// wallColumn returns a vertical run of wall cells in the given column,
 // inclusive of both ends.
-func wallColumn(x, fromY, toY int) []spatial.Position {
-	out := make([]spatial.Position, 0, toY-fromY+1)
+func wallColumn(x, fromY, toY int) []encounter.PropInput {
+	out := make([]encounter.PropInput, 0, toY-fromY+1)
 	for y := fromY; y <= toY; y++ {
-		out = append(out, spatial.Position{X: float64(x), Y: float64(y)})
+		out = append(out, rubble(x, y))
 	}
 	return out
 }

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -61,7 +61,7 @@ func TestTombWatch(t *testing.T) {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
-				Occluders: wallRow(6, 5, 7),
+				Props: wallRow(6, 5, 7),
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -273,7 +273,7 @@ func TestTombWatch(t *testing.T) {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
 				ID: cryptRoom, Width: 12, Height: 12,
-				Occluders: wallRow(6, 5, 7),
+				Props: wallRow(6, 5, 7),
 			}},
 		},
 		Members: sequelMembers,

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -132,14 +132,28 @@ const (
 //
 // # What it does NOT change
 //
-// Occluders and boundaries inside a chamber are untouched: still authored,
-// still carrying BlocksMovement and BlocksLineOfSight independently, so a
-// blocker somebody placed and a low altar you can see over both stay
-// expressible. Kirk's point on the ruling was that both should be deliberate —
-// in his words, "if I wanted rock, I could place it and set it to block LoS. I
-// could put an obstacle that does not. I can have both but should be
-// deliberate" — and what this slice changes is that the DEFAULT is deliberate
-// too.
+// Props and boundaries inside a chamber are untouched: still authored, still
+// carrying BlocksMovement and BlocksLineOfSight independently, so a blocker
+// somebody placed and a low altar you can see over both stay expressible.
+// Kirk's point on the ruling was that both should be deliberate — in his words,
+// "if I wanted rock, I could place it and set it to block LoS. I could put an
+// obstacle that does not. I can have both but should be deliberate" — and what
+// this slice changes is that the DEFAULT is deliberate too.
+//
+// THAT SENTENCE WAS HALF FALSE WHEN IT WAS WRITTEN, and it is worth saying so
+// here rather than quietly correcting it, because of what it took to notice.
+// It was true of boundaries, which have carried both flags all along. It was
+// false of a chamber's CONTENTS, which were bare cells the module decided for:
+// every one blocked sight, none blocked movement, hardcoded. The low altar you
+// can see over is the reference tomb's own coffin (`blocks_los: false`), and it
+// was precisely the thing that could not be authored — the example the comment
+// reached for was the counter-example. Fixed in rpg-toolkit#1128, where a
+// chamber's contents became [PropInput] and the promise became true.
+//
+// The lesson is this file's own, one paragraph up: a composition that may not
+// hold fiction has to be READ for it, and what hides is a sentence that
+// describes the design correctly while the code does something else. This one
+// survived writing, review and a mutation battery — nothing tests a comment.
 //
 // # Why a sealed set rather than a bool
 //


### PR DESCRIPTION
Closes #1128. Lands **before** the world-model S5 content compiler (#1127), which is what turned this up: 13 of the reference tomb's 15 authored props would have compiled into lies.

## The defect, measured before anything was written

`occluderEntity.BlocksLineOfSight()` was a hardcoded `true` and `BlocksMovement()` a hardcoded `false`, so the one thing a room could place was **transparent to walk through and opaque to look through** — the inverse of a pillar, a statue and a coffin alike. Against `43bc69a`, on a 12x8 chamber with a three-cell coffin at x=5:

```
$ go test -run TestZZOccluderDefectProbe -v .
--- DEFECT PROBE: authored occluders, against unmodified main ---
A. the coffin BLOCKS SIGHT and cannot be told not to: delve sees wight = false
B. stepping ONTO the coffin SUCCEEDED — she is standing at (25, 14), inside it
C. stepping THROUGH the coffin SUCCEEDED — she walked clean through it
D. RoomInput.Occluders element type: spatial.Position — no ref, no flags
```

She stands inside the coffin, walks out through its far side, and cannot see the wight beyond.

## The shape

`RoomInput.Occluders []spatial.Position` becomes `Props []PropInput`:

```go
type PropInput struct {
	Ref               string           // opaque content ref, never inspected here
	At                spatial.Position // room-local, compiled through Origin
	BlocksMovement    *bool            // REQUIRED
	BlocksLineOfSight *bool            // REQUIRED
}
```

**Both answers required, neither defaulted** — #1033's law, and `void.go`'s own argument one type over: a nil pointer is obviously absent, where a false bool is a legal-looking answer nobody wrote. All four combinations are real content, so no zero value could stand in for a missing answer.

Pointers cost something, and the mutation battery below paid for them in the same PR that introduced them: because the flags are pointers, copying the `Props` **slice** no longer copies the props, and `deepCopyRoomInputs`' promise quietly stopped holding. That is the honest bill for this shape — and it is also the best argument for it, because the thing the pointers buy is that *absence is representable at all*, which is the only reason a coffin authored `blocks_los: false` can be told apart from one that said nothing.

| declared | example | scene in `props_test.go` |
|---|---|---|
| both | pillar, statue | go round it, cannot see past |
| movement only | **the tomb's coffin**, a low altar | seen over, not walked through |
| sight only | curtain, fog bank | walked through blind |
| neither | candles, a rug | present, drawn, in nobody's way |

`AtlasRegion.Occluders []spatial.Position` becomes `Props []AtlasProp` carrying ref and both flags, so a client can finally tell a pillar from a statue — the half rpg-project#227 recorded as the reason authored content could not land.

**A movement-blocking prop denies a place to stand, not a path.** `Step` deliberately does not check adjacency (`StepOutput.Doors`' doc comment), so a step is a placement question; a seam that walks a path cell by cell asks once per cell. That distinction is written into `PropInput`'s godoc and into the test that could have been misread as asserting otherwise.

## Persistence: the rename was NOT enough, and this is the part to read

This is the load-bearing design decision in the PR, and the reasoning generalises past props, so it is written out rather than assumed.

`occluders` → `props` is the #1053/#1068 detectable rename. **That precedent has a precondition nobody has had to state before: it only signals through a REQUIRED field.** The mechanism is "the old dialect lands nowhere, and then the field's *absence* is the defect" — `MemberOutcomeData.Cell` works because a member who stood nowhere is impossible, so absence is loud.

**A room's contents are optional.** A chamber with nothing in it is an ordinary chamber. So the rename alone would have made an old blob land nowhere and then loaded it **clean, as a room with no props** — silently discarding every blocker somebody authored, and reporting success. A party walking through pillars in a dungeon whose load said it was fine. That is the exact failure mode the precedent exists to prevent, arrived at *by following the precedent*.

So the rename is paired with a **tombstone**: `RoomData.Occluders` survives as a `json.RawMessage` that nothing decodes, whose only question is whether the key was present at all, refused loudly when it was. Absence cannot be the signal here, so presence is.

**The rule for the next person renaming a persisted field: a detectable rename is sufficient only when the field is required. For an optional one it must be paired with a positive check on the old name, or the migration is silent data loss wearing a passing test.**

Both persisted flags are required at load too, refused by name.

## The doc lie this also fixes

`void.go:135-137` promised:

> Occluders and boundaries inside a chamber are untouched: still authored, still carrying BlocksMovement and BlocksLineOfSight independently, so a blocker somebody placed **and a low altar you can see over** both stay expressible.

True of boundaries (`spatial.Boundary` carries both flags). **False of a chamber's contents.** The low altar you can see over is `reference-tomb.yaml`'s own coffin (`blocks_los: false`) — the example the comment reached for was the counter-example. The sentence is corrected in place and the miss is recorded there rather than quietly erased, because of what it took to notice: it survived writing, review and a full mutation battery. Nothing tests a comment.

## Test evidence

RED first: the defect probe above, then `props_test.go`'s scenes failing to compile against a type that did not exist yet (`undefined: encounter.PropInput`, 11 build errors). Full evidence in the job's `red-evidence.txt`.

```
$ go test -count=1 ./...
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter          0.073s
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter/cmd/...  0.003s

$ go test -race -count=1 ./...
ok  github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter          1.380s
```

**Lint, at both versions CI pins** — `v2.2.1` (ci-enhanced) and `v2.3.1` (ci-optimized), installed to a scratch dir, run the way each workflow runs it (from inside the module, which resolves `rulebooks/dnd5e/.golangci.yml`): **0 issues** under both. `go fmt ./...` and `go mod tidy` leave the tree unmodified, which ci-optimized checks explicitly.

## Mutation battery: 23/23 killed, and one survivor was a real hole

Baseline audited GREEN before any mutant; harness refuses to run on a dirty tree (a stale-snapshot restore has destroyed uncommitted work twice). First pass killed 19/22. The three survivors were all honest:

- Two were **missing tests** — nothing asked the *load* seam to refuse a persisted prop with an answer absent. Construction refusing a nil proves nothing about a blob, which is hand-editable JSON by nature.
- One was a **real defect I had introduced**: `deepCopyRoomInputs` promises the persistence source never aliases caller-owned state (T6 review M4), and copying the `Props` slice *looked* like it kept that promise — but a prop's answers are pointers, so the copied elements pointed back at the caller's bools. A caller flipping one after construction rewrote what `ToData` would save while the running encounter, which dereferences once at `compileCanvas`, went on behaving the other way. **The same defect T6 fixed, one indirection down.** Fixed in `57c33a2` with the deep copy and a test that flips the caller's bool and checks the save.

Second pass, with a mutant added for the new deep copy: **23/23 killed, 0 survivors.**

## gorelease

```
$ gorelease -base v0.23.0
## incompatible changes
AtlasRegion.Occluders: removed
RoomData.Occluders: changed from []PositionData to encoding/json.RawMessage
RoomInput.Occluders: removed
## compatible changes
AtlasProp, AtlasRegion.Props, PropData, PropInput, RoomData.Props, RoomInput.Props: added

Suggested version: v0.24.0 (with tag rulebooks/dnd5e/encounter/v0.24.0)
```

The tagger will mint **`rulebooks/dnd5e/encounter/v0.24.0`**.

## Blast radius, measured not assumed

`session` pins `encounter v0.17.0` and `resolution` pins `v0.21.0` — both behind today's `v0.23.0` — so neither is affected by this PR; they catch up when they upgrade, which is the pattern this wave has been running on (no-backcompat-baggage, Kirk 2026-08-15). **Follow-up for whoever moves session forward:** its own flat `Atlas.Occluders []spatial.Position` (`session/types.go:69`, built in `convert.go:67`) is a separate projection that will want the ref and the flags too, or the identity this PR adds stops at the seam.

## One naming deviation, flagged deliberately

The ruling named the type `OccluderInput`. I shipped `PropInput`, because "occluder" is precisely what the fixed type no longer means — a coffin you can see over occludes nothing, and a name that says otherwise is the class of defect the `void.go` correction above is about (Kirk on that file: name the mechanic, not the material; and "two name corrections in one review is the pattern"). The refs themselves say `dnd5e:props:*`, so this is content's own vocabulary rather than an invention. Easy to change if the reviewer disagrees — it is one rename.

— fix-1127 agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDQZK1KxnA2xtk1vnRoT8V
