### PR TITLE
fix(encounter)!: take spatial's orientation correction, and drop its own copy

### DIFF
--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -431,19 +431,30 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	// entries) read exactly like an ordinary move, by design: the room
 	// boundary is invisible in world space.
 	require.Equal(t, []string{
-		"alice start: corridor(6,5) -> absolute(6,-8)",
-		"goblin start: corridor(9,4) -> absolute(9,-9)",
-		"alice move: corridor(7,5) -> absolute(7,-9)",
-		"alice move: corridor(8,5) -> absolute(8,-9)",
-		"alice move: corridor(9,5) -> absolute(9,-10)",
-		"alice arrive via gate: vault(0,5) -> absolute(10,-10)",
-		"alice move: vault(0,6) -> absolute(10,-11)",
-		"alice reload checkpoint: vault(0,6) -> absolute(10,-11)",
-		"goblin move: corridor(9,5) -> absolute(9,-10)",
-		"goblin arrive via gate: vault(0,5) -> absolute(10,-10)",
-		"alice move: vault(1,6) -> absolute(11,-12)",
-		"alice move: vault(2,6) -> absolute(12,-12)",
-		"alice outcome: vault(2,6) -> absolute(12,-12)",
-		"goblin outcome: vault(0,5) -> absolute(10,-10)",
+		// EVERY ABSOLUTE HERE MOVED when rpg-toolkit#1141 corrected the hex
+		// offset schemes, and every AUTHORED one stayed put -- corridor(6,5)
+		// is still corridor(6,5). That split is the reassuring part: the scene
+		// plays out identically and only the projection underneath it changed.
+		//
+		// The continuity this test is named for still holds and is still what
+		// the comparison enforces: one authored cell projects to ONE absolute
+		// cell everywhere in the story. corridor(9,5) is absolute(7,-12) for
+		// alice and for the goblin; vault(0,5) is absolute(8,-13) at both
+		// arrivals and at the goblin's outcome; vault(0,6) survives a reload
+		// unchanged.
+		"alice start: corridor(6,5) -> absolute(4,-9)",
+		"goblin start: corridor(9,4) -> absolute(7,-11)",
+		"alice move: corridor(7,5) -> absolute(5,-10)",
+		"alice move: corridor(8,5) -> absolute(6,-11)",
+		"alice move: corridor(9,5) -> absolute(7,-12)",
+		"alice arrive via gate: vault(0,5) -> absolute(8,-13)",
+		"alice move: vault(0,6) -> absolute(7,-13)",
+		"alice reload checkpoint: vault(0,6) -> absolute(7,-13)",
+		"goblin move: corridor(9,5) -> absolute(7,-12)",
+		"goblin arrive via gate: vault(0,5) -> absolute(8,-13)",
+		"alice move: vault(1,6) -> absolute(8,-14)",
+		"alice move: vault(2,6) -> absolute(9,-15)",
+		"alice outcome: vault(2,6) -> absolute(9,-15)",
+		"goblin outcome: vault(0,5) -> absolute(8,-13)",
 	}, proj.transcript, "the story IS the projected continuity, told in order")
 }

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -104,7 +104,7 @@ func vaultChaseHexSeamWall() []spatial.Boundary {
 //
 // The gate joins corridor (9,5) — its own last column — to vault local (0,5),
 // which is absolute column 10, row 5. Same-row neighbouring columns are
-// adjacent in odd-q for either parity, so those two cells kiss (W3) as
+// adjacent in odd-r for either parity, so those two cells kiss (W3) as
 // spatial's own conversion has it, not as a formula this fixture rolled.
 func vaultChaseHexSetup() *encounter.SetupInput {
 	gate := vaultChaseHexGate()

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -110,13 +110,23 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// under a new key, absolute, with the room label gone because a member's
 	// chamber is derived from where they stand.
 	//
+	// FOUR VALUES MOVED when rpg-toolkit#1141 corrected the hex offset schemes,
+	// and only four: the two members' absolute cells, and the two intel payloads
+	// that mirror them (each member holds where it SEES the other, so those
+	// track the cells by construction). Everything else here is byte-identical
+	// -- every tag, key, log entry, bubble, ending, and every AUTHORED value,
+	// since room origins, props, boundaries and connection endpoints are all
+	// written in the offset frame and did not move. That is the check that
+	// justified updating a golden at all: this file exists to pin tags and wire
+	// shape, and none of that changed.
+	//
 	// And this blob now carries a FIGHT. The two members are one doorway apart
 	// with nothing between them, so they see each other at first light and
 	// trigger detection forms a bubble — which used to be invisible here only
 	// because sight stopped at a room boundary. That makes the golden strictly
 	// richer: it is the one place the bubbles array and intel's holdings are
 	// pinned as exact bytes.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTAsInkiOi0yfQ==","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotMiwieSI6LTZ9","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque","orientation":"pointy"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","props":[{"ref":"test:props:rubble","at":{"x":1,"y":2},"blocks_movement":true,"blocks_line_of_sight":true}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-2,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":7,"y":3},"to_position":{"x":0,"y":3}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-2,"y":-6}},{"id":"p1","kind":"player","cell":{"x":-10,"y":-2}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTMsInkiOjZ9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotNSwieSI6LTJ9","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque","orientation":"pointy"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","props":[{"ref":"test:props:rubble","at":{"x":1,"y":2},"blocks_movement":true,"blocks_line_of_sight":true}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-2,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":7,"y":3},"to_position":{"x":0,"y":3}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-5,"y":-2}},{"id":"p1","kind":"player","cell":{"x":-13,"y":6}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
 	s.Equal(expected, string(bs))
 }
 
@@ -2072,6 +2082,36 @@ func validAnchoredHexData() encounter.EncounterData {
 	}
 }
 
