### PR TITLE
fix(spatial)!: pointy-top uses row offsets and flat-top uses column offsets

### DIFF
--- a/tools/spatial/hex_offset_law_test.go
+++ b/tools/spatial/hex_offset_law_test.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spatial_test
+
+// hex_offset_law_test.go pins WHICH OFFSET SCHEME each hex orientation uses,
+// which is the one thing about offset coordinates that cannot be checked by
+// round-tripping.
+//
+// Every existing test converts offset -> cube -> offset through the same pair of
+// functions, so a scheme mismatched to its orientation name round-trips
+// perfectly, produces self-consistent distances, neighbours and lines, and is
+// invisible to all of them. It becomes visible exactly once: when somebody draws
+// it (rpg-toolkit#1140, found by rendering a dungeon in a browser).
+//
+// The convention these assert is the standard one:
+//
+//   - "odd-q" / "even-q" offset  <->  FLAT-top hexes. Columns are shifted, so
+//     the offset applies per COLUMN.
+//   - "odd-r" / "even-r" offset  <->  POINTY-top hexes. Rows are shifted, so the
+//     offset applies per ROW.
+//
+// The discriminator below is a neighbour that exists under one scheme and not
+// the other, so it cannot be satisfied by a rotation or a relabelling.
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// cubeDistance is the hex distance between two cube coordinates.
+func cubeDistance(a, b spatial.CubeCoordinate) int {
+	abs := func(n int) int {
+		if n < 0 {
+			return -n
+		}
+		return n
+	}
+	dx, dy, dz := abs(a.X-b.X), abs(a.Y-b.Y), abs(a.Z-b.Z)
+	if dy > dx {
+		dx = dy
+	}
+	if dz > dx {
+		dx = dz
+	}
+	return dx
+}
+
+func offsetNeighbours(t *testing.T, o spatial.HexOrientation, col, row int) int {
+	t.Helper()
+	origin := spatial.OffsetCoordinateToCubeWithOrientation(spatial.Position{}, o)
+	other := spatial.OffsetCoordinateToCubeWithOrientation(
+		spatial.Position{X: float64(col), Y: float64(row)}, o)
+
+	return cubeDistance(origin, other)
+}
+
+// TestPointyTopUsesRowOffsets pins pointy-top to an odd-r scheme.
+//
+// Under odd-r the odd ROWS are shifted, which makes [-1,1] a neighbour of the
+// origin. Under odd-q -- the COLUMN-shifted scheme, which belongs to flat-top --
+// that same pair is two steps apart. So this single assertion says which scheme
+// is in use and cannot be satisfied by the other.
+func TestPointyTopUsesRowOffsets(t *testing.T) {
+	if got := offsetNeighbours(t, spatial.HexOrientationPointyTop, -1, 1); got != 1 {
+		t.Fatalf("pointy-top should use odd-r (row-shifted) offsets, so [-1,1] should "+
+			"neighbour the origin; got distance %d. A distance of 2 means pointy-top is "+
+			"running the odd-q scheme, which belongs to FLAT-top.", got)
+	}
+}
+
+// TestFlatTopUsesColumnOffsets is the mirror: under odd-q the odd COLUMNS are
+// shifted, which makes [1,-1] a neighbour of the origin, and under odd-r it is
+// two steps away.
+func TestFlatTopUsesColumnOffsets(t *testing.T) {
+	if got := offsetNeighbours(t, spatial.HexOrientationFlatTop, 1, -1); got != 1 {
+		t.Fatalf("flat-top should use odd-q (column-shifted) offsets, so [1,-1] should "+
+			"neighbour the origin; got distance %d. A distance of 2 means flat-top is "+
+			"running the odd-r scheme, which belongs to POINTY-top.", got)
+	}
+}
+
+// TestTheTwoOrientationsAreNotTheSameScheme guards the fix from being applied to
+// both branches at once, which would restore the symmetry while leaving them
+// swapped -- the bug wearing different labels.
+func TestTheTwoOrientationsAreNotTheSameScheme(t *testing.T) {
+	pointy := offsetNeighbours(t, spatial.HexOrientationPointyTop, -1, 1)
+	flat := offsetNeighbours(t, spatial.HexOrientationFlatTop, -1, 1)
+	if pointy == flat {
+		t.Fatalf("the two orientations answered identically (%d) for [-1,1]; they use "+
+			"different offset schemes and must disagree somewhere", pointy)
+	}
+}

