### PR TITLE
feat(encounter)!: a chamber is the rectangle somebody drew — the floor mask, and both orientations settable (world-model S5a)

### DIFF
--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -50,13 +50,17 @@ type AtlasRegion struct {
 	// Grid is the region's coordinate family (GridShapeSquare or GridShapeHex).
 	Grid spatial.GridShape
 
-	// Origin is the region's dungeon-absolute anchor (RoomInput.Origin).
+	// Origin is the region's anchor, in the same authored columns and rows
+	// Width and Height are counted in (RoomInput.Origin). For a SQUARE field
+	// those are the absolute axes and this is a dungeon-absolute cell; for a
+	// hex one they are not, and [Atlas.Orientation] is the frame that turns
+	// this rectangle into cells.
 	Origin spatial.Position
 
-	// Width is the region's horizontal dimension, in cells.
+	// Width is how many columns wide the region is.
 	Width int
 
-	// Height is the region's vertical dimension, in cells.
+	// Height is how many rows tall the region is.
 	Height int
 
 	// Props is the things standing in this region, in dungeon-absolute

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -15,6 +15,17 @@ import (
 // and occluders, and every connection's absolute doorway pair (#929 T3 —
 // the read surface promised by RoomInput.Origin's doc comment).
 type Atlas struct {
+	// Orientation is which way this field's hexes point, or nil for a square
+	// field (rpg-toolkit#1127).
+	//
+	// Reported because a region describes itself as "a Width x Height
+	// rectangle anchored HERE" rather than by listing its cells, and that
+	// sentence is ambiguous on hex without this: the same rectangle covers a
+	// different set of cells under each layout. A host walking the rectangle
+	// itself — which [AtlasRegion] explicitly invites — needs the same frame
+	// the encounter used.
+	Orientation Orientation
+
 	// Regions is every region, sorted by region ID (C8).
 	Regions []AtlasRegion
 
@@ -185,7 +196,7 @@ func (e *Encounter) Atlas() (Atlas, error) {
 		for j, p := range ri.Props {
 			props[j] = AtlasProp{
 				Ref:               p.Ref,
-				At:                p.At.Add(ri.Origin),
+				At:                absoluteOf(ri, e.orientation, p.At),
 				BlocksMovement:    *p.BlocksMovement,
 				BlocksLineOfSight: *p.BlocksLineOfSight,
 			}
@@ -194,8 +205,8 @@ func (e *Encounter) Atlas() (Atlas, error) {
 		boundaries := make([]AtlasBoundary, len(ri.Boundaries))
 		for j, b := range ri.Boundaries {
 			boundaries[j] = AtlasBoundary{
-				From:              b.From.Add(ri.Origin),
-				To:                b.To.Add(ri.Origin),
+				From:              absoluteOf(ri, e.orientation, b.From),
+				To:                absoluteOf(ri, e.orientation, b.To),
 				BlocksMovement:    b.BlocksMovement,
 				BlocksLineOfSight: b.BlocksLineOfSight,
 			}
@@ -237,7 +248,7 @@ func (e *Encounter) Atlas() (Atlas, error) {
 	// on any normally-constructed encounter).
 	sort.Slice(doorways, func(i, j int) bool { return doorways[i].Connection < doorways[j].Connection })
 
-	return Atlas{Regions: regions, Doorways: doorways}, nil
+	return Atlas{Orientation: e.orientation, Regions: regions, Doorways: doorways}, nil
 }
 
 // Grid reports the field's coordinate family — GridShapeSquare or

--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -231,9 +231,9 @@ func (e *Encounter) Atlas() (Atlas, error) {
 		doorways[i] = AtlasDoorway{
 			Connection: ci.ID,
 			From:       ci.From,
-			FromCell:   ci.FromPosition.Add(roomsByID[ci.From].Origin),
+			FromCell:   absoluteOf(roomsByID[ci.From], e.orientation, ci.FromPosition),
 			To:         ci.To,
-			ToCell:     ci.ToPosition.Add(roomsByID[ci.To].Origin),
+			ToCell:     absoluteOf(roomsByID[ci.To], e.orientation, ci.ToPosition),
 		}
 	}
 	// Currently redundant — e.connectionsInput is already sorted by ID at

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -89,7 +89,7 @@ func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.Setu
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: orientationFor(shape)},
 			Rooms:  []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
 		},
 		Members: []encounter.MemberInput{
@@ -99,21 +99,48 @@ func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.Setu
 	}
 }
 
-// bruteForceLocalCells independently enumerates a room's valid integer
-// local cells using ONLY spatial's public API (NewSquareGrid/
-// NewAxialHexGrid + IsValidPosition) — no dependency on this module's
-// own enumeration, so it is a genuine independent oracle for
-// TestAtlasCellsMatchIsValidPosition (#929 T3 ruling 4).
-func bruteForceLocalCells(shape spatial.GridShape, width, height int) []spatial.Position {
-	var grid spatial.Grid
+// orientationFor is the declaration a single-room fixture of this family needs:
+// one for hex, none for square (rpg-toolkit#1127).
+func orientationFor(shape spatial.GridShape) encounter.Orientation {
 	if shape == spatial.GridShapeHex {
-		grid = spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: float64(width), SpanHeight: float64(height)})
-	} else {
-		grid = spatial.NewSquareGrid(spatial.SquareGridConfig{Width: float64(width), Height: float64(height)})
+		return encounter.HexesArePointyTop()
 	}
 
-	pad := width + height + 4 // generous — bigger than any valid span in either family
+	return nil
+}
+
+// bruteForceLocalCells independently enumerates a room's cells, WITHOUT asking
+// this module — a genuine oracle for TestRegionMembershipMatchesIsValidPosition
+// (#929 T3 ruling 4).
+//
+// THE HEX ORACLE CHANGED IN rpg-toolkit#1127, and the change is the whole
+// slice. It used to be spatial.NewAxialHexGrid + IsValidPosition, because a hex
+// room WAS an origin-centred axial rhombus. A chamber is now the offset
+// rectangle its author drew, so the oracle is that rectangle's image under
+// spatial's own offset->cube conversion — still spatial's public API only, and
+// still not this module's answer, which is what makes it an oracle rather than
+// a mirror.
+//
+// Square is untouched: for square, offset and grid coordinates are the same
+// thing, so the rectangle and the grid's IsValidPosition are one set and this
+// still asks the grid.
+func bruteForceLocalCells(shape spatial.GridShape, width, height int) []spatial.Position {
 	var cells []spatial.Position
+
+	if shape == spatial.GridShapeHex {
+		for col := 0; col < width; col++ {
+			for row := 0; row < height; row++ {
+				cube := spatial.OffsetCoordinateToCubeWithOrientation(
+					spatial.Position{X: float64(col), Y: float64(row)}, spatial.HexOrientationPointyTop)
+				cells = append(cells, spatial.Position{X: float64(cube.X), Y: float64(cube.Y)})
+			}
+		}
+
+		return cells
+	}
+
+	grid := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: float64(width), Height: float64(height)})
+	pad := width + height + 4 // generous — bigger than any valid span
 	for x := -pad; x <= pad; x++ {
 		for y := -pad; y <= pad; y++ {
 			pos := spatial.Position{X: float64(x), Y: float64(y)}
@@ -122,22 +149,31 @@ func bruteForceLocalCells(shape spatial.GridShape, width, height int) []spatial.
 			}
 		}
 	}
+
 	return cells
 }
 
-// TestRegionMembershipMatchesIsValidPosition is the ruling-4 property test,
+// TestRegionMembershipMatchesTheAuthoredChamber is the ruling-4 property test,
 // asked of the thing that answers membership now (rpg-toolkit#1108). For a
 // spread of dimension parities (odd, even, and 1xN thin rooms) across both grid
 // families, the cells RegionAt claims for a region (Origin zero, so absolute ==
-// local) must be EXACTLY the set spatial's own IsValidPosition accepts — not a
-// subset, not a superset. A one-cell span drift fails this for some parity in
-// the spread.
+// local) must be EXACTLY the chamber its author drew — not a subset, not a
+// superset. A one-cell drift fails this for some parity in the spread.
+//
+// Its name and its oracle both changed in rpg-toolkit#1127, and the old ones
+// were the defect rather than the casualty: it used to compare against
+// spatial's IsValidPosition, which was right while a hex room was an axial
+// rhombus and became the wrong question when a chamber became the offset
+// rectangle somebody drew. Under the rhombus reading this test passed on 100
+// dimension pairs while the reference tomb's chambers reported 156 cells as
+// floor that nobody had drawn — the property held, and it was a property of the
+// wrong set.
 //
 // It used to compare Atlas's enumerated Cells against the same brute-force set.
 // The Atlas no longer enumerates, and this is the stronger question anyway: it
 // pins the lookup every verb in the module actually consults, rather than a
 // parallel enumerator that agreed with it.
