### PR TITLE
fix(session)!: take the orientation correction; one fixture, no logic

### DIFF
--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.26.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.27.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,12 +18,12 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.26.0 h1:wCxquvgbv4Ni2/aGcwlMy0VzS8a375MdNNVpRNFRuMM=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.26.0/go.mod h1:1qaWyNBiHhFgB6Yf/7TD0i/9bCFUL+mLruHYNxEcIqM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.27.0 h1:fLD8SiJ6voh0aDGTYQ2cNQEnru/8h8rMoRW5C7BRvC8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.27.0/go.mod h1:Fqd/JDv0wXdPqdP0Tf5QBWd3Fu/tSgUU10yh5Hdbjoc=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 h1:ZBHWR+o9pwpTRSEEnkFPDsj+h5htLa8N8Ywhspglc44=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0/go.mod h1:wANmNP7YRPCvm2Qj/EpT0026fSX6TkqLk1xvkkNHF80=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0 h1:FqMCjTNi/M/brqwlJvBc70eDx+PqWZ6mZLoJOxxOHJw=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -303,23 +303,30 @@ func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
 	})
 	s.Require().NoError(err)
 
-	// Alice walks to the threshold itself.
+	// Alice walks to a threshold on the seam — the corridor's last column,
+	// ROW ONE, because the scene needs her standing somewhere that has a vault
+	// neighbour which is not the doorway.
+	//
+	// She used to walk straight along row 0 to (5,0). That stopped working
+	// when rpg-toolkit#1141 corrected the offset schemes: from (5,0) the ONLY
+	// adjacent vault cell is now the doorway itself, so there is no wrong step
+	// to take from there and the scenario cannot be built. Row 1 has one.
+	//
+	// The path is computed rather than eyeballed — a breadth-first walk over
+	// the corridor's real cells, around the prop at local (1,1).
 	_, err = s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
 		Path: []spatial.Position{
-			hexCell(1, 0), hexCell(2, 0), hexCell(3, 0), hexCell(4, 0), hexCell(5, 0),
+			hexCell(1, 0), hexCell(2, 0), hexCell(3, 0), hexCell(3, 1), hexCell(4, 1), hexCell(5, 1),
 		},
 	})
 	s.Require().NoError(err)
 
-	// (3,-1) is a vault cell and an axial neighbour of the threshold she is
-	// standing on — adjacent, in the next room, and joined to nothing. The
-	// doorway is at (3,0), one cell over.
 	_, err = s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
-		// The vault's column 6, one row down: a real cell, a genuine neighbour
-		// of the threshold she is standing on, and joined to it by nothing —
-		// the gate is on row 0.
+		// The vault's column 6, row 1: a real cell, a genuine neighbour of the
+		// threshold she is standing on, and joined to it by nothing — the gate
+		// is on row 0. (This cell is unchanged; only the threshold moved.)
 		Path: []spatial.Position{hexCell(6, 1)},
 	})
 	s.Require().Error(err)

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -313,7 +313,10 @@ func (s *MoveTestSuite) TestAStepWithNoDoorwayIsRefused() {
 	// to take from there and the scenario cannot be built. Row 1 has one.
 	//
 	// The path is computed rather than eyeballed — a breadth-first walk over
-	// the corridor's real cells, around the prop at local (1,1).
+	// the corridor's real in-bounds cells, so no step here re-derives the
+	// projection by hand. The pillar at local (1,1) is on the map but blocks
+	// sight only, never movement (see occludingProps) — the walk has nothing
+	// to route around.
 	_, err = s.mgr.Move(ctx, &session.MoveInput{
 		Session: "hex", Member: "alice",
 		Path: []spatial.Position{


### PR DESCRIPTION
Completes the **toolkit** half of the hex-orientation correction: bumps `encounter` to **v0.27.0** and `spatial` to **v0.10.0** (#1141, #1143).

**One subtest failed, and `regionCells` needed no change.**

## The thing that was worth worrying about, and wasn't

This package carries what its own comment calls *"a SECOND implementation of a projection the composition also owns"* — and after `encounter` turned out to restate the convention wrongly in `hexRuns`, a third copy was the obvious risk.

It isn't one. `regionCells` **delegates** the projection rather than restating it: it walks a region's rectangle and calls `HexCellAt` per cell, with no orientation branch anywhere. So the correction flowed straight through.

That is the difference that explains the two waves: `encounter` said *"POINTY-TOP is odd-q"* in its own words and needed 148 subtests fixed; this package asks, and needed one.

## The one fixture

`TestAStepWithNoDoorwayIsRefused` had to be **rethreaded, not retargeted**.

The scene needs Alice standing somewhere with a vault neighbour that is **not** the doorway. From her old threshold at offset `(5,0)`, the only adjacent vault cell is now the doorway itself — so there is no wrong step left to take from there and the scenario cannot be built at all.

Moved her to the seam's **row 1**, which has one. The target cell `hexCell(6,1)` is **unchanged**; only the threshold and the walk to it moved. The path was computed by a breadth-first search over the corridor's real cells (around the prop at local `(1,1)`) rather than eyeballed — same discipline as #1143, since re-deriving a projection by hand is how the original error gets typed in twice.

## Nothing else moved

`hexSeamWalls` already asks `hexSteps` which pairs are adjacent instead of assuming, so it corrected itself — a fixture written the durable way, and a useful contrast with the ones in #1143 that named absolute cells.

## Evidence

| check | result |
|---|---|
| `go test ./...` (uncached) | **ok** — both packages |
| `go vet ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run ./...` | **0 issues** |
| `go mod tidy` | clean; no `replace`, no `go.work` |

## What is left

The toolkit is done after this. Still open:

- **#1140** — the gap this all started from. Even with the convention correct, `GridKind` says `SQUARE` or `HEX` and stops, so **the wire still never tells a client which way the hexes point**. What changed is that the honest answer is now the authored orientation instead of its opposite, so the field can finally carry something true.
- **#1139** — the room-local → absolute seam rpg-api works around with a throwaway probe.

Then downstream: protos field → rpg-api (its `internal/sessionworld` pins `(1,-4)` for the tomb's authored `start: [1,3]`, which moves) → web, where `DEFAULT_LAYOUT = 'flat'` exists *because of* this bug and inverts once the convention is right.

— asset-pipeline agent, on behalf of KirkDiggler
