### PR TITLE
feat(session)!: speak the new Atlas — one map of cells, props that say what they are

### DIFF
--- a/rulebooks/dnd5e/session/atlasmap_test.go
+++ b/rulebooks/dnd5e/session/atlasmap_test.go
@@ -39,9 +39,9 @@ func TestAtlasMapSuite(t *testing.T) {
 // order pin written against it passes with the sorting deleted, which is
 // exactly what the first version of this file did.
 func backwardsWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field: encounter.FieldInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "alpha", Width: 4, Height: 4, Origin: spatial.Position{X: 4, Y: 0}},
 				{ID: "beta", Width: 4, Height: 4, Origin: spatial.Position{X: 0, Y: 0}},
@@ -98,9 +98,9 @@ func (s *AtlasMapSuite) atlas() *session.Atlas {
 // instead of passing review.
 func (s *AtlasMapSuite) TestNothingOnTheMapNamesARoom() {
 	s.Equal(
-		[]string{"Grid", "Cells", "Occluders", "Boundaries", "Doorways"},
+		[]string{"Grid", "Cells", "Props", "Boundaries", "Doorways"},
 		fieldsOf(session.Atlas{}),
-		"the map is a grid, its cells, what blocks sight, its walls, and its doorways",
+		"the map is a grid, its cells, the things standing on it, its walls, and its doorways",
 	)
 	s.Equal(
 		[]string{"Connection", "From", "To"},

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -213,6 +213,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		Participants: cast,
 		Initiative:   m.initiative,
 		Standing:     scope.standing,
+		Sight:        sightSeam{},
 		Cost:         price.cost,
 		Machine: resolution.NewStrike(&resolution.StrikeInput{
 			AttackerID: in.Attacker,

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -87,10 +87,10 @@ const duelAC = 12
 // duel delivered to a real stream rather than discarded. One world, so a
 // fixture drift cannot make the two suites disagree about what was swung at.
 func duelWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{},
 		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -348,10 +348,10 @@ func (s *AttackTestSuite) TestAMonsterAttackerIsRefused() {
 	})
 	s.Require().NoError(err)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{},
 		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -414,10 +414,10 @@ func (s *AttackTestSuite) TestAnEmptyHandIsRefused() {
 	})
 	s.Require().NoError(err)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{},
 		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -453,10 +453,10 @@ func (s *AttackTestSuite) TestASheetlessTargetIsRefusedByName() {
 	})
 	s.Require().NoError(err)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{},
 		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -499,10 +499,10 @@ func (s *AttackTestSuite) duelAmong(members []string, sheets ...*character.Data)
 			Position: spatial.Position{X: float64(i + 1), Y: 1},
 		})
 	}
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{},
 		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members:    placed,
 		Endings:    []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 		Retention:  encounter.RetentionUnbounded,

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -239,8 +239,12 @@ func drive(out *bytes.Buffer) error {
 	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
 		Session: "crypt-run", ID: "skel-1",
 		Ref: refs.Monsters.Skeleton().String(),
-		// The vault is anchored at (6,0), so its local (4,5) is (10,5) on
-		// the map — and the map is what this seam speaks.
+		// The vault is anchored at (6,0), so its local (1,1) is (7,1) on the
+		// map — and the map is what this seam speaks. It stands OFF THE
+		// ARCH'S LANE: from the threshold the open gate is a corridor of
+		// sight down row 1 and this is three rows off it, so the approach
+		// sees nothing. Stepping through puts her in the room, where the
+		// lane becomes the whole chamber.
 		Position: spatial.Position{X: 10, Y: 5},
 	})
 	if err != nil {
@@ -256,8 +260,14 @@ func drive(out *bytes.Buffer) error {
 		return err
 	}
 	fmt.Fprintln(out, "\n== the map, in dungeon-absolute space ==")
-	fmt.Fprintf(out, "   one %s map: %d cells, %d of them blocking sight, %d walls\n",
-		atlas.Grid, len(atlas.Cells), len(atlas.Occluders), len(atlas.Boundaries))
+	blocking := 0
+	for _, p := range atlas.Props {
+		if p.BlocksLineOfSight {
+			blocking++
+		}
+	}
+	fmt.Fprintf(out, "   one %s map: %d cells, %d props (%d of them blocking sight), %d walls\n",
+		atlas.Grid, len(atlas.Cells), len(atlas.Props), blocking, len(atlas.Boundaries))
 	for _, d := range atlas.Doorways {
 		fmt.Fprintf(out, "   %s: (%v,%v) kisses (%v,%v)\n",
 			d.Connection, d.From.X, d.From.Y, d.To.X, d.To.Y)
@@ -276,6 +286,21 @@ func drive(out *bytes.Buffer) error {
 	}
 	fmt.Fprintf(out, "   delivered %d events\n", walked.Delivery.Events)
 
+	// SHE DOES NOT REACH THE GATE. The arch is open on row 1, and an opening is
+	// an opening in both directions — the vault can see out of it exactly as
+	// far as somebody can see in. So the contact happens on the APPROACH,
+	// two cells short of the threshold, rather than on the step through it.
+	//
+	// This scene used to walk her to (5,1) and cross to (6,1), with the fight
+	// starting on the crossing. That reading depended on rooms separating
+	// themselves; on one canvas (rpg-toolkit#1127) the only thing that stops a
+	// sightline is something drawn, and nothing is drawn across an open arch.
+	// The same lesson the tomb's forcing case landed on: an arch you are seen
+	// through, a door you are not.
+	if walked.Formed != nil {
+		return fmt.Errorf("the approach should be unseen at torchlight, but a fight started")
+	}
+
 	fmt.Fprintln(out, "\n== and through it, into something waiting ==")
 	// A doorway is a step. The antechamber's threshold is (5,1) and the
 	// vault's is (6,1): one cell apart on the map, so this is a one-step walk
@@ -292,9 +317,7 @@ func drive(out *bytes.Buffer) error {
 	}
 
 	// The doorway is where the fight starts, and the host is told in the same
-	// response that told it about the crossing. There is no window to answer
-	// and no rule for the host to apply: the composition detected the contact,
-	// started the fight, and named the order.
+	// response that told it about the crossing.
 	if crossed.Formed == nil {
 		return fmt.Errorf("expected crossing into the vault to start a fight")
 	}
@@ -358,18 +381,38 @@ func drive(out *bytes.Buffer) error {
 func authoredCrypt() (*encounter.EncounterData, error) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
+		// Geometry decides what is visible, not range — the same position
+		// session takes in v1 (see sightRangeCells). The rubble and the walls
+		// are what this scene is demonstrating; a sight radius would only
+		// confuse which of the two stopped a sightline.
+		Sight: encEveryoneSees{},
 		Field: encounter.FieldInput{
+			// The space between the chambers is ROCK, which is the ordinary
+			// dungeon reading and the one that keeps this scene about the gate:
+			// with transparent void, a watcher could see into the vault around
+			// the doorway rather than through it (rpg-toolkit#1116).
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
-				{ID: "antechamber", Width: 6, Height: 6},
+				{ID: "antechamber", Width: 6, Height: 6,
+					// The seam with the vault, open only on row 1 where the gate
+					// is. Rooms used to imply this: when each chamber had its own
+					// grid, nothing crossed between them except through a declared
+					// doorway. On one canvas (rpg-toolkit#1127) two chambers side
+					// by side are one open space, so without these walls the
+					// skeletons see straight into the antechamber and the fight
+					// starts before anybody walks anywhere.
+					Boundaries: squareSeam(6, 6, 1),
+				},
 				// The vault is split by rubble with one sightline through it at
 				// y=3. Crossing the gate puts alice where both of them can be
 				// seen — sight is a LANE now (spatial v0.9.1), so she looks
 				// past the rubble's corner rather than dead down its file, and
 				// the fight that starts is the whole room's rather than one
 				// skeleton's.
-				{ID: "vault", Width: 6, Height: 6, Origin: spatial.Position{X: 6, Y: 0}, Occluders: []spatial.Position{
-					{X: 2, Y: 0}, {X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 4}, {X: 2, Y: 5},
-				}},
+				{ID: "vault", Width: 6, Height: 6, Origin: spatial.Position{X: 6, Y: 0}, Props: rubble(
+					spatial.Position{X: 2, Y: 0}, spatial.Position{X: 2, Y: 1}, spatial.Position{X: 2, Y: 2},
+					spatial.Position{X: 2, Y: 4}, spatial.Position{X: 2, Y: 5},
+				)},
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "antechamber", To: "vault",
@@ -389,4 +432,70 @@ func authoredCrypt() (*encounter.EncounterData, error) {
 	}
 	data := enc.ToData()
 	return &data, nil
+}
+
+// rubble is the vault's pile of fallen stone, one prop per cell.
+//
+// Both answers are stated rather than defaulted (rpg-toolkit#1033): rubble is
+// climbed over neither — it stops a walker and it stops a sightline — and
+// saying so here is the point, since the same call could describe a coffin
+// (walked around, seen over) by changing one word.
+func rubble(at ...spatial.Position) []encounter.PropInput {
+	blocks := true
+	out := make([]encounter.PropInput, 0, len(at))
+	for _, cell := range at {
+		out = append(out, encounter.PropInput{
+			Ref:               "rubble",
+			At:                cell,
+			BlocksMovement:    &blocks,
+			BlocksLineOfSight: &blocks,
+		})
+	}
+
+	return out
+}
+
+// encEveryoneSees is the workbench's sight capability: unbounded range, so the
+// only thing that hides a member is something drawn on the map.
+// encEveryoneSees gives every member the same torchlit radius.
+type encEveryoneSees struct{}
+
+func (encEveryoneSees) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	out := make(map[encounter.MemberID]int, len(members))
+	for _, id := range members {
+		out[id] = torchlight
+	}
+
+	return out, nil
+}
+
+// torchlight is how far anybody in this crypt can see, in cells.
+//
+// A NUMBER, deliberately, and a small one. The composition refuses to invent
+// this (encounter.ErrNoSight) because sight is per-creature and per-light
+// source, so it asks — and what a scene answers changes what the scene IS.
+// Unbounded, the open arch on row 1 shows the whole vault from halfway down the
+// antechamber and the fight starts before anybody reaches the gate. At two
+// cells the crypt is lit by what the party carries, which is the story this
+// workbench is telling.
+const torchlight = 1_000_000
+
+// squareSeam is the wall between two side-by-side square chambers, with one row
+// left open for the doorway. Room-local to the WEST chamber, where column
+// width-1 is its last and column width is the east chamber's first.
+func squareSeam(width, rows, openRow int) []spatial.Boundary {
+	out := make([]spatial.Boundary, 0, rows)
+	for row := 0; row < rows; row++ {
+		if row == openRow {
+			continue // the gate itself
+		}
+		out = append(out, spatial.Boundary{
+			From:              spatial.Position{X: float64(width - 1), Y: float64(row)},
+			To:                spatial.Position{X: float64(width), Y: float64(row)},
+			BlocksMovement:    true,
+			BlocksLineOfSight: true,
+		})
+	}
+
+	return out
 }

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -286,17 +286,13 @@ func drive(out *bytes.Buffer) error {
 	}
 	fmt.Fprintf(out, "   delivered %d events\n", walked.Delivery.Events)
 
-	// SHE DOES NOT REACH THE GATE. The arch is open on row 1, and an opening is
-	// an opening in both directions — the vault can see out of it exactly as
-	// far as somebody can see in. So the contact happens on the APPROACH,
-	// two cells short of the threshold, rather than on the step through it.
-	//
-	// This scene used to walk her to (5,1) and cross to (6,1), with the fight
-	// starting on the crossing. That reading depended on rooms separating
-	// themselves; on one canvas (rpg-toolkit#1127) the only thing that stops a
-	// sightline is something drawn, and nothing is drawn across an open arch.
-	// The same lesson the tomb's forcing case landed on: an arch you are seen
-	// through, a door you are not.
+	// SHE REACHES THE GATE UNSEEN, and that is a claim about LIGHT rather than
+	// about walls. The arch on row 1 is open, and an opening is an opening in
+	// both directions — the vault can see out of it exactly as far as somebody
+	// can see in — so nothing here hides her except the range of what she
+	// carries. At session's four cells the skeleton is out of it until she is
+	// through; unbounded, this fight starts halfway down the antechamber and
+	// bob joins it from the far room. See sightRangeCells.
 	if walked.Formed != nil {
 		return fmt.Errorf("the approach should be unseen at torchlight, but a fight started")
 	}
@@ -381,10 +377,10 @@ func drive(out *bytes.Buffer) error {
 func authoredCrypt() (*encounter.EncounterData, error) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		// Geometry decides what is visible, not range — the same position
-		// session takes in v1 (see sightRangeCells). The rubble and the walls
-		// are what this scene is demonstrating; a sight radius would only
-		// confuse which of the two stopped a sightline.
+		// Governs THIS construction only: once session loads the world it
+		// supplies its own sight seam, so the walk below runs on session's
+		// answer rather than this one. Matched to it anyway, so the scene
+		// reads the same however it is entered.
 		Sight: encEveryoneSees{},
 		Field: encounter.FieldInput{
 			// The space between the chambers is ROCK, which is the ordinary
@@ -455,30 +451,29 @@ func rubble(at ...spatial.Position) []encounter.PropInput {
 	return out
 }
 
-// encEveryoneSees is the workbench's sight capability: unbounded range, so the
-// only thing that hides a member is something drawn on the map.
-// encEveryoneSees gives every member the same torchlit radius.
+// encEveryoneSees gives every member the same sight radius.
 type encEveryoneSees struct{}
 
 func (encEveryoneSees) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
 	out := make(map[encounter.MemberID]int, len(members))
 	for _, id := range members {
-		out[id] = torchlight
+		out[id] = sightRadius
 	}
 
 	return out, nil
 }
 
-// torchlight is how far anybody in this crypt can see, in cells.
+// sightRadius is how far anybody in this crypt can see, in cells.
 //
-// A NUMBER, deliberately, and a small one. The composition refuses to invent
-// this (encounter.ErrNoSight) because sight is per-creature and per-light
-// source, so it asks — and what a scene answers changes what the scene IS.
-// Unbounded, the open arch on row 1 shows the whole vault from halfway down the
-// antechamber and the fight starts before anybody reaches the gate. At two
-// cells the crypt is lit by what the party carries, which is the story this
-// workbench is telling.
-const torchlight = 1_000_000
+// Four, matching session's own answer (sightRangeCells) so this scene behaves
+// the same whether it is driven through session or built directly here. Twenty
+// feet at five feet to the cell: a torch's bright light.
+//
+// It is a NUMBER and not a shrug. Unbounded, the open arch on row 1 shows the
+// whole vault from halfway down the antechamber, the fight starts before
+// anybody reaches the gate, and bob — whose entire purpose in this scene is to
+// keep exploring while alice fights — is pulled into it from the far room.
+const sightRadius = 4
 
 // squareSeam is the wall between two side-by-side square chambers, with one row
 // left open for the doorway. Room-local to the WEST chamber, where column

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -59,13 +59,22 @@ func projectGrid(shape spatial.GridShape) GridKind {
 func projectAtlas(in encounter.Atlas) Atlas {
 	out := Atlas{Doorways: make([]AtlasDoorway, 0, len(in.Doorways))}
 
-	for _, room := range in.Rooms {
-		// W1: every room in a field shares one grid family, so the last
+	for _, region := range in.Regions {
+		// W1: every region in a field shares one grid family, so the last
 		// writer wins and every writer agrees.
-		out.Grid = projectGrid(room.Grid)
-		out.Cells = append(out.Cells, room.Cells...)
-		out.Occluders = append(out.Occluders, room.Occluders...)
-		for _, b := range room.Boundaries {
+		out.Grid = projectGrid(region.Grid)
+		out.Cells = append(out.Cells, regionCells(region, in.Orientation)...)
+
+		for _, prop := range region.Props {
+			out.Props = append(out.Props, AtlasProp{
+				Ref:               prop.Ref,
+				At:                prop.At,
+				BlocksMovement:    prop.BlocksMovement,
+				BlocksLineOfSight: prop.BlocksLineOfSight,
+			})
+		}
+
+		for _, b := range region.Boundaries {
 			out.Boundaries = append(out.Boundaries, AtlasBoundary{
 				From:              b.From,
 				To:                b.To,
@@ -76,7 +85,12 @@ func projectAtlas(in encounter.Atlas) Atlas {
 	}
 
 	sortCells(out.Cells)
-	sortCells(out.Occluders)
+	sort.Slice(out.Props, func(i, j int) bool {
+		if out.Props[i].At != out.Props[j].At {
+			return before(out.Props[i].At, out.Props[j].At)
+		}
+		return out.Props[i].Ref < out.Props[j].Ref
+	})
 	sort.Slice(out.Boundaries, func(i, j int) bool {
 		if out.Boundaries[i].From != out.Boundaries[j].From {
 			return before(out.Boundaries[i].From, out.Boundaries[j].From)
@@ -90,6 +104,47 @@ func projectAtlas(in encounter.Atlas) Atlas {
 			From:       d.FromCell,
 			To:         d.ToCell,
 		})
+	}
+
+	return out
+}
+
+// regionCells enumerates the cells a region owns, in dungeon-absolute space.
+//
+// A region describes itself as "a Width x Height rectangle anchored HERE"
+// rather than by listing cells (rpg-toolkit#1127), which is the whole reason
+// [encounter.Atlas] reports an Orientation: on hex, the same rectangle covers
+// a different set of cells under each layout, so the frame is not optional.
+//
+// # Why the anchor is added in OFFSET space
+//
+// An authored rectangle SHEARS when it becomes axial. Adding the anchor in
+// axial instead would put that shear back one level up — two chambers anchored
+// six columns apart would land at axial distances that vary by row. Three
+// callers inside the composition got this wrong before #1131 found them, so
+// this is not a hypothetical: it is the arithmetic with a track record.
+//
+// This is a SECOND implementation of a projection the composition also owns,
+// which is a thing worth being nervous about. It is kept honest rather than
+// trusted: TestEveryProjectedCellIsOwnedByItsRegion asks the composition's own
+// RegionAt about every cell this produces, so the two answers cannot drift
+// apart without a test failing. If the composition ever exports the
+// enumeration itself, this should be deleted in favour of it.
+func regionCells(r encounter.AtlasRegion, o encounter.Orientation) []spatial.Position {
+	out := make([]spatial.Position, 0, r.Width*r.Height)
+
+	for row := 0; row < r.Height; row++ {
+		for col := 0; col < r.Width; col++ {
+			if r.Grid == spatial.GridShapeHex {
+				out = append(out, encounter.HexCellAt(o, col+int(r.Origin.X), row+int(r.Origin.Y)))
+				continue
+			}
+
+			out = append(out, spatial.Position{
+				X: r.Origin.X + float64(col),
+				Y: r.Origin.Y + float64(row),
+			})
+		}
 	}
 
 	return out

--- a/rulebooks/dnd5e/session/convert_test.go
+++ b/rulebooks/dnd5e/session/convert_test.go
@@ -49,7 +49,7 @@ var projectedPairs = []struct {
 	// every field of a room accounted for: the ones that survive match by
 	// name, and the four that describe a room AS a room have to be justified
 	// below rather than quietly disappearing with the type that held them.
-	{"AtlasRoom folded into Atlas", encounter.AtlasRoom{}, session.Atlas{}},
+	{"AtlasRoom folded into Atlas", encounter.AtlasRegion{}, session.Atlas{}},
 	{"AtlasBoundary", encounter.AtlasBoundary{}, session.AtlasBoundary{}},
 	{"AtlasDoorway", encounter.AtlasDoorway{}, session.AtlasDoorway{}},
 	{"Status", encounter.Status{}, session.Status{}},
@@ -73,18 +73,42 @@ var omitted = map[string]string{
 	// The seam speaks ONE MAP (rpg-project#227). The composition keeps rooms
 	// and projects the absolute geometry out of them; by the time a map
 	// reaches a client the decomposition has done its job.
-	"encounter.Atlas.Rooms":  "the decomposition itself — folded into the flat Cells/Occluders/Boundaries",
-	"encounter.AtlasRoom.ID": "a room id, which is exactly what the one-map seam stops carrying",
-	"encounter.AtlasRoom.Origin": "an anchor exists to project room-local coordinates, and nothing " +
+	"encounter.Atlas.Regions":  "the decomposition itself — folded into the flat Cells/Props/Boundaries",
+	"encounter.AtlasRegion.ID": "a room id, which is exactly what the one-map seam stops carrying",
+	"encounter.AtlasRegion.Origin": "an anchor exists to project room-local coordinates, and nothing " +
 		"on this side has one left to project",
-	"encounter.AtlasRoom.Width":  "a room's span; the map's extent is the extent of Cells",
-	"encounter.AtlasRoom.Height": "a room's span; the map's extent is the extent of Cells",
+	"encounter.AtlasRegion.Width":  "a room's span; the map's extent is the extent of Cells",
+	"encounter.AtlasRegion.Height": "a room's span; the map's extent is the extent of Cells",
+
+	// The frame, and the reason it does not need to cross.
+	//
+	// A region describes itself as a rectangle, and on hex the same rectangle
+	// covers different cells under each layout — so the composition reports an
+	// Orientation for a host that walks the rectangle itself
+	// (rpg-toolkit#1127). This seam does not hand out rectangles. It enumerates
+	// the cells and sends those, so a client never does the conversion and
+	// never needs the frame it would be done in. Carrying it would be handing
+	// over the tool for a job nobody on that side has.
+	"encounter.Atlas.Orientation": "the hex frame for turning a rectangle into cells; this seam sends " +
+		"the CELLS, so a client never performs that conversion",
 
 	// Placement answers a cell, not a chamber (rpg-toolkit#1046). The room is
 	// the composition's own decomposition, and a caller that wanted it would
 	// be reconstructing the frame the reshape removed.
-	"encounter.Member.Room":        "a room id; the seam reports the cell instead",
-	"encounter.MemberOutcome.Room": "a room id; the composition's own bookkeeping — Position already names the cell on the map",
+	// Renamed from Room to Region when chambers became named regions of one
+	// canvas (rpg-toolkit#1127). The omission survives the rename, and it is
+	// the one worth arguing with: a region is now an AUTHORED name — "the
+	// hall", "the tomb" — rather than the incidental grouping it was when this
+	// entry was written. Telling a player which room they are standing in is a
+	// reasonable thing for a client to want.
+	//
+	// It stays omitted because a region id alone is not usable without the
+	// membership map that says which cells belong to it, and handing THAT over
+	// is handing back the decomposition this seam exists to flatten. If a
+	// client needs the name, the shape to give it is per-cell and
+	// viewer-authorised, not a global map.
+	"encounter.Member.Region":        "a region id; the seam reports the cell instead",
+	"encounter.MemberOutcome.Region": "a region id; the composition's own bookkeeping — Position already names the cell on the map",
 
 	// A doorway's endpoints kept their meaning and lost their qualifier: on one
 	// map there is no second pair of From/To fields naming rooms to

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -66,10 +66,10 @@ func cryptWorld(t fataler) *encounter.EncounterData {
 		occluders = append(occluders, spatial.Position{X: 5, Y: float64(y)})
 	}
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{}, Standing: encEveryoneStanding{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
-			{ID: "crypt", Width: 10, Height: 10, Occluders: occluders},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
+			{ID: "crypt", Width: 10, Height: 10, Props: occludingProps(occluders...)},
 		}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},

--- a/rulebooks/dnd5e/session/economy_test.go
+++ b/rulebooks/dnd5e/session/economy_test.go
@@ -100,10 +100,10 @@ func aFight(
 		t.Fatalf("building manager: %v", err)
 	}
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{},
 		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: encounter.MemberID(alice.ID), Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 		},

--- a/rulebooks/dnd5e/session/entities_test.go
+++ b/rulebooks/dnd5e/session/entities_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
-	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // EntitiesTestSuite covers loading a character through the host's repository:
@@ -51,7 +50,7 @@ func (s *EntitiesTestSuite) SetupSubTest() { s.SetupTest() }
 func (s *EntitiesTestSuite) joinBob() (*session.JoinOutput, error) {
 	return s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 }
 
@@ -92,7 +91,7 @@ func (s *EntitiesTestSuite) TestSpeedIsDerivedRatherThanDefaulted() {
 
 	humanOut, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "human-one",
-		Position: spatial.Position{X: 7, Y: 0},
+		Position: hexCell(3, 2),
 	})
 	s.Require().NoError(err)
 
@@ -107,7 +106,7 @@ func (s *EntitiesTestSuite) TestSpeedIsDerivedRatherThanDefaulted() {
 func (s *EntitiesTestSuite) TestJoiningAPlayerWithNoCharacterIsRejected() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "nobody",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrNoCharacter)
@@ -132,7 +131,7 @@ func (s *EntitiesTestSuite) TestJoiningAPlayerWithNoCharacterIsRejected() {
 func (s *EntitiesTestSuite) TestARejectedJoinPlacesNobody() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "nobody",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 	s.Require().Error(err)
 
@@ -174,7 +173,7 @@ func (s *EntitiesTestSuite) TestSpawnedContentIsNeverLookedUpAsACharacter() {
 
 	out, err := s.mgr.Spawn(context.Background(), &session.SpawnInput{
 		Session: "sess", ID: "ogre-7", Ref: refs.Monsters.Skeleton().String(),
-		Position: spatial.Position{X: 7, Y: 0},
+		Position: hexCell(3, 2),
 	})
 	s.Require().NoError(err, "content that lives in code needs no stored sheet")
 	s.Require().NotNil(out.NPC)
@@ -194,7 +193,7 @@ func (s *EntitiesTestSuite) TestSpawnedContentIsNeverLookedUpAsACharacter() {
 func (s *EntitiesTestSuite) TestAMonsterCannotJoin() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "ogre-7",
-		Position: spatial.Position{X: 7, Y: 0},
+		Position: hexCell(3, 2),
 	})
 	s.ErrorIs(err, session.ErrNoCharacter)
 }
@@ -219,7 +218,7 @@ func (s *EntitiesTestSuite) TestEveryPlayerJoinConsultsTheRepository() {
 
 	_, err = s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "carol",
-		Position: spatial.Position{X: 7, Y: 0},
+		Position: hexCell(3, 2),
 	})
 	s.Require().NoError(err)
 	s.Greater(s.characters.loads, first, "a second join must load again, not reuse")
@@ -238,7 +237,7 @@ func (s *EntitiesTestSuite) TestARepositoryReportingSuccessWithNoDataIsRejected(
 
 	_, err = mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrBadRepository)
@@ -264,7 +263,7 @@ func (s *EntitiesTestSuite) TestACorruptConditionIsDroppedRatherThanRejected() {
 
 	out, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "corrupt-one",
-		Position: spatial.Position{X: 7, Y: 0},
+		Position: hexCell(3, 2),
 	})
 
 	s.Require().NoError(err, "upstream currently swallows this; if that changes, so must this test")
@@ -323,7 +322,7 @@ func BenchmarkJoinPlayer(b *testing.B) {
 
 		if _, err := mgr.Join(ctx, &session.JoinInput{
 			Session: "sess", Member: "bob",
-			Position: spatial.Position{X: 6, Y: 0},
+			Position: hexCell(2, 2),
 		}); err != nil {
 			b.Fatalf("join: %v", err)
 		}
@@ -339,7 +338,7 @@ func BenchmarkSpawnMonster(b *testing.B) {
 
 		if _, err := mgr.Spawn(ctx, &session.SpawnInput{
 			Session: "sess", ID: "ogre-7", Ref: refs.Monsters.Skeleton().String(),
-			Position: spatial.Position{X: 6, Y: 0},
+			Position: hexCell(2, 2),
 		}); err != nil {
 			b.Fatalf("spawn: %v", err)
 		}

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -149,21 +149,19 @@ var (
 	// leaves the party somewhere nobody chose.
 	ErrBrokenPath = errors.New("path is not a walk")
 
-	// ErrNoCrossing is returned by Move when a step lands in another room and
-	// no doorway joins it to the cell the walker is standing on.
+	// ErrLocked is returned when a door refuses to open because it is locked.
 	//
-	// Distinct from ErrBrokenPath, which means the two cells are not adjacent
-	// at all. These are different author mistakes: a broken path is arithmetic
-	// a caller can check against the map it already has, while two rooms may
-	// TOUCH without a door between them (W2 permits it), so a pair of cells can
-	// be perfectly adjacent and still have nothing to walk through. That second
-	// case is invisible to a client reading only the Atlas's cells — it is in
-	// the doorway list or it is nowhere — which is exactly why it earns a
-	// sentinel of its own rather than being folded into "not a walk".
+	// A fiction beat, not a defect: the party found the way and the way is
+	// shut, which is a thing to tell a player and a reason to go looking for a
+	// key or roll against the DC. It earns a sentinel of its own for that
+	// reason — a host that could only see "bad position" would have nothing to
+	// say and would send somebody hunting a bug in coordinates that are fine.
 	//
-	// Distinct from ErrBadPosition too: "there is no cell there" and "there is
-	// no way there from here" send whoever reads them to different places.
-	ErrNoCrossing = errors.New("no doorway joins those cells")
+	// NOT yet raised for a walk INTO a locked door. The composition refuses
+	// that with a placement error carrying the door's state as text only, so a
+	// blocked step still arrives here as ErrBadPosition (rpg-toolkit#1135).
+	// This is the translation of the door verb's own refusal until then.
+	ErrLocked = errors.New("door is locked")
 
 	// ErrNoConnection is the translation of a composition-side refusal to cross
 	// a doorway.

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -172,8 +172,6 @@ func kindOf(payload []byte) EventKind {
 	switch beat.Beat {
 	case "moved":
 		return EventMoved
-	case "traversed":
-		return EventTraversed
 	case "joined":
 		return EventJoined
 	case "exited":

--- a/rulebooks/dnd5e/session/events_test.go
+++ b/rulebooks/dnd5e/session/events_test.go
@@ -46,9 +46,9 @@ func (s *EventsTestSuite) SetupTest() {
 // twoRoomParty puts alice and dave in the corridor and carol in the sealed
 // vault, so one member is genuinely unable to perceive what the others do.
 func twoRoomParty(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field: encounter.FieldInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "corridor", Width: 8, Height: 8},
 				{ID: "vault", Width: 8, Height: 8, Origin: spatial.Position{X: 20, Y: 0}},

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -182,9 +182,9 @@ func (panicFataler) Fatalf(format string, args ...any) {
 // authoredTomb is content, not a live encounter: the blob a host would have
 // sitting in storage from an authoring pipeline.
 func authoredTomb() *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field:    encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 		},

--- a/rulebooks/dnd5e/session/fight_starts_test.go
+++ b/rulebooks/dnd5e/session/fight_starts_test.go
@@ -107,10 +107,10 @@ func buildAmbush(t fataler, alice spatial.Position, extra ...encounter.MemberInp
 	}
 	members = append(members, extra...)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
-			{ID: "hall", Width: 8, Height: 8, Occluders: occluders},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
+			{ID: "hall", Width: 8, Height: 8, Props: occludingProps(occluders...)},
 		}},
 		Members: members,
 		Endings: []encounter.EndingInput{

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.17.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.26.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,10 +18,10 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.17.0 h1:jEt9/1IXGFULEKWxJUbj388m51utDClG1WoT5mR7Xx8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.17.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0 h1:ua6yx4VVYHANoiQtf1vqO84e1ulli9ywss8G+5vnhj0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.9.0/go.mod h1:GpAKS7PrFBK2aUsHbAOJt/Z7djlDzmmlMuloyGq2XKs=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.26.0 h1:wCxquvgbv4Ni2/aGcwlMy0VzS8a375MdNNVpRNFRuMM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.26.0/go.mod h1:1qaWyNBiHhFgB6Yf/7TD0i/9bCFUL+mLruHYNxEcIqM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 h1:ZBHWR+o9pwpTRSEEnkFPDsj+h5htLa8N8Ywhspglc44=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0/go.mod h1:wANmNP7YRPCvm2Qj/EpT0026fSX6TkqLk1xvkkNHF80=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/move_internal_test.go
+++ b/rulebooks/dnd5e/session/move_internal_test.go
@@ -42,9 +42,9 @@ func (walkEveryoneStanding) Standing(_ []encounter.MemberID) ([]encounter.Member
 func walkWorld(t *testing.T, family spatial.GridShape) *encounter.Encounter {
 	t.Helper()
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: sightSeam{},
 		Initiative: walkOrderAsGiven{}, Standing: walkEveryoneStanding{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: canvasFor(family), Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 4, Height: 4, Grid: family, Origin: spatial.Position{X: 30, Y: 40}},
 			{ID: "annex", Width: 12, Height: 12, Grid: family, Origin: spatial.Position{X: 60, Y: 40}},
 		}},
@@ -128,4 +128,19 @@ func TestStandsAtReadsTheRosterRow(t *testing.T) {
 func TestStandsAtRefusesSomebodyWhoIsNotHere(t *testing.T) {
 	_, err := standsAt(walkWorld(t, spatial.GridShapeSquare), "nobody")
 	require.ErrorIs(t, err, ErrNoMember)
+}
+
+// canvasFor declares the canvas a walkWorld of this family needs.
+//
+// Orientation is REQUIRED on hex and must be absent on square: the composition
+// refuses a hex field that does not say which way its hexes point, because the
+// same authored rectangle covers different cells under each layout
+// (rpg-toolkit#1127). Square has no such choice to make.
+func canvasFor(family spatial.GridShape) encounter.CanvasInput {
+	canvas := encounter.CanvasInput{Void: encounter.VoidIsOpaque()}
+	if family == spatial.GridShapeHex {
+		canvas.Orientation = encounter.HexesArePointyTop()
+	}
+
+	return canvas
 }

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -43,9 +43,9 @@ func (s *MoveTestSuite) SetupTest() {
 // three steps to her east — near enough to walk onto, far enough that a walk
 // can be interrupted before reaching it.
 func corridorWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field:    encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -216,9 +216,9 @@ func (s *MoveTestSuite) TestHexAdjacencyUsesCubeDistance() {
 	// And a genuine hex neighbour is accepted, so the check is not simply
 	// rejecting everything.
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
-		Session: "hex", Member: "alice", Path: []spatial.Position{{X: 1, Y: 0}},
+		Session: "hex", Member: "alice", Path: []spatial.Position{hexCell(1, 0)},
 	})
-	s.Require().NoError(err, "axial (1,0) is a real neighbour and must be walkable")
+	s.Require().NoError(err, "the next column along is a real neighbour and must be walkable")
 	s.Len(out.Steps, 1)
 }
 
@@ -270,11 +270,13 @@ func (s *MoveTestSuite) TestAWalkCrossesTheDoorway() {
 
 	out, err := s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
-		Path: []spatial.Position{{X: 1, Y: 0}, {X: 2, Y: 0}, {X: 3, Y: 0}},
+		Path: []spatial.Position{
+			hexCell(1, 0), hexCell(2, 0), hexCell(3, 0), hexCell(4, 0), hexCell(5, 0), hexCell(6, 0),
+		},
 	})
 	s.Require().NoError(err, "the doorway is a step like any other")
-	s.Require().Len(out.Steps, 3, "two in the corridor, one through the gate")
-	s.Equal(spatial.Position{X: 3, Y: 0}, out.Steps[2].Position, "she is on the far side")
+	s.Require().Len(out.Steps, 6, "five along the corridor, one through the gate")
+	s.Equal(hexCell(6, 0), out.Steps[5].Position, "she is on the far side, in the vault")
 	s.NotZero(out.Steps[2].Seq)
 }
 
@@ -283,9 +285,17 @@ func (s *MoveTestSuite) TestAWalkCrossesTheDoorway() {
 //
 // A caller can no longer name a connection, so "no such connection" is not a
 // mistake it can make. What it CAN do is name a cell in the next room with
-// nothing joining it to where the walker stands — and that has its own
-// refusal, because two rooms touching without a door is a thing W2 allows and
-// a client reading only the map's cells cannot see.
+// nothing joining it to where the walker stands — two rooms touching without a
+// door is a thing W2 allows, and a client reading only the map's cells cannot
+// see it coming.
+//
+// That refusal USED TO HAVE ITS OWN SENTINEL. It no longer does: the
+// composition answers a blocked step with a placement refusal carrying the
+// reason as text, so "there is no cell there" and "there is no way there from
+// here" now arrive as the same thing. The step is still refused — that is what
+// this test protects — but a host can no longer tell a wall from a typo.
+// rpg-toolkit#1135 is what would give the distinction a source again, and when
+// it lands the assertion below should get sharper, not disappear.
 func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
 	ctx := context.Background()
 	_, err := s.mgr.StartSession(ctx, &session.StartSessionInput{
@@ -296,7 +306,9 @@ func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
 	// Alice walks to the threshold itself.
 	_, err = s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
-		Path: []spatial.Position{{X: 1, Y: 0}, {X: 2, Y: 0}},
+		Path: []spatial.Position{
+			hexCell(1, 0), hexCell(2, 0), hexCell(3, 0), hexCell(4, 0), hexCell(5, 0),
+		},
 	})
 	s.Require().NoError(err)
 
@@ -305,12 +317,16 @@ func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
 	// doorway is at (3,0), one cell over.
 	_, err = s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
-		Path: []spatial.Position{{X: 3, Y: -1}},
+		// The vault's column 6, one row down: a real cell, a genuine neighbour
+		// of the threshold she is standing on, and joined to it by nothing —
+		// the gate is on row 0.
+		Path: []spatial.Position{hexCell(6, 1)},
 	})
 	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrNoCrossing)
 	s.NotErrorIs(err, session.ErrBrokenPath, "the cells ARE adjacent — that is the point")
-	s.NotErrorIs(err, session.ErrBadPosition, "and the cell exists; there is just no way through")
+	s.ErrorIs(err, session.ErrBadPosition,
+		"currently the only answer available: the composition does not distinguish "+
+			"a walled crossing from a cell that is not there (rpg-toolkit#1135)")
 }
 
 // TestAWalkComesBackThroughTheSameDoorway pins the direction a fixture will not
@@ -334,30 +350,32 @@ func (s *MoveTestSuite) TestAWalkComesBackThroughTheSameDoorway() {
 	})
 	s.Require().NoError(err)
 
-	// Out: the corridor is anchored at the origin, the vault at (6,0), and the
-	// gate joins corridor-local (2,0) to vault-local (-3,0) — absolute (2,0)
-	// and (3,0), one axial step apart.
+	// Out: the corridor owns authored columns 0..5 and the vault 6..11, and the
+	// gate joins the corridor's last column to the vault's first on row 0 —
+	// one step apart on the map, however far apart their columns read.
 	out, err := s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
-		Path: []spatial.Position{{X: 1, Y: 0}, {X: 2, Y: 0}, {X: 3, Y: 0}},
+		Path: []spatial.Position{
+			hexCell(1, 0), hexCell(2, 0), hexCell(3, 0), hexCell(4, 0), hexCell(5, 0), hexCell(6, 0),
+		},
 	})
 	s.Require().NoError(err)
-	s.Require().Len(out.Steps, 3, "the walk ran to the end: nothing here stops it")
+	s.Require().Len(out.Steps, 6, "the walk ran to the end: nothing here stops it")
 	s.Require().Nil(out.Outcome, "and nothing ended underfoot")
-	s.Equal(spatial.Position{X: 3, Y: 0}, out.Steps[2].Position, "the far side, in the vault")
+	s.Equal(hexCell(6, 0), out.Steps[5].Position, "the far side, in the vault")
 
 	// And back, against the direction the connection was declared in.
 	back, err := s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
-		Path: []spatial.Position{{X: 2, Y: 0}},
+		Path: []spatial.Position{hexCell(5, 0)},
 	})
 	s.Require().NoError(err, "a doorway is crossable both ways")
 	s.Require().Len(back.Steps, 1)
-	s.Equal(spatial.Position{X: 2, Y: 0}, back.Steps[0].Position)
+	s.Equal(hexCell(5, 0), back.Steps[0].Position)
 
 	where, err := s.mgr.Where(ctx, &session.WhereInput{Session: "hex", Member: "alice"})
 	s.Require().NoError(err)
-	s.Equal(spatial.Position{X: 2, Y: 0}, where.Position,
+	s.Equal(hexCell(5, 0), where.Position,
 		"standing back on the corridor threshold, read cold")
 }
 
@@ -388,7 +406,7 @@ func (s *MoveTestSuite) TestAStepOntoNoCellUsesOurSentinelNotTheirs() {
 	// Demoting the inner error must cost its MESSAGE nothing: whoever debugs
 	// this still needs to know it was owned by no room rather than, say, a
 	// fractional hex cell.
-	s.Contains(err.Error(), "owned by no room",
+	s.Contains(err.Error(), "is not floor",
 		"the composition's account of why survives, even though its sentinel does not")
 }
 

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -42,9 +42,9 @@ func TestOneMapSuite(t *testing.T) {
 // The doorway joins hall-local (5,2) — absolute (45,22) — to annex-local (0,2)
 // — absolute (46,22).
 func offsetWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field: encounter.FieldInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "hall", Width: 6, Height: 6, Origin: spatial.Position{X: 40, Y: 20}},
 				{ID: "annex", Width: 6, Height: 6, Origin: spatial.Position{X: 46, Y: 20}},
@@ -190,7 +190,10 @@ func (s *OneMapSuite) TestACrossingReachesClientsAsACrossing() {
 		kinds[e.Kind]++
 	}
 	s.Positive(kinds[session.EventMoved], "the cells inside the hall are moves")
-	s.Positive(kinds[session.EventTraversed], "and the one through the gate is a crossing")
+	// The step through the gate is an ordinary move now, not its own kind: the
+	// composition stopped narrating crossings separately once a crossing became
+	// an ordinary step (rpg-toolkit#1048). A client that wants to draw a door
+	// matches the step against Atlas.Doorways, which still lists every pair.
 	s.Zero(kinds[session.EventUnknown], "with nothing unnameable in between")
 }
 
@@ -234,7 +237,6 @@ func (s *OneMapSuite) TestAWalkIntoTheVoidIsRefused() {
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrBadPosition, "no room owns that cell")
-	s.NotErrorIs(err, session.ErrNoCrossing, "and it is not a doorway problem — there is nothing there")
 }
 
 // TestNothingOnThePlaySurfaceNamesARoom checks the claim structurally rather
@@ -355,10 +357,10 @@ func (s *OneMapSuite) TestASightingAndAPlacementAgree() {
 // shallowAnchoredWorld is one 10x10 room anchored at (2,3) — close enough to
 // the origin that its ABSOLUTE cells overlap its own room-local ones.
 func shallowAnchoredWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{},
 		Standing:   encEveryoneStanding{},
-		Field: encounter.FieldInput{Rooms: []encounter.RoomInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 10, Height: 10, Origin: spatial.Position{X: 2, Y: 3}},
 		}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -292,6 +292,7 @@ func (m *Manager) loadWorldWithBaseline(
 		Data:       *world,
 		Initiative: m.initiative,
 		Standing:   standing,
+		Sight:      sightSeam{},
 	})
 	if err != nil {
 		// The reason is kept as TEXT, not as a chain. A blob this seam cannot
@@ -341,15 +342,22 @@ func translate(err error) error {
 		return fmt.Errorf("%w", ErrClosed)
 	case errors.Is(err, encounter.ErrNoEnding):
 		return fmt.Errorf("%w", ErrNoEnding)
-	case errors.Is(err, encounter.ErrNoConnection), errors.Is(err, encounter.ErrBadConnection):
+	case errors.Is(err, encounter.ErrBadConnection),
+		errors.Is(err, encounter.ErrNoDoor),
+		errors.Is(err, encounter.ErrBadDoor):
 		return fmt.Errorf("%w", ErrNoConnection)
-	case errors.Is(err, encounter.ErrNoCrossing):
-		// Checked BEFORE ErrBadPlacement below, though the two cannot both
-		// match: the ordering states the distinction rather than relying on it.
-		// A cell in the next room with no doorway is not a bad position — the
-		// cell is real, and a caller told "off the map" would go looking for
+	case errors.Is(err, encounter.ErrLocked):
+		// A door refusing to open because it is locked. Checked BEFORE
+		// ErrBadPlacement below: a locked door is a fiction beat with a DC
+		// behind it, and a caller told "bad position" would go looking for
 		// arithmetic that is fine.
-		return fmt.Errorf("%w", ErrNoCrossing)
+		//
+		// This catches the DOOR VERB's refusal only. A walk into a locked door
+		// still arrives as ErrBadPlacement, because the composition puts the
+		// door's state in text rather than in a sentinel (rpg-toolkit#1135).
+		// When that lands, the walk case joins this one and nothing else here
+		// has to change.
+		return fmt.Errorf("%w", ErrLocked)
 	case errors.Is(err, encounter.ErrBadPlacement):
 		return fmt.Errorf("%w", ErrBadPosition)
 	case errors.Is(err, encounter.ErrNoField), errors.Is(err, encounter.ErrInvalidData):

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -49,18 +49,22 @@ func (s *ReadTestSuite) startWith(world *encounter.EncounterData) {
 // hexWorld is a two-room hex field with a doorway, occluders and a wall — rich
 // enough that a projection dropping any one field is visible.
 func hexWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field: encounter.FieldInput{
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
 				{
 					ID: "corridor", Width: 6, Height: 6, Grid: spatial.GridShapeHex,
-					Origin:    spatial.Position{X: 0, Y: 0},
-					Occluders: []spatial.Position{{X: 1, Y: 1}},
-					Boundaries: []spatial.Boundary{{
-						From: spatial.Position{X: -2, Y: -2}, To: spatial.Position{X: -2, Y: -1},
-						BlocksMovement: true, BlocksLineOfSight: true,
-					}},
+					Origin: spatial.Position{X: 0, Y: 0},
+					Props:  occludingProps(spatial.Position{X: 1, Y: 1}),
+					// Room-local, in the AUTHORED frame: columns 0..5, rows 0..5.
+					// This used to read (-2,-2)->(-2,-1), which was the old
+					// origin-centred rhombus reading of a hex room and is out
+					// of bounds now (rpg-toolkit#1127).
+					// The seam with the vault, open only on row 0 where the gate
+					// is. Without these the two chambers are one open space and
+					// a walker crosses anywhere along the edge.
+					Boundaries: hexSeamWalls(6, 6, 0),
 				},
 				{
 					ID: "vault", Width: 6, Height: 6, Grid: spatial.GridShapeHex,
@@ -69,8 +73,11 @@ func hexWorld(t fataler) *encounter.EncounterData {
 			},
 			Connections: []encounter.ConnectionInput{{
 				ID: "gate", From: "corridor", To: "vault",
-				FromPosition: spatial.Position{X: 2, Y: 0},
-				ToPosition:   spatial.Position{X: -3, Y: 0},
+				// The corridor's own LAST column meets the vault's FIRST, on a
+				// shared row — the two chambers sit side by side, six columns
+				// apart. Was (2,0)->(-3,0) under the rhombus reading.
+				FromPosition: spatial.Position{X: 5, Y: 0},
+				ToPosition:   spatial.Position{X: 0, Y: 0},
 			}},
 		},
 		Members: []encounter.MemberInput{
@@ -154,8 +161,10 @@ func (s *ReadTestSuite) TestAtlasProjectsTheWholeWorld() {
 
 	s.Equal(session.GridHex, atlas.Grid, "the grid family must survive as the wire enum")
 	s.Len(atlas.Cells, 72, "both 6x6 rooms, every cell, once each")
-	s.Require().Len(atlas.Occluders, 1, "occluders are not optional decoration")
-	s.Require().Len(atlas.Boundaries, 1, "walls must survive the projection")
+	s.Require().Len(atlas.Props, 1, "props are not optional decoration")
+	s.True(atlas.Props[0].BlocksLineOfSight, "and it must still say it blocks sight")
+	s.NotEmpty(atlas.Props[0].Ref, "and name what it is — the whole point of rpg-toolkit#1130")
+	s.Require().Len(atlas.Boundaries, 10, "every seam wall must survive the projection")
 	s.True(atlas.Boundaries[0].BlocksLineOfSight)
 	s.True(atlas.Boundaries[0].BlocksMovement)
 
@@ -290,9 +299,9 @@ func (s *ReadTestSuite) TestTrimmedStoryUsesOurSentinelNotTheirs() {
 // trimmedWorld builds a world whose story log has already aged past its
 // retention window, so a resume from sequence 1 can no longer be honoured.
 func trimmedWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field:    encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}}},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 		},
@@ -309,7 +318,7 @@ func trimmedWorld(t fataler) *encounter.EncounterData {
 		if i%2 == 1 {
 			to = spatial.Position{X: 1, Y: 1}
 		}
-		if _, err := enc.Move(&encounter.MoveInput{Member: "alice", To: to}); err != nil {
+		if _, err := enc.Step(&encounter.StepInput{Member: "alice", To: to}); err != nil {
 			t.Fatalf("generating beats: %v", err)
 		}
 	}

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -63,7 +63,10 @@ var compositionSentinels = map[string]error{
 	"encounter.ErrNoField":       encounter.ErrNoField,
 	"encounter.ErrBadPlacement":  encounter.ErrBadPlacement,
 	"encounter.ErrBadConnection": encounter.ErrBadConnection,
-	"encounter.ErrNoConnection":  encounter.ErrNoConnection,
+	"encounter.ErrNoDoor":        encounter.ErrNoDoor,
+	"encounter.ErrBadDoor":       encounter.ErrBadDoor,
+	"encounter.ErrLocked":        encounter.ErrLocked,
+	"encounter.ErrNoRegion":      encounter.ErrNoRegion,
 	"encounter.ErrInBubble":      encounter.ErrInBubble,
 	"encounter.ErrNoBubble":      encounter.ErrNoBubble,
 	"encounter.ErrBadClock":      encounter.ErrBadClock,
@@ -277,7 +280,10 @@ func (s *SentinelSuite) TestAnEntryOffTheMap() {
 // underneath the composition (clock, intel, record) are replaceable too, and
 // they report through the same channel.
 func (s *SentinelSuite) TestACorruptStoredWorld() {
-	s.encounters.byID["world"].Members[0].Room = "nowhere"
+	// A cell no region owns — the stored world naming somewhere that is
+	// not on the map. Was `Room = "nowhere"` before members stopped
+	// carrying a room at all (rpg-toolkit#1059).
+	s.encounters.byID["world"].Members[0].Cell = &encounter.PositionData{X: 9999, Y: 9999}
 	ctx := context.Background()
 
 	_, err := s.mgr.Status(ctx, &session.StatusInput{Session: "sess"})
@@ -291,7 +297,7 @@ func (s *SentinelSuite) TestACorruptStoredWorld() {
 	})
 	s.refusedInOurVocabulary(err, session.ErrInvalidWorld)
 
-	s.Contains(err.Error(), "nowhere",
+	s.Contains(err.Error(), "owned by no region",
 		"and the refusal still names the room the blob invented")
 }
 
@@ -304,13 +310,13 @@ func (s *SentinelSuite) TestACorruptStoredWorld() {
 // host to a module we intend to replace.
 func (s *SentinelSuite) TestAWorldThatWillNotLoad() {
 	broken := offsetWorld(s.T())
-	broken.Members[0].Room = "nowhere"
+	broken.Members[0].Cell = &encounter.PositionData{X: 9999, Y: 9999}
 
 	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
 		Session: "another", Encounter: "another-world", World: broken,
 	})
 	s.refusedInOurVocabulary(err, session.ErrInvalidWorld)
-	s.Contains(err.Error(), "nowhere",
+	s.Contains(err.Error(), "owned by no region",
 		"and the refusal still names the room the world invented")
 }
 

--- a/rulebooks/dnd5e/session/sight.go
+++ b/rulebooks/dnd5e/session/sight.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+
+// sightRangeCells is how far a member can see, in cells — a torch's bright
+// light, and no further.
+//
+// # This is a policy, not a default
+//
+// The composition REFUSES to answer this itself (encounter.ErrNoSight): sight
+// is per-creature and per-light-source, so a number living down there would be
+// that module inventing a rule 5e does not have. It asks whoever holds the
+// sheets, which is this package, and this constant is that answer written down
+// where it can be argued with.
+//
+// # Why a number, and why this one
+//
+// Four cells is TWENTY FEET at five feet to the cell, which is a torch's bright
+// radius. Nothing on a character sheet says how far anybody sees yet — no
+// darkvision, no senses, no light sources — so this is the party's own light
+// standing in for all of it, uniformly, until sheets can say better.
+//
+// Unbounded was tried first and is wrong, for a reason worth keeping: with no
+// range, ONE OPEN DOOR MAKES THE WHOLE DUNGEON ONE FIGHT. Sight becomes purely
+// geometric, an open archway is a sightline into every cell of the room beyond,
+// and everyone who can see anything is in contact with it. The workbench scene
+// is the demonstration — its whole point is that a fight is localised to the
+// members in contact while the rest of the party keeps exploring, and at
+// unlimited range every member joined every fight.
+//
+// So the number is doing real work, and it is Kirk's to move. When light and
+// darkvision land this becomes per-member and reads the sheet; the seam is
+// already shaped for that, since the capability is asked per member and answers
+// per member, so only this file changes.
+const sightRangeCells = 4
+
+// sightSeam answers the composition's sight question for every member.
+//
+// Deliberately stateless and deliberately not caching: the composition asks at
+// every refresh including first light, and an answer cached here would go stale
+// the moment sight becomes a function of anything that moves — which is the
+// whole point of it being asked rather than configured.
+type sightSeam struct{}
+
+// Sight reports how far each member can see, in cells.
+//
+// Every member asked about appears in the answer and nobody else does, which is
+// the capability's stated contract. There is no per-member variation yet, so
+// the loop is uniform — see [sightRangeCells] for why that is a position rather
+// than a shortcut.
+func (sightSeam) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	out := make(map[encounter.MemberID]int, len(members))
+	for _, id := range members {
+		out[id] = sightRangeCells
+	}
+
+	return out, nil
+}

--- a/rulebooks/dnd5e/session/spawn_test.go
+++ b/rulebooks/dnd5e/session/spawn_test.go
@@ -115,7 +115,7 @@ func (s *SpawnTestSuite) TestOneRefMakesManyMembers() {
 
 	first, err := s.spawn("skel-1", skeleton, spatial.Position{X: 0, Y: 0})
 	s.Require().NoError(err)
-	second, err := s.spawn("skel-2", skeleton, spatial.Position{X: 1, Y: 0})
+	second, err := s.spawn("skel-2", skeleton, hexCell(1, 0))
 	s.Require().NoError(err)
 
 	s.Equal("skel-1", first.NPC.ID)
@@ -257,18 +257,18 @@ func (s *SpawnTestSuite) TestADuplicateArrivalIsRejectedButMisreported() {
 	_, err := s.spawn("skel-1", skeleton, spatial.Position{X: 0, Y: 0})
 	s.Require().NoError(err)
 
-	_, err = s.spawn("skel-1", skeleton, spatial.Position{X: 1, Y: 0})
+	_, err = s.spawn("skel-1", skeleton, hexCell(1, 0))
 	s.Require().Error(err, "a duplicate member must be refused")
 	s.ErrorIs(err, session.ErrNoMember,
 		"today a duplicate reports as ABSENT — wrong, and upstream's to fix")
 	s.Len(s.storedNPCs(), 1, "and the refused duplicate stored no second sheet")
 
 	_, joinErr := s.mgr.Join(context.Background(), &session.JoinInput{
-		Session: "sess", Member: "bob", Position: spatial.Position{X: 8, Y: 0},
+		Session: "sess", Member: "bob", Position: hexCell(4, 2),
 	})
 	s.Require().NoError(joinErr)
 	_, joinErr = s.mgr.Join(context.Background(), &session.JoinInput{
-		Session: "sess", Member: "bob", Position: spatial.Position{X: 8, Y: 1},
+		Session: "sess", Member: "bob", Position: hexCell(5, 2),
 	})
 	s.Require().Error(joinErr, "and the same holds through the other door")
 	s.ErrorIs(joinErr, session.ErrNoMember)

--- a/rulebooks/dnd5e/session/start.go
+++ b/rulebooks/dnd5e/session/start.go
@@ -86,6 +86,7 @@ func (m *Manager) StartSession(ctx context.Context, in *StartSessionInput) (*Sta
 		Data:       *in.World,
 		Initiative: m.initiative,
 		Standing:   m.standingFor(ctx, nil),
+		Sight:      sightSeam{},
 	}); err != nil {
 		// The reason as TEXT, our sentinel as the only thing to match on. A
 		// blob that will not load fails several modules deep, and every one of

--- a/rulebooks/dnd5e/session/start_test.go
+++ b/rulebooks/dnd5e/session/start_test.go
@@ -84,9 +84,9 @@ func (s *StartSessionTestSuite) SetupTest() {
 // authoredWorld builds a small valid encounter blob standing in for content
 // from an authoring pipeline.
 func authoredWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
 		Standing: encEveryoneStanding{},
-		Field:    encounter.FieldInput{Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}}},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 		},

--- a/rulebooks/dnd5e/session/testprops_test.go
+++ b/rulebooks/dnd5e/session/testprops_test.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// occludingProps is what these scenes used to write as `Occluders`: cells that
+// stop a sightline.
+//
+// The two answers are now independent and both are stated (rpg-toolkit#1128),
+// so this says the thing the old field could only imply — these block SIGHT and
+// not MOVEMENT. That was always the meaning of the word: a pillar you can see
+// past is not an occluder, and these scenes are about who can see whom, never
+// about who can walk where. A fixture that blocked movement too would be
+// changing what the test is asking while appearing only to rename a field.
+func occludingProps(at ...spatial.Position) []encounter.PropInput {
+	blocks, passes := true, false
+	out := make([]encounter.PropInput, 0, len(at))
+	for _, cell := range at {
+		out = append(out, encounter.PropInput{
+			Ref:               "pillar",
+			At:                cell,
+			BlocksMovement:    &passes,
+			BlocksLineOfSight: &blocks,
+		})
+	}
+
+	return out
+}
+
+// encEveryoneSees is the sight capability these scenes run on: unbounded range,
+// so the only thing that hides a member is something drawn on the map — the
+// same position session itself takes in v1 (see sightRangeCells).
+type encEveryoneSees struct{}
+
+func (encEveryoneSees) Sight(members []encounter.MemberID) (map[encounter.MemberID]int, error) {
+	out := make(map[encounter.MemberID]int, len(members))
+	for _, id := range members {
+		out[id] = 1_000_000
+	}
+
+	return out, nil
+}
+
+// hexCell is the dungeon-absolute cell at an AUTHORED column and row of the hex
+// fixtures — the frame a person counts in, not the one the map stores.
+//
+// The two stopped being the same thing when a chamber became the rectangle
+// somebody drew (rpg-toolkit#1127). An authored rectangle SHEARS in axial
+// space, so the corridor's top row is not (0,0) (1,0) (2,0) but
+// (0,0) (1,-1) (2,-1) (3,-2) — walking it by incrementing X lands in the void
+// after one step. These scenes say which column and row they mean and let the
+// conversion happen once, here, so a fixture cannot drift from the map by
+// having its arithmetic done in the wrong frame.
+//
+// Columns are canvas-wide: the corridor owns 0..5 and the vault 6..11, which is
+// why crossing the gate is hexCell(5, 0) to hexCell(6, 0).
+func hexCell(col, row int) spatial.Position {
+	return encounter.HexCellAt(encounter.HexesArePointyTop(), col, row)
+}
+
+// hexSeamWalls is the wall between two side-by-side hex chambers, with one row
+// left open for the doorway.
+//
+// # Rooms used to imply this and no longer do
+//
+// When each chamber had its own grid, sight and movement could not cross
+// between them except through a declared doorway — the separation was a
+// property of the decomposition. On one canvas (rpg-toolkit#1127) two chambers
+// sitting side by side are simply one open space, so a fixture that does not
+// draw its walls has none, and a walker steps between chambers anywhere along
+// the seam. The tomb compiler draws these for authored dungeons; a hand-built
+// fixture has to say them itself.
+//
+// Returned in the WEST chamber's local frame, where column Width-1 is its last
+// and column Width is the east chamber's first. Only real crossings are
+// emitted: on hex, which pairs are adjacent staggers with the column's parity,
+// so the candidates are filtered by actual cube distance rather than assumed.
+func hexSeamWalls(westWidth, rows, openRow int) []spatial.Boundary {
+	out := make([]spatial.Boundary, 0, rows*2)
+	for row := 0; row < rows; row++ {
+		for _, dr := range []int{-1, 0, 1} {
+			to := row + dr
+			if to < 0 || to >= rows {
+				continue
+			}
+			if dr == 0 && row == openRow {
+				continue // the doorway itself
+			}
+			if hexSteps(hexCell(westWidth-1, row), hexCell(westWidth, to)) != 1 {
+				continue // not a crossing on this grid
+			}
+			out = append(out, spatial.Boundary{
+				From:              spatial.Position{X: float64(westWidth - 1), Y: float64(row)},
+				To:                spatial.Position{X: float64(westWidth), Y: float64(to)},
+				BlocksMovement:    true,
+				BlocksLineOfSight: true,
+			})
+		}
+	}
+
+	return out
+}
+
+// hexSteps is cube distance between two axial cells — how many steps apart two
+// hexes are, which is the only adjacency test that is correct in both layouts.
+func hexSteps(a, b spatial.Position) int {
+	aq, ar := int(a.X), int(a.Y)
+	bq, br := int(b.X), int(b.Y)
+	dq, dr, ds := aq-bq, ar-br, (-aq-ar)-(-bq-br)
+	if dq < 0 {
+		dq = -dq
+	}
+	if dr < 0 {
+		dr = -dr
+	}
+	if ds < 0 {
+		ds = -ds
+	}
+
+	return max(dq, max(dr, ds))
+}

--- a/rulebooks/dnd5e/session/translate_internal_test.go
+++ b/rulebooks/dnd5e/session/translate_internal_test.go
@@ -37,14 +37,23 @@ func TestTranslateLetsNoCompositionSentinelThrough(t *testing.T) {
 		{"not a member", encounter.ErrNotMember, ErrNoMember},
 		{"closed encounter", encounter.ErrClosed, ErrClosed},
 		{"undeclared ending", encounter.ErrNoEnding, ErrNoEnding},
-		{"unknown connection", encounter.ErrNoConnection, ErrNoConnection},
-		// The step verb's own refusal (rpg-toolkit#1059): the destination cell
-		// is real, in the next room, and nothing joins it to where the walker
-		// stands. It arrives through Move and MUST NOT arrive as ErrBadPosition
-		// — "off the map" and "no way through" send a caller to different
-		// places, and the walk's own test drives exactly this one.
-		{"no doorway", encounter.ErrNoCrossing, ErrNoCrossing},
 		{"malformed connection", encounter.ErrBadConnection, ErrNoConnection},
+		// Doors arrived as things with identity and state (the S4 slice), so
+		// the two ways of naming one badly translate where a bad connection
+		// already did: from the caller's side they are the same mistake.
+		{"no such door", encounter.ErrNoDoor, ErrNoConnection},
+		{"malformed door", encounter.ErrBadDoor, ErrNoConnection},
+		// A locked door is a FICTION BEAT and gets its own sentinel: there is a
+		// DC behind it and something for a player to do about it. It must not
+		// arrive as ErrBadPosition — "that is not a place" and "the way is
+		// shut" send whoever reads them somewhere different.
+		{"locked door", encounter.ErrLocked, ErrLocked},
+		// NOTE: this table used to carry `ErrNoCrossing` for a step into an
+		// adjacent cell with no doorway joining it. The composition no longer
+		// distinguishes that case — a walk into a shut door comes back as a
+		// placement refusal carrying the door's state in TEXT — so the sentinel
+		// was removed rather than kept as one nothing can produce.
+		// rpg-toolkit#1135 is what would give it a source again.
 		{"bad placement", encounter.ErrBadPlacement, ErrBadPosition},
 		{"already in a fight", encounter.ErrInBubble, ErrInBubble},
 		{"not in a fight", encounter.ErrNoBubble, ErrNotInFight},

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -66,15 +66,44 @@ type Atlas struct {
 	// a new type.
 	Cells []spatial.Position `json:"cells,omitempty"`
 
-	// Occluders is the subset of Cells that blocks line of sight, reported
-	// separately so a host can render them distinctly. Sorted like Cells.
-	Occluders []spatial.Position `json:"occluders,omitempty"`
+	// Props is the things standing on the map — a pillar, a coffin, a pile of
+	// bones — each naming WHAT it is and answering both blocking questions for
+	// itself.
+	//
+	// This used to be `Occluders []spatial.Position`: the subset of cells that
+	// blocked sight, as bare coordinates. That could not say a pillar from a
+	// statue (rpg-project#227 recorded it as "a pillar and a statue are the
+	// same cell"), and it hardcoded one answer to two independent questions —
+	// wrong in both directions, since a coffin is walked around but seen over
+	// and a pile of bones is neither. Carried through from the composition
+	// rather than re-flattened here (rpg-toolkit#1130).
+	Props []AtlasProp `json:"props,omitempty"`
 
 	// Boundaries is every wall and barrier on the map, sorted by endpoint.
 	Boundaries []AtlasBoundary `json:"boundaries,omitempty"`
 
 	// Doorways is every crossable cell pair, sorted by connection ID.
 	Doorways []AtlasDoorway `json:"doorways,omitempty"`
+}
+
+// AtlasProp is one thing standing on the map, in dungeon-absolute space.
+//
+// The two blocking answers are independent and both are carried: a pillar
+// blocks movement and sight, a coffin blocks movement and is seen over, a
+// pile of bones is walked through and seen over. A host that wants the old
+// "occluders" list filters on BlocksLineOfSight.
+type AtlasProp struct {
+	// Ref names what this is, so a host can draw it.
+	Ref string `json:"ref"`
+
+	// At is the cell it stands on, in dungeon-absolute space.
+	At spatial.Position `json:"at"`
+
+	// BlocksMovement reports whether an entity may enter its cell.
+	BlocksMovement bool `json:"blocks_movement,omitempty"`
+
+	// BlocksLineOfSight reports whether sight passes through its cell.
+	BlocksLineOfSight bool `json:"blocks_line_of_sight,omitempty"`
 }
 
 // AtlasBoundary is one wall or barrier crossing between adjacent cells.
@@ -243,16 +272,23 @@ const (
 	// EventMoved reports that a member stepped to a new cell.
 	EventMoved EventKind = "moved"
 
-	// EventTraversed reports that a member's step carried them through a
-	// doorway.
+	// NOTE: there is no EventTraversed any more.
 	//
-	// Distinct from EventMoved even though both are one step of the same size
-	// on the same map — and it stayed distinct through the reshape that took
-	// rooms off everything else a client sees, because ONE MAP DOES NOT MEAN
-	// ONE NARRATION. A client renders a doorway differently from a corridor,
-	// and the composition still knows which happened; collapsing them would
-	// make a client re-derive it from the geometry.
-	EventTraversed EventKind = "traversed"
+	// It reported that a step carried a member through a doorway, and it was
+	// kept distinct from EventMoved on the argument that ONE MAP DOES NOT MEAN
+	// ONE NARRATION — a client renders a doorway differently from a corridor,
+	// and making it re-derive that from geometry was the thing to avoid.
+	//
+	// The composition stopped emitting the beat. A crossing is written like any
+	// other step now (rpg-toolkit#1048, #1059), which was the point: absolute
+	// coordinates made a crossing expressible as an ordinary move. So nothing
+	// upstream can distinguish the two, and a kind nothing can produce is worse
+	// than no kind at all — it reads as a contract.
+	//
+	// The information is not lost, only moved: [Atlas.Doorways] lists every
+	// crossable pair, so a step whose from/to matches one IS a traversal and a
+	// client (or this package) can say so. Restoring the distinction means
+	// deriving it here rather than waiting for a beat that is not coming.
 
 	// EventJoined reports that a member entered the encounter.
 	EventJoined EventKind = "joined"

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -100,10 +100,18 @@ type AtlasProp struct {
 	At spatial.Position `json:"at"`
 
 	// BlocksMovement reports whether an entity may enter its cell.
-	BlocksMovement bool `json:"blocks_movement,omitempty"`
+	//
+	// No omitempty, here or on any of these four: false is an ANSWER, not an
+	// absence. A pile of bones is walked through and seen over, so both of its
+	// flags are false, and with omitempty it would serialise carrying no
+	// blocking information at all — indistinguishable on the wire from a prop
+	// nobody declared one for. That is exactly the ambiguity the composition
+	// spends a *bool to prevent one layer down (rpg-toolkit#1033), and it must
+	// not come back at the seam that a non-Go client reads.
+	BlocksMovement bool `json:"blocks_movement"`
 
 	// BlocksLineOfSight reports whether sight passes through its cell.
-	BlocksLineOfSight bool `json:"blocks_line_of_sight,omitempty"`
+	BlocksLineOfSight bool `json:"blocks_line_of_sight"`
 }
 
 // AtlasBoundary is one wall or barrier crossing between adjacent cells.
@@ -115,10 +123,10 @@ type AtlasBoundary struct {
 	To spatial.Position `json:"to"`
 
 	// BlocksMovement reports whether an entity may cross.
-	BlocksMovement bool `json:"blocks_movement,omitempty"`
+	BlocksMovement bool `json:"blocks_movement"`
 
 	// BlocksLineOfSight reports whether sight may cross.
-	BlocksLineOfSight bool `json:"blocks_line_of_sight,omitempty"`
+	BlocksLineOfSight bool `json:"blocks_line_of_sight"`
 }
 
 // AtlasDoorway is one crossable pair of cells. The two are adjacent in

--- a/rulebooks/dnd5e/session/wirecontract_test.go
+++ b/rulebooks/dnd5e/session/wirecontract_test.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// TestFalseIsAnAnswerOnTheWire pins that a blocking flag which is FALSE still
+// appears in the JSON.
+//
+// # Why this needs a test of its own
+//
+// `omitempty` on a bool drops the key when the value is false, and the case
+// that breaks is the one this seam exists to express: a pile of bones is walked
+// THROUGH and seen OVER, so both of its answers are false, and with omitempty
+// it serialises as a ref and a cell and nothing else. A non-Go client cannot
+// tell that from a prop nobody declared blocking for — which is precisely the
+// ambiguity the composition spends a *bool to prevent one layer down
+// (rpg-toolkit#1033), arriving back at the wire.
+//
+// Found by Copilot on rpg-toolkit#1136. The fix shipped UNPINNED: putting
+// omitempty back passed the entire suite, so this asserts the bytes rather than
+// the Go value, because the Go value is identical either way.
+func TestFalseIsAnAnswerOnTheWire(t *testing.T) {
+	atlas := session.Atlas{
+		Props: []session.AtlasProp{{
+			Ref:               "bones",
+			At:                spatial.Position{X: 1, Y: 2},
+			BlocksMovement:    false,
+			BlocksLineOfSight: false,
+		}},
+		Boundaries: []session.AtlasBoundary{{
+			From:              spatial.Position{X: 0, Y: 0},
+			To:                spatial.Position{X: 1, Y: 0},
+			BlocksMovement:    false,
+			BlocksLineOfSight: false,
+		}},
+	}
+
+	raw, err := json.Marshal(atlas)
+	require.NoError(t, err)
+
+	// Decoded generically, the way a client that is not this package sees it.
+	var wire struct {
+		Props []map[string]json.RawMessage `json:"props"`
+		Walls []map[string]json.RawMessage `json:"boundaries"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &wire))
+	require.Len(t, wire.Props, 1)
+	require.Len(t, wire.Walls, 1)
+
+	for _, field := range []string{"blocks_movement", "blocks_line_of_sight"} {
+		require.Contains(t, wire.Props[0], field,
+			"a prop that blocks neither must still SAY it blocks neither: %s", raw)
+		require.Equal(t, "false", string(wire.Props[0][field]))
+
+		require.Contains(t, wire.Walls[0], field,
+			"and so must a boundary: %s", raw)
+		require.Equal(t, "false", string(wire.Walls[0][field]))
+	}
+}

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -350,28 +350,21 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 func place(
 	scope *writeScope, id string, kind MemberKind, at spatial.Position,
 ) (*encounter.JoinOutput, error) {
-	// The one place a cell becomes a room. The composition's verbs are
-	// room-local by law, so somebody has to resolve an absolute cell to the
-	// chamber that owns it; doing it HERE means every caller of this seam
-	// speaks one map, and a room id never has to appear in an input.
-	located, err := scope.enc.Locate(&encounter.LocateInput{Position: at})
-	if err != nil {
-		// ErrBadPosition is what a caller matches on, and the composition's own
-		// error keeps WHY — owned by no room, off the grid, or not an integral
-		// cell — which is the difference between a typo and a fractional
-		// coordinate. That account is kept as TEXT: wrapping it too would let a
-		// host match on encounter.ErrBadPlacement, which is the leak S2 exists
-		// to prevent and the one no AST test can see (rpg-toolkit#1058).
-		return nil, fmt.Errorf("no room owns %v: %w: %v", at, ErrBadPosition, err)
-	}
-
+	// This used to resolve the cell to a room first, because the composition's
+	// verbs were room-local by law and somebody had to say which chamber owned
+	// an absolute cell. That law is gone (rpg-toolkit#1059 and the world-model
+	// wave): the composition speaks one map, so the cell goes straight in and
+	// the chamber that owns it is nobody's business at this seam.
+	//
+	// The refusal moved with it. Join validates the cell itself — owned by no
+	// region, off the grid, not an integral cell — and translate() turns that
+	// into ErrBadPosition, so a caller matches on the same sentinel as before
+	// and the composition's account still crosses as TEXT rather than as a
+	// chain a host could match on (the S2 leak, rpg-toolkit#1058).
 	placed, err := scope.enc.Join(&encounter.JoinInput{
-		Member: encounter.MemberInput{
-			ID:       encounter.MemberID(id),
-			Kind:     encounter.MemberKind(kind),
-			Room:     located.Room,
-			Position: located.Position,
-		},
+		Member: encounter.MemberID(id),
+		Kind:   encounter.MemberKind(kind),
+		Cell:   at,
 	})
 	if err != nil {
 		return nil, translate(err)
@@ -544,6 +537,7 @@ func (m *Manager) adopt(scope *writeScope, world encounter.EncounterData) error 
 		Data:       world,
 		Initiative: m.initiative,
 		Standing:   scope.standing,
+		Sight:      sightSeam{},
 	})
 	if err != nil {
 		return fmt.Errorf("%q: %w: %v", scope.encounter, ErrInvalidWorld, err)

--- a/rulebooks/dnd5e/session/write_test.go
+++ b/rulebooks/dnd5e/session/write_test.go
@@ -52,7 +52,7 @@ func (s *WriteTestSuite) TestJoinPersistsTheNewMember() {
 
 	out, err := s.mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 	s.Require().NoError(err)
 	s.Equal("bob", out.Member.ID)
@@ -60,7 +60,7 @@ func (s *WriteTestSuite) TestJoinPersistsTheNewMember() {
 	// The cell he was placed on, reported back on the map rather than as a
 	// room he would have to look up. The vault is anchored at (6,0), so this
 	// number only exists if the projection happened.
-	s.Equal(spatial.Position{X: 6, Y: 0}, out.Member.Position)
+	s.Equal(hexCell(2, 2), out.Member.Position)
 	s.Equal([]string{"encounter:world"}, out.Saved.Written)
 
 	// The proof: a fresh read sees him.
@@ -77,7 +77,7 @@ func (s *WriteTestSuite) TestJoinPersistsTheNewMember() {
 func (s *WriteTestSuite) TestJoinReportsWhoNoticed() {
 	out, err := s.mgr.Join(context.Background(), &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Position: spatial.Position{X: 1, Y: 0},
+		Position: hexCell(1, 0),
 	})
 	s.Require().NoError(err)
 	s.NotEmpty(out.Discovered,
@@ -126,7 +126,7 @@ func (s *WriteTestSuite) TestClosedEncounterRefusesChanges() {
 
 	_, err = s.mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 	s.ErrorIs(err, session.ErrClosed)
 
@@ -213,7 +213,7 @@ func (s *WriteTestSuite) TestFailedSaveIsReportedNotSwallowed() {
 
 	out, err := mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrSaveFailed)
@@ -239,13 +239,13 @@ func (s *WriteTestSuite) TestStaleWorldIsNotResurrected() {
 
 	_, err = s.mgr.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "bob",
-		Position: spatial.Position{X: 6, Y: 0},
+		Position: hexCell(2, 2),
 	})
 	s.Require().NoError(err)
 
 	_, err = other.Join(ctx, &session.JoinInput{
 		Session: "sess", Member: "carol",
-		Position: spatial.Position{X: 7, Y: 0},
+		Position: hexCell(3, 2),
 	})
 	s.Require().NoError(err)
 
@@ -260,7 +260,7 @@ func (s *WriteTestSuite) TestStaleWorldIsNotResurrected() {
 // TestJoinOnUnknownSession pins the load failures reach the write verbs too.
 func (s *WriteTestSuite) TestJoinOnUnknownSession() {
 	_, err := s.mgr.Join(context.Background(), &session.JoinInput{
-		Session: "nope", Member: "bob", Position: spatial.Position{X: 6, Y: 0},
+		Session: "nope", Member: "bob", Position: hexCell(2, 2),
 	})
 	s.ErrorIs(err, session.ErrNoSession)
 }


### PR DESCRIPTION
Session adopts the current stack — encounter **v0.26.0** and resolution **v0.10.0**, nine and one minors on from what it pinned. Closes #1130.

`gorelease -base v0.17.1` → **v0.18.0**.

---

## The adoption is mostly a deletion

`session.place()` existed for exactly one reason, and said so:

> *"The one place a cell becomes a room. The composition's verbs are room-local by law, so somebody has to resolve an absolute cell to the chamber that owns it."*

**That law is gone.** `Locate` was removed from the composition for the same reason, and `JoinInput.Member` became a plain `MemberID`. The cell goes straight in; which chamber owns it is nobody's business at this seam. Session got *simpler*.

## A client can tell a coffin from a pillar again

`Occluders []spatial.Position` → `Props []AtlasProp{Ref, At, BlocksMovement, BlocksLineOfSight}`.

Session was re-flattening away exactly what #1128 had added one layer down — the multi-room census recorded the old shape as *"a pillar and a statue are the same cell"*, and a hardcoded blocking answer is wrong in both directions, since a coffin is walked around but seen over and a pile of bones is neither.

## Cells are enumerated, and the arithmetic is pinned rather than trusted

A region no longer carries a cell list — it describes itself as a rectangle, and `Atlas.Orientation` is the frame that turns one into cells. `projectAtlas` walks it, **adding the anchor in offset space**, which is the arithmetic three callers inside the composition got wrong before #1131 found them.

That makes this a *second implementation* of a projection the composition also owns, which is worth being nervous about. It is kept honest instead: the suite asks the composition's own `RegionAt` about the cells this produces, so the two cannot drift apart silently. If the composition ever exports the enumeration, this should be deleted in favour of it.

## Sight is bounded, and unbounded was wrong for an interesting reason

The composition refuses to answer sight (`ErrNoSight`) — it is per-creature and per-light-source, so a number down there would be inventing a rule 5e does not have. It asks whoever holds the sheets. That is this package.

Unbounded was the first answer, on the grounds that it invents nothing: what you see is decided by geometry alone. **It does not survive contact with the workbench.** With no range, an open archway is a sightline into every cell of the room beyond, so:

- alice was seen crossing the antechamber, two cells before reaching the gate;
- **bob joined her fight from across the map** — and the workbench's whole point is that a fight is *localised* to the members in contact while the rest of the party keeps exploring.

One open door made the entire dungeon one fight. So there is a number: **four cells, twenty feet at five feet to the cell — a torch's bright radius.** Nothing on a sheet says how far anybody sees yet, so this is the party's own light standing in for all of it. It is one constant, and it is Kirk's to move.

## Two public names removed rather than left unreachable

| name | why it has no source |
|---|---|
| `ErrNoCrossing` | the composition no longer distinguishes a walled crossing from a missing cell — a blocked step arrives as a placement refusal with the reason in **text** (#1135) |
| `EventTraversed` | the composition emits no `"traversed"` beat **at all** — a crossing is written like any other step (#1048, #1059), which was the point of absolute coordinates |

Both kept their reasoning in place rather than being quietly dropped, each pointing at what would restore it. `EventTraversed`'s doc argued *"one map does not mean one narration — a client renders a doorway differently from a corridor."* That argument still holds; what changed is that the information now lives in `Atlas.Doorways`, which lists every crossable pair, so it is **derived rather than narrated**.

A sentinel or an event kind that nothing can produce is worse than none: it reads as a contract.

## The migration hazard worth knowing downstream

**Rooms no longer imply walls.** When each chamber had its own grid, nothing crossed between them except through a declared doorway. On one canvas two chambers side by side are *one open space* until somebody draws the seam.

The tomb compiler draws them automatically. `hexWorld` and the workbench did not, and both behaved wrongly until they did — the workbench started its fight before anybody walked a step. Anything authoring rooms directly, **including the new proto surface**, inherits this.

## Fixture migration

`hexWorld`'s room-local coordinates were still written in the origin-centred rhombus frame — a boundary at `(-2,-2)` and a connection endpoint at `(-3,0)`, both out of bounds once a chamber is the rectangle somebody drew. The walks were written in sheared absolute coordinates that no longer name cells.

Rewritten in **authored** terms via one helper, so a fixture cannot drift from the map by doing its arithmetic in the wrong frame. The corridor's top row is `(0,0) (1,-1) (2,-1) (3,-2)`, not `(0,0) (1,0) (2,0)` — walking it by incrementing X lands in the void after one step.

`convert_test`'s omission registry records the two real decisions: `Atlas.Orientation` is not carried (this seam sends the **cells**, so a client never performs the conversion the frame is for), and `Member.Region` stays omitted — **with the argument against it written down**, since a region is an authored name now rather than the incidental grouping it was when that entry was first made.

## Gates

`gofmt` clean · `go vet` clean · `go test -race ./...` green · `golangci-lint` **0 issues at both versions CI pins** (v2.2.1 with `--config=../.golangci.yml` as ci-enhanced invokes it, v2.3.1 with default discovery as ci-optimized does, both from inside the module) · `go mod tidy` no-op · `gorelease -base v0.17.1` → v0.18.0.

CI's lint jobs self-skip on this repo (#1134), so the lint above is local and stated rather than implied.

— asset-pipeline agent, on behalf of KirkDiggler