+// TestLoadRefusesAnAxialDiagonalAsAdjacent is the Load-seam mirror of
+// encounter_test.go's TestSetupRefusesAnAxialDiagonalAsAdjacent, and a separate
+// test for the same reason.
+//
+// Both existing Load W3 rows sit at distance 3, which a Chebyshev-on-axial
+// implementation rejects too, so neither tells the correct formula from that
+// mutant. Only a (1,1) diagonal does: Chebyshev calls it 1, cube distance calls
+// it 2.
+//
+// That delta stopped being reachable from validAnchoredHexData by any single
+// field change when rpg-toolkit#1141 corrected the offset schemes — see the
+// Setup-seam test for the sweep that established it. Hence its own scenario
+// rather than a reshaped shared base.
+func (s *DataTestSuite) TestLoadRefusesAnAxialDiagonalAsAdjacent() {
+	data := validAnchoredHexData()
+	// Same three values as the Setup-seam mirror; they compile to (8,-8) and
+	// (9,-7).
+	data.Field.Rooms[1].Origin = &encounter.PositionData{X: 8, Y: -9}
+	data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 8, Y: 0}
+	data.Field.Connections[0].ToPosition = &encounter.PositionData{X: 0, Y: 7}
+
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:       data,
+		Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	})
+	s.Require().ErrorIs(err, encounter.ErrBadConnection)
+	s.Contains(err.Error(), "distance 2",
+		"a (1,1) axial diagonal is two steps apart, and only the cube formula says so")
+}
+
 // TestLoadAnchoring pins the Load-seam one-defect rows for W1 (mixed grid
 // families), origin legality (non-integral, infinite, and non-representable
 // — isRepresentableInteger, encounter.go), W5 (nil origin presence, naming
@@ -2142,19 +2182,6 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 			// — this must fail on adjacency, not on the earlier bounds check.
 			d.Field.Connections[0].ToPosition = &encounter.PositionData{X: 1, Y: 4}
 		}, encounter.ErrBadConnection, "not adjacent"},