-func (s *EncounterTestSuite) TestRegionMembershipMatchesIsValidPosition() {
+func (s *EncounterTestSuite) TestRegionMembershipMatchesTheAuthoredChamber() {
 	dims := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	shapes := map[string]spatial.GridShape{"square": spatial.GridShapeSquare, "hex": spatial.GridShapeHex}
 
@@ -165,7 +201,7 @@ func (s *EncounterTestSuite) TestRegionMembershipMatchesIsValidPosition() {
 					}
 
 					s.Require().Equal(want, got,
-						"RegionAt must agree exactly with spatial's own IsValidPosition")
+						"RegionAt must claim exactly the chamber that was drawn")
 				})
 			}
 		}

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -359,7 +359,7 @@ func TestAHexFieldNeedsNoSuchLaw(t *testing.T) {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 					Origin: spatial.Position{X: -20, Y: -20}},

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -331,19 +331,24 @@ func printStatus(enc *encounter.Encounter) {
 // own bounds (SquareGrid.Distance and AxialHexGrid.Distance's own
 // implementations), so any instance of the right family computes the
 // correct distance between two dungeon-absolute doorway cells (#929 T5).
-// regionExtent is the absolute rectangle a region covers, from the anchor and
-// span it reports — the arithmetic AtlasRegion's doc comment describes, which
+// regionExtent is the rectangle a region covers, in the columns and rows it
+// was authored in — the arithmetic AtlasRegion's doc comment describes, which
 // is all the Atlas hands out now that it no longer enumerates cells
-// (rpg-toolkit#1108). Square regions start at their origin; hex spans are
-// origin-centred.
-func regionExtent(r encounter.AtlasRegion) (qMin, qMax, rMin, rMax float64) {
-	if r.Grid == spatial.GridShapeHex {
-		qMin = r.Origin.X - float64(r.Width/2)
-		rMin = r.Origin.Y - float64(r.Height/2)
-	} else {
-		qMin, rMin = r.Origin.X, r.Origin.Y
-	}
-	return qMin, qMin + float64(r.Width) - 1, rMin, rMin + float64(r.Height) - 1
+// (rpg-toolkit#1108).
+//
+// ONE ARITHMETIC FOR BOTH FAMILIES since rpg-toolkit#1127: a chamber is the
+// rectangle somebody drew, so it runs from its anchor for Width columns and
+// Height rows whichever grid it is on. For a SQUARE field those columns and
+// rows are the absolute axes and this rectangle is a footprint in world space,
+// which is what printAtlas labels it. For a hex one they are not — the
+// absolute cells are what encounter.HexCellAt makes of each pair under
+// Atlas.Orientation, and the footprint is a sheared parallelogram no pair of
+// intervals describes. This workbench's dungeon is square, so the label is
+// honest for what it actually prints; a hex workbench would have to say
+// "columns" and "rows" and mean it.
+func regionExtent(r encounter.AtlasRegion) (colMin, colMax, rowMin, rowMax float64) {
+	return r.Origin.X, r.Origin.X + float64(r.Width) - 1,
+		r.Origin.Y, r.Origin.Y + float64(r.Height) - 1
 }
 
 func atlasDistanceGrid(family spatial.GridShape) spatial.Grid {

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -62,20 +62,24 @@ func continuityViolation(family spatial.GridShape, positions []spatial.Position,
 func vaultChaseHexGate() encounter.ConnectionInput {
 	return encounter.ConnectionInput{
 		ID: "gate", From: "corridor", To: "vault",
-		FromPosition: spatial.Position{X: 4, Y: 1},
-		ToPosition:   spatial.Position{X: -5, Y: -2},
+		FromPosition: spatial.Position{X: 9, Y: 5},
+		ToPosition:   spatial.Position{X: 0, Y: 5},
 	}
 }
 
-// vaultChaseHexSeamWall is the corridor's wall along its Q-max edge, open at
-// the gate's row. The corridor's own last column is Q=4 and the vault's first
-// is Q=5, so every edge here has one endpoint in each chamber — a sentence no
-// room could say before the field became one canvas (rpg-toolkit#1106), and
-// the reason this scene needs to say it: with one canvas and no wall, the two
+// vaultChaseHexSeamWall is the corridor's wall along its last column, open at
+// the gate's row. The corridor's own last column is 9 and the vault's first is
+// 10, so every edge here has one endpoint in each chamber — a sentence no room
+// could say before the field became one canvas (rpg-toolkit#1106), and the
+// reason this scene needs to say it: with one canvas and no wall, the two
 // chambers share an open seam and there is nowhere in the vault to disappear
-// to. R is the vault's own range, [-2,7], intersected with the corridor's
-// [-5,4].
-func vaultChaseHexSeamWall() []spatial.Boundary { return hexSeamWall(4, -2, 4, 1) }
+// to.
+//
+// Counted in the chamber's own offset rows since rpg-toolkit#1127, so the range
+// is simply its full height.
+func vaultChaseHexSeamWall() []spatial.Boundary {
+	return hexOffsetSeamWall(encounter.HexesArePointyTop(), 9, 0, 9, 5)
+}
 
 // vaultChaseHexSetup is the hex-family sibling of chase_test.go's
 // TestVaultChase fixture (#929 T4 — "the vault-chase fixture/story, or a
@@ -104,7 +108,7 @@ func vaultChaseHexSetup() *encounter.SetupInput {
 		Rooms: []encounter.RoomInput{
 			{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex,
 				Boundaries: vaultChaseHexSeamWall()},
-			{ID: "vault", Width: 10, Height: 10, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: 3}},
+			{ID: "vault", Width: 10, Height: 10, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: 0}},
 		},
 		Connections: []encounter.ConnectionInput{gate},
 	}

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -5,7 +5,6 @@ package encounter_test
 
 import (
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,13 +93,19 @@ func vaultChaseHexSeamWall() []spatial.Boundary {
 // leaving the vault's Origin fixed at the one geometry this scene ever
 // actually uses.
 //
-// Geometry: corridor is 10x10 hex at Origin (0,0) — Q,R both in [-5,4].
-// The vault's Origin is (10,3): vault's Q-range ([5,14]) is fully
-// disjoint from corridor's ([-5,4]) regardless of R (W2), and the gate's
-// endpoints — corridor (4,1) [Q-max edge] and vault local (-5,-2)
-// [Q-min edge] — land on absolute (4,1) and (5,1): cube distance 1, a
-// genuine axial neighbor via the standard (+1,0) offset, not a formula
-// quirk (W3).
+// Geometry, in the frame a hex chamber is authored in since
+// rpg-toolkit#1127 — OFFSET columns and rows, counted from the chamber's own
+// corner. Corridor is 10x10 at Origin (0,0), so columns 0-9 and rows 0-9;
+// the vault is 10x10 at Origin (10,0), so columns 10-19. The two column
+// ranges do not meet, so the chambers share no cell (W2) — and unlike the
+// rhombus reading this replaces, that is now true under EITHER orientation,
+// because a chamber's footprint no longer depends on which way its hexes
+// point.
+//
+// The gate joins corridor (9,5) — its own last column — to vault local (0,5),
+// which is absolute column 10, row 5. Same-row neighbouring columns are
+// adjacent in odd-q for either parity, so those two cells kiss (W3) as
+// spatial's own conversion has it, not as a formula this fixture rolled.
 func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()
 	field := encounter.FieldInput{
@@ -117,18 +122,32 @@ func vaultChaseHexSetup() *encounter.SetupInput {
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: field,
 		Members: []encounter.MemberInput{
-			{ID: alice, Kind: encounter.KindPlayer, Room: "corridor", Position: spatial.Position{X: 1, Y: 1}},
-			// One hex-step from the gate's corridor-side endpoint (4,1) via
-			// the (0,+1) offset — close enough that the pursuit decider's
-			// "jump to last-seen position" IS a genuine single-step move,
-			// not a room-spanning teleport (#929 T4: every recorded beat in
-			// this scene, not just the doorway, is a real single-cell hop).
+			{ID: alice, Kind: encounter.KindPlayer, Room: "corridor", Position: spatial.Position{X: 6, Y: 5}},
+			// One hex-step from the gate's corridor-side endpoint (9,5), and
+			// BESIDE the seam rather than in line with it. Both halves are
+			// load-bearing, and neither is arbitrary.
+			//
+			// One step, because [Encounter.Step] does not check adjacency
+			// (its doc comment says so, deliberately) and neither does the
+			// silent stepTo a Pump moves a monster with — so the pursuit
+			// decider's "jump to the last-seen cell" lands wherever that cell
+			// is, in one go. It is the FIXTURE that makes every recorded beat
+			// a real single-cell hop, not the verb, which is exactly why this
+			// scene can claim continuity over the whole transcript.
+			//
+			// Beside, because the seam wall leaves one edge open — (9,5) to
+			// (10,5) — and a watcher off that line cannot see through it: the
+			// ray from (9,4) into the vault crosses a walled edge in every
+			// direction. So this goblin watches her walk the corridor and
+			// loses her AT the threshold, which is what leaves the ghost on
+			// the corridor's own gate cell one step away, and what makes the
+			// decider reach for the doorway on its second think.
 			{ID: goblin, Kind: encounter.KindMonster, Room: "corridor",
-				Position: spatial.Position{X: 4, Y: 0}, Decider: pursuit},
+				Position: spatial.Position{X: 9, Y: 4}, Decider: pursuit},
 		},
 		Endings: []encounter.EndingInput{
 			{Key: "sanctuary", Trigger: encounter.TriggerReachedPosition{
-				Room: "vault", Position: spatial.Position{X: -3, Y: -3}}},
+				Room: "vault", Position: spatial.Position{X: 2, Y: 6}}},
 		},
 	}
 }
@@ -176,9 +195,17 @@ func (p *continuityProjector) useEncounter(enc *encounter.Encounter) {
 // project turns one room-local position into the canvas cell the authored
 // layout puts it at, records it in the human-readable transcript, and returns
 // the absolute position for the caller's own path-continuity bookkeeping.
+//
+// The arithmetic is offset-then-convert since rpg-toolkit#1127: a hex
+// chamber's local cell and its anchor are both counted in authored columns and
+// rows, and the SUM is what becomes an axial cell. Adding the anchor in axial —
+// what this used to do — is the shear that made a chamber a rhombus, one level
+// up.
 func (p *continuityProjector) project(member, verb, room string, pos spatial.Position) spatial.Position {
 	p.t.Helper()
-	absolute := pos.Add(p.originOf(room))
+	origin := p.originOf(room)
+	absolute := encounter.HexCellAt(encounter.HexesArePointyTop(),
+		int(pos.X)+int(origin.X), int(pos.Y)+int(origin.Y))
 	p.transcript = append(p.transcript, fmt.Sprintf("%s %s: %s(%g,%g) -> absolute(%g,%g)",
 		member, verb, room, pos.X, pos.Y, absolute.X, absolute.Y))
 	return absolute
@@ -195,15 +222,14 @@ func (p *continuityProjector) project(member, verb, room string, pos spatial.Pos
 // transcript row says which.
 func (p *continuityProjector) locate(member, verb string, absolute spatial.Position) spatial.Position {
 	p.t.Helper()
+	col, row := hexOffsetOfCell(absolute)
 	for _, r := range p.rooms {
-		local := absolute.Subtract(r.Origin)
-		qMin, qMax := hexSpan(r.Width)
-		rMin, rMax := hexSpan(r.Height)
-		if local.X < qMin || local.X > qMax || local.Y < rMin || local.Y > rMax {
+		localCol, localRow := col-int(r.Origin.X), row-int(r.Origin.Y)
+		if localCol < 0 || localCol >= r.Width || localRow < 0 || localRow >= r.Height {
 			continue
 		}
-		p.transcript = append(p.transcript, fmt.Sprintf("%s %s: %s(%g,%g) -> absolute(%g,%g)",
-			member, verb, r.ID, local.X, local.Y, absolute.X, absolute.Y))
+		p.transcript = append(p.transcript, fmt.Sprintf("%s %s: %s(%d,%d) -> absolute(%g,%g)",
+			member, verb, r.ID, localCol, localRow, absolute.X, absolute.Y))
 		return absolute
 	}
 	require.FailNow(p.t, "cell belongs to no chamber",
@@ -211,11 +237,19 @@ func (p *continuityProjector) locate(member, verb string, absolute spatial.Posit
 	return absolute
 }
 
-// hexSpan is an axial hex room's own [min,max] cell bounds along one axis: the
-// origin-centred half-open span tools/spatial gives an AxialHexGrid.
-func hexSpan(dim int) (min, max float64) {
-	half := float64(dim) / 2
-	return math.Ceil(-half), math.Ceil(half) - 1
+// hexOffsetOfCell is [encounter.HexCellAt] run backwards: the authored
+// [col,row] a dungeon-absolute cell came from.
+//
+// The fixture's own arithmetic, deliberately — this file projects with the
+// layout it authored rather than asking the composition, so the transcript
+// stays independent of the code it describes and the two cannot agree by
+// sharing a mistake. What it may borrow is tools/spatial's conversion, which
+// belongs to neither side of that comparison.
+func hexOffsetOfCell(cell spatial.Position) (col, row int) {
+	q, r := int(cell.X), int(cell.Y)
+	offset := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}.
+		ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+	return int(offset.X), int(offset.Y)
 }
 
 // TestVaultChaseAbsoluteContinuity is the wave's payoff scene (#929 T4):
@@ -246,8 +280,8 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	var alicePath, goblinPath []spatial.Position
 
 	// ---- Beat 1: starting placements, mutual sight ----------------------
-	alicePath = append(alicePath, proj.project(string(alice), "start", "corridor", spatial.Position{X: 1, Y: 1}))
-	goblinPath = append(goblinPath, proj.project(string(goblin), "start", "corridor", spatial.Position{X: 4, Y: 0}))
+	alicePath = append(alicePath, proj.project(string(alice), "start", "corridor", spatial.Position{X: 6, Y: 5}))
+	goblinPath = append(goblinPath, proj.project(string(goblin), "start", "corridor", spatial.Position{X: 9, Y: 4}))
 
 	st, _ := seen(t, enc, alice, goblin)
 	require.Equal(t, intel.Current, st, "beat 1: alice sees the goblin across the open corridor")
@@ -260,34 +294,39 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	require.NoError(t, err, "beat 1: alice breaks off to run")
 
 	// ---- Beat 2: alice steps toward the gate, one hex at a time ----------
-	for _, to := range []spatial.Position{{X: 2, Y: 1}, {X: 3, Y: 1}, {X: 4, Y: 1}} {
-		_, err = enc.Step(&encounter.StepInput{Member: alice, To: to})
+	for _, to := range []spatial.Position{{X: 7, Y: 5}, {X: 8, Y: 5}, {X: 9, Y: 5}} {
+		absolute := proj.project(string(alice), "move", "corridor", to)
+		_, err = enc.Step(&encounter.StepInput{Member: alice, To: absolute})
 		require.NoError(t, err, "alice steps toward the gate")
-		alicePath = append(alicePath, proj.project(string(alice), "move", "corridor", to))
+		alicePath = append(alicePath, absolute)
 	}
 
 	// Through the gate: one more step, to the cell on the other side. The
 	// departure cell was already recorded as alicePath's last entry, so only
 	// the arrival cell is new.
-	throughTheGate := proj.project(string(alice), "arrive via gate", "vault", spatial.Position{X: -5, Y: -2})
+	throughTheGate := proj.project(string(alice), "arrive via gate", "vault", spatial.Position{X: 0, Y: 5})
 	travOut, err := enc.Step(&encounter.StepInput{Member: alice, To: throughTheGate})
 	require.NoError(t, err, "alice slips through the gate")
 	require.Equal(t, "gate", travOut.Crossing, "the doorway is named, and decides nothing")
-	require.Equal(t, spatial.Position{X: 4, Y: 1}, travOut.Stepped.From, "the departure cell matches the last recorded move")
+	require.Equal(t, alicePath[len(alicePath)-1], travOut.Stepped.From, "the departure cell matches the last recorded move")
 	require.Equal(t, throughTheGate, travOut.Stepped.To)
 	alicePath = append(alicePath, throughTheGate)
 
-	// She takes one more step deeper into the vault before the pause, OFF the
-	// gate's row, and THAT is what puts the wall between them: standing in the
-	// opening she was still in plain view (rpg-toolkit#1106).
-	deeper := proj.project(string(alice), "move", "vault", spatial.Position{X: -5, Y: -3})
+	// She takes one more step deeper into the vault before the pause, off the
+	// gate's row. The wall took her one step earlier, at the threshold itself:
+	// the goblin watches from beside the seam, so crossing the opening is
+	// already out of its sight (see vaultChaseHexSetup's placement note). This
+	// step is what puts a second cell between the ghost and where she actually
+	// is, so the pursuit has somewhere to be wrong about.
+	deeper := proj.project(string(alice), "move", "vault", spatial.Position{X: 0, Y: 6})
 	_, err = enc.Step(&encounter.StepInput{Member: alice, To: deeper})
 	require.NoError(t, err, "alice steps deeper into the vault")
 	alicePath = append(alicePath, deeper)
 
 	// The ghost forms at the goblin's LAST SIGHT of her, which the wall beside
-	// the gate is what makes possible: a room boundary hid nothing here, and
-	// standing in the opening she was in plain view.
+	// the gate is what makes possible: a room boundary hid nothing here
+	// (rpg-toolkit#1106), and without a wall on the seam the vault would be in
+	// plain view from the corridor and there would be nowhere to disappear to.
 	st, p := seen(t, enc, goblin, alice)
 	require.Equal(t, intel.Held, st, "beat 2: the goblin's sight of alice fades — the wall took her")
 
@@ -312,36 +351,41 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	// Re-project alice's CURRENT position on the reloaded encounter — it
 	// must be identical to her last pre-reload position (distance 0,
 	// trivially continuous): a reload never moves anyone.
-	afterReload := proj.project(string(alice), "reload checkpoint", "vault", spatial.Position{X: -5, Y: -3})
+	afterReload := proj.project(string(alice), "reload checkpoint", "vault", spatial.Position{X: 0, Y: 6})
 	require.Equal(t, beforeReload, afterReload, "beat 3: the projected position is unchanged by the reload")
 
 	// ---- Beat 4: the pursuit crosses too ----------------------------------
 	pumpOut1, err := enc.Pump(&encounter.PumpInput{})
 	require.NoError(t, err, "beat 4: the pursuit resumes")
 	require.Len(t, pumpOut1.MonsterMoves, 1, "beat 4: the goblin steps toward the threshold")
-	// The pump reports where it walked on the MAP — no room needed to read
-	// it, and no arithmetic to redo (rpg-toolkit#1062). The corridor is
-	// anchored at the origin, so this one cell reads the same either way;
-	// the crossing below is where the two frames part company.
-	require.Equal(t, spatial.Position{X: 4, Y: 1}, pumpOut1.MonsterMoves[0].To)
+	// The pump reports where it walked on the MAP — no room needed to read it,
+	// and no arithmetic to redo (rpg-toolkit#1062). It went to the ghost, and
+	// the ghost stands on the last cell it saw her on: the corridor's own gate
+	// cell, which is the fourth thing her path recorded. Asserted as that
+	// entry rather than as a literal, so the two cannot drift apart — and note
+	// that the absolute cell is NOT the pair either of them was authored as
+	// (rpg-toolkit#1127), which is exactly why the pump reports absolute.
+	require.Equal(t, alicePath[3], pumpOut1.MonsterMoves[0].To)
 	goblinPath = append(goblinPath, proj.locate(string(goblin), "move", pumpOut1.MonsterMoves[0].To))
 
 	pumpOut2, err := enc.Pump(&encounter.PumpInput{})
 	require.NoError(t, err, "beat 4: the goblin follows her through")
 	require.Len(t, pumpOut2.MonsterMoves, 1, "beat 4: the goblin comes through the gate")
-	// vault-local (-5,-2) through the vault's (10,3) anchor: the same absolute
-	// cell alice's own step landed on, and the same cell the movement beat
-	// carries. ONE list, because there is one kind of step.
-	require.Equal(t, spatial.Position{X: 5, Y: 1}, pumpOut2.MonsterMoves[0].To)
+	// Standing on the ghost and she is not there, the decider reaches for the
+	// door it is standing in — so vault-local (0,5) through the vault's (10,0)
+	// anchor: the same absolute cell alice's own step landed on, and the same
+	// cell the movement beat carries. ONE list, because there is one kind of
+	// step.
+	require.Equal(t, throughTheGate, pumpOut2.MonsterMoves[0].To)
 	goblinPath = append(goblinPath, proj.locate(string(goblin), "arrive via gate", pumpOut2.MonsterMoves[0].To))
 
 	// ---- Beat 5: sanctuary ------------------------------------------------
-	for _, to := range []spatial.Position{{X: -4, Y: -3}, {X: -3, Y: -3}} {
+	for _, to := range []spatial.Position{{X: 1, Y: 6}, {X: 2, Y: 6}} {
 		absolute := proj.project(string(alice), "move", "vault", to)
 		moveOut, mErr := enc.Step(&encounter.StepInput{Member: alice, To: absolute})
 		require.NoError(t, mErr, "alice steps toward sanctuary")
 		alicePath = append(alicePath, absolute)
-		if to == (spatial.Position{X: -3, Y: -3}) {
+		if to == (spatial.Position{X: 2, Y: 6}) {
 			require.NotNil(t, moveOut.Outcome, "the ending fires on arrival")
 			require.Equal(t, "sanctuary", moveOut.Outcome.Ending)
 
@@ -387,19 +431,19 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	// entries) read exactly like an ordinary move, by design: the room
 	// boundary is invisible in world space.
 	require.Equal(t, []string{
-		"alice start: corridor(1,1) -> absolute(1,1)",
-		"goblin start: corridor(4,0) -> absolute(4,0)",
-		"alice move: corridor(2,1) -> absolute(2,1)",
-		"alice move: corridor(3,1) -> absolute(3,1)",
-		"alice move: corridor(4,1) -> absolute(4,1)",
-		"alice arrive via gate: vault(-5,-2) -> absolute(5,1)",
-		"alice move: vault(-5,-3) -> absolute(5,0)",
-		"alice reload checkpoint: vault(-5,-3) -> absolute(5,0)",
-		"goblin move: corridor(4,1) -> absolute(4,1)",
-		"goblin arrive via gate: vault(-5,-2) -> absolute(5,1)",
-		"alice move: vault(-4,-3) -> absolute(6,0)",
-		"alice move: vault(-3,-3) -> absolute(7,0)",
-		"alice outcome: vault(-3,-3) -> absolute(7,0)",
-		"goblin outcome: vault(-5,-2) -> absolute(5,1)",
+		"alice start: corridor(6,5) -> absolute(6,-8)",
+		"goblin start: corridor(9,4) -> absolute(9,-9)",
+		"alice move: corridor(7,5) -> absolute(7,-9)",
+		"alice move: corridor(8,5) -> absolute(8,-9)",
+		"alice move: corridor(9,5) -> absolute(9,-10)",
+		"alice arrive via gate: vault(0,5) -> absolute(10,-10)",
+		"alice move: vault(0,6) -> absolute(10,-11)",
+		"alice reload checkpoint: vault(0,6) -> absolute(10,-11)",
+		"goblin move: corridor(9,5) -> absolute(9,-10)",
+		"goblin arrive via gate: vault(0,5) -> absolute(10,-10)",
+		"alice move: vault(1,6) -> absolute(11,-12)",
+		"alice move: vault(2,6) -> absolute(12,-12)",
+		"alice outcome: vault(2,6) -> absolute(12,-12)",
+		"goblin outcome: vault(0,5) -> absolute(10,-10)",
 	}, proj.transcript, "the story IS the projected continuity, told in order")
 }

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -100,7 +100,7 @@ func vaultChaseHexSeamWall() []spatial.Boundary { return hexSeamWall(4, -2, 4, 1
 func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()
 	field := encounter.FieldInput{
-		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 		Rooms: []encounter.RoomInput{
 			{ID: "corridor", Width: 10, Height: 10, Grid: spatial.GridShapeHex,
 				Boundaries: vaultChaseHexSeamWall()},

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -1131,7 +1131,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	// the ending-trigger validation above already ran, and compileEndings is
 	// the SAME projection Setup runs, so a reloaded encounter's endings fire on
 	// the cells the original's did.
-	e.endings = compileEndings(endingInputsForValidation, roomInputs)
+	e.endings = compileEndings(endingInputsForValidation, roomInputs, e.orientation)
 
 	// Restore outcome if present
 	if data.Outcome != nil {

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -893,7 +893,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	for i, ed := range data.Endings {
 		endingInputsForValidation[i] = EndingInput{Key: ed.Key, Trigger: endingTriggerFromData(ed)}
 	}
-	if err := validateEndingTriggers(endingInputsForValidation, roomGrids); err != nil {
+	if err := validateEndingTriggers(roomInputs, endingInputsForValidation, roomGrids); err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
 

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -122,6 +122,17 @@ type FieldData struct {
 // it is a fact of the same species as.
 type CanvasData struct {
 	Void string `json:"void"`
+
+	// Orientation is which way this field's hexes point, or empty for a
+	// square field (rpg-toolkit#1127). Carries the declaration's own word for
+	// Void's reason — a wire form meaning "the second layout" would
+	// reinterpret every old blob the day a third arrives.
+	//
+	// Omitted when empty so a square field's blob is byte-identical to what
+	// it was before orientations existed, and REQUIRED for a hex one:
+	// reloading a hex field without it would read every stored cell in the
+	// wrong frame, which is a dungeon drawn correctly and played wrong.
+	Orientation string `json:"orientation,omitempty"`
 }
 
 // RoomData mirrors RoomInput exactly to persist construction inputs — true
@@ -427,7 +438,10 @@ func (e *Encounter) ToData() EncounterData {
 
 	// Deep-copy field from stored inputs
 	fieldData := FieldData{
-		Canvas:      CanvasData{Void: string(e.void.Kind())},
+		Canvas: CanvasData{
+			Void:        string(e.void.Kind()),
+			Orientation: orientationName(e.orientation),
+		},
 		Rooms:       make([]RoomData, len(e.fieldInput)),
 		Connections: make([]ConnectionData, len(e.connectionsInput)),
 	}
@@ -791,7 +805,11 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
-	roomGrids, err := buildValidRoomGrids(roomInputs)
+	orientation, err := orientationFromData(fieldGridShape(roomInputs), data.Field.Canvas.Orientation)
+	if err != nil {
+		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
+	}
+	roomGrids, err := buildValidRoomGrids(roomInputs, orientation)
 	if err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
@@ -800,7 +818,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
-	if err = validateConnectionInputs(roomInputs, roomGrids, connectionInputs); err != nil {
+	if err = validateConnectionInputs(roomInputs, roomGrids, orientation, connectionInputs); err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
 
@@ -812,7 +830,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
-	if err = validateDoorInputs(roomInputs, roomGrids, doorInputs); err != nil {
+	if err = validateDoorInputs(roomInputs, roomGrids, orientation, doorInputs); err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
 
@@ -860,7 +878,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		// spans but which is not floor. The SAME lookup the live verbs use
 		// (rpg-toolkit#1108); it used to be a twin that had to be kept in step
 		// by hand.
-		if _, owned := regionAt(roomInputs, roomGrids, cell); !owned {
+		if _, owned := regionAt(roomInputs, roomGrids, orientation, cell); !owned {
 			return nil, fmt.Errorf("load encounter: member %q cell is owned by no region: %w: %w", m.ID, ErrInvalidData, ErrBadPlacement)
 		}
 	}
@@ -902,7 +920,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 			// cell against the region NAMED BESIDE IT in the blob; with the
 			// region derived rather than stored there is nothing to
 			// cross-check, only somewhere to be (rpg-toolkit#1108).
-			if _, owned := regionAt(roomInputs, roomGrids, spatial.Position{X: om.Cell.X, Y: om.Cell.Y}); !owned {
+			if _, owned := regionAt(roomInputs, roomGrids, orientation, spatial.Position{X: om.Cell.X, Y: om.Cell.Y}); !owned {
 				return nil, fmt.Errorf("load encounter: outcome member %q cell is owned by no region: %w: %w", om.ID, ErrInvalidData, ErrBadPlacement)
 			}
 		}
@@ -1029,6 +1047,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		retention:   normalizeRetention(data.Retention),
 		logFloor:    logFloorOf(data.Log),
 		void:        void,
+		orientation: orientation,
 	}
 
 	// Compile the authored rooms into the canvas — the SAME compileCanvas
@@ -1038,7 +1057,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 	// construction).
 	e.doors, e.doorsByID = doorRecordsFrom(doorInputs)
 
-	e.canvas, err = compileCanvas(roomInputs, roomGrids, void, e.doors)
+	e.canvas, err = compileCanvas(roomInputs, roomGrids, void, orientation, e.doors)
 	if err != nil {
 		return nil, fmt.Errorf("load encounter: %w: %w", ErrInvalidData, err)
 	}
@@ -1123,7 +1142,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		}
 		for i, m := range data.Outcome.Members {
 			cell := spatial.Position{X: m.Cell.X, Y: m.Cell.Y}
-			region, _ := regionAt(roomInputs, roomGrids, cell)
+			region, _ := regionAt(roomInputs, roomGrids, orientation, cell)
 			outcome.Members[i] = MemberOutcome{
 				ID: m.ID,
 				// The region is DERIVED from the cell, through the same

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -73,7 +73,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
 					Props:      []encounter.PropInput{rubble(1, 2)},
@@ -303,7 +303,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		setup := &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Rooms: []encounter.RoomInput{
 					{ID: "hex-room", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
 				},
@@ -1494,7 +1494,7 @@ func (s *DataTestSuite) TestLoadPropOnBoundaryCellAccepted() {
 func (s *DataTestSuite) TestLoadPropIDCrossRoomCollisionAccepted() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "opaque"},
+			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms: []encounter.RoomData{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridTypeHex,
 					Origin: &encounter.PositionData{X: 0, Y: 0}, Props: []encounter.PropData{rubbleData(-5, 4)}},
@@ -1857,7 +1857,7 @@ func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
 func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "opaque"},
+			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms: []encounter.RoomData{
 				{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 			},
@@ -1918,7 +1918,7 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "opaque"},
+			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 7}},
@@ -1948,7 +1948,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 func validHexAxialData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "opaque"},
+			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0},
 					Props: []encounter.PropData{rubbleData(2, 2)}},
@@ -2028,7 +2028,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 func validAnchoredHexData() encounter.EncounterData {
 	return encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "opaque"},
+			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 6, Y: -5}},
@@ -2445,7 +2445,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 	data := encounter.EncounterData{
 		Field: encounter.FieldData{
-			Canvas: encounter.CanvasData{Void: "opaque"},
+			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms:  []encounter.RoomData{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}}},
 		},
 		Endings: []encounter.EndingData{
@@ -2497,7 +2497,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -77,14 +77,14 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 			Rooms: []encounter.RoomInput{
 				{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -10, Y: 7},
 					Props:      []encounter.PropInput{rubble(1, 2)},
-					Boundaries: []spatial.Boundary{{From: spatial.Position{X: -2, Y: -2}, To: spatial.Position{X: -2, Y: -1}, BlocksMovement: true, BlocksLineOfSight: true}},
+					Boundaries: []spatial.Boundary{{From: spatial.Position{X: 2, Y: 2}, To: spatial.Position{X: 2, Y: 3}, BlocksMovement: true, BlocksLineOfSight: true}},
 				},
-				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -3, Y: 7}},
+				{ID: "hall", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: -2, Y: 7}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "door1", From: "crypt", To: "hall",
-				FromPosition: spatial.Position{X: 3, Y: 0},
-				ToPosition:   spatial.Position{X: -3, Y: 0},
+				FromPosition: spatial.Position{X: 7, Y: 3},
+				ToPosition:   spatial.Position{X: 0, Y: 3},
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -116,7 +116,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// because sight stopped at a room boundary. That makes the golden strictly
 	// richer: it is the one place the bubbles array and intel's holdings are
 	// pinned as exact bytes.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMywieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","props":[{"ref":"test:props:rubble","at":{"x":1,"y":2},"blocks_movement":true,"blocks_line_of_sight":true}],"boundaries":[{"from":{"x":-2,"y":-2},"to":{"x":-2,"y":-1},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-3,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":3,"y":0},"to_position":{"x":-3,"y":0}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-3,"y":7}},{"id":"p1","kind":"player","cell":{"x":-10,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOi0yfQ==","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMiwieSI6LTZ9","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque","orientation":"pointy"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","props":[{"ref":"test:props:rubble","at":{"x":1,"y":2},"blocks_movement":true,"blocks_line_of_sight":true}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-2,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":7,"y":3},"to_position":{"x":0,"y":3}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-2,"y":-6}},{"id":"p1","kind":"player","cell":{"x":-10,"y":-2}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
 	s.Equal(expected, string(bs))
 }
 
@@ -1870,39 +1870,63 @@ func connHexRoomData(pos encounter.PositionData) encounter.EncounterData {
 	}
 }
 
-// TestHexRoomBoundsLoad is the Load-seam counterpart to
-// encounter_test.go's TestHexRoomBounds.
+// TestHexRoomBoundsLoad is the Load-seam counterpart to encounter_test.go's
+// TestHexRoomBounds, and every cell in it moved with rpg-toolkit#1127.
+//
+// The chamber is a 4x3 OFFSET rectangle at the origin, so it owns authored
+// columns 0..2... 0..3 and rows 0..2, and the absolute cells below are that
+// rectangle's image on the canvas. The subtests used to be named for an
+// origin-centred axial span — "Q at exactly -Width/2 accepted (lower bound
+// inclusive)" — and that span is what the slice replaced: a chamber is
+// anchored at its CORNER now, so there is no lower bound to be inclusive of,
+// and the boundary that matters is the rectangle's own edge.
+//
+// Each accepted cell names the authored [col,row] it came from, because an
+// absolute axial pair is unreadable on its own and a reader checking this test
+// should not have to run the conversion in their head.
 func (s *DataTestSuite) TestHexRoomBoundsLoad() {
-	s.Run("positive Q, positive R within span accepted", func() {
+	load := func(cell encounter.PositionData) error {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 1, Y: 1})})
-		s.Require().NoError(err)
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+			Initiative: orderAsGiven{}, Data: connHexRoomData(cell)})
+		return err
+	}
+
+	s.Run("the chamber's own corner accepted", func() {
+		// authored [0,0]
+		s.Require().NoError(load(encounter.PositionData{X: 0, Y: 0}))
 	})
 
-	s.Run("negative Q within span accepted — rejected under the old offset HexGrid", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -1, Y: 0})})
-		s.Require().NoError(err, "axial hex rooms are origin-centered; negative Q is ordinary, not a defect")
+	s.Run("its far corner accepted", func() {
+		// authored [3,2] — the last column of the last row
+		s.Require().NoError(load(encounter.PositionData{X: 3, Y: -4}))
 	})
 
-	s.Run("Q at exactly +Width/2 rejected (upper bound exclusive)", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: 2, Y: 0})})
-		s.Require().Error(err)
+	s.Run("a negative R inside it accepted", func() {
+		// authored [0,2]. A negative absolute coordinate is ordinary: the
+		// conversion from offset to axial produces them for almost every
+		// chamber, and the reference tomb's own R values run -21 to 0.
+		s.Require().NoError(load(encounter.PositionData{X: 0, Y: -2}))
+	})
+
+	s.Run("one column past the last rejected", func() {
+		// authored [4,0], which the 4-wide rectangle does not hold
+		err := load(encounter.PositionData{X: 4, Y: -2})
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "owned by no region")
 	})
 
-	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -2, Y: 0})})
-		s.Require().NoError(err)
+	s.Run("one column before the first rejected", func() {
+		// authored [-1,0] — outside the rectangle, where under the old
+		// origin-centred reading it would have been comfortably inside
+		err := load(encounter.PositionData{X: -1, Y: 0})
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
+		s.Require().Contains(err.Error(), "owned by no region")
 	})
 
-	s.Run("Q beyond -Width/2 rejected", func() {
-		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: connHexRoomData(encounter.PositionData{X: -3, Y: 0})})
-		s.Require().Error(err)
+	s.Run("one row past the last rejected", func() {
+		// authored [0,3]
+		err := load(encounter.PositionData{X: 0, Y: -3})
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "owned by no region")
 	})
@@ -1921,23 +1945,24 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
-				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 7}},
+				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionData{{
 				ID: "gate", From: "hex-a", To: "hex-b",
-				FromPosition: &encounter.PositionData{X: 4, Y: 4},
-				ToPosition:   &encounter.PositionData{X: -3, Y: -3},
+				FromPosition: &encounter.PositionData{X: 9, Y: 4},
+				ToPosition:   &encounter.PositionData{X: 0, Y: 4},
 			}},
 		},
 		Members: []encounter.MemberData{
-			{ID: "p1", Kind: encounter.KindPlayer, Cell: &encounter.PositionData{X: 1, Y: 1}}, /*ROOM:"hex-a"*/
+			{ID: "p1", Kind: encounter.KindPlayer, Cell: &encounter.PositionData{X: 1, Y: -2}}, /*ROOM:"hex-a" authored [1,1]*/
 		},
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, Data: data})
-	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
+	s.Require().NoError(err,
+		"the chambers meet at hex-a's last column and hex-b's first, on the same row")
 }
 
 // validHexAxialData returns a fresh EncounterData with two hex rooms
@@ -1952,12 +1977,12 @@ func validHexAxialData() encounter.EncounterData {
 			Rooms: []encounter.RoomData{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0},
 					Props: []encounter.PropData{rubbleData(2, 2)}},
-				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 1}},
+				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 8, Y: 0}},
 			},
 			Connections: []encounter.ConnectionData{{
 				ID: "gate", From: "hex-a", To: "hex-b",
-				FromPosition: &encounter.PositionData{X: 3, Y: 0},
-				ToPosition:   &encounter.PositionData{X: -4, Y: -1},
+				FromPosition: &encounter.PositionData{X: 7, Y: 3},
+				ToPosition:   &encounter.PositionData{X: 0, Y: 3},
 			}},
 		},
 		Members: []encounter.MemberData{
@@ -1984,7 +2009,7 @@ func (s *DataTestSuite) TestLoadHexIntegralAxial() {
 			d.Field.Connections[0].FromPosition = &encounter.PositionData{X: 1.5, Y: 1}
 		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"connection to-position fractional", func(d *encounter.EncounterData) {
-			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: -1.5, Y: -1}
+			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 0.5, Y: 3}
 		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"prop cell fractional", func(d *encounter.EncounterData) {
 			// #929 T3 Opus round F2: prop integrality is now universal
@@ -2031,12 +2056,12 @@ func validAnchoredHexData() encounter.EncounterData {
 			Canvas: encounter.CanvasData{Void: "opaque", Orientation: "pointy"},
 			Rooms: []encounter.RoomData{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 0, Y: 0}},
-				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 6, Y: -5}},
+				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridTypeHex, Origin: &encounter.PositionData{X: 10, Y: -2}},
 			},
 			Connections: []encounter.ConnectionData{{
 				ID: "gate", From: "hex-big", To: "hex-small",
-				FromPosition: &encounter.PositionData{X: 4, Y: 0},
-				ToPosition:   &encounter.PositionData{X: -1, Y: 4},
+				FromPosition: &encounter.PositionData{X: 9, Y: 1},
+				ToPosition:   &encounter.PositionData{X: 0, Y: 4},
 			}},
 		},
 		Members: []encounter.MemberData{
@@ -2128,7 +2153,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 			// from (6,-5) to (6,-3): the gate's endpoints, once anchored,
 			// differ by axial (ΔQ=1,ΔR=1) — cube distance (1+1+2)/2=2, NOT
 			// 1 — while still disjoint from hex-big (W2 passes).
-			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 6, Y: -3}
+			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 10, Y: -4}
 		}, encounter.ErrBadConnection, "distance 2"},
 	}
 	for _, tc := range cases {
@@ -2482,7 +2507,7 @@ func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 	s.Require().NoError(err)
 
 	s.Equal(string(bs1), string(bs2), "origins (including hex-small's negative-axial one) must survive a second round trip byte-identically")
-	s.Contains(string(bs1), `"origin":{"x":6,"y":-5}`, "the negative-axial origin must be present, not truncated or dropped")
+	s.Contains(string(bs1), `"origin":{"x":10,"y":-2}`, "the negative-axial origin must be present, not truncated or dropped")
 }
 
 // TestReloadedAnchoredEncounterAcceptsSameTraverse pins behavior-identity