--- a/tools/spatial/hex_offset_law_test.go
+++ b/tools/spatial/hex_offset_law_test.go
@@ -47,7 +47,13 @@ func cubeDistance(a, b spatial.CubeCoordinate) int {
 	return dx
 }
 
-func offsetNeighbours(t *testing.T, o spatial.HexOrientation, col, row int) int {
+// stepsFromOrigin is how many hex steps the offset cell [col,row] is from the
+// offset origin, under the given orientation.
+//
+// It answers a DISTANCE, and the assertions below all turn on whether that
+// distance is 1 -- "is this cell a neighbour of the origin" -- so the value one
+// step out and the value two steps out are both meaningful and both appear.
+func stepsFromOrigin(t *testing.T, o spatial.HexOrientation, col, row int) int {
 	t.Helper()
 	origin := spatial.OffsetCoordinateToCubeWithOrientation(spatial.Position{}, o)
 	other := spatial.OffsetCoordinateToCubeWithOrientation(
@@ -63,7 +69,7 @@ func offsetNeighbours(t *testing.T, o spatial.HexOrientation, col, row int) int 
 // that same pair is two steps apart. So this single assertion says which scheme
 // is in use and cannot be satisfied by the other.
 func TestPointyTopUsesRowOffsets(t *testing.T) {
-	if got := offsetNeighbours(t, spatial.HexOrientationPointyTop, -1, 1); got != 1 {
+	if got := stepsFromOrigin(t, spatial.HexOrientationPointyTop, -1, 1); got != 1 {
 		t.Fatalf("pointy-top should use odd-r (row-shifted) offsets, so [-1,1] should "+
 			"neighbour the origin; got distance %d. A distance of 2 means pointy-top is "+
 			"running the odd-q scheme, which belongs to FLAT-top.", got)
@@ -74,7 +80,7 @@ func TestPointyTopUsesRowOffsets(t *testing.T) {
 // shifted, which makes [1,-1] a neighbour of the origin, and under odd-r it is
 // two steps away.
 func TestFlatTopUsesColumnOffsets(t *testing.T) {
-	if got := offsetNeighbours(t, spatial.HexOrientationFlatTop, 1, -1); got != 1 {
+	if got := stepsFromOrigin(t, spatial.HexOrientationFlatTop, 1, -1); got != 1 {
 		t.Fatalf("flat-top should use odd-q (column-shifted) offsets, so [1,-1] should "+
 			"neighbour the origin; got distance %d. A distance of 2 means flat-top is "+
 			"running the odd-r scheme, which belongs to POINTY-top.", got)
@@ -85,8 +91,8 @@ func TestFlatTopUsesColumnOffsets(t *testing.T) {
 // both branches at once, which would restore the symmetry while leaving them
 // swapped -- the bug wearing different labels.
 func TestTheTwoOrientationsAreNotTheSameScheme(t *testing.T) {
-	pointy := offsetNeighbours(t, spatial.HexOrientationPointyTop, -1, 1)
-	flat := offsetNeighbours(t, spatial.HexOrientationFlatTop, -1, 1)
+	pointy := stepsFromOrigin(t, spatial.HexOrientationPointyTop, -1, 1)
+	flat := stepsFromOrigin(t, spatial.HexOrientationFlatTop, -1, 1)
 	if pointy == flat {
 		t.Fatalf("the two orientations answered identically (%d) for [-1,1]; they use "+
 			"different offset schemes and must disagree somewhere", pointy)

--- a/tools/spatial/los_law_test.go
+++ b/tools/spatial/los_law_test.go
@@ -312,14 +312,28 @@ func (s *LineOfSightLawSuite) TestLeaningIsNotWandering() {
 			forward:  spatial.Position{X: 0, Y: 2},
 		},
 		{
+			// These two cells SWAPPED when rpg-toolkit#1140 corrected which
+			// offset scheme pointy-top uses (see hex_offset_law_test.go).
+			//
+			// The scenario is unchanged and so is its intent: a blocker one step
+			// away, a target directly behind it that stays dark, and another at
+			// the same distance in a different lane that does not. What moved is
+			// WHICH offset pair names those hexes. Pointy-top used to run the
+			// column-shifted odd-q scheme, under which [0,2] sat behind the
+			// blocker; on the row-shifted odd-r scheme it actually uses, [1,2]
+			// does, and [0,2] is the open lane.
+			//
+			// Verified against the grid rather than re-derived by hand: with the
+			// blocker at [0,1], the only cell two steps from the origin whose
+			// sight is blocked is [1,2].
 			name: "hex-pointy",
 			grid: spatial.NewHexGrid(spatial.HexGridConfig{
 				Width: 6, Height: 6, Orientation: spatial.HexOrientationPointyTop,
 			}),
 			blocker:  spatial.Position{X: 0, Y: 1},
 			from:     spatial.Position{X: 0, Y: 0},
-			sideways: spatial.Position{X: 0, Y: 2},
-			forward:  spatial.Position{X: 1, Y: 2},
+			sideways: spatial.Position{X: 1, Y: 2},
+			forward:  spatial.Position{X: 0, Y: 2},
 		},
 	} {
 		s.Run(tc.name, func() {

--- a/tools/spatial/position.go
+++ b/tools/spatial/position.go
@@ -199,14 +199,14 @@ func (c CubeCoordinate) ToOffsetCoordinate() Position {
 func (c CubeCoordinate) ToOffsetCoordinateWithOrientation(orientation HexOrientation) Position {
 	switch orientation {
 	case HexOrientationFlatTop:
-		// Flat-top: odd-r offset coordinates
-		col := float64(c.X + (c.Z-(c.Z&1))/2)
-		row := float64(c.Z)
-		return Position{X: col, Y: row}
-	default:
-		// Pointy-top: odd-q offset coordinates (default)
+		// Flat-top hexes shift their COLUMNS, which is the odd-q scheme.
 		col := float64(c.X)
 		row := float64(c.Z + (c.X-(c.X&1))/2)
+		return Position{X: col, Y: row}
+	default:
+		// Pointy-top hexes shift their ROWS, which is the odd-r scheme.
+		col := float64(c.X + (c.Z-(c.Z&1))/2)
+		row := float64(c.Z)
 		return Position{X: col, Y: row}
 	}
 }
@@ -225,15 +225,15 @@ func OffsetCoordinateToCubeWithOrientation(pos Position, orientation HexOrientat
 
 	switch orientation {
 	case HexOrientationFlatTop:
-		// Flat-top: odd-r offset coordinates
-		x := col - (row-(row&1))/2
-		z := row
+		// Flat-top hexes shift their COLUMNS, which is the odd-q scheme.
+		x := col
+		z := row - (col-(col&1))/2
 		y := -x - z
 		return CubeCoordinate{X: x, Y: y, Z: z}
 	default:
-		// Pointy-top: odd-q offset coordinates (default)
-		x := col
-		z := row - (col-(col&1))/2
+		// Pointy-top hexes shift their ROWS, which is the odd-r scheme.
+		x := col - (row-(row&1))/2
+		z := row
 		y := -x - z
 		return CubeCoordinate{X: x, Y: y, Z: z}
 	}


### PR DESCRIPTION
Fixes the root cause behind #1140. Does **not** close it — the wire still cannot tell a client how to lay out a map, and that needs the follow-up wave below.

## What was wrong

`OffsetCoordinateToCubeWithOrientation` had the two orientations running each other's offset schemes:

```go
case HexOrientationFlatTop:
    // Flat-top: odd-r offset coordinates     <- odd-r is POINTY-top
default:
    // Pointy-top: odd-q offset coordinates   <- odd-q is FLAT-top
```

Columns shift for **flat**-top hexes (odd-q); rows shift for **pointy**-top ones (odd-r). Both directions — forward and `ToOffsetCoordinateWithOrientation` — were swapped **identically**.

## Why nothing caught it

That identical swap is the whole story. Every caller goes offset → cube → offset through the same mismatched pair, so distances, neighbours, line of sight, pathfinding and round-trips are all perfectly self-consistent. **The bug is invisible to every property that stays inside the coordinate system**, which is every property the existing tests check.

It becomes visible exactly once: when somebody draws it.

## How it surfaced

Rendering the reference tomb in a browser (rpg-dnd5e-web#759). It is authored `orientation: pointy` and came out as a **diagonal staircase** instead of three chambers side by side.

Confirmed against spatial's own `hexPixel` (a pointy-top formula on cube x,z). Running a 28×8 chamber chain through this function:

| declared | bbox via spatial's own hexPixel | aspect |
|---|---|---|
| `flat` | 47.63 × 10.50 | **4.54** |
| `pointy` | 41.57 × 30.00 | 1.39 |

A 28×8 offset rectangle drawn pointy-top should be 46.77 × 10.50, aspect **4.45**. So the **flat** declaration is what produces correct pointy geometry — the definition of swapped.

## The tests

`hex_offset_law_test.go` pins the one thing no round-trip can: **which scheme each orientation uses**. The discriminator is a neighbour that exists under one scheme and not the other (`[-1,1]` for odd-r, `[1,-1]` for odd-q), so it cannot be satisfied by a rotation or a relabelling. A third test refuses the "fix" of swapping both branches at once — that would restore the symmetry while leaving them wrong.

RED baseline before the fix, with the diagnosis the tests were written to give:

```
pointy-top should use odd-r (row-shifted) offsets, so [-1,1] should neighbour
the origin; got distance 2. A distance of 2 means pointy-top is running the
odd-q scheme, which belongs to FLAT-top.
```

## The one existing test that changed

`los_law_test.go`'s `hex-pointy` fixture had two cells **swap roles** — the same swap seen from the other side. With a blocker one step out, the cell directly behind it was `[0,2]` under odd-q and is `[1,2]` under odd-r.

Verified against the grid rather than re-derived by hand: with the blocker at `[0,1]`, `[1,2]` is the *only* cell two steps from the origin whose sight is blocked. The scenario and its intent are unchanged; only which offset pair names those hexes moved.

## Downstream, measured and deliberately not touched

`rulebooks/dnd5e/encounter` fails **148 subtests** against this change (verified via a local `GOWORK` override, not committed). Two causes:

1. It carries its **own copy** of the scheme in `hexRuns`/`footprintCells`, with the same swapped assumption baked in.
2. Fixtures that name absolute cells, which moved.

It pins `spatial v0.9.1`, so it is **unaffected until somebody bumps it**. That bump is its own wave, per this repo's module-isolation rule. Filed separately.

Worth noting: `encounter/dungeonspec` — the tomb compiler — passes unchanged.

## Evidence

| check | result |
|---|---|
| `go test ./...` (spatial) | **ok**, full suite |
| `go vet ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run ./...` | 34 goconst issues — **all pre-existing**, verified identical on `main` at `e1f8ba7`, none in files this PR touches |

Marked `!` because coordinate meaning changes for hex worlds. Nothing durable holds them — worlds are compiled from YAML per encounter and sessions are Redis with a TTL — so this is the cheap moment.

— asset-pipeline agent, on behalf of KirkDiggler