-		{"W3: hex axial (1,1) delta is NOT adjacent (cube distance 2)", func(d *encounter.EncounterData) {
-			// Load-seam mirror of encounter_test.go's TestSetupAnchoring
-			// row of the same name (#929 hardening round, test-gap closure
-			// item 6): both existing Load W3 rows above sit at cube/
-			// Chebyshev distance 3 either way ("endpoints do not kiss") —
-			// neither discriminates a Chebyshev-on-axial mutant (which
-			// would wrongly accept max(|ΔQ|,|ΔR|)=1 as adjacent) from the
-			// correct cube-distance formula. hex-small's Origin shifts
-			// from (6,-5) to (6,-3): the gate's endpoints, once anchored,
-			// differ by axial (ΔQ=1,ΔR=1) — cube distance (1+1+2)/2=2, NOT
-			// 1 — while still disjoint from hex-big (W2 passes).
-			d.Field.Rooms[1].Origin = &encounter.PositionData{X: 10, Y: -4}
-		}, encounter.ErrBadConnection, "distance 2"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
@@ -2541,14 +2568,27 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	enc1, err := encounter.NewEncounter(setup)
 	s.Require().NoError(err)
 
-	// The gate's two sides, on the canvas. hex-big's authored [9,1] compiles
-	// to axial (9,-6) and hex-small's [0,4] — through its (10,-2) anchor,
-	// so authored [10,2] absolute — to (10,-7). Neither reads the same as its
-	// authored pair any more, and that is the point of rpg-toolkit#1127
-	// rather than an inconvenience: a chamber is drawn in offset columns and
-	// run on a cube grid, and the compile is where the two meet.
-	nearSide := spatial.Position{X: 9, Y: -6}
-	farSide := spatial.Position{X: 10, Y: -7}
+	// The gate's two sides, on the canvas — READ from the compiled field
+	// rather than written down. Neither side reads the same as its authored
+	// pair, and that is the point of rpg-toolkit#1127 rather than an
+	// inconvenience: a chamber is drawn in offset columns and run on a cube
+	// grid, and the compile is where the two meet.
+	//
+	// These used to be the literals (9,-6) and (10,-7). They moved when
+	// rpg-toolkit#1141 corrected the offset schemes, which is exactly why they
+	// are no longer literals: what this test is about is that the field behaves
+	// identically across a round trip, and hard-coding the projection's current
+	// output made it fail for a reason that has nothing to do with that.
+	atlas, err := enc1.Atlas()
+	s.Require().NoError(err)
+	s.Require().Len(atlas.Doorways, 1, "the fixture authors exactly one connection")
+	nearSide := atlas.Doorways[0].FromCell
+	farSide := atlas.Doorways[0].ToCell
+
+	// Still worth asserting the compile did something: the absolute cells are
+	// not the authored pairs.
+	s.NotEqual(spatial.Position{X: 9, Y: 1}, nearSide, "authored [9,1] is not its own absolute cell")
+	s.NotEqual(spatial.Position{X: 0, Y: 4}, farSide, "authored [0,4] is not its own absolute cell")
 
 	out1, err := enc1.Step(&encounter.StepInput{Member: "p1", To: farSide})
 	s.Require().NoError(err, "the original encounter accepts the step through the gate")

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -1092,6 +1092,46 @@ func validAnchoredHexSetup() *encounter.SetupInput {
 	}
 }
 
