### PR TITLE
feat(session): the atlas says which way its hexes point (#1140)

### DIFF
--- a/docs/adr/0040-atlas-carries-render-layout.md
+++ b/docs/adr/0040-atlas-carries-render-layout.md
@@ -1,0 +1,96 @@
+# ADR-0040: The Atlas Carries a Render Layout, Named Apart From the Authoring Orientation
+
+**Date:** 2026-08-21
+**Status:** Accepted (Kirk, 2026-08-21 — "go with option 1")
+
+## Context
+
+`session.Atlas` is one flat map: a `Grid` family, every cell in axial
+coordinates, props, boundaries, doorways. The composition's
+`encounter.Atlas.Orientation` reaches the projection — it is what
+`regionCells` uses to turn each authored rectangle into cells — and was then
+deliberately dropped, with the reason recorded in `convert_test.go`'s
+omission audit: *"this seam sends the CELLS, so a client never performs that
+conversion."*
+
+That reasoning is correct about **coordinates** and silent about **drawing**.
+Axial `(q,r)` fixes the topology — the same six neighbours either way — but
+not the picture: the same cell set laid out pointy-top and flat-top gives two
+different images, roughly one rotated from the other. A client putting pixels
+on a screen has to pick one, and nothing on the wire told it which.
+
+The first client to try (rpg-dnd5e-web#758, reading the reference tomb from
+a live server) guessed from the content and drew three chambers as a
+**diagonal staircase**. Worse, the guess that *looked* right was wrong: the
+tomb is authored `orientation: pointy` and, at the time, drawing it pointy
+was incorrect — because `tools/spatial` had the two orientations running each
+other's offset schemes, swapped identically in both directions so every
+round-trip cancelled the error (rpg-toolkit#1140, root-caused and fixed as
+#1141 → #1143 → #1145). With that fixed, the authored word and the correct
+render layout finally agree. But the wire still did not say it. `GridKind`
+is `square` or `hex` and stops.
+
+## Options considered
+
+1. **`Atlas.Layout HexLayout`** — a new string enum, `pointy_top` /
+   `flat_top`, present exactly when `Grid` is hex, projected from the
+   composition's `Orientation.Kind()`. Additive. `Grid` stays orthogonal.
+2. **Fold it into `GridKind`** — `square` / `hex_pointy` / `hex_flat`. One
+   field, no inconsistent state expressible. Rejected: it conflates the
+   distance family with the drawing, turns every client's "is it hex" check
+   into a two-value test, and changes a proto enum the web already switches on.
+3. **Keep it off the wire and document the rule.** Rejected by the evidence:
+   the web found its answer by measuring a bounding box. A rule a client
+   cannot read off the wire gets re-derived by experiment, once per client.
+4. **Change the projection so the words agree.** Already done (#1141). It does
+   not close the gap — the wire still said nothing.
+
+## Decision
+
+Option 1. `Atlas` gains
+
+```go
+Layout HexLayout `json:"layout,omitempty"`   // "pointy_top" | "flat_top" | absent
+```
+
+projected by `projectLayout(encounter.Orientation)`: pointy → `pointy_top`,
+flat → `flat_top`, nil (a square field, which declares no orientation by law)
+or an unrecognised kind → empty, for the reason `projectGrid` gives — a guess
+turns an impossible state into a wrong picture.
+
+**The name is the decision.** The composition keeps `Orientation`: the frame
+an author typed offset cells in, which this seam consumes and never hands
+out. The wire carries `Layout`: what a client does with the cells it
+receives. Same two values, a different question — and the staircase happened
+precisely because the two questions shared a word. They now do not.
+
+The convert audit (`TestEveryInnerFieldIsCarriedOrJustified`) learns the
+difference between a rename and a drop: a `renamed` map records the inner
+field, the outer field it became, and why the name changed, and asserts the
+target field exists. A rename recorded as an omission would be a decision
+hiding behind the wrong label.
+
+## Consequences
+
+### Positive
+- A client can draw a hex atlas correctly from the wire alone. The next
+  client does not repeat rpg-dnd5e-web's bounding-box experiment.
+- Additive: compatible for every existing host; `gorelease` clean.
+- The composition's law — hex must declare, square must not — is visible at
+  the wire as "layout present iff grid is hex".
+
+### Negative
+- One more field a transport must mirror: rpg-api-protos gains a `HexLayout`
+  enum on `GetAtlasResponse`, rpg-api translates it, and the web replaces its
+  hardcoded `DEFAULT_LAYOUT = 'flat'` (which was pinned to the *bug's*
+  answer and inverts now that the projection is correct).
+
+### Neutral
+- Two vocabularies for one underlying fact, by design. Anyone tempted to
+  unify them should reread the Context.
+
+## Rule
+
+**A field on the wire is named for the question the receiver asks, not for
+the one the author answered.** When the same value serves two questions at
+two seams, give it two names so a reader cannot mistake one for the other.

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -122,6 +122,12 @@ because this directory's `README.md` index silently drifted to listing 7 of 37.
   `DCHalfDamageFloorTen`) — no function arm. *Rule: a new `DCSource` case must
   cite a RAW rule; 5e already closed this set, and we inherit their closure
   rather than inventing an open one.*
+- **0040** — **The atlas says which way its hexes point**: `Atlas.Layout`
+  (`pointy_top` / `flat_top`, present iff the grid is hex) is the render word,
+  projected from the composition's authoring `Orientation` and deliberately not
+  sharing its name — a client drew the tomb as a staircase because the two
+  questions shared one word. *Rule: a wire field is named for the question the
+  receiver asks, not the one the author answered.*
 
 ---
 

--- a/rulebooks/dnd5e/session/atlasmap_test.go
+++ b/rulebooks/dnd5e/session/atlasmap_test.go
@@ -98,9 +98,9 @@ func (s *AtlasMapSuite) atlas() *session.Atlas {
 // instead of passing review.
 func (s *AtlasMapSuite) TestNothingOnTheMapNamesARoom() {
 	s.Equal(
-		[]string{"Grid", "Cells", "Props", "Boundaries", "Doorways"},
+		[]string{"Grid", "Layout", "Cells", "Props", "Boundaries", "Doorways"},
 		fieldsOf(session.Atlas{}),
-		"the map is a grid, its cells, the things standing on it, its walls, and its doorways",
+		"the map is a grid, which way its hexes point, its cells, the things standing on it, its walls, and its doorways",
 	)
 	s.Equal(
 		[]string{"Connection", "From", "To"},

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -46,9 +46,14 @@ func projectGrid(shape spatial.GridShape) GridKind {
 
 // projectLayout maps the composition's authoring frame onto the wire's render
 // word (rpg-toolkit#1140). Nil — a square field, which declares no orientation
-// by law — yields the empty string, and so does an unrecognised kind, for the
-// reason projectGrid gives: a guess would turn an impossible state into a
-// wrong picture.
+// by law — yields the empty string, which is what keeps Atlas.Layout's
+// "present exactly when the grid is hex" true.
+//
+// The default arm is unreachable, the way projectGrid's is: encounter.Orientation
+// is SEALED by an unexported method, so the only kinds that can exist are the
+// two named here, and a hex field must declare one of them. It still refuses
+// to guess rather than invent a layout, for the reason projectGrid gives — a
+// guess would turn an impossible state into a wrong picture.
 func projectLayout(o encounter.Orientation) HexLayout {
 	if o == nil {
 		return ""

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -44,6 +44,25 @@ func projectGrid(shape spatial.GridShape) GridKind {
 	}
 }
 
+// projectLayout maps the composition's authoring frame onto the wire's render
+// word (rpg-toolkit#1140). Nil — a square field, which declares no orientation
+// by law — yields the empty string, and so does an unrecognised kind, for the
+// reason projectGrid gives: a guess would turn an impossible state into a
+// wrong picture.
+func projectLayout(o encounter.Orientation) HexLayout {
+	if o == nil {
+		return ""
+	}
+	switch o.Kind() {
+	case encounter.OrientationPointyTop:
+		return HexLayoutPointyTop
+	case encounter.OrientationFlatTop:
+		return HexLayoutFlatTop
+	default:
+		return ""
+	}
+}
+
 // projectAtlas flattens the composition's room-by-room map into one map.
 //
 // The composition answers in its own terms — a footprint per room, a doorway
@@ -57,7 +76,7 @@ func projectGrid(shape spatial.GridShape) GridKind {
 // the decomposition the reshape exists to hide — and would eventually depend
 // on it. One order, derived from the coordinates themselves.
 func projectAtlas(in encounter.Atlas) Atlas {
-	out := Atlas{Doorways: make([]AtlasDoorway, 0, len(in.Doorways))}
+	out := Atlas{Layout: projectLayout(in.Orientation), Doorways: make([]AtlasDoorway, 0, len(in.Doorways))}
 
 	for _, region := range in.Regions {
 		// W1: every region in a field shares one grid family, so the last

--- a/rulebooks/dnd5e/session/convert_test.go
+++ b/rulebooks/dnd5e/session/convert_test.go
@@ -60,6 +60,25 @@ var projectedPairs = []struct {
 	{"StoryEntry", record.Entry{}, session.StoryEntry{}},
 }
 
+// renamed lists inner fields carried across under a DIFFERENT name, each with
+// the reason the name had to change. The audit below matches fields by name,
+// so without this a rename is indistinguishable from a drop — and a rename
+// that is recorded as an omission is a decision hiding behind the wrong label.
+//
+// The frame crosses as a render word (rpg-toolkit#1140). The composition
+// keeps Orientation as the frame an author typed offset cells in; this seam
+// sends the CELLS, already converted, so a client never needs that frame. What
+// a client DOES need — and found out by drawing the reference tomb as a
+// diagonal staircase — is which way to lay the hexes out, because the same
+// axial set draws as two different pictures. Same two values, different
+// question, and the staircase happened precisely because the two questions
+// shared a word. So the field is named for what a client does with it.
+var renamed = map[string]struct{ outer, reason string }{
+	"encounter.Atlas.Orientation": {outer: "Layout",
+		reason: "the frame an author typed in becomes the layout a client draws in — same " +
+			"two values, a different question, and a different name so they cannot be confused"},
+}
+
 // omitted lists inner fields deliberately not carried across, each with the
 // reason. Anything absent from a projection and absent from here is a bug, not
 // a decision.
@@ -79,18 +98,6 @@ var omitted = map[string]string{
 		"on this side has one left to project",
 	"encounter.AtlasRegion.Width":  "a room's span; the map's extent is the extent of Cells",
 	"encounter.AtlasRegion.Height": "a room's span; the map's extent is the extent of Cells",
-
-	// The frame, and the reason it does not need to cross.
-	//
-	// A region describes itself as a rectangle, and on hex the same rectangle
-	// covers different cells under each layout — so the composition reports an
-	// Orientation for a host that walks the rectangle itself
-	// (rpg-toolkit#1127). This seam does not hand out rectangles. It enumerates
-	// the cells and sends those, so a client never does the conversion and
-	// never needs the frame it would be done in. Carrying it would be handing
-	// over the tool for a job nobody on that side has.
-	"encounter.Atlas.Orientation": "the hex frame for turning a rectangle into cells; this seam sends " +
-		"the CELLS, so a client never performs that conversion",
 
 	// Placement answers a cell, not a chamber (rpg-toolkit#1046). The room is
 	// the composition's own decomposition, and a caller that wanted it would
@@ -135,6 +142,12 @@ func (s *ConvertTestSuite) TestEveryInnerFieldIsCarriedOrJustified() {
 					continue
 				}
 				key := innerType.String() + "." + field.Name
+				if as, ok := renamed[key]; ok {
+					_, exists := outerFields[as.outer]
+					s.True(exists, "%s is recorded as carried into %T as %q, but no such field exists", key, pair.outer, as.outer)
+					s.NotEmpty(as.reason, "%s must record WHY it was renamed", key)
+					continue
+				}
 				reason, justified := omitted[key]
 				s.True(justified,
 					"%s is not carried into %T and is not listed as a deliberate omission — "+
@@ -164,6 +177,12 @@ func (s *ConvertTestSuite) TestOmissionsStillApply() {
 		s.True(known[key],
 			"%s is listed as a deliberate omission but no longer exists on any projected "+
 				"type — remove the entry rather than leaving a reason for a field that is gone",
+			key)
+	}
+	for key := range renamed {
+		s.True(known[key],
+			"%s is listed as a rename but no longer exists on any projected type — "+
+				"remove the entry rather than leaving a reason for a field that is gone",
 			key)
 	}
 }

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -329,3 +329,52 @@ func trimmedWorld(t fataler) *encounter.EncounterData {
 func TestReadSuite(t *testing.T) {
 	suite.Run(t, new(ReadTestSuite))
 }
+
+// TestAtlasSaysWhichWayTheHexesPoint pins the one fact a client cannot recover
+// from the cells (rpg-toolkit#1140). The same axial set draws as two different
+// pictures, pointy-top and flat-top, and the first client to render the
+// reference tomb guessed from the content and got a diagonal staircase. So the
+// atlas says it — as a render word, Layout, not the authoring word the
+// composition keeps, because confusing those two is exactly how the staircase
+// happened.
+func (s *ReadTestSuite) TestAtlasSaysWhichWayTheHexesPoint() {
+	s.startWith(hexWorld(s.T()))
+	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Equal(session.HexLayoutPointyTop, atlas.Layout,
+		"hexWorld is authored pointy-top, and after rpg-toolkit#1141 that IS the way to draw it")
+}
+
+// TestAtlasLayoutCoversBothHexLayouts guards the mapping in both directions,
+// for the same reason TestGridProjectionCoversBothFamilies does: a projection
+// hard-coded to pointy would pass every fixture in this file.
+func (s *ReadTestSuite) TestAtlasLayoutCoversBothHexLayouts() {
+	flat, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+		Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesAreFlatTop()},
+			Rooms: []encounter.RoomInput{{ID: "cell", Width: 4, Height: 4, Grid: spatial.GridShapeHex}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "cell", Position: spatial.Position{X: 0, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{{Key: "out", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	data := flat.ToData()
+	s.startWith(&data)
+
+	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Equal(session.HexLayoutFlatTop, atlas.Layout, "a flat-top field must not be reported as pointy")
+}
+
+// TestASquareAtlasHasNoLayout mirrors the composition's own law at the wire: a
+// hex field must declare an orientation and a square field must not. A square
+// map that said "pointy_top" would be a client believing something that cannot
+// be true about the grid it is drawing.
+func (s *ReadTestSuite) TestASquareAtlasHasNoLayout() {
+	s.startWith(authoredWorld(s.T()))
+	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Empty(atlas.Layout, "square grids have no hex layout; the field is absent, not defaulted")
+}

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -35,6 +35,32 @@ const (
 	GridHex GridKind = "hex"
 )
 
+// HexLayout names which way a hex map's cells point when drawn: the one fact
+// about a hex atlas a client cannot recover from the cells (rpg-toolkit#1140).
+//
+// Axial coordinates fix the topology — the same six neighbours either way —
+// and not the picture: the same cell set laid out pointy-top and flat-top
+// gives two different images, roughly one rotated from the other. A client
+// putting pixels on a screen has to pick one, and the first one to try guessed
+// from the content and drew the reference tomb as a diagonal staircase.
+//
+// This is the RENDER word, deliberately not the authoring word. The composition
+// holds an Orientation: the frame an author typed offset cells in, which this
+// seam consumes when it enumerates the cells and never hands out. Same two
+// values, different question — and the staircase happened because the two
+// questions shared a word, so here they do not.
+type HexLayout string
+
+const (
+	// HexLayoutPointyTop draws each hex with a vertex up: rows run straight
+	// and alternate rows stagger.
+	HexLayoutPointyTop HexLayout = "pointy_top"
+
+	// HexLayoutFlatTop draws each hex with an edge up: columns run straight
+	// and alternate columns stagger.
+	HexLayoutFlatTop HexLayout = "flat_top"
+)
+
 // Atlas is the static world map in dungeon-absolute space.
 //
 // ONE MAP. The composition underneath keeps rooms and projects the absolute
@@ -56,6 +82,13 @@ type Atlas struct {
 	// per room: a field has a single grid family by law (W1), so a per-room
 	// grid was the same answer repeated.
 	Grid GridKind `json:"grid"`
+
+	// Layout is how to lay the cells out to draw them, present exactly when
+	// Grid is hex and absent otherwise — the composition's own law (a hex
+	// field must declare an orientation, a square field must not) mirrored at
+	// the wire. Not a default: a square map that said pointy_top would be a
+	// client believing something that cannot be true about its grid.
+	Layout HexLayout `json:"layout,omitempty"`
 
 	// Cells is every cell of the map, sorted by coordinate. Occluded cells
 	// are included: occlusion is walkability, not ownership.


### PR DESCRIPTION
Closes #1140 on the toolkit side. Decision recorded as **ADR-0040**; Kirk picked option 1 on the issue.

## What

`session.Atlas` gains `Layout HexLayout` — `"pointy_top"` / `"flat_top"` on a hex map, absent on square — projected from the composition's `Orientation.Kind()`. That is the one fact a client could not recover from the cells: axial coordinates fix the topology and not the picture, and the first client to render the reference tomb guessed from the content and drew a diagonal staircase.

**The name is the decision.** The composition keeps `Orientation` — the frame an author typed offset cells in, which this seam consumes and never hands out. The wire carries `Layout` — what a client does with the cells it receives. Same two values, a different question, and the staircase happened because the two questions shared one word.

The convert audit learns the difference between a **rename** and a **drop**: a `renamed` map records the inner field, the outer field it became, and why, and asserts the target exists. Recording this as an omission would have been a decision hiding behind the wrong label.

## Evidence

- RED observed: both hex-layout tests failed with an empty `Layout` before `projectLayout` existed; the square test and the rename-aware audit passed.
- Mutation: swapping the two `projectLayout` arms is killed by **two named tests** (`TestAtlasSaysWhichWayTheHexesPoint`, `TestAtlasLayoutCoversBothHexLayouts`), restored after.
- `TestNothingOnTheMapNamesARoom` (the type-shape pin) was updated deliberately — that test exists so a new field goes through review, which this one has.
- `go test ./...` in `rulebooks/dnd5e/session` — PASS; pre-commit lint/tests — PASS; `scripts/check-decisions.sh` — 41/41 ADRs in the digest.
- Additive: expected `gorelease` verdict is compatible → `session/v0.20.0` on merge.

## Downstream (sequenced, each its own PR)

protos — `HexLayout` enum + `layout` on `GetAtlasResponse` → rpg-api — pure translation, session pin to v0.20.0, and the `internal/sessionworld` start literal that moved with #1141 → rpg-dnd5e-web — replace the hardcoded `DEFAULT_LAYOUT = 'flat'` (pinned to the *bug's* answer) with the wire field, recapture the tomb fixture, verify in the browser.

— asset-pipeline agent, on behalf of KirkDiggler