@@ -2500,27 +2525,30 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
-				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
+				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: -2}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "hex-big", To: "hex-small",
-				FromPosition: spatial.Position{X: 4, Y: 0},
-				ToPosition:   spatial.Position{X: -1, Y: 4},
+				FromPosition: spatial.Position{X: 9, Y: 1},
+				ToPosition:   spatial.Position{X: 0, Y: 4},
 			}},
 		},
 		Members: []encounter.MemberInput{
-			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-big", Position: spatial.Position{X: 4, Y: 0}},
+			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-big", Position: spatial.Position{X: 9, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	}
 	enc1, err := encounter.NewEncounter(setup)
 	s.Require().NoError(err)
 
-	// hex-small local (-1,4) through its (6,-5) anchor is (5,-1) — the far
-	// side of the gate; hex-big's own (4,0) is the near side, and since that
-	// room is anchored at the origin it reads the same either way.
-	nearSide := spatial.Position{X: 4, Y: 0}
-	farSide := spatial.Position{X: 5, Y: -1}
+	// The gate's two sides, on the canvas. hex-big's authored [9,1] compiles
+	// to axial (9,-6) and hex-small's [0,4] — through its (10,-2) anchor,
+	// so authored [10,2] absolute — to (10,-7). Neither reads the same as its
+	// authored pair any more, and that is the point of rpg-toolkit#1127
+	// rather than an inconvenience: a chamber is drawn in offset columns and
+	// run on a cube grid, and the compile is where the two meet.
+	nearSide := spatial.Position{X: 9, Y: -6}
+	farSide := spatial.Position{X: 10, Y: -7}
 
 	out1, err := enc1.Step(&encounter.StepInput{Member: "p1", To: farSide})
 	s.Require().NoError(err, "the original encounter accepts the step through the gate")
@@ -2600,7 +2628,7 @@ func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
 	// OTHER corner (1,4) — still a legal LOCAL cell, but cube distance 2
 	// from the absolute anchor, same defect TestLoadAnchoring's "W3" row
 	// pins via a struct mutation — this pins it via raw bytes instead.
-	hostile := bytes.Replace(bs, []byte(`"to_position":{"x":-1,"y":4}`), []byte(`"to_position":{"x":1,"y":4}`), 1)
+	hostile := bytes.Replace(bs, []byte(`"to_position":{"x":0,"y":4}`), []byte(`"to_position":{"x":2,"y":4}`), 1)
 	s.Require().NotEqual(bs, hostile, "the byte replacement must actually have matched something")
 
 	var data encounter.EncounterData

--- a/rulebooks/dnd5e/encounter/doc.go
+++ b/rulebooks/dnd5e/encounter/doc.go
@@ -98,7 +98,8 @@
 //     absolute footprints must be expressible as a SINGLE grid of the
 //     field's family, because that is what the rooms compile into
 //     (#1106). Square grids start at (0,0), so a square field cannot
-//     reach a negative cell; hex grids are origin-centred and always fit.
+//     reach a negative cell; a hex canvas is an origin-centred axial span
+//     and always widens to cover the sheared footprints it holds.
 //     The remedy for a rejection is a relabelling — shift every Origin by
 //     the same vector — since a field's absolute frame only ever means
 //     "relative to the other rooms".

--- a/rulebooks/dnd5e/encounter/door.go
+++ b/rulebooks/dnd5e/encounter/door.go
@@ -326,7 +326,10 @@ func normalizeDoorEdge(e DoorEdge) DoorEdge {
 // wall drawn across nothing — #880's rule ("both endpoints must be in the floor
 // footprint"), and the reason rpg-toolkit#1116's declaration has to land first
 // for this to even be askable.
-func validateDoorInputs(rooms []RoomInput, grids map[string]spatial.Grid, doors []DoorInput) error {
+func validateDoorInputs(
+	rooms []RoomInput, grids map[string]spatial.Grid,
+	orientation Orientation, doors []DoorInput,
+) error {
 	if len(doors) == 0 {
 		return nil
 	}
@@ -345,7 +348,9 @@ func validateDoorInputs(rooms []RoomInput, grids map[string]spatial.Grid, doors 
 	walls := make(map[DoorEdge]string)
 	for _, r := range rooms {
 		for _, b := range r.Boundaries {
-			walls[normalizeDoorEdge(DoorEdge{From: b.From.Add(r.Origin), To: b.To.Add(r.Origin)})] = r.ID
+			walls[normalizeDoorEdge(DoorEdge{
+				From: absoluteOf(r, orientation, b.From), To: absoluteOf(r, orientation, b.To),
+			})] = r.ID
 		}
 	}
 
@@ -385,7 +390,7 @@ func validateDoorInputs(rooms []RoomInput, grids map[string]spatial.Grid, doors 
 					d.ID, raw.From.X, raw.From.Y, raw.To.X, raw.To.Y, ErrBadDoor)
 			}
 			for _, end := range []spatial.Position{edge.From, edge.To} {
-				if _, floor := regionAt(rooms, grids, end); !floor {
+				if _, floor := regionAt(rooms, grids, orientation, end); !floor {
 					return fmt.Errorf("door %q edge endpoint (%g,%g) is not floor: %w",
 						d.ID, end.X, end.Y, ErrBadDoor)
 				}

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -50,17 +50,19 @@ type declaredEnding struct {
 // target into the single canvas cell an arrival is compared against. Every
 // room named here has already been checked to exist by validateEndingTriggers,
 // which both construction seams run before this.
-func compileEndings(endings []EndingInput, rooms []RoomInput) []declaredEnding {
-	origins := make(map[string]spatial.Position, len(rooms))
-	for _, r := range rooms {
-		origins[r.ID] = r.Origin
-	}
-
+//
+// Through [absoluteOf], the one projection this package has, rather than
+// through an addition of its own (rpg-toolkit#1127). An ending is compared to a
+// member's live cell by EQUALITY, so a second projection here would not be
+// merely untidy: on a hex field it lands the sanctuary tile somewhere no member
+// can ever stand, and the encounter simply never ends — the liveness hole
+// ErrNoEnding exists to prevent, arrived at from the inside.
+func compileEndings(endings []EndingInput, rooms []RoomInput, orientation Orientation) []declaredEnding {
 	out := make([]declaredEnding, 0, len(endings))
 	for _, ei := range endings {
 		de := declaredEnding{key: ei.Key, trigger: ei.Trigger}
 		if t, ok := ei.Trigger.(TriggerReachedPosition); ok {
-			de.cell = t.Position.Add(origins[t.Room])
+			de.cell = absoluteOf(roomByID(rooms, t.Room), orientation, t.Position)
 		}
 		out = append(out, de)
 	}
@@ -1415,7 +1417,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 
 	// Store endings in declaration order (deterministic evaluation, C8), each
 	// positional one compiled to the canvas cell it fires on.
-	e.endings = compileEndings(in.Endings, in.Field.Rooms)
+	e.endings = compileEndings(in.Endings, in.Field.Rooms, e.orientation)
 
 	// First light: build sight percepts for each member using refreshSight
 	firstLight, err := e.rebuildPercepts(memberIDs)
@@ -1559,18 +1561,6 @@ func (e *Encounter) cellOf(record *memberRecord) (spatial.Position, error) {
 		return spatial.Position{}, fmt.Errorf("member %q: not placed on the map: %w", record.ID, ErrNoField)
 	}
 	return cell, nil
-}
-
-// roomOrigin is the construction-time anchor lookup compileCanvas and member
-// placement share. Rooms are few and this runs once per placed thing at
-// construction, so a linear scan is the whole implementation.
-func roomOrigin(rooms []RoomInput, id string) spatial.Position {
-	for _, r := range rooms {
-		if r.ID == id {
-			return r.Origin
-		}
-	}
-	return spatial.Position{}
 }
 
 // Status returns the encounter's current state (Open or Closed with Outcome).

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -237,9 +237,12 @@ func deepCopyRoomInputs(rooms []RoomInput) []RoomInput {
 // the wire. HexGrid's bounded offset column/row coordinates would force a
 // lossy, orientation-dependent offset<->cube conversion at that seam for no
 // benefit inside the composition, which never renders a grid itself.
-// width/height become AxialHexGridConfig's SpanWidth/SpanHeight — see
-// RoomInput.Grid's doc comment for what that means for a hex room's
-// Position values (origin-centered, negative coordinates legal).
+// width/height become AxialHexGridConfig's SpanWidth/SpanHeight, an
+// origin-centred axial span. THAT SPAN IS THE CANVAS, NOT A CHAMBER
+// (rpg-toolkit#1127): a room's own grid is still built here because a hex
+// canvas needs one and because square rooms decide their bounds with it, but
+// which cells a hex CHAMBER owns is [footprintHolds]' answer and no longer
+// this grid's — see orientation.go for why the two ever differed.
 func buildRoomGrid(shape spatial.GridShape, width, height int) spatial.Grid {
 	switch shape {
 	case spatial.GridShapeHex:
@@ -739,8 +742,8 @@ func buildValidRoomGrids(rooms []RoomInput, orientation Orientation) (map[string
 		}
 	}
 
-	// W2 — rooms never overlap: distinct rooms' absolute cell sets (local
-	// cell + Origin) must be disjoint. Zero-value origins are legal on
+	// W2 — rooms never overlap: distinct rooms' absolute cell sets must be
+	// disjoint. Zero-value origins are legal on
 	// their own; a multi-room field that leaves every Origin defaulted
 	// collides every room at (0,0) and is rejected HERE — there is no
 	// separate "origin required" check (RoomInput.Origin's doc comment).
@@ -919,11 +922,11 @@ func gridShapeName(shape spatial.GridShape) string {
 }
 
 // validateGridFamilies rejects a field whose rooms declare more than one
-// grid family (W1 — one geometry per field). Local→absolute is element-wise
-// addition (RoomInput.Origin's doc comment): a hex room's axial Q/R and a
-// square room's Cartesian X/Y cannot be added together and mean anything, so
-// a mixed field has no coherent absolute space at all — this must reject
-// before W2/W3 ever try to build one. Compares ALL pairs semantically, not
+// grid family (W1 — one geometry per field). A hex chamber's authored columns
+// and rows and a square room's Cartesian X/Y do not land in the same absolute
+// space — the first is converted, the second is not (RoomInput.Grid's doc
+// comment) — so a mixed field has no coherent absolute space at all, and this
+// must reject before W2/W3 ever try to build one. Compares ALL pairs semantically, not
 // just adjacent-in-slice: a three-room field ordered square, hex, square
 // must still be caught even though both adjacent pairs (0,1) and (1,2)
 // already mismatch on their own — see #929 T1 mutation notes for why an
@@ -990,17 +993,21 @@ func roomAbsoluteBounds(r RoomInput, orientation Orientation) (qMin, qMax, rMin,
 }
 
 // validateRoomsDisjoint rejects a field whose rooms' absolute footprints
-// share a cell (W2 — rooms never overlap): absolute = local cell + Origin,
-// element-wise (RoomInput.Origin's doc comment). Touching — adjacent cells,
-// no shared cell — is legal; this rejects ONLY a shared cell. Both grid
-// families are solid rectangles in their OWN coordinate system (a hex
-// room's Q,R span is a rhombus embedded in 2D axial space, but each axis
-// is independently an interval, exactly like square's X,Y), so two rooms'
-// footprints overlap iff BOTH axes' intervals intersect — no enumeration:
-// O(1) per room pair, not O(cells). The witness cell, when rejecting, is
-// the component-wise max of the two rooms' interval mins — the
-// lexicographically-first cell both footprints necessarily contain,
-// deterministic regardless of iteration order.
+// share a cell (W2 — rooms never overlap). Touching — adjacent cells, no
+// shared cell — is legal; this rejects ONLY a shared cell.
+//
+// TWO TESTS, AND WHICH ONE DECIDES DEPENDS ON THE FAMILY. A SQUARE chamber is
+// a rectangle in the very frame the canvas runs on, so its bounding box is the
+// chamber: both axes' intervals intersecting is exactly a shared cell, O(1) per
+// pair and exact. A HEX chamber is an authored rectangle sheared into axial
+// space (rpg-toolkit#1127), so its box strictly contains it, and the box test
+// is only a fast REJECT — two boxes that miss cannot share a cell, two that
+// meet very well might not. The verdict there is [hexFootprintsOverlap], on
+// runs rather than cells: O(Width) per pair, still not O(cells).
+//
+// The witness cell, when rejecting, is the component-wise max of the two
+// rooms' interval mins — the lexicographically-first cell both BOXES
+// necessarily contain, deterministic regardless of iteration order.
 func validateRoomsDisjoint(rooms []RoomInput, orientation Orientation) error {
 	type bounds struct{ qMin, qMax, rMin, rMax int }
 	bs := make([]bounds, len(rooms))

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1022,9 +1022,9 @@ func validateRoomsDisjoint(rooms []RoomInput, orientation Orientation) error {
 			// A SHEARED ONE (rpg-toolkit#1127), so on hex it is a fast REJECT
 			// path and never a verdict: two boxes that miss cannot share a
 			// cell, but two that meet very well might not. Deciding on the box
-			// is what refused the reference tomb outright under flat-top —
-			// `room "entrance" and room "hall" overlap at absolute cell
-			// (3, -9)` — for chambers that share no cell at all.
+			// is what refused the reference tomb outright in BOTH
+			// orientations — `room "entrance" and room "hall" overlap at
+			// absolute cell (1, -4)` — for chambers that share no cell at all.
 			if qOverlap && rOverlap && rooms[i].Grid == spatial.GridShapeHex &&
 				!hexFootprintsOverlap(rooms[i], rooms[j], orientation) {
 				continue

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1141,7 +1141,7 @@ func validateConnectionInputs(
 // doc comment): unknown room, out-of-bounds position, or (hex only)
 // non-integral position all reject with ErrNoEnding, no verb prefix — each
 // caller wraps its own at the call site.
-func validateEndingTriggers(endings []EndingInput, roomGrids map[string]spatial.Grid) error {
+func validateEndingTriggers(rooms []RoomInput, endings []EndingInput, roomGrids map[string]spatial.Grid) error {
 	for _, ei := range endings {
 		trigger, ok := ei.Trigger.(TriggerReachedPosition)
 		if !ok {
@@ -1151,7 +1151,7 @@ func validateEndingTriggers(endings []EndingInput, roomGrids map[string]spatial.
 		if !ok {
 			return fmt.Errorf("ending %q trigger names unknown room %q: %w", ei.Key, trigger.Room, ErrNoEnding)
 		}
-		if !grid.IsValidPosition(trigger.Position) {
+		if !localIsInRoom(roomByID(rooms, trigger.Room), roomGrids, trigger.Position) {
 			return fmt.Errorf("ending %q trigger position is out of bounds: %w", ei.Key, ErrNoEnding)
 		}
 		if !isIntegralAxialPosition(grid, trigger.Position) {
@@ -1313,7 +1313,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 
 	// A TriggerReachedPosition ending must name a real room and reachable
 	// position (#929 T3 Opus round F5) — see validateEndingTriggers.
-	if err := validateEndingTriggers(in.Endings, roomGrids); err != nil {
+	if err := validateEndingTriggers(in.Field.Rooms, in.Endings, roomGrids); err != nil {
 		return nil, fmt.Errorf("newencounter: %w", err)
 	}
 
@@ -1383,11 +1383,10 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		// Room-local at authoring, absolute on the canvas: the member's
 		// declared cell is checked against their own room's grid — the frame
 		// they were written in — and then placed at the one cell that is.
-		grid, ok := roomGrids[mi.Room]
-		if !ok {
+		if _, ok := roomGrids[mi.Room]; !ok {
 			return nil, fmt.Errorf("newencounter member placement: member %q names unknown room %q: %w", mi.ID, mi.Room, ErrBadPlacement)
 		}
-		if !grid.IsValidPosition(mi.Position) {
+		if !localIsInRoom(roomByID(in.Field.Rooms, mi.Room), roomGrids, mi.Position) {
 			return nil, fmt.Errorf("newencounter member placement: member %q position out of bounds in room %q: %w", mi.ID, mi.Room, ErrBadPlacement)
 		}
 

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -105,6 +105,13 @@ type Encounter struct {
 	// there is no second answer to keep in step — see [canvasRoom].
 	void Void
 
+	// orientation is which way this field's hexes point, or nil for a square
+	// field (CanvasInput.Orientation). Kept from construction because the
+	// mask needs it on every RegionAt: a chamber's cells are the offset
+	// rectangle somebody drew, and "offset" is only meaningful with this in
+	// hand.
+	orientation Orientation
+
 	clock *clock.Tick
 	// bubbles are the localized initiative bubbles currently running. Zero or
 	// more: a bubble exists only while a fight does, and an encounter with no
@@ -556,7 +563,7 @@ func (e *Encounter) enforceRetention() error {
 // "newencounter: %w", LoadEncounter wraps "load encounter: %w: %w" with
 // ErrInvalidData — so the SAME validator produces a message honest about
 // which seam actually rejected it.
-func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
+func buildValidRoomGrids(rooms []RoomInput, orientation Orientation) (map[string]spatial.Grid, error) {
 	seenIDs := make(map[string]bool, len(rooms))
 	grids := make(map[string]spatial.Grid, len(rooms))
 	for _, r := range rooms {
@@ -735,14 +742,14 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 	// their own; a multi-room field that leaves every Origin defaulted
 	// collides every room at (0,0) and is rejected HERE — there is no
 	// separate "origin required" check (RoomInput.Origin's doc comment).
-	if err := validateRoomsDisjoint(rooms); err != nil {
+	if err := validateRoomsDisjoint(rooms, orientation); err != nil {
 		return nil, err
 	}
 
 	// W6 — the field is one canvas: its whole absolute footprint must fit in a
 	// single grid of its family (rpg-toolkit#1106). Runs after W2, which is
 	// what makes the footprint a well-defined union in the first place.
-	qMin, qMax, rMin, rMax := fieldAbsoluteBounds(rooms)
+	qMin, qMax, rMin, rMax := fieldAbsoluteBounds(rooms, orientation)
 	if _, _, err := canvasSpan(rooms[0].Grid, qMin, qMax, rMin, rMax); err != nil {
 		return nil, err
 	}
@@ -753,10 +760,10 @@ func buildValidRoomGrids(rooms []RoomInput) (map[string]spatial.Grid, error) {
 // fieldAbsoluteBounds returns the union of every room's absolute footprint —
 // the field's own bounding box, in dungeon-absolute cells. Requires at least
 // one room, which both construction seams check before calling.
-func fieldAbsoluteBounds(rooms []RoomInput) (qMin, qMax, rMin, rMax int) {
-	qMin, qMax, rMin, rMax = roomAbsoluteBounds(rooms[0])
+func fieldAbsoluteBounds(rooms []RoomInput, orientation Orientation) (qMin, qMax, rMin, rMax int) {
+	qMin, qMax, rMin, rMax = roomAbsoluteBounds(rooms[0], orientation)
 	for _, r := range rooms[1:] {
-		q0, q1, r0, r1 := roomAbsoluteBounds(r)
+		q0, q1, r0, r1 := roomAbsoluteBounds(r, orientation)
 		qMin, qMax = min(qMin, q0), max(qMax, q1)
 		rMin, rMax = min(rMin, r0), max(rMax, r1)
 	}
@@ -822,8 +829,11 @@ func canvasSpan(shape spatial.GridShape, qMin, qMax, rMin, rMax int) (width, hei
 // Both seams run buildValidRoomGrids first, which is what lets this read the
 // family off rooms[0] alone: W1 gives every room in a field the same one, and a
 // mixed field never reaches here.
-func compileCanvas(rooms []RoomInput, grids map[string]spatial.Grid, void Void, doors []*doorRecord) (*canvasRoom, error) {
-	qMin, qMax, rMin, rMax := fieldAbsoluteBounds(rooms)
+func compileCanvas(
+	rooms []RoomInput, grids map[string]spatial.Grid,
+	void Void, orientation Orientation, doors []*doorRecord,
+) (*canvasRoom, error) {
+	qMin, qMax, rMin, rMax := fieldAbsoluteBounds(rooms, orientation)
 	width, height, err := canvasSpan(rooms[0].Grid, qMin, qMax, rMin, rMax)
 	if err != nil {
 		return nil, err
@@ -849,7 +859,7 @@ func compileCanvas(rooms []RoomInput, grids map[string]spatial.Grid, void Void, 
 				blocksMovement:    *p.BlocksMovement,
 				blocksLineOfSight: *p.BlocksLineOfSight,
 			}
-			if perr := canvas.PlaceEntity(prop, p.At.Add(ri.Origin)); perr != nil {
+			if perr := canvas.PlaceEntity(prop, absoluteOf(ri, orientation, p.At)); perr != nil {
 				return nil, fmt.Errorf("prop placement: %w: %w", ErrBadPlacement, perr)
 			}
 		}
@@ -859,8 +869,8 @@ func compileCanvas(rooms []RoomInput, grids map[string]spatial.Grid, void Void, 
 		// same edge either way round and a wall has no side.
 		for _, b := range ri.Boundaries {
 			if berr := canvas.RegisterBoundary(spatial.Boundary{
-				From:              b.From.Add(ri.Origin),
-				To:                b.To.Add(ri.Origin),
+				From:              absoluteOf(ri, orientation, b.From),
+				To:                absoluteOf(ri, orientation, b.To),
 				BlocksMovement:    b.BlocksMovement,
 				BlocksLineOfSight: b.BlocksLineOfSight,
 			}); berr != nil {
@@ -881,11 +891,12 @@ func compileCanvas(rooms []RoomInput, grids map[string]spatial.Grid, void Void, 
 	}
 
 	return &canvasRoom{
-		BasicRoom: canvas,
-		void:      void,
-		rooms:     rooms,
-		grids:     grids,
-		hasVoid:   fieldHasVoid(rooms, width, height),
+		BasicRoom:   canvas,
+		void:        void,
+		rooms:       rooms,
+		grids:       grids,
+		orientation: orientation,
+		hasVoid:     fieldHasVoid(rooms, width, height),
 	}, nil
 }
 
@@ -960,7 +971,16 @@ func axisBounds(shape spatial.GridShape, dim int) (min, max int) {
 // Requires Origin to already be integral (buildValidRoomGrids' origin
 // legality runs before W2) — the int() truncation here is exact, not
 // lossy, for every Origin this is ever called with.
-func roomAbsoluteBounds(r RoomInput) (qMin, qMax, rMin, rMax int) {
+func roomAbsoluteBounds(r RoomInput, orientation Orientation) (qMin, qMax, rMin, rMax int) {
+	// A HEX chamber's footprint is the authored offset rectangle, which is a
+	// sheared parallelogram in axial space — so its bounding box comes from
+	// the shape itself rather than from an assumed rhombus
+	// (rpg-toolkit#1127). Read from hexRuns, which is O(Width) or O(Height)
+	// rather than a cell-by-cell sweep.
+	if r.Grid == spatial.GridShapeHex {
+		return hexFootprintBounds(r, orientation)
+	}
+
 	localQMin, localQMax := axisBounds(r.Grid, r.Width)
 	localRMin, localRMax := axisBounds(r.Grid, r.Height)
 	oq, or := int(r.Origin.X), int(r.Origin.Y)
@@ -979,16 +999,27 @@ func roomAbsoluteBounds(r RoomInput) (qMin, qMax, rMin, rMax int) {
 // the component-wise max of the two rooms' interval mins — the
 // lexicographically-first cell both footprints necessarily contain,
 // deterministic regardless of iteration order.
-func validateRoomsDisjoint(rooms []RoomInput) error {
+func validateRoomsDisjoint(rooms []RoomInput, orientation Orientation) error {
 	type bounds struct{ qMin, qMax, rMin, rMax int }
 	bs := make([]bounds, len(rooms))
 	for i, r := range rooms {
-		bs[i].qMin, bs[i].qMax, bs[i].rMin, bs[i].rMax = roomAbsoluteBounds(r)
+		bs[i].qMin, bs[i].qMax, bs[i].rMin, bs[i].rMax = roomAbsoluteBounds(r, orientation)
 	}
 	for i := 0; i < len(rooms); i++ {
 		for j := i + 1; j < len(rooms); j++ {
 			qOverlap := bs[i].qMin <= bs[j].qMax && bs[j].qMin <= bs[i].qMax
 			rOverlap := bs[i].rMin <= bs[j].rMax && bs[j].rMin <= bs[i].rMax
+			// THE BOX TEST IS EXACT FOR A RECTANGLE AND ONLY CONSERVATIVE FOR
+			// A SHEARED ONE (rpg-toolkit#1127), so on hex it is a fast REJECT
+			// path and never a verdict: two boxes that miss cannot share a
+			// cell, but two that meet very well might not. Deciding on the box
+			// is what refused the reference tomb outright under flat-top —
+			// `room "entrance" and room "hall" overlap at absolute cell
+			// (3, -9)` — for chambers that share no cell at all.
+			if qOverlap && rOverlap && rooms[i].Grid == spatial.GridShapeHex &&
+				!hexFootprintsOverlap(rooms[i], rooms[j], orientation) {
+				continue
+			}
 			if qOverlap && rOverlap {
 				witness := spatial.Position{
 					X: float64(max(bs[i].qMin, bs[j].qMin)),
@@ -1011,7 +1042,10 @@ func validateRoomsDisjoint(rooms []RoomInput) error {
 // that do not kiss — are not adjacent absolute cells once each is anchored
 // to its own room's Origin. Error messages carry NO verb prefix — shared
 // with LoadEncounter, same reasoning as buildValidRoomGrids' doc comment.
-func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Grid, connections []ConnectionInput) error {
+func validateConnectionInputs(
+	rooms []RoomInput, roomGrids map[string]spatial.Grid,
+	orientation Orientation, connections []ConnectionInput,
+) error {
 	roomsByID := make(map[string]RoomInput, len(rooms))
 	for _, r := range rooms {
 		roomsByID[r.ID] = r
@@ -1039,13 +1073,13 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 			return fmt.Errorf("connection %q connects room %q to itself: %w", c.ID, c.From, ErrBadConnection)
 		}
 
-		if !roomGrids[c.From].IsValidPosition(c.FromPosition) {
+		if !localIsInRoom(fromRoom, roomGrids, c.FromPosition) {
 			return fmt.Errorf("connection %q from-position out of bounds: %w", c.ID, ErrBadConnection)
 		}
 		if !isIntegralAxialPosition(roomGrids[c.From], c.FromPosition) {
 			return fmt.Errorf("connection %q from-position is not an integral axial cell: %w", c.ID, ErrBadConnection)
 		}
-		if !roomGrids[c.To].IsValidPosition(c.ToPosition) {
+		if !localIsInRoom(toRoom, roomGrids, c.ToPosition) {
 			return fmt.Errorf("connection %q to-position out of bounds: %w", c.ID, ErrBadConnection)
 		}
 		if !isIntegralAxialPosition(roomGrids[c.To], c.ToPosition) {
@@ -1071,8 +1105,8 @@ func validateConnectionInputs(rooms []RoomInput, roomGrids map[string]spatial.Gr
 		// formula (AxialHexGrid: cube distance; SquareGrid: Chebyshev) —
 		// using the from-room's is an arbitrary but consistent choice, not
 		// a hand-rolled formula that could silently diverge from spatial's.
-		fromAbs := c.FromPosition.Add(fromRoom.Origin)
-		toAbs := c.ToPosition.Add(toRoom.Origin)
+		fromAbs := absoluteOf(fromRoom, orientation, c.FromPosition)
+		toAbs := absoluteOf(toRoom, orientation, c.ToPosition)
 		// Strict != 1, not > 1: origin legality's integrality requirement
 		// (every family) only constrains ORIGINS, not endpoints — square
 		// endpoints stay fractional-tolerant by design (RoomInput.Grid's
@@ -1232,11 +1266,23 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		return nil, fmt.Errorf("newencounter: field does not say what its void is (FieldInput.Canvas.Void): %w", ErrNoField)
 	}
 
+	// And which way its hexes point, if it has any (rpg-toolkit#1127).
+	// Required for a hex field and refused for a square one — see
+	// [Orientation] for why the second half is a refusal rather than a shrug.
+	//
+	// Resolved BEFORE the room list is validated, because the mask needs it:
+	// W2 measures a hex chamber's real footprint, and "footprint" is a
+	// sentence about offset columns that this answer completes.
+	orientation, err := fieldOrientation(in.Field.Rooms, in.Field.Canvas.Orientation)
+	if err != nil {
+		return nil, fmt.Errorf("newencounter: %w", err)
+	}
+
 	// Check rooms: unique non-empty IDs, recognized grid shape. roomGrids
 	// holds each room's constructed Grid, reused below for connection
 	// bounds validation and again in the room-construction loop so a
 	// room's shape is built exactly once.
-	roomGrids, err := buildValidRoomGrids(in.Field.Rooms)
+	roomGrids, err := buildValidRoomGrids(in.Field.Rooms, orientation)
 	if err != nil {
 		return nil, fmt.Errorf("newencounter: %w", err)
 	}
@@ -1244,13 +1290,13 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// Check connections: unique non-empty IDs, endpoints resolve to distinct
 	// declared rooms, endpoints in bounds (per the room's own grid) and off
 	// any prop.
-	if err = validateConnectionInputs(in.Field.Rooms, roomGrids, in.Field.Connections); err != nil {
+	if err = validateConnectionInputs(in.Field.Rooms, roomGrids, orientation, in.Field.Connections); err != nil {
 		return nil, fmt.Errorf("newencounter: %w", err)
 	}
 
 	// Check doors: names, states, and edges that are real crossings on real
 	// floor and belong to exactly one door (rpg-toolkit#1123).
-	if err = validateDoorInputs(in.Field.Rooms, roomGrids, in.Field.Doors); err != nil {
+	if err = validateDoorInputs(in.Field.Rooms, roomGrids, orientation, in.Field.Doors); err != nil {
 		return nil, fmt.Errorf("newencounter: %w", err)
 	}
 
@@ -1290,6 +1336,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		fieldInput:       deepCopyRoomInputs(in.Field.Rooms),
 		connectionsInput: connectionsInput,
 		void:             in.Field.Canvas.Void,
+		orientation:      orientation,
 	}
 	e.doors, e.doorsByID = doorRecordsFrom(in.Field.Doors)
 
@@ -1318,7 +1365,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 	// diverging the moment a caller reused its RoomInputs. Load needs no such
 	// care — its roomInputs are freshly converted from the blob and alias
 	// nothing (LoadEncounter's own note, and TestAliasImmunityLoadEncounter).
-	e.canvas, err = compileCanvas(e.fieldInput, roomGrids, in.Field.Canvas.Void, e.doors)
+	e.canvas, err = compileCanvas(e.fieldInput, roomGrids, in.Field.Canvas.Void, orientation, e.doors)
 	if err != nil {
 		return nil, fmt.Errorf("newencounter: %w", err)
 	}
@@ -1344,7 +1391,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 			return nil, fmt.Errorf("newencounter member placement: member %q position out of bounds in room %q: %w", mi.ID, mi.Room, ErrBadPlacement)
 		}
 
-		if err = e.canvas.PlaceEntity(entity, mi.Position.Add(roomOrigin(in.Field.Rooms, mi.Room))); err != nil {
+		if err = e.canvas.PlaceEntity(entity, absoluteOf(roomByID(in.Field.Rooms, mi.Room), e.orientation, mi.Position)); err != nil {
 			return nil, fmt.Errorf("newencounter member placement: %w: %w", ErrBadPlacement, err)
 		}
 

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -425,7 +425,7 @@ func (s *EncounterTestSuite) TestSetupPropIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "r", Width: 12, Height: 10, Grid: spatial.GridShapeHex,
 					Props: []encounter.PropInput{rubble(-5, 4)}},
@@ -724,7 +724,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 			Field: encounter.FieldInput{
-				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Rooms: []encounter.RoomInput{
 					{ID: "r1", Width: 4, Height: 3, Grid: spatial.GridShapeHex},
 				},
@@ -783,7 +783,7 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
 				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 7}},
@@ -822,7 +822,7 @@ func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
 					Props: []encounter.PropInput{rubble(2, 2)}},
@@ -896,7 +896,7 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Members: []encounter.MemberInput{
@@ -924,7 +924,7 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Members: []encounter.MemberInput{
@@ -1031,7 +1031,7 @@ func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
@@ -1298,7 +1298,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "square-first", Width: 5, Height: 5},
 				{ID: "hex-second", Width: 5, Height: 5, Grid: spatial.GridShapeHex},
@@ -1367,7 +1367,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-r-b", Width: 4, Height: 4, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 0, Y: 4}},
@@ -1530,7 +1530,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex(
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -1666,7 +1666,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Endings: []encounter.EndingInput{
@@ -1754,7 +1754,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() 
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Endings: []encounter.EndingInput{

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -771,35 +771,52 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 // Load-seam counterpart: TestHexConnectionEndpointNegativeAxialLoad in
 // data_test.go.
 //
-// #929 T1 follow-up: both rooms are hex (W1 forbids mixing families in one
-// field — see TestSetupAnchoring's W1 row) rather than the original
-// square+hex pairing. hex-a is 10x10 (Q,R valid [-5,5)); hex-b is 6x6 (Q,R
-// valid [-3,3)), anchored at (8,7) so its NEGATIVE-axial corner (-3,-3) —
-// the coordinate that gives this test its name — sits immediately east of
-// hex-a's own (4,4) corner: absolute (5,4) is a cube-distance-1 neighbor of
-// (4,4) (W3), and hex-b's absolute Q span ([5,10]) shares no Q value with
-// hex-a's ([-5,4]), so the rooms stay disjoint (W2) regardless of R.
-func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
-	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-			Rooms: []encounter.RoomInput{
-				{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
-				{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 7}},
+// TestAHexChambersCellsAreOffsetNotAxial replaces a test whose SUBJECT this
+// slice deleted, and the replacement is the same question asked of the new
+// answer.
+//
+// It used to be TestHexConnectionEndpointNegativeAxial, and it pinned that a
+// connection endpoint at a NEGATIVE axial coordinate validates — which was
+// right while a hex room was an origin-centred rhombus, where roughly half of
+// every chamber's own cells had a negative coordinate. A chamber is the offset
+// rectangle its author drew now (rpg-toolkit#1127), so its local cells run
+// [0,Width) x [0,Height) and a negative one is outside it. That is not a
+// narrowing of what a dungeon can be — the same hexes are still reachable, and
+// a chamber can still be anchored anywhere — it is a change of the frame the
+// author counts in, from one where the middle is zero to one where the corner
+// is.
+func (s *EncounterTestSuite) TestAHexChambersCellsAreOffsetNotAxial() {
+	build := func(to spatial.Position) error {
+		_, err := encounter.NewEncounter(&encounter.SetupInput{
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
+				Rooms: []encounter.RoomInput{
+					{ID: "hex-a", Width: 10, Height: 10, Grid: spatial.GridShapeHex},
+					{ID: "hex-b", Width: 6, Height: 6, Grid: spatial.GridShapeHex,
+						Origin: spatial.Position{X: 10, Y: 0}},
+				},
+				Connections: []encounter.ConnectionInput{{
+					ID: "gate", From: "hex-a", To: "hex-b",
+					FromPosition: spatial.Position{X: 9, Y: 4},
+					ToPosition:   to,
+				}},
 			},
-			Connections: []encounter.ConnectionInput{{
-				ID: "gate", From: "hex-a", To: "hex-b",
-				FromPosition: spatial.Position{X: 4, Y: 4},
-				ToPosition:   spatial.Position{X: -3, Y: -3},
-			}},
-		},
-		Members: []encounter.MemberInput{
-			{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-a", Position: spatial.Position{X: 1, Y: 1}},
-		},
-		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
-	})
-	s.Require().NoError(err, "a connection endpoint at a negative axial coordinate must validate")
+			Members: []encounter.MemberInput{
+				{ID: "p1", Kind: encounter.KindPlayer, Room: "hex-a", Position: spatial.Position{X: 1, Y: 1}},
+			},
+			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+		})
+		return err
+	}
+
+	s.Require().NoError(build(spatial.Position{X: 0, Y: 4}),
+		"the chambers meet at hex-a's last column and hex-b's first, on the same row")
+
+	err := build(spatial.Position{X: -3, Y: -3})
+	s.Require().ErrorIs(err, encounter.ErrBadConnection,
+		"a negative local cell is outside the rectangle somebody drew")
+	s.Contains(err.Error(), "out of bounds")
 }
 
 // validHexAxialSetup returns a fresh SetupInput with two hex rooms joined
@@ -809,15 +826,17 @@ func (s *EncounterTestSuite) TestHexConnectionEndpointNegativeAxial() {
 // enforcement (isIntegralAxialPosition) rejects a fractional X or Y at
 // any of these positions in a hex room.
 //
-// #929 T1: both rooms are Width=8,Height=8, so each has valid axial Q,R in
-// [-4,4) (i.e. -4..3). gate.FromPosition sits at hex-a's own Q=3 boundary
-// (an interior cell like the original (1,1) can never kiss anything — every
-// neighbor of an interior cell is still inside that room's own footprint).
-// hex-b's Origin (8,1) anchors it immediately past that boundary: absolute
-// FromPosition (3,0) and absolute ToPosition local(-4,-1)+(8,1)=(4,0) are
-// cube-distance 1 (W3), while hex-b's absolute Q span ([4,11]) shares no Q
-// value with hex-a's ([-4,3]), so the two rooms stay disjoint (W2)
-// regardless of R.
+// Both rooms are Width=8,Height=8 offset rectangles (rpg-toolkit#1127), so each
+// chamber's own cells are columns 0..7 and rows 0..7 counted from its corner.
+// hex-b is anchored at column 8, immediately east of hex-a's last column, so
+// the two rectangles tile without sharing a cell (W2) and the gate's two
+// endpoints — hex-a's (7,3) and hex-b's (0,3), the same row either side of the
+// seam — land on adjacent absolute cells (W3).
+//
+// gate.FromPosition sits on hex-a's boundary column rather than somewhere in
+// the middle, and that part has not changed: an interior cell can never kiss
+// anything, because every neighbour of an interior cell is still inside that
+// room's own footprint.
 func validHexAxialSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
@@ -826,12 +845,12 @@ func validHexAxialSetup() *encounter.SetupInput {
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-a", Width: 8, Height: 8, Grid: spatial.GridShapeHex,
 					Props: []encounter.PropInput{rubble(2, 2)}},
-				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 1}},
+				{ID: "hex-b", Width: 8, Height: 8, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 8, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "hex-a", To: "hex-b",
-				FromPosition: spatial.Position{X: 3, Y: 0},
-				ToPosition:   spatial.Position{X: -4, Y: -1},
+				FromPosition: spatial.Position{X: 7, Y: 3},
+				ToPosition:   spatial.Position{X: 0, Y: 3},
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -914,7 +933,12 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	})
 
 	s.Run("integral negative axial target accepted", func() {
-		_, err := enc.Step(&encounter.StepInput{Member: "p1", To: spatial.Position{X: -2, Y: -1}})
+		// Absolute cells are axial and a negative R is entirely ordinary —
+		// the reference tomb's own run from -21 to 0. What changed in
+		// rpg-toolkit#1127 is which cells a chamber HOLDS, so this names one
+		// it does: the chamber's authored column 2, row 5, which lands on
+		// axial (2,-6).
+		_, err := enc.Step(&encounter.StepInput{Member: "p1", To: spatial.Position{X: 2, Y: -6}})
 		s.Require().NoError(err)
 	})
 }
@@ -946,10 +970,12 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	})
 
 	s.Run("integral negative axial position accepted", func() {
+		// The chamber's authored column 0, row 7 — axial (0,-7). See the
+		// Move counterpart for why a negative R is unremarkable.
 		_, err := enc.Join(&encounter.JoinInput{
 			Member: "p3",
 			Kind:   encounter.KindPlayer,
-			Cell:   spatial.Position{X: -3, Y: -3},
+			Cell:   spatial.Position{X: 0, Y: -7},
 		})
 		s.Require().NoError(err)
 	})
@@ -1009,24 +1035,26 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 // validAnchoredHexSetup returns THE core fixture for the W-law tests below:
 // two hex rooms, asymmetric in every dimension (T1 review lesson —
 // symmetric fixtures hide cross-wiring mutants: a prior wave's full sweep
-// missed four of them this way). hex-big is 10x4 (Q valid [-5,4), R valid
-// [-2,2)) at the zero-value Origin; hex-small is 3x9 (Q valid [-1,2), R
-// valid [-4,5)) anchored at (6,-5) — a NEGATIVE-axial origin, on purpose.
+// missed four of them this way). hex-big is a 10x4 offset rectangle at the
+// zero-value Origin, so columns 0..9 and rows 0..3; hex-small is 3x9 anchored
+// at column 10, so columns 10..12 and rows 0..8 (rpg-toolkit#1127 — a chamber
+// is the rectangle somebody drew, counted from its corner, and the spans this
+// comment used to quote were the rhombus reading).
 //
-// The connection's endpoints are each their own room's OWN boundary cell —
-// an interior cell can never kiss anything, since every neighbor of an
-// interior cell is still inside that room's own footprint — and are
-// computed, not guessed, from the span arithmetic above: FromPosition
-// (4,0) is hex-big's max-Q boundary; ToPosition (-1,4) is hex-small's
-// min-Q/max-R corner. Anchored, their absolute cells are (4,0) and (5,-1):
-// ΔQ=1, ΔR=-1, ΔS=0, cube distance (1+1+0)/2 = 1 — adjacent, and
-// deliberately OFF-AXIS (both ΔQ and ΔR nonzero) so a Manhattan-distance
-// mutant (|ΔQ|+|ΔR|=2) would wrongly reject this valid base — see
-// TestAnchoringMutationEvidence.
+// The connection's endpoints are each their own room's OWN boundary cell — an
+// interior cell can never kiss anything, since every neighbour of an interior
+// cell is still inside that room's own footprint. FromPosition (9,1) is
+// hex-big's last column; ToPosition (0,2) is hex-small's first. Converted to
+// the canvas they are axial (9,-6) and (10,-7): ΔQ=1, ΔR=-1, ΔS=0, cube
+// distance (1+1+0)/2 = 1 — adjacent, and deliberately OFF-AXIS (both ΔQ and ΔR
+// nonzero) so a Manhattan-distance mutant (|ΔQ|+|ΔR|=2) would wrongly reject
+// this valid base. That off-axis pair is why the rows differ by one either side
+// of the seam rather than matching: on a pointy-top grid a same-row crossing is
+// the on-axis one.
 //
-// hex-big's absolute Q span is [-5,4]; hex-small's is local[-1,1]+6=[5,7]:
-// the two share NO Q value at all, so W2 holds regardless of R — the
-// rooms are disjoint, touching only through the one declared doorway.
+// hex-big owns columns 0..9 and hex-small columns 10..12: the two share no
+// column at all, so W2 holds regardless of row — the rooms are disjoint,
+// touching only through the one declared doorway.
 func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
@@ -1034,12 +1062,12 @@ func validAnchoredHexSetup() *encounter.SetupInput {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
-				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 6, Y: -5}},
+				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: 0}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "hex-big", To: "hex-small",
-				FromPosition: spatial.Position{X: 4, Y: 0},
-				ToPosition:   spatial.Position{X: -1, Y: 4},
+				FromPosition: spatial.Position{X: 9, Y: 1},
+				ToPosition:   spatial.Position{X: 0, Y: 2},
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -1102,21 +1130,22 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 			in.Field.Rooms[1].Origin = spatial.Position{X: 0, Y: 0}
 		}, encounter.ErrNoField, "overlap at absolute cell"},
 		{"W3: endpoints do not kiss", func(in *encounter.SetupInput) {
-			// (1,4) is still a legal LOCAL cell in hex-small (max Q, max R)
-			// — this must fail on adjacency, not on the earlier bounds check.
+			// (1,4) is still a legal LOCAL cell in hex-small (its middle
+			// column, well inside its rows) — this must fail on adjacency,
+			// not on the earlier bounds check.
 			in.Field.Connections[0].ToPosition = spatial.Position{X: 1, Y: 4}
 		}, encounter.ErrBadConnection, "not adjacent"},
 		{"W3: hex axial (1,1) delta is NOT adjacent (cube distance 2)", func(in *encounter.SetupInput) {
-			// hex-small's Origin shifts by (0,+2) from the valid base's
-			// (6,-5) to (6,-3): the gate's endpoints, once anchored, now
-			// differ by axial (ΔQ=1,ΔR=1) — cube distance (1+1+2)/2=2, NOT
-			// 1. A "Chebyshev-on-axial" mutant (max(|ΔQ|,|ΔR|)=1) would
-			// wrongly ACCEPT this as adjacent — see the mutation evidence
-			// table in the #929 T1 fix-round report. Still disjoint from
-			// hex-big (W2 passes): hex-small's absolute Q span becomes
-			// local[-1,1]+6=[5,7], still sharing no Q value with hex-big's
-			// [-5,4], so this is a genuine W3-only defect.
-			in.Field.Rooms[1].Origin = spatial.Position{X: 6, Y: -3}
+			// hex-small's Origin shifts two rows north of the valid base's
+			// (10,0): the gate's endpoints, once compiled, are axial (9,-6)
+			// and (10,-5), differing by (ΔQ=1,ΔR=1) — cube distance
+			// (1+1+2)/2=2, NOT 1. A "Chebyshev-on-axial" mutant
+			// (max(|ΔQ|,|ΔR|)=1) would wrongly ACCEPT this as adjacent — see
+			// the mutation evidence table in the #929 T1 fix-round report.
+			// Still disjoint from hex-big (W2 passes): hex-small owns columns
+			// 10..12 whatever its rows are, and hex-big owns 0..9, so this is
+			// a genuine W3-only defect.
+			in.Field.Rooms[1].Origin = spatial.Position{X: 10, Y: -2}
 		}, encounter.ErrBadConnection, "distance 2"},
 	}
 	for _, tc := range cases {

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -719,7 +719,10 @@ func (s *EncounterTestSuite) TestSetupRoomValidation() {
 // only gridless could kill a "grid shape ignored, always builds square"
 // mutant; the negative-Q case below now kills that mutant independently.
 func (s *EncounterTestSuite) TestHexRoomBounds() {
-	// Width=4, Height=3 => Q valid in [-2,2), R valid in [-1.5,1.5).
+	// Width=4, Height=3 => the chamber's own columns 0..3 and rows 0..2
+	// (rpg-toolkit#1127 — a chamber is the rectangle somebody drew, counted
+	// from its corner). Positions here are ROOM-LOCAL, so they are read in
+	// exactly those terms.
 	hexSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
@@ -736,29 +739,35 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 		}
 	}
 
-	s.Run("positive Q, positive R within span accepted", func() {
+	s.Run("a cell inside it accepted", func() {
 		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 1, Y: 1}))
 		s.Require().NoError(err)
 	})
 
-	s.Run("negative Q within span accepted — rejected under the old offset HexGrid", func() {
-		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: -1, Y: 0}))
-		s.Require().NoError(err, "axial hex rooms are origin-centered; negative Q is ordinary, not a defect")
+	s.Run("its own corner accepted", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 0, Y: 0}))
+		s.Require().NoError(err, "a chamber is anchored at its corner, and the corner is a cell")
 	})
 
-	s.Run("Q at exactly +Width/2 rejected (upper bound exclusive)", func() {
-		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 2, Y: 0}))
-		s.Require().Error(err)
+	s.Run("its far corner accepted", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 3, Y: 2}))
+		s.Require().NoError(err, "the last column of the last row is still inside")
+	})
+
+	s.Run("one column past the last rejected", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 4, Y: 0}))
 		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
 	})
 
-	s.Run("Q at exactly -Width/2 accepted (lower bound inclusive)", func() {
-		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: -2, Y: 0}))
-		s.Require().NoError(err)
+	s.Run("one row past the last rejected", func() {
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: 0, Y: 3}))
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
 	})
 
-	s.Run("Q beyond -Width/2 rejected", func() {
-		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: -3, Y: 0}))
+	s.Run("a negative column rejected", func() {
+		// Under the origin-centred reading this was comfortably inside the
+		// room, which is the clearest single statement of what changed.
+		_, err := encounter.NewEncounter(hexSetup(spatial.Position{X: -1, Y: 0}))
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
 	})
@@ -880,7 +889,7 @@ func (s *EncounterTestSuite) TestSetupHexIntegralAxial() {
 			in.Field.Connections[0].FromPosition = spatial.Position{X: 1.5, Y: 1}
 		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"connection to-position fractional", func(in *encounter.SetupInput) {
-			in.Field.Connections[0].ToPosition = spatial.Position{X: -1.5, Y: -1}
+			in.Field.Connections[0].ToPosition = spatial.Position{X: 0.5, Y: 3}
 		}, encounter.ErrBadConnection, "not an integral axial cell"},
 		{"prop cell fractional", func(in *encounter.SetupInput) {
 			// #929 T3 Opus round F2: prop integrality is now universal
@@ -1037,7 +1046,7 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 // symmetric fixtures hide cross-wiring mutants: a prior wave's full sweep
 // missed four of them this way). hex-big is a 10x4 offset rectangle at the
 // zero-value Origin, so columns 0..9 and rows 0..3; hex-small is 3x9 anchored
-// at column 10, so columns 10..12 and rows 0..8 (rpg-toolkit#1127 — a chamber
+// at column 10 and row -2, so columns 10..12 and rows -2..6 (rpg-toolkit#1127 — a chamber
 // is the rectangle somebody drew, counted from its corner, and the spans this
 // comment used to quote were the rhombus reading).
 //
@@ -1062,12 +1071,12 @@ func validAnchoredHexSetup() *encounter.SetupInput {
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-big", Width: 10, Height: 4, Grid: spatial.GridShapeHex},
-				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: 0}},
+				{ID: "hex-small", Width: 3, Height: 9, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 10, Y: -2}},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "hex-big", To: "hex-small",
 				FromPosition: spatial.Position{X: 9, Y: 1},
-				ToPosition:   spatial.Position{X: 0, Y: 2},
+				ToPosition:   spatial.Position{X: 0, Y: 4},
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -1145,7 +1154,7 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 			// Still disjoint from hex-big (W2 passes): hex-small owns columns
 			// 10..12 whatever its rows are, and hex-big owns 0..9, so this is
 			// a genuine W3-only defect.
-			in.Field.Rooms[1].Origin = spatial.Position{X: 10, Y: -2}
+			in.Field.Rooms[1].Origin = spatial.Position{X: 10, Y: -4}
 		}, encounter.ErrBadConnection, "distance 2"},
 	}
 	for _, tc := range cases {
@@ -1400,11 +1409,16 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 			Rooms: []encounter.RoomInput{
 				{ID: "hex-r-a", Width: 4, Height: 4, Grid: spatial.GridShapeHex},
 				{ID: "hex-r-b", Width: 4, Height: 4, Grid: spatial.GridShapeHex, Origin: spatial.Position{X: 0, Y: 4}},
+				// hex-r-a owns rows 0..3 and hex-r-b rows 4..7, over the SAME
+				// columns 0..3 — the case the run decomposition exists for
+				// (rpg-toolkit#1127): both chambers key on every column, so
+				// disjointness is decided per column on the rows, not waved
+				// through by a bounding box that misses.
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "hex-r-a", To: "hex-r-b",
-				FromPosition: spatial.Position{X: 0, Y: 1},
-				ToPosition:   spatial.Position{X: 0, Y: -2},
+				FromPosition: spatial.Position{X: 0, Y: 3},
+				ToPosition:   spatial.Position{X: 0, Y: 0},
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -1774,12 +1788,17 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 	}
 }
 
-// TestSetupEndingTriggerHexNegativeAxialMustAccept is
-// TestSetupEndingTriggerMustAccept's hex-specific sibling (W1 forbids
-// mixing families in one fixture): hex rooms are ORIGIN-CENTERED, so a
-// negative Q/R trigger position is the NORMAL case for roughly half of
-// any room, not an edge case — the realistic hazard N2 names explicitly.
-func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() {
+// TestSetupEndingTriggerHexFarCornerMustAccept is
+// TestSetupEndingTriggerMustAccept's hex-specific sibling (W1 forbids mixing
+// families in one fixture): the far corner of a chamber is where a "reach this
+// cell" ending most often sits — stairs at the back of a room — and it is the
+// cell a bounds check written for the wrong frame is most likely to reject.
+//
+// It was TestSetupEndingTriggerHexNegativeAxialMustAccept until
+// rpg-toolkit#1127, when a hex room stopped being origin-centred and its own
+// cells stopped being half negative. The hazard N2 names is unchanged; the cell
+// that embodies it moved.
+func (s *EncounterTestSuite) TestSetupEndingTriggerHexFarCornerMustAccept() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		Field: encounter.FieldInput{
@@ -1787,7 +1806,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNegativeAxialMustAccept() 
 			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
 		},
 		Endings: []encounter.EndingInput{
-			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "crypt", Position: spatial.Position{X: -2, Y: -2}}},
+			{Key: "reach", Trigger: encounter.TriggerReachedPosition{Room: "crypt", Position: spatial.Position{X: 7, Y: 7}}},
 		},
 	}
 	enc, err := encounter.NewEncounter(setup)

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -24,14 +24,29 @@ const (
 type MemberID = core.EntityID
 
 // RoomInput describes a room to be created.
+//
+// A CHAMBER IS THE RECTANGLE SOMEBODY DREW (rpg-toolkit#1127). Width and
+// Height mean the same thing in both grid families — the columns and rows of
+// the rectangle a human sees on screen — and a chamber's cells are exactly the
+// Width x Height of them. Square is the degenerate case where nothing shears.
+//
+// That sentence is worth stating because it used to be false. Width and Height
+// were read as an AXIAL span for a hex room: a rhombus, origin-centred, which
+// is not a shape anybody authors. One name meant two shapes, and the cost was
+// measured rather than argued — on the reference tomb, [Encounter.RegionAt]
+// called 380 cells floor against the 224 somebody drew, and the same three
+// chambers could not be built flat-top at all. See orientation.go.
 type RoomInput struct {
 	// ID is the unique room identifier.
 	ID string
 
-	// Width is the room's horizontal dimension.
+	// Width is how many columns wide the chamber is — the rectangle's own
+	// horizontal dimension, in both grid families. See the type's doc
+	// comment.
 	Width int
 
-	// Height is the room's vertical dimension.
+	// Height is how many rows tall the chamber is. See the type's doc
+	// comment.
 	Height int
 
 	// Grid selects the room's coordinate system: GridShapeSquare (the zero
@@ -44,30 +59,47 @@ type RoomInput struct {
 	// zero value keeps every pre-existing room square, so v0.1 persisted
 	// blobs without this field unmarshal to square unchanged.
 	//
-	// GridShapeHex rooms speak AXIAL cube coordinates (tools/spatial's
-	// AxialHexGrid), not offset: Position.X is Q, Position.Y is R, and S
-	// = -(Q+R) is derived. Bounds are ORIGIN-CENTERED spans, unlike
-	// square — Q is valid in [-Width/2, Width/2) and R in
-	// [-Height/2, Height/2), so negative coordinates are legal and
-	// expected, not a defect. Distance, adjacency, and line of sight in a
-	// hex room run true cube hex math via spatial. This is a deliberate
-	// choice, not an implementation detail: the wire (and Platform's
-	// pathing) already speaks cube coordinates natively, and axial is
-	// cube's 2D projection — an IDENTITY mapping to the wire. A bounded
-	// offset column/row grid (spatial's HexGrid) would force a lossy,
-	// orientation-dependent offset<->cube conversion at that seam for no
-	// benefit, since the composition never renders a grid itself.
+	// A GridShapeHex room is AUTHORED in offset [col,row] pairs — counted
+	// from the chamber's own corner, [0,Width) x [0,Height), exactly as a
+	// square room is — and RUNS on the axial cube coordinates the canvas and
+	// the wire speak (Position.X is Q, Position.Y is R, S = -(Q+R) derived).
+	// The two frames are not the same numbers and are not meant to be: an
+	// offset rectangle shears when it becomes axial, so a chamber's cells
+	// stay a contiguous, non-overlapping set while the smallest rhombus
+	// containing them is strictly bigger than they are.
+	//
+	// EVERY FIELD IN THIS TYPE IS IN THE AUTHORED FRAME. Origin, PropInput.At,
+	// Boundaries' endpoints, MemberInput.Position, ConnectionInput's
+	// endpoints and TriggerReachedPosition.Position are all columns and rows;
+	// every cell a VERB reports or accepts is absolute and axial. The
+	// conversion happens once, at construction, and [CanvasInput.Orientation]
+	// is the declaration it needs — an offset pair means nothing until the
+	// orientation is known, since the same [2,3] is a different hex under each
+	// layout, with different neighbours.
+	//
+	// The canvas speaking axial is a deliberate choice, not an implementation
+	// detail: the wire (and Platform's pathing) already speaks cube
+	// coordinates natively, and axial is cube's 2D projection — an IDENTITY
+	// mapping to the wire. Distance, adjacency and line of sight all run true
+	// cube math via spatial and never see an offset pair. Content, which draws
+	// rectangles, never sees an axial one.
 	Grid spatial.GridShape
 
 	// Props are the things standing in this room that are not creatures —
 	// room-local at authoring, compiled onto the canvas at construction, each
-	// one registered at Props[i].At + Origin in the dungeon's own absolute
-	// frame. See [PropInput].
+	// one registered at the absolute cell its authored column and row name.
+	// See [PropInput].
 	Props []PropInput
 
 	// Boundaries are the walls this room draws, as edges between adjacent
 	// cells — room-local at authoring, compiled through Origin onto the
 	// canvas at construction (rpg-toolkit#1106).
+	//
+	// WHICH CELLS ARE ADJACENT IS THE GRID'S ANSWER, not a pair of offsets to
+	// hardcode. In axial space a cell's +Q neighbours are (q+1,r) and
+	// (q+1,r-1) always; in the authored offset frame the answer STAGGERS with
+	// the column's parity, so a seam wall built from one hardcoded pair has a
+	// hole in every other row. Ask spatial.
 	//
 	// AN ENDPOINT MAY LIE OUTSIDE THIS ROOM, and that is the whole point.
 	// Until the field became one canvas, a boundary was registered on the
@@ -87,15 +119,23 @@ type RoomInput struct {
 	// silently dropped.
 	Boundaries []spatial.Boundary
 
-	// Origin is this room's dungeon-absolute anchor: local (0,0) maps to
-	// Origin in the field's shared absolute space. Local→absolute is
-	// element-wise addition (local cell + Origin) — for hex rooms this is
-	// ordinary axial cube arithmetic (axial+axial is valid cube math), not
-	// a special case. The zero value anchors a room at the absolute
-	// origin, which is legal on its own; in a multi-room field, leaving
-	// every Origin at its zero value collides every room at (0,0) and is
-	// rejected by W2 (see NewEncounter) — there is no separate
-	// "origin required" check.
+	// Origin is this room's anchor: which column and row of the FIELD the
+	// chamber's own (0,0) corner sits at. Local plus Origin is the authored
+	// cell, and THAT is what becomes an absolute one — offset-then-convert,
+	// in that order (rpg-toolkit#1127).
+	//
+	// The order is the whole of it. For a square room the two are the same
+	// arithmetic. For a hex room, adding the anchor in AXIAL instead puts the
+	// shear back one level up: two chambers anchored six columns apart would
+	// land at axial distances that vary by row, and the seam between them
+	// would stop being a straight line. So an anchor is counted in the same
+	// columns and rows the author counts their chamber in, and there is
+	// exactly one function in this package that spends it.
+	//
+	// The zero value anchors a room at the field's own corner, which is legal
+	// on its own; in a multi-room field, leaving every Origin at its zero
+	// value collides every room there and is rejected by W2 (see
+	// NewEncounter) — there is no separate "origin required" check.
 	//
 	// Origin must be an INTEGRAL cell (X and Y both whole numbers) for
 	// EVERY grid family, square included — not just hex. W2's "rooms never
@@ -195,10 +235,10 @@ type PropInput struct {
 	// type's doc comment.
 	Ref string
 
-	// At is where it stands, ROOM-LOCAL, compiled to At + the room's Origin
-	// on the canvas. Must be an integral cell in every grid family: a prop
-	// is a cell OF its region, and a region's cells are integral
-	// ([AtlasRegion.Props]).
+	// At is where it stands, ROOM-LOCAL in the authored frame, compiled to
+	// the absolute cell that column and row name (see [RoomInput.Origin]).
+	// Must be an integral cell in every grid family: a prop is a cell OF its
+	// region, and a region's cells are integral ([AtlasRegion.Props]).
 	At spatial.Position
 
 	// BlocksMovement is whether a member can end a step on this cell.
@@ -229,10 +269,12 @@ type ConnectionInput struct {
 	// To is the destination room ID.
 	To string
 
-	// FromPosition is the endpoint cell within room From.
+	// FromPosition is the endpoint cell within room From — ROOM-LOCAL in the
+	// authored frame (see [RoomInput.Origin]).
 	FromPosition spatial.Position
 
-	// ToPosition is the endpoint cell within room To.
+	// ToPosition is the endpoint cell within room To — ROOM-LOCAL in the
+	// authored frame.
 	ToPosition spatial.Position
 }
 
@@ -282,8 +324,9 @@ type MemberInput struct {
 	// Room is the ID of the room where the member is placed.
 	Room string
 
-	// Position is the member's location within the room — ROOM-LOCAL, and
-	// compiled to Position + that room's Origin on the canvas.
+	// Position is the member's location within the room — ROOM-LOCAL in the
+	// authored frame, and compiled to the absolute cell that column and row
+	// names on the canvas (see [RoomInput.Origin]).
 	Position spatial.Position
 
 	// Decider is the monster's decision-making engine (monsters only).
@@ -306,8 +349,9 @@ type TriggerReachedPosition struct {
 	// Room is the target room ID.
 	Room string
 
-	// Position is the target position within the room — ROOM-LOCAL, compiled
-	// to Position + that room's Origin at construction.
+	// Position is the target position within the room — ROOM-LOCAL in the
+	// authored frame, compiled at construction to the one absolute cell an
+	// arrival is compared against (see [RoomInput.Origin]).
 	Position spatial.Position
 
 	// Member is the target member ID (empty = any player member).

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -33,9 +33,11 @@ type MemberID = core.EntityID
 // That sentence is worth stating because it used to be false. Width and Height
 // were read as an AXIAL span for a hex room: a rhombus, origin-centred, which
 // is not a shape anybody authors. One name meant two shapes, and the cost was
-// measured rather than argued — on the reference tomb, [Encounter.RegionAt]
-// called 380 cells floor against the 224 somebody drew, and the same three
-// chambers could not be built flat-top at all. See orientation.go.
+// measured rather than argued — the reference tomb's three chambers did not
+// construct at ALL under that reading, in either orientation, and with the
+// disjointness check disabled so the footprints could be seen, 88% of what
+// [Encounter.RegionAt] called floor was somewhere nobody drew. See
+// orientation.go.
 type RoomInput struct {
 	// ID is the unique room identifier.
 	ID string

--- a/rulebooks/dnd5e/encounter/oneplace_internal_test.go
+++ b/rulebooks/dnd5e/encounter/oneplace_internal_test.go
@@ -49,6 +49,13 @@ import (
 // So: one Subtract, one region lookup. A second implementation has to subtract
 // an origin in order to exist, and this is the test it fails.
 //
+// The one function is footprintHolds since rpg-toolkit#1127, and it used to be
+// regionAt — which is a move rather than an addition, and worth the sentence
+// because the slice that moved it briefly had TWO: regionAt subtracting to ask
+// about integrality, and footprintHolds subtracting to ask about ownership.
+// Two subtractions for two questions in two functions is exactly the shape this
+// test exists to catch, so both questions were put in the one place instead.
+//
 // If a legitimate second use ever appears — a delta between two cells for a
 // beat, say — the honest fix is to name it in the expected list, not to delete
 // the test. The point is that a second one becomes a decision somebody makes on
@@ -63,7 +70,7 @@ func TestRegionOwnershipIsAskedInOneFunction(t *testing.T) {
 		return ok && sel.Sel.Name == "Subtract"
 	})
 
-	require.Equal(t, []string{"regionAt"}, callers,
+	require.Equal(t, []string{"footprintHolds"}, callers,
 		"region ownership must be answered in exactly one place (rpg-toolkit#1108): a second "+
 			"function projecting an absolute cell into a room's local frame is a second answer "+
 			"to which region holds it")

--- a/rulebooks/dnd5e/encounter/orientation.go
+++ b/rulebooks/dnd5e/encounter/orientation.go
@@ -21,25 +21,24 @@ import (
 // cells stay a contiguous, non-overlapping set, but the smallest rhombus
 // containing them is strictly bigger than they are.
 //
-// Measured on the reference tomb's own three chambers, against the constructor:
+// Measured on the reference tomb's own three chambers (6, 10 and 12 columns
+// wide, 8 rows tall, laid left to right), against the constructor:
 //
-//   - pointy-top built, and then RegionAt reported 380 cells as floor against
-//     the 224 somebody drew. 156 places a member could stand, and be reported
-//     standing, that nobody put there.
-//   - flat-top DID NOT BUILD AT ALL — `room "entrance" and room "hall" overlap
-//     at absolute cell (3, -9)` — because W2 compared bounding boxes and the
-//     sheared rhombi intersect where the chambers do not.
+//   - NEITHER ORIENTATION BUILT. `room "entrance" and room "hall" overlap at
+//     absolute cell (1, -4)`, pointy-top and flat-top alike, because W2
+//     compared origin-centred spans and those intersect where the chambers do
+//     not. So Kirk's ruling that "flat and pointy top are both valid and should
+//     be settable" was not merely awkward to honour: neither was reachable.
 //
-// So Kirk's ruling that "flat and pointy top are both valid and should be
-// settable" was not merely awkward to honour, it was unreachable. This file is
-// what delivers it.
+//   - With W2 disabled, so the footprint itself is observable, the two
+//     readings turn out to disagree about nearly every cell. Of the 224 cells
+//     the author drew, 25 are inside the rhombi under pointy-top and 24 under
+//     flat-top. 88% of what RegionAt then called floor was somewhere nobody
+//     drew, and 199 of the 224 drawn cells were not floor at all.
 //
-// A third thing fell out of the measurement and is worth recording because it
-// is the sharpest form of the argument: an origin-centred axial span can only
-// be EVEN (axisBounds gives [-dim/2, dim/2-1]), so RoomInput{Width, Height}
-// could not express an 11-cell rhombus at all. The tomb's chambers were not
-// merely approximated by the old reading — several of them were not
-// expressible under it.
+// With the mask: 224 cells drawn, 224 reported floor, nothing phantom and
+// nothing missing, in BOTH orientations. That is what this file delivers, and
+// TestTheFloorIsExactlyWhatWasDrawn is where it is pinned.
 //
 // # The mask is a FUNCTION, not a set
 //
@@ -50,6 +49,14 @@ import (
 // comparisons, O(1), derived from four numbers RoomData already carries —
 // width, height, origin, and the field's orientation. There is no cell list on
 // the wire and none in memory.
+//
+// It is not free, and the price is VOID. A chamber's cells are a sheared
+// parallelogram and the canvas holding it is an origin-centred axial span, so
+// the span is far larger than the floor: the tomb's canvas is 90.5% void
+// pointy-top and 93.5% flat-top, where the rhombus reading's was 43.2%. Void
+// costs no memory — nothing is allocated per cell — but it IS what
+// [Encounter.IsLineOfSightBlocked] scans under [VoidIsOpaque], which is why
+// voidcost_internal_test.go measures its worst case on this shape.
 //
 // The second question ("does it belong in tools/spatial?") answers itself the
 // same way: there is no new grid type here. spatial already owns both

--- a/rulebooks/dnd5e/encounter/orientation.go
+++ b/rulebooks/dnd5e/encounter/orientation.go
@@ -229,15 +229,19 @@ func hexOffsetOf(o Orientation, cell spatial.Position) (col, row int) {
 // the same change: a chamber's anchor says where its rectangle starts, in the
 // columns and rows the author counts in. Anchoring in axial would put the
 // shear back, one level up.
-func footprintHolds(r RoomInput, o Orientation, grids map[string]spatial.Grid, cell spatial.Position) bool {
+func footprintHolds(r RoomInput, o Orientation, grid spatial.Grid, cell spatial.Position) bool {
 	if r.Grid != spatial.GridShapeHex {
-		grid, ok := grids[r.ID]
-		if !ok {
-			return false
-		}
 		local := cell.Subtract(r.Origin)
 
-		return grid.IsValidPosition(local)
+		return isIntegralAxialPosition(grid, local) && grid.IsValidPosition(local)
+	}
+
+	// A fractional axial position is not a cell at all, and no chamber holds
+	// one (interim tools/spatial#926 enforcement). Asked here rather than in
+	// regionAt so that turning an absolute cell into a room's own frame
+	// happens in exactly ONE function — see TestRegionOwnershipIsAskedInOneFunction.
+	if !isIntegralAxialPosition(grid, cell) {
+		return false
 	}
 
 	col, row := hexOffsetOf(o, cell)

--- a/rulebooks/dnd5e/encounter/orientation.go
+++ b/rulebooks/dnd5e/encounter/orientation.go
@@ -405,20 +405,27 @@ func roomByID(rooms []RoomInput, id string) RoomInput {
 	return RoomInput{}
 }
 
-// fieldGridShape reports the grid family a field is drawn on, read off its
-// first room.
+// fieldGridShape reports the grid family a field is drawn on.
 //
-// W1 gives every room in a valid field the same family, so one room answers for
-// all of them — and this runs BEFORE W1 does, which is deliberate rather than a
-// gap: a mixed field is refused either way, and asking here only decides which
-// error the author sees first. An empty field answers square, and is refused a
-// moment later for being empty.
+// ANY hex room makes this a hex field, rather than reading the family off the
+// first room, and that is about ERROR ORDER rather than about grids. W1 gives
+// every room in a valid field the same family, so on a valid field the two
+// readings are identical. On an INVALID one they differ, and reading the first
+// room would make a field of [square, hex] answer "square" and get refused for
+// declaring an orientation — burying the real defect, which is that it mixes
+// families, under a complaint about a field that is not square either. Asking
+// "is there a hex room here" lets a mixed field satisfy this check and reach
+// W1, which is the rule that has something useful to say about it.
+//
+// An empty field answers square, and is refused a moment later for being empty.
 func fieldGridShape(rooms []RoomInput) spatial.GridShape {
-	if len(rooms) == 0 {
-		return spatial.GridShapeSquare
+	for _, r := range rooms {
+		if r.Grid == spatial.GridShapeHex {
+			return spatial.GridShapeHex
+		}
 	}
 
-	return rooms[0].Grid
+	return spatial.GridShapeSquare
 }
 
 // fieldOrientation checks a declared orientation against the field it describes.

--- a/rulebooks/dnd5e/encounter/orientation.go
+++ b/rulebooks/dnd5e/encounter/orientation.go
@@ -1,0 +1,450 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// orientation.go is A CHAMBER IS THE RECTANGLE SOMEBODY DREW
+// (rpg-toolkit#1127).
+//
+// # What was wrong
+//
+// A hex room's Width and Height were read as an AXIAL span — a rhombus, and an
+// origin-centred one. Authors do not draw rhombi. Every authored dungeon in
+// this project is a run of rectangular chambers in OFFSET coordinates
+// ([col,row] pairs), and an offset rectangle SHEARS when it becomes axial: its
+// cells stay a contiguous, non-overlapping set, but the smallest rhombus
+// containing them is strictly bigger than they are.
+//
+// Measured on the reference tomb's own three chambers, against the constructor:
+//
+//   - pointy-top built, and then RegionAt reported 380 cells as floor against
+//     the 224 somebody drew. 156 places a member could stand, and be reported
+//     standing, that nobody put there.
+//   - flat-top DID NOT BUILD AT ALL — `room "entrance" and room "hall" overlap
+//     at absolute cell (3, -9)` — because W2 compared bounding boxes and the
+//     sheared rhombi intersect where the chambers do not.
+//
+// So Kirk's ruling that "flat and pointy top are both valid and should be
+// settable" was not merely awkward to honour, it was unreachable. This file is
+// what delivers it.
+//
+// A third thing fell out of the measurement and is worth recording because it
+// is the sharpest form of the argument: an origin-centred axial span can only
+// be EVEN (axisBounds gives [-dim/2, dim/2-1]), so RoomInput{Width, Height}
+// could not express an 11-cell rhombus at all. The tomb's chambers were not
+// merely approximated by the old reading — several of them were not
+// expressible under it.
+//
+// # The mask is a FUNCTION, not a set
+//
+// Nothing here stores a cell list, and that answers the first of the two
+// questions Kirk's ruling (4) on rpg-toolkit#1105 left riding on the floor mask
+// ("computed per load, or persisted?"). A cell is floor iff converting it back
+// to offset space lands inside [0,Width) x [0,Height): one conversion and two
+// comparisons, O(1), derived from four numbers RoomData already carries —
+// width, height, origin, and the field's orientation. There is no cell list on
+// the wire and none in memory.
+//
+// The second question ("does it belong in tools/spatial?") answers itself the
+// same way: there is no new grid type here. spatial already owns both
+// directions of the offset<->cube conversion, and this is the composition
+// asking them. What lives here is the RULE about which cells a chamber owns,
+// and that rule's other half is [regionAt] — a second answer to "who owns this
+// cell" is exactly what region.go exists to prevent.
+//
+// # Why the composition is allowed to know this
+//
+// Orientation looks like a rendering fact, and it is not. The composition
+// already knows the grid FAMILY — square versus hex is a thing it holds and
+// reasons with — and pointy versus flat is the same species one level finer:
+// how the grid is laid out, which is what a grid IS. It is not fiction and not
+// a picture; it is the difference between two cells being neighbours and not.
+
+// OrientationKind names which way a field's hexes point, in the form the blob
+// carries it. See [Orientation].
+type OrientationKind string
+
+const (
+	// OrientationPointyTop is the pointy-top layout, whose offset form is
+	// odd-q: columns run straight and rows stagger.
+	OrientationPointyTop OrientationKind = "pointy"
+
+	// OrientationFlatTop is the flat-top layout, whose offset form is odd-r:
+	// rows run straight and columns stagger.
+	OrientationFlatTop OrientationKind = "flat"
+)
+
+// Orientation is which way a hex field's cells point: a closed set, sealed the
+// way [Void] and [DoorState] are and for the same reason.
+//
+// # Required exactly where it means something
+//
+// A HEX field must declare one, and a SQUARE field must not. Both halves are
+// refusals rather than one being a default, and the second is the interesting
+// one: a square grid has no orientation, so a square field that declares one
+// has an author believing something that cannot be true about their own
+// dungeon. Ignoring it would be this module deciding that a statement with no
+// meaning is harmless, which is the same move as inventing a default — see
+// [Void]'s doc comment for the argument at length.
+//
+// # What it decides
+//
+// Every authored cell in a hex field is an OFFSET [col,row] pair, and an offset
+// pair means nothing until the orientation is known: the same [2,3] is a
+// different hex under each layout, with different neighbours. So this is not a
+// presentational preference — it is the frame every other coordinate in the
+// field is written in, which is why it is construction data and why it
+// round-trips through persistence.
+//
+// It does NOT change any distance, adjacency or sight rule. Those run on cube
+// coordinates, which are orientation-free; spatial's AxialHexGrid carries no
+// orientation at all, correctly. Orientation lives at exactly one seam — the
+// conversion between what an author wrote and what the canvas runs on — and
+// this type is that seam.
+type Orientation interface {
+	// Kind names which layout this is: the word the blob carries, and the
+	// word an error quotes back.
+	Kind() OrientationKind
+
+	// spatial reports the tools/spatial orientation this corresponds to.
+	//
+	// Unexported, which SEALS the set: a third layout cannot be declared
+	// outside this package, and adding one means editing this file with the
+	// caller that forces it in hand.
+	spatial() spatial.HexOrientation
+}
+
+// HexesArePointyTop declares a field's hexes pointy-top, whose offset form is
+// odd-q. The reference tomb's layout.
+//
+// A function rather than a package-level variable so nothing can reassign what
+// it means at runtime — [VoidIsOpaque]'s reasoning, and the save gate's before
+// it.
+func HexesArePointyTop() Orientation { return pointyTop{} }
+
+type pointyTop struct{}
+
+func (pointyTop) Kind() OrientationKind           { return OrientationPointyTop }
+func (pointyTop) spatial() spatial.HexOrientation { return spatial.HexOrientationPointyTop }
+
+// HexesAreFlatTop declares a field's hexes flat-top, whose offset form is odd-r.
+func HexesAreFlatTop() Orientation { return flatTop{} }
+
+type flatTop struct{}
+
+func (flatTop) Kind() OrientationKind           { return OrientationFlatTop }
+func (flatTop) spatial() spatial.HexOrientation { return spatial.HexOrientationFlatTop }
+
+// orientationFromData resolves the persisted word back to the declaration it
+// names, or reports that a square field carries one it should not.
+//
+// Refusals by name and loud, per the standing precedent (rpg-toolkit#1053/#1068:
+// fail loudly, no migration). An ABSENT word on a hex field is a blob written
+// before the field declared anything, and loading it under a guess would read
+// every stored cell in the wrong frame — a dungeon drawn correctly and played
+// wrong. An UNKNOWN word is a dialect this build does not speak.
+func orientationFromData(shape spatial.GridShape, name string) (Orientation, error) {
+	if shape != spatial.GridShapeHex {
+		if name != "" {
+			return nil, fmt.Errorf(
+				"a square field declares orientation %q, and a square grid has none (canvas.orientation): %w",
+				name, ErrNoField)
+		}
+
+		return nil, nil
+	}
+
+	switch OrientationKind(name) {
+	case OrientationPointyTop:
+		return HexesArePointyTop(), nil
+	case OrientationFlatTop:
+		return HexesAreFlatTop(), nil
+	case "":
+		return nil, fmt.Errorf(
+			"hex field does not say which way its hexes point (canvas.orientation): %w", ErrNoField)
+	default:
+		return nil, fmt.Errorf(
+			"field declares orientation %q, which this build does not know (canvas.orientation): %w",
+			name, ErrNoField)
+	}
+}
+
+// orientationName renders a declaration for persistence, or empty for a square
+// field.
+func orientationName(o Orientation) string {
+	if o == nil {
+		return ""
+	}
+
+	return string(o.Kind())
+}
+
+// HexCellAt returns the dungeon-absolute cell an authored offset [col,row] pair
+// names, under the given orientation.
+//
+// EXPORTED BECAUSE CONTENT NEEDS IT. A compiler turning an authored dungeon
+// into a field has to put things where the author said, and "where the author
+// said" is an offset pair — so the conversion cannot be private to this package
+// without every caller reimplementing it, which is how two answers to one
+// question get born. It is the same function [regionAt] runs backwards.
+//
+// The conversion itself is spatial's, not this module's: offset -> cube through
+// [spatial.OffsetCoordinateToCubeWithOrientation], then cube read as axial with
+// Q = X and R = Y, which is the reading [spatial.AxialHexGrid] uses (its
+// axialToCube derives Z = -Q-R, so the two agree by construction rather than by
+// coincidence — pinned by TestOffsetAndAxialAgreeWithSpatial).
+func HexCellAt(o Orientation, col, row int) spatial.Position {
+	cube := spatial.OffsetCoordinateToCubeWithOrientation(
+		spatial.Position{X: float64(col), Y: float64(row)}, o.spatial())
+
+	return spatial.Position{X: float64(cube.X), Y: float64(cube.Y)}
+}
+
+// hexOffsetOf is HexCellAt run backwards: the authored [col,row] a
+// dungeon-absolute cell came from.
+func hexOffsetOf(o Orientation, cell spatial.Position) (col, row int) {
+	q, r := int(cell.X), int(cell.Y)
+	offset := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}.
+		ToOffsetCoordinateWithOrientation(o.spatial())
+
+	return int(offset.X), int(offset.Y)
+}
+
+// footprintHolds reports whether a room owns a dungeon-absolute cell — THE
+// MASK, and the only implementation of it.
+//
+// For a SQUARE field this is the rectangle it always was, asked through the
+// room's own grid so square behaviour is untouched by any of this. For a HEX
+// field it is the authored offset rectangle: convert the cell back to offset
+// space and check the bounds. Note what is NOT here — no rhombus, no
+// axisBounds, no origin-centred span. Those were the approximation.
+//
+// The origin is subtracted in OFFSET space for hex, which is the other half of
+// the same change: a chamber's anchor says where its rectangle starts, in the
+// columns and rows the author counts in. Anchoring in axial would put the
+// shear back, one level up.
+func footprintHolds(r RoomInput, o Orientation, grids map[string]spatial.Grid, cell spatial.Position) bool {
+	if r.Grid != spatial.GridShapeHex {
+		grid, ok := grids[r.ID]
+		if !ok {
+			return false
+		}
+		local := cell.Subtract(r.Origin)
+
+		return grid.IsValidPosition(local)
+	}
+
+	col, row := hexOffsetOf(o, cell)
+	col -= int(r.Origin.X)
+	row -= int(r.Origin.Y)
+
+	return col >= 0 && col < r.Width && row >= 0 && row < r.Height
+}
+
+// hexRuns decomposes a hex chamber's footprint into contiguous runs, which is
+// what lets W2 and the canvas bounds be computed WITHOUT enumerating cells.
+//
+// # Why runs rather than a cell set
+//
+// maxFieldCells allows four million cells, so "build both footprints and
+// intersect" is a real cost on a legal field, paid at every construction. But a
+// sheared rectangle is not shapeless: along one axis it decomposes into
+// contiguous intervals, one per authored column (pointy) or row (flat), and two
+// intervals intersect in O(1). So the whole disjointness question costs
+// O(Width) or O(Height) rather than O(Width x Height).
+//
+// The key is the coordinate that does NOT shear:
+//
+//   - POINTY-TOP is odd-q, so Q = col exactly and only R staggers. Key by Q;
+//     for a fixed column, R decreases by exactly one per row, so the run is
+//     [r(row=Height-1), r(row=0)].
+//   - FLAT-TOP is odd-r, so the authored ROW is recoverable as -(Q+R) and only
+//     Q staggers. Key by that; for a fixed row, Q increases by exactly one per
+//     column.
+//
+// Both facts are read off spatial's own conversion rather than assumed, and
+// pinned by TestRunsAgreeWithEnumeration, which compares this against a full
+// cell-by-cell sweep over a spread of shapes and both orientations.
+func hexRuns(r RoomInput, o Orientation) map[int][2]int {
+	runs := make(map[int][2]int, max(r.Width, r.Height))
+
+	oc, or := int(r.Origin.X), int(r.Origin.Y)
+	if o.Kind() == OrientationPointyTop {
+		for col := 0; col < r.Width; col++ {
+			top := HexCellAt(o, col+oc, or)
+			bottom := HexCellAt(o, col+oc, r.Height-1+or)
+			runs[int(top.X)] = [2]int{int(bottom.Y), int(top.Y)}
+		}
+
+		return runs
+	}
+
+	for row := 0; row < r.Height; row++ {
+		left := HexCellAt(o, oc, row+or)
+		right := HexCellAt(o, r.Width-1+oc, row+or)
+		runs[-(int(left.X) + int(left.Y))] = [2]int{int(left.X), int(right.X)}
+	}
+
+	return runs
+}
+
+// hexFootprintBounds returns a hex chamber's absolute axial bounding box, from
+// its runs rather than from an assumed rhombus.
+func hexFootprintBounds(r RoomInput, o Orientation) (qMin, qMax, rMin, rMax int) {
+	first := true
+	for key, run := range hexRuns(r, o) {
+		var q0, q1, r0, r1 int
+		if o.Kind() == OrientationPointyTop {
+			q0, q1, r0, r1 = key, key, run[0], run[1]
+		} else {
+			// key is the authored row; the run is a Q interval, and R is
+			// -Q-row on each end.
+			q0, q1 = run[0], run[1]
+			r0, r1 = -run[1]-key, -run[0]-key
+		}
+		if first {
+			qMin, qMax, rMin, rMax = q0, q1, r0, r1
+			first = false
+			continue
+		}
+		qMin, qMax = min(qMin, q0), max(qMax, q1)
+		rMin, rMax = min(rMin, r0), max(rMax, r1)
+	}
+
+	return
+}
+
+// hexFootprintsOverlap reports whether two hex chambers share a cell — W2, on
+// the authored shape rather than on the box that contains it.
+//
+// THIS IS WHAT MAKES FLAT-TOP CONSTRUCTIBLE. The interval test on bounding
+// boxes is exact for a rectangle and merely conservative for a sheared one, and
+// "conservative" here meant refusing the reference tomb outright: its chambers
+// share no cell in either orientation (measured: 0 shared cells across all three
+// pairs, union exactly 224) while their flat-top boxes intersect.
+func hexFootprintsOverlap(a, b RoomInput, o Orientation) bool {
+	runsA, runsB := hexRuns(a, o), hexRuns(b, o)
+	if len(runsB) < len(runsA) {
+		runsA, runsB = runsB, runsA
+	}
+
+	for key, ra := range runsA {
+		rb, shared := runsB[key]
+		if !shared {
+			continue
+		}
+		if ra[0] <= rb[1] && rb[0] <= ra[1] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// absoluteOf projects an authored room-local cell onto the canvas.
+//
+// THERE IS EXACTLY ONE OF THESE, and that is the point. rpg-toolkit#1106
+// deleted a function of this name for a good reason — it was a RUNTIME bridge,
+// run on every query, and the wave's whole argument was that a field should
+// stop projecting a world model it already has. This is the other kind: it runs
+// at CONSTRUCTION only, spending the anchor once, exactly as
+// RoomInput.Origin's doc comment says an origin is spent. No verb calls it.
+//
+// For a SQUARE room, local plus origin, which is what it always was. For a HEX
+// room, both the local cell and the origin are counted in OFFSET columns and
+// rows — the frame an author writes in — and the sum is converted once. Adding
+// in axial instead would put the shear back one level up: two chambers anchored
+// six columns apart would land at axial distances that vary by row, and the
+// seam between them would stop being a straight line.
+func absoluteOf(r RoomInput, o Orientation, local spatial.Position) spatial.Position {
+	if r.Grid != spatial.GridShapeHex {
+		return local.Add(r.Origin)
+	}
+
+	return HexCellAt(o, int(local.X)+int(r.Origin.X), int(local.Y)+int(r.Origin.Y))
+}
+
+// localIsInRoom reports whether an authored room-local cell is inside its
+// chamber — the bounds check that used to be the room grid's.
+//
+// A hex room's grid is a spatial.AxialHexGrid whose bounds are an
+// origin-centred axial span, and that is no longer what a chamber is, so asking
+// it would refuse every legal offset cell of a chamber anchored anywhere but
+// the middle of nowhere. Square still asks the grid, because for square the
+// grid's rectangle IS the chamber and nothing about that changed.
+func localIsInRoom(r RoomInput, grids map[string]spatial.Grid, local spatial.Position) bool {
+	if r.Grid != spatial.GridShapeHex {
+		grid, ok := grids[r.ID]
+
+		return ok && grid.IsValidPosition(local)
+	}
+
+	return local.X >= 0 && local.X < float64(r.Width) &&
+		local.Y >= 0 && local.Y < float64(r.Height)
+}
+
+// roomByID returns the room with the given ID, or a zero RoomInput.
+//
+// The zero value is deliberate rather than an error return: every caller here
+// has already had its room name validated (an unknown room is a construction
+// defect refused long before this), so a not-found is unreachable and returning
+// an error would be a branch no test could reach and no caller could act on.
+func roomByID(rooms []RoomInput, id string) RoomInput {
+	for _, r := range rooms {
+		if r.ID == id {
+			return r
+		}
+	}
+
+	return RoomInput{}
+}
+
+// fieldGridShape reports the grid family a field is drawn on, read off its
+// first room.
+//
+// W1 gives every room in a valid field the same family, so one room answers for
+// all of them — and this runs BEFORE W1 does, which is deliberate rather than a
+// gap: a mixed field is refused either way, and asking here only decides which
+// error the author sees first. An empty field answers square, and is refused a
+// moment later for being empty.
+func fieldGridShape(rooms []RoomInput) spatial.GridShape {
+	if len(rooms) == 0 {
+		return spatial.GridShapeSquare
+	}
+
+	return rooms[0].Grid
+}
+
+// fieldOrientation checks a declared orientation against the field it describes.
+//
+// The mirror of [orientationFromData] for the Setup seam, where the declaration
+// arrives typed rather than as a word. Both seams end at the same two rules —
+// a hex field must declare one, a square field must not — because #929 T2's
+// standing arrangement is that Load routes through the SAME validators Setup
+// uses rather than a parallel reimplementation, and two copies of a rule are
+// two rules waiting to disagree.
+func fieldOrientation(rooms []RoomInput, declared Orientation) (Orientation, error) {
+	if fieldGridShape(rooms) != spatial.GridShapeHex {
+		if declared != nil {
+			return nil, fmt.Errorf(
+				"a square field declares orientation %q, and a square grid has none "+
+					"(FieldInput.Canvas.Orientation): %w", declared.Kind(), ErrNoField)
+		}
+
+		return nil, nil
+	}
+
+	if declared == nil {
+		return nil, fmt.Errorf(
+			"hex field does not say which way its hexes point "+
+				"(FieldInput.Canvas.Orientation): %w", ErrNoField)
+	}
+
+	return declared, nil
+}

--- a/rulebooks/dnd5e/encounter/orientation_internal_test.go
+++ b/rulebooks/dnd5e/encounter/orientation_internal_test.go
@@ -1,0 +1,229 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+// orientation_internal_test.go pins the ARITHMETIC the floor mask is built out
+// of (rpg-toolkit#1127), against enumeration and against tools/spatial itself.
+//
+// It exists because orientation.go's doc comments named two tests that had not
+// been written — the exact failure the mutation battery is for: a comment
+// claiming a guarantee nothing checks. Both are here now, and both found
+// something. See each test for what.
+//
+// The public seam is orientation_test.go, and that is where behaviour belongs.
+// What is here is unreachable from outside: hexRuns and hexFootprintBounds are
+// an OPTIMIZATION — they answer questions a full cell sweep would answer more
+// slowly — so the honest test compares them to that sweep rather than to a
+// hand-written expectation, which would only re-state the implementation.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// bothOrientations is every layout a hex field may declare, which is what makes
+// "flat and pointy top are both valid" (Kirk's ruling) a thing tests can range
+// over rather than a thing a fixture picks.
+func bothOrientations() []Orientation {
+	return []Orientation{HexesArePointyTop(), HexesAreFlatTop()}
+}
+
+// footprintCells enumerates a chamber's absolute cells the slow, obvious way:
+// every authored column and row, converted one at a time. The reference every
+// other function here is measured against.
+func footprintCells(r RoomInput, o Orientation) map[[2]int]bool {
+	out := make(map[[2]int]bool, r.Width*r.Height)
+	for col := 0; col < r.Width; col++ {
+		for row := 0; row < r.Height; row++ {
+			c := HexCellAt(o, col+int(r.Origin.X), row+int(r.Origin.Y))
+			out[[2]int{int(c.X), int(c.Y)}] = true
+		}
+	}
+	return out
+}
+
+// spreadOfChambers is a range of shapes chosen to hit the parities that matter:
+// odd and even widths, odd and even heights, odd and even anchors, and the
+// degenerate single column and single row. Offset conversion staggers on
+// parity, so a fixture that is even everywhere proves the arithmetic for half
+// the inputs.
+func spreadOfChambers() []RoomInput {
+	var out []RoomInput
+	for _, w := range []int{1, 2, 3, 6, 7} {
+		for _, h := range []int{1, 2, 5, 8} {
+			for _, anchor := range [][2]int{{0, 0}, {1, 0}, {0, 1}, {3, 5}, {-4, -3}} {
+				out = append(out, RoomInput{
+					ID:   fmt.Sprintf("w%dh%d@%d,%d", w, h, anchor[0], anchor[1]),
+					Grid: spatial.GridShapeHex, Width: w, Height: h,
+					Origin: spatial.Position{X: float64(anchor[0]), Y: float64(anchor[1])},
+				})
+			}
+		}
+	}
+	return out
+}
+
+// TestOffsetAndAxialAgreeWithSpatial pins the reading [HexCellAt] takes of
+// spatial's own cube coordinate: Q is cube.X and R is cube.Y.
+//
+// That is not the only reading available — a cube triple has three components
+// and axial keeps two — and picking the wrong pair produces cells that look
+// plausible and are somewhere else. The check is that spatial's TWO directions
+// agree: the cube it derives from an offset pair must be the cube
+// [spatial.AxialHexGrid] derives from the axial pair this hands it (its
+// axialToCube sets Z = -Q-R). So the two are the same coordinate, by
+// construction rather than by coincidence.
+func TestOffsetAndAxialAgreeWithSpatial(t *testing.T) {
+	for _, o := range bothOrientations() {
+		t.Run(string(o.Kind()), func(t *testing.T) {
+			for col := -8; col <= 8; col++ {
+				for row := -8; row <= 8; row++ {
+					fromOffset := spatial.OffsetCoordinateToCubeWithOrientation(
+						spatial.Position{X: float64(col), Y: float64(row)}, o.spatial())
+
+					axial := HexCellAt(o, col, row)
+					q, r := int(axial.X), int(axial.Y)
+					fromAxial := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}
+
+					require.Equal(t, fromOffset, fromAxial,
+						"offset [%d,%d]: the cube spatial derives from the pair an author "+
+							"wrote must be the cube it derives from the axial cell we hand it",
+						col, row)
+
+					// And back again, which is what [regionAt] runs to decide
+					// ownership: a cell that does not round-trip is a cell the
+					// mask would put in the wrong chamber.
+					backCol, backRow := hexOffsetOf(o, axial)
+					require.Equal(t, [2]int{col, row}, [2]int{backCol, backRow},
+						"offset [%d,%d] must survive the round trip", col, row)
+				}
+			}
+		})
+	}
+}
+
+// TestRunsAgreeWithEnumeration pins [hexRuns] and [hexFootprintBounds] against
+// a full cell-by-cell sweep of the same chamber.
+//
+// Both exist so W2 and the canvas span can be computed WITHOUT enumerating —
+// maxFieldCells allows four million cells, and building two footprints to
+// intersect them is a real cost on a legal field — so the only honest
+// expectation to compare against is the enumeration they replace.
+//
+// THIS FOUND A REAL DEFECT and is the reason it is written as two claims rather
+// than one. The runs alone are insensitive to the sign of the key that groups
+// them: flip it on both sides and every lookup still matches, so W2 cannot tell.
+// The BOUNDS decode that key back into an authored row, and there the sign is
+// load-bearing. A mutant flipping it survived the entire public suite.
+func TestRunsAgreeWithEnumeration(t *testing.T) {
+	for _, o := range bothOrientations() {
+		for _, r := range spreadOfChambers() {
+			t.Run(string(o.Kind())+"/"+r.ID, func(t *testing.T) {
+				cells := footprintCells(r, o)
+
+				// Claim 1: the runs cover exactly the footprint. Expanded back
+				// into cells, they must BE the enumeration — not a superset
+				// (W2 would refuse legal fields) and not a subset (it would
+				// accept overlapping ones).
+				expanded := map[[2]int]bool{}
+				for key, run := range hexRuns(r, o) {
+					require.LessOrEqual(t, run[0], run[1], "a run's interval must be ordered")
+					for v := run[0]; v <= run[1]; v++ {
+						if o.Kind() == OrientationPointyTop {
+							expanded[[2]int{key, v}] = true // key is Q, run is R
+						} else {
+							expanded[[2]int{v, -v - key}] = true // key is the row, run is Q
+						}
+					}
+				}
+				require.Equal(t, cells, expanded,
+					"the runs must expand to exactly the cells the author drew")
+
+				// Claim 2: the bounding box is the enumeration's own.
+				qMin, qMax, rMin, rMax := hexFootprintBounds(r, o)
+				eqMin, eqMax, erMin, erMax := boundsOf(cells)
+				require.Equal(t,
+					[4]int{eqMin, eqMax, erMin, erMax}, [4]int{qMin, qMax, rMin, rMax},
+					"the footprint's box must be the box its cells actually occupy")
+			})
+		}
+	}
+}
+
+// boundsOf is the bounding box of an enumerated cell set — the slow answer
+// [hexFootprintBounds] is measured against.
+func boundsOf(cells map[[2]int]bool) (qMin, qMax, rMin, rMax int) {
+	first := true
+	for c := range cells {
+		if first {
+			qMin, qMax, rMin, rMax = c[0], c[0], c[1], c[1]
+			first = false
+			continue
+		}
+		qMin, qMax = min(qMin, c[0]), max(qMax, c[0])
+		rMin, rMax = min(rMin, c[1]), max(rMax, c[1])
+	}
+	return
+}
+
+// TestOverlapAgreesWithEnumeration pins [hexFootprintsOverlap] — W2's verdict
+// on hex — against intersecting the two enumerated cell sets.
+//
+// The pairs are built to include the case the reference tomb IS: two chambers
+// whose bounding boxes intersect and which share no cell. That case is the
+// whole reason this function exists (the box test refused the tomb outright),
+// and it is also the one an implementation is most likely to get wrong in the
+// safe-looking direction — reporting an overlap that is not there refuses a
+// legal dungeon, and no fixture notices until somebody authors one.
+func TestOverlapAgreesWithEnumeration(t *testing.T) {
+	var chambers []RoomInput
+	for _, w := range []int{1, 3, 6} {
+		for _, h := range []int{1, 4, 8} {
+			for _, anchor := range [][2]int{{0, 0}, {1, 0}, {0, 1}, {3, 0}, {6, 0}, {0, 4}, {2, 3}, {-2, 1}} {
+				chambers = append(chambers, RoomInput{
+					ID:   fmt.Sprintf("w%dh%d@%d,%d", w, h, anchor[0], anchor[1]),
+					Grid: spatial.GridShapeHex, Width: w, Height: h,
+					Origin: spatial.Position{X: float64(anchor[0]), Y: float64(anchor[1])},
+				})
+			}
+		}
+	}
+
+	for _, o := range bothOrientations() {
+		t.Run(string(o.Kind()), func(t *testing.T) {
+			boxesMetButDisjoint := 0
+			for i := range chambers {
+				for j := i + 1; j < len(chambers); j++ {
+					a, b := chambers[i], chambers[j]
+					cellsA, cellsB := footprintCells(a, o), footprintCells(b, o)
+					shared := false
+					for c := range cellsA {
+						if cellsB[c] {
+							shared = true
+							break
+						}
+					}
+					require.Equal(t, shared, hexFootprintsOverlap(a, b, o),
+						"%s vs %s: the runs must agree with the cells", a.ID, b.ID)
+
+					aqMin, aqMax, arMin, arMax := hexFootprintBounds(a, o)
+					bqMin, bqMax, brMin, brMax := hexFootprintBounds(b, o)
+					if !shared && aqMin <= bqMax && bqMin <= aqMax && arMin <= brMax && brMin <= arMax {
+						boxesMetButDisjoint++
+					}
+				}
+			}
+			// The discriminating case has to be PRESENT, or this test passes
+			// by never asking the question that matters — the box test would
+			// satisfy it on its own.
+			require.Positive(t, boxesMetButDisjoint,
+				"the spread must contain pairs whose boxes meet and whose cells do not, "+
+					"which is the case the box test gets wrong")
+		})
+	}
+}

--- a/rulebooks/dnd5e/encounter/orientation_test.go
+++ b/rulebooks/dnd5e/encounter/orientation_test.go
@@ -310,3 +310,124 @@ func (s *OrientationSuite) TestChambersThatDoOverlapAreStillRefused() {
 		})
 	}
 }
+
+// TestTheMapReportsDoorwaysInTheAuthoredFrame — [Atlas.Doorways] carries the
+// two absolute cells a connection joins, and a HOST STEERS BY THEM: the pursuit
+// decider in this package's own fixtures walks through a door by moving to
+// AtlasDoorway.ToCell.
+//
+// Found by mutation, and it was a live defect rather than a gap: Atlas built
+// those two cells by adding the room's anchor in axial, which is the arithmetic
+// rpg-toolkit#1127 replaced everywhere else. Nothing noticed, because every
+// fixture that read a doorway off the Atlas was square. So this asserts the
+// pair against the projection an author's own columns and rows name, and then
+// asserts the property that makes a doorway a doorway at all — the two cells
+// are ADJACENT, which the wrong arithmetic breaks and a coordinate comparison
+// alone would not reveal.
+func (s *OrientationSuite) TestTheMapReportsDoorwaysInTheAuthoredFrame() {
+	for _, o := range []struct {
+		name string
+		o    encounter.Orientation
+	}{
+		{"pointy-top", encounter.HexesArePointyTop()},
+		{"flat-top", encounter.HexesAreFlatTop()},
+	} {
+		s.Run(o.name, func() {
+			field := hexTomb(o.o)
+			// The seams the chambers already share: entrance|hall at column
+			// 5|6, hall|tomb at 15|16, both on row 3.
+			field.Connections = []encounter.ConnectionInput{
+				{ID: "arch", From: "entrance", To: "hall",
+					FromPosition: spatial.Position{X: 5, Y: 3}, ToPosition: spatial.Position{X: 0, Y: 3}},
+				{ID: "stair", From: "hall", To: "tomb",
+					FromPosition: spatial.Position{X: 9, Y: 3}, ToPosition: spatial.Position{X: 0, Y: 3}},
+			}
+
+			enc, err := s.build(field, spatial.Position{X: 0, Y: 0}, "entrance")
+			s.Require().NoError(err)
+
+			atlas, err := enc.Atlas()
+			s.Require().NoError(err)
+			s.Require().Len(atlas.Doorways, 2)
+
+			canvas, err := enc.Canvas()
+			s.Require().NoError(err)
+			grid := canvas.GetGrid()
+
+			// Sorted by connection ID (C8), so "arch" then "stair".
+			s.Equal(encounter.HexCellAt(o.o, 5, 3), atlas.Doorways[0].FromCell)
+			s.Equal(encounter.HexCellAt(o.o, 6, 3), atlas.Doorways[0].ToCell)
+			s.Equal(encounter.HexCellAt(o.o, 15, 3), atlas.Doorways[1].FromCell)
+			s.Equal(encounter.HexCellAt(o.o, 16, 3), atlas.Doorways[1].ToCell)
+
+			for _, d := range atlas.Doorways {
+				s.Equal(1.0, grid.Distance(d.FromCell, d.ToCell),
+					"doorway %q joins two cells that must be one step apart", d.Connection)
+
+				fromRegion, fromFloor := enc.RegionAt(d.FromCell)
+				toRegion, toFloor := enc.RegionAt(d.ToCell)
+				s.True(fromFloor, "doorway %q's near cell must be floor", d.Connection)
+				s.True(toFloor, "doorway %q's far cell must be floor", d.Connection)
+				s.Equal(string(d.From), string(fromRegion))
+				s.Equal(string(d.To), string(toRegion))
+			}
+		})
+	}
+}
+
+// TestAChambersEdgeIsAnEdge — the mask's upper bound, asked at the Setup seam
+// rather than of RegionAt.
+//
+// Column Width is the first column the chamber does not have, and a member
+// authored there is authored outside their own room. It reads like a
+// restatement of TestTheFloorIsExactlyWhatWasDrawn and is not: that test asks
+// [Encounter.RegionAt], which runs footprintHolds, while this asks
+// NewEncounter, which runs localIsInRoom — a SECOND bounds rule, in the
+// authored frame, and mutation found it unpinned at exactly this edge.
+func (s *OrientationSuite) TestAChambersEdgeIsAnEdge() {
+	o := encounter.HexesArePointyTop()
+
+	s.Run("the last column is inside", func() {
+		_, err := s.build(hexTomb(o), spatial.Position{X: 5, Y: 7}, "entrance")
+		s.Require().NoError(err, "entrance is 6 wide and 8 tall, so [5,7] is its far corner")
+	})
+
+	s.Run("one past it is not", func() {
+		_, err := s.build(hexTomb(o), spatial.Position{X: 6, Y: 0}, "entrance")
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Contains(err.Error(), "out of bounds")
+	})
+
+	s.Run("nor is one past the last row", func() {
+		_, err := s.build(hexTomb(o), spatial.Position{X: 0, Y: 8}, "entrance")
+		s.Require().ErrorIs(err, encounter.ErrBadPlacement)
+		s.Contains(err.Error(), "out of bounds")
+	})
+}
+
+// TestASquareBlobMustNotDeclareAnOrientation — the Load seam's half of the
+// refusal TestAFieldSaysWhichWayItsHexesPoint pins at Setup.
+//
+// #929 T2's standing arrangement is that Load routes through the SAME
+// validators Setup uses, and that arrangement is a claim about the code which
+// only a test at BOTH seams can hold to. Mutation found this one unpinned:
+// deleting the square refusal from the Load path broke nothing.
+func (s *OrientationSuite) TestASquareBlobMustNotDeclareAnOrientation() {
+	field := encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+		Rooms:  []encounter.RoomInput{{ID: "hall", Width: 6, Height: 6}},
+	}
+	enc, err := s.build(field, spatial.Position{X: 1, Y: 1}, "hall")
+	s.Require().NoError(err)
+
+	data := enc.ToData()
+	s.Empty(data.Field.Canvas.Orientation, "a square field writes none")
+
+	data.Field.Canvas.Orientation = "pointy"
+	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoField)
+	s.Contains(strings.ToLower(err.Error()), "orientation")
+}

--- a/rulebooks/dnd5e/encounter/orientation_test.go
+++ b/rulebooks/dnd5e/encounter/orientation_test.go
@@ -15,27 +15,30 @@ package encounter_test
 // non-overlapping set, but the smallest rhombus containing them is strictly
 // bigger than they are.
 //
-// Measured against the constructor before this file existed, on the reference
-// tomb's own three chambers:
+// Measured against the constructor, on the reference tomb's own three
+// chambers — the ones this file builds:
 //
-//   - pointy-top constructed, and RegionAt then reported 380 cells as floor
-//     against the 224 the author drew — 156 places a member may stand, and be
-//     reported standing, that nobody put there.
-//   - flat-top DID NOT CONSTRUCT AT ALL: `room "entrance" and room "hall"
-//     overlap at absolute cell (3, -9)`, because W2 compared bounding boxes and
-//     the sheared rhombi intersect even though the chambers do not.
+//   - NEITHER ORIENTATION CONSTRUCTED. `room "entrance" and room "hall"
+//     overlap at absolute cell (1, -4)`, pointy and flat alike, because W2
+//     compared origin-centred spans and those intersect even though the
+//     chambers do not.
+//   - With W2 disabled so the footprint itself could be seen: of the 224 cells
+//     the author drew, 25 fell inside the rhombi under pointy-top and 24 under
+//     flat-top. 88% of what RegionAt then called floor was somewhere nobody
+//     drew, and 199 of the drawn cells were not floor at all.
 //
-// So "both settable" was not merely awkward, it was unreachable. What fixes it
-// is the room saying which rectangle it is rather than which rhombus contains
-// it — the floor mask Kirk deferred on rpg-toolkit#1105 until a caller forced
-// one, and this is the caller.
+// So "both settable" was not merely awkward, it was unreachable — and so was
+// either. What fixes it is the room saying which rectangle it is rather than
+// which rhombus contains it: the floor mask Kirk deferred on rpg-toolkit#1105
+// until a caller forced one, and this is the caller.
 //
 // # The mask is a function, not a set
 //
 // Nothing here stores a cell list. A cell is floor iff converting it back to
 // offset space lands inside [0,Width) x [0,Height) — one conversion and two
 // comparisons, O(1), from four numbers RoomData already persists (width,
-// height, origin, and the field's orientation). See [OrientationInput].
+// height, origin, and the field's orientation). See
+// [encounter.CanvasInput.Orientation].
 
 import (
 	"strings"
@@ -127,8 +130,8 @@ func (s *OrientationSuite) TestTheFloorIsExactlyWhatWasDrawn() {
 			}
 			s.Require().Equal(224, drawn, "the tomb is 6+10+12 wide and 8 tall")
 
-			// And NOTHING else is. Swept over the whole canvas, which is where
-			// the 156 phantom cells used to be.
+			// And NOTHING else is. Swept over the whole canvas, which is
+			// where the rhombus reading's phantom floor was.
 			canvas, cerr := enc.Canvas()
 			s.Require().NoError(cerr)
 			dims := canvas.GetGrid().GetDimensions()
@@ -142,7 +145,8 @@ func (s *OrientationSuite) TestTheFloorIsExactlyWhatWasDrawn() {
 				}
 			}
 			s.Equal(224, floorCells,
-				"no cell is floor but undrawn — this counted 380 against the rhombus reading")
+				"no cell is floor but undrawn — under the rhombus reading 88%% of the "+
+					"reported floor was somewhere nobody drew")
 		})
 	}
 }

--- a/rulebooks/dnd5e/encounter/orientation_test.go
+++ b/rulebooks/dnd5e/encounter/orientation_test.go
@@ -1,0 +1,308 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+// orientation_test.go is A CHAMBER IS THE RECTANGLE SOMEBODY DREW
+// (rpg-toolkit#1127's mask, and Kirk's ruling that "flat and pointy top are
+// both valid and should be settable").
+//
+// A hex room's Width and Height have always been read as an AXIAL span — a
+// rhombus, centred on the origin. Authors do not draw rhombi. Every authored
+// dungeon in this project, the reference tomb included, is a run of rectangular
+// chambers in OFFSET coordinates, and an offset rectangle shears when it is
+// converted to axial: its cells are still a perfectly good, contiguous,
+// non-overlapping set, but the smallest rhombus containing them is strictly
+// bigger than they are.
+//
+// Measured against the constructor before this file existed, on the reference
+// tomb's own three chambers:
+//
+//   - pointy-top constructed, and RegionAt then reported 380 cells as floor
+//     against the 224 the author drew — 156 places a member may stand, and be
+//     reported standing, that nobody put there.
+//   - flat-top DID NOT CONSTRUCT AT ALL: `room "entrance" and room "hall"
+//     overlap at absolute cell (3, -9)`, because W2 compared bounding boxes and
+//     the sheared rhombi intersect even though the chambers do not.
+//
+// So "both settable" was not merely awkward, it was unreachable. What fixes it
+// is the room saying which rectangle it is rather than which rhombus contains
+// it — the floor mask Kirk deferred on rpg-toolkit#1105 until a caller forced
+// one, and this is the caller.
+//
+// # The mask is a function, not a set
+//
+// Nothing here stores a cell list. A cell is floor iff converting it back to
+// offset space lands inside [0,Width) x [0,Height) — one conversion and two
+// comparisons, O(1), from four numbers RoomData already persists (width,
+// height, origin, and the field's orientation). See [OrientationInput].
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type OrientationSuite struct {
+	suite.Suite
+}
+
+func TestOrientationSuite(t *testing.T) {
+	suite.Run(t, new(OrientationSuite))
+}
+
+// The reference tomb's own shape: three chambers, 6/10/12 wide, all 8 tall,
+// laid left to right in offset columns 0..27.
+type authoredChamber struct {
+	id      string
+	col0, w int
+}
+
+var tombChambers = []authoredChamber{{"entrance", 0, 6}, {"hall", 6, 10}, {"tomb", 16, 12}}
+
+const tombHeight = 8
+
+// hexTomb builds the tomb as the author drew it: each chamber an offset
+// rectangle, anchored so its columns land where the layout says.
+//
+// The Origin is in OFFSET columns now, which is the change: a room's anchor
+// says where its rectangle starts, not where the centre of a rhombus sits.
+func hexTomb(o encounter.Orientation) encounter.FieldInput {
+	rooms := make([]encounter.RoomInput, 0, len(tombChambers))
+	for _, c := range tombChambers {
+		rooms = append(rooms, encounter.RoomInput{
+			ID: c.id, Grid: spatial.GridShapeHex, Width: c.w, Height: tombHeight,
+			Origin: spatial.Position{X: float64(c.col0), Y: 0},
+		})
+	}
+
+	return encounter.FieldInput{
+		Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: o},
+		Rooms:  rooms,
+	}
+}
+
+func (s *OrientationSuite) build(field encounter.FieldInput, at spatial.Position, room string) (*encounter.Encounter, error) {
+	return encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: field,
+		Members: []encounter.MemberInput{
+			{ID: "delve", Kind: encounter.KindPlayer, Room: room, Position: at},
+		},
+		Endings: []encounter.EndingInput{{Key: "out", Trigger: encounter.TriggerExternal{}}},
+	})
+}
+
+// TestTheFloorIsExactlyWhatWasDrawn is the whole point, asked of RegionAt
+// itself rather than of any arithmetic of this test's own.
+func (s *OrientationSuite) TestTheFloorIsExactlyWhatWasDrawn() {
+	for _, o := range []struct {
+		name string
+		o    encounter.Orientation
+	}{
+		{"pointy-top", encounter.HexesArePointyTop()},
+		{"flat-top", encounter.HexesAreFlatTop()},
+	} {
+		s.Run(o.name, func() {
+			enc, err := s.build(hexTomb(o.o), spatial.Position{X: 0, Y: 0}, "entrance")
+			s.Require().NoError(err, "the authored chambers must construct — flat-top could not, before the mask")
+
+			// Every cell the author drew is floor, and belongs to its own
+			// chamber.
+			drawn := 0
+			for _, c := range tombChambers {
+				for col := c.col0; col < c.col0+c.w; col++ {
+					for row := 0; row < tombHeight; row++ {
+						cell := encounter.HexCellAt(o.o, col, row)
+						region, floor := enc.RegionAt(cell)
+						s.Require().True(floor, "%s [%d,%d] -> %v must be floor", c.id, col, row, cell)
+						s.Require().Equal(c.id, region, "and must belong to %s", c.id)
+						drawn++
+					}
+				}
+			}
+			s.Require().Equal(224, drawn, "the tomb is 6+10+12 wide and 8 tall")
+
+			// And NOTHING else is. Swept over the whole canvas, which is where
+			// the 156 phantom cells used to be.
+			canvas, cerr := enc.Canvas()
+			s.Require().NoError(cerr)
+			dims := canvas.GetGrid().GetDimensions()
+
+			floorCells := 0
+			for q := -int(dims.Width); q <= int(dims.Width); q++ {
+				for r := -int(dims.Height); r <= int(dims.Height); r++ {
+					if _, ok := enc.RegionAt(spatial.Position{X: float64(q), Y: float64(r)}); ok {
+						floorCells++
+					}
+				}
+			}
+			s.Equal(224, floorCells,
+				"no cell is floor but undrawn — this counted 380 against the rhombus reading")
+		})
+	}
+}
+
+// TestTheChambersStillKiss — W3's promise, on the authored shape. A seam is
+// only a seam if the cells either side of it are adjacent, and the whole
+// dungeon depends on it: a doorway is an ordinary step between two adjacent
+// absolute cells.
+func (s *OrientationSuite) TestTheChambersStillKiss() {
+	for _, o := range []struct {
+		name string
+		o    encounter.Orientation
+	}{
+		{"pointy-top", encounter.HexesArePointyTop()},
+		{"flat-top", encounter.HexesAreFlatTop()},
+	} {
+		s.Run(o.name, func() {
+			enc, err := s.build(hexTomb(o.o), spatial.Position{X: 0, Y: 0}, "entrance")
+			s.Require().NoError(err)
+
+			canvas, cerr := enc.Canvas()
+			s.Require().NoError(cerr)
+			grid := canvas.GetGrid()
+
+			for _, seam := range []int{5, 15} {
+				adjacent := 0
+				for row := 0; row < tombHeight; row++ {
+					near := encounter.HexCellAt(o.o, seam, row)
+					far := encounter.HexCellAt(o.o, seam+1, row)
+					if grid.Distance(near, far) == 1 {
+						adjacent++
+					}
+				}
+				s.Equal(tombHeight, adjacent,
+					"every row of the seam at %d|%d must kiss, or a doorway is not a step", seam, seam+1)
+			}
+		})
+	}
+}
+
+// TestAFieldSaysWhichWayItsHexesPoint — required exactly where it means
+// something, and refused where it does not.
+//
+// A square grid has no orientation, so declaring one is an author believing
+// something that cannot be true about their own dungeon. Refusing it is the
+// same call [Void] makes about a word this build does not know: the honest
+// answer to a statement with no meaning is not to ignore it.
+func (s *OrientationSuite) TestAFieldSaysWhichWayItsHexesPoint() {
+	s.Run("a hex field must say", func() {
+		field := hexTomb(encounter.HexesArePointyTop())
+		field.Canvas.Orientation = nil
+
+		_, err := s.build(field, spatial.Position{X: 0, Y: 0}, "entrance")
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Contains(strings.ToLower(err.Error()), "orientation")
+	})
+
+	s.Run("a square field must not", func() {
+		field := encounter.FieldInput{
+			Canvas: encounter.CanvasInput{
+				Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop(),
+			},
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 6, Height: 6}},
+		}
+
+		_, err := s.build(field, spatial.Position{X: 1, Y: 1}, "hall")
+		s.Require().ErrorIs(err, encounter.ErrNoField)
+		s.Contains(strings.ToLower(err.Error()), "orientation")
+	})
+
+	s.Run("and a square field is untouched by any of this", func() {
+		field := encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 6, Height: 6}},
+		}
+
+		enc, err := s.build(field, spatial.Position{X: 1, Y: 1}, "hall")
+		s.Require().NoError(err)
+
+		region, floor := enc.RegionAt(spatial.Position{X: 5, Y: 5})
+		s.True(floor)
+		s.Equal("hall", region)
+		_, floor = enc.RegionAt(spatial.Position{X: 6, Y: 5})
+		s.False(floor, "a square room is its rectangle, exactly as it always was")
+	})
+}
+
+// TestTheOrientationSurvivesASave — it is construction truth, and a reload that
+// forgot it would read every stored cell in the wrong frame.
+func (s *OrientationSuite) TestTheOrientationSurvivesASave() {
+	enc, err := s.build(hexTomb(encounter.HexesAreFlatTop()), spatial.Position{X: 0, Y: 0}, "entrance")
+	s.Require().NoError(err)
+
+	data := enc.ToData()
+	s.Equal("flat", data.Field.Canvas.Orientation)
+
+	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{},
+	})
+	s.Require().NoError(err)
+
+	region, floor := back.RegionAt(encounter.HexCellAt(encounter.HexesAreFlatTop(), 20, 6))
+	s.True(floor)
+	s.Equal("tomb", region)
+
+	s.Run("and a hex blob without one is refused by name", func() {
+		d := enc.ToData()
+		d.Field.Canvas.Orientation = ""
+		_, lerr := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Data: d, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+			Initiative: orderAsGiven{},
+		})
+		s.Require().ErrorIs(lerr, encounter.ErrNoField)
+		s.Contains(lerr.Error(), "orientation")
+	})
+
+	s.Run("and one this build has never heard of is too", func() {
+		d := enc.ToData()
+		d.Field.Canvas.Orientation = "sideways"
+		_, lerr := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+			Data: d, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+			Initiative: orderAsGiven{},
+		})
+		s.Require().ErrorIs(lerr, encounter.ErrNoField)
+		s.Contains(lerr.Error(), "sideways")
+	})
+}
+
+// TestTheMapReportsTheOrientation — a host drawing the floor needs it, because
+// the region report says "a Width x Height rectangle anchored here" and that
+// sentence is ambiguous without knowing which way the hexes point.
+func (s *OrientationSuite) TestTheMapReportsTheOrientation() {
+	enc, err := s.build(hexTomb(encounter.HexesArePointyTop()), spatial.Position{X: 0, Y: 0}, "entrance")
+	s.Require().NoError(err)
+
+	atlas, err := enc.Atlas()
+	s.Require().NoError(err)
+	s.Require().NotNil(atlas.Orientation)
+	s.Equal(encounter.OrientationPointyTop, atlas.Orientation.Kind())
+}
+
+// TestChambersThatDoOverlapAreStillRefused — the mask must not buy flat-top's
+// construction by making W2 toothless.
+func (s *OrientationSuite) TestChambersThatDoOverlapAreStillRefused() {
+	for _, o := range []struct {
+		name string
+		o    encounter.Orientation
+	}{
+		{"pointy-top", encounter.HexesArePointyTop()},
+		{"flat-top", encounter.HexesAreFlatTop()},
+	} {
+		s.Run(o.name, func() {
+			field := hexTomb(o.o)
+			// Slide the hall one column west, straight into the entrance.
+			field.Rooms[1].Origin = spatial.Position{X: 5, Y: 0}
+
+			_, err := s.build(field, spatial.Position{X: 0, Y: 0}, "entrance")
+			s.Require().ErrorIs(err, encounter.ErrNoField)
+			s.Contains(err.Error(), "overlap")
+		})
+	}
+}

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -115,9 +115,9 @@ func (s *snapshotSpyDecider) Decide(snap encounter.Snapshot) (encounter.Intent, 
 // the real Atlas after construction, which is what a host would do; this is
 // the same arithmetic for the cases where ordering makes that awkward.
 func doorwaysFrom(field encounter.FieldInput) []encounter.AtlasDoorway {
-	origin := map[string]spatial.Position{}
+	rooms := map[string]encounter.RoomInput{}
 	for _, room := range field.Rooms {
-		origin[room.ID] = room.Origin
+		rooms[room.ID] = room
 	}
 
 	out := make([]encounter.AtlasDoorway, 0, len(field.Connections))
@@ -125,12 +125,30 @@ func doorwaysFrom(field encounter.FieldInput) []encounter.AtlasDoorway {
 		out = append(out, encounter.AtlasDoorway{
 			Connection: c.ID,
 			From:       c.From,
-			FromCell:   c.FromPosition.Add(origin[c.From]),
+			FromCell:   authoredCellAt(field, rooms[c.From], c.FromPosition),
 			To:         c.To,
-			ToCell:     c.ToPosition.Add(origin[c.To]),
+			ToCell:     authoredCellAt(field, rooms[c.To], c.ToPosition),
 		})
 	}
 	return out
+}
+
+// authoredCellAt is a fixture's own copy of the projection the composition
+// spends a room's anchor with — element-wise addition for a square room, and
+// for a hex one the authored offset column and row added FIRST and converted
+// once (rpg-toolkit#1127).
+//
+// A copy rather than a call, because the point of a fixture that builds a
+// decider's map by hand is to compare the composition's answer against
+// arithmetic done independently of it. What it borrows is tools/spatial's
+// conversion, through the exported [encounter.HexCellAt], which belongs to
+// neither side of that comparison.
+func authoredCellAt(field encounter.FieldInput, room encounter.RoomInput, local spatial.Position) spatial.Position {
+	if room.Grid != spatial.GridShapeHex {
+		return local.Add(room.Origin)
+	}
+	return encounter.HexCellAt(field.Canvas.Orientation,
+		int(local.X)+int(room.Origin.X), int(local.Y)+int(room.Origin.Y))
 }
 
 // onceStepDecider intends one step to a fixed absolute cell, then holds

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -150,13 +150,11 @@ func regionAt(
 		if !ok {
 			continue
 		}
-		if !isIntegralAxialPosition(grid, cell.Subtract(ri.Origin)) {
-			continue
-		}
-		// footprintHolds is THE mask (rpg-toolkit#1127): for a square room
-		// the rectangle it always was, for a hex one the authored offset
-		// rectangle rather than the rhombus that contains it.
-		if !footprintHolds(ri, orientation, grids, cell) {
+		// footprintHolds is THE mask (rpg-toolkit#1127), and the only place
+		// this package turns an absolute cell into a room's own frame: for a
+		// square room the rectangle it always was, for a hex one the authored
+		// offset rectangle rather than the rhombus that contains it.
+		if !footprintHolds(ri, orientation, grid, cell) {
 			continue
 		}
 		return ri.ID, true

--- a/rulebooks/dnd5e/encounter/region.go
+++ b/rulebooks/dnd5e/encounter/region.go
@@ -73,7 +73,7 @@ type RegionID = string
 // in absolute space. Standing in one is a fact about the doorway, not about
 // which region holds you.
 func (e *Encounter) RegionAt(cell spatial.Position) (RegionID, bool) {
-	return regionAt(e.fieldInput, e.roomGrids, cell)
+	return regionAt(e.fieldInput, e.roomGrids, e.orientation, cell)
 }
 
 // MembersIn reports who is standing in a region, in the same stable order (and
@@ -142,17 +142,21 @@ func (e *Encounter) MembersIn(region RegionID) ([]Member, error) {
 // so the predicate answers the question it claims to. HEX ONLY: square is
 // fractional-tolerant by design, and a square member standing between cells is
 // really in the region whose span holds them. (Found by Copilot on PR #1109.)
-func regionAt(rooms []RoomInput, grids map[string]spatial.Grid, cell spatial.Position) (RegionID, bool) {
+func regionAt(
+	rooms []RoomInput, grids map[string]spatial.Grid, orientation Orientation, cell spatial.Position,
+) (RegionID, bool) {
 	for _, ri := range rooms {
 		grid, ok := grids[ri.ID]
 		if !ok {
 			continue
 		}
-		local := cell.Subtract(ri.Origin)
-		if !isIntegralAxialPosition(grid, local) {
+		if !isIntegralAxialPosition(grid, cell.Subtract(ri.Origin)) {
 			continue
 		}
-		if !grid.IsValidPosition(local) {
+		// footprintHolds is THE mask (rpg-toolkit#1127): for a square room
+		// the rectangle it always was, for a hex one the authored offset
+		// rectangle rather than the rhombus that contains it.
+		if !footprintHolds(ri, orientation, grids, cell) {
 			continue
 		}
 		return ri.ID, true

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -383,16 +383,27 @@ func (s *RegionSuite) TestRegionAtAnswersExactlyWhatTheAuthoredGridWould() {
 	})
 
 	s.Run("hex", func() {
-		// Hex spans are origin-CENTERED: [-dim/2, dim/2).
+		// A hex chamber is the OFFSET rectangle its author drew
+		// (rpg-toolkit#1127), anchored at its corner — so the oracle is
+		// "convert this cell back to offset and see whether it lands in the
+		// rectangle", which is the same sentence as the square case above in
+		// a frame that has to be converted into.
+		//
+		// This used to read `local.X >= -3 && local.X < 3` and so on, because
+		// a hex room's span was origin-CENTRED. That reading is what put 156
+		// cells of the reference tomb's chambers on the floor that nobody had
+		// drawn.
 		origin := spatial.Position{X: 3, Y: -2}
 		enc := s.oneRoom(spatial.GridShapeHex, 6, 4, origin)
 		for q := -10; q <= 10; q++ {
 			for r := -10; r <= 10; r++ {
 				cell := spatial.Position{X: float64(q), Y: float64(r)}
-				local := cell.Subtract(origin)
-				want := local.X >= -3 && local.X < 3 && local.Y >= -2 && local.Y < 2
+				offset := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}.
+					ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
+				col, row := offset.X-origin.X, offset.Y-origin.Y
+				want := col >= 0 && col < 6 && row >= 0 && row < 4
 				_, ok := enc.RegionAt(cell)
-				s.Require().Equal(want, ok, "hex cell %v (local %v)", cell, local)
+				s.Require().Equal(want, ok, "hex cell %v (authored col,row %v,%v)", cell, col, row)
 			}
 		}
 	})

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -439,12 +439,15 @@ func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
 func (s *RegionSuite) oneRoom(shape spatial.GridShape, w, h int, origin spatial.Position) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
-			{ID: "only", Width: w, Height: h, Grid: shape, Origin: origin},
-		}},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: orientationFor(shape)},
+			Rooms: []encounter.RoomInput{
+				{ID: "only", Width: w, Height: h, Grid: shape, Origin: origin},
+			}},
 		Members: []encounter.MemberInput{
-			// Local (0,0) is a cell in both families: square rooms start
-			// there, hex rooms are centered on it.
+			// Local (0,0) is a cell in both families, and since
+			// rpg-toolkit#1127 it is the same cell in both: the corner a
+			// chamber is counted from. Hex rooms used to be centred on it.
 			{ID: alice, Kind: encounter.KindPlayer, Room: "only", Position: spatial.Position{X: 0, Y: 0}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},

--- a/rulebooks/dnd5e/encounter/step.go
+++ b/rulebooks/dnd5e/encounter/step.go
@@ -246,8 +246,8 @@ func (e *Encounter) stepTo(member *memberRecord, to spatial.Position) (executedA
 // which gate from the Atlas.
 func (e *Encounter) crossingOf(from, to spatial.Position) string {
 	for _, c := range e.connectionsInput {
-		near := c.FromPosition.Add(roomOrigin(e.fieldInput, c.From))
-		far := c.ToPosition.Add(roomOrigin(e.fieldInput, c.To))
+		near := absoluteOf(roomByID(e.fieldInput, c.From), e.orientation, c.FromPosition)
+		far := absoluteOf(roomByID(e.fieldInput, c.To), e.orientation, c.ToPosition)
 		if (near == from && far == to) || (far == from && near == to) {
 			return c.ID
 		}

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -514,7 +514,7 @@ func (s *StepSuite) TestGridReportsTheFieldsFamily() {
 func (s *StepSuite) TestGridReportsAHexFieldAsHex() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Rooms: []encounter.RoomInput{
 			{ID: stepWest, Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 				Origin: stepWestOrigin},
 		}},

--- a/rulebooks/dnd5e/encounter/testwalls_test.go
+++ b/rulebooks/dnd5e/encounter/testwalls_test.go
@@ -195,3 +195,51 @@ func hexSeamWall(atQ, rMin, rMax int, gapRows ...int) []spatial.Boundary {
 	}
 	return out
 }
+
+// hexOffsetSeamWall is hexSeamWall re-derived for the frame a hex chamber is
+// authored in since rpg-toolkit#1127: OFFSET columns and rows, counted from the
+// chamber's own corner.
+//
+// It computes which crossings exist rather than knowing them, and that is the
+// point. In axial space a cell's +Q neighbours are (q+1,r) and (q+1,r-1),
+// always — a fact hexSeamWall could hardcode. In offset space the answer
+// STAGGERS with the column's parity, so a wall built from a hardcoded pair has
+// a hole in every other row. Asking spatial which offset pairs are actually
+// adjacent is both shorter and correct for either orientation.
+//
+// A gap row leaves only the straight crossing open, exactly as squareSeamWall's
+// does, so a doorway is a doorway rather than a diagonal shortcut around its
+// own frame.
+func hexOffsetSeamWall(o encounter.Orientation, atCol, rowMin, rowMax int, gapRows ...int) []spatial.Boundary {
+	gap := make(map[int]bool, len(gapRows))
+	for _, g := range gapRows {
+		gap[g] = true
+	}
+
+	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 1e6, SpanHeight: 1e6})
+
+	out := make([]spatial.Boundary, 0, (rowMax-rowMin+1)*2)
+	for row := rowMin; row <= rowMax; row++ {
+		near := encounter.HexCellAt(o, atCol, row)
+		for _, dr := range []int{-1, 0, 1} {
+			to := row + dr
+			if to < rowMin || to > rowMax {
+				continue
+			}
+			if dr == 0 && gap[row] {
+				continue // the doorway itself
+			}
+			if grid.Distance(near, encounter.HexCellAt(o, atCol+1, to)) != 1 {
+				continue // not a crossing at all on this grid
+			}
+			out = append(out, spatial.Boundary{
+				From:              spatial.Position{X: float64(atCol), Y: float64(row)},
+				To:                spatial.Position{X: float64(atCol + 1), Y: float64(to)},
+				BlocksMovement:    true,
+				BlocksLineOfSight: true,
+			})
+		}
+	}
+
+	return out
+}

--- a/rulebooks/dnd5e/encounter/testwalls_test.go
+++ b/rulebooks/dnd5e/encounter/testwalls_test.go
@@ -169,43 +169,17 @@ func squareSeamWall(atX, height int, gapRows ...int) []spatial.Boundary {
 	return out
 }
 
-// hexSeamWall is squareSeamWall's axial-hex sibling. A hex cell's neighbours
-// across the +Q edge are (q+1,r) and (q+1,r-1) — two crossings per cell, not
-// three — and rows are given as an inclusive [rMin,rMax] range because an axial
-// room's span is origin-centred and its R values are routinely negative.
-func hexSeamWall(atQ, rMin, rMax int, gapRows ...int) []spatial.Boundary {
-	gap := make(map[int]bool, len(gapRows))
-	for _, g := range gapRows {
-		gap[g] = true
-	}
-
-	out := make([]spatial.Boundary, 0, (rMax-rMin+1)*2)
-	for r := rMin; r <= rMax; r++ {
-		for _, dr := range []int{0, -1} {
-			if dr == 0 && gap[r] {
-				continue // the doorway itself
-			}
-			out = append(out, spatial.Boundary{
-				From:              spatial.Position{X: float64(atQ), Y: float64(r)},
-				To:                spatial.Position{X: float64(atQ + 1), Y: float64(r + dr)},
-				BlocksMovement:    true,
-				BlocksLineOfSight: true,
-			})
-		}
-	}
-	return out
-}
-
-// hexOffsetSeamWall is hexSeamWall re-derived for the frame a hex chamber is
-// authored in since rpg-toolkit#1127: OFFSET columns and rows, counted from the
-// chamber's own corner.
+// hexOffsetSeamWall is squareSeamWall's hex sibling, in the frame a hex chamber
+// is authored in since rpg-toolkit#1127: OFFSET columns and rows, counted from
+// the chamber's own corner.
 //
 // It computes which crossings exist rather than knowing them, and that is the
-// point. In axial space a cell's +Q neighbours are (q+1,r) and (q+1,r-1),
-// always — a fact hexSeamWall could hardcode. In offset space the answer
-// STAGGERS with the column's parity, so a wall built from a hardcoded pair has
-// a hole in every other row. Asking spatial which offset pairs are actually
-// adjacent is both shorter and correct for either orientation.
+// point. It replaced an axial version that hardcoded them, which it could: in
+// axial space a cell's +Q neighbours are (q+1,r) and (q+1,r-1), always. In
+// offset space the answer STAGGERS with the column's parity, so a wall built
+// from one hardcoded pair has a hole in every other row. Asking spatial which
+// offset pairs are actually adjacent is both shorter and correct for either
+// orientation.
 //
 // A gap row leaves only the straight crossing open, exactly as squareSeamWall's
 // does, so a doorway is a doorway rather than a diagonal shortcut around its

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -78,6 +78,17 @@ type CanvasInput struct {
 	// sightline. REQUIRED — see [Void] for why there is no default to fall
 	// back on.
 	Void Void
+
+	// Orientation is which way this field's hexes point — REQUIRED for a hex
+	// field, and REFUSED for a square one, which has no orientation to
+	// declare. See [Orientation].
+	//
+	// It sits here rather than on the room because it is a fact about the
+	// MAP: every chamber in one field is drawn on one grid, and a field whose
+	// rooms could disagree about which way its cells point would be a field
+	// whose seams do not meet. That is the same reason W1 gives one grid
+	// family to a whole field rather than one per room.
+	Orientation Orientation
 }
 
 // VoidKind names what void does to a sightline, in the form the story and the
@@ -254,8 +265,9 @@ type canvasRoom struct {
 	// rooms and grids are the SAME slices and maps the encounter holds, so
 	// asking this room what is floor and asking [Encounter.RegionAt] are one
 	// question — see IsLineOfSightBlocked.
-	rooms []RoomInput
-	grids map[string]spatial.Grid
+	rooms       []RoomInput
+	grids       map[string]spatial.Grid
+	orientation Orientation
 
 	// hasVoid is whether this field has any cell no chamber owns — see
 	// fieldHasVoid. Purely a cost decision: where there is no void, opaque and
@@ -273,11 +285,14 @@ type canvasRoom struct {
 // count the same way: an AxialHexGrid of Width x Height holds Width*Height
 // integer (Q,R) pairs, exactly as a square grid holds Width*Height cells.
 //
-// THIS IS NOT THE FLOOR MASK, which Kirk's ruling (4) on rpg-toolkit#1105
-// deferred until a caller forces one. A mask is a per-cell structure with two
-// unanswered questions riding on it — computed per load or persisted, and
-// whether it belongs in tools/spatial — and this is one derived bit, computed
-// from numbers already in hand, never stored and never persisted. The measured
+// IT COUNTS THE MASK, not a rhombus (rpg-toolkit#1127). Width*Height is the
+// authored floor count in BOTH families, because a chamber is an offset
+// rectangle either way and an offset rectangle has exactly Width*Height cells
+// however it shears when it becomes axial. What changed under hex is the other
+// side of the comparison: the canvas span is origin-centred and covers the
+// sheared footprint, so it is much larger than the floor and this reports void
+// where the rhombus reading used to report none. That is the honest answer —
+// see orientation.go for what the rhombus reading was getting wrong. The measured
 // case for it: on a twenty-chamber field whose rooms tile their canvas exactly,
 // deleting this check costs a sight refresh 121 ms against transparent's 30 ms —
 // and 46.7 MB of allocation against 24.2 MB — every byte of it spent proving
@@ -349,7 +364,7 @@ func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 func (c *canvasRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
 	if c.hasVoid && c.void.blocksSight() {
 		for _, cell := range spatial.CanonicalBoundaryRay(c.GetGrid(), from, to) {
-			if _, floor := regionAt(c.rooms, c.grids, cell); !floor {
+			if _, floor := regionAt(c.rooms, c.grids, c.orientation, cell); !floor {
 				return true
 			}
 		}

--- a/rulebooks/dnd5e/encounter/void.go
+++ b/rulebooks/dnd5e/encounter/void.go
@@ -348,19 +348,27 @@ func fieldHasVoid(rooms []RoomInput, width, height int) bool {
 // the two mean the same thing and cost the same (fieldHasVoid, pinned by
 // TestOpaqueCostsNothingWhereThereIsNoVoid).
 //
-// WHERE THERE IS VOID, THIS IS USUALLY CHEAPER THAN NOT DOING IT — measured,
-// because the shape of the cost is not the shape it looks like. Scanning the
-// ray is arithmetic, and the spatial call it can skip rasterizes, walks
-// boundaries, walks blocking entities and then walks a lean lane per neighbour.
-// So finding void EARLY returns before any of that: a twenty-chamber field with
-// gaps refreshed sight 1.6-1.7x FASTER under opaque than under transparent, and
-// reference tomb's shape 1.4-1.6x faster. The price is paid by rays that never
-// leave the floor, which run the scan in full and then delegate anyway: one
-// forty-by-forty chamber with a void margin and forty members measured 1.34x
-// SLOWER. That is the honest worst case, and it is the one to beat if a caller
-// ever forces the floor mask. Ratios rather than times because the times move
-// with the machine and the ratios did not; both are in
-// voidcost_internal_test.go, which is where they are re-runnable.
+// WHERE VOID LIES BETWEEN THE CHAMBERS, THIS IS CHEAPER THAN NOT DOING IT —
+// measured, because the shape of the cost is not the shape it looks like.
+// Scanning the ray is arithmetic, and the spatial call it can skip rasterizes,
+// walks boundaries, walks blocking entities and then walks a lean lane per
+// neighbour. So finding void EARLY returns before any of that: a twenty-chamber
+// square field with gaps refreshed sight 1.7x FASTER under opaque than under
+// transparent, and a three-chamber square field 1.2-1.4x faster.
+//
+// THE PRICE IS PAID BY RAYS THAT NEVER LEAVE THE FLOOR, which run the scan in
+// full and then delegate anyway — and since rpg-toolkit#1127 the worst case is
+// no longer a contrived fixture. The reference tomb is HEX, and a hex canvas
+// holding sheared rectangles is 90.5% void pointy-top, yet opaque measures
+// 1.34-1.40x SLOWER on it: a party of eight in three chambers looks mostly at
+// people in the same chamber, and none of those rays ever reach the void. That
+// is the number to beat if this is ever asked to go faster. (The old worst
+// case, one forty-by-forty square chamber with a void margin, sits at
+// 1.35-1.43x — the same place, for the same reason.)
+//
+// Ratios rather than times because the times move with the machine and the
+// ratios did not; both are in voidcost_internal_test.go, which is where they
+// are re-runnable.
 func (c *canvasRoom) IsLineOfSightBlocked(from, to spatial.Position) bool {
 	if c.hasVoid && c.void.blocksSight() {
 		for _, cell := range spatial.CanonicalBoundaryRay(c.GetGrid(), from, to) {

--- a/rulebooks/dnd5e/encounter/voidcost_internal_test.go
+++ b/rulebooks/dnd5e/encounter/voidcost_internal_test.go
@@ -21,21 +21,34 @@ import (
 //
 //	go test -run XXX -bench BenchmarkSight -benchtime 30x .
 //
-// One run on an AMD 7945HX. Absolute times move with whatever else the machine
-// is doing; the RATIOS held across repeats, and they are the finding:
+// One machine, an AMD 7945HX, re-measured for rpg-toolkit#1127 over -count=3
+// at 300x. Absolute times move with whatever else the machine is doing; the
+// RATIOS held across repeats, and they are the finding:
 //
-//	tomb-shaped, 3 chambers, 8 members   transparent   84us  opaque   53us  1.4-1.6x FASTER
-//	20 chambers with gaps, 60 members    transparent 31.7ms  opaque 18.9ms  1.6-1.7x FASTER
-//	one 40x40 chamber, void margin, 40   transparent  3.1ms  opaque  4.1ms  1.34x slower
-//	20 chambers, canvas tiled, NO void   transparent 29.7ms  opaque 29.6ms  parity
+//	SQUARE, 3 chambers, 8 members        transparent  80-86us  opaque  59-71us  1.2-1.4x FASTER
+//	20 chambers with gaps, 60 members    transparent   37.4ms  opaque   22.2ms  1.7x FASTER
+//	one 40x40 chamber, void margin, 40   transparent 3.0-3.2ms opaque 4.3-4.4ms 1.35-1.43x slower
+//	20 chambers, canvas tiled, NO void   transparent   31.3ms  opaque   29.3ms  parity
+//	HEX reference tomb, pointy, 8        transparent  67-69us  opaque  92-94us  1.34-1.40x slower
+//	HEX reference tomb, flat, 8          (same field) opaque 97-108us  1.06-1.16x the pointy one
 //
-// Where there IS void, opaque is FASTER, which is not the intuition: the scan is
-// arithmetic, and the spatial call it returns before rasterizes, walks
-// boundaries, walks blocking entities and then walks a lean lane per neighbour.
-// Finding void early skips all of that. The price is paid by rays that never
-// leave the floor, which scan in full and delegate anyway — the third row, and
-// the honest worst case. That 1.34x is the number to beat if a caller ever
-// forces the floor mask rpg-toolkit#1105's ruling (4) deferred.
+// Where there IS void BETWEEN the chambers, opaque is FASTER, which is not the
+// intuition: the scan is arithmetic, and the spatial call it returns before
+// rasterizes, walks boundaries, walks blocking entities and then walks a lean
+// lane per neighbour. Finding void early skips all of that. The price is paid
+// by rays that never leave the floor, which scan in full and delegate anyway.
+//
+// THE LAST TWO ROWS ARE THE ONES THAT MATTER NOW, and they were not here
+// before rpg-toolkit#1127 because the field they measure could not be built.
+// The reference tomb is hex, and a hex canvas holding a sheared rectangle is
+// 90.5% void pointy-top, 93.5% flat-top — yet opaque is SLOWER on it, not
+// faster, because a party of eight in three chambers looks mostly at people in
+// the same chamber, and those rays never leave the floor. So the worst case is
+// no longer a contrived margin fixture: it is the shape the game actually runs,
+// at 1.34-1.40x, and it is the number to beat if the floor mask is ever asked
+// to go faster. Flat-top costs a further 6-16% for the same 224 cells of
+// floor — the price of the bigger canvas, and worth knowing before an author
+// picks a layout for looks.
 //
 // The fourth row is the one that was bad, and is the reason fieldHasVoid
 // exists. Deleting its check from IsLineOfSightBlocked and re-running that pair
@@ -76,9 +89,41 @@ func benchField(rooms, dim, stride, anchor int, void Void) FieldInput {
 	return FieldInput{Canvas: CanvasInput{Void: void}, Rooms: ri}
 }
 
+// hexTombField is the REFERENCE TOMB'S OWN SHAPE, in the family the game
+// actually runs on: three hex chambers 6, 10 and 12 columns wide and 8 rows
+// tall, laid left to right (rpg-toolkit#1127).
+//
+// It is here because the mask made this shape possible AND made it expensive
+// in a way no square field is. A chamber is an authored rectangle, which shears
+// into a parallelogram in axial space, while the canvas that must hold it is an
+// origin-centred axial span — so the canvas is far bigger than the floor.
+// Measured: 90.5% void pointy-top, 93.5% flat-top, against 43.2% for the same
+// three chambers read as rhombi. Every square fixture in this file is under
+// 10%, so the ratios above were measured on a field nothing in the game looks
+// like.
+func hexTombField(void Void, o Orientation) FieldInput {
+	widths := []int{6, 10, 12}
+	ri := make([]RoomInput, len(widths))
+	col := 0
+	for i, w := range widths {
+		ri[i] = RoomInput{ID: fmt.Sprintf("r%d", i), Grid: spatial.GridShapeHex,
+			Width: w, Height: 8, Origin: spatial.Position{X: float64(col), Y: 0}}
+		col += w
+	}
+	return FieldInput{Canvas: CanvasInput{Void: void, Orientation: o}, Rooms: ri}
+}
+
 // benchSightRefresh times one full percept rebuild over the whole roster, which
 // is the loop the scan actually runs inside.
 func benchSightRefresh(b *testing.B, rooms, dim, stride, anchor, members int, void Void) {
+	b.Helper()
+	benchSightRefreshOn(b, benchField(rooms, dim, stride, anchor, void), rooms, dim, members)
+}
+
+// benchSightRefreshOn is benchSightRefresh over a field somebody else built —
+// the hex tomb, whose chambers are not all one size and so cannot be described
+// by benchField's rooms/dim/stride triple.
+func benchSightRefreshOn(b *testing.B, field FieldInput, rooms, dim, members int) {
 	b.Helper()
 
 	mi := make([]MemberInput, members)
@@ -90,7 +135,7 @@ func benchSightRefresh(b *testing.B, rooms, dim, stride, anchor, members int, vo
 
 	enc, err := NewEncounter(&SetupInput{
 		Sight: benchSight{1 << 20}, Standing: benchStanding{}, Initiative: benchRoller{},
-		Field:   benchField(rooms, dim, stride, anchor, void),
+		Field:   field,
 		Members: mi,
 		Endings: []EndingInput{{Key: "done", Trigger: TriggerExternal{}}},
 	})
@@ -136,4 +181,21 @@ func BenchmarkSightNoVoidTransparent(b *testing.B) {
 }
 func BenchmarkSightNoVoidOpaque(b *testing.B) {
 	benchSightRefresh(b, 20, 20, 20, 0, 60, VoidIsOpaque())
+}
+
+// The reference tomb in its own family: three hex chambers, a party of eight,
+// on a canvas that is 90% void because a sheared rectangle needs one that big
+// (rpg-toolkit#1127). See hexTombField.
+func BenchmarkSightHexTombTransparent(b *testing.B) {
+	benchSightRefreshOn(b, hexTombField(VoidIsTransparent(), HexesArePointyTop()), 3, 6, 8)
+}
+func BenchmarkSightHexTombOpaque(b *testing.B) {
+	benchSightRefreshOn(b, hexTombField(VoidIsOpaque(), HexesArePointyTop()), 3, 6, 8)
+}
+
+// The same tomb flat-top, which is a different canvas (93.5% void) for the same
+// 224 cells of floor — the price of the other layout, measured rather than
+// assumed.
+func BenchmarkSightHexTombFlatOpaque(b *testing.B) {
+	benchSightRefreshOn(b, hexTombField(VoidIsOpaque(), HexesAreFlatTop()), 3, 6, 8)
 }


### PR DESCRIPTION
Part **A of two** for world-model S5 (#1127). This one makes the geometry honest; **B** is the `dungeonspec` compiler and the forcing case that rides on it.

Kirk's hex ruling — *"flat and pointy top are both valid and should be settable"* — turned out to be unreachable, and finding out why is what this PR is. It also answers ruling (4) on #1105, which deferred the floor mask *until a caller forces it*. This is the caller.

---

## A chamber is the rectangle somebody drew

A hex room's `Width` and `Height` were read as an **axial span** — a rhombus, and an origin-centred one. Authors do not draw rhombi. Every authored dungeon in this project, `reference-tomb.yaml` included, is a run of rectangular chambers in **offset** `[col,row]` coordinates, and an offset rectangle **shears** when it becomes axial: the cells stay a contiguous, non-overlapping set, but the smallest rhombus containing them is strictly bigger than they are.

So one name meant two shapes. `{Width, Height}` now means the one thing everywhere — **the rectangle a human sees on screen** — and square is simply the degenerate case where nothing shears.

## The evidence, re-measured

Every figure this wave had been quoting was inherited rather than run, and **none of them reproduce**. Re-measured against the constructor on the tomb's own three chambers (6, 10, 12 columns wide, 8 rows tall, laid left to right). The harness is [`baseline.sh`](#the-harness) below — it refuses a dirty tree, mutates real source, runs, and restores.

| | rhombus reading | the mask |
|---|---|---|
| pointy-top constructs | **no** — `room "entrance" and room "hall" overlap at absolute cell (1, -4)` | yes |
| flat-top constructs | **no** — same cell, same message | yes |
| authored cells reported as floor | 25 of 224 (pointy) / 24 of 224 (flat) † | **224 of 224** |
| floor reported that nobody drew | **88%** of everything `RegionAt` called floor † | **0** |
| canvas void | 43.2% † | 90.5% pointy / 93.5% flat |

† with W2 disabled, since otherwise the refusal hides the footprint question entirely.

**Neither orientation built.** The claim that pointy-top worked and only flat-top was refused understated it: "both settable" was not merely awkward to honour — *either* alone was out of reach. And the two readings do not merely differ at the edges; they barely overlap.

Three inherited claims are corrected in-tree rather than quietly dropped (`0283886`):

- ~~"pointy-top built and reported 380 floor against 224 drawn — 156 phantom, 41%"~~ → neither built; 88% phantom once observable.
- ~~"flat-top refused at absolute cell (3, -9)"~~ → both refused, at `(1, -4)`.
- ~~"an origin-centred axial span can only be EVEN, so `{Width, Height}` could not express an 11-cell rhombus"~~ → **false**, and it was the paragraph that read most like proof. `axisBounds(11)` is `[-5,5]`: eleven cells. Every `dim` yields exactly `dim` cells, odd included.

## The mask is a function, not a set

Nothing stores a cell list, which answers the first of the two questions ruling (4) left open (*"computed per load, or persisted?"*). A cell is floor iff converting it back to offset space lands inside `[0,Width) x [0,Height)`: one conversion, two comparisons, **O(1)**, from four numbers `RoomData` already carries. Nothing on the wire, nothing in memory.

The second question (*"does it belong in `tools/spatial`?"*) answers itself: there is no new grid type here. `spatial` already owns both directions of the offset↔cube conversion; this is the composition asking them. What lives here is the **rule about which cells a chamber owns**, and that rule's other half is `regionAt` — a second answer to "who owns this cell" is exactly what `region.go` exists to prevent.

W2 keeps the box test as a **fast reject** and decides on **runs**: a sheared rectangle decomposes into contiguous intervals along the axis that does not stagger, so disjointness costs `O(Width)` rather than `O(Width*Height)`. `maxFieldCells` allows four million cells, so "build both footprints and intersect" is a real cost on a legal field.

## What it costs — the void profile, re-measured on the field the game runs

`voidcost_internal_test.go`'s every fixture was **square** and under 10% void, so the profile it published was measured on a field nothing in this game looks like. The reference tomb is hex, and until this PR it could not be constructed at all — which is why the gap went unnoticed rather than unaddressed.

```
SQUARE, 3 chambers, 8 members        transparent  80-86us  opaque  59-71us   1.2-1.4x FASTER
20 chambers with gaps, 60 members    transparent   37.4ms  opaque   22.2ms   1.7x FASTER
one 40x40 chamber, void margin, 40   transparent 3.0-3.2ms opaque 4.3-4.4ms  1.35-1.43x slower
20 chambers, canvas tiled, NO void   transparent   31.3ms  opaque   29.3ms   parity
HEX reference tomb, pointy, 8        transparent  67-69us  opaque  92-94us   1.34-1.40x slower
HEX reference tomb, flat, 8          (same field)          opaque 97-108us   1.06-1.16x the pointy one
```
<sub>AMD 7945HX, `-count=3 -benchtime 300x`. Ratios held across repeats; absolute times move with the machine.</sub>

**The finding reverses on hex.** Opaque is *slower* on a canvas that is 90.5% void, not faster — because a party of eight in three chambers looks mostly at people in the *same* chamber, and those rays never reach the void at all. So the worst case is no longer a contrived margin fixture; it is the shape somebody actually plays, at **1.34–1.40x**, and that is the number to beat if the mask is ever asked to go faster. Flat-top costs a further 6–16% for the same 224 cells of floor — the price of the bigger canvas, worth knowing before an author picks a layout for looks.

`fieldHasVoid` needed no arithmetic change: `Σ(Width*Height)` **is** the exact mask count in both families, because an offset rectangle has exactly `Width*Height` cells however it shears. What changed is the other side of the comparison.

## One projection, and a live defect it was hiding

`absoluteOf` is the one place a room's anchor is spent. Three callers were still adding it in axial, and one of them mattered:

- **`Atlas.Doorways`** built both endpoint cells by axial addition. **A host steers by those cells** — this package's own pursuit decider walks through a door by moving to `AtlasDoorway.ToCell` — so on a hex field it would have steered into the void. Found by mutation; nothing caught it because every fixture reading a doorway off the Atlas is square.
- **`compileEndings`** did the same, and an ending is compared to a live cell by **equality**. A second projection there does not disagree at the edges: it puts the sanctuary tile somewhere no member can ever stand and the encounter simply never ends — the liveness hole `ErrNoEnding` exists to prevent, reached from the inside.
- **`roomOrigin`** was the third and had no callers left at all. Deleted.

## Mutation

29 mutants on the mask's decisions, W2's hex verdict, the conversion, the declaration and the persistence. **22 killed before, 27 after**, and the two survivors are equivalent by construction and named in `2dd1164` so the next battery does not re-litigate them.

It found five real gaps, including the Atlas defect above, and one thing worse than a gap: **`orientation.go`'s doc comments named two tests that had never been written** — `TestOffsetAndAxialAgreeWithSpatial` and `TestRunsAgreeWithEnumeration`. Prose claiming a guarantee nothing checks. Both exist now, and the second earned its keep immediately: `hexRuns` groups cells under a key, and the runs alone are **insensitive to that key's sign** — flip it on both sides and every W2 lookup still matches. `hexFootprintBounds` decodes the key back into an authored row, where the sign is load-bearing, and the mutant flipping it survived the entire public suite. It dies against enumeration.

## No baggage

- `hexSeamWall`, the axial seam-wall helper: no callers left after the fixture migration. Deleted. Its argument survives where it is the point — the axial version *could* hardcode which pairs cross an edge; the offset one cannot, because the answer staggers with the column's parity, so a hardcoded pair leaves a hole in every other row.
- `roomOrigin`: no callers. Deleted.
- The rhombus reading itself, in the one place it was still executable outside the module: the freeroam workbench subtracted `Width/2` to place a hex region.

## Two claims in the vault-chase scene were about the rhombus, and are restated

`continuity_test.go` is re-derived in the authored frame, not nudged (per the rule the migration set itself). Two of its claims were false and one was false *on `main` too*:

- The goblin stood one step from the gate and the comment called its jump to the last-seen cell *"a genuine single-step move, not a room-spanning teleport"*. `Step` does not check adjacency and neither does the pump's `stepTo` — **both say so in their own doc comments** — so that property was never the verb's. It is the fixture's, and the comment now says which.
- The scene twice claimed she was *"in plain view standing in the opening"*. She was not, on `main` either: the pin two beats later (`MonsterMoves[0].To` is the **corridor's** gate cell) is only reachable if the ghost formed there, which means the goblin lost her *at* the threshold. The seam wall leaves exactly one edge open and a watcher off that line sees nothing through it — sight through a doorway is a corridor, not a cone. The placement now says so, and earns the doorway branch of the pursuit decider that carries the scene through.

## Contract docs

`field.go` is where a chamber is **defined**, and the change had never reached it: it still told an author a hex room's bounds were `[-Width/2, Width/2)`. An author following the doc would have written a rhombus and the compiler would have refused it. Rewritten, along with W1's reasoning, W2's (the box test is exact for square and a *fast reject* for hex — the doc claimed it decided), `buildRoomGrid`, `doc.go`'s W6 sentence, and `AtlasRegion.Origin`, which a host reads: it is an **authored** anchor now, absolute only on square.

## Compatibility

`gorelease -base v0.24.0` reports **compatible changes only** and suggests **v0.25.0** — ten additions, nothing removed or re-signed. That is worth stating plainly because it is *misleading*: the break here is in **meaning**, not signature. A hex `RoomInput{Width, Height}` covers a different set of cells than it did, and no tool can see that. The commits carry `!` for it. Pre-1.0, v0.25.0 is the right tag either way.

In-repo consumers pin older versions and are untouched — `resolution` on `v0.21.0`, `session` on `v0.17.0`. Session's adoption is explicitly not in this slice.

## Gates

`gofmt` clean · `go vet` clean · `go test -race -count=1 ./...` green · `golangci-lint` **0 issues at both versions CI pins** (`v2.2.1` as ci-enhanced invokes it with `--config=../.golangci.yml`, and `v2.3.1` as ci-optimized does with default discovery, both from inside the module) · `go mod tidy` no-op · `gorelease` above.

<h3 id="the-harness">The harness</h3>

Both the baseline measurement and the mutation battery **refuse to run against a dirty tree** — they mutate real source and restore with `git checkout --`, which over uncommitted work destroys it. They live outside the repo (this is a measurement, not a deliverable); the mutation list is reproduced in `2dd1164`'s body, and the baseline is three edits: `footprintHolds`' hex branch back to `grid.IsValidPosition`, `roomAbsoluteBounds`' hex branch deleted, and W2's run test deleted.

Refs #1127

— asset-pipeline agent, on behalf of KirkDiggler