+// TestSetupRefusesAnAxialDiagonalAsAdjacent keeps the discriminator that used
+// to be a row in TestSetupAnchoring, and it is a separate test because that row
+// stopped being buildable.
+//
+// # What it discriminates
+//
+// A "Chebyshev-on-axial" implementation of adjacency — max(|dQ|,|dR|) <= 1 —
+// accepts pairs the cube-distance formula rejects. The two disagree on exactly
+// one shape: a (1,1) diagonal, where Chebyshev says 1 and the true distance is
+// (1+1+2)/2 = 2. Every other near-miss delta is rejected by both, so only a
+// (1,1) or (-1,-1) delta can tell the correct formula from that mutant.
+//
+// # Why it is not a row any more
+//
+// When rpg-toolkit#1141 corrected the hex offset schemes, the projection from
+// authored cells to absolute ones changed, and a (1,1) delta became UNREACHABLE
+// from validAnchoredHexSetup by changing any single field. Verified by sweeping
+// all three independently against the compiled endpoints: origins from (5,-20)
+// to (20,12), every legal ToPosition in hex-small, and every legal FromPosition
+// in hex-big. None produces one. That is a property of the corrected geometry,
+// not a search that gave up.
+//
+// So the scenario gets its own setup rather than the shared base being reshaped
+// around it — reshaping the base would have moved every other row in this suite
+// and its mirror in data_test.go to preserve one assertion.
+func (s *EncounterTestSuite) TestSetupRefusesAnAxialDiagonalAsAdjacent() {
+	setup := validAnchoredHexSetup()
+	// Chosen by asking the compiler which combination lands on the diagonal,
+	// not by re-deriving the projection by hand: these compile to (8,-8) and
+	// (9,-7).
+	setup.Field.Rooms[1].Origin = spatial.Position{X: 8, Y: -9}
+	setup.Field.Connections[0].FromPosition = spatial.Position{X: 8, Y: 0}
+	setup.Field.Connections[0].ToPosition = spatial.Position{X: 0, Y: 7}
+
+	_, err := encounter.NewEncounter(setup)
+	s.Require().ErrorIs(err, encounter.ErrBadConnection)
+	s.Contains(err.Error(), "distance 2",
+		"a (1,1) axial diagonal is two steps apart, and only the cube formula says so")
+}
+
 // TestSetupAnchoring pins the one-defect rows for W1 (mixed grid families),
 // origin legality (non-integral origin), and W3 (endpoints that don't
 // kiss) — each breaking exactly ONE thing about validAnchoredHexSetup's
@@ -1150,18 +1190,6 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 			// not on the earlier bounds check.
 			in.Field.Connections[0].ToPosition = spatial.Position{X: 1, Y: 4}
 		}, encounter.ErrBadConnection, "not adjacent"},
-		{"W3: hex axial (1,1) delta is NOT adjacent (cube distance 2)", func(in *encounter.SetupInput) {
-			// hex-small's Origin shifts two rows north of the valid base's
-			// (10,0): the gate's endpoints, once compiled, are axial (9,-6)
-			// and (10,-5), differing by (ΔQ=1,ΔR=1) — cube distance
-			// (1+1+2)/2=2, NOT 1. A "Chebyshev-on-axial" mutant
-			// (max(|ΔQ|,|ΔR|)=1) would wrongly ACCEPT this as adjacent — see
-			// the mutation evidence table in the #929 T1 fix-round report.
-			// Still disjoint from hex-big (W2 passes): hex-small owns columns
-			// 10..12 whatever its rows are, and hex-big owns 0..9, so this is
-			// a genuine W3-only defect.
-			in.Field.Rooms[1].Origin = spatial.Position{X: 10, Y: -4}
-		}, encounter.ErrBadConnection, "distance 2"},
 	}
 	for _, tc := range cases {
 		s.Run(tc.name, func() {

--- a/rulebooks/dnd5e/encounter/go.mod
+++ b/rulebooks/dnd5e/encounter/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/rulebooks/dnd5e/encounter/go.sum
+++ b/rulebooks/dnd5e/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0 h1:89nU27faMf80JrIJlQeVeYac
 github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0/go.mod h1:BlYgBeigB1mUum7FG8AUxWX32tgBrBLFg4/t//+tSvk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q+6k8n0krpcnka+lLyflk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0 h1:FqMCjTNi/M/brqwlJvBc70eDx+PqWZ6mZLoJOxxOHJw=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/rulebooks/dnd5e/encounter/orientation.go
+++ b/rulebooks/dnd5e/encounter/orientation.go
@@ -79,11 +79,11 @@ type OrientationKind string
 
 const (
 	// OrientationPointyTop is the pointy-top layout, whose offset form is
-	// odd-q: columns run straight and rows stagger.
+	// odd-r: rows run straight and columns stagger.
 	OrientationPointyTop OrientationKind = "pointy"
 
-	// OrientationFlatTop is the flat-top layout, whose offset form is odd-r:
-	// rows run straight and columns stagger.
+	// OrientationFlatTop is the flat-top layout, whose offset form is odd-q:
+	// columns run straight and rows stagger.
 	OrientationFlatTop OrientationKind = "flat"
 )
 
@@ -128,7 +128,7 @@ type Orientation interface {
 }
 
 // HexesArePointyTop declares a field's hexes pointy-top, whose offset form is
-// odd-q. The reference tomb's layout.
+// odd-r. The reference tomb's layout.
 //
 // A function rather than a package-level variable so nothing can reassign what
 // it means at runtime — [VoidIsOpaque]'s reasoning, and the save gate's before
@@ -140,7 +140,7 @@ type pointyTop struct{}
 func (pointyTop) Kind() OrientationKind           { return OrientationPointyTop }
 func (pointyTop) spatial() spatial.HexOrientation { return spatial.HexOrientationPointyTop }
 
-// HexesAreFlatTop declares a field's hexes flat-top, whose offset form is odd-r.
+// HexesAreFlatTop declares a field's hexes flat-top, whose offset form is odd-q.
 func HexesAreFlatTop() Orientation { return flatTop{} }
 
 type flatTop struct{}
@@ -266,7 +266,7 @@ func footprintHolds(r RoomInput, o Orientation, grid spatial.Grid, cell spatial.
 // maxFieldCells allows four million cells, so "build both footprints and
 // intersect" is a real cost on a legal field, paid at every construction. But a
 // sheared rectangle is not shapeless: along one axis it decomposes into
-// contiguous intervals, one per authored column (pointy) or row (flat), and two
+// contiguous intervals, one per authored column (flat) or row (pointy), and two
 // intervals intersect in O(1). So the whole disjointness question costs
 // O(Width) or O(Height) rather than O(Width x Height).
 //

--- a/rulebooks/dnd5e/encounter/orientation.go
+++ b/rulebooks/dnd5e/encounter/orientation.go
@@ -272,12 +272,16 @@ func footprintHolds(r RoomInput, o Orientation, grid spatial.Grid, cell spatial.
 //
 // The key is the coordinate that does NOT shear:
 //
-//   - POINTY-TOP is odd-q, so Q = col exactly and only R staggers. Key by Q;
+//   - FLAT-TOP is odd-q, so Q = col exactly and only R staggers. Key by Q;
 //     for a fixed column, R decreases by exactly one per row, so the run is
 //     [r(row=Height-1), r(row=0)].
-//   - FLAT-TOP is odd-r, so the authored ROW is recoverable as -(Q+R) and only
-//     Q staggers. Key by that; for a fixed row, Q increases by exactly one per
-//     column.
+//   - POINTY-TOP is odd-r, so the authored ROW is recoverable as -(Q+R) and
+//     only Q staggers. Key by that; for a fixed row, Q increases by exactly one
+//     per column.
+//
+// Those two bullets USED TO NAME THE OTHER ORIENTATION, because spatial had the
+// schemes swapped (rpg-toolkit#1141). The arithmetic below is unchanged; which
+// orientation it belongs to is what moved.
 //
 // Both facts are read off spatial's own conversion rather than assumed, and
 // pinned by TestRunsAgreeWithEnumeration, which compares this against a full
@@ -286,7 +290,7 @@ func hexRuns(r RoomInput, o Orientation) map[int][2]int {
 	runs := make(map[int][2]int, max(r.Width, r.Height))
 
 	oc, or := int(r.Origin.X), int(r.Origin.Y)
-	if o.Kind() == OrientationPointyTop {
+	if o.Kind() == OrientationFlatTop {
 		for col := 0; col < r.Width; col++ {
 			top := HexCellAt(o, col+oc, or)
 			bottom := HexCellAt(o, col+oc, r.Height-1+or)
@@ -311,7 +315,7 @@ func hexFootprintBounds(r RoomInput, o Orientation) (qMin, qMax, rMin, rMax int)
 	first := true
 	for key, run := range hexRuns(r, o) {
 		var q0, q1, r0, r1 int
-		if o.Kind() == OrientationPointyTop {
+		if o.Kind() == OrientationFlatTop {
 			q0, q1, r0, r1 = key, key, run[0], run[1]
 		} else {
 			// key is the authored row; the run is a Q interval, and R is

--- a/rulebooks/dnd5e/encounter/orientation_internal_test.go
+++ b/rulebooks/dnd5e/encounter/orientation_internal_test.go
@@ -134,7 +134,9 @@ func TestRunsAgreeWithEnumeration(t *testing.T) {
 				for key, run := range hexRuns(r, o) {
 					require.LessOrEqual(t, run[0], run[1], "a run's interval must be ordered")
 					for v := run[0]; v <= run[1]; v++ {
-						if o.Kind() == OrientationPointyTop {
+						// Mirrors hexRuns' contract, which swapped orientations
+						// when rpg-toolkit#1141 corrected the offset schemes.
+						if o.Kind() == OrientationFlatTop {
 							expanded[[2]int{key, v}] = true // key is Q, run is R
 						} else {
 							expanded[[2]int{v, -v - key}] = true // key is the row, run is Q

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -427,7 +427,19 @@ func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
 	hexOrigin := spatial.Position{X: 3, Y: -2}
 	hex := s.oneRoom(spatial.GridShapeHex, 6, 6, hexOrigin)
 
-	frac := spatial.Position{X: 3.5, Y: -1.5}
+	// A REAL cell of this room, asked for in the frame the room is authored in
+	// rather than written down as an absolute literal. It used to be the
+	// literal (4,-1); that stopped being floor when rpg-toolkit#1141 corrected
+	// the offset schemes and the projection moved underneath it. What the test
+	// is about — that a fractional position is not a cell and an integral one
+	// beside it is — has nothing to do with which absolute cell that happens to
+	// be, so it no longer names one.
+	cell := encounter.HexCellAt(orientationFor(spatial.GridShapeHex),
+		int(hexOrigin.X)+3, int(hexOrigin.Y)+3)
+
+	// Half a step off a genuine cell, so it is unambiguously between cells
+	// rather than merely outside the room.
+	frac := spatial.Position{X: cell.X + 0.5, Y: cell.Y + 0.5}
 	_, ok := hex.RegionAt(frac)
 	s.False(ok, "a fractional axial position is not a cell, so no region holds it")
 
@@ -435,7 +447,7 @@ func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
 	s.Require().Error(err, "and the verbs agree — which is the whole point")
 	s.ErrorIs(err, encounter.ErrBadPlacement)
 
-	_, ok = hex.RegionAt(spatial.Position{X: 4, Y: -1})
+	_, ok = hex.RegionAt(cell)
 	s.True(ok, "the integral cell beside it is ordinary floor")
 
 	squareOrigin := spatial.Position{X: 4, Y: 6}


### PR DESCRIPTION
Closes #1142. Takes `tools/spatial` **v0.10.0** (#1141) into `encounter`.

**148 subtests failed on the bump**, from two causes. The first accounts for 143 of them.

## 1. This module carried its own copy of the convention

`hexRuns` and `hexFootprintBounds` branch on orientation to pick the coordinate that does *not* shear, so the footprint decomposes into contiguous runs. Both branches named the wrong orientation, in the doc as plainly as in the code:

> - POINTY-TOP is odd-q, so Q = col exactly and only R staggers…
> - FLAT-TOP is odd-r, so the authored ROW is recoverable as -(Q+R)…

That is exactly the swap spatial had, restated independently. The **arithmetic was correct**; which orientation it belonged to was not — so the two branches simply trade places.

What caught it: `TestRunsAgreeWithEnumeration` and `TestOverlapAgreesWithEnumeration`, which compare the runs against a cell-by-cell sweep. Two implementations of one answer, and a test that makes them agree — working exactly as intended.

**That single change took 148 failures down to 5.**

## 2. Fixtures naming absolute cells

Each was re-derived **by asking the system**, never by hand — re-deriving a projection by hand is how the original error gets typed in a second time.

- **The golden blob** — **four** values moved and only four: two member cells, and the two intel payloads that mirror them (each member holds where it *sees* the other, so those track by construction). Every tag, key, log entry, bubble, ending and **every authored value** is byte-identical, since room origins, props, boundaries and connection endpoints are all written in the offset frame. That check is what justified touching a golden whose whole purpose is pinning wire shape.
- **The vault-chase transcript** — every *absolute* moved; every *authored* cell stayed (`corridor(6,5)` is still `corridor(6,5)`). The continuity the test is named for still holds and is still what the comparison enforces: one authored cell projects to one absolute cell across the whole story — `corridor(9,5)` is `absolute(7,-12)` for alice *and* the goblin, `vault(0,5)` is `absolute(8,-13)` at both arrivals and the goblin's outcome.
- **The fractional-cell test** no longer names an absolute literal at all. It asks `HexCellAt` for a cell of the room under test and puts the fractional probe half a step off it.
- **The reloaded-traverse test** now **reads** the gate's two sides off the compiled atlas instead of hard-coding `(9,-6)`/`(10,-7)`, and separately asserts they are *not* the authored pair — which is the fact it was demonstrating anyway. It fails now only if the field stops round-tripping, which is what it is for.

## The axial-diagonal rows became their own tests

A **(1,1) delta is the only shape** that separates cube distance from a Chebyshev-on-axial mutant: Chebyshev says 1, the truth is 2. Every other near-miss is rejected by both, so no other delta discriminates.

Under the corrected projection that delta is **unreachable from the shared fixture by any single-field change**. Verified by sweeping each field independently — origins from `(5,-20)` to `(20,12)`, every legal `ToPosition` in hex-small, every legal `FromPosition` in hex-big. None produces one. That is a property of the geometry (origin moves are not pure translations under parity shear), not a search that gave up.

So the scenario gets its own setup in both suites rather than the shared base being reshaped around it — reshaping the base would have moved a dozen other rows and their Load-seam mirrors to preserve one assertion.

## Evidence

| check | result |
|---|---|
| `go test ./...` (uncached) | **ok** — all three packages |
| `go vet ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run ./...` | **0 issues** |
| `go mod tidy` | clean; no `replace`, no `go.work` |

Downstream measurement was done with a `go.work` `replace` held **outside** the repo and passed as `GOWORK=`, never committed.

`encounter/dungeonspec` — the tomb compiler — **passed unchanged throughout**, including before the `hexRuns` fix. It works in the authored frame and hands off, so the correction flows through it without a fixture touch.

## Next

`session` is the remaining toolkit consumer: it projects the Atlas and has its own `regionCells`, which its code already flags as *"a SECOND implementation of a projection the composition also owns… if the composition ever exports the enumeration itself, this should be deleted in favour of it."* Worth doing together rather than fixing a third copy. Then #1140's proto field, then api and web.

— asset-pipeline agent, on behalf of KirkDiggler
